### PR TITLE
[lldb] Check for 2nd symbol in IsStaticSwiftRuntime

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -119,8 +119,8 @@ enum class RuntimeKind { Swift, ObjC };
 
 /// Detect a statically linked Swift runtime by looking for a well-known symbol.
 static bool IsStaticSwiftRuntime(Module &image) {
-  static ConstString swift_release_dealloc_sym("_swift_release_dealloc");
-  return image.FindFirstSymbolWithNameAndType(swift_release_dealloc_sym);
+  static ConstString swift_reflection_version_sym("swift_release");
+  return image.FindFirstSymbolWithNameAndType(swift_reflection_version_sym);
 }
 
 /// \return the Swift or Objective-C runtime found in the loaded images.


### PR DESCRIPTION
"_swift_release_dealloc" is not present when compiling a binary in embedded Swift mode, but "swift_release" is.