### PR TITLE
[lldb] Prevent mutation of CommandAlias::GetOptionArguments

### DIFF
--- a/lldb/source/Interpreter/CommandAlias.cpp
+++ b/lldb/source/Interpreter/CommandAlias.cpp
@@ -8,6 +8,7 @@
 
 #include "lldb/Interpreter/CommandAlias.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #include "lldb/Interpreter/CommandInterpreter.h"
@@ -211,9 +212,9 @@ std::pair<lldb::CommandObjectSP, OptionArgVectorSP> CommandAlias::Desugar() {
     // FIXME: This doesn't work if the original alias fills a slot in the
     // underlying alias, since this just appends the two lists.
     auto desugared = ((CommandAlias *)underlying.get())->Desugar();
-    auto options = GetOptionArguments();
-    options->insert(options->begin(), desugared.second->begin(),
-                    desugared.second->end());
+    OptionArgVectorSP options = std::make_shared<OptionArgVector>();
+    llvm::append_range(*options, *desugared.second);
+    llvm::append_range(*options, *GetOptionArguments());
     return {desugared.first, options};
   }
 

--- a/lldb/test/API/commands/command/nested_alias/TestNestedAlias.py
+++ b/lldb/test/API/commands/command/nested_alias/TestNestedAlias.py
@@ -101,3 +101,7 @@ class NestedAliasTestCase(TestBase):
         self.expect('command alias two expr -- 2')
         self.expect('command alias add_two two +')
         self.expect('add_two 3', patterns=[' = 5$'])
+        # Check that aliases to aliases to raw input commands work the second
+        # and subsequent times.
+        self.expect('add_two 3', patterns=[' = 5$'])
+        self.expect('add_two 3', patterns=[' = 5$'])


### PR DESCRIPTION
Fix a mutation of `CommandAlias::m_option_args_sp`, which resulted in cases where
aliases would fail to run on second, and subsequent times.

For example, an alias such as:

```
command alias p1 p 1
```

When run the second time, the following error would be reported to the user:

```
error: expression failed to parse:
error: <user expression 1>:1:1: expression is not assignable
--  1
^   ~
```

To fix this, `CommandAlias::Desugar` now constructs options to a freshly constructed
vector, rather than by appending to the results of `GetOptionArguments`.

rdar://107770836

Differential Revision: https://reviews.llvm.org/D150078

(cherry picked from commit 765237779ce4dbb60f4faf9ebc91386ce5218e15)
