### PR TITLE
[lldb] Change dwim-print to default to disabled persistent results

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -75,6 +75,10 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
       return false;
   }
 
+  // If the user has not specified, default to disabling persistent results.
+  if (m_expr_options.suppress_persistent_result == eLazyBoolCalculate)
+    m_expr_options.suppress_persistent_result = eLazyBoolYes;
+
   auto verbosity = GetDebugger().GetDWIMPrintVerbosity();
 
   Target *target_ptr = m_exe_ctx.GetTargetPtr();

--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -150,7 +150,7 @@ Status CommandObjectExpression::CommandOptions::SetOptionValue(
     bool persist_result =
         OptionArgParser::ToBoolean(option_arg, true, &success);
     if (success)
-      suppress_persistent_result = !persist_result;
+      suppress_persistent_result = !persist_result ? eLazyBoolYes : eLazyBoolNo;
     else
       error.SetErrorStringWithFormat(
           "could not convert \"%s\" to a boolean value.",
@@ -197,7 +197,7 @@ void CommandObjectExpression::CommandOptions::OptionParsingStarting(
   auto_apply_fixits = eLazyBoolCalculate;
   top_level = false;
   allow_jit = true;
-  suppress_persistent_result = false;
+  suppress_persistent_result = eLazyBoolCalculate;
   // BEGIN SWIFT
   bind_generic_types = eBindAuto;
   // END SWIFT
@@ -215,8 +215,9 @@ CommandObjectExpression::CommandOptions::GetEvaluateExpressionOptions(
   options.SetCoerceToId(display_opts.use_objc);
   // Explicitly disabling persistent results takes precedence over the
   // m_verbosity/use_objc logic.
-  if (suppress_persistent_result)
-    options.SetSuppressPersistentResult(true);
+  if (suppress_persistent_result != eLazyBoolCalculate)
+    options.SetSuppressPersistentResult(suppress_persistent_result ==
+                                        eLazyBoolYes);
   else if (m_verbosity == eLanguageRuntimeDescriptionDisplayVerbosityCompact)
     options.SetSuppressPersistentResult(display_opts.use_objc);
   options.SetUnwindOnError(unwind_on_error);

--- a/lldb/source/Commands/CommandObjectExpression.h
+++ b/lldb/source/Commands/CommandObjectExpression.h
@@ -53,7 +53,7 @@ public:
     lldb::LanguageType language;
     LanguageRuntimeDescriptionDisplayVerbosity m_verbosity;
     LazyBool auto_apply_fixits;
-    bool suppress_persistent_result;
+    LazyBool suppress_persistent_result;
 // BEGIN SWIFT
     lldb::BindGenericTypes bind_generic_types;
 // END SWIFT

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -16,18 +16,16 @@ class TestCase(TestBase):
         self.ci.HandleCommand(cmd, result)
         return result.GetOutput().rstrip()
 
-    VAR_IDENT_RAW = r"(?:\$\d+|\w+) = "
-    VAR_IDENT = re.compile(VAR_IDENT_RAW)
+    VAR_IDENT = re.compile(r"(?:\$\d+|\w+) = ")
 
-    def _mask_persistent_var(self, string: str) -> str:
+    def _strip_result_var(self, string: str) -> str:
         """
-        Replace persistent result variables (ex '$0', '$1', etc) with a regex
-        that matches any persistent result (r'\$\d+'). The returned string can
-        be matched against other `expression` results.
+        Strip (persistent) result variables (ex '$0 = ', or 'someVar = ', etc).
+
+        This allows for using the output of `expression`/`frame variable`, to
+        compare it to `dwim-print` output, which disables result variables.
         """
-        before, after = self.VAR_IDENT.split(string, maxsplit=1)
-        # Support either a frame variable (\w+) or a persistent result (\$\d+).
-        return re.escape(before) + self.VAR_IDENT_RAW + re.escape(after)
+        return self.VAR_IDENT.subn("", string, 1)[0]
 
     def _expect_cmd(
         self,
@@ -46,19 +44,16 @@ class TestCase(TestBase):
         if actual_cmd == "frame variable":
             resolved_cmd = resolved_cmd.replace(" -- ", " ", 1)
 
-        expected_output = self._run_cmd(resolved_cmd)
+        resolved_cmd_output = self._run_cmd(resolved_cmd)
+        dwim_cmd_output = self._strip_result_var(resolved_cmd_output)
 
         # Verify dwim-print chose the expected command.
         self.runCmd("settings set dwim-print-verbosity full")
-        substrs = [f"note: ran `{resolved_cmd}`"]
-        patterns = []
 
-        if self.VAR_IDENT.search(expected_output):
-            patterns.append(self._mask_persistent_var(expected_output))
-        else:
-            substrs.append(expected_output)
-
-        self.expect(dwim_cmd, substrs=substrs, patterns=patterns)
+        self.expect(dwim_cmd, substrs=[
+            f"note: ran `{resolved_cmd}`",
+            dwim_cmd_output,
+        ])
 
     def test_variables(self):
         """Test dwim-print with variables."""

--- a/lldb/test/API/commands/expression/persistent_result/TestPersistentResult.py
+++ b/lldb/test/API/commands/expression/persistent_result/TestPersistentResult.py
@@ -31,7 +31,7 @@ class TestCase(TestBase):
         self.expect("expression i", substrs=["(int) $0 = 30"])
         self.expect("expression $0", substrs=["(int) $0 = 30"])
 
-    def test_p_persists_result(self):
-        """Test `p` does persist a result variable."""
-        self.expect("p i", substrs=["(int) $0 = 30"])
-        self.expect("p $0", substrs=["(int) $0 = 30"])
+    def test_p_does_not_persist_results(self):
+        """Test `p` does not persist a result variable."""
+        self.expect("p i", startstr="(int) 30")
+        self.expect("p $0", error=True)

--- a/lldb/test/API/functionalities/alias/TestPAlias.py
+++ b/lldb/test/API/functionalities/alias/TestPAlias.py
@@ -7,5 +7,5 @@ class TestCase(TestBase):
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.c"))
-        self.expect("p -g", substrs=["$0 = -"])
+        self.expect("p -g", startstr="(int) -41")
         self.expect("p -i0 -g", error=True)

--- a/lldb/test/Shell/Swift/DeserializationFailure.test
+++ b/lldb/test/Shell/Swift/DeserializationFailure.test
@@ -15,7 +15,7 @@
 b main
 run
 # Create a SwiftASTContext, to induce error output.
-p 1
+expression 1
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: a.out:{{ }}{{.*}}The serialized module is corrupted.

--- a/lldb/test/Shell/Swift/DynamicTyperesolutionConflict.test
+++ b/lldb/test/Shell/Swift/DynamicTyperesolutionConflict.test
@@ -21,8 +21,8 @@
 b Dylib.swift:9
 run
 target v foofoo
-p input
-p input
+expression input
+expression input
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: {{Swift}} error in fallback scratch context

--- a/lldb/test/Shell/Swift/MissingVFSOverlay.test
+++ b/lldb/test/Shell/Swift/MissingVFSOverlay.test
@@ -12,7 +12,7 @@
 b main
 run
 # Create a SwiftASTContext, to induce error output.
-p 1
+expression 1
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: a.out:{{ }}

--- a/lldb/test/Shell/Swift/RemoteASTImport.test
+++ b/lldb/test/Shell/Swift/RemoteASTImport.test
@@ -45,7 +45,7 @@
 
 b Library.swift:10
 run
-p input
+expression input
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK-NOT: undeclared identifier {{'SYNTAX_ERROR'}}


### PR DESCRIPTION
Change `dwim-print` to now disable persistent results by default, unless requested by
the user with the `--persistent-result` flag.

Ex:

```
(lldb) dwim-print 1 + 1
(int) 2
(lldb) dwim-print --persistent-result on -- 1 + 1
(int) $0 = 2
```

Users who wish to enable persistent results can make and use an alias that includes
`--persistent-result on`.

Differential Revision: https://reviews.llvm.org/D145609

(cherry picked from commit 385496385476fc9735da5fa4acabc34654e8b30d)
