### PR TITLE
[DebugInfo] Handle swift sync args used by dbg.value intrinsics

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2040,6 +2040,8 @@ bool IRTranslator::translateKnownIntrinsic(const CallInst &CI, Intrinsic::ID ID,
           DIExpression::get(AI->getContext(), ExprOperands.drop_front());
       MIRBuilder.buildFIDbgValue(getOrCreateFrameIndex(*AI), DI.getVariable(),
                                  ExprDerefRemoved);
+    } else if (translateIfSwiftAsyncArg(*V, DI, MIRBuilder,
+                                        false /*IsIndirect*/)) {
     } else {
       for (Register Reg : getOrCreateVRegs(*V)) {
         // FIXME: This does not handle register-indirect values at offset 0. The

--- a/llvm/test/CodeGen/AArch64/GlobalISel/debug-insts-swift.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/debug-insts-swift.ll
@@ -1,0 +1,33 @@
+; RUN: llc -global-isel -mtriple=aarch64 %s -stop-after=irtranslator -o - | FileCheck %s
+
+
+; CHECK: ![[var_dbg_declare:[0-9]+]] = !DILocalVariable(name: "var1"
+
+
+define void @debug_declare(i8* swiftasync %async_state) !dbg !7 {
+  call void @llvm.dbg.declare(metadata i8* %async_state, metadata !11, metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16)), !dbg !12
+  ; CHECK: DBG_VALUE $x22, 0, ![[var_dbg_declare]], !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16)
+  ret void, !dbg !12
+}
+
+declare void @llvm.dbg.declare(metadata, metadata, metadata)
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "myclang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "tmp.c", directory: "blah")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+
+!8 = !DISubroutineType(types: !9)
+!9 = !{null, !10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+
+!7 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !2)
+
+!11 = !DILocalVariable(name: "var1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+
+!12 = !DILocation(line: 1, column: 14, scope: !7)

--- a/llvm/test/CodeGen/AArch64/GlobalISel/debug-insts-swift.ll
+++ b/llvm/test/CodeGen/AArch64/GlobalISel/debug-insts-swift.ll
@@ -2,12 +2,19 @@
 
 
 ; CHECK: ![[var_dbg_declare:[0-9]+]] = !DILocalVariable(name: "var1"
+; CHECK: ![[var_dbg_value:[0-9]+]] = !DILocalVariable(name: "var2"
 
 
 define void @debug_declare(i8* swiftasync %async_state) !dbg !7 {
   call void @llvm.dbg.declare(metadata i8* %async_state, metadata !11, metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16)), !dbg !12
   ; CHECK: DBG_VALUE $x22, 0, ![[var_dbg_declare]], !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16)
   ret void, !dbg !12
+}
+
+define void @debug_value(i8* swiftasync %async_state) !dbg !13 {
+  call void @llvm.dbg.value(metadata i8* %async_state, metadata !14, metadata !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16, DW_OP_deref)), !dbg !15
+  ; CHECK: DBG_VALUE $x22, $noreg, ![[var_dbg_value]], !DIExpression(DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16, DW_OP_deref)
+  ret void, !dbg !15
 }
 
 declare void @llvm.dbg.declare(metadata, metadata, metadata)
@@ -27,7 +34,10 @@ declare void @llvm.dbg.value(metadata, metadata, metadata)
 !10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 
 !7 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !2)
+!13 = distinct !DISubprogram(name: "foo2", scope: !1, file: !1, line: 1, type: !8, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !2)
 
 !11 = !DILocalVariable(name: "var1", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!14 = !DILocalVariable(name: "var2", arg: 1, scope: !13, file: !1, line: 1, type: !10)
 
 !12 = !DILocation(line: 1, column: 14, scope: !7)
+!15 = !DILocation(line: 1, column: 14, scope: !13)

--- a/llvm/test/DebugInfo/ARM/swift-async.ll
+++ b/llvm/test/DebugInfo/ARM/swift-async.ll
@@ -1,7 +1,7 @@
 ; RUN: llc -O0 -filetype=obj < %s | llvm-dwarfdump --name n - | FileCheck %s
 ;
 ; CHECK: DW_TAG_formal_parameter
-; FIXME-CHECK-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg22 W22), DW_OP_deref, DW_OP_plus_uconst 0x18, DW_OP_plus_uconst 0x8)
+; CHECK-NEXT: DW_AT_location	(DW_OP_entry_value(DW_OP_reg22 W22), DW_OP_deref, DW_OP_plus_uconst 0x18, DW_OP_plus_uconst 0x8)
 ; CHECK: DW_AT_name	("n")
 
 ; ModuleID = '/tmp/t.ll'


### PR DESCRIPTION
The first commit performs a minor NFC refactor that enables the second commit to implement handling of swift async args used by dbg value intrinsics.