### PR TITLE
[DebugInfo] Temporarily change LDV implementation for X86

### DIFF
--- a/llvm/lib/CodeGen/LiveDebugValues/LiveDebugValues.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/LiveDebugValues.cpp
@@ -130,9 +130,10 @@ bool LiveDebugValues::runOnMachineFunction(MachineFunction &MF) {
 
 bool llvm::debuginfoShouldUseDebugInstrRef(const Triple &T) {
   // Enable by default on x86_64, disable if explicitly turned off on cmdline.
-  if (T.getArch() == llvm::Triple::x86_64 &&
-      ValueTrackingVariableLocations != cl::boolOrDefault::BOU_FALSE)
-    return true;
+  // Work around a crash in Swift async function debug info handling.
+  //if (T.getArch() == llvm::Triple::x86_64 &&
+  //    ValueTrackingVariableLocations != cl::boolOrDefault::BOU_FALSE)
+  //  return true;
 
   // Enable if explicitly requested on command line.
   return ValueTrackingVariableLocations == cl::boolOrDefault::BOU_TRUE;

--- a/llvm/test/DebugInfo/MIR/X86/live-debug-values-reg-copy.mir
+++ b/llvm/test/DebugInfo/MIR/X86/live-debug-values-reg-copy.mir
@@ -1,4 +1,4 @@
-# RUN: llc -run-pass=livedebugvalues %s -o - | FileCheck %s
+# RUN: llc -experimental-debug-variable-locations=true -run-pass=livedebugvalues %s -o - | FileCheck %s
 #
 # This test tests tracking variables value transferring from one register to another.
 # This example is altered additionally in order to test transferring from one float register

--- a/llvm/test/DebugInfo/MIR/X86/live-debug-values-stack-clobber.mir
+++ b/llvm/test/DebugInfo/MIR/X86/live-debug-values-stack-clobber.mir
@@ -1,4 +1,4 @@
-# RUN: llc -mtriple=x86_64-unknown-unknown %s -o - -run-pass=livedebugvalues | FileCheck %s
+# RUN: llc -experimental-debug-variable-locations=true -mtriple=x86_64-unknown-unknown %s -o - -run-pass=livedebugvalues | FileCheck %s
 #
 # Fix some of PR42772. Consider the code below: the arguments are forced onto
 # the stack by the FORCE_SPILL macro, and go out of liveness if the

--- a/llvm/test/DebugInfo/X86/debug-info-default-template-parameter.ll
+++ b/llvm/test/DebugInfo/X86/debug-info-default-template-parameter.ll
@@ -13,8 +13,8 @@
 ;   return 0;
 ; }
 ;
-; RUN: llc -filetype=obj -dwarf-version=4 %s -o - | llvm-dwarfdump - --debug-info | FileCheck %s --check-prefixes=DWARF-DUMP,DWARFv4
-; RUN: llc -filetype=obj -dwarf-version=4 -strict-dwarf=true %s -o - | llvm-dwarfdump - --debug-info | FileCheck %s --check-prefixes=DWARF-DUMP,STRICT
+; RUN: llc -experimental-debug-variable-locations=true -experimental-debug-variable-locations=true -filetype=obj -dwarf-version=4 %s -o - | llvm-dwarfdump - --debug-info | FileCheck %s --check-prefixes=DWARF-DUMP,DWARFv4
+; RUN: llc -experimental-debug-variable-locations=true -filetype=obj -dwarf-version=4 -strict-dwarf=true %s -o - | llvm-dwarfdump - --debug-info | FileCheck %s --check-prefixes=DWARF-DUMP,STRICT
 
 ; DWARF-DUMP:       DW_TAG_class_type
 ; DWARF-DUMP-LABEL:   DW_AT_name      ("foo<char, 3, true, 1>")

--- a/llvm/test/DebugInfo/X86/instr-ref-flag.ll
+++ b/llvm/test/DebugInfo/X86/instr-ref-flag.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -o - -stop-before=finalize-isel -march=x86-64 \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-before=finalize-isel -march=x86-64 \
 ; RUN: | FileCheck %s --check-prefixes=INSTRREFON
 ; RUN: llc %s -o - -stop-before=finalize-isel -march=x86-64 \
 ; RUN:    -experimental-debug-variable-locations=true \

--- a/llvm/test/DebugInfo/X86/instr-ref-opt-bisect.ll
+++ b/llvm/test/DebugInfo/X86/instr-ref-opt-bisect.ll
@@ -1,23 +1,23 @@
-; RUN: llc %s -o - -stop-after=livedebugvalues -opt-bisect-limit=0 \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -opt-bisect-limit=0 \
 ; RUN:   | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -opt-bisect-limit=10 \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -opt-bisect-limit=10 \
 ; RUN:   | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -opt-bisect-limit=20 \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -opt-bisect-limit=20 \
 ; RUN:   | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -opt-bisect-limit=30 \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -opt-bisect-limit=30 \
 ; RUN:   | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -opt-bisect-limit=40 \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -opt-bisect-limit=40 \
 ; RUN:   | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -opt-bisect-limit=100 \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -opt-bisect-limit=100 \
 ; RUN:   | FileCheck %s
 ;; Test fast-isel for good measure too,
-; RUN: llc %s -o - -stop-after=livedebugvalues -fast-isel=true \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -fast-isel=true \
 ; RUN:   | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -fast-isel=true \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -fast-isel=true \
 ; RUN:   -opt-bisect-limit=0 | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -fast-isel=true \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -fast-isel=true \
 ; RUN:   -opt-bisect-limit=10 | FileCheck %s
-; RUN: llc %s -o - -stop-after=livedebugvalues -fast-isel=true \
+; RUN: llc -experimental-debug-variable-locations=true %s -o - -stop-after=livedebugvalues -fast-isel=true \
 ; RUN:   -opt-bisect-limit=100 | FileCheck %s
 
 ; The function below should be optimised with the "default" optimisation level.

--- a/llvm/test/DebugInfo/X86/live-debug-values-expr-conflict.ll
+++ b/llvm/test/DebugInfo/X86/live-debug-values-expr-conflict.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -mtriple=x86_64-unknown-unknown -o - -stop-after=livedebugvalues | FileCheck %s
+; RUN: llc %s -mtriple=x86_64-unknown-unknown -o - -stop-after=livedebugvalues -experimental-debug-variable-locations=true | FileCheck %s
 ;
 ; In the C below, 'baz' is re-assigned with a value that gets salvaged, making
 ; it's dbg.value base itself on 'bar', but with a complex expression.

--- a/llvm/test/DebugInfo/X86/swift-async-entryvalues.ll
+++ b/llvm/test/DebugInfo/X86/swift-async-entryvalues.ll
@@ -1,4 +1,4 @@
-; RUN: llc -stop-after=livedebugvalues -verify-machineinstrs -march=x86-64 -o - %s | FileCheck %s
+; RUN: llc -experimental-debug-variable-locations=true -stop-after=livedebugvalues -verify-machineinstrs -march=x86-64 -o - %s | FileCheck %s
 ;
 ; CHECK: DBG_VALUE $r14, 0, {{.*}}, !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)
 ; CHECK: DBG_VALUE $r14, 0, {{.*}}, !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16)

