### PR TITLE
[clang][cas] Only handle CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS with caching

### DIFF
--- a/clang/test/CAS/test-for-deterministic-outputs.c
+++ b/clang/test/CAS/test-for-deterministic-outputs.c
@@ -45,6 +45,11 @@
 // NOERROR-NOT: error:
 // ERROR: error: encountered non-reproducible token, caching will be skipped
 
+// Verify we don't double output without caching enabled.
+// RUN: env CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS=1 %clang -E %s | FileCheck %s -check-prefix=NO_CACHE
+// NO_CACHE: getit
+// NO_CACHE-NOT: getit
+
 void getit(const char **p1, const char **p2, const char **p3) {
   *p1 = __DATE__;
   *p2 = __TIMESTAMP__;

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -377,8 +377,13 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV,
   StringRef Tool = ArgV[1];
   void *GetExecutablePathVP = (void *)(intptr_t)GetExecutablePath;
   if (Tool == "-cc1") {
-    if (std::getenv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS")) {
-      // Perform the compile twice in order to catch differences in the output.
+    if (std::getenv("CLANG_CACHE_TEST_DETERMINISTIC_OUTPUTS") &&
+        find(ArgV, StringRef("-fcache-compile-job")) != ArgV.end()) {
+      // With caching enabled, perform the compile twice in order to catch
+      // differences in the output.
+      // FIXME: while it is unlikely caching will be enabled when the output
+      // is to stdout (e.g. `-E`, or `-S -o -`), we should avoid writing
+      // output twice.
       int RC = cc1_main(ArrayRef(ArgV).slice(1), ArgV[0], GetExecutablePathVP);
       if (RC != 0)
         return RC;


### PR DESCRIPTION
When caching is disabled, we don't want to run the compile twice. First, because it is wasteful when we won't detect any issues. Second, because it works around errors with -E writing twice to stdout in scripts. Technically, we could have caching enabled with -E or -o - and see the same issue, but it's non-trivial to fix that without introducing maintenance issues in cc1_main until we upstream this code.

rdar://109163869