### PR TITLE
Fix the part of stepping over watchpoints that lldb can fix

### DIFF
--- a/lldb/source/Target/StopInfo.cpp
+++ b/lldb/source/Target/StopInfo.cpp
@@ -831,6 +831,11 @@ protected:
           = std::static_pointer_cast<StopInfoWatchpoint>(shared_from_this());
       ThreadPlanSP step_over_wp_sp(new ThreadPlanStepOverWatchpoint(
           *(thread_sp.get()), me_as_siwp_sp, wp_sp));
+      // When this plan is done we want to stop, so set this as a Controlling
+      // plan.    
+      step_over_wp_sp->SetIsControllingPlan(true);
+      step_over_wp_sp->SetOkayToDiscard(false);
+
       Status error;
       error = thread_sp->QueueThreadPlan(step_over_wp_sp, false);
       // If we couldn't push the thread plan, just stop here:

--- a/lldb/test/API/commands/watchpoints/step_over_watchpoint/TestStepOverWatchpoint.py
+++ b/lldb/test/API/commands/watchpoints/step_over_watchpoint/TestStepOverWatchpoint.py
@@ -11,37 +11,11 @@ from lldbsuite.test import lldbutil
 class TestStepOverWatchpoint(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    @expectedFailureAll(
-        oslist=["freebsd", "linux"],
-        archs=[
-            'aarch64',
-            'arm'],
-        bugnumber="llvm.org/pr26031")
-    @expectedFailureAll(oslist=["linux"], bugnumber="bugs.swift.org/SR-796")
-    # Read-write watchpoints not supported on SystemZ
-    @expectedFailureAll(archs=['s390x'])
-    @expectedFailureAll(
-        oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
-        archs=['aarch64', 'arm'],
-        bugnumber="<rdar://problem/34027183>")
-    @add_test_categories(["basic_process"])
-    def test(self):
+    def get_to_start(self, bkpt_text):
         """Test stepping over watchpoints."""
         self.build()
-        target = self.createTestTarget()
-
-        lldbutil.run_break_set_by_symbol(self, 'main')
-
-        process = target.LaunchSimple(None, None,
-                                      self.get_process_working_directory())
-        self.assertTrue(process.IsValid(), PROCESS_IS_VALID)
-        self.assertState(process.GetState(), lldb.eStateStopped,
-                         PROCESS_STOPPED)
-
-        thread = lldbutil.get_stopped_thread(process,
-                                             lldb.eStopReasonBreakpoint)
-        self.assertTrue(thread.IsValid(), "Failed to get thread.")
-
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(self, bkpt_text,
+                                                                       lldb.SBFileSpec("main.c"))
         frame = thread.GetFrameAtIndex(0)
         self.assertTrue(frame.IsValid(), "Failed to get frame.")
 
@@ -56,14 +30,45 @@ class TestStepOverWatchpoint(TestBase):
         self.assertSuccess(error, "Error while setting watchpoint")
         self.assertTrue(read_watchpoint, "Failed to set read watchpoint.")
 
+        # Disable the breakpoint we hit so we don't muddy the waters with
+        # stepping off from the breakpoint:
+        bkpt.SetEnabled(False)
+        
+        return (target, process, thread, read_watchpoint)
+    
+    @expectedFailureAll(
+        oslist=["freebsd", "linux"],
+        archs=[
+            'aarch64',
+            'arm'],
+        bugnumber="llvm.org/pr26031")
+    # Read-write watchpoints not supported on SystemZ
+    @expectedFailureAll(archs=['s390x'])
+    @add_test_categories(["basic_process"])
+    def test_step_over(self):
+        target, process, thread, wp = self.get_to_start("Set a breakpoint here")
+    
         thread.StepOver()
         self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonWatchpoint,
                         STOPPED_DUE_TO_WATCHPOINT)
         self.assertEquals(thread.GetStopDescription(20), 'watchpoint 1')
 
