### PR TITLE
[clang][cli] Accept option spelling as `Twine` (follow-up)

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -412,7 +412,7 @@ normalizeStringPairVector(OptSpecifier Opt, int, const ArgList &Args,
 }
 
 static void denormalizeStringPairVector(
-    ArgumentConsumer Consumer, const char *Spelling,
+    ArgumentConsumer Consumer, const Twine &Spelling,
     Option::OptionClass OptClass, unsigned TableIndex,
     const std::vector<std::pair<std::string, std::string>> &Values) {
   std::vector<std::string> Joined;


### PR DESCRIPTION
This is a follow-up to https://reviews.llvm.org/D157035.