### PR TITLE
Improve error msg in DNBProcessAttach if we can't stop inferior

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -521,7 +521,9 @@ nub_process_t DNBProcessAttach(nub_process_t attach_pid,
 
     if (set_events == 0) {
       if (err_str && err_len > 0)
-        snprintf(err_str, err_len, "operation timed out");
+        snprintf(err_str, err_len,
+                 "attached to process, but could not pause execution; attach "
+                 "failed");
       pid = INVALID_NUB_PROCESS;
     } else {
       if (set_events & (eEventProcessRunningStateChanged |


### PR DESCRIPTION
Improve error msg in DNBProcessAttach if we can't stop inferior

When we attach to a process, we task_for_pid(), ptrace(), and then we try to halt execution of the process and time out after thirty seconds if we cannot interrupt it.  At this point, we must assume we have no control of the inferior process and the attach has failed. The error message we return currently is "operation timed out"; this change improves on that error message to make it more clear what is going on.  Thanks to Jim for pointing this out.

rdar://101152233
(cherry picked from commit 71548de4d885b74e7291db55e8705417ffd49c95)