### PR TITLE
[lldb] Mark parsing Swift expressions with generics as not cacheable

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1753,6 +1753,16 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     return ParseResult::unrecoverable_error;
   }
 
+  {
+    // If any generics are present, this expression is not parseable.
+    m_is_cacheable =
+        !llvm::any_of(parsed_expr->code_manipulator->GetVariableInfo(),
+                     [](const auto &variable) {
+                       return variable.IsMetadataPointer() ||
+                              variable.IsPackCount() ||
+                              variable.IsUnboundPack();
+                     });
+  }
   auto dumpModule = [&](const char *msg) {
     std::string s;
     llvm::raw_string_ostream ss(s);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -97,6 +97,11 @@ public:
   ParseResult Parse(DiagnosticManager &diagnostic_manager,
                     uint32_t first_line = 0, uint32_t last_line = UINT32_MAX);
 
+  /// Returns true if the call to parse of this type is cacheable.
+  bool IsParseCacheable() const {
+    return m_is_cacheable;
+  }
+
   //------------------------------------------------------------------
   /// Ready an already-parsed expression for execution, possibly
   /// evaluating it statically.
@@ -198,6 +203,9 @@ private:
 
   /// If true, we are running in REPL mode
   EvaluateExpressionOptions m_options;
+
+  /// Indicates whether the call to Parse of this type is cacheable.
+  bool m_is_cacheable;
 };
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -138,6 +138,10 @@ public:
   void WillStartExecuting() override;
   void DidFinishExecuting() override;
 
+  bool IsParseCacheable() override {
+    return m_parser->IsParseCacheable();
+  }
+
 private:
   //------------------------------------------------------------------
   /// Populate m_in_cplusplus_method and m_in_objectivec_method based on the

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
@@ -6,30 +6,45 @@ import unittest2
 
 
 class TestArchetypeInConditionalBreakpoint(TestBase):
+    @swiftTest
+    def test_stops_free_function(self):
+        self.stops("break here for free function")
 
     @swiftTest
-    def test_stops(self):
+    def test_doesnt_stop_free_function(self):
+        self.doesnt_stop("break here for free function")
+
+    @swiftTest
+    def test_stops_class(self):
+        self.stops("break here for class")
+
+    @swiftTest
+    def test_doesnt_stop_class(self):
+        self.doesnt_stop("break here for class")
+
+    def stops(self, breakpoint_string):
         """Tests that using archetypes in a conditional breakpoint's expression works correctly"""
         self.build()
         target = lldbutil.run_to_breakpoint_make_target(self)
 
         breakpoint = target.BreakpointCreateBySourceRegex(
-                "break here", lldb.SBFileSpec("main.swift"))
+            breakpoint_string, lldb.SBFileSpec("main.swift")
+        )
 
         breakpoint.SetCondition("T.self == Int.self")
         _, process, _, _ = lldbutil.run_to_breakpoint_do_run(self, target, breakpoint)
-    
+
         self.assertEqual(process.state, lldb.eStateStopped)
+        self.expect("expression T.self", substrs=["Int"])
 
-
-    @swiftTest
-    def test_doesnt_stop(self):
+    def doesnt_stop(self, breakpoint_string):
         """Tests that using archetypes in a conditional breakpoint's expression works correctly"""
         self.build()
         target = lldbutil.run_to_breakpoint_make_target(self)
 
         breakpoint = target.BreakpointCreateBySourceRegex(
-                "break here", lldb.SBFileSpec("main.swift"))
+            breakpoint_string, lldb.SBFileSpec("main.swift")
+        )
 
         breakpoint.SetCondition("T.self == Double.self")
 
@@ -41,4 +56,3 @@ class TestArchetypeInConditionalBreakpoint(TestBase):
 
         # Make sure that we didn't stop since the condition doesn't match
         self.assertEqual(process.state, lldb.eStateExited)
-

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/main.swift
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/main.swift
@@ -1,4 +1,18 @@
+
 func f<T>(t: T) {
-  print(1) // break here
+  print(1) // break here for free function
 }
+f(t: "This is a string")
+f(t: "This is another string")
+f(t: true)
 f(t: 5)
+
+class MyClass<T> {
+  func f() {
+    print(1) // break here for class
+  }
+}
+MyClass<String>().f()
+MyClass<String>().f()
+MyClass<Bool>().f()
+MyClass<Int>().f()


### PR DESCRIPTION
Because a Swift expression may have different generic instantiations in different invocations, we cannot cache the parsing of them.

(cherry picked from commit 97bb2d80e2d25d1ebcc2c19d2edf5e13b0944a84)