### PR TITLE
Revert "cmake: add missing dependency on Attributes.inc"

### DIFF
--- a/llvm/include/llvm/IR/CMakeLists.txt
+++ b/llvm/include/llvm/IR/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(LLVM_TARGET_DEFINITIONS Attributes.td)
 tablegen(LLVM Attributes.inc -gen-attrs)
-add_public_tablegen_target(attributes_gen)
 
 set(LLVM_TARGET_DEFINITIONS Intrinsics.td)
 tablegen(LLVM IntrinsicImpl.inc -gen-intrinsic-impl)

--- a/llvm/lib/AsmParser/CMakeLists.txt
+++ b/llvm/lib/AsmParser/CMakeLists.txt
@@ -8,7 +8,6 @@ add_llvm_component_library(LLVMAsmParser
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/ASMParser
 
   DEPENDS
-  attributes_gen
   intrinsics_gen
 
   LINK_COMPONENTS

--- a/llvm/unittests/Analysis/CMakeLists.txt
+++ b/llvm/unittests/Analysis/CMakeLists.txt
@@ -64,8 +64,6 @@ add_llvm_unittest_with_input_files(AnalysisTests
   ${ANALYSIS_TEST_SOURCES}
   )
 
-add_dependencies(AnalysisTests attributes_gen)
-
 target_link_libraries(AnalysisTests PRIVATE LLVMTestingSupport)
 
 # On AIX, enable run-time linking to allow symbols from the plugins shared

--- a/llvm/utils/TableGen/CMakeLists.txt
+++ b/llvm/utils/TableGen/CMakeLists.txt
@@ -86,9 +86,6 @@ add_tablegen(llvm-tblgen LLVM
   X86RecognizableInstr.cpp
   WebAssemblyDisassemblerEmitter.cpp
   $<TARGET_OBJECTS:obj.LLVMTableGenCommon>
-
-  DEPENDS
-  attributes_gen
   )
 target_link_libraries(llvm-tblgen PRIVATE LLVMTableGenGlobalISel)
 set_target_properties(llvm-tblgen PROPERTIES FOLDER "Tablegenning")


### PR DESCRIPTION
This reverts commit 4e97979aaaaf748f378f3931044d2742db804bd3.

Fixing this a slightly different way upstream.