### PR TITLE
[lldb] Increase the maximum number of classes we can read from shared cache

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -2321,7 +2321,10 @@ AppleObjCRuntimeV2::SharedCacheClassInfoExtractor::UpdateISAToDescriptorMap() {
 
   // The number of entries to pre-allocate room for.
   // Each entry is (addrsize + 4) bytes
-  const uint32_t max_num_classes = 163840;
+  // FIXME: It is not sustainable to continue incrementing this value every time
+  // the shared cache grows. This is because it requires allocating memory in
+  // the inferior process and some inferior processes have small memory limits.
+  const uint32_t max_num_classes = 212992;
 
   UtilityFunction *get_class_info_code = GetClassInfoUtilityFunction(exe_ctx);
   if (!get_class_info_code) {


### PR DESCRIPTION
The shared cache has grown past the previously hardcoded limit. As a temporary measure, I am increasing the hardcoded number of classes we can expect to read from the shared cache. This is not a good long-term solution.

Differential Revision: https://reviews.llvm.org/D153817

(cherry picked from commit 7ed3c2edf017840e0c7c358aa48d2d67d4b55dcb)