### PR TITLE
[lldb] Include SafeMachO.h before ReflectionContext.h (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -31,6 +31,7 @@
 #include "lldb/Core/ValueObjectVariable.h"
 #include "lldb/DataFormatters/StringPrinter.h"
 #include "lldb/Host/OptionParser.h"
+#include "lldb/Host/SafeMachO.h"
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Interpreter/CommandObject.h"
 #include "lldb/Interpreter/CommandObjectMultiword.h"

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -19,6 +19,7 @@
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 #include "lldb/Core/ValueObjectMemory.h"
+#include "lldb/Host/SafeMachO.h"
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ProcessStructReader.h"

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
@@ -6,6 +6,7 @@
 
 #include "lldb/Core/DataFileCache.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Host/SafeMachO.h"
 
 #include "llvm/Support/DJB.h"
 #include "llvm/Support/OnDiskHashTable.h"


### PR DESCRIPTION
Always include SafeMachO.h before ReflectionContext.h to avoid conflicting symbols between mach/machine.h and
llvm/BinaryFormat/MachO.h.

(cherry picked from commit ecf8d982f0129ecabb1fc5ee5bc7d963e06a2143)