### PR TITLE
[lldb] If the function cannot be found, use the symbol to get instructions.

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -15,11 +15,25 @@ class TestCase(lldbtest.TestBase):
         target, _, thread, _ = lldbutil.run_to_source_breakpoint(self, "await f()", src)
         self.assertEqual(thread.frame[0].function.mangled, "$s1a5entryO4mainyyYaFZ")
 
-        function = target.FindFunctions("$s1a5entryO4mainyyYaFZTQ0_")[0].function
-        instructions = list(function.GetInstructions(target))
+        sym_ctx_list = target.FindFunctions("$s1a5entryO4mainyyYaFZTQ0_", lldb.eFunctionNameTypeAuto)
+        self.assertEquals(sym_ctx_list.GetSize(), 1)
+        symbolContext = sym_ctx_list.GetContextAtIndex(0)
+        function = symbolContext.GetFunction()
+        if function:
+            instructions = list(function.GetInstructions(target))
+        else:
+            symbol = symbolContext.GetSymbol()
+            self.assertIsNotNone(symbol)
+            instructions = list(symbol.GetInstructions(target))
 
         # Expected to be a trampoline that tail calls `swift_task_switch`.
-        self.assertIn("swift_task_switch", instructions[-1].GetComment(target))
+        for inst in reversed(instructions):
+            control_flow_kind = inst.GetControlFlowKind(target)
+            if control_flow_kind == lldb.eInstructionControlFlowKindOther:
+                continue
+            self.assertEqual(control_flow_kind, lldb.eInstructionControlFlowKindJump)
+            self.assertIn("swift_task_switch", inst.GetComment(target))
+            break
 
         # Using the line table, build a set of the non-zero line numbers for
         # this this function - and verify that there is exactly one line.


### PR DESCRIPTION
In https://github.com/apple/swift/pull/67077, we split a method's debugging information into declaration and definition to address some compatibility issues under LTO.

However, a test case from lldb was found to have failed.
Sorry, I have no lldb related knowledge. This change may not be correct, so please let me know if there are any problems.

cc @kastiglione @adrian-prantl
