### PR TITLE
[lldb][NFCI] Add SBTraceCursor.h to swig headers file

### DIFF
--- a/lldb/bindings/headers.swig
+++ b/lldb/bindings/headers.swig
@@ -63,6 +63,7 @@
 #include "lldb/API/SBThreadCollection.h"
 #include "lldb/API/SBThreadPlan.h"
 #include "lldb/API/SBTrace.h"
+#include "lldb/API/SBTraceCursor.h"
 #include "lldb/API/SBType.h"
 #include "lldb/API/SBTypeCategory.h"
 #include "lldb/API/SBTypeEnumMember.h"


### PR DESCRIPTION
Differential Revision: https://reviews.llvm.org/D156934

(cherry picked from commit 08dc847d55fbdfa7ff6cb8034633139df0199562)