### PR TITLE
Fix mccas replay stable

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -684,7 +684,10 @@ std::optional<int> ObjectStoreCachingOutputs::replayCachedResult(
 Expected<std::optional<int>> ObjectStoreCachingOutputs::replayCachedResult(
     const llvm::cas::CASID &ResultCacheKey,
     clang::cas::CompileJobCacheResult &Result, bool JustComputedResult) {
-  if (JustComputedResult)
+  // FIXME: The correct fix for MCCAS replay is that you have an official CASID
+  // file output going all the way down into ObjectWriter, we can remove this
+  // callback and special case.
+  if (JustComputedResult && !ComputedJobNeedsReplay)
     return std::nullopt;
 
   llvm::cas::ObjectStore &CAS = Result.getCAS();

--- a/clang/test/CAS/mccas-replay-test.cpp
+++ b/clang/test/CAS/mccas-replay-test.cpp
@@ -1,0 +1,31 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: export LLVM_CACHE_CAS_PATH=%t/cas && %clang-cache \
+// RUN:   %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Rcompile-job-cache %s -o %t/tmp.o -g 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// CACHE-MISS: remark: compile job cache miss
+
+// RUN: llvm-objdump -h %t/tmp.o | FileCheck %s -check-prefix=CHECK-OBJDUMP
+
+// RUN: export LLVM_CACHE_CAS_PATH=%t/cas && %clang-cache \
+// RUN:   %clang -target arm64-apple-macosx12.0.0 -c -Xclang -fcas-backend -Rcompile-job-cache %s -o %t/tmp.o -g 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// CACHE-HIT: remark: compile job cache hit
+
+// RUN: llvm-objdump -h %t/tmp.o 2>&1 | FileCheck %s -check-prefix=CHECK-OBJDUMP
+
+// CHECK-OBJDUMP: Sections:
+// CHECK-OBJDUMP-NEXT: Idx Name             Size     VMA              Type
+// CHECK-OBJDUMP-NEXT:   0 __text           {{[0-9a-f]+}} {{[0-9a-f]+}} TEXT
+// CHECK-OBJDUMP-NEXT:   1 __debug_abbrev   {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+// CHECK-OBJDUMP-NEXT:   2 __debug_info     {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+// CHECK-OBJDUMP-NEXT:   3 __debug_str      {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+// CHECK-OBJDUMP-NEXT:   4 __apple_names    {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+// CHECK-OBJDUMP-NEXT:   5 __apple_objc     {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+// CHECK-OBJDUMP-NEXT:   6 __apple_namespac {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+// CHECK-OBJDUMP-NEXT:   7 __apple_types    {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+// CHECK-OBJDUMP-NEXT:   8 __compact_unwind {{[0-9a-f]+}} {{[0-9a-f]+}} DATA
+// CHECK-OBJDUMP-NEXT:   9 __debug_line     {{[0-9a-f]+}} {{[0-9a-f]+}} DATA, DEBUG
+
+// REQUIRES: aarch64-registered-target
+
+int foo() {
+    return 1;
+}


### PR DESCRIPTION
Fix replayCachedResult bug with MCCAS
    
    When using MCCAS to cache build results, we see a bug where if there is
    a cache miss, MCCAS does not write the final serialized object file to
    the output, the object files all are 0 bytes in size. This patch fixes
    that bug.
    
    (cherry picked from commit 5469668e84d47d094b7816c788a39fb5efac15b5)