### PR TITLE
Add iOSSupport folder to the reject list for frameworks

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1945,7 +1945,8 @@ ProcessModule(ModuleSP module_sp, std::string m_description,
           // modules must be imported from the SDK instead.
           if (!p.startswith("/System/Library") && !IsDeviceSupport(p) &&
               !p.startswith(
-                  "/Library/Apple/System/Library/PrivateFrameworks")) {
+                  "/Library/Apple/System/Library/PrivateFrameworks") &&
+              !p.startswith("/System/iOSSupport/System/Library/Frameworks")) {
             LOG_PRINTF(GetLog(LLDBLog::Types), "adding framework path \"%s\"/.. .",
                        framework_path.c_str());
             framework_search_paths.push_back(


### PR DESCRIPTION
The macCatalyst support folder looks like it contains frameworks, however, these are binary-only and don't contain any Clang headers or Swift modules. These are to be found in the SDK.

rdar://107869141