### PR TITLE
LanguageRuntime: ensure that we have a scratch context

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -780,7 +780,7 @@ SwiftLanguageRuntimeImpl::GetMemberVariableOffsetRemoteAST(
     llvm::StringRef member_name) {
   auto scratch_ctx =
       instance_type.GetTypeSystem().dyn_cast_or_null<SwiftASTContext>();
-  if (scratch_ctx->HasFatalErrors())
+  if (scratch_ctx == nullptr || scratch_ctx->HasFatalErrors())
     return {};
 
   auto *remote_ast = &GetRemoteASTContext(*scratch_ctx);


### PR DESCRIPTION
We would previously not ensure that we had an initialised scratch context before we would check if we encountered any fatal errors. Protect against this case, while the experience may be degraded, this prevents the debugger from terminating abnormally.

(cherry picked from commit 2270bcd101b4aa25b173fe4a0ae814f8d244e297)