### PR TITLE
[lldb] Make access to ReflectionContext thread safe

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -452,7 +452,8 @@ SwiftLanguageRuntimeImpl::GetMemoryReader() {
   if (!m_memory_reader_sp) {
     m_memory_reader_sp.reset(new LLDBMemoryReader(
         m_process, [&](swift::remote::RemoteAbsolutePointer pointer) {
-          auto *reflection_context = GetReflectionContext();
+          ThreadSafeReflectionContext reflection_context =
+              GetReflectionContext();
           return reflection_context->stripSignedPointer(pointer);
         }));
   }
@@ -1103,7 +1104,7 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
     if (!tr)
       return {};
 
-    auto *reflection_ctx = GetReflectionContext();
+    ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
     auto &builder = reflection_ctx->getBuilder();
     auto tc = swift::reflection::TypeConverter(builder);
     LLDBTypeInfoProvider tip(*this, *ts);
@@ -1310,7 +1311,7 @@ SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
                                            exe_ctx, omit_empty_base_classes,
                                            child_indexes);
     case ReferenceKind::Strong: {
-      auto *reflection_ctx = GetReflectionContext();
+      ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
       auto &builder = reflection_ctx->getBuilder();
       TypeConverter tc(builder);
       LLDBTypeInfoProvider tip(*this, *ts);
@@ -1490,7 +1491,7 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
     llvm::StringRef type_name = TypeSystemSwiftTypeRef::GetBaseName(
         ts->CanonicalizeSugar(dem, type_node));
 
-    auto *reflection_ctx = GetReflectionContext();
+    ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
     if (!reflection_ctx)
       return {};
     CompilerType instance_type = valobj->GetCompilerType();
@@ -1604,7 +1605,7 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
 
 bool SwiftLanguageRuntimeImpl::ForEachSuperClassType(
     ValueObject &instance, std::function<bool(SuperClassType)> fn) {
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return false;
   CompilerType instance_type = instance.GetCompilerType();
@@ -1671,7 +1672,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Pack(
     lldb::DynamicValueType use_dynamic, TypeAndOrName &pack_type_or_name,
     Address &address, Value::ValueType &value_type) {
   Log *log(GetLog(LLDBLog::Types));
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return false;
   
@@ -1992,7 +1993,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
       return false;
     }
   Log *log(GetLog(LLDBLog::Types));
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   const auto *typeref = reflection_ctx->readTypeFromInstance(instance_ptr);
   if (!typeref) {
     LLDB_LOGF(log,
@@ -2215,7 +2216,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
 
   swift::remote::RemoteAddress remote_existential(existential_address);
 
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   auto pair = reflection_ctx->projectExistentialAndUnwrapClass(
       remote_existential, *protocol_typeref);
   if (use_local_buffer)
@@ -2346,7 +2347,7 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParameters(
   auto ts =
       unbound_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   Status error;
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx) {
     LLDB_LOG(GetLog(LLDBLog::Types),
              "No reflection context available.");
@@ -2414,7 +2415,7 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
   using namespace swift::Demangle;
 
   Status error;
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx) {
     LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
              "No reflection context available.");
@@ -2874,7 +2875,7 @@ SwiftLanguageRuntimeImpl::GetValueType(ValueObject &in_value,
       // Read the value witness table and check if the data is inlined in
       // the existential container or not.
       swift::remote::RemoteAddress remote_existential(existential_address);
-      auto *reflection_ctx = GetReflectionContext();
+      ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
       llvm::Optional<bool> is_inlined =
           reflection_ctx->isValueInlinedInExistentialContainer(
               remote_existential);
@@ -3254,7 +3255,7 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
     return nullptr;
 
   // Build a TypeRef.
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return nullptr;
 
@@ -3329,7 +3330,7 @@ SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
   if (out_tr)
     *out_tr = type_ref;
 
-  auto *reflection_ctx = GetReflectionContext();
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return nullptr;
 


### PR DESCRIPTION
ReflectionContext can potentially be accessed by multiple threads at the same time, make accessing ReflectionContext thread safe by hiding it behind a lock.

rdar://112207497
(cherry picked from commit 26456d743fdc3cd01334a1f59242e715d6f1e5c6)