### PR TITLE
[lldb] Disable llvm::None deprecation warnings when including Swift

### DIFF
--- a/llvm/include/llvm/ADT/None.h
+++ b/llvm/include/llvm/ADT/None.h
@@ -22,12 +22,12 @@
 namespace llvm {
 /// A simple null object to allow implicit construction of std::optional<T>
 /// and similar types without having to spell out the specialization's name.
-#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
+#if !defined(SWIFT_TARGET) && !defined(LLDB_ENABLE_SWIFT) // radar://112153764 -- remove once swift transitions
 LLVM_DEPRECATED("Use std::nullopt_t instead", "std::nullopt_t")
 #endif // SWIFT_TARGET
 typedef std::nullopt_t NoneType;
 
-#ifndef SWIFT_TARGET // radar://112153764 -- remove once swift transitions
+#if !defined(SWIFT_TARGET) && !defined(LLDB_ENABLE_SWIFT) // radar://112153764 -- remove once swift transitions
 LLVM_DEPRECATED("Use std::nullopt instead.", "std::nullopt")
 #endif // SWIFT_TARGET
 inline constexpr std::nullopt_t None = std::nullopt;


### PR DESCRIPTION
Swift hasn't migrated everything to `std::optional` yet, ignore the deprecation of `None` until that's been done.