### PR TITLE
Simplify address mask setting logic in AddressableBits

### DIFF
--- a/lldb/source/Utility/AddressableBits.cpp
+++ b/lldb/source/Utility/AddressableBits.cpp
@@ -37,42 +37,14 @@ void AddressableBits::SetProcessMasks(Process &process) {
   if (m_low_memory_addr_bits == 0 && m_high_memory_addr_bits == 0)
     return;
 
-  // If we don't have an addressable bits value for low memory,
-  // see if we have a Code/Data mask already, and use that.
-  // Or use the high memory addressable bits value as a last
-  // resort.
-  addr_t low_addr_mask;
-  if (m_low_memory_addr_bits == 0) {
-    if (process.GetCodeAddressMask() != UINT64_MAX)
-      low_addr_mask = process.GetCodeAddressMask();
-    else if (process.GetDataAddressMask() != UINT64_MAX)
-      low_addr_mask = process.GetDataAddressMask();
-    else
-      low_addr_mask = ~((1ULL << m_high_memory_addr_bits) - 1);
-  } else {
-    low_addr_mask = ~((1ULL << m_low_memory_addr_bits) - 1);
+  if (m_low_memory_addr_bits != 0) {
+    addr_t low_addr_mask = ~((1ULL << m_low_memory_addr_bits) - 1);
+    process.SetCodeAddressMask(low_addr_mask);
+    process.SetDataAddressMask(low_addr_mask);
   }
 
-  // If we don't have an addressable bits value for high memory,
-  // see if we have a Code/Data mask already, and use that.
-  // Or use the low memory addressable bits value as a last
-  // resort.
-  addr_t hi_addr_mask;
-  if (m_high_memory_addr_bits == 0) {
-    if (process.GetHighmemCodeAddressMask() != UINT64_MAX)
-      hi_addr_mask = process.GetHighmemCodeAddressMask();
-    else if (process.GetHighmemDataAddressMask() != UINT64_MAX)
-      hi_addr_mask = process.GetHighmemDataAddressMask();
-    else
-      hi_addr_mask = ~((1ULL << m_low_memory_addr_bits) - 1);
-  } else {
-    hi_addr_mask = ~((1ULL << m_high_memory_addr_bits) - 1);
-  }
-
-  process.SetCodeAddressMask(low_addr_mask);
-  process.SetDataAddressMask(low_addr_mask);
-
-  if (low_addr_mask != hi_addr_mask) {
+  if (m_high_memory_addr_bits != 0) {
+    addr_t hi_addr_mask = ~((1ULL << m_high_memory_addr_bits) - 1);
     process.SetHighmemCodeAddressMask(hi_addr_mask);
     process.SetHighmemDataAddressMask(hi_addr_mask);
   }


### PR DESCRIPTION
Simplify address mask setting logic in AddressableBits

I wrote some complicated conditionals for how to handle a partially specified AddressableBits object in https://reviews.llvm.org/D158041 , and how to reuse existing masks if they were set and we had an unspecified value.

I don't think this logic is the right thing to start with.  Simplify back to the most straightforward
setting, where only the bits that have been specified are set in the Process.

(cherry picked from commit d37642b4a261b5b5687725fd60f7da5dc5ec4782)