### PR TITLE
cherry-pick llvm-cas-object-format to stable

### DIFF
--- a/clang/test/CAS/cached-diags-scratch-space.c
+++ b/clang/test/CAS/cached-diags-scratch-space.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+// RUN: llvm-cas --cas %t/cas --ingest %s > %t/casid
 
 // Check that this doesn't crash and provides proper round-tripping.
 

--- a/clang/test/CAS/cas-backend.c
+++ b/clang/test/CAS/cas-backend.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+// RUN: llvm-cas --cas %t/cas --ingest %s > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-backend \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \

--- a/clang/test/CAS/fcache-compile-job-dependency-file.c
+++ b/clang/test/CAS/fcache-compile-job-dependency-file.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t/src
-// RUN: llvm-cas --cas %t/cas --ingest --data %t/src > %t/casid
+// RUN: llvm-cas --cas %t/cas --ingest %t/src > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
@@ -58,7 +58,7 @@
 // DEPS_SYS: sys.h
 
 // Using another cas path to avoid reusing artifacts.
-// RUN: llvm-cas --cas %t/cas2 --ingest --data %t/src
+// RUN: llvm-cas --cas %t/cas2 --ingest %t/src
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas2 -fcas-fs @%t/casid -fcache-compile-job \

--- a/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
+++ b/clang/test/CAS/fcache-compile-job-serialized-diagnostics.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+// RUN: llvm-cas --cas %t/cas --ingest %s > %t/casid
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas \
 // RUN:   -fcas-fs @%t/casid -fcache-compile-job \

--- a/clang/test/CAS/fcache-compile-job.c
+++ b/clang/test/CAS/fcache-compile-job.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+// RUN: llvm-cas --cas %t/cas --ingest %s > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
@@ -35,7 +35,7 @@
 
 // Check for a handling error if the CAS is removed but not action cache.
 // First need to ingest the input file so the compile cache can be constructed.
-// RUN: llvm-cas --ingest --cas %t/cas.new --data %s
+// RUN: llvm-cas --ingest --cas %t/cas.new  %s
 // Add the 'key => result' association we got earlier.
 // RUN: llvm-cas --cas %t/cas.new --put-cache-key @%t/cache-key @%t/cache-result
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \

--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -6,7 +6,7 @@
 // RUN: rm -rf %t %t.cas %t.cas_2
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest %t > %t/casid
 
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fno-implicit-modules \

--- a/clang/test/CAS/fmodule-file-cache-key-lazy.c
+++ b/clang/test/CAS/fmodule-file-cache-key-lazy.c
@@ -6,7 +6,7 @@
 // RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest %t > %t/casid
 
 // == Build B
 

--- a/clang/test/CAS/fmodule-file-cache-key-with-pch.c
+++ b/clang/test/CAS/fmodule-file-cache-key-with-pch.c
@@ -7,7 +7,7 @@
 // RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest %t > %t/casid
 
 // == Build B
 
@@ -63,7 +63,7 @@
 // == Clear pcms to ensure they load from cache, and re-ingest with pch
 
 // RUN: rm %t/*.pcm
-// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest %t > %t/casid
 // RUN: rm %t/*.pch
 
 // == Build tu

--- a/clang/test/CAS/fmodule-file-cache-key.c
+++ b/clang/test/CAS/fmodule-file-cache-key.c
@@ -6,7 +6,7 @@
 // RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
 
-// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest %t > %t/casid
 
 // == Build B
 

--- a/clang/test/CAS/output-path-create-directories.c
+++ b/clang/test/CAS/output-path-create-directories.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t %t.cas
 // RUN: split-file %s %t
-// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest %t > %t/casid
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=Mod -fno-implicit-modules \

--- a/clang/test/CAS/output-path-error.c
+++ b/clang/test/CAS/output-path-error.c
@@ -3,7 +3,7 @@
 // REQUIRES: shell
 
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+// RUN: llvm-cas --cas %t/cas --ingest %s > %t/casid
 
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -1,7 +1,7 @@
 // REQUIRES: shell
 
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: llvm-cas --cas %t/cas --ingest --data %s > %t/casid
+// RUN: llvm-cas --cas %t/cas --ingest %s > %t/casid
 //
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
@@ -60,7 +60,7 @@
 // RUN: clang-cas-test -print-include-tree -cas %t/cas @%t/include-tree-id | FileCheck %s -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
 
 // Print key from plugin CAS.
