### PR TITLE
Fix a bug in handling ^C at the "y/n/a" completion prompt.

### DIFF
--- a/lldb/include/lldb/Host/Editline.h
+++ b/lldb/include/lldb/Host/Editline.h
@@ -164,6 +164,10 @@ public:
   /// of Editline.
   static Editline *InstanceFor(::EditLine *editline);
 
+  static void
+  DisplayCompletions(Editline &editline,
+                     llvm::ArrayRef<CompletionResult::Completion> results);
+
   /// Sets a string to be used as a prompt, or combined with a line number to
   /// form a prompt.
   void SetPrompt(const char *prompt);

--- a/lldb/source/Host/common/Editline.cpp
+++ b/lldb/source/Host/common/Editline.cpp
@@ -940,12 +940,12 @@ PrintCompletion(FILE *output_file,
   }
 }
 
-static void
-DisplayCompletions(::EditLine *editline, FILE *output_file,
-                   llvm::ArrayRef<CompletionResult::Completion> results) {
+void Editline::DisplayCompletions(
+    Editline &editline, llvm::ArrayRef<CompletionResult::Completion> results) {
   assert(!results.empty());
 
-  fprintf(output_file, "\n" ANSI_CLEAR_BELOW "Available completions:\n");
+  fprintf(editline.m_output_file,
+          "\n" ANSI_CLEAR_BELOW "Available completions:\n");
   const size_t page_size = 40;
   bool all = false;
 
@@ -957,7 +957,7 @@ DisplayCompletions(::EditLine *editline, FILE *output_file,
   const size_t max_len = longest->GetCompletion().size();
 
   if (results.size() < page_size) {
-    PrintCompletion(output_file, results, max_len);
+    PrintCompletion(editline.m_output_file, results, max_len);
     return;
   }
 
@@ -966,17 +966,25 @@ DisplayCompletions(::EditLine *editline, FILE *output_file,
     size_t remaining = results.size() - cur_pos;
     size_t next_size = all ? remaining : std::min(page_size, remaining);
 
-    PrintCompletion(output_file, results.slice(cur_pos, next_size), max_len);
+    PrintCompletion(editline.m_output_file, results.slice(cur_pos, next_size),
+                    max_len);
 
     cur_pos += next_size;
 
     if (cur_pos >= results.size())
       break;
 
-    fprintf(output_file, "More (Y/n/a): ");
+    fprintf(editline.m_output_file, "More (Y/n/a): ");
     char reply = 'n';
-    int got_char = el_getc(editline, &reply);
-    fprintf(output_file, "\n");
+    int got_char = el_getc(editline.m_editline, &reply);
+    // Check for a ^C or other interruption.
+    if (editline.m_editor_status == EditorStatus::Interrupted) {
+      editline.m_editor_status = EditorStatus::Editing;
+      fprintf(editline.m_output_file, "^C\n");
+      break;
+    }
+
+    fprintf(editline.m_output_file, "\n");
     if (got_char == -1 || reply == 'n')
       break;
     if (reply == 'a')
@@ -1047,7 +1055,7 @@ unsigned char Editline::TabCommand(int ch) {
     return CC_REDISPLAY;
   }
 
-  DisplayCompletions(m_editline, m_output_file, results);
+  DisplayCompletions(*this, results);
 
   DisplayInput();
   MoveCursor(CursorLocation::BlockEnd, CursorLocation::EditingCursor);

--- a/lldb/test/API/iohandler/completion/TestIOHandlerCompletion.py
+++ b/lldb/test/API/iohandler/completion/TestIOHandlerCompletion.py
@@ -75,6 +75,12 @@ class IOHandlerCompletionTest(PExpectTest):
         self.child.send("n")
         self.expect_prompt()
 
+        # Start tab completion and abort showing more commands with '^C'.
+        self.child.send("\t")
+        self.child.expect_exact("More (Y/n/a)")
+        self.child.sendcontrol("c")
+        self.expect_prompt()
+
         # Shouldn't crash or anything like that.
         self.child.send("regoinvalid\t")
         self.expect_prompt()


### PR DESCRIPTION
We just forget to check for interrupt while waiting for the answer to the prompt. But if we are in the interrupt state then the lower layers of the EditLine code just eat all characters so we never get out of the query prompt. You're pretty much stuck and have to kill lldb.

The solution is to check for the interrupt. The patch is a little bigger because where I needed to check the Interrupt state I only had the ::EditLine object, but the editor state is held in lldb's EditLine wrapper, so I had to do a little work to get my hands on it.

(cherry picked from commit 0f339e6567bffb290e409ef5de272fb75ce70234)