### PR TITLE
Show error messages from DebugSymbols DBGShellCommand agent

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5444,6 +5444,8 @@ uint32_t ObjectFileMachO::GetNumThreadContexts() {
 
 std::string ObjectFileMachO::GetIdentifierString() {
   std::string result;
+  Log *log(
+      GetLog(LLDBLog::Symbols | LLDBLog::Process | LLDBLog::DynamicLoader));
   ModuleSP module_sp(GetModule());
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
@@ -5479,6 +5481,8 @@ std::string ObjectFileMachO::GetIdentifierString() {
                 result = buf;
                 if (buf)
                   free(buf);
+                LLDB_LOGF(log, "LC_NOTE 'kern ver str' found with text '%s'",
+                          result.c_str());
                 return result;
               }
             }
@@ -5502,6 +5506,7 @@ std::string ObjectFileMachO::GetIdentifierString() {
                                               buf) == ident_command.cmdsize) {
           buf[ident_command.cmdsize - 1] = '\0';
           result = buf;
+          LLDB_LOGF(log, "LC_IDENT found with text '%s'", result.c_str());
         }
         if (buf)
           free(buf);
@@ -5514,6 +5519,7 @@ std::string ObjectFileMachO::GetIdentifierString() {
 
 addr_t ObjectFileMachO::GetAddressMask() {
   addr_t mask = 0;
+  Log *log(GetLog(LLDBLog::Process));
   ModuleSP module_sp(GetModule());
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
@@ -5541,6 +5547,10 @@ addr_t ObjectFileMachO::GetAddressMask() {
               if (num_addr_bits != 0) {
                 mask = ~((1ULL << num_addr_bits) - 1);
               }
+              LLDB_LOGF(log,
+                        "LC_NOTE 'addrable bits' found, value %d bits, "
+                        "mask 0x%" PRIx64,
+                        num_addr_bits, mask);
               break;
             }
           }
@@ -5556,6 +5566,8 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
                                                 bool &value_is_offset,
                                                 UUID &uuid,
                                                 ObjectFile::BinaryType &type) {
+  Log *log(
+      GetLog(LLDBLog::Symbols | LLDBLog::Process | LLDBLog::DynamicLoader));
   value = LLDB_INVALID_ADDRESS;
   value_is_offset = false;
   uuid.Clear();
@@ -5635,20 +5647,31 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
               uuid = UUID(raw_uuid, sizeof(uuid_t));
               // convert the "main bin spec" type into our
               // ObjectFile::BinaryType enum
+              const char *typestr = "unrecognized type";
               switch (binspec_type) {
               case 0:
                 type = eBinaryTypeUnknown;
+                typestr = "uknown";
                 break;
               case 1:
                 type = eBinaryTypeKernel;
+                typestr = "xnu kernel";
                 break;
               case 2:
                 type = eBinaryTypeUser;
+                typestr = "userland dyld";
                 break;
               case 3:
                 type = eBinaryTypeStandalone;
+                typestr = "standalone";
                 break;
               }
+              LLDB_LOGF(log,
+                        "LC_NOTE 'main bin spec' found, version %d type %d "
+                        "(%s), value 0x%" PRIx64 " value-is-slide==%s uuid %s",
+                        version, type, typestr, value,
+                        value_is_offset ? "true" : "false",
+                        uuid.GetAsString().c_str());
               if (!m_data.GetU32(&offset, &log2_pagesize, 1))
                 return false;
               if (version > 1 && !m_data.GetU32(&offset, &platform, 1))
@@ -6859,6 +6882,8 @@ bool ObjectFileMachO::CanContainSwiftReflectionData(const Section &section) {
 ObjectFileMachO::MachOCorefileAllImageInfos
 ObjectFileMachO::GetCorefileAllImageInfos() {
   MachOCorefileAllImageInfos image_infos;
+  Log *log(
+      GetLog(LLDBLog::Symbols | LLDBLog::Process | LLDBLog::DynamicLoader));
 
   // Look for an "all image infos" LC_NOTE.
   lldb::offset_t offset = MachHeaderSizeFromMagic(m_header.magic);
@@ -6888,6 +6913,9 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
         //  offset += 4; // uint32_t entries_size;
         //  offset += 4; // uint32_t unused;
 
+        LLDB_LOGF(log,
+                  "LC_NOTE 'all image infos' found version %d with %d images",
+                  version, imgcount);
         offset = entries_fileoff;
         for (uint32_t i = 0; i < imgcount; i++) {
           // Read the struct image_entry.
@@ -6919,6 +6947,12 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
                                                     vmaddr};
             image_entry.segment_load_addresses.push_back(new_seg);
           }
+          LLDB_LOGF(
+              log, "  image entry: %s %s 0x%" PRIx64 " %s",
+              image_entry.filename.c_str(),
+              image_entry.uuid.GetAsString().c_str(), image_entry.load_address,
+              image_entry.currently_executing ? "currently executing"
+                                              : "not currently executing");
           image_infos.all_image_infos.push_back(image_entry);
         }
       } else if (strcmp("load binary", data_owner) == 0) {
@@ -6938,6 +6972,14 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
           image_entry.slide = slide;
           image_entry.currently_executing = true;
           image_infos.all_image_infos.push_back(image_entry);
+          LLDB_LOGF(log,
+                    "LC_NOTE 'load binary' found, filename %s uuid %s load "
+                    "address 0x%" PRIx64 " slide 0x%" PRIx64,
+                    filename.c_str(),
+                    image_entry.uuid.IsValid()
+                        ? image_entry.uuid.GetAsString().c_str()
+                        : "00000000-0000-0000-0000-000000000000",
+                    load_address, slide);
         }
       }
     }

