### PR TITLE
Swift: update `getValueOr` to `value_or`

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -155,7 +155,7 @@ public:
     ret->ValueUpdated();
 
     if (variable) {
-      const size_t pvar_byte_size = ret->GetByteSize().getValueOr(0);
+      const size_t pvar_byte_size = ret->GetByteSize().value_or(0);
       uint8_t *pvar_data = ret->GetValueBytes();
 
       Status read_error;
@@ -409,7 +409,7 @@ public:
         // FIXME: This may not work if the value is not bitwise-takable.
         execution_unit->ReadMemory(
             m_persistent_variable_sp->GetValueBytes(), var_addr,
-            m_persistent_variable_sp->GetByteSize().getValueOr(0), read_error);
+            m_persistent_variable_sp->GetByteSize().value_or(0), read_error);
 
         if (!read_error.Success()) {
           err.SetErrorStringWithFormat(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1368,7 +1368,7 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
     os << '.' << idx;
     child_byte_size =
         GetBitSize(pack_element_type, exe_ctx.GetBestExecutionContextScope())
-            .getValueOr(0);
+            .value_or(0);
     int stack_dir = -1;
     child_byte_offset = ts->GetPointerByteSize() * idx * stack_dir;
     child_bitfield_bit_size = 0;
@@ -2120,7 +2120,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
       return {};
     if (use_local_buffer)
       PushLocalBuffer(existential_address,
-                      in_value.GetByteSize().getValueOr(0));
+                      in_value.GetByteSize().value_or(0));
 
     auto result = remote_ast.getDynamicTypeAndAddressForExistential(
         remote_existential, swift_type);
@@ -2186,7 +2186,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
 
 
   if (use_local_buffer)
-    PushLocalBuffer(existential_address, in_value.GetByteSize().getValueOr(0));
+    PushLocalBuffer(existential_address, in_value.GetByteSize().value_or(0));
 
   swift::remote::RemoteAddress remote_existential(existential_address);
 
@@ -2850,7 +2850,7 @@ SwiftLanguageRuntimeImpl::GetValueType(ValueObject &in_value,
 
       if (use_local_buffer)
         PushLocalBuffer(existential_address,
-                        in_value.GetByteSize().getValueOr(0));
+                        in_value.GetByteSize().value_or(0));
 
       // Read the value witness table and check if the data is inlined in
       // the existential container or not.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2775,7 +2775,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
           (ReconstructType(type), omit_empty_base_classes, exe_ctx),
           (ReconstructType(type), omit_empty_base_classes, exe_ctx));
     }()
-                        .getValueOr(0);
+                        .value_or(0);
 
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "Using SwiftASTContext::GetNumChildren fallback for type %s",
@@ -2831,7 +2831,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
                           (ReconstructType(type), exe_ctx),
                           (ReconstructType(type), exe_ctx));
     }()
-                        .getValueOr(0);
+                        .value_or(0);
   }
 
   LLDB_LOGF(GetLog(LLDBLog::Types),
@@ -2926,7 +2926,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     if (auto *swift_ast_context = GetSwiftASTContext())
       ast_num_children = swift_ast_context->GetNumChildren(
           ReconstructType(type), omit_empty_base_classes, exe_ctx);
-    return ast_num_children.getValueOr(0);
+    return ast_num_children.value_or(0);
   };
   auto impl = [&]() -> CompilerType {
     ExecutionContextScope *exe_scope = nullptr;
@@ -2974,7 +2974,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
             child_name = "rawValue";
             auto bit_size = raw_value.GetBitSize(
                 exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr);
-            child_byte_size = bit_size.getValueOr(0) / 8;
+            child_byte_size = bit_size.value_or(0) / 8;
             child_byte_offset = 0;
             child_bitfield_bit_size = 0;
             child_bitfield_bit_offset = 0;
@@ -3057,7 +3057,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   if (ModuleList::GetGlobalModuleListProperties().GetSwiftValidateTypeSystem())
     if (get_ast_num_children() <
         runtime->GetNumChildren({weak_from_this(), type}, exe_scope)
-            .getValueOr(0))
+            .value_or(0))
       return impl();
   if (ShouldSkipValidation(type))
     return impl();
@@ -3125,7 +3125,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
           GetCanonicalType(type), name, exe_ctx, omit_empty_base_classes,
           child_indexes);
       if (found_numidx.first) {
-        size_t index_size = found_numidx.second.getValueOr(0);
+        size_t index_size = found_numidx.second.value_or(0);
 #ifndef NDEBUG
         // This block is a custom VALIDATE_AND_RETURN implementation to support
         // checking the return value, plus the by-ref `child_indexes`.


### PR DESCRIPTION
LLVM has replaced the spelling for `getValueOr` to `value_or` to more closely match the C++ standard.  This matches the spelling to avoid a deprecation warning.