### PR TITLE
Make Swift result variables persistent

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -52,6 +52,7 @@
 #include "lldb/lldb-private-types.h"
 
 #ifdef LLDB_ENABLE_SWIFT
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #endif //LLDB_ENABLE_SWIFT
 

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -27,6 +27,7 @@
 
 #ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #endif //LLDB_ENABLE_SWIFT
 
 #include <memory>

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -44,6 +44,7 @@
 
 #ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #endif //LLDB_ENABLE_SWIFT
 
 using namespace lldb_private;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -13,13 +13,14 @@
 #include "SwiftExpressionParser.h"
 
 #include "SwiftASTManipulator.h"
+#include "SwiftDiagnostic.h"
 #include "SwiftExpressionSourceCode.h"
+#include "SwiftExpressionVariable.h"
+#include "SwiftPersistentExpressionState.h"
 #include "SwiftREPLMaterializer.h"
 #include "SwiftSILManipulator.h"
 #include "SwiftUserExpression.h"
 
-#include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
-#include "Plugins/ExpressionParser/Swift/SwiftExpressionVariable.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/ModuleList.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -125,6 +125,10 @@ static CompilerType ImportType(SwiftASTContextForExpressions &target_context,
   return target_context.ImportType(source_type, error);
 }
 
+static CompilerDecl GetCompilerDecl(swift::Decl *decl) {
+  return {SwiftASTContext::GetSwiftASTContext(&decl->getASTContext()), decl};
+}
+
 namespace {
 class LLDBNameLookup : public swift::SILDebuggerClient {
 public:
@@ -219,7 +223,7 @@ public:
       // kind lldb explicitly wants to globalize.
       if (shouldGlobalize(value_decl->getBaseName().getIdentifier(),
                           value_decl->getKind()))
-        m_staged_decls.AddDecl(value_decl, false, {});
+        m_staged_decls.AddDecl(GetCompilerDecl(value_decl), false, {});
     }
   }
 
@@ -253,11 +257,11 @@ public:
           "[LLDBExprNameLookup::lookupAdditions (%u)] Searching for %s", count,
           NameStr.empty() ? "<anonymous>" : NameStr.str().c_str());
 
-    std::vector<swift::ValueDecl *> results;
+    std::vector<CompilerDecl> results;
 
     for (auto *alias : m_type_aliases) {
       if (alias->getName().str() == NameStr) {
-        results.push_back(alias);
+        results.push_back(GetCompilerDecl(alias));
         break;
       }
     }
@@ -292,13 +296,18 @@ public:
 
       size_t num_external_results = RV.size();
       if (!is_debugger_variable && num_external_results > 0) {
-        std::vector<swift::ValueDecl *> persistent_results;
+        std::vector<CompilerDecl> persistent_results;
         m_persistent_vars->GetSwiftPersistentDecls(NameStr, {},
                                                    persistent_results);
 
-        size_t num_persistent_results = persistent_results.size();
-        for (size_t idx = 0; idx < num_persistent_results; idx++) {
-          swift::ValueDecl *value_decl = persistent_results[idx];
+        for (CompilerDecl & decl : persistent_results) {
+          if (decl.GetTypeSystem() !=
+              SwiftASTContext::GetSwiftASTContext(&DC->getASTContext())) {
+            LLDB_LOG(m_log, "ignoring persistent result from other context");
+            continue;
+          }
+          auto *value_decl =
+              static_cast<swift::ValueDecl *>(decl.GetOpaqueDecl());
           if (!value_decl)
             continue;
           swift::DeclName value_decl_name = value_decl->getName();
@@ -332,15 +341,15 @@ public:
             }
           }
           if (!skip_it)
-            results.push_back(value_decl);
+            results.push_back(decl);
         }
       } else {
         m_persistent_vars->GetSwiftPersistentDecls(NameStr, results, results);
       }
     }
 
-    for (size_t idx = 0; idx < results.size(); idx++) {
-      swift::ValueDecl *value_decl = results[idx];
+    for (CompilerDecl &decl : results) {
+      auto *value_decl = static_cast<swift::ValueDecl *>(decl.GetOpaqueDecl());
       // No import required.
       assert(&DC->getASTContext() == &value_decl->getASTContext());
       RV.push_back(swift::LookupResultEntry(value_decl));
@@ -405,26 +414,28 @@ public:
           NameStr.empty() ? "<anonymous>" : NameStr.str().c_str());
 
     // Find decls that come from the current compilation.
-    std::vector<swift::ValueDecl *> current_compilation_results;
+    std::vector<CompilerDecl> current_compilation_results;
     for (auto result : RV) {
       auto result_decl = result.getValueDecl();
       auto result_decl_context = result_decl->getDeclContext();
       if (result_decl_context->isChildContextOf(DC) || result_decl_context == DC)
-        current_compilation_results.push_back(result_decl);
+        current_compilation_results.push_back(GetCompilerDecl(result_decl));
     }
 
     // Find persistent decls, excluding decls that are equivalent to
     // decls from the current compilation.  This makes the decls from
     // the current compilation take precedence.
-    std::vector<swift::ValueDecl *> persistent_decl_results;
+    std::vector<CompilerDecl> persistent_decl_results;
     m_persistent_vars->GetSwiftPersistentDecls(
         NameStr, current_compilation_results, persistent_decl_results);
 
     // Append the persistent decls that we found to the result vector.
     for (auto result : persistent_decl_results) {
       // No import required.
-      assert(&DC->getASTContext() == &result->getASTContext());
-      RV.push_back(swift::LookupResultEntry(result));
+      auto *result_decl =
+          static_cast<swift::ValueDecl *>(result.GetOpaqueDecl());
+      assert(&DC->getASTContext() == &result_decl->getASTContext());
+      RV.push_back(swift::LookupResultEntry(result_decl));
     }
 
     return !persistent_decl_results.empty();
@@ -1836,16 +1847,15 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
               persistent_variable));
 
       // This is only exercised by the PlaygroundsREPL tests.
-      persistent_state->RegisterSwiftPersistentDecl(decl);
+      persistent_state->RegisterSwiftPersistentDecl(GetCompilerDecl(decl));
     }
 
     if (repl) {
       llvm::SmallVector<swift::ValueDecl *, 1> non_variables;
       parsed_expr->code_manipulator->FindNonVariableDeclarations(non_variables);
 
-      for (swift::ValueDecl *decl : non_variables) {
-        persistent_state->RegisterSwiftPersistentDecl(decl);
-      }
+      for (swift::ValueDecl *decl : non_variables)
+        persistent_state->RegisterSwiftPersistentDecl(GetCompilerDecl(decl));
     }
   }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -206,10 +206,10 @@ public:
 
     const char *name_cstr = Name.get();
     if (name_cstr && name_cstr[0] == '$') {
-      if (m_log)
-        m_log->Printf("[LLDBExprNameLookup::shouldGlobalize] Returning true to "
-                      "globalizing %s",
-                      name_cstr);
+      LLDB_LOG(m_log,
+               "[LLDBExprNameLookup::shouldGlobalize] Returning true to "
+               "globalizing {0}",
+               name_cstr);
       return true;
     }
     return false;
@@ -234,10 +234,9 @@ public:
     static unsigned counter = 0;
     unsigned count = counter++;
 
-    if (m_log) {
-      m_log->Printf("[LLDBExprNameLookup::lookupOverrides(%u)] Searching for %s",
-                    count, Name.getIdentifier().get());
-    }
+    LLDB_LOG(m_log,
+             "[LLDBExprNameLookup::lookupOverrides({0})] Searching for \"{1}\"",
+             count, Name.getIdentifier().get());
 
     return false;
   }
@@ -253,10 +252,10 @@ public:
     if (NameStr.empty())
       return false;
 
-    if (m_log)
-      m_log->Printf(
-          "[LLDBExprNameLookup::lookupAdditions (%u)] Searching for %s", count,
-          NameStr.empty() ? "<anonymous>" : NameStr.str().c_str());
+    LLDB_LOG(
+        m_log,
+        "[LLDBExprNameLookup::lookupAdditions ({0})] Searching for \"{1}\"",
+        count, NameStr);
 
     std::vector<CompilerDecl> results;
 
