### PR TITLE
Make Get(Canonical)SwiftType(opaque_type) private (NFC)

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -35,6 +35,7 @@ class VarDecl;
 } // namespace swift
 
 namespace lldb_private {
+class SwiftASTContextForExpressions;
 
 class SwiftASTManipulatorBase {
 public:
@@ -194,8 +195,10 @@ protected:
 
 class SwiftASTManipulator : public SwiftASTManipulatorBase {
 public:
-  SwiftASTManipulator(swift::SourceFile &source_file, bool repl,
+  SwiftASTManipulator(SwiftASTContextForExpressions &swift_ast_ctx,
+                      swift::SourceFile &source_file, bool repl,
                       lldb::BindGenericTypes bind_generic_types);
+  SwiftASTContextForExpressions &GetScratchContext() { return m_swift_ast_ctx; }
 
   void FindSpecialNames(llvm::SmallVectorImpl<swift::Identifier> &names,
                         llvm::StringRef prefix);
@@ -294,6 +297,7 @@ private:
 
   std::vector<ResultLocationInfo> m_result_info;
   llvm::StringMap<swift::TypeBase *> m_type_aliases;
+  SwiftASTContextForExpressions &m_swift_ast_ctx;
 };
 }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -331,7 +331,7 @@ static bool AddVariableInfo(
   }
 
   // Report a fatal error if self can't be reconstructed as a Swift AST type.
-  if (is_self && !GetSwiftType(target_type))
+  if (is_self && !ast_context.GetSwiftType(target_type))
     return false;
 
   auto ts = target_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
@@ -356,7 +356,7 @@ static bool AddVariableInfo(
   }
 
   if (log && is_self)
-    if (swift::Type swift_type = GetSwiftType(target_type)) {
+    if (swift::Type swift_type = ast_context.GetSwiftType(target_type)) {
       std::string s;
       llvm::raw_string_ostream ss(s);
       swift_type->dump(ss);

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1549,8 +1549,7 @@ LazyBool SwiftLanguage::IsLogicalTrue(ValueObject &valobj, Status &error) {
 
   Scalar scalar_value;
 
-  auto swift_ty = GetCanonicalSwiftType(valobj.GetCompilerType());
-  CompilerType valobj_type = ToCompilerType(swift_ty);
+  CompilerType valobj_type = valobj.GetCompilerType();
   Flags type_flags(valobj_type.GetTypeInfo());
   if (valobj_type.GetTypeSystem().isa_and_nonnull<TypeSystemSwift>()) {
     if (type_flags.AllSet(eTypeIsStructUnion) &&

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -51,11 +51,6 @@ class TypeBase;
 
 namespace lldb_private {
 
-/// Statically cast a CompilerType to a Swift type.
-swift::Type GetSwiftType(CompilerType type);
-/// Statically cast a CompilerType to a Swift type and get its canonical form.
-swift::CanType GetCanonicalSwiftType(CompilerType type);
-
 class SwiftLanguageRuntimeStub;
 class SwiftLanguageRuntimeImpl;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -89,7 +89,7 @@ SwiftLanguageRuntimeImpl::GetMemberVariableOffsetRemoteAST(
   auto *remote_ast = &GetRemoteASTContext(*scratch_ctx);
   // Check whether we've already cached this offset.
   swift::TypeBase *swift_type =
-      GetCanonicalSwiftType(instance_type).getPointer();
+      scratch_ctx->GetCanonicalSwiftType(instance_type).getPointer();
   if (swift_type == nullptr)
     return {};
 
@@ -134,7 +134,7 @@ SwiftLanguageRuntimeImpl::GetMemberVariableOffsetRemoteAST(
               "[MemberVariableOffsetResolver] resolved non-class type = %s",
               bound.GetTypeName().AsCString());
 
-          swift_type = GetCanonicalSwiftType(bound).getPointer();
+          swift_type = scratch_ctx->GetCanonicalSwiftType(bound).getPointer();
           MemberID key{swift_type, ConstString(member_name).GetCString()};
           auto it = m_member_offsets.find(key);
           if (it != m_member_offsets.end())
@@ -228,7 +228,7 @@ SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ProtocolRemoteAST(
 
   swift::remote::RemoteAddress remote_existential(existential_address);
   auto &remote_ast = GetRemoteASTContext(*swift_ast_ctx);
-  auto swift_type = GetSwiftType(protocol_type);
+  auto swift_type = swift_ast_ctx->GetSwiftType(protocol_type);
   if (!swift_type)
     return {};
   if (use_local_buffer)
@@ -284,7 +284,7 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
   base_type = swift_ast_ctx->ImportType(base_type, error);
 
   if (base_type.GetTypeInfo() & lldb::eTypeIsSwift) {
-    swift::Type target_swift_type(GetSwiftType(base_type));
+    swift::Type target_swift_type(swift_ast_ctx->GetSwiftType(base_type));
     if (target_swift_type->hasArchetype())
       target_swift_type = target_swift_type->mapTypeOutOfContext().getPointer();
 
@@ -410,7 +410,7 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
               swift_ast_ctx->ImportType(concrete_type, import_error);
 
           if (target_concrete_type.IsValid())
-            return swift::Type(GetSwiftType(target_concrete_type));
+            return swift::Type(swift_ast_ctx->GetSwiftType(target_concrete_type));
 
           return type;
         },

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -408,11 +408,14 @@ public:
   CompilerType GetCompilerType(ConstString mangled_name);
   /// Import compiler_type into this context and return the swift::Type.
   swift::Type GetSwiftType(CompilerType compiler_type);
+  /// Import compiler_type into this context and return the swift::CanType.
+  swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
 protected:
   swift::Type GetSwiftType(lldb::opaque_compiler_type_t opaque_type);
-public:
   swift::CanType
   GetCanonicalSwiftType(lldb::opaque_compiler_type_t opaque_type);
+
+public:
 
   /// Imports the type from the passed in type into this SwiftASTContext. The
   /// type must be a Swift type. If the type can be imported, returns the
@@ -583,7 +586,7 @@ public:
   static bool IsGenericType(const CompilerType &compiler_type);
 
   /// Whether this is the Swift error type.
-  bool IsErrorType(lldb::opaque_compiler_type_t type);
+  bool IsErrorType(lldb::opaque_compiler_type_t type) override;
 
   struct ProtocolInfo {
     uint32_t m_num_protocols;
@@ -606,8 +609,8 @@ public:
     uint32_t GetInstanceTypeIndex() const { return m_num_payload_words; }
   };
 
-  static bool GetProtocolTypeInfo(const CompilerType &type,
-                                  ProtocolInfo &protocol_info);
+  bool GetProtocolTypeInfo(const CompilerType &type,
+                           ProtocolInfo &protocol_info);
 
   static void ApplyWorkingDir(llvm::SmallVectorImpl<char> &clang_argument,
                               llvm::StringRef cur_working_dir);
@@ -718,7 +721,7 @@ public:
                                      size_t idx);
   CompilerType GetBoundGenericType(lldb::opaque_compiler_type_t type,
                                    size_t idx);
-  static CompilerType GetGenericArgumentType(CompilerType ct, size_t idx);
+  CompilerType GetGenericArgumentType(CompilerType ct, size_t idx);
   CompilerType GetGenericArgumentType(lldb::opaque_compiler_type_t type,
                                       size_t idx) override;
 
@@ -730,10 +733,9 @@ public:
   bool IsMeaninglessWithoutDynamicResolution(
       lldb::opaque_compiler_type_t type) override;
 
-  static bool GetSelectedEnumCase(const CompilerType &type,
-                                  const DataExtractor &data, ConstString *name,
-                                  bool *has_payload, CompilerType *payload,
-                                  bool *is_indirect);
+  bool GetSelectedEnumCase(const CompilerType &type, const DataExtractor &data,
+                           ConstString *name, bool *has_payload,
+                           CompilerType *payload, bool *is_indirect);
 
   // Dumping types
 #ifndef NDEBUG

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -124,6 +124,7 @@ public:
 
   virtual bool IsImportedType(lldb::opaque_compiler_type_t type,
                               CompilerType *original_type) = 0;
+  virtual bool IsErrorType(lldb::opaque_compiler_type_t type) = 0;
   virtual CompilerType GetErrorType() = 0;
   virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
   static CompilerType GetInstanceType(CompilerType ct);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -267,6 +267,7 @@ public:
   /// builtins (int <-> Swift.Int) as Clang types.
   CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,
                                     bool *is_imported = nullptr);
+  bool IsErrorType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;


### PR DESCRIPTION
to avoid accidentally importing types into a non-scratch SwiftASTContext. All uses are via the expression evaluator and it should always use the scratch context.