### PR TITLE
Move non-copyable types

### DIFF
--- a/llvm/lib/MCCAS/MCCASDebugV1.cpp
+++ b/llvm/lib/MCCAS/MCCASDebugV1.cpp
@@ -291,7 +291,7 @@ Expected<dwarf::Attribute> AbbrevEntryReader::readAttr() {
 static Expected<int64_t> handleImplicitConst(BinaryStreamReader &Reader) {
   int64_t ImplicitVal;
   if (auto E = Reader.readSLEB128(ImplicitVal))
-    return E;
+    return std::move(E);
   return ImplicitVal;
 }
 

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -519,7 +519,7 @@ static Expected<ObjectProxy> ingestFileSystemImpl(ObjectStore &CAS,
   llvm::DenseSet<llvm::sys::fs::UniqueID> SeenDirectories;
   for (auto &Path : Paths)
     if (Error E = recursiveAccess(**FS, Path, SeenDirectories))
-      return E;
+      return std::move(E);
 
   return (*FS)->createTreeFromNewAccesses(
       [&](const llvm::vfs::CachedDirectoryEntry &Entry,


### PR DESCRIPTION
Older clang versions can't elide the copy, resulting in build failures when returning an `llvm::Error` that isn't explicitly moved.

```
FAILED: lib/MCCAS/CMakeFiles/LLVMMCCAS.dir/MCCASDebugV1.cpp.o 
/usr/bin/clang++ --target=x86_64-unknown-linux-gnu -DGTEST_HAS_RTTI=0 -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_GNU_SOURCE -D_LIBCPP_ENABLE_HARDENED_MODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/ewilde/work/swift-project/build/Ninja-ReleaseAssert+stdlib-Release/llvm-linux-x86_64/lib/MCCAS -I/home/ewilde/work/swift-project/llvm-project/llvm/lib/MCCAS -I/home/ewilde/work/swift-project/build/Ninja-ReleaseAssert+stdlib-Release/llvm-linux-x86_64/include -I/home/ewilde/work/swift-project/llvm-project/llvm/include -Wno-unknown-warning-option -Werror=unguarded-availability-new -fno-stack-protector -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -pedantic -Wno-long-long -Wc++98-compat-extra-semi -Wimplicit-fallthrough -Wcovered-switch-default -Wno-class-memaccess -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fdiagnostics-color -ffunction-sections -fdata-sections -O3 -DNDEBUG -std=c++17  -fno-exceptions -funwind-tables -fno-rtti -UNDEBUG -MD -MT lib/MCCAS/CMakeFiles/LLVMMCCAS.dir/MCCASDebugV1.cpp.o -MF lib/MCCAS/CMakeFiles/LLVMMCCAS.dir/MCCASDebugV1.cpp.o.d -o lib/MCCAS/CMakeFiles/LLVMMCCAS.dir/MCCASDebugV1.cpp.o -c /home/ewilde/work/swift-project/llvm-project/llvm/lib/MCCAS/MCCASDebugV1.cpp
/home/ewilde/work/swift-project/llvm-project/llvm/lib/MCCAS/MCCASDebugV1.cpp:294:12: error: call to deleted constructor of 'llvm::Error'
    return E;
           ^
/home/ewilde/work/swift-project/llvm-project/llvm/include/llvm/Support/Error.h:183:3: note: 'Error' has been explicitly marked deleted here
  Error(const Error &Other) = delete;
  ^
/home/ewilde/work/swift-project/llvm-project/llvm/include/llvm/Support/Error.h:490:18: note: passing argument to parameter 'Err' here
  Expected(Error Err)
                 ^
1 error generated.

```