### PR TITLE
[cherry-pick][swift/release/5.9] [lldb][cmake] Allow specifying custom libcxx for tests in standalone builds

### DIFF
--- a/lldb/cmake/modules/LLDBStandalone.cmake
+++ b/lldb/cmake/modules/LLDBStandalone.cmake
@@ -25,6 +25,9 @@ set(LLVM_MAIN_SRC_DIR ${LLVM_BUILD_MAIN_SRC_DIR} CACHE PATH "Path to LLVM source
 set(LLVM_MAIN_INCLUDE_DIR ${LLVM_MAIN_INCLUDE_DIR} CACHE PATH "Path to llvm/include")
 set(LLVM_BINARY_DIR ${LLVM_BINARY_DIR} CACHE PATH "Path to LLVM build tree")
 
+set(LLDB_TEST_LIBCXX_ROOT_DIR "${LLVM_BINARY_DIR}" CACHE PATH
+    "The build root for libcxx. Used in standalone builds to point the API tests to a custom build of libcxx.")
+
 set(LLVM_LIT_ARGS "-sv" CACHE STRING "Default options for lit")
 
 set(lit_file_name "llvm-lit")

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -134,9 +134,18 @@ if(TARGET clang)
     # FIXME: Standalone builds should import the cxx target as well.
     if(LLDB_BUILT_STANDALONE)
       # For now check that the include directory exists.
-      set(cxx_dir "${LLVM_BINARY_DIR}/include/c++")
-      if(NOT EXISTS ${cxx_dir})
-        message(WARNING "LLDB test suite requires libc++ in llvm/projects/libcxx or an existing build symlinked to ${cxx_dir}")
+      set(cxx_dir "${LLDB_TEST_LIBCXX_ROOT_DIR}/include/c++")
+      if(EXISTS ${cxx_dir})
+        # These variables make sure the API tests can run against a custom
+        # build of libcxx even for standalone builds.
+        set(LLDB_HAS_LIBCXX ON)
+        set(LIBCXX_LIBRARY_DIR "${LLDB_TEST_LIBCXX_ROOT_DIR}/lib${LIBCXX_LIBDIR_SUFFIX}")
+        set(LIBCXX_GENERATED_INCLUDE_DIR "${LLDB_TEST_LIBCXX_ROOT_DIR}/include/c++/v1")
+      else()
+        message(FATAL_ERROR
+            "Couldn't find libcxx build in '${LLDB_TEST_LIBCXX_ROOT_DIR}'. To run the "
+            "test-suite for a standalone LLDB build please build libcxx and point "
+            "LLDB_TEST_LIBCXX_ROOT_DIR to it.")
       endif()
     else()
       # We require libcxx for the test suite, so if we aren't building it,


### PR DESCRIPTION
Standalone builds currently do not set the `LLDB_HAS_LIBCXX`, `LIBCXX_LIBRARY_DIR`, `LIBCXX_GENERATED_INCLUDE_DIR`. These are necessary for API tests with `USE_LIBCPP` to run against a custom built libcxx. Thus on all buildbots using standalone builds (most notably the public swift-ci), the API tests always run against the libcxx headers in the system SDK.

This patch introduces a new cmake variable `LLDB_TEST_LIBCXX_ROOT_DIR` that allows us to point the tests in standalone builds to a custom libcxx directory.

Since the user can control the libcxx location we can hard error if no such custom libcxx build exists.

Differential Revision: https://reviews.llvm.org/D150954

(cherry picked from commit 2901ce3ac24799dacda21be3903d6d8294b70ea0)