### PR TITLE
LLVMSupport: partially backport 6613f4aff85b24a13d4f5f7e9cd24bf3f44037a3

### DIFF
--- a/llvm/include/llvm/Support/DynamicLibrary.h
+++ b/llvm/include/llvm/Support/DynamicLibrary.h
@@ -45,6 +45,9 @@ public:
   /// Returns true if the object refers to a valid library.
   bool isValid() const { return Data != &Invalid; }
 
+  /// Return the OS specific handle value.
+  void *getOSSpecificHandle() const { return Data; }
+
   /// Searches through the library for the symbol \p symbolName. If it is
   /// found, the address of that symbol is returned. If not, NULL is returned.
   /// Note that NULL will also be returned if the library failed to load.


### PR DESCRIPTION
This partially backports the API changes from
6613f4aff85b24a13d4f5f7e9cd24bf3f44037a3 to accommodate the plugin loading support for Swift Macros.