### PR TITLE
When the Debugger runs HandleProcessEvent it should allow selecting the "Most relevant" frame.

### DIFF
--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1664,8 +1664,10 @@ void Debugger::HandleProcessEvent(const EventSP &event_sp) {
 
     // Display running state changes first before any STDIO
     if (got_state_changed && !state_is_stopped) {
+      // This is a public stop which we are going to announce to the user, so 
+      // we should force the most relevant frame selection here.
       Process::HandleProcessStateChangedEvent(event_sp, output_stream_sp.get(),
-                                              DoNoSelectMostRelevantFrame,
+                                              SelectMostRelevantFrame,
                                               pop_process_io_handler,
                                               // BEGIN SWIFT
                                               pop_command_interpreter
@@ -1709,7 +1711,7 @@ void Debugger::HandleProcessEvent(const EventSP &event_sp) {
     // Now display any stopped state changes after any STDIO
     if (got_state_changed && state_is_stopped) {
       Process::HandleProcessStateChangedEvent(event_sp, output_stream_sp.get(),
-                                              DoNoSelectMostRelevantFrame,
+                                              SelectMostRelevantFrame,
                                               pop_process_io_handler,
                                               // BEGIN SWIFT
                                               pop_command_interpreter

--- a/lldb/test/Shell/Recognizer/assert.test
+++ b/lldb/test/Shell/Recognizer/assert.test
@@ -10,7 +10,6 @@
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 run
 # CHECK: thread #{{.*}}stop reason = hit program assert
-frame info
 # CHECK: frame #{{.*}}`main at assert.c
 frame recognizer info 0
 # CHECK: frame 0 is recognized by Assert StackFrame Recognizer


### PR DESCRIPTION
If you don't do that, then the correct frame gets selected, but it happens AFTER the frame info gets printed in the stop message, so you don't see the selected frame.

The test for this hid the issue because it ran `frame info` and checked the result of that.  That happens after the recognizer selects the frame, and so it was right.  But if the recognizer is working correctly it will have already done the same printing in the stop message, and this way we also verify that the stop message was right.

Differential Revision: https://reviews.llvm.org/D150315

(cherry picked from commit 7b5dc63fc4464e777e4210a68120b36cb283a9fd)