### PR TITLE
Preserve NUMBER_OF_PROCESSORS in lit tests on Windows

### DIFF
--- a/llvm/utils/lit/lit/TestingConfig.py
+++ b/llvm/utils/lit/lit/TestingConfig.py
@@ -70,6 +70,7 @@ class TestingConfig(object):
                 "COMSPEC",
                 "INCLUDE",
                 "LIB",
+                "NUMBER_OF_PROCESSORS",
                 "PATHEXT",
                 "USERPROFILE",
             ]


### PR DESCRIPTION
When doing a full build of the Swift toolchain on Windows and then building and running tests for apple/swift, we occasionally run into an issue where the `NUMBER_OF_PROCESSORS` environment variable has disappeared. This seems like the most likely cause.

```
lit.py: S:\SourceCache\llvm-project\llvm\utils\lit\lit\TestingConfig.py:138: fatal: unable to parse config file 'S:/SourceCache/swift\\test\\lit.cfg', traceback: Traceback (most recent call last):
  File "S:\SourceCache\llvm-project\llvm\utils\lit\lit\TestingConfig.py", line 127, in load_from_path
    exec(compile(data, path, 'exec'), cfg_globals, None)
  File "S:/SourceCache/swift\test\lit.cfg", line 1450, in <module>
    config.environment['NUMBER_OF_PROCESSORS'] = os.environ['NUMBER_OF_PROCESSORS']
  File "C:\Users\tristan\AppData\Local\Programs\Python\Python39\lib\os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'NUMBER_OF_PROCESSORS'
```