### PR TITLE
Fix a swift test that was incorrectly using IsDynamic.

### DIFF
--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -70,7 +70,6 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
               self.check_expression("self", "a.H<Int>")
               frame = threads[0].GetFrameAtIndex(0)
               lldbutil.check_variable(self, frame.FindVariable("self"),
-                                      use_dynamic=True,
                                       # FIXME: This should be '@thick a.H<Swift.Int>.Type'
                                       # but valobj.GetDynamicValue(lldb.eDynamicCanRunTarget)
                                       # doesn't seem to do its job.


### PR DESCRIPTION
The test asks for but does not get (because of bugs) a dynamic value.  Then it asserts that the value IsDynamic.  That wasn't right, it didn't get a dynamic value just a "wrapper" for the static value in this case.

(cherry picked from commit abe5abb2427d095cb1afd83557b4735b57a118b0)