### PR TITLE
Convert switch to exhaustive.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2759,7 +2759,6 @@ public:
       bool use_fixits = false;
       llvm::SourceMgr::DiagKind source_mgr_kind;
       switch (info.Kind) {
-      default:
       case swift::DiagnosticKind::Error:
         source_mgr_kind = llvm::SourceMgr::DK_Error;
         use_fixits = true;
@@ -2767,9 +2766,11 @@ public:
       case swift::DiagnosticKind::Warning:
         source_mgr_kind = llvm::SourceMgr::DK_Warning;
         break;
-
       case swift::DiagnosticKind::Note:
         source_mgr_kind = llvm::SourceMgr::DK_Note;
+        break;
+      case swift::DiagnosticKind::Remark:
+        source_mgr_kind = llvm::SourceMgr::DK_Remark;
         break;
       }
 


### PR DESCRIPTION
This is a hypothetical case because LLDB doesn't turn on any remarks in the expression evaluator.

(cherry picked from commit d7d693c3c1845b0cee787b6b1a1c0e7742cb93ca)