### PR TITLE
Support Swift plugin server paths without plugin names.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1127,10 +1127,15 @@ void SwiftASTContext::DiagnoseWarnings(Process &process, Module &module) const {
 /// by converting  ${toolchain}/usr/(local)?/lib/swift/host/plugins
 /// into           ${toolchain}/usr/bin/swift-plugin-server
 /// FIXME: move this to Host, it may be platform-specific.
-static std::string GetPluginServer(llvm::StringRef plugin_library_path) {
-  llvm::StringRef path = llvm::sys::path::parent_path(plugin_library_path);
-  if (llvm::sys::path::filename(path) != "plugins")
-    return {};
+std::string
+SwiftASTContext::GetPluginServer(llvm::StringRef plugin_library_path) {
+  llvm::StringRef path = plugin_library_path;
+  if (llvm::sys::path::filename(path) != "plugins") {
+    // Strip off a plugin name.
+    path = llvm::sys::path::parent_path(plugin_library_path);
+    if (llvm::sys::path::filename(path) != "plugins")
+      return {};
+  }
   path = llvm::sys::path::parent_path(path);
   if (llvm::sys::path::filename(path) != "host")
     return {};
@@ -1145,10 +1150,7 @@ static std::string GetPluginServer(llvm::StringRef plugin_library_path) {
     path = llvm::sys::path::parent_path(path);
   llvm::SmallString<256> server(path);
   llvm::sys::path::append(server, "bin", "swift-plugin-server");
-  std::string result(server);
-  if (FileSystem::Instance().Exists(result))
-    return result;
-  return {};
+  return std::string(server);
 }
 
 static std::string GetPluginServerForSDK(llvm::StringRef sdk_path) {
@@ -1325,8 +1327,12 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
             // Rewrite them to go through an ABI-compatible swift-plugin-server.
             if (known_plugin_search_paths.insert(path).second) {
               if (known_external_plugin_search_paths.insert(path).second) {
-                std::string server = get_plugin_server(
-                    path, [&]() { return GetPluginServer(path); });
+                std::string server = get_plugin_server(path, [&]() {
+                  std::string server = SwiftASTContext::GetPluginServer(path);
+                  if (!server.empty() && !FileSystem::Instance().Exists(server))
+                    server.clear();
+                  return server;
+                });
                 if (server.empty())
                   continue;
                 if (exists(path))

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -261,6 +261,7 @@ public:
   void AddExtraClangArgs(const std::vector<std::string> &ExtraArgs);
   static void AddExtraClangArgs(const std::vector<std::string>& source,
                                 std::vector<std::string>& dest);
+  static std::string GetPluginServer(llvm::StringRef plugin_library_path);
 
   /// Add the target's swift-extra-clang-flags to the ClangImporter options.
   void AddUserClangArgs(TargetProperties &props);

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -167,6 +167,25 @@ TEST_F(TestSwiftASTContext, ApplyWorkingDir) {
   EXPECT_EQ(dot_dot_path, llvm::SmallString<128>("-iquote."));
 }
 
+TEST_F(TestSwiftASTContext, PluginPath) {
+  llvm::StringRef path(
+      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
+      "lib/swift/host/plugins/libFoo.dylib");
+  llvm::StringRef local_path(
+      "/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/"
+      "local/lib/swift/host/plugins/libFoo.dylib");
+  std::string server("/Xcode.app/Contents/Developer/Toolchains/"
+                     "XcodeDefault.xctoolchain/usr/bin/swift-plugin-server");
+  EXPECT_EQ(SwiftASTContext::GetPluginServer(path), server);
+  EXPECT_EQ(
+      SwiftASTContext::GetPluginServer(llvm::sys::path::parent_path(path)),
+      server);
+  EXPECT_EQ(SwiftASTContext::GetPluginServer(local_path), server);
+  EXPECT_EQ(
+      SwiftASTContext::GetPluginServer(llvm::sys::path::parent_path(local_path)),
+      server);
+}
+
 namespace {
 const std::vector<std::string> duplicated_flags = {
     "-DMACRO1",


### PR DESCRIPTION
Support Swift plugin server paths without plugin names.
    
The old code assumed that all plugin paths end in a dylib or
executable name, thi patch makes it also work with a path pointing to
a plugin directory.
    
rdar://112122752