### PR TITLE
[clang][modules] Don't validate textual header includes

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -3796,6 +3796,8 @@ static bool RenderModulesOptions(Compilation &C, const Driver &D,
     if (Args.hasFlag(options::OPT_fprebuilt_implicit_modules,
                      options::OPT_fno_prebuilt_implicit_modules, false))
       CmdArgs.push_back("-fprebuilt-implicit-modules");
+    // Workaround for rdar://110154680.
+    CmdArgs.push_back("-fno-modules-validate-textual-header-includes");
     if (Args.hasFlag(options::OPT_fmodules_validate_input_files_content,
                      options::OPT_fno_modules_validate_input_files_content,
                      false))

--- a/clang/test/Modules/no-undeclared-includes-lookup-cache.c
+++ b/clang/test/Modules/no-undeclared-includes-lookup-cache.c
@@ -1,0 +1,28 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- include/module.modulemap
+module A [no_undeclared_includes] { textual header "A.h" }
+module B { header "B.h" }
+//--- include/A.h
+// Even textual headers within module A now inherit [no_undeclared_includes] and
+// thus do not have that include.
+#if __has_include(<B.h>)
+#endif
+//--- include/B.h
+
+//--- tu.c
+#if !__has_include(<B.h>)
+#error Main TU does have that include.
+#endif
+
+#include "A.h"
+
+#if !__has_include(<B.h>)
+#error Main TU still has that include.
+// We hit the above because the unsuccessful __has_include check in A.h taints
+// lookup cache (HeaderSearch::LookupFileCache) of this CompilerInstance.
+#endif
+
+// RUN: %clang -I %t/include -fmodules -fimplicit-module-maps \
+// RUN:   -fmodules-cache-path=%t/cache -fsyntax-only %t/tu.c


### PR DESCRIPTION
This fixes rdar://110154680 by preventing tainting the header lookup cache with results from incompatible contexts (with different `RequestingModules`). More information in the discussion here: https://reviews.llvm.org/D132779