### PR TITLE
Added -fcas-emit-casid-file to emit a .casid file

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -516,6 +516,9 @@ ENUM_CODEGENOPT(ZeroCallUsedRegs, llvm::ZeroCallUsedRegs::ZeroCallUsedRegsKind,
 /// Whether to use CASID backend.
 CODEGENOPT(UseCASBackend, 1, 0)
 
+/// Whether to emit a .casid File.
+CODEGENOPT(EmitCASIDFile, 1, 0)
+
 /// The CASObjectFormat used when CAS output is used.
 ENUM_CODEGENOPT(CASObjMode, llvm::CASBackendMode,
                 2, llvm::CASBackendMode::Native)

--- a/clang/include/clang/CodeGen/BackendUtil.h
+++ b/clang/include/clang/CodeGen/BackendUtil.h
@@ -48,7 +48,8 @@ namespace clang {
                          const CASOptions &CASOpts, // MCCAS
                          StringRef TDesc, llvm::Module *M, BackendAction Action,
                          llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
-                         std::unique_ptr<raw_pwrite_stream> OS);
+                         std::unique_ptr<raw_pwrite_stream> OS,
+                         std::unique_ptr<raw_pwrite_stream> CasidOS = nullptr);
 
   void EmbedBitcode(llvm::Module *M, const CodeGenOptions &CGOpts,
                     llvm::MemoryBufferRef Buf);

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7855,6 +7855,11 @@ defm cas_backend : BoolFOption<"cas-backend",
     PosFlag<SetTrue, [], [ClangOption], "Enable using CASBackend for object file output">,
     NegFlag<SetFalse>>;
 
+defm cas_emit_casid_file : BoolFOption<"cas-emit-casid-file",
+    CodeGenOpts<"EmitCASIDFile">, DefaultFalse,
+    PosFlag<SetTrue, [], [], "Emit .casid file next to object file when using cas backend">,
+    NegFlag<SetFalse>>;
+
 def fcas_backend_mode : Joined<["-"], "fcas-backend-mode=">,
     Group<f_Group>, MetaVarName<"<native|casid|verify>">,
     HelpText<"CASBackendMode for output kind">,

--- a/clang/test/CAS/cas-emit-casid.c
+++ b/clang/test/CAS/cas-emit-casid.c
@@ -1,0 +1,31 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: cat %t/test.o.casid | FileCheck %s --check-prefix=NATIVE_FILENAME
+// NATIVE_FILENAME: CASID:Jllvmcas://{{.*}}
+//
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: cat %t/test.o.casid | FileCheck %s --check-prefix=VERIFY_FILENAME
+// VERIFY_FILENAME: CASID:Jllvmcas://{{.*}}
+//
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: not cat %t/test.o.casid
+//
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o -
+// RUN: not cat %t/test.o.casid
+//
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o -
+// RUN: not cat %t/test.o.casid
+//
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o -
+// RUN: not cat %t/test.o.casid
+
+void test(void) {}
+
+int test1(void) {
+  return 0;
+}

--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -90,7 +90,8 @@ public:
           const llvm::MCAsmLayout &, cas::ObjectStore &, raw_ostream *)>
           CreateFromMcAssembler,
       std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-          SerializeObjectFile) const;
+          SerializeObjectFile,
+      raw_pwrite_stream *CasIDOS = nullptr) const;
   // END MCCAS
 
 

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -52,7 +52,8 @@ public:
           CreateFromMcAssembler,
       std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
           SerializeObjectFile,
