### PR TITLE
[lldb][NFC] Expose GetReflectionContext in SwiftLanguageRuntime's API

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntimeImpl.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -25,7 +26,7 @@ namespace {
 /// 32-bit or 64-bit pointers, with and without ObjC interoperability.
 template <typename ReflectionContext>
 class TargetReflectionContext
-    : public SwiftLanguageRuntimeImpl::ReflectionContextInterface {
+    : public ReflectionContextInterface {
   ReflectionContext m_reflection_ctx;
   swift::reflection::TypeConverter m_type_converter;
 
@@ -142,10 +143,9 @@ public:
     return m_reflection_ctx.getBuilder().lookupSuperclass(tr);
   }
 
-  bool ForEachSuperClassType(
-      swift::remote::TypeInfoProvider *tip, lldb::addr_t pointer,
-      std::function<bool(SwiftLanguageRuntimeImpl::SuperClassType)> fn)
-      override {
+  bool ForEachSuperClassType(swift::remote::TypeInfoProvider *tip,
+                             lldb::addr_t pointer,
+                             std::function<bool(SuperClassType)> fn) override {
     // Guard against faulty self-referential metadata.
     unsigned limit = 256;
     auto md_ptr = m_reflection_ctx.readMetadataFromInstance(pointer);
@@ -239,8 +239,8 @@ public:
 } // namespace
 
 namespace lldb_private {
-std::unique_ptr<SwiftLanguageRuntimeImpl::ReflectionContextInterface>
-SwiftLanguageRuntimeImpl::ReflectionContextInterface::CreateReflectionContext(
+std::unique_ptr<ReflectionContextInterface>
+ReflectionContextInterface::CreateReflectionContext(
     uint8_t ptr_size, std::shared_ptr<swift::remote::MemoryReader> reader,
     bool ObjCInterop, SwiftMetadataCache *swift_metadata_cache) {
   using ReflectionContext32ObjCInterop =

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -1,0 +1,142 @@
+#ifndef liblldb_SwiftReflectionContextInterface_h_
+#define liblldb_SwiftReflectionContextInterface_h_
+
+#include <mutex>
+
+#include "lldb/lldb-types.h"
+#include "swift/ABI/ObjectFile.h"
+#include "swift/Remote/RemoteAddress.h"
+#include "swift/RemoteInspection/TypeRef.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Memory.h"
+
+namespace swift {
+namespace Demangle {
+class Demangler;
+} // namespace Demangle
+namespace reflection {
+class RecordTypeInfo;
+class TypeInfo;
+} // namespace reflection
+namespace remote {
+class MemoryReader;
+struct TypeInfoProvider;
+} // namespace remote
+} // namespace swift
+
+namespace lldb_private {
+struct SwiftMetadataCache;
+
+/// Returned by \ref ForEachSuperClassType. Not every user of \p
+/// ForEachSuperClassType needs all of these. By returning this
+/// object we call into the runtime only when needed.
+/// Using function objects to avoid instantiating ReflectionContext in this
+/// header.
+struct SuperClassType {
+  std::function<const swift::reflection::RecordTypeInfo *()>
+      get_record_type_info;
+  std::function<const swift::reflection::TypeRef *()> get_typeref;
+};
+
+/// An abstract interface to swift::reflection::ReflectionContext
+/// objects of varying pointer sizes.  This class encapsulates all
+/// traffic to ReflectionContext and abstracts the detail that
+/// ReflectionContext is a template that needs to be specialized for
+/// a specific pointer width.
+class ReflectionContextInterface {
+public:
+  /// Return a reflection context.
+  static std::unique_ptr<ReflectionContextInterface> CreateReflectionContext(
+      uint8_t pointer_size, std::shared_ptr<swift::remote::MemoryReader> reader,
+      bool objc_interop, SwiftMetadataCache *swift_metadata_cache);
+
+  virtual ~ReflectionContextInterface() = default;
+
+  virtual llvm::Optional<uint32_t> AddImage(
+      llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
+          swift::ReflectionSectionKind)>
+          find_section,
+      llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
+  virtual llvm::Optional<uint32_t>
+  AddImage(swift::remote::RemoteAddress image_start,
+           llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
+  virtual llvm::Optional<uint32_t>
+  ReadELF(swift::remote::RemoteAddress ImageStart,
+          llvm::Optional<llvm::sys::MemoryBlock> FileBuffer,
+          llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
+  virtual const swift::reflection::TypeRef *
+  GetTypeRefOrNull(llvm::StringRef mangled_type_name) = 0;
+  virtual const swift::reflection::TypeRef *
+  GetTypeRefOrNull(swift::Demangle::Demangler &dem,
+                   swift::Demangle::NodePointer node) = 0;
+  virtual const swift::reflection::TypeInfo *
+  GetClassInstanceTypeInfo(const swift::reflection::TypeRef *type_ref,
+                           swift::remote::TypeInfoProvider *provider) = 0;
+  virtual const swift::reflection::TypeInfo *
+  GetTypeInfo(const swift::reflection::TypeRef *type_ref,
+              swift::remote::TypeInfoProvider *provider) = 0;
+  virtual const swift::reflection::TypeInfo *
+  GetTypeInfoFromInstance(lldb::addr_t instance,
+                          swift::remote::TypeInfoProvider *provider) = 0;
+  virtual swift::remote::MemoryReader &GetReader() = 0;
+  virtual const swift::reflection::TypeRef *
+  LookupSuperclass(const swift::reflection::TypeRef *tr) = 0;
+  virtual bool
+  ForEachSuperClassType(swift::remote::TypeInfoProvider *tip,
+                        lldb::addr_t pointer,
+                        std::function<bool(SuperClassType)> fn) = 0;
+  virtual llvm::Optional<std::pair<const swift::reflection::TypeRef *,
+                                   swift::remote::RemoteAddress>>
+  ProjectExistentialAndUnwrapClass(
+      swift::remote::RemoteAddress existential_addess,
+      const swift::reflection::TypeRef &existential_tr) = 0;
+  virtual llvm::Optional<int32_t>
+  ProjectEnumValue(swift::remote::RemoteAddress enum_addr,
+                   const swift::reflection::TypeRef *enum_type_ref,
+                   swift::remote::TypeInfoProvider *provider) = 0;
+  virtual const swift::reflection::TypeRef *
+  ReadTypeFromMetadata(lldb::addr_t metadata_address,
+                       bool skip_artificial_subclasses = false) = 0;
+  virtual const swift::reflection::TypeRef *
+  ReadTypeFromInstance(lldb::addr_t instance_address,
+                       bool skip_artificial_subclasses = false) = 0;
+  virtual llvm::Optional<bool> IsValueInlinedInExistentialContainer(
+      swift::remote::RemoteAddress existential_address) = 0;
+  virtual const swift::reflection::TypeRef *
+  ApplySubstitutions(const swift::reflection::TypeRef *type_ref,
+                     swift::reflection::GenericArgumentMap substitutions) = 0;
+  virtual swift::remote::RemoteAbsolutePointer
+  StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
+};
+
+/// A wrapper around TargetReflectionContext, which holds a lock to ensure
+/// exclusive access.
+struct ThreadSafeReflectionContext {
+  ThreadSafeReflectionContext(ReflectionContextInterface *reflection_ctx,
+                              std::recursive_mutex &mutex)
+      : m_reflection_ctx(reflection_ctx), m_lock(mutex, std::adopt_lock) {}
+
+  static ThreadSafeReflectionContext MakeInvalid() {
+    // This exists so we can create an "empty" reflection context in the stub
+    // language runtime.
+    static std::recursive_mutex mutex;
+    return ThreadSafeReflectionContext(nullptr, mutex);
+  }
+
+  ReflectionContextInterface *operator->() const { return m_reflection_ctx; }
+
+  operator bool() const { return m_reflection_ctx != nullptr; }
+
+private:
+  ReflectionContextInterface *m_reflection_ctx;
+  // This lock operates on a recursive mutex because the initialization
+  // of ReflectionContext recursive calls itself (see
+  // SwiftLanguageRuntimeImpl::SetupReflection).
+  std::lock_guard<std::recursive_mutex> m_lock;
+};
+
+} // namespace lldb_private
+#endif

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -12,6 +12,7 @@
 
 #include "SwiftLanguageRuntime.h"
 #include "Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h"
+#include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntimeImpl.h"
 #include "SwiftMetadataCache.h"
 
@@ -234,6 +235,11 @@ public:
     assert(false && "called into swift language runtime stub");                \
   } while (0)
 
+  ThreadSafeReflectionContext GetReflectionContext() {
+    STUB_LOG();
+    return ThreadSafeReflectionContext::MakeInvalid();
+  }
+
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
@@ -446,7 +452,7 @@ static bool HasReflectionInfo(ObjectFile *obj_file) {
   return hasReflectionSection;
 }
 
-SwiftLanguageRuntimeImpl::ThreadSafeReflectionContext 
+ThreadSafeReflectionContext 
 SwiftLanguageRuntimeImpl::GetReflectionContext() {
   m_reflection_ctx_mutex.lock();
   SetupReflection();
@@ -2334,6 +2340,11 @@ void SwiftLanguageRuntime::Terminate() {
 #define FORWARD(METHOD, ...)                                                   \
   assert(m_impl || m_stub);                                                    \
   return m_impl ? m_impl->METHOD(__VA_ARGS__) : m_stub->METHOD(__VA_ARGS__);
+
+ThreadSafeReflectionContext
+SwiftLanguageRuntime::GetReflectionContext() {
+  FORWARD(GetReflectionContext);
+}
 
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -14,6 +14,7 @@
 #define liblldb_SwiftLanguageRuntime_h_
 
 #include "Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h"
+#include "Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h"
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "lldb/Breakpoint/BreakpointPrecondition.h"
 #include "lldb/Core/PluginInterface.h"
@@ -50,9 +51,11 @@ class TypeBase;
 } // namespace swift
 
 namespace lldb_private {
+struct ThreadSafeReflectionContext;
 
 class SwiftLanguageRuntimeStub;
 class SwiftLanguageRuntimeImpl;
+class ReflectionContextInterface;
 
 class SwiftLanguageRuntime : public LanguageRuntime {
 protected:
@@ -68,6 +71,7 @@ protected:
   std::unique_ptr<SwiftLanguageRuntimeImpl> m_impl;
 
 public:
+  ThreadSafeReflectionContext GetReflectionContext();
   static char ID;
 
   bool isA(const void *ClassID) const override {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "LLDBMemoryReader.h"
+#include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntime.h"
 #include "SwiftLanguageRuntimeImpl.h"
 #include "SwiftMetadataCache.h"
@@ -208,9 +209,6 @@ lldb::addr_t SwiftLanguageRuntime::MaybeMaskNonTrivialReferencePointer(
 
   return addr & ~mask;
 }
-
-SwiftLanguageRuntimeImpl::ReflectionContextInterface::
-    ~ReflectionContextInterface() {}
 
 const CompilerType &SwiftLanguageRuntimeImpl::GetBoxMetadataType() {
   if (m_box_metadata_type.IsValid())

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntimeImpl.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Utility/LLDBLog.h"


### PR DESCRIPTION
This is in preparation for building type infos from DWARF, which will need access to the reflection context and it's builder.

(cherry picked from commit 41a8e85005206e3a979bd99785900f543cf8f143)