### PR TITLE
[lldb] Replace use of p with expression in (Swift) shell tests

### DIFF
--- a/lldb/test/Shell/Swift/DeserializationFailure.test
+++ b/lldb/test/Shell/Swift/DeserializationFailure.test
@@ -15,7 +15,7 @@
 b main
 run
 # Create a SwiftASTContext, to induce error output.
-p 1
+expression 1
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: a.out:{{ }}{{.*}}The serialized module is corrupted.

--- a/lldb/test/Shell/Swift/DynamicTyperesolutionConflict.test
+++ b/lldb/test/Shell/Swift/DynamicTyperesolutionConflict.test
@@ -21,8 +21,8 @@
 b Dylib.swift:9
 run
 target v foofoo
-p input
-p input
+expression input
+expression input
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: {{Swift}} error in fallback scratch context

--- a/lldb/test/Shell/Swift/MissingVFSOverlay.test
+++ b/lldb/test/Shell/Swift/MissingVFSOverlay.test
@@ -12,7 +12,7 @@
 b main
 run
 # Create a SwiftASTContext, to induce error output.
-p 1
+expression 1
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK: a.out:{{ }}

--- a/lldb/test/Shell/Swift/RemoteASTImport.test
+++ b/lldb/test/Shell/Swift/RemoteASTImport.test
@@ -45,7 +45,7 @@
 
 b Library.swift:10
 run
-p input
+expression input
 
 # The {{ }} avoids accidentally matching the input script!
 # CHECK-NOT: undeclared identifier {{'SYNTAX_ERROR'}}


### PR DESCRIPTION
(cherry picked from commit c1b4d2db7c4b36804020adcb9a5da257ccb7779e)
