### PR TITLE
Separate clangimporter errors

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1381,8 +1381,7 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
 
   if (expr_diagnostics.HasErrors())
     return make_error<ModuleImportError>(
-        expr_diagnostics.GetAllErrors().AsCString(
-            "Explicit module import error"));
+        llvm::toString(expr_diagnostics.GetAllErrors()));
 
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
   if (repl || !playground) {

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1975,7 +1975,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // Clang diagnostic.
   if (m_swift_ast_ctx.HasErrors() || m_swift_ast_ctx.HasClangImporterErrors()) {
     diagnostic_manager.PutString(eDiagnosticSeverityRemark,
-                                 "couldn't IRGen expression.");
+                                 "couldn't IRGen expression");
     DiagnoseSwiftASTContextError();
     return ParseResult::unrecoverable_error;
   }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1974,31 +1974,18 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // If IRGen failed without errors, the root cause may be a fatal
   // Clang diagnostic.
   if (m_swift_ast_ctx.HasErrors() || m_swift_ast_ctx.HasClangImporterErrors()) {
-    diagnostic_manager.Printf(eDiagnosticSeverityRemark,
-                              "couldn't IRGen expression.");
+    diagnostic_manager.PutString(eDiagnosticSeverityRemark,
+                                 "couldn't IRGen expression.");
     DiagnoseSwiftASTContextError();
     return ParseResult::unrecoverable_error;
   }
 
   if (!m_module) {
-    auto &warnings = m_swift_ast_ctx.GetModuleImportWarnings();
-    for (StringRef message : warnings) {
-      // FIXME: Don't store diagnostics as strings.
-      auto severity = eDiagnosticSeverityWarning;
-      if (message.consume_front("warning: "))
-        severity = eDiagnosticSeverityWarning;
-      if (message.consume_front("error: "))
-        severity = eDiagnosticSeverityError;
-      diagnostic_manager.PutString(severity, message);
-    }
-    std::string error = "couldn't IRGen expression";
     diagnostic_manager.Printf(
-        eDiagnosticSeverityError, "couldn't IRGen expression: %s",
-        warnings.empty()
-            ? "Please enable the expression log by running \"log enable lldb "
-              "expr\", then run the failing expression again, and file a "
-              "bugreport with the log output."
-            : "Please check the above error messages for possible root causes.");
+        eDiagnosticSeverityError,
+        "couldn't IRGen expression. Please enable the expression log by "
+        "running \"log enable lldb expr\", then run the failing expression "
+        "again, and file a bug report with the log output.");
     return ParseResult::unrecoverable_error;
   }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -1,0 +1,418 @@
