### PR TITLE
"settings set -g target.load-script-from-symbol-file" shouldn't crash.

### DIFF
--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -213,7 +213,7 @@ Status Debugger::SetPropertyValue(const ExecutionContext *exe_ctx,
 
   TargetSP target_sp;
   LoadScriptFromSymFile load_script_old_value = eLoadScriptFromSymFileFalse;
-  if (is_load_script && exe_ctx->GetTargetSP()) {
+  if (is_load_script && exe_ctx && exe_ctx->GetTargetSP()) {
     target_sp = exe_ctx->GetTargetSP();
     load_script_old_value =
         target_sp->TargetProperties::GetLoadScriptFromSymbolFile();

--- a/lldb/test/API/commands/settings/TestSettings.py
+++ b/lldb/test/API/commands/settings/TestSettings.py
@@ -971,3 +971,11 @@ class SettingsCommandTestCase(TestBase):
 
         # Test OptionValueLanguage
         self.verify_setting_value_json("repl-lang", "c++")
+        
+    def test_global_option(self):
+        # This command used to crash the settings because -g was signaled by a
+        # NULL execution context (not one with an empty Target...) and in the
+        # special handling for load-script-from-symbol-file this wasn't checked.
+        self.runCmd("settings set -g target.load-script-from-symbol-file true")
+
+          


### PR DESCRIPTION
-g is specified by passing in nullptr ExecutionContext, but in some load-script-from-symbol-file specific code, the ExecutionContext was asked for its Target w/o checking whether the pointer was null.

Fix that and add a test.

(cherry picked from commit c1885d2dfa950d0f78978546f92be15bc6cca474)