### PR TITLE
[clang] set DebugCompilationDir in PCHContainer

### DIFF
--- a/clang/lib/CodeGen/ObjectFilePCHContainerOperations.cpp
+++ b/clang/lib/CodeGen/ObjectFilePCHContainerOperations.cpp
@@ -163,6 +163,8 @@ public:
     CodeGenOpts.setDebugInfo(llvm::codegenoptions::FullDebugInfo);
     CodeGenOpts.setDebuggerTuning(CI.getCodeGenOpts().getDebuggerTuning());
     CodeGenOpts.DwarfVersion = CI.getCodeGenOpts().DwarfVersion;
+    CodeGenOpts.DebugCompilationDir =
+        CI.getInvocation().getCodeGenOpts().DebugCompilationDir;
     CodeGenOpts.DebugPrefixMap =
         CI.getInvocation().getCodeGenOpts().DebugPrefixMap;
     CodeGenOpts.DebugStrictDwarf = CI.getCodeGenOpts().DebugStrictDwarf;

--- a/clang/test/Modules/module-debuginfo-compdir.m
+++ b/clang/test/Modules/module-debuginfo-compdir.m
@@ -1,0 +1,24 @@
+// UNSUPPORTED: target={{.*}}-zos{{.*}}, target={{.*}}-aix{{.*}}
+// REQUIRES: asserts
+
+// Modules:
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -x objective-c -fmodules -fmodule-format=obj \
+// RUN:   -fdebug-compilation-dir=/OVERRIDE \
+// RUN:   -fimplicit-module-maps -DMODULES -fmodules-cache-path=%t %s \
+// RUN:   -I %S/Inputs -I %t -emit-llvm -o %t.ll \
+// RUN:   -mllvm -debug-only=pchcontainer &>%t-mod.ll
+// RUN: cat %t-mod.ll | FileCheck %s
+
+// PCH:
+// RUN: %clang_cc1 -x objective-c -emit-pch -fmodule-format=obj -I %S/Inputs \
+// RUN:   -fdebug-compilation-dir=/OVERRIDE \
+// RUN:   -o %t.pch %S/Inputs/DebugObjC.h \
+// RUN:   -mllvm -debug-only=pchcontainer &>%t-pch.ll
+// RUN: cat %t-pch.ll | FileCheck %s
+
+#ifdef MODULES
+@import DebugObjC;
+#endif
+
+// CHECK: !DIFile(filename: "{{.*}}DebugObjC{{(\.h)?}}", directory: "/OVERRIDE")


### PR DESCRIPTION
This change sets the debug compilation directory when generating debug information for PCH object containers. This allows for overriding the compilation directory in debug information in precompiled pcm files.

This is a cherry pick of https://github.com/llvm/llvm-project/pull/67744