+//===-- StoringDiagnosticConsumer.h -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_StoringDiagnosticConsumer_h_
+#define liblldb_StoringDiagnosticConsumer_h_
+
+#include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
+
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
+#include "swift/AST/DiagnosticsSema.h"
+#include "swift/Basic/DiagnosticOptions.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Frontend/PrintingDiagnosticConsumer.h"
+
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Process.h"
+
+namespace lldb_private {
+
+class ANSIColorStringStream : public llvm::raw_string_ostream {
+public:
+  ANSIColorStringStream(bool colorize)
+      : llvm::raw_string_ostream(m_buffer), m_colorize(colorize) {}
+  /// Changes the foreground color of text that will be output from
+  /// this point forward.
+  ///
+  /// \param colors      ANSI color to use, the special SAVEDCOLOR can
+  ///                    be used to change only the bold attribute, and
+  ///                    keep colors untouched.
+  /// \param bold        bold/brighter text, default false
+  /// \param bg          if true change the background,
+  ///                    default: change foreground
+  /// \returns           itself so it can be used within << invocations.
+  raw_ostream &changeColor(enum Colors colors, bool bold = false,
+                           bool bg = false) override {
+    if (llvm::sys::Process::ColorNeedsFlush())
+      flush();
+    const char *colorcode;
+    if (colors == SAVEDCOLOR)
+      colorcode = llvm::sys::Process::OutputBold(bg);
+    else
+      colorcode =
+          llvm::sys::Process::OutputColor(static_cast<char>(colors), bold, bg);
+    if (colorcode) {
+      size_t len = strlen(colorcode);
+      write(colorcode, len);
+    }
+    return *this;
+  }
+
+  /// Resets the colors to terminal defaults. Call this when you are
+  /// done outputting colored text, or before program exit.
+  raw_ostream &resetColor() override {
+    if (llvm::sys::Process::ColorNeedsFlush())
+      flush();
+    const char *colorcode = llvm::sys::Process::ResetColor();
+    if (colorcode) {
+      size_t len = strlen(colorcode);
+      write(colorcode, len);
+    }
+    return *this;
+  }
+
+  /// Reverses the forground and background colors.
+  raw_ostream &reverseColor() override {
+    if (llvm::sys::Process::ColorNeedsFlush())
+      flush();
+    const char *colorcode = llvm::sys::Process::OutputReverse();
+    if (colorcode) {
+      size_t len = strlen(colorcode);
+      write(colorcode, len);
+    }
+    return *this;
+  }
+
+  /// This function determines if this stream is connected to a "tty"
+  /// or "console" window. That is, the output would be displayed to
+  /// the user rather than being put on a pipe or stored in a file.
+  bool is_displayed() const override { return m_colorize; }
+
+  /// This function determines if this stream is displayed and
+  /// supports colors.
+  bool has_colors() const override { return m_colorize; }
+
+protected:
+  std::string m_buffer;
+  bool m_colorize;
+};
+
+
+class StoringDiagnosticConsumer : public swift::DiagnosticConsumer {
+public:
+  StoringDiagnosticConsumer(SwiftASTContext &ast_context)
+      : m_ast_context(ast_context) {
+    m_ast_context.GetDiagnosticEngine().resetHadAnyError();
+    m_ast_context.GetDiagnosticEngine().addConsumer(*this);
+  }
+
+  ~StoringDiagnosticConsumer() {
+    m_ast_context.GetDiagnosticEngine().takeConsumers();
+  }
+
+  /// Consume a Diagnostic from the Swift compiler.
+  void handleDiagnostic(swift::SourceManager &source_mgr,
+                        const swift::DiagnosticInfo &info) override {
+    llvm::StringRef bufferName = "<anonymous>";
+    unsigned bufferID = 0;
+    std::pair<unsigned, unsigned> line_col = {0, 0};
+
+    llvm::SmallString<256> text;
+    {
+      llvm::raw_svector_ostream out(text);
+      swift::DiagnosticEngine::formatDiagnosticText(out, info.FormatString,
+                                                    info.FormatArgs);
+    }
+
+    swift::SourceLoc source_loc = info.Loc;
+    if (source_loc.isValid()) {
+      bufferID = source_mgr.findBufferContainingLoc(source_loc);
+      bufferName = source_mgr.getDisplayNameForLoc(source_loc);
+      line_col = source_mgr.getPresumedLineAndColumnForLoc(source_loc);
+    }
+
+    bool use_fixits = false;
+    std::string formatted_text;
+    if (!line_col.first) {
+      formatted_text = text.str();
+    } else {
+      ANSIColorStringStream os(m_colorize);
+
+      // Determine what kind of diagnostic we're emitting, and whether
+      // we want to use its fixits:
+      llvm::SourceMgr::DiagKind source_mgr_kind;
+      switch (info.Kind) {
+      case swift::DiagnosticKind::Error:
+        source_mgr_kind = llvm::SourceMgr::DK_Error;
+        use_fixits = true;
+        break;
+      case swift::DiagnosticKind::Warning:
+        source_mgr_kind = llvm::SourceMgr::DK_Warning;
+        break;
+      case swift::DiagnosticKind::Note:
+        source_mgr_kind = llvm::SourceMgr::DK_Note;
+        break;
+      case swift::DiagnosticKind::Remark:
+        source_mgr_kind = llvm::SourceMgr::DK_Remark;
+        break;
+      }
+
+      // Swift may insert note diagnostics after an error diagnostic with fixits
+      // related to that error. Check if the latest inserted diagnostic is an
+      // error one, and that the diagnostic being processed is a note one that
+      // points to the same error, and if so, copy the fixits from the note
+      // diagnostic to the error one. There may be subsequent notes with fixits
+      // related to the same error, but we only copy the first one as the fixits
+      // are mutually exclusive (for example, one may suggest inserting a '?'
+      // and the next may suggest inserting '!')
+      if (info.Kind == swift::DiagnosticKind::Note &&
+          !m_raw_swift_diagnostics.empty()) {
+        auto &last_diagnostic = m_raw_swift_diagnostics.back();
+        if (last_diagnostic.kind == swift::DiagnosticKind::Error &&
+            last_diagnostic.fixits.empty() &&
+            last_diagnostic.bufferID == bufferID &&
+            last_diagnostic.column == line_col.second &&
+            last_diagnostic.line == line_col.first)
+          last_diagnostic.fixits.insert(last_diagnostic.fixits.end(),
+                                        info.FixIts.begin(), info.FixIts.end());
+      }
+
+      // Translate ranges.
+      llvm::SmallVector<llvm::SMRange, 2> ranges;
+      for (auto R : info.Ranges)
+        ranges.push_back(getRawRange(source_mgr, R));
+
+      // Translate fix-its.
+      llvm::SmallVector<llvm::SMFixIt, 2> fix_its;
+      for (swift::DiagnosticInfo::FixIt F : info.FixIts)
+        fix_its.push_back(getRawFixIt(source_mgr, F));
+
+      // Display the diagnostic.
+      auto message = source_mgr.GetMessage(source_loc, source_mgr_kind, text,
+                                           ranges, fix_its);
+      source_mgr.getLLVMSourceMgr().PrintMessage(os, message);
+
+      // str() implicitly flushes the stram.
+      std::string &s = os.str();
+      formatted_text = !s.empty() ? std::move(s) : std::string(text);
+    }
+    RawDiagnostic diagnostic(
+        formatted_text, info.Kind, bufferName, bufferID, line_col.first,
+        line_col.second,
+        use_fixits ? info.FixIts : llvm::ArrayRef<swift::Diagnostic::FixIt>());
+    if (info.ID == swift::diag::error_from_clang.ID ||
+        info.ID == swift::diag::bridging_header_error.ID) {
+      if (m_raw_clang_diagnostics.empty() ||
+          m_raw_clang_diagnostics.back() != diagnostic) {
+        m_raw_clang_diagnostics.push_back(std::move(diagnostic));
+        if (info.Kind == swift::DiagnosticKind::Error)
+          m_num_clang_errors++;
+      }
+    } else {
+      m_raw_swift_diagnostics.push_back(std::move(diagnostic));
+      if (info.Kind == swift::DiagnosticKind::Error)
+        m_num_swift_errors++;
+    }
+  }
+
+  void Clear() {
+    m_raw_swift_diagnostics.clear();
+    m_num_swift_errors = 0;
+    // Don't reset Clang errors. ClangImporter's DiagnosticEngine doesn't either.
+    // Don't reset LLDB diagnostics.
+  }
+
+  unsigned HasDiagnostics() {
+    return !m_raw_clang_diagnostics.empty() ||
+           !m_raw_swift_diagnostics.empty() || !m_diagnostics.empty();
+  }
+
+  unsigned NumClangErrors() { return m_num_clang_errors; }
+
+  static DiagnosticSeverity SeverityForKind(swift::DiagnosticKind kind) {
+    switch (kind) {
+    case swift::DiagnosticKind::Error:
+      return eDiagnosticSeverityError;
+    case swift::DiagnosticKind::Warning:
+      return eDiagnosticSeverityWarning;
+    case swift::DiagnosticKind::Note:
+    case swift::DiagnosticKind::Remark:
+      return eDiagnosticSeverityRemark;
+    }
+
+    llvm_unreachable("Unhandled DiagnosticKind in switch.");
+  }
+
+  // Forward and consume the stored diagnostics to \c diagnostic_manager.
+  void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
+                        SwiftASTContext::DiagnosticCursor cursor,
+                        uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
+                        uint32_t last_line = UINT32_MAX) {
+    // Move all diagnostics starting at the cursor into diagnostic_manager.
+    bool added_one_diagnostic = false;
+    for (size_t i = cursor.lldb; i < m_diagnostics.size(); ++i) {
+      diagnostic_manager.AddDiagnostic(std::move(m_diagnostics[i]));
+      added_one_diagnostic = true;
+    }
+    m_diagnostics.resize(std::min(m_diagnostics.size(), cursor.lldb));
+
+    // We often make expressions and wrap them in some code.  When we
+    // see errors we want the line numbers to be correct so we correct
+    // them below. LLVM stores in SourceLoc objects as character
+    // offsets so there is no way to get LLVM to move its error line
+    // numbers around by adjusting the source location, we must do it
+    // manually. We also want to use the same error formatting as LLVM
+    // and Clang, so we must muck with the string.
+
+    auto format_diagnostic = [&](const RawDiagnostic &diagnostic,
+                                 const DiagnosticOrigin origin) {
+      const DiagnosticSeverity severity = SeverityForKind(diagnostic.kind);
+
+      // Make sure the error line is in range or in another file.
+      if (diagnostic.bufferID == bufferID && !diagnostic.bufferName.empty() &&
+          (diagnostic.line < first_line || diagnostic.line > last_line))
+        return;
+
+      // Heuristic to skip expected expression warnings.
+      if (diagnostic.description.find("$__lldb") != std::string::npos)
+        return;
+
+      // Diagnose global errors.
+      if (severity == eDiagnosticSeverityError && diagnostic.line == 0) {
+        diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
+                                         severity, origin);
+        added_one_diagnostic = true;
+        return;
+      }
+
+      // Need to remap the error/warning to a different line.
+      StreamString match;
+      match.Printf("%s:%u:", diagnostic.bufferName.str().c_str(),
+                   diagnostic.line);
+      const size_t match_len = match.GetString().size();
+      size_t match_pos = diagnostic.description.find(match.GetString().str());
+      if (match_pos == std::string::npos)
+        return;
+
+      // We have some <file>:<line>:" instances that need to be updated.
+      StreamString fixed_description;
+      size_t start_pos = 0;
+      do {
+        if (match_pos > start_pos)
+          fixed_description.Printf(
+              "%s",
+              diagnostic.description.substr(start_pos, match_pos).c_str());
+        fixed_description.Printf("%s:%u:", diagnostic.bufferName.str().c_str(),
+                                 diagnostic.line - first_line + 1);
+        start_pos = match_pos + match_len;
+        match_pos =
+            diagnostic.description.find(match.GetString().str(), start_pos);
+      } while (match_pos != std::string::npos);
+
+      // Append any last remaining text.
+      if (start_pos < diagnostic.description.size())
+        fixed_description.Printf(
+            "%s",
+            diagnostic.description
+                .substr(start_pos, diagnostic.description.size() - start_pos)
+                .c_str());
+
+      auto new_diagnostic = std::make_unique<SwiftDiagnostic>(
+          fixed_description.GetData(), severity, origin, bufferID);
+      for (auto fixit : diagnostic.fixits)
+        new_diagnostic->AddFixIt(fixit);
+
+      diagnostic_manager.AddDiagnostic(std::move(new_diagnostic));
+      if (diagnostic.kind == swift::DiagnosticKind::Error)
+        added_one_diagnostic = true;
+    };
+
+    for (size_t i = cursor.clang; i < m_raw_clang_diagnostics.size(); ++i)
+      format_diagnostic(m_raw_clang_diagnostics[i], eDiagnosticOriginClang);
+
+    for (size_t i = cursor.swift; i < m_raw_swift_diagnostics.size(); ++i)
+      format_diagnostic(m_raw_swift_diagnostics[i], eDiagnosticOriginSwift);
+
+    if (added_one_diagnostic)
+      return;
+
+    // We found no error that is newer than the cursor position.
+    // ClangImporter errors often happen outside the current transaction.
+    for (const RawDiagnostic &diagnostic : m_raw_clang_diagnostics)
+      diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
+                                       SeverityForKind(diagnostic.kind),
+                                       eDiagnosticOriginClang);
+
+    // If we printed a clang error, ignore Swift warnings, which are
+    // expected: The default lldb_expr wrapper produces some warnings.
+    if (!m_num_clang_errors || m_num_swift_errors)
+      for (const RawDiagnostic &diagnostic : m_raw_swift_diagnostics)
+        diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
+                                         SeverityForKind(diagnostic.kind),
+                                         eDiagnosticOriginSwift);
+  }
+
+  bool GetColorize() const { return m_colorize; }
+
+  bool SetColorize(bool b) {
+    const bool old = m_colorize;
+    m_colorize = b;
+    return old;
+  }
+
+  void AddDiagnostic(std::unique_ptr<Diagnostic> diagnostic) {
+    if (diagnostic)
+      m_diagnostics.push_back(std::move(diagnostic));
+  }
+
+private:
+  // We don't currently use lldb_private::Diagostic or any of the lldb
+  // DiagnosticManager machinery to store diagnostics as they
+  // occur. Instead, we store them in raw form using this struct, then
+  // transcode them to SwiftDiagnostics in PrintDiagnostic.
+  struct RawDiagnostic {
+    RawDiagnostic() = default;
+    RawDiagnostic(std::string in_desc, swift::DiagnosticKind in_kind,
+                  llvm::StringRef in_bufferName, unsigned in_bufferID,
+                  uint32_t in_line, uint32_t in_column,
+                  llvm::ArrayRef<swift::Diagnostic::FixIt> in_fixits)
+        : description(in_desc), kind(in_kind), bufferName(in_bufferName),
+          bufferID(in_bufferID), line(in_line), column(in_column),
+          fixits(in_fixits) {}
+    RawDiagnostic(const RawDiagnostic &other)
+        : description(other.description), kind(other.kind),
+          bufferName(other.bufferName), bufferID(other.bufferID),
+          line(other.line), column(other.column), fixits(other.fixits) {}
+    bool operator==(const RawDiagnostic& other) {
+      return kind == other.kind && bufferID == other.bufferID &&
+             line == other.line && column == other.column &&
+             description == other.description;
+    }
+    bool operator!=(const RawDiagnostic &other) { return !(*this == other); }
+
+    std::string description;
+    swift::DiagnosticKind kind = swift::DiagnosticKind::Error;
+    llvm::StringRef bufferName;
+    unsigned bufferID;
+    uint32_t line;
+    uint32_t column;
+    std::vector<swift::DiagnosticInfo::FixIt> fixits;
+  };
+
+  SwiftASTContext &m_ast_context;
+  /// Stores all diagnostics coming from the Swift compiler.
+  std::vector<RawDiagnostic> m_raw_swift_diagnostics;
+  std::vector<RawDiagnostic> m_raw_clang_diagnostics;
+  /// Stores diagnostics coming from LLDB.
+  std::vector<std::unique_ptr<Diagnostic>> m_diagnostics;
+
+  unsigned m_num_swift_errors = 0;
+  unsigned m_num_clang_errors = 0;
+  bool m_colorize = false;
+
+  friend class SwiftASTContext::ScopedDiagnostics;
+};
+
+} // namespace lldb_private
+
+#endif

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2751,12 +2751,16 @@ public:
       line_col = source_mgr.getPresumedLineAndColumnForLoc(source_loc);
     }
 
