### PR TITLE
[lldb] Add support for eStopReasonTrace in Scripted Process

### DIFF
--- a/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedThread.cpp
@@ -257,6 +257,9 @@ bool ScriptedThread::CalculateStopInfo() {
     stop_info_sp =
         StopInfo::CreateStopReasonWithSignal(*this, signal, description.data());
   } break;
+  case lldb::eStopReasonTrace: {
+    stop_info_sp = StopInfo::CreateStopReasonToTrace(*this);
+  } break;
   case lldb::eStopReasonException: {
 #if defined(__APPLE__)
     StructuredData::Dictionary *mach_exception;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1174,13 +1174,13 @@ bool Process::SetExitStatus(int status, const char *cstr) {
   std::lock_guard<std::mutex> guard(m_exit_status_mutex);
 
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
-  LLDB_LOG(log, "(plugin = %s status=%i (0x%8.8x), description=%s%s%s)",
+  LLDB_LOGF(log, "(plugin = %s status=%i (0x%8.8x), description=%s%s%s)",
            GetPluginName().data(), status, status, cstr ? "\"" : "",
            cstr ? cstr : "NULL", cstr ? "\"" : "");
 
   // We were already in the exited state
   if (m_private_state.GetValue() == eStateExited) {
-    LLDB_LOG(log,
+    LLDB_LOGF(log,
              "(plugin = %s) ignoring exit status because state was already set "
              "to eStateExited",
              GetPluginName().data());
@@ -1467,7 +1467,7 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
   }
 
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
-  LLDB_LOG(log, "(plugin = %s, state = %s, restarted = %i)",
+  LLDB_LOGF(log, "(plugin = %s, state = %s, restarted = %i)",
            GetPluginName().data(), StateAsCString(new_state), restarted);
   const StateType old_state = m_public_state.GetValue();
   m_public_state.SetValue(new_state);
@@ -1477,7 +1477,7 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
   // program to run.
   if (!StateChangedIsExternallyHijacked()) {
     if (new_state == eStateDetached) {
-      LLDB_LOG(log,
+      LLDB_LOGF(log,
                "(plugin = %s, state = %s) -- unlocking run lock for detach",
                GetPluginName().data(), StateAsCString(new_state));
       m_public_run_lock.SetStopped();
@@ -1485,7 +1485,7 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
       const bool old_state_is_stopped = StateIsStoppedState(old_state, false);
       if ((old_state_is_stopped != new_state_is_stopped)) {
         if (new_state_is_stopped && !restarted) {
-          LLDB_LOG(log, "(plugin = %s, state = %s) -- unlocking run lock",
+          LLDB_LOGF(log, "(plugin = %s, state = %s) -- unlocking run lock",
                    GetPluginName().data(), StateAsCString(new_state));
           m_public_run_lock.SetStopped();
         }
@@ -1496,10 +1496,10 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
 
 Status Process::Resume() {
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process));
-  LLDB_LOG(log, "(plugin = %s) -- locking run lock", GetPluginName().data());
+  LLDB_LOGF(log, "(plugin = %s) -- locking run lock", GetPluginName().data());
   if (!m_public_run_lock.TrySetRunning()) {
     Status error("Resume request failed - process still running.");
-    LLDB_LOG(log, "(plugin = %s) -- TrySetRunning failed, not resuming.",
+    LLDB_LOGF(log, "(plugin = %s) -- TrySetRunning failed, not resuming.",
              GetPluginName().data());
     return error;
   }
@@ -1573,7 +1573,7 @@ void Process::SetPrivateState(StateType new_state) {
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process | LLDBLog::Unwind));
   bool state_changed = false;
 
-  LLDB_LOG(log, "(plugin = %s, state = %s)", GetPluginName().data(),
+  LLDB_LOGF(log, "(plugin = %s, state = %s)", GetPluginName().data(),
            StateAsCString(new_state));
 
   std::lock_guard<std::recursive_mutex> thread_guard(m_thread_list.GetMutex());
@@ -1615,14 +1615,14 @@ void Process::SetPrivateState(StateType new_state) {
       if (!m_mod_id.IsLastResumeForUserExpression())
         m_mod_id.SetStopEventForLastNaturalStopID(event_sp);
       m_memory_cache.Clear();
-      LLDB_LOG(log, "(plugin = %s, state = %s, stop_id = %u",
+      LLDB_LOGF(log, "(plugin = %s, state = %s, stop_id = %u",
                GetPluginName().data(), StateAsCString(new_state),
                m_mod_id.GetStopID());
     }
 
     m_private_state_broadcaster.BroadcastEvent(event_sp);
   } else {
-    LLDB_LOG(log, "(plugin = %s, state = %s) state didn't change. Ignoring...",
+    LLDB_LOGF(log, "(plugin = %s, state = %s) state didn't change. Ignoring...",
              GetPluginName().data(), StateAsCString(new_state));
   }
 }

--- a/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
+++ b/lldb/test/API/functionalities/scripted_process/TestScriptedProcess.py
@@ -214,7 +214,7 @@ class ScriptedProcesTestCase(TestBase):
         self.assertTrue(thread, "Invalid thread.")
         self.assertEqual(thread.GetThreadID(), 0x19)
         self.assertEqual(thread.GetName(), "DummyScriptedThread.thread-1")
-        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonSignal)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonTrace)
 
         self.assertGreater(thread.GetNumFrames(), 0)
 

--- a/lldb/test/API/functionalities/scripted_process/dummy_scripted_process.py
+++ b/lldb/test/API/functionalities/scripted_process/dummy_scripted_process.py
@@ -69,7 +69,7 @@ class DummyScriptedThread(ScriptedThread):
         return lldb.eStateStopped
 
     def get_stop_reason(self) -> Dict[str, Any]:
-        return {"type": lldb.eStopReasonSignal, "data": {"signal": signal.SIGINT}}
+        return { "type": lldb.eStopReasonTrace, "data": {} }
 
     def get_register_context(self) -> str:
         return struct.pack(


### PR DESCRIPTION
This PR adds support to the `lldb::eStopReasonTrace` to Scripted Processes and fixed some logging to actually print the process plugin correctly.