### PR TITLE
[JITLink] Truncate ELF symbol sizes to fit containing block.

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -499,6 +499,11 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySymbols() {
         TargetFlagsType Flags = makeTargetFlags(Sym);
         orc::ExecutorAddrDiff Offset = getRawOffset(Sym, Flags);
 
+        // Truncate symbol if it would overflow -- ELF size fields can't be
+        // trusted.
+        uint64_t Size =
+          std::min(static_cast<uint64_t>(Sym.st_size), B->getSize() - Offset);
+
         // In RISCV, temporary symbols (Used to generate dwarf, eh_frame
         // sections...) will appear in object code's symbol table, and LLVM does
         // not use names on these temporary symbols (RISCV gnu toolchain uses
@@ -506,11 +511,9 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySymbols() {
         // anonymous symbol.
         auto &GSym =
             Name->empty()
-                ? G->addAnonymousSymbol(*B, Offset, Sym.st_size,
-                                        false, false)
-                : G->addDefinedSymbol(*B, Offset, *Name, Sym.st_size, L,
-                                      S, Sym.getType() == ELF::STT_FUNC,
-                                      false);
+                ? G->addAnonymousSymbol(*B, Offset, Size, false, false)
+                : G->addDefinedSymbol(*B, Offset, *Name, Size, L, S,
+                                      Sym.getType() == ELF::STT_FUNC, false);
 
         GSym.setTargetFlags(Flags);
         setGraphSymbol(SymIndex, GSym);


### PR DESCRIPTION
LLVM currently emits dubious symbol sizes for aliases. E.g. assembling the following with LLVM top-of-tree...

```
$ cat foo.s
        <snip>
        .data
        .globl  base
base:
        .dword  42
        .size   base, 8

.set alias, base+4
```

results in both base and alias having symbol size 8, even alias starts at base + 4. This also means that alias extends past the end of the .data section in this example.

We should probably teach LLVM not to do this in the future, but as a short-term fix this patch teaches JITLink to simply truncate symbols that would extend past the end of their containing block.

rdar://114207607