### PR TITLE
[lldb] Remove duplicate methods

### DIFF
--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -133,6 +133,11 @@ public:
       FileSpec &lldb_shlib_spec, FileSpec &file_spec, bool verify) {
     return false;
   }
+
+  /// Return the default set of library paths to search in.  This allows a
+  /// platform specific extension for system libraries that may need to be
+  /// resolved (e.g. `/usr/lib` on Unicies and `Path` on Windows).
+  static std::vector<std::string> GetSwiftLibrarySearchPaths() { return {}; }
 #endif
 
   struct SDKOptions {
@@ -164,20 +169,6 @@ public:
   /// \return Returns either std::nullopt or a reference to a const std::string
   /// containing the distribution id
   static llvm::StringRef GetDistributionId() { return llvm::StringRef(); }
-
-#ifdef LLDB_ENABLE_SWIFT
-  static FileSpec GetSwiftResourceDir() { return {}; }
-  static FileSpec GetSwiftResourceDir(llvm::Triple triple) { return {}; }
-  static bool ComputeSwiftResourceDirectory(
-      FileSpec &lldb_shlib_spec, FileSpec &file_spec, bool verify) {
-    return false;
-  }
-
-  /// Return the default set of library paths to search in.  This allows a
-  /// platform specific extension for system libraries that may need to be
-  /// resolved (e.g. `/usr/lib` on Unicies and `Path` on Windows).
-  static std::vector<std::string> GetSwiftLibrarySearchPaths() { return {}; }
-#endif
 
 protected:
   static bool ComputeSharedLibraryDirectory(FileSpec &file_spec);


### PR DESCRIPTION
It looks like there was a merge issue, resulting in duplicate function declarations in HostInfoBase. This patch de-duplicates the duplicate functions.