### PR TITLE
Fix MetadataLoader treatment of NumExtraInhabitants.

### DIFF
--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1508,11 +1508,12 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     DINode::DIFlags Flags = (Record.size() > 6)
                                 ? static_cast<DINode::DIFlags>(Record[6])
                                 : DINode::FlagZero;
+    uint32_t NumExtraInhabitants = (Record.size() > 7) ? Record[7] : 0;
 
     MetadataList.assignValue(
         GET_OR_DISTINCT(DIBasicType,
                         (Context, Record[1], getMDString(Record[2]), Record[3],
-                         Record[4], Record[5], Record[7], Flags)), 
+                         Record[4], Record[5], NumExtraInhabitants, Flags)),
         NextMetadataNo);
     NextMetadataNo++;
     break;
@@ -1588,7 +1589,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
       return error("Alignment value is too large");
     uint32_t AlignInBits = Record[8];
     uint64_t OffsetInBits = 0;
-    uint32_t NumExtraInhabitants = Record[22];
+    uint32_t NumExtraInhabitants = (Record.size() > 22) ? Record[22] : 0;
     DINode::DIFlags Flags = static_cast<DINode::DIFlags>(Record[10]);
     Metadata *Elements = nullptr;
     unsigned RuntimeLang = Record[12];


### PR DESCRIPTION
After 89d458b39924770463945611afc10710a111a47e and #7662, the code of MetadataLoader.cpp allows the new NumExtraInhabitants field, but it always supposes it is available. Some tests do not seem to like that. When compiling with asserts, binaries like `opt` will crash with an assertion accessing `SmallVector` indices out of bounds, while in no-asserts it just keeps going, probably using garbage values.

Change two places where the `Record` was accessed with `operator[]` without first checking for the `Record` size to check for the size. Use a default of `0` in case the record is not found.

The test that failed before these changes are:

```
  LLVM :: Bitcode/DIExpression-4.0.ll
  LLVM :: Bitcode/DIExpression-aggresult.ll
  LLVM :: Bitcode/DIExpression-deref.ll
  LLVM :: Bitcode/DIExpression-minus-upgrade.ll
  LLVM :: Bitcode/DIGlobalVariableExpression.ll
  LLVM :: Bitcode/DIGlobalVariableExpression2.ll
  LLVM :: Bitcode/DIModule-fortran-module.ll
  LLVM :: Bitcode/DINamespace.ll
  LLVM :: Bitcode/DISubprogram-v4.ll
  LLVM :: Bitcode/DISubprogram-v5.ll
  LLVM :: Bitcode/DITemplateParameter-5.0.ll
  LLVM :: Bitcode/diglobalvariable-3.8.ll
  LLVM :: Bitcode/dilocalvariable-3.9.ll
  LLVM :: Bitcode/disubrange-v0.ll
  LLVM :: Bitcode/dityperefs-3.8.ll
  LLVM :: Bitcode/invalid.test
  LLVM :: Bitcode/upgrade-cu-locals.ll
  LLVM :: Bitcode/upgrade-dbg-addr.ll
  LLVM :: Bitcode/upgrade-dbg-value.ll
  LLVM :: Bitcode/upgrade-pointer-address-space.ll
  LLVM :: ThinLTO/X86/drop-debug-info.ll
```

The failure looked like the following:

```
  Assertion failed: (idx < size()), function operator[], file SmallVector.h, line 294.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.	Program arguments: /Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis -o - /Users/danielrodriguez/code/swift-source/llvm-project/llvm/test/Bitcode/DIExpression-minus-upgrade.ll.bc
 #0 0x00000001003507b7 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x1001ca7b7)
 #1 0x000000010034ed55 llvm::sys::RunSignalHandlers() (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x1001c8d55)
 #2 0x0000000100351040 SignalHandler(int) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x1001cb040)
 #3 0x00007ff805ec05ed (/usr/lib/system/libsystem_platform.dylib+0x7ff8004245ed)
 #4 0x0000000000000000
 #5 0x00007ff805db9b45 (/usr/lib/system/libsystem_c.dylib+0x7ff80031db45)
 #6 0x00007ff805db8e5e (/usr/lib/system/libsystem_c.dylib+0x7ff80031ce5e)
 #7 0x0000000100385573 llvm::MetadataLoader::MetadataLoaderImpl::parseOneMetadata(llvm::SmallVectorImpl<unsigned long long>&, unsigned int, (anonymous namespace)::(anonymous namespace)::PlaceholderQueue&, llvm::StringRef, unsigned int&) (.cold.50) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x1001ff573)
 #8 0x00000001001d13a3 llvm::MetadataLoader::MetadataLoaderImpl::parseOneMetadata(llvm::SmallVectorImpl<unsigned long long>&, unsigned int, (anonymous namespace)::(anonymous namespace)::PlaceholderQueue&, llvm::StringRef, unsigned int&) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x10004b3a3)
 #9 0x00000001001c9496 llvm::MetadataLoader::MetadataLoaderImpl::parseMetadata(bool) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x100043496)
 #10 0x00000001001d2f71 llvm::MetadataLoader::parseMetadata(bool) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x10004cf71)
 #11 0x00000001001b33b7 (anonymous namespace)::BitcodeReader::parseModule(unsigned long long, bool, llvm::ParserCallbacks) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x10002d3b7)
 #12 0x000000010018f2f5 llvm::BitcodeModule::getModuleImpl(llvm::LLVMContext&, bool, bool, bool, llvm::ParserCallbacks) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x1000092f5)
 #13 0x000000010019008a llvm::BitcodeModule::getLazyModule(llvm::LLVMContext&, bool, bool, llvm::ParserCallbacks) (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x10000a08a)
 #14 0x0000000100189593 main (/Users/danielrodriguez/code/swift-source/build/my_macos/llvm-macosx-x86_64/bin/llvm-dis+0x100003593)
 #15 0x0000000200a0941f
```

With these changes, those tests all pass and the crash does not reproduce.

/cc @augusto2112 