### PR TITLE
[lldb] Try Clang fallback in TSSwiftTypeRef::GetNumFields

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2819,6 +2819,9 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
     } else if (is_imported) {
       // A known imported type, but where clang has no info. Return early to
       // avoid loading Swift ASTContexts, only to return the same zero value.
+      LLDB_LOGF(GetLog(LLDBLog::Types),
+                "No CompilerType for imported Clang type %s",
+                AsMangledName(type));
       return 0;
     }
     return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2813,7 +2813,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
               switch (clang_type.GetTypeClass()) {
               case lldb::eTypeClassObjCInterface:
               case lldb::eTypeClassObjCObject:
-                // Imported clang types are treated as having no fields.
+                // Imported ObjC types are treated as having no fields.
                 return 0;
               default:
                 return clang_type.GetNumFields();

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2798,32 +2798,37 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
                                               ExecutionContext *exe_ctx) {
   LLDB_SCOPED_TIMER();
   FALLBACK(GetNumFields, (ReconstructType(type), exe_ctx));
-
-  auto impl = [&]() -> llvm::Optional<uint32_t> {
-    if (exe_ctx)
-      if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP()))
-        if (auto num_fields =
-                runtime->GetNumFields(GetCanonicalType(type), exe_ctx))
-          return num_fields;
-
-    if (CompilerType clang_type = GetAsClangTypeOrNull(type))
-      return clang_type.GetNumFields(exe_ctx);
-    return {};
-  };
-  if (auto num_fields = impl()) {
-    // Use a lambda to intercept and unwrap the `Optional` return value.
-    // Optional<uint32_t> uses more lax equivalency function.
-    return [&]() -> llvm::Optional<uint32_t> {
-      auto impl = [&]() { return num_fields; };
-      ExecutionContext exe_ctx_obj;
-      if (exe_ctx)
-        exe_ctx_obj = *exe_ctx;
-      VALIDATE_AND_RETURN(impl, GetNumFields, type, exe_ctx_obj,
-                          (ReconstructType(type), exe_ctx),
-                          (ReconstructType(type), exe_ctx));
-    }()
-                        .getValueOr(0);
-  }
+  if (exe_ctx)
+    if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP()))
+      if (auto num_fields =
+              runtime->GetNumFields(GetCanonicalType(type), exe_ctx))
+        // Use a lambda to intercept & unwrap the `Optional` return value from
+        // `SwiftLanguageRuntime::GetNumFields`.
+        // Optional<uint32_t> uses more lax equivalency function.
+        return [&]() -> llvm::Optional<uint32_t> {
+          auto impl = [&]() -> llvm::Optional<uint32_t> {
+            if (!type)
+              return 0;
+            if (auto clang_type = GetAsClangTypeOrNull(type)) {
+              switch (clang_type.GetTypeClass()) {
+              case lldb::eTypeClassObjCInterface:
+              case lldb::eTypeClassObjCObject:
+                // Imported clang types are treated as having no fields.
+                return 0;
+              default:
+                return clang_type.GetNumFields();
+              }
+            }
+            return num_fields;
+          };
+          ExecutionContext exe_ctx_obj;
+          if (exe_ctx)
+            exe_ctx_obj = *exe_ctx;
+          VALIDATE_AND_RETURN(impl, GetNumFields, type, exe_ctx_obj,
+                              (ReconstructType(type), exe_ctx),
+                              (ReconstructType(type), exe_ctx));
+        }()
+                            .getValueOr(0);
 
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "Using SwiftASTContext::GetNumFields fallback for type %s",

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2798,37 +2798,45 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
                                               ExecutionContext *exe_ctx) {
   LLDB_SCOPED_TIMER();
   FALLBACK(GetNumFields, (ReconstructType(type), exe_ctx));
-  if (exe_ctx)
-    if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP()))
-      if (auto num_fields =
-              runtime->GetNumFields(GetCanonicalType(type), exe_ctx))
-        // Use a lambda to intercept & unwrap the `Optional` return value from
-        // `SwiftLanguageRuntime::GetNumFields`.
-        // Optional<uint32_t> uses more lax equivalency function.
-        return [&]() -> llvm::Optional<uint32_t> {
-          auto impl = [&]() -> llvm::Optional<uint32_t> {
-            if (!type)
-              return 0;
-            if (auto clang_type = GetAsClangTypeOrNull(type)) {
-              switch (clang_type.GetTypeClass()) {
-              case lldb::eTypeClassObjCInterface:
-              case lldb::eTypeClassObjCObject:
-                // Imported ObjC types are treated as having no fields.
-                return 0;
-              default:
-                return clang_type.GetNumFields();
-              }
-            }
-            return num_fields;
-          };
-          ExecutionContext exe_ctx_obj;
-          if (exe_ctx)
-            exe_ctx_obj = *exe_ctx;
-          VALIDATE_AND_RETURN(impl, GetNumFields, type, exe_ctx_obj,
-                              (ReconstructType(type), exe_ctx),
-                              (ReconstructType(type), exe_ctx));
-        }()
-                            .getValueOr(0);
+
+  auto impl = [&]() -> llvm::Optional<uint32_t> {
+    if (exe_ctx)
+      if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP()))
+        if (auto num_fields =
+                runtime->GetNumFields(GetCanonicalType(type), exe_ctx))
+          return num_fields;
+
+    bool is_imported = false;
+    if (auto clang_type = GetAsClangTypeOrNull(type, &is_imported)) {
+      switch (clang_type.GetTypeClass()) {
+      case lldb::eTypeClassObjCObject:
+      case lldb::eTypeClassObjCInterface:
+        // Imported ObjC types are treated as having no fields.
+        return 0;
+      default:
+        return clang_type.GetNumFields(exe_ctx);
+      }
+    } else if (is_imported) {
+      // A known imported type, but where clang has no info. Return early to
+      // avoid loading Swift ASTContexts, only to return the same zero value.
+      return 0;
+    }
+    return {};
+  };
+  if (auto num_fields = impl()) {
+    // Use a lambda to intercept and unwrap the `Optional` return value.
+    // Optional<uint32_t> uses more lax equivalency function.
+    return [&]() -> llvm::Optional<uint32_t> {
+      auto impl = [&]() { return num_fields; };
+      ExecutionContext exe_ctx_obj;
+      if (exe_ctx)
+        exe_ctx_obj = *exe_ctx;
+      VALIDATE_AND_RETURN(impl, GetNumFields, type, exe_ctx_obj,
+                          (ReconstructType(type), exe_ctx),
+                          (ReconstructType(type), exe_ctx));
+    }()
+                        .getValueOr(0);
+  }
 
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "Using SwiftASTContext::GetNumFields fallback for type %s",
@@ -3263,8 +3271,9 @@ bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
                       (ReconstructType(type)));
 }
 
-CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
-    lldb::opaque_compiler_type_t type) {
+CompilerType
+TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,
+                                             bool *is_imported) {
   using namespace swift::Demangle;
   Demangler dem;
   NodePointer node = GetDemangledType(dem, AsMangledName(type));
@@ -3281,7 +3290,9 @@ CompilerType TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(
       return node_clangtype.second;
   }
   CompilerType clang_type;
-  IsImportedType(type, &clang_type);
+  bool imported = IsImportedType(type, &clang_type);
+  if (is_imported)
+    *is_imported = imported;
   return clang_type;
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -265,7 +265,8 @@ public:
                       CompilerType *original_type) override;
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
   /// builtins (int <-> Swift.Int) as Clang types.
-  CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type);
+  CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,
+                                    bool *is_imported = nullptr);
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;


### PR DESCRIPTION
For Clang types, avoid loading Swift ASTContexts in `TypeSystemSwiftTypeRef::GetNumFields`.

This new logic checks if a type is an imported Clang type. If it's imported, but no type info is available (ex private/internal types), then zero is returned. If a Clang type is available, then, depending on the type class, return the Clang type's `GetNumFields`.

Note that there's logic to avoid calling `GetNumFields` on ObjC types. This is to match the current behavior.