### PR TITLE
[lldb] Fix incorrect uses of LLDB_LOG_ERROR in the Swift language run…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1892,7 +1892,7 @@ void SwiftLanguageRuntimeImpl::WillStartExecutingUserExpression(
   if (!type_system_or_err) {
     LLDB_LOG_ERROR(
         log, type_system_or_err.takeError(),
-        "SwiftLanguageRuntime: Unable to get pointer to type system");
+        "SwiftLanguageRuntime: Unable to get pointer to type system: {0}");
     return;
   }
 
@@ -1967,7 +1967,7 @@ void SwiftLanguageRuntimeImpl::DidFinishExecutingUserExpression(
   if (!type_system_or_err) {
     LLDB_LOG_ERROR(
         log, type_system_or_err.takeError(),
-        "SwiftLanguageRuntime: Unable to get pointer to type system");
+        "SwiftLanguageRuntime: Unable to get pointer to type system: {0}");
     return;
   }
 


### PR DESCRIPTION
…time

Same changes as e0e36e3725b5 but for the Swift language runtime.

(cherry picked from commit d8dedc257b8eb95a5e4437e4eaf6c93101ebdbb9)