### PR TITLE
[clang][deps] Remove duplicate command-line parsing

### DIFF
--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -242,14 +242,6 @@ static void ParseArgs(int argc, char **argv) {
   if (auto *A = Args.getLastArgNoClaim(OPT_DASH_DASH))
     CommandLine.insert(CommandLine.end(), A->getValues().begin(),
                        A->getValues().end());
-
-  Verbose = Args.hasArg(OPT_verbose);
-
-  RoundTripArgs = Args.hasArg(OPT_round_trip_args);
-
-  if (auto *A = Args.getLastArgNoClaim(OPT_DASH_DASH))
-    CommandLine.insert(CommandLine.end(), A->getValues().begin(),
-                       A->getValues().end());
 }
 
 class SharedStream {


### PR DESCRIPTION
In 4d595afe, we merged 384fca55, but some command-line parsing accidentally got duplicated. This made `clang/test/ClangScanDeps/P1689.cppm` fail with an error complaining about two `-o` arguments.