### PR TITLE
Core: render Swift AST sections properly when dumping

### DIFF
--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -152,7 +152,7 @@ const char *Section::GetTypeAsCString() const {
 
   // BEGIN SWIFT
   case eSectionTypeSwiftModules:
-    break;
+    return "swift-ast";
   // END SWIFT
   }
   return "unknown";


### PR DESCRIPTION
Adjust the rendering for the Swift AST section when listing the sections to make it easy to identify when scanning.  We already have a diff to break in the switch, might as well as take the opportunity to render the string.