### PR TITLE
[lldb] Set up the structure to build type infos from DWARF

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -312,6 +312,9 @@ public:
 #endif
     ConstString mangled(wrapped);
     CompilerType swift_type = m_typesystem.GetTypeFromMangledTypename(mangled);
+    if (const auto *type_info = LookupTypeInfoInSymbolFile(mangled))
+      return type_info;
+
     auto ts = swift_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
     if (!ts)
       return nullptr;
@@ -326,6 +329,18 @@ public:
     }
     
     return GetOrCreateTypeInfo(clang_type);
+  }
+  
+  const swift::reflection::TypeInfo *
+  LookupTypeInfoInSymbolFile(ConstString mangled_name) {
+    ExecutionContext exe_ctx;
+    m_runtime.GetProcess().CalculateExecutionContext(exe_ctx);
+    if (const auto *type_info =
+            m_typesystem.GetTypeSystemSwiftTypeRef().LookupTypeInfoInSymbolFile(
+                mangled_name, &exe_ctx, this))
+      return type_info;
+
+    return nullptr;
   }
   
   const swift::reflection::TypeInfo *

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -32,6 +32,8 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/Status.h"
 
+#include "swift/RemoteInspection/TypeLowering.h"
+
 #include "clang/AST/DeclObjC.h"
 
 using namespace lldb;
@@ -202,8 +204,10 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
 
   // Cache this type.
   if (type_sp && mangled_name &&
-      SwiftLanguageRuntime::IsSwiftMangledName(mangled_name.GetStringRef()))
+      SwiftLanguageRuntime::IsSwiftMangledName(mangled_name.GetStringRef())) {
     m_swift_typesystem.SetCachedType(mangled_name, type_sp);
+    m_swift_typesystem.SetCachedDie(mangled_name, *die.GetDIERef());
+  }
   die.GetDWARF()->GetDIEToType()[die.GetDIE()] = type_sp.get();
 
   return type_sp;
@@ -295,4 +299,11 @@ DWARFASTParserSwift::GetDeclContextForUIDFromDWARF(const DWARFDIE &die) {
 lldb_private::CompilerDeclContext
 DWARFASTParserSwift::GetDeclContextContainingUIDFromDWARF(const DWARFDIE &die) {
   return CompilerDeclContext();
+}
+
+const swift::reflection::TypeInfo *DWARFASTParserSwift::BuildTypeInfo(
+    ConstString mangled_name, const lldb_private::ExecutionContext *exe_ctx,
+    swift::remote::TypeInfoProvider *provider) {
+  // TODO: implement this.
+  return nullptr;
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -19,6 +19,15 @@
 class DWARFDebugInfoEntry;
 class DWARFDIECollection;
 
+namespace swift {
+namespace reflection {
+class TypeInfo;
+} // namespace reflection
+namespace remote {
+struct TypeInfoProvider;
+} // namespace remote
+} // namespace swift
+
 namespace lldb_private { class TypeSystemSwiftTypeRef; }
 
 class DWARFASTParserSwift : public DWARFASTParser {
@@ -66,6 +75,15 @@ public:
                     "yet been implemented");
     return lldb_private::ConstString();
   }
+
+  /// Build a type info from a mangled name. As an implementation detail, this
+  /// function and ReflectionContext::GetTypeInfo are co-recursive, as this
+  /// function may ask for the type infos of the type's members to build the
+  /// current type, and ReflectionContext::GetTypeInfo may query it back.
+  const swift::reflection::TypeInfo *
+  BuildTypeInfo(lldb_private::ConstString mangled_name,
+                const lldb_private::ExecutionContext *exe_ctx,
+                swift::remote::TypeInfoProvider *provider);
 
   static bool classof(const DWARFASTParser *Parser) {
     return Parser->GetKind() == Kind::DWARFASTParserSwift;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1576,6 +1576,27 @@ void TypeSystemSwiftTypeRef::SetCachedType(ConstString mangled,
   m_swift_type_map.Insert(mangled.GetCString(), type_sp);
 }
 
+std::optional<DIERef>
+TypeSystemSwiftTypeRef::GetCachedDie(ConstString mangled) {
+  DIERef ref(LLDB_INVALID_ADDRESS);
+  if (m_swift_die_map.Lookup(mangled, ref))
+    return ref;
+  return {};
+}
+
+void TypeSystemSwiftTypeRef::SetCachedDie(ConstString mangled,
+                                          const DIERef ref) {
+  m_swift_die_map.Insert(mangled, ref);
+}
+
+const swift::reflection::TypeInfo *
+TypeSystemSwiftTypeRef::LookupTypeInfoInSymbolFile(ConstString mangled_name,
+                                    lldb_private::ExecutionContext *exe_ctx,
+                                    swift::remote::TypeInfoProvider *provider) {
+  auto *parser = llvm::cast<DWARFASTParserSwift>(GetDWARFParser());
+  return parser->BuildTypeInfo(mangled_name, exe_ctx, provider);
+}
+
 bool TypeSystemSwiftTypeRef::SupportsLanguage(lldb::LanguageType language) {
   return language == eLanguageTypeSwift;
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -13,6 +13,7 @@
 #ifndef liblldb_TypeSystemSwiftTypeRef_h_
 #define liblldb_TypeSystemSwiftTypeRef_h_
 
+#include "Plugins/SymbolFile/DWARF/DIERef.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 #include "lldb/Core/SwiftForward.h"
 #include "lldb/Utility/ThreadSafeDenseMap.h"
@@ -30,6 +31,12 @@ class Node;
 using NodePointer = Node *;
 class Demangler;
 } // namespace Demangle
+namespace reflection {
+class TypeInfo;
+} // namespace reflection
+namespace remote {
+struct TypeInfoProvider;
+} // namespace remote
 } // namespace swift
 
 namespace lldb_private {
@@ -261,6 +268,15 @@ public:
   lldb::TypeSP GetCachedType(ConstString mangled);
   lldb::TypeSP GetCachedType(lldb::opaque_compiler_type_t type);
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp);
+
+  std::optional<DIERef> GetCachedDie(ConstString mangled);
+  void SetCachedDie(ConstString mangled, const DIERef ref);
+
+  const swift::reflection::TypeInfo *
+  LookupTypeInfoInSymbolFile(ConstString mangled_name,
+                            lldb_private::ExecutionContext *exe_ctx,
+                            swift::remote::TypeInfoProvider *provider);
+
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
@@ -449,6 +465,8 @@ protected:
   ThreadSafeDenseMap<const char *, lldb::TypeSP> m_swift_type_map;
   /// Map ConstString Clang type identifiers to Clang types.
   ThreadSafeDenseMap<const char *, lldb::TypeSP> m_clang_type_cache;
+  /// Map from type's mangled names to their corresponding DIERefs.
+  ThreadSafeDenseMap<ConstString, DIERef> m_swift_die_map;
 };
 
 /// This one owns a SwiftASTContextForExpressions.


### PR DESCRIPTION
Currently, TypeSystemSwiftTypeRef queries the ReflectionContext for type infos, and ReflectionContext context can potentially query LLDBTypeInfoProvider for any types it didn't find. LLDBTypeInfoProvider produces type infos for clang types.

This patch hooks up DWARFASTParserSwift into the existing system, by making LLDBTypeInfoProvider query it before looking up clang types. DWARFASTParserSwift is passed enough information to potentially recursively query ReflectionContext for sub type infos necessary to answer the current type info query.