### PR TITLE
When loading kernel binary, use DownloadObjectAndSymbolFile last

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -763,28 +763,13 @@ bool DynamicLoaderDarwinKernel::KextImageInfo::LoadImageUsingMemoryModule(
       module_spec.GetUUID() = m_uuid;
       module_spec.GetArchitecture() = target.GetArchitecture();
 
-      // For the kernel, we really do need an on-disk file copy of the binary
-      // to do anything useful. This will force a call to dsymForUUID if it
-      // exists, instead of depending on the DebugSymbols preferences being
-      // set.
-      Status kernel_search_error;
-      if (IsKernel()) {
-        if (Symbols::DownloadObjectAndSymbolFile(module_spec,
-                                                 kernel_search_error, true)) {
-          if (FileSystem::Instance().Exists(module_spec.GetFileSpec())) {
-            m_module_sp = std::make_shared<Module>(module_spec.GetFileSpec(),
-                                                   target.GetArchitecture());
-          }
-        }
-      }
-
       // If the current platform is PlatformDarwinKernel, create a ModuleSpec
       // with the filename set to be the bundle ID for this kext, e.g.
       // "com.apple.filesystems.msdosfs", and ask the platform to find it.
       // PlatformDarwinKernel does a special scan for kexts on the local
       // system.
       PlatformSP platform_sp(target.GetPlatform());
-      if (!m_module_sp && platform_sp) {
+      if (platform_sp) {
         static ConstString g_platform_name(
             PlatformDarwinKernel::GetPluginNameStatic());
         if (platform_sp->GetPluginName() == g_platform_name.GetStringRef()) {
@@ -805,6 +790,22 @@ bool DynamicLoaderDarwinKernel::KextImageInfo::LoadImageUsingMemoryModule(
       // search methods.
       if (!m_module_sp) {
         m_module_sp = target.GetOrCreateModule(module_spec, true /* notify */);
+      }
+
+      // For the kernel, we really do need an on-disk file copy of the binary
+      // to do anything useful. This will force a call to dsymForUUID if it
+      // exists, instead of depending on the DebugSymbols preferences being
+      // set.
+      Status kernel_search_error;
+      if (IsKernel() &&
+          (!m_module_sp || !m_module_sp->GetSymbolFileFileSpec())) {
+        if (Symbols::DownloadObjectAndSymbolFile(module_spec,
+                                                 kernel_search_error, true)) {
+          if (FileSystem::Instance().Exists(module_spec.GetFileSpec())) {
+            m_module_sp = std::make_shared<Module>(module_spec.GetFileSpec(),
+                                                   target.GetArchitecture());
+          }
+        }
       }
 
       if (IsKernel() && !m_module_sp) {


### PR DESCRIPTION
When loading kernel binary, use DownloadObjectAndSymbolFile last

When lldb starts a kernel debug session, it has the UUID of the kernel binary.  lldb will try three different methods to find a binary and symbol file for this UUID.  Currently it calls out to Symbols::DownloadObjectAndSymbolFile() first, which may be the slowest method when a DBGShellCommand can find the UUID on a network filesystem or downloaded from a server.

This patch tries the local searches first, then falls back to that method.

Differential Revision: https://reviews.llvm.org/D157165

(cherry picked from commit 0d8d31bbf55cedc1dad5c165187a084c1430f407)