### PR TITLE
[lldb] Print hint if object description is requested but not implemented

### DIFF
--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -325,6 +325,8 @@ public:
 
   llvm::StringRef GetAutosuggestionAnsiSuffix() const;
 
+  bool GetShowDontUsePoHint() const;
+
   bool GetUseSourceCache() const;
 
   bool SetUseSourceCache(bool use_source_cache);

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -229,6 +229,10 @@ let Definition = "debugger" in {
     Global,
     DefaultStringValue<"${ansi.normal}">,
     Desc<"When displaying suggestion in a color-enabled terminal, use the ANSI terminal code specified in this format immediately after the suggestion.">;
+  def ShowDontUsePoHint: Property<"show-dont-use-po-hint", "Boolean">,
+    Global,
+    DefaultTrue,
+    Desc<"If true, and object description was requested for a type that does not implement it, LLDB will print a hint telling the user to consider using p instead.">;
   def DWIMPrintVerbosity: Property<"dwim-print-verbosity", "Enum">,
     Global,
     DefaultEnumValue<"eDWIMPrintVerbosityNone">,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -434,6 +434,12 @@ llvm::StringRef Debugger::GetAutosuggestionAnsiSuffix() const {
       idx, g_debugger_properties[idx].default_cstr_value);
 }
 
+bool Debugger::GetShowDontUsePoHint() const {
+  const uint32_t idx = ePropertyShowDontUsePoHint;  
+  return m_collection_sp->GetPropertyAtIndexAsBoolean(nullptr,
+      idx, g_debugger_properties[idx].default_uint_value != 0);
+}
+
 bool Debugger::GetUseSourceCache() const {
   const uint32_t idx = ePropertyUseSourceCache;
   return GetPropertyAtIndexAs<bool>(

--- a/lldb/test/API/lang/objc/objc-po-hint/Makefile
+++ b/lldb/test/API/lang/objc/objc-po-hint/Makefile
@@ -1,0 +1,4 @@
+OBJC_SOURCES := main.m
+LD_EXTRAS = -lobjc -framework Foundation
+
+include Makefile.rules

--- a/lldb/test/API/lang/objc/objc-po-hint/TestObjcPoHint.py
+++ b/lldb/test/API/lang/objc/objc-po-hint/TestObjcPoHint.py
@@ -1,0 +1,49 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestObjcPoHint(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test_show_po_hint(self):
+        ### Test that the po hint is shown once with the DWIM print command
+        self.build()
+        _, _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "Set breakpoint here", lldb.SBFileSpec("main.m")
+        )
+        # Make sure the hint is printed the first time
+        self.expect(
+            "dwim-print -O -- foo",
+            substrs=[
+                "note: object description requested, but type doesn't implement "
+                'a custom object description. Consider using "p" instead of "po"',
+                "<Foo: 0x",
+            ],
+        )
+
+        # Make sure it's not printed again.
+        self.expect(
+            "dwim-print -O -- foo",
+            substrs=[
+                "note: object description"
+            ],
+            matching=False,
+        )
+
+    def test_show_po_hint_disabled(self):
+        ### Test that when the setting is disabled the hint is not printed
+        self.build()
+        _, _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "Set breakpoint here", lldb.SBFileSpec("main.m")
+        )
+        self.runCmd("setting set show-dont-use-po-hint false")
+        # Make sure the hint is printed the first time
+        self.expect(
+            "dwim-print -O -- foo",
+            substrs=[
+                "note: object description"
+            ],
+            matching=False,
+        )

--- a/lldb/test/API/lang/objc/objc-po-hint/main.m
+++ b/lldb/test/API/lang/objc/objc-po-hint/main.m
@@ -1,0 +1,22 @@
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject {}
+
+-(id) init;
+
+@end
+
+@implementation Foo
+
+-(id) init
+{
+    return self = [super init];
+}
+@end
+
+int main()
+{
+    Foo *foo = [Foo new];
+    NSLog(@"a"); // Set breakpoint here.
+    return 0;
+}


### PR DESCRIPTION
Lots of users use "po" as their default print command. If the type doesn't implement the description function the output is often not what the user wants. Print a hint telling the user that they might prefer using "p" instead.

Differential Revision: https://reviews.llvm.org/D153489

(cherry picked from commit 5f45a87bf029cc4b9815f5f819906198b07e00d1) (cherry picked from commit c963487159af7f580c1470918c29116665a2f1c9)