### PR TITLE
[APINotes] NFC: reduce diff with upstream

### DIFF
--- a/clang/include/clang/APINotes/APINotesReader.h
+++ b/clang/include/clang/APINotes/APINotesReader.h
@@ -12,8 +12,8 @@
 // method parameters.
 //
 //===----------------------------------------------------------------------===//
-#ifndef LLVM_CLANG_API_NOTES_READER_H
-#define LLVM_CLANG_API_NOTES_READER_H
+#ifndef LLVM_CLANG_APINOTES_READER_H
+#define LLVM_CLANG_APINOTES_READER_H
 
 #include "clang/APINotes/Types.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -226,4 +226,4 @@ public:
 } // end namespace api_notes
 } // end namespace clang
 
-#endif // LLVM_CLANG_API_NOTES_READER_H
+#endif // LLVM_CLANG_APINOTES_READER_H

--- a/clang/include/clang/APINotes/APINotesWriter.h
+++ b/clang/include/clang/APINotes/APINotesWriter.h
@@ -12,8 +12,8 @@
 // method parameters.
 //
 //===----------------------------------------------------------------------===//
-#ifndef LLVM_CLANG_API_NOTES_WRITER_H
-#define LLVM_CLANG_API_NOTES_WRITER_H
+#ifndef LLVM_CLANG_APINOTES_WRITER_H
+#define LLVM_CLANG_APINOTES_WRITER_H
 
 #include "clang/APINotes/Types.h"
 #include "llvm/Support/VersionTuple.h"
@@ -27,7 +27,6 @@ namespace llvm {
 }
 
 namespace clang {
-
 class FileEntry;
 
 namespace api_notes {
@@ -36,18 +35,18 @@ namespace api_notes {
 /// read by the \c APINotesReader.
 class APINotesWriter {
   class Implementation;
-  Implementation &Impl;
+  std::unique_ptr<Implementation> Implementation;
 
 public:
   /// Create a new API notes writer with the given module name and
   /// (optional) source file.
-  APINotesWriter(llvm::StringRef moduleName, const FileEntry *SF);
+  APINotesWriter(llvm::StringRef ModuleName, const FileEntry *SF);
   ~APINotesWriter();
 
   APINotesWriter(const APINotesWriter &) = delete;
   APINotesWriter &operator=(const APINotesWriter &) = delete;
 
-  void writeToStream(llvm::raw_ostream &os);
+  void writeToStream(llvm::raw_ostream &OS);
 
   /// Add information about a specific Objective-C class or protocol or a C++
   /// namespace.
@@ -124,8 +123,7 @@ public:
   /// Add module options
   void addModuleOptions(ModuleOptions opts);
 };
+} // namespace api_notes
+} // namespace clang
 
-} // end namespace api_notes
-} // end namespace clang
-
-#endif // LLVM_CLANG_API_NOTES_WRITER_H
+#endif // LLVM_CLANG_APINOTES_WRITER_H


### PR DESCRIPTION
A part of API Notes implementation was recently upstreamed (https://reviews.llvm.org/D92797). This change updates the downstream implementation to match upstream more closely to prevent merge conflicts.