### PR TITLE
Handle new Swift builtin storage type (distributed actor storage)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5268,6 +5268,7 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
     swift_flags |= eTypeHasDynamicSelf;
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
@@ -5419,6 +5420,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinPackIndex:    
@@ -5909,6 +5911,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
@@ -6012,6 +6015,7 @@ uint32_t SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
@@ -6152,6 +6156,7 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
@@ -6383,6 +6388,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
@@ -6572,6 +6578,7 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
@@ -6727,6 +6734,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
@@ -7037,6 +7045,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     const swift::TypeKind type_kind = swift_can_type->getKind();
     switch (type_kind) {
     case swift::TypeKind::BuiltinDefaultActorStorage:
+    case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
     case swift::TypeKind::BuiltinExecutor:
     case swift::TypeKind::BuiltinJob:
     case swift::TypeKind::BuiltinTuple:
@@ -7423,6 +7432,7 @@ bool SwiftASTContext::DumpTypeValue(
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:


### PR DESCRIPTION
A new builtin type was introduced in Swift in https://github.com/apple/swift/pull/64237 for "non default (executor) distributed actors", this is a feature from Swift 5.9.

This patch adds this type to switches in the SwiftASTContext in `lldb` to prevent warnings and ensure proper handling (i.e. the same handling as `BuiltinDefaultActorStorage` enjoys).

Thanks @kavon for the ping