### PR TITLE
[lldb] Disable variable watchpoints when going out of scope

### DIFF
--- a/lldb/include/lldb/Breakpoint/Watchpoint.h
+++ b/lldb/include/lldb/Breakpoint/Watchpoint.h
@@ -90,6 +90,40 @@ public:
   void SetWatchVariable(bool val);
   bool CaptureWatchedValue(const ExecutionContext &exe_ctx);
 
+  /// \struct WatchpointVariableContext
+  /// \brief Represents the context of a watchpoint variable.
+  ///
+  /// This struct encapsulates the information related to a watchpoint variable,
+  /// including the watch ID and the execution context in which it is being
+  /// used. This struct is passed as a Baton to the \b
+  /// VariableWatchpointDisabler breakpoint callback.
+  struct WatchpointVariableContext {
+    /// \brief Constructor for WatchpointVariableContext.
+    /// \param watch_id The ID of the watchpoint.
+    /// \param exe_ctx The execution context associated with the watchpoint.
+    WatchpointVariableContext(lldb::watch_id_t watch_id,
+                              ExecutionContext exe_ctx)
+        : watch_id(watch_id), exe_ctx(exe_ctx) {}
+
+    lldb::watch_id_t watch_id; ///< The ID of the watchpoint.
+    ExecutionContext
+        exe_ctx; ///< The execution context associated with the watchpoint.
+  };
+
+  class WatchpointVariableBaton : public TypedBaton<WatchpointVariableContext> {
+  public:
+    WatchpointVariableBaton(std::unique_ptr<WatchpointVariableContext> Data)
+        : TypedBaton(std::move(Data)) {}
+  };
+
+  bool SetupVariableWatchpointDisabler(lldb::StackFrameSP frame_sp) const;
+
+  /// Callback routine to disable the watchpoint set on a local variable when
+  ///  it goes out of scope.
+  static bool VariableWatchpointDisabler(
+      void *baton, lldb_private::StoppointCallbackContext *context,
+      lldb::user_id_t break_id, lldb::user_id_t break_loc_id);
+
   void GetDescription(Stream *s, lldb::DescriptionLevel level);
   void Dump(Stream *s) const override;
   void DumpSnapshots(Stream *s, const char *prefix = nullptr) const;

--- a/lldb/test/Shell/Watchpoint/Inputs/val.c
+++ b/lldb/test/Shell/Watchpoint/Inputs/val.c
@@ -1,0 +1,7 @@
+int main() {
+  int val = 0;
+  // Break here
+  val++;
+  val++;
+  return 0;
+}

--- a/lldb/test/Shell/Watchpoint/Inputs/watchpoint.in
+++ b/lldb/test/Shell/Watchpoint/Inputs/watchpoint.in
@@ -1,0 +1,13 @@
+breakpoint set -p "Break here"
+r
+watchpoint set variable val
+watchpoint modify -c "val == 1"
+c
+# CHECK: Watchpoint 1 hit:
+# CHECK-NEXT: old value: 0
+# CHECK-NEXT: new value: 1
+# CHECK-NEXT: Process {{[0-9]+}} resuming
+# CHECK-NEXT: Process {{[0-9]+}} stopped
+# CHECK-NEXT: {{.*}} stop reason = watchpoint 1
+c
+# CHECK: Process {{[0-9]+}} exited with status = 0 (0x00000000)

--- a/lldb/test/Shell/Watchpoint/LocalVariableWatchpointDisabler.test
+++ b/lldb/test/Shell/Watchpoint/LocalVariableWatchpointDisabler.test
@@ -1,0 +1,3 @@
+# REQUIRES: system-darwin
+# RUN: %clang_host -x c %S/Inputs/val.c -g -o %t
+# RUN: %lldb -b -s %S/Inputs/watchpoint.in %t 2>&1 | FileCheck %S/Inputs/watchpoint.in


### PR DESCRIPTION
If we use a variable watchpoint with a condition using a scope variable, if we go out-of-scope, the watpoint remains active which can the expression evaluator to fail to parse the watchpoint condition (because of the missing varible bindings).

This was discovered after `watchpoint_callback.test` started failing on the green dragon bot.

This patch should address that issue by setting an internal breakpoint on the return addresss of the current frame when creating a variable watchpoint. The breakpoint has a callback that will disable the watchpoint if the the breakpoint execution context matches the watchpoint execution context.

This is only enabled for local variables.

This patch also re-enables the failing test following e1086384e584.

rdar://109574319

Differential Revision: https://reviews.llvm.org/D151366