### PR TITLE
[lldb] Prevent dwim-print from showing kNoResult error

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Core/ValueObject.h"
 #include "lldb/DataFormatters/DumpValueObjectOptions.h"
 #include "lldb/Expression/ExpressionVariable.h"
+#include "lldb/Expression/UserExpression.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandObject.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
@@ -178,7 +179,8 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
                                         expr);
       }
 
-      valobj_sp->Dump(result.GetOutputStream(), dump_options);
+      if (valobj_sp->GetError().GetError() != UserExpression::kNoResult)
+        valobj_sp->Dump(result.GetOutputStream(), dump_options);
 
       if (suppress_result)
         if (auto result_var_sp =

--- a/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/TestDWIMPrint.py
@@ -138,3 +138,9 @@ class TestCase(TestBase):
         self.runCmd("type summary add -e -s 'stub summary' Structure")
         self._expect_cmd(f"dwim-print s", "frame variable")
         self._expect_cmd(f"dwim-print (struct Structure)s", "expression")
+
+    def test_void_result(self):
+        """Test dwim-print does not surface an error message for void expressions."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "// break here", lldb.SBFileSpec("main.c"))
+        self.expect("dwim-print (void)15", matching=False, patterns=["(?i)error"])


### PR DESCRIPTION
Expression evaluation for `void` valued expressions sets an error using the `kNoResult`
code. Like the `expression` command, `dwim-print` should also not print such errors.

Before:

```
(lldb) dwim-print (void)printf("hi\n")
hi
Error: 'unknown error'
```

After:

```
(lldb) dwim-print (void)printf("hi\n")
hi
```

rdar://109746544

Differential Revision: https://reviews.llvm.org/D151351

(cherry picked from commit 061a839033dc5f11c4e43fb64ed49cc85e1e5f32)
