### PR TITLE
Relax test to not rely on the variable being optimized out

### DIFF
--- a/lldb/test/API/functionalities/unused-inlined-parameters/TestUnusedInlinedParameters.py
+++ b/lldb/test/API/functionalities/unused-inlined-parameters/TestUnusedInlinedParameters.py
@@ -14,6 +14,6 @@ class TestUnusedInlinedParameters(TestBase):
         lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.c"))
 
         # For the unused parameters, only check the types.
-        self.assertIn("(void *) unused1 = <no location, value may have been optimized out>",
+        self.assertIn("(void *) unused1",
                       lldbutil.get_description(self.frame().FindVariable("unused1")))
         self.assertEqual(42, self.frame().FindVariable("used").GetValueAsUnsigned())


### PR DESCRIPTION
(cherry picked from commit 1585ee1077930d4a906b3265bb40a90ba4758c99)