### PR TITLE
[IncludeTree] Support APINotes with IncludeTree

### DIFF
--- a/clang/include/clang/APINotes/APINotesManager.h
+++ b/clang/include/clang/APINotes/APINotesManager.h
@@ -77,6 +77,13 @@ class APINotesManager {
   /// a failure.
   std::unique_ptr<APINotesReader> loadAPINotes(const FileEntry *apiNotesFile);
 
+  /// Load the API notes associated with the given buffer, whether it is
+  /// the binary or source form of API notes.
+  ///
+  /// \returns the API notes reader for this file, or null if there is
+  /// a failure.
+  std::unique_ptr<APINotesReader> loadAPINotes(StringRef Buffer);
+
   /// Load the given API notes file for the given header directory.
   ///
   /// \param HeaderDir The directory at which we
@@ -125,6 +132,25 @@ public:
   bool loadCurrentModuleAPINotes(Module *module,
                                  bool lookInModule,
                                  ArrayRef<std::string> searchPaths);
+
+  /// Get FileEntry for the APINotes of the current module.
+  ///
+  /// \param module The current module.
+  /// \param lookInModule Whether to look inside the module itself.
+  /// \param searchPaths The paths in which we should search for API notes
+  /// for the current module.
+  ///
+  /// \returns a vector of FileEntry where APINotes files are.
+  llvm::SmallVector<const FileEntry *, 2>
+  getCurrentModuleAPINotes(Module *module, bool lookInModule,
+                           ArrayRef<std::string> searchPaths);
+
+  /// Load Compiled API notes for current module.
+  ///
+  /// \param Buffers Array of compiled API notes.
+  ///
+  /// \returns true if API notes were successfully loaded, \c false otherwise.
+  bool loadCurrentModuleAPINotesFromBuffer(ArrayRef<StringRef> Buffers);
 
   /// Retrieve the set of API notes readers for the current module.
   ArrayRef<APINotesReader *> getCurrentModuleReaders() const {

--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -40,6 +40,8 @@ def err_cas_cannot_parse_include_tree_id : Error<
   "CAS cannot parse include-tree-id '%0'">, DefaultFatal;
 def err_cas_missing_include_tree_id : Error<
   "CAS missing expected include-tree '%0'">, DefaultFatal;
+def err_cas_cannot_load_api_notes_include_tree : Error<
+  "cannot load APINotes from include-tree-id '%0'">, DefaultFatal;
 
 def warn_clang_cache_disabled_caching: Warning<
   "caching disabled because %0">,

--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -698,6 +698,8 @@ def err_drv_target_variant_invalid : Error<
 
 def err_drv_inputs_and_include_tree : Error<
   "passing input files is incompatible with '-fcas-include-tree'">;
+def err_drv_incompatible_option_include_tree : Error<
+  "passing incompatible option '%0' with '-fcas-include-tree'">;
 
 def err_drv_invalid_directx_shader_module : Error<
   "invalid profile : %0">;

--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -57,6 +57,7 @@ public:
   class Module;
   class ModuleImport;
   class ModuleMap;
+  class APINotes;
 
   Expected<File> getBaseFile();
 
@@ -644,6 +645,46 @@ private:
   friend class IncludeTreeRoot;
 };
 
+/// A list of \c APINotes that is compiled and loaded.
+class IncludeTree::APINotes : public IncludeTreeBase<APINotes> {
+public:
+  static constexpr StringRef getNodeKind() { return "APIN"; }
+
+  llvm::Error
+  forEachAPINotes(llvm::function_ref<llvm::Error(StringRef)> Callback);
+
+  static Expected<APINotes> create(ObjectStore &DB,
+                                   ArrayRef<ObjectRef> APINoteList);
+
+  static Expected<APINotes> get(ObjectStore &CAS, ObjectRef Ref);
+
+  llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
+
+private:
+  friend class IncludeTreeBase<APINotes>;
+  friend class IncludeTreeRoot;
+
+  explicit APINotes(ObjectProxy Node) : IncludeTreeBase(std::move(Node)) {
+    assert(isValid(*this));
+  }
+
+  static bool isValid(const ObjectProxy &Node) {
+    if (!IncludeTreeBase::isValid(Node))
+      return false;
+    IncludeTreeBase Base(Node);
+    return Base.getData().empty() && Base.getNumReferences() < 2;
+  }
+
+  static bool isValid(ObjectStore &CAS, ObjectRef Ref) {
+    auto Node = CAS.getProxy(Ref);
+    if (!Node) {
+      llvm::consumeError(Node.takeError());
+      return false;
+    }
+    return isValid(*Node);
+  }
+};
+
 /// Represents the include-tree result for a translation unit.
 class IncludeTreeRoot : public IncludeTreeBase<IncludeTreeRoot> {
 public:
@@ -661,6 +702,12 @@ public:
 
   std::optional<ObjectRef> getModuleMapRef() const {
     if (auto Index = getModuleMapRefIndex())
+      return getReference(*Index);
+    return std::nullopt;
+  }
+
+  std::optional<ObjectRef> getAPINotesRef() const {
+    if (auto Index = getAPINotesRefIndex())
       return getReference(*Index);
     return std::nullopt;
   }
@@ -699,10 +746,20 @@ public:
     return std::nullopt;
   }
 
+  Expected<std::optional<IncludeTree::APINotes>> getAPINotes() {
+    if (std::optional<ObjectRef> Ref = getAPINotesRef()) {
+      auto Node = getCAS().getProxy(*Ref);
+      if (!Node)
+        return Node.takeError();
+      return IncludeTree::APINotes(*Node);
+    }
+    return std::nullopt;
+  }
+
   static Expected<IncludeTreeRoot>
   create(ObjectStore &DB, ObjectRef MainFileTree, ObjectRef FileList,
-         std::optional<ObjectRef> PCHRef,
-         std::optional<ObjectRef> ModuleMapRef);
+         std::optional<ObjectRef> PCHRef, std::optional<ObjectRef> ModuleMapRef,
+         std::optional<ObjectRef> APINotesRef);
 
   static Expected<IncludeTreeRoot> get(ObjectStore &DB, ObjectRef Ref);
 
