### PR TITLE
[CASOption] clang CASOption improvements

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -8,14 +8,8 @@
 
 let Component = "CAS" in {
 
-def err_builtin_cas_cannot_be_initialized : Error<
-  "CAS cannot be initialized from '%0' on disk (check -fcas-path): %1">,
-  DefaultFatal;
-def err_plugin_cas_cannot_be_initialized : Error<
-  "plugin CAS cannot be initialized from '%0': %1">,
-  DefaultFatal;
-def err_builtin_actioncache_cannot_be_initialized : Error<
-  "ActionCache cannot be initialized from '%0' on disk (check -fcas-path)">,
+def err_cas_cannot_be_initialized : Error<
+  "CAS cannot be initialized from the specified '-fcas-*' options: %0">,
   DefaultFatal;
 def err_cas_cannot_parse_root_id : Error<
   "CAS cannot parse root-id '%0' specified by -fcas-fs">, DefaultFatal;

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -15,6 +15,7 @@
 #define LLVM_CLANG_CAS_CASOPTIONS_H
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Error.h"
 #include <string>
 #include <vector>
 
@@ -63,7 +64,8 @@ public:
 
   friend bool operator==(const CASConfiguration &LHS,
                          const CASConfiguration &RHS) {
-    return LHS.CASPath == RHS.CASPath;
+    return LHS.CASPath == RHS.CASPath && LHS.PluginPath == RHS.PluginPath &&
+           LHS.PluginOptions == RHS.PluginOptions;
   }
   friend bool operator!=(const CASConfiguration &LHS,
                          const CASConfiguration &RHS) {
@@ -101,6 +103,10 @@ public:
   getOrCreateDatabases(DiagnosticsEngine &Diags,
                        bool CreateEmptyDBsOnFailure = false) const;
 
+  llvm::Expected<std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+                           std::shared_ptr<llvm::cas::ActionCache>>>
+  getOrCreateDatabases() const;
+
   /// Freeze CAS Configuration. Future calls will return the same
   /// CAS instance, even if the configuration changes again later.
   ///
@@ -116,7 +122,7 @@ public:
 
 private:
   /// Initialize Cached CAS and ActionCache.
-  void initCache(DiagnosticsEngine &Diags) const;
+  llvm::Error initCache() const;
 
   struct CachedCAS {
     /// A cached CAS instance.

--- a/clang/test/CAS/plugin-cas.c
+++ b/clang/test/CAS/plugin-cas.c
@@ -48,11 +48,11 @@
 // RUN:   -cc1 %s -fcas-path %t/cas \
 // RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option no-such-option=2 2>&1 | FileCheck %s --check-prefix=FAIL-PLUGIN-OPT
-// FAIL-PLUGIN-OPT: fatal error: plugin CAS cannot be initialized {{.*}}: unknown option: no-such-option
+// FAIL-PLUGIN-OPT: fatal error: CAS cannot be initialized from the specified '-fcas-*' options: unknown option: no-such-option
 
 // RUN: not %clang -cc1depscan -o %t/t.rsp -fdepscan=inline -cc1-args \
 // RUN:   -cc1 %s -fcas-path %t/cas -fcas-plugin-path %t/non-existent 2>&1 | FileCheck %s --check-prefix=NOTEXISTENT
-// NOTEXISTENT: fatal error: plugin CAS cannot be initialized
+// NOTEXISTENT: fatal error: CAS cannot be initialized from the specified '-fcas-*' options
 
 #warning some warning
 void test() {}

--- a/clang/unittests/CAS/CASOptionsTest.cpp
+++ b/clang/unittests/CAS/CASOptionsTest.cpp
@@ -153,4 +153,30 @@ TEST(CASOptionsTest, freezeConfig) {
   EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 }
 
+TEST(CASOptionsTest, equal) {
+  CASOptions Opt1, Opt2;
+  ASSERT_TRUE(Opt1 == Opt2);
+
+  Opt1.CASPath = "some/path";
+  Opt2.CASPath = "some/path";
+  ASSERT_TRUE(Opt1 == Opt2);
+  Opt2.CASPath = "other/path";
+  ASSERT_TRUE(Opt1 != Opt2);
+
+  Opt1.CASPath.clear();
+  Opt1.PluginPath = "plugin/path";
+  ASSERT_TRUE(Opt1 != Opt2);
+  Opt2.CASPath.clear();
+  ASSERT_TRUE(Opt1 != Opt2);
+  Opt2.PluginPath = "plugin/path2";
+  ASSERT_TRUE(Opt1 != Opt2);
+  Opt2.PluginPath = "plugin/path";
+  ASSERT_TRUE(Opt1 == Opt2);
+
+  Opt1.PluginOptions.emplace_back("key", "value");
+  ASSERT_TRUE(Opt1 != Opt2);
+  Opt2.PluginOptions.emplace_back("key", "value");
+  ASSERT_TRUE(Opt1 == Opt2);
+}
+
 } // end namespace


### PR DESCRIPTION
This addresses two issues in clang::CASOptions:
* The equality comparison is wrong when plugin is used.
* You need a clang diagnostics to create ObjectStore/ActionCache from CASOptions