### PR TITLE
Implement a workaround to acrtificially extend the lifetime of async 

### DIFF
--- a/lldb/test/API/lang/swift/async/variables/Makefile
+++ b/lldb/test/API/lang/swift/async/variables/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
+++ b/lldb/test/API/lang/swift/async/variables/TestSwiftAsyncVariables.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftAsyncVariables(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test(self):
+        """Test local variables in async functions"""
+        self.build()
+        src = lldb.SBFileSpec('main.swift')
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', src)
+
+        while process.selected_thread.stop_reason == lldb.eStopReasonBreakpoint:
+            self.expect("frame variable x", substrs=["23"])
+            process.Continue()

--- a/lldb/test/API/lang/swift/async/variables/main.swift
+++ b/lldb/test/API/lang/swift/async/variables/main.swift
@@ -1,0 +1,23 @@
+import Swift
+func use<T>(_ t: T) {}
+func sink<T>(_ t: T) {}
+
+func split() async {}
+
+func f(_ xs: [Int?]) async {
+  for x in xs {
+    let x = x!
+    sink(x) // break here
+  }
+  await split()
+  for x in xs {
+    let x = x!
+    sink(x) // break here
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    await f([23])
+  }
+}

--- a/llvm/include/llvm/CodeGen/DebugHandlerBase.h
+++ b/llvm/include/llvm/CodeGen/DebugHandlerBase.h
@@ -98,7 +98,8 @@ protected:
 
   /// Ensure that a label will be emitted before MI.
   void requestLabelBeforeInsn(const MachineInstr *MI) {
-    LabelsBeforeInsn.insert(std::make_pair(MI, nullptr));
+    if (!LabelsBeforeInsn.count(MI))
+      LabelsBeforeInsn.insert(std::make_pair(MI, nullptr));
   }
 
   /// Ensure that a label will be emitted after MI.

--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -1946,6 +1946,10 @@ struct MachineInstrExpressionTrait : DenseMapInfo<MachineInstr*> {
   }
 };
 
+// BEGIN SWIFT
+bool isSwiftAsyncContext(const MachineFunction &MF, Register Reg);
+// END SWIFT
+  
 //===----------------------------------------------------------------------===//
 // Debugging Support
 

--- a/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
@@ -300,6 +300,7 @@ void DebugHandlerBase::beginFunction(const MachineFunction *MF) {
         Entries.front().getInstr()->getDebugVariable();
     if (DIVar->isParameter() &&
         getDISubprogram(DIVar->getScope())->describes(&MF->getFunction())) {
+
       if (!IsDescribedByReg(Entries.front().getInstr()))
         LabelsBeforeInsn[Entries.front().getInstr()] = Asm->getFunctionBegin();
       if (Entries.front().getInstr()->getDebugExpression()->isFragment()) {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1562,6 +1562,20 @@ static bool validThroughout(LexicalScopes &LScopes,
   if (LSRange.size() == 0)
     return false;
 
+  // BEGIN SWIFT
+  // Swift async function handling.
+  {
+    auto &MI = *DbgValue;
+    auto MF = MBB->getParent();
+    auto *Expr = MI.getDebugExpression();
+    if (Expr && Expr->isEntryValue())
+      for (const MachineOperand &MO : MI.debug_operands())
+        if (MO.isReg() && MO.getReg() != 0)
+          if (isSwiftAsyncContext(*MF, MO.getReg()))
+            return true;
+  }
+  // END SWIFT
+
   const MachineInstr *LScopeBegin = LSRange.front().first;
   // If the scope starts before the DBG_VALUE then we may have a negative
   // result. Otherwise the location is live coming into the scope and we

--- a/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/InstrRefBasedImpl.cpp
@@ -155,23 +155,6 @@ static cl::opt<unsigned>
                          cl::desc("livedebugvalues-stack-ws-limit"),
                          cl::init(250));
 
-// BEGIN SWIFT
-static bool isSwiftAsyncContext(const MachineFunction &MF, Register Reg) {
-  const llvm::Function &F = MF.getFunction();
-  if (!MF.getProperties().hasProperty(
-          MachineFunctionProperties::Property::TracksLiveness))
-    return false;
-  unsigned I = 0;
-  for (auto R : MF.getRegInfo().liveins()) {
-    if (R.first == (unsigned)Reg &&
-        F.hasParamAttribute(I, Attribute::SwiftAsync))
-      return true;
-    ++I;
-  }
-  return false;
-}
-// END SWIFT
-
 DbgOpID DbgOpID::UndefID = DbgOpID(0xffffffff);
 
 /// Tracker for converting machine value locations and variable values into

--- a/llvm/lib/CodeGen/MachineRegisterInfo.cpp
+++ b/llvm/lib/CodeGen/MachineRegisterInfo.cpp
@@ -671,3 +671,20 @@ bool MachineRegisterInfo::isGeneralPurposeRegister(const MachineFunction &MF,
                                                    MCRegister Reg) const {
   return getTargetRegisterInfo()->isGeneralPurposeRegister(MF, Reg);
 }
+
+// BEGIN SWIFT
+bool llvm::isSwiftAsyncContext(const MachineFunction &MF, Register Reg) {
+  const llvm::Function &F = MF.getFunction();
+  if (!MF.getProperties().hasProperty(
+          MachineFunctionProperties::Property::TracksLiveness))
+    return false;
+  unsigned I = 0;
+  for (auto R : MF.getRegInfo().liveins()) {
+    if (R.first == (unsigned)Reg &&
+        F.hasParamAttribute(I, Attribute::SwiftAsync))
+      return true;
+    ++I;
+  }
+  return false;
+}
+// END SWIFT


### PR DESCRIPTION
Implement a workaround to acrtificially extend the lifetime of async DBG_VALUEs.

A better solution would be to lower async dbg.declare intrinsics into
MMI side-table entries. This patch, however, is less risky to
implement in the swift/release/5.9 branch.

rdar://107687703