### PR TITLE
[lldb] Distinguish between Clang and Swift errors in SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1976,10 +1976,24 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
   // If IRGen failed without errors, the root cause may be a fatal
   // Clang diagnostic.
-  if (expr_diagnostics->HasErrors() ||
+  using ErrorKind = SwiftASTContext::ScopedDiagnostics::ErrorKind;
+  // GetOptionalErrorKind() returns all diagnostics that occurred to during the
+  // lifetime of expr_diagnostics, but there could be earlier ClangImporter
+  // errors that still caused the expression to fail.
+  std::optional<ErrorKind> error_kind =
+      expr_diagnostics->GetOptionalErrorKind();
+  if (error_kind == ErrorKind::clang ||
       m_swift_ast_ctx.HasClangImporterErrors()) {
+    diagnostic_manager.PutString(
+        eDiagnosticSeverityRemark,
+        "couldn't IRGen expression: Clang importer error");
+    DiagnoseSwiftASTContextError();
+    return ParseResult::unrecoverable_error;
+  }
+
+  if (error_kind == ErrorKind::swift) {
     diagnostic_manager.PutString(eDiagnosticSeverityRemark,
-                                 "couldn't IRGen expression");
+                                 "couldn't IRGen expression: Swift error");
     DiagnoseSwiftASTContextError();
     return ParseResult::unrecoverable_error;
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -922,19 +922,25 @@ void SwiftASTContext::ScopedDiagnostics::PrintDiagnostics(
                              last_line);
 }
 
-bool SwiftASTContext::ScopedDiagnostics::HasErrors() const {
+std::optional<SwiftASTContext::ScopedDiagnostics::ErrorKind>
+SwiftASTContext::ScopedDiagnostics::GetOptionalErrorKind() const {
+  using ErrorKind = SwiftASTContext::ScopedDiagnostics::ErrorKind;
   auto &consumer = *static_cast<StoringDiagnosticConsumer *>(&m_consumer);
 
-  if (consumer.m_num_swift_errors > m_cursor.m_num_swift_errors)
-    return true;
   if (consumer.m_raw_clang_diagnostics.size() > m_cursor.clang)
-    return true;
+    return ErrorKind::clang;
+  if (consumer.m_num_swift_errors > m_cursor.m_num_swift_errors)
+    return ErrorKind::swift;
 
   for (size_t i = m_cursor.lldb; i < consumer.m_diagnostics.size(); ++i)
     if (consumer.m_diagnostics[i]->GetSeverity() == eDiagnosticSeverityError)
-      return true;
+      return ErrorKind::swift;
 
-  return false;
+  return {};
+}
+
+bool SwiftASTContext::ScopedDiagnostics::HasErrors() const {
+  return GetOptionalErrorKind() != std::nullopt;
 }
 
 llvm::Error SwiftASTContext::ScopedDiagnostics::GetAllErrors() const {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -472,6 +472,7 @@ public:
     const DiagnosticCursor m_cursor;
 
   public:
+    enum class ErrorKind { swift, clang };
     ScopedDiagnostics(swift::DiagnosticConsumer &consumer);
     ~ScopedDiagnostics();
     /// Print all diagnostics that happened during the lifetime of
@@ -481,6 +482,7 @@ public:
                           uint32_t bufferID = UINT32_MAX,
                           uint32_t first_line = 0,
                           uint32_t last_line = UINT32_MAX) const;
+    std::optional<ErrorKind> GetOptionalErrorKind() const;
     bool HasErrors() const;
     /// Return all errors and warnings that happened during the lifetime of this
     /// object.


### PR DESCRIPTION
SwiftASTContext may encounter Clang or Swift errors. Change ScopedDiagnostics to expose the error kind it encountered, so callers can adequately deal with the error kind.