@@ -409,10 +408,10 @@ public:
     if (NameStr.empty())
       return false;
 
-    if (m_log)
-      m_log->Printf(
-          "[LLDBREPLNameLookup::lookupAdditions (%u)] Searching for %s", count,
-          NameStr.empty() ? "<anonymous>" : NameStr.str().c_str());
+    LLDB_LOG(
+        m_log,
+        "[LLDBREPLNameLookup::lookupAdditions ({0})] Searching for \"{1}\"",
+        count, NameStr);
 
     // Find decls that come from the current compilation.
     std::vector<CompilerDecl> current_compilation_results;
@@ -614,11 +613,10 @@ static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
 
   auto swift_self_type = GetSwiftType(imported_self_type);
   if (!swift_self_type) {
-    Log *log = GetLog(LLDBLog::Types | LLDBLog::Expressions);
-    if (log)
-      log->Printf("Couldn't get SwiftASTContext type for self type %s.",
-                  imported_self_type.GetDisplayTypeName().AsCString("<unknown>"));
-    
+    LLDB_LOG(GetLog(LLDBLog::Types | LLDBLog::Expressions),
+             "Couldn't get SwiftASTContext type for self type {0}.",
+             imported_self_type.GetDisplayTypeName());
+
     return;
   }
 
@@ -658,19 +656,14 @@ static void AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
         swift_ast_context.GetASTContext()->getIdentifier("$__lldb_context"),
         imported_self_type);
 
-    if (!type_alias_decl) {
-      Log *log = GetLog(LLDBLog::Expressions);
-      if (log)
-        log->Printf("SEP:AddRequiredAliases: Failed to make the "
-                    "$__lldb_context typealias.");
-    }
-  } else {
-    Log *log = GetLog(LLDBLog::Expressions);
-    if (log)
-      log->Printf("SEP:AddRequiredAliases: Failed to resolve the self "
-                  "archetype - could not make the $__lldb_context "
-                  "typealias.");
-  }
+    if (!type_alias_decl)
+      LLDB_LOG(GetLog(LLDBLog::Expressions),
+               "SEP:AddRequiredAliases: Failed to make the $__lldb_context "
+               "typealias.");
+  } else
+    LLDB_LOG(GetLog(LLDBLog::Expressions),
+             "SEP:AddRequiredAliases: Failed to resolve the self archetype - "
+             "could not make the $__lldb_context typealias.");
 }
 
 static void ResolveSpecialNames(
@@ -697,8 +690,7 @@ static void ResolveSpecialNames(
 
     resolved_names.insert(name_cs);
 
-    if (log)
-      log->Printf("Resolving special name %s", name_cs.AsCString());
+    LLDB_LOG(log, "Resolving special name {0}");
 
     lldb::ExpressionVariableSP expr_var_sp =
         persistent_state->GetVariable(name_cs);
@@ -939,9 +931,8 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       return llvm::None;
     }
 
-    if (log)
-      log->Printf("Added %s variable to struct at offset %llu",
-                  is_result ? "result" : "error", (unsigned long long)offset);
+    LLDB_LOG(log, "Added {0} variable to struct at offset {1}",
+             is_result ? "result" : "error", (unsigned long long)offset);
   } else if (auto *variable_metadata = llvm::dyn_cast<
                  SwiftASTManipulatorBase::VariableMetadataVariable>(
                  variable.m_metadata.get())) {
@@ -956,10 +947,9 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       return llvm::None;
     }
 
-    if (log)
-      log->Printf("Added variable %s to struct at offset %llu",
-                  variable_metadata->m_variable_sp->GetName().AsCString(),
-                  (unsigned long long)offset);
+    LLDB_LOG(log, "Added variable {0} to struct at offset {1}",
+             variable_metadata->m_variable_sp->GetName(),
+             (unsigned long long)offset);
   } else if (auto *variable_metadata = llvm::dyn_cast<
                  SwiftASTManipulatorBase::VariableMetadataPersistent>(
                  variable.m_metadata.get())) {
@@ -1005,14 +995,14 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       return llvm::None;
     }
 
-    if (log)
-      log->Printf(
-          "Added persistent variable %s with flags 0x%llx to "
-          "struct at offset %llu",
-          variable_metadata->m_persistent_variable_sp->GetName().AsCString(),
-          (unsigned long long)
-              variable_metadata->m_persistent_variable_sp->m_flags,
-          (unsigned long long)offset);
+    LLDB_LOGF(
+        log,
+        "Added persistent variable %s with flags 0x%llx to "
+        "struct at offset %llu",
+        variable_metadata->m_persistent_variable_sp->GetName().AsCString(),
+        (unsigned long long)
+            variable_metadata->m_persistent_variable_sp->m_flags,
+        (unsigned long long)offset);
   }
 
   bool unowned_self = false;
@@ -1179,19 +1169,19 @@ AddArchetypesTypeAliases(std::unique_ptr<SwiftASTManipulator> &code_manipulator,
     auto bound_type =
         runtime->BindGenericTypeParameters(stack_frame, dependent_type);
     if (!bound_type) {
-      LLDB_LOGV(
+      LLDB_LOG(
           log,
           "[AddArchetypesTypeAliases] Could not bind dependent generic param "
-          "type %s",
-          dependent_type.GetMangledTypeName().GetCString());
+          "type {0}",
+          dependent_type.GetMangledTypeName());
       continue;
     }
 
-    LLDB_LOGV(log,
-              "[AddArchetypesTypeAliases] Binding dependent generic param "
-              "type %s to %s",
-              dependent_type.GetMangledTypeName().GetCString(),
-              bound_type.GetMangledTypeName().GetCString());
+    LLDB_LOG(log,
+             "[AddArchetypesTypeAliases] Binding dependent generic param "
+             "type {0} to {1}",
+             dependent_type.GetMangledTypeName(),
+             bound_type.GetMangledTypeName());
     auto identifier =
         swift_ast_context.GetASTContext()->getIdentifier(type_name);
 
@@ -1211,16 +1201,15 @@ AddArchetypesTypeAliases(std::unique_ptr<SwiftASTManipulator> &code_manipulator,
         identifier, bound_type, true, code_manipulator->GetFuncDecl());
     if (type_alias_decl) {
       type_aliases.push_back(type_alias_decl);
-      LLDB_LOGV(log,
-                "[AddArchetypesTypeAliases] Adding typealias from %s to "
-                "%s",
-                type_name, bound_type.GetMangledTypeName().GetCString());
-    } else {
       LLDB_LOG(log,
-               "[AddArchetypesTypeAliases] Could not add typealias from %s to "
-               "%s",
-               type_name, bound_type.GetMangledTypeName().GetCString());
-    }
+               "[AddArchetypesTypeAliases] Adding typealias from {0} to "
+               "{1}",
+               type_name, bound_type.GetMangledTypeName());
+    } else
+      LLDB_LOG(log,
+               "[AddArchetypesTypeAliases] Could not add typealias from {0} to "
+               "{1}",
+               type_name, bound_type.GetMangledTypeName());
   }
   return type_aliases;
 }
@@ -1268,7 +1257,7 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     swift::ModuleDecl *module = swift_ast_context.GetModule(module_info, error);
 
     if (error.Fail() || !module) {
-      LLDB_LOG(log, "couldn't load Swift Standard Library\n");
+      LLDB_LOG(log, "couldn't load Swift Standard Library");
       return error.ToError();
     }
 
@@ -1489,17 +1478,15 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   swift::Mangle::ASTMangler mangler;
   auto *entrypoint_decl = manipulator.GetEntrypointDecl();
   if (!entrypoint_decl) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: no "
-        "entrypoint decl.");
+    LLDB_LOG(log, "[RedirectCallFromSinkToTrampolineFunction] Could not set "
+                  "the call: no entrypoint decl.");
     return false;
   }
 
   auto *func_decl = manipulator.GetFuncDecl();
   if (!func_decl) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: no "
