### PR TITLE
[DependencyScanning] Allow sharing of explicit modules between a PCH and a TU that doesn't use PCH

### DIFF
--- a/clang/include/clang/Lex/PreprocessorOptions.h
+++ b/clang/include/clang/Lex/PreprocessorOptions.h
@@ -227,6 +227,13 @@ public:
       FileEntryRef)>
       DependencyDirectivesForFile;
 
+  /// True if doing dependency scanning.
+  ///
+  /// NOTE: Used for making \c LangOptions.NeededByPCHOrCompilationUsesPCH
+  /// benign in the context of explicit modules, it can be removed if
+  /// \c NeededByPCHOrCompilationUsesPCH is removed.
+  bool DependencyScanning = false;
+
   /// Set up preprocessor for RunAnalysis action.
   bool SetUpStaticAnalyzer = false;
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -273,6 +273,7 @@ public:
                      FileManager *FileMgr,
                      std::shared_ptr<PCHContainerOperations> PCHContainerOps,
                      DiagnosticConsumer *DiagConsumer) override {
+    Invocation->getPreprocessorOpts().DependencyScanning = true;
     // Make a deep copy of the original Clang invocation.
     CompilerInvocation OriginalInvocation(*Invocation);
     // Restore the value of DisableFree, which may be modified by Tooling.

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -92,6 +92,7 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
 
   CI.resetNonModularOptions();
   CI.clearImplicitModuleBuildOptions();
+  CI.getLangOpts()->NeededByPCHOrCompilationUsesPCH = false;
 
   // Remove options incompatible with explicit module build or are likely to
   // differ between identical modules discovered from different translation

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -109,6 +109,7 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
     CI.getCodeGenOpts().CoverageCompilationDir.clear();
     CI.getCodeGenOpts().CoverageDataFile.clear();
     CI.getCodeGenOpts().CoverageNotesFile.clear();
+    CI.getCodeGenOpts().RelaxAll = false;
   }
 
   // Map output paths that affect behaviour to "-" so their existence is in the

--- a/clang/test/ClangScanDeps/shared-module-for-tu-and-pch.c
+++ b/clang/test/ClangScanDeps/shared-module-for-tu-and-pch.c
@@ -1,0 +1,42 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.debug.template > %t/cdb.debug.json
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.release.template > %t/cdb.release.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.debug.json -format=experimental-full -brief | FileCheck %s
+// RUN: clang-scan-deps -compilation-database %t/cdb.release.json -format=experimental-full -brief | FileCheck %s
+// CHECK: num modules: 1
+
+//--- cdb.json.debug.template
+[{
+  "directory": "DIR",
+  "file": "DIR/tu.c",
+  "command": "clang -target x86_64-apple-macosx12 -x c -fmodules -gmodules -fmodules-cache-path=DIR/cache -I DIR/include -c DIR/tu.c -o DIR/tu.o -O0 -g"
+},
+{
+  "directory": "DIR",
+  "file": "DIR/tu.prefix.h",
+  "command": "clang -target x86_64-apple-macosx12 -x c-header -fmodules -gmodules -fmodules-cache-path=DIR/cache -I DIR/include -c DIR/tu.prefix.h -o DIR/tu.pch -O0 -g"
+}]
+//--- cdb.json.release.template
+[{
+  "directory": "DIR",
+  "file": "DIR/tu.c",
+  "command": "clang -target x86_64-apple-macosx12 -x c -fmodules -gmodules -fmodules-cache-path=DIR/cache -I DIR/include -c DIR/tu.c -o DIR/tu.o -Os -g"
+},
+{
+  "directory": "DIR",
+  "file": "DIR/tu.prefix.h",
+  "command": "clang -target x86_64-apple-macosx12 -x c-header -fmodules -gmodules -fmodules-cache-path=DIR/cache -I DIR/include -c DIR/tu.prefix.h -o DIR/tu.pch -Os -g"
+}]
+
+//--- include/module.modulemap
+module Top { header "top.h" }
+//--- include/top.h
+#define TOP int
+//--- tu.c
+#include "top.h"
+TOP fn(void);
+//--- tu.prefix.h
+#include "top.h"

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -98,6 +98,7 @@ static std::vector<std::string> ModuleDepTargets;
 static bool DeprecatedDriverCommand;
 static ResourceDirRecipeKind ResourceDirRecipe;
 static bool Verbose;
+static bool BriefResult;
 static std::vector<const char *> CommandLine;
 static bool EmitCASCompDB;
 static std::string OnDiskCASPath;
@@ -239,6 +240,7 @@ static void ParseArgs(int argc, char **argv) {
                        A->getValues().end());
 
   Verbose = Args.hasArg(OPT_verbose);
+  BriefResult = Args.hasArg(OPT_brief_result);
 
   RoundTripArgs = Args.hasArg(OPT_round_trip_args);
 
@@ -738,6 +740,8 @@ public:
 
     OS << llvm::formatv("{0:2}\n", Value(std::move(Output)));
   }
+
+  size_t getNumModules() const { return Modules.size(); }
 
 private:
   struct IndexedModuleID {
@@ -1315,6 +1319,11 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
   if (RoundTripArgs)
     if (FD && FD->roundTripCommands(llvm::errs()))
       HadErrors = true;
+
+  if (BriefResult && FD) {
+    llvm::outs() << "num modules: " << FD->getNumModules() << '\n';
+    return HadErrors;
+  }
 
   std::sort(TreeResults.begin(), TreeResults.end(),
             [](const DepTreeResult &LHS, const DepTreeResult &RHS) -> bool {

--- a/clang/tools/clang-scan-deps/Opts.td
+++ b/clang/tools/clang-scan-deps/Opts.td
@@ -45,6 +45,8 @@ defm prefix_map : Eq<"prefix-map", "Path to remap, as \"<old>=<new>\".">;
 
 def verbose : F<"v", "Use verbose output">;
 
+def brief_result : F<"brief", "Use brief dependency info output">;
+
 def round_trip_args : F<"round-trip-args", "verify that command-line arguments are canonical by parsing and re-serializing">;
 
 def DASH_DASH : Option<["--"], "", KIND_REMAINING_ARGS>;


### PR DESCRIPTION
This cherry-picks https://reviews.llvm.org/D148369 along with adding a commit to deal with `NeededByPCHOrCompilationUsesPCH` (that only exists in apple fork) so the upstream test can actually pass.