### PR TITLE
[clang] Adopt `FileEntryRef` in `APINotesManager` and `SourceMgrAdapter`

### DIFF
--- a/clang/include/clang/APINotes/APINotesManager.h
+++ b/clang/include/clang/APINotes/APINotesManager.h
@@ -74,7 +74,7 @@ class APINotesManager {
   ///
   /// \returns the API notes reader for this file, or null if there is
   /// a failure.
-  std::unique_ptr<APINotesReader> loadAPINotes(const FileEntry *apiNotesFile);
+  std::unique_ptr<APINotesReader> loadAPINotes(FileEntryRef apiNotesFile);
 
   /// Load the API notes associated with the given buffer, whether it is
   /// the binary or source form of API notes.
@@ -88,8 +88,7 @@ class APINotesManager {
   /// \param HeaderDir The directory at which we
   ///
   /// \returns true if an error occurred.
-  bool loadAPINotes(const DirectoryEntry *HeaderDir,
-                    const FileEntry *APINotesFile);
+  bool loadAPINotes(const DirectoryEntry *HeaderDir, FileEntryRef APINotesFile);
 
   /// Look for API notes in the given directory.
   ///

--- a/clang/include/clang/Basic/SourceMgrAdapter.h
+++ b/clang/include/clang/Basic/SourceMgrAdapter.h
@@ -38,7 +38,7 @@ class SourceMgrAdapter {
   unsigned ErrorDiagID, WarningDiagID, NoteDiagID;
 
   /// The default file to use when mapping buffers.
-  const FileEntry *DefaultFile;
+  OptionalFileEntryRef DefaultFile;
 
   /// A mapping from (LLVM source manager, buffer ID) pairs to the
   /// corresponding file ID within the Clang source manager.
@@ -53,7 +53,8 @@ public:
   /// manager and diagnostics engine.
   SourceMgrAdapter(SourceManager &srcMgr, DiagnosticsEngine &diag,
                    unsigned errorDiagID, unsigned warningDiagID,
-                   unsigned noteDiagID, const FileEntry *defaultFile = nullptr);
+                   unsigned noteDiagID,
+                   OptionalFileEntryRef defaultFile = std::nullopt);
 
   ~SourceMgrAdapter();
 

--- a/clang/lib/Basic/SourceMgrAdapter.cpp
+++ b/clang/lib/Basic/SourceMgrAdapter.cpp
@@ -26,7 +26,7 @@ SourceMgrAdapter::SourceMgrAdapter(SourceManager &srcMgr,
                                    unsigned errorDiagID,
                                    unsigned warningDiagID,
                                    unsigned noteDiagID,
-                                   const FileEntry *defaultFile)
+                                   OptionalFileEntryRef defaultFile)
   : SrcMgr(srcMgr), Diag(diag), ErrorDiagID(errorDiagID),
     WarningDiagID(warningDiagID), NoteDiagID(noteDiagID),
     DefaultFile(defaultFile) { }
@@ -52,11 +52,10 @@ SourceLocation SourceMgrAdapter::mapLocation(const llvm::SourceMgr &llvmSrcMgr,
     FileID fileID;
     if (DefaultFile) {
       // Map to the default file.
-      fileID =
-          SrcMgr.getOrCreateFileID(DefaultFile->getLastRef(), SrcMgr::C_User);
+      fileID = SrcMgr.getOrCreateFileID(*DefaultFile, SrcMgr::C_User);
 
       // Only do this once.
-      DefaultFile = nullptr;
+      DefaultFile = std::nullopt;
     } else {
       // Make a copy of the memory buffer.
       StringRef bufferName = buffer->getBufferIdentifier();


### PR DESCRIPTION
This also removes the usage of `FileEntry::getLastRef()`, which will get removed in a subsequent commit.