### PR TITLE
[lldb] Remove XFAIL from xmm/ymm-related tests

### DIFF
--- a/lldb/test/Shell/Register/x86-64-write.test
+++ b/lldb/test/Shell/Register/x86-64-write.test
@@ -1,9 +1,3 @@
-# xfail with system debugserver until the fix for
-# https://reviews.llvm.org/D123269 in
-# lldb/tools/debugserver/source/MacOSX/x86_64/DNBArchImplX86_64.cpp
-# has made it into released tools.
-# XFAIL: system-debugserver
-
 # XFAIL: system-windows
 # REQUIRES: native && target-x86_64
 # RUN: %clangxx_host %p/Inputs/x86-64-write.cpp -o %t


### PR DESCRIPTION
These were added in 4d3cc27831383 but are no longer needed in swift-ci. The debugserver is new enough for these tests to pass.

(cherry picked from commit 71173d2900065afab8b31473701c7c51ba8d8282)