### PR TITLE
[lldb] Fix cherry-pick using replaced API in Debugger.cpp

### DIFF
--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -435,8 +435,8 @@ llvm::StringRef Debugger::GetAutosuggestionAnsiSuffix() const {
 }
 
 bool Debugger::GetShowDontUsePoHint() const {
-  const uint32_t idx = ePropertyShowDontUsePoHint;  
-  return m_collection_sp->GetPropertyAtIndexAsBoolean(nullptr,
+  const uint32_t idx = ePropertyShowDontUsePoHint;
+  return GetPropertyAtIndexAs<bool>(
       idx, g_debugger_properties[idx].default_uint_value != 0);
 }
 


### PR DESCRIPTION
68909d3f8b275f44ac77892f9ce53f145c3117ae cherry-picked an use of an old version of a collection method (GetPropertyAtIndexAsBoolean vs GetPropertyAtIndexAs<bool>)