### PR TITLE
[APINotes] Remove unused API

### DIFF
--- a/clang/include/clang/APINotes/APINotesYAMLCompiler.h
+++ b/clang/include/clang/APINotes/APINotesYAMLCompiler.h
@@ -31,13 +31,6 @@ namespace clang {
 class FileEntry;
 
 namespace api_notes {
-enum class ActionType {
-  None,
-  YAMLToBinary,
-  BinaryToYAML,
-  Dump,
-};
-
 /// Converts API notes from YAML format to binary format.
 bool compileAPINotes(llvm::StringRef yamlInput, const FileEntry *sourceFile,
                      llvm::raw_ostream &os,


### PR DESCRIPTION
Compiled API Notes were deprecated and removed in 2019. `clang::api_notes::ActionType` has no usages and should be removed as well.