### PR TITLE
Streamline expression parser error messages.

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -341,11 +341,10 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
       std::string msg;
       {
         llvm::raw_string_ostream os(msg);
-        os << "expression failed to parse:\n";
         if (!diagnostic_manager.Diagnostics().empty())
           os << diagnostic_manager.GetString();
         else
-          os << "unknown error";
+          os << "expression failed to parse (no further compiler diagnostics)";
         if (target->GetEnableNotifyAboutFixIts() && fixed_expression &&
             !fixed_expression->empty())
           os << "\nfixed expression suggested:\n  " << *fixed_expression;

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -101,7 +101,10 @@ void CommandReturnObject::AppendError(llvm::StringRef in_string) {
   SetStatus(eReturnStatusFailed);
   if (in_string.empty())
     return;
-  error(GetErrorStream()) << in_string.rtrim() << '\n';
+  // Workaround to deal with already fully formatted compiler diagnostics.
+  llvm::StringRef msg(in_string.rtrim());
+  msg.consume_front("error: ");
+  error(GetErrorStream()) << msg << '\n';
 }
 
 void CommandReturnObject::SetError(const Status &error,

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -98,8 +98,8 @@ class ExprDiagnosticsTestCase(TestBase):
         value = frame.EvaluateExpression("struct Redef { double x; };", top_level_opts)
         value = frame.EvaluateExpression("struct Redef { float y; };", top_level_opts)
         self.assertFalse(value.GetError().Success())
-        self.assertIn(
-            "error: <user expression 9>:1:8: redefinition of 'Redef'\nstruct Redef { float y; };\n       ^\n<user expression 8>:1:8: previous definition is here\nstruct Redef { double x; };\n       ^",
+        self.assertIn(            
+            "error: <user expression 9>:1:8: redefinition of 'Redef'\nstruct Redef { float y; };\n       ^\n<user expression 8>:1:8: previous definition is here\nstruct Redef { double x; };\n       ^\n\n",
             value.GetError().GetCString(),
         )
 

--- a/lldb/test/API/commands/expression/fixits/TestFixIts.py
+++ b/lldb/test/API/commands/expression/fixits/TestFixIts.py
@@ -154,7 +154,6 @@ class ExprCommandWithFixits(TestBase):
         multiple_runs_options.SetRetriesWithFixIts(0)
         value = frame.EvaluateExpression(two_runs_expr, multiple_runs_options)
         errmsg = value.GetError().GetCString()
-        self.assertIn("expression failed to parse", errmsg)
         self.assertIn("using declaration resolved to type without 'typename'", errmsg)
         self.assertIn("fixed expression suggested:", errmsg)
         self.assertIn("using typename T::TypeDef", errmsg)
@@ -166,7 +165,6 @@ class ExprCommandWithFixits(TestBase):
         multiple_runs_options.SetRetriesWithFixIts(1)
         value = frame.EvaluateExpression(two_runs_expr, multiple_runs_options)
         errmsg = value.GetError().GetCString()
-        self.assertIn("expression failed to parse", errmsg)
         self.assertIn("fixed expression suggested:", errmsg)
         # Both our fixed expressions should be in the suggested expression.
         self.assertIn("using typename T::TypeDef", errmsg)


### PR DESCRIPTION
Currently the expression parser prints a mostly useless generic error before printing the compiler error:

  (lldb) p 1+x)
  error: expression failed to parse:
  error: <user expression 18>:1:3: use of undeclared identifier 'x'
  1+x)
     ^

This is distracting and as far as I can tell only exists to work around the fact that the first "error: " is unconditionally injected by CommandReturnObject. The solution is not very elegant, but the result looks much better.

(Partially addresses rdar://110492710)

Differential Revision: https://reviews.llvm.org/D152590

(cherry picked from commit 133c3eaac0a532380c3d6ad21a60da1490f51fb8)