### PR TITLE
[lldb][testsuite] Refactor use of check_expression

### DIFF
--- a/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -24,18 +24,6 @@ class TestExpressionsInSwiftMethodsFromObjC(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        value = self.frame().EvaluateExpression(expression)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "%s expected: %s got: %s" % (
-            expression, expected_result, answer)
-        self.assertTrue(answer == expected_result, report_str)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_expressions_from_objc(self):
@@ -45,7 +33,6 @@ class TestExpressionsInSwiftMethodsFromObjC(TestBase):
             self, 'Stop here in NSObject derived class',
             lldb.SBFileSpec('main.swift'))
 
-        self.check_expression("m_computed_ivar == 5", "true")
-        self.check_expression("m_ivar", "10", use_summary=False)
-        self.check_expression("self.m_ivar == 11", "false")
-
+        lldbutil.check_expression(self, self.frame(), "m_computed_ivar == 5", "true", use_summary=True)
+        lldbutil.check_expression(self, self.frame(), "m_ivar", "10", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "self.m_ivar == 11", "false", use_summary=True)

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -24,18 +24,6 @@ class TestExpressionsInSwiftMethodsPureSwift(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        value = self.frame().EvaluateExpression(expression)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "%s expected: %s got: %s" % (
-            expression, expected_result, answer)
-        self.assertTrue(answer == expected_result, report_str)
-
     @swiftTest
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""
@@ -43,7 +31,6 @@ class TestExpressionsInSwiftMethodsPureSwift(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, 'Stop here in Pure Swift class', lldb.SBFileSpec('main.swift'))
 
-        self.check_expression("m_computed_ivar == 5", "true")
-        self.check_expression("m_ivar", "10", use_summary=False)
-        self.check_expression("self.m_ivar == 11", "false")
-
+        lldbutil.check_expression(self, self.frame(), "m_computed_ivar == 5", "true")
+        lldbutil.check_expression(self, self.frame(), "m_ivar", "10", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "self.m_ivar == 11", "false")

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -46,7 +46,7 @@ class TestExclusivitySuppression(TestBase):
         frame = thread.frames[0]
         self.assertTrue(frame, "Frame 0 is valid.")
 
-        self.check_expression(frame, "w.s.i", "8", use_summary=False)
+        lldbutil.check_expression(self, frame, "w.s.i", "8", use_summary=False)
 
     # Test that we properly handle nested expression evaluations by:
     # (1) Breaking at breakpoint 1

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -73,28 +73,14 @@ class TestExclusivitySuppression(TestBase):
 
         # Evaluate w.s.i at breakpoint 2 to check that exclusivity checking
         # is suppressed inside the nested expression
-        self.check_expression(thread.frames[0], "i", "8", use_summary=False)
+        lldbutil.check_expression(self, thread.frames[0], "i", "8", use_summary=False)
 
         # Return to breakpoint 1 and evaluate w.s.i again to check that
         # exclusivity checking is still suppressed
-        self.dbg.HandleCommand('thread ret -x')
-        self.check_expression(thread.frame[0], "w.s.i", "8", use_summary=False)
+        self.dbg.HandleCommand("thread ret -x")
+        lldbutil.check_expression(self, thread.frame[0], "w.s.i", "8", use_summary=False)
 
     def setUp(self):
         TestBase.setUp(self)
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
-
-    def check_expression(self, frame, expression, expected_result, use_summary=True):
-        value = frame.EvaluateExpression(expression)
-        self.assertTrue(value.IsValid(), expression + " returned a valid value")
-        if self.TraceOn():
-            print(value.GetSummary())
-            print(value.GetValue())
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "%s expected: %s got: %s" % (
-            expression, expected_result, answer)
-        self.assertTrue(answer == expected_result, report_str)

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -72,7 +72,7 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
                 process, breakpoints[i])
 
             self.assertTrue(len(threads) == 1)
-            lldbutil.check_expression(self.frame(), "i", str(i), use_summary=False)
+            lldbutil.check_expression(self, self.frame(), "i", str(i), use_summary=False)
 
             self.runCmd("continue")
 
@@ -108,8 +108,8 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
                 process, breakpoints[i])
 
             self.assertTrue(len(threads) == 1)
