### PR TITLE
[lldb] Fix size of write when querying ptr auth mask

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -29,7 +29,7 @@ bool LLDBMemoryReader::queryDataLayout(DataLayoutQueryType type, void *inBuffer,
     // disk. Setting the bit in the mask ensures it isn't accidentally cleared
     // by ptrauth stripping.
     mask_pattern |= LLDB_FILE_ADDRESS_BIT;
-    memcpy(outBuffer, &mask_pattern, sizeof(uint64_t));
+    memcpy(outBuffer, &mask_pattern, m_process.GetAddressByteSize());
     return true;
   }
   case DLQ_GetObjCReservedLowBits: {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -519,12 +519,13 @@ void SwiftLanguageRuntimeImpl::SetupReflection() {
       objc_interop ? "with Objective-C interopability" : "Swift only";
 
   auto &triple = exe_module->GetArchitecture().GetTriple();
-  if (triple.isArch64Bit()) {
+  auto byte_size = m_process.GetAddressByteSize();
+  if (byte_size == 8) {
     LLDB_LOGF(log, "Initializing a 64-bit reflection context (%s) for \"%s\"",
               triple.str().c_str(), objc_interop_msg);
     m_reflection_ctx = ReflectionContextInterface::CreateReflectionContext64(
         this->GetMemoryReader(), objc_interop, GetSwiftMetadataCache());
-  } else if (triple.isArch32Bit()) {
+  } else if (byte_size == 4) {
     LLDB_LOGF(log,
               "Initializing a 32-bit reflection context (%s) for \"%s\"",
               triple.str().c_str(), objc_interop_msg);


### PR DESCRIPTION
According to the MemoryReader documentation, querying the pointer authentication mask should treat the out buffer as pointer-sized in the target process:

```
  /// The query should ignore inBuffer, and treat outBuffer as pointer-sized
  /// buffer (the size of a target pointer, not a swift_addr_t) which should be
  /// populated with the mask of pointer addressable bits.
  DLQ_GetPtrAuthMask,
```

LLDB was mistakenly treating the buffer as 8 bytes long.

rdar://114237716