### PR TITLE
[lldb] Add an overload to SetModuleLoadAddress that takes an unsigned…

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -61056,12 +61056,12 @@ SWIGINTERN PyObject *_wrap_SBTarget_SetModuleLoadAddress(PyObject *self, PyObjec
   PyObject *resultobj = 0;
   lldb::SBTarget *arg1 = (lldb::SBTarget *) 0 ;
   lldb::SBModule arg2 ;
-  int64_t arg3 ;
+  uint64_t arg3 ;
   void *argp1 = 0 ;
   int res1 = 0 ;
   void *argp2 ;
   int res2 = 0 ;
-  long long val3 ;
+  unsigned long long val3 ;
   int ecode3 = 0 ;
   PyObject *swig_obj[3] ;
   lldb::SBError result;
@@ -61085,11 +61085,11 @@ SWIGINTERN PyObject *_wrap_SBTarget_SetModuleLoadAddress(PyObject *self, PyObjec
       if (SWIG_IsNewObj(res2)) delete temp;
     }
   }
-  ecode3 = SWIG_AsVal_long_SS_long(swig_obj[2], &val3);
+  ecode3 = SWIG_AsVal_unsigned_SS_long_SS_long(swig_obj[2], &val3);
   if (!SWIG_IsOK(ecode3)) {
-    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "SBTarget_SetModuleLoadAddress" "', argument " "3"" of type '" "int64_t""'");
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "SBTarget_SetModuleLoadAddress" "', argument " "3"" of type '" "uint64_t""'");
   } 
-  arg3 = static_cast< int64_t >(val3);
+  arg3 = static_cast< uint64_t >(val3);
   {
     SWIG_PYTHON_THREAD_BEGIN_ALLOW;
     result = (arg1)->SetModuleLoadAddress(arg2,arg3);
@@ -90556,7 +90556,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "SBTarget_GetMaximumNumberOfChildrenToDisplay", _wrap_SBTarget_GetMaximumNumberOfChildrenToDisplay, METH_O, "SBTarget_GetMaximumNumberOfChildrenToDisplay(SBTarget self) -> uint32_t"},
 	 { "SBTarget_SetSectionLoadAddress", _wrap_SBTarget_SetSectionLoadAddress, METH_VARARGS, "SBTarget_SetSectionLoadAddress(SBTarget self, SBSection section, lldb::addr_t section_base_addr) -> SBError"},
 	 { "SBTarget_ClearSectionLoadAddress", _wrap_SBTarget_ClearSectionLoadAddress, METH_VARARGS, "SBTarget_ClearSectionLoadAddress(SBTarget self, SBSection section) -> SBError"},
-	 { "SBTarget_SetModuleLoadAddress", _wrap_SBTarget_SetModuleLoadAddress, METH_VARARGS, "SBTarget_SetModuleLoadAddress(SBTarget self, SBModule module, int64_t sections_offset) -> SBError"},
+	 { "SBTarget_SetModuleLoadAddress", _wrap_SBTarget_SetModuleLoadAddress, METH_VARARGS, "SBTarget_SetModuleLoadAddress(SBTarget self, SBModule module, uint64_t sections_offset) -> SBError"},
 	 { "SBTarget_ClearModuleLoadAddress", _wrap_SBTarget_ClearModuleLoadAddress, METH_VARARGS, "SBTarget_ClearModuleLoadAddress(SBTarget self, SBModule module) -> SBError"},
 	 { "SBTarget_FindFunctions", _wrap_SBTarget_FindFunctions, METH_VARARGS, "\n"
 		"SBTarget_FindFunctions(SBTarget self, char const * name, uint32_t name_type_mask=eFunctionNameTypeAny) -> SBSymbolContextList\n"

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -10639,7 +10639,7 @@ class SBTarget(object):
         return _lldb.SBTarget_ClearSectionLoadAddress(self, section)
 
     def SetModuleLoadAddress(self, module, sections_offset):
-        r"""SetModuleLoadAddress(SBTarget self, SBModule module, int64_t sections_offset) -> SBError"""
+        r"""SetModuleLoadAddress(SBTarget self, SBModule module, uint64_t sections_offset) -> SBError"""
         return _lldb.SBTarget_SetModuleLoadAddress(self, module, sections_offset)
 
     def ClearModuleLoadAddress(self, module):

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -377,6 +377,30 @@ public:
   ///     failure.
   lldb::SBError ClearSectionLoadAddress(lldb::SBSection section);
 
+#ifndef SWIG
+  /// Slide all file addresses for all module sections so that \a module
+  /// appears to loaded at these slide addresses.
+  ///
+  /// When you need all sections within a module to be loaded at a
+  /// rigid slide from the addresses found in the module object file,
+  /// this function will allow you to easily and quickly slide all
+  /// module sections.
+  ///
+  /// \param[in] module
+  ///     The module to load.
+  ///
+  /// \param[in] sections_offset
+  ///     An offset that will be applied to all section file addresses
+  ///     (the virtual addresses found in the object file itself).
+  ///
+  /// \return
+  ///     An error to indicate success, fail, and any reason for
+  ///     failure.
+  [[deprecated("Use SetModuleLoadAddress(lldb::SBModule, uint64_t)")]]
+  lldb::SBError SetModuleLoadAddress(lldb::SBModule module,
+                                     int64_t sections_offset);
+#endif
+
   /// Slide all file addresses for all module sections so that \a module
   /// appears to loaded at these slide addresses.
   ///
@@ -398,7 +422,7 @@ public:
   LLDB_DEPRECATED_FIXME("Use SetModuleLoadAddress(lldb::SBModule, uint64_t)",
                         "SetModuleLoadAddress(lldb::SBModule, uint64_t)")
   lldb::SBError SetModuleLoadAddress(lldb::SBModule module,
-                                     int64_t sections_offset);
+                                     uint64_t sections_offset);
 
   /// Clear the section base load addresses for all sections in a module.
   ///

