### PR TITLE
[clang][cas] Remove unsafe global CAS object from clang-scan-deps

### DIFF
--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -96,7 +96,9 @@ static bool Verbose;
 static bool PrintTiming;
 static std::vector<const char *> CommandLine;
 static bool EmitCASCompDB;
-static CASOptions CASOpts;
+static std::string OnDiskCASPath;
+static std::string CASPluginPath;
+static std::vector<std::pair<std::string, std::string>> CASPluginOptions;
 static bool InMemoryCAS;
 static std::string PrefixMapToolchain;
 static std::string PrefixMapSDK;
@@ -220,12 +222,12 @@ static void ParseArgs(int argc, char **argv) {
   InMemoryCAS = Args.hasArg(OPT_in_memory_cas);
 
   if (const llvm::opt::Arg *A = Args.getLastArg(OPT_cas_path_EQ))
-    CASOpts.CASPath = A->getValue();
+    OnDiskCASPath = A->getValue();
   if (const llvm::opt::Arg *A = Args.getLastArg(OPT_fcas_plugin_path_EQ))
-    CASOpts.PluginPath = A->getValue();
+    CASPluginPath = A->getValue();
   for (const llvm::opt::Arg *A : Args.filtered(OPT_fcas_plugin_option_EQ)) {
     auto [L, R] = StringRef(A->getValue()).split('=');
-    CASOpts.PluginOptions.emplace_back(std::string(L), std::string(R));
+    CASPluginOptions.emplace_back(std::string(L), std::string(R));
   }
 
   if (const llvm::opt::Arg *A = Args.getLastArg(OPT_prefix_map_toolchain_EQ))
@@ -563,7 +565,7 @@ static bool outputFormatRequiresCAS() {
 }
 
 static bool useCAS() {
-  return InMemoryCAS || !CASOpts.CASPath.empty() || outputFormatRequiresCAS();
+  return InMemoryCAS || !OnDiskCASPath.empty() || outputFormatRequiresCAS();
 }
 
 static llvm::json::Array toJSONSorted(const llvm::StringSet<> &Set) {
@@ -1129,6 +1131,11 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
       llvm::errs(), new DiagnosticOptions(), false);
   DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
   Diags.setClient(DiagsConsumer.get(), /*ShouldOwnClient=*/false);
+
+  CASOptions CASOpts;
+  CASOpts.CASPath = OnDiskCASPath;
+  CASOpts.PluginPath = CASPluginPath;
+  CASOpts.PluginOptions = CASPluginOptions;
 
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;


### PR DESCRIPTION
When using a plugin CAS, the global destruction may cause crashes if we have a global CAS object.

rdar://116235144