### PR TITLE
[clang] Add `#include <variant>` as `PPCachedActions` uses `std::variant`.

### DIFF
--- a/clang/include/clang/Lex/PPCachedActions.h
+++ b/clang/include/clang/Lex/PPCachedActions.h
@@ -16,6 +16,7 @@
 
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/SmallVector.h"
+#include <variant>
 
 namespace clang {
 


### PR DESCRIPTION
rdar://111220655