### PR TITLE
[lldb][NFCI] Remove Section::CanContainSwiftReflectionData

### DIFF
--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -209,8 +209,6 @@ public:
   ObjectFile *GetObjectFile() { return m_obj_file; }
   const ObjectFile *GetObjectFile() const { return m_obj_file; }
 
-  bool CanContainSwiftReflectionData() const;
-
   /// Read the section data from the object file that the section
   /// resides in.
   ///

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -25,7 +25,6 @@
 #include <optional>
 
 namespace swift {
-class SwiftObjectFileFormat;
 enum ReflectionSectionKind : uint8_t;
 }
 namespace lldb_private {
@@ -724,12 +723,6 @@ public:
 
   virtual llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
-
-#ifdef LLDB_ENABLE_SWIFT
-  virtual bool CanContainSwiftReflectionData(const Section &section) {
-    return false;
-  }
-#endif // LLDB_ENABLE_SWIFT
 
   /// Load binaries listed in a corefile
   ///

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -378,14 +378,6 @@ void Section::SetPermissions(uint32_t permissions) {
   m_executable = (permissions & ePermissionsExecutable) != 0;
 }
 
-bool Section::CanContainSwiftReflectionData() const {
-#ifdef LLDB_ENABLE_SWIFT
-  return m_obj_file->CanContainSwiftReflectionData(*this);
-#else
-  return false;
-#endif // LLDB_ENABLE_SWIFT
-}
-
 lldb::offset_t Section::GetSectionData(void *dst, lldb::offset_t dst_len,
                                        lldb::offset_t offset) {
   if (m_obj_file)

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -3598,11 +3598,3 @@ llvm::StringRef ObjectFileELF::GetReflectionSectionIdentifier(
   llvm_unreachable("Swift support disabled");
 #endif //LLDB_ENABLE_SWIFT
 }
-
-#ifdef LLDB_ENABLE_SWIFT
-bool ObjectFileELF::CanContainSwiftReflectionData(const Section &section) {
-  swift::SwiftObjectFileFormatELF file_format;
-  return file_format.sectionContainsReflectionData(
-      section.GetName().GetStringRef());
-}
-#endif // LLDB_ENABLE_SWIFT

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -401,11 +401,6 @@ private:
 
   llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
-
-#ifdef LLDB_ENABLE_SWIFT
-  bool
-  CanContainSwiftReflectionData(const lldb_private::Section &section) override;
-#endif // LLDB_ENABLE_SWIFT
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_ELF_OBJECTFILEELF_H

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6956,14 +6956,6 @@ llvm::StringRef ObjectFileMachO::GetReflectionSectionIdentifier(
 #endif //LLDB_ENABLE_SWIFT
 }
 
-#ifdef LLDB_ENABLE_SWIFT
-bool ObjectFileMachO::CanContainSwiftReflectionData(const Section &section) {
-  swift::SwiftObjectFileFormatMachO file_format;
-  return file_format.sectionContainsReflectionData(
-      section.GetName().GetStringRef());
-}
-#endif // LLDB_ENABLE_SWIFT
-
 ObjectFileMachO::MachOCorefileAllImageInfos
 ObjectFileMachO::GetCorefileAllImageInfos() {
   MachOCorefileAllImageInfos image_infos;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -231,11 +231,6 @@ protected:
   llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 
-#ifdef LLDB_ENABLE_SWIFT
-  bool
-  CanContainSwiftReflectionData(const lldb_private::Section &section) override;
-#endif // LLDB_ENABLE_SWIFT
-
   /// A corefile may include metadata about all of the binaries that were
   /// present in the process when the corefile was taken.  This is only
   /// implemented for Mach-O files for now; we'll generalize it when we

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -1444,11 +1444,3 @@ llvm::StringRef ObjectFilePECOFF::GetReflectionSectionIdentifier(
   llvm_unreachable("Swift support disabled");
 #endif //LLDB_ENABLE_SWIFT
 }
-
-#ifdef LLDB_ENABLE_SWIFT
-bool ObjectFilePECOFF::CanContainSwiftReflectionData(const Section &section) {
-  swift::SwiftObjectFileFormatCOFF file_format;
-  return file_format.sectionContainsReflectionData(
-      section.GetName().GetStringRef());
-}
-#endif // LLDB_ENABLE_SWIFT

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -268,11 +268,6 @@ protected:
   llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 
-#ifdef LLDB_ENABLE_SWIFT
-  bool
-  CanContainSwiftReflectionData(const lldb_private::Section &section) override;
-#endif // LLDB_ENABLE_SWIFT
-
   typedef std::vector<section_header_t> SectionHeaderColl;
   typedef SectionHeaderColl::iterator SectionHeaderCollIter;
   typedef SectionHeaderColl::const_iterator SectionHeaderCollConstIter;


### PR DESCRIPTION
Instead of giving Section swift-specific knowledge, I think it would make more sense for the Swift plugins that need this knowledge to compute it.