### PR TITLE
[clang][cas] Cherry-pick recent cas include-tree improvements

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -106,8 +106,7 @@ public:
 
   /// Collect dependency tree.
   llvm::Expected<llvm::cas::ObjectProxy>
-  getDependencyTree(const std::vector<std::string> &CommandLine, StringRef CWD,
-                    DepscanPrefixMapping PrefixMapping = {});
+  getDependencyTree(const std::vector<std::string> &CommandLine, StringRef CWD);
 
   /// If \p DiagGenerationAsCompilation is true it will generate error
   /// diagnostics same way as the normal compilation, with "N errors generated"
@@ -117,14 +116,12 @@ public:
   getDependencyTreeFromCompilerInvocation(
       std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-      bool DiagGenerationAsCompilation,
-      DepscanPrefixMapping PrefixMapping = {});
+      bool DiagGenerationAsCompilation);
 
   Expected<cas::IncludeTreeRoot>
   getIncludeTree(cas::ObjectStore &DB,
                  const std::vector<std::string> &CommandLine, StringRef CWD,
-                 LookupModuleOutputCallback LookupModuleOutput,
-                 const DepscanPrefixMapping &PrefixMapping);
+                 LookupModuleOutputCallback LookupModuleOutput);
 
   /// If \p DiagGenerationAsCompilation is true it will generate error
   /// diagnostics same way as the normal compilation, with "N errors generated"
@@ -133,7 +130,6 @@ public:
   Expected<cas::IncludeTreeRoot> getIncludeTreeFromCompilerInvocation(
       cas::ObjectStore &DB, std::shared_ptr<CompilerInvocation> Invocation,
       StringRef CWD, LookupModuleOutputCallback LookupModuleOutput,
-      const DepscanPrefixMapping &PrefixMapping,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
       bool DiagGenerationAsCompilation);
 
@@ -155,8 +151,7 @@ public:
   getTranslationUnitDependencies(const std::vector<std::string> &CommandLine,
                                  StringRef CWD,
                                  const llvm::StringSet<> &AlreadySeen,
-                                 LookupModuleOutputCallback LookupModuleOutput,
-                                 DepscanPrefixMapping PrefixMapping);
+                                 LookupModuleOutputCallback LookupModuleOutput);
 
   /// Given a compilation context specified via the Clang driver command-line,
   /// gather modular dependencies of module with the given name, and return the
@@ -165,8 +160,7 @@ public:
   getModuleDependencies(StringRef ModuleName,
                         const std::vector<std::string> &CommandLine,
                         StringRef CWD, const llvm::StringSet<> &AlreadySeen,
-                        LookupModuleOutputCallback LookupModuleOutput,
-                        DepscanPrefixMapping PrefixMapping);
+                        LookupModuleOutputCallback LookupModuleOutput);
 
   ScanningOutputFormat getScanningFormat() const {
     return Worker.getScanningFormat();
@@ -187,13 +181,11 @@ public:
 
   static std::unique_ptr<DependencyActionController>
   createActionController(DependencyScanningWorker &Worker,
-                         LookupModuleOutputCallback LookupModuleOutput,
-                         DepscanPrefixMapping PrefixMapping);
+                         LookupModuleOutputCallback LookupModuleOutput);
 
 private:
   std::unique_ptr<DependencyActionController>
-  createActionController(LookupModuleOutputCallback LookupModuleOutput,
-                         DepscanPrefixMapping PrefixMapping);
+  createActionController(LookupModuleOutputCallback LookupModuleOutput);
 
 private:
   DependencyScanningWorker Worker;

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningWorker.h
@@ -31,7 +31,6 @@ using CachingOnDiskFileSystemPtr =
     llvm::IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem>;
 
 class DependencyScanningWorkerFilesystem;
-struct DepscanPrefixMapping;
 
 /// A command-line tool invocation that is part of building a TU.
 ///
@@ -99,12 +98,6 @@ public:
                                                const ModuleDeps &MD) {
     return llvm::Error::success();
   }
-
-  /// FIXME: This is temporary until we eliminate the split between consumers in
-  /// \p DependencyScanningTool and collectors in \p DependencyScanningWorker
-  /// and have them both in the same file. see FIXME in \p
-  /// DependencyScanningAction::runInvocation.
-  virtual const DepscanPrefixMapping *getPrefixMapping() { return nullptr; }
 };
 
 /// An individual dependency scanning worker that is able to run on its own

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -41,14 +41,13 @@ void configureInvocationForCaching(CompilerInvocation &CI, CASOptions CASOpts,
                                    bool ProduceIncludeTree);
 
 struct DepscanPrefixMapping {
-  Optional<std::string> NewSDKPath;
-  Optional<std::string> NewToolchainPath;
-  SmallVector<std::string> PrefixMap;
+  /// Add path mappings to the \p Mapper.
+  static void configurePrefixMapper(const CompilerInvocation &Invocation,
+                                    llvm::PrefixMapper &Mapper);
 
-  /// Add path mappings from the current path in \p Invocation to the new path
-  /// from \c DepscanPrefixMapping to the \p Mapper.
-  llvm::Error configurePrefixMapper(const CompilerInvocation &Invocation,
-                                    llvm::PrefixMapper &Mapper) const;
+  /// Add path mappings to the \p Mapper.
+  static void configurePrefixMapper(ArrayRef<std::string> PathPrefixMappings,
+                                    llvm::PrefixMapper &Mapper);
 
   /// Apply the mappings from \p Mapper to \p Invocation.
   static void remapInvocationPaths(CompilerInvocation &Invocation,
@@ -61,7 +60,6 @@ Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::dependencies::DependencyScanningTool &Tool,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     CompilerInvocation &Invocation, StringRef WorkingDirectory,
-    const tooling::dependencies::DepscanPrefixMapping &PrefixMapping,
     llvm::cas::ObjectStore &DB);
 
 } // end namespace clang

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -43,7 +43,8 @@ private:
                                const Driver &D, const llvm::opt::ArgList &Args,
                                llvm::opt::ArgStringList &CmdArgs,
                                const InputInfo &Output,
-                               const InputInfoList &Inputs) const;
+                               const InputInfoList &Inputs,
+                               std::optional<StringRef> &Sysroot) const;
 
   void RenderTargetOptions(const llvm::Triple &EffectiveTriple,
                            const llvm::opt::ArgList &Args, bool KernelOrKext,
@@ -103,6 +104,11 @@ private:
   void DumpCompilationDatabaseFragmentToDir(
       StringRef Dir, Compilation &C, StringRef Target, const InputInfo &Output,
       const InputInfo &Input, const llvm::opt::ArgList &Args) const;
+
+  void AddPrefixMappingOptions(const llvm::opt::ArgList &Args,
+                               llvm::opt::ArgStringList &CmdArgs,
+                               const Driver &D,
+                               std::optional<StringRef> Sysroot) const;
 
 public:
   Clang(const ToolChain &TC, bool HasIntegratedBackend = true);

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -2081,8 +2081,12 @@ CompilerInstance::loadModule(SourceLocation ImportLoc,
           PrivateModule, PP->getIdentifierInfo(Module->Name)->getTokenID());
       PrivPath.push_back(std::make_pair(&II, Path[0].second));
 
+      std::string FileName;
+      // If there is a modulemap module or prebuilt module, load it.
       if (PP->getHeaderSearchInfo().lookupModule(PrivateModule, ImportLoc, true,
-                                                 !IsInclusionDirective))
+                                                 !IsInclusionDirective) ||
+          selectModuleSource(nullptr, PrivateModule, FileName, BuiltModules,
+                             PP->getHeaderSearchInfo()) != MS_ModuleNotFound)
         Sub = loadModule(ImportLoc, PrivPath, Visibility, IsInclusionDirective);
       if (Sub) {
         MapPrivateSubModToTopLevel = true;

--- a/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/CASFSActionController.cpp
@@ -22,8 +22,7 @@ namespace {
 class CASFSActionController : public CallbackActionController {
 public:
   CASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
-                        llvm::cas::CachingOnDiskFileSystem &CacheFS,
-                        DepscanPrefixMapping PrefixMapping);
+                        llvm::cas::CachingOnDiskFileSystem &CacheFS);
 
   llvm::Error initialize(CompilerInstance &ScanInstance,
                          CompilerInvocation &NewInvocation) override;
@@ -38,7 +37,6 @@ public:
 
 private:
   llvm::cas::CachingOnDiskFileSystem &CacheFS;
-  DepscanPrefixMapping PrefixMapping;
   std::optional<llvm::TreePathPrefixMapper> Mapper;
   CASOptions CASOpts;
 };