-    if (line_col.first != 0) {
+    bool use_fixits = false;
+    std::string formatted_text;
+    if (!line_col.first) {
+      formatted_text = text.str();
+      use_fixits = false;
+    } else {
       ANSIColorStringStream os(m_colorize);
 
       // Determine what kind of diagnostic we're emitting, and whether
       // we want to use its fixits:
-      bool use_fixits = false;
       llvm::SourceMgr::DiagKind source_mgr_kind;
       switch (info.Kind) {
       case swift::DiagnosticKind::Error:
@@ -2809,28 +2813,15 @@ public:
                                            ranges, fix_its);
       source_mgr.getLLVMSourceMgr().PrintMessage(os, message);
 
-      // Use the llvm::raw_string_ostream::str() accessor as it will
-      // flush the stream into our "message" and return us a reference
-      // to "message".
-      std::string &message_ref = os.str();
-
-      if (message_ref.empty())
-        m_raw_diagnostics.push_back(RawDiagnostic(
-            std::string(text), info.Kind, bufferName, bufferID, line_col.first,
-            line_col.second,
-            use_fixits ? info.FixIts
-                       : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
-      else
-        m_raw_diagnostics.push_back(RawDiagnostic(
-            message_ref, info.Kind, bufferName, bufferID, line_col.first,
-            line_col.second,
-            use_fixits ? info.FixIts
-                       : llvm::ArrayRef<swift::Diagnostic::FixIt>()));
-    } else {
-      m_raw_diagnostics.push_back(RawDiagnostic(
-          std::string(text), info.Kind, bufferName, bufferID, line_col.first,
-          line_col.second, llvm::ArrayRef<swift::Diagnostic::FixIt>()));
+      // str() implicitly flushes the stram.
+      std::string &s = os.str();
+      formatted_text = !s.empty() ? std::move(s) : std::string(text);
     }
+    m_raw_diagnostics.push_back(
+        {formatted_text, info.Kind, bufferName, bufferID, line_col.first,
+         line_col.second,
+         use_fixits ? info.FixIts
+                    : llvm::ArrayRef<swift::Diagnostic::FixIt>()});
 
     if (info.Kind == swift::DiagnosticKind::Error)
       m_num_errors++;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1020,7 +1020,6 @@ public:
     std::string formatted_text;
     if (!line_col.first) {
       formatted_text = text.str();
-      use_fixits = false;
     } else {
       ANSIColorStringStream os(m_colorize);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4806,27 +4806,15 @@ bool SwiftASTContext::SetColorizeDiagnostics(bool b) {
 void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                                        uint32_t bufferID, uint32_t first_line,
                                        uint32_t last_line) const {
+  // VALID_OR_RETURN cannot be used here here since would exit on error.
   LLDB_SCOPED_TIMER();
-  // If this is a fatal error, copy the error into the AST context's
-  // fatal error field, and then put it to the stream, otherwise just
-  // dump the diagnostics to the stream.
-
-  // N.B. you cannot use VALID_OR_RETURN here since that exits if
-  // you have fatal errors, which are what we are trying to print
-  // here.
   if (!m_ast_context_ap.get()) {
-    SymbolFile *sym_file = GetSymbolFile();
-    if (sym_file) {
-      ConstString name =
-          sym_file->GetObjectFile()->GetModule()->GetObjectName();
-      m_fatal_errors.SetErrorStringWithFormat("Null context for %s.",
-                                              name.AsCString());
-    } else {
-      m_fatal_errors.SetErrorString("Unknown fatal error occurred.");
-    }
+    RaiseFatalError("Swift compiler could not be initialized");
     return;
   }
 
+  // Forward diagnostics into diagnostic_manager.
+  // If there is a fatal error, also copy the error into m_fatal_errors.
   if (m_ast_context_ap->Diags.hasFatalErrorOccurred() &&
       !m_reported_fatal_error) {
     DiagnosticManager fatal_diagnostics;
@@ -4836,9 +4824,9 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
           ->PrintDiagnostics(fatal_diagnostics, bufferID, first_line,
                              last_line);
     if (fatal_diagnostics.Diagnostics().size())
-      m_fatal_errors.SetErrorString(fatal_diagnostics.GetString().c_str());
+      RaiseFatalError(fatal_diagnostics.GetString());
     else
-      m_fatal_errors.SetErrorString("Unknown fatal error occurred.");
+      RaiseFatalError("Unknown fatal error occurred.");
 
     m_reported_fatal_error = true;
 
@@ -4885,9 +4873,9 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
     if (use_all_compiler_flags && !extra_clang_args.empty()) {
       // We cannot reconfigure ClangImporter after its creation.
       // Instead poison the SwiftASTContext so it gets recreated.
-      m_fatal_errors.SetErrorStringWithFormat(
-          "New Swift image added: %s. ClangImporter needs to be reinitialized.",
-          module_sp->GetFileSpec().GetPath().c_str());
+      RaiseFatalError(
+          "New Swift image added: " + module_sp->GetFileSpec().GetPath() +
+          "ClangImporter needs to be reinitialized.");
       HEALTH_LOG_PRINTF(
           "New Swift image added: %s. ClangImporter needs to be reinitialized.",
           module_sp->GetFileSpec().GetPath().c_str());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericParamList.h"
@@ -2307,7 +2308,7 @@ Status SwiftASTContext::GetAllErrors() const {
   if (error.Success()) {
     // Retrieve the error message from the DiagnosticConsumer.
     DiagnosticManager diagnostic_manager;
-    PrintDiagnostics(diagnostic_manager);
+    PrintDiagnostics(diagnostic_manager, true);
     error.SetErrorString(diagnostic_manager.GetString());
   }
   return error;
@@ -2731,6 +2732,7 @@ public:
     m_ast_context.GetDiagnosticEngine().takeConsumers();
   }
 
+  /// Consume a Diagnostic from the Swift compiler.
   void handleDiagnostic(swift::SourceManager &source_mgr,
                         const swift::DiagnosticInfo &info) override {
     llvm::StringRef bufferName = "<anonymous>";
@@ -2786,9 +2788,9 @@ public:
       // related to the same error, but we only copy the first one as the fixits
       // are mutually exclusive (for example, one may suggest inserting a '?'
       // and the next may suggest inserting '!')
-      if (!m_raw_diagnostics.empty() &&
-          info.Kind == swift::DiagnosticKind::Note) {
-        auto &last_diagnostic = m_raw_diagnostics.back();
+      if (info.Kind == swift::DiagnosticKind::Note &&
+          !m_raw_swift_diagnostics.empty()) {
+        auto &last_diagnostic = m_raw_swift_diagnostics.back();
         if (last_diagnostic.kind == swift::DiagnosticKind::Error &&
             last_diagnostic.fixits.empty() &&
             last_diagnostic.bufferID == bufferID &&
@@ -2817,31 +2819,39 @@ public:
       std::string &s = os.str();
       formatted_text = !s.empty() ? std::move(s) : std::string(text);
     }
-    m_raw_diagnostics.push_back(
-        {formatted_text, info.Kind, bufferName, bufferID, line_col.first,
-         line_col.second,
-         use_fixits ? info.FixIts
-                    : llvm::ArrayRef<swift::Diagnostic::FixIt>()});
-
-    if (info.Kind == swift::DiagnosticKind::Error)
-      m_num_errors++;
+    RawDiagnostic diagnostic(
+        formatted_text, info.Kind, bufferName, bufferID, line_col.first,
+        line_col.second,
+        use_fixits ? info.FixIts : llvm::ArrayRef<swift::Diagnostic::FixIt>());
+    if (info.ID == swift::diag::error_from_clang.ID) {
+      if (m_raw_clang_diagnostics.empty() ||
+          m_raw_clang_diagnostics.back() != diagnostic) {
+        m_raw_clang_diagnostics.push_back(std::move(diagnostic));
+        if (info.Kind == swift::DiagnosticKind::Error)
+          m_num_clang_errors++;
+      }
+    } else {
+      m_raw_swift_diagnostics.push_back(std::move(diagnostic));
+      if (info.Kind == swift::DiagnosticKind::Error)
+        m_num_swift_errors++;
+    }
   }
 
   void Clear() {
     m_ast_context.GetDiagnosticEngine().resetHadAnyError();
-    m_raw_diagnostics.clear();
+    m_raw_swift_diagnostics.clear();
     m_diagnostics.clear();
-    m_num_errors = 0;
+    m_num_swift_errors = 0;
+    // Don't reset Clang errors. ClangImporter's DiagnosticEngine doesn't either.
   }
 
   unsigned NumErrors() {
-    if (m_num_errors)
-      return m_num_errors;
-    else if (m_ast_context.GetASTContext()->hadError())
-      return 1;
-    else
-      return 0;
+    if (m_num_swift_errors)
+      return m_num_swift_errors;
+    return m_ast_context.GetASTContext()->hadError();
   }
+
+  unsigned NumClangErrors() { return m_num_clang_errors; }
 
   static DiagnosticSeverity SeverityForKind(swift::DiagnosticKind kind) {
     switch (kind) {
@@ -2857,93 +2867,101 @@ public:
     llvm_unreachable("Unhandled DiagnosticKind in switch.");
   }
 
+  // Forward the stored diagnostics to \c diagnostic_manager.
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
                         uint32_t last_line = UINT32_MAX) {
     bool added_one_diagnostic = !m_diagnostics.empty();
 
-    for (std::unique_ptr<Diagnostic> &diagnostic : m_diagnostics) {
+    for (std::unique_ptr<Diagnostic> &diagnostic : m_diagnostics)
       diagnostic_manager.AddDiagnostic(std::move(diagnostic));
-    }
 
-    for (const RawDiagnostic &diagnostic : m_raw_diagnostics) {
-      // We often make expressions and wrap them in some code.  When
-      // we see errors we want the line numbers to be correct so we
-      // correct them below. LLVM stores in SourceLoc objects as
-      // character offsets so there is no way to get LLVM to move its
-      // error line numbers around by adjusting the source location,
-      // we must do it manually. We also want to use the same error
-      // formatting as LLVM and Clang, so we must muck with the
-      // string.
+    // We often make expressions and wrap them in some code.  When we
+    // see errors we want the line numbers to be correct so we correct
+    // them below. LLVM stores in SourceLoc objects as character
+    // offsets so there is no way to get LLVM to move its error line
+    // numbers around by adjusting the source location, we must do it
+    // manually. We also want to use the same error formatting as LLVM
+    // and Clang, so we must muck with the string.
 
+    auto format_diagnostic = [&](const RawDiagnostic &diagnostic) {
       const DiagnosticSeverity severity = SeverityForKind(diagnostic.kind);
       const DiagnosticOrigin origin = eDiagnosticOriginSwift;
 
-      if (first_line > 0 && bufferID != UINT32_MAX) {
-        // Make sure the error line is in range or in another file.
-        if (diagnostic.bufferID == bufferID && !diagnostic.bufferName.empty() &&
-            (diagnostic.line < first_line || diagnostic.line > last_line))
-          continue;
-        // Need to remap the error/warning to a different line.
-        StreamString match;
-        match.Printf("%s:%u:", diagnostic.bufferName.str().c_str(),
-                     diagnostic.line);
-        const size_t match_len = match.GetString().size();
-        size_t match_pos = diagnostic.description.find(match.GetString().str());
-        if (match_pos != std::string::npos) {
-          // We have some <file>:<line>:" instances that need to be updated.
-          StreamString fixed_description;
-          size_t start_pos = 0;
-          do {
-            if (match_pos > start_pos)
-              fixed_description.Printf(
-                  "%s",
-                  diagnostic.description.substr(start_pos, match_pos).c_str());
-            fixed_description.Printf(
-                "%s:%u:", diagnostic.bufferName.str().c_str(),
-                diagnostic.line - first_line + 1);
-            start_pos = match_pos + match_len;
-            match_pos =
-                diagnostic.description.find(match.GetString().str(), start_pos);
-          } while (match_pos != std::string::npos);
+      if ((first_line <= 0) || (bufferID == UINT32_MAX))
+        return;
+      
+      // Make sure the error line is in range or in another file.
+      if (diagnostic.bufferID == bufferID && !diagnostic.bufferName.empty() &&
+          (diagnostic.line < first_line || diagnostic.line > last_line))
+        return;
 
-          // Append any last remaining text.
-          if (start_pos < diagnostic.description.size())
-            fixed_description.Printf(
-                "%s", diagnostic.description
-                          .substr(start_pos,
-                                  diagnostic.description.size() - start_pos)
-                          .c_str());
+      // Need to remap the error/warning to a different line.
+      StreamString match;
+      match.Printf("%s:%u:", diagnostic.bufferName.str().c_str(),
+                   diagnostic.line);
+      const size_t match_len = match.GetString().size();
+      size_t match_pos = diagnostic.description.find(match.GetString().str());
+      if (match_pos == std::string::npos)
+        return;
 
-          auto new_diagnostic = std::make_unique<SwiftDiagnostic>(
-              fixed_description.GetData(), severity, origin, bufferID);
-          for (auto fixit : diagnostic.fixits)
-            new_diagnostic->AddFixIt(fixit);
+      // We have some <file>:<line>:" instances that need to be updated.
+      StreamString fixed_description;
+      size_t start_pos = 0;
+      do {
+        if (match_pos > start_pos)
+          fixed_description.Printf(
+              "%s",
+              diagnostic.description.substr(start_pos, match_pos).c_str());
+        fixed_description.Printf("%s:%u:", diagnostic.bufferName.str().c_str(),
+                                 diagnostic.line - first_line + 1);
+        start_pos = match_pos + match_len;
+        match_pos =
+            diagnostic.description.find(match.GetString().str(), start_pos);
+      } while (match_pos != std::string::npos);
 
-          diagnostic_manager.AddDiagnostic(std::move(new_diagnostic));
-          if (diagnostic.kind == swift::DiagnosticKind::Error)
-            added_one_diagnostic = true;
+      // Append any last remaining text.
+      if (start_pos < diagnostic.description.size())
+        fixed_description.Printf(
+            "%s",
+            diagnostic.description
+                .substr(start_pos, diagnostic.description.size() - start_pos)
+                .c_str());
 
-        }
-      }
-    }
+      auto new_diagnostic = std::make_unique<SwiftDiagnostic>(
+          fixed_description.GetData(), severity, origin, bufferID);
+      for (auto fixit : diagnostic.fixits)
+        new_diagnostic->AddFixIt(fixit);
+
+      diagnostic_manager.AddDiagnostic(std::move(new_diagnostic));
+      if (diagnostic.kind == swift::DiagnosticKind::Error)
+        added_one_diagnostic = true;
+    };
+
+    for (auto &diag : m_raw_clang_diagnostics)
+      format_diagnostic(diag);
+    for (auto &diag : m_raw_swift_diagnostics)
+      format_diagnostic(diag);
 
     // In general, we don't want to see diagnostics from outside of
-    // the source text range of the actual user expression. But if we
-    // didn't find any diagnostics in the text range, it's probably
-    // because the source range was not specified correctly, and we
-    // don't want to lose legit errors because of that. So in that
-    // case we'll add them all here:
+    // the source text range of the actual user expression. This
+    // either indicates a bug in LLDB or that there is only a
+    // ClangImporter diagnostic.
     if (!added_one_diagnostic) {
       // This will report diagnostic errors from outside the
       // expression's source range. Those are not interesting to
       // users, so we only emit them in debug builds.
-      for (const RawDiagnostic &diagnostic : m_raw_diagnostics) {
-        const DiagnosticSeverity severity = SeverityForKind(diagnostic.kind);
-        const DiagnosticOrigin origin = eDiagnosticOriginSwift;
+      for (const RawDiagnostic &diagnostic : m_raw_clang_diagnostics)
         diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
-                                         severity, origin);
-      }
+                                         SeverityForKind(diagnostic.kind),
+                                         eDiagnosticOriginClang);
+
+      // If we printed a clang error, ignore Swift warnings, which are expected.
+      if (!m_num_clang_errors || m_num_swift_errors)
+        for (const RawDiagnostic &diagnostic : m_raw_swift_diagnostics)
+          diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
+                                           SeverityForKind(diagnostic.kind),
+                                           eDiagnosticOriginSwift);
     }
   }
 
@@ -2955,6 +2973,7 @@ public:
     return old;
   }
 
+  /// This is only used by ReconstructTypes.
   void AddDiagnostic(std::unique_ptr<Diagnostic> diagnostic) {
     if (diagnostic)
       m_diagnostics.push_back(std::move(diagnostic));
@@ -2973,6 +2992,13 @@ private:
         : description(in_desc), kind(in_kind), bufferName(in_bufferName),
           bufferID(in_bufferID), line(in_line), column(in_column),
           fixits(in_fixits) {}
+    bool operator==(const RawDiagnostic& other) {
+      return kind == other.kind && bufferID == other.bufferID &&
+             line == other.line && column == other.column &&
+             description == other.description;
+    }
+    bool operator!=(const RawDiagnostic &other) { return !(*this == other); }
+
     std::string description;
     swift::DiagnosticKind kind;
     const llvm::StringRef bufferName;
@@ -2981,14 +3007,16 @@ private:
     uint32_t column;
     std::vector<swift::DiagnosticInfo::FixIt> fixits;
   };
-  typedef std::vector<RawDiagnostic> RawDiagnosticBuffer;
-  typedef std::vector<std::unique_ptr<Diagnostic>> DiagnosticList;
 
   SwiftASTContext &m_ast_context;
-  RawDiagnosticBuffer m_raw_diagnostics;
-  DiagnosticList m_diagnostics;
+  /// Stores all diagnostics coming from the Swift compiler.
+  std::vector<RawDiagnostic> m_raw_swift_diagnostics;
+  std::vector<RawDiagnostic> m_raw_clang_diagnostics;
+  /// Stores diagnostics coming from LLDB.
+  std::vector<std::unique_ptr<Diagnostic>> m_diagnostics;
 
-  unsigned m_num_errors = 0;
+  unsigned m_num_swift_errors = 0;
+  unsigned m_num_clang_errors = 0;
   bool m_colorize = false;
 };
 
@@ -3040,7 +3068,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
           m_module_import_warnings.push_back(message);
         } else {
           DiagnosticManager diagnostic_manager;
-          PrintDiagnostics(diagnostic_manager);
+          PrintDiagnostics(diagnostic_manager, true);
           std::string underlying_error = diagnostic_manager.GetString();
           message = "failed to initialize ClangImporter: ";
           message += underlying_error;
@@ -3353,7 +3381,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
   swift::ModuleDecl *module_decl = ast->getModuleByName(module_basename_sref);
   if (HasErrors()) {
     DiagnosticManager diagnostic_manager;
-    PrintDiagnostics(diagnostic_manager);
+    PrintDiagnostics(diagnostic_manager, true);
     std::string diagnostic = diagnostic_manager.GetString();
     error.SetErrorStringWithFormat(
         "failed to get module \"%s\" from AST context:\n%s",
@@ -4738,8 +4766,14 @@ bool SwiftASTContext::HasErrors() {
     return (
         static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
             ->NumErrors() != 0);
-  else
-    return false;
+  return false;
+}
+bool SwiftASTContext::HasClangImporterErrors() {
+  if (m_diagnostic_consumer_ap.get())
+    return (
+        static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
+            ->NumClangErrors() != 0);
+  return false;
 }
 
 bool SwiftASTContext::HasFatalErrors(swift::ASTContext *ast_context) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -937,14 +937,12 @@ bool SwiftASTContext::ScopedDiagnostics::HasErrors() const {
   return false;
 }
 
-Status SwiftASTContext::ScopedDiagnostics::GetAllErrors() const {
+llvm::Error SwiftASTContext::ScopedDiagnostics::GetAllErrors() const {
   // Retrieve the error message from the DiagnosticConsumer.
   DiagnosticManager diagnostic_manager;
   PrintDiagnostics(diagnostic_manager);
-
-  Status error;
-  error.SetErrorString(diagnostic_manager.GetString());
-  return error;
+  return llvm::make_error<llvm::StringError>(diagnostic_manager.GetString(),
+                                             llvm::inconvertibleErrorCode());
 }
 
 SwiftASTContext::ScopedDiagnostics::~ScopedDiagnostics() {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2722,8 +2722,7 @@ protected:
 class StoringDiagnosticConsumer : public swift::DiagnosticConsumer {
 public:
   StoringDiagnosticConsumer(SwiftASTContext &ast_context)
-      : m_ast_context(ast_context), m_raw_diagnostics(), m_diagnostics(),
-        m_num_errors(0), m_colorize(false) {
+      : m_ast_context(ast_context) {
     m_ast_context.GetDiagnosticEngine().resetHadAnyError();
     m_ast_context.GetDiagnosticEngine().addConsumer(*this);
   }
@@ -2981,11 +2980,8 @@ private:
                   uint32_t in_line, uint32_t in_column,
                   llvm::ArrayRef<swift::Diagnostic::FixIt> in_fixits)
         : description(in_desc), kind(in_kind), bufferName(in_bufferName),
-          bufferID(in_bufferID), line(in_line), column(in_column) {
-      for (auto fixit : in_fixits) {
-        fixits.push_back(fixit);
-      }
-    }
+          bufferID(in_bufferID), line(in_line), column(in_column),
+          fixits(in_fixits) {}
     std::string description;
     swift::DiagnosticKind kind;
     const llvm::StringRef bufferName;
@@ -3002,7 +2998,7 @@ private:
   DiagnosticList m_diagnostics;
 
   unsigned m_num_errors = 0;
-  bool m_colorize;
+  bool m_colorize = false;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h"
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
@@ -18,9 +19,6 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DebuggerClient.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/DiagnosticsClangImporter.h"
-#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/GenericSignature.h"
@@ -35,20 +33,17 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Types.h"
 #include "swift/ASTSectionImporter/ASTSectionImporter.h"
-#include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/Platform.h"
 #include "swift/Basic/PrimarySpecificPaths.h"
-#include "swift/Basic/SourceManager.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
-#include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IRGen/Linking.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/Sema/IDETypeChecking.h"
@@ -70,7 +65,6 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/Process.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/raw_ostream.h"
@@ -87,7 +81,6 @@
 #include "swift/Strings.h"
 
 #include "Plugins/ExpressionParser/Clang/ClangHost.h"
-#include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
 #include "Plugins/ExpressionParser/Swift/SwiftUserExpression.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "lldb/Core/Debugger.h"
@@ -911,377 +904,72 @@ static std::string GetClangModulesCacheProperty() {
   return std::string(path);
 }
 
+SwiftASTContext::ScopedDiagnostics::ScopedDiagnostics(
+    swift::DiagnosticConsumer &consumer)
+    : m_consumer(consumer),
+      m_cursor({static_cast<StoringDiagnosticConsumer *>(&m_consumer)
+                    ->m_raw_swift_diagnostics.size(),
+                static_cast<StoringDiagnosticConsumer *>(&m_consumer)
+                    ->m_raw_clang_diagnostics.size(),
+                static_cast<StoringDiagnosticConsumer *>(&m_consumer)
+                    ->m_diagnostics.size()}) {}
 
-namespace lldb_private {
+void SwiftASTContext::ScopedDiagnostics::PrintDiagnostics(
+    DiagnosticManager &diagnostic_manager, uint32_t bufferID,
+    uint32_t first_line, uint32_t last_line) const {
+  auto consumer = static_cast<StoringDiagnosticConsumer *>(&m_consumer);
+  consumer->PrintDiagnostics(diagnostic_manager, m_cursor, bufferID, first_line,
+                             last_line);
+}
 
-class ANSIColorStringStream : public llvm::raw_string_ostream {
-public:
-  ANSIColorStringStream(bool colorize)
-      : llvm::raw_string_ostream(m_buffer), m_colorize(colorize) {}
-  /// Changes the foreground color of text that will be output from
-  /// this point forward.
-  /// \param Color ANSI color to use, the special SAVEDCOLOR can be
-  ///        used to change only the bold attribute, and keep colors
-  ///        untouched.
-  /// \param Bold bold/brighter text, default false
-  /// \param BG if true change the background,
-  ///        default: change foreground
-  /// \returns itself so it can be used within << invocations.
-  raw_ostream &changeColor(enum Colors colors, bool bold = false,
-                           bool bg = false) override {
-    if (llvm::sys::Process::ColorNeedsFlush())
-      flush();
-    const char *colorcode;
-    if (colors == SAVEDCOLOR)
-      colorcode = llvm::sys::Process::OutputBold(bg);
-    else
-      colorcode =
-          llvm::sys::Process::OutputColor(static_cast<char>(colors), bold, bg);
-    if (colorcode) {
-      size_t len = strlen(colorcode);
-      write(colorcode, len);
-    }
-    return *this;
-  }
+bool SwiftASTContext::ScopedDiagnostics::HasErrors() const {
+  auto &consumer = *static_cast<StoringDiagnosticConsumer *>(&m_consumer);
 
-  /// Resets the colors to terminal defaults. Call this when you are
-  /// done outputting colored text, or before program exit.
-  raw_ostream &resetColor() override {
-    if (llvm::sys::Process::ColorNeedsFlush())
-      flush();
-    const char *colorcode = llvm::sys::Process::ResetColor();
-    if (colorcode) {
-      size_t len = strlen(colorcode);
-      write(colorcode, len);
-    }
-    return *this;
-  }
+  if (consumer.m_num_swift_errors > m_cursor.m_num_swift_errors)
+    return true;
+  if (consumer.m_raw_clang_diagnostics.size() > m_cursor.clang)
+    return true;
 
-  /// Reverses the forground and background colors.
-  raw_ostream &reverseColor() override {
-    if (llvm::sys::Process::ColorNeedsFlush())
-      flush();
-    const char *colorcode = llvm::sys::Process::OutputReverse();
-    if (colorcode) {
-      size_t len = strlen(colorcode);
-      write(colorcode, len);
-    }
-    return *this;
-  }
+  for (size_t i = m_cursor.lldb; i < consumer.m_diagnostics.size(); ++i)
+    if (consumer.m_diagnostics[i]->GetSeverity() == eDiagnosticSeverityError)
+      return true;
 
-  /// This function determines if this stream is connected to a "tty"
-  /// or "console" window. That is, the output would be displayed to
-  /// the user rather than being put on a pipe or stored in a file.
-  bool is_displayed() const override { return m_colorize; }
+  return false;
+}
 
-  /// This function determines if this stream is displayed and
-  /// supports colors.
-  bool has_colors() const override { return m_colorize; }
+Status SwiftASTContext::ScopedDiagnostics::GetAllErrors() const {
+  // Retrieve the error message from the DiagnosticConsumer.
+  DiagnosticManager diagnostic_manager;
+  PrintDiagnostics(diagnostic_manager);
 
-protected:
-  std::string m_buffer;
-  bool m_colorize;
-};
+  Status error;
+  error.SetErrorString(diagnostic_manager.GetString());
+  return error;
+}
 
-class StoringDiagnosticConsumer : public swift::DiagnosticConsumer {
-public:
-  StoringDiagnosticConsumer(SwiftASTContext &ast_context)
-      : m_ast_context(ast_context) {
-    m_ast_context.GetDiagnosticEngine().resetHadAnyError();
-    m_ast_context.GetDiagnosticEngine().addConsumer(*this);
-  }
+SwiftASTContext::ScopedDiagnostics::~ScopedDiagnostics() {
+  auto &consumer = *static_cast<StoringDiagnosticConsumer *>(&m_consumer);
+  auto &lldb_diags = consumer.m_diagnostics;
+  auto &swift_diags = consumer.m_raw_swift_diagnostics;
 
-  ~StoringDiagnosticConsumer() {
-    m_ast_context.GetDiagnosticEngine().takeConsumers();
-  }
+  // Intentionally don't reset clang diagnostics. Fatal clang
+  // diagnostics cannot be recovered from and they may need be
+  // surfaced as a root cause later on.
+  lldb_diags.resize(std::min(lldb_diags.size(), m_cursor.lldb));
+  swift_diags.resize(std::min(swift_diags.size(), m_cursor.swift));
 
-  /// Consume a Diagnostic from the Swift compiler.
-  void handleDiagnostic(swift::SourceManager &source_mgr,
-                        const swift::DiagnosticInfo &info) override {
-    llvm::StringRef bufferName = "<anonymous>";
-    unsigned bufferID = 0;
-    std::pair<unsigned, unsigned> line_col = {0, 0};
+  assert(consumer.m_num_swift_errors >= m_cursor.m_num_swift_errors);
+  consumer.m_num_swift_errors = m_cursor.m_num_swift_errors;
 
-    llvm::SmallString<256> text;
-    {
-      llvm::raw_svector_ostream out(text);
-      swift::DiagnosticEngine::formatDiagnosticText(out, info.FormatString,
-                                                    info.FormatArgs);
-    }
+  consumer.m_ast_context.GetDiagnosticEngine().resetHadAnyError();
+}
 
-    swift::SourceLoc source_loc = info.Loc;
-    if (source_loc.isValid()) {
-      bufferID = source_mgr.findBufferContainingLoc(source_loc);
-      bufferName = source_mgr.getDisplayNameForLoc(source_loc);
-      line_col = source_mgr.getPresumedLineAndColumnForLoc(source_loc);
-    }
-
-    bool use_fixits = false;
-    std::string formatted_text;
-    if (!line_col.first) {
-      formatted_text = text.str();
-    } else {
-      ANSIColorStringStream os(m_colorize);
-
-      // Determine what kind of diagnostic we're emitting, and whether
-      // we want to use its fixits:
-      llvm::SourceMgr::DiagKind source_mgr_kind;
-      switch (info.Kind) {
-      case swift::DiagnosticKind::Error:
-        source_mgr_kind = llvm::SourceMgr::DK_Error;
-        use_fixits = true;
-        break;
-      case swift::DiagnosticKind::Warning:
-        source_mgr_kind = llvm::SourceMgr::DK_Warning;
-        break;
-      case swift::DiagnosticKind::Note:
-        source_mgr_kind = llvm::SourceMgr::DK_Note;
-        break;
-      case swift::DiagnosticKind::Remark:
-        source_mgr_kind = llvm::SourceMgr::DK_Remark;
-        break;
-      }
-
-      // Swift may insert note diagnostics after an error diagnostic with fixits
-      // related to that error. Check if the latest inserted diagnostic is an
-      // error one, and that the diagnostic being processed is a note one that
-      // points to the same error, and if so, copy the fixits from the note
-      // diagnostic to the error one. There may be subsequent notes with fixits
-      // related to the same error, but we only copy the first one as the fixits
-      // are mutually exclusive (for example, one may suggest inserting a '?'
-      // and the next may suggest inserting '!')
-      if (info.Kind == swift::DiagnosticKind::Note &&
-          !m_raw_swift_diagnostics.empty()) {
-        auto &last_diagnostic = m_raw_swift_diagnostics.back();
-        if (last_diagnostic.kind == swift::DiagnosticKind::Error &&
-            last_diagnostic.fixits.empty() &&
-            last_diagnostic.bufferID == bufferID &&
-            last_diagnostic.column == line_col.second &&
-            last_diagnostic.line == line_col.first)
-          last_diagnostic.fixits.insert(last_diagnostic.fixits.end(),
-                                        info.FixIts.begin(), info.FixIts.end());
-      }
-
-      // Translate ranges.
-      llvm::SmallVector<llvm::SMRange, 2> ranges;
-      for (auto R : info.Ranges)
-        ranges.push_back(getRawRange(source_mgr, R));
-
-      // Translate fix-its.
-      llvm::SmallVector<llvm::SMFixIt, 2> fix_its;
-      for (swift::DiagnosticInfo::FixIt F : info.FixIts)
-        fix_its.push_back(getRawFixIt(source_mgr, F));
-
-      // Display the diagnostic.
-      auto message = source_mgr.GetMessage(source_loc, source_mgr_kind, text,
-                                           ranges, fix_its);
-      source_mgr.getLLVMSourceMgr().PrintMessage(os, message);
-
-      // str() implicitly flushes the stram.
-      std::string &s = os.str();
-      formatted_text = !s.empty() ? std::move(s) : std::string(text);
-    }
-    RawDiagnostic diagnostic(
-        formatted_text, info.Kind, bufferName, bufferID, line_col.first,
-        line_col.second,
-        use_fixits ? info.FixIts : llvm::ArrayRef<swift::Diagnostic::FixIt>());
-    if (info.ID == swift::diag::error_from_clang.ID) {
-      if (m_raw_clang_diagnostics.empty() ||
-          m_raw_clang_diagnostics.back() != diagnostic) {
-        m_raw_clang_diagnostics.push_back(std::move(diagnostic));
-        if (info.Kind == swift::DiagnosticKind::Error)
-          m_num_clang_errors++;
-      }
-    } else {
-      m_raw_swift_diagnostics.push_back(std::move(diagnostic));
-      if (info.Kind == swift::DiagnosticKind::Error)
-        m_num_swift_errors++;
-    }
-  }
-
-  void Clear() {
-    m_ast_context.GetDiagnosticEngine().resetHadAnyError();
-    m_raw_swift_diagnostics.clear();
-    m_diagnostics.clear();
-    m_num_swift_errors = 0;
-    // Don't reset Clang errors. ClangImporter's DiagnosticEngine doesn't either.
-  }
-
-  unsigned NumErrors() {
-    if (m_num_swift_errors)
-      return m_num_swift_errors;
-    return m_ast_context.GetASTContext()->hadError();
-  }
-
-  unsigned NumClangErrors() { return m_num_clang_errors; }
-
-  static DiagnosticSeverity SeverityForKind(swift::DiagnosticKind kind) {
-    switch (kind) {
-    case swift::DiagnosticKind::Error:
-      return eDiagnosticSeverityError;
-    case swift::DiagnosticKind::Warning:
-      return eDiagnosticSeverityWarning;
-    case swift::DiagnosticKind::Note:
-    case swift::DiagnosticKind::Remark:
-      return eDiagnosticSeverityRemark;
-    }
-
-    llvm_unreachable("Unhandled DiagnosticKind in switch.");
-  }
-
-  // Forward the stored diagnostics to \c diagnostic_manager.
-  void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
-                        uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
-                        uint32_t last_line = UINT32_MAX) {
-    bool added_one_diagnostic = !m_diagnostics.empty();
-
-    for (std::unique_ptr<Diagnostic> &diagnostic : m_diagnostics)
-      diagnostic_manager.AddDiagnostic(std::move(diagnostic));
-
-    // We often make expressions and wrap them in some code.  When we
-    // see errors we want the line numbers to be correct so we correct
-    // them below. LLVM stores in SourceLoc objects as character
-    // offsets so there is no way to get LLVM to move its error line
-    // numbers around by adjusting the source location, we must do it
-    // manually. We also want to use the same error formatting as LLVM
-    // and Clang, so we must muck with the string.
-
-    auto format_diagnostic = [&](const RawDiagnostic &diagnostic) {
-      const DiagnosticSeverity severity = SeverityForKind(diagnostic.kind);
-      const DiagnosticOrigin origin = eDiagnosticOriginSwift;
-
-      if ((first_line <= 0) || (bufferID == UINT32_MAX))
-        return;
-      
-      // Make sure the error line is in range or in another file.
-      if (diagnostic.bufferID == bufferID && !diagnostic.bufferName.empty() &&
-          (diagnostic.line < first_line || diagnostic.line > last_line))
-        return;
-
-      // Need to remap the error/warning to a different line.
-      StreamString match;
-      match.Printf("%s:%u:", diagnostic.bufferName.str().c_str(),
-                   diagnostic.line);
-      const size_t match_len = match.GetString().size();
-      size_t match_pos = diagnostic.description.find(match.GetString().str());
-      if (match_pos == std::string::npos)
-        return;
-
-      // We have some <file>:<line>:" instances that need to be updated.
-      StreamString fixed_description;
-      size_t start_pos = 0;
-      do {
-        if (match_pos > start_pos)
-          fixed_description.Printf(
-              "%s",
-              diagnostic.description.substr(start_pos, match_pos).c_str());
-        fixed_description.Printf("%s:%u:", diagnostic.bufferName.str().c_str(),
-                                 diagnostic.line - first_line + 1);
-        start_pos = match_pos + match_len;
-        match_pos =
-            diagnostic.description.find(match.GetString().str(), start_pos);
-      } while (match_pos != std::string::npos);
-
-      // Append any last remaining text.
-      if (start_pos < diagnostic.description.size())
-        fixed_description.Printf(
-            "%s",
-            diagnostic.description
-                .substr(start_pos, diagnostic.description.size() - start_pos)
-                .c_str());
-
-      auto new_diagnostic = std::make_unique<SwiftDiagnostic>(
-          fixed_description.GetData(), severity, origin, bufferID);
-      for (auto fixit : diagnostic.fixits)
-        new_diagnostic->AddFixIt(fixit);
-
-      diagnostic_manager.AddDiagnostic(std::move(new_diagnostic));
-      if (diagnostic.kind == swift::DiagnosticKind::Error)
-        added_one_diagnostic = true;
-    };
-
-    for (auto &diag : m_raw_clang_diagnostics)
-      format_diagnostic(diag);
-    for (auto &diag : m_raw_swift_diagnostics)
-      format_diagnostic(diag);
-
-    // In general, we don't want to see diagnostics from outside of
-    // the source text range of the actual user expression. This
-    // either indicates a bug in LLDB or that there is only a
-    // ClangImporter diagnostic.
-    if (!added_one_diagnostic) {
-      // This will report diagnostic errors from outside the
-      // expression's source range. Those are not interesting to
-      // users, so we only emit them in debug builds.
-      for (const RawDiagnostic &diagnostic : m_raw_clang_diagnostics)
-        diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
-                                         SeverityForKind(diagnostic.kind),
-                                         eDiagnosticOriginClang);
-
-      // If we printed a clang error, ignore Swift warnings, which are expected.
-      if (!m_num_clang_errors || m_num_swift_errors)
-        for (const RawDiagnostic &diagnostic : m_raw_swift_diagnostics)
-          diagnostic_manager.AddDiagnostic(diagnostic.description.c_str(),
-                                           SeverityForKind(diagnostic.kind),
-                                           eDiagnosticOriginSwift);
-    }
-  }
-
-  bool GetColorize() const { return m_colorize; }
-
-  bool SetColorize(bool b) {
-    const bool old = m_colorize;
-    m_colorize = b;
-    return old;
-  }
-
-  void AddDiagnostic(std::unique_ptr<Diagnostic> diagnostic) {
-    if (diagnostic)
-      m_diagnostics.push_back(std::move(diagnostic));
-  }
-
-private:
-  // We don't currently use lldb_private::Diagostic or any of the lldb
-  // DiagnosticManager machinery to store diagnostics as they
-  // occur. Instead, we store them in raw form using this struct, then
-  // transcode them to SwiftDiagnostics in PrintDiagnostic.
-  struct RawDiagnostic {
-    RawDiagnostic(std::string in_desc, swift::DiagnosticKind in_kind,
-                  llvm::StringRef in_bufferName, unsigned in_bufferID,
-                  uint32_t in_line, uint32_t in_column,
-                  llvm::ArrayRef<swift::Diagnostic::FixIt> in_fixits)
-        : description(in_desc), kind(in_kind), bufferName(in_bufferName),
-          bufferID(in_bufferID), line(in_line), column(in_column),
-          fixits(in_fixits) {}
-    bool operator==(const RawDiagnostic& other) {
-      return kind == other.kind && bufferID == other.bufferID &&
-             line == other.line && column == other.column &&
-             description == other.description;
-    }
-    bool operator!=(const RawDiagnostic &other) { return !(*this == other); }
-
-    std::string description;
-    swift::DiagnosticKind kind;
-    const llvm::StringRef bufferName;
-    unsigned bufferID;
-    uint32_t line;
-    uint32_t column;
-    std::vector<swift::DiagnosticInfo::FixIt> fixits;
-  };
-
-  SwiftASTContext &m_ast_context;
-  /// Stores all diagnostics coming from the Swift compiler.
-  std::vector<RawDiagnostic> m_raw_swift_diagnostics;
-  std::vector<RawDiagnostic> m_raw_clang_diagnostics;
-  /// Stores diagnostics coming from LLDB.
-  std::vector<std::unique_ptr<Diagnostic>> m_diagnostics;
-
-  unsigned m_num_swift_errors = 0;
-  unsigned m_num_clang_errors = 0;
-  bool m_colorize = false;
-};
-
-} // namespace lldb_private
+std::unique_ptr<SwiftASTContext::ScopedDiagnostics>
+SwiftASTContext::getScopedDiagnosticConsumer() {
+  auto &consumer =
+      *static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get());
+  return std::make_unique<SwiftASTContext::ScopedDiagnostics>(consumer);
+}
 
 #ifndef NDEBUG
 SwiftASTContext::SwiftASTContext()
@@ -1426,8 +1114,9 @@ static void printASTValidationError(
 }
 
 void SwiftASTContext::DiagnoseWarnings(Process &process, Module &module) const {
-  if (HasErrors() || HasClangImporterErrors())
-    process.PrintWarningCantLoadSwiftModule(module, GetAllErrors().AsCString());
+  if (HasDiagnostics())
+    process.PrintWarningCantLoadSwiftModule(module,
+                                            GetAllDiagnostics().AsCString());
 }
 
 /// Locate the swift-plugin-server for a plugin library,
@@ -2064,7 +1753,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
                                     m_description, errs, got_serialized_options,
                                     found_swift_modules)) {
       // Validation errors are not fatal for the context.
-      swift_ast_sp->AddDiagnostic(eDiagnosticSeverityWarning, errs.str());
+      swift_ast_sp->AddDiagnostic(eDiagnosticSeverityError, errs.str());
     }
 
     llvm::StringRef serialized_triple =
@@ -2673,21 +2362,22 @@ Status SwiftASTContext::IsCompatible() { return GetFatalErrors(); }
 Status SwiftASTContext::GetFatalErrors() const {
   Status error;
   if (HasFatalErrors())
-    error = GetAllErrors();
+    error = GetAllDiagnostics();
   return error;
 }
 
-Status SwiftASTContext::GetAllErrors() const {
+Status SwiftASTContext::GetAllDiagnostics() const {
   Status error = m_fatal_errors;
   if (error.Success()) {
     // Retrieve the error message from the DiagnosticConsumer.
     DiagnosticManager diagnostic_manager;
-    PrintDiagnostics(diagnostic_manager, true);
+    PrintDiagnostics(diagnostic_manager);
     error.SetErrorString(diagnostic_manager.GetString());
+    static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
+        ->Clear();
   }
   return error;
 }
-
 
 void SwiftASTContext::LogFatalErrors() const {
   // Avoid spamming the health log with redundant copies of the fatal error.
@@ -3057,20 +2747,20 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       swift::DWARFImporterDelegate *delegate = nullptr;
       if (props.GetUseSwiftDWARFImporter())
         delegate = &m_typeref_typesystem->GetDWARFImporterDelegate();
+      auto importer_diags = getScopedDiagnosticConsumer();
       clang_importer_ap = swift::ClangImporter::create(
           *m_ast_context_ap, "", m_dependency_tracker.get(), delegate);
 
       // Handle any errors.
-      if (!clang_importer_ap || HasErrors()) {
-        AddDiagnostic(eDiagnosticSeverityWarning,
-                        "failed to create ClangImporter");
+      if (!clang_importer_ap || importer_diags->HasErrors()) {
+        AddDiagnostic(eDiagnosticSeverityError,
+                      "failed to create ClangImporter");
         if (GetLog(LLDBLog::Types)) {
           DiagnosticManager diagnostic_manager;
-          PrintDiagnostics(diagnostic_manager, true);
+          importer_diags->PrintDiagnostics(diagnostic_manager);
           std::string underlying_error = diagnostic_manager.GetString();
-          LOG_PRINTF(GetLog(LLDBLog::Types),
-                     "failed to initialize ClangImporter: %s",
-                     underlying_error.c_str());
+          HEALTH_LOG_PRINTF("failed to initialize ClangImporter: %s",
+                            underlying_error.c_str());
         }
       }
       if (clang_importer_ap)
@@ -3374,11 +3064,16 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
     return nullptr;
   }
 
-  ClearDiagnostics();
+  // Create a diagnostic consumer for the diagnostics produced by the import.
+  auto import_diags = getScopedDiagnosticConsumer();
+
+  // Perform the import.
   swift::ModuleDecl *module_decl = ast->getModuleByName(module_basename_sref);
-  if (HasErrors()) {
+
+  // Error handling.
+  if (import_diags->HasErrors()) {
     DiagnosticManager diagnostic_manager;
-    PrintDiagnostics(diagnostic_manager, true);
+    import_diags->PrintDiagnostics(diagnostic_manager);
     std::string diagnostic = diagnostic_manager.GetString();
     error.SetErrorStringWithFormat(
         "failed to get module \"%s\" from AST context:\n%s",
@@ -4757,11 +4452,11 @@ uint32_t SwiftASTContext::GetPointerByteSize() {
   return m_pointer_byte_size;
 }
 
-bool SwiftASTContext::HasErrors() const {
+bool SwiftASTContext::HasDiagnostics() const {
   assert(m_diagnostic_consumer_ap);
   return (
       static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
-          ->NumErrors() != 0);
+          ->HasDiagnostics());
 }
 bool SwiftASTContext::HasClangImporterErrors() const {
   assert(m_diagnostic_consumer_ap);
@@ -4787,13 +4482,6 @@ bool SwiftASTContext::HasFatalErrors(swift::ASTContext *ast_context) {
   return (ast_context && ast_context->Diags.hasFatalErrorOccurred());
 }
 
-void SwiftASTContext::ClearDiagnostics() {
-  assert(!HasFatalErrors() && "Never clear a fatal diagnostic!");
-  assert(m_diagnostic_consumer_ap.get());
-  static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
-      ->Clear();
-}
-
 bool SwiftASTContext::SetColorizeDiagnostics(bool b) {
   assert(m_diagnostic_consumer_ap.get());
   return static_cast<StoringDiagnosticConsumer *>(
@@ -4815,11 +4503,13 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
   // Forward diagnostics into diagnostic_manager.
   // If there is a fatal error, also copy the error into m_fatal_errors.
   assert(m_diagnostic_consumer_ap);
+  auto &diags =
+      *static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get());
   if (m_ast_context_ap->Diags.hasFatalErrorOccurred() &&
       !m_reported_fatal_error) {
     DiagnosticManager fatal_diagnostics;
-    static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
-        ->PrintDiagnostics(fatal_diagnostics, bufferID, first_line, last_line);
+    diags.PrintDiagnostics(fatal_diagnostics, {}, bufferID, first_line,
+                           last_line);
     if (fatal_diagnostics.Diagnostics().size())
       RaiseFatalError(fatal_diagnostics.GetString());
     else
@@ -4836,8 +4526,8 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
           fatal_diagnostic->getKind(), fatal_diagnostic->GetCompilerID());
     }
   } else {
-    static_cast<StoringDiagnosticConsumer *>(m_diagnostic_consumer_ap.get())
-        ->PrintDiagnostics(diagnostic_manager, bufferID, first_line, last_line);
+    diags.PrintDiagnostics(diagnostic_manager, {}, bufferID, first_line,
+                           last_line);
   }
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -434,16 +434,21 @@ public:
   bool HasClangImporterErrors() const;
 
   void AddDiagnostic(DiagnosticSeverity severity, llvm::StringRef message);
-  void RaiseFatalError(std::string msg) { m_fatal_errors.SetErrorString(msg); }
+  void RaiseFatalError(std::string msg) const {
+    m_fatal_errors.SetErrorString(msg);
+  }
   static bool HasFatalErrors(swift::ASTContext *ast_context);
   bool HasFatalErrors() const {
     return m_fatal_errors.Fail() || HasFatalErrors(m_ast_context_ap.get());
   }
 
+  /// Return all errors and warnings that haven't been cleared.
   Status GetAllErrors() const;
+  /// Return only fatal errors.
   Status GetFatalErrors() const;
+  /// Notify the Process about any Swift or ClangImporter errors.
   void DiagnoseWarnings(Process &process, Module &module) const override;
-  void LogFatalErrors() const;
+  
 
   // NEVER call this without checking HasFatalErrors() first.
   // This clears the fatal-error state which is terrible.
@@ -820,6 +825,9 @@ protected:
   /// Similar logic applies to this "reverse" map
   typedef llvm::DenseMap<swift::TypeBase *, const char *>
       SwiftMangledNameFromTypeMap;
+
+  /// Called by the VALID_OR_RETURN macro to log all errors.
+  void LogFatalErrors() const;
 
   llvm::TargetOptions *getTargetOptions();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -484,7 +484,7 @@ public:
     bool HasErrors() const;
     /// Return all errors and warnings that happened during the lifetime of this
     /// object.
-    Status GetAllErrors() const;
+    llvm::Error GetAllErrors() const;
   };
   std::unique_ptr<ScopedDiagnostics> getScopedDiagnosticConsumer();
   /// \}

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -423,7 +423,21 @@ public:
 
   CompilerType GetErrorType() override;
 
+  /// Error handling
+  /// \{
   bool HasErrors();
+  bool HasClangImporterErrors();
+
+  void RaiseFatalError(std::string msg) { m_fatal_errors.SetErrorString(msg); }
+  static bool HasFatalErrors(swift::ASTContext *ast_context);
+  bool HasFatalErrors() const {
+    return m_fatal_errors.Fail() || HasFatalErrors(m_ast_context_ap.get());
+  }
+
+  Status GetAllErrors() const;
+  Status GetFatalErrors() const;
+  void DiagnoseWarnings(Process &process, Module &module) const override;
+  void LogFatalErrors() const;
 
   // NEVER call this without checking HasFatalErrors() first.
   // This clears the fatal-error state which is terrible.
@@ -436,6 +450,7 @@ public:
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
                         uint32_t last_line = UINT32_MAX) const;
+  /// \}
 
   ConstString GetMangledTypeName(swift::TypeBase *);
 
@@ -454,17 +469,6 @@ public:
   typedef llvm::StringMap<swift::ModuleDecl *> SwiftModuleMap;
 
   const SwiftModuleMap &GetModuleCache() { return m_swift_module_cache; }
-
-  void RaiseFatalError(std::string msg) { m_fatal_errors.SetErrorString(msg); }
-  static bool HasFatalErrors(swift::ASTContext *ast_context);
-  bool HasFatalErrors() const {
-    return m_fatal_errors.Fail() || HasFatalErrors(m_ast_context_ap.get());
-  }
-
-  Status GetAllErrors() const;
-  Status GetFatalErrors() const;
-  void DiagnoseWarnings(Process &process, Module &module) const override;
-  void LogFatalErrors() const;
 
   /// Return a list of warnings collected from ClangImporter.
   const std::vector<std::string> &GetModuleImportWarnings() const {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1409,16 +1409,18 @@ TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
   }
 }
 
-void TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
+Status TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
     SymbolContext &sc) {
-  Status error;
+  Status status;
   lldb::ProcessSP process_sp;
   if (auto target_sp = sc.target_sp)
     process_sp = target_sp->GetProcessSP();
   if (!m_swift_ast_context_initialized)
+    // Stash sc, the import will happen lazily when SwiftASTContext is created.
     m_initial_symbol_context = std::make_unique<SymbolContext>(sc);
   else if (auto *swift_ast_ctx = GetSwiftASTContext())
-    swift_ast_ctx->PerformCompileUnitImports(sc, process_sp, error);
+    swift_ast_ctx->PerformCompileUnitImports(sc, process_sp, status);
+  return status;
 }
 
 UserExpression *TypeSystemSwiftTypeRefForExpressions::GetUserExpression(

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -481,7 +481,7 @@ public:
 
   /// Forwards to SwiftASTContext.
   PersistentExpressionState *GetPersistentExpressionState() override;
-  void PerformCompileUnitImports(SymbolContext &sc);
+  Status PerformCompileUnitImports(SymbolContext &sc);
 
   friend class SwiftASTContextForExpressions;
 protected:

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2798,7 +2798,9 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
   if (frame_sp && frame_sp.get() && swift_scratch_ctx) {
     SymbolContext sc =
         frame_sp->GetSymbolContext(lldb::eSymbolContextEverything);
-    swift_scratch_ctx->PerformCompileUnitImports(sc);
+    Status status = swift_scratch_ctx->PerformCompileUnitImports(sc);
+    if (status.Fail())
+      Debugger::ReportError(status.AsCString(), GetDebugger().GetID());
   }
 
   if (!swift_scratch_ctx)

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
@@ -22,6 +22,7 @@ class TestSwiftMissingVFSOverlay(TestBase):
         in the expression evaluator"""
         self.build()
         lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift"), extra_images=["Foo"]
+            self, "break here", lldb.SBFileSpec("main.swift"),
+            extra_images=["Foo"]
         )
-        self.expect("expr y", error=True, substrs=["overlay.yaml", "IRGen"])
+        self.expect("expr y", error=True, substrs=["IRGen", "overlay.yaml"])


### PR DESCRIPTION
SwiftASTContext resets the state of the DiagnosticConsumer after each
import to make failed module imports non-fatal, however, the internal
state of the DiagnosticEngine in Swift's embedded Clang compiler does
not reset when encountering a fatal error. By storing Clang
diagnostics separately, these errors can be surfaces when an
expression fails to IRGen (which is usually when these fatal Clang
diagnostics turn into an unrecoverable problem).

rdar://108557254