### PR TITLE
[Cherry-pick into stable/20230725] Fix the DEVELOPER_DIR computation (#70528)

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -461,13 +461,11 @@ static llvm::Expected<std::string> GetXcodeSDK(XcodeSDK sdk) {
     // Invoke xcrun with the shlib dir.
     if (FileSpec fspec = HostInfo::GetShlibDir()) {
       if (FileSystem::Instance().Exists(fspec)) {
-        std::string contents_dir =
-            XcodeSDK::FindXcodeContentsDirectoryInPath(fspec.GetPath());
-        llvm::StringRef shlib_developer_dir =
-            llvm::sys::path::parent_path(contents_dir);
-        if (!shlib_developer_dir.empty()) {
-          auto sdk =
-              xcrun(sdk_name, show_sdk_path, std::move(shlib_developer_dir));
+        llvm::SmallString<0> shlib_developer_dir(
+            XcodeSDK::FindXcodeContentsDirectoryInPath(fspec.GetPath()));
+        llvm::sys::path::append(shlib_developer_dir, "Developer");
+        if (FileSystem::Instance().Exists(shlib_developer_dir)) {
+          auto sdk = xcrun(sdk_name, show_sdk_path, shlib_developer_dir);
           if (!sdk)
             return sdk.takeError();
           if (!sdk->empty())


### PR DESCRIPTION
```
commit c42b640208aa74c65cef5943bc05522780a72723
Author: Adrian Prantl <adrian-prantl@users.noreply.github.com>
Date:   Mon Oct 30 10:00:40 2023 -0700

    Fix the DEVELOPER_DIR computation (#70528)
    
    The code was incorrectly going into the wrong direction by removing one
    component instead of appendeing /Developer to it. Due to fallback
    mechanisms in xcrun this never seemed to have caused any issues.
```
