### PR TITLE
[lldb] Change how valobj of indirect Swift value types in C++ are ext…

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -12,6 +12,7 @@
 
 #include "SwiftLanguage.h"
 
+#include "SwiftUnsafeTypes.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/ValueObject.h"
@@ -1024,9 +1025,9 @@ SwiftLanguage::GetHardcodedSynthetics() {
         return nullptr;
       }
 
-      auto swift_valobj =
+      auto maybe_swift_valobj =
           SwiftLanguageRuntime::ExtractSwiftValueObjectFromCxxWrapper(valobj);
-      if (!swift_valobj) {
+      if (!maybe_swift_valobj) {
         StreamString clang_desc;
         type.DumpTypeDescription(&clang_desc);
 
@@ -1040,9 +1041,16 @@ SwiftLanguage::GetHardcodedSynthetics() {
                   clang_desc.GetData(), swift_desc.GetData());
         return nullptr;
       }
+      auto [swift_valobj, should_wrap_in_ptr] = *maybe_swift_valobj;
+
+      CompilerType cast_target_type = swift_type;
+      if (should_wrap_in_ptr)
+        cast_target_type =
+            type_system_swift.GetPointerType(swift_type.GetOpaqueQualType());
+
       // Cast it to a Swift type since thhe swift runtime expects a Swift value
       // object.
-      auto casted_to_swift = swift_valobj->Cast(swift_type);
+      auto casted_to_swift = swift_valobj->Cast(cast_target_type);
       if (!casted_to_swift) {
         LLDB_LOGF(log, "[Matching CxxBridgedSyntheticChildProvider] - "
                        "Could not cast value object to swift type.");
@@ -1074,9 +1082,26 @@ SwiftLanguage::GetHardcodedSynthetics() {
 
       casted_to_swift->SetName(ConstString("Swift_Type"));
 
+      ValueObjectSP target_valobj;
+      if (should_wrap_in_ptr) {
+        // If we have a pointer to a Swift value type, dereference it.
+        auto children = lldb_private::formatters::swift::
+            ExtractChildrenFromSwiftPointerValueObject(casted_to_swift);
+
+        if (children.empty())
+          return nullptr;
+
+        // The pointer should only have one child: the pointee.
+        assert(children.size() == 1 &&
+               "Unexpected size for pointer's children!");
+        target_valobj = children[0];
+      } else {
+        target_valobj = casted_to_swift;
+      }
+
       SyntheticChildrenSP synth_sp =
           SyntheticChildrenSP(new ValueObjectWrapperSyntheticChildren(
-              casted_to_swift, SyntheticChildren::Flags()));
+              target_valobj, SyntheticChildren::Flags()));
       return synth_sp;
     });
     g_formatters.push_back([](lldb_private::ValueObject &valobj,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -223,8 +223,11 @@ public:
       std::function<CompilerType(unsigned, unsigned)> finder);
 
   /// Extract the value object which contains the Swift type's "contents".
-  /// Returns null if this is not a C++ wrapping a Swift type.
-  static lldb::ValueObjectSP
+  /// Returns None if this is not a C++ wrapping a Swift type, returns
+  /// the a pair containing the extracted value object and a boolean indicating
+  /// whether the corresponding Swift type should be a pointer (for example, if
+  /// the Swift type is a value type but the storage is behind a C pointer.
+  static std::optional<std::pair<lldb::ValueObjectSP, bool>>
   ExtractSwiftValueObjectFromCxxWrapper(ValueObject &valobj);
 
   TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,


### PR DESCRIPTION
…racted

Change how value objects of indirect Swift value types in C++ are extracted. By indirect Swift value type I mean a value type (structs, enums) which are stored in the C++ value object behind a pointer. Previously, LLDB would first dereference the pointer and then cast it. Now LLDB will first cast the type from C++ pointer to Swift pointer, and then dereference that pointer.

rdar://115021829
rdar://110430600
(cherry picked from commit 449db6d50231bf32de2107f569e4dd6c52dac7eb)