### PR TITLE
Revert "rebranch: temporarily disable deprecation warnings for `Optional` in swift sources"

### DIFF
--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -92,10 +92,7 @@ public:
   }
 
   constexpr bool has_value() const noexcept { return hasVal; }
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
   LLVM_DEPRECATED("Use has_value instead.", "has_value")
-#endif
   constexpr bool hasValue() const noexcept {
     return hasVal;
   }
@@ -314,28 +311,18 @@ public:
   constexpr const T *getPointer() const { return &Storage.value(); }
   T *getPointer() { return &Storage.value(); }
   constexpr const T &value() const & { return Storage.value(); }
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
   LLVM_DEPRECATED("Use value instead.", "value")
-#endif
   constexpr const T &getValue() const & {
     return Storage.value();
   }
   T &value() & { return Storage.value(); }
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
-  LLVM_DEPRECATED("Use value instead.", "value")
-#endif
-  T &getValue() & {
+  LLVM_DEPRECATED("Use value instead.", "value") T &getValue() & {
     return Storage.value();
   }
 
   constexpr explicit operator bool() const { return has_value(); }
   constexpr bool has_value() const { return Storage.has_value(); }
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
   LLVM_DEPRECATED("Use has_value instead.", "has_value")
-#endif
   constexpr bool hasValue() const {
     return Storage.has_value();
   }
@@ -348,10 +335,7 @@ public:
     return has_value() ? value() : std::forward<U>(alt);
   }
   template <typename U>
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
   LLVM_DEPRECATED("Use value_or instead.", "value_or")
-#endif
   constexpr T getValueOr(U &&alt) const & {
     return has_value() ? value() : std::forward<U>(alt);
   }
@@ -372,11 +356,7 @@ public:
   }
 
   T &&value() && { return std::move(Storage.value()); }
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
-  LLVM_DEPRECATED("Use value instead.", "value")
-#endif
-  T &&getValue() && {
+  LLVM_DEPRECATED("Use value instead.", "value") T &&getValue() && {
     return std::move(Storage.value());
   }
   T &&operator*() && { return std::move(Storage.value()); }
@@ -385,10 +365,7 @@ public:
     return has_value() ? std::move(value()) : std::forward<U>(alt);
   }
   template <typename U>
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
   LLVM_DEPRECATED("Use value_or instead.", "value_or")
-#endif
   T getValueOr(U &&alt) && {
     return has_value() ? std::move(value()) : std::forward<U>(alt);
   }
@@ -402,10 +379,7 @@ public:
     return None;
   }
   template <class Function>
-// Workaround to avoid deprecation warnings: rdar://102362022
-#ifndef SWIFT_LLVM_SUPPORT_IS_AVAILABLE
   LLVM_DEPRECATED("Use transform instead.", "transform")
-#endif
   auto map(const Function &F)
       && -> Optional<decltype(F(std::move(*this).value()))> {
     if (*this)


### PR DESCRIPTION
This reverts commit 4d1b0b474398ce3cc35a7c49743ffb2810c49b25.

The next rebranch will see the replacement of all `llvm::Optional` APIs with `std::optional`. As such, we actually want deprecation warnings to show up if folks are trying to use the `llvm::Optional` APIs.