### PR TITLE
Fix replayCachedResult bug with MCCAS

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -684,7 +684,10 @@ std::optional<int> ObjectStoreCachingOutputs::replayCachedResult(
 Expected<std::optional<int>> ObjectStoreCachingOutputs::replayCachedResult(
     const llvm::cas::CASID &ResultCacheKey,
     clang::cas::CompileJobCacheResult &Result, bool JustComputedResult) {
-  if (JustComputedResult)
+  // FIXME: The correct fix for MCCAS replay is that you have an official CASID
+  // file output going all the way down into ObjectWriter, we can remove this
+  // callback and special case.
+  if (JustComputedResult && !ComputedJobNeedsReplay)
     return std::nullopt;
 
   llvm::cas::ObjectStore &CAS = Result.getCAS();

--- a/clang/test/CAS/mccas-replay-test.cpp
+++ b/clang/test/CAS/mccas-replay-test.cpp
@@ -1,0 +1,19 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: export LLVM_CACHE_CAS_PATH=%t/cas && %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c -Xclang -fcas-backend -Rcompile-job-cache %s -o %t/tmp.o 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// CACHE-MISS: remark: compile job cache miss
+
+// RUN: wc -c %t/tmp.o | FileCheck %s -check-prefix=CACHE-MISS-FILE
+// CACHE-MISS-FILE-NOT: 0 %t/tmp.o 
+
+// RUN: export LLVM_CACHE_CAS_PATH=%t/cas && %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c -Xclang -fcas-backend -Rcompile-job-cache %s -o %t/tmp.o 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// CACHE-HIT: remark: compile job cache hit
+
+// RUN: wc -c %t/tmp.o | FileCheck %s -check-prefix=CACHE-HIT-FILE
+// CACHE-HIT-FILE-NOT: 0 %t/tmp.o 
+
+
+int foo() {
+    return 1;
+}


### PR DESCRIPTION
When using MCCAS to cache build results, we see a bug where if there is a cache miss, MCCAS does not write the final serialized object file to the output, the object files all are 0 bytes in size. This patch fixes that bug.

(cherry picked from commit 8ff300f058b909451da95d48c79515bd47c9192f)