### PR TITLE
Recognize BSS-only DATA segments as sections that need to be slid

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6165,7 +6165,8 @@ bool ObjectFileMachO::SectionIsLoadable(const Section *section) {
   if (!section)
     return false;
   const bool is_dsym = (m_header.filetype == MH_DSYM);
-  if (section->GetFileSize() == 0 && !is_dsym)
+  if (section->GetFileSize() == 0 && !is_dsym &&
+      section->GetName() != GetSegmentNameDATA())
     return false;
   if (section->IsThreadSpecific())
     return false;

--- a/lldb/test/API/macosx/bss-only-data-section-sliding/Makefile
+++ b/lldb/test/API/macosx/bss-only-data-section-sliding/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/macosx/bss-only-data-section-sliding/TestBSSOnlyDataSectionSliding.py
+++ b/lldb/test/API/macosx/bss-only-data-section-sliding/TestBSSOnlyDataSectionSliding.py
@@ -1,0 +1,27 @@
+"""Test that we a BSS-data only DATA segment is slid with other segments."""
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestBSSOnlyDataSectionSliding(TestBase):
+    @skipUnlessDarwin
+    def test_with_python_api(self):
+        """Test that we get thread names when interrupting a process."""
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+
+        target = self.dbg.CreateTarget(exe, "", "", False, lldb.SBError())
+        self.assertTrue(target, VALID_TARGET)
+
+        module = target.modules[0]
+        self.assertTrue(module.IsValid())
+        data_sect = module.section["__DATA"]
+        self.assertTrue(data_sect.IsValid())
+
+        target.SetModuleLoadAddress(module, 0x170000000)
+        self.assertEqual(
+            data_sect.GetFileAddress() + 0x170000000, data_sect.GetLoadAddress(target)
+        )

--- a/lldb/test/API/macosx/bss-only-data-section-sliding/main.c
+++ b/lldb/test/API/macosx/bss-only-data-section-sliding/main.c
@@ -1,0 +1,2 @@
+int glob = 0;
+int main() { return glob; }


### PR DESCRIPTION
Recognize BSS-only DATA segments as sections that need to be slid

ObjectFileMachO::SetLoadAddress() should allow for a DATA segment that has no file content to be slid in the vmaddr, it is valid to have such a section.

Differential Revision: https://reviews.llvm.org/D154037 rdar://99744343

(cherry picked from commit 623e8455919af69b039fe7450118ba953423a027)