### PR TITLE
[lldb] Fix return with ternary operator preventing RVO with MSVC.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2343,7 +2343,12 @@ void SwiftLanguageRuntime::Terminate() {
 
 ThreadSafeReflectionContext
 SwiftLanguageRuntime::GetReflectionContext() {
-  FORWARD(GetReflectionContext);
+  // Hand written because the ternary operator prevents RVO when compiling with
+  // MSVC.
+  assert(m_impl || m_stub);
+  if (m_impl)
+    return m_impl->GetReflectionContext();
+  return m_stub->GetReflectionContext();
 }
 
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(


### PR DESCRIPTION
(cherry picked from commit 39c9340636e9f1f385276db6f61dc41fa078d305)