### PR TITLE
[lldb] Improve logging for nonexistent AST paths

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -17,6 +17,8 @@
 #include "lldb/Core/Section.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Utility/DataBufferLLVM.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/RangeMap.h"
 #include "lldb/Utility/RegularExpression.h"
 #include "lldb/Utility/Timer.h"
@@ -1565,10 +1567,12 @@ SymbolFileDWARFDebugMap::GetASTData(lldb::LanguageType language) {
                         __FUNCTION__, file_spec.GetPath().c_str());
         }
       } else {
-        if (log)
-          log->Printf("SymbolFileDWARFDebugMap::%s() - found reference to AST "
-                      "file %s, but could not find the file, ignoring",
-                      __FUNCTION__, file_spec.GetPath().c_str());
+        for (Log *current_log : {log, GetLog(LLDBLog::Types)})
+          if (current_log)
+            current_log->Printf("SymbolFileDWARFDebugMap::%s() - ignoring "
+                                "nonexistent AST file %s - referenced from %s",
+                                __FUNCTION__, file_spec.GetPath().c_str(),
+                                m_objfile_sp->GetFileSpec().GetPath().c_str());
       }
 
       // Regardless of whether we could find the specified file, start the next


### PR DESCRIPTION
When a binary references a nonexistent .swiftmodule path, the logging to identify this issue has gone to the `dwarf` channel only. This patch makes the log also go to the `lldb` channel. When there are issues with Swift expression evaluation, it's common to look at the `lldb types` log. Nonexistent .swiftmodule paths are important to surface in the types log, because without those, expressions that involve API from the missing .swiftmodule will fail.

Additionally, this log message was reworded and adds the path of the binary that contains the nonexistent .swiftmodule path.