### PR TITLE
Silence a spurious warning about the SDK location when debugging Swif…

### DIFF
--- a/lldb/include/lldb/Host/linux/HostInfoLinux.h
+++ b/lldb/include/lldb/Host/linux/HostInfoLinux.h
@@ -31,6 +31,12 @@ public:
   static llvm::StringRef GetDistributionId();
   static FileSpec GetProgramFileSpec();
 
+  static llvm::Expected<llvm::StringRef> GetSDKRoot(SDKOptions options) {
+    if (options.XcodeSDK && options.XcodeSDK->GetType() == XcodeSDK::Type::Linux)
+      return "/";
+    return llvm::make_error<HostInfoError>("cannot determine SDK root");
+  }
+
 protected:
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);
   static bool ComputeSystemPluginsDirectory(FileSpec &file_spec);


### PR DESCRIPTION
…t code on Linux.

rdar://108765542
(cherry picked from commit e35aac04737c8bf1f1dcc57d24728a07160e4141)