### PR TITLE
[clang] Fix assertion failure using -MJ with -fsyntax-only

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -2444,7 +2444,8 @@ void Clang::DumpCompilationDatabase(Compilation &C, StringRef Filename,
     CWD = ".";
   CDB << "{ \"directory\": \"" << escape(*CWD) << "\"";
   CDB << ", \"file\": \"" << escape(Input.getFilename()) << "\"";
-  CDB << ", \"output\": \"" << escape(Output.getFilename()) << "\"";
+  if (Output.isFilename())
+    CDB << ", \"output\": \"" << escape(Output.getFilename()) << "\"";
   CDB << ", \"arguments\": [\"" << escape(D.ClangExecutable) << "\"";
   SmallString<128> Buf;
   Buf = "-x";
@@ -2456,7 +2457,8 @@ void Clang::DumpCompilationDatabase(Compilation &C, StringRef Filename,
     CDB << ", \"" << escape(Buf) << "\"";
   }
   CDB << ", \"" << escape(Input.getFilename()) << "\"";
-  CDB << ", \"-o\", \"" << escape(Output.getFilename()) << "\"";
+  if (Output.isFilename())
+    CDB << ", \"-o\", \"" << escape(Output.getFilename()) << "\"";
   for (auto &A: Args) {
     auto &O = A->getOption();
     // Skip language selection, which is positional.

--- a/clang/test/Driver/compilation_database.c
+++ b/clang/test/Driver/compilation_database.c
@@ -1,10 +1,20 @@
 // RUN: mkdir -p %t.workdir && cd %t.workdir
 // RUN: %clang -no-canonical-prefixes -fintegrated-as -MD -MP --sysroot=somewhere -c -x c %s -xc++ %s -Wall -MJ - 2>&1 | FileCheck %s
 // RUN: not %clang -no-canonical-prefixes -c -x c %s -MJ %s/non-existant 2>&1 | FileCheck --check-prefix=ERROR %s
+// RUN: %clang -fsyntax-only %s -MJ - 2>&1 | FileCheck %s -check-prefix=SYNTAX_ONLY
 
 // CHECK: { "directory": "{{[^"]*}}workdir",  "file": "[[SRC:[^"]+[/|\\]compilation_database.c]]", "output": "compilation_database.o", "arguments": ["{{[^"]*}}clang{{[^"]*}}", "-xc", "[[SRC]]", "-o", "compilation_database.o", "-no-canonical-prefixes", "-fintegrated-as", "--sysroot=somewhere", "-c", "-Wall",{{.*}} "--target={{[^"]+}}"]},
 // CHECK: { "directory": "{{.*}}",  "file": "[[SRC:[^"]+[/|\\]compilation_database.c]]", "output": "compilation_database.o", "arguments": ["{{[^"]*}}clang{{[^"]*}}", "-xc++", "[[SRC]]", "-o", "compilation_database.o", "-no-canonical-prefixes", "-fintegrated-as", "--sysroot=somewhere", "-c", "-Wall",{{.*}} "--target={{[^"]+}}"]},
 // ERROR: error: compilation database '{{.*}}/non-existant' could not be opened:
+
+// SYNTAX_ONLY:      {
+// SYNTAX_ONLY-SAME: "directory": "{{[^"]*}}workdir",
+// SYNTAX_ONLY-SAME: "file": "{{[^"]*}}compilation_database.c"
+// SYNTAX_ONLY-NOT:  "output"
+// SYNTAX_ONLY-SAME: "arguments": [
+// SYNTAX_ONLY-NOT:    "-o"
+// SYNTAX_ONLY-SAME: ]
+// SYNTAX_ONLY-SAME: }
 
 int main(void) {
   return 0;


### PR DESCRIPTION
If there is no output filename we should not assert when writing output for -MJ.

Differential Revision: https://reviews.llvm.org/D159016

(cherry picked from commit aca23d8ac30d773c1513d1708bdda8149acc075a)