-// RUN: llvm-cas --cas plugin://%llvmshlibdir/libCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ingest --data %s > %t/casid-plugin
+// RUN: llvm-cas --cas plugin://%llvmshlibdir/libCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ingest %s > %t/casid-plugin
 // RUN: %clang -cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fcas-path %t/cas-plugin -fcas-fs @%t/casid-plugin -fcache-compile-job \
 // RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \

--- a/clang/test/CAS/test-for-deterministic-module.c
+++ b/clang/test/CAS/test-for-deterministic-module.c
@@ -2,7 +2,7 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: llvm-cas --cas %t.cas --ingest --data %t > %t/casid
+// RUN: llvm-cas --cas %t.cas --ingest %t > %t/casid
 //
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fmodule-name=A -fno-implicit-modules \

--- a/llvm/test/CAS/Inputs/cas-creation-stress-test.sh
+++ b/llvm/test/CAS/Inputs/cas-creation-stress-test.sh
@@ -16,7 +16,7 @@ for c in $(seq 1 $NUM_REPEAT); do
 
   pids=""
   for x in $(seq 1 10); do
-    $LLVM_CAS_TOOL --ingest --data $INGEST_FILE --cas $CAS_PATH &
+    $LLVM_CAS_TOOL --ingest $INGEST_FILE --cas $CAS_PATH &
     pids="$pids $!"
   done
 

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -75,6 +75,7 @@ set(LLVM_TEST_DEPENDS
           llvm-bitcode-strip
           llvm-c-test
           llvm-cas
+          llvm-cas-object-format
           llvm-cas-dump
           llvm-cat
           llvm-cfi-verify

--- a/llvm/test/tools/llvm-cas-object-format/materialize-objects.s
+++ b/llvm/test/tools/llvm-cas-object-format/materialize-objects.s
@@ -1,0 +1,13 @@
+// REQUIRES: x86-registered-target
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: llvm-mc -cas %t/cas -cas-backend -mccas-casid -triple x86_64-apple-darwin10 %s -filetype=obj -o %t/test.o
+// RUN: cd %t && llvm-cas --ingest --cas %t/cas --casid-file %t/test.o > %t/output.casid
+// RUN: llvm-cas-object-format --cas %t/cas --materialize-objects --output-prefix %t/output @%t/output.casid 
+
+        .text
+_foo:
+        ret
+
+_baz:
+        call _foo
+        ret

--- a/llvm/test/tools/llvm-cas/ingest-blobs-casid.test
+++ b/llvm/test/tools/llvm-cas/ingest-blobs-casid.test
@@ -1,0 +1,82 @@
+; REQUIRES: aarch64-registered-target
+; RUN: rm -rf %t && mkdir -p %t
+; RUN: split-file %s %t
+
+; RUN: llc --filetype=obj %t/a.ll -o %t/a.o
+; RUN: llc --filetype=obj %t/b.ll -o %t/b.o
+; RUN: llvm-cas --ingest %t/a.o %t/b.o --cas %t/cas > %t/just-blobs.id
+; RUN: llvm-cas-dump --cas %t/cas --object-stats - @%t/just-blobs.id | FileCheck %s --check-prefix=JUST-BLOBS
+
+; JUST-BLOBS: Kind                        Count            Parents           Children           Data (B)           Cost (B)        
+; JUST-BLOBS-NEXT: ====                        =====            =======           ========           ========           ========        
+; JUST-BLOBS-NEXT: builtin:node
+; JUST-BLOBS-NEXT: builtin:tree
+; JUST-BLOBS-NEXT: TOTAL
+
+; RUN: llc --filetype=obj --cas-backend --cas=%t/cas --mccas-casid --mtriple=arm64-apple-darwin %t/a.ll -o %t/a.id
+; RUN: llc --filetype=obj --cas-backend --cas=%t/cas --mccas-casid --mtriple=arm64-apple-darwin %t/b.ll -o %t/b.id
+; RUN: llvm-cas --ingest --casid-file %t/a.id %t/b.id --cas %t/cas > %t/casid-file.id
+; RUN: llvm-cas-dump --cas %t/cas --object-stats - @%t/casid-file.id | FileCheck %s --check-prefix=CASID-FILE
+
+; CASID-FILE: Kind                        Count            Parents           Children           Data (B)           Cost (B)        
+; CASID-FILE-NEXT: ====                        =====            =======           ========           ========           ========        
+; CASID-FILE-NEXT: builtin:node
+; CASID-FILE-NEXT: builtin:tree
+; CASID-FILE-NEXT: mc:addends
+; CASID-FILE-NEXT: mc:assembler
+; CASID-FILE-NEXT: mc:atom
+; CASID-FILE-NEXT: mc:cstring
+; CASID-FILE-NEXT: mc:data
+; CASID-FILE-NEXT: mc:data_in_code
+; CASID-FILE-NEXT: mc:group
+; CASID-FILE-NEXT: mc:header
+; CASID-FILE-NEXT: mc:padding
+; CASID-FILE-NEXT: mc:section
+; CASID-FILE-NEXT: mc:symbol_table
+; CASID-FILE-NEXT: TOTAL
+
+;--- a.ll
+; ModuleID = '/tmp/a.cpp'
+source_filename = "/tmp/a.cpp"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx14.0.0"
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define noundef i32 @_Z3foov() #0 {
+entry:
+  ret i32 1
+}
+
+attributes #0 = { mustprogress noinline nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+crc,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+sha3,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 1}
+!3 = !{i32 7, !"frame-pointer", i32 1}
+!4 = !{!"clang version 18.0.0 (git@github.com:apple/llvm-project.git d3fd8ffd82db3374b06bfd2e30a85cf05916f565)"}
+
+;--- b.ll
+; ModuleID = '/tmp/b.cpp'
+source_filename = "/tmp/b.cpp"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx14.0.0"
+
+; Function Attrs: mustprogress noinline nounwind optnone ssp uwtable(sync)
+define noundef i32 @_Z3barv() #0 {
+entry:
+  ret i32 1
+}
+
+attributes #0 = { mustprogress noinline nounwind optnone ssp uwtable(sync) "frame-pointer"="non-leaf" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="apple-m1" "target-features"="+aes,+crc,+dotprod,+fp-armv8,+fp16fml,+fullfp16,+lse,+neon,+ras,+rcpc,+rdm,+sha2,+sha3,+v8.1a,+v8.2a,+v8.3a,+v8.4a,+v8.5a,+v8a,+zcm,+zcz" }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 1}
+!3 = !{i32 7, !"frame-pointer", i32 1}
+!4 = !{!"clang version 18.0.0 (git@github.com:apple/llvm-project.git d3fd8ffd82db3374b06bfd2e30a85cf05916f565)"}

