### PR TITLE
Fix an issue introduced in resolving a conflict

### DIFF
--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -179,6 +179,11 @@ CreateFrontendAction(CompilerInstance &CI) {
   }
 #endif
 
+  if (!FEOpts.IndexStorePath.empty()) {
+    CI.getCodeGenOpts().ClearASTBeforeBackend = false;
+    Act = index::createIndexDataRecordingAction(FEOpts, std::move(Act));
+    CI.setGenModuleActionWrapper(&index::createIndexDataRecordingAction);
+  }
   // Wrap the base FE action in an extract api action to generate
   // symbol graph as a biproduct of comilation ( enabled with
   // --emit-symbol-graph option )


### PR DESCRIPTION
I accidentally deleted some code during conflict resolution.  Now add them back.