### PR TITLE
[lldb] Try Clang fallback in TSSwiftTypeRef::GetNumFields (#6671)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -265,7 +265,8 @@ public:
                       CompilerType *original_type) override;
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
   /// builtins (int <-> Swift.Int) as Clang types.
-  CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type);
+  CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,
+                                    bool *is_imported = nullptr);
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;


### PR DESCRIPTION
For Clang types, avoid loading Swift ASTContexts in `TypeSystemSwiftTypeRef::GetNumFields`.

This new logic checks if a type is an imported Clang type. If it's imported, but no type info is available (ex private/internal types), then zero is returned. If a Clang type is available, then, depending on the type class, return the Clang type's `GetNumFields`.

Note that there's logic to avoid calling `GetNumFields` on ObjC types. This is to match the current behavior.

(cherry picked from commit 80c77db9e2c9e748eb60e8f452d389fe1d856c49)
