### PR TITLE
SymbolFile: minor u-opt for loading fission'ed DWARF

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1776,6 +1776,10 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
     dwo_file.AppendPathComponent(dwo_name);
   }
 
+  if (dwo_file.GetFileNameExtension() == ".pcm" ||
+      dwo_file.GetFileNameExtension() == ".pch")
+    return nullptr;
+
   if (!FileSystem::Instance().Exists(dwo_file)) {
     unit.SetDwoError(Status::createWithFormat(
         "unable to locate .dwo debug file \"{0}\" for skeleton DIE "
@@ -1789,10 +1793,6 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
     }
     return nullptr;
   }
-
-  if (dwo_file.GetFileNameExtension() == ".pcm" ||
-      dwo_file.GetFileNameExtension() == ".pch")
-    return nullptr;
 
   const lldb::offset_t file_offset = 0;
   DataBufferSP dwo_file_data_sp;


### PR DESCRIPTION
In the case that the DWO is a PCM or PCH we will ignore the processing of the fissioned matter.  Hoist the check before the `fstat` to avoid an unnecessary FS access.

This is not usptream'ed as the change here is local to the Swift tree.