### PR TITLE
[cherry-pick][swift/release/5.9] [lldb][test] Skip TestStdFunctionStepIntoCallable.py on 5.9

### DIFF
--- a/lldb/test/API/lang/cpp/std-function-step-into-callable/TestStdFunctionStepIntoCallable.py
+++ b/lldb/test/API/lang/cpp/std-function-step-into-callable/TestStdFunctionStepIntoCallable.py
@@ -14,6 +14,7 @@ class LibCxxFunctionSteppingIntoCallableTestCase(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIf(bugnumber="rdar://109655952") # Started failing after we compiled standalone tests against freshly built libcxx
     @add_test_categories(["libc++"])
     def test(self):
         """Test that std::function as defined by libc++ is correctly printed by LLDB"""


### PR DESCRIPTION
With https://github.com/apple/swift/pull/66018 we started to run standalone tests (e.g., the ones on swift-ci) against newly built libcxx. This caused the test to fail on the 5.9 branch. The first step-in into a pointer to a data member didn't behave as expected.

Thus skip it for now.