### PR TITLE
[clang][VarDecl] Reset un-evaluated constant for all C++ modes (#65818)

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2520,10 +2520,10 @@ APValue *VarDecl::evaluateValueImpl(SmallVectorImpl<PartialDiagnosticAt> &Notes,
   bool Result = Init->EvaluateAsInitializer(Eval->Evaluated, Ctx, this, Notes,
                                             IsConstantInitialization);
 
-  // In C++11, this isn't a constant initializer if we produced notes. In that
+  // In C++, this isn't a constant initializer if we produced notes. In that
   // case, we can't keep the result, because it may only be correct under the
   // assumption that the initializer is a constant context.
-  if (IsConstantInitialization && Ctx.getLangOpts().CPlusPlus11 &&
+  if (IsConstantInitialization && Ctx.getLangOpts().CPlusPlus &&
       !Notes.empty())
     Result = false;
 

--- a/clang/test/SemaCXX/constant-expression.cpp
+++ b/clang/test/SemaCXX/constant-expression.cpp
@@ -154,3 +154,8 @@ namespace PR31701 {
     const C c = C::n<i>;
   }
 }
+
+struct PR65784s{
+  int *ptr;
+} const PR65784[] = {(int *)""};
+PR65784s PR65784f() { return *PR65784; }


### PR DESCRIPTION
After commit 610ec954e1f8 ("[clang] allow const structs/unions/arrays to be constant expressions for C"), attempts to evaluate structs/unions/arrays as constants are also performed for C++98 and C++03.

An assertion was getting tripped up since the potentially-partially evaluated value was not being reset for those 2 language modes.  Make sure to reset it now for all C++ modes.

Fixes: #65784
(cherry picked from commit 26181544f7512eb2713243f301b712f845de13ef)