### PR TITLE
[clang][cas] Do not unload the CAS plugin library during exit 

### DIFF
--- a/llvm/include/llvm/Support/DynamicLibrary.h
+++ b/llvm/include/llvm/Support/DynamicLibrary.h
@@ -58,8 +58,9 @@ public:
 
   /// This function permanently loads the dynamic library at the given path
   /// using the library load operation from the host operating system. The
-  /// library instance will only be closed when global destructors run, and
-  /// there is no guarantee when the library will be unloaded.
+  /// library instance will only be closed when global destructors run unless
+  /// \p CloseOnExit is false, and there is no guarantee when the library will
+  /// be unloaded.
   ///
   /// This returns a valid DynamicLibrary instance on success and an invalid
   /// instance on failure (see isValid()). \p *errMsg will only be modified if
@@ -68,15 +69,17 @@ public:
   /// It is safe to call this function multiple times for the same library.
   /// Open a dynamic library permanently.
   static DynamicLibrary getPermanentLibrary(const char *filename,
-                                            std::string *errMsg = nullptr);
+                                            std::string *errMsg = nullptr,
+                                            bool CloseOnExit = true);
 
   /// Registers an externally loaded library. The library will be unloaded
-  /// when the program terminates.
+  /// when the program terminates unless \p CloseOnExit is false.
   ///
   /// It is safe to call this function multiple times for the same library,
   /// though ownership is only taken if there was no error.
   static DynamicLibrary addPermanentLibrary(void *handle,
-                                            std::string *errMsg = nullptr);
+                                            std::string *errMsg = nullptr,
+                                            bool CloseOnExit = true);
 
   /// This function permanently loads the dynamic library at the given path.
   /// Use this instead of getPermanentLibrary() when you won't need to get
@@ -84,14 +87,16 @@ public:
   ///
   /// It is safe to call this function multiple times for the same library.
   static bool LoadLibraryPermanently(const char *Filename,
-                                     std::string *ErrMsg = nullptr) {
-    return !getPermanentLibrary(Filename, ErrMsg).isValid();
+                                     std::string *ErrMsg = nullptr,
+                                     bool CloseOnExit = true) {
+    return !getPermanentLibrary(Filename, ErrMsg, CloseOnExit).isValid();
   }
 
   /// This function loads the dynamic library at the given path, using the
   /// library load operation from the host operating system. The library
   /// instance will be closed when closeLibrary is called or global destructors
-  /// are run, but there is no guarantee when the library will be unloaded.
+  /// are run (unless \p CloseOnExit is false), but there is no guarantee when
+  /// the library will be unloaded.
   ///
   /// This returns a valid DynamicLibrary instance on success and an invalid
   /// instance on failure (see isValid()). \p *Err will only be modified if the
@@ -99,7 +104,8 @@ public:
   ///
   /// It is safe to call this function multiple times for the same library.
   static DynamicLibrary getLibrary(const char *FileName,
-                                   std::string *Err = nullptr);
+                                   std::string *Err = nullptr,
+                                   bool CloseOnExit = true);
 
   /// This function closes the dynamic library at the given path, using the
   /// library close operation of the host operating system, and there is no

--- a/llvm/lib/CAS/PluginCAS.cpp
+++ b/llvm/lib/CAS/PluginCAS.cpp
@@ -69,8 +69,10 @@ Expected<std::shared_ptr<PluginCASContext>> PluginCASContext::create(
 
   SmallString<256> PathBuf = PluginPath;
   std::string ErrMsg;
-  sys::DynamicLibrary Lib =
-      sys::DynamicLibrary::getPermanentLibrary(PathBuf.c_str(), &ErrMsg);
+  // Note: we cannot close the dynamic library, because we may have a global
+  // reference that will call llcas_cas_dispose.
+  sys::DynamicLibrary Lib = sys::DynamicLibrary::getPermanentLibrary(
+      PathBuf.c_str(), &ErrMsg, /*CloseOnExit=*/false);
   if (!Lib.isValid())
     return reportError(ErrMsg);
 

--- a/llvm/lib/Support/Unix/DynamicLibrary.inc
+++ b/llvm/lib/Support/Unix/DynamicLibrary.inc
@@ -15,8 +15,9 @@
 
 DynamicLibrary::HandleSet::~HandleSet() {
   // Close the libraries in reverse order.
-  for (void *Handle : llvm::reverse(Handles))
-    ::dlclose(Handle);
+  for (HandleState HS : llvm::reverse(Handles))
+    if (HS.CloseOnExit)
+      ::dlclose(HS.Handle);
   if (Process)
     ::dlclose(Process);
 

--- a/llvm/lib/Support/Windows/DynamicLibrary.inc
+++ b/llvm/lib/Support/Windows/DynamicLibrary.inc
@@ -22,8 +22,9 @@
 //===----------------------------------------------------------------------===//
 
 DynamicLibrary::HandleSet::~HandleSet() {
-  for (void *Handle : llvm::reverse(Handles))
-    FreeLibrary(HMODULE(Handle));
+  for (HandleState HS : llvm::reverse(Handles))
+    if (HS.CloseOnExit)
+      FreeLibrary(HMODULE(HS.Handle));
 
   // 'Process' should not be released on Windows.
   assert((!Process || Process == this) && "Bad Handle");


### PR DESCRIPTION
There may be a global reference to the CAS that will try to call
cas_dispose, so we must not unload the library before that happens (and
the order is unspecified).

rdar://116235144