### PR TITLE
[lldb][NFCI] Qualify param type in SBDebugger::FindTargetWithProcessID

### DIFF
--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -218,7 +218,7 @@ public:
 
   uint32_t GetIndexOfTarget(lldb::SBTarget target);
 
-  lldb::SBTarget FindTargetWithProcessID(pid_t pid);
+  lldb::SBTarget FindTargetWithProcessID(lldb::pid_t pid);
 
   lldb::SBTarget FindTargetWithFileAndArch(const char *filename,
                                            const char *arch);


### PR DESCRIPTION
We should specify that this is the pid_t as defined in the lldb namespace, not some other pid_t. This doesn't really affect builds but it makes writing tooling against the SBAPI easier.

I have verified that this does not change the emitted mangled name and does not break ABI.

(cherry picked from commit e0466a7463ecbd6a3bbe3296f5f7c5ece749564f)