### PR TITLE
Fix issues with llvm-cas-object-size-pr bot because of auto path divergences

### DIFF
--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -29,9 +29,6 @@ namespace clang {
 
 class DiagnosticsEngine;
 
-/// Set \p Path to a reasonable default on-disk cache path for the current user.
-void getClangDefaultCachePath(llvm::SmallVectorImpl<char> &Path);
-
 /// Base class for options configuring which CAS to use. Separated for the
 /// fields where we don't need special move/copy logic.
 ///

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -17,13 +17,6 @@
 using namespace clang;
 using namespace llvm::cas;
 
-void clang::getClangDefaultCachePath(SmallVectorImpl<char> &Path) {
-  // FIXME: Should this return 'Error' instead of hard-failing?
-  if (!llvm::sys::path::cache_directory(Path))
-    llvm::report_fatal_error("cannot get default cache directory");
-  llvm::sys::path::append(Path, "clang-cache");
-}
-
 std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
           std::shared_ptr<llvm::cas::ActionCache>>
 CASOptions::getOrCreateDatabases(DiagnosticsEngine &Diags,
@@ -106,7 +99,7 @@ void CASOptions::initCache(DiagnosticsEngine &Diags) const {
 
   SmallString<256> PathBuf;
   if (CASPath == "auto") {
-    getClangDefaultCachePath(PathBuf);
+    getDefaultOnDiskCASPath(PathBuf);
     CASPath = PathBuf;
   }
   std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>> DBs;

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -263,8 +263,11 @@ cas::createCASFromIdentifier(StringRef Path) {
                              "No CAS identifier is provided");
 
   // FIXME: some current default behavior.
-  if (Path == "auto")
-    return createOnDiskCAS(getDefaultOnDiskCASPath());
+  SmallString<256> PathBuf;
+  if (Path == "auto") {
+    getDefaultOnDiskCASPath(PathBuf);
+    Path = PathBuf;
+  }
 
   // Fallback is to create UnifiedOnDiskCache.
   auto UniDB = builtin::createBuiltinUnifiedOnDiskCache(Path);


### PR DESCRIPTION
Due to the commit dfc2901bf4ed19e49b2458e976fd3f323312c2cf the behavior of clang and llvm-cas-object-format when using auto for the CAS path diverges. The default paths are not the same, which leads to issues with the object file statistics.

Also, llvm-cas-object-format does not create a UnifiedOnDiskCache when the cas path is auto.

This PR addresses both issues, by making sure llvm-cas-object-format always creates a UnifiedOnDiskCache, and clang uses the same CAS path as llvm-cas-object-format when the cas path is set to auto.