### PR TITLE
[lldb][Swift] Update for 'PluginLoader'

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTMangler.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
@@ -27,11 +28,11 @@
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/OperatorNameLookup.h"
+#include "swift/AST/PluginLoader.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
-#include "swift/AST/ASTWalker.h"
 #include "swift/ASTSectionImporter/ASTSectionImporter.h"
 #include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Basic/Dwarf.h"
@@ -3082,6 +3083,10 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
         "ClangImporter-owned clang::ASTContext for '" + m_description,
         m_clangimporter->getClangASTContext());
   }
+
+  // Set up the plugin loader.
+  m_ast_context_ap->setPluginLoader(std::make_unique<swift::PluginLoader>(
+      *m_ast_context_ap, m_dependency_tracker.get()));
 
   // Set up the required state for the evaluator in the TypeChecker.
   registerIDERequestFunctions(m_ast_context_ap->evaluator);


### PR DESCRIPTION
Companion of https://github.com/apple/swift/pull/65322

`swift::ASTContext` requires `setPluginLoader()` for loading plugins.