### PR TITLE
[lit] Avoid os.path.realpath in lit.py due to MAX_PATH limitations on…

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -70,7 +70,7 @@ class ShellEnvironment(object):
         if os.path.isabs(newdir):
             self.cwd = newdir
         else:
-            self.cwd = os.path.realpath(os.path.join(self.cwd, newdir))
+            self.cwd = os.path.abspath(os.path.join(self.cwd, newdir))
 
 class TimeoutHelper(object):
     """
@@ -401,7 +401,7 @@ def executeBuiltinMkdir(cmd, cmd_shenv):
         dir = to_unicode(dir) if kIsWindows else to_bytes(dir)
         cwd = to_unicode(cwd) if kIsWindows else to_bytes(cwd)
         if not os.path.isabs(dir):
-            dir = os.path.realpath(os.path.join(cwd, dir))
+            dir = os.path.abspath(os.path.join(cwd, dir))
         if parent:
             lit.util.mkdir_p(dir)
         else:
@@ -446,7 +446,7 @@ def executeBuiltinRm(cmd, cmd_shenv):
         path = to_unicode(path) if kIsWindows else to_bytes(path)
         cwd = to_unicode(cwd) if kIsWindows else to_bytes(cwd)
         if not os.path.isabs(path):
-            path = os.path.realpath(os.path.join(cwd, path))
+            path = os.path.abspath(os.path.join(cwd, path))
         if force and not os.path.exists(path):
             continue
         try:

--- a/llvm/utils/lit/lit/builtin_commands/diff.py
+++ b/llvm/utils/lit/lit/builtin_commands/diff.py
@@ -229,7 +229,7 @@ def main(argv):
     try:
         for file in args:
             if file != "-" and not os.path.isabs(file):
-                file = os.path.realpath(os.path.join(os.getcwd(), file))
+                file = os.path.abspath(os.path.join(os.getcwd(), file))
 
             if flags.recursive_diff:
                 if file == "-":

--- a/llvm/utils/lit/lit/discovery.py
+++ b/llvm/utils/lit/lit/discovery.py
@@ -52,8 +52,7 @@ def getTestSuite(item, litConfig, cache):
         # configuration to load instead.
         config_map = litConfig.params.get('config_map')
         if config_map:
-            cfgpath = os.path.realpath(cfgpath)
-            target = config_map.get(os.path.normcase(cfgpath))
+            target = config_map.get(os.path.normcase(os.path.abspath(cfgpath)))
             if target:
                 cfgpath = target
 
@@ -63,16 +62,16 @@ def getTestSuite(item, litConfig, cache):
 
         cfg = TestingConfig.fromdefaults(litConfig)
         cfg.load_from_path(cfgpath, litConfig)
-        source_root = os.path.realpath(cfg.test_source_root or path)
-        exec_root = os.path.realpath(cfg.test_exec_root or path)
+        source_root = os.path.abspath(cfg.test_source_root or path)
+        exec_root = os.path.abspath(cfg.test_exec_root or path)
         return Test.TestSuite(cfg.name, source_root, exec_root, cfg), ()
 
     def search(path):
         # Check for an already instantiated test suite.
-        real_path = os.path.realpath(path)
-        res = cache.get(real_path)
+        full_path = os.path.normcase(os.path.abspath(path))
+        res = cache.get(full_path)
         if res is None:
-            cache[real_path] = res = search1(path)
+            cache[full_path] = res = search1(path)
         return res
 
     # Canonicalize the path.

--- a/llvm/utils/lit/tests/Inputs/config-map-discovery/driver.py
+++ b/llvm/utils/lit/tests/Inputs/config-map-discovery/driver.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 main_config = sys.argv[1]
-main_config = os.path.realpath(main_config)
+main_config = os.path.abspath(main_config)
 main_config = os.path.normcase(main_config)
 
 config_map = {main_config : sys.argv[2]}

--- a/llvm/utils/lit/tests/Inputs/config-map-discovery/lit.alt.cfg
+++ b/llvm/utils/lit/tests/Inputs/config-map-discovery/lit.alt.cfg
@@ -5,5 +5,5 @@ config.suffixes = ['.txt']
 config.test_format = lit.formats.ShTest()
 
 import os
-config.test_exec_root = os.path.realpath(os.path.dirname(__file__))
+config.test_exec_root = os.path.abspath(os.path.dirname(__file__))
 config.test_source_root = os.path.join(config.test_exec_root, "tests")

--- a/llvm/utils/lit/tests/Inputs/use-llvm-tool-required/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/use-llvm-tool-required/lit.cfg
@@ -5,7 +5,8 @@ config.test_format = lit.formats.ShTest()
 config.test_source_root = None
 config.test_exec_root = None
 import os.path
-config.llvm_tools_dir = os.path.realpath(os.path.dirname(__file__))
+
+config.llvm_tools_dir = os.path.abspath(os.path.dirname(__file__))
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
 lit.llvm.llvm_config.use_llvm_tool('found', required=True)

--- a/llvm/utils/lit/tests/Inputs/use-llvm-tool/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/use-llvm-tool/lit.cfg
@@ -5,8 +5,9 @@ config.test_format = lit.formats.ShTest()
 config.test_source_root = None
 config.test_exec_root = None
 import os.path
-this_dir = os.path.realpath(os.path.dirname(__file__))
-config.llvm_tools_dir = os.path.join(this_dir, 'build')
+
+this_dir = os.path.abspath(os.path.dirname(__file__))
+config.llvm_tools_dir = os.path.join(this_dir, "build")
 import lit.llvm
 lit.llvm.initialize(lit_config, config)
 lit.llvm.llvm_config.with_environment('CASE1', os.path.join(this_dir, 'env-case1'))


### PR DESCRIPTION
… Windows

lit.py uses os.path.realpath on file paths. Somewhere between Python 3.7 and 3.9, os.path.realpath was updated to resolve substitute drives on Windows (subst S: C:\Long\Path\To\My\Code). This is a problem because it prevents using substitute drives to work around MAX_PATH path length limitations on Windows.

We run into this while building & testing, the Swift compiler on Windows, which uses a substitute drive in CI to shorten the workspace directory. cmake builds without resolving the substitute drive and can apply its logic to avoid output files exceeding MAX_PATH. However, when running tests, lit.py's use of os.path.realpath will resolve the substitute drive (with newer Python versions), resulting in some paths being longer than MAX_PATH, which cause all kinds of failures (for example rd in tests fails, or link.exe fails, etc).

How tested: Ran check-all, and lit tests, saw no failures
```
> ninja -C build check-all
Testing Time: 262.63s
  Skipped          :    24
  Unsupported      :  2074
  Passed           : 51812
  Expectedly Failed:   167

> python utils\lit\lit.py --path ..\build\bin utils\lit\tests
Testing Time: 12.17s
  Unsupported:  6
  Passed     : 47
```

Patch by Tristan Labelle!

Differential Revision: https://reviews.llvm.org/D152709
Reviewed By: rnk, compnerd