### PR TITLE
[lldb] Remove compute_mydir from downstream tests (NFC)

### DIFF
--- a/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
+++ b/lldb/test/API/commands/target/dump-pcm-info/TestDumpPCMInfo.py
@@ -13,8 +13,6 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     @no_debug_info_test
     @skipUnlessDarwin
     def test(self):

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -19,8 +19,6 @@ import unittest2
 
 class TestSwiftUnknownSelf(lldbtest.TestBase):
 
-    mydir = lldbtest.TestBase.compute_mydir(__file__)
-
     def check_class(self, var_self, weak):
         self.expect("v self", substrs=["hello", "world"])
         lldbutil.check_variable(self, var_self, num_children=2)


### PR DESCRIPTION
See https://reviews.llvm.org/D128077 for more context.

(cherry picked from commit faf7344028aa594d5d9d46cb371e04354d8f73c2)