### PR TITLE
Improve error messaging when debugserver fails to complete attaching

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -1846,3 +1846,11 @@ bool DNBGetAddressingBits(uint32_t &addressing_bits) {
 
   return addressing_bits > 0;
 }
+
+nub_process_t DNBGetParentProcessID(nub_process_t child_pid) {
+  return MachProcess::GetParentProcessID(child_pid);
+}
+
+bool DNBProcessIsBeingDebugged(nub_process_t pid) {
+  return MachProcess::ProcessIsBeingDebugged(pid);
+}

--- a/lldb/tools/debugserver/source/DNB.h
+++ b/lldb/tools/debugserver/source/DNB.h
@@ -247,4 +247,9 @@ std::string DNBGetMacCatalystVersionString();
 bool DNBDebugserverIsTranslated();
 
 bool DNBGetAddressingBits(uint32_t &addressing_bits);
+
+nub_process_t DNBGetParentProcessID(nub_process_t child_pid);
+
+bool DNBProcessIsBeingDebugged(nub_process_t pid);
+
 #endif

--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.h
@@ -126,6 +126,11 @@ public:
   static bool GetOSVersionNumbers(uint64_t *major, uint64_t *minor,
                                   uint64_t *patch);
   static std::string GetMacCatalystVersionString();
+
+  static nub_process_t GetParentProcessID(nub_process_t child_pid);
+
+  static bool ProcessIsBeingDebugged(nub_process_t pid);
+
 #ifdef WITH_BKS
   static void BKSCleanupAfterAttach(const void *attach_token,
                                     DNBError &err_str);

--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -3630,14 +3630,8 @@ static bool attach_failed_due_to_uid_mismatch (nub_process_t pid,
 // processes and step through to find the one we're looking for
 // (as process_does_not_exist() does).
 static bool process_is_already_being_debugged (nub_process_t pid) {
-  struct kinfo_proc kinfo;
-  int mib[] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, pid};
-  size_t len = sizeof(struct kinfo_proc);
-  if (sysctl(mib, sizeof(mib) / sizeof(mib[0]), &kinfo, &len, NULL, 0) != 0) {
-    return false; // pid doesn't exist? well, it's not being debugged...
-  }
-  if (kinfo.kp_proc.p_flag & P_TRACED)
-    return true; // is being debugged already
+  if (DNBProcessIsBeingDebugged(pid) && DNBGetParentProcessID(pid) != getpid())
+    return true;
   else
     return false;
 }


### PR DESCRIPTION
Improve error messaging when debugserver fails to complete attaching

When debugserver is attaching to a process, it first task_for_pid()'s and then ptrace(PT_ATTACHEXC)'s.  When that ptrace() fails to complete, we are in a semi-attached state that we need to give up from, and our error reporting isn't ideal -- we can even claim that the process is already being debugged (by ourselves).

Differential Revision: https://reviews.llvm.org/D155037 rdar://101152233

(cherry picked from commit bb136f5b393c7c7fe821242d2734bbc5c7287560)