### PR TITLE
[X86] Use explicit ArrayRef<int> template arg to fix clang6 template deduction failure

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -43047,7 +43047,7 @@ static SDValue combineTargetShuffle(SDValue N, SelectionDAG &DAG,
     // See if this reduces to a PSHUFD which is no more expensive and can
     // combine with more operations. Note that it has to at least flip the
     // dwords as otherwise it would have been removed as a no-op.
-    if (ArrayRef(Mask).equals({2, 3, 0, 1})) {
+    if (ArrayRef<int>(Mask).equals({2, 3, 0, 1})) {
       int DMask[] = {0, 1, 2, 3};
       int DOffset = N.getOpcode() == X86ISD::PSHUFLW ? 0 : 2;
       DMask[DOffset + 0] = DOffset + 1;
@@ -43082,8 +43082,8 @@ static SDValue combineTargetShuffle(SDValue N, SelectionDAG &DAG,
         int MappedMask[8];
         for (int i = 0; i < 8; ++i)
           MappedMask[i] = 2 * DMask[WordMask[i] / 2] + WordMask[i] % 2;
-        if (ArrayRef(MappedMask).equals({0, 0, 1, 1, 2, 2, 3, 3}) ||
-            ArrayRef(MappedMask).equals({4, 4, 5, 5, 6, 6, 7, 7})) {
+        if (ArrayRef<int>(MappedMask).equals({0, 0, 1, 1, 2, 2, 3, 3}) ||
+            ArrayRef<int>(MappedMask).equals({4, 4, 5, 5, 6, 6, 7, 7})) {
           // We can replace all three shuffles with an unpack.
           V = DAG.getBitcast(VT, D.getOperand(0));
           return DAG.getNode(MappedMask[0] == 0 ? X86ISD::UNPCKL


### PR DESCRIPTION
Fixes [#64782](https://github.com/llvm/llvm-project/issues/64782)

```
/home/ewilde/work/llvm-project/llvm/lib/Target/X86/X86ISelLowering.cpp:43050:17: error: cannot use parentheses when declaring variable with deduced class template specialization type
    if (ArrayRef(Mask).equals({2, 3, 0, 1})) {
                ^
/home/ewilde/work/llvm-project/llvm/lib/Target/X86/X86ISelLowering.cpp:43050:18: error: variable declaration in condition must have an initializer
    if (ArrayRef(Mask).equals({2, 3, 0, 1})) {
                 ^
/home/ewilde/work/llvm-project/llvm/lib/Target/X86/X86ISelLowering.cpp:43085:21: error: cannot use parentheses when declaring variable with deduced class template specialization type
        if (ArrayRef(MappedMask).equals({0, 0, 1, 1, 2, 2, 3, 3}) ||
                    ^
/home/ewilde/work/llvm-project/llvm/lib/Target/X86/X86ISelLowering.cpp:43085:22: error: variable declaration in condition must have an initializer
        if (ArrayRef(MappedMask).equals({0, 0, 1, 1, 2, 2, 3, 3}) ||
```

Cherry-Pick: 4772c66cfb00d60f8f687930e9dd3aa1b6872228

