### PR TITLE
[Darwin][StableABI][ASan] Remove version mismatch check from stable a…

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1286,6 +1286,8 @@ void SanitizerArgs::addArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
     CmdArgs.push_back("-asan-instrumentation-with-call-threshold=0");
     CmdArgs.push_back("-mllvm");
     CmdArgs.push_back("-asan-max-inline-poisoning-size=0");
+    CmdArgs.push_back("-mllvm");
+    CmdArgs.push_back("-asan-guard-against-version-mismatch=0");
   }
 
   // Only pass the option to the frontend if the user requested,

--- a/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
+++ b/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
@@ -49,7 +49,7 @@ void __asan_init(void) {
 
   __asan_abi_init();
 }
-void __asan_version_mismatch_check_v8(void) {}
+
 void __asan_handle_no_return(void) { __asan_abi_handle_no_return(); }
 
 // Variables concerning RTL state. These provisionally exist for completeness

--- a/compiler-rt/test/asan_abi/TestCases/Darwin/llvm_interface_symbols.cpp
+++ b/compiler-rt/test/asan_abi/TestCases/Darwin/llvm_interface_symbols.cpp
@@ -7,7 +7,6 @@
 // RUN: | grep " [TU] "                                           \
 // RUN: | grep -o "\(__asan\)[^ ]*"                               \
 // RUN: | grep -v "\(__asan_abi\)[^ ]*"                           \
-// RUN: | sed -e "s/__asan_version_mismatch_check_v[0-9]+/__asan_version_mismatch_check/" \
 // RUN: > %t.exports
 // RUN: sed -e ':a' -e 'N' -e '$!ba'                              \
 // RUN:     -e 's/ //g'                                           \
@@ -17,7 +16,9 @@
 // RUN: | grep -v -f %p/../../../../lib/asan_abi/asan_abi_tbd.txt \
 // RUN: | grep -e "INTERFACE_\(WEAK_\)\?FUNCTION"                 \
 // RUN: | grep -v "__sanitizer[^ ]*"                              \
-// RUN: | sed -e "s/.*(//" -e "s/).*//" > %t.imports
+// RUN: | sed -e "s/.*(//" -e "s/).*//"                           \
+// RUN: | sed -e "/^__asan_version_mismatch_check/d"              \
+// RUN: > %t.imports
 // RUN: sort %t.imports | uniq > %t.imports-sorted
 // RUN: sort %t.exports | uniq > %t.exports-sorted
 // RUN: diff %t.imports-sorted %t.exports-sorted


### PR DESCRIPTION
…bi shim

By its nature the stable abi does not require a version check symbol. This patch sets -asan-guard-against-version-mismatch=0 for stable abi. And updates tests to reflect this

rdar://114208627

Differential Revision: https://reviews.llvm.org/D158570