### PR TITLE
Replace ReflectionContext::GetBuilder() with more specific high-level…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -669,10 +669,8 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
       return {};
 
     ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
-    auto &builder = reflection_ctx->GetBuilder();
-    auto tc = swift::reflection::TypeConverter(builder);
     LLDBTypeInfoProvider tip(*this, *ts);
-    auto *cti = tc.getClassInstanceTypeInfo(tr, 0, &tip);
+    auto *cti = reflection_ctx->GetClassInstanceTypeInfo(tr, &tip);
     if (auto *rti =
             llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(cti)) {
       LLDB_LOGF(GetLog(LLDBLog::Types),
@@ -680,7 +678,7 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
                 type.GetMangledTypeName().GetCString(), rti->getNumFields());
 
       // The superclass, if any, is an extra child.
-      if (builder.lookupSuperclass(tr))
+      if (reflection_ctx->LookupSuperclass(tr))
         return rti->getNumFields() + 1;
       return rti->getNumFields();
     }
@@ -743,9 +741,9 @@ SwiftLanguageRuntimeImpl::GetNumFields(CompilerType type,
         return referent.GetNumFields(exe_ctx);
       return 0;
     case ReferenceKind::Strong:
-      TypeConverter tc(GetReflectionContext()->GetBuilder());
+      ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
       LLDBTypeInfoProvider tip(*this, *ts);
-      auto *cti = tc.getClassInstanceTypeInfo(tr, 0, &tip);
+      auto *cti = reflection_ctx->GetClassInstanceTypeInfo(tr, &tip);
       if (auto *rti = llvm::dyn_cast_or_null<RecordTypeInfo>(cti)) {
         return rti->getNumFields();
       }
@@ -876,18 +874,16 @@ SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
                                            child_indexes);
     case ReferenceKind::Strong: {
       ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
-      auto &builder = reflection_ctx->GetBuilder();
-      TypeConverter tc(builder);
       LLDBTypeInfoProvider tip(*this, *ts);
       // `current_tr` iterates the class hierarchy, from the current class, each
       // superclass, and ends on null.
       auto *current_tr = tr;
       while (current_tr) {
         auto *record_ti = llvm::dyn_cast_or_null<RecordTypeInfo>(
-            tc.getClassInstanceTypeInfo(current_tr, 0, &tip));
+            reflection_ctx->GetClassInstanceTypeInfo(current_tr, &tip));
         if (!record_ti)
           break;
-        auto *super_tr = builder.lookupSuperclass(current_tr);
+        auto *super_tr = reflection_ctx->LookupSuperclass(current_tr);
         uint32_t offset = super_tr ? 1 : 0;
         auto found_size = findFieldWithName(record_ti->getFields(), name, false,
                                             child_indexes, offset);
@@ -1393,18 +1389,13 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Pack(
           });
 
       // Build a TypeRef from the demangle tree.
-      auto typeref_or_err =
-          decodeMangledType(reflection_ctx->GetBuilder(), pack_element);
-      if (typeref_or_err.isError()) {
-        LLDB_LOGF(log, "Couldn't get TypeRef for %s",
-                  pack_type.GetMangledTypeName().GetCString());
+      auto type_ref = reflection_ctx->GetTypeRefOrNull(dem, pack_element);
+      if (!type_ref)
         return {};
-      }
-      auto typeref = typeref_or_err.getType();
 
       // Apply the substitutions.
       auto bound_typeref =
-          typeref->subst(reflection_ctx->GetBuilder(), substitutions);
+          reflection_ctx->ApplySubstitutions(type_ref, substitutions);
       swift::Demangle::NodePointer node = bound_typeref->getDemangling(dem);
       CompilerType type = ts->RemangleAsType(dem, node);
 
@@ -1818,11 +1809,10 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParameters(
   Demangler dem;
   NodePointer unbound_node =
       dem.demangleSymbol(unbound_type.GetMangledTypeName().GetStringRef());
-  auto type_ref_or_err =
-      decodeMangledType(reflection_ctx->GetBuilder(), unbound_node);
-  if (type_ref_or_err.isError()) {
+  auto type_ref = reflection_ctx->GetTypeRefOrNull(dem, unbound_node);
+  if (!type_ref) {
     LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
-             "Couldn't get TypeRef of unbound type.");
+             "Couldn't get TypeRef of unbound type");
     return {};
   }
 
@@ -1842,28 +1832,24 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParameters(
       return;
     }
 
-    NodePointer child_node =
-        dem.demangleSymbol(type.GetMangledTypeName().GetStringRef());
-    auto type_ref_or_err =
-        decodeMangledType(reflection_ctx->GetBuilder(), child_node);
-    if (type_ref_or_err.isError()) {
+    auto type_ref = reflection_ctx->GetTypeRefOrNull(
+        type.GetMangledTypeName().GetStringRef());
+    if (!type_ref) {
       LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
                "Couldn't get TypeRef when binding generic type parameters.");
       failure = true;
       return;
     }
 
-    substitutions.insert({{depth, index}, type_ref_or_err.getType()});
+    substitutions.insert({{depth, index}, type_ref});
   });
 
   if (failure)
     return {};
 
-  const swift::reflection::TypeRef *type_ref = type_ref_or_err.getType();
-
   // Apply the substitutions.
   const swift::reflection::TypeRef *bound_type_ref =
