### PR TITLE
Fix test crash on non-MachO platforms by using correct target triple

### DIFF
--- a/clang/test/CAS/cas-emit-casid.c
+++ b/clang/test/CAS/cas-emit-casid.c
@@ -1,27 +1,28 @@
+// REQUIRES: aarch64-registered-target
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o %t/test.o 
 // RUN: cat %t/test.o.casid | FileCheck %s --check-prefix=NATIVE_FILENAME
 // NATIVE_FILENAME: CASID:Jllvmcas://{{.*}}
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o %t/test.o 
 // RUN: cat %t/test.o.casid | FileCheck %s --check-prefix=VERIFY_FILENAME
 // VERIFY_FILENAME: CASID:Jllvmcas://{{.*}}
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o %t/test.o 
 // RUN: not cat %t/test.o.casid
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o -
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o -
 // RUN: not cat %t/test.o.casid
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o -
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o -
 // RUN: not cat %t/test.o.casid
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o -
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o -
 // RUN: not cat %t/test.o.casid
 
 void test(void) {}


### PR DESCRIPTION
MCCAS is only supported with MachO object files. To make sure that no tests fail on other plaforms, add proper target triple to the test and guard it with aarch64-registered-target.

Test failure:

https://ci.swift.org/job/pr-apple-llvm-project-llvm-linux/94

******************** TEST 'Clang :: CAS/cas-emit-casid.c' FAILED ********************
Exit Code: 1

Command Output (stderr):
--
RUN: at line 1: rm -rf /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp && mkdir -p /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp
+ rm -rf /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp
+ mkdir -p /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp
RUN: at line 2: /home/build-user/llvm-project/build/bin/clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file /home/build-user/llvm-project/clang/test/CAS/cas-emit-casid.c -o /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp/test.o
+ /home/build-user/llvm-project/build/bin/clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file /home/build-user/llvm-project/clang/test/CAS/cas-emit-casid.c -o /home/build-user/llvm-project/build/tools/clang/test/CAS/Output/cas-emit-casid.c.tmp/test.o
unexpected object format
UNREACHABLE executed at /home/build-user/llvm-project/llvm/lib/MC/MCAsmBackend.cpp:86!
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump: