### PR TITLE
[Sanitizers] Remove BuildId from sanitizers stacktrace on Darwin

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_printer.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_printer.cpp
@@ -198,7 +198,9 @@ void RenderFrame(InternalScopedString *buffer, const char *format, int frame_no,
         RenderModuleLocation(buffer, info->module, info->module_offset,
                              info->module_arch, strip_path_prefix);
 
+#if !SANITIZER_APPLE
         MaybeBuildIdToBuffer(*info, /*PrefixSpace=*/true, buffer);
+#endif
       } else {
         buffer->append("(<unknown module>)");
       }
@@ -211,7 +213,9 @@ void RenderFrame(InternalScopedString *buffer, const char *format, int frame_no,
         // Always strip the module name for %M.
         RenderModuleLocation(buffer, StripModuleName(info->module),
                              info->module_offset, info->module_arch, "");
+#if !SANITIZER_APPLE
         MaybeBuildIdToBuffer(*info, /*PrefixSpace=*/true, buffer);
+#endif
       } else {
         buffer->append("(%p)", (void *)address);
       }

--- a/compiler-rt/lib/sanitizer_common/tests/sanitizer_stacktrace_printer_test.cpp
+++ b/compiler-rt/lib/sanitizer_common/tests/sanitizer_stacktrace_printer_test.cpp
@@ -123,11 +123,19 @@ TEST(SanitizerStacktracePrinter, RenderFrame) {
   RenderFrame(&str, "%M", frame_no, info.address, &info, false);
   EXPECT_NE(nullptr, internal_strstr(str.data(), "(module+0x"));
   EXPECT_NE(nullptr, internal_strstr(str.data(), "200"));
+#if SANITIZER_APPLE
+  EXPECT_EQ(nullptr, internal_strstr(str.data(), "BuildId: 5566"));
+#else
   EXPECT_NE(nullptr, internal_strstr(str.data(), "BuildId: 5566"));
+#endif
   str.clear();
 
   RenderFrame(&str, "%L", frame_no, info.address, &info, false);
+#if SANITIZER_APPLE
+  EXPECT_STREQ("(/path/to/module+0x200)", str.data());
+#else
   EXPECT_STREQ("(/path/to/module+0x200) (BuildId: 5566)", str.data());
+#endif
   str.clear();
 
   RenderFrame(&str, "%b", frame_no, info.address, &info, false);


### PR DESCRIPTION
On Darwin, we do not want to show the BuildId appended at the end of stack frames in Sanitizers. The BuildId/UUID can be seen by using the print_module_map=1 sanitizer option.

Differential Revision: https://reviews.llvm.org/D150298

rdar://108324403