### PR TITLE
[lldb] Make use of target triple in TypeSystemSwiftTypeRef

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -891,8 +891,6 @@ TypeSystemSwiftTypeRef::GetSwiftName(const clang::Decl *clang_decl,
   // swiftification rules.
   if (auto *importer = GetNameImporter())
     return importer->ImportName(named_decl);
-  if (auto *swift_ast_context = GetSwiftASTContext())
-    return swift_ast_context->ImportName(named_decl);
   return {};
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1508,7 +1508,9 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
     return module->GetArchitecture().GetTriple();
   else if (auto target_sp = GetTargetWP().lock())
     return target_sp->GetArchitecture().GetTriple();
-  llvm_unreachable("Expected module or target");
+  LLDB_LOGF(
+      GetLog(LLDBLog::Types),
+      "Cannot determine triple when no Module or no Target is available.");
   return {};
 }
 


### PR DESCRIPTION
Update `TypeSystemSwiftTypeRef::GetTriple` to make use of an available target.

With this change, `GetNameImporter` can work in more cases, since it only needs a triple. And since `GetNameImporter` can be expected to return a `ClangNameImporter` instance, the fallback to using Swift ASTContexts can be removed.

This eliminates another case of unnecessarily loading Swift ASTContexts, which incurs a one time overhead that should only be paid when required.

Partial follow up to https://github.com/apple/llvm-project/pull/6654