### PR TITLE
[Cherry-pick into next] Avoid reconstructing the type of self in the per-module SwiftASTContext.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -212,19 +212,10 @@ CompilerType SwiftASTContext::GetCompilerType(swift::TypeBase *swift_type) {
 }
 
 swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
-  if (compiler_type.GetTypeSystem().isa_and_nonnull<SwiftASTContext>())
+  if (compiler_type.GetTypeSystem().GetSharedPointer().get() == this)
     return reinterpret_cast<swift::TypeBase *>(
         compiler_type.GetOpaqueQualType());
-
-  // FIXME: Suboptimal performance, because the ConstString is looked up again.
-  if (auto ts = compiler_type.GetTypeSystem()
-      .dyn_cast_or_null<TypeSystemSwiftTypeRef>()) {
-    ConstString mangled_name(
-        reinterpret_cast<const char *>(compiler_type.GetOpaqueQualType()));
-    if (auto *swift_ast_context = ts->GetSwiftASTContext())
-      return swift_ast_context->ReconstructType(mangled_name);
-  }
-  return {};
+  return ReconstructType(compiler_type.GetMangledTypeName());
 }
 
 swift::Type SwiftASTContext::GetSwiftType(opaque_compiler_type_t opaque_type) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -406,8 +406,11 @@ public:
 
   CompilerType GetCompilerType(swift::TypeBase *swift_type);
   CompilerType GetCompilerType(ConstString mangled_name);
+  /// Import compiler_type into this context and return the swift::Type.
   swift::Type GetSwiftType(CompilerType compiler_type);
+protected:
   swift::Type GetSwiftType(lldb::opaque_compiler_type_t opaque_type);
+public:
   swift::CanType
   GetCanonicalSwiftType(lldb::opaque_compiler_type_t opaque_type);
 


### PR DESCRIPTION
```
commit 7efc6964f261ab13ca1bd95b3bf770c5150ac109
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Oct 19 17:35:15 2023 -0700

    Avoid reconstructing the type of self in the per-module SwiftASTContext.
    
    It will need to be reconstructed in SwiftASTContextForExpressions
    right after, so also use the scratch context here.
```
