### PR TITLE
🍒/5.9/21be357873c0325495c7f6599259579735f54f3e+9dbce774eea515e400954f1d0ffbd858c839b546

### DIFF
--- a/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
+++ b/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
@@ -788,6 +788,8 @@ main = foo
                                 testing::ContainsRegex("line 7, in baz"),
                                 testing::ContainsRegex("ZeroDivisionError")))));
 
+#if !((defined(_WIN32) || defined(_WIN64)) && (defined(__aarch64__) || defined(_M_ARM64)))
+
   static const char script2[] = R"(
 class MyError(Exception):
   def __str__(self):
@@ -804,6 +806,8 @@ def main():
                        llvm::Failed<PythonException>(testing::Property(
                            &PythonException::ReadBacktrace,
                            testing::ContainsRegex("unprintable MyError"))));
+
+#endif
 }
 
 TEST_F(PythonDataObjectsTest, TestRun) {

--- a/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
+++ b/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
@@ -802,10 +802,13 @@ def main():
 
   PythonScript lol(script2);
 
-  EXPECT_THAT_EXPECTED(lol(),
-                       llvm::Failed<PythonException>(testing::Property(
-                           &PythonException::ReadBacktrace,
-                           testing::ContainsRegex("unprintable MyError"))));
+  EXPECT_THAT_EXPECTED(
+      lol(),
+      llvm::Failed<PythonException>(testing::Property(
+          &PythonException::ReadBacktrace,
+          testing::AnyOf(
+              testing::ContainsRegex("MyError: <exception str\\(\\) failed>"),
+              testing::ContainsRegex("unprintable MyError")))));
 
 #endif
 }


### PR DESCRIPTION
- [LLDB] Skip python exception unit test on AArch64/Windows
- [lldb] Update PythonDataObjectsTests for new exception formatting
