### PR TITLE
Add --analysis-only flag to llvm-cas-dump, and print the name of the casid file when dumping cas contents

### DIFF
--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -18,7 +18,8 @@
 ; DWARF: 0x0000000000000000      3      3      1   0             0  is_stmt prologue_end
 ; DWARF: 0x0000000000000008      3      3      1   0             0  is_stmt end_sequence
 
-; CHECK:      mc:assembler  llvmcas://{{.*}}
+; CHECK: CASID File Name: {{.+}}
+; CHECK-NEXT:      mc:assembler  llvmcas://{{.*}}
 ; CHECK-NEXT:   mc:header  llvmcas://{{.*}}
 ; CHECK-NEXT:   mc:group  llvmcas://{{.*}}
 ; CHECK-NEXT:     mc:debug_abbrev_section  llvmcas://{{.*}}

--- a/llvm/test/tools/llvm-cas-dump/stats-dump.test
+++ b/llvm/test/tools/llvm-cas-dump/stats-dump.test
@@ -63,4 +63,3 @@ PRETTY-NEXT: sec-ref-size                {{[0-9]+}}
 PRETTY-NEXT: atom-ref-size          {{[0-9]+}}
 
 ANALYSIS-ONLY-NOT: llvmcas://{{[0-9a-f]+}}
-ANALYSIS-ONLY: Collecting object stats...

--- a/llvm/test/tools/llvm-cas-dump/stats-dump.test
+++ b/llvm/test/tools/llvm-cas-dump/stats-dump.test
@@ -11,6 +11,8 @@ RUN: llvm-cas-dump --cas %t/cas --object-stats - --object-stats-format=pretty --
 RUN: llvm-cas-dump --cas %t/cas --object-stats %t/statspretty.txt --object-stats-format=pretty --casid-file %t/stats-dump.id
 RUN: cat %t/statspretty.txt | FileCheck %s -check-prefix=PRETTY
 
+RUN: llvm-cas-dump --cas %t/cas --object-stats %t/stats.txt --casid-file %t/stats-dump.id --analysis-only | FileCheck %s -check-prefix=ANALYSIS-ONLY
+
 CSV: Kind, Count, Parents, Children, Data (B), Cost (B)
 CSV-NEXT: builtin:node, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
 CSV-NEXT: builtin:tree, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}, {{[0-9]+}}
@@ -59,3 +61,6 @@ PRETTY-NEXT: TOTAL                          {{([0-9]+,)?[0-9]+}} {{[0-9]+\.[0-9]
 PRETTY: num-tiny-objects              {{[0-9]+}}
 PRETTY-NEXT: sec-ref-size                {{[0-9]+}}
 PRETTY-NEXT: atom-ref-size          {{[0-9]+}}
+
+ANALYSIS-ONLY-NOT: llvmcas://{{[0-9a-f]+}}
+ANALYSIS-ONLY: Collecting object stats...

--- a/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
+++ b/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
@@ -80,7 +80,7 @@ static void computeStats(ObjectStore &CAS, ArrayRef<ObjectProxy> TopLevels,
   ExitOnError ExitOnErr;
   ExitOnErr.setBanner("llvm-cas-object-format: compute-stats: ");
 
-  outs() << "Collecting object stats...\n";
+  llvm::errs() << "Collecting object stats...\n";
 
   // In the first traversal, just collect a POT. Use NumPaths as a "Seen" list.
   StatsCollector Collector(CAS, ObjectStatsFormat);
@@ -203,16 +203,17 @@ int main(int argc, char *argv[]) {
 
     ExitOnErr(Printer.printMCObject(*Ref, *Obj));
   }
+
   if (!ComputeStats.empty()) {
     if (!Files.empty()) {
-      llvm::outs() << ("Making summary object...\n");
+      llvm::errs() << "Making summary object...\n";
       HierarchicalTreeBuilder Builder;
       for (auto &File : Files) {
         Builder.push(File.second, TreeEntry::Regular, File.first());
       }
       ObjectProxy SummaryRef = ExitOnErr(Builder.create(*CAS));
       SummaryIDs.emplace_back(SummaryRef);
-      llvm::outs() << ("summary tree: ");
+      llvm::errs() << "summary tree: ";
       outs() << SummaryRef.getID() << "\n";
     }
 

--- a/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
+++ b/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
@@ -171,6 +171,11 @@ int main(int argc, char *argv[]) {
   StringMap<ObjectRef> Files;
   SmallVector<ObjectProxy> SummaryIDs;
   for (StringRef InputStr : InputStrings) {
+    // Print object file name dumping cas contents, but not when dumping object
+    // stats.
+    if (ComputeStats.empty())
+      outs() << "CASID File Name: " << InputStr << "\n";
+
     auto ID = getCASIDFromInput(*CAS, InputStr);
 
     if (AnalysisCASTree) {


### PR DESCRIPTION
This change patch does a few things:

1. It prints the the extra information that llvm-cas-dump prints when dumping object stats, such as "Collecting stats..." etc, to stderr. So that the output to stdout is just the summary tree cas id, which can be stored in a file to dump object-stats again

2. It adds the `--analysis-only` flag to llvm-cas-dump from llvm-cas-object-format. This flag is used to generate object stats without creating a new summary tree, the cas id provided should already be a summary tree.

3. Prints the name of the cas id file when dumping cas contents. This is just extra information which is helpful when dumping out cas contents for many cas id files, and we want to know which cas dump belongs to which object file.