### PR TITLE
[DebugInfo] Remove code that was missed during revert eee1f7cef8562.

### DIFF
--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -348,13 +348,10 @@ DIDerivedType *DIBuilder::createTypedef(DIType *Ty, StringRef Name,
                                         DIScope *Context, uint32_t AlignInBits,
                                         DINode::DIFlags Flags,
                                         DINodeArray Annotations) {
-  auto *T =
-      DIDerivedType::get(VMContext, dwarf::DW_TAG_typedef, Name, File, LineNo,
-                         getNonCompileUnitScope(Context), Ty, 0, AlignInBits, 0,
-                         std::nullopt, std::nullopt, Flags, nullptr, Annotations);
-  if (isa_and_nonnull<DILocalScope>(Context))
-    getSubprogramNodesTrackingVector(Context).emplace_back(T);
-  return T;
+  return DIDerivedType::get(VMContext, dwarf::DW_TAG_typedef, Name, File,
+                            LineNo, getNonCompileUnitScope(Context), Ty, 0,
+                            AlignInBits, 0, std::nullopt, std::nullopt, Flags,
+                            nullptr, Annotations);
 }
 
 DIDerivedType *DIBuilder::createFriend(DIType *Ty, DIType *FriendTy) {


### PR DESCRIPTION
This code should have been removed as part of revert eee1f7cef8562.

This should fix the test failure in https://smooshbase.apple.com/ci/view/BuildWrangler/job/apple-clang-stage1-RA-next/

rdar://116346936 ([blue dragon][apple-clang-stage1-RA-next]  Clang.CodeGenCXX.debug-info-nodebug.cpp)