### PR TITLE
PECOFF: consume errors properly

### DIFF
--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -866,10 +866,14 @@ ObjectFilePECOFF::AppendFromExportTable(SectionList *sect_list,
   for (const auto &entry : m_binary->export_directories()) {
     llvm::StringRef sym_name;
     if (auto err = entry.getSymbolName(sym_name)) {
-      LLDB_LOG(log,
-               "ObjectFilePECOFF::AppendFromExportTable - failed to get export "
-               "table entry name: {0}",
-               llvm::fmt_consume(std::move(err)));
+      if (log)
+        log->Format(
+            __FILE__, __func__,
+            "ObjectFilePECOFF::AppendFromExportTable - failed to get export "
+            "table entry name: {0}",
+            llvm::fmt_consume(std::move(err)));
+      else
+        llvm::consumeError(std::move(err));
       continue;
     }
     Symbol symbol;
@@ -887,10 +891,13 @@ ObjectFilePECOFF::AppendFromExportTable(SectionList *sect_list,
       // it in symtab and make a note using the symbol name.
       llvm::StringRef forwarder_name;
       if (auto err = entry.getForwardTo(forwarder_name)) {
-        LLDB_LOG(log,
-                 "ObjectFilePECOFF::AppendFromExportTable - failed to get "
-                 "forwarder name of forwarder export '{0}': {1}",
-                 sym_name, llvm::fmt_consume(std::move(err)));
+        if (log)
+          log->Format(__FILE__, __func__,
+                      "ObjectFilePECOFF::AppendFromExportTable - failed to get "
+                      "forwarder name of forwarder export '{0}': {1}",
+                      sym_name, llvm::fmt_consume(std::move(err)));
+        else
+          llvm::consumeError(std::move(err));
         continue;
       }
       llvm::SmallString<256> new_name = {symbol.GetDisplayName().GetStringRef(),
@@ -902,10 +909,13 @@ ObjectFilePECOFF::AppendFromExportTable(SectionList *sect_list,
 
     uint32_t function_rva;
     if (auto err = entry.getExportRVA(function_rva)) {
-      LLDB_LOG(log,
-               "ObjectFilePECOFF::AppendFromExportTable - failed to get "
-               "address of export entry '{0}': {1}",
-               sym_name, llvm::fmt_consume(std::move(err)));
+      if (log)
+        log->Format(__FILE__, __func__,
+                    "ObjectFilePECOFF::AppendFromExportTable - failed to get "
+                    "address of export entry '{0}': {1}",
+                    sym_name, llvm::fmt_consume(std::move(err)));
+      else
+        llvm::consumeError(std::move(err));
       continue;
     }
     // Skip the symbol if it doesn't look valid.


### PR DESCRIPTION
We would not ensure that the error is consumed in the case that logging is disabled. Ensure that we properly drop the error on the floor or we would re-trigger the checked failure.

Differential Revision: https://reviews.llvm.org/D147669
Reviewed By: sgraenitz

(cherry picked from commit d87cd45e4d855b57aed76dbd72c270ed152542ff)