### PR TITLE
5.9: [lldb][Test] Check variadic generic vals with heap allocated metadata.

### DIFF
--- a/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
+++ b/lldb/test/API/lang/swift/variadic_generics/TestSwiftVariadicGenerics.py
@@ -115,3 +115,16 @@ class TestSwiftVariadicGenerics(TestBase):
         # f9(s: S<repeat each T>)
         process.Continue()
         self.expect("frame variable", substrs=["t", "0 = 23", "1 = 2.71"])
+
+        # f10<each T>(args: repeat each T)
+        process.Continue()
+        self.expect(
+            "frame variable", substrs=[
+                "Pack{(a.A, a.B)}",
+                "args",
+                "i = 23",
+                "d ="
+                # FIXME: The wrong value for d is currently shown.
+                #"d = 2.71"
+            ]
+        )

--- a/lldb/test/API/lang/swift/variadic_generics/a.swift
+++ b/lldb/test/API/lang/swift/variadic_generics/a.swift
@@ -67,3 +67,18 @@ func f9<each T>(s9: S<repeat each T>) {
 }
 
 f9(s9: s)
+
+func f10<each T>(args: repeat each T) {
+  print("break here")
+}
+
+func f10_maker<each T>(args: repeat each T) -> () -> () {
+  return { f10(args: repeat each args) }
+}
+
+func f10_caller() {
+  let f10 = f10_maker(args: a, b)
+  f10()
+}
+
+f10_caller()


### PR DESCRIPTION
rdar://110195273