### PR TITLE
Avoid a roundtrip through SwiftASTContext in findSwiftSelf() (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2442,20 +2442,9 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
   }
 
   Demangler dem;
-  NodePointer canonical = TypeSystemSwiftTypeRef::Transform(
-      dem, dem.demangleSymbol(mangled_name.GetStringRef()),
-      [](NodePointer node) {
-        if (node->getKind() != Node::Kind::DynamicSelf)
-          return node;
-        // Substitute the static type for dynamic self.
-        assert(node->getNumChildren() == 1);
-        if (node->getNumChildren() != 1)
-          return node;
-        NodePointer type = node->getChild(0);
-        if (type->getKind() != Node::Kind::Type || type->getNumChildren() != 1)
-          return node;
-        return type->getChild(0);
-      });
+
+  NodePointer canonical = TypeSystemSwiftTypeRef::GetStaticSelfType(
+      dem, dem.demangleSymbol(mangled_name.GetStringRef()));
 
   // Build the list of type substitutions.
   swift::reflection::GenericArgumentMap substitutions;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5166,6 +5166,17 @@ CompilerType SwiftASTContext::GetReferentType(opaque_compiler_type_t type) {
   return ToCompilerType({ref_type});
 }
 
+CompilerType
+SwiftASTContext::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
+  VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
+
+  swift::Type swift_type = GetSwiftType(type);
+  if (auto *dyn_self =
+          llvm::dyn_cast_or_null<swift::DynamicSelfType>(swift_type))
+    return ToCompilerType({dyn_self->getSelfType().getPointer()});
+  return {weak_from_this(), type};
+}
+
 bool SwiftASTContext::IsFullyRealized(const CompilerType &compiler_type) {
   if (swift::CanType swift_can_type = ::GetCanonicalSwiftType(compiler_type)) {
     if (swift::isa<swift::MetatypeType>(swift_can_type))

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -806,6 +806,7 @@ public:
                       CompilerType *original_type) override;
 
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) override;
 
   /// Retrieve/import the modules imported by the compilation
   /// unit. Early-exists with false if there was an import failure.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -128,6 +128,8 @@ public:
   virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);
   virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) = 0;
+  /// Return the static type if this is a DynamicSelf type else the input type.
+  virtual CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) = 0;
   enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
   struct TupleElement {
     ConstString element_name;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3429,6 +3429,38 @@ TypeSystemSwiftTypeRef::GetReferentType(opaque_compiler_type_t type) {
                       (ReconstructType(type)), (ReconstructType(type)));
 }
 
+swift::Demangle::NodePointer
+TypeSystemSwiftTypeRef::GetStaticSelfType(swift::Demangle::Demangler &dem,
+                                          swift::Demangle::NodePointer node) {
+  using namespace swift::Demangle;
+  return TypeSystemSwiftTypeRef::Transform(dem, node, [](NodePointer node) {
+    if (node->getKind() != Node::Kind::DynamicSelf)
+      return node;
+    // Substitute the static type for dynamic self.
+    assert(node->getNumChildren() == 1);
+    if (node->getNumChildren() != 1)
+      return node;
+    NodePointer type = node->getChild(0);
+    if (type->getKind() != Node::Kind::Type || type->getNumChildren() != 1)
+      return node;
+    return type->getChild(0);
+  });
+}
+
+CompilerType
+TypeSystemSwiftTypeRef::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
+  auto impl = [&]() -> CompilerType {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = GetDemangledType(dem, AsMangledName(type));
+    auto *type_node = dem.createNode(Node::Kind::Type);
+    type_node->addChild(GetStaticSelfType(dem, node), dem);
+    return RemangleAsType(dem, type_node);
+  };
+  VALIDATE_AND_RETURN(impl, GetStaticSelfType, type, g_no_exe_ctx,
+                      (ReconstructType(type)), (ReconstructType(type)));
+}
+
 CompilerType
 TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -271,6 +271,11 @@ public:
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) override;
+  static swift::Demangle::NodePointer
+  GetStaticSelfType(swift::Demangle::Demangler &dem,
+                    swift::Demangle::NodePointer node);
+
   /// Wrap type inside a SILPackType.
   CompilerType CreateSILPackType(CompilerType type, bool indirect);
   struct PackTypeInfo {


### PR DESCRIPTION
This eliminates one of the reasons why a SwiftASTContextForModule() is instantiated by the expression evaluator.

rdar://113997661