### PR TITLE
[swift/release/5.9] [clang][AST] Temporarily disable assert in getInjectedClassNameType

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -4612,7 +4612,8 @@ QualType ASTContext::getInjectedClassNameType(CXXRecordDecl *Decl,
   } else if (CXXRecordDecl *PrevDecl = Decl->getPreviousDecl()) {
     assert(PrevDecl->TypeForDecl && "previous declaration has no type");
     Decl->TypeForDecl = PrevDecl->TypeForDecl;
-    assert(isa<InjectedClassNameType>(Decl->TypeForDecl));
+    // FIXME: rdar://109876539
+    // assert(isa<InjectedClassNameType>(Decl->TypeForDecl));
   } else {
     Type *newType =
       new (*this, TypeAlignment) InjectedClassNameType(Decl, TST);


### PR DESCRIPTION
When LLDB ASTImports a class declaration it will create a new default-constructed RecordDecl. Such a default-constructerd decl doesn't have its `TypeForDecl` set correctly yet. To determine the `TypeForDecl`, ASTImporter calls DeclContext::lookup() on the new decl. If we have an external source like the ASTReader installed on the ASTContext, we can end up calling into getInjectedClassNameType. If the external source created a redeclaration chain between this new ASTImporter decl and the external one, we can end up temporarily setting the `TypeForDecl` to one that is not an `InjectedClassNameType`. This invariant is only briefly violated and later corrected by the ASTImporter. But at that point we already tripped this assert during
`DeclContext::lookup()`.

Because this potentially requires significant/risky changes to LLDB, disable this assert for now in order to unblock swift compiler devs working with nightly (i.e., assert-enabled) builds of LLDB.

rdar://109876539