### PR TITLE
[lldb] Convert more tests to use `expression` directly (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -28,7 +28,7 @@ class TestSwiftWerror(TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f "+log)
         
-        self.expect("p foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+        self.expect("expression foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
         sanity = 0
         import io
         logfile = io.open(log, "r", encoding='utf-8')

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -49,7 +49,7 @@ class TestSwiftDedupMacros(TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f "+log)
         
-        self.expect("p foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
+        self.expect("expression foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
         debug = 0
         space = 0
         ndebug = 0

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -53,11 +53,11 @@ class TestSwiftObjCMainConflictingDylibs(TestBase):
         process = target.LaunchSimple(None, None, os.getcwd())
         # This is failing because the Target-SwiftASTContext uses the
         # amalgamated target header search options from all dylibs.
-        self.expect("p baz", "wrong baz", substrs=["i_am_from_Foo"])
+        self.expect("expression baz", "wrong baz", substrs=["i_am_from_Foo"])
         self.expect("fr var baz", "wrong baz", substrs=["i_am_from_Foo"])
 
 
         process.Continue()
-        self.expect("p baz", "correct baz", substrs=["i_am_from_Foo"])
+        self.expect("expression baz", "correct baz", substrs=["i_am_from_Foo"])
         self.expect("fr var baz", "correct baz", substrs=["i_am_from_Foo"])
         

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -52,9 +52,9 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         
         # This initially fails with the shared scratch context and is
         # then retried with the per-dylib scratch context.
-        # self.expect("p bar", "expected result", substrs=["$R0", "42"])
-        # self.expect("p $R0", "expected result", substrs=["$R1", "42"])
-        # self.expect("p $R1", "expected result", substrs=["$R2", "42"])
+        # self.expect("expression bar", "expected result", substrs=["$R0", "42"])
+        # self.expect("expression $R0", "expected result", substrs=["$R1", "42"])
+        # self.expect("expression $R1", "expected result", substrs=["$R2", "42"])
         
         # This works by accident because the search paths are in the right order.
         foo_breakpoint = target.BreakpointCreateBySourceRegex(
@@ -64,7 +64,7 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         # FIXME: The following expression evaluator tests are disabled
         # because it's nondeterministic which one will work.
 
-        # self.expect("p foo", "expected result", substrs=["$R3", "23"])
-        # self.expect("p $R3", "expected result", substrs=["23"])
-        # self.expect("p $R4", "expected result", substrs=["23"])
+        # self.expect("expression foo", "expected result", substrs=["$R3", "23"])
+        # self.expect("expression $R3", "expected result", substrs=["23"])
+        # self.expect("expression $R4", "expected result", substrs=["23"])
 

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -22,7 +22,7 @@ class TestSwiftRewriteClangPaths(TestBase):
         self.runCmd('log enable lldb types -f "%s"' % log)
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
             self, 'main')
-        self.expect("p 1", substrs=["1"])
+        self.expect("expression 1", substrs=["1"])
 
         # Scan through the types log.
         import io

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -52,7 +52,7 @@ class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
         # This test tests that the search paths from all swiftmodules
         # that are part of the main binary are honored.
         self.expect("fr var foo", "expected result", substrs=["23"])
-        self.expect("p foo", "expected result", substrs=["$R0", "i", "23"])
+        self.expect("expression foo", "expected result", substrs=["$R0", "i", "23"])
         process.Continue()
         self.expect("fr var bar", "expected result", substrs=["42"])
-        self.expect("p bar", "expected result", substrs=["j", "42"])
+        self.expect("expression bar", "expected result", substrs=["j", "42"])

--- a/lldb/test/API/lang/swift/class_empty/main.swift
+++ b/lldb/test/API/lang/swift/class_empty/main.swift
@@ -17,7 +17,7 @@ class Empty : CustomStringConvertible {
 
 func main() {
   var e = Empty()
-  print(e) //% self.expect("p 1", substrs=['1'])
+  print(e) //% self.expect("expression 1", substrs=['1'])
 }
 
 main()

--- a/lldb/test/API/lang/swift/closure_shortcuts/main.swift
+++ b/lldb/test/API/lang/swift/closure_shortcuts/main.swift
@@ -15,8 +15,8 @@ func main() -> Int {
   let names = ["foo", "patatino"]
 
   var reversedNames = names.sorted(by: {
-    $0 > $1 } //%self.expect('p $0', substrs=['patatino'])
-              //%self.expect('p $1', substrs=['foo'])
+    $0 > $1 } //%self.expect('expr $0', substrs=['patatino'])
+              //%self.expect('expr $1', substrs=['foo'])
               //%self.expect('frame var $0', substrs=['patatino'])
               //%self.expect('frame var $1', substrs=['foo'])
   )

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -34,7 +34,7 @@ class TestSwiftDeploymentTarget(TestBase):
         lldbutil.run_to_source_breakpoint(self,
                                           "break here",
                                           lldb.SBFileSpec('main.swift'))
-        self.expect("p f", substrs=['i = 23'])
+        self.expect("expression f", substrs=['i = 23'])
 
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
@@ -47,7 +47,7 @@ class TestSwiftDeploymentTarget(TestBase):
         bkpt = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('NewerTarget.swift'))
         lldbutil.continue_to_breakpoint(process, bkpt)
-        self.expect("p self", substrs=['i = 23'])
+        self.expect("expression self", substrs=['i = 23'])
 
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.
@@ -61,7 +61,7 @@ class TestSwiftDeploymentTarget(TestBase):
         lldbutil.run_to_source_breakpoint(self,
                                           "break here",
                                           lldb.SBFileSpec('main.swift'))
-        self.expect("p f", substrs=['i = 23'])
+        self.expect("expression f", substrs=['i = 23'])
 
         found_no_ast = False
         found_triple = False

--- a/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
+++ b/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
@@ -19,4 +19,4 @@ class TestSwiftExprAllocator(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
-        self.expect("p x", substrs=['23'])
+        self.expect("expression x", substrs=['23'])

--- a/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
+++ b/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
@@ -36,7 +36,7 @@ class TestSwiftMacCatalyst(TestBase):
         self.expect("fr v s", "Hello macCatalyst")
         expr_log = self.getBuildArtifact("expr.log")
         self.expect('log enable lldb expr -f "%s"' % expr_log)
-        self.expect("p s", "Hello macCatalyst")
+        self.expect("expression s", "Hello macCatalyst")
         import io
         expr_logfile = io.open(expr_log, "r", encoding='utf-8')
 

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -26,6 +26,6 @@ class TestSwiftMissingSDK(TestBase):
         os.unlink(self.getBuildArtifact("fakesdk"))
         lldbutil.run_to_source_breakpoint(self, 'break here',
                                           lldb.SBFileSpec('main.swift'))
-        self.expect("p message", VARIABLES_DISPLAYED_CORRECTLY,
+        self.expect("expression message", VARIABLES_DISPLAYED_CORRECTLY,
                     substrs = ["Hello"])
 

--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/main.swift
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/main.swift
@@ -13,8 +13,8 @@ extension Measurement where UnitType == UnitAngle {
   }
 
   func f() {
-    return //%self.expect('p self.radians', substrs=["CGFloat) $R0", "= 1.745"])
-           //%self.expect('p self', substrs=["Measurement<UnitAngle>"])
+    return //%self.expect('expression self.radians', substrs=["CGFloat) $R0", "= 1.745"])
+           //%self.expect('expression self', substrs=["Measurement<UnitAngle>"])
   }
 }
 

--- a/lldb/test/API/lang/swift/protocol_extension_two/main.swift
+++ b/lldb/test/API/lang/swift/protocol_extension_two/main.swift
@@ -10,8 +10,8 @@ extension Patatino where T == Winky {
   }
 
   func f() {
-    return //%self.expect('p self.baciotto', substrs=["(Int) $R0 = 0"])
-           //%self.expect('p self', substrs=["a.Patatino<a.Winky>"])
+    return //%self.expect('expression self.baciotto', substrs=["(Int) $R0 = 0"])
+           //%self.expect('expression self', substrs=["a.Patatino<a.Winky>"])
   }
 }
 

--- a/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
+++ b/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
@@ -25,7 +25,7 @@ class TestSwiftRuntimeLibraryPath(lldbtest.TestBase):
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
             self, 'main')
 
-        self.expect("p 1")
+        self.expect("expression 1")
         import io
         logfile = io.open(log, "r", encoding='utf-8')
         in_expr_log = 0

--- a/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
+++ b/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
@@ -19,7 +19,7 @@ class TestSwiftHealthCheck(TestBase):
 
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
             self, 'main')
-        self.expect("p 1")
+        self.expect("expression 1")
         result = lldb.SBCommandReturnObject()
         ret_val = self.dbg.GetCommandInterpreter().HandleCommand("swift-healthcheck", result)
         log = result.GetOutput()[:-1].split(" ")[-1]

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -26,7 +26,7 @@ class TestSwiftTripleDetection(TestBase):
                                                               arch+"-apple-macos-unknown")
         bkpt = target.BreakpointCreateByName("main")
         process = target.LaunchSimple(None, None, self.get_process_working_directory())
-        self.expect("p 1")
+        self.expect("expression 1")
         import io
         types_logfile = io.open(types_log, "r", encoding='utf-8')
 

--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -177,9 +177,9 @@ class TestSwiftTypes(TestBase):
 
         self.expect("frame variable --raw hello", substrs=['String'])
 
-        self.expect("p/x int64_minus_two", substrs=['0xfffffffffffffffe'])
-        self.expect("p/u ~1", substrs=['18446744073709551614'])
-        self.expect("p/d ~1", substrs=['-2'])
+        self.expect("expression/x int64_minus_two", substrs=['0xfffffffffffffffe'])
+        self.expect("expression/u ~1", substrs=['18446744073709551614'])
+        self.expect("expression/d ~1", substrs=['-2'])
 
         self.expect('frame variable uint8_max', substrs=['-1'], matching=False)
         self.expect(

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -35,7 +35,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
 
         lldbutil.run_to_name_breakpoint(self, 'main')
 
-        self.expect("p 1")
+        self.expect("expression 1")
         self.check_log(log, "MacOSX")
 
     @swiftTest

--- a/lldb/test/API/linux/aarch64/non_address_bit_memory_access/TestAArch64LinuxNonAddressBitMemoryAccess.py
+++ b/lldb/test/API/linux/aarch64/non_address_bit_memory_access/TestAArch64LinuxNonAddressBitMemoryAccess.py
@@ -153,10 +153,10 @@ class AArch64LinuxNonAddressBitMemoryAccessTestCase(TestBase):
 
         # This should fill the cache by doing a read of buf_with_non_address
         # with the non-address bits removed (which is == buf).
-        self.runCmd("p buf_with_non_address")
+        self.runCmd("expression buf_with_non_address")
         # This will read from the cache since the two pointers point to the
         # same place.
-        self.runCmd("p buf")
+        self.runCmd("expression buf")
 
         # Open log ignoring utf-8 decode errors
         with open(log_file, 'r', errors='ignore') as f:

--- a/lldb/test/Shell/Commands/command-source.test
+++ b/lldb/test/Shell/Commands/command-source.test
@@ -6,7 +6,7 @@
 # RUN: %lldb -x -b -o 'settings set interpreter.stop-command-source-on-error false' -o "command source %s" 2>&1 | FileCheck %s --check-prefix CONTINUE
 
 bogus
-p 10+1
+expression 10+1
 
 # CONTINUE: $0 = 11
 # STOP-NOT: $0 = 11

--- a/lldb/test/Shell/Commands/command-stop-hook-no-target.test
+++ b/lldb/test/Shell/Commands/command-stop-hook-no-target.test
@@ -1,4 +1,4 @@
 # RUN: %clang_host -g %S/Inputs/main.c -o %t
-# RUN: %lldb -b -o 'target stop-hook add --name test --shlib test -o "p 95000 + 126"' -o 'file %t' -o 'b main' -o 'r' 2>&1 | FileCheck %s
+# RUN: %lldb -b -o 'target stop-hook add --name test --shlib test -o "expression 95000 + 126"' -o 'file %t' -o 'b main' -o 'r' 2>&1 | FileCheck %s
 # CHECK: Stop hook #1 added
 # CHECK-NOT: 95126

--- a/lldb/test/Shell/Expr/nodefaultlib.cpp
+++ b/lldb/test/Shell/Expr/nodefaultlib.cpp
@@ -7,10 +7,10 @@
 // XFAIL: system-netbsd || system-freebsd || system-darwin
 
 // RUN: %build %s --nodefaultlib -o %t
-// RUN: %lldb %t -o "b main" -o run -o "p call_me(5, 6)" -o exit \
+// RUN: %lldb %t -o "b main" -o run -o "expression call_me(5, 6)" -o exit \
 // RUN:   | FileCheck %s
 
-// CHECK: p call_me(5, 6)
+// CHECK: expression call_me(5, 6)
 // CHECK: (int) $0 = 30
 
 int call_me(int x, long y) { return x * y; }

--- a/lldb/test/Shell/Register/x86-64-fp-read.test
+++ b/lldb/test/Shell/Register/x86-64-fp-read.test
@@ -9,9 +9,9 @@ process launch
 # CHECK: Process {{.*}} stopped
 
 # fdiv (%rbx) gets encoded into 2 bytes, int3 into 1 byte
-print (void*)($pc-3)
+expression (void*)($pc-3)
 # CHECK: (void *) $0 = [[FDIV:0x[0-9a-f]*]]
-print &zero
+expression &zero
 # CHECK: (uint32_t *) $1 = [[ZERO:0x[0-9a-f]*]]
 
 register read --all
@@ -32,9 +32,9 @@ register read --all
 # CHECK-DAG: st{{(mm)?}}7 = {0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00}
 
 # legacy approach, superseded by fip/fdp registers
-print (void*)($fiseg*0x100000000 + $fioff)
+expression (void*)($fiseg*0x100000000 + $fioff)
 # CHECK: (void *) $2 = [[FDIV]]
-print (uint32_t*)($foseg * 0x100000000 + $fooff)
+expression (uint32_t*)($foseg * 0x100000000 + $fooff)
 # CHECK: (uint32_t *) $3 = [[ZERO]]
 
 process continue

--- a/lldb/test/Shell/Register/x86-db-read.test
+++ b/lldb/test/Shell/Register/x86-db-read.test
@@ -15,13 +15,13 @@ watchpoint set variable -w write g_32w
 watchpoint set variable -w read_write g_32rw
 # CHECK: Watchpoint created: Watchpoint 4: addr = 0x{{[0-9a-f]*}} size = 4 state = enabled type = rw
 
-print &g_8w
+expression &g_8w
 # CHECK: (uint8_t *) $0 = [[VAR8W:0x[0-9a-f]*]]
-print &g_16rw
+expression &g_16rw
 # CHECK: (uint16_t *) $1 = [[VAR16RW:0x[0-9a-f]*]]
-print &g_32w
+expression &g_32w
 # CHECK: (uint32_t *) $2 = [[VAR32W:0x[0-9a-f]*]]
-print &g_32rw
+expression &g_32rw
 # CHECK: (uint32_t *) $3 = [[VAR64RW:0x[0-9a-f]*]]
 
 register read --all

--- a/lldb/test/Shell/Register/x86-fp-read.test
+++ b/lldb/test/Shell/Register/x86-fp-read.test
@@ -9,9 +9,9 @@ process launch
 # CHECK: Process {{.*}} stopped
 
 # fdiv (%rbx) gets encoded into 2 bytes, int3 into 1 byte
-print (void*)($pc-3)
+expression (void*)($pc-3)
 # CHECK: (void *) $0 = [[FDIV:0x[0-9a-f]*]]
-print &zero
+expression &zero
 # CHECK: (uint32_t *) $1 = [[ZERO:0x[0-9a-f]*]]
 
 register read --all

--- a/lldb/test/Shell/Settings/Inputs/DontStopCommandSource.in
+++ b/lldb/test/Shell/Settings/Inputs/DontStopCommandSource.in
@@ -1,3 +1,3 @@
 settings set interpreter.stop-command-source-on-error false
 bogus
-print 123400000 + 56789
+expression 123400000 + 56789

--- a/lldb/test/Shell/Settings/Inputs/StopCommandSource.in
+++ b/lldb/test/Shell/Settings/Inputs/StopCommandSource.in
@@ -1,3 +1,3 @@
 settings set interpreter.stop-command-source-on-error true
 bogus
-print 123400000 + 56789
+expression 123400000 + 56789

--- a/lldb/test/Shell/Settings/TestStopCommandSourceOnError.test
+++ b/lldb/test/Shell/Settings/TestStopCommandSourceOnError.test
@@ -12,10 +12,10 @@
 # RUN: %lldb -b -o 'settings set interpreter.stop-command-source-on-error false' -s %S/Inputs/StopCommandSource.in | FileCheck %s --check-prefix CONTINUE
 
 # FIXME: Should continue
-# RUN: not %lldb -b -s %S/Inputs/DontStopCommandSource.in -o 'bogus' -o 'print 111100000 + 11111' | FileCheck %s --check-prefix STOP
+# RUN: not %lldb -b -s %S/Inputs/DontStopCommandSource.in -o 'bogus' -o 'expression 111100000 + 11111' | FileCheck %s --check-prefix STOP
 
 # FIXME: Should continue
-# RUN: not %lldb -b -o 'settings set interpreter.stop-command-source-on-error false' -o 'bogus' -o 'print 123400000 + 56789'  | FileCheck %s --check-prefix STOP
+# RUN: not %lldb -b -o 'settings set interpreter.stop-command-source-on-error false' -o 'bogus' -o 'expression 123400000 + 56789'  | FileCheck %s --check-prefix STOP
 
 # FIXME: Should continue
 # RUN: not %lldb -b -s %S/Inputs/DontStopCommandSource.in | FileCheck %s --check-prefix STOP

--- a/lldb/test/Shell/SymbolFile/DWARF/debug-types-expressions.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/debug-types-expressions.test
@@ -40,18 +40,18 @@ frame variable *a
 # CHECK-NEXT:   j = 42
 # CHECK-NEXT: }
 
-print a->f()
-# CHECK-LABEL: print a->f()
+expression a->f()
+# CHECK-LABEL: expression a->f()
 # CHECK: (int) $0 = 47
 
-print ns::A()
-# CHECK-LABEL: print ns::A()
+expression ns::A()
+# CHECK-LABEL: expression ns::A()
 # CHECK: (ns::A) $1 = (i = 147)
 
-print ns::A().i + a->i
-# CHECK-LABEL: print ns::A().i + a->i
+expression ns::A().i + a->i
+# CHECK-LABEL: expression ns::A().i + a->i
 # CHECK: (int) $2 = 194
 
-print ns::A().getA()
+expression ns::A().getA()
 # CHECK-LABEL: ns::A().getA()
 # CHECK: (A) $3 = (i = 146)

--- a/lldb/test/Shell/SymbolFile/DWARF/split-dwarf-expression-eval-bug.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/split-dwarf-expression-eval-bug.cpp
@@ -11,10 +11,10 @@
 // RUN: %clang_host -c -gsplit-dwarf -g %s -o %t2.o -DTWO
 // RUN: %clang_host -c -gsplit-dwarf -g %s -o %t3.o -DTHREE
 // RUN: %clang_host %t1.o %t2.o %t3.o -o %t
-// RUN: %lldb %t -o "br set -n foo" -o run -o "p bool_in_first_cu" -o exit \
+// RUN: %lldb %t -o "br set -n foo" -o run -o "expression bool_in_first_cu" -o exit \
 // RUN:   | FileCheck %s
 
-// CHECK: (lldb) p bool_in_first_cu
+// CHECK: (lldb) expression bool_in_first_cu
 // CHECK: (bool) $0 = true
 
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_GNU_call_site-DW_AT_low_pc.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_GNU_call_site-DW_AT_low_pc.s
@@ -11,7 +11,7 @@
 # REQUIRES: target-x86_64, system-linux, lld
 
 # RUN: %clang_host -o %t %s
-# RUN: %lldb %t -o r -o 'p p' -o exit | FileCheck %s
+# RUN: %lldb %t -o r -o 'expression p' -o exit | FileCheck %s
 
 # CHECK: (int) $0 = 1
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_variable-DW_AT_const_value.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/DW_TAG_variable-DW_AT_const_value.s
@@ -1,7 +1,7 @@
 # This tests that lldb is able to print DW_TAG_variable using DW_AT_const_value.
 
 # RUN: llvm-mc -triple x86_64-unknown-linux-gnu %s -filetype=obj > %t.o
-# RUN: %lldb %t.o -o "p/x magic64" -o exit | FileCheck %s
+# RUN: %lldb %t.o -o "expression/x magic64" -o exit | FileCheck %s
 
 # CHECK: (const long) $0 = 0xed9a924c00011151
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-basic.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-basic.test
@@ -51,12 +51,12 @@ type lookup EC
 # CHECK-NEXT:   e3
 # CHECK-NEXT: }
 
-print (E) 1
-# CHECK-LABEL: print (E) 1
+expression (E) 1
+# CHECK-LABEL: expression (E) 1
 # CHECK: (E) $0 = e2
 
-print (EC) 1
-# CHECK-LABEL: print (EC) 1
+expression (EC) 1
+# CHECK-LABEL: expression (EC) 1
 # CHECK: (EC) $1 = e2
 
 target variable a e ec

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-missing-signature.test
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-missing-signature.test
@@ -14,10 +14,10 @@ LOOKUPE: no type was found matching 'E'
 RUN: %lldb %t -b -o "type lookup EC" | FileCheck --check-prefix=LOOKUPEC %s
 LOOKUPEC: no type was found matching 'EC'
 
-RUN: not %lldb %t -b -o "print (E) 1" 2>&1 | FileCheck --check-prefix=PRINTE %s
+RUN: not %lldb %t -b -o "expression (E) 1" 2>&1 | FileCheck --check-prefix=PRINTE %s
 PRINTE: use of undeclared identifier 'E'
 
-RUN: not %lldb %t -b -o "print (EC) 1" 2>&1 | FileCheck --check-prefix=PRINTEC %s
+RUN: not %lldb %t -b -o "expression (EC) 1" 2>&1 | FileCheck --check-prefix=PRINTEC %s
 PRINTEC: use of undeclared identifier 'EC'
 
 RUN: %lldb %t -b -o "target variable a e ec" | FileCheck --check-prefix=VARS %s

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/dwarf5-line-strp.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/dwarf5-line-strp.s
@@ -3,7 +3,7 @@
 # UNSUPPORTED: system-darwin, system-windows
 
 # RUN: llvm-mc -filetype=obj -o %t -triple x86_64-pc-linux %s
-# RUN: %lldb %t -o "p main" \
+# RUN: %lldb %t -o "expression main" \
 # RUN:   -o exit | FileCheck %s
 
 # CHECK: (void (*)()) $0 = 0x0000000000000000

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/limit-debug-info.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/limit-debug-info.s
@@ -3,10 +3,10 @@
 # RUN: llvm-mc --triple=x86_64-pc-windows --filetype=obj --defsym EXE=0 %s >%t.exe.o
 # RUN: lld-link /OUT:%t.dll %t.dll.o /SUBSYSTEM:console /dll /noentry /debug
 # RUN: lld-link /OUT:%t.exe %t.exe.o /SUBSYSTEM:console /debug /force
-# RUN: %lldb %t.exe -o "target modules add %t.dll" -o "p var" \
+# RUN: %lldb %t.exe -o "target modules add %t.dll" -o "expression var" \
 # RUN:   -o exit 2>&1 | FileCheck %s
 
-# CHECK: (lldb) p var
+# CHECK: (lldb) expression var
 # CHECK: (A) $0 = (member = 47)
 
         .section        .debug_abbrev,"dr"

--- a/lldb/test/Shell/SymbolFile/NativePDB/Inputs/inline_sites_live.lldbinit
+++ b/lldb/test/Shell/SymbolFile/NativePDB/Inputs/inline_sites_live.lldbinit
@@ -1,7 +1,7 @@
 br set -p BP_bar -f inline_sites_live.cpp
 br set -p BP_foo -f inline_sites_live.cpp
 run
-p param
+expression param
 continue
-p param
-p local
+expression param
+expression local

--- a/lldb/test/Shell/SymbolFile/NativePDB/Inputs/local-variables.lldbinit
+++ b/lldb/test/Shell/SymbolFile/NativePDB/Inputs/local-variables.lldbinit
@@ -1,30 +1,30 @@
 break set -f local-variables.cpp -l 17
 run a b c d e f g
-p argc
+expression argc
 step
-p SomeLocal
+expression SomeLocal
 step
-p Param1
-p Param2
+expression Param1
+expression Param2
 step
-p Param1
-p Param2
-p Local1
+expression Param1
+expression Param2
+expression Local1
 step
-p Param1
-p Param2
-p Local1
-p Local2
+expression Param1
+expression Param2
+expression Local1
+expression Local2
 step
-p Param1
-p Param2
-p Local1
-p Local2
+expression Param1
+expression Param2
+expression Local1
+expression Local2
 step
-p Param1
-p Param2
-p Local1
-p Local2
+expression Param1
+expression Param2
+expression Local1
+expression Local2
 continue
 
 target modules dump ast

--- a/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/inline_sites_live.cpp
@@ -24,11 +24,11 @@ int main(int argc, char** argv) {
 
 // CHECK:      * thread #1, stop reason = breakpoint 1
 // CHECK-NEXT:    frame #0: {{.*}}`main [inlined] bar(param=2)
-// CHECK:      (lldb) p param
+// CHECK:      (lldb) expression param
 // CHECK-NEXT: (int) $0 = 2
 // CHECK:      * thread #1, stop reason = breakpoint 2
 // CHECK-NEXT:    frame #0: {{.*}}`main [inlined] foo(param=1)
-// CHECK:      (lldb) p param
+// CHECK:      (lldb) expression param
 // CHECK-NEXT: (int) $1 = 1
-// CHECK-NEXT: (lldb) p local
+// CHECK-NEXT: (lldb) expression local
 // CHECK-NEXT: (int) $2 = 2

--- a/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
+++ b/lldb/test/Shell/SymbolFile/NativePDB/local-variables.cpp
@@ -37,7 +37,7 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:    20
 
 // CHECK:      Process {{.*}} launched: '{{.*}}local-variables.cpp.tmp.exe'
-// CHECK-NEXT: (lldb) p argc
+// CHECK-NEXT: (lldb) expression argc
 // CHECK-NEXT: (int) $0 = 8
 // CHECK-NEXT: (lldb) step
 // CHECK-NEXT: Process {{.*}} stopped
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:    19 }
 // CHECK-NEXT:    20
 
-// CHECK:      (lldb) p SomeLocal
+// CHECK:      (lldb) expression SomeLocal
 // CHECK-NEXT: (int) $1 = 16
 // CHECK-NEXT: (lldb) step
 // CHECK-NEXT: Process {{.*}} stopped
@@ -64,9 +64,9 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:    11     ++Local1;
 // CHECK-NEXT:    12     ++Local2;
 
-// CHECK:      (lldb) p Param1
+// CHECK:      (lldb) expression Param1
 // CHECK-NEXT: (int) $2 = 16
-// CHECK-NEXT: (lldb) p Param2
+// CHECK-NEXT: (lldb) expression Param2
 // CHECK-NEXT: (char) $3 = 'a'
 // CHECK-NEXT: (lldb) step
 // CHECK-NEXT: Process {{.*}} stopped
@@ -80,11 +80,11 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:    12     ++Local2;
 // CHECK-NEXT:    13     return Local1;
 
-// CHECK:      (lldb) p Param1
+// CHECK:      (lldb) expression Param1
 // CHECK-NEXT: (int) $4 = 16
-// CHECK-NEXT: (lldb) p Param2
+// CHECK-NEXT: (lldb) expression Param2
 // CHECK-NEXT: (char) $5 = 'a'
-// CHECK-NEXT: (lldb) p Local1
+// CHECK-NEXT: (lldb) expression Local1
 // CHECK-NEXT: (unsigned int) $6 = 17
 // CHECK-NEXT: (lldb) step
 // CHECK-NEXT: Process {{.*}} stopped
@@ -98,13 +98,13 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:    13     return Local1;
 // CHECK-NEXT:    14   }
 
-// CHECK:      (lldb) p Param1
+// CHECK:      (lldb) expression Param1
 // CHECK-NEXT: (int) $7 = 16
-// CHECK-NEXT: (lldb) p Param2
+// CHECK-NEXT: (lldb) expression Param2
 // CHECK-NEXT: (char) $8 = 'a'
-// CHECK-NEXT: (lldb) p Local1
+// CHECK-NEXT: (lldb) expression Local1
 // CHECK-NEXT: (unsigned int) $9 = 17
-// CHECK-NEXT: (lldb) p Local2
+// CHECK-NEXT: (lldb) expression Local2
 // CHECK-NEXT: (char) $10 = 'b'
 // CHECK-NEXT: (lldb) step
 // CHECK-NEXT: Process {{.*}} stopped
@@ -118,13 +118,13 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:    14   }
 // CHECK-NEXT:    15
 
-// CHECK:      (lldb) p Param1
+// CHECK:      (lldb) expression Param1
 // CHECK-NEXT: (int) $11 = 16
-// CHECK-NEXT: (lldb) p Param2
+// CHECK-NEXT: (lldb) expression Param2
 // CHECK-NEXT: (char) $12 = 'a'
-// CHECK-NEXT: (lldb) p Local1
+// CHECK-NEXT: (lldb) expression Local1
 // CHECK-NEXT: (unsigned int) $13 = 18
-// CHECK-NEXT: (lldb) p Local2
+// CHECK-NEXT: (lldb) expression Local2
 // CHECK-NEXT: (char) $14 = 'b'
 // CHECK-NEXT: (lldb) step
 // CHECK-NEXT: Process {{.*}} stopped
@@ -138,13 +138,13 @@ int main(int argc, char **argv) {
 // CHECK-NEXT:    15
 // CHECK-NEXT:    16   int main(int argc, char **argv) {
 
-// CHECK:      (lldb) p Param1
+// CHECK:      (lldb) expression Param1
 // CHECK-NEXT: (int) $15 = 16
-// CHECK-NEXT: (lldb) p Param2
+// CHECK-NEXT: (lldb) expression Param2
 // CHECK-NEXT: (char) $16 = 'a'
-// CHECK-NEXT: (lldb) p Local1
+// CHECK-NEXT: (lldb) expression Local1
 // CHECK-NEXT: (unsigned int) $17 = 18
-// CHECK-NEXT: (lldb) p Local2
+// CHECK-NEXT: (lldb) expression Local2
 // CHECK-NEXT: (char) $18 = 'c'
 // CHECK-NEXT: (lldb) continue
 // CHECK-NEXT: Process {{.*}} resuming

--- a/lldb/test/Shell/SymbolFile/PDB/Inputs/ExpressionsTest0.script
+++ b/lldb/test/Shell/SymbolFile/PDB/Inputs/ExpressionsTest0.script
@@ -1,7 +1,7 @@
 breakpoint set --file ExpressionsTest.cpp --line 19
 run
-print result
-print N0::N1::sum(N0::N1::buf1, sizeof(N0::N1::buf1))
-print N1::sum(N1::buf1, sizeof(N1::buf1))
-print sum(buf1, sizeof(buf1))
-print sum(buf1, 1000000000)
+expression result
+expression N0::N1::sum(N0::N1::buf1, sizeof(N0::N1::buf1))
+expression N1::sum(N1::buf1, sizeof(N1::buf1))
+expression sum(buf1, sizeof(buf1))
+expression sum(buf1, 1000000000)

--- a/lldb/test/Shell/SymbolFile/PDB/Inputs/ExpressionsTest1.script
+++ b/lldb/test/Shell/SymbolFile/PDB/Inputs/ExpressionsTest1.script
@@ -1,1 +1,1 @@
-print sum(buf0, 1)
+expression sum(buf0, 1)

--- a/lldb/test/Shell/SymbolFile/PDB/Inputs/ExpressionsTest2.script
+++ b/lldb/test/Shell/SymbolFile/PDB/Inputs/ExpressionsTest2.script
@@ -1,2 +1,2 @@
-print sum(buf0, result - 28)
-print sum(buf1 + 3, 3)
+expression sum(buf0, result - 28)
+expression sum(buf1 + 3, 3)

--- a/lldb/test/Shell/SymbolFile/PDB/Inputs/VBases.script
+++ b/lldb/test/Shell/SymbolFile/PDB/Inputs/VBases.script
@@ -2,6 +2,6 @@ breakpoint set --file VBases.cpp --line 15
 
 run
 
-print c
+expression c
 
 frame variable c

--- a/lldb/test/Shell/SymbolFile/PDB/expressions.test
+++ b/lldb/test/Shell/SymbolFile/PDB/expressions.test
@@ -2,34 +2,34 @@ REQUIRES: system-windows, msvc
 RUN: %build --compiler=msvc --nodefaultlib --output=%t.exe %S/Inputs/ExpressionsTest.cpp
 RUN: not %lldb -b -s %S/Inputs/ExpressionsTest0.script -s %S/Inputs/ExpressionsTest1.script -s %S/Inputs/ExpressionsTest2.script -- %t.exe 2>&1 | FileCheck %s
 
-// Check the variable value through `print`
-CHECK: (lldb) print result
+// Check the variable value through `expression`
+CHECK: (lldb) expression result
 CHECK: (char) $0 = '\x1c'
 
 // Call the function just like in the code
-CHECK: (lldb) print N0::N1::sum(N0::N1::buf1, sizeof(N0::N1::buf1))
+CHECK: (lldb) expression N0::N1::sum(N0::N1::buf1, sizeof(N0::N1::buf1))
 CHECK: (char) $1 = '\x1c'
 
 // Try the relaxed namespaces search
-CHECK: (lldb) print N1::sum(N1::buf1, sizeof(N1::buf1))
+CHECK: (lldb) expression N1::sum(N1::buf1, sizeof(N1::buf1))
 CHECK: (char) $2 = '\x1c'
 
 // Try the relaxed variables and functions search
-CHECK: (lldb) print sum(buf1, sizeof(buf1))
+CHECK: (lldb) expression sum(buf1, sizeof(buf1))
 CHECK: (char) $3 = '\x1c'
 
 // Make a crash during expression calculation
-CHECK: (lldb) print sum(buf1, 1000000000)
+CHECK: (lldb) expression sum(buf1, 1000000000)
 CHECK: The process has been returned to the state before expression evaluation.
 
 // Make one more crash
-CHECK: (lldb) print sum(buf0, 1)
+CHECK: (lldb) expression sum(buf0, 1)
 CHECK: The process has been returned to the state before expression evaluation.
 
 // Check if the process state was restored succesfully
-CHECK: (lldb) print sum(buf0, result - 28)
+CHECK: (lldb) expression sum(buf0, result - 28)
 CHECK: (char) $4 = '\0'
 
 // Call the function with arbitrary parameters
-CHECK: (lldb) print sum(buf1 + 3, 3)
+CHECK: (lldb) expression sum(buf1 + 3, 3)
 CHECK: (char) $5 = '\f'


### PR DESCRIPTION
Convert more uses of `p` and `print`, following on the initial conversion done in [D141539](https://reviews.llvm.org/D141539).

This also cherry picks [D146230](https://reviews.llvm.org/D146230)