### PR TITLE
[OSX][TargetLibraryInfo] Mark memrchr as unavailable on OSX

### DIFF
--- a/llvm/lib/Analysis/TargetLibraryInfo.cpp
+++ b/llvm/lib/Analysis/TargetLibraryInfo.cpp
@@ -203,6 +203,7 @@ static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setAvailable(LibFunc_getchar_unlocked);
     TLI.setAvailable(LibFunc_putc_unlocked);
     TLI.setAvailable(LibFunc_putchar_unlocked);
+    TLI.setUnavailable(LibFunc_memrchr);
 
     if (T.isMacOSXVersionLT(10, 5)) {
       TLI.setUnavailable(LibFunc_memset_pattern4);


### PR DESCRIPTION
On Mac OSX  (tested version macOS 12.4, sdk 12.1) llvm can replace call to `strrchr()` with call to `memrchr()` when string length is known at compile time. This results in link error, because `memrchr` is not present in `libSystem`. It is needed to disable this optimization in `TargetLibraryInfo` for affected OSX versions.

This non-standard function (`memrchr`) is not present on (at least) several versions of MacOS https://www.gnu.org/software/gnulib/manual/html_node/memrchr.html , so, in this patch `memrchr` is marked as unavailable for all versions. If someone knows versions where it should be available - please let me know.

Github issue: https://github.com/llvm/llvm-project/issues/62254

Tests for this feature also cannot be easily added: https://reviews.llvm.org/D134134#3801747

~~~

Huawei RRI, OS Lab

Reviewed By: nikic

Differential Revision: https://reviews.llvm.org/D155168

(cherry-picked from a7a6ef3b809100a1e7724443afe94d020d4c956b)