### PR TITLE
Fix clang optional usage in CIndexDiagnostic.h

### DIFF
--- a/clang/tools/libclang/CIndexDiagnostic.h
+++ b/clang/tools/libclang/CIndexDiagnostic.h
@@ -18,9 +18,10 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
-#include <memory>
-#include <vector>
 #include <assert.h>
+#include <memory>
+#include <optional>
+#include <vector>
 
 namespace clang {
 
@@ -57,11 +58,11 @@ public:
   void recordSourceFileContents(
       CXFile file, StringRef contents, CXSourceRange originalSourceRange);
 
-  Optional<StringRef> getSourceFileContents(
+  std::optional<StringRef> getSourceFileContents(
       CXFile file, CXSourceRange &originalSourceRange) {
     auto found = FileContents.find(file);
     if (found == FileContents.end())
-      return None;
+      return std::nullopt;
 
     originalSourceRange = found->second.OriginalSourceRange;
     return found->second.Contents;

--- a/clang/tools/libclang/CXLoadedDiagnostic.cpp
+++ b/clang/tools/libclang/CXLoadedDiagnostic.cpp
@@ -14,6 +14,7 @@
 #include "CXFile.h"
 #include "CXString.h"
 #include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/FileEntry.h"
 #include "clang/Basic/FileManager.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Frontend/SerializedDiagnosticReader.h"
@@ -383,10 +384,10 @@ std::error_code DiagLoader::visitSourceFileContentsRecord(
           OriginalStartLoc, OriginalEndLoc, OriginalSourceRange))
     return EC;
 
-  auto file = const_cast<FileEntry *>(TopDiags->Files[ID]);
-  if (!file)
+  auto fileItr = TopDiags->Files.find(ID);
+  if (fileItr == TopDiags->Files.end())
     return reportInvalidFile("Source file contents for unknown file ID");
-
+  FileEntry *file = const_cast<FileEntry*>(&fileItr->second.getFileEntry());
   StringRef CopiedContents(TopDiags->copyString(Contents),
                            Contents.size());
 


### PR DESCRIPTION
Optional changed in LLVM. Fixing patch to use `std::optional` and `std::nullopt` instead of `llvm::Optional` and `llvm::None`.

rdar://112176816