### PR TITLE
[Index] Fix clang-index scan-deps-by-mod-name

### DIFF
--- a/clang/test/Index/Core/scan-deps-by-mod-name.m
+++ b/clang/test/Index/Core/scan-deps-by-mod-name.m
@@ -27,4 +27,5 @@
 // CHECK-NEXT:     module-deps:
 // CHECK-NEXT:       ModA:[[HASH_MOD_A]]
 // CHECK-NEXT:     file-deps:
+// CHECK-NEXT:       {{.*}}ModA-{{.*}}.input
 // CHECK-NEXT:     build-args: -cc1 {{.*}} -fmodule-file={{(ModA=)?}}{{.*}}ModA_{{.*}}.pcm


### PR DESCRIPTION
rdar://109477437
(cherry picked from commit 9f77c5e83061e8dff7527eebb17aed2db06e8730)