### PR TITLE
Recognize `addressing_bits` kv in stop reply packet

### DIFF
--- a/lldb/docs/lldb-gdb-remote.txt
+++ b/lldb/docs/lldb-gdb-remote.txt
@@ -1596,6 +1596,24 @@ for this region.
 //                                  Example:
 //                                  thread-pcs:dec14,2cf872b0,2cf8681c,2d02d68c,2cf716a8;
 //
+//  "addressing_bits" unsigned optional  Specifies how many bits in addresses 
+//                                       are significant for addressing, base 
+//                                       10.  If bits 38..0 in a 64-bit 
+//                                       pointer are significant for 
+//                                       addressing, then the value is 39.  
+//                                       This is needed on e.g. AArch64
+//                                       v8.3 ABIs that use pointer 
+//                                       authentication in the high bits.
+//                                       This value is normally sent in the
+//                                       qHostInfo packet response, and if the
+//                                       value cannot change during the process
+//                                       lifetime, it does not need to be 
+//                                       duplicated here in the stop packet.
+//                                       For a firmware environment with early
+//                                       start code that may be changing the
+//                                       page table setup, a dynamically set
+//                                       value may be needed.
+//
 // BEST PRACTICES:
 //  Since register values can be supplied with this packet, it is often useful
 //  to return the PC, SP, FP, LR (if any), and FLAGS registers so that separate

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -2238,6 +2238,13 @@ StateType ProcessGDBRemote::SetThreadStopInfo(StringExtractor &stop_packet) {
         StreamString ostr;
         ostr.Printf("%" PRIu64 " %" PRIu64, pid_tid->first, pid_tid->second);
         description = std::string(ostr.GetString());
+      } else if (key.compare("addressing_bits") == 0) {
+        uint64_t addressing_bits;
+        if (!value.getAsInteger(0, addressing_bits)) {
+          addr_t address_mask = ~((1ULL << addressing_bits) - 1);
+          SetCodeAddressMask(address_mask);
+          SetDataAddressMask(address_mask);
+        }
       } else if (key.size() == 2 && ::isxdigit(key[0]) && ::isxdigit(key[1])) {
         uint32_t reg = UINT32_MAX;
         if (!key.getAsInteger(16, reg))


### PR DESCRIPTION
Recognize `addressing_bits` kv in stop reply packet

If a remote stub provides the addressing_bits kv pair in the stop reply packet, update the Process address masks with that value as it possibly changes during the process runtime. This is an unusual situation, most likely a JTAG remote stub and some very early startup code that is setting up the page tables.  Nearly all debug sessions will have a single address mask that cannot change during the lifetime of a Process.

Differential Revision: https://reviews.llvm.org/D149803 rdar://61900565

(cherry picked from commit 4fac08ff1dcd02c89c677365b10921399caf79df)