### PR TITLE
Avoid spurious import fixits in the REPL

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1691,11 +1691,13 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
         parsed_expr.takeError(),
         [&](const ModuleImportError &MIE) {
           diagnostic_manager.PutString(eDiagnosticSeverityError, MIE.message());
-          // There are no fallback contexts in REPL and playgrounds.
-          if (repl || playground || MIE.is_new_dylib) {
+          if (MIE.is_new_dylib) {
             retry = true;
             return;
           }
+          // There are no fallback contexts in REPL and playgrounds.
+          if (repl || playground)
+            return;
           if (!m_sc.target_sp->UseScratchTypesystemPerModule()) {
             // This, together with the fatal error forces
             // a per-module scratch to be instantiated on

--- a/lldb/test/Shell/SwiftREPL/ImportError.test
+++ b/lldb/test/Shell/SwiftREPL/ImportError.test
@@ -5,3 +5,4 @@
 
 import ModuleThatDoesNotExist
 // CHECK: error: no such module 'ModuleThatDoesNotExist'
+// CHECK-NOT: fixed expression suggested


### PR DESCRIPTION
There is no point in invoking the per-module fallback and import retry mechanism inside the repl.

rdar://110492710