### PR TITLE
[lldb] Re-enable TestSwiftRegex (#6798)

### DIFF
--- a/lldb/test/API/lang/swift/regex/Makefile
+++ b/lldb/test/API/lang/swift/regex/Makefile
@@ -1,5 +1,8 @@
-SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -Xfrontend -enable-bare-slash-regex -Xfrontend -disable-availability-checking
+ifeq "$(OS)" "Darwin"
+	OS_SWIFTFLAGS := -target $(ARCH)-apple-macosx13.0
+endif
 
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -enable-bare-slash-regex $(OS_SWIFTFLAGS)
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -27,20 +27,52 @@ class TestSwiftRegex(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    def test_swift_regex(self):
-        """Test Swift's regex support"""
+    @skipIf(macos_version=["<", "13"])
+    def test_swift_regex_frame_var(self):
+        """Test frame variable support for Swift regexes."""
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', self.main_source_spec)
         self.expect('v regex',
                     substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>) regex = {'])
-        self.expect('po regex',
-                    substrs=['Regex<(Substring, Substring, Substring, Substring)>'])
-
         self.expect('v dslRegex',
                     substrs=['(_StringProcessing.Regex<Substring>) dslRegex = {'])
-        self.expect('po dslRegex',
+
+    @swiftTest
+    @skipIf(macos_version=["<", "13"])
+    def test_swift_regex_expr_desc(self):
+        """Test expression object description support for Swift regexes."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', self.main_source_spec)
+        self.expect('expr -O -- regex',
+                    substrs=['Regex<(Substring, Substring, Substring, Substring)>'])
+        self.expect('expr -O -- dslRegex',
                     substrs=['Regex<Substring>'])
+
+    @swiftTest
+    @skipIf(macos_version=["<", "13"])
+    def test_swift_regex_frame_var_desc(self):
+        """Test frame variable object description support for Swift regexes."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', self.main_source_spec)
+        self.expect('vo regex',
+                    substrs=['Regex<(Substring, Substring, Substring, Substring)>'])
+        self.expect('vo dslRegex',
+                    substrs=['Regex<Substring>'])
+
+    @swiftTest
+    @skipIf(macos_version=["<", "13"])
+    def test_swift_regex_expr(self):
+        """Test expression support for Swift regexes."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', self.main_source_spec)
+        self.expect('expr regex',
+                    substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>) $R0 = {'])
+        self.expect('expr dslRegex',
+                    substrs=['(_StringProcessing.Regex<Substring>) $R1 = {'])
 
     @swiftTest
     @skipIf(macos_version=["<", "13"])


### PR DESCRIPTION
To evaluate the command `expr -O -- regex`, the target triple needs to specify macOS 13 
or greater. The underlying issue should have been an error when `main.swift` was being 
compiled, but `-disable-availability-checking` was being used. As it was, the 
expression evaluation would result in this error (which was only seen in the logs):

> error: 'Regex' is only available in macOS 13.0 or newer

While debugging the issue, the use of `v`/`vo`/`expr`/`expr -O` were split out into 
separate test functions. Interestingly `vo` will succeed even in the case where `expr 
-O` did not.

This reverts commit de23e7653f890619c7263c7d8c2466ecc7dba941.

rdar://106107613

(cherry-picked from commit f18ed27ef0d8ec67128989830b9646aa02c649dc)