-        process.Continue()
-        self.assertState(process.GetState(), lldb.eStateStopped,
-                         PROCESS_STOPPED)
+    @expectedFailureAll(
+        oslist=["freebsd", "linux"],
+        archs=[
+            'aarch64',
+            'arm'],
+        bugnumber="llvm.org/pr26031")
+    # Read-write watchpoints not supported on SystemZ
+    @expectedFailureAll(archs=['s390x'])
+    @expectedFailureAll(
+        oslist=["ios", "watchos", "tvos", "bridgeos", "macosx"],
+        archs=['aarch64', 'arm'],
+        bugnumber="<rdar://problem/34027183>")
+    @add_test_categories(["basic_process"])
+    def test_step_instruction(self):
+        target, process, thread, wp = self.get_to_start("Set breakpoint after call")
+
         self.assertEquals(thread.GetStopDescription(20), 'step over')
 
         self.step_inst_for_watchpoint(1)

--- a/lldb/test/API/commands/watchpoints/step_over_watchpoint/TestStepOverWatchpoint.py
+++ b/lldb/test/API/commands/watchpoints/step_over_watchpoint/TestStepOverWatchpoint.py
@@ -34,7 +34,7 @@ class TestStepOverWatchpoint(TestBase):
         # stepping off from the breakpoint:
         bkpt.SetEnabled(False)
         
-        return (target, process, thread, read_watchpoint)
+        return (target, process, thread, frame, read_watchpoint)
     
     @expectedFailureAll(
         oslist=["freebsd", "linux"],
@@ -46,7 +46,7 @@ class TestStepOverWatchpoint(TestBase):
     @expectedFailureAll(archs=['s390x'])
     @add_test_categories(["basic_process"])
     def test_step_over(self):
-        target, process, thread, wp = self.get_to_start("Set a breakpoint here")
+        target, process, thread, frame, wp = self.get_to_start("Set a breakpoint here")
     
         thread.StepOver()
         self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonWatchpoint,
@@ -67,7 +67,7 @@ class TestStepOverWatchpoint(TestBase):
         bugnumber="<rdar://problem/34027183>")
     @add_test_categories(["basic_process"])
     def test_step_instruction(self):
-        target, process, thread, wp = self.get_to_start("Set breakpoint after call")
+        target, process, thread, frame, wp = self.get_to_start("Set breakpoint after call")
 
         self.assertEquals(thread.GetStopDescription(20), 'step over')
 
@@ -83,6 +83,7 @@ class TestStepOverWatchpoint(TestBase):
         if re.match("^mips", arch) or re.match("powerpc64le", arch):
             self.runCmd("watchpoint delete 1")
 
+        error = lldb.SBError()
         # resolve_location=True, read=False, write=True
         write_watchpoint = write_value.Watch(True, False, True, error)
         self.assertTrue(write_watchpoint, "Failed to set write watchpoint.")

--- a/lldb/test/API/commands/watchpoints/step_over_watchpoint/main.c
+++ b/lldb/test/API/commands/watchpoints/step_over_watchpoint/main.c
@@ -11,8 +11,8 @@ void watch_write() {
 }
 
 int main() {
-    watch_read();
-    g_temp = g_watch_me_read;
+    watch_read(); // Set a breakpoint here
+    g_temp = g_watch_me_read; // Set breakpoint after call
     watch_write();
     g_watch_me_write = g_temp;
     return 0;


### PR DESCRIPTION
There are two bugs with stepping over watchpoint hits in lldb.  One is an lldb bug - the ThreadPlanStepOverWatchpoint needs to be registered as a "Controlling Plan" or it won't trigger a public stop when it completes.  The other is a kernel issue where if an instruction single step triggers the wp, we only get the single step completion exception, not the watchpoint hit.

But since wp triggering instructions are seldom branch instructions, and lldb runs from branch to branch using breakpoints, with this fix you will only miss the watchpoint hit if you are unlucky enough for the faulting instruction to be the first one in the source line, or the first one in the next source line.

So it's worth having this fix even if we haven't gotten the kernel fix yet.