@@ -46,17 +44,15 @@ private:
 
 CASFSActionController::CASFSActionController(
     LookupModuleOutputCallback LookupModuleOutput,
-    llvm::cas::CachingOnDiskFileSystem &CacheFS,
-    DepscanPrefixMapping PrefixMapping)
-    : CallbackActionController(std::move(LookupModuleOutput)), CacheFS(CacheFS),
-      PrefixMapping(std::move(PrefixMapping)) {}
+    llvm::cas::CachingOnDiskFileSystem &CacheFS)
+    : CallbackActionController(std::move(LookupModuleOutput)),
+      CacheFS(CacheFS) {}
 
 Error CASFSActionController::initialize(CompilerInstance &ScanInstance,
                                         CompilerInvocation &NewInvocation) {
   // Setup prefix mapping.
   Mapper.emplace(&CacheFS);
-  if (Error E = PrefixMapping.configurePrefixMapper(NewInvocation, *Mapper))
-    return E;
+  DepscanPrefixMapping::configurePrefixMapper(NewInvocation, *Mapper);
 
   const PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
   if (!PPOpts.Includes.empty() || !PPOpts.ImplicitPCHInclude.empty())
@@ -197,8 +193,6 @@ Error CASFSActionController::finalizeModuleInvocation(CompilerInvocation &CI,
 std::unique_ptr<DependencyActionController>
 dependencies::createCASFSActionController(
     LookupModuleOutputCallback LookupModuleOutput,
-    llvm::cas::CachingOnDiskFileSystem &CacheFS,
-    DepscanPrefixMapping PrefixMapping) {
-  return std::make_unique<CASFSActionController>(LookupModuleOutput, CacheFS,
-                                                 std::move(PrefixMapping));
+    llvm::cas::CachingOnDiskFileSystem &CacheFS) {
+  return std::make_unique<CASFSActionController>(LookupModuleOutput, CacheFS);
 }

--- a/clang/lib/Tooling/DependencyScanning/CachingActions.h
+++ b/clang/lib/Tooling/DependencyScanning/CachingActions.h
@@ -20,13 +20,11 @@ namespace clang::tooling::dependencies {
 
 std::unique_ptr<DependencyActionController>
 createIncludeTreeActionController(LookupModuleOutputCallback LookupModuleOutput,
-                                  cas::ObjectStore &DB,
-                                  DepscanPrefixMapping PrefixMapping);
+                                  cas::ObjectStore &DB);
 
 std::unique_ptr<DependencyActionController>
 createCASFSActionController(LookupModuleOutputCallback LookupModuleOutput,
-                            llvm::cas::CachingOnDiskFileSystem &CacheFS,
-                            DepscanPrefixMapping PrefixMapping);
+                            llvm::cas::CachingOnDiskFileSystem &CacheFS);
 
 /// The PCH recorded file paths with canonical paths, create a VFS that
 /// allows remapping back to the non-canonical source paths so that they are

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningTool.cpp
@@ -162,11 +162,9 @@ private:
 
 llvm::Expected<llvm::cas::ObjectProxy>
 DependencyScanningTool::getDependencyTree(
-    const std::vector<std::string> &CommandLine, StringRef CWD,
-    DepscanPrefixMapping PrefixMapping) {
+    const std::vector<std::string> &CommandLine, StringRef CWD) {
   GetDependencyTree Consumer(*Worker.getCASFS());
-  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS(),
-                                                std::move(PrefixMapping));
+  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS());
   auto Result =
       Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
