### PR TITLE
[lldb] Use summary string for ObjectiveC.Selector (NFC)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -779,33 +779,6 @@ lldb_private::formatters::swift::EnumSyntheticFrontEndCreator(
   return (new EnumSyntheticFrontEnd(valobj_sp));
 }
 
-bool lldb_private::formatters::swift::ObjC_Selector_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
-  static ConstString g_ptr("ptr");
-  static ConstString g__rawValue("_rawValue");
-
-  ValueObjectSP ptr_sp(valobj.GetChildAtNamePath({g_ptr, g__rawValue}));
-  if (!ptr_sp)
-    return false;
-
-  auto ptr_value = ptr_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
-
-  if (0 == ptr_value || LLDB_INVALID_ADDRESS == ptr_value)
-    return false;
-
-  StringPrinter::ReadStringAndDumpToStreamOptions read_options;
-  read_options.SetLocation(ptr_value);
-  read_options.SetTargetSP(valobj.GetTargetSP());
-  read_options.SetStream(&stream);
-  read_options.SetQuote('"');
-  read_options.SetNeedsZeroTermination(true);
-  read_options.SetEscapeStyle(StringPrinter::EscapeStyle::Swift);
-
-  return StringPrinter::ReadStringAndDumpToStream<
-      StringPrinter::StringElementType::ASCII>(read_options);
-}
-
 template <int Key> struct TypePreservingNSNumber;
 
 template <> struct TypePreservingNSNumber<0> {

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -108,9 +108,6 @@ bool GLKit_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool BuiltinObjC_SummaryProvider(ValueObject &valobj, Stream &stream,
                                  const TypeSummaryOptions &options);
 
-bool ObjC_Selector_SummaryProvider(ValueObject &valobj, Stream &stream,
-                                   const TypeSummaryOptions &options);
-
 bool TypePreservingNSNumber_SummaryProvider(ValueObject &valobj, Stream &stream,
                                             const TypeSummaryOptions &options);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -160,10 +160,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   basic_synth_flags.SetCascades(true).SetSkipPointers(true).SetSkipReferences(
       true);
 
-  AddCXXSummary(swift_category_sp,
-                lldb_private::formatters::swift::ObjC_Selector_SummaryProvider,
-                "ObjectiveC.Selector", ConstString("ObjectiveC.Selector"),
-                summary_flags);
+  AddStringSummary(swift_category_sp, "${var.ptr._rawValue%s}",
+                   ConstString("ObjectiveC.Selector"), summary_flags);
 
   AddCXXSynthetic(
       swift_category_sp,


### PR DESCRIPTION
Replace the `ObjC_Selector_SummaryProvider` function with the equivalent summary string.