### PR TITLE
🍒 Revert "cmake: add missing dependencies on Attributes.inc"

### DIFF
--- a/llvm/unittests/Analysis/CMakeLists.txt
+++ b/llvm/unittests/Analysis/CMakeLists.txt
@@ -64,8 +64,6 @@ add_llvm_unittest_with_input_files(AnalysisTests
   ${ANALYSIS_TEST_SOURCES}
   )
 
-add_dependencies(AnalysisTests intrinsics_gen)
-
 target_link_libraries(AnalysisTests PRIVATE LLVMTestingSupport)
 
 # On AIX, enable run-time linking to allow symbols from the plugins shared

--- a/llvm/utils/TableGen/CMakeLists.txt
+++ b/llvm/utils/TableGen/CMakeLists.txt
@@ -89,9 +89,6 @@ add_tablegen(llvm-tblgen LLVM
   X86RecognizableInstr.cpp
   WebAssemblyDisassemblerEmitter.cpp
   $<TARGET_OBJECTS:obj.LLVMTableGenCommon>
-
-  DEPENDS
-  intrinsics_gen # via llvm-min-tablegen
   )
 target_link_libraries(llvm-tblgen PRIVATE LLVMTableGenGlobalISel)
 set_target_properties(llvm-tblgen PROPERTIES FOLDER "Tablegenning")


### PR DESCRIPTION
Cherry-Picks: https://github.com/apple/llvm-project/commit/d462f65b8242a82d2430605a741825bf10ebaca0

This reverts commit 30b4351c7c75296dc60fc887212cdc98e85e9996.

This caused a dependency cycle that the Swift build picked up on:

```
CMake Error: The inter-target dependency graph contains the following strongly connected component (cycle):
  "llvm-tblgen" of type EXECUTABLE
    depends on "LLVMCodeGenTypes" (weak)
    depends on "LLVMTableGenGlobalISel" (weak)
    depends on "intrinsics_gen" (strong)
  "LLVMTableGenGlobalISel" of type STATIC_LIBRARY
    depends on "LLVMCodeGenTypes" (weak)
    depends on "vt_gen" (strong)
  "vt_gen" of type UTILITY
    depends on "llvm-tblgen" (strong)
  "autogen_intrinsics_RISCV" of type UTILITY
    depends on "llvm-tblgen" (strong)
  "intrinsics_gen" of type UTILITY
    depends on "llvm-tblgen" (strong)
    depends on "autogen_intrinsics_RISCV" (strong)
  "LLVMCodeGenTypes" of type STATIC_LIBRARY
    depends on "vt_gen" (strong)
```

rdar://113636528