### PR TITLE
[clang] Add "Wsystem-headers-in-module" to features.json

### DIFF
--- a/clang/tools/driver/features.json
+++ b/clang/tools/driver/features.json
@@ -19,6 +19,9 @@
       "name": "libclang-cache-queries"
     },
     {
+      "name": "Wsystem-headers-in-module"
+    },
+    {
       "name": "deployment-target-environment-variables",
       "value": [
         "MACOSX_DEPLOYMENT_TARGET",


### PR DESCRIPTION
We want to detect this feature to prevent using Wsystem-headers unnecessarily across dependencies.

rdar://115139189
(cherry picked from commit 631048e6364eed9923b8306779adba3a0069b834)