--- a/llvm/test/DebugInfo/X86/swift-async-entryvalues2.ll
+++ b/llvm/test/DebugInfo/X86/swift-async-entryvalues2.ll
@@ -1,4 +1,4 @@
-; RUN: llc -stop-after=livedebugvalues -verify-machineinstrs -march=x86-64 -o - %s | FileCheck %s
+; RUN: llc -experimental-debug-variable-locations=true -stop-after=livedebugvalues -verify-machineinstrs -march=x86-64 -o - %s | FileCheck %s
 ;
 ; CHECK: DBG_VALUE $r14, 0, {{.*}}, !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 8, DW_OP_deref)
 ; CHECK: DBG_VALUE $r14, 0, {{.*}}, !DIExpression(DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 16, DW_OP_plus_uconst, 16)

--- a/llvm/test/DebugInfo/assignment-tracking/X86/assignment-tracking-not-enabled.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/assignment-tracking-not-enabled.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -stop-after=finalize-isel -o - \
+; RUN: llc %s -stop-after=finalize-isel -o - -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_
 
 ;; Check that SelectionDAG downgrades dbg.assigns to dbg.values if assignment

--- a/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-cfg.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-cfg.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -o - -stop-after=finalize-isel \
+; RUN: llc %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_
 
 ;; Test coalescing of contiguous fragments in adjacent location definitions.

--- a/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-simple.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/coalesce-simple.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -o - -stop-after=finalize-isel \
+; RUN: llc %s -o - -stop-after=finalize-isel -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_
 
 ;; Test coalescing of contiguous fragments in adjacent location definitions.

--- a/llvm/test/DebugInfo/assignment-tracking/X86/loop-sink.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/loop-sink.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -stop-after=finalize-isel -o - \
+; RUN: llc %s -stop-after=finalize-isel -o - -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --implicit-check-not=DBG
 
 ;; Tiny loop with a store sunk out of it:

--- a/llvm/test/DebugInfo/assignment-tracking/X86/nested-loop-frags.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/nested-loop-frags.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -stop-after=finalize-isel -o - \
+; RUN: llc %s -stop-after=finalize-isel -o - -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --implicit-check-not=DBG
 
 ;; Test a variety of block inputs and lattice configurations for the assignment

--- a/llvm/test/DebugInfo/assignment-tracking/X86/order-of-defs.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/order-of-defs.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -stop-after=finalize-isel -o - \
+; RUN: llc %s -stop-after=finalize-isel -o - -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_
 
 ;; Ensure that the order of several debug intrinsics between non-debug

--- a/llvm/test/DebugInfo/assignment-tracking/X86/use-known-value-at-early-mem-def-2.ll
+++ b/llvm/test/DebugInfo/assignment-tracking/X86/use-known-value-at-early-mem-def-2.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -stop-after=finalize-isel -o - \
+; RUN: llc %s -stop-after=finalize-isel -o - -experimental-debug-variable-locations=true \
 ; RUN: | FileCheck %s --implicit-check-not=DBG_VALUE
 
 ;; Check that sandwiching instructions between a linked store and dbg.assign


### PR DESCRIPTION
Don't use InstrRef until we can address an issue with EntryValue handling.

rdar://115309905