### PR TITLE
[clang] NFC: A couple of test fixes

### DIFF
--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -817,7 +817,7 @@ public:
   ///
   // FIXME: Move OnlyLocalDecls, UseBumpAllocator to setters on the ASTUnit, we
   // shouldn't need to specify them at construction time.
-  static ASTUnit *LoadFromCommandLine(
+  static std::unique_ptr<ASTUnit> LoadFromCommandLine(
       const char **ArgBegin, const char **ArgEnd,
       std::shared_ptr<PCHContainerOperations> PCHContainerOps,
       IntrusiveRefCntPtr<DiagnosticsEngine> Diags, StringRef ResourceFilesPath,

--- a/clang/lib/CrossTU/CrossTranslationUnit.cpp
+++ b/clang/lib/CrossTU/CrossTranslationUnit.cpp
@@ -609,10 +609,10 @@ CrossTranslationUnitContext::ASTLoader::loadFromSource(
   IntrusiveRefCntPtr<DiagnosticsEngine> Diags(
       new DiagnosticsEngine{DiagID, &*DiagOpts, DiagClient});
 
-  return std::unique_ptr<ASTUnit>(ASTUnit::LoadFromCommandLine(
+  return ASTUnit::LoadFromCommandLine(
       CommandLineArgs.begin(), (CommandLineArgs.end()),
       CI.getPCHContainerOperations(), Diags,
-      CI.getHeaderSearchOpts().ResourceDir));
+      CI.getHeaderSearchOpts().ResourceDir);
 }
 
 llvm::Expected<InvocationListTy>

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1737,7 +1737,7 @@ std::unique_ptr<ASTUnit> ASTUnit::LoadFromCompilerInvocation(
   return AST;
 }
 
-ASTUnit *ASTUnit::LoadFromCommandLine(
+std::unique_ptr<ASTUnit> ASTUnit::LoadFromCommandLine(
     const char **ArgBegin, const char **ArgEnd,
     std::shared_ptr<PCHContainerOperations> PCHContainerOps,
     IntrusiveRefCntPtr<DiagnosticsEngine> Diags, StringRef ResourceFilesPath,
@@ -1841,7 +1841,7 @@ ASTUnit *ASTUnit::LoadFromCommandLine(
     return nullptr;
   }
 
-  return AST.release();
+  return AST;
 }
 
 bool ASTUnit::Reparse(std::shared_ptr<PCHContainerOperations> PCHContainerOps,

--- a/clang/tools/libclang/CIndex.cpp
+++ b/clang/tools/libclang/CIndex.cpp
@@ -3872,7 +3872,7 @@ clang_parseTranslationUnit_Impl(CXIndex CIdx, const char *source_filename,
       *CXXIdx, source_filename,
       LibclangInvocationReporter::OperationKind::ParseOperation, options,
       llvm::makeArrayRef(*Args), /*InvocationArgs=*/None, unsaved_files);
-  std::unique_ptr<ASTUnit> Unit(ASTUnit::LoadFromCommandLine(
+  std::unique_ptr<ASTUnit> Unit = ASTUnit::LoadFromCommandLine(
       Args->data(), Args->data() + Args->size(),
       CXXIdx->getPCHContainerOperations(), Diags,
       CXXIdx->getClangResourcesPath(), CXXIdx->getOnlyLocalDecls(),
@@ -3882,7 +3882,7 @@ clang_parseTranslationUnit_Impl(CXIndex CIdx, const char *source_filename,
       /*AllowPCHWithCompilerErrors=*/true, SkipFunctionBodies, SingleFileParse,
       /*UserFilesAreVolatile=*/true, ForSerialization, RetainExcludedCB,
       CXXIdx->getPCHContainerOperations()->getRawReader().getFormat(),
-      &ErrUnit));
+      &ErrUnit);
 
   // Early failures in LoadFromCommandLine may return with ErrUnit unset.
   if (!Unit && !ErrUnit)

--- a/clang/unittests/Frontend/ASTUnitTest.cpp
+++ b/clang/unittests/Frontend/ASTUnitTest.cpp
@@ -166,7 +166,7 @@ TEST_F(ASTUnitTest, LoadFromCommandLineEarlyError) {
   auto PCHContainerOps = std::make_shared<PCHContainerOperations>();
   std::unique_ptr<clang::ASTUnit> ErrUnit;
 
-  ASTUnit *AST = ASTUnit::LoadFromCommandLine(
+  std::unique_ptr<ASTUnit> AST = ASTUnit::LoadFromCommandLine(
       &Args[0], &Args[4], PCHContainerOps, Diags, "", false,
       CaptureDiagsKind::All, None, true, 0, TU_Complete, false, false, false,
       SkipFunctionBodiesScope::None, false, true, false, false, None, &ErrUnit,
@@ -193,7 +193,7 @@ TEST_F(ASTUnitTest, LoadFromCommandLineWorkingDirectory) {
   auto PCHContainerOps = std::make_shared<PCHContainerOperations>();
   std::unique_ptr<clang::ASTUnit> ErrUnit;
 
-  auto *AST = ASTUnit::LoadFromCommandLine(
+  std::unique_ptr<ASTUnit> AST = ASTUnit::LoadFromCommandLine(
       &Args[0], &Args[4], PCHContainerOps, Diags, "", false,
       CaptureDiagsKind::All, None, true, 0, TU_Complete, false, false, false,
       SkipFunctionBodiesScope::None, false, true, false, false, None, &ErrUnit,

--- a/clang/unittests/Frontend/ReparseWorkingDirTest.cpp
+++ b/clang/unittests/Frontend/ReparseWorkingDirTest.cpp
@@ -77,12 +77,14 @@ public:
 };
 
 TEST_F(ReparseWorkingDirTest, ReparseWorkingDir) {
-  // Setup the working directory path. We use '//root/' to allow the path to be
-  // valid on both Windows and Unix. We need the trailing slash for the path
-  // to be treated as absolute.
+  // Setup the working directory path.
   SmallString<16> WorkingDir;
-  llvm::sys::path::append(WorkingDir, "//root",
-                          llvm::sys::path::get_separator());
+#ifdef _WIN32
+  WorkingDir = "C:\\";
+#else
+  WorkingDir = "/";
+#endif
+  llvm::sys::path::append(WorkingDir, "root");
   setWorkingDirectory(WorkingDir);
 
   SmallString<32> Header;


### PR DESCRIPTION
This was fixed upstream in https://reviews.llvm.org/D154134 + https://reviews.llvm.org/D154257. Fix `ReparseWorkingDirTest` for Windows, and fix a leak in the unit test `LoadFromCommandLineWorkingDirectory`.