### PR TITLE
TypeSystem: add a platform hook for library search path additions

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -147,6 +147,11 @@ public:
       FileSpec &lldb_shlib_spec, FileSpec &file_spec, bool verify) {
     return false;
   }
+
+  /// Return the default set of library paths to search in.  This allows a
+  /// platform specific extension for system libraries that may need to be
+  /// resolved (e.g. `/usr/lib` on Unicies and `Path` on Windows).
+  static std::vector<std::string> GetSwiftLibrarySearchPaths() { return {}; }
 #endif
 
 protected:

--- a/lldb/include/lldb/Host/windows/HostInfoWindows.h
+++ b/lldb/include/lldb/Host/windows/HostInfoWindows.h
@@ -42,6 +42,7 @@ public:
   static bool ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
                                             FileSpec &file_spec, bool verify);
   static llvm::Expected<llvm::StringRef> GetSDKRoot(SDKOptions options);
+  static std::vector<std::string> GetSwiftLibrarySearchPaths();
 #endif
 
 private:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3528,6 +3528,8 @@ GetLibrarySearchPaths(const swift::SearchPathOptions &search_path_opts) {
     paths.push_back(path);
   for (std::string path : search_path_opts.LibrarySearchPaths)
     paths.push_back(path);
+  for (const std::string &path : HostInfo::GetSwiftLibrarySearchPaths())
+    paths.emplace_back(path);
   return paths;
 }
 


### PR DESCRIPTION
Windows does not provide a library search path through a mechanism similar to `DT_RPATH` or `LC_RPATH`.  Libraries are instead resolved via the environment variable `Path`.  Add a hook to inject the default library search path into the repl instance.  This is required to ensure that system libraries are available.  With this, it is finally possible to run the REPL on Windows without any additional parameters.