### PR TITLE
[lldb] Change how valobj of indirect Swift value types in C++ are ext…

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1082,26 +1082,25 @@ SwiftLanguage::GetHardcodedSynthetics() {
 
       casted_to_swift->SetName(ConstString("Swift_Type"));
 
-      ValueObjectSP target_valobj;
+      SyntheticChildrenSP synth_sp;
       if (should_wrap_in_ptr) {
-        // If we have a pointer to a Swift value type, dereference it.
+        // If we have a pointer to a Swift value type, dereference the pointer
+        // and present those as the contents instead.
         auto children = lldb_private::formatters::swift::
             ExtractChildrenFromSwiftPointerValueObject(casted_to_swift);
 
         if (children.empty())
           return nullptr;
-
         // The pointer should only have one child: the pointee.
         assert(children.size() == 1 &&
                "Unexpected size for pointer's children!");
-        target_valobj = children[0];
-      } else {
-        target_valobj = casted_to_swift;
-      }
 
-      SyntheticChildrenSP synth_sp =
-          SyntheticChildrenSP(new ValueObjectWrapperSyntheticChildren(
-              target_valobj, SyntheticChildren::Flags()));
+        synth_sp = SyntheticChildrenSP(new ValueObjectWrapperSyntheticChildren(
+            children[0], SyntheticChildren::Flags()));
+      } else {
+        synth_sp = SyntheticChildrenSP(new ValueObjectWrapperSyntheticChildren(
+            casted_to_swift, SyntheticChildren::Flags()));
+      }
       return synth_sp;
     });
     g_formatters.push_back([](lldb_private::ValueObject &valobj,


### PR DESCRIPTION
…racted

Change how value objects of indirect Swift value types in C++ are extracted. By indirect Swift value type I mean a value type (structs, enums) which are stored in the C++ value object behind a pointer. Previously, LLDB would first dereference the pointer and then cast it. Now LLDB will first cast the type from C++ pointer to Swift pointer, and then dereference that pointer.

rdar://115021829
rdar://110430600
(cherry picked from commit 29334a7307a7e25cbf6ead0b02ddaf8bc29bef85)