### PR TITLE
[lldb] Have crashlog warn when remapped paths are inaccessible.

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Be sure to add the python path that points to the LLDB shared library.
 #
 # To use this in the embedded python interpreter using "lldb":
@@ -24,7 +24,7 @@
 #
 # On MacOSX sh, bash:
 #   PYTHONPATH=/path/to/LLDB.framework/Resources/Python ./crashlog.py ~/Library/Logs/DiagnosticReports/a.crash
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 import abc
 import concurrent.futures
@@ -53,7 +53,9 @@ try:
 except ImportError:
     # Ask the command line driver for the path to the lldb module. Copy over
     # the environment so that SDKROOT is propagated to xcrun.
-    command =  ['xcrun', 'lldb', '-P'] if platform.system() == 'Darwin' else ['lldb', '-P']
+    command = (
+        ["xcrun", "lldb", "-P"] if platform.system() == "Darwin" else ["lldb", "-P"]
+    )
     # Extend the PYTHONPATH if the path exists and isn't already there.
     lldb_python_path = subprocess.check_output(command).decode("utf-8").strip()
     if os.path.exists(lldb_python_path) and not sys.path.__contains__(lldb_python_path):
@@ -62,16 +64,20 @@ except ImportError:
     try:
         import lldb
     except ImportError:
-        print("error: couldn't locate the 'lldb' module, please set PYTHONPATH correctly")
+        print(
+            "error: couldn't locate the 'lldb' module, please set PYTHONPATH correctly"
+        )
         sys.exit(1)
 
 from lldb.utils import symbolication
+
 
 def read_plist(s):
     if sys.version_info.major == 3:
         return plistlib.loads(s)
     else:
         return plistlib.readPlistFromString(s)
+
 
 class CrashLog(symbolication.Symbolicator):
     class Thread:
@@ -92,13 +98,16 @@ class CrashLog(symbolication.Symbolicator):
 
         def dump(self, prefix):
             if self.app_specific_backtrace:
-                print("%Application Specific Backtrace[%u] %s" % (prefix, self.index, self.reason))
+                print(
+                    "%Application Specific Backtrace[%u] %s"
+                    % (prefix, self.index, self.reason)
+                )
             else:
                 print("%sThread[%u] %s" % (prefix, self.index, self.reason))
             if self.frames:
                 print("%s  Frames:" % (prefix))
                 for frame in self.frames:
-                    frame.dump(prefix + '    ')
+                    frame.dump(prefix + "    ")
             if self.registers:
                 print("%s  Registers:" % (prefix))
                 for reg in self.registers.keys():
@@ -115,37 +124,59 @@ class CrashLog(symbolication.Symbolicator):
             display_frame_idx = -1
             for frame_idx, frame in enumerate(self.frames):
                 disassemble = (
-                    this_thread_crashed or options.disassemble_all_threads) and frame_idx < options.disassemble_depth
+                    this_thread_crashed or options.disassemble_all_threads
+                ) and frame_idx < options.disassemble_depth
 
                 # Except for the zeroth frame, we should subtract 1 from every
                 # frame pc to get the previous line entry.
                 pc = frame.pc & crash_log.addr_mask
                 pc = pc if frame_idx == 0 or pc == 0 else pc - 1
-                symbolicated_frame_addresses = crash_log.symbolicate(pc, options.verbose)
+                symbolicated_frame_addresses = crash_log.symbolicate(
+                    pc, options.verbose
+                )
 
                 if symbolicated_frame_addresses:
                     symbolicated_frame_address_idx = 0
                     for symbolicated_frame_address in symbolicated_frame_addresses:
                         display_frame_idx += 1
-                        print('[%3u] %s' % (frame_idx, symbolicated_frame_address))
-                        if (options.source_all or self.did_crash(
-                        )) and display_frame_idx < options.source_frames and options.source_context:
+                        print("[%3u] %s" % (frame_idx, symbolicated_frame_address))
+                        if (
+                            (options.source_all or self.did_crash())
+                            and display_frame_idx < options.source_frames
+                            and options.source_context
+                        ):
                             source_context = options.source_context
-                            line_entry = symbolicated_frame_address.get_symbol_context().line_entry
+                            line_entry = (
+                                symbolicated_frame_address.get_symbol_context().line_entry
+                            )
                             if line_entry.IsValid():
                                 strm = lldb.SBStream()
                                 if line_entry:
                                     crash_log.debugger.GetSourceManager().DisplaySourceLinesWithLineNumbers(
-                                        line_entry.file, line_entry.line, source_context, source_context, "->", strm)
+                                        line_entry.file,
+                                        line_entry.line,
+                                        source_context,
+                                        source_context,
+                                        "->",
+                                        strm,
+                                    )
                                 source_text = strm.GetData()
                                 if source_text:
                                     # Indent the source a bit
-                                    indent_str = '    '
-                                    join_str = '\n' + indent_str
-                                    print('%s%s' % (indent_str, join_str.join(source_text.split('\n'))))
+                                    indent_str = "    "
+                                    join_str = "\n" + indent_str
+                                    print(
+                                        "%s%s"
+                                        % (
+                                            indent_str,
+                                            join_str.join(source_text.split("\n")),
+                                        )
+                                    )
                         if symbolicated_frame_address_idx == 0:
                             if disassemble:
-                                instructions = symbolicated_frame_address.get_instructions()
+                                instructions = (
+                                    symbolicated_frame_address.get_instructions()
+                                )
                                 if instructions:
                                     print()
                                     symbolication.disassemble_instructions(
@@ -154,7 +185,8 @@ class CrashLog(symbolication.Symbolicator):
                                         frame.pc,
                                         options.disassemble_before,
                                         options.disassemble_after,
-                                        frame.index > 0)
+                                        frame.index > 0,
+                                    )
                                     print()
                         symbolicated_frame_address_idx += 1
                 else:
@@ -164,8 +196,8 @@ class CrashLog(symbolication.Symbolicator):
                 for reg in self.registers.keys():
                     print("    %-8s = %#16.16x" % (reg, self.registers[reg]))
             elif self.crashed:
-               print()
-               print("No thread state (register information) available")
+                print()
+                print("No thread state (register information) available")
 
         def add_ident(self, ident):
             if ident not in self.idents:
@@ -180,7 +212,7 @@ class CrashLog(symbolication.Symbolicator):
             else:
                 s = "Thread[%u]" % self.index
             if self.reason:
-                s += ' %s' % self.reason
+                s += " %s" % self.reason
             return s
 
     class Frame:
@@ -193,8 +225,7 @@ class CrashLog(symbolication.Symbolicator):
 
         def __str__(self):
             if self.description:
-                return "[%3u] 0x%16.16x %s" % (
-                    self.index, self.pc, self.description)
+                return "[%3u] 0x%16.16x %s" % (self.index, self.pc, self.description)
             else:
                 return "[%3u] 0x%16.16x" % (self.index, self.pc)
 
@@ -203,32 +234,27 @@ class CrashLog(symbolication.Symbolicator):
 
     class DarwinImage(symbolication.Image):
         """Class that represents a binary images in a darwin crash log"""
-        dsymForUUIDBinary = '/usr/local/bin/dsymForUUID'
+
+        dsymForUUIDBinary = "/usr/local/bin/dsymForUUID"
         if not os.path.exists(dsymForUUIDBinary):
             try:
-                dsymForUUIDBinary = subprocess.check_output('which dsymForUUID',
-                                                            shell=True).decode("utf-8").rstrip('\n')
+                dsymForUUIDBinary = (
+                    subprocess.check_output("which dsymForUUID", shell=True)
+                    .decode("utf-8")
+                    .rstrip("\n")
+                )
             except:
                 dsymForUUIDBinary = ""
 
-        dwarfdump_uuid_regex = re.compile(
-            'UUID: ([-0-9a-fA-F]+) \(([^\(]+)\) .*')
+        dwarfdump_uuid_regex = re.compile("UUID: ([-0-9a-fA-F]+) \(([^\(]+)\) .*")
 
         def __init__(
-                self,
-                text_addr_lo,
-                text_addr_hi,
-                identifier,
-                version,
-                uuid,
-                path,
-                verbose):
+            self, text_addr_lo, text_addr_hi, identifier, version, uuid, path, verbose
+        ):
             symbolication.Image.__init__(self, path, uuid)
             self.add_section(
-                symbolication.Section(
-                    text_addr_lo,
-                    text_addr_hi,
-                    "__TEXT"))
+                symbolication.Section(text_addr_lo, text_addr_hi, "__TEXT")
+            )
             self.identifier = identifier
             self.version = version
             self.verbose = verbose
