### PR TITLE
[lldb] Fix typealias not being emitted for weakly captured generic

### DIFF
--- a/lldb/test/API/lang/swift/expression/weak_generic_self/Makefile
+++ b/lldb/test/API/lang/swift/expression/weak_generic_self/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftWeakGenericSelf(TestBase):
+    @swiftTest
+    def test(self):
+        """Confirms that expression evaluation works with a generic class
+        type within a closure that weakly captures it"""
+        self.build()
+        _, _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("expression self", substrs=["GenericClass<Int>?", "t = 42"])

--- a/lldb/test/API/lang/swift/expression/weak_generic_self/main.swift
+++ b/lldb/test/API/lang/swift/expression/weak_generic_self/main.swift
@@ -1,0 +1,17 @@
+class GenericClass<T> {
+  let t: T
+
+  init(t: T) {
+    self.t = t
+  }
+
+  func foo() {
+    { [weak self] in
+      print(self) // break here
+    }()
+  }
+}
+
+let instance = GenericClass<Int>(t: 42)
+instance.foo()
+


### PR DESCRIPTION
The typealias to $__lldb_context (the self type) was not being emitted when self was weakly captured and the type of self was a generic class type. Fix this, and also make AddRequiredAliases return an error code in case it was unable to emit one of the required aliases.

rdar://104697539
(cherry picked from commit 6fb5c0fa201ce4171a70cc958d04e4c3a620fddc)