### PR TITLE
[cherry-pick][swift/release/5.9] [lldb][Test] Fix TestFrameFormatNameWithArgs.test on Linux

### DIFF
--- a/lldb/test/Shell/Settings/Inputs/names.cpp
+++ b/lldb/test/Shell/Settings/Inputs/names.cpp
@@ -1,5 +1,3 @@
-#include <functional>
-
 namespace detail {
 template <typename T> struct Quux {};
 } // namespace detail
@@ -7,15 +5,16 @@ template <typename T> struct Quux {};
 using FuncPtr = detail::Quux<double> (*(*)(int))(float);
 
 struct Foo {
-  template <typename T> void foo(T const &t) const noexcept(true) {}
+  template <typename T> void foo(T arg) const noexcept(true) {}
 
-  template <size_t T> void operator<<(size_t) {}
+  template <int T> void operator<<(int) {}
 
   template <typename T> FuncPtr returns_func_ptr(detail::Quux<int> &&) const noexcept(false) { return nullptr; }
 };
 
 namespace ns {
-template <typename T> int foo(T const &t) noexcept(false) { return 0; }
+template <typename T> int foo(char const *str) noexcept(false) { return 0; }
+template <typename T> int foo(T t) { return 1; }
 
 template <typename T> FuncPtr returns_func_ptr(detail::Quux<int> &&) { return nullptr; }
 } // namespace ns
@@ -24,20 +23,20 @@ int bar() { return 1; }
 
 namespace {
 int anon_bar() { return 1; }
-auto anon_lambda = [](std::function<int(int (*)(int))>) mutable {};
+auto anon_lambda = [] {};
 } // namespace
 
 int main() {
-  ns::foo(bar);
-  ns::foo(std::function{bar});
+  ns::foo<decltype(bar)>(bar);
+  ns::foo<decltype(bar)>("bar");
   ns::foo(anon_lambda);
-  ns::foo(std::function{anon_bar});
-  ns::foo(&Foo::foo<std::function<int(int)>>);
+  ns::foo(anon_bar);
+  ns::foo<decltype(&Foo::foo<int(int)>)>("method");
   ns::returns_func_ptr<int>(detail::Quux<int>{});
   Foo f;
-  f.foo(std::function{bar});
-  f.foo(std::function{anon_bar});
+  f.foo(anon_bar);
   f.operator<< <(2 > 1)>(0);
   f.returns_func_ptr<int>(detail::Quux<int>{});
+
   return 0;
 }

--- a/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
@@ -7,19 +7,19 @@ break set -n returns_func_ptr
 run
 # CHECK: frame int ns::foo<int ()>(t={{.*}})
 c
-# CHECK: frame int ns::foo<std::__1::function<int ()>>(t= Function = bar() )
+# CHECK: frame int ns::foo<std::{{.*}}function<int ()>>(t= Function = bar() )
 c
 # CHECK: frame int ns::foo<(anonymous namespace)::$_0>(t={{.*}})
 c
-# CHECK: frame int ns::foo<std::__1::function<int ()>>(t= Function = (anonymous namespace)::anon_bar() )
+# CHECK: frame int ns::foo<std::{{.*}}function<int ()>>(t= Function = (anonymous namespace)::anon_bar() )
 c
-# CHECK: frame int ns::foo<void (Foo::*)(std::__1::function<int (int)> const&) const noexcept>(t={{.*}})
+# CHECK: frame int ns::foo<void (Foo::*)(std::{{.*}}function<int (int)> const&) const noexcept>(t={{.*}})
 c
 # CHECK: frame ns::returns_func_ptr<int>((null)={{.*}})
 c
-# CHECK: frame void Foo::foo<std::__1::function<int ()>>(this={{.*}}, t= Function = bar() ) const
+# CHECK: frame void Foo::foo<std::{{.*}}function<int ()>>(this={{.*}}, t= Function = bar() ) const
 c
-# CHECK: frame void Foo::foo<std::__1::function<int ()>>(this={{.*}}, t= Function = (anonymous namespace)::anon_bar() ) const
+# CHECK: frame void Foo::foo<std::{{.*}}function<int ()>>(this={{.*}}, t= Function = (anonymous namespace)::anon_bar() ) const
 c
 # CHECK: frame void Foo::operator<<<1ul>(this={{.*}}, (null)=0)
 c

--- a/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
@@ -1,4 +1,4 @@
-# REQUIRES: system-darwin
+# UNSUPPORTED: system-windows
 # RUN: %clangxx_host -g -O0 %S/Inputs/names.cpp -std=c++17 -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 settings set -f frame-format "frame ${function.name-with-args}\n"
@@ -8,21 +8,19 @@ break set -n returns_func_ptr
 run
 # CHECK: frame int ns::foo<int ()>(t={{.*}})
 c
-# CHECK: frame int ns::foo<std::{{.*}}function<int ()>>(t= Function = bar() )
+# CHECK: frame int ns::foo<int ()>(str="bar")
 c
-# CHECK: frame int ns::foo<(anonymous namespace)::$_0>(t={{.*}})
+# CHECK: frame int ns::foo<(anonymous namespace)::$_0>(t=(anonymous namespace)::(unnamed class) @ {{.*}})
 c
-# CHECK: frame int ns::foo<std::{{.*}}function<int ()>>(t= Function = (anonymous namespace)::anon_bar() )
+# CHECK: frame int ns::foo<int (*)()>(t=({{.*}}`(anonymous namespace)::anon_bar() at {{.*}}))
 c
-# CHECK: frame int ns::foo<void (Foo::*)(std::{{.*}}function<int (int)> const&) const noexcept>(t={{.*}})
+# CHECK: frame int ns::foo<void (Foo::*)(int (*)(int)) const noexcept>(str="method")
 c
 # CHECK: frame ns::returns_func_ptr<int>((null)={{.*}})
 c
-# CHECK: frame void Foo::foo<std::{{.*}}function<int ()>>(this={{.*}}, t= Function = bar() ) const
+# CHECK: frame void Foo::foo<int (*)()>(this={{.*}}, arg=({{.*}}`(anonymous namespace)::anon_bar() at {{.*}}))
 c
-# CHECK: frame void Foo::foo<std::{{.*}}function<int ()>>(this={{.*}}, t= Function = (anonymous namespace)::anon_bar() ) const
-c
-# CHECK: frame void Foo::operator<<<1ul>(this={{.*}}, (null)=0)
+# CHECK: frame void Foo::operator<<<1>(this={{.*}}, (null)=0)
 c
 # CHECK: frame Foo::returns_func_ptr<int>(this={{.*}}, (null)={{.*}})
 q

--- a/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
+++ b/lldb/test/Shell/Settings/TestFrameFormatNameWithArgs.test
@@ -1,3 +1,4 @@
+# REQUIRES: system-darwin
 # RUN: %clangxx_host -g -O0 %S/Inputs/names.cpp -std=c++17 -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 settings set -f frame-format "frame ${function.name-with-args}\n"


### PR DESCRIPTION
(cherry picked from commit `9dd413a1be61f8fd84e67d255a245260755d8230`)
(cherry picked from commit `3e03873e363b5aa90e4488da63a6de0648d11aba`)
(cherry picked from commit `c188910694ab821aabc0ca11f4636b69f5f7b4f1`)