### PR TITLE
Fix crash in clang/test/CAS/cas-backend.c

### DIFF
--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -1988,8 +1988,10 @@ Error InMemoryCASDWARFObject::partitionCUData(ArrayRef<char> DebugInfoData,
   uint64_t OffsetPtr = 0;
   DWARFUnitHeader Header;
   DWARFSection Section = {toStringRef(DebugInfoData), 0 /*Address*/};
-  Header.extract(*Ctx, DWARFDataExtractor(*this, Section, isLittleEndian(), 8),
-                 &OffsetPtr, DWARFSectionKind::DW_SECT_INFO);
+  if (Error E = Header.extract(
+          *Ctx, DWARFDataExtractor(*this, Section, isLittleEndian(), 8),
+          &OffsetPtr, DWARFSectionKind::DW_SECT_INFO))
+    return E;
 
   DWARFUnitVector UV;
   DWARFCompileUnit DCU(*Ctx, Section, Header, &Abbrev, &getRangesSection(),


### PR DESCRIPTION
PR https://github.com/llvm/llvm-project/pull/68242 changed DWARFUnitHeader::extract to return an Error, which had to be correctly handled in MCCAS. This change fixes that issue.

(cherry picked from commit 7773cc56ede6d66358d04f14242a571531f048a3)