### PR TITLE
🌲Disable strict preprocessor on Windows

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -510,7 +510,8 @@ if( MSVC )
   if (NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Enable standards-conforming preprocessor.
     # https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor
-    append("/Zc:preprocessor" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    # TODO: rdar://113996252 -- Re-enable once CI has a newer Windows SDK
+    #append("/Zc:preprocessor" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
   endif ()
 
   # Some projects use the __cplusplus preprocessor macro to check support for


### PR DESCRIPTION
The Windows SDK on CI is not compliant, so enabling strict preprocessor mode is resulting in build failures in headers in the SDK itself. This is preventing actionable progress on rebranch, so disabling until we have a newer Windows SDK that is compliant.

Radar tracking updating the SDK: rdar://113996252
We should re-enable the strict preprocessing once that task is completed.

Failures we hope to get past:
```
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\oaidl.h(487): warning C5103: pasting '/' and '/' does not result in a valid preprocessing token
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\shared\wtypes.h(745): note: in expansion of macro '_VARIANT_BOOL'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\oaidl.h(487): error C2059: syntax error: '/'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\oaidl.h(487): error C2238: unexpected token(s) preceding ';'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\oaidl.h(502): warning C5103: pasting '/' and '/' does not result in a valid preprocessing token
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\shared\wtypes.h(745): note: in expansion of macro '_VARIANT_BOOL'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\oaidl.h(502): error C2059: syntax error: '/'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\oaidl.h(502): error C2238: unexpected token(s) preceding ';'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\propidlbase.h(319): warning C5103: pasting '/' and '/' does not result in a valid preprocessing token
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\shared\wtypes.h(745): note: in expansion of macro '_VARIANT_BOOL'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\propidlbase.h(319): error C2059: syntax error: '/'
16:43:57 C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um\propidlbase.h(319): error C2238: unexpected token(s) preceding ';
```