### PR TITLE
[lldb] Restore upstream implementation of ClangPersistentVariables::RemovePersistentVariable

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
@@ -120,8 +120,6 @@ private:
   uint32_t m_next_user_file_id = 0;
   // The counter used by GetNextPersistentVariableName
   uint32_t m_next_persistent_variable_id = 0;
-  /// The counter used by GetNextResultName when is_error is true.
-  uint32_t m_next_persistent_error_id;
 
   typedef llvm::DenseMap<const char *, clang::TypeDecl *>
       ClangPersistentTypeMap;


### PR DESCRIPTION
Change `ClangPersistentVariables::RemovePersistentVariable` to use the implementation of upstream lldb.

For reasons unknown to me, this version of `ClangPersistentVariables` has been supporting Swift-specific persistent variable names, such as `$R1` or `$E1`. As far as I know, this support isn't needed on the Clang side. Such variables are already supported on the Swift side, see `SwiftPersistentExpressionState`.

rdar://115829246