@@ -729,6 +786,7 @@ private:
 
   std::optional<unsigned> getPCHRefIndex() const;
   std::optional<unsigned> getModuleMapRefIndex() const;
+  std::optional<unsigned> getAPINotesRefIndex() const;
 
   explicit IncludeTreeRoot(ObjectProxy Node)
       : IncludeTreeBase(std::move(Node)) {

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -566,13 +566,15 @@ llvm::Error IncludeTree::ModuleMap::forEachModule(
   });
 }
 
-static constexpr char HasPCH = 0x01;
-static constexpr char HasModuleMap = 0x02;
+static constexpr char HasPCH = 1;
+static constexpr char HasModuleMap = 1 << 1;
+static constexpr char HasAPINotes = 1 << 2;
 
 Expected<IncludeTreeRoot>
 IncludeTreeRoot::create(ObjectStore &DB, ObjectRef MainFileTree,
                         ObjectRef FileList, std::optional<ObjectRef> PCHRef,
-                        std::optional<ObjectRef> ModuleMapRef) {
+                        std::optional<ObjectRef> ModuleMapRef,
+                        std::optional<ObjectRef> APINotesRef) {
   assert(IncludeTree::isValid(DB, MainFileTree));
   assert(IncludeTree::FileList::isValid(DB, FileList));
   assert(!ModuleMapRef || IncludeTree::ModuleMap::isValid(DB, *ModuleMapRef));
@@ -582,12 +584,16 @@ IncludeTreeRoot::create(ObjectStore &DB, ObjectRef MainFileTree,
     Data[0] |= HasPCH;
   if (ModuleMapRef)
     Data[0] |= HasModuleMap;
+  if (APINotesRef)
+    Data[0] |= HasAPINotes;
 
   SmallVector<ObjectRef> Refs = {MainFileTree, FileList};
   if (PCHRef)
     Refs.push_back(*PCHRef);
   if (ModuleMapRef)
     Refs.push_back(*ModuleMapRef);
+  if (APINotesRef)
+    Refs.push_back(*APINotesRef);
 
   return IncludeTreeBase::create(DB, Refs, Data);
 }
@@ -610,6 +616,11 @@ std::optional<unsigned> IncludeTreeRoot::getPCHRefIndex() const {
 std::optional<unsigned> IncludeTreeRoot::getModuleMapRefIndex() const {
   if (getData()[0] & HasModuleMap)
     return (getData()[0] & HasPCH) ? 3u : 2u;
+  return std::nullopt;
+}
+std::optional<unsigned> IncludeTreeRoot::getAPINotesRefIndex() const {
+  if (getData()[0] & HasAPINotes)
+    return 2 + (getPCHRefIndex() ? 1 : 0) + (getModuleMapRefIndex() ? 1 : 0);
   return std::nullopt;
 }
 
@@ -743,6 +754,46 @@ llvm::Error IncludeTree::ModuleMap::print(llvm::raw_ostream &OS,
   return forEachModule([&](Module M) { return M.print(OS, Indent); });
 }
 
+llvm::Expected<IncludeTree::APINotes>
+IncludeTree::APINotes::create(ObjectStore &DB,
+                              ArrayRef<ObjectRef> APINoteList) {
+  assert(APINoteList.size() < 2 && "Too many APINotes added");
+  return IncludeTreeBase::create(DB, APINoteList, {});
+}
+
+llvm::Expected<IncludeTree::APINotes>
+IncludeTree::APINotes::get(ObjectStore &DB, ObjectRef Ref) {
+  auto Node = DB.getProxy(Ref);
+  if (!Node)
+    return Node.takeError();
+  if (!isValid(*Node))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "not an APINodes node kind");
+  return APINotes(std::move(*Node));
+}
+
+llvm::Error IncludeTree::APINotes::print(llvm::raw_ostream &OS,
+                                         unsigned Indent) {
+  return forEachReference([&](ObjectRef Ref) -> llvm::Error {
+    auto Node = getCAS().getProxy(Ref);
+    if (!Node)
+      return Node.takeError();
+    OS.indent(Indent) << Node->getID() << "\n";
+    OS.indent(Indent) << Node->getData() << "\n";
+    return llvm::Error::success();
+  });
+}
+
+llvm::Error IncludeTree::APINotes::forEachAPINotes(
+    llvm::function_ref<llvm::Error(StringRef)> CB) {
+  return forEachReference([&](ObjectRef Ref) {
+    auto N = getCAS().getProxy(Ref);
+    if (!N)
+      return N.takeError();
+    return CB(N->getData());
+  });
+}
+
 llvm::Error IncludeTreeRoot::print(llvm::raw_ostream &OS, unsigned Indent) {
   if (std::optional<ObjectRef> PCHRef = getPCHRef()) {
     OS.indent(Indent) << "(PCH) ";
@@ -766,6 +817,14 @@ llvm::Error IncludeTreeRoot::print(llvm::raw_ostream &OS, unsigned Indent) {
   std::optional<IncludeTree::FileList> List;
   if (llvm::Error E = getFileList().moveInto(List))
     return E;
+  std::optional<IncludeTree::APINotes> APINotes;
+  if (llvm::Error E = getAPINotes().moveInto(APINotes))
+    return E;
+  if (APINotes) {
+    OS.indent(Indent) << "APINotes:\n";
+    if (llvm::Error E = APINotes->print(OS, Indent))
+      return E;
+  }
   return List->print(OS, Indent);
 }
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -21,6 +21,7 @@
 #include "clang/Basic/Stack.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/Version.h"
+#include "clang/CAS/IncludeTree.h"
 #include "clang/Config/config.h"
 #include "clang/Frontend/CASDependencyCollector.h"
 #include "clang/Frontend/ChainedDiagnosticConsumer.h"
@@ -804,6 +805,52 @@ CompilerInstance::createCodeCompletionConsumer(Preprocessor &PP,
   return new PrintingCodeCompleteConsumer(Opts, OS);
 }
 
+static void loadAPINotesFromIncludeTree(cas::ObjectStore &DB,
+                                        api_notes::APINotesManager &APINotes,
+                                        DiagnosticsEngine &Diags,
+                                        StringRef IncludeTreeRootID) {
+  Expected<llvm::cas::CASID> RootID = DB.parseID(IncludeTreeRootID);
+  if (!RootID) {
+    llvm::consumeError(RootID.takeError());
+    Diags.Report(diag::err_cas_cannot_parse_include_tree_id)
+        << IncludeTreeRootID;
+    return;
+  }
+  std::optional<llvm::cas::ObjectRef> Ref = DB.getReference(*RootID);
+  if (!Ref) {
+    Diags.Report(diag::err_cas_missing_include_tree_id) << IncludeTreeRootID;
+    return;
+  }
+  auto Root = cas::IncludeTreeRoot::get(DB, *Ref);
+  if (!Root) {
+    consumeError(Root.takeError());
+    Diags.Report(diag::err_cas_missing_include_tree_id) << IncludeTreeRootID;
+    return;
+  }
+  auto Notes = Root->getAPINotes();
+  if (!Notes) {
+    consumeError(Notes.takeError());
+    Diags.Report(diag::err_cas_cannot_load_api_notes_include_tree)
+        << IncludeTreeRootID;
+    return;
+  }
+  if (!*Notes)
+    return;
+  std::vector<StringRef> Buffers;
+
+  if (auto E = (*Notes)->forEachAPINotes([&](StringRef Buffer) {
+        Buffers.push_back(Buffer);
+        return llvm::Error::success();
+      })) {
+    consumeError(std::move(E));
+    Diags.Report(diag::err_cas_cannot_load_api_notes_include_tree)
+        << IncludeTreeRootID;
+    return;
+  }
+
+  APINotes.loadCurrentModuleAPINotesFromBuffer(Buffers);
+}
+
 void CompilerInstance::createSema(TranslationUnitKind TUKind,
                                   CodeCompleteConsumer *CompletionConsumer) {
   TheSema.reset(new Sema(getPreprocessor(), getASTContext(), getASTConsumer(),
@@ -815,10 +862,18 @@ void CompilerInstance::createSema(TranslationUnitKind TUKind,
   // If we're building a module and are supposed to load API notes,
   // notify the API notes manager.
   if (auto currentModule = getPreprocessor().getCurrentModule()) {
-    (void)TheSema->APINotes.loadCurrentModuleAPINotes(
-            currentModule,
-            getLangOpts().APINotesModules,
-            getAPINotesOpts().ModuleSearchPaths);
+    // If using include tree, APINotes for current module is loaded from include
+    // tree.
+    if (getFrontendOpts().CASIncludeTreeID.empty())
+      (void)TheSema->APINotes.loadCurrentModuleAPINotes(
+          currentModule, getLangOpts().APINotesModules,
+          getAPINotesOpts().ModuleSearchPaths);
+    else
+      loadAPINotesFromIncludeTree(
+          *getCASOpts().getOrCreateDatabases(getDiagnostics()).first,
+          TheSema->APINotes, getDiagnostics(),
+          getFrontendOpts().CASIncludeTreeID);
+
     // Check for any attributes we should add to the module
     for (auto reader : TheSema->APINotes.getCurrentModuleReaders()) {
       // swift_infer_import_as_member

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3527,6 +3527,11 @@ static void ParseAPINotesArgs(APINotesOptions &Opts, ArgList &Args,
   }
   for (const Arg *A : Args.filtered(OPT_iapinotes_modules))
     Opts.ModuleSearchPaths.push_back(A->getValue());
+
+  if (Args.hasFlag(OPT_fapinotes, OPT_fno_apinotes, false) &&
+      Args.hasArg(OPT_fcas_include_tree))
+    diags.Report(diag::err_drv_incompatible_option_include_tree)
+        << "-fapinotes";
 }
 
 static void GeneratePointerAuthArgs(LangOptions &Opts,

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -73,6 +73,8 @@ void tooling::dependencies::configureInvocationForCaching(
     // above resets \p HeaderSearchOptions) when properly supporting
     // `-gmodules`.
     CI.getCodeGenOpts().DebugTypeExtRefs = false;
+    // Clear APINotes options.
+    CI.getAPINotesOpts().ModuleSearchPaths = {};
   } else {
     FileSystemOpts.CASFileSystemRootID = std::move(RootID);
     FileSystemOpts.CASFileSystemWorkingDirectory = std::move(WorkingDir);

--- a/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
@@ -1,0 +1,92 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Extract the include-tree commands
+// RUN: %deps-to-rsp %t/deps.json --module-name Top > %t/Top.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Left > %t/Left.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// Extract include-tree casids
+// RUN: cat %t/Top.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Top.casid
+// RUN: cat %t/Left.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Left.casid
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Top.casid | FileCheck %s -check-prefix=WITH-APINOTES
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Left.casid | FileCheck %s -check-prefix=WITHOUT-APINOTES
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid  | FileCheck %s -check-prefix=WITHOUT-APINOTES
+
+// WITH-APINOTES: APINotes:
+// WITH-APINOTES-NEXT: llvmcas://
+// WITH-APINOTES-NEXT: Name: Top
+// WITH-APINOTES-NEXT: Functions:
+// WITH-APINOTES-NEXT:   - Name: top
+// WITH-APINOTES-NEXT:     Availability: none
+// WITH-APINOTES-NEXT:     AvailabilityMsg: "don't use this"
+// WITHOUT-APINOTES-NOT: APINotes:
+
+// Build the include-tree commands
+// RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// Ensure the pcm comes from the action cache
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_MISS
+// RUN: rm -rf %t/outputs
+// RUN: %clang @%t/tu.rsp -verify -fno-cache-compile-job
+
+// Check cache hits
+// RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+// RUN: %clang @%t/Left.rsp 2>&1 | FileCheck %s -check-prefix=CACHE_HIT
+
+// CACHE_MISS: compile job cache miss
+// CACHE_HIT: compile job cache hit
+
+// Check incompatible with -fapinotes
+// RUN: not %clang -cc1 -fcas-include-tree @%t/Top.casid -fapinotes \
+// RUN:   -fcas-path %t/cas -fsyntax-only 2>&1 | \
+// RUN:   FileCheck %s -check-prefix=INCOMPATIBLE
+
+// INCOMPATIBLE: error: passing incompatible option '-fapinotes' with '-fcas-include-tree'
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -fapinotes-modules -iapinotes-modules DIR"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export *}
+module Left { header "Left.h" export *}
+
+//--- Top.h
+#pragma once
+struct Top {
+  int x;
+};
+void top(void);
+
+//--- Left.h
+#include "Top.h"
+void left(void);
+
+//--- tu.m
+#import "Left.h"
+
+void tu(void) {
+  top(); // expected-error {{'top' is unavailable: don't use this}}
+  left();
+}
+// expected-note@Top.h:5{{'top' has been explicitly marked unavailable here}}
+
+//--- Top.apinotes
+Name: Top
+Functions:
+  - Name: top
+    Availability: none
+    AvailabilityMsg: "don't use this"


### PR DESCRIPTION
Add support for APINotes when using include-tree. Loading APINotes during dependency scanning and store the APINotes as part of the IncludeTree so it can be loaded directly from IncludeTree during compilation.

Only support `-fapinotes-module` and emit error when the old deprecated `-fapinotes` is used because that option uses an expensive and unbounded search for APNotes based on SourceLoc of Decls.