-            lldbutil.check_expression(self.frame(), "m_t", str(class_bkpts[i]), use_summary=False)
-            lldbutil.check_expression(self.frame(), "m_s.m_s", str(class_bkpts[i]), use_summary=False)
+            lldbutil.check_expression(self, self.frame(), "m_t", str(class_bkpts[i]), use_summary=False)
+            lldbutil.check_expression(self, self.frame(), "m_s.m_s", str(class_bkpts[i]), use_summary=False)
 
             self.runCmd("continue")
 

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -41,25 +41,6 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.build()
         self.do_ivar_test()
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        opts = lldb.SBExpressionOptions()
-        opts.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)
-        value = self.frame().EvaluateExpression(expression, opts)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-
-        self.assertSuccess(value.GetError(), "expression failed")
-        if self.TraceOn():
-            print(value.GetSummary())
-            print(value.GetValue())
-
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "Use summary: %d %s expected: %s got: %s" % (
-            use_summary, expression, expected_result, answer)
-        self.assertTrue(answer == expected_result, report_str)
-
     def do_test(self):
         """Test expressions in generic contexts"""
         exe_name = "a.out"
@@ -91,7 +72,7 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
                 process, breakpoints[i])
 
             self.assertTrue(len(threads) == 1)
-            self.check_expression("i", str(i), use_summary=False)
+            lldbutil.check_expression(self.frame(), "i", str(i), use_summary=False)
 
             self.runCmd("continue")
 
@@ -127,10 +108,8 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
                 process, breakpoints[i])
 
             self.assertTrue(len(threads) == 1)
