### PR TITLE
Add a hook to adjust the compiler version precision in warning. (NFC)

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1192,13 +1192,17 @@ void Module::ReportWarningCantLoadSwiftModule(
                           &m_swift_import_warning);
 }
 
+static llvm::VersionTuple GetAdjustedVersion(llvm::VersionTuple version) {
+  return version;
+}
+
 void Module::ReportWarningToolchainMismatch(
     CompileUnit &comp_unit, llvm::Optional<lldb::user_id_t> debugger_id) {
   if (SymbolFile *sym_file = GetSymbolFile()) {
     llvm::VersionTuple sym_file_version =
-        sym_file->GetProducerVersion(comp_unit);
+        GetAdjustedVersion(sym_file->GetProducerVersion(comp_unit));
     llvm::VersionTuple swift_version =
-        swift::version::getCurrentCompilerVersion();
+        GetAdjustedVersion(swift::version::getCurrentCompilerVersion());
     if (sym_file_version != swift_version) {
       std::string str = llvm::formatv(
           "{0} was compiled with a different Swift compiler "


### PR DESCRIPTION
(cherry picked from commit 186466da4e3db0c9dd328671c084875b87566261)