### PR TITLE
[Sanitizers] UUID/Build ID is 16 bytes on Darwin.

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_common.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_common.h
@@ -790,7 +790,11 @@ inline const char *ModuleArchToString(ModuleArch arch) {
   return "";
 }
 
+#if SANITIZER_APPLE
+const uptr kModuleUUIDSize = 16;
+#else
 const uptr kModuleUUIDSize = 32;
+#endif
 const uptr kMaxSegName = 16;
 
 // Represents a binary loaded into virtual memory (e.g. this can be an

--- a/compiler-rt/lib/sanitizer_common/tests/CMakeLists.txt
+++ b/compiler-rt/lib/sanitizer_common/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SANITIZER_UNITTESTS
   sanitizer_list_test.cpp
   sanitizer_lzw_test.cpp
   sanitizer_mac_test.cpp
+  sanitizer_module_uuid_size.cpp
   sanitizer_mutex_test.cpp
   sanitizer_nolibc_test.cpp
   sanitizer_posix_test.cpp

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_module_uuid_size.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_module_uuid_size.cpp
@@ -1,0 +1,10 @@
+#include "sanitizer_common/sanitizer_common.h"
+#include "gtest/gtest.h"
+
+TEST(ModuleUUID, kModuleUUIDSize) {
+#if SANITIZER_APPLE
+    EXPECT_EQ(__sanitizer::kModuleUUIDSize, 16ULL);
+#else
+    EXPECT_EQ(__sanitizer::kModuleUUIDSize, 32ULL);
+#endif
+}


### PR DESCRIPTION
https://reviews.llvm.org/D114294 changed the kModuleUUIDSize from 16 to 32 for all platforms. This is not true for Darwin where the UUID is 16 bytes.

Differential Revision: https://reviews.llvm.org/D152309 rdar://110346025