### PR TITLE
Add two new entitlements when debugserver is built by Apple

### DIFF
--- a/lldb/tools/debugserver/resources/debugserver-entitlements.plist
+++ b/lldb/tools/debugserver/resources/debugserver-entitlements.plist
@@ -26,5 +26,9 @@
     <true/>
     <key>com.apple.private.cs.debugger</key>
     <true/>
+    <key>com.apple.private.thread-set-state</key>
+    <true/>
+    <key>com.apple.private.set-exception-port</key>
+    <true/>
 </dict>
 </plist>

--- a/lldb/tools/debugserver/resources/debugserver-macosx-private-entitlements.plist
+++ b/lldb/tools/debugserver/resources/debugserver-macosx-private-entitlements.plist
@@ -6,5 +6,9 @@
     <true/>
     <key>com.apple.private.cs.debugger</key>
     <true/>
+    <key>com.apple.private.thread-set-state</key>
+    <true/>
+    <key>com.apple.private.set-exception-port</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Add two new entitlements when debugserver is built by Apple

Two new entitlements, com.apple.private.thread-set-state and com.apple.private.set-exception-port should be included in the debugserver entitlement plist when built internally at Apple. The desktop builds of debugserver don't need these entitlements; don't add them to debugserver-macosx-entitlements.plist.

rdar://108912676
rdar://103032208
(cherry picked from commit 3858e9d6c5136e5a491795c1dcb720361c525526)