### PR TITLE
[cxx-interop] Workaround a Swift compiler bug

### DIFF
--- a/clang/include/clang/AST/StmtIterator.h
+++ b/clang/include/clang/AST/StmtIterator.h
@@ -133,10 +133,10 @@ struct StmtIterator : public StmtIteratorImpl<StmtIterator, Stmt*&> {
   StmtIterator(const VariableArrayType *t)
       : StmtIteratorImpl<StmtIterator, Stmt*&>(t) {}
 
-private:
   StmtIterator(const StmtIteratorBase &RHS)
       : StmtIteratorImpl<StmtIterator, Stmt *&>(RHS) {}
 
+private:
   inline friend StmtIterator
   cast_away_const(const ConstStmtIterator &RHS);
 };


### PR DESCRIPTION
see https://github.com/apple/llvm-project/pull/7174

```
<unknown>:0: error: calling a private constructor of class 'clang::StmtIterator'
swift/llvm-project/clang/include/clang/AST/StmtIterator.h:137:3: note: declared private here
  StmtIterator(const StmtIteratorBase &RHS)
  ^
```

rdar://113514872