### PR TITLE
[lldb] Remove unnecessary GetNumFields call in SwiftLanguage::GetHardcodedSynthetics

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -916,7 +916,7 @@ SwiftLanguage::GetHardcodedSynthetics() {
               }
 
               ExecutionContext exe_ctx(valobj.GetExecutionContextRef());
-              if (is_imported && type.GetNumFields(&exe_ctx) == 0)
+              if (is_imported)
                 return true;
               if (valobj.IsBaseClass() && type.IsRuntimeGeneratedType()) {
                 auto parent(valobj.GetParent());


### PR DESCRIPTION
The Swift implementation of `HardcodedSyntheticFinder` conditionally adds `ObjCRuntimeSyntheticProvider` for eligible types.

The logic has included the following check:

```
is_imported && type.GetNumFields() == 0
```

However, the second part of this condition (`GetNumFields() == 0`) doesn't seem needed. The original commit doesn't explain why it's there, nor are there comments. The tests do not require the condition either.

When coupled with the change to `TypeSystemSwiftTypeRef::GetNumFields` in https://github.com/apple/llvm-project/pull/6671, the requirement that `GetNumFields() == 0` causes bugs. The bug is because the implementation `TypeSystemClang::GetNumFields` returns only the number of ivars declared in an ObjC `@interface`, which can often be zero. For example in the cases where ivars are declared in the `@implementation`. (Aside: This begs the question of how useful `GetNumFields` is for ObjC types).
