### PR TITLE
[dsymutil] Keep DSYMUTIL_REPRODUCER_PATH in addition to LLVM_DIAGNOST…

### DIFF
--- a/llvm/test/tools/dsymutil/X86/reproducer.test
+++ b/llvm/test/tools/dsymutil/X86/reproducer.test
@@ -21,8 +21,13 @@ RUN: env TMPDIR="%t/tempdir" dsymutil -o - -f %t/Inputs/basic.macho.x86_64
 RUN: not ls %t/tempdir/dsymutil-*
 
 # Create a reproducer.
-RUN: env LLVM_DIAGNOSTIC_DIR=%t.repro dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
+RUN: rm -rf %t.repro
+RUN: env DSYMUTIL_REPRODUCER_PATH=%t.repro dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
 RUN: llvm-dwarfdump -a %t.generate | FileCheck %s
+
+RUN: rm -rf %t.diags
+RUN: env LLVM_DIAGNOSTIC_DIR=%t.diags dsymutil -gen-reproducer -f -o %t.generate -oso-prepend-path=%t %t/Inputs/basic.macho.x86_64 2>&1 | FileCheck %s --check-prefixes=REPRODUCER
+RUN: ls %t.diags | grep 'dsymutil-' | count 1
 
 # Remove the input files and verify that was successful.
 RUN: rm -rf %t

--- a/llvm/tools/dsymutil/Reproducer.cpp
+++ b/llvm/tools/dsymutil/Reproducer.cpp
@@ -8,15 +8,21 @@
 
 #include "Reproducer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Process.h"
 
 using namespace llvm;
 using namespace llvm::dsymutil;
 
 static std::string createReproducerDir(std::error_code &EC) {
   SmallString<128> Root;
-  if (const char *Path = getenv("LLVM_DIAGNOSTIC_DIR")) {
+  if (const char *Path = getenv("DSYMUTIL_REPRODUCER_PATH")) {
     Root.assign(Path);
-    EC = sys::fs::create_directory(Root);
+    EC = sys::fs::create_directories(Root);
+  } else if (const char *Path = getenv("LLVM_DIAGNOSTIC_DIR")) {
+    Root.assign(Path);
+    llvm::sys::path::append(
+        Root, "dsymutil-" + llvm::Twine(llvm::sys::Process::getProcessId()));
+    EC = sys::fs::create_directories(Root);
   } else {
     EC = sys::fs::createUniqueDirectory("dsymutil", Root);
   }


### PR DESCRIPTION
…IC_DIR

For LLVM_DIAGNOSTIC_DIR we want to create a subdirectory while for DSYMUTIL_REPRODUCER_PATH we want to use the directory specified. The latter makes writing a test a whole lot easier. Keep both to support both scenarios.

(cherry picked from commit bd206a363af392fc802e8f6e1dde282ca4490eaa)