### PR TITLE
[lldb] Correct do_test argument in TestExec.test_skipping_exec

### DIFF
--- a/lldb/test/API/functionalities/exec/TestExec.py
+++ b/lldb/test/API/functionalities/exec/TestExec.py
@@ -30,7 +30,7 @@ class ExecTestCase(TestBase):
     @skipIfAsan # rdar://problem/43756823
     @skipIfWindows
     def test_skipping_exec (self):
-        self.do_test(False)
+        self.do_test(True)
 
     def do_test(self, skip_exec):
         self.build()


### PR DESCRIPTION
This matches the code in upstream llvm.