### PR TITLE
Discard Intrinsic::objc_clang_arc_noop_use that was not lowered

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/IRTranslator.cpp
@@ -2216,7 +2216,9 @@ bool IRTranslator::translateKnownIntrinsic(const CallInst &CI, Intrinsic::ID ID,
   case Intrinsic::experimental_noalias_scope_decl:
   case Intrinsic::var_annotation:
   case Intrinsic::sideeffect:
-    // Discard annotate attributes, assumptions, and artificial side-effects.
+  case Intrinsic::objc_clang_arc_noop_use:
+    // Discard annotate attributes, assumptions, artificial side-effects and
+    // left over objc arc intrinsic.
     return true;
   case Intrinsic::read_volatile_register:
   case Intrinsic::read_register: {

--- a/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/FastISel.cpp
@@ -1204,6 +1204,8 @@ bool FastISel::selectIntrinsicCall(const IntrinsicInst *II) {
   case Intrinsic::assume:
   // Neither does the llvm.experimental.noalias.scope.decl intrinsic
   case Intrinsic::experimental_noalias_scope_decl:
+  // Neither does the llvm.objc.clang.arc.noop.use intrinsic.
+  case Intrinsic::objc_clang_arc_noop_use:
     return true;
   case Intrinsic::dbg_declare: {
     const DbgDeclareInst *DI = cast<DbgDeclareInst>(II);

--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -6811,8 +6811,9 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
   case Intrinsic::experimental_noalias_scope_decl:
   case Intrinsic::var_annotation:
   case Intrinsic::sideeffect:
-    // Discard annotate attributes, noalias scope declarations, assumptions, and
-    // artificial side-effects.
+  case Intrinsic::objc_clang_arc_noop_use:
+    // Discard annotate attributes, noalias scope declarations, assumptions,
+    // artificial side-effects and left over objc arc intrinsic.
     return;
 
   case Intrinsic::codeview_annotation: {


### PR DESCRIPTION
In optnone mode, we don't run ObjCARCContract pass which lowers llvm.objc.clang.arc.noop.use intrinsic.

Discard it, so we don't crash during instruction selection.

Fixes rdar://114572179