### PR TITLE
DNM: Disable two tests that fail after enabling opaque pointer types in Swift

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
@@ -4,4 +4,8 @@ Test that Swift unsafe types get formatted properly
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+# Skip test until rdar://109831415 is fixed. After moving to opaque pointer
+# usage this test fails.
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,
+                                                           skipIfDarwin,
+                                                           skipIfLinux])

--- a/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
@@ -32,6 +32,10 @@ class TestSwiftConsumeOperatorType(TestBase):
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=["aarch64"], oslist=["linux"])
     @swiftTest
+    # Skip test until rdar://109831415 is fixed. After moving to opaque pointer
+    # usage this test fails.
+    @skipIfDarwin
+    @skipIfLinux
     def test_swift_consume_operator(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.


### PR DESCRIPTION
To be able to see how far we can get disable these two tests to see whether other things break in CI.

https://github.com/apple/swift/pull/66077 is the PR that trys to enable opaque pointers in Swift.

rdar://109831415