### PR TITLE
Reland "Re-enable LLDB in the automerger pre-merge test build"

### DIFF
--- a/apple-ci/clang/am/build.sh
+++ b/apple-ci/clang/am/build.sh
@@ -29,5 +29,7 @@ xcrun cmake -G Ninja \
  -DCMAKE_C_COMPILER=$HOST_COMPILER_PATH/clang \
  -DCMAKE_CXX_COMPILER=$HOST_COMPILER_PATH/clang++ \
  -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
- -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt" \
+ -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lldb" \
+ -DLLDB_ENABLE_SWIFT_SUPPORT=OFF \
+ -DLLDB_INCLUDE_TESTS=OFF \
  $SRC_DIR/llvm && $NINJA


### PR DESCRIPTION
Reverts apple/llvm-project#6782