--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -2206,6 +2206,18 @@ SBError SBTarget::SetModuleLoadAddress(lldb::SBModule module,
                                        int64_t slide_offset) {
   LLDB_INSTRUMENT_VA(this, module, slide_offset);
 
+  if (slide_offset < 0) {
+    SBError sb_error;
+    sb_error.SetErrorStringWithFormat("slide must be positive");
+    return sb_error;
+  }
+
+  return SetModuleLoadAddress(module, static_cast<uint64_t>(slide_offset));
+}
+
+SBError SBTarget::SetModuleLoadAddress(lldb::SBModule module,
+                                               uint64_t slide_offset) {
+
   SBError sb_error;
 
   TargetSP target_sp(GetSP());

--- a/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
+++ b/lldb/test/API/functionalities/multiple-slides/TestMultipleSlides.py
@@ -53,7 +53,8 @@ class MultipleSlidesTestCase(TestBase):
         # In memory, we have something like
         #    0x1000 - 0x17ff  first[]
         #    0x1800 - 0x1fff  second[]
-        target.SetModuleLoadAddress(module, 0)
+        error = target.SetModuleLoadAddress(module, 0)
+        self.assertSuccess(error)
         self.expect("expression/d ((int*)&first)[0]", substrs=["= 5"])
         self.expect("expression/d ((int*)&second)[0]", substrs=["= 6"])
         self.assertEqual(
@@ -74,7 +75,8 @@ class MultipleSlidesTestCase(TestBase):
         # but if the original entries are still present in lldb,
         # the beginning address of second[] will get a load address
         # of 0x1800, instead of 0x17c0 (0x1800-64) as we need to get.
-        target.SetModuleLoadAddress(module, first_size - 64)
+        error = target.SetModuleLoadAddress(module, first_size - 64)
+        self.assertSuccess(error)
         self.expect("expression/d ((int*)&first)[0]", substrs=["= 5"])
         self.expect("expression/d ((int*)&second)[0]", substrs=["= 6"])
         self.assertNotEqual(
@@ -87,7 +89,8 @@ class MultipleSlidesTestCase(TestBase):
         )
 
         # Slide it back to the original vmaddr.
-        target.SetModuleLoadAddress(module, 0)
+        error = target.SetModuleLoadAddress(module, 0)
+        self.assertSuccess(error)
         self.expect("expression/d ((int*)&first)[0]", substrs=["= 5"])
         self.expect("expression/d ((int*)&second)[0]", substrs=["= 6"])
         self.assertEqual(
@@ -98,3 +101,7 @@ class MultipleSlidesTestCase(TestBase):
             second_sym.GetStartAddress().GetLoadAddress(target),
             second_sym.GetStartAddress().GetFileAddress(),
         )
+
+        # Make sure we can use a slide > INT64_MAX.
+        error = target.SetModuleLoadAddress(module, 0xFFFFFFFF12345678)
+        self.assertSuccess(error)


### PR DESCRIPTION
… value

Currently, SBTarget::SetModuleLoadAddress does not accept large slides needed to load images in high memory. This function should always have taken an unsigned as the slide, as it immediately passes it to Target::SetSectionLoadAddress which takes an unsigned.

This patch adds an overload and exposes that to SWIG instead of the signed variant. I've marked the signed variant as deprecated and added check that the slide is positive.

rdar://101355155

Differential revision: https://reviews.llvm.org/D147482

(cherry picked from commit ea95da1809008abd9b81b0fb2cc6ec6438c4c0e0)