### PR TITLE
[lldb] Use Swift runtime to dynamically type Swift-implemented ObjC classes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -530,6 +530,18 @@ uint64_t ClassDescriptorV2::GetInstanceSize() {
   return 0;
 }
 
+// From the ObjC runtime.
+static uint8_t IS_SWIFT_STABLE = 1U << 1;
+
+bool ClassDescriptorV2::IsSwift() const {
+  std::unique_ptr<objc_class_t> objc_class;
+  if (auto *process = m_runtime.GetProcess())
+    if (Read_objc_class(process, objc_class))
+      return objc_class->m_flags & IS_SWIFT_STABLE;
+
+  return false;
+}
+
 ClassDescriptorV2::iVarsStorage::iVarsStorage() : m_ivars(), m_mutex() {}
 
 size_t ClassDescriptorV2::iVarsStorage::size() { return m_ivars.size(); }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
@@ -34,6 +34,8 @@ public:
     return true; // any Objective-C v2 runtime class descriptor we vend is valid
   }
 
+  bool IsSwift() const override;
+
   // a custom descriptor is used for tagged pointers
   bool GetTaggedPointerInfo(uint64_t *info_bits = nullptr,
                             uint64_t *value_bits = nullptr,

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -84,6 +84,8 @@ public:
       return (m_is_cf == eLazyBoolYes);
     }
 
+    virtual bool IsSwift() const { return false; }
+
     virtual bool IsValid() = 0;
 
     /// There are two routines in the ObjC runtime that tagged pointer clients

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct Document {
+    var kind: Kind
+    var path: String
+
+    enum Kind {
+        case binary
+        case text
+    }
+}
+
+@objc(App)
+class App : NSObject {
+    var name: String = "Debugger"
+    var version: (Int, Int) = (1, 0)
+    var recentDocuments: [Document]? = [
+        Document(kind: .binary, path: "/path/to/something"),
+    ]
+}

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
@@ -1,0 +1,5 @@
+OBJC_SOURCES := main.m
+SWIFT_SOURCES := App.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @skipUnlessFoundation
+    @swiftTest
+    def test(self):
+        """Verify printing of Swift implemented ObjC objects."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+
+        # For Swift implemented objects, it's assumed the ObjC runtime prints
+        # only a pointer, and cannot generate any child values.
+        self.expect("v -d no app", startstr="(App *) app = 0x")
+        self.expect(
+            "v -d no -P1 app",
+            matching=False,
+            substrs=["name", "version", "recentDocuments"],
+        )
+
+        # With dynamic typing, the Swift runtime produces Swift child values.
+        self.expect("v app", startstr="(App?) app = 0x")
+        self.expect("v app.name", startstr='(String) app.name = "Debugger"')
+        self.expect(
+            "v app.version", startstr="((Int, Int)) app.version = (0 = 1, 1 = 0)"
+        )
+
+        documents = """\
+([a.Document]?) app.recentDocuments = 1 value {
+  [0] = {
+    kind = binary
+    path = "/path/to/something"
+  }
+}
+"""
+        self.expect("v app.recentDocuments", startstr=documents)

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+@interface App : NSObject
+@end
+
+int main() {
+  App *app = [App new];
+  printf("break here\n");
+  return 0;
+}


### PR DESCRIPTION
ObjC classes can be implemented in Swift. For such classes, lldb needs the Swift runtime to reflect on the type. This is because the ObjC metadata for those classes doesn't have the full info that the Swift runtime has. Given that some Swift types cannot be represented in ObjC, this is expected.

This change identifies when an ObjC class is implemented in Swift. When that is the case, the Swift runtime is used to determine its dynamic type. This allows the debugger to show the user the Swift representation – all the properties are shown as children, even non-ObjC types and values.

A consequence of this change is that when debugging ObjC code, the debugger will show Swift types for Swift-implemented classes. For example, given a class named `Engine`, instead of showing the ObjC spelling: `Engine *`, the Swift spelling will be used instead: `Engine?`.

This functionality will be crucial with the work to [re-implement Foundation in Swift](https://www.swift.org/blog/future-of-foundation/). LLDB will need access to the Swift representation of types in order to provide user friendly data formatters.

rdar://108478831