--- a/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
+++ b/lldb/source/Symbol/LocateSymbolFileMacOSX.cpp
@@ -330,7 +330,8 @@ FileSpec Symbols::FindSymbolFileInBundle(const FileSpec &dsym_bundle_fspec,
 
 static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,
                                                 ModuleSpec &module_spec,
-                                                Status &error) {
+                                                Status &error,
+                                                const std::string &command) {
   Log *log = GetLog(LLDBLog::Host);
   bool success = false;
   if (uuid_dict != NULL && CFGetTypeID(uuid_dict) == CFDictionaryGetTypeID()) {
@@ -342,7 +343,10 @@ static bool GetModuleSpecInfoFromUUIDDictionary(CFDictionaryRef uuid_dict,
                                                CFSTR("DBGError"));
     if (cf_str && CFGetTypeID(cf_str) == CFStringGetTypeID()) {
       if (CFCString::FileSystemRepresentation(cf_str, str)) {
-        error.SetErrorString(str);
+        std::string errorstr = command;
+        errorstr += ":\n";
+        errorstr += str;
+        error.SetErrorString(errorstr);
       }
     }
 
@@ -652,7 +656,8 @@ bool Symbols::DownloadObjectAndSymbolFile(ModuleSpec &module_spec,
     CFCString uuid_cfstr(uuid_str.c_str());
     CFDictionaryRef uuid_dict =
         (CFDictionaryRef)CFDictionaryGetValue(plist.get(), uuid_cfstr.get());
-    return GetModuleSpecInfoFromUUIDDictionary(uuid_dict, module_spec, error);
+    return GetModuleSpecInfoFromUUIDDictionary(uuid_dict, module_spec, error,
+                                               command.GetData());
   }
 
   if (const CFIndex num_values = ::CFDictionaryGetCount(plist.get())) {
@@ -661,13 +666,14 @@ bool Symbols::DownloadObjectAndSymbolFile(ModuleSpec &module_spec,
     ::CFDictionaryGetKeysAndValues(plist.get(), NULL,
                                    (const void **)&values[0]);
     if (num_values == 1) {
-      return GetModuleSpecInfoFromUUIDDictionary(values[0], module_spec, error);
+      return GetModuleSpecInfoFromUUIDDictionary(values[0], module_spec, error,
+                                                 command.GetData());
     }
 
     for (CFIndex i = 0; i < num_values; ++i) {
       ModuleSpec curr_module_spec;
       if (GetModuleSpecInfoFromUUIDDictionary(values[i], curr_module_spec,
-                                              error)) {
+                                              error, command.GetData())) {
         if (module_spec.GetArchitecture().IsCompatibleMatch(
                 curr_module_spec.GetArchitecture())) {
           module_spec = curr_module_spec;


### PR DESCRIPTION
Show error messages from DebugSymbols DBGShellCommand agent

The DebugSymbols DBGShellsCommand, which can find the symbols for binaries, has a mechanism to return error messages when it cannot find a symbol file.  Those errors were not printed to the user for several corefile use case scenarios; this patch fixes that.

Also add dyld/process logging for the LC_NOTE metadata parsers in ObjectFileMachO, to help in seeing what lldb is basing its searches on.

Differential Revision: https://reviews.llvm.org/D157160

(cherry picked from commit 1290869ef2f72b7d59a92fa3cd48e6da29686c71)