--- a/llvm/test/tools/llvm-cas/ingest-remap.test
+++ b/llvm/test/tools/llvm-cas/ingest-remap.test
@@ -1,6 +1,6 @@
 RUN: rm -rf %t && mkdir -p %t
 
-RUN: llvm-cas --cas %t/cas --ingest --prefix-map %S/Inputs=/^input --data %S/Inputs > %t/cas.id
+RUN: llvm-cas --cas %t/cas --ingest --prefix-map %S/Inputs=/^input %S/Inputs > %t/cas.id
 RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/cas.id | FileCheck %s
 
 CHECK: syml

--- a/llvm/test/tools/llvm-cas/ingest.test
+++ b/llvm/test/tools/llvm-cas/ingest.test
@@ -1,11 +1,11 @@
 RUN: rm -rf %t
 RUN: mkdir %t
 
-RUN: llvm-cas --cas %t/cas --ingest --data %S/Inputs > %t/cas.id
+RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
 RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/cas.id | FileCheck %s
 
 // Using the plugin.
-RUN: llvm-cas --cas plugin://%llvmshlibdir/libCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ingest --data %S/Inputs > %t/cas-plugin.id
+RUN: llvm-cas --cas plugin://%llvmshlibdir/libCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ingest %S/Inputs > %t/cas-plugin.id
 RUN: llvm-cas --cas plugin://%llvmshlibdir/libCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ls-tree-recursive @%t/cas-plugin.id | FileCheck %s
 RUN: llvm-cas --cas %t/cas-plugin -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext --ls-tree-recursive @%t/cas-plugin.id | FileCheck %s
 

--- a/llvm/test/tools/llvm-cas/print-id.test
+++ b/llvm/test/tools/llvm-cas/print-id.test
@@ -1,7 +1,7 @@
 RUN: rm -rf %t
 RUN: mkdir %t
 
-RUN: llvm-cas --cas %t/cas --ingest --data %S/Inputs > %t/id
+RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/id
 
 # Confirm that the ID has the right prefix, is well-formed, and that there's
 # nothing else on the line.

--- a/llvm/tools/llvm-cas-object-format/CMakeLists.txt
+++ b/llvm/tools/llvm-cas-object-format/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  CAS
+  RemoteCachingService
+  MCCAS
+  )
+
+add_llvm_tool(llvm-cas-object-format
+  llvm-cas-object-format.cpp
+  )