-            self.check_expression(
-                "m_t", str(class_bkpts[i]), use_summary=False)
-            self.check_expression(
-                "m_s.m_s", str(class_bkpts[i]), use_summary=False)
+            lldbutil.check_expression(self.frame(), "m_t", str(class_bkpts[i]), use_summary=False)
+            lldbutil.check_expression(self.frame(), "m_s.m_s", str(class_bkpts[i]), use_summary=False)
 
             self.runCmd("continue")
 

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -24,20 +24,6 @@ class TestDefiningOverloadedFunctions(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        value = self.frame().EvaluateExpression(expression)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-        if self.TraceOn():
-            print(value.GetSummary())
-            print(value.GetValue())
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "%s expected: %s got: %s" % (
-            expression, expected_result, answer)
-        self.assertTrue(answer == expected_result, report_str)
-
     @swiftTest
     def test_simple_overload_expressions(self):
         """Test defining overloaded functions"""
@@ -51,7 +37,7 @@ class TestDefiningOverloadedFunctions(TestBase):
         error = value_obj.GetError()
         self.assertSuccess(error)
 
-        self.check_expression("$overload(10)", "1", False)
+        lldbutil.check_expression(self, self.frame(), "$overload(10)", "1", use_summary=False)
 
         # Here's the second function:
         value_obj = self.frame().EvaluateExpression(
@@ -59,6 +45,5 @@ class TestDefiningOverloadedFunctions(TestBase):
         error = value_obj.GetError()
         self.assertSuccess(error)
 
-        self.check_expression('$overload(10)', '1', False)
-        self.check_expression('$overload("some string")', '2', False)
-
+        lldbutil.check_expression(self, self.frame(), '$overload(10)', '1', use_summary=False)
+        lldbutil.check_expression(self, self.frame(), '$overload("some string")', '2', use_summary=False)

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -24,22 +24,6 @@ class TestSwiftExprInProtocolExtension(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        value = self.frame().EvaluateExpression(
-            expression, lldb.eDynamicCanRunTarget)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "%s expected: %s got: %s" % (
-            expression, expected_result, answer)
-        if answer != expected_result:
-            print(report_str)
-            print(value.GetError())
-
-        self.assertTrue(answer == expected_result, report_str)
-
     def continue_to_bkpt(self, process, bkpt):
         threads = lldbutil.continue_to_breakpoint(process, bkpt)
         self.assertTrue(len(threads) == 1)
@@ -83,9 +67,9 @@ class TestSwiftExprInProtocolExtension(TestBase):
 
         # Check that we can evaluate expressions correctly in the struct
         # method.
-        self.check_expression("self.x", "10", False)
-        self.check_expression("self.y", '"Hello world"', True)
-        self.check_expression("local_var", "111", False)
+        lldbutil.check_expression(self, self.frame(), "self.x", "10", False)
+        lldbutil.check_expression(self, self.frame(), "self.y", '"Hello world"', True)
+        lldbutil.check_expression(self, self.frame(), "local_var", "111", False)
 
         # And check that we got the type of self right:
         self_var = self.frame().EvaluateExpression(
@@ -98,16 +82,16 @@ class TestSwiftExprInProtocolExtension(TestBase):
         # Now continue to the static method and check things there:
         self.continue_to_bkpt(process, static_bkpt)
 
-        self.check_expression("self.cvar", "333", False)
-        self.check_expression("local_var", "222", False)
+        lldbutil.check_expression(self, self.frame(), "self.cvar", "333", False)
+        lldbutil.check_expression(self, self.frame(), "local_var", "222", False)
 
         # This continues to the class version:
         self.continue_to_bkpt(process, method_bkpt)
         # Check that we can evaluate expressions correctly in the struct
         # method.
-        self.check_expression("self.x", "10", False)
-        self.check_expression("self.y", '"Hello world"', True)
-        self.check_expression("local_var", "111", False)
+        lldbutil.check_expression(self, self.frame(), "self.x", "10", False)
+        lldbutil.check_expression(self, self.frame(), "self.y", '"Hello world"', True)
+        lldbutil.check_expression(self, self.frame(), "local_var", "111", False)
 
         # And check that we got the type of self right:
         self_var = self.frame().EvaluateExpression(
@@ -120,16 +104,16 @@ class TestSwiftExprInProtocolExtension(TestBase):
         # Now continue to the static method and check things there:
         self.continue_to_bkpt(process, static_bkpt)
 
-        self.check_expression("self.cvar", "333", False)
-        self.check_expression("local_var", "222", False)
+        lldbutil.check_expression(self, self.frame(), "self.cvar", "333", False)
+        lldbutil.check_expression(self, self.frame(), "local_var", "222", False)
 
         # This continues to the enum version:
         self.continue_to_bkpt(process, method_bkpt)
         # Check that we can evaluate expressions correctly in the struct
         # method.
-        self.check_expression("self.x", "10", False)
-        self.check_expression("self.y", '"Hello world"', True)
-        self.check_expression("local_var", "111", False)
+        lldbutil.check_expression(self, self.frame(), "self.x", "10", False)
+        lldbutil.check_expression(self, self.frame(), "self.y", '"Hello world"', True)
+        lldbutil.check_expression(self, self.frame(), "local_var", "111", False)
 
         # And check that we got the type of self right:
         self_var = self.frame().EvaluateExpression(
@@ -142,7 +126,5 @@ class TestSwiftExprInProtocolExtension(TestBase):
         # Now continue to the static method and check things there:
         self.continue_to_bkpt(process, static_bkpt)
 
-        self.check_expression("self.cvar", "333", False)
-        self.check_expression("local_var", "222", False)
-
-
+        lldbutil.check_expression(self, self.frame(), "self.cvar", "333", False)
+        lldbutil.check_expression(self, self.frame(), "local_var", "222", False)

--- a/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
@@ -25,20 +25,6 @@ class TestSimpleSwiftExpressions(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        value = self.frame().EvaluateExpression(expression)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-        if self.TraceOn():
-            print(value.GetSummary())
-            print(value.GetValue())
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "%s expected: %s got: %s" % (
-            expression, expected_result, answer)
-        self.assertTrue(answer == expected_result, report_str)
-
     @swiftTest
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""
@@ -53,19 +39,19 @@ class TestSimpleSwiftExpressions(TestBase):
 
         # Test simple math with constants
 
-        self.check_expression("5 + 6", "11", use_summary=False)
-        self.check_expression("is_five + is_six", "11", use_summary=False)
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(), "5 + 6", "11", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "is_five + is_six", "11", use_summary=False)
+        lldbutil.check_expression(self, self.frame(),
             "if (1 == 1) { return is_five + is_six }",
             "11",
             use_summary=False)
 
         # Test boolean operations with simple variables:
         # Bool's are currently enums, so their value is actually in the value.
-        self.check_expression("is_eleven == is_five + is_six", "true")
+        lldbutil.check_expression(self, self.frame(), "is_eleven == is_five + is_six", "true")
 
         # Try a slightly more complex container for our expression:
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             "if is_five == 5 { return is_five + is_six } else { return is_five }",
             "11",
             use_summary=False)
@@ -78,25 +64,25 @@ class TestSimpleSwiftExpressions(TestBase):
             "if is_five == 5 { return is_five + is_six } else { return false } is invalid")
 
         # Make sure we get the correct branch of a complex result expression:
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             "if is_five == 6 {return is_five} else if is_six == 5 {return is_six} ; is_eleven",
             "11",
             use_summary=False)
 
         # Make sure we can access globals:
         # Commented out till we resolve <rdar://problem/15695494> Accessing global variables causes LLVM ERROR and exit...
-        # self.check_expression ("my_global", "30")
+        # lldbutil.check_expression(self, self.frame(), "my_global", "30", use_summary=True)
 
         # Non-simple names:
         # Note: python 2 and python 3 have different default encodings.
         # This can be removed once python 2 is gone entirely.
         if sys.version_info.major == 2:
-            self.check_expression(
+            lldbutil.check_expression(self, self.frame(),
                 u"\u20ac_varname".encode("utf-8"),
                 "5",
                 use_summary=False)
         else:
-            self.check_expression(
+            lldbutil.check_expression(self, self.frame(),
                 u"\u20ac_varname",
                 "5",
                 use_summary=False)
@@ -104,48 +90,50 @@ class TestSimpleSwiftExpressions(TestBase):
         # See if we can do the same manipulations with tuples:
         # Commented out due to: <rdar://problem/15476525> Expressions with
         # tuple elements assert
-        self.check_expression("a_tuple.0 + a_tuple.1", "11", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "a_tuple.0 + a_tuple.1", "11", use_summary=False)
 
         # See if we can do some manipulations with dicts:
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             'str_int_dict["five"]! + str_int_dict["six"]!',
             "11",
             use_summary=False)
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             'int_str_dict[Int(is_five + is_six)]!',
             '"eleven"')
+
         # Commented out, touching the dict twice causes it to die, probably the same problem
         # as <rdar://problem/15306399>
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             'str_int_dict["five"] = 6; str_int_dict["five"]! + str_int_dict["six"]!',
             "12",
             use_summary=False)
 
         # See if we can use a switch statement in an expression:
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             "switch is_five { case 0..<6: return 1; case 7..<11: return 2; case _: return 4; }; 3;",
             "1",
             use_summary=False)
 
         # These ones are int-convertible and Equatable so we can do some things
         # with them anyway:
-        self.check_expression("enum_eleven", "Eleven", False)
-        self.check_expression("enum_eleven == SomeValues.Eleven", "true")
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(), "enum_eleven", "Eleven", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "enum_eleven == SomeValues.Eleven", "true", use_summary=True)
+        lldbutil.check_expression(self, self.frame(),
             "SomeValues.Five.toInt() + SomeValues.Six.toInt()",
             "11",
             use_summary=False)
