### PR TITLE
libclang: declare blocks interfaces always

### DIFF
--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -48,6 +48,10 @@
 #define CINDEX_VERSION_STRING                                                  \
   CINDEX_VERSION_STRINGIZE(CINDEX_VERSION_MAJOR, CINDEX_VERSION_MINOR)
 
+#ifndef __has_feature
+#define __has_feature(feature) 0
+#endif
+
 LLVM_CLANG_C_EXTERN_C_BEGIN
 
 /** \defgroup CINDEX libclang: C Interface to Clang
@@ -3687,8 +3691,6 @@ typedef enum CXChildVisitResult (*CXCursorVisitor)(CXCursor cursor,
 CINDEX_LINKAGE unsigned clang_visitChildren(CXCursor parent,
                                             CXCursorVisitor visitor,
                                             CXClientData client_data);
-#ifdef __has_feature
-#if __has_feature(blocks)
 /**
  * Visitor invoked for each cursor found by a traversal.
  *
@@ -3699,8 +3701,12 @@ CINDEX_LINKAGE unsigned clang_visitChildren(CXCursor parent,
  * The visitor should return one of the \c CXChildVisitResult values
  * to direct clang_visitChildrenWithBlock().
  */
+#if __has_feature(blocks)
 typedef enum CXChildVisitResult (^CXCursorVisitorBlock)(CXCursor cursor,
                                                         CXCursor parent);
+#else
+typedef _CXChildVisitResult *CXCursorVisitorBlock;
+#endif
 
 /**
  * Visits the children of a cursor using the specified block.  Behaves
@@ -3708,8 +3714,6 @@ typedef enum CXChildVisitResult (^CXCursorVisitorBlock)(CXCursor cursor,
  */
 CINDEX_LINKAGE unsigned
 clang_visitChildrenWithBlock(CXCursor parent, CXCursorVisitorBlock block);
-#endif
-#endif
 
 /**
  * @}
@@ -5615,11 +5619,12 @@ CINDEX_LINKAGE CXResult clang_findReferencesInFile(
 CINDEX_LINKAGE CXResult clang_findIncludesInFile(
     CXTranslationUnit TU, CXFile file, CXCursorAndRangeVisitor visitor);
 
-#ifdef __has_feature
 #if __has_feature(blocks)
-
 typedef enum CXVisitorResult (^CXCursorAndRangeVisitorBlock)(CXCursor,
                                                              CXSourceRange);
+#else
+typedef struct _CXCursorAndRangeVisitorBlock *CXCursorAndRangeVisitorBlock;
+#endif
 
 CINDEX_LINKAGE
 CXResult clang_findReferencesInFileWithBlock(CXCursor, CXFile,
@@ -5628,9 +5633,6 @@ CXResult clang_findReferencesInFileWithBlock(CXCursor, CXFile,
 CINDEX_LINKAGE
 CXResult clang_findIncludesInFileWithBlock(CXTranslationUnit, CXFile,
                                            CXCursorAndRangeVisitorBlock);
-
-#endif
-#endif
 
 /**
  * The client's data object that is associated with a CXFile.

--- a/clang/include/clang-c/Index.h
+++ b/clang/include/clang-c/Index.h
@@ -3705,7 +3705,7 @@ CINDEX_LINKAGE unsigned clang_visitChildren(CXCursor parent,
 typedef enum CXChildVisitResult (^CXCursorVisitorBlock)(CXCursor cursor,
                                                         CXCursor parent);
 #else
-typedef _CXChildVisitResult *CXCursorVisitorBlock;
+typedef struct _CXChildVisitResult *CXCursorVisitorBlock;
 #endif
 
 /**


### PR DESCRIPTION
The implementation of these methods is not reliant on the availability of the Blocks extension in the compiler.  However, when building on Windows, the interface declaration is important for the attribution of the DLL storage.  Without the attribution, the method implementation is built but not made available as part of the ABI.  Use a check for the blocks extension to determine how method signature is viewed rather than controlling whether it is part of the interface.

(cherry picked from commit ce5ad23ac29bb70427dd22d9ee480d22e0aa6cf1)