### PR TITLE
Prioritize using a segment with the name TEXT instead off fileoff 0

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6141,20 +6141,22 @@ Section *ObjectFileMachO::GetMachHeaderSection() {
   SectionList *section_list = GetSectionList();
   if (!section_list)
     return nullptr;
+
+  // Some binaries can have a TEXT segment with a non-zero file offset.
+  // Binaries in the shared cache are one example.  Some hand-generated
+  // binaries may not be laid out in the normal TEXT,DATA,LC_SYMTAB order
+  // in the file, even though they're laid out correctly in vmaddr terms.
+  SectionSP text_segment_sp =
+      section_list->FindSectionByName(GetSegmentNameTEXT());
+  if (text_segment_sp.get() && SectionIsLoadable(text_segment_sp.get()))
+    return text_segment_sp.get();
+
   const size_t num_sections = section_list->GetSize();
   for (size_t sect_idx = 0; sect_idx < num_sections; ++sect_idx) {
     Section *section = section_list->GetSectionAtIndex(sect_idx).get();
     if (section->GetFileOffset() == 0 && SectionIsLoadable(section))
       return section;
   }
-
-  // We may have a binary in the shared cache that has a non-zero
-  // file address for its first segment, traditionally the __TEXT segment.
-  // Search for it by name and return it as our next best guess.
-  SectionSP text_segment_sp =
-      GetSectionList()->FindSectionByName(GetSegmentNameTEXT());
-  if (text_segment_sp.get() && SectionIsLoadable(text_segment_sp.get()))
-    return text_segment_sp.get();
 
   return nullptr;
 }


### PR DESCRIPTION
Prioritize using a segment with the name TEXT instead off fileoff 0

lldb needs to find the virtual address of the mach header of a binary.  It first scans for a segment which starts at file offset 0, and uses the vmaddr of that segment.  If no segment starts at fileoff 0, it looks for a segment named __TEXT.

This patch changes the order of those, to first search for the TEXT segment.  We have a situation where binaries exist that have the DATA segment first, which does not have the vmaddr of the mach header, it merely happens to come first in the binary file.  It's an unusual arrangement, but not breaking any rules of Mach-O.  So lldb needs to handle this.

Differential Revision: https://reviews.llvm.org/D150239 rdar://109128418

(cherry picked from commit f9759d0cb6dc19aa67dbe1c3d56404041f8b4c7e)