### PR TITLE
lldb [NFC] Add logging to Process when address masks are updated

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1393,21 +1393,11 @@ public:
   lldb::addr_t GetHighmemCodeAddressMask();
   lldb::addr_t GetHighmemDataAddressMask();
 
-  void SetCodeAddressMask(lldb::addr_t code_address_mask) {
-    m_code_address_mask = code_address_mask;
-  }
+  void SetCodeAddressMask(lldb::addr_t code_address_mask);
+  void SetDataAddressMask(lldb::addr_t data_address_mask);
 
-  void SetDataAddressMask(lldb::addr_t data_address_mask) {
-    m_data_address_mask = data_address_mask;
-  }
-
-  void SetHighmemCodeAddressMask(lldb::addr_t code_address_mask) {
-    m_highmem_code_address_mask = code_address_mask;
-  }
-
-  void SetHighmemDataAddressMask(lldb::addr_t data_address_mask) {
-    m_highmem_data_address_mask = data_address_mask;
-  }
+  void SetHighmemCodeAddressMask(lldb::addr_t code_address_mask);
+  void SetHighmemDataAddressMask(lldb::addr_t data_address_mask);
 
   /// Some targets might use bits in a code address to indicate a mode switch,
   /// ARM uses bit zero to signify a code address is thumb, so any ARM ABI

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -5854,6 +5854,34 @@ lldb::addr_t Process::GetHighmemDataAddressMask() {
   return GetDataAddressMask();
 }
 
+void Process::SetCodeAddressMask(lldb::addr_t code_address_mask) {
+  Log *log = GetLog(LLDBLog::Process);
+  LLDB_LOGF(log, "Setting Process code address mask to 0x%" PRIx64,
+            code_address_mask);
+  m_code_address_mask = code_address_mask;
+}
+
+void Process::SetDataAddressMask(lldb::addr_t data_address_mask) {
+  Log *log = GetLog(LLDBLog::Process);
+  LLDB_LOGF(log, "Setting Process data address mask to 0x%" PRIx64,
+            data_address_mask);
+  m_data_address_mask = data_address_mask;
+}
+
+void Process::SetHighmemCodeAddressMask(lldb::addr_t code_address_mask) {
+  Log *log = GetLog(LLDBLog::Process);
+  LLDB_LOGF(log, "Setting Process highmem code address mask to 0x%" PRIx64,
+            code_address_mask);
+  m_highmem_code_address_mask = code_address_mask;
+}
+
+void Process::SetHighmemDataAddressMask(lldb::addr_t data_address_mask) {
+  Log *log = GetLog(LLDBLog::Process);
+  LLDB_LOGF(log, "Setting Process highmem data address mask to 0x%" PRIx64,
+            data_address_mask);
+  m_highmem_data_address_mask = data_address_mask;
+}
+
 addr_t Process::FixCodeAddress(addr_t addr) {
   if (ABISP abi_sp = GetABI())
     addr = abi_sp->FixCodeAddress(addr);


### PR DESCRIPTION
lldb [NFC] Add logging to Process when address masks are updated

To aid in integration testing/debugging. Verifying that the address mask/addressable bits values from different sources are correctly registered by lldb.

(cherry picked from commit 538df1d8a2428d06de7f26c859969ddec14928c1)