### PR TITLE
Add support for Dwarf 5 in MCCAS

### DIFF
--- a/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
+++ b/llvm/include/llvm/DebugInfo/DWARF/DWARFFormValue.h
@@ -79,6 +79,7 @@ public:
 
   dwarf::Form getForm() const { return Form; }
   uint64_t getRawUValue() const { return Value.uval; }
+  int64_t getRawSValue() const { return Value.sval; }
 
   bool isFormClass(FormClass FC) const;
   const DWARFUnit *getUnit() const { return U; }

--- a/llvm/include/llvm/MCCAS/MCCASDebugV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASDebugV1.h
@@ -72,6 +72,9 @@ struct DataWriter {
   /// Write ULEB128(V) to the data stream.
   void writeULEB128(uint64_t V) { encodeULEB128(V, DataStream); }
 
+  /// Write SLEB128(V) to the data stream.
+  void writeSLEB128(int64_t V) { encodeSLEB128(V, DataStream); }
+
   /// Write V to the data stream.
   void writeByte(uint8_t V) { DataStream << V; }
 

--- a/llvm/include/llvm/MCCAS/MCCASDebugV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASDebugV1.h
@@ -20,6 +20,7 @@ namespace mccasformats {
 namespace v1 {
 
 constexpr unsigned Dwarf4HeaderSize32Bit = 11;
+constexpr unsigned Dwarf5HeaderSize32Bit = 12;
 
 /// Returns true if the values associated with a combination of Form and Attr
 /// are not expected to deduplicate.

--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.h
@@ -479,6 +479,7 @@ struct DwarfSectionsCache {
   MCSection *Line;
   MCSection *Str;
   MCSection *Abbrev;
+  MCSection *StrOffsets;
 };
 
 /// Queries `Asm` for all dwarf sections and returns an object with (possibly

--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.h
@@ -581,6 +581,10 @@ private:
   struct CUSplit {
     SmallVector<MutableArrayRef<char>> SplitCUData;
     SmallVector<size_t> AbbrevOffsets;
+    /// A list of Dwarf versions of the compile units, to help determine what
+    /// the Compile Unit header format and size is like when creating
+    /// CASObjects.
+    SmallVector<uint16_t> DwarfVersions;
   };
   /// Split the data of the __debug_info section it into multiple pieces, one
   /// per Compile Unit(CU) and return them. The abbreviation offset for each CU

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -112,12 +112,13 @@ public:
   /// unit.
   Error partitionCUData(ArrayRef<char> DebugInfoData, uint64_t AbbrevOffset,
                         DWARFContext *Ctx, MCCASBuilder &Builder,
-                        AbbrevSetWriter &AbbrevWriter);
+                        AbbrevSetWriter &AbbrevWriter, uint16_t DwarfVersion);
 };
 
 struct CUInfo {
   uint64_t CUSize;
   uint32_t AbbrevOffset;
+  uint16_t DwarfVersion;
 };
 static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(
     MutableArrayRef<char> CUData, support::endianness Endian,
@@ -1749,10 +1750,25 @@ getAndSetDebugAbbrevOffsetAndSkip(MutableArrayRef<char> CUData,
   if (auto E = Reader.readInteger(DwarfVersion))
     return std::move(E);
 
-  // TODO: Dwarf 5 has a different order for the next fields.
-  if (DwarfVersion != 4)
-    return createStringError(inconvertibleErrorCode(),
-                             "Expected Dwarf 4 input");
+  if (DwarfVersion >= 5) {
+    // From Dwarf 5 Section 7.5.1.1:
+    // Compile Unit Header Format is now changed with unit_type and address_size
+    // after the version. Parse both values from the header.
+    uint8_t UnitType;
+    if (auto E = Reader.readInteger(UnitType))
+      return std::move(E);
+    if (UnitType != dwarf::DW_UT_compile)
+      return createStringError(
+          inconvertibleErrorCode(),
+          "Unit type is not DW_UT_compile, and is incompatible with MCCAS!");
+    uint8_t AddressSize;
+    if (auto E = Reader.readInteger(AddressSize))
+      return std::move(E);
+    if (AddressSize != 8)
+      return createStringError(
+          inconvertibleErrorCode(),
+          "Address size is not 8 bytes, unsupported architecture for MCCAS!");
+  }
 
   // TODO: Handle Dwarf 64 format, which uses 8 bytes.
   size_t AbbrevPosition = Reader.getOffset();
@@ -1774,7 +1790,7 @@ getAndSetDebugAbbrevOffsetAndSkip(MutableArrayRef<char> CUData,
   if (auto E = Reader.skip(*Size))
     return std::move(E);
 
-  return CUInfo{Reader.getOffset(), AbbrevOffset};
+  return CUInfo{Reader.getOffset(), AbbrevOffset, DwarfVersion};
 }
 
 /// Given a list of MCFragments, return a vector with the concatenation of their
@@ -1814,6 +1830,7 @@ MCCASBuilder::splitDebugInfoSectionData(MutableArrayRef<char> DebugInfoData) {
       return Info.takeError();
     Split.SplitCUData.push_back(DebugInfoData.take_front(Info->CUSize));
     Split.AbbrevOffsets.push_back(Info->AbbrevOffset);
+    Split.DwarfVersions.push_back(Info->DwarfVersion);
     DebugInfoData = DebugInfoData.drop_front(Info->CUSize);
   }
 
@@ -1962,7 +1979,8 @@ Error InMemoryCASDWARFObject::partitionCUData(ArrayRef<char> DebugInfoData,
                                               uint64_t AbbrevOffset,
                                               DWARFContext *Ctx,
                                               MCCASBuilder &Builder,
-                                              AbbrevSetWriter &AbbrevWriter) {
+                                              AbbrevSetWriter &AbbrevWriter,
+                                              uint16_t DwarfVersion) {
   StringRef AbbrevSectionContribution =
       getAbbrevSection().drop_front(AbbrevOffset);
   DataExtractor Data(AbbrevSectionContribution, isLittleEndian(), 8);
@@ -1981,13 +1999,24 @@ Error InMemoryCASDWARFObject::partitionCUData(ArrayRef<char> DebugInfoData,
 
   DWARFDie CUDie = DCU.getUnitDIE(false);
   assert(CUDie);
-  // Copy 11 bytes which represents the 32-bit DWARF Header for DWARF4.
-  if (DebugInfoData.size() < Dwarf4HeaderSize32Bit)
-    return createStringError(inconvertibleErrorCode(),
-                             "DebugInfoData is too small, it doesn't even "
-                             "contain a 32-bit DWARF Header");
+  ArrayRef<char> HeaderData;
+  if (DwarfVersion >= 5) {
+    // Copy 12 bytes which represents the 32-bit DWARF Header for DWARF5.
+    if (DebugInfoData.size() < Dwarf5HeaderSize32Bit)
+      return createStringError(inconvertibleErrorCode(),
+                               "DebugInfoData is too small, it doesn't even "
+                               "contain a 32-bit DWARF5 Header");
 
-  ArrayRef<char> HeaderData = DebugInfoData.take_front(Dwarf4HeaderSize32Bit);
+    HeaderData = DebugInfoData.take_front(Dwarf5HeaderSize32Bit);
+  } else {
+    // Copy 11 bytes which represents the 32-bit DWARF Header for DWARF4.
+    if (DebugInfoData.size() < Dwarf4HeaderSize32Bit)
+      return createStringError(inconvertibleErrorCode(),
+                               "DebugInfoData is too small, it doesn't even "
+                               "contain a 32-bit DWARF4 Header");
+
+    HeaderData = DebugInfoData.take_front(Dwarf4HeaderSize32Bit);
+  }
   Expected<DIETopLevelRef> Converted =
       DIEToCASConverter(DebugInfoData, Builder)
           .convert(CUDie, HeaderData, AbbrevWriter);
@@ -2017,20 +2046,32 @@ Error MCCASBuilder::splitDebugInfoAndAbbrevSections() {
 
   Expected<SmallVector<char, 0>> FullAbbrevData =
       mergeMCFragmentContents(AbbrevFragmentList);
+
   if (!FullAbbrevData)
     return FullAbbrevData.takeError();
 
-  InMemoryCASDWARFObject CASObj(
-      *FullAbbrevData, Asm.getBackend().Endian == support::endianness::little);
+  const MCSection::FragmentListType &StringOffsetsFragmentList =
+      DwarfSections.StrOffsets->getFragmentList();
+
+  Expected<SmallVector<char, 0>> FullStringOffsetsData =
+      mergeMCFragmentContents(StringOffsetsFragmentList);
+
+  if (!FullStringOffsetsData)
+    return FullStringOffsetsData.takeError();
+
+  InMemoryCASDWARFObject CASObj(*FullAbbrevData, *FullStringOffsetsData,
+                                Asm.getBackend().Endian ==
+                                    support::endianness::little);
   auto DWARFObj = std::make_unique<InMemoryCASDWARFObject>(CASObj);
   auto DWARFContextHolder = std::make_unique<DWARFContext>(std::move(DWARFObj));
   auto *DWARFCtx = DWARFContextHolder.get();
 
   AbbrevSetWriter AbbrevWriter;
-  for (auto [CUData, AbbrevOffset] :
-       llvm::zip(SplitInfo->SplitCUData, SplitInfo->AbbrevOffsets)) {
+  for (auto [CUData, AbbrevOffset, DwarfVersion] :
+       llvm::zip(SplitInfo->SplitCUData, SplitInfo->AbbrevOffsets,
+                 SplitInfo->DwarfVersions)) {
     if (auto E = CASObj.partitionCUData(CUData, AbbrevOffset, DWARFCtx, *this,
-                                        AbbrevWriter))
+                                        AbbrevWriter, DwarfVersion))
       return E;
   }
   return Error::success();
@@ -3190,7 +3231,22 @@ Error mccasformats::v1::visitDebugInfo(
   StringRef DistinctData = LoadedTopRef->DistinctData.getData();
   BinaryStreamReader DistinctReader(DistinctData, support::endianness::little);
   ArrayRef<char> HeaderData;
-  if (auto E = DistinctReader.readArray(HeaderData, Dwarf4HeaderSize32Bit))
+
+  auto BeginOffset = DistinctReader.getOffset();
+  auto Size = getSizeFromDwarfHeader(DistinctReader);
+  if (!Size)
+    return Size.takeError();
+
+  // 2-byte Dwarf version identifier.
+  uint16_t DwarfVersion;
+  if (auto E = DistinctReader.readInteger(DwarfVersion))
+    return E;
+
+  DistinctReader.setOffset(BeginOffset);
+
+  if (auto E = DistinctReader.readArray(
+          HeaderData,
+          DwarfVersion >= 5 ? Dwarf5HeaderSize32Bit : Dwarf4HeaderSize32Bit))
     return E;
   HeaderCallback(toStringRef(HeaderData));
 

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -2227,6 +2227,8 @@ Error MCCASBuilder::createDebugStrSection() {
   startSection(DwarfSections.Str);
   for (auto DebugStringRef : *DebugStringRefs)
     addNode(DebugStringRef);
+  if (auto E = createPaddingRef(DwarfSections.Str))
+    return E;
   return finalizeSection<DebugStringSectionRef>();
 }
 

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -79,15 +79,24 @@ class AbbrevSetWriter;
 /// debug info.
 class InMemoryCASDWARFObject : public DWARFObject {
   ArrayRef<char> DebugAbbrevSection;
+  DWARFSection DebugStringOffsetsSection;
   bool IsLittleEndian;
 
 public:
-  InMemoryCASDWARFObject(ArrayRef<char> AbbrevContents, bool IsLittleEndian)
-      : DebugAbbrevSection(AbbrevContents), IsLittleEndian(IsLittleEndian) {}
+  InMemoryCASDWARFObject(ArrayRef<char> AbbrevContents,
+                         ArrayRef<char> StringOffsetsContents,
+                         bool IsLittleEndian)
+      : DebugAbbrevSection(AbbrevContents),
+        DebugStringOffsetsSection({toStringRef(StringOffsetsContents)}),
+        IsLittleEndian(IsLittleEndian) {}
   bool isLittleEndian() const override { return IsLittleEndian; }
 
   StringRef getAbbrevSection() const override {
     return toStringRef(DebugAbbrevSection);
+  }
+
+  const DWARFSection &getStrOffsetsSection() const override {
+    return DebugStringOffsetsSection;
   }
 
   std::optional<RelocAddrEntry> find(const DWARFSection &Sec,
@@ -1475,7 +1484,8 @@ DwarfSectionsCache mccasformats::v1::getDwarfSections(MCAssembler &Asm) {
       Asm.getContext().getObjectFileInfo()->getDwarfInfoSection(),
       Asm.getContext().getObjectFileInfo()->getDwarfLineSection(),
       Asm.getContext().getObjectFileInfo()->getDwarfStrSection(),
-      Asm.getContext().getObjectFileInfo()->getDwarfAbbrevSection()};
+      Asm.getContext().getObjectFileInfo()->getDwarfAbbrevSection(),
+      Asm.getContext().getObjectFileInfo()->getDwarfStrOffSection()};
 }
 
 Error MCCASBuilder::prepare() {

--- a/llvm/test/CAS/dwarf-5.ll
+++ b/llvm/test/CAS/dwarf-5.ll
@@ -1,8 +1,12 @@
 ; RUN: rm -rf %t && mkdir -p %t
 ; RUN: llc --filetype=obj --mccas-verify --cas-backend --cas=%t/cas %s -o %t/dwarf-5.o 
-; RUN: dwarfdump %t/dwarf-5.o | FileCheck %s 
+; RUN: llvm-dwarfdump %t/dwarf-5.o | FileCheck %s
 ; CHECK: .debug_info contents:
 ; CHECK-NEXT: 0x{{[0-9a-f]+}}: Compile Unit: length = 0x{{[0-9a-f]+}}, format = DWARF32, version = 0x0005
+
+source_filename = "/Users/shubham/Development/Delta/alternate/CommandLine.cpp"
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+target triple = "arm64-apple-macosx14.0.0"
 
 %"class.llvm::StringRef" = type { ptr, i64 }
 %"class.llvm::function_ref" = type { ptr, i64 }

--- a/llvm/test/CAS/dwarf-5.ll
+++ b/llvm/test/CAS/dwarf-5.ll
@@ -1,0 +1,116 @@
+; RUN: rm -rf %t && mkdir -p %t
+; RUN: llc --filetype=obj --mccas-verify --cas-backend --cas=%t/cas %s -o %t/dwarf-5.o 
+; RUN: dwarfdump %t/dwarf-5.o | FileCheck %s 
+; CHECK: .debug_info contents:
+; CHECK-NEXT: 0x{{[0-9a-f]+}}: Compile Unit: length = 0x{{[0-9a-f]+}}, format = DWARF32, version = 0x0005
+
+%"class.llvm::StringRef" = type { ptr, i64 }
+%"class.llvm::function_ref" = type { ptr, i64 }
+%"class.llvm::function_ref.1" = type { ptr, i64 }
+%"class.llvm::SmallString" = type { %"class.llvm::SmallVector" }
+%"class.llvm::SmallVector" = type { %"class.llvm::SmallVectorImpl.2" }
+%"class.llvm::SmallVectorImpl.2" = type { %"class.llvm::SmallVectorTemplateBase.3" }
+%"class.llvm::SmallVectorTemplateBase.3" = type { %"class.llvm::SmallVectorTemplateCommon.4" }
+%"class.llvm::SmallVectorTemplateCommon.4" = type { %"class.llvm::SmallVectorBase" }
+%"class.llvm::SmallVectorBase" = type { ptr, i64, i64 }
+define void @_ZN4llvm2cl26TokenizeWindowsCommandLineENS_9StringRefERNS_11StringSaverERNS_15SmallVectorImplIPKcEEb([2 x i64] %0, ptr noundef nonnull align 1 dereferenceable(1) %1, ptr noundef nonnull align 8 dereferenceable(24) %2, i1 noundef zeroext %3) #0 !dbg !114 {
+  ret void, !dbg !195
+}
+define internal void @_ZL30tokenizeWindowsCommandLineImplN4llvm9StringRefERNS_11StringSaverENS_12function_refIFvS0_EEEbNS3_IFvvEEEb([2 x i64] %0, ptr noundef nonnull align 1 dereferenceable(1) %1, [2 x i64] %2, i1 noundef zeroext %3, [2 x i64] %4, i1 noundef zeroext %5) #0 !dbg !12 {
+  %7 = alloca %"class.llvm::StringRef", align 8
+  %8 = alloca %"class.llvm::function_ref", align 8
+  %9 = alloca %"class.llvm::function_ref.1", align 8
+  %10 = alloca ptr, align 8
+  %11 = alloca i8, align 1
+  %12 = alloca i8, align 1
+  %13 = alloca %"class.llvm::SmallString", align 8
+  %14 = alloca i32, align 4
+  %15 = alloca i64, align 8
+  %16 = alloca i64, align 8
+  %17 = alloca %"class.llvm::StringRef", align 8
+  %18 = zext i1 %3 to i8
+  %19 = zext i1 %5 to i8
+  %20 = call noundef ptr @_ZN4llvm11SmallStringILj128EEC1Ev(ptr noundef nonnull align 8 dereferenceable(24) %13), !dbg !256
+  %21 = call noundef i64 @_ZNK4llvm9StringRef4sizeEv(ptr noundef nonnull align 8 dereferenceable(16) %7), !dbg !264
+  br label %22, !dbg !265
+  br label %22, !dbg !283, !llvm.loop !284
+}
+define internal noundef ptr @"_ZN4llvm12function_refIFvvEEC1IRZNS_2cl26TokenizeWindowsCommandLineENS_9StringRefERNS_11StringSaverERNS_15SmallVectorImplIPKcEEbE3$_1EEOT_PNSt3__19enable_ifIXooL_ZNSH_17integral_constantIbLb1EE5valueEEsr3std14is_convertibleIDTclclsr3stdE7declvalISF_EEEEvEE5valueEvE4typeE"(ptr noundef nonnull returned align 8 dereferenceable(16) %0, ptr noundef nonnull align 1 dereferenceable(1) %1, ptr noundef %2) unnamed_addr #3 align 2 !dbg !312 {
+  %4 = alloca ptr, align 8
+  %5 = alloca ptr, align 8
+  %6 = alloca ptr, align 8
+  %7 = load ptr, ptr %4, align 8
+  ret ptr %7, !dbg !330
+}
+define linkonce_odr noundef ptr @_ZN4llvm11SmallStringILj128EEC1Ev(ptr noundef nonnull returned align 8 dereferenceable(24) %0) unnamed_addr #3 align 2 !dbg !331 {
+  %2 = alloca ptr, align 8
+  %3 = load ptr, ptr %2, align 8
+  ret ptr %3, !dbg !339
+}
+define linkonce_odr noundef i64 @_ZNK4llvm9StringRef4sizeEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 align 2 !dbg !340 {
+  %2 = alloca ptr, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.llvm::StringRef", ptr %3, i32 0, i32 1, !dbg !344
+  %5 = load i64, ptr %4, align 8, !dbg !344
+  ret i64 %5, !dbg !345
+}
+declare void @llvm.trap() #4
+define linkonce_odr noundef ptr @_ZNSt3__122__uninitialized_fill_nIcPcmcEET0_S2_T1_RKT2_(ptr noundef %0, i64 noundef %1, ptr noundef nonnull align 1 dereferenceable(1) %2) #0 !dbg !469 {
+  call void @llvm.trap(), !dbg !489
+  unreachable, !dbg !491
+}
+define linkonce_odr noundef ptr @_ZN4llvm25SmallVectorTemplateCommonIcvE5beginEv(ptr noundef nonnull align 8 dereferenceable(24) %0) #0 align 2 !dbg !492 {
+  %2 = alloca ptr, align 8
+  %3 = load ptr, ptr %2, align 8
+  %4 = getelementptr inbounds %"class.llvm::SmallVectorBase", ptr %3, i32 0, i32 0, !dbg !495
+  %5 = load ptr, ptr %4, align 8, !dbg !495
+  ret ptr %5, !dbg !496
+}
+!llvm.module.flags = !{!1, !2, !6}
+!llvm.dbg.cu = !{!7}
+!1 = !{i32 7, !"Dwarf Version", i32 5}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!6 = !{i32 7, !"frame-pointer", i32 1}
+!7 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !8, emissionKind: FullDebug, sdk: "MacOSX14.0.sdk")
+!8 = !DIFile(filename: "/Users/shubham/Development/Delta/alternate/CommandLine.cpp", directory: "/Users/shubham/Development/Delta/alternate", checksumkind: CSK_MD5, checksum: "ed7ae158f20f7914bc5fb843291e80da")
+!12 = distinct !DISubprogram(name: "tokenizeWindowsCommandLineImpl", type: !13, unit: !7, retainedNodes: !36)
+!13 = !DISubroutineType(types: !14)
+!14 = !{}
+!32 = !DISubroutineType(types: !33)
+!33 = !{}
+!36 = !{}
+!101 = !DISubroutineType(types: !102)
+!102 = !{}
+!114 = distinct !DISubprogram(name: "TokenizeWindowsCommandLine", type: !116, unit: !7, retainedNodes: !36)
+!116 = !DISubroutineType(types: !117)
+!117 = !{}
+!195 = !DILocation(line: 428, scope: !114)
+!256 = !DILocation(line: 410, scope: !12)
+!260 = distinct !DILexicalBlock(scope: !12, line: 412, column: 3)
+!264 = !DILocation(line: 412, scope: !260)
+!265 = !DILocation(line: 412, scope: !260)
+!267 = distinct !DILexicalBlock(scope: !260, line: 412, column: 20)
+!283 = !DILocation(line: 412, scope: !267)
+!284 = distinct !{}
+!312 = distinct !DISubprogram(name: "function_ref<(lambda at /Users/shubham/Development/Delta/alternate/CommandLine.cpp:424:16) &>", type: !313, unit: !7, retainedNodes: !36)
+!313 = !DISubroutineType(types: !314)
+!314 = !{}
+!330 = !DILocation(line: 348, scope: !312)
+!331 = distinct !DISubprogram(name: "SmallString", type: !332, unit: !7, retainedNodes: !36)
+!332 = !DISubroutineType(types: !333)
+!333 = !{}
+!339 = !DILocation(line: 399, scope: !331)
+!340 = distinct !DISubprogram(name: "size", type: !32, unit: !7, retainedNodes: !36)
+!344 = !DILocation(line: 372, scope: !340)
+!345 = !DILocation(line: 372, scope: !340)
+!444 = !DISubroutineType(types: !445)
+!445 = !{}
+!462 = distinct !DISubprogram(name: "end", scope: !462)
+!469 = distinct !DISubprogram(name: "__uninitialized_fill_n<char, char>", type: !444, unit: !7, retainedNodes: !36)
+!483 = distinct !DISubprogram(name: "__voidify<char>", unit: !7, retainedNodes: !36)
+!488 = distinct !DILocation(line: 214, scope: !469)
+!489 = !DILocation(line: 137, scope: !483, inlinedAt: !488)
+!491 = !DILocation(line: 214, scope: !469)
+!492 = distinct !DISubprogram(name: "begin", type: !101, unit: !7, retainedNodes: !36)
+!495 = !DILocation(line: 290, scope: !492)
+!496 = !DILocation(line: 290, scope: !492)