-      type_ref->subst(reflection_ctx->GetBuilder(), substitutions);
+      reflection_ctx->ApplySubstitutions(type_ref, substitutions);
   NodePointer node = bound_type_ref->getDemangling(dem);
   return ts->GetTypeSystemSwiftTypeRef().RemangleAsType(dem, node);
 }
@@ -1918,18 +1904,14 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
     return get_canonical();
 
   // Build a TypeRef from the demangle tree.
-  auto type_ref_or_err =
-      decodeMangledType(reflection_ctx->GetBuilder(), canonical);
-  if (type_ref_or_err.isError()) {
-    LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
-             "Couldn't get TypeRef");
+  const swift::reflection::TypeRef *type_ref =
+      reflection_ctx->GetTypeRefOrNull(dem, canonical);
+  if (!type_ref)
     return get_canonical();
-  }
-  const swift::reflection::TypeRef *type_ref = type_ref_or_err.getType();
 
   // Apply the substitutions.
   const swift::reflection::TypeRef *bound_type_ref =
-      type_ref->subst(reflection_ctx->GetBuilder(), substitutions);
+      reflection_ctx->ApplySubstitutions(type_ref, substitutions);
   NodePointer node = bound_type_ref->getDemangling(dem);
 
   // Import the type into the scratch context. Subsequent conversions
@@ -2647,32 +2629,16 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
   if (!reflection_ctx)
     return nullptr;
 
-  auto type_ref_or_err =
-      swift::Demangle::decodeMangledType(reflection_ctx->GetBuilder(), node);
-  if (type_ref_or_err.isError()) {
-    LLDB_LOGF(log,
-              "[SwiftLanguageRuntimeImpl::GetTypeRef] Could not find typeref "
-              "for type: %s. Decode mangled type failed. Error: %s\n.",
-              type.GetMangledTypeName().GetCString(),
-              type_ref_or_err.getError()->copyErrorString());
+  auto type_ref = reflection_ctx->GetTypeRefOrNull(dem, node);
+  if (!type_ref)
     return nullptr;
-  }
-  const swift::reflection::TypeRef *type_ref = type_ref_or_err.getType();
-  if (type_ref) {
-    if (log && log->GetVerbose()) {
-      std::stringstream ss;
-      type_ref->dump(ss);
-      LLDB_LOGF(log,
-                "[SwiftLanguageRuntimeImpl::GetTypeRef] Found typeref for "
-                "type: %s:\n%s",
-                type.GetMangledTypeName().GetCString(), ss.str().c_str());
-    }
-  } else {
-    LLDB_LOGF(
-        log,
-        "[SwiftLanguageRuntimeImpl::GetTypeRef] could not find typeref for "
-        "type: %s:\n",
-        type.GetMangledTypeName().GetCString());
+  if (log && log->GetVerbose()) {
+    std::stringstream ss;
+    type_ref->dump(ss);
+    LLDB_LOGF(log,
+              "[SwiftLanguageRuntimeImpl::GetTypeRef] Found typeref for "
+              "type: %s:\n%s",
+              type.GetMangledTypeName().GetCString(), ss.str().c_str());
   }
   return type_ref;
 }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -232,10 +232,20 @@ public:
     ReadELF(swift::remote::RemoteAddress ImageStart,
             llvm::Optional<llvm::sys::MemoryBlock> FileBuffer,
             llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
+    virtual const swift::reflection::TypeRef *
+    GetTypeRefOrNull(StringRef mangled_type_name) = 0;
+    virtual const swift::reflection::TypeRef *
+    GetTypeRefOrNull(swift::Demangle::Demangler &dem,
+                     swift::Demangle::NodePointer node) = 0;
+    virtual const swift::reflection::TypeInfo *
+    GetClassInstanceTypeInfo(const swift::reflection::TypeRef *type_ref,
+                             swift::remote::TypeInfoProvider *provider) = 0;
     virtual const swift::reflection::TypeInfo *
     GetTypeInfo(const swift::reflection::TypeRef *type_ref,
                 swift::remote::TypeInfoProvider *provider) = 0;
     virtual swift::remote::MemoryReader &GetReader() = 0;
+    virtual const swift::reflection::TypeRef *
+    LookupSuperclass(const swift::reflection::TypeRef *tr) = 0;
     virtual bool
     ForEachSuperClassType(swift::remote::TypeInfoProvider *tip,
                           lldb::addr_t pointer,
@@ -251,9 +261,11 @@ public:
     virtual const swift::reflection::TypeRef *
     ReadTypeFromInstance(lldb::addr_t instance_address,
                          bool skip_artificial_subclasses = false) = 0;
-    virtual swift::reflection::TypeRefBuilder &GetBuilder() = 0;
     virtual llvm::Optional<bool> IsValueInlinedInExistentialContainer(
         swift::remote::RemoteAddress existential_address) = 0;
+    virtual const swift::reflection::TypeRef *
+    ApplySubstitutions(const swift::reflection::TypeRef *type_ref,
+                       swift::reflection::GenericArgumentMap substitutions) = 0;
     virtual swift::remote::RemoteAbsolutePointer
     StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
   };


### PR DESCRIPTION
… APIs (NFC)

to avoid leaking an implementation detail.