### PR TITLE
[🌲] Muting llvm::None warning in Swift for now

### DIFF
--- a/llvm/include/llvm/ADT/ArrayRef.h
+++ b/llvm/include/llvm/ADT/ArrayRef.h
@@ -508,70 +508,90 @@ namespace llvm {
   /// @{
   /// Construct an ArrayRef from a single element.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const T &OneElt) {
     return OneElt;
   }
 
   /// Construct an ArrayRef from a pointer and length.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const T *data, size_t length) {
     return ArrayRef<T>(data, length);
   }
 
   /// Construct an ArrayRef from a range.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const T *begin, const T *end) {
     return ArrayRef<T>(begin, end);
   }
 
   /// Construct an ArrayRef from a SmallVector.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const SmallVectorImpl<T> &Vec) {
     return Vec;
   }
 
   /// Construct an ArrayRef from a SmallVector.
   template <typename T, unsigned N>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const SmallVector<T, N> &Vec) {
     return Vec;
   }
 
   /// Construct an ArrayRef from a std::vector.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const std::vector<T> &Vec) {
     return Vec;
   }
 
   /// Construct an ArrayRef from a std::array.
   template <typename T, std::size_t N>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const std::array<T, N> &Arr) {
     return Arr;
   }
 
   /// Construct an ArrayRef from an ArrayRef (no-op) (const)
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const ArrayRef<T> &Vec) {
     return Vec;
   }
 
   /// Construct an ArrayRef from an ArrayRef (no-op)
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> &makeArrayRef(ArrayRef<T> &Vec) {
     return Vec;
   }
 
   /// Construct an ArrayRef from a C array.
   template <typename T, size_t N>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "ArrayRef")
+#endif // SWIFT_TARGET
   ArrayRef<T> makeArrayRef(const T (&Arr)[N]) {
     return ArrayRef<T>(Arr);
   }
@@ -608,56 +628,72 @@ namespace llvm {
 
   /// Construct a MutableArrayRef from a single element.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(T &OneElt) {
     return OneElt;
   }
 
   /// Construct a MutableArrayRef from a pointer and length.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(T *data, size_t length) {
     return MutableArrayRef<T>(data, length);
   }
 
   /// Construct a MutableArrayRef from a SmallVector.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(SmallVectorImpl<T> &Vec) {
     return Vec;
   }
 
   /// Construct a MutableArrayRef from a SmallVector.
   template <typename T, unsigned N>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(SmallVector<T, N> &Vec) {
     return Vec;
   }
 
   /// Construct a MutableArrayRef from a std::vector.
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(std::vector<T> &Vec) {
     return Vec;
   }
 
   /// Construct a MutableArrayRef from a std::array.
   template <typename T, std::size_t N>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(std::array<T, N> &Arr) {
     return Arr;
   }
 
   /// Construct a MutableArrayRef from a MutableArrayRef (no-op) (const)
   template <typename T>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(const MutableArrayRef<T> &Vec) {
     return Vec;
   }
 
   /// Construct a MutableArrayRef from a C array.
   template <typename T, size_t N>
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
   LLVM_DEPRECATED("Use deduction guide instead", "MutableArrayRef")
+#endif // SWIFT_TARGET
   MutableArrayRef<T> makeMutableArrayRef(T (&Arr)[N]) {
     return MutableArrayRef<T>(Arr);
   }

--- a/llvm/include/llvm/ADT/None.h
+++ b/llvm/include/llvm/ADT/None.h
@@ -22,9 +22,14 @@
 namespace llvm {
 /// A simple null object to allow implicit construction of std::optional<T>
 /// and similar types without having to spell out the specialization's name.
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
 LLVM_DEPRECATED("Use std::nullopt_t instead", "std::nullopt_t")
+#endif // SWIFT_TARGET
 typedef std::nullopt_t NoneType;
+
+#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
 LLVM_DEPRECATED("Use std::nullopt instead.", "std::nullopt")
+#endif // SWIFT_TARGET
 inline constexpr std::nullopt_t None = std::nullopt;
 }
 


### PR DESCRIPTION
Swift can't do anything with the None warnings until the release/5.9 branch is well and dead and folks don't need to cherry-pick things back anymore. The wall of warnings is mostly unhelpful as it masks actual issues.

 - Tracking replacing `llvm::None` and `llvm::Optional` with `std::nullopt` and `std::optional` in rdar://112153764