### PR TITLE
Revert "[lldb] Remove xfail from swift test"

### DIFF
--- a/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
@@ -30,6 +30,7 @@ class TestSwiftConsumeOperatorType(TestBase):
 
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=['aarch64'], oslist=['linux'])
+    @expectedFailureAll(bugnumber='rdar://115518559')
     @swiftTest
     def test_swift_consume_operator(self):
         """Check that we properly show variables at various points of the CFG while


### PR DESCRIPTION
This reverts commit 99f35977d2240794205659b48013b7a6e491b94b.

It is still failing on X86.