### PR TITLE
[lldb] Try GetTargetWP before GetSwiftASTContext (#6656)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -229,10 +229,13 @@ TypeSP TypeSystemSwiftTypeRef::LookupClangType(
     return result;
   }
 
-  SwiftASTContext *target_holder = GetSwiftASTContext();
-  if (!target_holder)
-    return {};
-  TargetSP target_sp = target_holder->GetTargetWP().lock();
+  TargetSP target_sp = GetTargetWP().lock();
+  if (!target_sp) {
+    SwiftASTContext *target_holder = GetSwiftASTContext();
+    if (!target_holder)
+      return {};
+    target_sp = target_holder->GetTargetWP().lock();
+  }
   if (!target_sp)
     return {};
   target_sp->GetImages().ForEach([&](const ModuleSP &module) -> bool {


### PR DESCRIPTION
`LookupClangType` needs the `Target` instance, and it has used `GetSwiftASTContext` to get to the target. It does not need anything directly from the ASTContext. To avoid unnecessarily loading Swift ASTContexts from `TypeSystemSwiftTypeRef`, this change tries `GetTargetWP` first, and if that succeeds, then the call to `GetSwiftASTContext` can be avoided entirely.

(cherry-picked from commit 2e31fa34a45f2217f7cd7e0b44ce030c78419156)