### PR TITLE
Revert "[lldb] Fix the way we set up the lldb modules infrastructure."

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -670,7 +670,6 @@ ClangModulesDeclVendor::Create(Target &target) {
       arch.GetTriple().str(),
       "-fmodules-validate-system-headers",
       "-Werror=non-modular-include-in-framework-module",
-      "-Xclang=-fincremental-extensions",
       "-Rmodule-build"};
 
   target.GetPlatform()->AddClangModuleCompilationOptions(
@@ -764,6 +763,8 @@ ClangModulesDeclVendor::Create(Target &target) {
   if (!action->BeginSourceFile(*instance,
                                instance->getFrontendOpts().Inputs[0]))
     return nullptr;
+
+  instance->getPreprocessor().enableIncrementalProcessing();
 
   instance->createASTReader();
 

--- a/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
+++ b/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             "expr @import LLDBTestModule",
             error=True,
             substrs=[
-                "module.h:4:1: error: use of undeclared identifier 'syntax_error_for_lldb_to_find'",
+                "module.h:4:1: error: unknown type name 'syntax_error_for_lldb_to_find'",
                 "syntax_error_for_lldb_to_find // comment that tests source printing",
                 "could not build module 'LLDBTestModule'",
             ],


### PR DESCRIPTION
This reverts commit c95a0c91c0de66eb1066f23c69332522656f188e.

llvm#65683 split `-fincremental-extensions` and `IncrementalProcessing` such that `IncrementalProcessing` can be used to extend the lifetime of various datastructures without parsing changes. LLDB really should not be parsing any differently to a regular compile, so switch back to using just `IncrementalProcessing`.