### PR TITLE
[lldb] Fix dead lock issue when loading modules in Scripted Process

### DIFF
--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -166,7 +166,6 @@ void ScriptedProcess::DidLaunch() { m_pid = GetInterface().GetProcessID(); }
 void ScriptedProcess::DidResume() {
   // Update the PID again, in case the user provided a placeholder pid at launch
   m_pid = GetInterface().GetProcessID();
-  GetLoadedDynamicLibrariesInfos();
 }
 
 Status ScriptedProcess::DoResume() {

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.h
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.h
@@ -12,6 +12,7 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/ScriptedMetadata.h"
+#include "lldb/Utility/State.h"
 #include "lldb/Utility/Status.h"
 
 #include "ScriptedThread.h"
@@ -93,6 +94,11 @@ public:
   void *GetImplementation() override;
 
   void ForceScriptedState(lldb::StateType state) override {
+    // If we're about to stop, we should fetch the loaded dynamic libraries
+    // dictionary before emitting the private stop event to avoid having the
+    // module loading happen while the process state is changing.
+    if (StateIsStoppedState(state, true))
+      GetLoadedDynamicLibrariesInfos();
     SetPrivateState(state);
   }
 


### PR DESCRIPTION
This patch attempts to fix a dead lock when loading modules in a Scripted Process.

This issue was triggered by loading the modules after the process did resume, but before the process actually stop, causing the language runtime mutex to be locked by a separate thread, responsible to unwind the stack (using the runtime unwind plan), while the module loading thread was trying to notify the runtimes of the newly loaded module.

To address that, this patch moves the module loading logic to be done before sending the stop event, to prevent the dead lock situation described above.

Differential Revision: https://reviews.llvm.org/D154649