### PR TITLE
Revert "[MC] Eagerly skip zero-sized .fill fragments"

### DIFF
--- a/llvm/lib/MC/MCStreamer.cpp
+++ b/llvm/lib/MC/MCStreamer.cpp
@@ -219,8 +219,7 @@ void MCStreamer::emitGPRel32Value(const MCExpr *Value) {
 /// Emit NumBytes bytes worth of the value specified by FillValue.
 /// This implements directives such as '.space'.
 void MCStreamer::emitFill(uint64_t NumBytes, uint8_t FillValue) {
-  if (NumBytes)
-    emitFill(*MCConstantExpr::create(NumBytes, getContext()), FillValue);
+  emitFill(*MCConstantExpr::create(NumBytes, getContext()), FillValue);
 }
 
 void llvm::MCStreamer::emitNops(int64_t NumBytes, int64_t ControlledNopLen,


### PR DESCRIPTION
This reverts commit 4b1532a46f66eb71bf80458fa67b86c618803b95.