### PR TITLE
[lldb] Fix refactor of check_expression ExpressionsInClassFunctions

### DIFF
--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -54,7 +54,7 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
             self.assertTrue(len(threads) == 1)
             lldbutil.check_expression(self, self.frame(), "i", str(i), False)
             if i == 6:
-              lldbutil.check_expression(self, self.frame(), "self", "a.H<Int>", use_summary=False)
+              lldbutil.check_expression(self, self.frame(), "self", "a.H<Int>")
               frame = threads[0].GetFrameAtIndex(0)
               lldbutil.check_variable(self, frame.FindVariable("self"),
                                       # FIXME: This should be '@thick a.H<Swift.Int>.Type'


### PR DESCRIPTION
Fix refactor of use_summary changing use_summary=False to True

rdar://116259823
(cherry picked from commit ec64abf383e8469a60e7f5b3f348f02c0aba2ae9)