### PR TITLE
[lldb] Fix wrong key string in SwiftLanguage::GetFormatterPrefixSuffix

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1459,13 +1459,13 @@ SwiftLanguage::GetFormatterPrefixSuffix(llvm::StringRef type_hint) {
   static const llvm::StringMap<
       std::pair<const llvm::StringRef, const llvm::StringRef>>
       g_affix_map = {
-          {"NSNumber::char", {"UInt8(", ")"}},
-          {"NSNumber::short", {"Int16(", ")"}},
-          {"NSNumber::int", {"Int32(", ")"}},
-          {"NSNumber::long", {"Int64(", ")"}},
-          {"NSNumber::int128_t", {"Int128(", ")"}},
-          {"NSNumber::float", {"Float(", ")"}},
-          {"NSNumber::double", {"Double(", ")"}},
+          {"NSNumber:char", {"UInt8(", ")"}},
+          {"NSNumber:short", {"Int16(", ")"}},
+          {"NSNumber:int", {"Int32(", ")"}},
+          {"NSNumber:long", {"Int64(", ")"}},
+          {"NSNumber:int128_t", {"Int128(", ")"}},
+          {"NSNumber:float", {"Float(", ")"}},
+          {"NSNumber:double", {"Double(", ")"}},
       };
 
   return g_affix_map.lookup(type_hint);


### PR DESCRIPTION
They key strings in SwiftLanguage::GetFormatterPrefixSuffix are supposed to only have only one ":" as a separator, not two.

rdar://115022612
(cherry picked from commit f2449013ff7f87a1b0be98433625aa300c5ae177)