### PR TITLE
Fix ld$hide symbols to only be generated for appropriate targets.

### DIFF
--- a/libunwind/src/Unwind_AppleExtras.cpp
+++ b/libunwind/src/Unwind_AppleExtras.cpp
@@ -9,9 +9,10 @@
 
 #include "config.h"
 
+#include <TargetConditionals.h>
 
 // static linker symbols to prevent wrong two level namespace for _Unwind symbols
-#if defined(__arm__)
+#if TARGET_OS_IOS && defined(__arm__)
    #define NOT_HERE_BEFORE_5_0(sym)     \
        extern const char sym##_tmp30 __asm("$ld$hide$os3.0$_" #sym ); \
        __attribute__((visibility("default"))) const char sym##_tmp30 = 0; \
@@ -27,10 +28,7 @@
           __attribute__((visibility("default"))) const char sym##_tmp42 = 0; \
        extern const char sym##_tmp43 __asm("$ld$hide$os4.3$_" #sym ); \
           __attribute__((visibility("default"))) const char sym##_tmp43 = 0;
-#elif defined(__aarch64__)
-  #define NOT_HERE_BEFORE_10_6(sym)
-  #define NEVER_HERE(sym)
-#else
+#elif TARGET_OS_OSX && !defined(__aarch64__)
   #define NOT_HERE_BEFORE_10_6(sym) \
     extern const char sym##_tmp4 __asm("$ld$hide$os10.4$_" #sym ); \
           __attribute__((visibility("default"))) const char sym##_tmp4 = 0; \
@@ -43,6 +41,9 @@
           __attribute__((visibility("default"))) const char sym##_tmp5 = 0; \
     extern const char sym##_tmp6 __asm("$ld$hide$os10.6$_" #sym ); \
           __attribute__((visibility("default"))) const char sym##_tmp6 = 0;
+#else
+  #define NOT_HERE_BEFORE_10_6(sym)
+  #define NEVER_HERE(sym)
 #endif
 
 


### PR DESCRIPTION
For some reason `TargetConditionals.h` was removed here, but the `$ld$hide$` symbols in `Unwind_AppleExtras.cpp` are target specific.

rdar://107911382