### PR TITLE
Fix narrowing error in MCCAS in 32 bit platforms

### DIFF
--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -104,7 +104,7 @@ public:
 };
 
 struct CUInfo {
-  size_t CUSize;
+  uint64_t CUSize;
   uint32_t AbbrevOffset;
 };
 static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(


### PR DESCRIPTION
With https://github.com/apple/llvm-project/pull/7169, we seem to have broken a 32-bit build of clang.

llvm/lib/MCCAS/MCCASObjectV1.cpp:1650:17: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
+ echo 'error: LLVM '\''ninja install-distribution '\'' failed!'
error: LLVM 'ninja install-distribution ' failed!

This patch addresses that fix