### PR TITLE
[clang][objc] Fix non-deterministic stub fixit output for missing requirements

### DIFF
--- a/clang/test/FixIt/fixit-fill-in-protocol-requirements.m
+++ b/clang/test/FixIt/fixit-fill-in-protocol-requirements.m
@@ -82,3 +82,32 @@
 @end
 // CHECK: fix-it:{{.*}}:{[[@LINE-1]]:1-[[@LINE-1]]:1}:"- (void)availableMethod { \n  <#code#>\n}\n\n- (void)deprecatedMethod { \n  <#code#>\n}\n\n"
 // AVAILABLE: fix-it:{{.*}}:{[[@LINE-2]]:1-[[@LINE-2]]:1}:"- (void)availableMethod { \n  <#code#>\n}\n\n- (void)deprecatedMethod { \n  <#code#>\n}\n\n+ (void)notYetAvailableMethod { \n  <#code#>\n}\n\n"
+
+@protocol PReq1
+-(void)reqZ1;
+@end
+
+@protocol PReq2
+-(void)reqZ1;
+-(void)reqA2;
+-(void)reqA1;
+@end
+
+// Ensure optional cannot hide required methods with the same selector.
+@protocol POpt
+@optional
+-(void)reqZ1;
+-(void)reqA2;
+-(void)reqA1;
+@end
+
+@interface MultiReqOpt <PReq1, PReq2, POpt>
+@end
+@implementation MultiReqOpt // expected-warning {{class 'MultiReqOpt' does not conform to protocols 'PReq1' and 'PReq2'}} expected-note {{add stubs}}
+@end
+// CHECK: fix-it:{{.*}}:{[[@LINE-1]]:1-[[@LINE-1]]:1}:"
+// Z1 is first due to being from the first listed protocol, PReq1
+// CHECK-SAME: - (void)reqZ1
+// A1 is before A2 because of secondary sort by name.
+// CHECK-SAME: - (void)reqA1
+// CHECK-SAME: - (void)reqA2

--- a/clang/test/FixIt/fixit-fill-in-protocol-requirements.m
+++ b/clang/test/FixIt/fixit-fill-in-protocol-requirements.m
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -triple=x86_64-apple-macos10.10 -verify -Wno-objc-root-class -serialize-diagnostic-file /dev/null %s
-// RUN: %clang_cc1 -triple=x86_64-apple-macos10.10 -fdiagnostics-parseable-fixits -serialize-diagnostic-file /dev/null %s 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -triple=x86_64-apple-macos10.12 -fdiagnostics-parseable-fixits -serialize-diagnostic-file /dev/null %s 2>&1 | FileCheck --check-prefix=AVAILABLE %s
+// RUN: %clang_cc1 -triple=x86_64-apple-macos10.10 -verify -Wno-objc-root-class -fallow-editor-placeholders %s
+// RUN: %clang_cc1 -triple=x86_64-apple-macos10.10 -fdiagnostics-parseable-fixits -fallow-editor-placeholders %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -triple=x86_64-apple-macos10.12 -fdiagnostics-parseable-fixits -fallow-editor-placeholders %s 2>&1 | FileCheck --check-prefix=AVAILABLE %s
 
 @protocol P1
 
@@ -18,7 +18,7 @@
 
 @end
 
-@implementation I // expected-warning {{warning: class 'I' does not conform to protocols 'P2' and 'P1'}} expected-note {{add stubs for missing protocol requirements}}
+@implementation I // expected-warning {{class 'I' does not conform to protocols 'P2' and 'P1'}} expected-note {{add stubs for missing protocol requirements}}
 
 @end
 // CHECK: fix-it:{{.*}}:{[[@LINE-1]]:1-[[@LINE-1]]:1}:"- (void)p2Method { \n  <#code#>\n}\n\n- (void)p1Method { \n  <#code#>\n}\n\n"
@@ -29,11 +29,11 @@
 
 @end
 
-@interface I (Category) <P3> // expected-warning {{warning: category 'Category' does not conform to protocols 'P3'}} expected-note {{add stubs for missing protocol requirements}}
+@interface I (Category) <P3>
 
 @end
 
-@implementation I (Category)
+@implementation I (Category) // expected-warning {{category 'Category' does not conform to protocol 'P3'}} expected-note {{add stubs for missing protocol requirements}}
 
 @end
 // CHECK: fix-it:{{.*}}:{[[@LINE-1]]:1-[[@LINE-1]]:1}:"+ (void)p3ClassMethod { \n  <#code#>\n}\n\n"
@@ -44,14 +44,14 @@
 
 @end
 
-@interface ThreeProtocols <P2, P1, P3> // expected-warning {{class 'ThreeProtocols' does not conform to protocols 'P2', 'P1' and 'P3'}} expected-note {{add stubs for missing protocol requirements}}
+@interface ThreeProtocols <P2, P1, P3>
 @end
-@implementation ThreeProtocols
+@implementation ThreeProtocols // expected-warning {{class 'ThreeProtocols' does not conform to protocols 'P2', 'P1' and 'P3'}} expected-note {{add stubs for missing protocol requirements}}
 @end
 
-@interface FourProtocols <P2, P3, P4> // expected-warning {{class 'ThreeProtocols' does not conform to protocols 'P2', 'P1', 'P3', ...}} expected-note {{add stubs for missing protocol requirements}}
+@interface FourProtocols <P2, P3, P4>
 @end
-@implementation FourProtocols
+@implementation FourProtocols // expected-warning {{class 'FourProtocols' does not conform to protocols 'P2', 'P1', 'P3', ...}} expected-note {{add stubs for missing protocol requirements}}
 @end
 
 // Unavailable methods
@@ -67,7 +67,7 @@
 @interface ImplementsAllAvailable <TakeAvailabilityIntoAccount>
 @end
 
-@implementation ImplementsAllAvailable // No warning!
+@implementation ImplementsAllAvailable // expected-warning {{class 'ImplementsAllAvailable' does not conform to protocol 'TakeAvailabilityIntoAccount'}} expected-note {{add stubs for missing protocol requirements}}
 
 - (void)availableMethod { }
 - (void)deprecatedMethod { }


### PR DESCRIPTION
When outputting fixits for missing methods, we had two issues
* If we found an optional method we could incorrectly hide the fixit for
  a requiremed method with the same selector from another protocol
* The fixit order wasn't deterministic when two protocols declared the
  same required selector

Fix by choosing the best candidate to store when walking methods.

rdar://109411920

---

Also: [clang][objc] Fix test for protocol stub fixits

This test has been silently broken for a while due to using
-serialize-diagnostics-file, which interferes with -verify (the verify
consumer runs, but does not cause the compilation to fail). Fix the
checks and use -fallow-editor-placeholders instead to enable the correct
diagnostic mode.