### PR TITLE
Older versions of clang don't implicitly elide copy

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -523,7 +523,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
                     .replayCachedResult(CacheKey, CachedResult,
                                         /*JustComputedResult*/ false)
                     .moveInto(Ret))
-    return E;
+    return std::move(E);
 
   if (Clang.getDiagnostics().hasErrorOccurred())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),


### PR DESCRIPTION
Clang is supposed to build as far back as Clang 5, which doesn't elide the copy when returning errors resulting in an `error: call to deleted constructor of 'llvm::Error'`.