### PR TITLE
ObjectFile: correct Swift AST section name for PE/COFF

### DIFF
--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -1015,7 +1015,7 @@ SectionType ObjectFilePECOFF::GetSectionType(llvm::StringRef sect_name,
           // .eh_frame can be truncated to 8 chars.
           .Cases(".eh_frame", ".eh_fram", eSectionTypeEHFrame)
           .Case(".gosymtab", eSectionTypeGoSymtab)
-          .Case(".swift_ast", eSectionTypeSwiftModules) // downstream change
+          .Case("swiftast", eSectionTypeSwiftModules) // downstream change
           .Default(eSectionTypeInvalid);
   if (section_type != eSectionTypeInvalid)
     return section_type;


### PR DESCRIPTION
PE/COFF has a section name limit at 8 characters.  To accommodate that we name the AST wrapping section `swiftast`.  The ELF name (`.swift_ast`) was replicated here without adjustment which results in LLDB being unable to locate the modulewrap content.  Match the behaviour of the compiler to allow LLDB to load the data.