### PR TITLE
Add missing headers

### DIFF
--- a/clang/lib/Frontend/CachedDiagnostics.cpp
+++ b/clang/lib/Frontend/CachedDiagnostics.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Support/EndianStream.h"
 #include "llvm/Support/StringSaver.h"
 #include "llvm/Support/YAMLTraits.h"
+#include <variant>
 
 using namespace clang;
 using namespace clang::cas;

--- a/clang/lib/Frontend/CachedDiagnostics.h
+++ b/clang/lib/Frontend/CachedDiagnostics.h
@@ -11,6 +11,8 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/Support/PrefixMapper.h"
+#include <memory>
+#include <optional>
 
 namespace clang {
 class DiagnosticConsumer;

--- a/llvm/include/llvm/TargetParser/SubtargetFeature.h
+++ b/llvm/include/llvm/TargetParser/SubtargetFeature.h
@@ -20,6 +20,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/bit.h"
 #include "llvm/Support/MathExtras.h"
 #include <array>
 #include <initializer_list>


### PR DESCRIPTION
Clang CachedDiagnostics uses std::unique_ptr, std::variant, and std::optional, coming from the `memory`, `variant`, and `optional` headers respectively. It looks like things shifted a bit so this wasn't building locally on Linux due to missing definitions.

llvm subtarget parser SubtargetFeature.h uses `llvm::popcount`, which comes from `llvm/ADT/bit.h`, which was causing build failures locally due to a missing `llvm::popcount` declaration.

Add missing `optional` include to include/llvm/Support/Format.h