### PR TITLE
[lldb] Subtract module start address when building addr to module map

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -776,6 +776,9 @@ SwiftLanguageRuntimeImpl::AddObjectFileToReflectionContext(
   std::tie(start_address, end_address) = *maybe_start_and_end;
 
   auto *section_list = object_file->GetSectionList();
+  if (section_list->GetSize() == 0)
+    return false;
+
   auto segment_iter = llvm::find_if(*section_list, [&](auto segment) {
     return segment->GetName() == segment_name.begin();
   });
@@ -818,11 +821,12 @@ SwiftLanguageRuntimeImpl::AddObjectFileToReflectionContext(
         std::memcpy(Buf, data.begin(), size);
 
         // The section's address is the start address for this image
-        // added with the section's virtual address. We need to use the
-        // virtual address instead of the file offset because the offsets
-        // encoded in the reflection section are calculated in the virtual
-        // address space.
-        auto address = start_address + section->GetFileAddress();
+        // added with the section's virtual address subtracting the start of the
+        // module's address. We need to use the virtual address instead of the
+        // file offset because the offsets encoded in the reflection section are
+        // calculated in the virtual address space.
+        auto address = start_address + section->GetFileAddress() -
+                       section_list->GetSectionAtIndex(0)->GetFileAddress();
         assert(address <= end_address && "Address outside of range!");
 
         swift::remote::RemoteRef<void> remote_ref(address, Buf);


### PR DESCRIPTION
When building the LLDBMemoryReader module to address map, it was assumed that a module would start at address 0, when this was not necessarily true. If many modules had a high start file address, the module map could potentially use up all the available space, and potentially clash with the pointer authentication mask. This patch accounts subtracts the module's start address when building the map, and also verifies that the addresses handed out can't be affected by the pointer authentication mask.

rdar://106055569
(cherry picked from commit c5274603e220c97054923e0702c6978cfe0da4ca)