### PR TITLE
[dsymutil] Rename DSYMUTIL_REPRODUCER_PATH to LLVM_DIAGNOSTIC_DIR

### DIFF
--- a/llvm/test/tools/dsymutil/X86/reproducer.test
+++ b/llvm/test/tools/dsymutil/X86/reproducer.test
@@ -21,7 +21,7 @@ RUN: env TMPDIR="%t/tempdir" dsymutil -o - -f %t/Inputs/basic.macho.x86_64
 RUN: not ls %t/tempdir/dsymutil-*
 
 # Create a reproducer.
-RUN: env DSYMUTIL_REPRODUCER_PATH=%t.repro dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
+RUN: env LLVM_DIAGNOSTIC_DIR=%t.repro dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
 RUN: llvm-dwarfdump -a %t.generate | FileCheck %s
 
 # Remove the input files and verify that was successful.

--- a/llvm/tools/dsymutil/Reproducer.cpp
+++ b/llvm/tools/dsymutil/Reproducer.cpp
@@ -14,7 +14,7 @@ using namespace llvm::dsymutil;
 
 static std::string createReproducerDir(std::error_code &EC) {
   SmallString<128> Root;
-  if (const char *Path = getenv("DSYMUTIL_REPRODUCER_PATH")) {
+  if (const char *Path = getenv("LLVM_DIAGNOSTIC_DIR")) {
     Root.assign(Path);
     EC = sys::fs::create_directory(Root);
   } else {


### PR DESCRIPTION
Rename DSYMUTIL_REPRODUCER_PATH to LLVM_DIAGNOSTIC_DIR as the latter is
more generic and already set in our downstream build.

(cherry picked from commit 76f20e9cff222351505ec9dbb83fdb93e64ad691)
