### PR TITLE
[Sanitizers][Darwin] In DlAddrSymbolizer, return only the module file…

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_mac.cpp
@@ -41,6 +41,12 @@ bool DlAddrSymbolizer::SymbolizePC(uptr addr, SymbolizedStack *stack) {
     stack->info.function_offset = addr - sym_addr;
   }
 
+  if (info.dli_fname) {
+    if (auto *last_occurence = internal_strrchr(info.dli_fname, '/')) {
+      stack->info.module = internal_strdup(last_occurence + 1);
+    }
+  }
+
   const char *demangled = DemangleSwiftAndCXX(info.dli_sname);
   if (!demangled) return false;
   stack->info.function = internal_strdup(demangled);

--- a/compiler-rt/test/sanitizer_common/TestCases/Darwin/symbolizer-file-name-dladdr.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/Darwin/symbolizer-file-name-dladdr.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx %s -O0 -o %t
+// RUN: %env_tool_opts=external_symbolizer_path= %run %t 2>&1 | FileCheck %s
+#include <sanitizer/common_interface_defs.h>
+#include <stdio.h>
+
+int main() {
+  //CHECK: #0{{.*}}
+  //CHECK: #1{{.*}}(symbolizer-file-name-dladdr.cpp.tmp
+  __sanitizer_print_stack_trace();
+  return 0;
+}


### PR DESCRIPTION
… name instead of the comlpete module path during symbolication.

Differential Revision: https://reviews.llvm.org/D152029

rdar://108858834

