### PR TITLE
[VirtualOutputBackend] Proper error reporting for FileSystem errors

### DIFF
--- a/llvm/lib/Support/VirtualOutputBackends.cpp
+++ b/llvm/lib/Support/VirtualOutputBackends.cpp
@@ -213,6 +213,7 @@ public:
 
   Error initializeFD(Optional<int> &FD);
   Error initializeStream();
+  Error reset();
 
   OnDiskOutputFile(StringRef OutputPath, Optional<OutputConfig> Config,
                    const OnDiskOutputBackend::OutputSettings &Settings)
@@ -420,10 +421,23 @@ areFilesDifferent(const llvm::Twine &Source, const llvm::Twine &Destination) {
   return FileDifference::SameContents;
 }
 
-Error OnDiskOutputFile::keep() {
+Error OnDiskOutputFile::reset() {
   // Destroy the streams to flush them.
   BufferOS.reset();
+  if (!FileOS)
+    return Error::success();
+
+  // Remember the error in raw_fd_ostream to be reported later.
+  std::error_code EC = FileOS->error();
+  // Clear the error to avoid fatal error when reset.
+  FileOS->clear_error();
   FileOS.reset();
+  return errorCodeToError(EC);
+}
+
+Error OnDiskOutputFile::keep() {
+  if (auto E = reset())
+    return E;
 
   // Close the file descriptor and remove crash cleanup before exit.
   auto RemoveDiscardOnSignal = make_scope_exit([&]() {
@@ -483,8 +497,8 @@ Error OnDiskOutputFile::keep() {
 
 Error OnDiskOutputFile::discard() {
   // Destroy the streams to flush them.
-  BufferOS.reset();
-  FileOS.reset();
+  if (auto E = reset())
+    return E;
 
   // Nothing on the filesystem to remove for stdout.
   if (OutputPath == "-")


### PR DESCRIPTION
Return proper llvm::Error from virtual output backend when it discovers file system error when keep/discard. Instead of triggering the fatal error in raw_fd_ostream, report the error_code as llvm::Error to caller.

rdar://107855318