### PR TITLE
ExecutionEngine: support `IMAGE_REL_AMD64_SECTION` relocations

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/Targets/RuntimeDyldCOFFX86_64.h
@@ -134,6 +134,13 @@ public:
       break;
     }
 
+    case COFF::IMAGE_REL_AMD64_SECTION: {
+      assert(static_cast<int16_t>(RE.SectionID) <= INT16_MAX && "Relocation overflow");
+      assert(static_cast<int16_t>(RE.SectionID) >= INT16_MIN && "Relocation underflow");
+      writeBytesUnaligned(RE.SectionID, Target, 2);
+      break;
+    }
+
     default:
       llvm_unreachable("Relocation type not implemented yet!");
       break;

--- a/llvm/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64.s
+++ b/llvm/test/ExecutionEngine/RuntimeDyld/X86/COFF_x86_64.s
@@ -4,6 +4,15 @@
 # RUN:   -dummy-extern external_data=0x2 -verify -check=%s %t/COFF_x86_64.o
 
 
+	.section section,"rx"
+section:
+	.long 0
+Lreloc:
+	.long 0
+# rtdyld-check: *{2}Lreloc = 1
+	.reloc 4, secidx, section+4
+
+
         .text
 	.def	 F;
 	.scl	2;


### PR DESCRIPTION
This relocation type is often used for debug information on Windows.  We would previously abort due to the unreachable for the unhandled relocation type.  Add support for this to prevent LLDB from aborting if it encounters this relocation type.

(cherry picked from commit d4a5bef170ce7c52c9f8bd3763c4b181da7d21c6)