### PR TITLE
[lldb] Fix bug to update process public run lock with process state

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -389,6 +389,13 @@ public:
 
   static ConstString &GetStaticBroadcasterClass();
 
+  static constexpr llvm::StringRef AttachSynchronousHijackListenerName =
+      "lldb.internal.Process.AttachSynchronous.hijack";
+  static constexpr llvm::StringRef LaunchSynchronousHijackListenerName =
+      "lldb.internal.Process.LaunchSynchronous.hijack";
+  static constexpr llvm::StringRef ResumeSynchronousHijackListenerName =
+      "lldb.internal.Process.ResumeSynchronous.hijack";
+
   ConstString &GetBroadcasterClass() const override {
     return GetStaticBroadcasterClass();
   }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3582,8 +3582,8 @@ Status Target::Launch(ProcessLaunchInfo &launch_info, Stream *stream) {
   // its own hijacking listener or if the process is created by the target
   // manually, without the platform).
   if (!launch_info.GetHijackListener())
-    launch_info.SetHijackListener(
-        Listener::MakeListener("lldb.Target.Launch.hijack"));
+    launch_info.SetHijackListener(Listener::MakeListener(
+        Process::LaunchSynchronousHijackListenerName.data()));
 
   // If we're not already connected to the process, and if we have a platform
   // that can launch a process for debugging, go ahead and do that here.
@@ -3759,8 +3759,8 @@ Status Target::Attach(ProcessAttachInfo &attach_info, Stream *stream) {
   ListenerSP hijack_listener_sp;
   const bool async = attach_info.GetAsync();
   if (!async) {
-    hijack_listener_sp =
-        Listener::MakeListener("lldb.Target.Attach.attach.hijack");
+    hijack_listener_sp = Listener::MakeListener(
+        Process::AttachSynchronousHijackListenerName.data());
     attach_info.SetHijackListener(hijack_listener_sp);
   }
 

--- a/llvm/include/llvm/ADT/StringRef.h
+++ b/llvm/include/llvm/ADT/StringRef.h
@@ -253,22 +253,35 @@ namespace llvm {
     /// @{
 
     /// Check if this string starts with the given \p Prefix.
-    [[nodiscard]] bool startswith(StringRef Prefix) const {
+    [[nodiscard]] bool starts_with(StringRef Prefix) const {
       return Length >= Prefix.Length &&
              compareMemory(Data, Prefix.Data, Prefix.Length) == 0;
     }
+    [[nodiscard]] bool startswith(StringRef Prefix) const {
+      return starts_with(Prefix);
+    }
 
     /// Check if this string starts with the given \p Prefix, ignoring case.
-    [[nodiscard]] bool startswith_insensitive(StringRef Prefix) const;
+    [[nodiscard]] bool starts_with_insensitive(StringRef Prefix) const;
+    [[nodiscard]] bool startswith_insensitive(StringRef Prefix) const {
+      return starts_with_insensitive(Prefix);
+    }
 
     /// Check if this string ends with the given \p Suffix.
-    [[nodiscard]] bool endswith(StringRef Suffix) const {
+    [[nodiscard]] bool ends_with(StringRef Suffix) const {
       return Length >= Suffix.Length &&
-        compareMemory(end() - Suffix.Length, Suffix.Data, Suffix.Length) == 0;
+             compareMemory(end() - Suffix.Length, Suffix.Data, Suffix.Length) ==
+                 0;
+    }
+    [[nodiscard]] bool endswith(StringRef Suffix) const {
+      return ends_with(Suffix);
     }
 
     /// Check if this string ends with the given \p Suffix, ignoring case.
-    [[nodiscard]] bool endswith_insensitive(StringRef Suffix) const;
+    [[nodiscard]] bool ends_with_insensitive(StringRef Suffix) const;
+    [[nodiscard]] bool endswith_insensitive(StringRef Suffix) const {
+      return ends_with_insensitive(Suffix);
+    }
 
     /// @}
     /// @name String Searching
@@ -622,7 +635,7 @@ namespace llvm {
     /// Returns true if this StringRef has the given prefix and removes that
     /// prefix.
     bool consume_front(StringRef Prefix) {
-      if (!startswith(Prefix))
+      if (!starts_with(Prefix))
         return false;
 
       *this = drop_front(Prefix.size());
@@ -642,7 +655,7 @@ namespace llvm {
     /// Returns true if this StringRef has the given suffix and removes that
     /// suffix.
     bool consume_back(StringRef Suffix) {
-      if (!endswith(Suffix))
+      if (!ends_with(Suffix))
         return false;
 
       *this = drop_back(Suffix.size());

--- a/llvm/lib/Support/StringRef.cpp
+++ b/llvm/lib/Support/StringRef.cpp
@@ -42,12 +42,12 @@ int StringRef::compare_insensitive(StringRef RHS) const {
   return Length < RHS.Length ? -1 : 1;
 }
 
-bool StringRef::startswith_insensitive(StringRef Prefix) const {
+bool StringRef::starts_with_insensitive(StringRef Prefix) const {
   return Length >= Prefix.Length &&
       ascii_strncasecmp(Data, Prefix.Data, Prefix.Length) == 0;
 }
 
-bool StringRef::endswith_insensitive(StringRef Suffix) const {
+bool StringRef::ends_with_insensitive(StringRef Suffix) const {
   return Length >= Suffix.Length &&
       ascii_strncasecmp(end() - Suffix.Length, Suffix.Data, Suffix.Length) == 0;
 }

--- a/llvm/unittests/ADT/StringRefTest.cpp
+++ b/llvm/unittests/ADT/StringRefTest.cpp
@@ -356,20 +356,20 @@ TEST(StringRefTest, Trim) {
 
 TEST(StringRefTest, StartsWith) {
   StringRef Str("hello");
-  EXPECT_TRUE(Str.startswith(""));
-  EXPECT_TRUE(Str.startswith("he"));
-  EXPECT_FALSE(Str.startswith("helloworld"));
-  EXPECT_FALSE(Str.startswith("hi"));
+  EXPECT_TRUE(Str.starts_with(""));
+  EXPECT_TRUE(Str.starts_with("he"));
+  EXPECT_FALSE(Str.starts_with("helloworld"));
+  EXPECT_FALSE(Str.starts_with("hi"));
 }
 
 TEST(StringRefTest, StartsWithInsensitive) {
   StringRef Str("heLLo");
-  EXPECT_TRUE(Str.startswith_insensitive(""));
-  EXPECT_TRUE(Str.startswith_insensitive("he"));
-  EXPECT_TRUE(Str.startswith_insensitive("hell"));
-  EXPECT_TRUE(Str.startswith_insensitive("HELlo"));
-  EXPECT_FALSE(Str.startswith_insensitive("helloworld"));
-  EXPECT_FALSE(Str.startswith_insensitive("hi"));
+  EXPECT_TRUE(Str.starts_with_insensitive(""));
+  EXPECT_TRUE(Str.starts_with_insensitive("he"));
+  EXPECT_TRUE(Str.starts_with_insensitive("hell"));
+  EXPECT_TRUE(Str.starts_with_insensitive("HELlo"));
+  EXPECT_FALSE(Str.starts_with_insensitive("helloworld"));
+  EXPECT_FALSE(Str.starts_with_insensitive("hi"));
 }
 
 TEST(StringRefTest, ConsumeFront) {
@@ -408,21 +408,21 @@ TEST(StringRefTest, ConsumeFrontInsensitive) {
 
 TEST(StringRefTest, EndsWith) {
   StringRef Str("hello");
-  EXPECT_TRUE(Str.endswith(""));
-  EXPECT_TRUE(Str.endswith("lo"));
-  EXPECT_FALSE(Str.endswith("helloworld"));
-  EXPECT_FALSE(Str.endswith("worldhello"));
-  EXPECT_FALSE(Str.endswith("so"));
+  EXPECT_TRUE(Str.ends_with(""));
+  EXPECT_TRUE(Str.ends_with("lo"));
+  EXPECT_FALSE(Str.ends_with("helloworld"));
+  EXPECT_FALSE(Str.ends_with("worldhello"));
+  EXPECT_FALSE(Str.ends_with("so"));
 }
 
 TEST(StringRefTest, EndsWithInsensitive) {
   StringRef Str("heLLo");
-  EXPECT_TRUE(Str.endswith_insensitive(""));
-  EXPECT_TRUE(Str.endswith_insensitive("lo"));
-  EXPECT_TRUE(Str.endswith_insensitive("LO"));
-  EXPECT_TRUE(Str.endswith_insensitive("ELlo"));
-  EXPECT_FALSE(Str.endswith_insensitive("helloworld"));
-  EXPECT_FALSE(Str.endswith_insensitive("hi"));
+  EXPECT_TRUE(Str.ends_with_insensitive(""));
+  EXPECT_TRUE(Str.ends_with_insensitive("lo"));
+  EXPECT_TRUE(Str.ends_with_insensitive("LO"));
+  EXPECT_TRUE(Str.ends_with_insensitive("ELlo"));
+  EXPECT_FALSE(Str.ends_with_insensitive("helloworld"));
+  EXPECT_FALSE(Str.ends_with_insensitive("hi"));
 }
 
 TEST(StringRefTest, ConsumeBack) {


### PR DESCRIPTION
This patch should address an issue that caused the process public run lock to not be updated during a process launch/attach when the process stops.

That caused the public run lock to report its state as running while the process state is stopped. This prevents the users to interact with the process (through the command line or via the SBAPI) since it's considered still running.

To address that, this patch refactors the name of the internal hijack listeners to a specific pattern `lldb.internal.<action>.hijack` that are used to ensure that we've attached to or launched a process successfully.

Then, when updating the process public state, after updating the state value, if the process is not hijacked externally, meaning if the process doens't have a hijack listener that matches the internal hijack listeners pattern, we can update the public run lock accordingly.

rdar://108283017

Differential Revision: https://reviews.llvm.org/D148400