### PR TITLE
[unittest] Use UnorderedElementsAre for StringMap keys

### DIFF
--- a/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
+++ b/clang-tools-extra/clangd/unittests/BackgroundIndexTests.cpp
@@ -580,8 +580,9 @@ TEST_F(BackgroundIndexTest, UncompilableFiles) {
   CDB.setCompileCommand(testPath("build/../A.cc"), Cmd);
   ASSERT_TRUE(Idx.blockUntilIdleForTest());
 
-  EXPECT_THAT(Storage.keys(), ElementsAre(testPath("A.cc"), testPath("A.h"),
-                                          testPath("B.h"), testPath("C.h")));
+  EXPECT_THAT(Storage.keys(),
+              UnorderedElementsAre(testPath("A.cc"), testPath("A.h"),
+                                   testPath("B.h"), testPath("C.h")));
 
   {
     auto Shard = MSS.loadShard(testPath("A.cc"));
@@ -635,7 +636,8 @@ TEST_F(BackgroundIndexTest, CmdLineHash) {
   CDB.setCompileCommand(testPath("build/../A.cc"), Cmd);
   ASSERT_TRUE(Idx.blockUntilIdleForTest());
 
-  EXPECT_THAT(Storage.keys(), ElementsAre(testPath("A.cc"), testPath("A.h")));
+  EXPECT_THAT(Storage.keys(),
+              UnorderedElementsAre(testPath("A.cc"), testPath("A.h")));
   // Make sure we only store the Cmd for main file.
   EXPECT_FALSE(MSS.loadShard(testPath("A.h"))->Cmd);
 


### PR DESCRIPTION
(cherry picked from commit 16c8709cf61b0787cb3e4e283e158d9f86d8d6d5)