### PR TITLE
[DWARFLinker] Release input DWARF after object has been linked

### DIFF
--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.cpp
@@ -272,14 +272,9 @@ DwarfLinkerForBinary::loadObject(const DebugMapObject &Obj,
   auto ErrorOrObj = loadObject(Obj, DebugMap.getTriple());
 
   if (ErrorOrObj) {
-    ContextForLinking.push_back(
-        std::unique_ptr<DWARFContext>(DWARFContext::create(*ErrorOrObj)));
-    AddressMapForLinking.push_back(
-        std::make_unique<AddressManager>(*this, *ErrorOrObj, Obj));
-
     ObjectsForLinking.push_back(std::make_unique<DWARFFile>(
-        Obj.getObjectFilename(), ContextForLinking.back().get(),
-        AddressMapForLinking.back().get(),
+        Obj.getObjectFilename(), DWARFContext::create(*ErrorOrObj),
+        std::make_unique<AddressManager>(*this, *ErrorOrObj, Obj),
         Obj.empty() ? Obj.getWarnings() : EmptyWarnings));
 
     Error E = RL.link(*ErrorOrObj);
@@ -554,8 +549,6 @@ bool DwarfLinkerForBinary::link(const DebugMap &Map) {
     return false;
 
   ObjectsForLinking.clear();
-  ContextForLinking.clear();
-  AddressMapForLinking.clear();
 
   DebugMap DebugMap(Map.getTriple(), Map.getBinaryPath());
 

--- a/llvm/tools/dsymutil/DwarfLinkerForBinary.h
+++ b/llvm/tools/dsymutil/DwarfLinkerForBinary.h
@@ -221,8 +221,6 @@ private:
   LinkOptions Options;
   std::unique_ptr<DwarfStreamer> Streamer;
   std::vector<std::unique_ptr<DWARFFile>> ObjectsForLinking;
-  std::vector<std::unique_ptr<DWARFContext>> ContextForLinking;
-  std::vector<std::unique_ptr<AddressManager>> AddressMapForLinking;
   std::vector<std::string> EmptyWarnings;
 
   /// A list of all .swiftinterface files referenced by the debug

--- a/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
+++ b/llvm/tools/llvm-dwarfutil/DebugInfoLinker.cpp
@@ -305,7 +305,6 @@ Error linkDebugInfo(object::ObjectFile &File, const Options &Options,
   DebugInfoLinker.setUpdate(!Options.DoGarbageCollection);
 
   std::vector<std::unique_ptr<DWARFFile>> ObjectsForLinking(1);
-  std::vector<std::unique_ptr<AddressesMap>> AddresssMapForLinking(1);
   std::vector<std::string> EmptyWarnings;
 
   // Unknown debug sections would be removed. Display warning
@@ -319,11 +318,9 @@ Error linkDebugInfo(object::ObjectFile &File, const Options &Options,
   }
 
   // Add object files to the DWARFLinker.
-  AddresssMapForLinking[0] =
-      std::make_unique<ObjFileAddressMap>(*Context, Options, File);
-
   ObjectsForLinking[0] = std::make_unique<DWARFFile>(
-      File.getFileName(), &*Context, AddresssMapForLinking[0].get(),
+      File.getFileName(), DWARFContext::create(File),
+      std::make_unique<ObjFileAddressMap>(*Context, Options, File),
       EmptyWarnings);
 
   for (size_t I = 0; I < ObjectsForLinking.size(); I++)


### PR DESCRIPTION
dsymutil is using an excessive amount of memory because it's holding on to the DWARF Context, even after it's done processing the corresponding object file. This patch releases the input DWARF after cloning, at which point it is no longer needed. This has always been the intended behavior, though I didn't bisect to figure out when this regressed.

When linking swift, this reduces peak (dirty) memory usage from 25 to 15 gigabytes.

rdar://111525100
(cherry picked from commit cf17bf78720f05aedd3e4a4b5252977e9a6d3e22)