--- a/llvm/test/DebugInfo/CAS/AArch64/debug_unopt.ll
+++ b/llvm/test/DebugInfo/CAS/AArch64/debug_unopt.ll
@@ -2,6 +2,7 @@
 ; RUN: llvm-cas-dump --cas=%t/cas --casid-file %t/debug_unopt.id | FileCheck %s
 ; CHECK: mc:debug_string_section llvmcas://
 ; CHECK-NEXT: mc:debug_string llvmcas://
+; CHECK-NEXT: mc:padding      llvmcas://
 ; CHECK-NEXT: mc:section      llvmcas://
 ; CHECK: mc:debug_line_section llvmcas://
 ; CHECK-NEXT: mc:debug_line_unopt llvmcas://

--- a/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
+++ b/llvm/test/tools/llvm-cas-dump/basic_debug_test.ll
@@ -43,6 +43,7 @@
 ; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
 ; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
 ; CHECK-NEXT:       mc:debug_string  llvmcas://{{.*}}
+; CHECK-NEXT:       mc:padding  llvmcas://{{.*}}
 ; CHECK-NEXT:     mc:debug_line_section  llvmcas://{{.*}}
 ; CHECK-NEXT:       mc:debug_line_distinct_data  llvmcas://{{.*}}
 ; CHECK-NEXT:       mc:debug_line  llvmcas://{{.*}}


### PR DESCRIPTION
MCCAS doesn't support DWARF 5 currently. Since we are switching to DWARF 5 on all platforms relatively soon, we need to have MCCAS support it as well.

Cherry-picked from https://github.com/apple/llvm-project/pull/7584