### PR TITLE
[lldb] Add interface to check if UserExpression::Parse() is cacheable

### DIFF
--- a/lldb/include/lldb/Expression/UserExpression.h
+++ b/lldb/include/lldb/Expression/UserExpression.h
@@ -192,6 +192,8 @@ public:
   /// expression.  Text() should contain the definition of this function.
   const char *FunctionName() override { return "$__lldb_expr"; }
 
+  /// Returns whether the call to Parse on this user expression is cacheable.
+  virtual bool IsParseCacheable() { return true; }
   /// Return the language that should be used when parsing.  To use the
   /// default, return eLanguageTypeUnknown.
   lldb::LanguageType Language() const override { return m_language; }

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -250,6 +250,7 @@ bool BreakpointLocation::ConditionSaysStop(ExecutionContext &exe_ctx,
   DiagnosticManager diagnostics;
 
   if (condition_hash != m_condition_hash || !m_user_expression_sp ||
+      !m_user_expression_sp->IsParseCacheable() ||
       !m_user_expression_sp->MatchesContext(exe_ctx)) {
     LanguageType language = eLanguageTypeUnknown;
     // See if we can figure out the language from the frame, otherwise use the


### PR DESCRIPTION
When setting conditional breakpoints, we currently assume that a call to UserExpression::Parse() can be cached and resued multiple times. This may not be true for every user expression. Add a new method so subclasses of UserExpression can customize if they are parseable or not.

(cherry picked from commit f3aa76550c193af4def44ea1ba1a97424390dabe) (cherry picked from commit 89d622fb091e889cfde9d649f32ecaf017d7e9a2)