### PR TITLE
FileSystem::EnumerateDirectory should skip entries w/o Status, not halt

### DIFF
--- a/lldb/source/Host/common/FileSystem.cpp
+++ b/lldb/source/Host/common/FileSystem.cpp
@@ -191,7 +191,7 @@ void FileSystem::EnumerateDirectory(Twine path, bool find_directories,
     const auto &Item = *Iter;
     ErrorOr<vfs::Status> Status = m_fs->status(Item.path());
     if (!Status)
-      break;
+      continue;
     if (!find_files && Status->isRegularFile())
       continue;
     if (!find_directories && Status->isDirectory())


### PR DESCRIPTION
FileSystem::EnumerateDirectory should skip entries w/o Status, not halt

EnumerateDirectory gets the vfs::Status of each directory entry to decide how to process it.  If it is unable to get the Status for a directory entry, it will currently halt the directory iteration entirely.  It should only skip this entry.

Differential Revision: https://reviews.llvm.org/D153822 rdar://110861210

(cherry picked from commit 2c1108f44342019a67ce55bb98e2a05b57a70b9a)