### PR TITLE
[lldb][CPlusPlus] Implement CPlusPlusLanguage::GetFunctionDisplayName

### DIFF
--- a/lldb/include/lldb/Core/FormatEntity.h
+++ b/lldb/include/lldb/Core/FormatEntity.h
@@ -241,6 +241,17 @@ public:
                              llvm::StringRef elements,
                              llvm::StringRef element_format);
 
+  /// For each variable in 'args' this function writes the variable
+  /// name and it's pretty-printed value representation to 'out_stream'
+  /// in following format:
+  ///
+  /// \verbatim
+  /// name_1=repr_1, name_2=repr_2 ...
+  /// \endverbatim
+  static void PrettyPrintFunctionArguments(Stream &out_stream,
+                                           VariableList const &args,
+                                           ExecutionContextScope *exe_scope);
+
 protected:
   static Status ParseInternal(llvm::StringRef &format, Entry &parent_entry,
                               uint32_t depth);

--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1039,6 +1039,71 @@ static inline bool IsToken(const char *var_name_begin, const char *var) {
   return (::strncmp(var_name_begin, var, strlen(var)) == 0);
 }
 
+/// Parses the basename out of a demangled function name
+/// that may include function arguments. Supports
+/// template functions.
+///
+/// Returns pointers to the opening and closing parenthesis of
+/// `full_name`. Can return nullptr for either parenthesis if
+/// none is exists.
+static std::pair<char const *, char const *>
+ParseBaseName(char const *full_name) {
+  const char *open_paren = strchr(full_name, '(');
+  const char *close_paren = nullptr;
+  const char *generic = strchr(full_name, '<');
+  // if before the arguments list begins there is a template sign
+  // then scan to the end of the generic args before you try to find
+  // the arguments list
+  if (generic && open_paren && generic < open_paren) {
+    int generic_depth = 1;
+    ++generic;
+    for (; *generic && generic_depth > 0; generic++) {
+      if (*generic == '<')
+        generic_depth++;
+      if (*generic == '>')
+        generic_depth--;
+    }
+    if (*generic)
+      open_paren = strchr(generic, '(');
+    else
+      open_paren = nullptr;
+  }
+
+  if (open_paren) {
+    if (IsToken(open_paren, "(anonymous namespace)")) {
+      open_paren = strchr(open_paren + strlen("(anonymous namespace)"), '(');
+      if (open_paren)
+        close_paren = strchr(open_paren, ')');
+    } else
+      close_paren = strchr(open_paren, ')');
+  }
+
+  return {open_paren, close_paren};
+}
+
+/// Writes out the function name in 'full_name' to 'out_stream'
+/// but replaces each argument type with the variable name
+/// and the corresponding pretty-printed value
+static void PrettyPrintFunctionNameWithArgs(Stream &out_stream,
+                                            char const *full_name,
+                                            ExecutionContextScope *exe_scope,
+                                            VariableList const &args) {
+  auto [open_paren, close_paren] = ParseBaseName(full_name);
+  if (open_paren)
+    out_stream.Write(full_name, open_paren - full_name + 1);
+  else {
+    out_stream.PutCString(full_name);
+    out_stream.PutChar('(');
+  }
+
+  FormatEntity::PrettyPrintFunctionArguments(out_stream, args, exe_scope);
+
+  if (close_paren)
+    out_stream.PutCString(close_paren);
+  else
+    out_stream.PutChar(')');
+}
+
 bool FormatEntity::FormatStringRef(const llvm::StringRef &format_str, Stream &s,
                                    const SymbolContext *sc,
                                    const ExecutionContext *exe_ctx,
@@ -1656,100 +1721,7 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
             variable_list_sp->AppendVariablesWithScope(
                 eValueTypeVariableArgument, args);
           if (args.GetSize() > 0) {
-            const char *open_paren = strchr(cstr, '(');
-            const char *close_paren = nullptr;
-            const char *generic = strchr(cstr, '<');
-            // if before the arguments list begins there is a template sign
-            // then scan to the end of the generic args before you try to find
-            // the arguments list
-            if (generic && open_paren && generic < open_paren) {
-              int generic_depth = 1;
-              ++generic;
-              for (; *generic && generic_depth > 0; generic++) {
-                if (*generic == '<')
-                  generic_depth++;
-                if (*generic == '>')
-                  generic_depth--;
-              }
-              if (*generic)
-                open_paren = strchr(generic, '(');
-              else
-                open_paren = nullptr;
-            }
-            if (open_paren) {
-              if (IsToken(open_paren, "(anonymous namespace)")) {
-                open_paren =
-                    strchr(open_paren + strlen("(anonymous namespace)"), '(');
-                if (open_paren)
-                  close_paren = strchr(open_paren, ')');
-              } else
-                close_paren = strchr(open_paren, ')');
-            }
-
-            if (open_paren)
-              s.Write(cstr, open_paren - cstr + 1);
-            else {
-              s.PutCString(cstr);
-              s.PutChar('(');
-            }
-            const size_t num_args = args.GetSize();
-            for (size_t arg_idx = 0; arg_idx < num_args; ++arg_idx) {
-              std::string buffer;
-
-              VariableSP var_sp(args.GetVariableAtIndex(arg_idx));
-              ValueObjectSP var_value_sp(
-                  ValueObjectVariable::Create(exe_scope, var_sp));
-              StreamString ss;
-              llvm::StringRef var_representation;
-              const char *var_name = var_value_sp->GetName().GetCString();
-              if (var_value_sp->GetCompilerType().IsValid()) {
-                if (exe_scope && exe_scope->CalculateTarget())
-                  var_value_sp =
-                      var_value_sp->GetQualifiedRepresentationIfAvailable(
-                          exe_scope->CalculateTarget()
-                              ->TargetProperties::GetPreferDynamicValue(),
-                          exe_scope->CalculateTarget()
-                              ->TargetProperties::GetEnableSyntheticValue());
-                if (var_value_sp->GetCompilerType().IsAggregateType() &&
-                    DataVisualization::ShouldPrintAsOneLiner(*var_value_sp)) {
-                  static StringSummaryFormat format(
-                      TypeSummaryImpl::Flags()
-                          .SetHideItemNames(false)
-                          .SetShowMembersOneLiner(true),
-                      "");
-                  format.FormatObject(var_value_sp.get(), buffer,
-                                      TypeSummaryOptions());
-                  var_representation = buffer;
-                } else
-                  var_value_sp->DumpPrintableRepresentation(
-                      ss,
-                      ValueObject::ValueObjectRepresentationStyle::
-                          eValueObjectRepresentationStyleSummary,
-                      eFormatDefault,
-                      ValueObject::PrintableRepresentationSpecialCases::eAllow,
-                      false);
-              }
-
-              if (!ss.GetString().empty())
-                var_representation = ss.GetString();
-              if (arg_idx > 0)
-                s.PutCString(", ");
-              if (var_value_sp->GetError().Success()) {
-                if (!var_representation.empty())
-                  s.Printf("%s=%s", var_name, var_representation.str().c_str());
-                else
-                  s.Printf("%s=%s at %s", var_name,
-                           var_value_sp->GetTypeName().GetCString(),
-                           var_value_sp->GetLocationAsCString());
-              } else
-                s.Printf("%s=<unavailable>", var_name);
-            }
-
-            if (close_paren)
-              s.PutCString(close_paren);
-            else
-              s.PutChar(')');
-
+            PrettyPrintFunctionNameWithArgs(s, cstr, exe_scope, args);
           } else {
             s.PutCString(cstr);
           }
@@ -2456,5 +2428,57 @@ void FormatEntity::AutoComplete(CompletionRequest &request) {
     StringList new_matches;
     AddMatches(entry_def, str, remainder, new_matches);
     request.AddCompletions(new_matches);
+  }
+}
+
+void FormatEntity::PrettyPrintFunctionArguments(
+    Stream &out_stream, VariableList const &args,
+    ExecutionContextScope *exe_scope) {
+  const size_t num_args = args.GetSize();
+  for (size_t arg_idx = 0; arg_idx < num_args; ++arg_idx) {
+    std::string buffer;
+
+    VariableSP var_sp(args.GetVariableAtIndex(arg_idx));
+    ValueObjectSP var_value_sp(ValueObjectVariable::Create(exe_scope, var_sp));
+    StreamString ss;
+    llvm::StringRef var_representation;
+    const char *var_name = var_value_sp->GetName().GetCString();
+    if (var_value_sp->GetCompilerType().IsValid()) {
+      if (exe_scope && exe_scope->CalculateTarget())
+        var_value_sp = var_value_sp->GetQualifiedRepresentationIfAvailable(
+            exe_scope->CalculateTarget()
+                ->TargetProperties::GetPreferDynamicValue(),
+            exe_scope->CalculateTarget()
+                ->TargetProperties::GetEnableSyntheticValue());
+      if (var_value_sp->GetCompilerType().IsAggregateType() &&
+          DataVisualization::ShouldPrintAsOneLiner(*var_value_sp)) {
+        static StringSummaryFormat format(TypeSummaryImpl::Flags()
+                                              .SetHideItemNames(false)
+                                              .SetShowMembersOneLiner(true),
+                                          "");
+        format.FormatObject(var_value_sp.get(), buffer, TypeSummaryOptions());
+        var_representation = buffer;
+      } else
+        var_value_sp->DumpPrintableRepresentation(
+            ss,
+            ValueObject::ValueObjectRepresentationStyle::
+                eValueObjectRepresentationStyleSummary,
+            eFormatDefault,
+            ValueObject::PrintableRepresentationSpecialCases::eAllow, false);
+    }
+
+    if (!ss.GetString().empty())
+      var_representation = ss.GetString();
+    if (arg_idx > 0)
+      out_stream.PutCString(", ");
+    if (var_value_sp->GetError().Success()) {
+      if (!var_representation.empty())
+        out_stream.Printf("%s=%s", var_name, var_representation.str().c_str());
+      else
+        out_stream.Printf("%s=%s at %s", var_name,
+                          var_value_sp->GetTypeName().GetCString(),
+                          var_value_sp->GetLocationAsCString());
+    } else
+      out_stream.Printf("%s=<unavailable>", var_name);
   }
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -23,11 +23,13 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/UniqueCStringMap.h"
+#include "lldb/Core/ValueObjectVariable.h"
 #include "lldb/DataFormatters/CXXFunctionPointer.h"
 #include "lldb/DataFormatters/DataVisualization.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/VectorType.h"
 #include "lldb/Symbol/SymbolFile.h"
+#include "lldb/Symbol/VariableList.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -169,6 +171,40 @@ static bool IsTrivialBasename(const llvm::StringRef &basename) {
 
   // We processed all characters. It is a vaild basename.
   return idx == basename.size();
+}
+
+/// Writes out the function name in 'full_name' to 'out_stream'
+/// but replaces each argument type with the variable name
+/// and the corresponding pretty-printed value
+static bool PrettyPrintFunctionNameWithArgs(Stream &out_stream,
+                                            char const *full_name,
+                                            ExecutionContextScope *exe_scope,
+                                            VariableList const &args) {
+  CPlusPlusLanguage::MethodName cpp_method{ConstString(full_name)};
+
+  if (!cpp_method.IsValid())
+    return false;
+
+  llvm::StringRef return_type = cpp_method.GetReturnType();
+  if (!return_type.empty()) {
+    out_stream.PutCString(return_type);
+    out_stream.PutChar(' ');
+  }
+
+  out_stream.PutCString(cpp_method.GetScopeQualifiedName());
+  out_stream.PutChar('(');
+
+  FormatEntity::PrettyPrintFunctionArguments(out_stream, args, exe_scope);
+
+  out_stream.PutChar(')');
+
+  llvm::StringRef qualifiers = cpp_method.GetQualifiers();
+  if (!qualifiers.empty()) {
+    out_stream.PutChar(' ');
+    out_stream.PutCString(qualifiers);
+  }
+
+  return true;
 }
 
 bool CPlusPlusLanguage::MethodName::TrySimplifiedParse() {
@@ -1469,4 +1505,67 @@ bool CPlusPlusLanguage::IsSourceFile(llvm::StringRef file_path) const {
   // Check if we're in a STL path (where the files usually have no extension
   // that we could check for.
   return file_path.contains("/usr/include/c++/");
+}
+
+bool CPlusPlusLanguage::GetFunctionDisplayName(
+    const SymbolContext *sc, const ExecutionContext *exe_ctx,
+    FunctionNameRepresentation representation, Stream &s) {
+  switch (representation) {
+  case FunctionNameRepresentation::eNameWithArgs: {
+    // Print the function name with arguments in it
+    if (sc->function) {
+      ExecutionContextScope *exe_scope =
+          exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr;
+      const char *cstr = sc->function->GetName().AsCString(nullptr);
+      if (cstr) {
+        const InlineFunctionInfo *inline_info = nullptr;
+        VariableListSP variable_list_sp;
+        bool get_function_vars = true;
+        if (sc->block) {
+          Block *inline_block = sc->block->GetContainingInlinedBlock();
+
+          if (inline_block) {
+            get_function_vars = false;
+            inline_info = sc->block->GetInlinedFunctionInfo();
+            if (inline_info)
+              variable_list_sp = inline_block->GetBlockVariableList(true);
+          }
+        }
+
+        if (get_function_vars) {
+          variable_list_sp =
+              sc->function->GetBlock(true).GetBlockVariableList(true);
+        }
+
+        if (inline_info) {
+          s.PutCString(cstr);
+          s.PutCString(" [inlined] ");
+          cstr = inline_info->GetName().GetCString();
+        }
+
+        VariableList args;
+        if (variable_list_sp)
+          variable_list_sp->AppendVariablesWithScope(eValueTypeVariableArgument,
+                                                     args);
+        if (args.GetSize() > 0) {
+          if (!PrettyPrintFunctionNameWithArgs(s, cstr, exe_scope, args))
+            return false;
+        } else {
+          s.PutCString(cstr);
+        }
+        return true;
+      }
+    } else if (sc->symbol) {
+      const char *cstr = sc->symbol->GetName().AsCString(nullptr);
+      if (cstr) {
+        s.PutCString(cstr);
+        return true;
+      }
+    }
+  } break;
+  default:
+    return false;
+  }
+
+  return false;
 }

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -109,6 +109,7 @@ void CPlusPlusLanguage::MethodName::Clear() {
   m_context = llvm::StringRef();
   m_arguments = llvm::StringRef();
   m_qualifiers = llvm::StringRef();
+  m_return_type = llvm::StringRef();
   m_parsed = false;
   m_parse_error = false;
 }
@@ -206,6 +207,7 @@ bool CPlusPlusLanguage::MethodName::TrySimplifiedParse() {
       m_basename = llvm::StringRef();
       m_arguments = llvm::StringRef();
       m_qualifiers = llvm::StringRef();
+      m_return_type = llvm::StringRef();
       return false;
     }
   }
