### PR TITLE
[lldb] Fix TestRealDefinition (#7564)

### DIFF
--- a/lldb/test/API/lang/objc/real-definition/TestRealDefinition.py
+++ b/lldb/test/API/lang/objc/real-definition/TestRealDefinition.py
@@ -27,13 +27,11 @@ class TestRealDefinition(TestBase):
         # Run at stop at main
         lldbutil.check_breakpoint(self, bpno=1, expected_hit_count=1)
 
-        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
-
         # This should display correctly.
         self.expect(
             "frame variable foo->_bar->_hidden_ivar",
             VARIABLES_DISPLAYED_CORRECTLY,
-            substrs=["(NSString *)", "foo->_bar->_hidden_ivar = 0x"],
+            substrs=["foo->_bar->_hidden_ivar = 0x"],
         )
 
     def test_frame_var_after_stop_at_implementation(self):
@@ -54,11 +52,9 @@ class TestRealDefinition(TestBase):
         # Run at stop at main
         lldbutil.check_breakpoint(self, bpno=1, expected_hit_count=1)
 
-        self.runCmd("settings set target.prefer-dynamic-value no-dynamic-values")
-
         # This should display correctly.
         self.expect(
             "frame variable foo->_bar->_hidden_ivar",
             VARIABLES_DISPLAYED_CORRECTLY,
-            substrs=["(NSString *)", "foo->_bar->_hidden_ivar = 0x"],
+            substrs=["foo->_bar->_hidden_ivar = 0x"],
         )


### PR DESCRIPTION
For a while, tests were run with `target.prefer-dynamic-value` overridden to 
`no-dynamic-values` – but the override was removed in 
[D132382](https://reviews.llvm.org/D132382). At that time, tests that failed were 
individually opted in to `no-dynamic-values`.

I don't recall specifics about `TestRealDefinition`, but it currently fails with 
`no-dynamic-values`, and that is correct behavior. This change removes the 
`no-dynamic-values` override.

(cherry-picked from commit 9714127b2d10cbce533461d88faf5e43e0662fff)