### PR TITLE
[Cherry-pick into swift/release/5.10] Fix log format strings

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -391,7 +391,7 @@ xcrun(const std::string &sdk, llvm::ArrayRef<llvm::StringRef> arguments,
   if (log) {
     std::string cmdstr;
     args.GetCommandString(cmdstr);
-    log->Printf("GetXcodeSDK() running shell cmd '%s'", cmdstr.c_str());
+    LLDB_LOG(log, "GetXcodeSDK() running shell cmd '{0}'", cmdstr);
   }
 
   int status = 0;
@@ -407,13 +407,13 @@ xcrun(const std::string &sdk, llvm::ArrayRef<llvm::StringRef> arguments,
   // Check that xcrun returned something useful.
   if (error.Fail()) {
     // Catastrophic error.
-    LLDB_LOG(log, "xcrun failed to execute: %s", error.AsCString());
+    LLDB_LOG(log, "xcrun failed to execute: {0}", error);
     return error.ToError();
   }
   if (status != 0) {
     // xcrun didn't find a matching SDK. Not an error, we'll try
     // different spellings.
-    LLDB_LOG(log, "xcrun returned exit code %d", status);
+    LLDB_LOG(log, "xcrun returned exit code {0}", status);
     return "";
   }
   if (output_str.empty()) {


### PR DESCRIPTION
```
commit b82c62978690a8a518f22780bd13ac2b5ddcd2b8
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Oct 25 16:42:20 2023 -0700

    Fix log format strings
```
