### PR TITLE
[ClangCAS] Fix downstream clang include-tree tests

### DIFF
--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -17,6 +17,7 @@ using namespace dependencies;
 TEST(IncludeTree, IncludeTreeScan) {
   std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  FS->setCurrentWorkingDirectory("/root");
   auto add = [&](StringRef Path, StringRef Contents) {
     FS->addFile(Path, 0, llvm::MemoryBuffer::getMemBuffer(Contents));
   };

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -248,6 +248,7 @@ TEST(DependencyScanner, ScanDepsWithFS) {
 TEST(DependencyScanner, DepScanFSWithCASProvider) {
   std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  FS->setCurrentWorkingDirectory("/root");
   StringRef Path = "a.h";
   StringRef Contents = "a";
   FS->addFile(Path, 0, llvm::MemoryBuffer::getMemBuffer(Contents));
@@ -278,6 +279,7 @@ TEST(DependencyScanner, DepScanFSWithCASProvider) {
     // cas::ObjectRef and will be able to provide it.
     DependencyScanningWorkerFilesystem DepFS(Service.getSharedCache(),
                                              new llvm::vfs::InMemoryFileSystem);
+    DepFS.setCurrentWorkingDirectory("/root");
     llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>> File =
         DepFS.openFileForRead(Path);
     ASSERT_TRUE(File);


### PR DESCRIPTION
Fix downstream clang cas tests that uses relative path without setting working directory.

rdar://115981387