### PR TITLE
Avoid a roundtrip through SwiftASTContext in findSwiftSelf() (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2422,20 +2422,9 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
   }
 
   Demangler dem;
-  NodePointer canonical = TypeSystemSwiftTypeRef::Transform(
-      dem, dem.demangleSymbol(mangled_name.GetStringRef()),
-      [](NodePointer node) {
-        if (node->getKind() != Node::Kind::DynamicSelf)
-          return node;
-        // Substitute the static type for dynamic self.
-        assert(node->getNumChildren() == 1);
-        if (node->getNumChildren() != 1)
-          return node;
-        NodePointer type = node->getChild(0);
-        if (type->getKind() != Node::Kind::Type || type->getNumChildren() != 1)
-          return node;
-        return type->getChild(0);
-      });
+
+  NodePointer canonical = TypeSystemSwiftTypeRef::GetStaticSelfType(
+      dem, dem.demangleSymbol(mangled_name.GetStringRef()));
 
   // Build the list of type substitutions.
   swift::reflection::GenericArgumentMap substitutions;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5154,6 +5154,17 @@ CompilerType SwiftASTContext::GetReferentType(opaque_compiler_type_t type) {
   return ToCompilerType({ref_type});
 }
 
+CompilerType
+SwiftASTContext::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
+  VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
+
+  swift::Type swift_type = GetSwiftType(type);
+  if (auto *dyn_self =
+          llvm::dyn_cast_or_null<swift::DynamicSelfType>(swift_type))
+    return ToCompilerType({dyn_self->getSelfType().getPointer()});
+  return {weak_from_this(), type};
+}
+
 bool SwiftASTContext::IsFullyRealized(const CompilerType &compiler_type) {
   if (swift::CanType swift_can_type = ::GetCanonicalSwiftType(compiler_type)) {
     if (swift::isa<swift::MetatypeType>(swift_can_type))

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -805,6 +805,7 @@ public:
                       CompilerType *original_type) override;
 
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) override;
 
   /// Retrieve/import the modules imported by the compilation
   /// unit. Early-exists with false if there was an import failure.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -128,6 +128,8 @@ public:
   virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);
   virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) = 0;
+  /// Return the static type if this is a DynamicSelf type else the input type.
+  virtual CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) = 0;
   enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };
   struct TupleElement {
     ConstString element_name;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -274,6 +274,11 @@ public:
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) override;
+  static swift::Demangle::NodePointer
+  GetStaticSelfType(swift::Demangle::Demangler &dem,
+                    swift::Demangle::NodePointer node);
+
   /// Wrap type inside a SILPackType.
   CompilerType CreateSILPackType(CompilerType type, bool indirect);
   struct PackTypeInfo {


### PR DESCRIPTION
This eliminates one of the reasons why a SwiftASTContextForModule() is instantiated by the expression evaluator.

rdar://113997661
(cherry picked from commit 483ae8b98490623053355c8bb6722673f32d4eab)