@@ -178,10 +176,9 @@ llvm::Expected<llvm::cas::ObjectProxy>
 DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
     std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-    bool DiagGenerationAsCompilation, DepscanPrefixMapping PrefixMapping) {
+    bool DiagGenerationAsCompilation) {
   GetDependencyTree Consumer(*Worker.getCASFS());
-  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS(),
-                                                std::move(PrefixMapping));
+  auto Controller = createCASFSActionController(nullptr, *Worker.getCASFS());
   Worker.computeDependenciesFromCompilerInvocation(
       std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
@@ -190,11 +187,9 @@ DependencyScanningTool::getDependencyTreeFromCompilerInvocation(
 
 Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
     cas::ObjectStore &DB, const std::vector<std::string> &CommandLine,
-    StringRef CWD, LookupModuleOutputCallback LookupModuleOutput,
-    const DepscanPrefixMapping &PrefixMapping) {
+    StringRef CWD, LookupModuleOutputCallback LookupModuleOutput) {
   GetIncludeTree Consumer(DB);
-  auto Controller = createIncludeTreeActionController(LookupModuleOutput, DB,
-                                                      std::move(PrefixMapping));
+  auto Controller = createIncludeTreeActionController(LookupModuleOutput, DB);
   llvm::Error Result =
       Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
@@ -206,12 +201,10 @@ Expected<cas::IncludeTreeRoot>
 DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
     cas::ObjectStore &DB, std::shared_ptr<CompilerInvocation> Invocation,
     StringRef CWD, LookupModuleOutputCallback LookupModuleOutput,
-    const DepscanPrefixMapping &PrefixMapping,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation) {
   GetIncludeTree Consumer(DB);
-  auto Controller = createIncludeTreeActionController(LookupModuleOutput, DB,
-                                                      std::move(PrefixMapping));
+  auto Controller = createIncludeTreeActionController(LookupModuleOutput, DB);
   Worker.computeDependenciesFromCompilerInvocation(
       std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
@@ -222,11 +215,9 @@ llvm::Expected<TranslationUnitDeps>
 DependencyScanningTool::getTranslationUnitDependencies(
     const std::vector<std::string> &CommandLine, StringRef CWD,
     const llvm::StringSet<> &AlreadySeen,
-    LookupModuleOutputCallback LookupModuleOutput,
-    DepscanPrefixMapping PrefixMapping) {
+    LookupModuleOutputCallback LookupModuleOutput) {
   FullDependencyConsumer Consumer(AlreadySeen);
-  auto Controller =
-      createActionController(LookupModuleOutput, std::move(PrefixMapping));
+  auto Controller = createActionController(LookupModuleOutput);
   llvm::Error Result =
       Worker.computeDependencies(CWD, CommandLine, Consumer, *Controller);
   if (Result)
@@ -237,11 +228,9 @@ DependencyScanningTool::getTranslationUnitDependencies(
 llvm::Expected<ModuleDepsGraph> DependencyScanningTool::getModuleDependencies(
     StringRef ModuleName, const std::vector<std::string> &CommandLine,
     StringRef CWD, const llvm::StringSet<> &AlreadySeen,
-    LookupModuleOutputCallback LookupModuleOutput,
-    DepscanPrefixMapping PrefixMapping) {
+    LookupModuleOutputCallback LookupModuleOutput) {
   FullDependencyConsumer Consumer(AlreadySeen);
-  auto Controller =
-      createActionController(LookupModuleOutput, std::move(PrefixMapping));
+  auto Controller = createActionController(LookupModuleOutput);
   llvm::Error Result = Worker.computeDependencies(CWD, CommandLine, Consumer,
                                                   *Controller, ModuleName);
   if (Result)
@@ -293,21 +282,17 @@ CallbackActionController::~CallbackActionController() {}
 std::unique_ptr<DependencyActionController>
 DependencyScanningTool::createActionController(
     DependencyScanningWorker &Worker,
-    LookupModuleOutputCallback LookupModuleOutput,
-    DepscanPrefixMapping PrefixMapping) {
+    LookupModuleOutputCallback LookupModuleOutput) {
   if (Worker.getScanningFormat() == ScanningOutputFormat::FullIncludeTree)
-    return createIncludeTreeActionController(
-        LookupModuleOutput, *Worker.getCAS(), std::move(PrefixMapping));
+    return createIncludeTreeActionController(LookupModuleOutput,
+                                             *Worker.getCAS());
   if (auto CacheFS = Worker.getCASFS())
-    return createCASFSActionController(LookupModuleOutput, *CacheFS,
-                                       std::move(PrefixMapping));
+    return createCASFSActionController(LookupModuleOutput, *CacheFS);
   return std::make_unique<CallbackActionController>(LookupModuleOutput);
 }
 
 std::unique_ptr<DependencyActionController>
 DependencyScanningTool::createActionController(
-    LookupModuleOutputCallback LookupModuleOutput,
-    DepscanPrefixMapping PrefixMapping) {
-  return createActionController(Worker, std::move(LookupModuleOutput),
-                                std::move(PrefixMapping));
+    LookupModuleOutputCallback LookupModuleOutput) {
+  return createActionController(Worker, std::move(LookupModuleOutput));
 }

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -177,17 +177,14 @@ public:
       const DependencyOutputOptions &Opts)
       : DependencyFileGenerator(Opts) {}
 
-  Error initialize(const CompilerInvocation &CI,
-                   const DepscanPrefixMapping &PrefixMapping) {
+  void initialize(const CompilerInvocation &CI) {
     llvm::PrefixMapper Mapper;
-    if (Error E = PrefixMapping.configurePrefixMapper(CI, Mapper))
-      return E;
+    DepscanPrefixMapping::configurePrefixMapper(CI, Mapper);
     if (Mapper.empty())
-      return Error::success();
+      return;
 
     ReverseMapper.addInverseRange(Mapper.getMappings());
     ReverseMapper.sort();
-    return Error::success();
   }
 
   void maybeAddDependency(StringRef Filename, bool FromModule, bool IsSystem,
@@ -426,9 +423,7 @@ public:
         auto DFG =
             std::make_shared<ReversePrefixMappingDependencyFileGenerator>(
                 *Opts);
-        if (auto *Mapping = Controller.getPrefixMapping())
-          if (auto E = DFG->initialize(ScanInstance.getInvocation(), *Mapping))
-            return reportError(std::move(E));
+        DFG->initialize(ScanInstance.getInvocation());
         ScanInstance.addDependencyCollector(std::move(DFG));
       }
 

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -25,10 +25,8 @@ class IncludeTreeBuilder;
 class IncludeTreeActionController : public CallbackActionController {
 public:
   IncludeTreeActionController(cas::ObjectStore &DB,
-                              DepscanPrefixMapping PrefixMapping,
                               LookupModuleOutputCallback LookupOutput)
-      : CallbackActionController(LookupOutput), DB(DB),
-        PrefixMapping(std::move(PrefixMapping)) {}
+      : CallbackActionController(LookupOutput), DB(DB) {}
 
   Expected<cas::IncludeTreeRoot> getIncludeTree();
 
@@ -43,10 +41,6 @@ private:
   Error finalizeModuleInvocation(CompilerInvocation &CI,
                                  const ModuleDeps &MD) override;
 
-  const DepscanPrefixMapping *getPrefixMapping() override {
-    return &PrefixMapping;
-  }
-
 private:
   IncludeTreeBuilder &current() {
     assert(!BuilderStack.empty());
@@ -56,7 +50,6 @@ private:
 private:
   cas::ObjectStore &DB;
   CASOptions CASOpts;
-  DepscanPrefixMapping PrefixMapping;
   llvm::PrefixMapper PrefixMapper;
   // IncludeTreePPCallbacks keeps a pointer to the current builder, so use a
   // pointer so the builder cannot move when resizing.
@@ -296,9 +289,7 @@ Expected<cas::IncludeTreeRoot> IncludeTreeActionController::getIncludeTree() {
 
 Error IncludeTreeActionController::initialize(
     CompilerInstance &ScanInstance, CompilerInvocation &NewInvocation) {
-  if (Error E =
-          PrefixMapping.configurePrefixMapper(NewInvocation, PrefixMapper))
-    return E;
+  DepscanPrefixMapping::configurePrefixMapper(NewInvocation, PrefixMapper);
 
   auto ensurePathRemapping = [&]() {
     if (PrefixMapper.empty())
@@ -822,8 +813,6 @@ IncludeTreeBuilder::createIncludeFile(StringRef Filename,
 
 std::unique_ptr<DependencyActionController>
 dependencies::createIncludeTreeActionController(
-    LookupModuleOutputCallback LookupModuleOutput, cas::ObjectStore &DB,
-    DepscanPrefixMapping PrefixMapping) {
-  return std::make_unique<IncludeTreeActionController>(
-      DB, std::move(PrefixMapping), LookupModuleOutput);
+    LookupModuleOutputCallback LookupModuleOutput, cas::ObjectStore &DB) {
+  return std::make_unique<IncludeTreeActionController>(DB, LookupModuleOutput);
 }

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -106,6 +106,8 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
   if (!CI.getLangOpts()->ModulesCodegen) {
     CI.getCodeGenOpts().DebugCompilationDir.clear();
     CI.getCodeGenOpts().CoverageCompilationDir.clear();
+    CI.getCodeGenOpts().CoverageDataFile.clear();
+    CI.getCodeGenOpts().CoverageNotesFile.clear();
   }
 
   // Map output paths that affect behaviour to "-" so their existence is in the

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -177,6 +177,14 @@ void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
   Mapper.mapInPlace(CodeGenOpts.ProfileInstrumentUsePath);
   Mapper.mapInPlace(CodeGenOpts.SampleProfileFile);
   Mapper.mapInPlace(CodeGenOpts.ProfileRemappingFile);
+
+  // Dependency output options.
+  // Note: these are not in the cache key, but they are in the module context
+  // hash, which indirectly impacts the cache key when importing a module.
+  // In the future we may change how -fmodule-file-cache-key works when
+  // remapping to avoid needing this.
+  for (auto &ExtraDep : Invocation.getDependencyOutputOpts().ExtraDeps)
+    Mapper.mapInPlace(ExtraDep.first);
 }
 
 void DepscanPrefixMapping::configurePrefixMapper(const CompilerInvocation &CI,

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -29,6 +29,12 @@ void tooling::dependencies::configureInvocationForCaching(
   // Clear this otherwise it defeats the purpose of making the compilation key
   // independent of certain arguments.
   CI.getCodeGenOpts().DwarfDebugFlags.clear();
+  if (FrontendOpts.ProgramAction == frontend::GeneratePCH) {
+    // Clear paths that are emitted into binaries; they do not affect PCH.
+    // For modules this is handled in ModuleDepCollector.
+    CI.getCodeGenOpts().CoverageDataFile.clear();
+    CI.getCodeGenOpts().CoverageNotesFile.clear();
+  }
 
   // "Fix" the CAS options.
   auto &FileSystemOpts = CI.getFileSystemOpts();

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -179,66 +179,28 @@ void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
   Mapper.mapInPlace(CodeGenOpts.ProfileRemappingFile);
 }
 
-Error DepscanPrefixMapping::configurePrefixMapper(
-    const CompilerInvocation &Invocation, llvm::PrefixMapper &Mapper) const {
-  auto isPathApplicableAsPrefix = [](StringRef Path) -> bool {
-    if (Path.empty())
-      return false;
-    if (llvm::sys::path::is_relative(Path))
-      return false;
-    if (Path == llvm::sys::path::root_path(Path))
-      return false;
-    return true;
-  };
+void DepscanPrefixMapping::configurePrefixMapper(const CompilerInvocation &CI,
+                                                 llvm::PrefixMapper &Mapper) {
+  return configurePrefixMapper(CI.getFrontendOpts().PathPrefixMappings, Mapper);
+}
 
-  const HeaderSearchOptions &HSOpts = Invocation.getHeaderSearchOpts();
+void DepscanPrefixMapping::configurePrefixMapper(
+    ArrayRef<std::string> PathPrefixMappings, llvm::PrefixMapper &Mapper) {
+  if (PathPrefixMappings.empty())
+    return;
 
-  if (NewSDKPath) {
-    StringRef SDK = HSOpts.Sysroot;
-    if (isPathApplicableAsPrefix(SDK))
-      // Need a new copy of the string since the invocation will be modified.
-      Mapper.add({SDK, *NewSDKPath});
-  }
-  if (NewToolchainPath) {
-    // Look up for the toolchain, assuming resources are at
-    // <toolchain>/usr/lib/clang/<VERSION>. Return a shallower guess if the
-    // directories do not match.
-    //
-    // FIXME: Should this append ".." instead of calling parent_path?
-    StringRef ResourceDir = HSOpts.ResourceDir;
-    StringRef Guess = llvm::sys::path::parent_path(ResourceDir);
-    for (StringRef Dir : {"clang", "lib", "usr"}) {
-      if (llvm::sys::path::filename(Guess) != Dir)
-        break;
-      Guess = llvm::sys::path::parent_path(Guess);
-    }
-    if (isPathApplicableAsPrefix(Guess))
-      // Need a new copy of the string since the invocation will be modified.
-      Mapper.add({Guess, *NewToolchainPath});
-  }
-  if (!PrefixMap.empty()) {
-    llvm::SmallVector<llvm::MappedPrefix> Split;
-    llvm::MappedPrefix::transformJoinedIfValid(PrefixMap, Split);
-    for (auto &MappedPrefix : Split) {
-      if (isPathApplicableAsPrefix(MappedPrefix.Old)) {
-        Mapper.add(MappedPrefix);
-      } else {
-        return createStringError(llvm::errc::invalid_argument,
-                                 "invalid prefix map: '" + MappedPrefix.Old +
-                                     "=" + MappedPrefix.New + "'");
-      }
-    }
-  }
+  llvm::SmallVector<llvm::MappedPrefix> Split;
+  llvm::MappedPrefix::transformJoinedIfValid(PathPrefixMappings, Split);
+  for (auto &MappedPrefix : Split)
+    Mapper.add(MappedPrefix);
 
   Mapper.sort();
-  return Error::success();
 }
 
 Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
     DependencyScanningTool &Tool, DiagnosticConsumer &DiagsConsumer,
     raw_ostream *VerboseOS, CompilerInvocation &Invocation,
-    StringRef WorkingDirectory, const DepscanPrefixMapping &PrefixMapping,
-    llvm::cas::ObjectStore &DB) {
+    StringRef WorkingDirectory, llvm::cas::ObjectStore &DB) {
   // Override the CASOptions. They may match (the caller having sniffed them
   // out of InputArgs) but if they have been overridden we want the new ones.
   Invocation.getCASOpts() = Tool.getCASOpts();
@@ -255,8 +217,7 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
         Tool.getCachingFileSystem());
   }
   llvm::PrefixMapper &Mapper = *MapperPtr;
-  if (Error E = PrefixMapping.configurePrefixMapper(Invocation, Mapper))
-    return std::move(E);
+  DepscanPrefixMapping::configurePrefixMapper(Invocation, Mapper);
 
   auto ScanInvocation = std::make_shared<CompilerInvocation>(Invocation);
   // An error during dep-scanning is treated as if the main compilation has
@@ -265,18 +226,18 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
 
   Optional<llvm::cas::CASID> Root;
   if (ProduceIncludeTree) {
-    if (Error E = Tool.getIncludeTreeFromCompilerInvocation(
-                          DB, std::move(ScanInvocation), WorkingDirectory,
-                          /*LookupModuleOutput=*/nullptr, PrefixMapping,
-                          DiagsConsumer, VerboseOS,
-                          /*DiagGenerationAsCompilation*/ true)
-                      .moveInto(Root))
+    if (Error E =
+            Tool.getIncludeTreeFromCompilerInvocation(
+                    DB, std::move(ScanInvocation), WorkingDirectory,
+                    /*LookupModuleOutput=*/nullptr, DiagsConsumer, VerboseOS,
+                    /*DiagGenerationAsCompilation*/ true)
+                .moveInto(Root))
       return std::move(E);
   } else {
     if (Error E = Tool.getDependencyTreeFromCompilerInvocation(
                           std::move(ScanInvocation), WorkingDirectory,
                           DiagsConsumer, VerboseOS,
-                          /*DiagGenerationAsCompilation*/ true, PrefixMapping)
+                          /*DiagGenerationAsCompilation*/ true)
                       .moveInto(Root))
       return std::move(E);
   }

--- a/clang/test/CAS/cached-diagnostics.c
+++ b/clang/test/CAS/cached-diagnostics.c
@@ -4,8 +4,8 @@
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src/main.c -I %t/src/inc -Wunknown-pragmas 2> %t/regular-diags1.txt
 
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -fdepscan-prefix-map=%t/src=/^src -o %t/t1.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t1.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src=/^src \
 // RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Wunknown-pragmas
 
 // Compare diagnostics after a miss.
@@ -41,8 +41,8 @@
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src2/main.c -I %t/src2/inc -Wunknown-pragmas 2> %t/regular-diags2.txt
 
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -fdepscan-prefix-map=%t/src2=/^src -o %t/t2.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t2.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src2=/^src \
 // RUN:     -emit-obj %t/src2/main.c -o %t/out2/output.o -I %t/src2/inc -Wunknown-pragmas
 // RUN: %clang @%t/t2.rsp -Rcompile-job-cache 2> %t/diags-hit2.txt
 

--- a/clang/test/CAS/depscan-include-tree.c
+++ b/clang/test/CAS/depscan-include-tree.c
@@ -2,7 +2,8 @@
 // RUN: split-file %s %t
 
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args -cc1 -triple x86_64-apple-macos11.0 \
-// RUN:     -emit-obj %t/t.c -o %t/t.o -dwarf-ext-refs -fmodule-format=obj \
+// RUN:     -emit-obj %t/t.c -o %t/t.o -dwarf-ext-refs -fmodule-format=obj  \
+// RUN:     -ftest-coverage -coverage-notes-file %t/t.gcno -coverage-data-file %t/t.gcda \
 // RUN:     -I %t/includes -isysroot %S/Inputs/SDK -fcas-path %t/cas -DSOME_MACRO -dependency-file %t/inline.d -MT deps
 
 // RUN: FileCheck %s -input-file %t/inline.rsp -DPREFIX=%t
@@ -13,6 +14,9 @@
 // CHECK: "-fcas-path" "[[PREFIX]]/cas"
 // CHECK: "-fcas-include-tree"
 // CHECK: "-isysroot"
+// CHECK: "-ftest-coverage"
+// CHECK: "-coverage-data-file" "[[PREFIX]]/t.gcda"
+// CHECK: "-coverage-notes-file" "[[PREFIX]]/t.gcno"
 // SHOULD-NOT: "-fcas-fs"
 // SHOULD-NOT: "-fcas-fs-working-directory"
 // SHOULD-NOT: "-I"

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -16,6 +16,7 @@
 // RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
 // RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
 // RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=inline    \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o \
@@ -29,6 +30,7 @@
 // RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
 // RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
 // RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
 // RUN:   -cas-args -fcas-path %t.d/cas --                                \
@@ -45,12 +47,14 @@
 // RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
 // RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
 // RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 //
 // CHECK:      "-fcas-path" "[[PREFIX]]/cas"
 // CHECK-SAME: "-working-directory" "/^testdir"
 // CHECK-SAME: "-x" "c" "/^source/depscan-prefix-map.c"
 // CHECK-SAME: "-isysroot" "/^sdk"
+// CHECK-SAME: "-fdepfile-entry=/^testdir/extra"
 
 // RUN: llvm-cas --cas %t.d/cas --ls-tree-recursive @%t.root              \
 // RUN: | FileCheck %s -check-prefix=CHECK-ROOT

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -5,46 +5,46 @@
 // RUN: rm -rf %t.d
 // RUN: mkdir %t.d
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=inline    \
-// RUN:    -fdepscan-prefix-map=%S=/^source                               \
-// RUN:    -fdepscan-prefix-map=%t.d=/^testdir                            \
-// RUN:    -fdepscan-prefix-map=%{objroot}=/^objroot                      \
-// RUN:    -fdepscan-prefix-map-toolchain=/^toolchain                     \
-// RUN:    -fdepscan-prefix-map-sdk=/^sdk                                 \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o \
 // RUN:              -isysroot %S/Inputs/SDK                              \
 // RUN:              -resource-dir %S/Inputs/toolchain_dir/usr/lib/clang/1000 \
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/usr/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
+// RUN:              -fdepscan-prefix-map=%S=/^source                     \
+// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
+// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
+// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=inline    \
-// RUN:    -fdepscan-prefix-map=%S=/^source                               \
-// RUN:    -fdepscan-prefix-map=%t.d=/^testdir                            \
-// RUN:    -fdepscan-prefix-map=%{objroot}=/^objroot                      \
-// RUN:    -fdepscan-prefix-map-toolchain=/^toolchain                     \
-// RUN:    -fdepscan-prefix-map-sdk=/^sdk                                 \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o \
 // RUN:              -isysroot %S/Inputs/SDK                              \
 // RUN:              -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 \
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
+// RUN:              -fdepscan-prefix-map=%S=/^source                     \
+// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
+// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
+// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
 // RUN:   -cas-args -fcas-path %t.d/cas --                                \
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon    \
 // RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
-// RUN:    -fdepscan-prefix-map=%S=/^source                               \
-// RUN:    -fdepscan-prefix-map=%t.d=/^testdir                            \
-// RUN:    -fdepscan-prefix-map=%{objroot}=/^objroot                      \
-// RUN:    -fdepscan-prefix-map-toolchain=/^toolchain                     \
-// RUN:    -fdepscan-prefix-map-sdk=/^sdk                                 \
 // RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o \
 // RUN:              -isysroot %S/Inputs/SDK                              \
 // RUN:              -resource-dir %S/Inputs/toolchain_dir/usr/lib/clang/1000 \
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/usr/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
+// RUN:              -fdepscan-prefix-map=%S=/^source                     \
+// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
+// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
+// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 //
 // CHECK:      "-fcas-path" "[[PREFIX]]/cas"
@@ -63,36 +63,6 @@
 // CHECK-ROOT-NEXT: tree {{.*}} /^sdk/Library/Frameworks/{{$}}
 // CHECK-ROOT-NEXT: file {{.*}} /^source/depscan-prefix-map.c{{$}}
 // CHECK-ROOT-NEXT: file {{.*}} /^toolchain/usr/lib/clang/1000/include/stdarg.h{{$}}
-
-// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t.d/cas --                                    \
-// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
-// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
-// RUN:    -fdepscan-prefix-map=/=/^foo                                       \
-// RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
-// RUN:      -fcas-path %t.d/cas                                              \
-// RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_ROOT
-// ERROR_ROOT: invalid prefix map: '/=/^foo'
-
-// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t.d/cas --                                    \
-// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
-// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
-// RUN:    -fdepscan-prefix-map==/^foo                                        \
-// RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
-// RUN:      -fcas-path %t.d/cas                                              \
-// RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_EMPTY
-// ERROR_EMPTY: invalid prefix map: '=/^foo'
-
-// RUN: not %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t.d/cas --                                    \
-// RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=daemon        \
-// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t                   \
-// RUN:    -fdepscan-prefix-map=relative=/^foo                                \
-// RUN:    -cc1-args -triple x86_64-apple-macos11.0 -x c %s -o %t.d/out.o     \
-// RUN:      -fcas-path %t.d/cas                                              \
-// RUN: 2>&1 | FileCheck %s -DPREFIX=%t.d -check-prefix=ERROR_RELATIVE
-// ERROR_RELATIVE: invalid prefix map: 'relative=/^foo'
 
 #include <stdarg.h>
 int test() { return 0; }

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -58,14 +58,15 @@
 // RUN: cp -R %S/Inputs/cmake-build %t/cmake-build
 // RUN: pushd %t/cmake-build
 // RUN: cache-build-session -prefix-map-cmake -v echo 2>&1 | FileCheck %s -check-prefix=SESSION-CMAKE-PREFIX
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session -prefix-map-cmake %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=CLANG-CMAKE-PREFIX -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session -prefix-map-cmake %clang-cache %clang -c %s -o %t.o -isysroot %S/Inputs/SDK -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -### 2>&1 | FileCheck %s -check-prefix=CLANG-CMAKE-PREFIX -DPREFIX=%t -DINPUTS=%S/Inputs
 // RUN: popd
 
 // SESSION-CMAKE-PREFIX: note: setting LLVM_CACHE_PREFIX_MAPS=/llvm/build=/^build;/llvm/llvm-project/llvm=/^src;/llvm/llvm-project/clang=/^src-clang;/llvm/llvm-project/clang-tools-extra=/^src-clang-tools-extra;/llvm/llvm-project/third-party/benchmark=/^src-benchmark;/llvm/llvm-project/other/benchmark=/^src-benchmark-1;/llvm/llvm-project/another/benchmark=/^src-benchmark-2{{$}}
 // SESSION-CMAKE-PREFIX: note: setting LLVM_CACHE_BUILD_SESSION_ID=
 
 // CLANG-CMAKE-PREFIX: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map-sdk=/^sdk" "-fdepscan-prefix-map-toolchain=/^toolchain"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=[[INPUTS]]/SDK=/^sdk"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=[[INPUTS]]/toolchain_dir=/^toolchain"
 // CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/build=/^build"
 // CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/llvm=/^src"
 // CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/clang=/^src-clang"

--- a/clang/test/CAS/fcas-include-tree-prefix-mapping.c
+++ b/clang/test/CAS/fcas-include-tree-prefix-mapping.c
@@ -3,11 +3,13 @@
 // RUN: mkdir %t/out
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
-// RUN:   -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t1.rsp -cc1-args \
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-llvm %t/src/main.c -o %t/out/output.ll -include %t/src/prefix.h -I %t/src/inc \
 // RUN:       -MT deps -dependency-file %t/t1.d
@@ -41,11 +43,13 @@
 // RUN: mkdir %t/out2
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
-// RUN:   -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t2.rsp -cc1-args \
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-llvm %t/src2/main.c -o %t/out2/output.ll -include %t/src2/prefix.h -I %t/src2/inc \
 // RUN:       -MT deps -dependency-file %t/t2.d
@@ -77,22 +81,26 @@
 // Check with PCH.
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
-// RUN:   -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/pch1.rsp -cc1-args \
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-pch -x c-header %t/src/prefix.h -o %t/out/prefix.h.pch -include %t/src/prefix.h -I %t/src/inc
 // RUN: %clang @%t/pch1.rsp
 
 // With different cas path to avoid cache hit.
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
-// RUN:   -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/pch2.rsp -cc1-args \
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas2 -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-pch -x c-header %t/src2/prefix.h -o %t/out2/prefix.h.pch -include %t/src2/prefix.h -I %t/src2/inc
 // RUN: %clang @%t/pch2.rsp
@@ -100,11 +108,13 @@
 // RUN: diff %t/out/prefix.h.pch %t/out2/prefix.h.pch
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
-// RUN:   -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t3.rsp -cc1-args \
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-obj %t/src/main.c -o %t/out/main.o -include-pch %t/out/prefix.h.pch -I %t/src/inc \
 // RUN:       -MT deps -dependency-file %t/t1.pch.d
@@ -115,11 +125,13 @@
 // RUN:   -e "s/' .*$//" > %t/cache-key3
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree \
-// RUN:   -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out -fdepscan-prefix-map-toolchain=/^toolchain -fdepscan-prefix-map-sdk=/^sdk \
 // RUN:   -o %t/t4.rsp -cc1-args \
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
+// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
+// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-obj %t/src2/main.c -o %t/out2/main.o -include-pch %t/out2/prefix.h.pch -I %t/src2/inc \
 // RUN:       -MT deps -dependency-file %t/t2.pch.d

--- a/clang/test/CAS/fcas-include-tree-with-pch.c
+++ b/clang/test/CAS/fcas-include-tree-with-pch.c
@@ -37,6 +37,14 @@
 // RUN: %clang @tu2.rsp -emit-llvm -o tree-rel.ll
 // RUN: diff -u source-rel.ll tree-rel.ll
 
+// Check that -coverage-notes-file and -coverage-data-file are stripped
+// RUN: %clang -cc1depscan -o pch3.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 -emit-pch -x c-header prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas \
+// RUN:     -ftest-coverage -coverage-notes-file %t/pch.gcno -coverage-data-file %t/pch.gcda
+// RUN: FileCheck %s -check-prefix=COVERAGE -input-file %t/pch3.rsp
+// COVERAGE-NOT: -coverage-data-file
+// COVERAGE-NOT: -coverage-notes-file
+
 //--- t1.c
 #if S2_MACRO
 #include "s2-link.h"

--- a/clang/test/CAS/pgo-profile.c
+++ b/clang/test/CAS/pgo-profile.c
@@ -37,9 +37,9 @@
 // RUN: mkdir -p %t.dir/a && mkdir -p %t.dir/b
 // RUN: cp %t.profdata %t.dir/a/a.profdata
 // RUN: cp %t.profdata %t.dir/b/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -fdepscan-prefix-map=%t.dir/a=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/a=/^testdir  \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -fdepscan-prefix-map=%t.dir/b=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/b=/^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
@@ -54,9 +54,9 @@
 // RUN: grep llvmcas %t.dir/cache-key1
 // RUN: diff -u %t.dir/cache-key1 %t.dir/cache-key2
 
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -fdepscan-prefix-map=%t.dir/a=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/a=/^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -fdepscan-prefix-map=%t.dir/b=/^testdir -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/b=/^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.inc.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.inc.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS

--- a/clang/test/ClangScanDeps/Inputs/removed-args/cdb.json.template
+++ b/clang/test/ClangScanDeps/Inputs/removed-args/cdb.json.template
@@ -1,7 +1,7 @@
 [
   {
     "directory": "DIR",
-    "command": "clang -fsyntax-only DIR/tu.c -fmodules -fimplicit-module-maps -fmodules-validate-once-per-build-session -fbuild-session-file=DIR/build-session -fmodules-prune-interval=123 -fmodules-prune-after=123 -fmodules-cache-path=DIR/cache -include DIR/header.h -grecord-command-line -fdebug-compilation-dir=DIR/debug -fcoverage-compilation-dir=DIR/coverage -o DIR/tu.o -serialize-diagnostics DIR/tu.diag -MT tu -MD -MF DIR/tu.d",
+    "command": "clang -fsyntax-only DIR/tu.c -fmodules -fimplicit-module-maps -fmodules-validate-once-per-build-session -fbuild-session-file=DIR/build-session -fmodules-prune-interval=123 -fmodules-prune-after=123 -fmodules-cache-path=DIR/cache -include DIR/header.h -grecord-command-line -fdebug-compilation-dir=DIR/debug -fcoverage-compilation-dir=DIR/coverage -ftest-coverage -o DIR/tu.o -serialize-diagnostics DIR/tu.diag -MT tu -MD -MF DIR/tu.d",
     "file": "DIR/tu.c"
   }
 ]

--- a/clang/test/ClangScanDeps/removed-args.c
+++ b/clang/test/ClangScanDeps/removed-args.c
@@ -23,6 +23,8 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK-NOT:          "-fdebug-compilation-dir="
 // CHECK-NOT:          "-fcoverage-compilation-dir="
+// CHECK-NOT:          "-coverage-notes-file
+// CHECK-NOT:          "-coverage-data-file
 // CHECK-NOT:          "-dwarf-debug-flags"
 // CHECK-NOT:          "-main-file-name"
 // CHECK-NOT:          "-include"
@@ -46,6 +48,8 @@
 // CHECK-NEXT:         "-cc1"
 // CHECK-NOT:          "-fdebug-compilation-dir=
 // CHECK-NOT:          "-fcoverage-compilation-dir=
+// CHECK-NOT:          "-coverage-notes-file
+// CHECK-NOT:          "-coverage-data-file
 // CHECK-NOT:          "-dwarf-debug-flags"
 // CHECK-NOT:          "-main-file-name"
 // CHECK-NOT:          "-include"

--- a/clang/test/Driver/fdepscan-prefix-map-sdk.c
+++ b/clang/test/Driver/fdepscan-prefix-map-sdk.c
@@ -1,0 +1,8 @@
+// RUN: %clang -fdepscan-prefix-map-sdk=/^sdk -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+// RUN: %clang -fdepscan-prefix-map-sdk=/^sdk -isysroot relative -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+
+// NONE-NOT: -fdepscan-prefix-map
+
+// RUN: %clang -fdepscan-prefix-map-sdk=/^sdk -isysroot /sys/path -### %s 2>&1 | FileCheck %s
+// RUN: %clang -fdepscan-prefix-map-sdk=/^sdk --sysroot /sys/path -### %s 2>&1 | FileCheck %s
+// CHECK: -fdepscan-prefix-map=/sys/path=/^sdk

--- a/clang/test/Driver/fdepscan-prefix-map-toolchain.c
+++ b/clang/test/Driver/fdepscan-prefix-map-toolchain.c
@@ -1,0 +1,15 @@
+// RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir '' -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+// RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir relative -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+// RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /lib/clang/10 -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+
+// NONE-NOT: -fdepscan-prefix-map
+
+// RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /tc/10 -### %s 2>&1 | FileCheck %s
+// RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /tc/lib/clang/10 -### %s 2>&1 | FileCheck %s
+// RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /tc/usr/lib/clang/10 -### %s 2>&1 | FileCheck %s
+
+// CHECK: -fdepscan-prefix-map=/tc=/^tc
+
+// Implicit resource-dir
+// RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -### %s 2>&1 | FileCheck %s -check-prefix=CHECK_IMPLICIT
+// CHECK_IMPLICIT: -fdepscan-prefix-map={{.*}}=/^tc

--- a/clang/test/Driver/fdepscan-prefix-map.c
+++ b/clang/test/Driver/fdepscan-prefix-map.c
@@ -1,0 +1,8 @@
+// RUN: %clang -fdepscan-prefix-map=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: %clang -fdepscan-prefix-map==/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: %clang -fdepscan-prefix-map=relative=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: %clang -fdepscan-prefix-map=/=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// INVALID: error: invalid argument '{{.*}}/^bad' to -fdepscan-prefix-map=
+
+// RUN: %clang -fdepscan-prefix-map=/good=/^good -### %s 2>&1 | FileCheck %s
+// CHECK: "-fdepscan-prefix-map=/good=/^good"

--- a/clang/test/Index/Core/scan-deps-cas.m
+++ b/clang/test/Index/Core/scan-deps-cas.m
@@ -70,7 +70,7 @@
 // INCLUDE_TREE-NEXT:   module:
 // INCLUDE_TREE-NEXT:     name: ModA
 // INCLUDE_TREE-NEXT:     context-hash: [[HASH_MOD_A:[A-Z0-9]+]]
-// INCLUDE_TREE-NEXT:     module-map-path: /Users/blangmuir/src/cas/llvm-project/clang/test/Index/Core/Inputs/module/module.modulemap
+// INCLUDE_TREE-NEXT:     module-map-path: [[PREFIX]]/Inputs/module/module.modulemap
 // INCLUDE_TREE-NEXT:     cache-key: [[ModA_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     module-deps:
 // INCLUDE_TREE-NEXT:     file-deps:

--- a/clang/test/Modules/implicit-private-with-submodule-explicit.m
+++ b/clang/test/Modules/implicit-private-with-submodule-explicit.m
@@ -1,0 +1,31 @@
+// Checks that the use of .Private to refer to _Private modules works with an
+// explicit module.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -x objective-c -fmodules -fno-implicit-modules -emit-module -fmodule-name=A %t/module.modulemap -o %t/A.pcm
+// RUN: %clang_cc1 -x objective-c -fmodules -fno-implicit-modules -emit-module -fmodule-name=A_Private %t/module.modulemap -o %t/A_Private.pcm
+
+// Check lazily-loaded module
+// RUN: %clang_cc1 -x objective-c -verify -fmodules -fno-implicit-modules -fmodule-file=A=%t/A.pcm -fmodule-file=A_Private=%t/A_Private.pcm -fsyntax-only %t/tu.m
+
+// Check eagerly-loaded module
+// RUN: %clang_cc1 -x objective-c -verify -fmodules -fno-implicit-modules -fmodule-file=%t/A.pcm -fmodule-file=%t/A_Private.pcm -fsyntax-only %t/tu.m
+
+//--- module.modulemap
+module A { header "a.h" }
+module A_Private { header "priv.h" }
+
+//--- a.h
+
+//--- priv.h
+void priv(void);
+
+//--- tu.m
+@import A.Private; // expected-warning{{no submodule named 'Private' in module 'A'; using top level 'A_Private'}}
+// expected-note@*:* {{defined here}}
+
+void tu(void) {
+  priv();
+}

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -265,10 +265,8 @@ llvm::cl::opt<bool> Verbose("v", llvm::cl::Optional,
 static bool emitCompilationDBWithCASTreeArguments(
     std::shared_ptr<llvm::cas::ObjectStore> DB,
     std::vector<tooling::CompileCommand> Inputs,
-    DiagnosticConsumer &DiagsConsumer,
-    const DepscanPrefixMapping &PrefixMapping,
-    DependencyScanningService &Service, llvm::ThreadPool &Pool,
-    llvm::raw_ostream &OS) {
+    DiagnosticConsumer &DiagsConsumer, DependencyScanningService &Service,
+    llvm::ThreadPool &Pool, llvm::raw_ostream &OS) {
 
   // Follow `-cc1depscan` and also ignore diagnostics.
   // FIXME: Seems not a good idea to do this..
@@ -329,7 +327,6 @@ static bool emitCompilationDBWithCASTreeArguments(
           tooling::dependencies::DependencyScanningTool &WorkerTool;
           DiagnosticConsumer &DiagsConsumer;
           StringRef CWD;
-          const DepscanPrefixMapping &PrefixMapping;
           SmallVectorImpl<const char *> &OutputArgs;
           llvm::StringSaver &Saver;
 
@@ -338,12 +335,10 @@ static bool emitCompilationDBWithCASTreeArguments(
               llvm::cas::ObjectStore &DB,
               tooling::dependencies::DependencyScanningTool &WorkerTool,
               DiagnosticConsumer &DiagsConsumer, StringRef CWD,
-              const DepscanPrefixMapping &PrefixMapping,
               SmallVectorImpl<const char *> &OutputArgs,
               llvm::StringSaver &Saver)
               : DB(DB), WorkerTool(WorkerTool), DiagsConsumer(DiagsConsumer),
-                CWD(CWD), PrefixMapping(PrefixMapping), OutputArgs(OutputArgs),
-                Saver(Saver) {}
+                CWD(CWD), OutputArgs(OutputArgs), Saver(Saver) {}
 
           bool
           runInvocation(std::shared_ptr<CompilerInvocation> Invocation,
@@ -352,7 +347,7 @@ static bool emitCompilationDBWithCASTreeArguments(
                         DiagnosticConsumer *DiagConsumer) override {
             Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
                 WorkerTool, DiagsConsumer, /*VerboseOS*/ nullptr, *Invocation,
-                CWD, PrefixMapping, DB);
+                CWD, DB);
             if (!Root) {
               llvm::consumeError(Root.takeError());
               return false;
@@ -369,7 +364,7 @@ static bool emitCompilationDBWithCASTreeArguments(
         llvm::StringSaver &Saver = PerThreadStates[I]->Saver;
         OutputArgs.push_back(Saver.save(Input->CommandLine.front()).data());
         ScanForCC1Action Action(*DB, WorkerTool, *IgnoringDiagsConsumer, CWD,
-                                PrefixMapping, OutputArgs, Saver);
+                                OutputArgs, Saver);
 
         llvm::IntrusiveRefCntPtr<FileManager> FileMgr =
             WorkerTool.getOrCreateFileManager();
@@ -871,6 +866,14 @@ int main(int argc, const char **argv) {
           }
         }
         AdjustedArgs.insert(AdjustedArgs.end(), FlagsEnd, Args.end());
+        if (!PrefixMapToolchain.empty())
+          AdjustedArgs.push_back("-fdepscan-prefix-map-toolchain=" +
+                                 PrefixMapToolchain);
+        if (!PrefixMapSDK.empty())
+          AdjustedArgs.push_back("-fdepscan-prefix-map-sdk=" + PrefixMapSDK);
+        for (StringRef Map : PrefixMaps) {
+          AdjustedArgs.push_back("-fdepscan-prefix-map=" + std::string(Map));
+        }
         return AdjustedArgs;
       });
 
@@ -902,13 +905,6 @@ int main(int argc, const char **argv) {
       FS = llvm::cantFail(llvm::cas::createCachingOnDiskFileSystem(*CAS));
   }
 
-  DepscanPrefixMapping PrefixMapping;
-  if (!PrefixMapToolchain.empty())
-    PrefixMapping.NewToolchainPath = PrefixMapToolchain;
-  if (!PrefixMapSDK.empty())
-    PrefixMapping.NewSDKPath = PrefixMapSDK;
-  PrefixMapping.PrefixMap.append(PrefixMaps.begin(), PrefixMaps.end());
-
   DependencyScanningService Service(ScanMode, Format, CASOpts, CAS, Cache, FS,
                                     OptimizeArgs, EagerLoadModules);
   llvm::ThreadPool Pool(llvm::hardware_concurrency(NumThreads));
@@ -920,7 +916,7 @@ int main(int argc, const char **argv) {
     }
     return emitCompilationDBWithCASTreeArguments(
         CAS, AdjustingCompilations->getAllCompileCommands(), *DiagsConsumer,
-        PrefixMapping, Service, Pool, llvm::outs());
+        Service, Pool, llvm::outs());
   }
 
   std::vector<std::unique_ptr<DependencyScanningTool>> WorkerTools;
@@ -963,7 +959,7 @@ int main(int argc, const char **argv) {
                  << " files using " << Pool.getThreadCount() << " workers\n";
   }
   for (unsigned I = 0; I < Pool.getThreadCount(); ++I) {
-    Pool.async([I, &CAS, &PrefixMapping, &Lock, &Index, &Inputs, &TreeResults,
+    Pool.async([I, &CAS, &Lock, &Index, &Inputs, &TreeResults,
                 &HadErrors, &FD, &WorkerTools, &DependencyOS, &Errs]() {
       llvm::StringSet<> AlreadySeenModules;
       while (true) {
@@ -1000,28 +996,27 @@ int main(int argc, const char **argv) {
                                              Errs))
             HadErrors = true;
         } else if (Format == ScanningOutputFormat::Tree) {
-          auto MaybeTree = WorkerTools[I]->getDependencyTree(
-              Input->CommandLine, CWD, PrefixMapping);
+          auto MaybeTree =
+              WorkerTools[I]->getDependencyTree(Input->CommandLine, CWD);
           std::unique_lock<std::mutex> LockGuard(Lock);
           TreeResults.emplace_back(LocalIndex, std::move(Filename),
                                    std::move(MaybeTree));
         } else if (Format == ScanningOutputFormat::IncludeTree) {
           auto MaybeTree = WorkerTools[I]->getIncludeTree(
-              *CAS, Input->CommandLine, CWD, LookupOutput, PrefixMapping);
+              *CAS, Input->CommandLine, CWD, LookupOutput);
           std::unique_lock<std::mutex> LockGuard(Lock);
           TreeResults.emplace_back(LocalIndex, std::move(Filename),
                                    std::move(MaybeTree));
         } else if (MaybeModuleName) {
           auto MaybeFullDeps = WorkerTools[I]->getModuleDependencies(
               *MaybeModuleName, Input->CommandLine, CWD, AlreadySeenModules,
-              LookupOutput, PrefixMapping);
+              LookupOutput);
           if (handleModuleResult(Filename, MaybeFullDeps, FD, LocalIndex,
                                  DependencyOS, Errs))
             HadErrors = true;
         } else {
           auto MaybeTUDeps = WorkerTools[I]->getTranslationUnitDependencies(
-              Input->CommandLine, CWD, AlreadySeenModules, LookupOutput,
-              PrefixMapping);
+              Input->CommandLine, CWD, AlreadySeenModules, LookupOutput);
           if (handleTranslationUnitResult(Filename, MaybeTUDeps, FD, LocalIndex,
                                           DependencyOS, Errs))
             HadErrors = true;

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -280,73 +280,23 @@ llvm::Error CC1DepScanDProtocol::getArgs(llvm::StringSaver &Saver,
   return Error::success();
 }
 
-llvm::Error
-CC1DepScanDProtocol::putCommand(StringRef WorkingDirectory,
-                                ArrayRef<const char *> Args,
-                                const DepscanPrefixMapping &Mapping) {
+llvm::Error CC1DepScanDProtocol::putCommand(StringRef WorkingDirectory,
+                                            ArrayRef<const char *> Args) {
   if (llvm::Error E = putString(WorkingDirectory))
     return E;
   if (llvm::Error E = putArgs(Args))
     return E;
-  return putDepscanPrefixMapping(Mapping);
+  return llvm::Error::success();
 }
 
-llvm::Error CC1DepScanDProtocol::getCommand(llvm::StringSaver &Saver,
-                                            StringRef &WorkingDirectory,
-                                            SmallVectorImpl<const char *> &Args,
-                                            DepscanPrefixMapping &Mapping) {
+llvm::Error
+CC1DepScanDProtocol::getCommand(llvm::StringSaver &Saver,
+                                StringRef &WorkingDirectory,
+                                SmallVectorImpl<const char *> &Args) {
   if (llvm::Error E = getString(Saver, WorkingDirectory))
     return E;
   if (llvm::Error E = getArgs(Saver, Args))
     return E;
-  return getDepscanPrefixMapping(Saver, Mapping);
-}
-
-llvm::Error CC1DepScanDProtocol::putDepscanPrefixMapping(
-    const DepscanPrefixMapping &Mapping) {
-  // Construct the message.
-  SmallString<256> FullMapping;
-  if (Mapping.NewSDKPath)
-    FullMapping.append(*Mapping.NewSDKPath);
-  FullMapping.push_back(0);
-  if (Mapping.NewToolchainPath)
-    FullMapping.append(*Mapping.NewToolchainPath);
-  FullMapping.push_back(0);
-  for (StringRef Map : Mapping.PrefixMap) {
-    FullMapping.append(Map);
-    FullMapping.push_back(0);
-  }
-  return putString(FullMapping);
-}
-
-llvm::Error
-CC1DepScanDProtocol::getDepscanPrefixMapping(llvm::StringSaver &Saver,
-                                             DepscanPrefixMapping &Mapping) {
-  StringRef FullMapping;
-  if (llvm::Error E = getString(Saver, FullMapping))
-    return E;
-
-  // Parse the mapping.
-  size_t Count = 0;
-  for (auto I = FullMapping.begin(), B = I, E = FullMapping.end(); I != E;
-       ++I) {
-    if (I != B && I[-1])
-      continue; // Wait for null-terminator.
-    StringRef Map = I;
-    switch (Count++) {
-    case 0:
-      if (!Map.empty())
-        Mapping.NewSDKPath = std::string(Map);
-      break;
-    case 1:
-      if (!Map.empty())
-        Mapping.NewToolchainPath = std::string(Map);
-      break;
-    default:
-      Mapping.PrefixMap.push_back(std::string(Map));
-      break;
-    }
-  }
   return llvm::Error::success();
 }
 

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -21,14 +21,7 @@
 #include <sys/un.h>     // FIXME: Unix-only. Not portable.
 #include <unistd.h>     // FIXME: Unix-only. Not portable.
 
-namespace clang {
-namespace tooling::dependencies {
-struct DepscanPrefixMapping;
-}
-
-namespace cc1depscand {
-using tooling::dependencies::DepscanPrefixMapping;
-
+namespace clang::cc1depscand {
 struct DepscanSharing {
   bool OnlyShareParent = false;
   bool ShareViaIdentifier = false;
@@ -137,20 +130,14 @@ public:
     return putMessage(String.size(), String.begin());
   }
 
-  llvm::Error putDepscanPrefixMapping(const DepscanPrefixMapping &Mapping);
-  llvm::Error getDepscanPrefixMapping(llvm::StringSaver &Saver,
-                                      DepscanPrefixMapping &Mapping);
-
   llvm::Error putArgs(ArrayRef<const char *> Args);
   llvm::Error getArgs(llvm::StringSaver &Saver,
                       SmallVectorImpl<const char *> &Args);
 
   llvm::Error putCommand(StringRef WorkingDirectory,
-                         ArrayRef<const char *> Args,
-                         const DepscanPrefixMapping &Mapping);
+                         ArrayRef<const char *> Args);
   llvm::Error getCommand(llvm::StringSaver &Saver, StringRef &WorkingDirectory,
-                         SmallVectorImpl<const char *> &Args,
-                         DepscanPrefixMapping &Mapping);
+                         SmallVectorImpl<const char *> &Args);
 
   llvm::Error putScanResultFailed(StringRef Reason);
   llvm::Error putScanResultSuccess(StringRef RootID,
@@ -240,8 +227,7 @@ private:
   explicit ScanDaemon(OpenSocket S) : OpenSocket(std::move(S)) {}
 };
 
-} // namespace cc1depscand
-} // namespace clang
+} // namespace clang::cc1depscand
 
 #endif /* LLVM_ON_UNIX */
 #endif // LLVM_CLANG_TOOLS_DRIVER_CC1DEPSCANPROTOCOL_H

--- a/clang/tools/driver/features.json
+++ b/clang/tools/driver/features.json
@@ -16,6 +16,9 @@
       "name": "extract-api-ignores"
     },
     {
+      "name": "depscan-prefix-map"
+    },
+    {
       "name": "deployment-target-environment-variables",
       "value": [
         "MACOSX_DEPLOYMENT_TARGET",

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -145,8 +145,8 @@ ScanningOutputFormat DependencyScannerServiceOptions::getFormat() const {
   if (llvm::sys::Process::GetEnv("CLANG_CACHE_USE_CASFS_DEPSCAN"))
     return ScanningOutputFormat::FullTree;
 
-  // Note: default caching behaviour is currently cas-fs.
-  return ScanningOutputFormat::FullTree;
+  // Use include-tree by default.
+  return ScanningOutputFormat::FullIncludeTree;
 }
 
 CXDependencyScannerService

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -230,7 +230,7 @@ static CXErrorCode getFullDependencies(DependencyScanningWorker *Worker,
   llvm::StringSet<> AlreadySeen;
   FullDependencyConsumer DepConsumer(AlreadySeen);
   auto Controller = DependencyScanningTool::createActionController(
-      *Worker, std::move(LookupOutput), /*PrefixMapping=*/{});
+      *Worker, std::move(LookupOutput));
 
   bool HasDiagConsumer = DiagConsumer;
   bool HasError = Error;

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -54,10 +54,8 @@ TEST(IncludeTree, IncludeTreeScan) {
                                           "-o"
                                           "t.cpp.o"};
   Optional<IncludeTreeRoot> Root;
-  DepscanPrefixMapping PrefixMapping;
   ASSERT_THAT_ERROR(
-      ScanTool
-          .getIncludeTree(*DB, CommandLine, /*CWD*/ "", nullptr, PrefixMapping)
+      ScanTool.getIncludeTree(*DB, CommandLine, /*CWD*/ "", nullptr)
           .moveInto(Root),
       llvm::Succeeded());
 


### PR DESCRIPTION
* [clang][deps] Remove -coverage-data-file and -coverage-notes-file from modules
* [clang][cas] Strip -coverage-data-file and -coverage-notes-file from PCH
* [clang][cas] Move -fdepscan-prefix-map-* options to clang driver
* [clang][cas] Prefix map -fdepfile-entry
* [clang][modules] Handle explicit modules when checking for .Private -> _Private
* [clang][cas] Switch to include-tree by default

rdar://107443796
rdar://106307646
rdar://107449872