### PR TITLE
Enable FIXME'd parts of TestSwiftVariadicGenerics, and pass -disable-availability-checking [5.9]

### DIFF
--- a/lldb/test/API/lang/swift/variadic_generics/Makefile
+++ b/lldb/test/API/lang/swift/variadic_generics/Makefile
@@ -1,6 +1,6 @@
 #C_SOURCES := main.c
 SWIFT_SOURCES := a.swift
 #HIDE_SWIFTMODULE = YES
-SWIFTFLAGS_EXTRAS = -Xfrontend -disable-round-trip-debug-types -enable-experimental-feature VariadicGenerics
+SWIFTFLAGS_EXTRAS = -Xfrontend -disable-round-trip-debug-types -enable-experimental-feature VariadicGenerics -Xfrontend -disable-availability-checking
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
+++ b/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
@@ -38,10 +38,9 @@ class TestSwiftVariadicGenerics(TestBase):
                              "Pack{(a.A, a.B)}", "more_ts", "i = 23", "d = 2.71"])
 
         # f4(uvs: (a, b), (a, b))
-        #process.Continue()
-        # FIXME: Crashes the demangler.
-        #self.expect("frame variable",
-        #            substrs=[""])
+        process.Continue()
+        self.expect("frame variable",
+                    substrs=[""])
 
         # f5(ts: (a, b), (42, b))
         process.Continue()

--- a/lldb/test/API/lang/swift/variadic_generics/a.swift
+++ b/lldb/test/API/lang/swift/variadic_generics/a.swift
@@ -26,12 +26,11 @@ public func f3<each T>(ts: repeat each T, more_ts: repeat each T) {
  
 f3(ts: a, b, more_ts: a, b)
 
-// FIXME: Crashes the demangler.
-//public func f4<each U, each V>(uvs: repeat (each U, each V)) {
-//  print("break here")
-//}
-// 
-//f4(uvs: (a, b), (a, b))
+public func f4<each U, each V>(uvs: repeat (each U, each V)) {
+  print("break here")
+}
+ 
+f4(uvs: (a, b), (a, b))
  
 public func f5<each T, U>(ts: repeat (each T, U)) {
   print("break here")


### PR DESCRIPTION
* Description: Once we start enforcing availability for variadic generic types, the tests need to pass this flag. Also re-enable some commented out tests that pass now.
* Risk: None; only the tests change.