### PR TITLE
Remove SwiftASTContext from ABI.cpp (NFC)

### DIFF
--- a/lldb/source/Target/ABI.cpp
+++ b/lldb/source/Target/ABI.cpp
@@ -20,11 +20,6 @@
 #include "llvm/MC/TargetRegistry.h"
 #include <cctype>
 
-#ifdef LLDB_ENABLE_SWIFT
-#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
-#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
-#endif //LLDB_ENABLE_SWIFT
-
 using namespace lldb;
 using namespace lldb_private;
 
@@ -93,15 +88,9 @@ ValueObjectSP ABI::GetReturnValueObject(Thread &thread, CompilerType &ast_type,
     lldb::LanguageType lang = ast_type.GetMinimumLanguage();
     PersistentExpressionState *persistent_expression_state;
     Target &target = *thread.CalculateTarget();
-#ifdef LLDB_ENABLE_SWIFT
-    if (lang == lldb::eLanguageTypeSwift)
-      persistent_expression_state = 
-        target.GetSwiftPersistentExpressionState(thread);
-    else
-#endif // LLDB_ENABLE_SWIFT
-      persistent_expression_state =
+    persistent_expression_state =
         target.GetPersistentExpressionStateForLanguage(lang);
-    
+
     if (!persistent_expression_state)
       return {};
 


### PR DESCRIPTION
The Swift-specific code here is obsolete since there is only a single persistent state in Swift any more.