### PR TITLE
[APINotes] NFC: Cleanup CMakeLists

### DIFF
--- a/clang/lib/APINotes/CMakeLists.txt
+++ b/clang/lib/APINotes/CMakeLists.txt
@@ -5,7 +5,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_library(clangAPINotes
   APINotesManager.cpp
-  APINotesWriter.cpp
   APINotesReader.cpp
   APINotesTypes.cpp
   APINotesWriter.cpp


### PR DESCRIPTION
`APINotesWriter.cpp` was listed twice as a source file