### PR TITLE
Host: introduce `GetSDKPath` extension point for Windows

### DIFF
--- a/lldb/include/lldb/Host/windows/HostInfoWindows.h
+++ b/lldb/include/lldb/Host/windows/HostInfoWindows.h
@@ -33,15 +33,17 @@ public:
   static bool GetHostname(std::string &s);
   static FileSpec GetProgramFileSpec();
   static FileSpec GetDefaultShell();
+
+  static bool GetEnvironmentVar(const std::string &var_name, std::string &var);
+
 #ifdef LLDB_ENABLE_SWIFT
   static FileSpec GetSwiftResourceDir();
   static std::string GetSwiftResourceDir(llvm::Triple triple,
                                          llvm::StringRef platform_sdk_path);
   static bool ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
                                             FileSpec &file_spec, bool verify);
+  static llvm::Expected<llvm::StringRef> GetSDKRoot(SDKOptions options);
 #endif
-
-  static bool GetEnvironmentVar(const std::string &var_name, std::string &var);
 
 private:
   static FileSpec m_program_filespec;

--- a/lldb/source/Host/windows/HostInfoWindowsSwift.cpp
+++ b/lldb/source/Host/windows/HostInfoWindowsSwift.cpp
@@ -13,6 +13,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include <llvm/Support/ConvertUTF.h>
 
 #include <string>
 
@@ -42,4 +43,14 @@ std::string
 HostInfoWindows::GetSwiftResourceDir(llvm::Triple triple,
                                      llvm::StringRef platform_sdk_path) {
   return GetSwiftResourceDir().GetPath();
+}
+
+llvm::Expected<llvm::StringRef> HostInfoWindows::GetSDKRoot(SDKOptions options) {
+  std::string buffer;
+  if (wchar_t *path = _wgetenv(L"SDKROOT"))
+    if (llvm::convertUTF16ToUTF8String(
+            llvm::ArrayRef{reinterpret_cast<llvm::UTF16 *>(path), wcslen(path)},
+            buffer))
+      return buffer;
+  return llvm::make_error<HostInfoError>("`SDKROOT` is unset");
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1418,16 +1418,16 @@ static llvm::Optional<StringRef> GetDSYMBundle(Module &module) {
 static std::string GetSDKPath(std::string m_description, XcodeSDK sdk) {
   auto sdk_path_or_err = HostInfo::GetXcodeSDKPath(sdk);
   if (!sdk_path_or_err) {
-    Debugger::ReportError("Error while searching for Xcode SDK: " +
+    Debugger::ReportError("Error while searching for SDK: " +
                           toString(sdk_path_or_err.takeError()));
-    HEALTH_LOG_PRINTF("Error while searching for Xcode SDK %s.",
+    HEALTH_LOG_PRINTF("Error while searching for SDK (XcodeSDK: %s)",
                       sdk.GetString().str().c_str());
     return {};
   }
 
   std::string sdk_path = sdk_path_or_err->str();
-  LOG_PRINTF(GetLog(LLDBLog::Types), "Host SDK path for sdk %s is %s.",
-             sdk.GetString().str().c_str(), sdk_path.c_str());
+  LOG_PRINTF(GetLog(LLDBLog::Types), "Host SDK path: `%s` (XcodeSDK: %s)",
+             sdk_path.c_str(), sdk.GetString().str().c_str());
   return sdk_path;
 }
 


### PR DESCRIPTION
Introduce a new extension point to allow a host to specify a SDK path. On Windows, there is the default global SDK path which is identified by the `SDKROOT` environment variable.  Wire this into the process to construct the proper search paths for the Swift module when debugging.