### PR TITLE
[clang][cas] Allow clang-cache on invocations without a compilation

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -114,3 +114,17 @@
 
 // RUN: not %clang-cache 2>&1 | FileCheck %s -check-prefix=NOCOMMAND
 // NOCOMMAND: error: missing compiler command for clang-cache
+
+// Link-only job should not attempt to cache.
+// RUN: touch %t.o
+// RUN: %clang-cache %clang -target arm64-apple-macosx12 %t.o -o %t -Wl,-ObjC -### 2>&1 | FileCheck %s -check-prefix=STATIC_LINK
+// STATIC_LINK-NOT: warning:
+// STATIC_LINK-NOT: "-cc1depscan"
+// STATIC_LINK: "{{[^"]*}}ld"
+
+// Unused option warning should only be emitted once.
+// RUN: touch %t.o
+// RUN: %clang-cache %clang -target arm64-apple-macosx12 -fsyntax-only %s -Wl,-ObjC 2>&1 | FileCheck %s -check-prefix=UNUSED_OPT
+// UNUSED_OPT-NOT: warning:
+// UNUSED_OPT: warning: -Wl,-ObjC: 'linker' input unused
+// UNUSED_OPT-NOT: warning:

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -8,6 +8,7 @@
 
 #include "CacheLauncherMode.h"
 #include "clang/Basic/DiagnosticCAS.h"
+#include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/Frontend/Utils.h"
@@ -41,7 +42,10 @@ static bool shouldCacheInvocation(ArrayRef<const char *> Args,
       llvm::remove_if(CheckArgs, [](StringRef Arg) { return Arg == "-###"; }),
       CheckArgs.end());
   CreateInvocationOptions Opts;
-  Opts.Diags = Diags;
+  // Ignore diagnostic parsing diagnostics; if they are real issues they will be
+  // seen when compiling. Just fallback to disabling caching here.
+  Opts.Diags = CompilerInstance::createDiagnostics(new DiagnosticOptions,
+                                                   new IgnoringDiagConsumer);
   // This enables picking the first invocation in a multi-arch build.
   Opts.RecoverOnError = true;
   std::shared_ptr<CompilerInvocation> CInvok =


### PR DESCRIPTION
When using clang-cache with a build system that does not have knowledge of which invocations are for compilation vs. linking, we do not want to error when using clang-cache with a link command. E.g. a Makefile with CC="clang-cache clang" where CC is being used as both compiler and linker.

In this case ignore the missing compile and disable caching. Also fix emitting command-line parsing warnings during the check.

rdar://114581253