### PR TITLE
[lldb] Check GetSwiftValidateTypeSystem where applicable

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3029,6 +3029,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   if (!runtime)
     return impl();
 #ifndef NDEBUG
+  if (!ModuleList::GetGlobalModuleListProperties().GetSwiftValidateTypeSystem())
+    return impl();
   // FIXME:
   // No point comparing the results if the reflection data has more
   // information.  There's a nasty chicken & egg problem buried here:
@@ -3107,6 +3109,9 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
 #ifndef NDEBUG
         // This block is a custom VALIDATE_AND_RETURN implementation to support
         // checking the return value, plus the by-ref `child_indexes`.
+        if (!ModuleList::GetGlobalModuleListProperties()
+                 .GetSwiftValidateTypeSystem())
+          return index_size;
         if (!GetSwiftASTContext())
           return index_size;
         auto swift_scratch_ctx_lock = SwiftScratchContextLock(exe_ctx);
@@ -3526,6 +3531,9 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
 #ifndef NDEBUG
   {
     auto result = impl();
+    if (!ModuleList::GetGlobalModuleListProperties()
+             .GetSwiftValidateTypeSystem())
+      return result;
     if (!GetSwiftASTContext())
       return result;
     std::vector<TupleElement> ast_elements;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3029,18 +3029,17 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   if (!runtime)
     return impl();
 #ifndef NDEBUG
-  if (!ModuleList::GetGlobalModuleListProperties().GetSwiftValidateTypeSystem())
-    return impl();
   // FIXME:
   // No point comparing the results if the reflection data has more
   // information.  There's a nasty chicken & egg problem buried here:
   // Because the API deals out an index into a list of children we
   // can't mix&match between the two typesystems if there is such a
   // divergence. We'll need to replace all calls at once.
-  if (get_ast_num_children() <
-      runtime->GetNumChildren({weak_from_this(), type}, exe_scope)
-          .getValueOr(0))
-    return impl();
+  if (ModuleList::GetGlobalModuleListProperties().GetSwiftValidateTypeSystem())
+    if (get_ast_num_children() <
+        runtime->GetNumChildren({weak_from_this(), type}, exe_scope)
+            .getValueOr(0))
+      return impl();
   if (ShouldSkipValidation(type))
     return impl();
   std::string ast_child_name;


### PR DESCRIPTION
The `VALIDATE_AND_RETURN` macros do a runtime check of `GetSwiftValidateTypeSystem`, to allow validation to be enabled/disabled. However there are some custom validations that don't use the macro. This change checks `GetSwiftValidateTypeSystem` in those custom validations too.