### PR TITLE
[5.9][clang][Darwin] Error out when missing requested libarclite library

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -604,6 +604,9 @@ def warn_drv_darwin_sdk_invalid_settings : Warning<
   "SDK settings were ignored as 'SDKSettings.json' could not be parsed">,
   InGroup<DiagGroup<"darwin-sdk-settings">>;
 
+def err_drv_darwin_sdk_missing_arclite : Error<
+  "SDK does not contain 'libarclite' at the path '%0'; try increasing the minimum deployment target">;
+
 def err_drv_trivial_auto_var_init_stop_after_missing_dependency : Error<
   "'-ftrivial-auto-var-init-stop-after=*' is used without "
   "'-ftrivial-auto-var-init=zero' or '-ftrivial-auto-var-init=pattern'">;

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1347,6 +1347,9 @@ void DarwinClang::AddLinkARCArgs(const ArgList &Args,
     P += "macosx";
   P += ".a";
 
+  if (!getVFS().exists(P))
+    getDriver().Diag(clang::diag::err_drv_darwin_sdk_missing_arclite) << P;
+
   CmdArgs.push_back(Args.MakeArgString(P));
 }
 

--- a/clang/test/Driver/arclite-link-external-toolchain.c
+++ b/clang/test/Driver/arclite-link-external-toolchain.c
@@ -4,5 +4,8 @@
 // RUN:   -isysroot %t.tmpdir/Xcode.app/Contents/Developers/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk \
 // RUN:   %s 2>&1 | FileCheck %s
 
+// CHECK: error: SDK does not contain 'libarclite' at the path '
+// CHECK: .tmpdir/Xcode.app/{{.*}}libarclite_macosx.a';
+// CHECK: try increasing the minimum deployment target
 // CHECK: -lfoo
 // CHECK: .tmpdir/Xcode.app/{{.*}}libarclite_macosx.a

--- a/clang/test/Driver/arclite-link.c
+++ b/clang/test/Driver/arclite-link.c
@@ -1,9 +1,13 @@
 // RUN: touch %t.o
-// RUN: %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -lfoo -mmacosx-version-min=10.10 %t.o 2>&1 | FileCheck -check-prefix=CHECK-ARCLITE-OSX %s
+// RUN: mkdir -p %t.tmpdir/Xcode.app/Contents/Developers/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk
+// RUN: %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -lfoo -mmacosx-version-min=10.10 %t.o \
+// RUN: -isysroot %t.tmpdir/Xcode.app/Contents/Developers/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk 2>&1 | FileCheck -check-prefix=CHECK-ARCLITE-OSX %s
 // RUN: %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -mmacosx-version-min=10.11 %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOARCLITE %s
 // RUN: %clang -### -target i386-apple-darwin10 -fobjc-link-runtime -mmacosx-version-min=10.7 %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOARCLITE %s
 // RUN: %clang -### -target x86_64-apple-darwin10 -fobjc-link-runtime -nostdlib %t.o 2>&1 | FileCheck -check-prefix=CHECK-NOSTDLIB %s
 
+// CHECK-ARCLITE-OSX: .tmpdir/Xcode.app/{{.*}}libarclite_macosx.a';
+// CHECK-ARCLITE-OSX: try increasing the minimum deployment target
 // CHECK-ARCLITE-OSX: -lfoo
 // CHECK-ARCLITE-OSX: libarclite_macosx.a
 // CHECK-ARCLITE-OSX: -framework


### PR DESCRIPTION
Starting with the SDKs provided with Xcode 14.3, this library no longer exists. Before this change this results in an opaque linker error in the case that your deployment target is low enough that this library is added. This produces a more useful error message in that case.

Differential Revision: https://reviews.llvm.org/D150988

(cherry picked from commit 2129cc1b3a14df5c24e5b2a680f18b88d5af4142)