### PR TITLE
[lldb] Fix Language Plugin decl printing (#6795)

### DIFF
--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -300,9 +300,14 @@ void ValueObjectPrinter::PrintDecl() {
     ConstString type_name_cstr(typeName.GetString());
     ConstString var_name_cstr(varName.GetString());
 
+    DumpValueObjectOptions decl_print_options;
+    // Pass printing helpers an option object that indicates whether the name
+    // should be shown or hidden.
+    decl_print_options.SetHideName(!ShouldShowName());
+
     StreamString dest_stream;
     if (m_options.m_decl_printing_helper(type_name_cstr, var_name_cstr,
-                                         m_options, dest_stream)) {
+                                         decl_print_options, dest_stream)) {
       decl_printed = true;
       m_stream->PutCString(dest_stream.GetString());
     }

--- a/lldb/test/API/commands/dwim-print/swift/TestDWIMPrintSwift.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestDWIMPrintSwift.py
@@ -28,3 +28,14 @@ class TestCase(TestBase):
             self, "// break here", lldb.SBFileSpec("main.swift")
         )
         self.expect(f"dwim-print -O -- 0x1000", substrs=["4096"])
+
+    @swiftTest
+    def test_print_swift_object_does_not_show_name(self):
+        """Ensure that objects are printed without a name, and without the '='
+        that would follow the name."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(f"dwim-print user", patterns=[r"^\(a\.User\) 0x[0-9a-f]{7,} \{"])

--- a/lldb/test/API/commands/dwim-print/swift/main.swift
+++ b/lldb/test/API/commands/dwim-print/swift/main.swift
@@ -6,9 +6,17 @@ class Object: CustomStringConvertible {
   }
 }
 
+class User {
+    var id: Int = 314159265358979322
+    var name: String = "Gwendolyn"
+    var groups: (admin: Bool, staff: Bool) = (false, true)
+}
+
 func main() {
     let object = Object()
-    _ = object // break here
+    let user = User()
+    // break here
+    print(object, user)
 }
 
 main()


### PR DESCRIPTION
`SwiftLanguage::GetDeclPrintingHelper` is a helper function used for Swift types. This 
code contains some very similar logic to the default logic in `ValueObjectPrinter`. 
Specifically:


`SwiftLanguage`:

```c++
else if (!options.m_hide_name)
  stream.Printf(" =");
```

`ValueObjectPrinter`:

```c++
else if (ShouldShowName())
  m_stream->Printf(" =");
```

The function `ValueObjectPrinter::ShouldShowName` is not accessible by `SwiftLanguage`.

To allow `SwiftLanguage` to make the right decision, and fit within the existing API 
boundary, this change uses a custom print options, which sets calls `SetHideName` 
according to the value of `ShouldShowName()`. This allows the Swift language decl 
printing helper to correctly know whether to print the name, or not.

(cherry-picked from commit e6d9bd64749b76fa4b8d7d7d720e2fbca4e863b5)