### PR TITLE
[lldb] Fix kind path in nodeAtPath call

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1054,9 +1054,8 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
     NodePointer root = SwiftLanguageRuntime::DemangleSymbolAsNode(
         type.GetMangledTypeName().GetStringRef(), dem);
     using Kind = Node::Kind;
-    auto *builtin_type =
-        swift_demangle::nodeAtPath(root, {Kind::Global, Kind::TypeMangling,
-                                          Kind::Type, Kind::BuiltinTypeName});
+    auto *builtin_type = swift_demangle::nodeAtPath(
+        root, {Kind::TypeMangling, Kind::Type, Kind::BuiltinTypeName});
     if (builtin_type)
       return 0;
   }


### PR DESCRIPTION
Fix to `nodeAtPath` API mistake in #6758. The `Global` kind is not to be passed as part of the path.