### PR TITLE
When ProcessMachCore has metadata for a binary, don't scan

### DIFF
--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.h
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.h
@@ -86,7 +86,13 @@ protected:
 
 private:
   void CreateMemoryRegions();
-  void LoadBinariesViaMetadata();
+
+  /// \return
+  ///   True if any metadata were found indicating the binary that should
+  ///   be loaded, regardless of whether the specified binary could be found.
+  ///   False if no metadata were present.
+  bool LoadBinariesViaMetadata();
+
   void LoadBinariesViaExhaustiveSearch();
   void LoadBinariesAndSetDYLD();
   void CleanupMemoryRegionPermissions();


### PR DESCRIPTION
When ProcessMachCore has metadata for a binary, don't scan

Mach-O corefiles have several possible types of metadata for the binaries that were running when the corefile was written. ProcessMachCore will try to find these binaries, and load them. When we have a hint, but could not find the binary, this change makes ProcessMachCore not fall back to scanning the corefile looking for ANY binary that it could load.  We sometimes have multiple binaries present in the memory in a corefile, but only the correct binary should be loaded, the others are data.

Differential Revision: https://reviews.llvm.org/D157168 rdar://112602508

(cherry picked from commit c5f81100e4471dfc2a802afb9333ca2684e02f8e)