### PR TITLE
[stable/20230725] Revert always ending translation unit

### DIFF
--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -719,7 +719,8 @@ bool Parser::ParseTopLevelDecl(DeclGroupPtrTy &Result,
 
     // Late template parsing can begin.
     Actions.SetLateTemplateParser(LateTemplateParserCallback, nullptr, this);
-    Actions.ActOnEndOfTranslationUnit();
+    if (!PP.isIncrementalProcessingEnabled())
+      Actions.ActOnEndOfTranslationUnit();
     //else don't tell Sema that we ended parsing: more input might come.
     return true;
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -670,7 +670,6 @@ ClangModulesDeclVendor::Create(Target &target) {
       arch.GetTriple().str(),
       "-fmodules-validate-system-headers",
       "-Werror=non-modular-include-in-framework-module",
-      "-Xclang=-fincremental-extensions",
       "-Rmodule-build"};
 
   target.GetPlatform()->AddClangModuleCompilationOptions(
@@ -764,6 +763,8 @@ ClangModulesDeclVendor::Create(Target &target) {
   if (!action->BeginSourceFile(*instance,
                                instance->getFrontendOpts().Inputs[0]))
     return nullptr;
+
+  instance->getPreprocessor().enableIncrementalProcessing();
 
   instance->createASTReader();
 

--- a/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
+++ b/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             "expr @import LLDBTestModule",
             error=True,
             substrs=[
-                "module.h:4:1: error: use of undeclared identifier 'syntax_error_for_lldb_to_find'",
+                "module.h:4:1: error: unknown type name 'syntax_error_for_lldb_to_find'",
                 "syntax_error_for_lldb_to_find // comment that tests source printing",
                 "could not build module 'LLDBTestModule'",
             ],


### PR DESCRIPTION
Reverts commit 76cfe6c67efa25ab42ed34e51201c3912765195f and f247725b91b8c1c07b4e50e5f006f670536fd3c7.

Only running `ActOnEndOfTranslationUnit` when `enableIncrementalProcessing` was false was the only NFC part of splitting `-fincremental-extensions` and `enableIncrementalProcessing` again (68090ee7224763bf7204de4d9f9ca7edc8203d40). LLDB started failing after that change with:
```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/cstdlib:127:9: error: declaration of 'calloc' must be imported from module 'Darwin.malloc._malloc' before it is required
```

Reverting that part of the change fixed LLDB and didn't cause any other test failures, so happy days.

Unfortunately most of what `Sema::ActOnEndOfTranslationUnit` does is additional diagnostics, which don't make a lot of sense from the Clang Importer in Swift. So this ends up being a significant regression if eg. `-warnings-as-errors` is enabled.

Resolves rdar://116194950.
