### PR TITLE
[clang][cas] Move some caching env variables from clang-cache to driver

### DIFF
--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -2,9 +2,18 @@
 
 // This compiles twice with replay disabled, ensuring that we get the same outputs for the same key.
 
+// Under clang-cache
+
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 CLANG_CACHE_REDACT_TIME_MACROS=1 %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache 2> %t/out.txt
 // RUN: FileCheck %s --check-prefix=CACHE-SKIPPED --input-file=%t/out.txt
+
+// Under clang driver
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 CLANG_CACHE_REDACT_TIME_MACROS=1 \
+// RUN: %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache \
+// RUN:   -fdepscan=inline -Xclang -fcas-path -Xclang %t/cas 2> %t/out_driver.txt
+// RUN: FileCheck %s --check-prefix=CACHE-SKIPPED --input-file=%t/out_driver.txt
 
 // CACHE-SKIPPED: remark: compile job cache skipped
 // CACHE-SKIPPED: remark: compile job cache skipped

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -164,18 +164,6 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &Args,
                  ServicePath});
   }
   Args.append({"-greproducible"});
-
-  if (llvm::sys::Process::GetEnv("CLANG_CACHE_REDACT_TIME_MACROS")) {
-    // Remove use of these macros to get reproducible outputs. This can
-    // accompany CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS to avoid fatal errors
-    // when the source uses these macros.
-    Args.append({"-Wno-builtin-macro-redefined", "-D__DATE__=\"redacted\"",
-                 "-D__TIMESTAMP__=\"redacted\"", "-D__TIME__=\"redacted\""});
-  }
-  if (llvm::sys::Process::GetEnv(
-          "CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES")) {
-    Args.append({"-Werror=reproducible-caching"});
-  }
 }
 
 static void addScanServerArgs(const char *SocketPath,
@@ -252,15 +240,6 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
       return std::nullopt;
     }
     addLauncherArgs(Args, Saver);
-    if (llvm::sys::Process::GetEnv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
-      // Run the compilation twice, without replaying, to check that we get the
-      // same compilation artifacts for the same key. If they are not the same
-      // the action cache will trigger a fatal error.
-      Args.append({"-Xclang", "-fcache-disable-replay"});
-      int Result = executeAsProcess(Args, Diags);
-      if (Result != 0)
-        return Result;
-    }
     return std::nullopt;
   }
 


### PR DESCRIPTION
Allows us to use CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS, CLANG_CACHE_REDACT_TIME_MACROS, and
CLANG_CACHE_CHECK_REPRODUCIBLE_CACHING_ISSUES without going through clang-cache. For deterministic outputs this calls cc1_main twice.

rdar://108161760
(cherry picked from commit a71d588a3a5933b3e29aedb0e3fb829f03e62f2e)