### PR TITLE
[clang][cas] Use module cache key as context hash

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -97,7 +97,8 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
   // differ between identical modules discovered from different translation
   // units.
   CI.getFrontendOpts().Inputs.clear();
-  CI.getFrontendOpts().OutputFile.clear();
+  // CAS: OutputFile cannot be empty when computing a cache key.
+  CI.getFrontendOpts().OutputFile = "-";
   // FIXME: a build system may want to provide a new path.
   CI.getFrontendOpts().IndexUnitOutputPath.clear();
 
@@ -117,7 +118,9 @@ ModuleDepCollector::makeInvocationForModuleBuildWithoutOutputs(
     CI.getDiagnosticOpts().DiagnosticSerializationFile = "-";
   if (!CI.getDependencyOutputOpts().OutputFile.empty())
     CI.getDependencyOutputOpts().OutputFile = "-";
-  CI.getDependencyOutputOpts().Targets.clear();
+  // CAS: -MT must be preserved for cache key.
+  if (!CI.getDependencyOutputOpts().Targets.empty())
+    CI.getDependencyOutputOpts().Targets = {"-"};
 
   CI.getFrontendOpts().ProgramAction = frontend::GenerateModule;
   CI.getLangOpts()->ModuleName = Deps.ID.ModuleName;
@@ -285,6 +288,22 @@ static std::string getModuleContextHash(const ModuleDeps &MD,
       HashBuilder;
   SmallString<32> Scratch;
 
+  auto FormatHash = [&](llvm::BLAKE3Result<16> Hash) {
+    std::array<uint64_t, 2> Words;
+    static_assert(sizeof(Hash) == sizeof(Words), "Hash must match Words");
+    std::memcpy(Words.data(), Hash.data(), sizeof(Hash));
+    return toString(llvm::APInt(sizeof(Words) * 8, Words), 36,
+                    /*Signed=*/false);
+  };
+
+  if (MD.ModuleCacheKey) {
+    // Cache keys have better canonicalization, so use them as the context hash.
+    // This reduces the number of modules needed when compatible configurations
+    // are used (e.g. change in -fmessage-length).
+    HashBuilder.add(*MD.ModuleCacheKey);
+    return FormatHash(HashBuilder.final());
+  }
+
   // Hash the compiler version and serialization version to ensure the module
   // will be readable.
   HashBuilder.add(getClangFullRepositoryVersion());
@@ -320,13 +339,30 @@ static std::string getModuleContextHash(const ModuleDeps &MD,
   }
 
   HashBuilder.add(EagerLoadModules);
-
-  llvm::BLAKE3Result<16> Hash = HashBuilder.final();
-  std::array<uint64_t, 2> Words;
-  static_assert(sizeof(Hash) == sizeof(Words), "Hash must match Words");
-  std::memcpy(Words.data(), Hash.data(), sizeof(Hash));
-  return toString(llvm::APInt(sizeof(Words) * 8, Words), 36, /*Signed=*/false);
+  return FormatHash(HashBuilder.final());
 }
+
+#ifndef NDEBUG
+static void checkCompileCacheKeyMatch(cas::ObjectStore &CAS,
+                                      StringRef OldKeyStr, cas::CASID NewKey) {
+  if (NewKey.toString() == OldKeyStr)
+    return;
+
+  // Mismatched keys, report error.
+  auto OldKey = CAS.parseID(OldKeyStr);
+  if (!OldKey)
+    llvm::report_fatal_error(OldKey.takeError());
+  SmallString<256> Err;
+  llvm::raw_svector_ostream OS(Err);
+  OS << "Compile cache key for module changed; previously:";
+  if (auto E = printCompileJobCacheKey(CAS, *OldKey, OS))
+    OS << std::move(E);
+  OS << "\nkey is now:";
+  if (auto E = printCompileJobCacheKey(CAS, NewKey, OS))
+    OS << std::move(E);
+  llvm::report_fatal_error(OS.str());
+}
+#endif
 
 void ModuleDepCollector::associateWithContextHash(const CompilerInvocation &CI,
                                                   ModuleDeps &Deps) {
@@ -521,17 +557,27 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
   if (auto E = MDC.Controller.finalizeModuleInvocation(CI, MD))
     Diags.Report(diag::err_cas_depscan_failed) << std::move(E);
 
-  MDC.associateWithContextHash(CI, MD);
-
-  // Finish the compiler invocation. Requires dependencies and the context hash.
-  MDC.addOutputPaths(CI, MD);
-
-  // Compute the cache key, if needed. Requires dependencies and outputs.
+  // Compute the cache key, if needed. Requires dependencies.
   if (MDC.ScanInstance.getFrontendOpts().CacheCompileJob) {
     auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
     if (auto Key = createCompileJobCacheKey(CAS, Diags, CI))
       MD.ModuleCacheKey = Key->toString();
   }
+
+  MDC.associateWithContextHash(CI, MD);
+
+  // Finish the compiler invocation. Requires dependencies and the context hash.
+  MDC.addOutputPaths(CI, MD);
+
+#ifndef NDEBUG
+  // Verify the key has not changed with final arguments.
+  if (MD.ModuleCacheKey) {
+    auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
+    auto Key = createCompileJobCacheKey(CAS, Diags, CI);
+    assert(Key);
+    checkCompileCacheKeyMatch(CAS, *MD.ModuleCacheKey, *Key);
+  }
+#endif
 
   MD.BuildArguments = CI.getCC1CommandLine();
 

--- a/clang/test/ClangScanDeps/modules-cas-context-hash.c
+++ b/clang/test/ClangScanDeps/modules-cas-context-hash.c
@@ -63,14 +63,38 @@
 //--- cdb1.json.template
 [{
   "directory": "DIR",
-  "command": "clang -Xclang -fcas-plugin-path -Xclang /1 -Xclang -fcas-plugin-option -Xclang a=x -fsyntax-only DIR/tu.c -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache1",
+  "arguments": [
+    "clang",
+    "-fsyntax-only",
+    "DIR/tu.c",
+    "-fmodules",
+    "-fimplicit-module-maps",
+
+    "-Xclang", "-fcas-plugin-path", "-Xclang", "/1",
+    "-Xclang", "-fcas-plugin-option", "-Xclang", "a=x",
+    "-fmodules-cache-path=DIR/cache1",
+    "-fmessage-length=1",
+    "-fcolor-diagnostics",
+  ],
   "file": "DIR/tu.c"
 }]
 
 //--- cdb2.json.template
 [{
   "directory": "DIR",
-  "command": "clang -Xclang -fcas-plugin-path -Xclang /2 -Xclang -fcas-plugin-option -Xclang b=y -fsyntax-only DIR/tu.c -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/cache2",
+  "arguments": [
+    "clang",
+    "-fsyntax-only",
+    "DIR/tu.c",
+    "-fmodules",
+    "-fimplicit-module-maps",
+
+    "-Xclang", "-fcas-plugin-path", "-Xclang", "/2",
+    "-Xclang", "-fcas-plugin-option", "-Xclang", "b=y",
+    "-fmodules-cache-path=DIR/cache2",
+    "-fmessage-length=2",
+    "-fno-color-diagnostics",
+  ],
   "file": "DIR/tu.c"
 }]
 


### PR DESCRIPTION
This improves canonicalization, reducing the number of cache misses when using compilation caching. For leaf modules this makes no difference since the extra compilation would be cached anyway, but when a module is imported the context hash is generally part of the path of the pcm, which then effects every downstream importer. This was previously causing spurious cache misses when changing options like -fmessage-length that are otherwise canonicalized away.

rdar://105844077
(cherry picked from commit 2249fb1cecfa5464fb64b1cc2b3fa19fb6fee56a)