### PR TITLE
[clang][cas] Prefix-map paths in <module-includes>

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -25,6 +25,7 @@
 #include "llvm/CAS/CASOutputBackend.h"
 #include "llvm/Support/BuryPointer.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/VirtualOutputBackend.h"
 #include <cassert>
 #include <list>
@@ -94,6 +95,9 @@ class CompilerInstance : public ModuleLoader {
 
   /// The \c ActionCache key for this compilation, if caching is enabled.
   std::optional<cas::CASID> CompileJobCacheKey;
+
+  /// The prefix mapper; empty by default.
+  llvm::PrefixMapper PrefixMapper;
 
   /// The file manager.
   IntrusiveRefCntPtr<FileManager> FileMgr;
@@ -355,6 +359,10 @@ public:
     CompileJobCacheKey = std::move(Key);
   }
   bool isSourceNonReproducible() const;
+
+  llvm::PrefixMapper &getPrefixMapper() { return PrefixMapper; }
+
+  void setPrefixMapper(llvm::PrefixMapper PM) { PrefixMapper = std::move(PM); }
 
   /// }
   /// @name Diagnostics Engine

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -297,7 +297,8 @@ Error IncludeTreeActionController::initialize(
       return;
 
     PreprocessorOptions &PPOpts = ScanInstance.getPreprocessorOpts();
-    if (PPOpts.Includes.empty() && PPOpts.ImplicitPCHInclude.empty())
+    if (PPOpts.Includes.empty() && PPOpts.ImplicitPCHInclude.empty() &&
+        !ScanInstance.getLangOpts().Modules)
       return;
 
     addReversePrefixMappingFileSystem(PrefixMapper, ScanInstance);
@@ -365,6 +366,7 @@ Error IncludeTreeActionController::initializeModuleBuild(
         return std::make_unique<LookupPCHModulesListener>(R);
       });
   ModuleScanInstance.addDependencyCollector(std::move(DC));
+  ModuleScanInstance.setPrefixMapper(PrefixMapper);
 
   return Error::success();
 }

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -650,7 +650,7 @@ bool ModuleDepCollector::isPrebuiltModule(const Module *M) {
   if (PrebuiltModuleFileIt == PrebuiltModuleFiles.end())
     return false;
   assert("Prebuilt module came from the expected AST file" &&
-         PrebuiltModuleFileIt->second == M->getASTFile()->getName());
+         PrebuiltModuleFileIt->second == M->getASTFile()->getNameAsRequested());
   return true;
 }
 

--- a/clang/test/ClangScanDeps/include-tree-prefix-mapping-pch-remap.c
+++ b/clang/test/ClangScanDeps/include-tree-prefix-mapping-pch-remap.c
@@ -1,0 +1,21 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/deps.json
+
+//--- cdb.json.template
+[{
+  "file": "tu.c",
+  "directory": "DIR",
+  "command": "clang DIR/tu.c -fsyntax-only -include DIR/prefix.h"
+}]
+
+//--- prefix.h
+// Note: this is a bit hacky, but we rely on the fact that dep directives lexing
+// will not see #error during the scan.
+#error "failed to find dependency directives"
+
+//--- tu.c

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -60,15 +60,24 @@ public:
   /// Map \p Path, and saving the new (or existing) path in \p NewPath.
   ///
   /// \pre \p Path is not a reference into \p NewPath.
-  void map(StringRef Path, SmallVectorImpl<char> &NewPath);
-  void map(StringRef Path, std::string &NewPath);
+  /// \returns true if \c NewPath was mapped.
+  bool map(StringRef Path, SmallVectorImpl<char> &NewPath);
+  /// Map \p Path, and saving the new (or existing) path in \p NewPath.
+  ///
+  /// \pre \p Path is not a reference into \p NewPath.
+  /// \returns true if \c NewPath was mapped.
+  bool map(StringRef Path, std::string &NewPath);
 
   /// Map \p Path, returning \a std::string.
   std::string mapToString(StringRef Path);
 
   /// Map \p Path in place.