@@ -223,6 +225,7 @@ void CPlusPlusLanguage::MethodName::Parse() {
         m_context = function.value().name.context;
         m_arguments = function.value().arguments;
         m_qualifiers = function.value().qualifiers;
+        m_return_type = function.value().return_type;
         m_parse_error = false;
       } else {
         m_parse_error = true;
@@ -254,6 +257,12 @@ llvm::StringRef CPlusPlusLanguage::MethodName::GetQualifiers() {
   if (!m_parsed)
     Parse();
   return m_qualifiers;
+}
+
+llvm::StringRef CPlusPlusLanguage::MethodName::GetReturnType() {
+  if (!m_parsed)
+    Parse();
+  return m_return_type;
 }
 
 std::string CPlusPlusLanguage::MethodName::GetScopeQualifiedName() {

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -55,7 +55,13 @@ public:
     llvm::StringRef GetArguments();
 
     llvm::StringRef GetQualifiers();
-    
+
+    /// Returns the methods return-type.
+    ///
+    /// Currently returns an empty llvm::StringRef
+    /// if the return-type is a function pointer.
+    llvm::StringRef GetReturnType();
+
     bool ContainsPath(llvm::StringRef path);
 
   private:
@@ -78,12 +84,13 @@ public:
     bool TrySimplifiedParse();
 
     ConstString m_full; // Full name:
-                        // "lldb::SBTarget::GetBreakpointAtIndex(unsigned int)
-                        // const"
-    llvm::StringRef m_basename;   // Basename:     "GetBreakpointAtIndex"
-    llvm::StringRef m_context;    // Decl context: "lldb::SBTarget"
-    llvm::StringRef m_arguments;  // Arguments:    "(unsigned int)"
-    llvm::StringRef m_qualifiers; // Qualifiers:   "const"
+                        // "size_t lldb::SBTarget::GetBreakpointAtIndex(unsigned
+                        // int) const"
+    llvm::StringRef m_basename;    // Basename:     "GetBreakpointAtIndex"
+    llvm::StringRef m_context;     // Decl context: "lldb::SBTarget"
+    llvm::StringRef m_arguments;   // Arguments:    "(unsigned int)"
+    llvm::StringRef m_qualifiers;  // Qualifiers:   "const"
+    llvm::StringRef m_return_type; // Return type:  "size_t"
     bool m_parsed = false;
     bool m_parse_error = false;
   };

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.h
@@ -136,6 +136,11 @@ public:
   ConstString
   GetDemangledFunctionNameWithoutArguments(Mangled mangled) const override;
 
+  bool GetFunctionDisplayName(const SymbolContext *sc,
+                              const ExecutionContext *exe_ctx,
+                              FunctionNameRepresentation representation,
+                              Stream &s) override;
+
   static bool IsCPPMangledName(llvm::StringRef name);
 
   // Extract C++ context and identifier from a string using heuristic matching

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusNameParser.h
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusNameParser.h
@@ -33,6 +33,7 @@ public:
     ParsedName name;
     llvm::StringRef arguments;
     llvm::StringRef qualifiers;
+    llvm::StringRef return_type;
   };
 
   // Treats given text as a function definition and parses it.

