### PR TITLE
Swift expression parser: surface ClangImporter setup errors.

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/Makefile
@@ -1,0 +1,7 @@
+SWIFT_SOURCES := main.swift
+SWIFT_BRIDGING_HEADER := bridging-header.h
+SWIFT_PRECOMPILE_BRIDGING_HEADER := NO
+
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR)
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
@@ -1,0 +1,32 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftExtraClangFlags(TestBase):
+
+    mydir = TestBase.compute_mydir(__file__)
+
+    NO_DEBUG_INFO_TESTCASE = True
+    
+    def setUp(self):
+        TestBase.setUp(self)
+
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(oslist=['windows'])
+    @swiftTest
+    def test_extra_clang_flags(self):
+        """
+        Test error handling when ClangImporter emits diagnostics.
+        """
+        self.build()
+        self.addTearDownHook(
+            lambda: self.runCmd("settings clear target.swift-extra-clang-flags"))
+        self.expect('settings set -- target.swift-extra-clang-flags '+
+                    '"-DBREAK_STUFF"')
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("expr 0", error=True,
+                    substrs=['failed to import bridging header'])

--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/bridging-header.h
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/bridging-header.h
@@ -1,0 +1,3 @@
+#ifdef BREAK_STUFF
+i am a syntax error
+#endif    

--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/main.swift
@@ -1,0 +1,1 @@
+print("break here")


### PR DESCRIPTION
And clean up error handling in that function in general.

rdar://108557254
(cherry picked from commit 8b8337bb18330f815acfcc9ba3577d6ed81bce8a)