### PR TITLE
Cherry-pick "[lldb] Re-add compile-time checks for SPI in HosInfoMacOSX" to stable/20230725

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -34,18 +34,21 @@
 #include <uuid/uuid.h>
 
 // Objective-C/C++ includes
+#include <AvailabilityMacros.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <Foundation/Foundation.h>
 #include <mach-o/dyld.h>
+#if defined(MAC_OS_X_VERSION_MIN_REQUIRED) && \
+  MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_VERSION_12_0
 #if __has_include(<mach-o/dyld_introspection.h>)
 #include <mach-o/dyld_introspection.h>
 #define SDK_HAS_NEW_DYLD_INTROSPECTION_SPIS
+#endif
 #endif
 #include <objc/objc-auto.h>
 
 // These are needed when compiling on systems
 // that do not yet have these definitions
-#include <AvailabilityMacros.h>
 #ifndef CPU_SUBTYPE_X86_64_H
 #define CPU_SUBTYPE_X86_64_H ((cpu_subtype_t)8)
 #endif


### PR DESCRIPTION
There were some checks removed previously in
bc196970b549782bffde5fdbfa450c565af11fc1.

However, all these SPIs are actually defined in macOS 12 and onward, not macOSX 10.12 as the previous commit would suggest. As a result, if you have access to these SPIs lldb will fail to compile correctly.

Instead of adding back the __builtin_availability checks, it seems easier just to check the minimum deployment target with Availability macros.

Differential Revision: https://reviews.llvm.org/D156838

(cherry picked from commit 6c2e3249160f5b68f6e09fed0435ee043659f2d9)