### PR TITLE
[stable/20230725] SwiftCallingConv: Fix the splitVectorEntry function (#69953)

### DIFF
--- a/clang/lib/CodeGen/SwiftCallingConv.cpp
+++ b/clang/lib/CodeGen/SwiftCallingConv.cpp
@@ -409,9 +409,10 @@ void SwiftAggLowering::splitVectorEntry(unsigned index) {
 
   CharUnits begin = Entries[index].Begin;
   for (unsigned i = 0; i != numElts; ++i) {
-    Entries[index].Type = eltTy;
-    Entries[index].Begin = begin;
-    Entries[index].End = begin + eltSize;
+    unsigned idx = index + i;
+    Entries[idx].Type = eltTy;
+    Entries[idx].Begin = begin;
+    Entries[idx].End = begin + eltSize;
     begin += eltSize;
   }
 }

--- a/clang/test/CodeGen/64bit-swiftcall.c
+++ b/clang/test/CodeGen/64bit-swiftcall.c
@@ -985,8 +985,8 @@ struct {
 } s;
 } union_het_vecint;
 TEST(union_het_vecint)
-// CHECK: define{{.*}} swiftcc void @return_union_het_vecint(ptr noalias sret([[UNION:.+]])
-// CHECK: define{{.*}} swiftcc void @take_union_het_vecint(ptr
+// CHECK: define{{.*}} swiftcc { i64, i64, i64, i64 } @return_union_het_vecint()
+// CHECK: define{{.*}} swiftcc void @take_union_het_vecint(i64 %0, i64 %1, i64 %2, i64 %3)
 
 typedef struct {
   float3 f3;
@@ -1044,3 +1044,20 @@ typedef struct {
 
 // CHECK-LABEL: use_atomic_padded(i64 %0, i64 %1)
 SWIFTCALL void use_atomic_padded(atomic_padded a) {}
+
+
+typedef union {
+  float4 v;
+  float3 v2;
+  struct {
+    float a;
+    float b;
+    float c;
+    float d;
+  };
+} vector_union;
+
+TEST(vector_union)
+
+// CHECK-LABEL: define swiftcc { float, float, float, float } @return_vector_union()
+// CHECK-LABEL: define swiftcc void @take_vector_union(float %0, float %1, float %2, float %3)


### PR DESCRIPTION
When splitting an entry into multiple entries, the indices of the split entries are a combination of the original split entry's and the number of elements we split that entry to.

Failure to do so resulted in non-sensical entries leading e.g to assertion failures in `getCoerceAndExpandTypes` and runtime failures in Swift programs.

(cherry picked from commit 08e9c462eaa900449c2250c7ae84d9d303de9fb4)

rdar://116852924