### PR TITLE
Cherrypick the fix for the windows aarch64 relocation issue

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
+++ b/llvm/lib/Target/AArch64/AArch64AsmPrinter.cpp
@@ -155,9 +155,9 @@ public:
     SetupMachineFunction(MF);
 
     if (STI->isTargetCOFF()) {
-      bool Internal = MF.getFunction().hasInternalLinkage();
-      COFF::SymbolStorageClass Scl = Internal ? COFF::IMAGE_SYM_CLASS_STATIC
-                                              : COFF::IMAGE_SYM_CLASS_EXTERNAL;
+      bool Local = MF.getFunction().hasLocalLinkage();
+      COFF::SymbolStorageClass Scl =
+          Local ? COFF::IMAGE_SYM_CLASS_STATIC : COFF::IMAGE_SYM_CLASS_EXTERNAL;
       int Type =
         COFF::IMAGE_SYM_DTYPE_FUNCTION << COFF::SCT_COMPLEX_TYPE_SHIFT;
 

--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64AsmBackend.cpp
@@ -313,6 +313,13 @@ static uint64_t adjustFixupValue(const MCFixup &Fixup, const MCValue &Target,
     return (Value >> 2) & 0x3fff;
   case AArch64::fixup_aarch64_pcrel_branch26:
   case AArch64::fixup_aarch64_pcrel_call26:
+    if (TheTriple.isOSBinFormatCOFF() && !IsResolved && SignedValue != 0) {
+      // MSVC link.exe and lld do not support this relocation type
+      // with a non-zero offset
+      Ctx.reportError(Fixup.getLoc(),
+                      "cannot perform a PC-relative fixup with a non-zero "
+                      "symbol offset");
+    }
     // Signed 28-bit immediate
     if (SignedValue > 134217727 || SignedValue < -134217728)
       Ctx.reportError(Fixup.getLoc(), "fixup value out of range");

--- a/llvm/test/CodeGen/AArch64/local-sym-storage-class.ll
+++ b/llvm/test/CodeGen/AArch64/local-sym-storage-class.ll
@@ -1,0 +1,15 @@
+; RUN: llc -mtriple aarch64-unknown-windows-msvc %s -o - | FileCheck %s
+
+define internal void @internal() {
+  ret void
+}
+
+define private void @private() {
+  ret void
+}
+
+; Check that the internal and private linkage symbols have IMAGE_SYM_CLASS_STATIC (3).
+; CHECK: .def    internal;
+; CHECK: .scl    3;
+; CHECK: .def    .Lprivate;
+; CHECK: .scl    3;

--- a/llvm/test/CodeGen/X86/local-sym-storage-class.ll
+++ b/llvm/test/CodeGen/X86/local-sym-storage-class.ll
@@ -1,0 +1,15 @@
+; RUN: llc -mtriple x86_64-unknown-windows-msvc %s -o - | FileCheck %s
+
+define internal void @internal() {
+  ret void
+}
+
+define private void @private() {
+  ret void
+}
+
+; Check that the internal and private linkage symbols have IMAGE_SYM_CLASS_STATIC (3).
+; CHECK: .def    internal;
+; CHECK: .scl    3;
+; CHECK: .def    .Lprivate;
+; CHECK: .scl    3;

--- a/llvm/test/MC/AArch64/coff-relocations-branch26.s
+++ b/llvm/test/MC/AArch64/coff-relocations-branch26.s
@@ -1,0 +1,75 @@
+// RUN: llvm-mc -triple aarch64-unknown-windows-msvc -filetype obj %s -o - | llvm-objdump -D -r - | FileCheck %s
+// RUN: not llvm-mc -triple aarch64-unknown-windows-msvc -filetype obj --defsym ERR=1 %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=ERR
+
+    .text
+main:
+    nop
+    b .Ltarget
+    b .Lother_target
+
+// A privte label target in the same section
+    .def .Ltarget
+    .scl 3
+    .type 32
+    .endef
+    .p2align 2
+.Ltarget:
+    ret
+
+// A privte label target in another section
+    .section "other"
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    .def .Lother_target
+    .scl 3
+    .type 32
+    .endef
+    .p2align 2
+.Lother_target:
+    ret
+
+// Check that both branches have a relocation with a zero offset.
+//
+// CHECK: 0000000000000000 <main>:
+// CHECK:        0: d503201f      nop
+// CHECK:        4: 14000000      b       0x4 <main+0x4>
+// CHECK:                 0000000000000004:  IMAGE_REL_ARM64_BRANCH26     .Ltarget
+// CHECK:        8: 14000000      b       0x8 <main+0x8>
+// CHECK:                 0000000000000008:  IMAGE_REL_ARM64_BRANCH26     .Lother_target
+// CHECK: 000000000000000c <.Ltarget>:
+// CHECK:        c: d65f03c0      ret
+// CHECK: 0000000000000000 <other>:
+// CHECK:        0: d503201f      nop
+// CHECK:        4: d503201f      nop
+// CHECK:        8: d503201f      nop
+// CHECK:        c: d503201f      nop
+// CHECK:       10: d503201f      nop
+// CHECK:       14: d503201f      nop
+// CHECK:       18: d503201f      nop
+// CHECK:       1c: d503201f      nop
+// CHECK: 0000000000000020 <.Lother_target>:
+// CHECK:       20: d65f03c0      ret
+
+.ifdef ERR
+    .section "err"
+err:
+    nop
+    b .Lerr_target+4
+// ERR: [[#@LINE-1]]:5: error: cannot perform a PC-relative fixup with a non-zero symbol offset
+
+    .def .Lerr_target
+    .scl 3
+    .type 32
+    .p2align 2
+    .endef
+.Lerr_target:
+    nop
+    nop
+    ret
+.endif


### PR DESCRIPTION
Cherrypick
https://reviews.llvm.org/rG1e7f592a890aad860605cf5220530b3744e107ba
https://reviews.llvm.org/rG3406934e4db4bf95c230db072608ed062c13ad5b

This fixes many swift tests under windows aarch64.