### PR TITLE
[llbd] Remove vestiges of GetCxxBridgedSyntheticChildProvider (NFC) (#7229)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -389,12 +389,6 @@ public:
     return {};
   }
 
-  lldb::SyntheticChildrenSP
-  GetCxxBridgedSyntheticChildProvider(ValueObjectSP valobj) {
-    STUB_LOG();
-    return {};
-  }
-
   void WillStartExecutingUserExpression(bool runs_in_playground_or_repl) {
     if (!runs_in_playground_or_repl)
       STUB_LOG();
@@ -2492,12 +2486,6 @@ bool SwiftLanguageRuntime::IsValidErrorValue(ValueObject &in_value) {
 lldb::SyntheticChildrenSP
 SwiftLanguageRuntime::GetBridgedSyntheticChildProvider(ValueObject &valobj) {
   FORWARD(GetBridgedSyntheticChildProvider, valobj);
-}
-
-lldb::SyntheticChildrenSP
-SwiftLanguageRuntime::GetCxxBridgedSyntheticChildProvider(
-    ValueObjectSP valobj) {
-  FORWARD(GetCxxBridgedSyntheticChildProvider, valobj);
 }
 
 void SwiftLanguageRuntime::WillStartExecutingUserExpression(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -459,10 +459,6 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
-  /// Get the synthetic child provider that displays Swift in C++ frames.
-  lldb::SyntheticChildrenSP
-  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
-
   /// Expression Callbacks.
   /// \{
   void WillStartExecutingUserExpression(bool);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -190,10 +190,6 @@ public:
   lldb::SyntheticChildrenSP
   GetBridgedSyntheticChildProvider(ValueObject &valobj);
 
-  /// Get the synthethic child provider that displays Swift in C++ frames.
-  lldb::SyntheticChildrenSP
-  GetCxxBridgedSyntheticChildProvider(lldb::ValueObjectSP valobj);
-
   bool IsABIStable();
 
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,


### PR DESCRIPTION
Necessary removals to build this branch.

Removed in https://github.com/apple/llvm-project/pull/6376

Linker failure:

```
ld: Undefined symbols:
  
lldb_private::SwiftLanguageRuntimeImpl::GetCxxBridgedSyntheticChildProvider(std::__1::sh
ared_ptr<lldb_private::ValueObject>), referenced from:
      
lldb_private::SwiftLanguageRuntime::GetCxxBridgedSyntheticChildProvider(std::__1::shared
_ptr<lldb_private::ValueObject>) in 
liblldbPluginSwiftLanguageRuntime.a[3](SwiftLanguageRuntime.cpp.o)
```

(cherry-picked from commit 4beceb85b8dd9fe5fea7161f0dafea9452da3a72)