### PR TITLE
[lldb][test] TestCPP20Standard.py: skip on older compilers

### DIFF
--- a/lldb/test/API/lang/cpp/standards/cpp20/TestCPP20Standard.py
+++ b/lldb/test/API/lang/cpp/standards/cpp20/TestCPP20Standard.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 class TestCPP20Standard(TestBase):
+    @skipIf(compiler="clang", compiler_version=['<', '11.0'])
     def test_cpp20(self):
         """
         Tests that we can evaluate an expression in C++20 mode


### PR DESCRIPTION
Requires C++20 support (at least for the spaceship operator). Seems to work back to Clang-11

(cherry picked from commit 53791896de3fcc5606c190fa4e4552383ee1dcb8)