### PR TITLE
[clang] Fix some llvm::Optional usage

### DIFF
--- a/clang/include/clang/Index/IndexUnitReader.h
+++ b/clang/include/clang/Index/IndexUnitReader.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Chrono.h"
+#include <optional>
 
 namespace clang {
 namespace index {

--- a/clang/include/indexstore/IndexStoreCXX.h
+++ b/clang/include/indexstore/IndexStoreCXX.h
@@ -16,13 +16,11 @@
 #include "indexstore/indexstore.h"
 #include "clang/Basic/PathRemapper.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 
 namespace indexstore {
   using llvm::ArrayRef;
-  using llvm::Optional;
   using llvm::StringRef;
 
 static inline StringRef stringFromIndexStoreStringRef(indexstore_string_ref_t str) {

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -93,7 +93,7 @@ private:
 
   /// Replay a cache hit.
   ///
-  /// Return status if should exit immediately, otherwise None.
+  /// Return status if should exit immediately, otherwise std::nullopt.
   std::optional<int> replayCachedResult(const llvm::cas::CASID &ResultCacheKey,
                                         llvm::cas::ObjectRef ResultID,
                                         bool JustComputedResult);
@@ -188,7 +188,7 @@ private:
   void tryReleaseLLBuildExecutionLane();
 
   static StringRef getOutputKindName(OutputKind Kind);
-  /// \returns \p None if \p Name doesn't match one of the output kind names.
+  /// \returns \p std::nullopt if \p Name doesn't match one of the output kind names.
   static std::optional<OutputKind> getOutputKindForName(StringRef Name);
 
   std::unique_ptr<llvm::cas::remote::KeyValueDBClient> RemoteKVClient;

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -55,7 +55,7 @@ createCompileJobCacheKeyForArgs(ObjectStore &CAS,
   return llvm::cantFail(Builder.create(CAS)).getID();
 }
 
-static Optional<llvm::cas::CASID>
+static std::optional<llvm::cas::CASID>
 createCompileJobCacheKeyImpl(ObjectStore &CAS, DiagnosticsEngine &Diags,
                              CompilerInvocation CI) {
   FrontendOptions &FrontendOpts = CI.getFrontendOpts();
@@ -132,7 +132,7 @@ createCompileJobCacheKeyImpl(ObjectStore &CAS, DiagnosticsEngine &Diags,
     Diags.Report(diag::err_cas_cannot_parse_root_id) << RootIDString;
     return std::nullopt;
   }
-  Optional<llvm::cas::ObjectRef> RootRef = CAS.getReference(*RootID);
+  std::optional<llvm::cas::ObjectRef> RootRef = CAS.getReference(*RootID);
   if (!RootRef) {
     Diags.Report(diag::err_cas_missing_root_id) << RootIDString;
     return std::nullopt;
@@ -175,14 +175,14 @@ canonicalizeForCaching(llvm::cas::ObjectStore &CAS, DiagnosticsEngine &Diags,
   return Opts;
 }
 
-llvm::Optional<llvm::cas::CASID> clang::canonicalizeAndCreateCacheKey(
+std::optional<llvm::cas::CASID> clang::canonicalizeAndCreateCacheKey(
     llvm::cas::ObjectStore &CAS, DiagnosticsEngine &Diags,
     CompilerInvocation &Invocation, CompileJobCachingOptions &Opts) {
   Opts = canonicalizeForCaching(CAS, Diags, Invocation);
   return createCompileJobCacheKeyImpl(CAS, Diags, Invocation);
 }
 
-Optional<llvm::cas::CASID>
+std::optional<llvm::cas::CASID>
 clang::createCompileJobCacheKey(ObjectStore &CAS, DiagnosticsEngine &Diags,
                                 const CompilerInvocation &OriginalInvocation) {
 
@@ -195,7 +195,7 @@ static Error printFileSystem(ObjectStore &CAS, ObjectRef Root,
                              raw_ostream &OS) {
   TreeSchema Schema(CAS);
   return Schema.walkFileTreeRecursively(
-      CAS, Root, [&](const NamedTreeEntry &Entry, Optional<TreeProxy> Tree) {
+      CAS, Root, [&](const NamedTreeEntry &Entry, std::optional<TreeProxy> Tree) {
         if (Entry.getKind() != TreeEntry::Tree || Tree->empty()) {
           OS << "\n  ";
           Entry.print(OS, CAS);

--- a/clang/lib/Index/IndexUnitReader.cpp
+++ b/clang/lib/Index/IndexUnitReader.cpp
@@ -10,7 +10,6 @@
 #include "IndexDataStoreUtils.h"
 #include "BitstreamVisitor.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Bitstream/BitstreamReader.h"
@@ -460,7 +459,7 @@ IndexUnitReader::createWithFilePath(StringRef FilePath,
   return Reader;
 }
 
-Optional<sys::TimePoint<>>
+std::optional<sys::TimePoint<>>
 IndexUnitReader::getModificationTimeForUnit(StringRef UnitFilename,
                                             StringRef StorePath,
                                             std::string &Error) {


### PR DESCRIPTION
(cherry picked from commit f12ff76cd3928cefeb756e755a46066a0f2ca98c)