### PR TITLE
[clang][cas] Update test after module-includes buffer change

### DIFF
--- a/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
@@ -105,7 +105,7 @@
 
 // CHECK-LABEL: System module-includes
 // CHECK-NEXT: #import "sys.h"
-// CHECK-NEXT: #import "/^tc/{{.*}}/stdbool.h"
+// CHECK-NEXT: #import "stdbool.h"
 
 // CHECK-NEXT:      {
 // CHECK-NEXT   "modules": [


### PR DESCRIPTION
After 396b5621 we do not put the absolute path of resource dir headers into the generated module-includes buffer. Update our test to match. Note: the resolved header does not change.