### PR TITLE
[lldb] Add list of types known to use @_originallyDefinedIn

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2472,12 +2472,22 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
 
   // Demangle the mangled name.
   swift::Demangle::Demangler dem;
-  ConstString mangled_name = type.GetMangledTypeName();
+  llvm::StringRef mangled_name = type.GetMangledTypeName().GetStringRef();
   auto ts = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!ts)
     return nullptr;
+
+  // List of commonly used types known to have been been annotated with
+  // @_originallyDefinedIn to a different module.
+  static llvm::StringMap<llvm::StringRef> known_types_with_redefined_modules = {
+      {"$s14CoreFoundation7CGFloatVD", "$s12CoreGraphics7CGFloatVD"}};
+
+  auto it = known_types_with_redefined_modules.find(mangled_name);
+  if (it != known_types_with_redefined_modules.end()) 
+    mangled_name = it->second;
+
   swift::Demangle::NodePointer node =
-      module_holder->GetCanonicalDemangleTree(dem, mangled_name.GetStringRef());
+      module_holder->GetCanonicalDemangleTree(dem, mangled_name);
   if (!node)
     return nullptr;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -4175,8 +4175,6 @@ bool TypeSystemSwiftTypeRef::ShouldSkipValidation(opaque_compiler_type_t type) {
   if (mangled_name == "$sSo6CGSizeVD")
     return true;
 
-  if (mangled_name == "$s14CoreFoundation7CGFloatVD")
-    return true;
   // We skip validation when dealing with a builtin type since builtins are
   // considered type aliases by Swift, which we're deviating from since
   // SwiftASTContext reconstructs Builtin types as TypeAliases pointing to the


### PR DESCRIPTION
Types defined wit @_originallyDefinedIn have a different mangled name emitted in the debug information and in the reflection metadata. Add a map of known common types that use this feature so we can find reflection metadata for them.

rdar://106506535
(cherry picked from commit 010321d5e4d64e85db48e126770113aa3be1e413)