### PR TITLE
[lldb] Avoid eager loading of SwiftASTContext from TSSwiftTypeRef::SetTriple

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1455,6 +1455,8 @@ SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContext() const {
         *const_cast<TypeSystemSwiftTypeRef *>(this));
     m_swift_ast_context =
         llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
+    if (m_swift_ast_context && !m_swift_ast_context_triple.str().empty())
+      m_swift_ast_context->SetTriple(m_swift_ast_context_triple);
   }
   return m_swift_ast_context;
 }
@@ -1522,8 +1524,10 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
 }
 
 void TypeSystemSwiftTypeRef::SetTriple(const llvm::Triple triple) {
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull())
     swift_ast_context->SetTriple(triple);
+  else
+    m_swift_ast_context_triple = triple;
 }
 
 void TypeSystemSwiftTypeRef::ClearModuleDependentCaches() {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -427,6 +427,7 @@ protected:
 #endif
 
   /// The sibling SwiftASTContext.
+  llvm::Triple m_swift_ast_context_triple;
   mutable bool m_swift_ast_context_initialized = false;
   mutable lldb::TypeSystemSP m_swift_ast_context_sp;
   mutable SwiftASTContext *m_swift_ast_context = nullptr;


### PR DESCRIPTION
`SetTriple` is called from `Module::SetArchitecture` – which in turn is called when dyld notifies lldb that binaries are loaded. This has previously caused the `TypeSystemSwiftTypeRef` type system to eagerly load its `SwiftASTContext`, at a time when it's not yet needed.

With this change, `SetTriple` won't cause eager loading of the `SwiftASTContext`. If the AST context hasn't been loaded, the triple will be saved. Only later, when the AST context is actually needed, will the triple be assigned.

rdar://110148469