### PR TITLE
[VirtualOutputBackend] Support OF_Append output files

### DIFF
--- a/llvm/include/llvm/Support/VirtualOutputConfig.def
+++ b/llvm/include/llvm/Support/VirtualOutputConfig.def
@@ -16,6 +16,7 @@
 
 HANDLE_OUTPUT_CONFIG_FLAG(Text, false) // OF_Text.
 HANDLE_OUTPUT_CONFIG_FLAG(CRLF, false) // OF_CRLF.
+HANDLE_OUTPUT_CONFIG_FLAG(Append, false) // OF_Append.
 HANDLE_OUTPUT_CONFIG_FLAG(DiscardOnSignal, true) // E.g., RemoveFileOnSignal.
 HANDLE_OUTPUT_CONFIG_FLAG(AtomicWrite, true) // E.g., use temporaries.
 HANDLE_OUTPUT_CONFIG_FLAG(ImplyCreateDirectories, true)

--- a/llvm/include/llvm/Support/VirtualOutputConfig.h
+++ b/llvm/include/llvm/Support/VirtualOutputConfig.h
@@ -53,8 +53,8 @@ public:
   constexpr OutputConfig &setTextWithCRLF(bool Value) {
     return Value ? setText().setCRLF() : setBinary();
   }
-  constexpr bool getTextWithCRLF() { return getText() && getCRLF(); }
-  constexpr bool getBinary() { return !getText(); }
+  constexpr bool getTextWithCRLF() const { return getText() && getCRLF(); }
+  constexpr bool getBinary() const { return !getText(); }
 
   /// Updates Text and CRLF flags based on \a sys::fs::OF_Text and \a
   /// sys::fs::OF_CRLF in \p Flags. Rejects CRLF without Text (calling

--- a/llvm/lib/Support/VirtualOutputConfig.cpp
+++ b/llvm/lib/Support/VirtualOutputConfig.cpp
@@ -17,7 +17,9 @@ using namespace llvm::vfs;
 OutputConfig &OutputConfig::setOpenFlags(const sys::fs::OpenFlags &Flags) {
   // Ignore CRLF on its own as invalid.
   using namespace llvm::sys::fs;
-  return Flags & OF_Text ? setText().setCRLF(Flags & OF_CRLF) : setBinary();
+  return Flags & OF_Text
+             ? setText().setCRLF(Flags & OF_CRLF).setAppend(Flags & OF_Append)
+             : setBinary().setAppend(Flags & OF_Append);
 }
 
 void OutputConfig::print(raw_ostream &OS) const {

--- a/llvm/unittests/Support/VirtualOutputConfigTest.cpp
+++ b/llvm/unittests/Support/VirtualOutputConfigTest.cpp
@@ -23,6 +23,7 @@ TEST(VirtualOutputConfigTest, construct) {
   EXPECT_TRUE(OutputConfig().getAtomicWrite());
   EXPECT_TRUE(OutputConfig().getImplyCreateDirectories());
   EXPECT_FALSE(OutputConfig().getOnlyIfDifferent());
+  EXPECT_FALSE(OutputConfig().getAppend());
 
   // Test inverted defaults.
   EXPECT_TRUE(OutputConfig().getNoText());
@@ -31,6 +32,7 @@ TEST(VirtualOutputConfigTest, construct) {
   EXPECT_FALSE(OutputConfig().getNoAtomicWrite());
   EXPECT_FALSE(OutputConfig().getNoImplyCreateDirectories());
   EXPECT_TRUE(OutputConfig().getNoOnlyIfDifferent());
+  EXPECT_TRUE(OutputConfig().getNoAppend());
 }
 
 TEST(VirtualOutputConfigTest, set) {
@@ -124,7 +126,6 @@ TEST(VirtualOutputConfigTest, OpenFlags) {
 
   // Most flags are not supported / have no effect.
   EXPECT_EQ(OutputConfig(), OutputConfig().setOpenFlags(OF_None));
-  EXPECT_EQ(OutputConfig(), OutputConfig().setOpenFlags(OF_Append));
   EXPECT_EQ(OutputConfig(), OutputConfig().setOpenFlags(OF_Delete));
   EXPECT_EQ(OutputConfig(), OutputConfig().setOpenFlags(OF_ChildInherit));
   EXPECT_EQ(OutputConfig(), OutputConfig().setOpenFlags(OF_UpdateAtime));
@@ -134,6 +135,7 @@ TEST(VirtualOutputConfigTest, OpenFlags) {
            OutputConfig(),
            OutputConfig().setText(),
            OutputConfig().setTextWithCRLF(),
+           OutputConfig().setAppend(),
 
            // Should be overridden despite being invalid.
            OutputConfig().setCRLF(),
@@ -143,6 +145,7 @@ TEST(VirtualOutputConfigTest, OpenFlags) {
     EXPECT_EQ(OutputConfig().setText(), Init.setOpenFlags(OF_Text));
     EXPECT_EQ(OutputConfig().setTextWithCRLF(),
               Init.setOpenFlags(OF_TextWithCRLF));
+    EXPECT_EQ(OutputConfig().setAppend(), Init.setOpenFlags(OF_Append));
   }
 }
 


### PR DESCRIPTION
Add support for appending output file types with both atomic and non-atomic update to the output file. Atomic append is implemented with a `llvm::LockFileManager` that locks the output file while appending to it.