### PR TITLE
[lldb] Improve error message when evaluating expression when not stopped

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -39,6 +39,7 @@
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/State.h"
 #include "lldb/Utility/StreamString.h"
 
 #ifdef LLDB_ENABLE_SWIFT
@@ -206,14 +207,17 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
 
     return execution_results;
   }
-  // Since we might need to call allocate memory and maybe call code to make
-  // the caller, we need to be stopped.
+
+  // Since we might need to allocate memory, we need to be stopped to run
+  // an expression.
   if (process != nullptr && process->GetState() != lldb::eStateStopped) {
-    error.SetErrorString("Can't make a function caller while the process is " 
-                          "running");
+    error.SetErrorStringWithFormatv(
+        "unable to evaluate expression while the process is {0}: the process "
+        "must be stopped because the expression might require allocating "
+        "memory.",
+        StateAsCString(process->GetState()));
     return execution_results;
   }
-
 
   // Explicitly force the IR interpreter to evaluate the expression when the
   // there is no process that supports running the expression for us. Don't

--- a/lldb/source/Expression/UtilityFunction.cpp
+++ b/lldb/source/Expression/UtilityFunction.cpp
@@ -21,6 +21,7 @@
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/State.h"
 #include "lldb/Utility/Stream.h"
 
 using namespace lldb_private;
@@ -64,11 +65,13 @@ FunctionCaller *UtilityFunction::MakeFunctionCaller(
     error.SetErrorString("Can't make a function caller without a process.");
     return nullptr;
   }
-  // Since we might need to call allocate memory and maybe call code to make
+  // Since we might need to allocate memory and maybe call code to make
   // the caller, we need to be stopped.
   if (process_sp->GetState() != lldb::eStateStopped) {
-    error.SetErrorString("Can't make a function caller while the process is " 
-                         "running");
+    error.SetErrorStringWithFormatv(
+        "Can't make a function caller while the process is {0}: the process "
+        "must be stopped to allocate memory.",
+        StateAsCString(process_sp->GetState()));
     return nullptr;
   }
 

--- a/lldb/test/Shell/Expr/TestExited.test
+++ b/lldb/test/Shell/Expr/TestExited.test
@@ -1,0 +1,3 @@
+# RUN: %clangxx_host %p/Inputs/call-function.cpp -g -o %t
+# RUN: %lldb %t -o 'r' -o 'expr strlen("")' 2>&1 | FileCheck %s
+# CHECK: error: unable to evaluate expression while the process is exited: the process must be stopped because the expression might require allocating memory.


### PR DESCRIPTION
When trying to run an expression after a process has existed, you
currently are shown the following error message:

  (lldb) p strlen("")
  error: Can't make a function caller while the process is running

This error is wrong and pretty uninformative. After this patch, the
following error message is shown:

  (lldb) p strlen("")
  error: unable to evaluate expression while the process is exited: the
  process must be stopped because the expression might require
  allocating memory.

rdar://109731325

Differential revision: https://reviews.llvm.org/D151497

(cherry picked from commit e31f99464216ef4d04ffa821e174522b699780ee)
