### PR TITLE
[lldb] Make use of target triple in TypeSystemSwiftTypeRef (#6692)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -870,8 +870,6 @@ TypeSystemSwiftTypeRef::GetSwiftName(const clang::Decl *clang_decl,
   // swiftification rules.
   if (auto *importer = GetNameImporter())
     return importer->ImportName(named_decl);
-  if (auto *swift_ast_context = GetSwiftASTContext())
-    return swift_ast_context->ImportName(named_decl);
   return {};
 }
 
@@ -1482,10 +1480,7 @@ swift::DWARFImporterDelegate &TypeSystemSwiftTypeRef::GetDWARFImporterDelegate()
   return *m_dwarf_importer_delegate_up;
 }
 
-ClangNameImporter *
-TypeSystemSwiftTypeRef::GetNameImporter() const {
-  if (llvm::isa<TypeSystemSwiftTypeRefForExpressions>(this) || !m_module)
-    return nullptr;
+ClangNameImporter *TypeSystemSwiftTypeRef::GetNameImporter() const {
   if (!m_name_importer_up) {
     swift::LangOptions lang_opts;
     lang_opts.setTarget(GetTriple());
@@ -1496,8 +1491,13 @@ TypeSystemSwiftTypeRef::GetNameImporter() const {
 }
 
 llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
-  if (m_module)
-    return m_module->GetArchitecture().GetTriple();
+  if (auto *module = GetModule())
+    return module->GetArchitecture().GetTriple();
+  else if (auto target_sp = GetTargetWP().lock())
+    return target_sp->GetArchitecture().GetTriple();
+  LLDB_LOGF(
+      GetLog(LLDBLog::Types),
+      "Cannot determine triple when no Module or no Target is available.");
   return {};
 }
 
@@ -2270,14 +2270,7 @@ bool TypeSystemSwiftTypeRef::IsVoidType(opaque_compiler_type_t type) {
 // AST related queries
 uint32_t TypeSystemSwiftTypeRef::GetPointerByteSize() {
   auto impl = [&]() -> uint32_t {
-    llvm::Triple triple;
-    if (auto *module = GetModule())
-      triple = module->GetArchitecture().GetTriple();
-    else if (auto target_sp = GetTargetWP().lock())
-      triple = target_sp->GetArchitecture().GetTriple();
-    else
-      assert(false && "Expected module or target");
-
+    llvm::Triple triple = GetTriple();
     if (triple.isArch64Bit())
       return 8;
     if (triple.isArch32Bit())


### PR DESCRIPTION
Update `TypeSystemSwiftTypeRef::GetTriple` to make use of an available target.

With this change, `GetNameImporter` can work in more cases, since it only needs a 
triple. And since `GetNameImporter` can be expected to return a `ClangNameImporter` 
instance, the fallback to using Swift ASTContexts can be removed.

This eliminates another case of unnecessarily loading Swift ASTContexts, which incurs a 
one time overhead that should only be paid when required.

Partial follow up to https://github.com/apple/llvm-project/pull/6654

(cherry-picked from commit f09759524024aa75839a6e11c98d9f16fbce7efb)