### PR TITLE
[AsmPrinter][DwarfDebug] Skip vars with fragments in different location kinds

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfDebug.cpp
@@ -1589,10 +1589,13 @@ void DwarfDebug::collectVariableInfoFromMFTable(
                       << "\n");
 
     if (DbgVariable *DbgVar = MFVars.lookup(Var)) {
-      if (DbgVar->hasFrameIndexExprs())
+      if (DbgVar->hasFrameIndexExprs() && RegVar->hasFrameIndexExprs())
         DbgVar->addMMIEntry(*RegVar);
-      else
+      else if (VI.inEntryValueRegister())
         DbgVar->getEntryValue()->addExpr(VI.getEntryValueRegister(), *VI.Expr);
+      else
+        LLVM_DEBUG(dbgs() << "Dropping debug info for " << VI.Var->getName()
+                          << ", conflicting fragment types\n");
     } else if (InfoHolder.addScopeVariable(Scope, RegVar.get())) {
       MFVars.insert({Var, RegVar.get()});
       ConcreteEntities.push_back(std::move(RegVar));

--- a/llvm/test/DebugInfo/AArch64/dbg-entry-value-swiftasync.mir
+++ b/llvm/test/DebugInfo/AArch64/dbg-entry-value-swiftasync.mir
@@ -8,16 +8,23 @@
 # CHECK-SAME:     DW_OP_GNU_entry_value(DW_OP_reg22 W22), DW_OP_piece 0x8,
 # CHECK-SAME:     DW_OP_GNU_entry_value(DW_OP_reg22 W22), DW_OP_plus_uconst 0x2a, DW_OP_piece 0x8)
 # CHECK-NEXT:   DW_AT_name    ("fragmented_var")
+# CHECK:      DW_TAG_variable
+# CHECK-NEXT:   DW_AT_location       (DW_OP_piece 0x8, DW_OP_GNU_entry_value(DW_OP_reg22 W22), DW_OP_piece 0x8)
+# CHECK-NEXT:   DW_AT_name    ("multi_type_fragmented_var")
 
 
 --- |
   target triple = "aarch64--"
   define void @foo(ptr %unused_arg, ptr swiftasync %async_arg) !dbg !4 {
+    %storage = alloca i64
     call void @llvm.dbg.declare(metadata ptr %async_arg, metadata !10, metadata !DIExpression(DW_OP_LLVM_entry_value, 1)), !dbg !12
     ; A two fragment variable.
     ; Fragments intentionally out of order to ensure the code can handle this.
     call void @llvm.dbg.declare(metadata ptr %async_arg, metadata !10, metadata !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 42, DW_OP_LLVM_fragment, 64, 64)), !dbg !12
     call void @llvm.dbg.declare(metadata ptr %async_arg, metadata !11, metadata !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_LLVM_fragment, 0, 64)), !dbg !12
+    ; A fragmented variable mixing entry values and stack slot locations.
+    call void @llvm.dbg.declare(metadata ptr %async_arg, metadata !13, metadata !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_LLVM_fragment, 64, 64)), !dbg !12
+    call void @llvm.dbg.declare(metadata ptr %storage, metadata !13, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 64)), !dbg !12
     ret void, !dbg !12
   }
   declare void @llvm.dbg.declare(metadata, metadata, metadata)
@@ -36,6 +43,7 @@
   !10 = !DILocalVariable(name: "a", scope: !4, file: !1, line: 1, type: !7)
   !11 = !DILocalVariable(name: "fragmented_var", scope: !4, file: !1, line: 1, type: !7)
   !12 = !DILocation(line: 1, column: 37, scope: !4)
+  !13 = !DILocalVariable(name: "multi_type_fragmented_var", scope: !4, file: !1, line: 1, type: !7)
 ...
 ---
 name:            foo
@@ -45,12 +53,19 @@ liveins:
 stack:
   - { id: 0, name: '', type: spill-slot, offset: -16, size: 8, alignment: 16,
       stack-id: default, callee-saved-register: '$lr', callee-saved-restored: true }
+  - { id: 1, name: '', type: default, offset: 0, size: 1, alignment: 8,
+      stack-id: default, callee-saved-register: '', callee-saved-restored: true,
+      debug-info-variable: '!13', debug-info-expression: '!DIExpression(DW_OP_LLVM_fragment, 0, 64)',
+      debug-info-location: '!12' }
+
 entry_values:
   - { entry-value-register: '$x22', debug-info-variable: '!10', debug-info-expression: '!DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_deref)',
       debug-info-location: '!12' }
   - { entry-value-register: '$x22', debug-info-variable: '!11', debug-info-expression: '!DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 42, DW_OP_deref, DW_OP_LLVM_fragment, 64, 64)',
       debug-info-location: '!12' }
   - { entry-value-register: '$x22', debug-info-variable: '!11', debug-info-expression: '!DIExpression(DW_OP_LLVM_entry_value, 1,  DW_OP_deref, DW_OP_LLVM_fragment, 0, 64)',
+      debug-info-location: '!12' }
+  - { entry-value-register: '$x22', debug-info-variable: '!13', debug-info-expression: '!DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_deref, DW_OP_LLVM_fragment, 64, 64)',
       debug-info-location: '!12' }
 body:             |
   bb.0 (%ir-block.0):


### PR DESCRIPTION
The AsmPrinter currently assumes that a Debug Variable will have all of its fragments with the same "kind" of location (i.e. all in the stack or all in entry values). This is not enforced by the verifier, so it needs to be handled properly. Until we do so, we conservatively drop one of the fragments.