### PR TITLE
[next][libclang] CXFile is now a FileEntryRef::MapEntry

### DIFF
--- a/clang/tools/libclang/CXLoadedDiagnostic.cpp
+++ b/clang/tools/libclang/CXLoadedDiagnostic.cpp
@@ -387,7 +387,8 @@ std::error_code DiagLoader::visitSourceFileContentsRecord(
   auto fileItr = TopDiags->Files.find(ID);
   if (fileItr == TopDiags->Files.end())
     return reportInvalidFile("Source file contents for unknown file ID");
-  FileEntry *file = const_cast<FileEntry*>(&fileItr->second.getFileEntry());
+
+  CXFile file = cxfile::makeCXFile(fileItr->second);
   StringRef CopiedContents(TopDiags->copyString(Contents),
                            Contents.size());
 


### PR DESCRIPTION
A `FileEntry *` was being passed to a call expecting a `CXFile`, but `CXFile` is now a `FileEntryRef::MapEntry` rather than a `FileEntry *`.

Resolves rdar://113414849.