### PR TITLE
Fix typo in swift section name

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Swift.def
+++ b/llvm/include/llvm/BinaryFormat/Swift.def
@@ -34,4 +34,4 @@ HANDLE_SWIFT_SECTION(acfuncs, "__swift5_acfuncs", "swift5_accessible_functions",
 HANDLE_SWIFT_SECTION(mpenum, "__swift5_mpenum", "swift5_mpenum", ".sw5mpen$B")
 
 // Debug info.
-HANDLE_SWIFT_SECTION(swiftast, "__swift_ast", "swift_ast", "swiftast")
+HANDLE_SWIFT_SECTION(swiftast, "__swift_ast", ".swift_ast", "swiftast")


### PR DESCRIPTION
(cherry picked from commit 92b4e05494126f39716048aa09a2b89485384574)