@@ -239,13 +265,15 @@ class CrashLog(symbolication.Symbolicator):
             """
             if self.verbose:
                 return True
-            return not (self.path.startswith("/System/Library/") or
-                        self.path.startswith("/usr/lib/"))
-
+            return not (
+                self.path.startswith("/System/Library/")
+                or self.path.startswith("/usr/lib/")
+            )
 
         def find_matching_slice(self):
             dwarfdump_cmd_output = subprocess.check_output(
-                'dwarfdump --uuid "%s"' % self.path, shell=True).decode("utf-8")
+                'dwarfdump --uuid "%s"' % self.path, shell=True
+            ).decode("utf-8")
             self_uuid = self.get_uuid()
             for line in dwarfdump_cmd_output.splitlines():
                 match = self.dwarfdump_uuid_regex.search(line)
@@ -259,8 +287,12 @@ class CrashLog(symbolication.Symbolicator):
             if not self.resolved_path:
                 self.unavailable = True
                 if self.show_symbol_progress():
-                    print(("error\n    error: unable to locate '%s' with UUID %s"
-                           % (self.path, self.get_normalized_uuid_string())))
+                    print(
+                        (
+                            "error\n    error: unable to locate '%s' with UUID %s"
+                            % (self.path, self.get_normalized_uuid_string())
+                        )
+                    )
                 return False
 
         def locate_module_and_debug_symbols(self):
@@ -272,41 +304,54 @@ class CrashLog(symbolication.Symbolicator):
             uuid_str = self.get_normalized_uuid_string()
             if self.show_symbol_progress():
                 with print_lock:
-                    print('Getting symbols for %s %s...' % (uuid_str, self.path))
+                    print("Getting symbols for %s %s..." % (uuid_str, self.path))
             if os.path.exists(self.dsymForUUIDBinary):
-                dsym_for_uuid_command = '%s %s' % (
-                    self.dsymForUUIDBinary, uuid_str)
+                dsym_for_uuid_command = "%s %s" % (self.dsymForUUIDBinary, uuid_str)
                 s = subprocess.check_output(dsym_for_uuid_command, shell=True)
                 if s:
                     try:
                         plist_root = read_plist(s)
                     except:
                         with print_lock:
-                            print(("Got exception: ", sys.exc_info()[1], " handling dsymForUUID output: \n", s))
+                            print(
+                                (
+                                    "Got exception: ",
+                                    sys.exc_info()[1],
+                                    " handling dsymForUUID output: \n",
+                                    s,
+                                )
+                            )
                         raise
                     if plist_root:
                         plist = plist_root[uuid_str]
                         if plist:
-                            if 'DBGArchitecture' in plist:
-                                self.arch = plist['DBGArchitecture']
-                            if 'DBGDSYMPath' in plist:
-                                self.symfile = os.path.realpath(
-                                    plist['DBGDSYMPath'])
-                            if 'DBGSymbolRichExecutable' in plist:
+                            if "DBGArchitecture" in plist:
+                                self.arch = plist["DBGArchitecture"]
+                            if "DBGDSYMPath" in plist:
+                                self.symfile = os.path.realpath(plist["DBGDSYMPath"])
+                            if "DBGSymbolRichExecutable" in plist:
                                 self.path = os.path.expanduser(
-                                    plist['DBGSymbolRichExecutable'])
+                                    plist["DBGSymbolRichExecutable"]
+                                )
                                 self.resolved_path = self.path
             if not self.resolved_path and os.path.exists(self.path):
                 if not self.find_matching_slice():
                     return False
             if not self.resolved_path and not os.path.exists(self.path):
                 try:
-                    mdfind_results = subprocess.check_output(
-                        ["/usr/bin/mdfind",
-                         "com_apple_xcode_dsym_uuids == %s" % uuid_str]).decode("utf-8").splitlines()
+                    mdfind_results = (
+                        subprocess.check_output(
+                            [
+                                "/usr/bin/mdfind",
+                                "com_apple_xcode_dsym_uuids == %s" % uuid_str,
+                            ]
+                        )
+                        .decode("utf-8")
+                        .splitlines()
+                    )
                     found_matching_slice = False
                     for dsym in mdfind_results:
-                        dwarf_dir = os.path.join(dsym, 'Contents/Resources/DWARF')
+                        dwarf_dir = os.path.join(dsym, "Contents/Resources/DWARF")
                         if not os.path.exists(dwarf_dir):
                             # Not a dSYM bundle, probably an Xcode archive.
                             continue
@@ -314,18 +359,19 @@ class CrashLog(symbolication.Symbolicator):
                             print('falling back to binary inside "%s"' % dsym)
                         self.symfile = dsym
                         for filename in os.listdir(dwarf_dir):
-                           self.path = os.path.join(dwarf_dir, filename)
-                           if self.find_matching_slice():
-                              found_matching_slice = True
-                              break
+                            self.path = os.path.join(dwarf_dir, filename)
+                            if self.find_matching_slice():
+                                found_matching_slice = True
+                                break
                         if found_matching_slice:
-                           break
+                            break
                 except:
                     pass
             if (self.resolved_path and os.path.exists(self.resolved_path)) or (
-                    self.path and os.path.exists(self.path)):
+                self.path and os.path.exists(self.path)
+            ):
                 with print_lock:
-                    print('Resolved symbols for %s %s...' % (uuid_str, self.path))
+                    print("Resolved symbols for %s %s..." % (uuid_str, self.path))
                 return True
             else:
                 self.unavailable = True
@@ -339,7 +385,9 @@ class CrashLog(symbolication.Symbolicator):
         self.system_profile = list()
         self.threads = list()
         self.backtraces = list()  # For application specific backtraces
-        self.idents = list()  # A list of the required identifiers for doing all stack backtraces
+        self.idents = (
+            list()
+        )  # A list of the required identifiers for doing all stack backtraces
         self.errors = list()
         self.exception = dict()
         self.crashed_thread_idx = -1
@@ -352,13 +400,13 @@ class CrashLog(symbolication.Symbolicator):
         if self.backtraces:
             print("\nApplication Specific Backtraces:")
             for thread in self.backtraces:
-                thread.dump('  ')
+                thread.dump("  ")
         print("\nThreads:")
         for thread in self.threads:
-            thread.dump('  ')
+            thread.dump("  ")
         print("\nImages:")
         for image in self.images:
-            image.dump('  ')
+            image.dump("  ")
 
     def set_main_image(self, identifier):
         for i, image in enumerate(self.images):
@@ -370,7 +418,7 @@ class CrashLog(symbolication.Symbolicator):
         for image in self.images:
             if image.identifier == identifier:
                 return image
-        regex_text = '^.*\.%s$' % (re.escape(identifier))
+        regex_text = "^.*\.%s$" % (re.escape(identifier))
         regex = re.compile(regex_text)
         for image in self.images:
             if regex.match(image.identifier):
@@ -384,7 +432,7 @@ class CrashLog(symbolication.Symbolicator):
                 return self.target
             # We weren't able to open the main executable as, but we can still
             # symbolicate
-            print('crashlog.create_target()...2')
+            print("crashlog.create_target()...2")
             if self.idents:
                 for ident in self.idents:
                     image = self.find_image_with_identifier(ident)
@@ -392,15 +440,17 @@ class CrashLog(symbolication.Symbolicator):
                         self.target = image.create_target(self.debugger)
                         if self.target:
                             return self.target  # success
-            print('crashlog.create_target()...3')
+            print("crashlog.create_target()...3")
             for image in self.images:
                 self.target = image.create_target(self.debugger)
                 if self.target:
                     return self.target  # success
-            print('crashlog.create_target()...4')
-            print('error: Unable to locate any executables from the crash log.')
-            print('       Try loading the executable into lldb before running crashlog')
-            print('       and/or make sure the .dSYM bundles can be found by Spotlight.')
+            print("crashlog.create_target()...4")
+            print("error: Unable to locate any executables from the crash log.")
+            print("       Try loading the executable into lldb before running crashlog")
+            print(
+                "       and/or make sure the .dSYM bundles can be found by Spotlight."
+            )
         return self.target
 
     def get_target(self):
@@ -414,8 +464,10 @@ class CrashLogFormatException(Exception):
 class CrashLogParseException(Exception):
     pass
 
+
 class InteractiveCrashLogException(Exception):
     pass
+
 
 class CrashLogParser:
     @staticmethod
@@ -447,10 +499,10 @@ class JSONCrashLogParser(CrashLogParser):
             except:
                 # The first line can contain meta data. Try stripping it and
                 # try again.
-                head, _, tail = buffer.partition('\n')
+                head, _, tail = buffer.partition("\n")
                 return json.loads(tail)
 
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             buffer = f.read()
         try:
             return parse_json(buffer)
@@ -465,84 +517,82 @@ class JSONCrashLogParser(CrashLogParser):
     def parse(self):
         try:
             self.parse_process_info(self.data)
-            self.parse_images(self.data['usedImages'])
+            self.parse_images(self.data["usedImages"])
             self.parse_main_image(self.data)
-            self.parse_threads(self.data['threads'])
-            if 'asi' in self.data:
-                self.crashlog.asi = self.data['asi']
-            if 'asiBacktraces' in self.data:
-                self.parse_app_specific_backtraces(self.data['asiBacktraces'])
-            if 'lastExceptionBacktrace' in self.data:
-                self.crashlog.asb = self.data['lastExceptionBacktrace']
+            self.parse_threads(self.data["threads"])
+            if "asi" in self.data:
+                self.crashlog.asi = self.data["asi"]
+            if "asiBacktraces" in self.data:
+                self.parse_app_specific_backtraces(self.data["asiBacktraces"])
+            if "lastExceptionBacktrace" in self.data:
+                self.crashlog.asb = self.data["lastExceptionBacktrace"]
             self.parse_errors(self.data)
             thread = self.crashlog.threads[self.crashlog.crashed_thread_idx]
-            reason = self.parse_crash_reason(self.data['exception'])
+            reason = self.parse_crash_reason(self.data["exception"])
             if thread.reason:
-                thread.reason = '{} {}'.format(thread.reason, reason)
+                thread.reason = "{} {}".format(thread.reason, reason)
             else:
                 thread.reason = reason
         except (KeyError, ValueError, TypeError) as e:
             raise CrashLogParseException(
-                'Failed to parse JSON crashlog: {}: {}'.format(
-                    type(e).__name__, e))
+                "Failed to parse JSON crashlog: {}: {}".format(type(e).__name__, e)
+            )
 
         return self.crashlog
 
     def get_used_image(self, idx):
-        return self.data['usedImages'][idx]
+        return self.data["usedImages"][idx]
 
     def parse_process_info(self, json_data):
-        self.crashlog.process_id = json_data['pid']
-        self.crashlog.process_identifier = json_data['procName']
+        self.crashlog.process_id = json_data["pid"]
+        self.crashlog.process_identifier = json_data["procName"]
 
     def parse_crash_reason(self, json_exception):
         self.crashlog.exception = json_exception
-        exception_type = json_exception['type']
+        exception_type = json_exception["type"]
         exception_signal = " "
-        if 'signal' in json_exception:
-            exception_signal += "({})".format(json_exception['signal'])
+        if "signal" in json_exception:
+            exception_signal += "({})".format(json_exception["signal"])
 
-        if 'codes' in json_exception:
-            exception_extra = " ({})".format(json_exception['codes'])
-        elif 'subtype' in json_exception:
-            exception_extra = " ({})".format(json_exception['subtype'])
+        if "codes" in json_exception:
+            exception_extra = " ({})".format(json_exception["codes"])
+        elif "subtype" in json_exception:
+            exception_extra = " ({})".format(json_exception["subtype"])
         else:
             exception_extra = ""
-        return "{}{}{}".format(exception_type, exception_signal,
-                                  exception_extra)
+        return "{}{}{}".format(exception_type, exception_signal, exception_extra)
 
     def parse_images(self, json_images):
         for json_image in json_images:
-            img_uuid = uuid.UUID(json_image['uuid'])
-            low = int(json_image['base'])
-            high = low + int(
-                json_image['size']) if 'size' in json_image else low
-            name = json_image['name'] if 'name' in json_image else ''
-            path = json_image['path'] if 'path' in json_image else ''
-            version = ''
-            darwin_image = self.crashlog.DarwinImage(low, high, name, version,
-                                                     img_uuid, path,
-                                                     self.verbose)
+            img_uuid = uuid.UUID(json_image["uuid"])
+            low = int(json_image["base"])
+            high = low + int(json_image["size"]) if "size" in json_image else low
+            name = json_image["name"] if "name" in json_image else ""
+            path = json_image["path"] if "path" in json_image else ""
+            version = ""
+            darwin_image = self.crashlog.DarwinImage(
+                low, high, name, version, img_uuid, path, self.verbose
+            )
             self.images.append(darwin_image)
             self.crashlog.images.append(darwin_image)
 
     def parse_main_image(self, json_data):
-        if 'procName' in json_data:
-            proc_name = json_data['procName']
+        if "procName" in json_data:
+            proc_name = json_data["procName"]
             self.crashlog.set_main_image(proc_name)
 
     def parse_frames(self, thread, json_frames):
         idx = 0
         for json_frame in json_frames:
-            image_id = int(json_frame['imageIndex'])
+            image_id = int(json_frame["imageIndex"])
             json_image = self.get_used_image(image_id)
-            ident = json_image['name'] if 'name' in json_image else ''
+            ident = json_image["name"] if "name" in json_image else ""
             thread.add_ident(ident)
             if ident not in self.crashlog.idents:
                 self.crashlog.idents.append(ident)
 
-            frame_offset = int(json_frame['imageOffset'])
-            image_addr = self.get_used_image(image_id)['base']
+            frame_offset = int(json_frame["imageOffset"])
+            image_addr = self.get_used_image(image_id)["base"]
             pc = image_addr + frame_offset
 
             if "symbol" in json_frame:
@@ -554,7 +604,7 @@ class JSONCrashLogParser(CrashLogParser):
                 image.symbols[symbol] = {
                     "name": symbol,
                     "type": "code",
-                    "address": frame_offset - location
+                    "address": frame_offset - location,
                 }
 
             thread.frames.append(self.crashlog.Frame(idx, pc, frame_offset))
@@ -566,14 +616,14 @@ class JSONCrashLogParser(CrashLogParser):
             # was at, so insert that address as the caller stack frame.
             if idx == 0 and pc == 0 and "lr" in thread.registers:
                 pc = thread.registers["lr"]
-                for image in self.data['usedImages']:
-                    text_lo = image['base']
-                    text_hi = text_lo + image['size']
+                for image in self.data["usedImages"]:
+                    text_lo = image["base"]
+                    text_hi = text_lo + image["size"]
                     if text_lo <= pc < text_hi:
-                      idx += 1
-                      frame_offset = pc - text_lo
-                      thread.frames.append(self.crashlog.Frame(idx, pc, frame_offset))
-                      break
+                        idx += 1
+                        frame_offset = pc - text_lo
+                        thread.frames.append(self.crashlog.Frame(idx, pc, frame_offset))
+                        break
 
             idx += 1
 
@@ -581,38 +631,39 @@ class JSONCrashLogParser(CrashLogParser):
         idx = 0
         for json_thread in json_threads:
             thread = self.crashlog.Thread(idx, False)
-            if 'name' in json_thread:
-                thread.name = json_thread['name']
-                thread.reason = json_thread['name']
-            if 'id' in json_thread:
-                thread.id = int(json_thread['id'])
-            if json_thread.get('triggered', False):
+            if "name" in json_thread:
+                thread.name = json_thread["name"]
+                thread.reason = json_thread["name"]
+            if "id" in json_thread:
+                thread.id = int(json_thread["id"])
+            if json_thread.get("triggered", False):
                 self.crashlog.crashed_thread_idx = idx
                 thread.crashed = True
-                if 'threadState' in json_thread:
+                if "threadState" in json_thread:
                     thread.registers = self.parse_thread_registers(
-                        json_thread['threadState'])
-            if 'queue' in json_thread:
-                thread.queue = json_thread.get('queue')
-            self.parse_frames(thread, json_thread.get('frames', []))
+                        json_thread["threadState"]
+                    )
+            if "queue" in json_thread:
+                thread.queue = json_thread.get("queue")
+            self.parse_frames(thread, json_thread.get("frames", []))
             self.crashlog.threads.append(thread)
             idx += 1
 
     def parse_asi_backtrace(self, thread, bt):
-        for line in bt.split('\n'):
+        for line in bt.split("\n"):
             frame_match = TextCrashLogParser.frame_regex.search(line)
             if not frame_match:
                 print("error: can't parse application specific backtrace.")
                 return False
 
-            (frame_id, frame_img_name, frame_addr,
-                frame_ofs) = frame_match.groups()
+            (frame_id, frame_img_name, frame_addr, frame_ofs) = frame_match.groups()
 
             thread.add_ident(frame_img_name)
             if frame_img_name not in self.crashlog.idents:
                 self.crashlog.idents.append(frame_img_name)
-            thread.frames.append(self.crashlog.Frame(int(frame_id), int(
-                frame_addr, 0), frame_ofs))
+            thread.frames.append(
+                self.crashlog.Frame(int(frame_id), int(frame_addr, 0), frame_ofs)
+            )
 
         return True
 
@@ -630,19 +681,19 @@ class JSONCrashLogParser(CrashLogParser):
                 registers.update(self.parse_thread_registers(state))
                 continue
             if key == "x":
-                gpr_dict = { str(idx) : reg for idx,reg in enumerate(state) }
+                gpr_dict = {str(idx): reg for idx, reg in enumerate(state)}
                 registers.update(self.parse_thread_registers(gpr_dict, key))
                 continue
             try:
-                value = int(state['value'])
-                registers["{}{}".format(prefix or '',key)] = value
+                value = int(state["value"])
+                registers["{}{}".format(prefix or "", key)] = value
             except (KeyError, ValueError, TypeError):
                 pass
         return registers
 
     def parse_errors(self, json_data):
-       if 'reportNotes' in json_data:
-          self.crashlog.errors = json_data['reportNotes']
+        if "reportNotes" in json_data:
+            self.crashlog.errors = json_data["reportNotes"]
 
 
 class CrashLogParseMode:
@@ -653,31 +704,38 @@ class CrashLogParseMode:
     SYSTEM = 4
     INSTRS = 5
 
+
 class TextCrashLogParser(CrashLogParser):
-    parent_process_regex = re.compile(r'^Parent Process:\s*(.*)\[(\d+)\]')
-    thread_state_regex = re.compile(r'^Thread \d+ crashed with')
-    thread_instrs_regex = re.compile(r'^Thread \d+ instruction stream')
-    thread_regex = re.compile(r'^Thread (\d+).*:')
-    app_backtrace_regex = re.compile(r'^Application Specific Backtrace (\d+).*:')
-    version = r'\(.+\)|(?:arm|x86_)[0-9a-z]+'
-    frame_regex = re.compile(r'^(\d+)\s+'              # id
-                             r'(.+?)\s+'               # img_name
-                             r'(?:' +version+ r'\s+)?' # img_version
-                             r'(0x[0-9a-fA-F]{4,})'    # addr (4 chars or more)
-                             r'(?: +(.*))?'            # offs
-                            )
-    null_frame_regex = re.compile(r'^\d+\s+\?\?\?\s+0{4,} +')
-    image_regex_uuid = re.compile(r'(0x[0-9a-fA-F]+)'          # img_lo
-                                  r'\s+-\s+'                   #   -
-                                  r'(0x[0-9a-fA-F]+)\s+'       # img_hi
-                                  r'[+]?(.+?)\s+'              # img_name
-                                  r'(?:(' +version+ r')\s+)?'  # img_version
-                                  r'(?:<([-0-9a-fA-F]+)>\s+)?' # img_uuid
-                                  r'(\?+|/.*)'                 # img_path
-                                 )
-    exception_type_regex = re.compile(r'^Exception Type:\s+(EXC_[A-Z_]+)(?:\s+\((.*)\))?')
-    exception_codes_regex = re.compile(r'^Exception Codes:\s+(0x[0-9a-fA-F]+),\s*(0x[0-9a-fA-F]+)')
-    exception_extra_regex = re.compile(r'^Exception\s+.*:\s+(.*)')
+    parent_process_regex = re.compile(r"^Parent Process:\s*(.*)\[(\d+)\]")
+    thread_state_regex = re.compile(r"^Thread \d+ crashed with")
+    thread_instrs_regex = re.compile(r"^Thread \d+ instruction stream")
+    thread_regex = re.compile(r"^Thread (\d+).*:")
+    app_backtrace_regex = re.compile(r"^Application Specific Backtrace (\d+).*:")
+    version = r"\(.+\)|(?:arm|x86_)[0-9a-z]+"
+    frame_regex = re.compile(
+        r"^(\d+)\s+"  # id
+        r"(.+?)\s+"  # img_name
+        r"(?:" + version + r"\s+)?"  # img_version
+        r"(0x[0-9a-fA-F]{4,})"  # addr (4 chars or more)
+        r"(?: +(.*))?"  # offs
+    )
+    null_frame_regex = re.compile(r"^\d+\s+\?\?\?\s+0{4,} +")
+    image_regex_uuid = re.compile(
+        r"(0x[0-9a-fA-F]+)"  # img_lo
+        r"\s+-\s+"  #   -
+        r"(0x[0-9a-fA-F]+)\s+"  # img_hi
+        r"[+]?(.+?)\s+"  # img_name
+        r"(?:(" + version + r")\s+)?"  # img_version
+        r"(?:<([-0-9a-fA-F]+)>\s+)?"  # img_uuid
+        r"(\?+|/.*)"  # img_path
+    )
+    exception_type_regex = re.compile(
+        r"^Exception Type:\s+(EXC_[A-Z_]+)(?:\s+\((.*)\))?"
+    )
+    exception_codes_regex = re.compile(
+        r"^Exception Codes:\s+(0x[0-9a-fA-F]+),\s*(0x[0-9a-fA-F]+)"
+    )
+    exception_extra_regex = re.compile(r"^Exception\s+.*:\s+(.*)")
 
     def __init__(self, debugger, path, verbose):
         super().__init__(debugger, path, verbose)
@@ -685,16 +743,16 @@ class TextCrashLogParser(CrashLogParser):
         self.app_specific_backtrace = False
         self.parse_mode = CrashLogParseMode.NORMAL
         self.parsers = {
-            CrashLogParseMode.NORMAL : self.parse_normal,
-            CrashLogParseMode.THREAD : self.parse_thread,
-            CrashLogParseMode.IMAGES : self.parse_images,
-            CrashLogParseMode.THREGS : self.parse_thread_registers,
-            CrashLogParseMode.SYSTEM : self.parse_system,
-            CrashLogParseMode.INSTRS : self.parse_instructions,
+            CrashLogParseMode.NORMAL: self.parse_normal,
+            CrashLogParseMode.THREAD: self.parse_thread,
+            CrashLogParseMode.IMAGES: self.parse_images,
+            CrashLogParseMode.THREGS: self.parse_thread_registers,
+            CrashLogParseMode.SYSTEM: self.parse_system,
+            CrashLogParseMode.INSTRS: self.parse_instructions,
         }
 
     def parse(self):
-        with open(self.path,'r') as f:
+        with open(self.path, "r") as f:
             lines = f.read().splitlines()
 
         for line in lines:
@@ -703,11 +761,13 @@ class TextCrashLogParser(CrashLogParser):
                 if self.thread:
                     if self.parse_mode == CrashLogParseMode.THREAD:
                         if self.thread.index == self.crashlog.crashed_thread_idx:
-                            self.thread.reason = ''
-                            if hasattr(self.crashlog, 'thread_exception'):
+                            self.thread.reason = ""
+                            if hasattr(self.crashlog, "thread_exception"):
                                 self.thread.reason += self.crashlog.thread_exception
-                            if hasattr(self.crashlog, 'thread_exception_data'):
-                                self.thread.reason += " (%s)" % self.crashlog.thread_exception_data
+                            if hasattr(self.crashlog, "thread_exception_data"):
+                                self.thread.reason += (
+                                    " (%s)" % self.crashlog.thread_exception_data
+                                )
                         if self.app_specific_backtrace:
                             self.crashlog.backtraces.append(self.thread)
                         else:
@@ -716,7 +776,9 @@ class TextCrashLogParser(CrashLogParser):
                 else:
                     # only append an extra empty line if the previous line
                     # in the info_lines wasn't empty
-                    if len(self.crashlog.info_lines) > 0 and len(self.crashlog.info_lines[-1]):
+                    if len(self.crashlog.info_lines) > 0 and len(
+                        self.crashlog.info_lines[-1]
+                    ):
                         self.crashlog.info_lines.append(line)
                 self.parse_mode = CrashLogParseMode.NORMAL
             else:
@@ -725,83 +787,88 @@ class TextCrashLogParser(CrashLogParser):
         return self.crashlog
 
     def parse_exception(self, line):
-        if not line.startswith('Exception'):
+        if not line.startswith("Exception"):
             return
-        if line.startswith('Exception Type:'):
+        if line.startswith("Exception Type:"):
             self.crashlog.thread_exception = line[15:].strip()
             exception_type_match = self.exception_type_regex.search(line)
             if exception_type_match:
                 exc_type, exc_signal = exception_type_match.groups()
-                self.crashlog.exception['type'] = exc_type
+                self.crashlog.exception["type"] = exc_type
                 if exc_signal:
-                    self.crashlog.exception['signal'] = exc_signal
-        elif line.startswith('Exception Subtype:'):
+                    self.crashlog.exception["signal"] = exc_signal
+        elif line.startswith("Exception Subtype:"):
             self.crashlog.thread_exception_subtype = line[18:].strip()
-            if 'type' in self.crashlog.exception:
-                self.crashlog.exception['subtype'] = self.crashlog.thread_exception_subtype
-        elif line.startswith('Exception Codes:'):
+            if "type" in self.crashlog.exception:
+                self.crashlog.exception[
+                    "subtype"
+                ] = self.crashlog.thread_exception_subtype
+        elif line.startswith("Exception Codes:"):
             self.crashlog.thread_exception_data = line[16:].strip()
-            if 'type' not in self.crashlog.exception:
+            if "type" not in self.crashlog.exception:
                 return
             exception_codes_match = self.exception_codes_regex.search(line)
             if exception_codes_match:
-                self.crashlog.exception['codes'] = self.crashlog.thread_exception_data
+                self.crashlog.exception["codes"] = self.crashlog.thread_exception_data
                 code, subcode = exception_codes_match.groups()
-                self.crashlog.exception['rawCodes'] = [int(code, base=16),
-                                                       int(subcode, base=16)]
+                self.crashlog.exception["rawCodes"] = [
+                    int(code, base=16),
+                    int(subcode, base=16),
+                ]
         else:
-            if 'type' not in self.crashlog.exception:
+            if "type" not in self.crashlog.exception:
                 return
             exception_extra_match = self.exception_extra_regex.search(line)
             if exception_extra_match:
-                self.crashlog.exception['message'] = exception_extra_match.group(1)
+                self.crashlog.exception["message"] = exception_extra_match.group(1)
 
     def parse_normal(self, line):
-        if line.startswith('Process:'):
-            (self.crashlog.process_name, pid_with_brackets) = line[
-                8:].strip().split(' [')
-            self.crashlog.process_id = pid_with_brackets.strip('[]')
-        elif line.startswith('Identifier:'):
+        if line.startswith("Process:"):
+            (self.crashlog.process_name, pid_with_brackets) = (
+                line[8:].strip().split(" [")
+            )
+            self.crashlog.process_id = pid_with_brackets.strip("[]")
+        elif line.startswith("Identifier:"):
             self.crashlog.process_identifier = line[11:].strip()
-        elif line.startswith('Version:'):
+        elif line.startswith("Version:"):
             version_string = line[8:].strip()
             matched_pair = re.search("(.+)\((.+)\)", version_string)
             if matched_pair:
                 self.crashlog.process_version = matched_pair.group(1)
-                self.crashlog.process_compatability_version = matched_pair.group(
-                    2)
+                self.crashlog.process_compatability_version = matched_pair.group(2)
             else:
                 self.crashlog.process = version_string
                 self.crashlog.process_compatability_version = version_string
         elif self.parent_process_regex.search(line):
-            parent_process_match = self.parent_process_regex.search(
-                line)
+            parent_process_match = self.parent_process_regex.search(line)
             self.crashlog.parent_process_name = parent_process_match.group(1)
             self.crashlog.parent_process_id = parent_process_match.group(2)
-        elif line.startswith('Exception'):
+        elif line.startswith("Exception"):
             self.parse_exception(line)
             return
-        elif line.startswith('Crashed Thread:'):
+        elif line.startswith("Crashed Thread:"):
             self.crashlog.crashed_thread_idx = int(line[15:].strip().split()[0])
             return
-        elif line.startswith('Triggered by Thread:'): # iOS
+        elif line.startswith("Triggered by Thread:"):  # iOS
             self.crashlog.crashed_thread_idx = int(line[20:].strip().split()[0])
             return
-        elif line.startswith('Report Version:'):
+        elif line.startswith("Report Version:"):
             self.crashlog.version = int(line[15:].strip())
             return
-        elif line.startswith('System Profile:'):
+        elif line.startswith("System Profile:"):
             self.parse_mode = CrashLogParseMode.SYSTEM
             return
-        elif (line.startswith('Interval Since Last Report:') or
-                line.startswith('Crashes Since Last Report:') or
-                line.startswith('Per-App Interval Since Last Report:') or
-                line.startswith('Per-App Crashes Since Last Report:') or
-                line.startswith('Sleep/Wake UUID:') or
-                line.startswith('Anonymous UUID:')):
+        elif (
+            line.startswith("Interval Since Last Report:")
+            or line.startswith("Crashes Since Last Report:")
+            or line.startswith("Per-App Interval Since Last Report:")
+            or line.startswith("Per-App Crashes Since Last Report:")
+            or line.startswith("Sleep/Wake UUID:")
+            or line.startswith("Anonymous UUID:")
+        ):
             # ignore these
             return
-        elif line.startswith('Thread'):
+        elif line.startswith("Thread"):
             thread_state_match = self.thread_state_regex.search(line)
             if thread_state_match:
                 self.app_specific_backtrace = False
@@ -810,7 +877,7 @@ class TextCrashLogParser(CrashLogParser):
                 self.parse_mode = CrashLogParseMode.THREGS
                 self.thread = self.crashlog.threads[thread_idx]
                 return
-            thread_insts_match  = self.thread_instrs_regex.search(line)
+            thread_insts_match = self.thread_instrs_regex.search(line)
             if thread_insts_match:
                 self.parse_mode = CrashLogParseMode.INSTRS
                 return
@@ -822,17 +889,17 @@ class TextCrashLogParser(CrashLogParser):
                 self.thread = self.crashlog.Thread(thread_idx, False)
                 return
             return
-        elif line.startswith('Binary Images:'):
+        elif line.startswith("Binary Images:"):
             self.parse_mode = CrashLogParseMode.IMAGES
             return
-        elif line.startswith('Application Specific Backtrace'):
+        elif line.startswith("Application Specific Backtrace"):
             app_backtrace_match = self.app_backtrace_regex.search(line)
             if app_backtrace_match:
                 self.parse_mode = CrashLogParseMode.THREAD
                 self.app_specific_backtrace = True
                 idx = int(app_backtrace_match.group(1))
                 self.thread = self.crashlog.Thread(idx, True)
-        elif line.startswith('Last Exception Backtrace:'): # iOS
+        elif line.startswith("Last Exception Backtrace:"):  # iOS
             self.parse_mode = CrashLogParseMode.THREAD
             self.app_specific_backtrace = True
             idx = 1
@@ -840,43 +907,51 @@ class TextCrashLogParser(CrashLogParser):
         self.crashlog.info_lines.append(line.strip())
 
     def parse_thread(self, line):
-        if line.startswith('Thread'):
+        if line.startswith("Thread"):
             return
         if self.null_frame_regex.search(line):
             print('warning: thread parser ignored null-frame: "%s"' % line)
             return
         frame_match = self.frame_regex.search(line)
         if frame_match:
-            (frame_id, frame_img_name, frame_addr,
-                frame_ofs) = frame_match.groups()
+            (frame_id, frame_img_name, frame_addr, frame_ofs) = frame_match.groups()
             ident = frame_img_name
             self.thread.add_ident(ident)
             if ident not in self.crashlog.idents:
                 self.crashlog.idents.append(ident)
-            self.thread.frames.append(self.crashlog.Frame(int(frame_id), int(
-                frame_addr, 0), frame_ofs))
+            self.thread.frames.append(
+                self.crashlog.Frame(int(frame_id), int(frame_addr, 0), frame_ofs)
+            )
         else:
             print('error: frame regex failed for line: "%s"' % line)
 
     def parse_images(self, line):
         image_match = self.image_regex_uuid.search(line)
         if image_match:
-            (img_lo, img_hi, img_name, img_version,
-                img_uuid, img_path) = image_match.groups()
-            image = self.crashlog.DarwinImage(int(img_lo, 0), int(img_hi, 0),
-                                            img_name.strip(),
-                                            img_version.strip()
-                                            if img_version else "",
-                                            uuid.UUID(img_uuid), img_path,
-                                            self.verbose)
+            (
+                img_lo,
+                img_hi,
+                img_name,
+                img_version,
+                img_uuid,
+                img_path,
+            ) = image_match.groups()
+            image = self.crashlog.DarwinImage(
+                int(img_lo, 0),
+                int(img_hi, 0),
+                img_name.strip(),
+                img_version.strip() if img_version else "",
+                uuid.UUID(img_uuid),
+                img_path,
+                self.verbose,
+            )
             self.crashlog.images.append(image)
         else:
             print("error: image regex failed for: %s" % line)
 
-
     def parse_thread_registers(self, line):
         # "r12: 0x00007fff6b5939c8  r13: 0x0000000007000006  r14: 0x0000000000002a03  r15: 0x0000000000000c00"
-        reg_values = re.findall('([a-z0-9]+): (0x[0-9a-f]+)', line, re.I)
+        reg_values = re.findall("([a-z0-9]+): (0x[0-9a-f]+)", line, re.I)
         for reg, value in reg_values:
             self.thread.registers[reg] = int(value, 16)
 
@@ -894,18 +969,18 @@ def usage():
 
 def save_crashlog(debugger, command, exe_ctx, result, dict):
     usage = "usage: %prog [options] <output-path>"
-    description = '''Export the state of current target into a crashlog file'''
+    description = """Export the state of current target into a crashlog file"""
     parser = optparse.OptionParser(
-        description=description,
-        prog='save_crashlog',
-        usage=usage)
+        description=description, prog="save_crashlog", usage=usage
+    )
     parser.add_option(
-        '-v',
-        '--verbose',
-        action='store_true',
-        dest='verbose',
-        help='display verbose debug info',
-        default=False)
+        "-v",
+        "--verbose",
+        action="store_true",
+        dest="verbose",
+        help="display verbose debug info",
+        default=False,
+    )
     try:
         (options, args) = parser.parse_args(shlex.split(command))
     except:
@@ -913,13 +988,12 @@ def save_crashlog(debugger, command, exe_ctx, result, dict):
         return
     if len(args) != 1:
         result.PutCString(
-            "error: invalid arguments, a single output file is the only valid argument")
+            "error: invalid arguments, a single output file is the only valid argument"
+        )
         return
-    out_file = open(args[0], 'w')
+    out_file = open(args[0], "w")
     if not out_file:
-        result.PutCString(
-            "error: failed to open file '%s' for writing...",
-            args[0])
+        result.PutCString("error: failed to open file '%s' for writing...", args[0])
         return
     target = exe_ctx.target
     if target:
@@ -928,21 +1002,27 @@ def save_crashlog(debugger, command, exe_ctx, result, dict):
         if process:
             pid = process.id
             if pid != lldb.LLDB_INVALID_PROCESS_ID:
-                out_file.write(
-                    'Process:         %s [%u]\n' %
-                    (identifier, pid))
-        out_file.write('Path:            %s\n' % (target.executable.fullpath))
-        out_file.write('Identifier:      %s\n' % (identifier))
-        out_file.write('\nDate/Time:       %s\n' %
-                       (datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
+                out_file.write("Process:         %s [%u]\n" % (identifier, pid))
+        out_file.write("Path:            %s\n" % (target.executable.fullpath))
+        out_file.write("Identifier:      %s\n" % (identifier))
         out_file.write(
-            'OS Version:      Mac OS X %s (%s)\n' %
-            (platform.mac_ver()[0], subprocess.check_output('sysctl -n kern.osversion', shell=True).decode("utf-8")))
-        out_file.write('Report Version:  9\n')
+            "\nDate/Time:       %s\n"
+            % (datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+        )
+        out_file.write(
+            "OS Version:      Mac OS X %s (%s)\n"
+            % (
+                platform.mac_ver()[0],
+                subprocess.check_output("sysctl -n kern.osversion", shell=True).decode(
+                    "utf-8"
+                ),
+            )
+        )
+        out_file.write("Report Version:  9\n")
         for thread_idx in range(process.num_threads):
             thread = process.thread[thread_idx]
-            out_file.write('\nThread %u:\n' % (thread_idx))
-            for (frame_idx, frame) in enumerate(thread.frames):
+            out_file.write("\nThread %u:\n" % (thread_idx))
+            for frame_idx, frame in enumerate(thread.frames):
                 frame_pc = frame.pc
                 frame_offset = 0
                 if frame.function:
@@ -950,51 +1030,60 @@ def save_crashlog(debugger, command, exe_ctx, result, dict):
                     block_range = block.range[frame.addr]
                     if block_range:
                         block_start_addr = block_range[0]
-                        frame_offset = frame_pc - block_start_addr.GetLoadAddress(target)
+                        frame_offset = frame_pc - block_start_addr.GetLoadAddress(
+                            target
+                        )
                     else:
-                        frame_offset = frame_pc - frame.function.addr.GetLoadAddress(target)
+                        frame_offset = frame_pc - frame.function.addr.GetLoadAddress(
+                            target
+                        )
                 elif frame.symbol:
                     frame_offset = frame_pc - frame.symbol.addr.GetLoadAddress(target)
                 out_file.write(
-                    '%-3u %-32s 0x%16.16x %s' %
-                    (frame_idx, frame.module.file.basename, frame_pc, frame.name))
+                    "%-3u %-32s 0x%16.16x %s"
+                    % (frame_idx, frame.module.file.basename, frame_pc, frame.name)
+                )
                 if frame_offset > 0:
-                    out_file.write(' + %u' % (frame_offset))
+                    out_file.write(" + %u" % (frame_offset))
                 line_entry = frame.line_entry
                 if line_entry:
                     if options.verbose:
                         # This will output the fullpath + line + column
-                        out_file.write(' %s' % (line_entry))
+                        out_file.write(" %s" % (line_entry))
                     else:
                         out_file.write(
-                            ' %s:%u' %
-                            (line_entry.file.basename, line_entry.line))
+                            " %s:%u" % (line_entry.file.basename, line_entry.line)
+                        )
                         column = line_entry.column
                         if column:
-                            out_file.write(':%u' % (column))
-                out_file.write('\n')
+                            out_file.write(":%u" % (column))
+                out_file.write("\n")
 
-        out_file.write('\nBinary Images:\n')
+        out_file.write("\nBinary Images:\n")
         for module in target.modules:
-            text_segment = module.section['__TEXT']
+            text_segment = module.section["__TEXT"]
             if text_segment:
                 text_segment_load_addr = text_segment.GetLoadAddress(target)
                 if text_segment_load_addr != lldb.LLDB_INVALID_ADDRESS:
-                    text_segment_end_load_addr = text_segment_load_addr + text_segment.size
+                    text_segment_end_load_addr = (
+                        text_segment_load_addr + text_segment.size
+                    )
                     identifier = module.file.basename
-                    module_version = '???'
+                    module_version = "???"
                     module_version_array = module.GetVersion()
                     if module_version_array:
-                        module_version = '.'.join(
-                            map(str, module_version_array))
+                        module_version = ".".join(map(str, module_version_array))
                     out_file.write(
-                        '    0x%16.16x - 0x%16.16x  %s (%s - ???) <%s> %s\n' %
-                        (text_segment_load_addr,
-                         text_segment_end_load_addr,
-                         identifier,
-                         module_version,
-                         module.GetUUIDString(),
-                         module.file.fullpath))
+                        "    0x%16.16x - 0x%16.16x  %s (%s - ???) <%s> %s\n"
+                        % (
+                            text_segment_load_addr,
+                            text_segment_end_load_addr,
+                            identifier,
+                            module_version,
+                            module.GetUUIDString(),
+                            module.file.fullpath,
+                        )
+                    )
         out_file.close()
     else:
         result.PutCString("error: invalid target")
@@ -1019,7 +1108,7 @@ def SymbolicateCrashLog(crash_log, options):
     if options.debug:
         crash_log.dump()
     if not crash_log.images:
-        print('error: no images in crash log')
+        print("error: no images in crash log")
         return
 
     if options.dump_image_list:
@@ -1034,7 +1123,6 @@ def SymbolicateCrashLog(crash_log, options):
     if not target:
         return
 
-
     if options.load_all_images:
         for image in crash_log.images:
             image.resolve = True
@@ -1048,6 +1136,7 @@ def SymbolicateCrashLog(crash_log, options):
     futures = []
     loaded_images = []
     with concurrent.futures.ThreadPoolExecutor() as executor:
+
         def add_module(image, target):
             return image, image.add_module(target)
 
@@ -1075,10 +1164,13 @@ def SymbolicateCrashLog(crash_log, options):
         for error in crash_log.errors:
             print(error)
 
+
 def load_crashlog_in_scripted_process(debugger, crash_log_file, options, result):
     crashlog_path = os.path.expanduser(crash_log_file)
     if not os.path.exists(crashlog_path):
-        raise InteractiveCrashLogException("crashlog file %s does not exist" % crashlog_path)
+        raise InteractiveCrashLogException(
+            "crashlog file %s does not exist" % crashlog_path
+        )
 
     crashlog = CrashLogParser.create(debugger, crashlog_path, False).parse()
 
@@ -1087,13 +1179,15 @@ def load_crashlog_in_scripted_process(debugger, crash_log_file, options, result)
     if options.target_path:
         target = debugger.CreateTarget(options.target_path)
         if not target:
-            raise InteractiveCrashLogException("couldn't create target provided by the user (%s)" % options.target_path)
+            raise InteractiveCrashLogException(
+                "couldn't create target provided by the user (%s)" % options.target_path
+            )
 
     # 2. If the user didn't provide a target, try to create a target using the symbolicator
     if not target or not target.IsValid():
         target = crashlog.create_target()
     # 3. If that didn't work, and a target is already loaded, use it
-    if (target is None  or not target.IsValid()) and debugger.GetNumTargets() > 0:
+    if (target is None or not target.IsValid()) and debugger.GetNumTargets() > 0:
         target = debugger.GetTargetAtIndex(0)
     # 4. Fail
     if target is None or not target.IsValid():
@@ -1103,16 +1197,23 @@ def load_crashlog_in_scripted_process(debugger, crash_log_file, options, result)
     if not ci:
         raise InteractiveCrashLogException("couldn't get command interpreter")
 
-    ci.HandleCommand('script from lldb.macosx import crashlog_scripted_process', result)
+    ci.HandleCommand("script from lldb.macosx import crashlog_scripted_process", result)
     if not result.Succeeded():
-        raise InteractiveCrashLogException("couldn't import crashlog scripted process module")
+        raise InteractiveCrashLogException(
+            "couldn't import crashlog scripted process module"
+        )
 
     structured_data = lldb.SBStructuredData()
-    structured_data.SetFromJSON(json.dumps({ "file_path" : crashlog_path,
-                                             "load_all_images": options.load_all_images }))
+    structured_data.SetFromJSON(
+        json.dumps(
+            {"file_path": crashlog_path, "load_all_images": options.load_all_images}
+        )
+    )
     launch_info = lldb.SBLaunchInfo(None)
     launch_info.SetProcessPluginName("ScriptedProcess")
-    launch_info.SetScriptedProcessClassName("crashlog_scripted_process.CrashLogScriptedProcess")
+    launch_info.SetScriptedProcessClassName(
+        "crashlog_scripted_process.CrashLogScriptedProcess"
+    )
     launch_info.SetScriptedProcessDictionary(structured_data)
     launch_info.SetLaunchFlags(lldb.eLaunchFlagStopAtEntry)
 
@@ -1126,6 +1227,7 @@ def load_crashlog_in_scripted_process(debugger, crash_log_file, options, result)
     process.Continue()
 
     if not options.skip_status:
+
         @contextlib.contextmanager
         def synchronous(debugger):
             async_state = debugger.GetAsync()
@@ -1148,151 +1250,171 @@ def load_crashlog_in_scripted_process(debugger, crash_log_file, options, result)
             if error.Success():
                 debugger.RunCommandInterpreter(True, False, run_options, 0, False, True)
 
+
 def CreateSymbolicateCrashLogOptions(
-        command_name,
-        description,
-        add_interactive_options):
+    command_name, description, add_interactive_options
+):
     usage = "usage: %prog [options] <FILE> [FILE ...]"
     option_parser = optparse.OptionParser(
-        description=description, prog='crashlog', usage=usage)
+        description=description, prog="crashlog", usage=usage
+    )
     option_parser.add_option(
-        '--version',
-        '-V',
-        dest='version',
-        action='store_true',
-        help='Show crashlog version',
-        default=False)
+        "--version",
+        "-V",
+        dest="version",
+        action="store_true",
+        help="Show crashlog version",
+        default=False,
+    )
     option_parser.add_option(
-        '--verbose',
-        '-v',
-        action='store_true',
-        dest='verbose',
-        help='display verbose debug info',
-        default=False)
+        "--verbose",
+        "-v",
+        action="store_true",
+        dest="verbose",
+        help="display verbose debug info",
+        default=False,
+    )
     option_parser.add_option(
-        '--debug',
-        '-g',
-        action='store_true',
-        dest='debug',
-        help='display verbose debug logging',
-        default=False)
+        "--debug",
+        "-g",
+        action="store_true",
+        dest="debug",
+        help="display verbose debug logging",
+        default=False,
+    )
     option_parser.add_option(
-        '--load-all',
-        '-a',
-        action='store_true',
-        dest='load_all_images',
-        help='load all executable images, not just the images found in the '
-        'crashed stack frames, loads stackframes for all the threads in '
-        'interactive mode.',
-        default=False)
+        "--load-all",
+        "-a",
+        action="store_true",
+        dest="load_all_images",
+        help="load all executable images, not just the images found in the "
+        "crashed stack frames, loads stackframes for all the threads in "
+        "interactive mode.",
+        default=False,
+    )
     option_parser.add_option(
-        '--images',
-        action='store_true',
-        dest='dump_image_list',
-        help='show image list',
-        default=False)
+        "--images",
+        action="store_true",
+        dest="dump_image_list",
+        help="show image list",
+        default=False,
+    )
     option_parser.add_option(
-        '--debug-delay',
-        type='int',
-        dest='debug_delay',
-        metavar='NSEC',
-        help='pause for NSEC seconds for debugger',
-        default=0)
+        "--debug-delay",
+        type="int",
+        dest="debug_delay",
+        metavar="NSEC",
+        help="pause for NSEC seconds for debugger",
+        default=0,
+    )
     option_parser.add_option(
-        '--crashed-only',
-        '-c',
-        action='store_true',
-        dest='crashed_only',
-        help='only symbolicate the crashed thread',
-        default=False)
+        "--crashed-only",
+        "-c",
+        action="store_true",
+        dest="crashed_only",
+        help="only symbolicate the crashed thread",
+        default=False,
+    )
     option_parser.add_option(
-        '--disasm-depth',
-        '-d',
-        type='int',
-        dest='disassemble_depth',
-        help='set the depth in stack frames that should be disassembled (default is 1)',
-        default=1)
+        "--disasm-depth",
+        "-d",
+        type="int",
+        dest="disassemble_depth",
+        help="set the depth in stack frames that should be disassembled (default is 1)",
+        default=1,
+    )
     option_parser.add_option(
-        '--disasm-all',
-        '-D',
-        action='store_true',
-        dest='disassemble_all_threads',
-        help='enabled disassembly of frames on all threads (not just the crashed thread)',
-        default=False)
+        "--disasm-all",
+        "-D",
+        action="store_true",
+        dest="disassemble_all_threads",
+        help="enabled disassembly of frames on all threads (not just the crashed thread)",
+        default=False,
+    )
     option_parser.add_option(
-        '--disasm-before',
-        '-B',
-        type='int',
-        dest='disassemble_before',
-        help='the number of instructions to disassemble before the frame PC',
-        default=4)
+        "--disasm-before",
+        "-B",
+        type="int",
+        dest="disassemble_before",
+        help="the number of instructions to disassemble before the frame PC",
+        default=4,
+    )
     option_parser.add_option(
-        '--disasm-after',
-        '-A',
-        type='int',
-        dest='disassemble_after',
-        help='the number of instructions to disassemble after the frame PC',
-        default=4)
+        "--disasm-after",
+        "-A",
+        type="int",
+        dest="disassemble_after",
+        help="the number of instructions to disassemble after the frame PC",
+        default=4,
+    )
     option_parser.add_option(
-        '--source-context',
-        '-C',
-        type='int',
-        metavar='NLINES',
-        dest='source_context',
-        help='show NLINES source lines of source context (default = 4)',
-        default=4)
+        "--source-context",
+        "-C",
+        type="int",
+        metavar="NLINES",
+        dest="source_context",
+        help="show NLINES source lines of source context (default = 4)",
+        default=4,
+    )
     option_parser.add_option(
-        '--source-frames',
-        type='int',
-        metavar='NFRAMES',
-        dest='source_frames',
-        help='show source for NFRAMES (default = 4)',
-        default=4)
+        "--source-frames",
+        type="int",
+        metavar="NFRAMES",
+        dest="source_frames",
+        help="show source for NFRAMES (default = 4)",
+        default=4,
+    )
     option_parser.add_option(
-        '--source-all',
-        action='store_true',
-        dest='source_all',
-        help='show source for all threads, not just the crashed thread',
-        default=False)
+        "--source-all",
+        action="store_true",
+        dest="source_all",
+        help="show source for all threads, not just the crashed thread",
+        default=False,
+    )
     if add_interactive_options:
         option_parser.add_option(
-            '-i',
-            '--interactive',
-            action='store_true',
-            help='parse a crash log and load it in a ScriptedProcess',
-            default=False)
+            "-i",
+            "--interactive",
+            action="store_true",
+            help="parse a crash log and load it in a ScriptedProcess",
+            default=False,
+        )
         option_parser.add_option(
-            '-b',
-            '--batch',
-            action='store_true',
-            help='dump symbolicated stackframes without creating a debug session',
-            default=True)
+            "-b",
+            "--batch",
+            action="store_true",
+            help="dump symbolicated stackframes without creating a debug session",
+            default=True,
+        )
         option_parser.add_option(
-            '--target',
-            '-t',
-            dest='target_path',
-            help='the target binary path that should be used for interactive crashlog (optional)',
-            default=None)
+            "--target",
+            "-t",
+            dest="target_path",
+            help="the target binary path that should be used for interactive crashlog (optional)",
+            default=None,
+        )
         option_parser.add_option(
-            '--skip-status',
-            '-s',
-            dest='skip_status',
-            action='store_true',
-            help='prevent the interactive crashlog to dump the process status and thread backtrace at launch',
-            default=False)
+            "--skip-status",
+            "-s",
+            dest="skip_status",
+            action="store_true",
+            help="prevent the interactive crashlog to dump the process status and thread backtrace at launch",
+            default=False,
+        )
     return option_parser
 
 
 def CrashLogOptionParser():
-    description = '''Symbolicate one or more darwin crash log files to provide source file and line information,
+    description = """Symbolicate one or more darwin crash log files to provide source file and line information,
 inlined stack frames back to the concrete functions, and disassemble the location of the crash
 for the first frame of the crashed thread.
 If this script is imported into the LLDB command interpreter, a "crashlog" command will be added to the interpreter
 for use at the LLDB command line. After a crash log has been parsed and symbolicated, a target will have been
 created that has all of the shared libraries loaded at the load addresses found in the crash log file. This allows
 you to explore the program as if it were stopped at the locations described in the crash log and functions can
