### PR TITLE
[clang] Update ptrauth test for type info [0 x ptr] change.

### DIFF
--- a/clang/test/CodeGenCXX/ptrauth-rtti-layout.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-rtti-layout.cpp
@@ -3,7 +3,7 @@
 
 struct A { int a; };
 
-// CHECK: @_ZTVN10__cxxabiv117__class_type_infoE = external global ptr
+// CHECK: @_ZTVN10__cxxabiv117__class_type_infoE = external global [0 x ptr]
 // CHECK: @_ZTVN10__cxxabiv117__class_type_infoE.ptrauth = private constant { ptr, i32, i64, i64 } { ptr getelementptr inbounds (ptr, ptr @_ZTVN10__cxxabiv117__class_type_infoE, i64 2), i32 2, i64 0, i64 0 }, section "llvm.ptrauth", align 8
 // CHECK: @_ZTS1A = linkonce_odr hidden constant [3 x i8] c"1A\00"
 // CHECK: @_ZTI1A = linkonce_odr hidden constant { ptr, ptr } { ptr @_ZTVN10__cxxabiv117__class_type_infoE.ptrauth, ptr inttoptr (i64 add (i64 ptrtoint (ptr @_ZTS1A to i64), i64 -9223372036854775808) to ptr) }


### PR DESCRIPTION
The upstream change was 8a2d68f6be50.

rdar://115803387