### PR TITLE
[lldb] Make access to ReflectionContext thread safe

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -500,6 +500,9 @@ public:
   bool AnyOf(
       std::function<bool(lldb_private::Module &module)> const &callback) const;
 
+  /// Atomically swaps the contents of this module list with \a other.
+  void Swap(ModuleList &other);
+
 protected:
   // Class typedefs.
   typedef std::vector<lldb::ModuleSP>

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1295,3 +1295,10 @@ bool ModuleList::AnyOf(
 
   return false;
 }
+
+
+void ModuleList::Swap(ModuleList &other) {
+  // scoped_lock locks both mutexes at once.
+  std::scoped_lock lock(m_modules_mutex, other.m_modules_mutex);
+  m_modules.swap(other.m_modules);
+}

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -447,11 +447,45 @@ static bool HasReflectionInfo(ObjectFile *obj_file) {
   return hasReflectionSection;
 }
 
-SwiftLanguageRuntimeImpl::ReflectionContextInterface *
+SwiftLanguageRuntimeImpl::ThreadSafeReflectionContext 
 SwiftLanguageRuntimeImpl::GetReflectionContext() {
-  if (!m_initialized_reflection_ctx)
-    SetupReflection();
-  return m_reflection_ctx.get();
+  m_reflection_ctx_mutex.lock();
+  SetupReflection();
+  // SetupReflection can potentially fail.
+  if (m_initialized_reflection_ctx)
+    ProcessModulesToAdd();
+  return {m_reflection_ctx.get(), m_reflection_ctx_mutex};
+}
+
+void SwiftLanguageRuntimeImpl::ProcessModulesToAdd() {
+  // A snapshot of the modules to be processed. This is necessary because
+  // AddModuleToReflectionContext may recursively call into this function again.
+  ModuleList modules_to_add_snapshot;
+  {
+    std::lock_guard<std::recursive_mutex> lock(m_modules_to_add.GetMutex());
+    modules_to_add_snapshot = m_modules_to_add;
+    m_modules_to_add.Clear();
+  }
+
+  if (modules_to_add_snapshot.IsEmpty())
+    return;
+
+  auto &target = m_process.GetTarget();
+  auto exe_module = target.GetExecutableModule();
+  Progress progress(
+      llvm::formatv("Setting up Swift reflection for '{0}'",
+                    exe_module->GetFileSpec().GetFilename().AsCString()),
+      modules_to_add_snapshot.GetSize());
+
+  size_t completion = 0;
+
+  // Add all defered modules to reflection context that were added to
+  // the target since this SwiftLanguageRuntime was created.
+  modules_to_add_snapshot.ForEach([&](const ModuleSP &module_sp) -> bool {
+    AddModuleToReflectionContext(module_sp);
+    progress.Increment(++completion);
+    return true;
+  });
 }
 
 SwiftMetadataCache *
