### PR TITLE
[5.9][index] NFC: Add a symbol kind for init accessor

### DIFF
--- a/clang/include/clang/Index/IndexSymbol.h
+++ b/clang/include/clang/Index/IndexSymbol.h
@@ -102,6 +102,7 @@ enum class SymbolSubKind : uint8_t {
   SwiftSubscript,
   SwiftAssociatedType,
   SwiftGenericTypeParam,
+  SwiftAccessorInit,
 };
 
 typedef uint32_t SymbolPropertySet;

--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -25,7 +25,7 @@
  * INDEXSTORE_VERSION_MAJOR is intended for "major" source/ABI breaking changes.
  */
 #define INDEXSTORE_VERSION_MAJOR 0
-#define INDEXSTORE_VERSION_MINOR 14 /* added C++ concept */
+#define INDEXSTORE_VERSION_MINOR 15 /* added Swift init accessor sub-symbol */
 
 #define INDEXSTORE_VERSION_ENCODE(major, minor) ( \
       ((major) * 10000)                           \
@@ -313,6 +313,7 @@ typedef enum {
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTGENERICTYPEPARAM = 1013,
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORREAD = 1014,
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY = 1015,
+  INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORINIT = 1016,
 } indexstore_symbol_subkind_t;
 
 INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_property_t) {

--- a/clang/lib/Index/IndexDataStoreUtils.cpp
+++ b/clang/lib/Index/IndexDataStoreUtils.cpp
@@ -169,6 +169,8 @@ SymbolSubKind index::getSymbolSubKind(indexstore_symbol_subkind_t K) {
     return SymbolSubKind::SwiftAccessorRead;
   case INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY:
     return SymbolSubKind::SwiftAccessorModify;
+  case INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORINIT:
+    return SymbolSubKind::SwiftAccessorInit;
   case INDEXSTORE_SYMBOL_SUBKIND_SWIFTEXTENSIONOFSTRUCT:
     return SymbolSubKind::SwiftExtensionOfStruct;
   case INDEXSTORE_SYMBOL_SUBKIND_SWIFTEXTENSIONOFCLASS:
@@ -397,6 +399,8 @@ indexstore_symbol_subkind_t index::getIndexStoreSubKind(SymbolSubKind K) {
     return INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORREAD;
   case SymbolSubKind::SwiftAccessorModify:
     return INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY;
+  case SymbolSubKind::SwiftAccessorInit:
+    return INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORINIT;
   case SymbolSubKind::SwiftExtensionOfStruct:
     return INDEXSTORE_SYMBOL_SUBKIND_SWIFTEXTENSIONOFSTRUCT;
   case SymbolSubKind::SwiftExtensionOfClass:

--- a/clang/lib/Index/IndexSymbol.cpp
+++ b/clang/lib/Index/IndexSymbol.cpp
@@ -560,6 +560,7 @@ StringRef index::getSymbolSubKindString(SymbolSubKind K) {
   case SymbolSubKind::SwiftAccessorMutableAddressor: return "acc-mutaddr";
   case SymbolSubKind::SwiftAccessorRead: return "acc-read";
   case SymbolSubKind::SwiftAccessorModify: return "acc-modify";
+  case SymbolSubKind::SwiftAccessorInit: return "acc-init";
   case SymbolSubKind::SwiftExtensionOfStruct: return "ext-struct";
   case SymbolSubKind::SwiftExtensionOfClass: return "ext-class";
   case SymbolSubKind::SwiftExtensionOfEnum: return "ext-enum";


### PR DESCRIPTION
This is a new kind of accessor that is being introduced to the Swift language.

(cherry picked from commit a48d9f888e64da419d2b9a4463f4aceee40f226d)