--- a/lldb/test/Shell/Settings/Inputs/names.cpp
+++ b/lldb/test/Shell/Settings/Inputs/names.cpp
@@ -1,0 +1,43 @@
+#include <functional>
+
+namespace detail {
+template <typename T> struct Quux {};
+} // namespace detail
+
+using FuncPtr = detail::Quux<double> (*(*)(int))(float);
+
+struct Foo {
+  template <typename T> void foo(T const &t) const noexcept(true) {}
+
+  template <size_t T> void operator<<(size_t) {}
+
+  template <typename T> FuncPtr returns_func_ptr(detail::Quux<int> &&) const noexcept(false) { return nullptr; }
+};
+
+namespace ns {
+template <typename T> int foo(T const &t) noexcept(false) { return 0; }
+
+template <typename T> FuncPtr returns_func_ptr(detail::Quux<int> &&) { return nullptr; }
+} // namespace ns
+
+int bar() { return 1; }
+
+namespace {
+int anon_bar() { return 1; }
+auto anon_lambda = [](std::function<int(int (*)(int))>) mutable {};
+} // namespace
+
+int main() {
+  ns::foo(bar);
+  ns::foo(std::function{bar});
+  ns::foo(anon_lambda);
+  ns::foo(std::function{anon_bar});
+  ns::foo(&Foo::foo<std::function<int(int)>>);
+  ns::returns_func_ptr<int>(detail::Quux<int>{});
+  Foo f;
+  f.foo(std::function{bar});
+  f.foo(std::function{anon_bar});
+  f.operator<< <(2 > 1)>(0);
+  f.returns_func_ptr<int>(detail::Quux<int>{});
+  return 0;
+}

