### PR TITLE
[lldb][NFCI] Include <cstdio> in SBDefines for FILE * definition

### DIFF
--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -15,6 +15,8 @@
 #include "lldb/lldb-types.h"
 #include "lldb/lldb-versioning.h"
 
+#include <cstdio> // For FILE *
+
 #ifndef LLDB_API
 #if defined(_WIN32)
 #if defined(LLDB_IN_LIBLLDB)


### PR DESCRIPTION
There are a few API headers that use FILE * but do not include the correct header for their definition. Instead of including <cstdio> in each of the headers manually, it seems easiest to include it in SBDefines to get them all at once.

rdar://109579348

Differential Revision: https://reviews.llvm.org/D151381

(cherry picked from commit 877ddac051c4fc6b32e3e45b02dc628b018b381b)