### PR TITLE
[lldb] Fix ApplyWorkingDir not properly handling . includes when working dir is .

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1581,6 +1581,10 @@ void SwiftASTContext::ApplyWorkingDir(
   llvm::SmallString<128> joined_path;
   llvm::sys::path::append(joined_path, cur_working_dir, arg);
   llvm::sys::path::remove_dots(joined_path);
+  // remove_dots can return an empty string if given a . or chain of ./.
+  if (joined_path.empty())
+    joined_path = ".";
+
   clang_argument.resize(prefix.size());
   clang_argument.append(joined_path.begin(), joined_path.end());
 }

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -82,6 +82,7 @@ TEST_F(TestSwiftASTContext, SwiftFriendlyTriple) {
 TEST_F(TestSwiftASTContext, ApplyWorkingDir) {
   std::string abs_working_dir = "/abs/dir";
   std::string rel_working_dir = "rel/dir";
+  std::string dot_working_dir = ".";
 
   // non-include option should not apply working dir
   llvm::SmallString<128> non_include_flag("-non-include-flag");
@@ -154,6 +155,16 @@ TEST_F(TestSwiftASTContext, ApplyWorkingDir) {
   EXPECT_EQ(module_file_with_name_rel_path,
             llvm::SmallString<128>(
                 "-fmodule-file=modulename=/abs/dir/relpath/module.pcm"));
+
+  // include path arg with cwd = .
+  llvm::SmallString<128> dot_rel_path("-iquoterel/path");
+  SwiftASTContext::ApplyWorkingDir(dot_rel_path, dot_working_dir);
+  EXPECT_EQ(dot_rel_path, llvm::SmallString<128>("-iquoterel/path"));
+
+  // . include path arg with cwd = . should stay as .
+  llvm::SmallString<128> dot_dot_path("-iquote.");
+  SwiftASTContext::ApplyWorkingDir(dot_dot_path, dot_working_dir);
+  EXPECT_EQ(dot_dot_path, llvm::SmallString<128>("-iquote."));
 }
 
 namespace {


### PR DESCRIPTION
Cherry-pick #7024 to Swift 5.9. This fixes an issue debugging iOS apps with modulemaps + implicit modules with Bazel (which uses `-iquote.` typically).

The proper behavior: The include should be preserved as `.` instead of the previous behavior where it became an empty string.