### PR TITLE
[clang][cas] Use module cache key as context hash

### DIFF
--- a/clang/test/ClangScanDeps/modules-cas-context-hash.c
+++ b/clang/test/ClangScanDeps/modules-cas-context-hash.c
@@ -63,14 +63,38 @@
 //--- cdb1.json.template
 [{
   "directory": "DIR",
-  "command": "clang -Xclang -fcas-plugin-path -Xclang /1 -Xclang -fcas-plugin-option -Xclang a=x -fsyntax-only DIR/tu.c -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache1",
+  "arguments": [
+    "clang",
+    "-fsyntax-only",
+    "DIR/tu.c",
+    "-fmodules",
+    "-fimplicit-module-maps",
+
+    "-Xclang", "-fcas-plugin-path", "-Xclang", "/1",
+    "-Xclang", "-fcas-plugin-option", "-Xclang", "a=x",
+    "-fmodules-cache-path=DIR/cache1",
+    "-fmessage-length=1",
+    "-fcolor-diagnostics",
+  ],
   "file": "DIR/tu.c"
 }]
 
 //--- cdb2.json.template
 [{
   "directory": "DIR",
-  "command": "clang -Xclang -fcas-plugin-path -Xclang /2 -Xclang -fcas-plugin-option -Xclang b=y -fsyntax-only DIR/tu.c -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache2",
+  "arguments": [
+    "clang",
+    "-fsyntax-only",
+    "DIR/tu.c",
+    "-fmodules",
+    "-fimplicit-module-maps",
+
+    "-Xclang", "-fcas-plugin-path", "-Xclang", "/2",
+    "-Xclang", "-fcas-plugin-option", "-Xclang", "b=y",
+    "-fmodules-cache-path=DIR/cache2",
+    "-fmessage-length=2",
+    "-fno-color-diagnostics",
+  ],
   "file": "DIR/tu.c"
 }]
 


### PR DESCRIPTION
This improves canonicalization, reducing the number of cache misses when using compilation caching. For leaf modules this makes no difference since the extra compilation would be cached anyway, but when a module is imported the context hash is generally part of the path of the pcm, which then effects every downstream importer. This was previously causing spurious cache misses when changing options like -fmessage-length that are otherwise canonicalized away.

rdar://105844077
(cherry picked from commit 2249fb1cecfa5464fb64b1cc2b3fa19fb6fee56a)