-        self.check_expression(
-            "enum_eleven = .Five; return enum_eleven == .Five", "true")
+        lldbutil.check_expression(self, self.frame(),
+                                  "enum_eleven = .Five; return enum_eleven == .Five", "true", use_summary=True)
 
         # Test expressions with a simple object:
-        self.check_expression("a_obj.x", "6", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "a_obj.x", "6", use_summary=False)
+
         # Should not have to make a second object here. This is another
         # side-effect of <rdar://problem/15306399>
-        self.check_expression("a_nother_obj.y", "6.5", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "a_nother_obj.y", "6.5", use_summary=False)
 
         # Test expressions with a struct:
-        self.check_expression("b_struct.b_int", "5", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "b_struct.b_int", "5", use_summary=False)
 
         # Test expression with Chars and strings:
 
@@ -153,15 +141,15 @@ class TestSimpleSwiftExpressions(TestBase):
         #self.check_expression ("a_char", "U+0061 U+0000 u'a'")
 
         # Interpolated strings and string addition:
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             '"Five: \(is_five) " + "Six: \(is_six)"',
-            '"Five: 5 Six: 6"')
+                                  '"Five: 5 Six: 6"', use_summary=True)
 
         # Next let's try some simple array accesses:
-        self.check_expression("an_int_array[0]", "5", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "an_int_array[0]", "5", use_summary=False)
 
         # Test expression with read-only variables:
-        self.check_expression("b_struct.b_read_only == 5", "true")
+        lldbutil.check_expression(self, self.frame(), "b_struct.b_read_only == 5", "true", use_summary=True)
         failed_value = self.frame().EvaluateExpression(
             "b_struct.b_read_only = 34")
         self.assertTrue(failed_value.IsValid(),
@@ -170,12 +158,11 @@ class TestSimpleSwiftExpressions(TestBase):
                         == False, "But it is an error.")
 
         # Check a simple value in a struct:
-        self.check_expression("b_struct_2.b_int", "20", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "b_struct_2.b_int", "20", use_summary=False)
 
         # Make sure this works for properties in extensions as well:
