### PR TITLE
[Frontend] Check for annot_repl_input_end in addition to eof

### DIFF
--- a/clang/lib/Frontend/FrontendActions.cpp
+++ b/clang/lib/Frontend/FrontendActions.cpp
@@ -79,7 +79,7 @@ void ReadPCHAndPreprocessAction::ExecuteAction() {
   PP.EnterMainSourceFile();
   do {
     PP.Lex(Tok);
-  } while (Tok.isNot(tok::eof));
+  } while (Tok.isNot(tok::eof) && Tok.isNot(tok::annot_repl_input_end));
 }
 
 std::unique_ptr<ASTConsumer>


### PR DESCRIPTION
247fa04116a6cabf8378c6c72d90b2f705e969de added a new `annot_repl_input_end` token that replaces EOF when `isIncrementalProcessingEnabled`. That's the case from Swift's Clang importer and the same context is used for module dependency scanning. Check for the new token kind in `ReadPCHAndPreprocessAction` rather than infinitely looping waiting for EOF.