### PR TITLE
[lldb] Remove spurious comment

### DIFF
--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -190,7 +190,6 @@ bool CommandObjectDWIMPrint::DoExecute(StringRef command,
   //   2. Verify the isa pointer is a known class
   //   3. Require addresses to be on the heap
   std::string modified_expr_storage;
-  // Either Swift was explicitly specified, or the frame is Swift.
   bool is_swift = language == lldb::eLanguageTypeSwift;
   if (is_swift && is_po) {
     lldb::addr_t addr;


### PR DESCRIPTION
The comment referred to a block that was moved above this function, but the comment remained.

(cherry picked from commit 0dd8550e91400eb0345549ee880a5b62e64195cb)