### PR TITLE
[Clang] Fix crash when emitting diagnostic for out of order designated initializers in C++

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -274,6 +274,9 @@ Bug Fixes
 - Fix assert that fails when the expression causing the this pointer to be
   captured by a block is part of a constexpr if statement's branch and
   instantiation of the enclosing method causes the branch to be discarded.
+- Fix crash when emitting diagnostic for out of order designated initializers
+  in C++.
+  (`#63605 <https://github.com/llvm/llvm-project/issues/63605>`_)
 
 Improvements to Clang's diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -2712,7 +2712,7 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
         SemaRef.Diag(DIE->getBeginLoc(), diag::ext_designated_init_reordered)
             << KnownField << PrevField << DIE->getSourceRange();
 
-        unsigned OldIndex = NumBases + PrevField->getFieldIndex();
+        unsigned OldIndex = StructuredIndex - 1;
         if (StructuredList && OldIndex <= StructuredList->getNumInits()) {
           if (Expr *PrevInit = StructuredList->getInit(OldIndex)) {
             SemaRef.Diag(PrevInit->getBeginLoc(),
@@ -2816,8 +2816,12 @@ InitListChecker::CheckDesignatedInitializer(const InitializedEntity &Entity,
     // If this the first designator, our caller will continue checking
     // the rest of this struct/class/union subobject.
     if (IsFirstDesignator) {
+      if (Field != RT->getDecl()->field_end() && Field->isUnnamedBitfield())
+        ++Field;
+
       if (NextField)
         *NextField = Field;
+
       StructuredIndex = FieldIndex;
       return false;
     }

--- a/clang/test/SemaCXX/cxx2a-initializer-aggregates.cpp
+++ b/clang/test/SemaCXX/cxx2a-initializer-aggregates.cpp
@@ -63,7 +63,7 @@ C c = {
   .x = 1, // override-note {{previous}}
   .x = 1, // override-error {{overrides prior initialization}} override-note {{previous}}
   .y = 1, // override-note {{previous}}
-  .y = 1, // override-error {{overrides prior initialization}}
+  .y = 1, // override-error {{overrides prior initialization}} // reorder-note {{previous initialization for field 'y' is here}}
   .x = 1, // reorder-error {{declaration order}} override-error {{overrides prior initialization}} override-note {{previous}}
   .x = 1, // override-error {{overrides prior initialization}}
 };
@@ -155,4 +155,44 @@ namespace deduction {
     j2<D, E>({}); // expected-error {{ambiguous}}
     j3<D, E>({}); // ok, selects E overload by SFINAE (too many braces for D)
   }
+}
+
+namespace GH63605 {
+struct A  {
+  unsigned x;
+  unsigned y;
+  unsigned z;
+};
+
+struct B {
+  unsigned a;
+  unsigned b;
+};
+
+struct : public A, public B {
+  unsigned : 2;
+  unsigned a : 6;
+  unsigned : 1;
+  unsigned b : 6;
+  unsigned : 2;
+  unsigned c : 6;
+  unsigned d : 1;
+  unsigned e : 2;
+} data = {
+  {.z=0,
+         // pedantic-note@-1 {{first non-designated initializer is here}}
+         // reorder-note@-2 {{previous initialization for field 'z' is here}}
+   .y=1, // reorder-error {{field 'z' will be initialized after field 'y'}}
+         // reorder-note@-1 {{previous initialization for field 'y' is here}}
+   .x=2}, // reorder-error {{field 'y' will be initialized after field 'x'}}
+  {.b=3,  // reorder-note {{previous initialization for field 'b' is here}}
+   .a=4}, // reorder-error {{field 'b' will be initialized after field 'a'}}
+    .e = 1, // reorder-note {{previous initialization for field 'e' is here}}
+            // pedantic-error@-1 {{mixture of designated and non-designated initializers in the same initializer list is a C99 extension}}
+    .d = 1, // reorder-error {{field 'e' will be initialized after field 'd'}}
+            // reorder-note@-1 {{previous initialization for field 'd' is here}}
+    .c = 1, // reorder-error {{field 'd' will be initialized after field 'c'}} // reorder-note {{previous initialization for field 'c' is here}}
+    .b = 1, // reorder-error {{field 'c' will be initialized after field 'b'}} // reorder-note {{previous initialization for field 'b' is here}}
+    .a = 1, // reorder-error {{field 'b' will be initialized after field 'a'}}
+};
 }


### PR DESCRIPTION
In C++ we are not allowed to use designated initializers to initialize fields out of order. In some cases when diagnosing this we are crashing because we are not indexing correctly and therefore going out of bounds.

This fixes: https://github.com/llvm/llvm-project/issues/63605

Differential Revision: https://reviews.llvm.org/D154675

(cherry picked from commit c9ef33e1d8a8aeb68a18f24af6d9fc9ab4ecf257)

Conflicts:
	clang/docs/ReleaseNotes.rst
	clang/test/SemaCXX/cxx2a-initializer-aggregates.cpp