### PR TITLE
[lldb] Fix "NameError: name 'self' is not defined" when using crashlog -c

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1042,7 +1042,7 @@ def SymbolicateCrashLog(crash_log, options):
         for thread in crash_log.threads:
             if thread.did_crash():
                 for ident in thread.idents:
-                    for image in self.crashlog.find_images_with_identifier(ident):
+                    for image in crash_log.find_images_with_identifier(ident):
                         image.resolve = True
 
     futures = []

--- a/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
+++ b/lldb/test/Shell/ScriptInterpreter/Python/Crashlog/json.test
@@ -3,6 +3,7 @@
 # RUN: cp %S/Inputs/a.out.ips %t.crash
 # RUN: %python %S/patch-crashlog.py --binary %t.out --crashlog %t.crash --offsets '{"main":20, "bar":9, "foo":16}' --json
 # RUN: %lldb %t.out -o 'command script import lldb.macosx.crashlog' -o 'crashlog %t.crash' 2>&1 | FileCheck %s
+# RUN: %lldb %t.out -o 'command script import lldb.macosx.crashlog' -o 'crashlog -c %t.crash' 2>&1 | FileCheck %s
 
 # RUN: cp %S/Inputs/a.out.ips %t.nometadata.crash
 # RUN: %python %S/patch-crashlog.py --binary %t.out --crashlog %t.nometadata.crash --offsets '{"main":20, "bar":9, "foo":16}' --json --no-metadata


### PR DESCRIPTION
This fixes a regression introduced by 27f27d15f6c9 that results in a
NameError: (name 'self' is not defined) when using crashlog with the -c
option.

rdar://110007391
(cherry picked from commit a10019a496d420769d7aae94f234ab6cf9fd778d)
