### PR TITLE
[clang-c] Include `stdbool.h` for `CAS.h`

### DIFF
--- a/clang/include/clang-c/CAS.h
+++ b/clang/include/clang-c/CAS.h
@@ -23,6 +23,7 @@
 #include "clang-c/CXErrorCode.h"
 #include "clang-c/CXString.h"
 #include "clang-c/Platform.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
(cherry picked from commit ef77f50d9d10704ee9c77f2b185c647046adc6c8)