### PR TITLE
[5.9][lldb][Swift][CMake] Correct RUNPATH in Linux builds

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -202,10 +202,17 @@ function(add_properties_for_swift_modules target reldir)
     set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH "${SWIFT_INSTALL_RPATH}")
 
     if (SWIFT_SWIFT_PARSER)
-      set_property(TARGET ${target}
-        APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")
-      set_property(TARGET ${target}
-        APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host")
+      if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+        set_property(TARGET ${target}
+          APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")
+        set_property(TARGET ${target}
+          APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host")
+      elseif (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD")
+        set_property(TARGET ${target}
+          APPEND PROPERTY BUILD_RPATH "$ORIGIN/${build_reldir}lib/swift/host")
+        set_property(TARGET ${target}
+          APPEND PROPERTY INSTALL_RPATH "$ORIGIN/${reldir}lib/swift/host")
+      endif()
     endif()
   endif()
 endfunction()

--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -195,7 +195,7 @@ function(add_properties_for_swift_modules target reldir)
       target_link_libraries(${target} PRIVATE swiftCore-linux-${arch})
       string(TOLOWER ${CMAKE_SYSTEM_NAME} platform)
       set(SWIFT_BUILD_RPATH "${LLDB_SWIFT_LIBS}/${platform}")
-      set(SWIFT_INSTALL_RPATH "$ORIGIN/swift/${platform}")
+      set(SWIFT_INSTALL_RPATH "$ORIGIN/${reldir}lib/swift/${platform}")
     endif()
 
     set_property(TARGET ${target} APPEND PROPERTY BUILD_RPATH "${SWIFT_BUILD_RPATH}")

--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -149,7 +149,11 @@ endif()
 # BEGIN Swift Mods
 # Note that add_properties_for_swift_modules appends RPATHs so it's critical
 # that this is called after lldb_setup_rpaths.
-add_properties_for_swift_modules(liblldb "../../../../../../usr/" "../../../../")
+if(LLDB_BUILD_FRAMEWORK)
+  add_properties_for_swift_modules(liblldb "../../../../../../usr/" "../../../../")
+else()
+  add_properties_for_swift_modules(liblldb "../")
+endif()
 # END Swift Mods
 
 if(LLDB_ENABLE_PYTHON)


### PR DESCRIPTION
Cherry-pick #7331 and #7359 into `swift/release/5.9`

* **Explanation**: Fix `RUNPATH` when building for Linux. In linux, `liblldb` is built/installed in `lib/`. Previously it was assumed to be installed in a `.framework` directory like in macOS. Also `RUNPATH` was set with `@loader_path` but in Linux, equivalent is `$ORIGIN`. This is required for enabling Macros in Linux
* **Risk**: Low. This doesn't affect other platforms. For Linux, the RUNPATH didn't work at all.
* **Testing**: Passes current test suite
* **Issues**: rdar://104346187
* **Reviewers**: Ben Barham (@bnbarham), Jonas Devlieghere (@JDevlieghere)