### PR TITLE
[lldb][test] TestCPP20Standard.py: make it a libc++ test

### DIFF
--- a/lldb/test/API/lang/cpp/standards/cpp20/Makefile
+++ b/lldb/test/API/lang/cpp/standards/cpp20/Makefile
@@ -1,3 +1,4 @@
+USE_LIBCPP := 1
 CXX_SOURCES := main.cpp
 CXXFLAGS_EXTRAS := -std=c++20
 

--- a/lldb/test/API/lang/cpp/standards/cpp20/TestCPP20Standard.py
+++ b/lldb/test/API/lang/cpp/standards/cpp20/TestCPP20Standard.py
@@ -4,6 +4,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 class TestCPP20Standard(TestBase):
+    @add_test_categories(["libc++"])
     @skipIf(compiler="clang", compiler_version=['<', '11.0'])
     def test_cpp20(self):
         """


### PR DESCRIPTION
We just want to test whether the language switch works. This is easier to control for libc++, since for bots building the tests against libstdc++ we might not have the necessary `<compare>` header available currently.

(cherry picked from commit 52882de0e641487329c9e093a90ea3dad01842c8)