### PR TITLE
[lldb] Don't special case Error existential handling in GetValueType

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2820,18 +2820,6 @@ SwiftLanguageRuntimeImpl::GetValueType(ValueObject &in_value,
     // object is a struct? (for a class, it's easy)
     if (static_type_flags.AllSet(eTypeIsSwift | eTypeIsProtocol) &&
         dynamic_type_flags.AnySet(eTypeIsStructUnion | eTypeIsEnumeration)) {
-      if (auto ts = static_type.GetTypeSystem()
-                        .dyn_cast_or_null<TypeSystemSwiftTypeRef>())
-        static_type = ts->ReconstructType(static_type);
-      auto swift_ast_ctx =
-          static_type.GetTypeSystem().dyn_cast_or_null<SwiftASTContext>();
-      if (!swift_ast_ctx)
-        return {};
-      if (swift_ast_ctx->IsErrorType(static_type.GetOpaqueQualType())) {
-        // ErrorType values are always a pointer
-        return Value::ValueType::LoadAddress;
-      }
-
       lldb::addr_t existential_address;
       bool use_local_buffer = false;
 


### PR DESCRIPTION
This avoids loading Swift ASTContexts (via the call to `ReconstructType`), solely for the purpose of special casing `Error`. Not using ASTContexts will save time performing operations that aren't strictly needed yet. The remainder of this function handles types generally (see `reflection_ctx->isValueInlinedInExistentialContainer`).