### PR TITLE
[CAS] Improvce CAS sensitive test requirements

### DIFF
--- a/clang/test/ClangScanDeps/cas-case-sensitivity.c
+++ b/clang/test/ClangScanDeps/cas-case-sensitivity.c
@@ -1,4 +1,4 @@
-// REQUIRES: case_insensitive_src_dir,ondisk_cas
+// REQUIRES: case_insensitive_build_dir,ondisk_cas
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t

--- a/clang/test/lit.cfg.py
+++ b/clang/test/lit.cfg.py
@@ -377,8 +377,8 @@ if "aix" in config.target_triple:
     ):
         exclude_unsupported_files_for_aix(config.test_source_root + directory)
 
-if os.path.exists(os.path.join(config.clang_src_dir, 'TeSt')):
-    config.available_features.add('case_insensitive_src_dir')
+if os.path.exists(os.path.join(config.clang_obj_root, 'TeSt')):
+    config.available_features.add('case_insensitive_build_dir')
 
 # Some tests perform deep recursion, which requires a larger pthread stack size
 # than the relatively low default of 192 KiB for 64-bit processes on AIX. The


### PR DESCRIPTION
In case source and build directories are mounted on different kind of file system and they have different case sensitivity, the tests is actually testing inside build directory so it should check for obj_root case sensitivity instead of src.