### PR TITLE
[Cherry-pick into next] Fix compilation errors with clang-10

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -563,7 +563,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
                     .replayCachedResult(CacheKey, CachedResult,
                                         /*JustComputedResult*/ false)
                     .moveInto(Ret))
-    return E;
+    return std::move(E);
 
   if (Clang.getDiagnostics().hasErrorOccurred())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -1971,7 +1971,7 @@ MCCASBuilder::createOptimizedLineSection(StringRef DebugLineStrRef) {
                                                    SubOpcode, Len,
                                                    IsEndSequence, IsRelocation);
       if (Err)
-        return Err;
+        return std::move(Err);
       if (IsRelocation) {
         // Move cursor to end of relocation and copy.
         LineTableDataReader.getRelocatedAddress(Cursor);
@@ -1996,7 +1996,7 @@ MCCASBuilder::createOptimizedLineSection(StringRef DebugLineStrRef) {
       auto Err = handleStandardOpcodesForLineTable(
           LineTableDataReader, Cursor, Opcode, IsSetFile, IsRelocation);
       if (Err)
-        return Err;
+        return std::move(Err);
       if (IsRelocation) {
         // Move cursor to end of relocation and copy.
         LineTableDataReader.getRelocatedValue(Cursor, 2);


### PR DESCRIPTION
```
commit 8e80a0623803ca3f0fc57732372e73ae857273fd
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Sep 21 10:54:55 2023 -0700

    Fix compilation errors with clang-10
```
