### PR TITLE
[TextAPI] fix -Wdocumentation flagged typo, NFC

### DIFF
--- a/llvm/include/llvm/TextAPI/InterfaceFile.h
+++ b/llvm/include/llvm/TextAPI/InterfaceFile.h
@@ -188,7 +188,7 @@ public:
 
   /// Determine if target triple slice exists in file.
   ///
-  /// \param Target the value to find.
+  /// \param Targ the value to find.
   bool hasTarget(const Target &Targ) const {
     return llvm::is_contained(Targets, Targ);
   }


### PR DESCRIPTION
(cherry picked from commit c917917cf654608da51860ab5d9b6add00c1b178)