### PR TITLE
Temporarily disable clangd/test/input-mirror.test

### DIFF
--- a/clang-tools-extra/clangd/test/input-mirror.test
+++ b/clang-tools-extra/clangd/test/input-mirror.test
@@ -1,3 +1,5 @@
+# REQUIRES: rdar107853608
+
 # RUN: clangd -pretty -sync -input-mirror-file %t < %s
 # Note that we have to use '-b' as -input-mirror-file does not have a newline at the end of file.
 # RUN: diff -b %t %s


### PR DESCRIPTION
Re-enable the test when the bug in diff is fixed.

rdar://107853608