### PR TITLE
[clang][cas] Prevent module cache sharing between cas-fs and include-tree

### DIFF
--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -368,6 +368,10 @@ public:
   /// is specified.
   unsigned CacheCompileJob : 1;
 
+  /// Whether this invocation is dependency scanning for include-tree. Used to
+  /// separate module cache for include-tree from cas-fs.
+  unsigned ForIncludeTreeScan : 1;
+
   /// Avoid checking if the compile job is already cached, force compilation and
   /// caching of compilation outputs. This is used for testing purposes.
   unsigned DisableCachedCompileJobReplay : 1;
@@ -582,7 +586,7 @@ public:
         ASTDumpLookups(false), BuildingImplicitModule(false),
         BuildingImplicitModuleUsesLock(true), ModulesEmbedAllFiles(false),
         IncludeTimestamps(true), UseTemporary(true), CacheCompileJob(false),
-        DisableCachedCompileJobReplay(false),
+        ForIncludeTreeScan(false), DisableCachedCompileJobReplay(false),
         MayEmitDiagnosticsAfterProcessingSourceFiles(false),
         WriteOutputAsCASID(false), AllowPCMWithCompilerErrors(false),
         ModulesShareFileManager(true), TimeTraceGranularity(500) {}

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5052,8 +5052,9 @@ std::string CompilerInvocation::getModuleHash(DiagnosticsEngine &Diags) const {
   }
 
   // Caching + implicit modules, which is only set in clang-scan-deps, puts
-  // additional CASIDs in the pcm.
-  HBuilder.add(getFrontendOpts().CacheCompileJob);
+  // additional CASIDs in the pcm for either cas-fs or include-tree.
+  HBuilder.add(getFrontendOpts().CacheCompileJob,
+               getFrontendOpts().ForIncludeTreeScan);
 
   llvm::MD5::MD5Result Result;
   HBuilder.getHasher().final(Result);

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -328,6 +328,7 @@ Error IncludeTreeActionController::initialize(
 
   // Enable caching in the resulting commands.
   ScanInstance.getFrontendOpts().CacheCompileJob = true;
+  ScanInstance.getFrontendOpts().ForIncludeTreeScan = true;
   CASOpts = ScanInstance.getCASOpts();
 
   return Error::success();

--- a/clang/test/ClangScanDeps/modules-cas-module-cache-hash.c
+++ b/clang/test/ClangScanDeps/modules-cas-module-cache-hash.c
@@ -1,0 +1,32 @@
+// Check that using the same module cache does not cause errors when switching
+// between cas-fs and include-tree.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full | FileCheck %s -check-prefix=INCLUDE_TREE
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-full | FileCheck %s  -check-prefix=CAS_FS
+
+// INCLUDE_TREE: "-fcas-include-tree"
+// CAS_FS: "-fcas-fs"
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only -fmodules -fimplicit-modules -fmodules-cache-path=DIR/mcp DIR/tu.c"
+}]
+
+//--- module.modulemap
+module M { header "M.h" }
+
+//--- M.h
+
+//--- tu.c
+#include "M.h"


### PR DESCRIPTION
Modules built by the dependency scanner for include-tree and cas-fs are not compatible, so prevent them from being shared by modifying the hash.

rdar://108746813