-        "func decl.");
+    LLDB_LOG(log, "[RedirectCallFromSinkToTrampolineFunction] Could not set "
+                  "the call: no func decl.");
     return false;
   }
 
@@ -1508,9 +1495,8 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
 
   auto *sink_decl = manipulator.GetSinkDecl();
   if (!sink_decl) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: no "
-        "sink decl.");
+    LLDB_LOG(log, "[RedirectCallFromSinkToTrampolineFunction] Could not set "
+                  "the call: no sink decl.");
     return false;
   }
 
@@ -1531,9 +1517,9 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
 
   assert(lldb_expr_func && wrapped_func && callee_func && sink_decl);
   if (!lldb_expr_func || !wrapped_func || !callee_func || !sink_func) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
-        "could not find one of the required functions in the IR.");
+    LLDB_LOG(log,
+             "[RedirectCallFromSinkToTrampolineFunction] Could not set the "
+             "call: could not find one of the required functions in the IR.");
     return false;
   }
 
@@ -1542,10 +1528,10 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   // There should be at least 3 params, the raw pointer, the self type, and at
   // least one pointer to metadata.
   if (callee_num_params < (have_self ? 3 : 2)) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
-        "callee function has %u parameters",
-        callee_num_params);
+    LLDB_LOG(log,
+             "[RedirectCallFromSinkToTrampolineFunction] Could not set the "
+             "call: callee function has {0} parameters",
+             callee_num_params);
     return false;
   }
 
@@ -1553,9 +1539,10 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   auto sink_num_params = sink_func_type->getNumParams();
 
   if (callee_num_params != sink_num_params) {
-    log->Printf(
+    LLDB_LOG(
+        log,
         "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
-        "callee function has %u parameters but sink has %u parameters.",
+        "callee function has {0} parameters but sink has {0} parameters.",
         callee_num_params, sink_num_params);
     return false;
   }
@@ -1564,18 +1551,17 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   // The entrypoint function should only have one basic block whith
   // materialization instructions and the call to the sink.
   if (basic_blocks.size() != 1) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
-        "entrypoint function has %zu basic blocks.",
-        basic_blocks.size());
+    LLDB_LOG(log,
+             "[RedirectCallFromSinkToTrampolineFunction] Could not set the "
+             "call: entrypoint function has {0} basic blocks.",
+             basic_blocks.size());
     return false;
   }
 
   auto &basic_block = basic_blocks.back();
   if (basic_block.getInstList().size() == 0) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
-        "basic block has no instructions.");
+    LLDB_LOG(log, "[RedirectCallFromSinkToTrampolineFunction] Could not set "
+                  "the call: basic block has no instructions.");
     return false;
   }
 
@@ -1591,17 +1577,16 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   }
 
   if (!sink_call) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
-        "call to sink function not found.");
+    LLDB_LOG(log, "[RedirectCallFromSinkToTrampolineFunction] Could not set "
+                  "the call: call to sink function not found.");
     return false;
   }
 
   if (sink_call->arg_size() != sink_num_params) {
-    log->Printf(
-        "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
-        "call to sink function has %u arguments.",
-        sink_call->arg_size());
+    LLDB_LOG(log,
+             "[RedirectCallFromSinkToTrampolineFunction] Could not set the "
+             "call: call to sink function has {0} arguments.",
+             sink_call->arg_size());
     return false;
   }
 
@@ -1623,7 +1608,8 @@ RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
   if (auto *load = llvm::dyn_cast<llvm::LoadInst>(self_load))
     self_opaque_ptr = load->getPointerOperand();
   if (!self_opaque_ptr) {
-    log->Printf(
+    LLDB_LOG(
+        log,
         "[RedirectCallFromSinkToTrampolineFunction] Could not set the call: "
         "could not find the argument of the load of the self pointer.");
     return false;
@@ -1780,9 +1766,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     llvm::raw_string_ostream ss(s);
     parsed_expr->source_file.dump(ss);
     ss.flush();
-
-    log->Printf("Source file after FixupResult:");
-    log->PutCString(s.c_str());
+    LLDB_LOG(log, "Source file after FixupResult:\n{0}", s);
   }
 
   // Allow variables to be re-used from previous REPL statements.
@@ -1868,19 +1852,17 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     //     llvm::raw_string_ostream ss(s);
     //     parsed_expr->source_file.dump(ss);
     //     ss.flush();
-    //
-    //     log->Printf("Source file after capture fixing:");
-    //     log->PutCString(s.c_str());
+    //     LLDB_LOG(log, "Source file after capture fixing:\n{0}", s);
     // }
 
     if (log) {
-      log->Printf("Variables:");
+      LLDB_LOG(log, "Variables:");
 
       for (const SwiftASTManipulatorBase::VariableInfo &variable :
            parsed_expr->code_manipulator->GetVariableInfo()) {
         StreamString ss;
         variable.Print(ss);
-        log->Printf("  %s", ss.GetData());
+        LLDB_LOG(log, "  {0}", ss.GetData());
       }
     }
   }
@@ -1904,9 +1886,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     llvm::raw_string_ostream ss(s);
     parsed_expr->source_file.dump(ss);
     ss.flush();
-
-    log->Printf("Source file before SILgen:");;
-    log->PutCString(s.c_str());
+    LLDB_LOG(log, "Source file before SILgen:\n{0}", s);
   }
   
   // FIXME: Should share TypeConverter instances
@@ -1922,9 +1902,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     llvm::raw_string_ostream ss(s);
     sil_module->print(ss, &parsed_expr->module);
     ss.flush();
-
-    log->Printf("SIL module before linking:");
-    log->PutCString(s.c_str());
+    LLDB_LOG(log, "SIL module before linking:\n{0}", s);
   }
 
   if (expr_diagnostics->HasErrors()) {
@@ -1937,9 +1915,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     llvm::raw_string_ostream ss(s);
     sil_module->print(ss, &parsed_expr->module);
     ss.flush();
-
-    log->Printf("Generated SIL module:");
-    log->PutCString(s.c_str());
+    LLDB_LOG(log, "Generated SIL module:\n{0}", s);
   }
 
   runSILDiagnosticPasses(*sil_module);
@@ -1950,9 +1926,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     llvm::raw_string_ostream ss(s);
     sil_module->print(ss, &parsed_expr->module);
     ss.flush();
