### PR TITLE
[Parse] Always end translation unit

### DIFF
--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -719,8 +719,7 @@ bool Parser::ParseTopLevelDecl(DeclGroupPtrTy &Result,
 
     // Late template parsing can begin.
     Actions.SetLateTemplateParser(LateTemplateParserCallback, nullptr, this);
-    if (!PP.isIncrementalProcessingEnabled())
-      Actions.ActOnEndOfTranslationUnit();
+    Actions.ActOnEndOfTranslationUnit();
     //else don't tell Sema that we ended parsing: more input might come.
     return true;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -670,6 +670,7 @@ ClangModulesDeclVendor::Create(Target &target) {
       arch.GetTriple().str(),
       "-fmodules-validate-system-headers",
       "-Werror=non-modular-include-in-framework-module",
+      "-Xclang=-fincremental-extensions",
       "-Rmodule-build"};
 
   target.GetPlatform()->AddClangModuleCompilationOptions(
@@ -763,8 +764,6 @@ ClangModulesDeclVendor::Create(Target &target) {
   if (!action->BeginSourceFile(*instance,
                                instance->getFrontendOpts().Inputs[0]))
     return nullptr;
-
-  instance->getPreprocessor().enableIncrementalProcessing();
 
   instance->createASTReader();
 

--- a/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
+++ b/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             "expr @import LLDBTestModule",
             error=True,
             substrs=[
-                "module.h:4:1: error: unknown type name 'syntax_error_for_lldb_to_find'",
+                "module.h:4:1: error: use of undeclared identifier 'syntax_error_for_lldb_to_find'",
                 "syntax_error_for_lldb_to_find // comment that tests source printing",
                 "could not build module 'LLDBTestModule'",
             ],


### PR DESCRIPTION
The check here was added back in
68090ee7224763bf7204de4d9f9ca7edc8203d40, but shouldn't actually be needed (it was added back in purely because it was part of the original change that joined the `-fincremental-extensions` with `IncrementalProcessing`).