### PR TITLE
[lldb] Check for nullptr before accessing parsed_expr->code_manipulator

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1753,16 +1753,16 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     return ParseResult::unrecoverable_error;
   }
 
-  {
-    // If any generics are present, this expression is not parseable.
+  // If any generics are present, this expression is not parseable.
+  if (parsed_expr->code_manipulator)
     m_is_cacheable =
         !llvm::any_of(parsed_expr->code_manipulator->GetVariableInfo(),
-                     [](const auto &variable) {
-                       return variable.IsMetadataPointer() ||
-                              variable.IsPackCount() ||
-                              variable.IsUnboundPack();
-                     });
-  }
+                      [](const auto &variable) {
+                        return variable.IsMetadataPointer() ||
+                               variable.IsPackCount() ||
+                               variable.IsUnboundPack();
+                      });
+
   auto dumpModule = [&](const char *msg) {
     std::string s;
     llvm::raw_string_ostream ss(s);


### PR DESCRIPTION
(cherry picked from commit 8b13537b9b9f8e244886f78cd6f483938257a744)