-
-    log->Printf("SIL module after diagnostic passes:");
-    log->PutCString(s.c_str());
+    LLDB_LOG(log, "SIL module after diagnostic passes:\n{0}", s);
   }
 
   if (expr_diagnostics->HasErrors()) {
@@ -2019,9 +1993,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     llvm::raw_string_ostream ss(s);
     m_module->print(ss, NULL);
     ss.flush();
-
-    log->Printf("Generated IR module:");
-    log->PutCString(s.c_str());
+    LLDB_LOG(log, "Generated IR module:\n{0}", s);
   }
 
   if (m_options.GetBindGenericTypes() == lldb::eDontBind &&
@@ -2041,9 +2013,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     llvm::raw_string_ostream ss(s);
     m_module->print(ss, NULL);
     ss.flush();
-
-    log->Printf("Generated IR module after replacing call to sink:");
-    log->PutCString(s.c_str());
+    LLDB_LOG(log, "Generated IR module after replacing call to sink:\n{0}", s);
   }
 
   {
@@ -2166,9 +2136,7 @@ Status SwiftExpressionParser::PrepareForExecution(
     err.SetErrorStringWithFormat("Couldn't find %s() in the module", orig_name);
     return err;
   } else {
-    if (log)
-      log->Printf("Found function %s for %s", function_name.AsCString(),
-                  "$__lldb_expr");
+    LLDB_LOG(log, "Found function {0} for {1}", function_name, "$__lldb_expr");
   }
 
   // Retrieve an appropriate symbol context.
@@ -2228,11 +2196,10 @@ bool SwiftExpressionParser::RewriteExpression(
       if (!start_loc.isValid()) {
         // getLocOffsetInBuffer will assert if you pass it an invalid
         // location, so we have to check that first.
-        if (log)
-          log->Printf(
-              "SwiftExpressionParser::RewriteExpression: ignoring fixit since "
-              "it contains an invalid source location: %s.",
-              range.str().str().c_str());
+        LLDB_LOG(log,
+                 "SwiftExpressionParser::RewriteExpression: ignoring fixit "
+                 "since it contains an invalid source location: {0}.",
+                 range.str());
         return false;
       }
 
@@ -2240,11 +2207,10 @@ bool SwiftExpressionParser::RewriteExpression(
       // than once, so we have to check that before we proceed:
       if (std::find(source_ranges.begin(), source_ranges.end(), range) !=
           source_ranges.end()) {
-        if (log)
-          log->Printf(
-              "SwiftExpressionParser::RewriteExpression: ignoring fix-it since "
-              "source range appears twice: %s.\n",
-              range.str().str().c_str());
+        LLDB_LOG(log,
+                 "SwiftExpressionParser::RewriteExpression: ignoring fix-it "
+                 "since source range appears twice: {0}.",
+                 range.str());
         return false;
       } else
         source_ranges.push_back(range);
@@ -2257,11 +2223,11 @@ bool SwiftExpressionParser::RewriteExpression(
           diagnostic->GetBufferID());
       if (!(start_loc.getOpaquePointerValue() >= Buffer->getBuffer().begin() &&
             start_loc.getOpaquePointerValue() <= Buffer->getBuffer().end())) {
-        if (log)
-          log->Printf(
-              "SwiftExpressionParser::RewriteExpression: ignoring fixit since "
-              "it contains a source location not in the specified buffer: %s.",
-              range.str().str().c_str());
+        LLDB_LOG(
+            log,
+            "SwiftExpressionParser::RewriteExpression: ignoring fixit since it "
+            "contains a source location not in the specified buffer: {0}.",
+            range.str());
       }
 
       unsigned offset = source_manager.getLocOffsetInBuffer(

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SwiftExpressionSourceCode.h"
+#include "SwiftPersistentExpressionState.h"
 
 #include "Plugins/ExpressionParser/Swift/SwiftASTManipulator.h"
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -619,7 +619,7 @@ Status SwiftExpressionSourceCode::GetText(
     }
     std::vector<swift::ValueDecl *> persistent_results;
     // Check if we have already declared the playground stub debug functions
-    persistent_state->GetSwiftPersistentDecls(ConstString("__builtin_log_with_id"), {},
+    persistent_state->GetSwiftPersistentDecls("__builtin_log_with_id", {},
                                               persistent_results);
 
     size_t num_persistent_results = persistent_results.size();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -617,7 +617,7 @@ Status SwiftExpressionSourceCode::GetText(
       status.SetErrorString("no persistent state");
       return status;
     }
-    std::vector<swift::ValueDecl *> persistent_results;
+    std::vector<CompilerDecl> persistent_results;
     // Check if we have already declared the playground stub debug functions
     persistent_state->GetSwiftPersistentDecls("__builtin_log_with_id", {},
                                               persistent_results);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -129,85 +129,66 @@ bool SwiftPersistentExpressionState::SwiftDeclMap::DeclsAreEquivalent(
 }
 
 void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
-    swift::ValueDecl *value_decl, bool check_existing, ConstString alias) {
-  std::string name_str;
+    swift::ValueDecl *value_decl, bool check_existing, llvm::StringRef alias) {
+  llvm::StringRef name;
 
-  if (alias.IsEmpty()) {
-    name_str = value_decl->getBaseName().getIdentifier().str().str();
-  } else {
-    name_str.assign(alias.GetCString());
-  }
+  if (alias.empty())
+    name = value_decl->getBaseName().getIdentifier().str();
+  else
+    name = alias;
 
-  if (!check_existing) {
-    m_swift_decls.insert(std::make_pair(name_str, value_decl));
+  auto it = m_swift_decls.find(name);
+  if (it == m_swift_decls.end()) {
+    m_swift_decls.insert({name, {value_decl}});
     return;
   }
 
-  SwiftDeclMapTy::iterator map_end = m_swift_decls.end();
-  std::pair<SwiftDeclMapTy::iterator, SwiftDeclMapTy::iterator> found_range =
-      m_swift_decls.equal_range(name_str);
+  llvm::SmallVectorImpl<swift::ValueDecl *> &decls = it->second;
+  if (check_existing)
+    decls.erase(std::remove_if(decls.begin(), decls.end(),
+                               [&value_decl](swift::ValueDecl *cur_decl) {
+                                 return DeclsAreEquivalent(cur_decl,
+                                                           value_decl);
+                               }),
+                decls.end());
 
-  if (found_range.first == map_end) {
-    m_swift_decls.insert(std::make_pair(name_str, value_decl));
-    return;
-  } else {
-    SwiftDeclMapTy::iterator cur_item;
-    bool done = false;
-    for (cur_item = found_range.first; !done && cur_item != found_range.second;
-         cur_item++) {
-      swift::ValueDecl *cur_decl = (*cur_item).second;
-      if (DeclsAreEquivalent(cur_decl, value_decl)) {
-        m_swift_decls.erase(cur_item);
-        break;
-      }
-    }
-
-    m_swift_decls.insert(std::make_pair(name_str, value_decl));
-  }
+  decls.push_back(value_decl);
 }
 
 bool SwiftPersistentExpressionState::SwiftDeclMap::FindMatchingDecls(
-    ConstString name,
+    llvm::StringRef name,
     const std::vector<swift::ValueDecl *> &excluding_equivalents,
     std::vector<swift::ValueDecl *> &matches) {
-  std::string name_str(name.AsCString());
+  auto it = m_swift_decls.find(name);
+  if (it == m_swift_decls.end())
+    return false;
+  llvm::SmallVectorImpl<swift::ValueDecl *> &decls = it->second;
+
   size_t start_num_items = matches.size();
-  size_t start_num_excluding_equivalents = excluding_equivalents.size();
+  for (auto &cur_decl : decls)
+    if (std::none_of(excluding_equivalents.begin(), excluding_equivalents.end(),
+                     [&](swift::ValueDecl *decl) {
+                       return DeclsAreEquivalent(cur_decl, decl);
+                     }))
+      matches.push_back(cur_decl);
 
-  std::pair<SwiftDeclMapTy::iterator, SwiftDeclMapTy::iterator> found_range =
-      m_swift_decls.equal_range(name_str);
-  for (SwiftDeclMapTy::iterator cur_item = found_range.first;
-       cur_item != found_range.second; cur_item++) {
-    bool add_it = true;
-    swift::ValueDecl *cur_decl = (*cur_item).second;
-
-    // Iterate over only the elements of `excluding_equivalents` that were
-    // originally there, in case `matches` aliases it.
-    for (size_t idx = 0; idx < start_num_excluding_equivalents; idx++) {
-      if (DeclsAreEquivalent(excluding_equivalents[idx], cur_decl)) {
-        add_it = false;
-        break;
-      }
-    }
-    if (add_it)
-      matches.push_back((*cur_item).second);
-  }
   return start_num_items != matches.size();
 }
 
 void SwiftPersistentExpressionState::SwiftDeclMap::CopyDeclsTo(
     SwiftPersistentExpressionState::SwiftDeclMap &target_map) {
-  for (auto elem : m_swift_decls)
-    target_map.AddDecl(elem.second, true, ConstString());
+  for (auto &entry : m_swift_decls)
+    for (auto &elem : entry.second)
+      target_map.AddDecl(elem, true, {});
 }
 
 void SwiftPersistentExpressionState::RegisterSwiftPersistentDecl(
     swift::ValueDecl *value_decl) {
-  m_swift_persistent_decls.AddDecl(value_decl, true, ConstString());
+  m_swift_persistent_decls.AddDecl(value_decl, true, {});
 }
 
 void SwiftPersistentExpressionState::RegisterSwiftPersistentDeclAlias(
-    swift::ValueDecl *value_decl, ConstString name) {
+    swift::ValueDecl *value_decl, llvm::StringRef name) {
   m_swift_persistent_decls.AddDecl(value_decl, true, name);
 }
 
@@ -217,7 +198,7 @@ void SwiftPersistentExpressionState::CopyInSwiftPersistentDecls(
 }
 
 bool SwiftPersistentExpressionState::GetSwiftPersistentDecls(
-    ConstString name,
+    llvm::StringRef name,
     const std::vector<swift::ValueDecl *> &excluding_equivalents,
     std::vector<swift::ValueDecl *> &matches) {
   return m_swift_persistent_decls.FindMatchingDecls(name, excluding_equivalents,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -89,7 +89,11 @@ SwiftPersistentExpressionState::GetCompilerTypeFromPersistentDecl(
 }
 
 bool SwiftPersistentExpressionState::SwiftDeclMap::DeclsAreEquivalent(
-    swift::Decl *lhs_decl, swift::Decl *rhs_decl) {
+    CompilerDecl lhs, CompilerDecl rhs) {
+  if (lhs.GetTypeSystem() != rhs.GetTypeSystem())
+    return false;
+  auto *lhs_decl = static_cast<swift::Decl *>(lhs.GetOpaqueDecl());
+  auto *rhs_decl = static_cast<swift::Decl *>(rhs.GetOpaqueDecl());
   swift::DeclKind lhs_kind = lhs_decl->getKind();
   swift::DeclKind rhs_kind = rhs_decl->getKind();
   if (lhs_kind != rhs_kind)
@@ -129,9 +133,10 @@ bool SwiftPersistentExpressionState::SwiftDeclMap::DeclsAreEquivalent(
 }
 
 void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
-    swift::ValueDecl *value_decl, bool check_existing, llvm::StringRef alias) {
-  llvm::StringRef name;
+    CompilerDecl decl, bool check_existing, llvm::StringRef alias) {
+  auto *value_decl = static_cast<swift::ValueDecl *>(decl.GetOpaqueDecl());
 
+  llvm::StringRef name;
   if (alias.empty())
     name = value_decl->getBaseName().getIdentifier().str();
   else
@@ -139,35 +144,34 @@ void SwiftPersistentExpressionState::SwiftDeclMap::AddDecl(
 
   auto it = m_swift_decls.find(name);
   if (it == m_swift_decls.end()) {
-    m_swift_decls.insert({name, {value_decl}});
+    m_swift_decls.insert({name, {decl}});
     return;
   }
 
-  llvm::SmallVectorImpl<swift::ValueDecl *> &decls = it->second;
+  llvm::SmallVectorImpl<CompilerDecl> &decls = it->second;
   if (check_existing)
     decls.erase(std::remove_if(decls.begin(), decls.end(),
-                               [&value_decl](swift::ValueDecl *cur_decl) {
-                                 return DeclsAreEquivalent(cur_decl,
-                                                           value_decl);
+                               [&decl](CompilerDecl cur_decl) {
+                                 return DeclsAreEquivalent(cur_decl, decl);
                                }),
                 decls.end());
 
-  decls.push_back(value_decl);
+  decls.push_back(decl);
 }
 
 bool SwiftPersistentExpressionState::SwiftDeclMap::FindMatchingDecls(
     llvm::StringRef name,
-    const std::vector<swift::ValueDecl *> &excluding_equivalents,
-    std::vector<swift::ValueDecl *> &matches) {
+    const std::vector<CompilerDecl> &excluding_equivalents,
+    std::vector<CompilerDecl> &matches) {
   auto it = m_swift_decls.find(name);
   if (it == m_swift_decls.end())
     return false;
-  llvm::SmallVectorImpl<swift::ValueDecl *> &decls = it->second;
+  llvm::SmallVectorImpl<CompilerDecl> &decls = it->second;
 
   size_t start_num_items = matches.size();
   for (auto &cur_decl : decls)
     if (std::none_of(excluding_equivalents.begin(), excluding_equivalents.end(),
-                     [&](swift::ValueDecl *decl) {
+                     [&](CompilerDecl decl) {
                        return DeclsAreEquivalent(cur_decl, decl);
                      }))
       matches.push_back(cur_decl);
@@ -183,12 +187,12 @@ void SwiftPersistentExpressionState::SwiftDeclMap::CopyDeclsTo(
 }
 
 void SwiftPersistentExpressionState::RegisterSwiftPersistentDecl(
-    swift::ValueDecl *value_decl) {
+    CompilerDecl value_decl) {
   m_swift_persistent_decls.AddDecl(value_decl, true, {});
 }
 
 void SwiftPersistentExpressionState::RegisterSwiftPersistentDeclAlias(
-    swift::ValueDecl *value_decl, llvm::StringRef name) {
+    CompilerDecl value_decl, llvm::StringRef name) {
   m_swift_persistent_decls.AddDecl(value_decl, true, name);
 }
 
@@ -199,8 +203,8 @@ void SwiftPersistentExpressionState::CopyInSwiftPersistentDecls(
 
 bool SwiftPersistentExpressionState::GetSwiftPersistentDecls(
     llvm::StringRef name,
-    const std::vector<swift::ValueDecl *> &excluding_equivalents,
-    std::vector<swift::ValueDecl *> &matches) {
+    const std::vector<CompilerDecl> &excluding_equivalents,
+    std::vector<CompilerDecl> &matches) {
   return m_swift_persistent_decls.FindMatchingDecls(name, excluding_equivalents,
                                                     matches);
 }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -45,13 +45,14 @@ class SwiftPersistentExpressionState : public PersistentExpressionState {
 public:
   class SwiftDeclMap {
   public:
-    void AddDecl(swift::ValueDecl *decl, bool check_existing, ConstString name);
+    void AddDecl(swift::ValueDecl *decl, bool check_existing,
+                 llvm::StringRef name);
 
     /// Find decls matching `name`, excluding decls that are equivalent to
     /// decls in `excluding_equivalents`, and put the results in `matches`.
     /// Return true if there are any results.
     bool FindMatchingDecls(
-        ConstString name,
+        llvm::StringRef name,
         const std::vector<swift::ValueDecl *> &excluding_equivalents,
         std::vector<swift::ValueDecl *> &matches);
 
@@ -59,10 +60,7 @@ public:
     static bool DeclsAreEquivalent(swift::Decl *lhs, swift::Decl *rhs);
 
   private:
-    typedef std::unordered_multimap<std::string, swift::ValueDecl *>
-        SwiftDeclMapTy;
-    typedef SwiftDeclMapTy::iterator iterator;
-    SwiftDeclMapTy m_swift_decls;
+    llvm::StringMap<llvm::SmallVector<swift::ValueDecl *, 1>> m_swift_decls;
   };
 
   //----------------------------------------------------------------------
@@ -102,7 +100,7 @@ public:
   void RegisterSwiftPersistentDecl(swift::ValueDecl *value_decl);
 
   void RegisterSwiftPersistentDeclAlias(swift::ValueDecl *value_decl,
-                                        ConstString name);
+                                        llvm::StringRef name);
 
   void CopyInSwiftPersistentDecls(SwiftDeclMap &source_map);
 
@@ -110,7 +108,7 @@ public:
   /// in `excluding_equivalents`, and put the results in `matches`.  Return true
   /// if there are any results.
   bool GetSwiftPersistentDecls(
-      ConstString name,
+      llvm::StringRef name,
       const std::vector<swift::ValueDecl *> &excluding_equivalents,
       std::vector<swift::ValueDecl *> &matches);
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -45,7 +45,7 @@ class SwiftPersistentExpressionState : public PersistentExpressionState {
 public:
   class SwiftDeclMap {
   public:
-    void AddDecl(swift::ValueDecl *decl, bool check_existing,
+    void AddDecl(CompilerDecl value_decl, bool check_existing,
                  llvm::StringRef name);
 
     /// Find decls matching `name`, excluding decls that are equivalent to
@@ -53,14 +53,15 @@ public:
     /// Return true if there are any results.
     bool FindMatchingDecls(
         llvm::StringRef name,
-        const std::vector<swift::ValueDecl *> &excluding_equivalents,
-        std::vector<swift::ValueDecl *> &matches);
+        const std::vector<CompilerDecl> &excluding_equivalents,
+        std::vector<CompilerDecl> &matches);
 
     void CopyDeclsTo(SwiftDeclMap &target_map);
-    static bool DeclsAreEquivalent(swift::Decl *lhs, swift::Decl *rhs);
+    static bool DeclsAreEquivalent(CompilerDecl lhs, CompilerDecl rhs);
 
   private:
-    llvm::StringMap<llvm::SmallVector<swift::ValueDecl *, 1>> m_swift_decls;
+    /// Each decl also stores the context it comes from.
+    llvm::StringMap<llvm::SmallVector<CompilerDecl, 1>> m_swift_decls;
   };
 
   //----------------------------------------------------------------------
@@ -97,9 +98,9 @@ public:
   llvm::Optional<CompilerType>
   GetCompilerTypeFromPersistentDecl(ConstString type_name) override;
 
-  void RegisterSwiftPersistentDecl(swift::ValueDecl *value_decl);
+  void RegisterSwiftPersistentDecl(CompilerDecl value_decl);
 
-  void RegisterSwiftPersistentDeclAlias(swift::ValueDecl *value_decl,
+  void RegisterSwiftPersistentDeclAlias(CompilerDecl value_decl,
                                         llvm::StringRef name);
 
   void CopyInSwiftPersistentDecls(SwiftDeclMap &source_map);
@@ -109,8 +110,8 @@ public:
   /// if there are any results.
   bool GetSwiftPersistentDecls(
       llvm::StringRef name,
-      const std::vector<swift::ValueDecl *> &excluding_equivalents,
-      std::vector<swift::ValueDecl *> &matches);
+      const std::vector<CompilerDecl> &excluding_equivalents,
+      std::vector<CompilerDecl> &matches);
 
   // This just adds this module to the list of hand-loaded modules, it doesn't
   // actually load it.

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -20,9 +20,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 
-#include <set>
 #include <string>
-#include <unordered_map>
 
 namespace lldb_private {
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -15,10 +15,6 @@
 
 #include "SwiftExpressionVariable.h"
 
-#include "swift/AST/Import.h"
-#include "swift/AST/Module.h"
-
-#include "lldb/Core/SwiftForward.h"
 #include "lldb/Expression/ExpressionVariable.h"
 
 #include "llvm/ADT/StringMap.h"
@@ -38,10 +34,6 @@ namespace lldb_private {
 /// Also provides an increasing, 0-based counter for naming result
 /// variables.
 class SwiftPersistentExpressionState : public PersistentExpressionState {
-
-  typedef llvm::StringMap<swift::AttributedImport<swift::ImportedModule>>
-      HandLoadedModuleSet;
-
 public:
   class SwiftDeclMap {
   public:
@@ -113,18 +105,6 @@ public:
       const std::vector<CompilerDecl> &excluding_equivalents,
       std::vector<CompilerDecl> &matches);
 
-  // This just adds this module to the list of hand-loaded modules, it doesn't
-  // actually load it.
-  void AddHandLoadedModule(
-      ConstString module_name,
-      swift::AttributedImport<swift::ImportedModule> attributed_import) {
-    m_hand_loaded_modules.insert_or_assign(module_name.GetStringRef(),
-                                           attributed_import);
-  }
-
-  /// This returns the list of hand-loaded modules.
-  HandLoadedModuleSet GetHandLoadedModules() { return m_hand_loaded_modules; }
-
 private:
   /// The counter used by GetNextResultName().
   uint32_t m_next_persistent_variable_id;
@@ -132,9 +112,6 @@ private:
   uint32_t m_next_persistent_error_id;
   /// The persistent functions declared by the user.
   SwiftDeclMap m_swift_persistent_decls;
-  /// These are the names of modules that we have loaded by hand into
-  /// the Contexts we make for parsing.
-  HandLoadedModuleSet m_hand_loaded_modules;
 };
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -12,6 +12,7 @@
 
 #include "SwiftREPLMaterializer.h"
 #include "SwiftASTManipulator.h"
+#include "SwiftPersistentExpressionState.h"
 
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "lldb/Core/DumpDataExtractor.h"

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -186,7 +186,7 @@ public:
 
     if (m_swift_decl) {
       llvm::cast<SwiftPersistentExpressionState>(persistent_state)
-          ->RegisterSwiftPersistentDeclAlias(m_swift_decl, name);
+          ->RegisterSwiftPersistentDeclAlias(m_swift_decl, name.GetStringRef());
     }
 
     return;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -186,7 +186,11 @@ public:
 
     if (m_swift_decl) {
       llvm::cast<SwiftPersistentExpressionState>(persistent_state)
-          ->RegisterSwiftPersistentDeclAlias(m_swift_decl, name.GetStringRef());
+          ->RegisterSwiftPersistentDeclAlias(
+              {SwiftASTContext::GetSwiftASTContext(
+                   &m_swift_decl->getASTContext()),
+               m_swift_decl},
+              name.GetStringRef());
     }
 
     return;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -10,19 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/AST/ASTContext.h"
-#include "swift/AST/GenericEnvironment.h"
-#include "swift/Demangling/Demangler.h"
-#include <stdio.h>
-#if HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-
 #include "SwiftASTManipulator.h"
 #include "SwiftExpressionParser.h"
 #include "SwiftExpressionSourceCode.h"
+#include "SwiftPersistentExpressionState.h"
 #include "SwiftREPLMaterializer.h"
-#include "SwiftASTManipulator.h"
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/Demangling/Demangler.h"
+#if HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
 
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "lldb/Core/Module.h"
@@ -46,8 +45,6 @@
 #include "swift/Demangling/Demangler.h"
 #include "swift/AST/GenericEnvironment.h"
 
-
-#include <cstdlib>
 #include <map>
 #include <string>
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -712,8 +712,8 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
   if (status.Fail() || !module_decl)
     return error("could not load Swift Standard Library", status.AsCString());
 
-  persistent_state->AddHandLoadedModule(ConstString("Swift"),
-                                        swift::ImportedModule(module_decl));
+  m_swift_ast_ctx->AddHandLoadedModule(ConstString("Swift"),
+                                       swift::ImportedModule(module_decl));
   m_result_delegate.RegisterPersistentState(persistent_state);
   m_error_delegate.RegisterPersistentState(persistent_state);
  

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1506,7 +1506,7 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
       if (!persistent_state)
         return;
 
-      persistent_state->RegisterSwiftPersistentDecl(var_decl);
+      persistent_state->RegisterSwiftPersistentDecl({ast_context, var_decl});
 
       ConstString mangled_name;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -15,6 +15,7 @@
 #include "SwiftLanguageRuntimeImpl.h"
 #include "SwiftMetadataCache.h"
 
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/Process/Utility/RegisterContext_x86.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "Utility/ARM64_DWARF_Registers.h"

--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -15,6 +15,8 @@
 
 #include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
 
+#include "lldb/Utility/StreamString.h"
+
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/DiagnosticsSema.h"

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -12,6 +12,7 @@
 
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
@@ -8030,8 +8031,7 @@ SwiftASTContext::GetASTVectorForModule(const Module *module) {
 
 SwiftASTContextForExpressions::SwiftASTContextForExpressions(
     std::string description, TypeSystemSwiftTypeRef &typeref_typesystem)
-    : SwiftASTContext(std::move(description), typeref_typesystem),
-      m_persistent_state_up(new SwiftPersistentExpressionState) {
+    : SwiftASTContext(std::move(description), typeref_typesystem) {
   assert(llvm::isa<TypeSystemSwiftTypeRefForExpressions>(m_typeref_typesystem));
 }
 
@@ -8080,7 +8080,7 @@ UserExpression *SwiftASTContextForExpressions::GetUserExpression(
 
 PersistentExpressionState *
 SwiftASTContextForExpressions::GetPersistentExpressionState() {
-  return m_persistent_state_up.get();
+  return GetTypeSystemSwiftTypeRef().GetPersistentExpressionState();
 }
 
 static void DescribeFileUnit(Stream &s, swift::FileUnit *file_unit) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8226,24 +8226,18 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
   return swift_module;
 }
 
-bool SwiftASTContext::GetImplicitImports(
-    SwiftASTContext &swift_ast_context, SymbolContext &sc,
-    ExecutionContextScope &exe_scope, lldb::ProcessSP process_sp,
+bool SwiftASTContextForExpressions::GetImplicitImports(
+    SymbolContext &sc, lldb::ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
   LLDB_SCOPED_TIMER();
-  if (!swift_ast_context.GetCompileUnitImports(sc, process_sp, modules,
-                                               error)) {
+  if (!GetCompileUnitImports(sc, process_sp, modules, error)) {
     return false;
   }
 
-  auto *persistent_expression_state =
-      sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
-
   // Get the hand-loaded modules from the SwiftPersistentExpressionState.
-  for (auto &module_pair :
-       persistent_expression_state->GetHandLoadedModules()) {
+  for (auto &module_pair : m_hand_loaded_modules) {
 
     auto &attributed_import = module_pair.second;
 
@@ -8257,7 +8251,7 @@ bool SwiftASTContext::GetImplicitImports(
     // Otherwise, try reloading the ModuleDecl using the module name.
     SourceModule module_info;
     module_info.path.emplace_back(module_pair.first());
-    auto *module = LoadOneModule(module_info, swift_ast_context, process_sp,
+    auto *module = LoadOneModule(module_info, *this, process_sp,
                                  /*import_dylibs=*/false, error);
     if (!module)
       return false;
@@ -8268,8 +8262,8 @@ bool SwiftASTContext::GetImplicitImports(
   return true;
 }
 
-void SwiftASTContext::LoadImplicitModules(TargetSP target, ProcessSP process,
-                                          ExecutionContextScope &exe_scope) {
+void SwiftASTContextForExpressions::LoadImplicitModules(
+    TargetSP target, ProcessSP process, ExecutionContextScope &exe_scope) {
   auto load_module = [&](ConstString module_name) {
     SourceModule module_info;
     module_info.path.push_back(module_name);
@@ -8282,8 +8276,6 @@ void SwiftASTContext::LoadImplicitModules(TargetSP target, ProcessSP process,
       return;
     }
 
-    auto *persistent_expression_state =
-        target->GetSwiftPersistentExpressionState(exe_scope);
     swift::ModuleDecl *module = GetModule(module_info, err);
     if (err.Fail()) {
       LOG_PRINTF(
@@ -8293,24 +8285,16 @@ void SwiftASTContext::LoadImplicitModules(TargetSP target, ProcessSP process,
       return;
     }
 
-    persistent_expression_state->AddHandLoadedModule(
-        module_name, swift::ImportedModule(module));
+    AddHandLoadedModule(module_name, swift::ImportedModule(module));
   };
 
   load_module(ConstString(swift::SWIFT_STRING_PROCESSING_NAME));
   load_module(ConstString(swift::SWIFT_CONCURRENCY_NAME));
 }
 
-bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
-                                       SymbolContext &sc,
-                                       ExecutionContextScope &exe_scope,
-                                       lldb::ProcessSP process_sp,
-                                       swift::SourceFile &source_file,
-                                       Status &error) {
+bool SwiftASTContextForExpressions::CacheUserImports(
+    lldb::ProcessSP process_sp, swift::SourceFile &source_file, Status &error) {
   llvm::SmallString<1> m_description;
-
-  auto *persistent_expression_state =
-      sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
 
   auto src_file_imports = source_file.getImports();
 
@@ -8347,13 +8331,12 @@ bool SwiftASTContext::CacheUserImports(SwiftASTContext &swift_ast_context,
         LOG_PRINTF(GetLog(LLDBLog::Types | LLDBLog::Expressions),
                    "Performing auto import on found module: %s.\n",
                    module_name.c_str());
-        if (!LoadOneModule(module_info, swift_ast_context, process_sp,
+        if (!LoadOneModule(module_info, *this, process_sp,
                            /*import_dylibs=*/true, error))
           return false;
 
         // How do we tell we are in REPL or playground mode?
-        persistent_expression_state->AddHandLoadedModule(module_const_str,
-                                                         attributed_import);
+        AddHandLoadedModule(module_const_str, attributed_import);
       }
     }
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1032,10 +1032,10 @@ SwiftASTContextForModule::~SwiftASTContextForModule() {
 
 /// This code comes from CompilerInvocation.cpp (setRuntimeResourcePath).
 static void ConfigureResourceDirs(swift::CompilerInvocation &invocation,
-                                  FileSpec resource_dir, llvm::Triple triple) {
+                                  StringRef resource_dir, llvm::Triple triple) {
   // Make sure the triple is right:
   invocation.setTargetTriple(triple.str());
-  invocation.setRuntimeResourcePath(resource_dir.GetPath().c_str());
+  invocation.setRuntimeResourcePath(resource_dir);
 }
 
 static const char *getImportFailureString(swift::serialization::Status status) {
@@ -1930,8 +1930,8 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 
   std::string resource_dir =
       HostInfo::GetSwiftResourceDir(triple, swift_ast_sp->GetPlatformSDKPath());
-  ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
-                        FileSpec(resource_dir), triple);
+  ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(), resource_dir,
+                        triple);
 
   // Apply the working directory to all relative paths.
   std::vector<std::string> DeserializedArgs = swift_ast_sp->GetClangArguments();
@@ -2390,8 +2390,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   llvm::Triple triple = swift_ast_sp->GetTriple();
   std::string resource_dir = HostInfo::GetSwiftResourceDir(
       triple, swift_ast_sp->GetPlatformSDKPath());
-  ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(),
-                        FileSpec(resource_dir), triple);
+  ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(), resource_dir,
+                        triple);
   const bool discover_implicit_search_paths =
       target.GetSwiftDiscoverImplicitSearchPaths();
 
@@ -2813,8 +2813,7 @@ void SwiftASTContext::InitializeSearchPathOptions(
   llvm::Triple triple(GetTriple());
   std::string resource_dir =
       HostInfo::GetSwiftResourceDir(triple, GetPlatformSDKPath());
-  ConfigureResourceDirs(GetCompilerInvocation(), FileSpec(resource_dir),
-                        triple);
+  ConfigureResourceDirs(GetCompilerInvocation(), resource_dir, triple);
 
   std::string sdk_path = GetPlatformSDKPath().str();
   if (TargetSP target_sp = GetTargetWP().lock())
@@ -2853,6 +2852,20 @@ void SwiftASTContext::InitializeSearchPathOptions(
     std::vector<std::string> &lpaths =
         invocation.getSearchPathOptions().LibrarySearchPaths;
     lpaths.insert(lpaths.begin(), "/usr/lib/swift");
+  }
+
+  // Set the default host plugin paths.
+  llvm::SmallString<256> plugin_path;
+  llvm::sys::path::append(plugin_path, resource_dir, "host", "plugins");
+  if (!FileSystem::Instance().Exists(plugin_path)) {
+    LOG_PRINTF(GetLog(LLDBLog::Types), "Host plugin path %s does not exist",
+               plugin_path.str().str().c_str());
+  } else {
+    std::string server = SwiftASTContext::GetPluginServer(plugin_path);
+    if (!server.empty() && FileSystem::Instance().Exists(server))
+      invocation.getSearchPathOptions().PluginSearchOpts.emplace_back(
+          swift::PluginSearchOption::ExternalPluginPath{plugin_path.str().str(),
+                                                        server});
   }
 
   llvm::StringMap<bool> processed;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -13,7 +13,6 @@
 #ifndef liblldb_SwiftASTContext_h_
 #define liblldb_SwiftASTContext_h_
 
-#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -22,6 +22,8 @@
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Utility/Either.h"
 
+#include "swift/AST/Import.h"
+#include "swift/AST/Module.h"
 #include "swift/Parse/ParseVersion.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
@@ -806,30 +808,6 @@ public:
 
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
 
-  /// Retrieves the modules that need to be implicitly imported in a given
-  /// execution scope. This includes the modules imported by both the compile
-  /// unit as well as any imports from previous expression evaluations.
-  static bool GetImplicitImports(
-      SwiftASTContext &swift_ast_context, SymbolContext &sc,
-      ExecutionContextScope &exe_scope, lldb::ProcessSP process_sp,
-      llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-          &modules,
-      Status &error);
-
-  // FIXME: the correct thing to do would be to get the modules by calling
-  // CompilerInstance::getImplicitImportInfo, instead of loading these
-  // modules manually. However, we currently don't have  access to a
-  // CompilerInstance, which is why this function is needed.
-  void LoadImplicitModules(lldb::TargetSP target, lldb::ProcessSP process,
-                           ExecutionContextScope &exe_scope);
-  /// Cache the user's imports from a SourceFile in a given execution scope such
-  /// that they are carried over into future expression evaluations.
-  static bool CacheUserImports(SwiftASTContext &swift_ast_context,
-                               SymbolContext &sc,
-                               ExecutionContextScope &exe_scope,
-                               lldb::ProcessSP process_sp,
-                               swift::SourceFile &source_file, Status &error);
-
   /// Retrieve/import the modules imported by the compilation
   /// unit. Early-exists with false if there was an import failure.
   bool GetCompileUnitImports(
@@ -1036,6 +1014,42 @@ public:
   PersistentExpressionState *GetPersistentExpressionState() override;
 
   void ModulesDidLoad(ModuleList &module_list);
+
+  typedef llvm::StringMap<swift::AttributedImport<swift::ImportedModule>>
+      HandLoadedModuleSet;
+
+  // Insert to the list of hand-loaded modules, (no actual loading occurs).
+  void AddHandLoadedModule(
+      ConstString module_name,
+      swift::AttributedImport<swift::ImportedModule> attributed_import) {
+    m_hand_loaded_modules.insert_or_assign(module_name.GetStringRef(),
+                                           attributed_import);
+  }
+
+  /// Retrieves the modules that need to be implicitly imported in a given
+  /// execution scope. This includes the modules imported by both the compile
+  /// unit as well as any imports from previous expression evaluations.
+  bool GetImplicitImports(
+      SymbolContext &sc, lldb::ProcessSP process_sp,
+      llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
+          &modules,
+      Status &error);
+
+  // FIXME: the correct thing to do would be to get the modules by calling
+  // CompilerInstance::getImplicitImportInfo, instead of loading these
+  // modules manually. However, we currently don't have  access to a
+  // CompilerInstance, which is why this function is needed.
+  void LoadImplicitModules(lldb::TargetSP target, lldb::ProcessSP process,
+                           ExecutionContextScope &exe_scope);
+  /// Cache the user's imports from a SourceFile in a given execution scope such
+  /// that they are carried over into future expression evaluations.
+  bool CacheUserImports(lldb::ProcessSP process_sp,
+                        swift::SourceFile &source_file, Status &error);
+
+protected:
+  /// These are the names of modules that we have loaded by hand into
+  /// the Contexts we make for parsing.
+  HandLoadedModuleSet m_hand_loaded_modules;
 
 private:
   std::unique_ptr<SwiftPersistentExpressionState> m_persistent_state_up;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -12,6 +12,7 @@
 
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "lldb/Core/PluginManager.h"
 #include <lldb/lldb-enumerations.h>

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -27,6 +27,7 @@
 
 #include "Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.h"
 #include "Plugins/ExpressionParser/Clang/ClangUtil.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
@@ -1376,8 +1377,8 @@ TypeSystemSwiftTypeRef::TypeSystemSwiftTypeRef(Module &module) {
 
 TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
     lldb::LanguageType language, Target &target, Module &module)
-  : TypeSystemSwiftTypeRef(module),
-    m_target_wp(target.shared_from_this()) {
+    : TypeSystemSwiftTypeRef(module), m_target_wp(target.shared_from_this()),
+      m_persistent_state_up(new SwiftPersistentExpressionState) {
   m_description = "TypeSystemSwiftTypeRefForExpressions(PerModuleFallback)";
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "%s::TypeSystemSwiftTypeRefForExpressions()",
@@ -1392,7 +1393,8 @@ TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
 
 TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
     lldb::LanguageType language, Target &target, const char *extra_options)
-  : m_target_wp(target.shared_from_this()) {
+    : m_target_wp(target.shared_from_this()),
+      m_persistent_state_up(new SwiftPersistentExpressionState) {
   m_description = "TypeSystemSwiftTypeRefForExpressions";
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "%s::TypeSystemSwiftTypeRefForExpressions()",
@@ -1417,7 +1419,7 @@ Status TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
     process_sp = target_sp->GetProcessSP();
   if (!m_swift_ast_context_initialized)
     // Stash sc, the import will happen lazily when SwiftASTContext is created.
-    m_initial_symbol_context = std::make_unique<SymbolContext>(sc);
+    m_initial_symbol_context_up = std::make_unique<SymbolContext>(sc);
   else if (auto *swift_ast_ctx = GetSwiftASTContext())
     swift_ast_ctx->PerformCompileUnitImports(sc, process_sp, status);
   return status;
@@ -1436,10 +1438,7 @@ UserExpression *TypeSystemSwiftTypeRefForExpressions::GetUserExpression(
 
 PersistentExpressionState *
 TypeSystemSwiftTypeRefForExpressions::GetPersistentExpressionState() {
-  auto *swift_ast_ctx = GetSwiftASTContext();
-  if (!swift_ast_ctx)
-    return nullptr;
-  return swift_ast_ctx->GetPersistentExpressionState();
+  return m_persistent_state_up.get();
 }
 
 SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContext() const {
@@ -1478,14 +1477,14 @@ TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext() const {
     return nullptr;
 
   assert(llvm::isa<SwiftASTContextForExpressions>(m_swift_ast_context));
-  if (m_initial_symbol_context) {
+  if (m_initial_symbol_context_up) {
     Status error;
     lldb::ProcessSP process_sp;
     if (TargetSP target_sp = GetTargetWP().lock())
       process_sp = target_sp->GetProcessSP();
-    m_swift_ast_context->PerformCompileUnitImports(*m_initial_symbol_context,
+    m_swift_ast_context->PerformCompileUnitImports(*m_initial_symbol_context_up,
                                                    process_sp, error);
-    m_initial_symbol_context.reset();
+    m_initial_symbol_context_up.reset();
   }
 
   return m_swift_ast_context;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -37,7 +37,8 @@ class ClangExternalASTSourceCallbacks;
 class ClangNameImporter;
 class SwiftASTContext;
 class SwiftASTContextForExpressions;
-
+class SwiftPersistentExpressionState;
+  
 /// A Swift TypeSystem that does not own a swift::ASTContext.
 class TypeSystemSwiftTypeRef : public TypeSystemSwift {
   /// LLVM RTTI support.
@@ -496,7 +497,8 @@ protected:
   ///        initialized. It should be replaced by something more
   ///        deterministic.
   /// Perform all the implicit imports for the current frame.
-  mutable std::unique_ptr<SymbolContext> m_initial_symbol_context;
+  mutable std::unique_ptr<SymbolContext> m_initial_symbol_context_up;
+  std::unique_ptr<SwiftPersistentExpressionState> m_persistent_state_up;
 };
 
 swift::DWARFImporterDelegate *

--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -22,6 +22,7 @@
 
 #ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #endif //LLDB_ENABLE_SWIFT
 
 using namespace lldb;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -72,6 +72,7 @@
 
 #ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #endif // LLDB_ENABLE_SWIFT
 
 using namespace lldb;

--- a/lldb/source/Target/ThreadPlanCallFunction.cpp
+++ b/lldb/source/Target/ThreadPlanCallFunction.cpp
@@ -29,6 +29,7 @@
 
 #ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #endif //LLDB_ENABLE_SWIFT
 
 using namespace lldb;


### PR DESCRIPTION
While also being more efficient and shorter, this is done mainly in preparation for followup changes.