### PR TITLE
[lldb] Add Foundation._NSSwiftTimeZone support

### DIFF
--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -67,6 +67,12 @@ public:
 
   virtual lldb::LanguageType GetLanguageType() const = 0;
 
+  /// Return the preferred language runtime instance, which in most cases will
+  /// be the current instance.
+  virtual LanguageRuntime *GetPreferredLanguageRuntime(ValueObject &in_value) {
+    return nullptr;
+  }
+
   virtual bool GetObjectDescription(Stream &str, ValueObject &object) = 0;
 
   virtual bool GetObjectDescription(Stream &str, Value &value,

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -181,7 +181,18 @@ bool ValueObjectDynamicValue::UpdateValue() {
       known_type != lldb::eLanguageTypeUnknown &&
       known_type != lldb::eLanguageTypeC) {
     runtime = process->GetLanguageRuntime(known_type);
-    if (runtime)
+    if (auto *preferred_runtime =
+            runtime->GetPreferredLanguageRuntime(*m_parent)) {
+      // Try the preferred runtime first.
+      found_dynamic_type = preferred_runtime->GetDynamicTypeAndAddress(
+          *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
+          value_type);
+      if (found_dynamic_type)
+        // Set the operative `runtime` for later use in this function.
+        runtime = preferred_runtime;
+    }
+    if (!found_dynamic_type)
+      // Fallback to the runtime for `known_type`.
       found_dynamic_type = runtime->GetDynamicTypeAndAddress(
           *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
           value_type);

--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -132,6 +132,20 @@ bool lldb_private::formatters::NSTimeZoneSummaryProvider(
       stream.Printf("%s", summary_stream.GetData());
       return true;
     }
+  } else if (class_name == "_NSSwiftTimeZone") {
+    llvm::ArrayRef<ConstString> identifier_path = {
+        ConstString("timeZone"),
+        ConstString("_timeZone"),
+        ConstString("some"),
+        ConstString("identifier"),
+    };
+    if (auto identifier_sp = valobj.GetChildAtNamePath(identifier_path)) {
+      std::string desc;
+      if (identifier_sp->GetSummaryAsCString(desc, options)) {
+        stream.PutCString(desc);
+        return true;
+      }
+    }
   }
 
   return false;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -636,6 +636,11 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Decimal summary provider", ConstString("Foundation.Decimal"),
       TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
 
+  lldb_private::formatters::AddCXXSummary(
+      swift_category_sp, lldb_private::formatters::NSTimeZoneSummaryProvider,
+      "NSTimeZone summary provider", ConstString("Foundation._NSSwiftTimeZone"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
+
   lldb_private::formatters::AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::URLComponentsSyntheticFrontEndCreator,

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.h
@@ -12,6 +12,7 @@
 #include <mutex>
 
 #include "AppleObjCRuntimeV2.h"
+#include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private.h"
 
 #include "Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h"
@@ -33,6 +34,8 @@ public:
   bool IsValid() override {
     return true; // any Objective-C v2 runtime class descriptor we vend is valid
   }
+
+  lldb::LanguageType GetImplementationLanguage() const override;
 
   // a custom descriptor is used for tagged pointers
   bool GetTaggedPointerInfo(uint64_t *info_bits = nullptr,

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -33,6 +33,7 @@
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/DynamicLoader.h"
 #include "lldb/Target/ExecutionContext.h"
+#include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
@@ -756,6 +757,19 @@ AppleObjCRuntimeV2::AppleObjCRuntimeV2(Process *process,
       HasSymbol(g_objc_getRealizedClassList_trylock);
   WarnIfNoExpandedSharedCache();
   RegisterObjCExceptionRecognizer(process);
+}
+
+LanguageRuntime *
+AppleObjCRuntimeV2::GetPreferredLanguageRuntime(ValueObject &in_value) {
+  if (auto process_sp = in_value.GetProcessSP()) {
+    assert(process_sp.get() == m_process);
+    if (auto descriptor_sp = GetNonKVOClassDescriptor(in_value)) {
+      LanguageType impl_lang = descriptor_sp->GetImplementationLanguage();
+      if (impl_lang != eLanguageTypeUnknown)
+        return process_sp->GetLanguageRuntime(impl_lang);
+    }
+  }
+  return nullptr;
 }
 
 bool AppleObjCRuntimeV2::GetDynamicTypeAndAddress(

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -37,6 +37,8 @@ public:
 
   static llvm::StringRef GetPluginNameStatic() { return "apple-objc-v2"; }
 
+  LanguageRuntime *GetPreferredLanguageRuntime(ValueObject &in_value) override;
+
   static char ID;
 
   bool isA(const void *ClassID) const override {

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -23,6 +23,7 @@
 #include "lldb/Symbol/Type.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Utility/ConstString.h"
+#include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private.h"
 
 class CommandObjectObjC_ClassTable_Dump;
@@ -82,6 +83,11 @@ public:
                                strcmp(class_name, "NSCFType") == 0);
       }
       return (m_is_cf == eLazyBoolYes);
+    }
+
+    /// Determine whether this class is implemented in Swift.
+    virtual lldb::LanguageType GetImplementationLanguage() const {
+      return lldb::eLanguageTypeObjC;
     }
 
     virtual bool IsValid() = 0;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -22,6 +22,7 @@
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ProcessStructReader.h"
+#include "lldb/Target/SectionLoadList.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -39,6 +40,7 @@
 #include "swift/Remote/MemoryReader.h"
 #include "swift/RemoteAST/RemoteAST.h"
 #include "swift/Runtime/Metadata.h"
+#include "swift/Strings.h"
 
 #include <sstream>
 
@@ -2941,6 +2943,80 @@ SwiftLanguageRuntimeImpl::GetValueType(ValueObject &in_value,
   return Value::ValueType::Scalar;
 }
 
+namespace {
+struct SwiftNominalType {
+  std::string module;
+  std::string identifier;
+};
+
+// Find the Swift class that backs an ObjC type.
+//
+// A Swift class that uses the @objc(<ClassName>) attribute will emit ObjC
+// metadata into the binary. Typically, ObjC classes have a symbol in the form
+// of OBJC_CLASS_$_<ClassName>, however for Swift classes, there are two symbols
+// that both point to the ObjC class metadata, where the second symbol is a
+// Swift mangled name.
+std::optional<SwiftNominalType> GetSwiftClass(ValueObject &valobj,
+                                              AppleObjCRuntime &objc_runtime) {
+  // To find the Swift symbol, the following preparation steps are taken:
+  //   1. Get the value's ISA pointer
+  //   2. Resolve the ISA load address into an Address instance
+  //   3. Get the Module that contains the Address
+  auto descriptor_sp = objc_runtime.GetClassDescriptor(valobj);
+  if (!descriptor_sp)
+    return {};
+
+  auto isa_load_addr = descriptor_sp->GetISA();
+  Address isa;
+  const auto &sections = objc_runtime.GetTargetRef().GetSectionLoadList();
+  if (!sections.ResolveLoadAddress(isa_load_addr, isa))
+    return {};
+
+  // Next, iterate over the Module's symbol table, looking for a symbol with
+  // following criteria:
+  //   1. The symbol address is the ISA address
+  //   2. The symbol name is a Swift mangled name
+  std::optional<StringRef> swift_symbol;
+  auto find_swift_symbol_for_isa = [&](Symbol *symbol) {
+    if (symbol->GetAddress() == isa) {
+      StringRef symbol_name =
+          symbol->GetMangled().GetMangledName().GetStringRef();
+      if (SwiftLanguageRuntime::IsSwiftMangledName(symbol_name)) {
+        swift_symbol = symbol_name;
+        return false;
+      }
+    }
+    return true;
+  };
+
+  isa.GetModule()->GetSymtab()->ForEachSymbolContainingFileAddress(
+      isa.GetFileAddress(), find_swift_symbol_for_isa);
+  if (!swift_symbol)
+    return {};
+
+  // Once the Swift symbol is found, demangle it into a node tree. The node tree
+  // provides the final data, the name of the class and the name of its module.
+  swift::Demangle::Context ctx;
+  auto *global = ctx.demangleSymbolAsNode(*swift_symbol);
+  using Kind = Node::Kind;
+  auto *class_node = swift_demangle::nodeAtPath(
+      global, {Kind::TypeMetadata, Kind::Type, Kind::Class});
+  if (class_node && class_node->getNumChildren() == 2) {
+    auto module_node = class_node->getFirstChild();
+    auto ident_node = class_node->getLastChild();
+    if (module_node->getKind() == Kind::Module && module_node->hasText() &&
+        ident_node->getKind() == Kind::Identifier && ident_node->hasText()) {
+      auto module_name = module_node->getText();
+      auto class_name = ident_node->getText();
+      return SwiftNominalType{module_name.str(), class_name.str()};
+    }
+  }
+
+  return {};
+}
+
+} // namespace
+
 bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
@@ -2967,9 +3043,22 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(
       dyn_name.startswith("__NS"))
     return false;
 
+  SwiftNominalType swift_class;
+
+  if (auto maybe_swift_class = GetSwiftClass(in_value, *objc_runtime)) {
+    swift_class = *maybe_swift_class;
+    std::string type_name =
+        (llvm::Twine(swift_class.module) + "." + swift_class.identifier).str();
+    dyn_class_type_or_name.SetName(type_name.data());
+    address.SetRawAddress(in_value.GetPointerValue());
+  } else {
+    swift_class.module = swift::MANGLING_MODULE_OBJC;
+    swift_class.identifier = dyn_name;
+  }
+
   std::string remangled;
   {
-    // Create a mangle tree for __C.dyn_name?.
+    // Create a mangle tree for Swift.Optional<$module.$class>
     using namespace swift::Demangle;
     NodeFactory factory;
     NodePointer global = factory.createNode(Node::Kind::Global);
@@ -2980,7 +3069,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(
     NodePointer ety = factory.createNode(Node::Kind::Type);
     bge->addChild(ety, factory);
     NodePointer e = factory.createNode(Node::Kind::Enum);
-    e->addChild(factory.createNode(Node::Kind::Module, "Swift"), factory);
+    e->addChild(factory.createNode(Node::Kind::Module, swift::STDLIB_NAME),
+                factory);
     e->addChild(factory.createNode(Node::Kind::Identifier, "Optional"),
                 factory);
     ety->addChild(e, factory);
@@ -2989,8 +3079,11 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ClangType(
     NodePointer cty = factory.createNode(Node::Kind::Type);
     list->addChild(cty, factory);
     NodePointer c = factory.createNode(Node::Kind::Class);
-    c->addChild(factory.createNode(Node::Kind::Module, "__C"), factory);
-    c->addChild(factory.createNode(Node::Kind::Identifier, dyn_name), factory);
+    c->addChild(factory.createNode(Node::Kind::Module, swift_class.module),
+                factory);
+    c->addChild(
+        factory.createNode(Node::Kind::Identifier, swift_class.identifier),
+        factory);
     cty->addChild(c, factory);
 
     auto mangling = mangleNode(global);

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct Document {
+    var kind: Kind
+    var path: String
+
+    enum Kind {
+        case binary
+        case text
+    }
+}
+
+@objc(App)
+class App : NSObject {
+    var name: String = "Debugger"
+    var version: (Int, Int) = (1, 0)
+    var recentDocuments: [Document]? = [
+        Document(kind: .binary, path: "/path/to/something"),
+    ]
+}

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
@@ -1,0 +1,5 @@
+OBJC_SOURCES := main.m
+SWIFT_SOURCES := App.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @skipUnlessFoundation
+    @swiftTest
+    def test(self):
+        """Verify printing of Swift implemented ObjC objects."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+
+        # For Swift implemented objects, it's assumed the ObjC runtime prints
+        # only a pointer, and cannot generate any child values.
+        self.expect("v -d no app", startstr="(App *) app = 0x")
+        self.expect(
+            "v -d no -P1 app",
+            matching=False,
+            substrs=["name", "version", "recentDocuments"],
+        )
+
+        # With dynamic typing, the Swift runtime produces Swift child values.
+        self.expect("v app", substrs=["App?) app = 0x"])
+        self.expect("v app.name", startstr='(String) app.name = "Debugger"')
+        self.expect(
+            "v app.version", startstr="((Int, Int)) app.version = (0 = 1, 1 = 0)"
+        )
+
+        documents = """\
+([a.Document]?) app.recentDocuments = 1 value {
+  [0] = {
+    kind = binary
+    path = "/path/to/something"
+  }
+}
+"""
+        self.expect("v app.recentDocuments", startstr=documents)

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+@interface App : NSObject
+@end
+
+int main() {
+  App *app = [App new];
+  printf("break here\n");
+  return 0;
+}


### PR DESCRIPTION
`_NSSwiftTimeZone` is the new Swift implementation of `NSTimeZone`.

This is tested by `TestDataFormatterObjCNSDate.py`, where the NSTimeZone summary string tests if run on macOS Sonoma, but with this change they pass.

See #7073 for the infrastructure changes that this depends on.

rdar://108478831