### PR TITLE
[JITLink] Use the union of ELF section permissions rdar://114207428.

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -374,7 +374,7 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySections() {
       }
     }
 
-    assert(GraphSec->getMemProt() == Prot && "MemProt should match");
+    GraphSec->setMemProt(GraphSec->getMemProt() | Prot);
 
     Block *B = nullptr;
     if (Sec.sh_type != ELF::SHT_NOBITS) {


### PR DESCRIPTION
Swift is currently generating multiple .rodata sections with a combination of SHF_ALLOC and (SHF_ALLOC | SHF_WRITABLE) flags and this was tripping an assert in the ELFLinkGraphBuilder. As a temporary workaround this patch just uses the union of the requested permissions.

rdar://114207428