### PR TITLE
Swift: handle type resolution failure more gracefully

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -788,6 +788,8 @@ SwiftLanguageRuntimeImpl::GetMemberVariableOffsetRemoteAST(
   // Check whether we've already cached this offset.
   swift::TypeBase *swift_type =
       GetCanonicalSwiftType(instance_type).getPointer();
+  if (swift_type == nullptr)
+    return {};
 
   // Perform the cache lookup.
   MemberID key{swift_type, ConstString(member_name).GetCString()};


### PR DESCRIPTION
The result of the type resolution was not verified which resulted in the debugger trying to resolve a function from a `nullptr` and subsequently crash.  This adds a check to ensure that we resolved the type before proceeding.