### PR TITLE
PECOFF: enforce move semantics and consume errors properly

### DIFF
--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -870,6 +870,7 @@ ObjectFilePECOFF::AppendFromExportTable(SectionList *sect_list,
                "ObjectFilePECOFF::AppendFromExportTable - failed to get export "
                "table entry name: {0}",
                llvm::fmt_consume(std::move(err)));
+      llvm::consumeError(std::move(err));
       continue;
     }
     Symbol symbol;
@@ -891,6 +892,7 @@ ObjectFilePECOFF::AppendFromExportTable(SectionList *sect_list,
                  "ObjectFilePECOFF::AppendFromExportTable - failed to get "
                  "forwarder name of forwarder export '{0}': {1}",
                  sym_name, llvm::fmt_consume(std::move(err)));
+        llvm::consumeError(std::move(err));
         continue;
       }
       llvm::SmallString<256> new_name = {symbol.GetDisplayName().GetStringRef(),
@@ -906,6 +908,7 @@ ObjectFilePECOFF::AppendFromExportTable(SectionList *sect_list,
                "ObjectFilePECOFF::AppendFromExportTable - failed to get "
                "address of export entry '{0}': {1}",
                sym_name, llvm::fmt_consume(std::move(err)));
+      llvm::consumeError(std::move(err));
       continue;
     }
     // Skip the symbol if it doesn't look valid.


### PR DESCRIPTION
We would not ensure that the error is consumed in the case that logging is disabled.  Ensure that we properly drop the error on the floor or we would re-trigger the checked failure.