### PR TITLE
[clang][cas] Fix issue when we emit caching-related diagnostic after source processing is done

### DIFF
--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -375,6 +375,10 @@ public:
   /// caching of compilation outputs. This is used for testing purposes.
   unsigned DisableCachedCompileJobReplay : 1;
 
+  /// Keep the diagnostic client open for receiving diagnostics after the source
+  /// files have been processed.
+  unsigned MayEmitDiagnosticsAfterProcessingSourceFiles : 1;
+
   /// Output (and read) PCM files regardless of compiler errors.
   unsigned AllowPCMWithCompilerErrors : 1;
 
@@ -570,10 +574,11 @@ public:
         ASTDumpDecls(false), ASTDumpLookups(false),
         BuildingImplicitModule(false), BuildingImplicitModuleUsesLock(true),
         ModulesEmbedAllFiles(false), IncludeTimestamps(true),
-        UseTemporary(true),
-        CacheCompileJob(false), DisableCachedCompileJobReplay(false),
-        AllowPCMWithCompilerErrors(false),
-        ModulesShareFileManager(true), TimeTraceGranularity(500) {}
+        UseTemporary(true), CacheCompileJob(false),
+        DisableCachedCompileJobReplay(false),
+        MayEmitDiagnosticsAfterProcessingSourceFiles(false),
+        AllowPCMWithCompilerErrors(false), ModulesShareFileManager(true),
+        TimeTraceGranularity(500) {}
 
   /// getInputKindForExtension - Return the appropriate input kind for a file
   /// extension. For example, "c" would return Language::C.

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1040,8 +1040,10 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
   noteBottomOfStack();
 
   auto FinishDiagnosticClient = llvm::make_scope_exit([&]() {
-    // Notify the diagnostic client that all files were processed.
-    getDiagnosticClient().finish();
+    if (!getFrontendOpts().MayEmitDiagnosticsAfterProcessingSourceFiles) {
+      // Notify the diagnostic client that all files were processed.
+      getDiagnosticClient().finish();
+    }
   });
 
   raw_ostream &OS = getVerboseOutputStream();
@@ -1244,6 +1246,7 @@ compileModuleImpl(CompilerInstance &ImportingInstance, SourceLocation ImportLoc,
   // Force implicitly-built modules to hash the content of the module file.
   HSOpts.ModulesHashContent = true;
   FrontendOpts.Inputs = {Input};
+  FrontendOpts.MayEmitDiagnosticsAfterProcessingSourceFiles = false;
 
   // Don't free the remapped file buffers; they are owned by our caller.
   PPOpts.RetainRemappedFileBuffers = true;

--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -19,19 +19,20 @@
 // CACHE-SKIPPED: remark: compile job cache skipped
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
-// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Wreproducible-caching 2> %t/out.txt
-// RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Wreproducible-caching -serialize-diagnostics %t/t.dia 2> %t/out.txt
+// RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt -DREMARK=remark
+// RUN: c-index-test -read-diagnostics %t/t.dia 2>&1 | FileCheck %s --check-prefix=CACHE-WARN -DREMARK=warning
 
 /// Check still a cache miss.
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -Rcompile-job-cache -Wreproducible-caching 2> %t/out.txt
-// RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt
+// RUN: FileCheck %s --check-prefix=CACHE-WARN --input-file=%t/out.txt -DREMARK=remark
 
-// CACHE-WARN: remark: compile job cache miss
+// CACHE-WARN: [[REMARK]]: compile job cache miss
 // CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
 // CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
 // CACHE-WARN: warning: encountered non-reproducible token, caching will be skipped
-// CACHE-WARN: remark: compile job cache skipped
+// CACHE-WARN: [[REMARK]]: compile job cache skipped
 
 /// Check -Werror doesn't actually error when we use the launcher.
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \

--- a/clang/tools/driver/cc1_main.cpp
+++ b/clang/tools/driver/cc1_main.cpp
@@ -1220,7 +1220,7 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
 
   DiagsBuffer->FlushDiagnostics(Clang->getDiagnostics());
 
-  auto FinishDiagnosticClient = llvm::make_scope_exit([&]() {
+  auto FinishDiagnosticClient = [&]() {
     // Notify the diagnostic client that all files were processed.
     Clang->getDiagnosticClient().finish();
 
@@ -1228,7 +1228,9 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
     // potentially about to delete. Uninstall the handler now so that any
     // later errors use the default handling behavior instead.
     llvm::remove_fatal_error_handler();
-  });
+  };
+  auto FinishDiagnosticClientScope =
+      llvm::make_scope_exit([&]() { FinishDiagnosticClient(); });
 
   if (!Success)
     return 1;
@@ -1241,8 +1243,7 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
   if (std::optional<int> Status = JobCache.tryReplayCachedResult(*Clang))
     return *Status; // FIXME: Should write out timers before exiting!
 
-  // ExecuteAction takes responsibility.
-  FinishDiagnosticClient.release();
+  Clang->getFrontendOpts().MayEmitDiagnosticsAfterProcessingSourceFiles = true;
 
   // Execute the frontend actions.
   {
@@ -1293,6 +1294,10 @@ int cc1_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
       llvm::timeTraceProfilerCleanup();
     }
   }
+
+  // Call this before the Clang pointer is moved below.
+  FinishDiagnosticClient();
+  FinishDiagnosticClientScope.release();
 
   // When running with -disable-free, don't do any destruction or shutdown.
   if (Clang->getFrontendOpts().DisableFree) {

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -382,8 +382,6 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV,
       int RC = cc1_main(ArrayRef(ArgV).slice(1), ArgV[0], GetExecutablePathVP);
       if (RC != 0)
         return RC;
-      // FIXME: cc1_main should possibly clean up global state itself.
-      llvm::remove_fatal_error_handler();
     }
     return cc1_main(ArrayRef(ArgV).slice(1), ArgV[0], GetExecutablePathVP);
   }


### PR DESCRIPTION
Introduce `FrontendOptions.MayEmitDiagnosticsAfterProcessingSourceFiles` to indicate that `CompilerInstance::ExecuteAction` should not "finish" the diagnostic client. This is set for caching compilations.

rdar://108014441