### PR TITLE
ASTContext: temporarily disable an assert to unblock debugging with swift C++ interop

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -4665,7 +4665,10 @@ QualType ASTContext::getTypedefType(const TypedefNameDecl *Decl,
   }
   if (Underlying.isNull() || Decl->getUnderlyingType() == Underlying)
     return QualType(Decl->TypeForDecl, 0);
-  assert(hasSameType(Decl->getUnderlyingType(), Underlying));
+
+  // Temporarily disabled to unblock debugging with swift C++ interop
+  // FIXME: fix the underlying problem (rdar://114264253)
+  // assert(hasSameType(Decl->getUnderlyingType(), Underlying));
 
   llvm::FoldingSetNodeID ID;
   TypedefType::Profile(ID, Decl, Underlying);


### PR DESCRIPTION
rdar://114264253