-  void mapInPlace(SmallVectorImpl<char> &Path);
-  void mapInPlace(std::string &Path);
+  /// \returns true if the path was modified.
+  bool mapInPlace(SmallVectorImpl<char> &Path);
+
+  /// Map \p Path in place.
+  /// \returns true if the path was modified.
+  bool mapInPlace(std::string &Path);
 
 protected:
   /// Map (or unmap) \p Path. On a match, fills \p Storage with the mapped path

--- a/llvm/lib/Support/PrefixMappingFileSystem.cpp
+++ b/llvm/lib/Support/PrefixMappingFileSystem.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/PrefixMappingFileSystem.h"
+#include "llvm/CAS/CASReference.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
@@ -14,6 +15,31 @@ using namespace llvm;
 using namespace llvm::vfs;
 
 namespace {
+
+class PrefixMappingFile : public vfs::File {
+  std::unique_ptr<vfs::File> Underlying;
+
+public:
+  PrefixMappingFile(std::unique_ptr<vfs::File> F) : Underlying(std::move(F)) {}
+
+  llvm::ErrorOr<Status> status() final {
+    auto S = Underlying->status();
+    if (S)
+      S->ExposesExternalVFSPath = true;
+    return S;
+  }
+  llvm::ErrorOr<std::string> getName() final { return Underlying->getName(); }
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+  getBuffer(const Twine &Name, int64_t FileSize, bool RequiresNullTerminator,
+            bool IsVolatile) final {
+    return Underlying->getBuffer(Name, FileSize, RequiresNullTerminator,
+                                 IsVolatile);
+  }
+  llvm::ErrorOr<std::optional<cas::ObjectRef>> getObjectRefForContent() final {
+    return Underlying->getObjectRefForContent();
+  }
+  std::error_code close() final { return Underlying->close(); }
+};
 
 class PrefixMappingFileSystem final : public ProxyFileSystem {
   mutable PrefixMapper Mapper;
@@ -26,17 +52,26 @@ public:
 #define PREFIX_MAP_PATH(Old, New)                                              \
   SmallString<256> New;                                                        \
   Old.toVector(New);                                                           \
-  Mapper.mapInPlace(New);
+  bool DidMap = Mapper.mapInPlace(New);                                        \
+  (void)DidMap; // Prevent unused variable warnings.
 
   llvm::ErrorOr<Status> status(const Twine &Path) override {
     PREFIX_MAP_PATH(Path, MappedPath)
-    return ProxyFileSystem::status(MappedPath);
+    auto S = ProxyFileSystem::status(MappedPath);
+    // If we remapped the path, indicate the external path.
+    if (DidMap && S)
+      S->ExposesExternalVFSPath = true;
+    return S;
   }
 
   llvm::ErrorOr<std::unique_ptr<File>>
   openFileForRead(const Twine &Path) override {
     PREFIX_MAP_PATH(Path, MappedPath)
-    return ProxyFileSystem::openFileForRead(MappedPath);
+    auto F = ProxyFileSystem::openFileForRead(MappedPath);
+    // If we remapped the path, indicate the external path.
+    if (DidMap && F)
+      F = std::make_unique<PrefixMappingFile>(std::move(F.get()));
+    return F;
   }
 
   directory_iterator dir_begin(const Twine &Path,


### PR DESCRIPTION
### [clang][cas] Fix dependency directive lookup for prefix-mapped paths
Currently we are failing to find dependency directives for prefix-mapped
paths in the scanner, such as -include options.

Match how ivfsoverlay marks remapped paths. We want to use the external
(remapped) path when we lookup directives; currently the way to do that
is getName() combined with ExposesExternalVFSPath; if in the future we
add explicit API for this we can drop the status flag.

### [clang][cas] Prefix-map paths in \<module-includes\>

When we generate \<module-includes\> for a system module that uses builtin
clang headers, the clang headers show up with an absolute path since
they are not relative to the module root directory. Prefix-map those
paths so that we can get cache hits across different clang resource
directory paths.

rdar://108381336