### PR TITLE
Turn fsanitize=function into a noop on Apple for all architectures

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -531,6 +531,9 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
 
   Kinds |= Default;
 
+  if (TC.getTriple().isOSDarwin() && !TC.getTriple().isX86())
+    Kinds &= ~SanitizerKind::Function;
+
   // We disable the vptr sanitizer if it was enabled by group expansion but RTTI
   // is disabled.
   if ((Kinds & SanitizerKind::Vptr) && (RTTIMode == ToolChain::RM_Disabled)) {

--- a/clang/test/CodeGen/ubsan-function.cpp
+++ b/clang/test/CodeGen/ubsan-function.cpp
@@ -2,6 +2,7 @@
 // RUN: %clang_cc1 -triple aarch64-linux-gnu -emit-llvm -o - %s -fsanitize=function -fno-sanitize-recover=all | FileCheck %s --check-prefixes=CHECK,64
 // RUN: %clang_cc1 -triple aarch64_be-linux-gnu -emit-llvm -o - %s -fsanitize=function -fno-sanitize-recover=all | FileCheck %s --check-prefixes=CHECK,64
 // RUN: %clang_cc1 -triple arm-none-eabi -emit-llvm -o - %s -fsanitize=function -fno-sanitize-recover=all | FileCheck %s --check-prefixes=CHECK,ARM,32
+// RUN: %clang_cc1 -triple apple-macosx-x86_64 -emit-llvm -o - %s -fsanitize=function -fno-sanitize-recover=all | FileCheck %s --check-prefixes=CHECK,64
 
 // CHECK: define{{.*}} void @_Z3funv() #0 !func_sanitize ![[FUNCSAN:.*]] {
 void fun() {}

--- a/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/lit.local.cfg.py
+++ b/compiler-rt/test/ubsan/TestCases/TypeCheck/Function/lit.local.cfg.py
@@ -6,3 +6,6 @@ if config.target_arch == "powerpc64":
 # Work around "library ... not found: needed by main executable" in qemu.
 if config.android and config.target_arch not in ["x86", "x86_64"]:
     config.unsupported = True
+
+if config.host_os == "Darwin" and config.target_arch not in ["x86", "x86_64"]:
+    config.unsupported = True


### PR DESCRIPTION
except x86 & x86_64. This reverts the sanitizer to its previos behavior for Apple platforms before the commit 67cbe1b8597272165c2529f8a14ec571abe29490

rdar://112390716