### PR TITLE
[lldb/python] Fix scripted_platform python module creation

### DIFF
--- a/lldb/bindings/python/CMakeLists.txt
+++ b/lldb/bindings/python/CMakeLists.txt
@@ -104,13 +104,7 @@ function(finish_swig_python swig_target lldb_python_bindings_dir lldb_python_tar
     ${lldb_python_target_dir}
     "plugins"
     FILES
-    "${LLDB_SOURCE_DIR}/examples/python/scripted_process/scripted_process.py")
-
-  create_python_package(
-    ${swig_target}
-    ${lldb_python_target_dir}
-    "plugins"
-    FILES
+    "${LLDB_SOURCE_DIR}/examples/python/scripted_process/scripted_process.py"
     "${LLDB_SOURCE_DIR}/examples/python/scripted_process/scripted_platform.py")
 
   if(APPLE)


### PR DESCRIPTION
This patch should fix the creation and addition of the `scripted_platform` python module into the `lldb.plugins` module.

Previously, we were creating the `plugins` submodule, each time with a different source file (either `scripted_process` or `scripted_platform`).

The removes the redundant `create_python_package` call and group both python source files toghether.

Differential Revision: https://reviews.llvm.org/D143122