### PR TITLE
[cherry-pick][swift/release/5.9] [clang][DebugInfo] Emit DW_AT_type of preferred name if available

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -2451,7 +2451,11 @@ void CGDebugInfo::completeClass(const RecordDecl *RD) {
   auto I = TypeCache.find(TyPtr);
   if (I != TypeCache.end() && !cast<llvm::DIType>(I->second)->isForwardDecl())
     return;
-  llvm::DIType *Res = CreateTypeDefinition(Ty->castAs<RecordType>());
+
+  // We want the canonical definition of the structure to not
+  // be the typedef. Since that would lead to circular typedef
+  // metadata.
+  auto [Res, PrefRes] = CreateTypeDefinition(Ty->castAs<RecordType>());
   assert(!Res->isForwardDecl());
   TypeCache[TyPtr].reset(Res);
 }
@@ -2562,10 +2566,25 @@ llvm::DIType *CGDebugInfo::CreateType(const RecordType *Ty) {
     return T;
   }
 
-  return CreateTypeDefinition(Ty);
+  auto [Def, Pref] = CreateTypeDefinition(Ty);
+
+  return Pref ? Pref : Def;
 }
 
-llvm::DIType *CGDebugInfo::CreateTypeDefinition(const RecordType *Ty) {
+llvm::DIType *CGDebugInfo::GetPreferredNameType(const CXXRecordDecl *RD,
+                                                llvm::DIFile *Unit) {
+  if (!RD)
+    return nullptr;
+
+  auto const *PNA = RD->getAttr<PreferredNameAttr>();
+  if (!PNA)
+    return nullptr;
+
+  return getOrCreateType(PNA->getTypedefType(), Unit);
+}
+
+std::pair<llvm::DIType *, llvm::DIType *>
+CGDebugInfo::CreateTypeDefinition(const RecordType *Ty) {
   RecordDecl *RD = Ty->getDecl();
 
   // Get overall information about the record type for the debug info.
@@ -2581,7 +2600,7 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const RecordType *Ty) {
 
   const RecordDecl *D = RD->getDefinition();
   if (!D || !D->isCompleteDefinition())
-    return FwdDecl;
+    return {FwdDecl, nullptr};
 
   if (const auto *CXXDecl = dyn_cast<CXXRecordDecl>(RD))
     CollectContainingType(CXXDecl, FwdDecl);
@@ -2620,7 +2639,12 @@ llvm::DIType *CGDebugInfo::CreateTypeDefinition(const RecordType *Ty) {
         llvm::MDNode::replaceWithPermanent(llvm::TempDICompositeType(FwdDecl));
 
   RegionMap[Ty->getDecl()].reset(FwdDecl);
-  return FwdDecl;
+
+  if (CGM.getCodeGenOpts().getDebuggerTuning() == llvm::DebuggerKind::LLDB)
+    if (auto *PrefDI = GetPreferredNameType(CXXDecl, DefUnit))
+      return {FwdDecl, PrefDI};
+
+  return {FwdDecl, nullptr};
 }
 
 llvm::DIType *CGDebugInfo::CreateType(const ObjCObjectType *Ty,
@@ -3645,7 +3669,7 @@ llvm::DICompositeType *CGDebugInfo::CreateLimitedType(const RecordType *Ty) {
 void CGDebugInfo::CollectContainingType(const CXXRecordDecl *RD,
                                         llvm::DICompositeType *RealDecl) {
   // A class's primary base or the class itself contains the vtable.
-  llvm::DICompositeType *ContainingType = nullptr;
+  llvm::DIType *ContainingType = nullptr;
   const ASTRecordLayout &RL = CGM.getContext().getASTRecordLayout(RD);
   if (const CXXRecordDecl *PBase = RL.getPrimaryBase()) {
     // Seek non-virtual primary base root.
@@ -3657,9 +3681,8 @@ void CGDebugInfo::CollectContainingType(const CXXRecordDecl *RD,
       else
         break;
     }
-    ContainingType = cast<llvm::DICompositeType>(
-        getOrCreateType(QualType(PBase->getTypeForDecl(), 0),
-                        getOrCreateFile(RD->getLocation())));
+    ContainingType = getOrCreateType(QualType(PBase->getTypeForDecl(), 0),
+                                     getOrCreateFile(RD->getLocation()));
   } else if (RD->isDynamicClass())
     ContainingType = RealDecl;
 

--- a/clang/lib/CodeGen/CGDebugInfo.h
+++ b/clang/lib/CodeGen/CGDebugInfo.h
@@ -190,7 +190,15 @@ class CGDebugInfo {
   llvm::DIType *CreateType(const FunctionType *Ty, llvm::DIFile *F);
   /// Get structure or union type.
   llvm::DIType *CreateType(const RecordType *Tyg);
-  llvm::DIType *CreateTypeDefinition(const RecordType *Ty);
+
+  /// Create definition for the specified 'Ty'.
+  ///
+  /// \returns A pair of 'llvm::DIType's. The first is the definition
+  /// of the 'Ty'. The second is the type specified by the preferred_name
+  /// attribute on 'Ty', which can be a nullptr if no such attribute
+  /// exists.
+  std::pair<llvm::DIType *, llvm::DIType *>
+  CreateTypeDefinition(const RecordType *Ty);
   llvm::DICompositeType *CreateLimitedType(const RecordType *Ty);
   void CollectContainingType(const CXXRecordDecl *RD,
                              llvm::DICompositeType *CT);
@@ -273,6 +281,12 @@ class CGDebugInfo {
       const CXXRecordDecl::base_class_const_range &Bases,
       llvm::DenseSet<CanonicalDeclPtr<const CXXRecordDecl>> &SeenTypes,
       llvm::DINode::DIFlags StartingFlags);
+
+  /// Helper function that returns the llvm::DIType that the
+  /// PreferredNameAttr attribute on \ref RD refers to. If no such
+  /// attribute exists, returns nullptr.
+  llvm::DIType *GetPreferredNameType(const CXXRecordDecl *RD,
+                                     llvm::DIFile *Unit);
 
   struct TemplateArgs {
     const TemplateParameterList *TList;

--- a/clang/test/CodeGen/preferred_name-chain.cpp
+++ b/clang/test/CodeGen/preferred_name-chain.cpp
@@ -1,0 +1,65 @@
+// RUN: %clang_cc1 -triple x86_64-unk-unk -o - -emit-llvm -debug-info-kind=standalone -debugger-tuning=lldb %s | FileCheck %s --check-prefixes=COMMON,LLDB
+// RUN: %clang_cc1 -triple x86_64-unk-unk -o - -emit-llvm -debug-info-kind=standalone -debugger-tuning=gdb %s | FileCheck %s --check-prefixes=COMMON,GDB
+
+template <typename T>
+struct Foo;
+
+typedef Foo<int> BarIntBase;
+typedef BarIntBase BarIntTmp;
+typedef BarIntTmp BarInt;
+
+template <typename T>
+using BarBase = Foo<T>;
+
+template <typename T>
+using BarTmp = BarBase<T>;
+
+template <typename T>
+using Bar = BarTmp<T>;
+
+template <typename T>
+struct [[clang::preferred_name(BarInt),
+         clang::preferred_name(Bar<char>)]] Foo{
+         };
+
+int main() {
+    Foo<int> varInt;
+
+// COMMON: !DILocalVariable(name: "varInt", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_INT_TY:[0-9]+]])
+// LLDB:   ![[BAR_INT_TY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarInt", file: ![[#]], line: [[#]], baseType: ![[BAR_INT_TMP:[0-9]+]])
+// LLDB:   ![[BAR_INT_TMP]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarIntTmp", file: ![[#]], line: [[#]], baseType: ![[BAR_INT_BASE:[0-9]+]])
+// LLDB:   ![[BAR_INT_BASE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarIntBase", file: ![[#]], line: [[#]], baseType: ![[FOO_INT:[0-9]+]])
+// LLDB:   ![[FOO_INT]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<int>", file: ![[#]], line: [[#]], size: [[#]]
+// GDB:    ![[BAR_INT_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<int>", file: ![[#]], line: [[#]], size: [[#]]
+
+    Foo<char> varChar;
+
+// COMMON: !DILocalVariable(name: "varChar", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_CHAR_TY:[0-9]+]])
+// LLDB:   ![[BAR_CHAR_TY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<char>", file: ![[#]], line: [[#]], baseType: ![[BAR_CHAR_TMP:[0-9]+]])
+// LLDB:   ![[BAR_CHAR_TMP]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarTmp<char>", file: ![[#]], line: [[#]], baseType: ![[BAR_CHAR_BASE:[0-9]+]])
+// LLDB:   ![[BAR_CHAR_BASE]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarBase<char>", file: ![[#]], line: [[#]], baseType: ![[FOO_CHAR:[0-9]+]])
+// LLDB:   ![[FOO_CHAR]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<char>"
+// GDB:    ![[BAR_CHAR_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<char>"
+
+    Foo<Foo<int>> varFooInt;
+
+// COMMON:      !DILocalVariable(name: "varFooInt", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[FOO_BAR_INT_TY:[0-9]+]])
+// COMMON:      ![[FOO_BAR_INT_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<Foo<int> >"
+// COMMON-SAME: templateParams: ![[PARAM:[0-9]+]]
+// COMMON:      ![[PARAM]] = !{![[TEMPL_TYPE_PARAM:[0-9]+]]}
+// GDB:         ![[TEMPL_TYPE_PARAM]] = !DITemplateTypeParameter(name: "T", type: ![[BAR_INT_TY]])
+// LLDB:        ![[TEMPL_TYPE_PARAM]] = !DITemplateTypeParameter(name: "T", type: ![[BAR_INT_TY]])
+
+    Foo<Foo<char>> varFooChar;
+
+// COMMON:      !DILocalVariable(name: "varFooChar", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[FOO_BAR_CHAR_TY:[0-9]+]])
+// COMMON:      ![[FOO_BAR_CHAR_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<Foo<char> >"
+// COMMON-SAME: templateParams: ![[CHAR_PARAM:[0-9]+]]
+// COMMON:      ![[CHAR_PARAM]] = !{![[CHAR_TEMPL_TYPE_PARAM:[0-9]+]]}
+// GDB:         ![[CHAR_TEMPL_TYPE_PARAM]] = !DITemplateTypeParameter(name: "T", type: ![[BAR_CHAR_TY]])
+// LLDB:        ![[CHAR_TEMPL_TYPE_PARAM]] = !DITemplateTypeParameter(name: "T", type: ![[BAR_CHAR_TY]])
+
+    return 0;
+}
+
+

--- a/clang/test/CodeGen/preferred_name.cpp
+++ b/clang/test/CodeGen/preferred_name.cpp
@@ -1,0 +1,89 @@
+// RUN: %clang_cc1 -triple x86_64-unk-unk -o - -emit-llvm -debug-info-kind=standalone -debugger-tuning=lldb %s | FileCheck %s --check-prefixes=COMMON,LLDB
+// RUN: %clang_cc1 -triple x86_64-unk-unk -o - -emit-llvm -debug-info-kind=standalone -debugger-tuning=gdb %s | FileCheck %s --check-prefixes=COMMON,GDB
+
+template <typename T>
+struct Foo;
+
+typedef Foo<int> BarInt;
+typedef Foo<double> BarDouble;
+
+template <typename T>
+using Bar = Foo<T>;
+
+template <typename T>
+struct [[clang::preferred_name(BarInt),
+         clang::preferred_name(BarDouble),
+         clang::preferred_name(Bar<short>),
+         clang::preferred_name(Bar<char>)]] Foo{
+         };
+
+int main() {
+    Foo<int> varInt;
+
+// COMMON: !DILocalVariable(name: "varInt", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_INT_TY:[0-9]+]])
+// LLDB:   ![[BAR_INT_TY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarInt", file: ![[#]], line: [[#]], baseType: ![[BAR_INT_BASE:[0-9]+]])
+// LLDB:   ![[BAR_INT_BASE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<int>", file: ![[#]], line: [[#]], size: [[#]]
+// GDB:    ![[BAR_INT_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<int>", file: ![[#]], line: [[#]], size: [[#]]
+
+    Foo<double> varDouble;
+
+// COMMON: !DILocalVariable(name: "varDouble", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_DOUBLE_TY:[0-9]+]])
+// LLDB:   ![[BAR_DOUBLE_TY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarDouble", file: ![[#]], line: [[#]], baseType: ![[BAR_DOUBLE_BASE:[0-9]+]])
+// LLDB:   ![[BAR_DOUBLE_BASE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<double>"
+// GDB:    ![[BAR_DOUBLE_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<double>"
+
+    Foo<short> varShort;
+
+// COMMON: !DILocalVariable(name: "varShort", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_SHORT_TY:[0-9]+]])
+// LLDB:   ![[BAR_SHORT_TY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<short>", file: ![[#]], line: [[#]], baseType: ![[BAR_SHORT_BASE:[0-9]+]])
+// LLDB:   ![[BAR_SHORT_BASE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<short>"
+// GDB:    ![[BAR_SHORT_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<short>"
+
+    Foo<char> varChar;
+
+// COMMON: !DILocalVariable(name: "varChar", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_CHAR_TY:[0-9]+]])
+// LLDB:   ![[BAR_CHAR_TY]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<char>", file: ![[#]], line: [[#]], baseType: ![[BAR_CHAR_BASE:[0-9]+]])
+// LLDB:   ![[BAR_CHAR_BASE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<char>"
+// GDB:    ![[BAR_CHAR_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<char>"
+
+    Foo<Foo<int>> varFooInt;
+
+// COMMON:      !DILocalVariable(name: "varFooInt", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[FOO_BAR_INT_TY:[0-9]+]])
+// COMMON:      ![[FOO_BAR_INT_TY]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<Foo<int> >"
+// COMMON-SAME: templateParams: ![[PARAM:[0-9]+]]
+// COMMON:      ![[PARAM]] = !{![[TEMPL_TYPE_PARAM:[0-9]+]]}
+// GDB:         ![[TEMPL_TYPE_PARAM]] = !DITemplateTypeParameter(name: "T", type: ![[BAR_INT_TY]])
+// LLDB:        ![[TEMPL_TYPE_PARAM]] = !DITemplateTypeParameter(name: "T", type: ![[BAR_INT_TY]])
+
+    BarInt barInt;
+
+// LLDB:   !DILocalVariable(name: "barInt", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_INT_TY]])
+// GDB:    !DILocalVariable(name: "barInt", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_INT_TYPEDEF:[0-9]+]])
+// GDB:    ![[BAR_INT_TYPEDEF]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarInt"
+
+    BarDouble barDouble;
+
+// LLDB:   !DILocalVariable(name: "barDouble", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_DOUBLE_TY]])
+// GDB:    !DILocalVariable(name: "barDouble", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_DOUBLE_TYPEDEF:[0-9]+]])
+// GDB:    ![[BAR_DOUBLE_TYPEDEF]] = !DIDerivedType(tag: DW_TAG_typedef, name: "BarDouble"
+
+    Bar<short> barShort;
+
+// LLDB:   !DILocalVariable(name: "barShort", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_SHORT_TY_2:[0-9]+]])
+// GDB:    !DILocalVariable(name: "barShort", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_SHORT_TYPEDEF:[0-9]+]])
+// GDB:    ![[BAR_SHORT_TYPEDEF]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<short>"
+
+    Bar<char> barChar;
+
+// LLDB:   ![[BAR_SHORT_TY_2]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<short>", file: ![[#]], line: [[#]], baseType: ![[BAR_SHORT_TY]])
+
+// LLDB:   !DILocalVariable(name: "barChar", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_CHAR_TY_2:[0-9]+]])
+// GDB:    !DILocalVariable(name: "barChar", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[BAR_CHAR_TYPEDEF:[0-9]+]])
+// GDB:    ![[BAR_CHAR_TYPEDEF]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<char>"
+
+// LLDB:   ![[BAR_CHAR_TY_2]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<char>", file: ![[#]], line: [[#]], baseType: ![[BAR_CHAR_TY]])
+
+    return 0;
+}
+
+

--- a/clang/test/Modules/Inputs/gmodules-preferred-name-alias.h
+++ b/clang/test/Modules/Inputs/gmodules-preferred-name-alias.h
@@ -1,0 +1,8 @@
+template<typename T> struct Foo;
+
+template<typename T>
+using Bar = Foo<T>;
+
+template<typename T> struct [[clang::preferred_name(Bar<T>)]] Foo {};
+
+template <typename T> struct Baz { Foo<char> member; };

--- a/clang/test/Modules/Inputs/gmodules-preferred-name-alias.modulemap
+++ b/clang/test/Modules/Inputs/gmodules-preferred-name-alias.modulemap
@@ -1,0 +1,4 @@
+module PreferredNameModule {
+  header "gmodules-preferred-name-alias.h"
+  export *
+}

--- a/clang/test/Modules/Inputs/gmodules-preferred-name-typedef.h
+++ b/clang/test/Modules/Inputs/gmodules-preferred-name-typedef.h
@@ -1,0 +1,7 @@
+template<typename T> struct Foo;
+
+typedef Foo<char> Bar;
+
+template<typename T> struct [[clang::preferred_name(Bar)]] Foo {};
+
+template <typename T> struct Baz { Foo<char> member; };

--- a/clang/test/Modules/Inputs/gmodules-preferred-name-typedef.modulemap
+++ b/clang/test/Modules/Inputs/gmodules-preferred-name-typedef.modulemap
@@ -1,0 +1,4 @@
+module PreferredNameModule {
+  header "gmodules-preferred-name-typedef.h"
+  export *
+}

--- a/clang/test/Modules/gmodules-preferred-name-alias.cpp
+++ b/clang/test/Modules/gmodules-preferred-name-alias.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -std=c++11 -dwarf-ext-refs -fmodule-format=obj \
+// RUN:     -fmodule-map-file=%S/Inputs/gmodules-preferred-name-alias.modulemap \
+// RUN:     -fmodules-cache-path=%t -debug-info-kind=standalone -debugger-tuning=lldb \
+// RUN:     -fmodules -mllvm -debug-only=pchcontainer -x c++ \
+// RUN:     -I %S/Inputs %s &> %t.ll
+// RUN: cat %t.ll | FileCheck %s
+
+#include "gmodules-preferred-name-alias.h"
+
+// CHECK: ![[#]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar<char>", scope: ![[#]], file: ![[#]], line: [[#]], baseType: ![[PREF_BASE:[0-9]+]])
+// CHECK: ![[PREF_BASE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<char>"

--- a/clang/test/Modules/gmodules-preferred-name-typedef.cpp
+++ b/clang/test/Modules/gmodules-preferred-name-typedef.cpp
@@ -1,0 +1,12 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -std=c++11 -dwarf-ext-refs -fmodule-format=obj \
+// RUN:     -fmodule-map-file=%S/Inputs/gmodules-preferred-name-typedef.modulemap \
+// RUN:     -fmodules-cache-path=%t -debug-info-kind=standalone -debugger-tuning=lldb \
+// RUN:     -fmodules -mllvm -debug-only=pchcontainer -x c++ \
+// RUN:     -I %S/Inputs %s &> %t.ll
+// RUN: cat %t.ll | FileCheck %s
+
+#include "gmodules-preferred-name-typedef.h"
+
+// CHECK: ![[#]] = !DIDerivedType(tag: DW_TAG_typedef, name: "Bar", scope: ![[#]], file: ![[#]], line: [[#]], baseType: ![[PREF_BASE:[0-9]+]])
+// CHECK: ![[PREF_BASE]] = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Foo<char>"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/TestDataFormatterLibcxxSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/shared_ptr/TestDataFormatterLibcxxSharedPtr.py
@@ -60,7 +60,7 @@ class TestCase(TestBase):
 
         valobj = self.expect_var_path(
             "sp_str",
-            type="std::shared_ptr<std::basic_string<char> >",
+            type="std::shared_ptr<std::string>",
             children=[ValueCheck(name="__ptr_", summary='"hello"')],
         )
         self.assertRegex(valobj.summary, r'^"hello"( strong=1)? weak=1$')

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unique_ptr/TestDataFormatterLibcxxUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/unique_ptr/TestDataFormatterLibcxxUniquePtr.py
@@ -60,7 +60,7 @@ class TestCase(TestBase):
 
         valobj = self.expect_var_path(
             "up_str",
-            type="std::unique_ptr<std::basic_string<char> >",
+            type="std::unique_ptr<std::string>",
             summary='"hello"',
             children=[ValueCheck(name="__value_", summary='"hello"')],
         )

--- a/lldb/test/API/lang/cpp/preferred_name/Makefile
+++ b/lldb/test/API/lang/cpp/preferred_name/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+CXXFLAGS_EXTRAS := -std=c++20 -glldb
+include Makefile.rules

--- a/lldb/test/API/lang/cpp/preferred_name/TestPreferredName.py
+++ b/lldb/test/API/lang/cpp/preferred_name/TestPreferredName.py
@@ -1,0 +1,42 @@
+"""
+Test formatting of types annotated with
+[[clang::preferred_name]] attributes.
+"""
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import decorators
+
+
+class TestPreferredName(TestBase):
+
+    def test_frame_var(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
+
+        self.expect("frame variable barInt", substrs=["BarInt"])
+        self.expect("frame variable barDouble", substrs=["BarDouble"])
+        self.expect("frame variable barShort", substrs=["Bar<short>"])
+        self.expect("frame variable barChar", substrs=["Bar<char>"])
+
+        self.expect("frame variable varInt", substrs=["BarInt"])
+        self.expect("frame variable varDouble", substrs=["BarDouble"])
+        self.expect("frame variable varShort", substrs=["Bar<short>"])
+        self.expect("frame variable varChar", substrs=["Bar<char>"])
+        self.expect("frame variable varFooInt", substrs=["Foo<BarInt>"])
+
+    def test_expr(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
+
+        self.expect_expr("barInt", result_type="BarInt")
+        self.expect_expr("barDouble", result_type="BarDouble")
+        self.expect_expr("barShort", result_type="Bar<short>")
+        self.expect_expr("barChar", result_type="Bar<char>")
+
+        self.expect_expr("varInt", result_type="BarInt")
+        self.expect_expr("varDouble", result_type="BarDouble")
+        self.expect_expr("varShort", result_type="Bar<short>")
+        self.expect_expr("varChar", result_type="Bar<char>")
+        self.expect_expr("varFooInt", result_type="Foo<BarInt>")

--- a/lldb/test/API/lang/cpp/preferred_name/main.cpp
+++ b/lldb/test/API/lang/cpp/preferred_name/main.cpp
@@ -1,0 +1,26 @@
+template <typename T> struct Foo;
+
+typedef Foo<int> BarInt;
+typedef Foo<double> BarDouble;
+
+template <typename T> using Bar = Foo<T>;
+
+template <typename T>
+struct [[clang::preferred_name(BarInt), clang::preferred_name(BarDouble),
+         clang::preferred_name(Bar<short>), clang::preferred_name(Bar<short>),
+         clang::preferred_name(Bar<double>),
+         clang::preferred_name(Bar<char>)]] Foo{};
+
+int main() {
+  BarInt barInt;
+  BarDouble barDouble;
+  Bar<short> barShort;
+  Bar<char> barChar;
+
+  Foo<int> varInt;
+  Foo<double> varDouble;
+  Foo<short> varShort;
+  Foo<char> varChar;
+  Foo<Foo<int>> varFooInt;
+  return 0;
+}

--- a/llvm/docs/ReleaseNotes.rst
+++ b/llvm/docs/ReleaseNotes.rst
@@ -169,6 +169,11 @@ Changes to the Debug Info
 
 During this release ...
 
+* When a template class annotated with the ``[[clang::preferred_name]]`` attribute
+  were to appear in a ``DW_AT_type``, the type will now be that of the preferred_name
+  instead. This is only enabled when tuned for LLDB at the moment.
+  (`D145803 <https://reviews.llvm.org/D145803>`_)
+
 Changes to the LLVM tools
 ---------------------------------
 


### PR DESCRIPTION
With this patch, whenever we emit a `DW_AT_type` for some declaration
and the type is a template class with a `clang::PreferredNameAttr`, we
will emit the typedef that the attribute refers to instead. I.e.,

```
0x123 DW_TAG_variable
        DW_AT_name "var"
        DW_AT_type (0x123 "basic_string<char>")

0x124 DW_TAG_structure_type
        DW_AT_name "basic_string<char>"
```
...becomes
```
0x123 DW_TAG_variable
        DW_AT_name "var"
        DW_AT_type (0x124 "std::string")

0x124 DW_TAG_structure_type
        DW_AT_name "basic_string<char>"

0x125 DW_TAG_typedef
        DW_AT_name "std::string"
        DW_AT_type (0x124 "basic_string<char>")
```

We do this by returning the preferred name typedef `DIType` when
we create a structure definition. In some cases, e.g., with `-gmodules`,
we don't complete the structure definition immediately but do so later
via `completeClassData`, which overwrites the `TypeCache`. In such cases
we don't actually want to rewrite the cache with the preferred name. We
handle this by returning both the definition and the preferred typedef
from `CreateTypeDefinition` and let the callee decide what to do with
it.

Essentially we set up the types as:
```
TypeCache[Record] => DICompositeType
ReplaceMap[Record] => DIDerivedType(baseType: DICompositeType)
```

For now we keep this behind LLDB tuning.

**Testing**

- Added clang unit-test
- `check-llvm`, `check-clang` pass
- Confirmed that this change correctly repoints
  `basic_string` references in some of my test programs.
- Will add follow-up LLDB API tests

Differential Revision: https://reviews.llvm.org/D145803