-be disassembled and lookups can be performed using the addresses found in the crash log.'''
-    return CreateSymbolicateCrashLogOptions('crashlog', description, True)
+be disassembled and lookups can be performed using the addresses found in the crash log."""
+    return CreateSymbolicateCrashLogOptions("crashlog", description, True)
+
 
 def SymbolicateCrashLogs(debugger, command_args, result):
     option_parser = CrashLogOptionParser()
@@ -1311,9 +1433,9 @@ def SymbolicateCrashLogs(debugger, command_args, result):
         return
 
     if options.debug:
-        print('command_args = %s' % command_args)
-        print('options', options)
-        print('args', args)
+        print("command_args = %s" % command_args)
+        print("options", options)
+        print("args", args)
 
     if options.debug_delay > 0:
         print("Waiting %u seconds for debugger to attach..." % options.debug_delay)
@@ -1336,25 +1458,34 @@ def SymbolicateCrashLogs(debugger, command_args, result):
         for crash_log_file in args:
             if should_run_in_interactive_mode(options, ci):
                 try:
-                    load_crashlog_in_scripted_process(debugger, crash_log_file,
-                                                      options, result)
+                    load_crashlog_in_scripted_process(
+                        debugger, crash_log_file, options, result
+                    )
                 except InteractiveCrashLogException as e:
                     result.SetError(str(e))
             else:
-                crash_log = CrashLogParser.create(debugger, crash_log_file, options.verbose).parse()
+                crash_log = CrashLogParser.create(
+                    debugger, crash_log_file, options.verbose
+                ).parse()
                 SymbolicateCrashLog(crash_log, options)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Create a new debugger instance
     debugger = lldb.SBDebugger.Create()
     result = lldb.SBCommandReturnObject()
     SymbolicateCrashLogs(debugger, sys.argv[1:], result)
     lldb.SBDebugger.Destroy(debugger)
 
+
 def __lldb_init_module(debugger, internal_dict):
     debugger.HandleCommand(
-        'command script add -o -c lldb.macosx.crashlog.Symbolicate crashlog')
+        "command script add -o -c lldb.macosx.crashlog.Symbolicate crashlog"
+    )
     debugger.HandleCommand(
-        'command script add -o -f lldb.macosx.crashlog.save_crashlog save_crashlog')
-    print('"crashlog" and "save_crashlog" commands have been installed, use '
-          'the "--help" options on these commands for detailed help.')
+        "command script add -o -f lldb.macosx.crashlog.save_crashlog save_crashlog"
+    )
+    print(
+        '"crashlog" and "save_crashlog" commands have been installed, use '
+        'the "--help" options on these commands for detailed help.'
+    )

--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -305,6 +305,8 @@ class CrashLog(symbolication.Symbolicator):
             if self.show_symbol_progress():
                 with print_lock:
                     print("Getting symbols for %s %s..." % (uuid_str, self.path))
+            # Keep track of unresolved source paths.
+            unavailable_source_paths = set()
             if os.path.exists(self.dsymForUUIDBinary):
                 dsym_for_uuid_command = "%s %s" % (self.dsymForUUIDBinary, uuid_str)
                 s = subprocess.check_output(dsym_for_uuid_command, shell=True)
@@ -334,6 +336,12 @@ class CrashLog(symbolication.Symbolicator):
                                     plist["DBGSymbolRichExecutable"]
                                 )
                                 self.resolved_path = self.path
+                            if "DBGSourcePathRemapping" in plist:
+                                path_remapping = plist["DBGSourcePathRemapping"]
+                                for _, value in path_remapping.items():
+                                    source_path = os.path.expanduser(value)
+                                    if not os.path.exists(source_path):
+                                        unavailable_source_paths.add(source_path)
             if not self.resolved_path and os.path.exists(self.path):
                 if not self.find_matching_slice():
                     return False
@@ -372,6 +380,12 @@ class CrashLog(symbolication.Symbolicator):
             ):
                 with print_lock:
                     print("Resolved symbols for %s %s..." % (uuid_str, self.path))
+                    if len(unavailable_source_paths):
+                        for source_path in unavailable_source_paths:
+                            print(
+                                "Could not access remapped source path for %s %s"
+                                % (uuid_str, source_path)
+                            )
                 return True
             else:
                 self.unavailable = True

--- a/lldb/examples/python/symbolication.py
+++ b/lldb/examples/python/symbolication.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 # Be sure to add the python path that points to the LLDB shared library.
 #
 # To use this in the embedded python interpreter using "lldb":
@@ -24,7 +24,7 @@
 #
 # On MacOSX sh, bash:
 #   PYTHONPATH=/path/to/LLDB.framework/Resources/Python ./crashlog.py ~/Library/Logs/DiagnosticReports/a.crash
-#----------------------------------------------------------------------
+# ----------------------------------------------------------------------
 
 import lldb
 import optparse
@@ -52,7 +52,9 @@ class Address:
         # Any original textual description of this address to be used as a
         # backup in case symbolication fails
         self.description = None
-        self.symbolication = None  # The cached symbolicated string that describes this address
+        self.symbolication = (
+            None  # The cached symbolicated string that describes this address
+        )
         self.inlined = False
 
     def __str__(self):
@@ -78,7 +80,8 @@ class Address:
             sb_addr = self.resolve_addr()
             if sb_addr:
                 self.sym_ctx = self.target.ResolveSymbolContextForAddress(
-                    sb_addr, lldb.eSymbolContextEverything)
+                    sb_addr, lldb.eSymbolContextEverything
+                )
             else:
                 self.sym_ctx = lldb.SBSymbolContext()
         return self.sym_ctx
@@ -94,7 +97,7 @@ class Address:
 
     def symbolicate(self, verbose=False):
         if self.symbolication is None:
-            self.symbolication = ''
+            self.symbolication = ""
             self.inlined = False
             sym_ctx = self.get_symbol_context()
             if sym_ctx:
@@ -102,9 +105,9 @@ class Address:
                 if module:
                     # Print full source file path in verbose mode
                     if verbose:
-                        self.symbolication += str(module.GetFileSpec()) + '`'
+                        self.symbolication += str(module.GetFileSpec()) + "`"
                     else:
-                        self.symbolication += module.GetFileSpec().GetFilename() + '`'
+                        self.symbolication += module.GetFileSpec().GetFilename() + "`"
                     function_start_load_addr = -1
                     function = sym_ctx.GetFunction()
                     block = sym_ctx.GetBlock()
@@ -116,22 +119,30 @@ class Address:
 
                         if inlined_block:
                             self.inlined = True
-                            self.symbolication += ' [inlined] ' + \
-                                inlined_block.GetInlinedName()
-                            block_range_idx = inlined_block.GetRangeIndexForBlockAddress(
-                                self.so_addr)
+                            self.symbolication += (
+                                " [inlined] " + inlined_block.GetInlinedName()
+                            )
+                            block_range_idx = (
+                                inlined_block.GetRangeIndexForBlockAddress(self.so_addr)
+                            )
                             if block_range_idx < lldb.UINT32_MAX:
-                                block_range_start_addr = inlined_block.GetRangeStartAddress(
-                                    block_range_idx)
-                                function_start_load_addr = block_range_start_addr.GetLoadAddress(
-                                    self.target)
+                                block_range_start_addr = (
+                                    inlined_block.GetRangeStartAddress(block_range_idx)
+                                )
+                                function_start_load_addr = (
+                                    block_range_start_addr.GetLoadAddress(self.target)
+                                )
                         if function_start_load_addr == -1:
-                            function_start_load_addr = function.GetStartAddress().GetLoadAddress(self.target)
+                            function_start_load_addr = (
+                                function.GetStartAddress().GetLoadAddress(self.target)
+                            )
                     elif symbol:
                         self.symbolication += symbol.GetName()
-                        function_start_load_addr = symbol.GetStartAddress().GetLoadAddress(self.target)
+                        function_start_load_addr = (
+                            symbol.GetStartAddress().GetLoadAddress(self.target)
+                        )
                     else:
-                        self.symbolication = ''
+                        self.symbolication = ""
                         return False
 
                     # Dump the offset from the current function or symbol if it
@@ -140,29 +151,36 @@ class Address:
                     if function_offset > 0:
                         self.symbolication += " + %u" % (function_offset)
                     elif function_offset < 0:
-                        self.symbolication += " %i (invalid negative offset, file a bug) " % function_offset
+                        self.symbolication += (
+                            " %i (invalid negative offset, file a bug) "
+                            % function_offset
+                        )
 
                     # Print out any line information if any is available
                     if line_entry.GetFileSpec():
                         # Print full source file path in verbose mode
                         if verbose:
-                            self.symbolication += ' at %s' % line_entry.GetFileSpec()
+                            self.symbolication += " at %s" % line_entry.GetFileSpec()
                         else:
-                            self.symbolication += ' at %s' % line_entry.GetFileSpec().GetFilename()
-                        self.symbolication += ':%u' % line_entry.GetLine()
+                            self.symbolication += (
+                                " at %s" % line_entry.GetFileSpec().GetFilename()
+                            )
+                        self.symbolication += ":%u" % line_entry.GetLine()
                         column = line_entry.GetColumn()
                         if column > 0:
-                            self.symbolication += ':%u' % column
+                            self.symbolication += ":%u" % column
                     return True
         return False
 
 
 class Section:
     """Class that represents an load address range"""
-    sect_info_regex = re.compile('(?P<name>[^=]+)=(?P<range>.*)')
-    addr_regex = re.compile('^\s*(?P<start>0x[0-9A-Fa-f]+)\s*$')
+
+    sect_info_regex = re.compile("(?P<name>[^=]+)=(?P<range>.*)")
+    addr_regex = re.compile("^\s*(?P<start>0x[0-9A-Fa-f]+)\s*$")
     range_regex = re.compile(
-        '^\s*(?P<start>0x[0-9A-Fa-f]+)\s*(?P<op>[-+])\s*(?P<end>0x[0-9A-Fa-f]+)\s*$')
+        "^\s*(?P<start>0x[0-9A-Fa-f]+)\s*(?P<op>[-+])\s*(?P<end>0x[0-9A-Fa-f]+)\s*$"
+    )
 
     def __init__(self, start_addr=None, end_addr=None, name=None):
         self.start_addr = start_addr
@@ -173,11 +191,7 @@ class Section:
     def InitWithSBTargetAndSBSection(cls, target, section):
         sect_load_addr = section.GetLoadAddress(target)
         if sect_load_addr != lldb.LLDB_INVALID_ADDRESS:
-            obj = cls(
-                sect_load_addr,
-                sect_load_addr +
-                section.size,
-                section.name)
+            obj = cls(sect_load_addr, sect_load_addr + section.size, section.name)
             return obj
         else:
             return None
@@ -188,29 +202,35 @@ class Section:
     def set_from_string(self, s):
         match = self.sect_info_regex.match(s)
         if match:
-            self.name = match.group('name')
-            range_str = match.group('range')
+            self.name = match.group("name")
+            range_str = match.group("range")
             addr_match = self.addr_regex.match(range_str)
             if addr_match:
-                self.start_addr = int(addr_match.group('start'), 16)
+                self.start_addr = int(addr_match.group("start"), 16)
                 self.end_addr = None
                 return True
 
             range_match = self.range_regex.match(range_str)
             if range_match:
-                self.start_addr = int(range_match.group('start'), 16)
-                self.end_addr = int(range_match.group('end'), 16)
-                op = range_match.group('op')
-                if op == '+':
+                self.start_addr = int(range_match.group("start"), 16)
+                self.end_addr = int(range_match.group("end"), 16)
+                op = range_match.group("op")
+                if op == "+":
                     self.end_addr += self.start_addr
                 return True
         print('error: invalid section info string "%s"' % s)
-        print('Valid section info formats are:')
-        print('Format                Example                    Description')
-        print('--------------------- -----------------------------------------------')
-        print('<name>=<base>        __TEXT=0x123000             Section from base address only')
-        print('<name>=<base>-<end>  __TEXT=0x123000-0x124000    Section from base address and end address')
-        print('<name>=<base>+<size> __TEXT=0x123000+0x1000      Section from base address and size')
+        print("Valid section info formats are:")
+        print("Format                Example                    Description")
+        print("--------------------- -----------------------------------------------")
+        print(
+            "<name>=<base>        __TEXT=0x123000             Section from base address only"
+        )
+        print(
+            "<name>=<base>-<end>  __TEXT=0x123000-0x124000    Section from base address and end address"
+        )
+        print(
+            "<name>=<base>+<size> __TEXT=0x123000+0x1000      Section from base address and size"
+        )
         return False
 
     def __str__(self):
@@ -218,7 +238,10 @@ class Section:
             if self.end_addr is not None:
                 if self.start_addr is not None:
                     return "%s=[0x%16.16x - 0x%16.16x)" % (
-                        self.name, self.start_addr, self.end_addr)
+                        self.name,
+                        self.start_addr,
+                        self.end_addr,
+                    )
             else:
                 if self.start_addr is not None:
                     return "%s=0x%16.16x" % (self.name, self.start_addr)
@@ -247,13 +270,12 @@ class Image:
 
     @classmethod
     def InitWithSBTargetAndSBModule(cls, target, module):
-        '''Initialize this Image object with a module from a target.'''
+        """Initialize this Image object with a module from a target."""
         obj = cls(module.file.fullpath, module.uuid)
         obj.resolved_path = module.platform_file.fullpath
         obj.resolved = True
         for section in module.sections:
-            symb_section = Section.InitWithSBTargetAndSBSection(
-                target, section)
+            symb_section = Section.InitWithSBTargetAndSBSection(target, section)
             if symb_section:
                 obj.section_infos.append(symb_section)
         obj.arch = module.triple
@@ -268,19 +290,19 @@ class Image:
     def debug_dump(self):
         print('path = "%s"' % (self.path))
         print('resolved_path = "%s"' % (self.resolved_path))
-        print('resolved = %i' % (self.resolved))
-        print('unavailable = %i' % (self.unavailable))
-        print('uuid = %s' % (self.uuid))
-        print('section_infos = %s' % (self.section_infos))
+        print("resolved = %i" % (self.resolved))
+        print("unavailable = %i" % (self.unavailable))
+        print("uuid = %s" % (self.uuid))
+        print("section_infos = %s" % (self.section_infos))
         print('identifier = "%s"' % (self.identifier))
-        print('version = %s' % (self.version))
-        print('arch = %s' % (self.arch))
-        print('module = %s' % (self.module))
+        print("version = %s" % (self.version))
+        print("arch = %s" % (self.arch))
+        print("module = %s" % (self.module))
         print('symfile = "%s"' % (self.symfile))
-        print('slide = %i (0x%x)' % (self.slide, self.slide))
+        print("slide = %i (0x%x)" % (self.slide, self.slide))
 
     def __str__(self):
-        s = ''
+        s = ""
         if self.uuid:
             s += "%s " % (self.get_uuid())
         if self.arch:
@@ -293,7 +315,7 @@ class Image:
         for section_info in self.section_infos:
             s += ", %s" % (section_info)
         if self.slide is not None:
-            s += ', slide = 0x%16.16x' % self.slide
+            s += ", slide = 0x%16.16x" % self.slide
         return s
 
     def add_section(self, section):
@@ -339,37 +361,41 @@ class Image:
                         num_sections_loaded = 0
                         for section_info in self.section_infos:
                             if section_info.name:
-                                section = self.module.FindSection(
-                                    section_info.name)
+                                section = self.module.FindSection(section_info.name)
                                 if section:
                                     error = target.SetSectionLoadAddress(
-                                        section, section_info.start_addr)
+                                        section, section_info.start_addr
+                                    )
                                     if error.Success():
                                         num_sections_loaded += 1
                                     else:
-                                        return 'error: %s' % error.GetCString()
+                                        return "error: %s" % error.GetCString()
                                 else:
-                                    return 'error: unable to find the section named "%s"' % section_info.name
+                                    return (
+                                        'error: unable to find the section named "%s"'
+                                        % section_info.name
+                                    )
                             else:
                                 return 'error: unable to find "%s" section in "%s"' % (
-                                    range.name, self.get_resolved_path())
+                                    range.name,
+                                    self.get_resolved_path(),
+                                )
                         if num_sections_loaded == 0:
-                            return 'error: no sections were successfully loaded'
+                            return "error: no sections were successfully loaded"
                     else:
-                        err = target.SetModuleLoadAddress(
-                            self.module, self.slide)
+                        err = target.SetModuleLoadAddress(self.module, self.slide)
                         if err.Fail():
                             return err.GetCString()
                     return None
                 else:
-                    return 'error: invalid module'
+                    return "error: invalid module"
             else:
-                return 'error: invalid target'
+                return "error: invalid target"
         else:
-            return 'error: no section infos'
+            return "error: no section infos"
 
     def add_module(self, target):
-        '''Add the Image described in this object to "target" and load the sections if "load" is True.'''
+        """Add the Image described in this object to "target" and load the sections if "load" is True."""
         if target:
             # Try and find using UUID only first so that paths need not match
             # up
@@ -381,35 +407,42 @@ class Image:
                 if not self.unavailable:
                     resolved_path = self.get_resolved_path()
                     self.module = target.AddModule(
-                        resolved_path, None, uuid_str, self.symfile)
+                        resolved_path, None, uuid_str, self.symfile
+                    )
             if not self.module and self.section_infos:
                 name = os.path.basename(self.path)
-                with tempfile.NamedTemporaryFile(suffix='.' + name) as tf:
+                with tempfile.NamedTemporaryFile(suffix="." + name) as tf:
                     data = {
-                        'triple': target.triple,
-                        'uuid': uuid_str,
-                        'type': 'sharedlibrary',
-                        'sections': list(),
-                        'symbols': list()
+                        "triple": target.triple,
+                        "uuid": uuid_str,
+                        "type": "sharedlibrary",
+                        "sections": list(),
+                        "symbols": list(),
                     }
                     for section in self.section_infos:
-                        data['sections'].append({
-                            'name' : section.name,
-                            'size': section.end_addr - section.start_addr
-                            })
-                    data['symbols'] = list(self.symbols.values())
-                    with open(tf.name, 'w') as f:
+                        data["sections"].append(
+                            {
+                                "name": section.name,
+                                "size": section.end_addr - section.start_addr,
+                            }
+                        )
+                    data["symbols"] = list(self.symbols.values())
+                    with open(tf.name, "w") as f:
                         f.write(json.dumps(data, indent=4))
                     self.module = target.AddModule(tf.name, None, uuid_str)
             if not self.module and not self.unavailable:
                 return 'error: unable to get module for (%s) "%s"' % (
-                    self.arch, self.get_resolved_path())
+                    self.arch,
+                    self.get_resolved_path(),
+                )
             if self.has_section_load_info():
                 return self.load_module(target)
             else:
-                return None  # No sections, the module was added to the target, so success
+                return (
+                    None  # No sections, the module was added to the target, so success
+                )
         else:
-            return 'error: invalid target'
+            return "error: invalid target"
 
     def locate_module_and_debug_symbols(self):
         # By default, just use the paths that were supplied in:
@@ -432,7 +465,7 @@ class Image:
         return None
 
     def create_target(self, debugger):
-        '''Create a target using the information in this Image object.'''
+        """Create a target using the information in this Image object."""
         if self.unavailable:
             return None
 
@@ -440,24 +473,28 @@ class Image:
             resolved_path = self.get_resolved_path()
             path_spec = lldb.SBFileSpec(resolved_path)
             error = lldb.SBError()
-            target = debugger.CreateTarget(
-                resolved_path, self.arch, None, False, error)
+            target = debugger.CreateTarget(resolved_path, self.arch, None, False, error)
             if target:
                 self.module = target.FindModule(path_spec)
                 if self.has_section_load_info():
                     err = self.load_module(target)
                     if err:
-                        print('ERROR: ', err)
+                        print("ERROR: ", err)
                 return target
             else:
-                print('error: unable to create a valid target for (%s) "%s"' % (self.arch, self.path))
+                print(
+                    'error: unable to create a valid target for (%s) "%s"'
+                    % (self.arch, self.path)
+                )
         else:
-            print('error: unable to locate main executable (%s) "%s"' % (self.arch, self.path))
+            print(
+                'error: unable to locate main executable (%s) "%s"'
+                % (self.arch, self.path)
+            )
         return None
 
 
 class Symbolicator:
-
     def __init__(self, debugger=None, target=None, images=list()):
         """A class the represents the information needed to symbolicate
         addresses in a program.
@@ -468,7 +505,7 @@ class Symbolicator:
         self.debugger = debugger
         self.target = target
         self.images = images  # a list of images to be used when symbolicating
-        self.addr_mask = 0xffffffffffffffff
+        self.addr_mask = 0xFFFFFFFFFFFFFFFF
 
     @classmethod
     def InitWithSBTarget(cls, target):
@@ -476,9 +513,9 @@ class Symbolicator:
         obj = cls(target=target)
         triple = target.triple
         if triple:
-            arch = triple.split('-')[0]
+            arch = triple.split("-")[0]
             if "arm" in arch:
-                obj.addr_mask = 0xfffffffffffffffe
+                obj.addr_mask = 0xFFFFFFFFFFFFFFFE
 
         for module in target.modules:
             image = Image.InitWithSBTargetAndSBModule(target, module)
@@ -501,7 +538,7 @@ class Symbolicator:
                 s += str(m) + "\n"
         s += "Images:\n"
         for image in self.images:
-            s += '    %s\n' % (image)
+            s += "    %s\n" % (image)
         return s
 
     def find_images_with_identifier(self, identifier):
@@ -510,7 +547,7 @@ class Symbolicator:
             if image.identifier == identifier:
                 images.append(image)
         if len(images) == 0:
-            regex_text = '^.*\.%s$' % (re.escape(identifier))
+            regex_text = "^.*\.%s$" % (re.escape(identifier))
             regex = re.compile(regex_text)
             for image in self.images:
                 if regex.match(image.identifier):
@@ -534,9 +571,9 @@ class Symbolicator:
                     if self.target.GetAddressByteSize() == 4:
                         triple = self.target.triple
                         if triple:
-                            arch = triple.split('-')[0]
+                            arch = triple.split("-")[0]
                             if "arm" in arch:
-                                self.addr_mask = 0xfffffffffffffffe
+                                self.addr_mask = 0xFFFFFFFFFFFFFFFE
                     return self.target
         return None
 
@@ -565,16 +602,20 @@ class Symbolicator:
                     # See if we were able to reconstruct anything?
                     while True:
                         inlined_parent_so_addr = lldb.SBAddress()
-                        inlined_parent_sym_ctx = symbolicated_address.sym_ctx.GetParentOfInlinedScope(
-                            symbolicated_address.so_addr, inlined_parent_so_addr)
+                        inlined_parent_sym_ctx = (
+                            symbolicated_address.sym_ctx.GetParentOfInlinedScope(
+                                symbolicated_address.so_addr, inlined_parent_so_addr
+                            )
+                        )
                         if not inlined_parent_sym_ctx:
                             break
                         if not inlined_parent_so_addr:
                             break
 
                         symbolicated_address = Address(
-                            self.target, inlined_parent_so_addr.GetLoadAddress(
-                                self.target))
+                            self.target,
+                            inlined_parent_so_addr.GetLoadAddress(self.target),
+                        )
                         symbolicated_address.sym_ctx = inlined_parent_sym_ctx
                         symbolicated_address.so_addr = inlined_parent_so_addr
                         symbolicated_address.symbolicate(verbose)
@@ -585,17 +626,13 @@ class Symbolicator:
                     if symbolicated_addresses:
                         return symbolicated_addresses
         else:
-            print('error: no target in Symbolicator')
+            print("error: no target in Symbolicator")
         return None
 
 
 def disassemble_instructions(
-        target,
-        instructions,
-        pc,
-        insts_before_pc,
-        insts_after_pc,
-        non_zeroeth_frame):
+    target, instructions, pc, insts_before_pc, insts_after_pc, non_zeroeth_frame
+):
     lines = list()
     pc_index = -1
     comment_column = 50
@@ -610,7 +647,7 @@ def disassemble_instructions(
         if comment:
             line_len = len(lines[-1])
             if line_len < comment_column:
-                lines[-1] += ' ' * (comment_column - line_len)
+                lines[-1] += " " * (comment_column - line_len)
                 lines[-1] += "; %s" % comment
 
     if pc_index >= 0:
@@ -632,9 +669,9 @@ def disassemble_instructions(
             end_idx = inst_idx
         for i in range(start_idx, end_idx + 1):
             if i == pc_index:
-                print(' -> ', lines[i])
+                print(" -> ", lines[i])
             else:
-                print('    ', lines[i])
+                print("    ", lines[i])
 
 
 def print_module_section_data(section):
@@ -651,8 +688,7 @@ def print_module_section(section, depth):
     if depth > 0:
         num_sub_sections = section.GetNumSubSections()
         for sect_idx in range(num_sub_sections):
-            print_module_section(
-                section.GetSubSectionAtIndex(sect_idx), depth - 1)
+            print_module_section(section.GetSubSectionAtIndex(sect_idx), depth - 1)
 
 
 def print_module_sections(module, depth):
@@ -666,55 +702,61 @@ def print_module_symbols(module):
 
 
 def Symbolicate(debugger, command_args):
-
     usage = "usage: %prog [options] <addr1> [addr2 ...]"
-    description = '''Symbolicate one or more addresses using LLDB's python scripting API..'''
+    description = (
+        """Symbolicate one or more addresses using LLDB's python scripting API.."""
+    )
     parser = optparse.OptionParser(
-        description=description,
-        prog='crashlog.py',
-        usage=usage)
+        description=description, prog="crashlog.py", usage=usage
+    )
     parser.add_option(
-        '-v',
-        '--verbose',
-        action='store_true',
-        dest='verbose',
-        help='display verbose debug info',
-        default=False)
+        "-v",
+        "--verbose",
+        action="store_true",
+        dest="verbose",
+        help="display verbose debug info",
+        default=False,
+    )
     parser.add_option(
-        '-p',
-        '--platform',
-        type='string',
-        metavar='platform',
-        dest='platform',
-        help='Specify the platform to use when creating the debug target. Valid values include "localhost", "darwin-kernel", "ios-simulator", "remote-freebsd", "remote-macosx", "remote-ios", "remote-linux".')
+        "-p",
+        "--platform",
+        type="string",
+        metavar="platform",
+        dest="platform",
+        help='Specify the platform to use when creating the debug target. Valid values include "localhost", "darwin-kernel", "ios-simulator", "remote-freebsd", "remote-macosx", "remote-ios", "remote-linux".',
+    )
     parser.add_option(
-        '-f',
-        '--file',
-        type='string',
-        metavar='file',
-        dest='file',
-        help='Specify a file to use when symbolicating')
+        "-f",
+        "--file",
+        type="string",
+        metavar="file",
+        dest="file",
+        help="Specify a file to use when symbolicating",
+    )
     parser.add_option(
-        '-a',
-        '--arch',
-        type='string',
-        metavar='arch',
-        dest='arch',
-        help='Specify a architecture to use when symbolicating')
+        "-a",
+        "--arch",
+        type="string",
+        metavar="arch",
+        dest="arch",
+        help="Specify a architecture to use when symbolicating",
+    )
     parser.add_option(
-        '-s',
-        '--slide',
-        type='int',
-        metavar='slide',
-        dest='slide',
-        help='Specify the slide to use on the file specified with the --file option',
-        default=None)
+        "-s",
+        "--slide",
+        type="int",
+        metavar="slide",
+        dest="slide",
+        help="Specify the slide to use on the file specified with the --file option",
+        default=None,
+    )
     parser.add_option(
-        '--section',
-        type='string',
-        action='append',
-        dest='section_strings',
-        help='specify <sect-name>=<start-addr> or <sect-name>=<start-addr>-<end-addr>')
+        "--section",
+        type="string",
+        action="append",
+        dest="section_strings",
+        help="specify <sect-name>=<start-addr> or <sect-name>=<start-addr>-<end-addr>",
+    )
     try:
         (options, args) = parser.parse_args(command_args)
     except:
@@ -743,15 +785,15 @@ def Symbolicate(debugger, command_args):
     if target:
         for addr_str in args:
             addr = int(addr_str, 0)
-            symbolicated_addrs = symbolicator.symbolicate(
-                addr, options.verbose)
+            symbolicated_addrs = symbolicator.symbolicate(addr, options.verbose)
             for symbolicated_addr in symbolicated_addrs:
                 print(symbolicated_addr)
             print()
     else:
-        print('error: no target for %s' % (symbolicator))
+        print("error: no target for %s" % (symbolicator))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Create a new debugger instance
     debugger = lldb.SBDebugger.Create()
     Symbolicate(debugger, sys.argv[1:])


### PR DESCRIPTION
It can be tricky to troubleshoot why the crashlog script can't show
inline sources. The two most common causes are that we couldn't find the
dSYM or, if we find the dSYM, that the path remapping included in the
dSYMForUUID output isn't accessible. The former is already easy to
diagnose, but the latter is harder because you'd have to manually invoke
dsymForUUID on the UUID and check the remapped path. This patch
automates that process and prints a warning if the remapped path doesn't
exist or is not accessible.

Differential revision: https://reviews.llvm.org/D152886