### PR TITLE
[lldb] Improve GetObjectDescription for Swift variables

### DIFF
--- a/lldb/test/API/lang/swift/cf/uuid/Makefile
+++ b/lldb/test/API/lang/swift/cf/uuid/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
+++ b/lldb/test/API/lang/swift/cf/uuid/TestCFUUID.py
@@ -1,0 +1,23 @@
+"""
+Test CFUUID object description.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        """Test CFUUID object description prints the UUID string."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"))
+        # Swift type validation fails in IsPossibleDynamicType rdar://109611675
+        self.runCmd("settings set symbols.swift-validate-typesystem false")
+        uuid = "68753A44-4D6F-1226-9C60-0050E4C00067"
+        self.expect("frame variable -O uuid", substrs=[uuid])
+        self.expect("dwim-print -O -- uuid", substrs=[uuid])
+        self.expect("expression -O -- uuid", substrs=[uuid])

--- a/lldb/test/API/lang/swift/cf/uuid/main.swift
+++ b/lldb/test/API/lang/swift/cf/uuid/main.swift
@@ -1,0 +1,9 @@
+import CoreFoundation
+import Foundation // Needed for `as CFString` cast
+
+func main() {
+    let uuid = CFUUIDCreateFromString(nil, "68753A44-4D6F-1226-9C60-0050E4C00067" as CFString)
+    print("break here")
+}
+
+main()


### PR DESCRIPTION
To generate the "object description" for a Swift value, the helper function `_DebuggerSupport.stringForPrintObject` is called with a single argument. The argument is one of the following:

1. A variable name
2. A `unsafeBitCast($address, to: AnyObject.self)` reference
3. A `UnsafePointer<T>(bitPattern: $address)!.pointee` pointer

Note that the `UnsafePointer` option is also used as a fallback if one of the first two fail.

The first case has up to now been used for persistent results (ex `$R0`, …), but there's no reason it shouldn't be used for variables, such as when `vo` or `dwim-print -O <variable>` are run.

In fact, there are at least two bugs with the `UnsafePointer` option, both of which occur when an invalid type name is constructed for `T`.

This change avoids the `UnsafePointer` case by using the first option more:
1. for persistent results, as previously
2. for source variables too

If the given value object is a `ValueObjectVariable` (or a synthetic wrapper around one), then the variable is referenced directly by name. This means that `$R0` and `someVariable` will both use this, the simplest of options. The existing comments illustrate the value of invoking this expression:

> * its name is something we can refer to in expressions for free
> * its type may be something we can't actually talk about in expressions so, just use the result variable's name in the expression and be done with it

rdar://107577284