### PR TITLE
[lldb] Handle `@objc` classes in Swift runtime

### DIFF
--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -67,6 +67,12 @@ public:
 
   virtual lldb::LanguageType GetLanguageType() const = 0;
 
+  /// Return the preferred language runtime instance, which in most cases will
+  /// be the current instance.
+  virtual LanguageRuntime *GetPreferredLanguageRuntime(ValueObject &in_value) {
+    return nullptr;
+  }
+
   virtual bool GetObjectDescription(Stream &str, ValueObject &object) = 0;
 
   virtual bool GetObjectDescription(Stream &str, Value &value,

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -181,7 +181,18 @@ bool ValueObjectDynamicValue::UpdateValue() {
       known_type != lldb::eLanguageTypeUnknown &&
       known_type != lldb::eLanguageTypeC) {
     runtime = process->GetLanguageRuntime(known_type);
-    if (runtime)
+    if (auto *preferred_runtime =
+            runtime->GetPreferredLanguageRuntime(*m_parent)) {
+      // Try the preferred runtime first.
+      found_dynamic_type = preferred_runtime->GetDynamicTypeAndAddress(
+          *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
+          value_type);
+      if (found_dynamic_type)
+        // Set the operative `runtime` for later use in this function.
+        runtime = preferred_runtime;
+    }
+    if (!found_dynamic_type)
+      // Fallback to the runtime for `known_type`.
       found_dynamic_type = runtime->GetDynamicTypeAndAddress(
           *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
           value_type);

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
@@ -12,6 +12,7 @@
 #include <mutex>
 
 #include "AppleObjCRuntimeV2.h"
+#include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private.h"
 
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
@@ -33,6 +34,8 @@ public:
   bool IsValid() override {
     return true; // any Objective-C v2 runtime class descriptor we vend is valid
   }
+
+  lldb::LanguageType GetImplementationLanguage() const override;
 
   // a custom descriptor is used for tagged pointers
   bool GetTaggedPointerInfo(uint64_t *info_bits = nullptr,

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -33,6 +33,7 @@
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/DynamicLoader.h"
 #include "lldb/Target/ExecutionContext.h"
+#include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
@@ -756,6 +757,19 @@ AppleObjCRuntimeV2::AppleObjCRuntimeV2(Process *process,
       HasSymbol(g_objc_getRealizedClassList_trylock);
   WarnIfNoExpandedSharedCache();
   RegisterObjCExceptionRecognizer(process);
+}
+
+LanguageRuntime *
+AppleObjCRuntimeV2::GetPreferredLanguageRuntime(ValueObject &in_value) {
+  if (auto process_sp = in_value.GetProcessSP()) {
+    assert(process_sp.get() == m_process);
+    if (auto descriptor_sp = GetNonKVOClassDescriptor(in_value)) {
+      LanguageType impl_lang = descriptor_sp->GetImplementationLanguage();
+      if (impl_lang != eLanguageTypeUnknown)
+        return process_sp->GetLanguageRuntime(impl_lang);
+    }
+  }
+  return nullptr;
 }
 
 bool AppleObjCRuntimeV2::GetDynamicTypeAndAddress(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -37,6 +37,8 @@ public:
 
   static llvm::StringRef GetPluginNameStatic() { return "apple-objc-v2"; }
 
+  LanguageRuntime *GetPreferredLanguageRuntime(ValueObject &in_value) override;
+
   static char ID;
 
   bool isA(const void *ClassID) const override {

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -23,6 +23,7 @@
 #include "lldb/Symbol/Type.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Utility/ConstString.h"
+#include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private.h"
 
 class CommandObjectObjC_ClassTable_Dump;
@@ -82,6 +83,11 @@ public:
                                strcmp(class_name, "NSCFType") == 0);
       }
       return (m_is_cf == eLazyBoolYes);
+    }
+
+    /// Determine whether this class is implemented in Swift.
+    virtual lldb::LanguageType GetImplementationLanguage() const {
+      return lldb::eLanguageTypeObjC;
     }
 
     virtual bool IsValid() = 0;

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct Document {
+    var kind: Kind
+    var path: String
+
+    enum Kind {
+        case binary
+        case text
+    }
+}
+
+@objc(App)
+class App : NSObject {
+    var name: String = "Debugger"
+    var version: (Int, Int) = (1, 0)
+    var recentDocuments: [Document]? = [
+        Document(kind: .binary, path: "/path/to/something"),
+    ]
+}

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
@@ -1,0 +1,5 @@
+OBJC_SOURCES := main.m
+SWIFT_SOURCES := App.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @skipUnlessFoundation
+    @swiftTest
+    def test(self):
+        """Verify printing of Swift implemented ObjC objects."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+
+        # For Swift implemented objects, it's assumed the ObjC runtime prints
+        # only a pointer, and cannot generate any child values.
+        self.expect("v -d no app", startstr="(App *) app = 0x")
+        self.expect(
+            "v -d no -P1 app",
+            matching=False,
+            substrs=["name", "version", "recentDocuments"],
+        )
+
+        # With dynamic typing, the Swift runtime produces Swift child values.
+        self.expect("v app", substrs=["App?) app = 0x"])
+        self.expect("v app.name", startstr='(String) app.name = "Debugger"')
+        self.expect(
+            "v app.version", startstr="((Int, Int)) app.version = (0 = 1, 1 = 0)"
+        )
+
+        documents = """\
+([a.Document]?) app.recentDocuments = 1 value {
+  [0] = {
+    kind = binary
+    path = "/path/to/something"
+  }
+}
+"""
+        self.expect("v app.recentDocuments", startstr=documents)

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+@interface App : NSObject
+@end
+
+int main() {
+  App *app = [App new];
+  printf("break here\n");
+  return 0;
+}


### PR DESCRIPTION
ObjC classes can be implemented in Swift. For such classes, lldb needs the Swift runtime to reflect on the type. This is because the ObjC metadata for those classes doesn't have the full info that the Swift runtime has. Given that some Swift types cannot be represented in ObjC, this is expected.

This set of changes identifies when an ObjC class is implemented in Swift. When that is the case, the Swift runtime is used to determine its dynamic type. This allows the debugger to show the user the Swift representation – all the properties are shown as children, even non-ObjC types and values.

A consequence of this change is that when debugging ObjC code, the debugger will show Swift types for Swift-implemented classes. For example, given a class named Engine, instead of showing the ObjC spelling: `Engine *`, the Swift spelling will be used instead: `Engine?`.

This functionality will be crucial with the work to [re-implement Foundation in Swift](https://www.swift.org/blog/future-of-foundation/). LLDB will need access to the Swift representation of types in order to provide user friendly data formatters.

This PR contains an upstream commit that can live outside of the apple/llvm-project ([D152837](https://reviews.llvm.org/D152837)), and includes an additional commit that  implements the Swift language runtime support for handling of `@objc` classes.

rdar://108478831
