### PR TITLE
[next][lldb][cmake] Fix relative path used for lldb executables

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -222,7 +222,7 @@ function(add_properties_for_swift_modules target reldir)
       target_link_libraries(${target} PRIVATE swiftCore-linux-${arch})
       string(TOLOWER ${CMAKE_SYSTEM_NAME} platform)
       set(SWIFT_BUILD_RPATH "${LLDB_SWIFT_LIBS}/${platform}")
-      set(SWIFT_INSTALL_RPATH "$ORIGIN/swift/${platform}")
+      set(SWIFT_INSTALL_RPATH "$ORIGIN/${reldir}lib/swift/${platform}")
     endif()
 
     set_property(TARGET ${target} APPEND PROPERTY BUILD_RPATH "${SWIFT_BUILD_RPATH}")


### PR DESCRIPTION
I had this looking directly in `./swift/<os>/` before, but now that an installed lldb executable also links against Swift libraries, this needs to be the more general `../lib/swift/<os>/`.

Pinging @rintaro and @bnbarham, this is a cherry-pick of #7359.