### PR TITLE
[lldb][tests] TestPreferredName.py: Fix for older compilers

### DIFF
--- a/lldb/test/API/lang/cpp/preferred_name/TestPreferredName.py
+++ b/lldb/test/API/lang/cpp/preferred_name/TestPreferredName.py
@@ -6,8 +6,7 @@ Test formatting of types annotated with
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import decorators
-
+from lldbsuite.test.decorators import *
 
 class TestPreferredName(TestBase):
 

--- a/lldb/test/API/lang/cpp/preferred_name/TestPreferredName.py
+++ b/lldb/test/API/lang/cpp/preferred_name/TestPreferredName.py
@@ -11,6 +11,7 @@ from lldbsuite.test import decorators
 
 class TestPreferredName(TestBase):
 
+    @skipIf(compiler="clang", compiler_version=['<', '16.0'])
     def test_frame_var(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))
@@ -26,6 +27,7 @@ class TestPreferredName(TestBase):
         self.expect("frame variable varChar", substrs=["Bar<char>"])
         self.expect("frame variable varFooInt", substrs=["Foo<BarInt>"])
 
+    @skipIf(compiler="clang", compiler_version=['<', '16.0'])
     def test_expr(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "return", lldb.SBFileSpec("main.cpp"))


### PR DESCRIPTION
This only works as of D145803, where we re-point the `DW_AT_type` based on existence of `[[clang::preferred_name]]`

(cherry picked from commit b767b050414399940f8d7f96e4564a1e5c84879f)