### PR TITLE
[lldb] Fix logging null typerefs on SwiftLanguageRuntimeImpl::GetTypeRef

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -292,7 +292,7 @@ public:
                 ss.str().c_str());
     }
 
-    if (log && log->GetVerbose()) {
+    if (type_info && log && log->GetVerbose()) {
       std::stringstream ss;
       type_info->dump(ss);
       log->Printf("[TargetReflectionContext::getTypeInfo] Found "
@@ -3243,12 +3243,21 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
     return nullptr;
   }
   const swift::reflection::TypeRef *type_ref = type_ref_or_err.getType();
-  if (log && log->GetVerbose()) {
-    std::stringstream ss;
-    type_ref->dump(ss);
-    LLDB_LOGF(log, "[SwiftLanguageRuntimeImpl::GetTypeRef] Found typeref for "
+  if (type_ref) {
+    if (log && log->GetVerbose()) {
+      std::stringstream ss;
+      type_ref->dump(ss);
+      LLDB_LOGF(log,
+                "[SwiftLanguageRuntimeImpl::GetTypeRef] Found typeref for "
                 "type: %s:\n%s",
                 type.GetMangledTypeName().GetCString(), ss.str().c_str());
+    }
+  } else {
+    LLDB_LOGF(
+        log,
+        "[SwiftLanguageRuntimeImpl::GetTypeRef] could not find typeref for "
+        "type: %s:\n",
+        type.GetMangledTypeName().GetCString());
   }
   return type_ref;
 }


### PR DESCRIPTION
rdar://107774688
(cherry picked from commit b56f6e3fea5fe1ddd870c8980cbf07ae811b9420)