### PR TITLE
Fix SBValue::FindValue for file static variables

### DIFF
--- a/lldb/source/API/SBFrame.cpp
+++ b/lldb/source/API/SBFrame.cpp
@@ -611,7 +611,8 @@ SBValue SBFrame::FindValue(const char *name, ValueType value_type,
                 stop_if_block_is_inlined_function,
                 [frame](Variable *v) { return v->IsInScope(frame); },
                 &variable_list);
-          if (value_type == eValueTypeVariableGlobal) {
+          if (value_type == eValueTypeVariableGlobal 
+              || value_type == eValueTypeVariableStatic) {
             const bool get_file_globals = true;
             VariableList *frame_vars = frame->GetVariableList(get_file_globals,
                                                               nullptr);

--- a/lldb/test/API/python_api/process/TestProcessAPI.py
+++ b/lldb/test/API/python_api/process/TestProcessAPI.py
@@ -48,8 +48,8 @@ class ProcessAPITestCase(TestBase):
         )
         frame = thread.GetFrameAtIndex(0)
 
-        # Get the SBValue for the global variable 'my_char'.
-        val = frame.FindValue("my_char", lldb.eValueTypeVariableGlobal)
+        # Get the SBValue for the file static variable 'my_char'.
+        val = frame.FindValue("my_char", lldb.eValueTypeVariableStatic)
         self.DebugSBValue(val)
 
         # Due to the typemap magic (see lldb.swig), we pass in 1 to ReadMemory and
@@ -148,8 +148,8 @@ class ProcessAPITestCase(TestBase):
         )
         frame = thread.GetFrameAtIndex(0)
 
-        # Get the SBValue for the global variable 'my_char'.
-        val = frame.FindValue("my_char", lldb.eValueTypeVariableGlobal)
+        # Get the SBValue for the static variable 'my_char'.
+        val = frame.FindValue("my_char", lldb.eValueTypeVariableStatic)
         self.DebugSBValue(val)
 
         # If the variable does not have a load address, there's no sense

--- a/lldb/test/API/python_api/process/main.cpp
+++ b/lldb/test/API/python_api/process/main.cpp
@@ -3,7 +3,7 @@
 
 // This simple program is to test the lldb Python API related to process.
 
-char my_char = 'u';
+static char my_char = 'u';
 char my_cstring[] = "lldb.SBProcess.ReadCStringFromMemory() works!";
 char *my_char_ptr = (char *)"Does it work?";
 uint32_t my_uint32 = 12345;


### PR DESCRIPTION
This was just a thinko. The API StackFrame::GetVariableList takes a bool for "get_file_globals" which if true will also find file statics and file globals. But we only were passing that as true if the ValueType was eValueTypeVariableGlobal, which meant that we never find file statics. It's okay if we cast too wide a net when we do GetVariableList as later on we check against the ValueType to filter globals from statics.

There was a test that had a whole bunch of globals and tested FindValue on all of them, but had no statics. So I just made one of the globals a file static, which verifies the fix.

Differential Revision: https://reviews.llvm.org/D151392

(cherry picked from commit 14186773e79b8c6787afac2f9ee69738151377ec)