### PR TITLE
hi/low addr space bits can be sent in stop-rely packet

### DIFF
--- a/lldb/docs/lldb-gdb-remote.txt
+++ b/lldb/docs/lldb-gdb-remote.txt
@@ -1661,6 +1661,18 @@ for this region.
 //                                       start code that may be changing the
 //                                       page table setup, a dynamically set
 //                                       value may be needed.
+//  "low_mem_addressing_bits" unsigned optional, specifies how many bits in 
+//                                       addresses in low memory are significant 
+//                                       for addressing, base 10.  AArch64 can 
+//                                       have different page table setups for low 
+//                                       and high memory, and therefore a different 
+//                                       number of bits used for addressing.
+//  "high_mem_addressing_bits" unsigned optional, specifies how many bits in 
+//                                       addresses in high memory are significant 
+//                                       for addressing, base 10.  AArch64 can have 
+//                                       different page table setups for low and 
+//                                       high memory, and therefore a different 
+//                                       number of bits used for addressing.
 //
 // BEST PRACTICES:
 //  Since register values can be supplied with this packet, it is often useful

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -502,15 +502,10 @@ public:
   /// object files can return an AddressableBits object that can can be
   /// used to set the address masks in the Process.
   ///
-  /// \param[out] address_bits
-  ///     Can be used to set the Process address masks.
-  ///
   /// \return
-  ///     Returns true if addressable bits metadata was found.
-  virtual bool GetAddressableBits(lldb_private::AddressableBits &address_bits) {
-    address_bits.Clear();
-    return false;
-  }
+  ///     Returns an AddressableBits object which can be used to set
+  ///     the address masks in the Process.
+  virtual lldb_private::AddressableBits GetAddressableBits() { return {}; }
 
   /// When the ObjectFile is a core file, lldb needs to locate the "binary" in
   /// the core file.  lldb can iterate over the pages looking for a valid

--- a/lldb/include/lldb/Utility/AddressableBits.h
+++ b/lldb/include/lldb/Utility/AddressableBits.h
@@ -29,9 +29,11 @@ public:
   void SetAddressableBits(uint32_t lowmem_addressing_bits,
                           uint32_t highmem_addressing_bits);
 
-  void SetProcessMasks(lldb_private::Process &process);
+  void SetLowmemAddressableBits(uint32_t lowmem_addressing_bits);
 
-  void Clear();
+  void SetHighmemAddressableBits(uint32_t highmem_addressing_bits);
+
+  void SetProcessMasks(lldb_private::Process &process);
 
 private:
   uint32_t m_low_memory_addr_bits;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5517,8 +5517,8 @@ std::string ObjectFileMachO::GetIdentifierString() {
   return result;
 }
 
-bool ObjectFileMachO::GetAddressableBits(AddressableBits &address_bits) {
-  address_bits.Clear();
+AddressableBits ObjectFileMachO::GetAddressableBits() {
+  AddressableBits addressable_bits;
 
   Log *log(GetLog(LLDBLog::Process));
   ModuleSP module_sp(GetModule());
@@ -5546,24 +5546,24 @@ bool ObjectFileMachO::GetAddressableBits(AddressableBits &address_bits) {
             if (version == 3) {
               uint32_t num_addr_bits = m_data.GetU32_unchecked(&offset);
               if (num_addr_bits != 0) {
-                address_bits.SetAddressableBits(num_addr_bits);
+                addressable_bits.SetAddressableBits(num_addr_bits);
               }
               LLDB_LOGF(log,
                         "LC_NOTE 'addrable bits' v3 found, value %d "
                         "bits",
                         num_addr_bits);
-              return true;
+              break;
             }
             if (version == 4) {
               uint32_t lo_addr_bits = m_data.GetU32_unchecked(&offset);
               uint32_t hi_addr_bits = m_data.GetU32_unchecked(&offset);
 
-              address_bits.SetAddressableBits(lo_addr_bits, hi_addr_bits);
+              addressable_bits.SetAddressableBits(lo_addr_bits, hi_addr_bits);
               LLDB_LOGF(log,
                         "LC_NOTE 'addrable bits' v4 found, value %d & %d bits",
                         lo_addr_bits, hi_addr_bits);
 
-              return true;
+              break;
             }
           }
         }
@@ -5571,7 +5571,7 @@ bool ObjectFileMachO::GetAddressableBits(AddressableBits &address_bits) {
       offset = cmd_offset + lc.cmdsize;
     }
   }
-  return false;
+  return addressable_bits;
 }
 
 bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -122,7 +122,7 @@ public:
 
   std::string GetIdentifierString() override;
 
-  bool GetAddressableBits(lldb_private::AddressableBits &address_bits) override;
+  lldb_private::AddressableBits GetAddressableBits() override;
 
   bool GetCorefileMainBinaryInfo(lldb::addr_t &value, bool &value_is_offset,
                                  lldb_private::UUID &uuid,

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1415,17 +1415,17 @@ GDBRemoteCommunicationClient::GetHostArchitecture() {
   return m_host_arch;
 }
 
-bool GDBRemoteCommunicationClient::GetAddressableBits(
-    lldb_private::AddressableBits &addressable_bits) {
-  addressable_bits.Clear();
+AddressableBits GDBRemoteCommunicationClient::GetAddressableBits() {
+  AddressableBits addressable_bits;
   if (m_qHostInfo_is_valid == eLazyBoolCalculate)
     GetHostInfo();
-  if (m_low_mem_addressing_bits != 0 || m_high_mem_addressing_bits != 0) {
-    addressable_bits.SetAddressableBits(m_low_mem_addressing_bits,
-                                        m_high_mem_addressing_bits);
-    return true;
-  }
-  return false;
+
+  // m_low_mem_addressing_bits and m_high_mem_addressing_bits
+  // will be 0 if we did not receive values; AddressableBits
+  // treats 0 as "unspecified".
+  addressable_bits.SetAddressableBits(m_low_mem_addressing_bits,
+                                      m_high_mem_addressing_bits);
+  return addressable_bits;
 }
 
 seconds GDBRemoteCommunicationClient::GetHostDefaultPacketTimeout() {

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.h
@@ -238,7 +238,7 @@ public:
 
   ArchSpec GetSystemArchitecture();
 
-  bool GetAddressableBits(lldb_private::AddressableBits &addressable_bits);
+  lldb_private::AddressableBits GetAddressableBits();
 
   bool GetHostname(std::string &s);
 

--- a/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
+++ b/lldb/source/Plugins/Process/mach-core/ProcessMachCore.cpp
@@ -574,10 +574,9 @@ Status ProcessMachCore::DoLoadCore() {
 
   CleanupMemoryRegionPermissions();
 
-  AddressableBits addressable_bits;
-  if (core_objfile->GetAddressableBits(addressable_bits)) {
-    addressable_bits.SetProcessMasks(*this);
-  }
+  AddressableBits addressable_bits = core_objfile->GetAddressableBits();
+  addressable_bits.SetProcessMasks(*this);
+
   return error;
 }
 


### PR DESCRIPTION
hi/low addr space bits can be sent in stop-rely packet

Add support for the `low_mem_addressing_bits` and
`high_mem_addressing_bits` keys in the stop reply packet, in addition to the existing `addressing_bits`.  Same behavior as in the qHostInfo packet.

Clean up AddressableBits so we don't need to check if any values have been set in the object before using it to potentially update the Process address masks.

Differential Revision: https://reviews.llvm.org/D158041

(cherry picked from commit 6f4a0c762fe2c0077865e0e30e3dfd67cd6287d1)