### PR TITLE
[lldb] Change how valobj of indirect Swift value types in C++ are extracted

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.h
@@ -26,6 +26,11 @@ bool UnsafeTypeSummaryProvider(ValueObject &valobj, Stream &stream,
 SyntheticChildrenFrontEnd *
 UnsafeTypeSyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
 
+/// Extracts a value object with a given Swift pointer type, returning a vector
+/// of it's children. The number and types of children will depend on which type
+/// of Swift pointer type the value object has.
+std::vector<lldb::ValueObjectSP>
+ExtractChildrenFromSwiftPointerValueObject(lldb::ValueObjectSP valobj_sp);
 }; // namespace swift
 }; // namespace formatters
 }; // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -223,8 +223,11 @@ public:
       std::function<CompilerType(unsigned, unsigned)> finder);
 
   /// Extract the value object which contains the Swift type's "contents".
-  /// Returns null if this is not a C++ wrapping a Swift type.
-  static lldb::ValueObjectSP
+  /// Returns None if this is not a C++ wrapping a Swift type, returns
+  /// the a pair containing the extracted value object and a boolean indicating
+  /// whether the corresponding Swift type should be a pointer (for example, if
+  /// the Swift type is a value type but the storage is behind a C pointer.
+  static std::optional<std::pair<lldb::ValueObjectSP, bool>>
   ExtractSwiftValueObjectFromCxxWrapper(ValueObject &valobj);
 
   TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,


### PR DESCRIPTION
This PR contains an NFC patch to the extraction of children from Swift pointer into a standalone function plus a patch to change how value objects of indirect Swift value types in C++ are extracted (from dereference + cast into cast + dereference).