### PR TITLE
[fuzzer][test] Disable big-file-copy.test for everything but macOS

### DIFF
--- a/compiler-rt/test/fuzzer/big-file-copy.test
+++ b/compiler-rt/test/fuzzer/big-file-copy.test
@@ -1,5 +1,5 @@
 REQUIRES: darwin
-UNSUPPORTED: tvos || watchos
+UNSUPPORTED: ios
 RUN: %cpp_compiler %S/BigFileCopy.cpp -o %t
 RUN: %run %t -runs=1 -rss_limit_mb=4096 2>big-file-out.txt; result=$?
 RUN: %run rm -f big-file.txt big-file-out.txt


### PR DESCRIPTION
This test is heavy on test resources and involves moving a large 2GB+ file across an ssh connection when testing on remote devices. Exclude all tests except for macOS testing (on host). Remote device testing for macOS may eventually cause a problem on macOS as well w/o better handling of tests that require more resource/time than we currently handle.
    Introduced by:
        https://reviews.llvm.org/D146189
    Subsequent exclusion of all but darwin by:
        https://reviews.llvm.org/D147094
    Subsequent exclusion of tvOS and watchOS by:
        https://reviews.llvm.org/D147502
    Subsequent exclusion of all but macOS...

rdar://107570309

Reviewed By: yln, thetruestblue

Differential Revision: https://reviews.llvm.org/D148727

(cherry picked from commit b62c39f9ef2af3dd398a67a5e9e8d7d0a097d941)