### PR TITLE
Only set the "low" address masks when only one adressable bits specified

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5545,9 +5545,7 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
           if (m_data.GetU32(&offset, &version, 1) != nullptr) {
             if (version == 3) {
               uint32_t num_addr_bits = m_data.GetU32_unchecked(&offset);
-              if (num_addr_bits != 0) {
-                addressable_bits.SetAddressableBits(num_addr_bits);
-              }
+              addressable_bits.SetAddressableBits(num_addr_bits);
               LLDB_LOGF(log,
                         "LC_NOTE 'addrable bits' v3 found, value %d "
                         "bits",
@@ -5558,7 +5556,10 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
               uint32_t lo_addr_bits = m_data.GetU32_unchecked(&offset);
               uint32_t hi_addr_bits = m_data.GetU32_unchecked(&offset);
 
-              addressable_bits.SetAddressableBits(lo_addr_bits, hi_addr_bits);
+              if (lo_addr_bits == hi_addr_bits)
+                addressable_bits.SetAddressableBits(lo_addr_bits);
+              else
+                addressable_bits.SetAddressableBits(lo_addr_bits, hi_addr_bits);
               LLDB_LOGF(log,
                         "LC_NOTE 'addrable bits' v4 found, value %d & %d bits",
                         lo_addr_bits, hi_addr_bits);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
@@ -1266,7 +1266,6 @@ bool GDBRemoteCommunicationClient::GetHostInfo(bool force) {
               ++num_keys_decoded;
           } else if (name.equals("addressing_bits")) {
             if (!value.getAsInteger(0, m_low_mem_addressing_bits)) {
-              m_high_mem_addressing_bits = m_low_mem_addressing_bits;
               ++num_keys_decoded;
             }
           } else if (name.equals("high_mem_addressing_bits")) {
@@ -1420,11 +1419,11 @@ AddressableBits GDBRemoteCommunicationClient::GetAddressableBits() {
   if (m_qHostInfo_is_valid == eLazyBoolCalculate)
     GetHostInfo();
 
-  // m_low_mem_addressing_bits and m_high_mem_addressing_bits
-  // will be 0 if we did not receive values; AddressableBits
-  // treats 0 as "unspecified".
-  addressable_bits.SetAddressableBits(m_low_mem_addressing_bits,
-                                      m_high_mem_addressing_bits);
+  if (m_low_mem_addressing_bits == m_high_mem_addressing_bits)
+    addressable_bits.SetAddressableBits(m_low_mem_addressing_bits);
+  else
+    addressable_bits.SetAddressableBits(m_low_mem_addressing_bits,
+                                        m_high_mem_addressing_bits);
   return addressable_bits;
 }
 


### PR DESCRIPTION
Only set the "low" address masks when only one adressable bits specified

qHostInfo / stop-reply packet / LC_NOTE "addrable bits" can all specify either a single value for all address masks, or separate masks for low and high memory addresses.

When the same number of addressing bits are used for all addresses, we use the "low memory" address masks for everything. (or another way, if the high address masks are not set, we use the low address masks with the assumption that all memory is using the same mask -- the most common situation).

I was setting low and high address masks when I had a single value from these metadata, but that gave the impression that the high address mask was specified explicitly.  After living on the code a bit, it's clearly better to only set the high address masks when we have a distinct high address mask value.

This patch is the minor adjustment to behave that way.

(cherry picked from commit 10f494d2896b8a58f69cc47d0db35d2b84c2fb44)