### PR TITLE
Cherry-pick "[lldb] Symtab::SectionFileAddressesChanged should clear the file address map instead of name map"

### DIFF
--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -84,8 +84,7 @@ size_t Symtab::GetNumSymbols() const {
 }
 
 void Symtab::SectionFileAddressesChanged() {
-  auto &name_to_index = GetNameToSymbolIndexMap(lldb::eFunctionNameTypeNone);
-  name_to_index.Clear();
+  m_file_addr_to_index.Clear();
   m_file_addr_to_index_computed = false;
 }
 


### PR DESCRIPTION
Currently, `SectionFileAddressesChanged` clears out the `name_to_index` map and sets `m_file_addr_to_index_compute` to false. This is strange, as these two fields are used for different purposes. What we should be doing is clearing the file address to index mapping.

There are 2 bugs here:
1. If we call SectionFileAddressesChanged after the name indexes have been computed, we end up with an empty name to index map, so lookups will fail. This doesn't happen today because we don't initialize the name indexes before calling this, but this is a refactor away from failing in this way.
2. Because we don't clear `m_file_addr_to_index` but still set it's computed flag to false, it ends up with twice the amount of information. One entry will be correct (since it was recalculated), one entry will be outdated.

rdar://110192434

Differential Revision: https://reviews.llvm.org/D152579

(cherry picked from commit 8fb919a1154a593fdf01e759ece7904afc73f687)