### PR TITLE
[lldb] Declare argument to `swift demangle`

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2096,7 +2096,10 @@ public:
       : CommandObjectParsed(interpreter, "demangle",
                             "Demangle a Swift mangled name",
                             "language swift demangle"),
-        m_options() {}
+        m_options() {
+    CommandArgumentData mangled_name_arg{eArgTypeSymbol};
+    m_arguments.push_back({mangled_name_arg});
+  }
 
   ~CommandObjectSwift_Demangle() {}
 

--- a/lldb/test/Shell/Commands/command-language-swift-demangle.test
+++ b/lldb/test/Shell/Commands/command-language-swift-demangle.test
@@ -1,0 +1,5 @@
+# RUN: %lldb -s %s 2>&1 | FileCheck %s
+language swift demangle $s6Module3oneSiyF
+language swift demangle s6Module3twoyyF
+# CHECK: Module.one() -> Swift.Int
+# CHECK: Module.two() -> ()


### PR DESCRIPTION
Without an argument declaration, lldb reports:

```
error: 'demangle' doesn't take any arguments.
```

rdar://104190981