### PR TITLE
[IncludeTree] Support APINotes with IncludeTree

### DIFF
--- a/clang/include/clang/APINotes/APINotesManager.h
+++ b/clang/include/clang/APINotes/APINotesManager.h
@@ -77,6 +77,13 @@ class APINotesManager {
   /// a failure.
   std::unique_ptr<APINotesReader> loadAPINotes(const FileEntry *apiNotesFile);
 
+  /// Load the API notes associated with the given buffer, whether it is
+  /// the binary or source form of API notes.
+  ///
+  /// \returns the API notes reader for this file, or null if there is
+  /// a failure.
+  std::unique_ptr<APINotesReader> loadAPINotes(StringRef Buffer);
+
   /// Load the given API notes file for the given header directory.
   ///
   /// \param HeaderDir The directory at which we
@@ -125,6 +132,25 @@ public:
   bool loadCurrentModuleAPINotes(Module *module,
                                  bool lookInModule,
                                  ArrayRef<std::string> searchPaths);
+
+  /// Get FileEntry for the APINotes of the current module.
+  ///
+  /// \param module The current module.
+  /// \param lookInModule Whether to look inside the module itself.
+  /// \param searchPaths The paths in which we should search for API notes
+  /// for the current module.
+  ///
+  /// \returns a vector of FileEntry where APINotes files are.
+  llvm::SmallVector<const FileEntry *, 2>
+  getCurrentModuleAPINotes(Module *module, bool lookInModule,
+                           ArrayRef<std::string> searchPaths);
+
+  /// Load Compiled API notes for current module.
+  ///
+  /// \param Buffers Array of compiled API notes.
+  ///
+  /// \returns true if API notes were successfully loaded, \c false otherwise.
+  bool loadCurrentModuleAPINotesFromBuffer(ArrayRef<StringRef> Buffers);
 
   /// Retrieve the set of API notes readers for the current module.
   ArrayRef<APINotesReader *> getCurrentModuleReaders() const {

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -40,6 +40,8 @@ def err_cas_cannot_parse_include_tree_id : Error<
   "CAS cannot parse include-tree-id '%0'">, DefaultFatal;
 def err_cas_missing_include_tree_id : Error<
   "CAS missing expected include-tree '%0'">, DefaultFatal;
+def err_cas_cannot_load_api_notes_include_tree : Error<
+  "cannot load APINotes from include-tree-id '%0'">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -680,6 +680,8 @@ def err_drv_target_variant_invalid : Error<
 
 def err_drv_inputs_and_include_tree : Error<
   "passing input files is incompatible with '-fcas-include-tree'">;
+def err_drv_incompatible_option_include_tree : Error<
+  "passing incompatible option '%0' with '-fcas-include-tree'">;
 
 def err_drv_invalid_directx_shader_module : Error<
   "invalid profile : %0">;

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -21,6 +21,7 @@
 #include "clang/Basic/Stack.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/Version.h"
+#include "clang/CAS/IncludeTree.h"
 #include "clang/Config/config.h"
 #include "clang/Frontend/CASDependencyCollector.h"
 #include "clang/Frontend/ChainedDiagnosticConsumer.h"
@@ -801,6 +802,52 @@ CompilerInstance::createCodeCompletionConsumer(Preprocessor &PP,
   return new PrintingCodeCompleteConsumer(Opts, OS);
 }
 
+static void loadAPINotesFromIncludeTree(cas::ObjectStore &DB,
+                                        api_notes::APINotesManager &APINotes,
+                                        DiagnosticsEngine &Diags,
+                                        StringRef IncludeTreeRootID) {
+  Expected<llvm::cas::CASID> RootID = DB.parseID(IncludeTreeRootID);
+  if (!RootID) {
+    llvm::consumeError(RootID.takeError());
+    Diags.Report(diag::err_cas_cannot_parse_include_tree_id)
+        << IncludeTreeRootID;
+    return;
+  }
+  Optional<llvm::cas::ObjectRef> Ref = DB.getReference(*RootID);
+  if (!Ref) {
+    Diags.Report(diag::err_cas_missing_include_tree_id) << IncludeTreeRootID;
+    return;
+  }
+  auto Root = cas::IncludeTreeRoot::get(DB, *Ref);
+  if (!Root) {
+    consumeError(Root.takeError());
+    Diags.Report(diag::err_cas_missing_include_tree_id) << IncludeTreeRootID;
+    return;
+  }
+  auto Notes = Root->getAPINotes();
+  if (!Notes) {
+    consumeError(Notes.takeError());
+    Diags.Report(diag::err_cas_cannot_load_api_notes_include_tree)
+        << IncludeTreeRootID;
+    return;
+  }
+  if (!*Notes)
+    return;
+  std::vector<StringRef> Buffers;
+
+  if (auto E = (*Notes)->forEachAPINotes([&](StringRef Buffer) {
+        Buffers.push_back(Buffer);
+        return llvm::Error::success();
+      })) {
+    consumeError(std::move(E));
+    Diags.Report(diag::err_cas_cannot_load_api_notes_include_tree)
+        << IncludeTreeRootID;
+    return;
+  }
+
+  APINotes.loadCurrentModuleAPINotesFromBuffer(Buffers);
+}
+
 void CompilerInstance::createSema(TranslationUnitKind TUKind,
                                   CodeCompleteConsumer *CompletionConsumer) {
   TheSema.reset(new Sema(getPreprocessor(), getASTContext(), getASTConsumer(),
@@ -812,10 +859,18 @@ void CompilerInstance::createSema(TranslationUnitKind TUKind,
   // If we're building a module and are supposed to load API notes,
   // notify the API notes manager.
   if (auto currentModule = getPreprocessor().getCurrentModule()) {
-    (void)TheSema->APINotes.loadCurrentModuleAPINotes(
-            currentModule,
-            getLangOpts().APINotesModules,
-            getAPINotesOpts().ModuleSearchPaths);
+    // If using include tree, APINotes for current module is loaded from include
+    // tree.
+    if (getFrontendOpts().CASIncludeTreeID.empty())
+      (void)TheSema->APINotes.loadCurrentModuleAPINotes(
+          currentModule, getLangOpts().APINotesModules,
+          getAPINotesOpts().ModuleSearchPaths);
+    else
+      loadAPINotesFromIncludeTree(
+          *getCASOpts().getOrCreateDatabases(getDiagnostics()).first,
+          TheSema->APINotes, getDiagnostics(),
+          getFrontendOpts().CASIncludeTreeID);
+
     // Check for any attributes we should add to the module
     for (auto reader : TheSema->APINotes.getCurrentModuleReaders()) {
       // swift_infer_import_as_member

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3638,6 +3638,11 @@ static void ParseAPINotesArgs(APINotesOptions &Opts, ArgList &Args,
   }
   for (const Arg *A : Args.filtered(OPT_iapinotes_modules))
     Opts.ModuleSearchPaths.push_back(A->getValue());
+
+  if (Args.hasFlag(OPT_fapinotes, OPT_fno_apinotes, false) &&
+      Args.hasArg(OPT_fcas_include_tree))
+    diags.Report(diag::err_drv_incompatible_option_include_tree)
+        << "-fapinotes";
 }
 
 static void GeneratePointerAuthArgs(LangOptions &Opts,

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "CachingActions.h"
+#include "clang/APINotes/APINotesManager.h"
+#include "clang/APINotes/APINotesReader.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Lex/Preprocessor.h"
@@ -127,6 +129,7 @@ private:
   Optional<cas::ObjectRef> PredefinesBufferRef;
   Optional<cas::ObjectRef> ModuleIncludesBufferRef;
   Optional<cas::ObjectRef> ModuleMapRef;
+  Optional<cas::ObjectRef> APINotesRef;
   /// When the builder is created from an existing tree, the main include tree.
   Optional<cas::ObjectRef> MainIncludeTreeRef;
   SmallVector<FilePPState> IncludeStack;
@@ -634,6 +637,7 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
 
   if (!ScanInstance.getLangOpts().CurrentModule.empty()) {
     SmallVector<cas::ObjectRef> Modules;
+    SmallVector<cas::ObjectRef> APINotes;
     auto AddModule = [&](Module *M) -> llvm::Error {
       Expected<cas::IncludeTree::Module> Mod = getIncludeTreeModule(DB, M);
       if (!Mod)
@@ -644,6 +648,23 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
     if (Module *M = ScanInstance.getPreprocessor().getCurrentModule()) {
       if (Error E = AddModule(M))
         return std::move(E);
+
+      // If it is currently module, load its APINotes.
+      api_notes::APINotesManager ANM(ScanInstance.getSourceManager(),
+                                     ScanInstance.getLangOpts());
+      auto Notes = ANM.getCurrentModuleAPINotes(
+          M, ScanInstance.getLangOpts().APINotesModules,
+          ScanInstance.getAPINotesOpts().ModuleSearchPaths);
+      for (auto *File : Notes) {
+        if (auto Buf =
+                ScanInstance.getSourceManager().getMemoryBufferForFileOrNone(
+                    File)) {
+          auto Note = DB.storeFromString({}, Buf->getBuffer());
+          if (!Note)
+            return Note.takeError();
+          APINotes.push_back(*Note);
+        }
+      }
     } else {
       // When building a TU or PCH, we can have headers files that are part of
       // both the public and private modules that are included textually. In
@@ -663,6 +684,13 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
     if (!ModMap)
       return ModMap.takeError();
     ModuleMapRef = ModMap->getRef();
+
+    if (!APINotes.empty()) {
+      auto ModAPINotes = cas::IncludeTree::APINotes::create(DB, APINotes);
+      if (!ModAPINotes)
+        return ModAPINotes.takeError();
+      APINotesRef = ModAPINotes->getRef();
+    }
   }
 
   auto FileList =
@@ -671,7 +699,8 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
     return FileList.takeError();
 
   return cas::IncludeTreeRoot::create(DB, MainIncludeTree->getRef(),
-                                      FileList->getRef(), PCHRef, ModuleMapRef);
+                                      FileList->getRef(), PCHRef, ModuleMapRef,
+                                      APINotesRef);
 }
 
 Error IncludeTreeBuilder::addModuleInputs(ASTReader &Reader) {

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -73,6 +73,8 @@ void tooling::dependencies::configureInvocationForCaching(
     // above resets \p HeaderSearchOptions) when properly supporting
     // `-gmodules`.
     CI.getCodeGenOpts().DebugTypeExtRefs = false;
+    // Clear APINotes options.
+    CI.getAPINotesOpts().ModuleSearchPaths = {};
   } else {
     FileSystemOpts.CASFileSystemRootID = std::move(RootID);
     FileSystemOpts.CASFileSystemWorkingDirectory = std::move(WorkingDir);

--- a/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
@@ -1,0 +1,101 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Extract the include-tree commands
+// RUN: %deps-to-rsp %t/deps.json --module-name Top > %t/Top.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Left > %t/Left.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// Extract include-tree casids
+// RUN: cat %t/Top.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Top.casid
+// RUN: cat %t/Left.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Left.casid
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Top.casid | FileCheck %s -check-prefix=WITH-APINOTES
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Left.casid | FileCheck %s -check-prefix=WITHOUT-APINOTES
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid  | FileCheck %s -check-prefix=WITHOUT-APINOTES
+
+// WITH-APINOTES: APINotes:
+// WITH-APINOTES-NEXT: llvmcas://
+// WITH-APINOTES-NEXT: Name: Top
+// WITH-APINOTES-NEXT: Functions:
+// WITH-APINOTES-NEXT:   - Name: top
+// WITH-APINOTES-NEXT:     Availability: none
+// WITH-APINOTES-NEXT:     AvailabilityMsg: "don't use this"
+// WITHOUT-APINOTES-NOT: APINotes:
+
+// Build the include-tree commands
+// RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// Ensure the pcm comes from the action cache
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/tu.rsp -verify -fno-cache-compile-job
+
+// Check cache hits
+// RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+// RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+
+// CACHE_MISS: compile job cache miss
+// CACHE_HIT: compile job cache hit
+
+// Check incompatible with -fapinotes
+// RUN: sed "s|DIR|%/t|g" %t/cdb_fail.json.template > %t/cdb_fail.json
+// RUN: not clang-scan-deps -compilation-database %t/cdb_fail.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives 2>&1 | \
+// RUN:   FileCheck %s -check-prefix=INCOMPATIBLE
+
+// INCOMPATIBLE: error: passing incompatible option '-fapinotes' with '-fcas-include-tree'
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -fapinotes-modules -iapinotes-modules DIR"
+}]
+
+//--- cdb_fail.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -fapinotes"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export *}
+module Left { header "Left.h" export *}
+
+//--- Top.h
+#pragma once
+struct Top {
+  int x;
+};
+void top(void);
+
+//--- Left.h
+#include "Top.h"
+void left(void);
+
+//--- tu.m
+#import "Left.h"
+
+void tu(void) {
+  top(); // expected-error {{'top' is unavailable: don't use this}}
+  left();
+}
+// expected-note@Top.h:5{{'top' has been explicitly marked unavailable here}}
+
+//--- Top.apinotes
+Name: Top
+Functions:
+  - Name: top
+    Availability: none
+    AvailabilityMsg: "don't use this"


### PR DESCRIPTION
Add support for APINotes when using include-tree. Loading APINotes during dependency scanning and store the APINotes as part of the IncludeTree so it can be loaded directly from IncludeTree during compilation.

Only support `-fapinotes-module` and emit error when the old deprecated `-fapinotes` is used because that option uses an expensive and unbounded search for APNotes based on SourceLoc of Decls.