### PR TITLE
[lldb] Reinstate default constructor for SBCommandInterpreter

### DIFF
--- a/lldb/include/lldb/API/SBCommandInterpreter.h
+++ b/lldb/include/lldb/API/SBCommandInterpreter.h
@@ -30,6 +30,7 @@ public:
     eBroadcastBitAsynchronousErrorData = (1 << 4)
   };
 
+  SBCommandInterpreter();
   SBCommandInterpreter(const lldb::SBCommandInterpreter &rhs);
 
   ~SBCommandInterpreter();
@@ -317,9 +318,8 @@ public:
 protected:
   friend class lldb_private::CommandPluginInterfaceImplementation;
 
-  SBCommandInterpreter(
-      lldb_private::CommandInterpreter *interpreter_ptr =
-          nullptr); // Access using SBDebugger::GetCommandInterpreter();
+  /// Access using SBDebugger::GetCommandInterpreter();
+  SBCommandInterpreter(lldb_private::CommandInterpreter *interpreter_ptr);
   lldb_private::CommandInterpreter &ref();
 
   lldb_private::CommandInterpreter *get();

--- a/lldb/source/API/SBCommandInterpreter.cpp
+++ b/lldb/source/API/SBCommandInterpreter.cpp
@@ -82,6 +82,10 @@ protected:
 };
 } // namespace lldb_private
 
+SBCommandInterpreter::SBCommandInterpreter() : m_opaque_ptr() {
+  LLDB_INSTRUMENT_VA(this);
+}
+
 SBCommandInterpreter::SBCommandInterpreter(CommandInterpreter *interpreter)
     : m_opaque_ptr(interpreter) {
   LLDB_INSTRUMENT_VA(this, interpreter);


### PR DESCRIPTION
The default constructor for SBCommandInterpreter was (unintentionally)
made protected in 27b6a4e63afe. The goal of the patch was to make the
constructor taking an lldb_private type protected, but due to the
presence of a default argument, this ctor also served as the default
constructor. The latter should remain public.

This commit reinstates the original behavior by removing the default
argument and having an explicit, public default constructor.

(cherry picked from commit 86f21e92ab6e422edda2c7a1da11670433ad26cb)
