### PR TITLE
[lldb] Fix grammar in error message emitted by IRExecutionUnit

### DIFF
--- a/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
+++ b/cross-project-tests/debuginfo-tests/dexter/dex/debugger/lldb/LLDB.py
@@ -288,6 +288,7 @@ class LLDB(DebuggerBase):
                 "use of undeclared identifier",
                 "no member named",
                 "Couldn't lookup symbols",
+                "Couldn't look up symbols",
                 "reference to local variable",
                 "invalid use of 'this' outside of a non-static member function",
             ]

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -464,7 +464,7 @@ void IRExecutionUnit::GetRunnableInfo(Status &error, lldb::addr_t &func_addr,
   if (m_failed_lookups.size()) {
     StreamString ss;
 
-    ss.PutCString("Couldn't lookup symbols:\n");
+    ss.PutCString("Couldn't look up symbols:\n");
 
     bool emitNewLine = false;
 

--- a/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
@@ -38,5 +38,5 @@ class ImportStdModule(TestBase):
         # Try to access our mock std::vector. This should fail but not crash LLDB as the
         # std::vector template should be missing from the std module.
         self.expect(
-            "expr (size_t)v.size()", substrs=["Couldn't lookup symbols"], error=True
+            "expr (size_t)v.size()", substrs=["Couldn't look up symbols"], error=True
         )

--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -90,7 +90,7 @@ class TestCase(TestBase):
             self.expect(
                 "expr const int *i = &A::int_val; *i",
                 error=True,
-                substrs=["Couldn't lookup symbols:"],
+                substrs=["Couldn't look up symbols:"],
             )
 
         # This should work on all platforms.

--- a/lldb/test/API/lang/cpp/const_static_integral_member_int128/TestConstStaticIntegralMemberInt128.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member_int128/TestConstStaticIntegralMemberInt128.py
@@ -23,14 +23,14 @@ class TestCase(TestBase):
         # for them and just treats them as normal variables (which will lead
         # to linker errors as they are not defined anywhere).
         self.expect(
-            "expr A::int128_max", error=True, substrs=["Couldn't lookup symbols:"]
+            "expr A::int128_max", error=True, substrs=["Couldn't look up symbols:"]
         )
         self.expect(
-            "expr A::uint128_max", error=True, substrs=["Couldn't lookup symbols:"]
+            "expr A::uint128_max", error=True, substrs=["Couldn't look up symbols:"]
         )
         self.expect(
-            "expr A::int128_min", error=True, substrs=["Couldn't lookup symbols:"]
+            "expr A::int128_min", error=True, substrs=["Couldn't look up symbols:"]
         )
         self.expect(
-            "expr A::uint128_min", error=True, substrs=["Couldn't lookup symbols:"]
+            "expr A::uint128_min", error=True, substrs=["Couldn't look up symbols:"]
         )

--- a/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
+++ b/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
@@ -35,19 +35,19 @@ class TestCase(TestBase):
         self.expect(
             "expr ClassWithDefaultedCtor().foo()",
             error=True,
-            substrs=["Couldn't lookup symbols:"],
+            substrs=["Couldn't look up symbols:"],
         )
 
         # FIXME: Calling deleted constructors should fail before linking.
         self.expect(
             "expr ClassWithDeletedCtor(1).value",
             error=True,
-            substrs=["Couldn't lookup symbols:"],
+            substrs=["Couldn't look up symbols:"],
         )
         self.expect(
             "expr ClassWithDeletedDefaultCtor().value",
             error=True,
-            substrs=["Couldn't lookup symbols:"],
+            substrs=["Couldn't look up symbols:"],
         )
 
     @skipIfWindows  # Can't find operator new.

--- a/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
+++ b/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
@@ -30,12 +30,12 @@ class UniqueTypesTestCase4(TestBase):
         )
         self.expect(
             "expression ns::FooDouble::value",
-            substrs=["Couldn't lookup symbols"],
+            substrs=["Couldn't look up symbols"],
             error=True,
         )
         self.expect(
             "expression ns::FooInt::value",
-            substrs=["Couldn't lookup symbols"],
+            substrs=["Couldn't look up symbols"],
             error=True,
         )
 


### PR DESCRIPTION
The error message "Couldn't lookup symbols" emitted from IRExecutionUnit
is grammatically incorrect. "Lookup" is noun when spelled without a
space. Update the error message to use the verb "look up" instead.

(cherry picked from commit a902015f543097720fed4d2c04e34daa0fdfbda7)
