### PR TITLE
Re-add bind_generic_types threading on GetEvaluateExpressionOptions

### DIFF
--- a/lldb/source/Commands/CommandObjectExpression.cpp
+++ b/lldb/source/Commands/CommandObjectExpression.cpp
@@ -252,6 +252,10 @@ CommandObjectExpression::CommandOptions::GetEvaluateExpressionOptions(
     options.SetTimeout(std::chrono::microseconds(timeout));
   else
     options.SetTimeout(std::nullopt);
+
+  // BEGIN SWIFT
+  options.SetBindGenericTypes(bind_generic_types);
+  // END SWIFT
   return options;
 }
 


### PR DESCRIPTION
Looks like the line that threaded bind_generic_types in CommandObjectExpression::CommandOptions::GetEvaluateExpressionOptions was dropped.

rdar://115022425