### PR TITLE
[NFC] Remove SkipData flag from getAndSetDebugAbbrevOffsetAndSkip 

### DIFF
--- a/clang/test/Driver/solaris-ld.c
+++ b/clang/test/Driver/solaris-ld.c
@@ -26,7 +26,6 @@
 // CHECK-GLD: "--as-needed" "-lgcc_s" "--no-as-needed"
 // CHECK-LD-SPARC32-SAME: "-lc"
 // CHECK-LD-SPARC32-SAME: "-lgcc"
-// CHECK-LD-SPARC32-SAME: "-lm"
 // CHECK-LD-SPARC32-SAME: "[[SYSROOT]]/usr/gcc/4.8/lib/gcc/sparc-sun-solaris2.11/4.8.2{{/|\\\\}}crtend.o"
 // CHECK-LD-SPARC32-SAME: "[[SYSROOT]]/usr/lib{{/|\\\\}}crtn.o"
 
@@ -49,7 +48,6 @@
 // CHECK-LD-SPARC64-SAME: "-lgcc_s"
 // CHECK-LD-SPARC64-SAME: "-lc"
 // CHECK-LD-SPARC64-SAME: "-lgcc"
-// CHECK-LD-SPARC64-SAME: "-lm"
 // CHECK-LD-SPARC64-SAME: "[[SYSROOT]]/usr/gcc/4.8/lib/gcc/sparc-sun-solaris2.11/4.8.2/sparcv9{{/|\\\\}}crtend.o"
 // CHECK-LD-SPARC64-SAME: "[[SYSROOT]]/usr/lib/sparcv9{{/|\\\\}}crtn.o"
 
@@ -72,7 +70,6 @@
 // CHECK-LD-X32-SAME: "-lgcc_s"
 // CHECK-LD-X32-SAME: "-lc"
 // CHECK-LD-X32-SAME: "-lgcc"
-// CHECK-LD-X32-SAME: "-lm"
 // CHECK-LD-X32-SAME: "[[SYSROOT]]/usr/gcc/4.9/lib/gcc/i386-pc-solaris2.11/4.9.4{{/|\\\\}}crtend.o"
 // CHECK-LD-X32-SAME: "[[SYSROOT]]/usr/lib{{/|\\\\}}crtn.o"
 
@@ -96,7 +93,6 @@
 // CHECK-LD-X64-SAME: "-lgcc_s"
 // CHECK-LD-X64-SAME: "-lc"
 // CHECK-LD-X64-SAME: "-lgcc"
-// CHECK-LD-X64-SAME: "-lm"
 // CHECK-LD-X64-SAME: "[[SYSROOT]]/usr/gcc/4.9/lib/gcc/i386-pc-solaris2.11/4.9.4/amd64{{/|\\\\}}crtend.o"
 // CHECK-LD-X64-SAME: "[[SYSROOT]]/usr/lib/amd64{{/|\\\\}}crtn.o"
 
@@ -110,7 +106,22 @@
 // CHECK-SPARC32-SHARED-SAME: "-lgcc_s"
 // CHECK-SPARC32-SHARED-SAME: "-lc"
 // CHECK-SPARC32-SHARED-NOT: "-lgcc"
-// CHECK-SPARC32-SHARED-NOT: "-lm"
+
+// Check that libm is only linked with clang++.
+// RUN: %clang -### %s --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOLIBM %s
+// RUN: %clang -### %s -shared --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-NOLIBM %s
+// RUN: %clangxx -### %s --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-LIBM %s
+// RUN: %clangxx -### %s -shared --target=sparc-sun-solaris2.11 \
+// RUN:     --gcc-toolchain="" --sysroot=%S/Inputs/solaris_sparc_tree 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-LIBM %s
+// CHECK-LIBM: "-lm"
+// CHECK-NOLIBM-NOT: "-lm"
 
 // Check the right ld flags are present with -pie.
 // RUN: %clang --target=sparc-sun-solaris2.11 -### %s -pie -fuse-ld= \

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -112,7 +112,7 @@ struct CUInfo {
 };
 static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(
     MutableArrayRef<char> CUData, support::endianness Endian,
-    std::optional<uint32_t> NewOffset = std::nullopt, bool SkipData = true);
+    std::optional<uint32_t> NewOffset = std::nullopt);
 Expected<cas::ObjectProxy>
 MCSchema::createFromMCAssemblerImpl(MachOCASWriter &ObjectWriter,
                                     MCAssembler &Asm, const MCAsmLayout &Layout,
@@ -1645,9 +1645,10 @@ mccasformats::v1::getSizeFromDwarfHeaderAndSkip(BinaryStreamReader &Reader) {
 /// contained in CUData, as well as the total number of bytes taken by the CU.
 /// Note: this is different from the length field of the Dwarf header, which
 /// does not account for the header size.
-static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(
-    MutableArrayRef<char> CUData, support::endianness Endian,
-    std::optional<uint32_t> NewOffset, bool SkipData) {
+static Expected<CUInfo>
+getAndSetDebugAbbrevOffsetAndSkip(MutableArrayRef<char> CUData,
+                                  support::endianness Endian,
+                                  std::optional<uint32_t> NewOffset) {
   BinaryStreamReader Reader(toStringRef(CUData), Endian);
   Expected<size_t> Size = getSizeFromDwarfHeader(Reader);
   if (!Size)
@@ -1681,13 +1682,10 @@ static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(
       return std::move(E);
   }
 
-  // Do not skip the CU length when materializing the debug info section, the CU
-  // length will be larger than the CUData length.
-  if (SkipData) {
     Reader.setOffset(AfterSizeOffset);
     if (auto E = Reader.skip(*Size))
       return std::move(E);
-  }
+
   return CUInfo{Reader.getOffset(), AbbrevOffset};
 }
 


### PR DESCRIPTION
When looking at the code in MCCASObjectV1.cpp, the function  ```getAndSetDebugAbbrevOffsetAndSkip```, is only called in one place, and the argument ```SkipData``` is always set to its default value of true, it seems like that argument is never used.

I built llvm with -fcas-backend-mode=verify with this change and it passed without an issue, safe to say this argument is not needed at all