-      std::optional<MCTargetOptions::ResultCallBackTy> CallBack);
+      std::optional<MCTargetOptions::ResultCallBackTy> CallBack,
+      raw_pwrite_stream *CasIDOS = nullptr);
 
   void recordRelocation(MCAssembler &Asm, const MCAsmLayout &Layout,
                         const MCFragment *Fragment, const MCFixup &Fixup,
@@ -122,6 +123,7 @@ public:
 
 private:
   raw_pwrite_stream &OS;
+  raw_pwrite_stream *CasIDOS;
 
   SmallString<512> InternalBuffer;
   raw_svector_ostream InternalOS;
@@ -157,7 +159,8 @@ std::unique_ptr<MCObjectWriter> createMachOCASWriter(
         CreateFromMcAssembler,
     std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
         SerializeObjectFile,
-    std::optional<MCTargetOptions::ResultCallBackTy> CallBack = std::nullopt);
+    std::optional<MCTargetOptions::ResultCallBackTy> CallBack = std::nullopt,
+    raw_pwrite_stream *CasIDOS = nullptr);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/Target/TargetMachine.h
+++ b/llvm/include/llvm/Target/TargetMachine.h
@@ -377,7 +377,8 @@ public:
   addPassesToEmitFile(PassManagerBase &, raw_pwrite_stream &,
                       raw_pwrite_stream *, CodeGenFileType,
                       bool /*DisableVerify*/ = true,
-                      MachineModuleInfoWrapperPass *MMIWP = nullptr) {
+                      MachineModuleInfoWrapperPass *MMIWP = nullptr,
+                      raw_pwrite_stream *CasIDOS = nullptr) {
     return true;
   }
 
@@ -443,11 +444,11 @@ public:
   /// emitted.  Typically this will involve several steps of code generation.
   /// \p MMIWP is an optional parameter that, if set to non-nullptr,
   /// will be used to set the MachineModuloInfo for this PM.
-  bool
-  addPassesToEmitFile(PassManagerBase &PM, raw_pwrite_stream &Out,
-                      raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
-                      bool DisableVerify = true,
-                      MachineModuleInfoWrapperPass *MMIWP = nullptr) override;
+  bool addPassesToEmitFile(PassManagerBase &PM, raw_pwrite_stream &Out,
+                           raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
+                           bool DisableVerify = true,
+                           MachineModuleInfoWrapperPass *MMIWP = nullptr,
+                           raw_pwrite_stream *CasIDOS = nullptr) override;
 
   virtual Error buildCodeGenPipeline(ModulePassManager &,
                                      MachineFunctionPassManager &,
@@ -482,11 +483,12 @@ public:
   /// machine code from the MI representation.
   bool addAsmPrinter(PassManagerBase &PM, raw_pwrite_stream &Out,
                      raw_pwrite_stream *DwoOut, CodeGenFileType FileType,
-                     MCContext &Context);
+                     MCContext &Context, raw_pwrite_stream *CasIDOS = nullptr);
 
   Expected<std::unique_ptr<MCStreamer>>
   createMCStreamer(raw_pwrite_stream &Out, raw_pwrite_stream *DwoOut,
-                   CodeGenFileType FileType, MCContext &Ctx);
+                   CodeGenFileType FileType, MCContext &Ctx,
+                   raw_pwrite_stream *CasIDOS = nullptr);
 
   /// True if the target uses physical regs (as nearly all targets do). False
   /// for stack machines such as WebAssembly and other virtual-register

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -69,14 +69,15 @@ std::unique_ptr<MCObjectWriter> MCAsmBackend::createCASObjectWriter(
         cas::ObjectStore &, raw_ostream *)>
         CreateFromMcAssembler,
     std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-        SerializeObjectFile) const {
+        SerializeObjectFile,
+    raw_pwrite_stream *CasIDOS) const {
   auto TW = createObjectTargetWriter();
   switch (TW->getFormat()) {
   case Triple::MachO:
     return createMachOCASWriter(cast<MCMachObjectTargetWriter>(std::move(TW)),
                                 TT, CAS, Mode, OS, Endian == support::little,
                                 CreateFromMcAssembler, SerializeObjectFile,
-                                MCOpts.ResultCallBack);
+                                MCOpts.ResultCallBack, CasIDOS);
   default:
     llvm_unreachable("unexpected object format");
   }


### PR DESCRIPTION
With -fcas-emit-casid-file, a .casid file will be emitted next to the object file only when -fcas-backend-mode=native, or -fcas-backend-mode=verify is used and the output is directed to a file, rather than stdout.