### PR TITLE
[Sanitizers][Driverkit] Stop using Sanitizer Allocator64 on Driverkit

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
@@ -284,7 +284,7 @@
 // For such platforms build this code with -DSANITIZER_CAN_USE_ALLOCATOR64=0 or
 // change the definition of SANITIZER_CAN_USE_ALLOCATOR64 here.
 #ifndef SANITIZER_CAN_USE_ALLOCATOR64
-#  if SANITIZER_RISCV64 || SANITIZER_IOS
+#  if SANITIZER_RISCV64 || SANITIZER_IOS || SANITIZER_DRIVERKIT
 #    define SANITIZER_CAN_USE_ALLOCATOR64 0
 #  elif defined(__mips64) || defined(__hexagon__)
 #    define SANITIZER_CAN_USE_ALLOCATOR64 0


### PR DESCRIPTION
Before refactoring this code, all arm64 were set to use the 32bit allocator. This patch reverts back that behavior for DriverKit.

Because we target DriverKit as the target OS, rather than a specific platform, reverting back to the previous behavior is preferred to fix a failure we are seeing on embedded platforms. Though it may be more correct in the future to match the allocator to the platform being used.

rdar://113649286

Differential Revision: https://reviews.llvm.org/D158028