### PR TITLE
[UBSan] Disable -fsanitize=function for arm64e.

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3444,6 +3444,8 @@ SanitizerMask Darwin::getSupportedSanitizers() const {
   Res |= SanitizerKind::FuzzerNoLink;
   Res |= SanitizerKind::ObjCCast;
 
+  if (getTriple().isArm64e())
+    Res &= ~SanitizerKind::Function;
   // Apple-Clang: Don't support LSan. rdar://problem/45841334
   Res &= ~SanitizerKind::Leak;
 

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/c.c
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/c.c
@@ -1,5 +1,6 @@
 // RUN: %clang -g -fsanitize=function %s -o %t
 // RUN: %run %t 2>&1 | FileCheck %s --check-prefix=CHECK --implicit-check-not='runtime error:'
+// XFAIL: arm64e-target-arch
 
 void f(void (*fp)(int (*)[])) { fp(0); }
 

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/function.cpp
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/function.cpp
@@ -3,6 +3,7 @@
 // RUN: %run %t 2>&1 | FileCheck %s --check-prefix=CHECK
 // Verify that we can disable symbolization if needed:
 // RUN: %env_ubsan_opts=symbolize=0 %run %t 2>&1 | FileCheck %s --check-prefix=NOSYM
+// XFAIL: arm64e-target-arch
 
 struct Shared {};
 using FnShared = void (*)(Shared *);


### PR DESCRIPTION
The function sanitizer broke for arm64e after ad31a2dcadfcd57a99bbd6d0050d2690fd84a883. We are disabling it temporarily for arm64e until a fix has been decided.

rdar://110075232