### PR TITLE
Don't enable stdin/out with a no-output test program

### DIFF
--- a/lldb/unittests/tools/lldb-server/tests/LLGSTest.cpp
+++ b/lldb/unittests/tools/lldb-server/tests/LLGSTest.cpp
@@ -24,8 +24,9 @@ using namespace llvm;
 TEST_F(TestBase, LaunchModePreservesEnvironment) {
   putenv(const_cast<char *>("LLDB_TEST_MAGIC_VARIABLE=LLDB_TEST_MAGIC_VALUE"));
 
-  auto ClientOr = TestClient::launch(getLogFileName(),
-                                     {getInferiorPath("environment_check")});
+  auto ClientOr = TestClient::launchCustom(
+      getLogFileName(),
+      /* disable_stdio */ true, {}, {getInferiorPath("environment_check")});
   ASSERT_THAT_EXPECTED(ClientOr, Succeeded());
   auto &Client = **ClientOr;
 
@@ -56,8 +57,9 @@ TEST_F(TestBase, DS_TEST(DebugserverEnv)) {
 }
 
 TEST_F(TestBase, LLGS_TEST(vAttachRichError)) {
-  auto ClientOr = TestClient::launch(getLogFileName(),
-                                     {getInferiorPath("environment_check")});
+  auto ClientOr = TestClient::launchCustom(
+      getLogFileName(),
+      /* disable_stdio */ true, {}, {getInferiorPath("environment_check")});
   ASSERT_THAT_EXPECTED(ClientOr, Succeeded());
   auto &Client = **ClientOr;
 


### PR DESCRIPTION
Don't enable stdin/out with a no-output test program

A followon to  https://reviews.llvm.org/D158237 ,
where this text can print stdout text when run
under address-sanitizer, and the test harness
does not expect any output, resulting in a test
failure on a sanitizer CI bot.

(cherry picked from commit 3621f83804809fa50892ee81d9b3854ec2e5074f)