### PR TITLE
[cherry-pick][Coroutines][NFC] Only look for Alloca or Load when finding dbg.decla…

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -1863,6 +1863,8 @@ static void insertSpills(const FrameDataInfo &FrameData, coro::Shape &Shape) {
             if (LdInst->getPointerOperandType() != LdInst->getType())
               break;
             CurDef = LdInst->getPointerOperand();
+            if (!isa<AllocaInst, LoadInst>(CurDef))
+              break;
             DIs = FindDbgDeclareUses(CurDef);
           }
         }


### PR DESCRIPTION
…re for temp spills

We only look for Alloca or Load in this case, so making it explicit.

Reviewed By: ChuanqiXu, MatzeB

Differential Revision: https://reviews.llvm.org/D157423

(cherry picked from commit f55e57ca0c43294e5c0021c1ddf7e36f3474a8f2)