### PR TITLE
[conditional-runtime-records] Consider llvm.used.conditional deps live if only declared

### DIFF
--- a/llvm/lib/Transforms/IPO/GlobalDCE.cpp
+++ b/llvm/lib/Transforms/IPO/GlobalDCE.cpp
@@ -387,7 +387,14 @@ GlobalValue *GlobalDCEPass::TargetFromConditionalUsedIfLive(MDNode *M) {
   bool AllDependenciesAlive = Dependencies.empty() ? false : true;
   bool AnyDependencyAlive = false;
   for (auto *Dep : Dependencies) {
-    bool Live = AliveGlobals.count(Dep) != 0;
+    GlobalObject *GlobalObjectDep = dyn_cast<GlobalObject>(Dep);
+    bool Live;
+    // For the purposes of llvm.used.conditional based stripping,
+    // consider all dependencies that are declarations to be live.
+    if (GlobalObjectDep && GlobalObjectDep->isDeclaration())
+      Live = true;
+    else
+      Live = AliveGlobals.count(Dep) != 0;
     if (Live)
       AnyDependencyAlive = true;
     else

--- a/llvm/test/Transforms/GlobalDCE/used.conditional-declaration-safe.ll
+++ b/llvm/test/Transforms/GlobalDCE/used.conditional-declaration-safe.ll
@@ -1,0 +1,18 @@
+; RUN: opt -S -passes=globaldce %s | FileCheck %s
+
+@conditional_gv = internal unnamed_addr constant i64 42
+@non_conditional_gv = internal unnamed_addr constant i64 42
+
+declare external void @some_externally_defined_symbol()
+
+@llvm.used = appending global [2 x i8*] [
+    i8* bitcast (i64* @conditional_gv to i8*),
+    i8* bitcast (i64* @non_conditional_gv to i8*)
+], section "llvm.metadata"
+
+!1 = !{i64* @conditional_gv, i32 0, !{void()* @some_externally_defined_symbol}}
+!llvm.used.conditional = !{!1}
+
+; CHECK-DAG: @conditional_gv
+; CHECK-DAG: @llvm.used = appending global [2 x ptr] [ptr @conditional_gv, ptr @non_conditional_gv], section "llvm.metadata"
+


### PR DESCRIPTION
The way that the Swift frontend populates `llvm.used.conditional` entries makes it possible for an entity to depend upon an LLVM GV that is not defined, but merely declared within in the current module.

Although less likely, this is even possible with monoLTO as we observed. Afterall, even monoLTO doesn't have true global visibility, there may always be externally defined symbols. In our case this symbol was the definition of _ObjectiveCBridgeable, which is defined in the Swift standard library.

GlobalDCE is free to strip any declarations that are not depended upon within the module. However, that is not to say the definition of that symbol is not used within the program. This led to erroneous stripping of _ObjectiveCBridgeable conformance records, and ultimately led to crashes with incorrectly bridged types.

To fix this I have modified GlobalDCE to consider any dependency listed in `llvm.used.conditional` as live if it is only declared within the module. This will reduce the effectiveness of conditional runtime records, but necessarily so.

I also considered modifying the frontend to only add entries when all deps are defined within the same compilation unit. However, that is overly cautious. A GV that is declared during compilation, might be defined during monoLTO opt, but we can't know till we get there.

cc: @kubamracek