### PR TITLE
Fix test crash on non-MachO platforms by using correct target triple

### DIFF
--- a/clang/test/CAS/cas-emit-casid.c
+++ b/clang/test/CAS/cas-emit-casid.c
@@ -1,27 +1,28 @@
+// REQUIRES: aarch64-registered-target
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o %t/test.o 
 // RUN: cat %t/test.o.casid | FileCheck %s --check-prefix=NATIVE_FILENAME
 // NATIVE_FILENAME: CASID:Jllvmcas://{{.*}}
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o %t/test.o 
 // RUN: cat %t/test.o.casid | FileCheck %s --check-prefix=VERIFY_FILENAME
 // VERIFY_FILENAME: CASID:Jllvmcas://{{.*}}
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o %t/test.o 
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o %t/test.o 
 // RUN: not cat %t/test.o.casid
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o -
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=native -Xclang -fcas-emit-casid-file %s -o -
 // RUN: not cat %t/test.o.casid
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o -
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=verify -Xclang -fcas-emit-casid-file %s -o -
 // RUN: not cat %t/test.o.casid
 //
 // RUN: rm -rf %t && mkdir -p %t
-// RUN: %clang -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o -
+// RUN: %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Xclang -fcas-path -Xclang %t/cas -Xclang -fcas-backend-mode=casid -Xclang -fcas-emit-casid-file %s -o -
 // RUN: not cat %t/test.o.casid
 
 void test(void) {}


### PR DESCRIPTION
MCCAS is only supported with MachO object files. To make sure that no tests fail on other plaforms, add proper target triple to the test and guard it with aarch64-registered-target.

(cherry picked from commit fd3c8a495ee57417f4071a241513807831f5de19)