--- a/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
@@ -1,0 +1,27 @@
+# RUN: %clangxx_host -g -O0 %S/Inputs/names.cpp -std=c++17 -o %t.out
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+settings set -f frame-format "frame ${function.name-with-args}\n"
+break set -n foo
+break set -n operator<<
+break set -n returns_func_ptr
+run
+# CHECK: frame int ns::foo<int ()>(t={{.*}})
+c
+# CHECK: frame int ns::foo<std::__1::function<int ()>>(t= Function = bar() )
+c
+# CHECK: frame int ns::foo<(anonymous namespace)::$_0>(t={{.*}})
+c
+# CHECK: frame int ns::foo<std::__1::function<int ()>>(t= Function = (anonymous namespace)::anon_bar() )
+c
+# CHECK: frame int ns::foo<void (Foo::*)(std::__1::function<int (int)> const&) const noexcept>(t={{.*}})
+c
+# CHECK: frame ns::returns_func_ptr<int>((null)={{.*}})
+c
+# CHECK: frame void Foo::foo<std::__1::function<int ()>>(this={{.*}}, t= Function = bar() ) const
+c
+# CHECK: frame void Foo::foo<std::__1::function<int ()>>(this={{.*}}, t= Function = (anonymous namespace)::anon_bar() ) const
+c
+# CHECK: frame void Foo::operator<<<1ul>(this={{.*}}, (null)=0)
+c
+# CHECK: frame Foo::returns_func_ptr<int>(this={{.*}}, (null)={{.*}})
+q

--- a/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
+++ b/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
@@ -17,117 +17,136 @@ using namespace lldb_private;
 TEST(CPlusPlusLanguage, MethodNameParsing) {
   struct TestCase {
     std::string input;
-    std::string context, basename, arguments, qualifiers, scope_qualified_name;
+    std::string return_type, context, basename, arguments, qualifiers,
+        scope_qualified_name;
   };
 
   TestCase test_cases[] = {
-      {"main(int, char *[]) ", "", "main", "(int, char *[])", "", "main"},
-      {"foo::bar(baz) const", "foo", "bar", "(baz)", "const", "foo::bar"},
-      {"foo::~bar(baz)", "foo", "~bar", "(baz)", "", "foo::~bar"},
-      {"a::b::c::d(e,f)", "a::b::c", "d", "(e,f)", "", "a::b::c::d"},
-      {"void f(int)", "", "f", "(int)", "", "f"},
+      {"main(int, char *[]) ", "", "", "main", "(int, char *[])", "", "main"},
+      {"foo::bar(baz) const", "", "foo", "bar", "(baz)", "const", "foo::bar"},
+      {"foo::~bar(baz)", "", "foo", "~bar", "(baz)", "", "foo::~bar"},
+      {"a::b::c::d(e,f)", "", "a::b::c", "d", "(e,f)", "", "a::b::c::d"},
+      {"void f(int)", "void", "", "f", "(int)", "", "f"},
 
       // Operators
       {"std::basic_ostream<char, std::char_traits<char> >& "
-       "std::operator<<<std::char_traits<char> >"
-       "(std::basic_ostream<char, std::char_traits<char> >&, char const*)",
-       "std", "operator<<<std::char_traits<char> >",
+       "std::operator<<<std::char_traits<char> >(std::basic_ostream<char, "
+       "std::char_traits<char> >&, char const*)",
+       "std::basic_ostream<char, std::char_traits<char> >&", "std",
+       "operator<<<std::char_traits<char> >",
        "(std::basic_ostream<char, std::char_traits<char> >&, char const*)", "",
        "std::operator<<<std::char_traits<char> >"},
       {"operator delete[](void*, clang::ASTContext const&, unsigned long)", "",
-       "operator delete[]", "(void*, clang::ASTContext const&, unsigned long)",
-       "", "operator delete[]"},
-      {"llvm::Optional<clang::PostInitializer>::operator bool() const",
+       "", "operator delete[]",
+       "(void*, clang::ASTContext const&, unsigned long)", "",
+       "operator delete[]"},
+      {"llvm::Optional<clang::PostInitializer>::operator bool() const", "",
        "llvm::Optional<clang::PostInitializer>", "operator bool", "()", "const",
        "llvm::Optional<clang::PostInitializer>::operator bool"},
-      {"(anonymous namespace)::FactManager::operator[](unsigned short)",
+      {"(anonymous namespace)::FactManager::operator[](unsigned short)", "",
        "(anonymous namespace)::FactManager", "operator[]", "(unsigned short)",
        "", "(anonymous namespace)::FactManager::operator[]"},
       {"const int& std::map<int, pair<short, int>>::operator[](short) const",
-       "std::map<int, pair<short, int>>", "operator[]", "(short)", "const",
-       "std::map<int, pair<short, int>>::operator[]"},
-      {"CompareInsn::operator()(llvm::StringRef, InsnMatchEntry const&)",
+       "const int&", "std::map<int, pair<short, int>>", "operator[]", "(short)",
+       "const", "std::map<int, pair<short, int>>::operator[]"},
+      {"CompareInsn::operator()(llvm::StringRef, InsnMatchEntry const&)", "",
        "CompareInsn", "operator()", "(llvm::StringRef, InsnMatchEntry const&)",
        "", "CompareInsn::operator()"},
-      {"llvm::Optional<llvm::MCFixupKind>::operator*() const &",
+      {"llvm::Optional<llvm::MCFixupKind>::operator*() const &", "",
        "llvm::Optional<llvm::MCFixupKind>", "operator*", "()", "const &",
        "llvm::Optional<llvm::MCFixupKind>::operator*"},
+      {"auto std::__1::ranges::__begin::__fn::operator()[abi:v160000]<char "
+       "const, 18ul>(char const (&) [18ul]) const",
+       "auto", "std::__1::ranges::__begin::__fn",
+       "operator()[abi:v160000]<char const, 18ul>", "(char const (&) [18ul])",
+       "const",
+       "std::__1::ranges::__begin::__fn::operator()[abi:v160000]<char const, "
+       "18ul>"},
       // Internal classes
-      {"operator<<(Cls, Cls)::Subclass::function()",
+      {"operator<<(Cls, Cls)::Subclass::function()", "",
        "operator<<(Cls, Cls)::Subclass", "function", "()", "",
        "operator<<(Cls, Cls)::Subclass::function"},
-      {"SAEC::checkFunction(context&) const::CallBack::CallBack(int)",
+      {"SAEC::checkFunction(context&) const::CallBack::CallBack(int)", "",
        "SAEC::checkFunction(context&) const::CallBack", "CallBack", "(int)", "",
        "SAEC::checkFunction(context&) const::CallBack::CallBack"},
       // Anonymous namespace
-      {"XX::(anonymous namespace)::anon_class::anon_func() const",
+      {"XX::(anonymous namespace)::anon_class::anon_func() const", "",
        "XX::(anonymous namespace)::anon_class", "anon_func", "()", "const",
        "XX::(anonymous namespace)::anon_class::anon_func"},
 
       // Lambda
       {"main::{lambda()#1}::operator()() const::{lambda()#1}::operator()() "
        "const",
-       "main::{lambda()#1}::operator()() const::{lambda()#1}", "operator()",
+       "", "main::{lambda()#1}::operator()() const::{lambda()#1}", "operator()",
        "()", "const",
        "main::{lambda()#1}::operator()() const::{lambda()#1}::operator()"},
 
       // Function pointers
-      {"string (*f(vector<int>&&))(float)", "", "f", "(vector<int>&&)", "",
-       "f"},
-      {"void (*&std::_Any_data::_M_access<void (*)()>())()", "std::_Any_data",
-       "_M_access<void (*)()>", "()", "",
+      {"string (*f(vector<int>&&))(float)", "", "", "f",
+       "(vector<int>&&)", "", "f"},
+      {"void (*&std::_Any_data::_M_access<void (*)()>())()", "",
+       "std::_Any_data", "_M_access<void (*)()>", "()", "",
        "std::_Any_data::_M_access<void (*)()>"},
       {"void (*(*(*(*(*(*(*(* const&func1(int))())())())())())())())()", "",
-       "func1", "(int)", "", "func1"},
+       "", "func1", "(int)", "", "func1"},
 
       // Decltype
       {"decltype(nullptr)&& std::forward<decltype(nullptr)>"
        "(std::remove_reference<decltype(nullptr)>::type&)",
-       "std", "forward<decltype(nullptr)>",
+       "decltype(nullptr)&&", "std", "forward<decltype(nullptr)>",
        "(std::remove_reference<decltype(nullptr)>::type&)", "",
        "std::forward<decltype(nullptr)>"},
 
       // Templates
       {"void llvm::PM<llvm::Module, llvm::AM<llvm::Module>>::"
        "addPass<llvm::VP>(llvm::VP)",
-       "llvm::PM<llvm::Module, llvm::AM<llvm::Module>>", "addPass<llvm::VP>",
-       "(llvm::VP)", "",
+       "void", "llvm::PM<llvm::Module, llvm::AM<llvm::Module>>",
+       "addPass<llvm::VP>", "(llvm::VP)", "",
        "llvm::PM<llvm::Module, llvm::AM<llvm::Module>>::"
        "addPass<llvm::VP>"},
       {"void std::vector<Class, std::allocator<Class> >"
        "::_M_emplace_back_aux<Class const&>(Class const&)",
-       "std::vector<Class, std::allocator<Class> >",
+       "void", "std::vector<Class, std::allocator<Class> >",
        "_M_emplace_back_aux<Class const&>", "(Class const&)", "",
        "std::vector<Class, std::allocator<Class> >::"
        "_M_emplace_back_aux<Class const&>"},
       {"unsigned long llvm::countTrailingOnes<unsigned int>"
        "(unsigned int, llvm::ZeroBehavior)",
-       "llvm", "countTrailingOnes<unsigned int>",
+       "unsigned long", "llvm", "countTrailingOnes<unsigned int>",
        "(unsigned int, llvm::ZeroBehavior)", "",
        "llvm::countTrailingOnes<unsigned int>"},
       {"std::enable_if<(10u)<(64), bool>::type llvm::isUInt<10u>(unsigned "
        "long)",
-       "llvm", "isUInt<10u>", "(unsigned long)", "", "llvm::isUInt<10u>"},
-      {"f<A<operator<(X,Y)::Subclass>, sizeof(B)<sizeof(C)>()", "",
+       "std::enable_if<(10u)<(64), bool>::type", "llvm", "isUInt<10u>",
+       "(unsigned long)", "", "llvm::isUInt<10u>"},
+      {"f<A<operator<(X,Y)::Subclass>, sizeof(B)<sizeof(C)>()", "", "",
        "f<A<operator<(X,Y)::Subclass>, sizeof(B)<sizeof(C)>", "()", "",
        "f<A<operator<(X,Y)::Subclass>, sizeof(B)<sizeof(C)>"},
-      {"llvm::Optional<llvm::MCFixupKind>::operator*() const volatile &&",
+      {"llvm::Optional<llvm::MCFixupKind>::operator*() const volatile &&", "",
        "llvm::Optional<llvm::MCFixupKind>", "operator*", "()",
        "const volatile &&", "llvm::Optional<llvm::MCFixupKind>::operator*"},
-      {"void foo<Dummy<char [10]>>()", "", "foo<Dummy<char [10]>>", "()", "",
-       "foo<Dummy<char [10]>>"},
+      {"void foo<Dummy<char [10]>>()", "void", "", "foo<Dummy<char [10]>>",
+       "()", "", "foo<Dummy<char [10]>>"},
+      {"void foo<Bar<Bar<int>[10]>>()", "void", "", "foo<Bar<Bar<int>[10]>>",
+       "()", "", "foo<Bar<Bar<int>[10]>>"},
+      {"void foo<Bar[10]>()", "void", "", "foo<Bar[10]>", "()", "",
+       "foo<Bar[10]>"},
+      {"void foo<Bar[]>()", "void", "", "foo<Bar[]>", "()", "", "foo<Bar[]>"},
 
       // auto return type
-      {"auto std::test_return_auto<int>() const", "std",
+      {"auto std::test_return_auto<int>() const", "auto", "std",
        "test_return_auto<int>", "()", "const", "std::test_return_auto<int>"},
-      {"decltype(auto) std::test_return_auto<int>(int) const", "std",
-       "test_return_auto<int>", "(int)", "const", "std::test_return_auto<int>"},
+      {"decltype(auto) std::test_return_auto<int>(int) const", "decltype(auto)",
+       "std", "test_return_auto<int>", "(int)", "const",
+       "std::test_return_auto<int>"},
 
       // abi_tag on class method
       {"v1::v2::Dummy[abi:c1][abi:c2]<v1::v2::Dummy[abi:c1][abi:c2]<int>> "
        "v1::v2::Dummy[abi:c1][abi:c2]<v1::v2::Dummy[abi:c1][abi:c2]<int>>"
        "::method2<v1::v2::Dummy[abi:c1][abi:c2]<v1::v2::Dummy[abi:c1][abi:c2]<"
        "int>>>(int, v1::v2::Dummy<int>) const &&",
+       // Return type
+       "v1::v2::Dummy[abi:c1][abi:c2]<v1::v2::Dummy[abi:c1][abi:c2]<int>>",
        // Context
        "v1::v2::Dummy[abi:c1][abi:c2]<v1::v2::Dummy[abi:c1][abi:c2]<int>>",
        // Basename
@@ -145,6 +164,8 @@ TEST(CPlusPlusLanguage, MethodNameParsing) {
        "v1::v2::with_tag_in_ns[abi:f1][abi:f2]<v1::v2::Dummy[abi:c1][abi:c2]"
        "<v1::v2::Dummy[abi:c1][abi:c2]<int>>>(int, v1::v2::Dummy<int>) const "
        "&&",
+       // Return type
+       "v1::v2::Dummy[abi:c1][abi:c2]<v1::v2::Dummy[abi:c1][abi:c2]<int>>",
        // Context
        "v1::v2",
        // Basename
@@ -160,6 +181,8 @@ TEST(CPlusPlusLanguage, MethodNameParsing) {
       {"auto ns::with_tag_in_ns[abi:special tag,0.0][abi:special "
        "tag,1.0]<Dummy<int>>"
        "(float) const &&",
+       // Return type
+       "auto",
        // Context
        "ns",
        // Basename
@@ -171,15 +194,15 @@ TEST(CPlusPlusLanguage, MethodNameParsing) {
        "tag,1.0]<Dummy<int>>"},
 
       // abi_tag on operator overloads
-      {"std::__1::error_code::operator bool[abi:v160000]() const",
+      {"std::__1::error_code::operator bool[abi:v160000]() const", "",
        "std::__1::error_code", "operator bool[abi:v160000]", "()", "const",
        "std::__1::error_code::operator bool[abi:v160000]"},
 
-      {"auto ns::foo::operator[][abi:v160000](size_t) const", "ns::foo",
+      {"auto ns::foo::operator[][abi:v160000](size_t) const", "auto", "ns::foo",
        "operator[][abi:v160000]", "(size_t)", "const",
        "ns::foo::operator[][abi:v160000]"},
 
-      {"auto Foo[abi:abc]<int>::operator<<<Foo[abi:abc]<int>>(int) &",
+      {"auto Foo[abi:abc]<int>::operator<<<Foo[abi:abc]<int>>(int) &", "auto",
        "Foo[abi:abc]<int>", "operator<<<Foo[abi:abc]<int>>", "(int)", "&",
        "Foo[abi:abc]<int>::operator<<<Foo[abi:abc]<int>>"},
 
@@ -191,6 +214,7 @@ TEST(CPlusPlusLanguage, MethodNameParsing) {
     CPlusPlusLanguage::MethodName method(ConstString(test.input));
     EXPECT_TRUE(method.IsValid()) << test.input;
     if (method.IsValid()) {
+      EXPECT_EQ(test.return_type, method.GetReturnType().str());
       EXPECT_EQ(test.context, method.GetContext().str());
       EXPECT_EQ(test.basename, method.GetBasename().str());
       EXPECT_EQ(test.arguments, method.GetArguments().str());

--- a/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
+++ b/lldb/unittests/Language/CPlusPlus/CPlusPlusLanguageTest.cpp
@@ -206,7 +206,7 @@ TEST(CPlusPlusLanguage, MethodNameParsing) {
        "Foo[abi:abc]<int>", "operator<<<Foo[abi:abc]<int>>", "(int)", "&",
        "Foo[abi:abc]<int>::operator<<<Foo[abi:abc]<int>>"},
 
-      {"auto A::operator<=>[abi:tag]<A::B>()", "A",
+      {"auto A::operator<=>[abi:tag]<A::B>()", "auto", "A",
        "operator<=>[abi:tag]<A::B>", "()", "",
        "A::operator<=>[abi:tag]<A::B>"}};
 


### PR DESCRIPTION
This patch implements the `GetFunctionDisplayName` API which gets
used by the frame-formatting code to decide how to print a
function name.

Currently this API trivially returns `false`, so we try to parse
the demangled function base-name by hand. We try find the closing
parenthesis by doing a forward scan through the demangled name. However,
for arguments that contain parenthesis (e.g., function pointers)
this would leave garbage in the frame function name.

By re-using the `CPlusPlusLanguage` parser for this we offload the
need to parse function names to a component that knows how to do this
already.

We leave the existing parsing code in `FormatEntity` since it's used
in cases where a language-plugin is not available (and is not
necessarily C++ specific).

**Example**

For following function:
```
int foo(std::function<int(void)> const& func) { return 1; }
```

Before patch:
```
frame #0: 0x000000010000151c a.out`foo(func= Function = bar() )> const&) at sample.cpp:11:49
```

After patch:
```
frame #0: 0x000000010000151c a.out`foo(func= Function = bar() ) at sample.cpp:11:49
```

**Testing**

* Added shell test

(cherry picked from commit 971407a8dd325988d0941f59a596005d700ccb2a)