### PR TITLE
[lldb/crashlog] Fix crash when loading non-symbolicated report

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -545,9 +545,11 @@ class JSONCrashLogParser(CrashLogParser):
             image_addr = self.get_used_image(image_id)['base']
             pc = image_addr + frame_offset
 
-            if 'symbol' in json_frame:
-                symbol = json_frame['symbol']
-                location = int(json_frame['symbolLocation'])
+            if "symbol" in json_frame:
+                symbol = json_frame["symbol"]
+                location = 0
+                if "symbolLocation" in json_frame and json_frame["symbolLocation"]:
+                    location = int(json_frame["symbolLocation"])
                 image = self.images[image_id]
                 image.symbols[symbol] = {
                     "name": symbol,

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/Inputs/interactive_crashlog/multithread-test.ips
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/Inputs/interactive_crashlog/multithread-test.ips
@@ -279,7 +279,7 @@
           "sourceFile": "thread",
           "sourceLine": 298,
           "symbol": "void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)(int&), std::__1::reference_wrapper<int> > >(void*)",
-          "symbolLocation": 84
+          "symbolLocation": null
         },
         {
           "imageIndex": 1,


### PR DESCRIPTION
This patch should address the crashes when parsing a the crash report frame dictionary.

If the crash report is not symbolicated, the `symbolLocation` key will be missing. In that case, we should just use the `imageOffset`.

rdar://109836386

Differential Revision: https://reviews.llvm.org/D151844