### PR TITLE
Replace IsFullyRealized() with !IsMeaninglessWithoutDynamicResolution() (NFC)

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1087,8 +1087,16 @@ bool SwiftASTManipulator::AddExternalVariables(
 
       swift::VarDecl *redirected_var_decl =
           GetVarDeclForVariableInFunction(variable, containing_function);
+      if (!redirected_var_decl) {
+        LLDB_LOG(log, "No var decl.");
+        continue;
+      }
       swift::PatternBindingDecl *pattern_binding =
           GetPatternBindingForVarDecl(redirected_var_decl, containing_function);
+      if (!pattern_binding) {
+        LLDB_LOG(log, "No pattern binding.");
+        continue;
+      }
 
       // Push the var decl and pattern binding so we add them to the function
       // later.

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -491,10 +491,16 @@ CompilerType SwiftExpressionParser::ResolveVariable(
   if (!var_type.IsValid())
     return {};
 
+  auto swift_type_system =
+      var_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!swift_type_system)
+    return {};
+
   // If the type can't be realized and dynamic types are allowed, fall back to
   // the dynamic type. We can only do this when not binding generic types
   // though, as we don't bind the generic parameters in that case.
-  if (!SwiftASTContext::IsFullyRealized(var_type) &&
+  if (swift_type_system->IsMeaninglessWithoutDynamicResolution(
+          var_type.GetOpaqueQualType()) &&
       bind_generic_types != lldb::eDontBind && use_dynamic_value) {
     var_type = GetSwiftTypeForVariableValueObject(
         valobj_sp->GetDynamicValue(use_dynamic), stack_frame_sp, runtime,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -850,12 +850,11 @@ SwiftASTContext::GetCachedEnumInfo(opaque_compiler_type_t type) {
   if (pos != enum_info_cache->end())
     return pos->second.get();
 
-  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
-  if (!SwiftASTContext::IsFullyRealized(ToCompilerType({swift_can_type})))
+  if (IsMeaninglessWithoutDynamicResolution(type))
     return nullptr;
 
   SwiftEnumDescriptorSP enum_info_sp;
-
+  swift::CanType swift_can_type(GetCanonicalSwiftType(type));
   if (auto *enum_type = swift_can_type->getAs<swift::EnumType>()) {
     enum_info_sp.reset(GetEnumInfoFromEnumDecl(GetASTContext(), swift_can_type,
                                                enum_type->getDecl()));
@@ -5175,17 +5174,6 @@ SwiftASTContext::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
           llvm::dyn_cast_or_null<swift::DynamicSelfType>(swift_type))
     return ToCompilerType({dyn_self->getSelfType().getPointer()});
   return {weak_from_this(), type};
-}
-
-bool SwiftASTContext::IsFullyRealized(const CompilerType &compiler_type) {
-  if (swift::CanType swift_can_type = ::GetCanonicalSwiftType(compiler_type)) {
-    if (swift::isa<swift::MetatypeType>(swift_can_type))
-      return true;
-    return !swift_can_type->hasArchetype() &&
-           !swift_can_type->hasTypeParameter();
-  }
-
-  return false;
 }
 
 bool SwiftASTContext::GetProtocolTypeInfo(const CompilerType &type,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -411,11 +411,11 @@ public:
   swift::CanType
   GetCanonicalSwiftType(lldb::opaque_compiler_type_t opaque_type);
 
-  // Imports the type from the passed in type into this SwiftASTContext. The
-  // type must be a Swift type. If the type can be imported, returns the
-  // CompilerType for the imported type.
-  // If it cannot be, returns an invalid CompilerType, and sets the error to
-  // indicate what went wrong.
+  /// Imports the type from the passed in type into this SwiftASTContext. The
+  /// type must be a Swift type. If the type can be imported, returns the
+  /// CompilerType for the imported type.
+  /// If it cannot be, returns an invalid CompilerType, and sets the error to
+  /// indicate what went wrong.
   CompilerType ImportType(CompilerType &type, Status &error);
 
   swift::ClangImporter *GetClangImporter();
@@ -581,8 +581,6 @@ public:
 
   /// Whether this is the Swift error type.
   bool IsErrorType(lldb::opaque_compiler_type_t type);
-
-  static bool IsFullyRealized(const CompilerType &compiler_type);
 
   struct ProtocolInfo {
     uint32_t m_num_protocols;


### PR DESCRIPTION
Replace IsFullyRealized() with !IsMeaninglessWithoutDynamicResolution() (NFC)

This patch eliminates yet another reason to instantiate a
SwiftASTContextForModule in the expression evaluator.

rdar://113997661