### PR TITLE
[RemoteCachingService/Client.h] Add missing include to fix compilation errors

### DIFF
--- a/llvm/include/llvm/RemoteCachingService/Client.h
+++ b/llvm/include/llvm/RemoteCachingService/Client.h
@@ -15,6 +15,7 @@
 #define LLVM_REMOTECACHINGSERVICE_CLIENT_H
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Error.h"
 #include <atomic>


### PR DESCRIPTION
(cherry picked from commit 26ec2529c738e2f19b07c9f3ca1591bc1042e2ff)