### PR TITLE
[stable/20230725][lldb][Swift][CMake] Correct RUNPATH in Linux builds

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -224,10 +224,17 @@ function(add_properties_for_swift_modules target reldir)
     set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH "${SWIFT_INSTALL_RPATH}")
 
     if (SWIFT_SWIFT_PARSER)
-      set_property(TARGET ${target}
-        APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")
-      set_property(TARGET ${target}
-        APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host")
+      if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+        set_property(TARGET ${target}
+          APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")
+        set_property(TARGET ${target}
+          APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host")
+      elseif (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD")
+        set_property(TARGET ${target}
+          APPEND PROPERTY BUILD_RPATH "$ORIGIN/${build_reldir}lib/swift/host")
+        set_property(TARGET ${target}
+          APPEND PROPERTY INSTALL_RPATH "$ORIGIN/${reldir}lib/swift/host")
+      endif()
     endif()
   endif()
 endfunction()

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -154,7 +154,11 @@ endif()
 # BEGIN Swift Mods
 # Note that add_properties_for_swift_modules appends RPATHs so it's critical
 # that this is called after lldb_setup_rpaths.
-add_properties_for_swift_modules(liblldb "../../../../../../usr/" "../../../../")
+if(LLDB_BUILD_FRAMEWORK)
+  add_properties_for_swift_modules(liblldb "../../../../../../usr/" "../../../../")
+else()
+  add_properties_for_swift_modules(liblldb "../")
+endif()
 # END Swift Mods
 
 if(LLDB_ENABLE_PYTHON)


### PR DESCRIPTION
Cherry-pick #7331 into `stable/20230725`
* When LLDB_BUILD_FRAMEWORK is not enabled, liblldb is built/installed in 'lib/'. Pass the correct path to 'add_properties_for_swift_modules
* '$ORIGIN' instead of '@loader_path' in Linux-like platforms

