### PR TITLE
[lldb] Add `operator StringRef` to ConstString

### DIFF
--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -180,6 +180,9 @@ public:
 
   bool operator<(ConstString rhs) const;
 
+  // Implicitly convert \class ConstString instances to \class StringRef.
+  operator llvm::StringRef() const { return GetStringRef(); }
+
   /// Get the string value as a C string.
   ///
   /// Get the value of the contained string as a NULL terminated C string

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -771,8 +771,7 @@ bool Module::LookupInfo::NameMatchesLookupInfo(
   // relatively inexpensive since no demangling is actually occuring. See
   // Mangled::SetValue for more context.
   const bool function_name_may_be_mangled =
-      Mangled::GetManglingScheme(function_name.GetStringRef()) !=
-      Mangled::eManglingSchemeNone;
+      Mangled::GetManglingScheme(function_name) != Mangled::eManglingSchemeNone;
   ConstString demangled_function_name = function_name;
   if (function_name_may_be_mangled) {
     Mangled mangled_function_name(function_name);
@@ -783,11 +782,10 @@ bool Module::LookupInfo::NameMatchesLookupInfo(
   // Otherwise just check that the demangled function name contains the
   // demangled user-provided name.
   if (Language *language = Language::FindPlugin(language_type))
-    return language->DemangledNameContainsPath(m_name.GetStringRef(),
-                                               demangled_function_name);
+    return language->DemangledNameContainsPath(m_name, demangled_function_name);
 
-  llvm::StringRef function_name_ref = demangled_function_name.GetStringRef();
-  return function_name_ref.contains(m_name.GetStringRef());
+  llvm::StringRef function_name_ref = demangled_function_name;
+  return function_name_ref.contains(m_name);
 }
 
 void Module::LookupInfo::Prune(SymbolContextList &sc_list,
@@ -831,7 +829,7 @@ void Module::LookupInfo::Prune(SymbolContextList &sc_list,
         CPlusPlusLanguage::MethodName cpp_method(full_name);
         if (cpp_method.IsValid()) {
           if (cpp_method.GetContext().empty()) {
-            if (cpp_method.GetBasename().compare(m_name.GetStringRef()) != 0) {
+            if (cpp_method.GetBasename().compare(m_name) != 0) {
               sc_list.RemoveContextAtIndex(i);
               continue;
             }
@@ -1054,8 +1052,8 @@ void Module::FindTypes(
       FindTypes_Impl(name, CompilerDeclContext(), UINT_MAX,
                      searched_symbol_files, typesmap);
       if (exact_match) {
-        typesmap.RemoveMismatchedTypes(type_scope, name.GetStringRef(),
-                                       type_class, exact_match);
+        typesmap.RemoveMismatchedTypes(type_scope, name, type_class,
+                                       exact_match);
       }
     }
   }
@@ -1160,7 +1158,7 @@ void Module::ReportWarningOptimization(
     return;
 
   StreamString ss;
-  ss << file_name.GetStringRef()
+  ss << file_name
      << " was compiled with optimization - stepping may behave "
         "oddly; variables may not be available.";
   Debugger::ReportWarning(std::string(ss.GetString()), debugger_id,
@@ -1872,7 +1870,7 @@ uint32_t Module::Hash() {
   llvm::raw_string_ostream id_strm(identifier);
   id_strm << m_arch.GetTriple().str() << '-' << m_file.GetPath();
   if (m_object_name)
-    id_strm << '(' << m_object_name.GetStringRef() << ')';
+    id_strm << '(' << m_object_name << ')';
   if (m_object_offset > 0)
     id_strm << m_object_offset;
   const auto mtime = llvm::sys::toTimeT(m_object_mod_time);
@@ -1886,7 +1884,7 @@ std::string Module::GetCacheKey() {
   llvm::raw_string_ostream strm(key);
   strm << m_arch.GetTriple().str() << '-' << m_file.GetFilename();
   if (m_object_name)
-    strm << '(' << m_object_name.GetStringRef() << ')';
+    strm << '(' << m_object_name << ')';
   strm << '-' << llvm::format_hex(Hash(), 10);
   return strm.str();
 }


### PR DESCRIPTION
Add a `StringRef` conversion function to `ConstString`.

This will make using llvm, and other non-ConstString, APIs more convenient.

For demonstration, this updates Module.cpp.

Differential Revision: https://reviews.llvm.org/D148175

(cherry-picked from commit ce7a54a27c0960e057a6eaf968d6967f75590fb1)