--- a/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
+++ b/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
@@ -1,0 +1,106 @@
+//===- llvm-cas-object-format.cpp - Tool for the CAS object format --------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/TreeSchema.h"
+#include "llvm/MCCAS/MCCASObjectV1.h"
+#include "llvm/RemoteCachingService/RemoteCachingService.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileOutputBuffer.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+cl::opt<std::string> CASPath("cas", cl::desc("Path to CAS on disk."));
+cl::list<std::string> InputFiles(cl::Positional, cl::desc("Input object"));
+cl::opt<bool> Silent("silent", cl::desc("only print final CAS ID"));
+cl::opt<std::string> OutputPrefix("output-prefix",
+                                  cl::desc("output object file prefix"),
+                                  cl::init("."));
+
+enum InputKind {
+  MaterializeObjects,
+};
+
+cl::opt<InputKind> InputFileKind(
+    cl::desc("choose input kind and action:"),
+    cl::values(clEnumValN(MaterializeObjects, "materialize-objects",
+                          "materialize objects from CAS tree")),
+    cl::init(InputKind::MaterializeObjects));
+
+static Error materializeObjectsFromCASTree(ObjectStore &CAS, ObjectProxy ID);
+
+int main(int argc, char *argv[]) {
+  ExitOnError ExitOnErr;
+  ExitOnErr.setBanner(std::string(argv[0]) + ": ");
+
+  RegisterGRPCCAS Y;
+  cl::ParseCommandLineOptions(argc, argv);
+
+  std::shared_ptr<ObjectStore> CAS =
+      ExitOnErr(createCASFromIdentifier(CASPath));
+
+  for (StringRef IF : InputFiles) {
+    ExitOnError ExitOnErr;
+    ExitOnErr.setBanner(("llvm-cas-object-format: " + IF + ": ").str());
+
+    switch (InputFileKind) {
+
+    case MaterializeObjects: {
+      auto ID = ExitOnErr(CAS->parseID(IF));
+      auto Proxy = ExitOnErr(CAS->getProxy(ID));
+      ExitOnErr(materializeObjectsFromCASTree(*CAS, Proxy));
+      return 0;
+    }
+    }
+  }
+}
+
+static Error materializeObjectsFromCASTree(ObjectStore &CAS, ObjectProxy ID) {
+  TreeSchema Schema(CAS);
+  return Schema.walkFileTreeRecursively(
+      CAS, ID.getRef(),
+      [&](const NamedTreeEntry &Entry, std::optional<TreeProxy>) -> Error {
+        if (Entry.getKind() != TreeEntry::Regular &&
+            Entry.getKind() != TreeEntry::Tree) {
+          return createStringError(inconvertibleErrorCode(),
+                                   "found non-regular entry: " +
+                                       Entry.getName());
+        }
+        SmallString<256> OutputPath(OutputPrefix);
+        StringRef ObjFileName = Entry.getName();
+        ObjFileName.consume_back(".casid");
+        llvm::sys::path::append(OutputPath, ObjFileName);
+
+        if (Entry.getKind() == TreeEntry::Tree) {
+          // Check the path exists, if not, create the directory.
+          if (!llvm::sys::fs::exists(OutputPath)) {
+            if (auto EC = llvm::sys::fs::create_directory(OutputPath))
+              return errorCodeToError(EC);
+          }
+          return Error::success();
+        }
+        auto ObjRoot = CAS.getProxy(Entry.getRef());
+        if (!ObjRoot)
+          return ObjRoot.takeError();
+
+        SmallString<50> ContentsStorage;
+        raw_svector_ostream ObjOS(ContentsStorage);
+        auto Schema = std::make_unique<llvm::mccasformats::v1::MCSchema>(CAS);
+        if (Error E = Schema->serializeObjectFile(*ObjRoot, ObjOS))
+          return E;
+        std::unique_ptr<llvm::FileOutputBuffer> Output;
+        if (Error E = llvm::FileOutputBuffer::create(OutputPath,
+                                                     ContentsStorage.size())
+                          .moveInto(Output))
+          return E;
+        llvm::copy(ContentsStorage, Output->getBufferStart());
+        return Output->commit();
+      });
+}

--- a/llvm/tools/llvm-cas/CMakeLists.txt
+++ b/llvm/tools/llvm-cas/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS
   Support
   CAS
   RemoteCachingService
+  CASUtil
   )
 
 add_llvm_tool(llvm-cas


### PR DESCRIPTION
This change cherry-picks the llvm-cas-object-format tool to next from experimental/cas/main, but leaves out all the JITLink code. It moves the --just-blobs and --casid-file ingestion to llvm-cas and llvm-cas-object-format can be used to materialize object files from the CAS.

(cherry picked from commit 14e6b2f5fd76eccc60579fd95ebfe88b83de400f)