-        self.check_expression("b_struct_2.b_float", "20.5", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "b_struct_2.b_float", "20.5", use_summary=False)
 
         # Here are a few tests of making variables in expressions:
-        self.check_expression(
+        lldbutil.check_expression(self, self.frame(),
             "var enum_six : SomeValues = SomeValues.Six; return enum_six == .Six", "true")
-

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -24,19 +24,6 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
 
     mydir = TestBase.compute_mydir(__file__)
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        opts = lldb.SBExpressionOptions()
-        opts.SetFetchDynamicValue(lldb.eDynamicCanRunTarget)
-        value = self.frame().EvaluateExpression(expression, opts)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = value.GetError()
-        self.assertEquals(answer, expected_result, report_str)
-
-
     @swiftTest
     def test_expressions_in_class_functions(self):
         """Test expressions in class func contexts"""
@@ -65,9 +52,10 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
                 process, breakpoints[i])
 
             self.assertTrue(len(threads) == 1)
-            self.check_expression("i", str(i), False)
+            lldbutil.check_expression("i", str(i), False)
+            self.check_expression(self, self.frame(), "i", str(i), use_summary=False)
             if i == 6:
-              self.check_expression("self", "a.H<Int>")
+              lldbutil.check_expression(self, self.frame(), "self", "a.H<Int>", use_summary=False)
               frame = threads[0].GetFrameAtIndex(0)
               lldbutil.check_variable(self, frame.FindVariable("self"),
                                       # FIXME: This should be '@thick a.H<Swift.Int>.Type'

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -52,8 +52,7 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
                 process, breakpoints[i])
 
             self.assertTrue(len(threads) == 1)
-            lldbutil.check_expression("i", str(i), False)
-            self.check_expression(self, self.frame(), "i", str(i), use_summary=False)
+            lldbutil.check_expression(self, self.frame(), "i", str(i), False)
             if i == 6:
               lldbutil.check_expression(self, self.frame(), "self", "a.H<Int>", use_summary=False)
               frame = threads[0].GetFrameAtIndex(0)

--- a/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
+++ b/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
@@ -32,19 +32,6 @@ class TestFilePrivate(TestBase):
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
-    def check_expression(self, expression, expected_result, use_summary=True):
-        value = self.frame().EvaluateExpression(expression)
-        self.assertTrue(value.IsValid(), expression + "returned a valid value")
-        # print value.GetSummary()
-        # print value.GetValue()
-        if use_summary:
-            answer = value.GetSummary()
-        else:
-            answer = value.GetValue()
-        report_str = "%s expected: %s got: %s" % (
-            expression, expected_result, answer)
-        self.assertTrue(answer == expected_result, report_str)
-
     @swiftTest
     def test(self):
         """Test that we find the right file-local private decls using the discriminator"""
@@ -74,14 +61,14 @@ class TestFilePrivate(TestBase):
             process, a_breakpoint)
 
         self.assertTrue(len(threads) == 1)
-        self.check_expression("privateVariable", "\"five\"")
+        lldbutil.check_expression(self, self.frame(), "privateVariable", "\"five\"", use_summary=True)
 
         process.Continue()
         threads = lldbutil.get_threads_stopped_at_breakpoint(
             process, b_breakpoint)
 
         self.assertTrue(len(threads) == 1)
-        self.check_expression("privateVariable", "3", False)
+        lldbutil.check_expression(self, self.frame(), "privateVariable", "3", use_summary=False)
 
         process.Continue()
         threads = lldbutil.get_threads_stopped_at_breakpoint(
@@ -89,7 +76,6 @@ class TestFilePrivate(TestBase):
 
         self.assertTrue(len(threads) == 1)
 
-        self.check_expression("privateVariable", None)
-        self.check_expression("privateVariable as Int", "3", False)
-        self.check_expression("privateVariable as String", "\"five\"")
-
+        lldbutil.check_expression(self, self.frame(), "privateVariable", None, use_summary=True)
+        lldbutil.check_expression(self, self.frame(), "privateVariable as Int", "3", use_summary=False)
+        lldbutil.check_expression(self, self.frame(), "privateVariable as String", "\"five\"", use_summary=True)


### PR DESCRIPTION
Several API tests were defining their own versions of `check_expression` that performed the same task. lldbutil has its own `check_expression` function and this commit replaces the self-defined `check_expression` with the lldbutil version.

Referred to in: rdar://32228544