### PR TITLE
[lldb] Improve handling of artificial subclasses

### DIFF
--- a/lldb/test/API/lang/swift/artificial_subclass/Makefile
+++ b/lldb/test/API/lang/swift/artificial_subclass/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
+++ b/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
@@ -1,0 +1,22 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftArtificialSubclass(TestBase):
+    @skipUnlessObjCInterop
+    @swiftTest
+    def test(self):
+        """ Test that displaying an artificial type works correctly"""
+        self.build()
+        _, _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        
+        self.expect(
+            "frame variable m",
+            substrs=["Subclass)", "Superclass", "a = 42", "b = 97"]
+        )

--- a/lldb/test/API/lang/swift/artificial_subclass/main.swift
+++ b/lldb/test/API/lang/swift/artificial_subclass/main.swift
@@ -1,0 +1,19 @@
+import ObjectiveC
+
+class Superclass {
+  let a = 42
+}
+
+class Subclass: Superclass {
+  let b = 97
+
+  override init() {
+    super.init()
+    let c: AnyClass = objc_allocateClassPair(Subclass.self, "DynamicSubclass", 0)!
+    objc_registerClassPair(c);
+    object_setClass(self, c)
+  }
+}
+
+let m = Subclass()
+print(m) // break here


### PR DESCRIPTION
An artificial subclass is a subclass which was registered at runtime, which is possible to do when Obj-C interop is enabled. Fix variables of these types being printed incorrectly.

rdar://101519300
(cherry picked from commit 58f6d82971f1049918a9040ef9f031cbd11574d5)