### PR TITLE
[lldb] Improve handling of artificial subclasses

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1080,6 +1080,11 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
     LLDBTypeInfoProvider tip(*this, *instance_ts);
     reflection_ctx->ForEachSuperClassType(
         &tip, pointer, [&](SuperClassType sc) -> bool {
+          // If the typeref is invalid, we don't want to process it (for
+          // example, this could be an artifical ObjC class).
+          if (!sc.get_typeref())
+            return false;
+
           if (!found_start) {
             // The ValueObject always points to the same class instance,
             // even when querying base classes. Drop base classes until we
@@ -1561,7 +1566,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
     }
   Log *log(GetLog(LLDBLog::Types));
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
-  const auto *typeref = reflection_ctx->ReadTypeFromInstance(instance_ptr);
+  const auto *typeref =
+      reflection_ctx->ReadTypeFromInstance(instance_ptr, true);
   if (!typeref) {
     LLDB_LOGF(log,
               "could not read typeref for type: %s (instance_ptr = 0x%" PRIx64

--- a/lldb/test/API/lang/swift/artificial_subclass/Makefile
+++ b/lldb/test/API/lang/swift/artificial_subclass/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
+++ b/lldb/test/API/lang/swift/artificial_subclass/TestSwiftArtificialSubclass.py
@@ -1,0 +1,22 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftArtificialSubclass(TestBase):
+    @skipUnlessObjCInterop
+    @swiftTest
+    def test(self):
+        """ Test that displaying an artificial type works correctly"""
+        self.build()
+        _, _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        
+        self.expect(
+            "frame variable m",
+            substrs=["Subclass)", "Superclass", "a = 42", "b = 97"]
+        )

--- a/lldb/test/API/lang/swift/artificial_subclass/main.swift
+++ b/lldb/test/API/lang/swift/artificial_subclass/main.swift
@@ -1,0 +1,19 @@
+import ObjectiveC
+
+class Superclass {
+  let a = 42
+}
+
+class Subclass: Superclass {
+  let b = 97
+
+  override init() {
+    super.init()
+    let c: AnyClass = objc_allocateClassPair(Subclass.self, "DynamicSubclass", 0)!
+    objc_registerClassPair(c);
+    object_setClass(self, c)
+  }
+}
+
+let m = Subclass()
+print(m) // break here


### PR DESCRIPTION
An artificial subclass is a subclass which was registered at runtime, which is possible to do when Obj-C interop is enabled. Fix variables of these types being printed incorrectly.

rdar://101519300
(cherry picked from commit 58f6d82971f1049918a9040ef9f031cbd11574d5)