### PR TITLE
[lldb] ifdef IsScratchContextLocked for asserts (#6875)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1913,7 +1913,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Pack(
   return true;
 }
 
-/// Determine whether the scratch SwiftASTContext has been locked.
+#ifndef NDEBUG
+/// Assert helper to determine if the scratch SwiftASTContext is locked.
 static bool IsScratchContextLocked(Target &target) {
   if (target.GetSwiftScratchContextLock().try_lock()) {
     target.GetSwiftScratchContextLock().unlock();
@@ -1922,10 +1923,11 @@ static bool IsScratchContextLocked(Target &target) {
   return true;
 }
 
-/// Determine whether the scratch SwiftASTContext has been locked.
+/// Assert helper to determine if the scratch SwiftASTContext is locked.
 static bool IsScratchContextLocked(TargetSP target) {
   return target ? IsScratchContextLocked(*target) : true;
 }
+#endif
 
 static bool IsPrivateNSClass(NodePointer node) {
   if (!node || node->getKind() != Node::Kind::Type ||


### PR DESCRIPTION
`IsScratchContextLocked` is racey, but is called only from asserts. Put these functions
behind `#ifndef NDEBUG` to make them less likely to be used accidentally.
(cherry-picked from commit d8d45aa3245eaa227d23bbcd6417a65792952a0a)