### PR TITLE
Move some breakpoints onto prints to prevent improved codegen from breaking tests.

### DIFF
--- a/lldb/test/API/lang/swift/variables/consume_operator/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator/main.swift
@@ -42,7 +42,8 @@ public func copyableVarTest() {
     print("stop here") // Set breakpoint
     var k = Klass()
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething()
     k = Klass()     // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -61,7 +62,8 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
     print("stop here") // Set breakpoint
     var k = x
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething()
     k = x // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -81,7 +83,8 @@ public func copyableValueArgTest(_ k: __owned Klass) {
 public func copyableVarArgTest(_ k: inout Klass) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething()
     k = Klass()     // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -98,7 +101,8 @@ public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
 public func addressOnlyVarArgTest<T : P>(_ k: inout T, _ x: T) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething()
     k = x // Set breakpoint
     k.doSomething() // Set breakpoint
@@ -132,7 +136,8 @@ public func copyableVarTestCCFlowTrueReinitOutOfBlockTest() {
     var k = Klass() // Set breakpoint
     k.doSomething()
     if trueBoolValue {
-        let m = consume k // Set breakpoint
+        print("stop here") // Set breakpoint
+        let m = consume k
         m.doSomething() // Set breakpoint
     }
     k = Klass() // Set breakpoint
@@ -143,7 +148,8 @@ public func copyableVarTestCCFlowTrueReinitInBlockTest() {
     var k = Klass() // Set breakpoint
     k.doSomething()
     if trueBoolValue {
-        let m = consume k // Set breakpoint
+        print("stop here") // Set breakpoint
+        let m = consume k
         m.doSomething()
         k = Klass() // Set breakpoint
         k.doSomething() // Set breakpoint

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
@@ -36,7 +36,8 @@ public func copyableVarTest() async {
     var k = Klass()    // Set breakpoint 05
     k.doSomething()
     await forceSplit() // Set breakpoint 06
-    let m = consume k    // Set breakpoint 07
+    print("stop here") // Set breakpoint 07
+    let m = consume k
     m.doSomething()    // Set breakpoint 08
     await forceSplit()
     k = Klass()        // Set breakpoint 09


### PR DESCRIPTION
rdar://109479440