### PR TITLE
[lldb] Fix variable name mismatch between signature and docs (NFC)

### DIFF
--- a/lldb/include/lldb/API/SBTrace.h
+++ b/lldb/include/lldb/API/SBTrace.h
@@ -50,7 +50,7 @@ public:
   /// \param[out] error
   ///   This will be set with an error in case of failures.
   ///
-  /// \param[in] directory
+  /// \param[in] bundle_dir
   ///   The directory where the trace files will be saved.
   ///
   /// \param[in] compact


### PR DESCRIPTION
The variable is named `bundle_dir` but the documentation referenced `directory` which generated a warning.

(cherry picked from commit f9f279dc64ac8366fc9095a30d4e0e33827d6bc1)