### PR TITLE
Make the TSan report capture data structure anonymous.

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -95,7 +95,7 @@ const char *thread_sanitizer_retrieve_report_data_command = R"(
 const int REPORT_TRACE_SIZE = 128;
 const int REPORT_ARRAY_SIZE = 4;
 
-struct data {
+struct {
     void *report;
     const char *description;
     int report_count;


### PR DESCRIPTION
This was using `struct data` which is way to common a name to use in an lldb expression, and was causing occasional failures in the TSan report gatherer.  The structure doesn't need to have a tag, so remove it to avoid future problems.

The same job was done for the other sanitizers in D145569, but this one was overlooked.

Differential Revision: https://reviews.llvm.org/D149394

(cherry picked from commit 47f72aede163348ee474be4a3004dc0a9195fa9c) (cherry picked from commit 11d00844719d822511cf3b1599d606ecf418139b)