@@ -463,79 +497,53 @@ SwiftLanguageRuntimeImpl::GetSwiftMetadataCache() {
 
 void SwiftLanguageRuntimeImpl::SetupReflection() {
   LLDB_SCOPED_TIMER();
- 
-  // SetupABIBit() iterates of the Target's images and thus needs to
-  // acquire that ModuleList's lock. We need to acquire this before
-  // locking m_add_module_mutex, since ModulesDidLoad can also be
-  // called from a place where that lock is already held:
-  // +   lldb_private::DynamicLoaderDarwin::AddModulesUsingImageInfos()
-  // +     lldb_private::ModuleList::AppendIfNeeded()
-  // +       lldb_private::Target::NotifyModuleAdded()
-  // +         lldb_private::Target::ModulesDidLoad()
 
+
+  std::lock_guard<std::recursive_mutex> lock(m_reflection_ctx_mutex);
+  if (m_initialized_reflection_ctx)
+    return;
+ 
   // The global ABI bit is read by the Swift runtime library.
   SetupABIBit();
 
-  // A copy of the modules that should be added, to prevent mutating the list
-  // while iterating over it.
-  ModuleList modules_snapshot;
-
   auto &target = m_process.GetTarget();
   auto exe_module = target.GetExecutableModule();
-  {
-    std::lock_guard<std::recursive_mutex> lock(m_add_module_mutex);
-    if (m_initialized_reflection_ctx)
-      return;
 
-    if (!exe_module) {
-      LLDB_LOGF(GetLog(LLDBLog::Types), "%s: Failed to get executable module",
-                LLVM_PRETTY_FUNCTION);
-      m_initialized_reflection_ctx = false;
-      return;
-    }
-
-    bool objc_interop = (bool)findRuntime(m_process, RuntimeKind::ObjC);
-    const char *objc_interop_msg =
-        objc_interop ? "with Objective-C interopability" : "Swift only";
-
-    auto &triple = exe_module->GetArchitecture().GetTriple();
-    if (triple.isArch64Bit()) {
-      LLDB_LOGF(GetLog(LLDBLog::Types),
-                "Initializing a 64-bit reflection context (%s) for \"%s\"",
-                triple.str().c_str(), objc_interop_msg);
-      m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext64(
-          this->GetMemoryReader(), objc_interop, GetSwiftMetadataCache());
-    } else if (triple.isArch32Bit()) {
-      LLDB_LOGF(GetLog(LLDBLog::Types),
-                "Initializing a 32-bit reflection context (%s) for \"%s\"",
-                triple.str().c_str(), objc_interop_msg);
-      m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext32(
-          this->GetMemoryReader(), objc_interop, GetSwiftMetadataCache());
-    } else {
-      LLDB_LOGF(GetLog(LLDBLog::Types),
-                "Could not initialize reflection context for \"%s\"",
-                triple.str().c_str());
-    }
-
-    modules_snapshot = std::move(m_modules_to_add);
-    m_modules_to_add.Clear();
-    m_initialized_reflection_ctx = true;
+  auto *log = GetLog(LLDBLog::Types);
+  if (!exe_module) {
+    LLDB_LOGF(log, "%s: Failed to get executable module",
+              LLVM_PRETTY_FUNCTION);
+    m_initialized_reflection_ctx = false;
+    return;
   }
 
-  Progress progress(
-      llvm::formatv("Setting up Swift reflection for '{0}'",
-                    exe_module->GetFileSpec().GetFilename().AsCString()),
-      modules_snapshot.GetSize());
+  bool objc_interop = (bool)findRuntime(m_process, RuntimeKind::ObjC);
+  const char *objc_interop_msg =
+      objc_interop ? "with Objective-C interopability" : "Swift only";
 
-  size_t completion = 0;
-
-  // Add all defered modules to reflection context that were added to
-  // the target since this SwiftLanguageRuntime was created.
-  modules_snapshot.ForEach([&](const ModuleSP &module_sp) -> bool {
-    AddModuleToReflectionContext(module_sp);
-    progress.Increment(++completion);
-    return true;
-  });
+  auto &triple = exe_module->GetArchitecture().GetTriple();
+  if (triple.isArch64Bit()) {
+    LLDB_LOGF(log, "Initializing a 64-bit reflection context (%s) for \"%s\"",
+              triple.str().c_str(), objc_interop_msg);
+    m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext64(
+        this->GetMemoryReader(), objc_interop, GetSwiftMetadataCache());
+  } else if (triple.isArch32Bit()) {
+    LLDB_LOGF(log,
+              "Initializing a 32-bit reflection context (%s) for \"%s\"",
+              triple.str().c_str(), objc_interop_msg);
+    m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext32(
+        this->GetMemoryReader(), objc_interop, GetSwiftMetadataCache());
+  } else {
+    LLDB_LOGF(log,
+              "Could not initialize reflection context for \"%s\"",
+              triple.str().c_str());
+  }
+  // We set m_initialized_reflection_ctx to true here because
+  // AddModuleToReflectionContext can potentially call into SetupReflection
+  // again (which will early exit). This is safe to do since every other thread
+  // using reflection context will have to wait until all the modules are added,
+  // since the thread performing the initialization locked the mutex.
+  m_initialized_reflection_ctx = true;
 }
 
 bool SwiftLanguageRuntimeImpl::IsABIStable() {
@@ -922,17 +930,9 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
 }
 
 void SwiftLanguageRuntimeImpl::ModulesDidLoad(const ModuleList &module_list) {
-  // If the reflection context hasn't been initialized, add them to
-  // the list of deferred modules so they are added in
-  // SetupReflection(), otherwise add them directly.
-  std::lock_guard<std::recursive_mutex> lock(m_add_module_mutex);
-  if (!m_initialized_reflection_ctx)
-    m_modules_to_add.AppendIfNeeded(module_list);
-  else
-    module_list.ForEach([&](const ModuleSP &module_sp) -> bool {
-      AddModuleToReflectionContext(module_sp);
-      return true;
-    });
+  // The modules will be lazily processed on the next call to
+  // GetReflectionContext.
+  m_modules_to_add.AppendIfNeeded(module_list);
 }
 
 std::string 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -461,11 +461,7 @@ void SwiftLanguageRuntimeImpl::ProcessModulesToAdd() {
   // A snapshot of the modules to be processed. This is necessary because
   // AddModuleToReflectionContext may recursively call into this function again.
   ModuleList modules_to_add_snapshot;
-  {
-    std::lock_guard<std::recursive_mutex> lock(m_modules_to_add.GetMutex());
-    modules_to_add_snapshot = m_modules_to_add;
-    m_modules_to_add.Clear();
-  }
+  modules_to_add_snapshot.Swap(m_modules_to_add);
 
   if (modules_to_add_snapshot.IsEmpty())
     return;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -256,6 +256,29 @@ public:
     stripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
   };
 
+  /// A wrapper around TargetReflectionContext, which holds a lock to ensure
+  /// exclusive access.
+  struct ThreadSafeReflectionContext {
+    ThreadSafeReflectionContext(ReflectionContextInterface *reflection_ctx,
+                             std::recursive_mutex &mutex)
+        : m_reflection_ctx(reflection_ctx), m_lock(mutex, std::adopt_lock) {}
+
+    ReflectionContextInterface *operator->() const {
+      return m_reflection_ctx;
+    }
+
+    operator bool() const {
+      return m_reflection_ctx != nullptr;
+    }
+
+  private:
+    ReflectionContextInterface *m_reflection_ctx;
+    // This lock operates on a recursive mutex because the initialization
+    // of ReflectionContext recursive calls itself (see
+    // SwiftLanguageRuntimeImpl::SetupReflection).
+    std::lock_guard<std::recursive_mutex> m_lock;
+  };
+
 protected:
   static void
   ForEachGenericParameter(swift::Demangle::NodePointer node,
@@ -384,8 +407,13 @@ private:
   /// Lazily initialize and return \p m_dynamic_exclusivity_flag_addr.
   llvm::Optional<lldb::addr_t> GetDynamicExclusivityFlagAddr();
 
-  /// Lazily initialize the reflection context. Return \p nullptr on failure.
-  ReflectionContextInterface *GetReflectionContext();
+  /// Lazily initialize the reflection context. Returns a
+  /// ThreadSafeReflectionContext with a \p nullptr on failure.
+  ThreadSafeReflectionContext GetReflectionContext();
+
+  // Add the modules in m_modules_to_add to the Reflection Context. The
+  // ModulesDidLoad() callback appends to m_modules_to_add.
+  void ProcessModulesToAdd();
 
   /// Lazily initialize and return \p m_SwiftNativeNSErrorISA.
   llvm::Optional<lldb::addr_t> GetSwiftNativeNSErrorISA();
@@ -409,12 +437,14 @@ private:
   /// \{
   std::unique_ptr<ReflectionContextInterface> m_reflection_ctx;
 
+  /// Mutex guarding accesses to the reflection context.
+  std::recursive_mutex m_reflection_ctx_mutex;
+
   SwiftMetadataCache m_swift_metadata_cache;
 
   /// Record modules added through ModulesDidLoad, which are to be
   /// added to the reflection context once it's being initialized.
   ModuleList m_modules_to_add;
-  std::recursive_mutex m_add_module_mutex;
 
   /// Add the image to the reflection context.
   /// \return true on success.


### PR DESCRIPTION
ReflectionContext can potentially be accessed by multiple threads at the same time, make accessing ReflectionContext thread safe by hiding it behind a lock.

rdar://112207497