### PR TITLE
Get LLDB building with clang-6

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -2304,7 +2304,7 @@ GDBRemoteCommunicationServerLLGS::Handle_P(StringExtractorGDBRemote &packet) {
   // Build the reginfos response.
   StreamGDBRemote response;
 
-  RegisterValue reg_value(ArrayRef(m_reg_bytes, reg_size),
+  RegisterValue reg_value(ArrayRef<uint8_t>(m_reg_bytes, reg_size),
                           m_current_process->GetArchitecture().GetByteOrder());
   Status error = reg_context.WriteRegister(reg_info, reg_value);
   if (error.Fail()) {


### PR DESCRIPTION
This patch gets clang-6 building with LLDB. The move from makeArrayRef to deduction guides in 984b800a036fc61ccb129a8da7592af9cadc94dd is tripping up clang-6 on Ubuntu 18.04.

Related to issue [#64782.](https://github.com/llvm/llvm-project/issues/64782).