### PR TITLE
[ORC][AArch64] Guard against negative offsets in writeIndirectStubsBl…

### DIFF
--- a/llvm/lib/ExecutionEngine/Orc/OrcABISupport.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/OrcABISupport.cpp
@@ -165,11 +165,11 @@ void OrcAArch64::writeIndirectStubsBlock(
   //
   // .section __orc_stubs
   // stub1:
-  //                 ldr     x0, ptr1       ; PC-rel load of ptr1
-  //                 br      x0             ; Jump to resolver
+  //                 ldr     x16, ptr1       ; PC-rel load of ptr1
+  //                 br      x16             ; Jump to resolver
   // stub2:
-  //                 ldr     x0, ptr2       ; PC-rel load of ptr2
-  //                 br      x0             ; Jump to resolver
+  //                 ldr     x16, ptr2       ; PC-rel load of ptr2
+  //                 br      x16             ; Jump to resolver
   //
   // ...
   //
@@ -188,8 +188,10 @@ void OrcAArch64::writeIndirectStubsBlock(
          "PointersBlock is out of range");
   uint64_t PtrDisplacement =
       PointersBlockTargetAddress - StubsBlockTargetAddress;
+  assert((PtrDisplacement % 8 == 0) &&
+         "Displacement to pointer is not a multiple of 8");
   uint64_t *Stub = reinterpret_cast<uint64_t *>(StubsBlockWorkingMem);
-  uint64_t PtrOffsetField = PtrDisplacement << 3;
+  uint64_t PtrOffsetField = ((PtrDisplacement >> 2) & 0x7ffff) << 5;
 
   for (unsigned I = 0; I < NumStubs; ++I)
     Stub[I] = 0xd61f020058000010 | PtrOffsetField;


### PR DESCRIPTION
…ock.

In OrcAArch64::writeIndirectStubsBlock, masks the high bits of the immediate operand to the stub's ldr instruction so that negative offsets to the stub pointer do not overflow.

No testcase -- this fixes most of the OrcLazy testcases for AArch64 (at least on Darwin), but we still need to fix the exception-handling test before we can turn them on.