### PR TITLE
[5.10][lldb][CMake] Update for swift-syntax FetchContent changes

### DIFF
--- a/lldb/CMakeLists.txt
+++ b/lldb/CMakeLists.txt
@@ -49,21 +49,6 @@ if (LLDB_ENABLE_SWIFT_SUPPORT)
   endif()
 endif()
 
-# When we have the early SwiftSyntax build, we can include its parser.
-if (LLDB_ENABLE_SWIFT_SUPPORT)
-  if(SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR)
-    set(SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS
-      ${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/cmake/SwiftSyntaxTargets.cmake)
-    if(NOT EXISTS "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS}")
-      message(STATUS "Skipping Swift Swift parser integration due to missing early SwiftSyntax")
-    else()
-      set(SWIFT_SWIFT_PARSER TRUE)
-      include(${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_TARGETS})
-    endif()
-  endif()
-endif()
-# END - Swift Mods
-
 # Define the LLDB_CONFIGURATION_xxx matching the build type.
 if(uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
   add_definitions(-DLLDB_CONFIGURATION_DEBUG)

--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -164,7 +164,7 @@ function(add_properties_for_swift_modules target reldir)
   endif()
 
   if (NOT BOOTSTRAPPING_MODE)
-    if (SWIFT_SWIFT_PARSER)
+    if (SWIFT_BUILD_SWIFT_SYNTAX)
       set(APSM_BOOTSTRAPPING_MODE "HOSTTOOLS")
     endif()
   else()
@@ -206,7 +206,7 @@ function(add_properties_for_swift_modules target reldir)
         ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/Windows/x86_64)
     endif()
 
-    if (SWIFT_SWIFT_PARSER)
+    if (SWIFT_BUILD_SWIFT_SYNTAX)
       if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
         set_property(TARGET ${target}
           APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")

--- a/lldb/tools/lldb-server/CMakeLists.txt
+++ b/lldb/tools/lldb-server/CMakeLists.txt
@@ -69,7 +69,7 @@ target_include_directories(lldb-server PRIVATE "${LLDB_SOURCE_DIR}/source")
 target_link_libraries(lldb-server PRIVATE ${LLDB_SYSTEM_LIBS})
 
 # BEGIN Swift Mods
-if(SWIFT_SWIFT_PARSER)
+if(SWIFT_BUILD_SWIFT_SYNTAX)
   add_properties_for_swift_modules(lldb-server "../")
 endif()
 # END Swift Mods

--- a/lldb/unittests/CMakeLists.txt
+++ b/lldb/unittests/CMakeLists.txt
@@ -43,7 +43,7 @@ function(add_lldb_unittest test_name)
   target_link_libraries(${test_name} PRIVATE ${ARG_LINK_LIBS})
 
   # BEGIN Swift Mods
-  if(SWIFT_SWIFT_PARSER)
+  if(SWIFT_BUILD_SWIFT_SYNTAX)
     add_properties_for_swift_modules(${test_name} "../")
   endif()
 # END Swift Mods


### PR DESCRIPTION
cherry-pick #7424 into `swift/release/5.10`

* **Explanation**: Build the `swift-syntax` host libraries using FetchContent rather than early-swiftsyntax. This simplifies the overall toolchain build process and fix the issues we've seen caused by swift-syntax not being rebuilt. We should be able to use this to fix cross-compiling on Linux
* **Scope**: Build system
* **Risk**: Mid, since we update the build mechanism. But removes some nasty hacks.
* **Testing**: Passes the current test suite
* **Issues**: rdar://115439072
* **Reviewer**: Ben Barham (@bnbarham)