### PR TITLE
[llvm/CAS] Introduce `ObjectStore::isMaterialized()`

### DIFF
--- a/llvm/include/llvm-c/CAS/PluginAPI_functions.h
+++ b/llvm/include/llvm-c/CAS/PluginAPI_functions.h
@@ -164,6 +164,10 @@ LLCAS_PUBLIC llcas_digest_t llcas_objectid_get_digest(llcas_cas_t,
 /**
  * Checks whether a \c llcas_objectid_t points to an existing object.
  *
+ * \param globally For CAS implementations that distinguish between local CAS
+ * and remote/distributed CAS, \p globally set to false indicates that the
+ * lookup will be restricted to the local CAS, returning "not found" even if the
+ * object might exist in the remote CAS.
  * \param error optional pointer to receive an error message if an error
  * occurred. If set, the memory it points to needs to be released via
  * \c llcas_string_dispose.
@@ -171,6 +175,7 @@ LLCAS_PUBLIC llcas_digest_t llcas_objectid_get_digest(llcas_cas_t,
  */
 LLCAS_PUBLIC llcas_lookup_result_t llcas_cas_contains_object(llcas_cas_t,
                                                              llcas_objectid_t,
+                                                             bool globally,
                                                              char **error);
 
 /**

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -151,6 +151,10 @@ public:
   /// Returns \c None if the object is not stored in this CAS.
   virtual std::optional<ObjectRef> getReference(const CASID &ID) const = 0;
 
+  /// \returns true if the object is directly available from the local CAS, for
+  /// implementations that have this kind of distinction.
+  virtual Expected<bool> isMaterialized(ObjectRef Ref) const = 0;
+
   /// Validate the underlying object referred by CASID.
   virtual Error validate(const CASID &ID) = 0;
 

--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -220,6 +220,8 @@ public:
     return std::nullopt;
   }
 
+  Expected<bool> isMaterialized(ObjectRef Ref) const final { return true; }
+
   ArrayRef<char> getDataConst(ObjectHandle Node) const final {
     return cast<InMemoryObject>(asInMemoryObject(Node)).getData();
   }

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -29,6 +29,8 @@ public:
 
   std::optional<ObjectRef> getReference(const CASID &ID) const final;
 
+  Expected<bool> isMaterialized(ObjectRef Ref) const final;
+
   ArrayRef<char> getDataConst(ObjectHandle Node) const final;
 
   void print(raw_ostream &OS) const final;
@@ -89,6 +91,10 @@ std::optional<ObjectRef> OnDiskCAS::getReference(const CASID &ID) const {
   if (!ObjID)
     return std::nullopt;
   return convertRef(*ObjID);
+}
+
+Expected<bool> OnDiskCAS::isMaterialized(ObjectRef ExternalRef) const {
+  return DB->containsObject(convertRef(ExternalRef));
 }
 
 ArrayRef<char> OnDiskCAS::getDataConst(ObjectHandle Node) const {

--- a/llvm/lib/CAS/PluginAPI.h
+++ b/llvm/lib/CAS/PluginAPI.h
@@ -48,7 +48,7 @@ struct llcas_functions_t {
   llcas_digest_t (*objectid_get_digest)(llcas_cas_t, llcas_objectid_t);
 
   llcas_lookup_result_t (*cas_contains_object)(llcas_cas_t, llcas_objectid_t,
-                                               char **error);
+                                               bool globally, char **error);
 
   llcas_lookup_result_t (*cas_load_object)(llcas_cas_t, llcas_objectid_t,
                                            llcas_loaded_object_t *,

--- a/llvm/lib/RemoteCachingService/CAS/GRPCRelayCAS.cpp
+++ b/llvm/lib/RemoteCachingService/CAS/GRPCRelayCAS.cpp
@@ -116,6 +116,7 @@ public:
                                ArrayRef<char> Data) final;
   CASID getID(ObjectRef Ref) const final;
   std::optional<ObjectRef> getReference(const CASID &ID) const final;
+  Expected<bool> isMaterialized(ObjectRef Ref) const final;
   Expected<std::optional<ObjectHandle>> loadIfExists(ObjectRef Ref) final;
   Error validate(const CASID &ID) final {
     // Not supported yet. Always return success.
@@ -301,6 +302,11 @@ std::optional<ObjectRef> GRPCRelayCAS::getReference(const CASID &ID) const {
          "Expected ID from same hash schema");
   auto &I = indexHash(ID.getHash());
   return toReference(I);
+}
+
+Expected<bool> GRPCRelayCAS::isMaterialized(ObjectRef Ref) const {
+  auto &I = asInMemoryIndexValue(Ref);
+  return (bool)I.Data.load();
 }
 
 Expected<std::optional<ObjectHandle>>

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -29,9 +29,11 @@ add_llvm_unittest(CASTests
   OnDiskGraphDBTest.cpp
   OnDiskHashMappedTrieTest.cpp
   OnDiskKeyValueDBTest.cpp
+  PluginCASTest.cpp
   ThreadSafeAllocatorTest.cpp
   TreeSchemaTest.cpp
   UnifiedOnDiskCacheTest.cpp
   )
 
 target_link_libraries(CASTests PRIVATE LLVMTestingSupport)
+add_dependencies(CASTests CASPluginTest)

--- a/llvm/unittests/CAS/PluginCASTest.cpp
+++ b/llvm/unittests/CAS/PluginCASTest.cpp
@@ -1,0 +1,106 @@
+//===- llvm/unittest/CAS/PluginCASTest.cpp --------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Config/config.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+#if LLVM_ENABLE_ONDISK_CAS
+
+using namespace llvm;
+using namespace llvm::cas;
+
+// See llvm/utils/unittest/UnitTestMain/TestMain.cpp
+extern const char *TestMainArgv0;
+
+// Just a reachable symbol to ease resolving of the executable's path.
+static std::string TestStringArg1("plugincas-test-string-arg1");
+
+static std::string getCASPluginPath() {
+  std::string Executable =
+      sys::fs::getMainExecutable(TestMainArgv0, &TestStringArg1);
+  llvm::SmallString<256> PathBuf(sys::path::parent_path(
+      sys::path::parent_path(sys::path::parent_path(Executable))));
+  std::string LibName = "libCASPluginTest";
+  sys::path::append(PathBuf, "lib", LibName + LLVM_PLUGIN_EXT);
+  return std::string(PathBuf);
+}
+
+TEST(PluginCASTest, isMaterialized) {
+  unittest::TempDir Temp("plugin-cas", /*Unique=*/true);
+  std::string UpDir(Temp.path("up"));
+  std::string DownDir(Temp.path("down"));
+  std::pair<std::string, std::string> PluginOpts[] = {
+      {"upstream-path", std::string(UpDir)}};
+
+  {
+    std::optional<
+        std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
+        DBs;
+    ASSERT_THAT_ERROR(
+        createPluginCASDatabases(getCASPluginPath(), DownDir, PluginOpts)
+            .moveInto(DBs),
+        Succeeded());
+    std::shared_ptr<ObjectStore> CAS;
+    std::shared_ptr<ActionCache> AC;
+    std::tie(CAS, AC) = std::move(*DBs);
+
+    std::optional<CASID> ID1, ID2;
+    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID1),
+                      Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "2").moveInto(ID2),
+                      Succeeded());
+    std::optional<ObjectRef> ID2Ref = CAS->getReference(*ID2);
+    ASSERT_TRUE(ID2Ref);
+    bool IsMaterialized = false;
+    ASSERT_THAT_ERROR(CAS->isMaterialized(*ID2Ref).moveInto(IsMaterialized),
+                      Succeeded());
+    EXPECT_TRUE(IsMaterialized);
+    ASSERT_THAT_ERROR(AC->put(*ID1, *ID2, /*Globally=*/true), Succeeded());
+  }
+
+  // Clear "local" cache.
+  sys::fs::remove_directories(DownDir);
+
+  {
+    std::optional<
+        std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
+        DBs;
+    ASSERT_THAT_ERROR(
+        createPluginCASDatabases(getCASPluginPath(), DownDir, PluginOpts)
+            .moveInto(DBs),
+        Succeeded());
+    std::shared_ptr<ObjectStore> CAS;
+    std::shared_ptr<ActionCache> AC;
+    std::tie(CAS, AC) = std::move(*DBs);
+
+    std::optional<CASID> ID1, ID2;
+    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID1),
+                      Succeeded());
+    ASSERT_THAT_ERROR(AC->get(*ID1, /*Globally=*/true).moveInto(ID2),
+                      Succeeded());
+    std::optional<ObjectRef> ID2Ref = CAS->getReference(*ID2);
+    ASSERT_TRUE(ID2Ref);
+    bool IsMaterialized = false;
+    ASSERT_THAT_ERROR(CAS->isMaterialized(*ID2Ref).moveInto(IsMaterialized),
+                      Succeeded());
+    EXPECT_FALSE(IsMaterialized);
+
+    std::optional<ObjectProxy> Obj;
+    ASSERT_THAT_ERROR(CAS->getProxy(*ID2Ref).moveInto(Obj), Succeeded());
+    ASSERT_THAT_ERROR(CAS->isMaterialized(*ID2Ref).moveInto(IsMaterialized),
+                      Succeeded());
+    EXPECT_TRUE(IsMaterialized);
+  }
+}
+
+#endif // LLVM_ENABLE_ONDISK_CAS


### PR DESCRIPTION
This returns true if the object is directly available from the local CAS, for implementations that have this kind of distinction. For such implementations it's useful to be able to identify whether objects need to be downloaded from the distributed cache.