### PR TITLE
Escape `@` symbol in documentation comment

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -4968,7 +4968,7 @@ public:
   }
 
   /// Is this an initializer for an array of characters, initialized by a string
-  /// literal or an @encode?
+  /// literal or an \@encode?
   bool isStringLiteralInit() const;
 
   /// Is this a transparent initializer list (that is, an InitListExpr that is


### PR DESCRIPTION
`@encode` was emitting a lot of warnings saying that it doesn't terminate a verabtim text block. The triggering warning is `-Wdocumentation`. Escaping it to quiet the warning spew.