### PR TITLE
Update downstream testcases after clang driver returns error with -###

### DIFF
--- a/clang/test/Driver/darwin-ld.c
+++ b/clang/test/Driver/darwin-ld.c
@@ -169,7 +169,7 @@
 // LINK_IOSSIM_PROFILE: libclang_rt.profile_iossim.a
 // LINK_IOSSIM_PROFILE: libclang_rt.iossim.a
 
-// RUN: %clang -target x86_64-apple-ios13-macabi -mlinker-version=400 -fprofile-instr-generate -### %t.o 2> %t.log
+// RUN: not %clang -target x86_64-apple-ios13-macabi -mlinker-version=400 -fprofile-instr-generate -### %t.o 2> %t.log
 // RUN: FileCheck -check-prefix=LINK_MACABI_PROFILE %s < %t.log
 // LINK_MACABI_PROFILE: {{ld(.exe)?"}}
 // LINK_MACABI_PROFILE: libclang_rt.profile_osx.a

--- a/clang/test/Driver/fdepscan-prefix-map.c
+++ b/clang/test/Driver/fdepscan-prefix-map.c
@@ -1,7 +1,7 @@
-// RUN: %clang -fdepscan-prefix-map=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
-// RUN: %clang -fdepscan-prefix-map==/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
-// RUN: %clang -fdepscan-prefix-map=relative=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
-// RUN: %clang -fdepscan-prefix-map=/=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: not %clang -fdepscan-prefix-map=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: not %clang -fdepscan-prefix-map==/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: not %clang -fdepscan-prefix-map=relative=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: not %clang -fdepscan-prefix-map=/=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
 // INVALID: error: invalid argument '{{.*}}/^bad' to -fdepscan-prefix-map=
 
 // RUN: %clang -fdepscan-prefix-map=/good=/^good -### %s 2>&1 | FileCheck %s

--- a/clang/test/Driver/fsanitize.c
+++ b/clang/test/Driver/fsanitize.c
@@ -568,25 +568,25 @@
 // RUN: not %clang --target=i386-pc-openbsd -fsanitize=memory %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-MSAN-OPENBSD
 // CHECK-MSAN-OPENBSD: unsupported option '-fsanitize=memory' for target 'i386-pc-openbsd'
 
-// RUN: %clang --target=x86_64-apple-darwin -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-X86-64-DARWIN
+// RUN: not %clang --target=x86_64-apple-darwin -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-X86-64-DARWIN
 // CHECK-LSAN-X86-64-DARWIN: unsupported option
 
-// RUN: %clang --target=x86_64-apple-ios-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-X86-64-IOSSIMULATOR
+// RUN: not %clang --target=x86_64-apple-ios-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-X86-64-IOSSIMULATOR
 // CHECK-LSAN-X86-64-IOSSIMULATOR: unsupported option
 
-// RUN: %clang --target=x86_64-apple-tvos-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-X86-64-TVOSSIMULATOR
+// RUN: not %clang --target=x86_64-apple-tvos-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-X86-64-TVOSSIMULATOR
 // CHECK-LSAN-X86-64-TVOSSIMULATOR: unsupported option
 
-// RUN: %clang --target=i386-apple-darwin -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-I386-DARWIN
+// RUN: not %clang --target=i386-apple-darwin -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-I386-DARWIN
 // CHECK-LSAN-I386-DARWIN: unsupported option
 
-// RUN: %clang --target=arm-apple-ios -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-ARM-IOS
+// RUN: not %clang --target=arm-apple-ios -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-ARM-IOS
 // CHECK-LSAN-ARM-IOS: unsupported option
 
-// RUN: %clang --target=i386-apple-ios-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-I386-IOSSIMULATOR
+// RUN: not %clang --target=i386-apple-ios-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-I386-IOSSIMULATOR
 // CHECK-LSAN-I386-IOSSIMULATOR: unsupported option
 
-// RUN: %clang --target=i386-apple-tvos-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-I386-TVOSSIMULATOR
+// RUN: not %clang --target=i386-apple-tvos-simulator -fsanitize=leak %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-LSAN-I386-TVOSSIMULATOR
 // CHECK-LSAN-I386-TVOSSIMULATOR: unsupported option
 
 

--- a/clang/test/Driver/sanitizer-ld.c
+++ b/clang/test/Driver/sanitizer-ld.c
@@ -699,7 +699,7 @@
 // CHECK-ASAN-DARWIN106-CXX-NOT: -lc++abi
 
 // Apple-Clang: Don't support LSan
-// RUN: %clangxx -fsanitize=leak -### %s 2>&1 \
+// RUN: not %clangxx -fsanitize=leak -### %s 2>&1 \
 // RUN:     -mmacosx-version-min=10.6 \
 // RUN:     --target=x86_64-apple-darwin13.4.0 -fuse-ld=ld -stdlib=platform \
 // RUN:     -resource-dir=%S/Inputs/resource_dir \


### PR DESCRIPTION
Update downstream testcases to pass after -### can return error if the driver options are incorrect.