### PR TITLE
[lldb] Increase the default timeouts when running under ASan

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -20,6 +20,11 @@ function(lldb_tablegen)
   endif()
 
   set(LLVM_TARGET_DEFINITIONS ${LTG_SOURCE})
+
+  if (LLVM_USE_SANITIZER MATCHES ".*Address.*")
+    list(APPEND LTG_UNPARSED_ARGUMENTS -DLLDB_SANITIZED)
+  endif()
+
   tablegen(LLDB ${LTG_UNPARSED_ARGUMENTS})
 
   if(LTG_TARGET)

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemoteProperties.td
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemoteProperties.td
@@ -3,7 +3,11 @@ include "../../../../include/lldb/Core/PropertiesBase.td"
 let Definition = "processgdbremote" in {
   def PacketTimeout: Property<"packet-timeout", "UInt64">,
     Global,
+#ifdef LLDB_SANITIZED
+    DefaultUnsignedValue<60>,
+#else
     DefaultUnsignedValue<5>,
+#endif
     Desc<"Specify the default packet timeout in seconds.">;
   def TargetDefinitionFile: Property<"target-definition-file", "FileSpec">,
     Global,

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -291,10 +291,18 @@ let Definition = "process" in {
     DefaultTrue,
     Desc<"If true, stop when the inferior exec's.">;
   def UtilityExpressionTimeout: Property<"utility-expression-timeout", "UInt64">,
+#ifdef LLDB_SANITIZED
+    DefaultUnsignedValue<60>,
+#else
     DefaultUnsignedValue<15>,
+#endif
     Desc<"The time in seconds to wait for LLDB-internal utility expressions.">;
   def InterruptTimeout: Property<"interrupt-timeout", "UInt64">,
+#ifdef LLDB_SANITIZED
+    DefaultUnsignedValue<60>,
+#else
     DefaultUnsignedValue<20>,
+#endif
     Desc<"The time in seconds to wait for an interrupt succeed in stopping the target.">;
   def SteppingRunsAllThreads: Property<"run-all-threads", "Boolean">,
     DefaultFalse,


### PR DESCRIPTION
Increase the default timeouts when running under ASan. We had something similar before we adopted tablegen, but the larger timeouts got lost in the transition, possibly because tablegen's preprocessor support is very limited. This patch passes a new define (LLDB_SANITIZED) to lldb-tablegen on which we can base the default value.

Differential revision: https://reviews.llvm.org/D156279

(cherry picked from commit 94e8fefe385cd3b6a4656bec244ddf9791056f0c) (cherry picked from commit 0722f29835b005bf7a5b991c0dd606b6b5e6c3c5)