### PR TITLE
Ensure breakpoints are in the intended scope by tying them to a print…

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/main.swift
@@ -3,7 +3,7 @@ func main() {
     let someSlice = a[1...]
     let arraySlice: ArraySlice<Int> = a[1...]
     let arraySubSequence: Array<Int>.SubSequence = a[1...]
-    // break here
+    print("break here")
 }
 
 main()

--- a/lldb/test/API/functionalities/data-formatter/swift/string-index/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/string-index/main.swift
@@ -18,7 +18,7 @@ func exercise(_ string: String) {
     let unicodeScalarIndices = allIndices(string.unicodeScalars)
     let utf8Indices = allIndices(string.utf8)
     let utf16Indices = allIndices(string.utf16)
-    // break here
+    print("break here")
 }
 
 func allIndices<T: Collection>(_ collection: T) -> [T.Index] {

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/main.swift
@@ -13,7 +13,7 @@ func exerciseString() {
 
 func exercise(_ string: String) {
     let substrings = allIndices(string).map { string[$0..<string.endIndex] }
-    // break here
+    print("break here")
 }
 
 func allIndices<T: Collection>(_ collection: T) -> [T.Index] {

--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -15,7 +15,7 @@ class TestCase(lldbtest.TestBase):
 
         source_file = lldb.SBFileSpec("main.swift")
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
-            self, "// break one", source_file)
+            self, "break one", source_file)
 
         # At "break one", only the `a` variable should have a value.
         frame = process.GetSelectedThread().frames[0]
@@ -23,8 +23,7 @@ class TestCase(lldbtest.TestBase):
         self.assertTrue(a.IsValid())
         self.assertGreater(a.unsigned, 0)
         b = frame.FindVariable("b")
-        self.assertTrue(b.IsValid())
-        self.assertEqual(b.unsigned, 0)
+        self.assertFalse(b.IsValid())
         d = frame.FindVariable("d")
         lldbutil.check_variable(self, d, False, value='23')
 
@@ -34,7 +33,7 @@ class TestCase(lldbtest.TestBase):
         target.DeleteAllBreakpoints()
 
         # Setup, and run to, the next breakpoint.
-        target.BreakpointCreateBySourceRegex("// break two", source_file)
+        target.BreakpointCreateBySourceRegex("break two", source_file)
         self.setAsync(False)
         process.Continue()
 

--- a/lldb/test/API/lang/swift/async/frame/variable/main.swift
+++ b/lldb/test/API/lang/swift/async/frame/variable/main.swift
@@ -7,9 +7,11 @@ func inner<T>(_ t: T) async {
   // is unknown.
   let d = t
   let a = await randInt(30)
-  let b = await randInt(a + 11) // break one
+  print("break one")
+  let b = await randInt(a + 11)
   use(a, b)
-  use(d) // break two
+  use(d)
+  print("break two")
 }
 
 func use<T>(_ t: T...) {}

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -221,6 +221,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         self.hit_correct_line(thread, "Second case with a where statement")
 
         thread.StepOver()
+        thread.StepOver()
         self.hit_correct_line(
             thread, "print in second case with where statement.")
 

--- a/lldb/test/API/lang/swift/swift_reference_counting/main.swift
+++ b/lldb/test/API/lang/swift/swift_reference_counting/main.swift
@@ -24,9 +24,13 @@ func lambda(_ Arg : Patatino) -> Int {
 }
 
 func main() -> Int {
-  var LiveObj = Patatino(37) //%self.expect('language swift refcount Blah', substrs=['cannot find \'Blah\''], error=True)
-  var Ret : Int = lambda(LiveObj) //%self.expect('language swift refcount LiveObj', substrs=['(strong =', 'unowned =', 'weak ='])
-  var MyStruct = Tinky() //%self.expect('language swift refcount MyStruct', substrs=['refcount only available for class types'], error=True)
+  var LiveObj = Patatino(37)
+  var Ret : Int = lambda(LiveObj)
+  var MyStruct = Tinky()
+  print("break here")
+  //%self.expect('language swift refcount Blah', substrs=['cannot find \'Blah\''], error=True)
+  //%self.expect('language swift refcount LiveObj', substrs=['(strong =', 'unowned =', 'weak ='])
+  //%self.expect('language swift refcount MyStruct', substrs=['refcount only available for class types'], error=True)
   return Ret
 }
 


### PR DESCRIPTION
… statement.

With the more accurate scopes emitted by https://github.com/apple/swift/pull/65783 this actually matters.