### PR TITLE
[lldb] Refactor IsTaggedPointer to use demangler

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -17,6 +17,7 @@
 
 #include "Plugins/ExpressionParser/Clang/ClangUtil.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
@@ -3124,38 +3125,29 @@ TypeAndOrName SwiftLanguageRuntimeImpl::FixUpDynamicType(
 bool SwiftLanguageRuntimeImpl::IsTaggedPointer(lldb::addr_t addr,
                                                CompilerType type) {
   Demangler dem;
-  auto *node = dem.demangleSymbol(type.GetMangledTypeName().GetStringRef());
-  Node::Kind kind_path[] = {Node::Kind::Global, Node::Kind::TypeMangling,
-                            Node::Kind::Type};
-  for (auto kind : kind_path) {
-    if (node && node->getKind() == kind && node->hasChildren()) {
-      node = node->getFirstChild();
-      continue;
-    }
+  auto *root = dem.demangleSymbol(type.GetMangledTypeName().GetStringRef());
+  using Kind = Node::Kind;
+  auto *unowned_node = swift_demangle::nodeAtPath(
+      root, {Kind::TypeMangling, Kind::Type, Kind::Unowned});
+  if (!unowned_node)
     return false;
-  }
-  switch (node->getKind()) {
-  case Node::Kind::Unowned: {
-    Target &target = m_process.GetTarget();
-    llvm::Triple triple = target.GetArchitecture().GetTriple();
-    // On Darwin the Swift runtime stores unowned references to
-    // Objective-C objects as a pointer to a struct that has the
-    // actual object pointer at offset zero. The least significant bit
-    // of the reference pointer indicates whether the reference refers
-    // to an Objective-C or Swift object.
-    //
-    // This is a property of the Swift runtime(!). In the future it
-    // may be necessary to check for the version of the Swift runtime
-    // (or indirectly by looking at the version of the remote
-    // operating system) to determine how to interpret references.
-    if (triple.isOSDarwin())
-      // Check whether this is a reference to an Objective-C object.
-      if ((addr & 1) == 1)
-        return true;
-  } break;
-  default:
-    break;
-  }
+
+  Target &target = m_process.GetTarget();
+  llvm::Triple triple = target.GetArchitecture().GetTriple();
+  // On Darwin the Swift runtime stores unowned references to
+  // Objective-C objects as a pointer to a struct that has the
+  // actual object pointer at offset zero. The least significant bit
+  // of the reference pointer indicates whether the reference refers
+  // to an Objective-C or Swift object.
+  //
+  // This is a property of the Swift runtime(!). In the future it
+  // may be necessary to check for the version of the Swift runtime
+  // (or indirectly by looking at the version of the remote
+  // operating system) to determine how to interpret references.
+  if (triple.isOSDarwin())
+    // Check whether this is a reference to an Objective-C object.
+    if ((addr & 1) == 1)
+      return true;
   return false;
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3128,7 +3128,7 @@ bool SwiftLanguageRuntimeImpl::IsTaggedPointer(lldb::addr_t addr,
   Node::Kind kind_path[] = {Node::Kind::Global, Node::Kind::TypeMangling,
                             Node::Kind::Type};
   for (auto kind : kind_path) {
-    if (node->getKind() == kind && node->hasChildren()) {
+    if (node && node->getKind() == kind && node->hasChildren()) {
       node = node->getFirstChild();
       continue;
     }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -1,0 +1,53 @@
+//===-- SwiftDemangle.h ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_SwiftDemangle_h_
+#define liblldb_SwiftDemangle_h_
+
+#include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/Demangler.h"
+#include "llvm/ADT/ArrayRef.h"
+
+namespace lldb_private {
+namespace swift_demangle {
+
+/// Access an inner node by following the given Node::Kind path.
+///
+/// Note: The Node::Kind path is relative to the given root node. The root
+/// node's Node::Kind must not to be included in the path.
+inline swift::Demangle::NodePointer
+nodeAtPath(swift::Demangle::NodePointer root,
+           llvm::ArrayRef<swift::Demangle::Node::Kind> kind_path) {
+  if (!root)
+    return nullptr;
+
+  auto *node = root;
+  for (auto kind : kind_path) {
+    for (auto *child : *node) {
+      assert(child && "swift::Demangle::Node has null child");
+      if (child && child->getKind() == kind) {
+        node = child;
+        break;
+      }
+    }
+    // The current step of the path (ie the current `kind`) was not found in the
+    // children of the current `node`. The requested path does not exist.
+    return nullptr;
+  }
+
+  return node;
+}
+
+} // namespace swift_demangle
+} // namespace lldb_private
+
+#endif

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -31,16 +31,19 @@ nodeAtPath(swift::Demangle::NodePointer root,
 
   auto *node = root;
   for (auto kind : kind_path) {
+    bool found = false;
     for (auto *child : *node) {
       assert(child && "swift::Demangle::Node has null child");
       if (child && child->getKind() == kind) {
         node = child;
+        found = true;
         break;
       }
     }
-    // The current step of the path (ie the current `kind`) was not found in the
-    // children of the current `node`. The requested path does not exist.
-    return nullptr;
+    // The current step (`kind`) of the path was not found in the children of
+    // the current `node`. The requested path does not exist.
+    if (!found)
+      return nullptr;
   }
 
   return node;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -14,7 +14,6 @@
 #define liblldb_SwiftDemangle_h_
 
 #include "swift/Demangling/Demangle.h"
-#include "swift/Demangling/Demangler.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace lldb_private {
@@ -23,7 +22,7 @@ namespace swift_demangle {
 /// Access an inner node by following the given Node::Kind path.
 ///
 /// Note: The Node::Kind path is relative to the given root node. The root
-/// node's Node::Kind must not to be included in the path.
+/// node's Node::Kind must not be included in the path.
 inline swift::Demangle::NodePointer
 nodeAtPath(swift::Demangle::NodePointer root,
            llvm::ArrayRef<swift::Demangle::Node::Kind> kind_path) {


### PR DESCRIPTION
Use the demangled node tree inside `IsTaggedPointer` to avoid loading the Swift ASTContext for the type.

A demangled tree for an unowned reference is structured like so:

```
kind=Global
  kind=TypeMangling
    kind=Type
      kind=Unowned
        kind=Type
          kind=Class
            kind=Module, text="SomeModule"
            kind=Identifier, text="TheClass"
```

rdar://107961993