### PR TITLE
[lldb] Use the address type when discovering the dynamic address

### DIFF
--- a/lldb/include/lldb/Core/Value.h
+++ b/lldb/include/lldb/Core/Value.h
@@ -145,6 +145,8 @@ public:
 
   void Clear();
 
+  static ValueType GetValueTypeFromAddressType(AddressType address_type);
+
 protected:
   Scalar m_value;
   CompilerType m_compiler_type;

--- a/lldb/source/Core/Value.cpp
+++ b/lldb/source/Core/Value.cpp
@@ -120,6 +120,20 @@ AddressType Value::GetValueAddressType() const {
   return eAddressTypeInvalid;
 }
 
+Value::ValueType Value::GetValueTypeFromAddressType(AddressType address_type) {
+  switch (address_type) {
+    case eAddressTypeFile:
+      return Value::ValueType::FileAddress;
+    case eAddressTypeLoad:
+      return Value::ValueType::LoadAddress;
+    case eAddressTypeHost:
+      return Value::ValueType::HostAddress;
+    case eAddressTypeInvalid:
+      return Value::ValueType::Invalid;
+  }
+  llvm_unreachable("Unexpected address type!");
+}
+
 RegisterInfo *Value::GetRegisterInfo() const {
   if (m_context_type == ContextType::RegisterInfo)
     return static_cast<RegisterInfo *>(m_context);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -277,17 +277,21 @@ protected:
   // Classes that inherit from SwiftLanguageRuntime can see and modify these
   Value::ValueType GetValueType(ValueObject &in_value,
                                 CompilerType dynamic_type,
+                                Value::ValueType static_value_type,
                                 bool is_indirect_enum_case);
   bool GetDynamicTypeAndAddress_Pack(ValueObject &in_value,
                                      CompilerType pack_type,
                                      lldb::DynamicValueType use_dynamic,
                                      TypeAndOrName &class_type_or_name,
-                                     Address &address);
+                                     Address &address,
+                                     Value::ValueType &value_type);
+
   bool GetDynamicTypeAndAddress_Class(ValueObject &in_value,
                                       CompilerType class_type,
                                       lldb::DynamicValueType use_dynamic,
                                       TypeAndOrName &class_type_or_name,
-                                      Address &address);
+                                      Address &address,
+                                      Value::ValueType &value_type);
 
   bool GetDynamicTypeAndAddress_Protocol(ValueObject &in_value,
                                          CompilerType protocol_type,
@@ -299,11 +303,13 @@ protected:
                                       CompilerType &bound_type,
                                       lldb::DynamicValueType use_dynamic,
                                       TypeAndOrName &class_type_or_name,
-                                      Address &address);
+                                      Address &address,
+                                      Value::ValueType &value_type);
 
   bool GetDynamicTypeAndAddress_IndirectEnumCase(
       ValueObject &in_value, lldb::DynamicValueType use_dynamic,
-      TypeAndOrName &class_type_or_name, Address &address);
+      TypeAndOrName &class_type_or_name, Address &address,
+      Value::ValueType &value_type);
 
   bool GetDynamicTypeAndAddress_ClangType(ValueObject &in_value,
                                           lldb::DynamicValueType use_dynamic,


### PR DESCRIPTION
Instead of trying to guess the value type after doing dynamic type
resolution, use the address type when performing it instead.