### PR TITLE
[lldb][test] Disable ObjectFilePECOFFTests

### DIFF
--- a/lldb/unittests/ObjectFile/CMakeLists.txt
+++ b/lldb/unittests/ObjectFile/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_subdirectory(Breakpad)
 add_subdirectory(ELF)
 add_subdirectory(MachO)
-if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  # PECOFF/TestSectionSize.cpp uses a SizeOfRawData key not recognized
-  # by the yaml2pecoff on this branch on darwin; test fails to build.
-  add_subdirectory(PECOFF)
-endif()
-
+# PECOFF/TestSectionSize.cpp uses a SizeOfRawData key not recognized
+# by the yaml2pecoff on this branch; test fails to build.
+# add_subdirectory(PECOFF)


### PR DESCRIPTION
This test was disabled on Darwin in
`6e99aa0cf31586f85111307a56497c2d3e42aeb9`. However, it's failing on Linux for the same reason. Simply disable this test on this branch for all platforms.