### PR TITLE
[NFC] Pull in None with Optional

### DIFF
--- a/llvm/include/llvm/ADT/Optional.h
+++ b/llvm/include/llvm/ADT/Optional.h
@@ -17,6 +17,7 @@
 #define LLVM_ADT_OPTIONAL_H
 
 #include <optional>
+#include "llvm/ADT/None.h"
 
 namespace llvm {
 // Legacy alias of llvm::Optional to std::optional.


### PR DESCRIPTION
None is frequently used with Optionals. The old llvm Optional header used to pull in None with it, so I'm adding that now to help move things along.