### PR TITLE
[lldb][test] Make missing libcxx directory in standalone tests a fatal error again

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -150,7 +150,7 @@ if(TARGET clang)
         set(LIBCXX_LIBRARY_DIR "${LLDB_TEST_LIBCXX_ROOT_DIR}/lib${LIBCXX_LIBDIR_SUFFIX}")
         set(LIBCXX_GENERATED_INCLUDE_DIR "${LLDB_TEST_LIBCXX_ROOT_DIR}/include/c++/v1")
       else()
-        message(WARNING
+        message(FATAL_ERROR
             "Couldn't find libcxx build in '${LLDB_TEST_LIBCXX_ROOT_DIR}'. To run the "
             "test-suite for a standalone LLDB build please build libcxx and point "
             "LLDB_TEST_LIBCXX_ROOT_DIR to it.")


### PR DESCRIPTION
(cherry picked from commit 939bd9551b6652e4b0a511ec690d6731be1063be)