### PR TITLE
[Cherry-pick into stable/20230725] Also log the error output from xcrun, if it fails. (#70716)

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -417,6 +417,8 @@ xcrun(const std::string &sdk, llvm::ArrayRef<llvm::StringRef> arguments,
     // xcrun didn't find a matching SDK. Not an error, we'll try
     // different spellings.
     LLDB_LOG(log, "xcrun returned exit code {0}", status);
+    if (!output_str.empty())
+      LLDB_LOG(log, "xcrun output was:\n{0}", output_str);
     return "";
   }
   if (output_str.empty()) {


### PR DESCRIPTION
```
commit 15733fe5f3cbf36ad1c9fbb0c6e4f31fdec224fa
Author: Adrian Prantl <adrian-prantl@users.noreply.github.com>
Date:   Tue Oct 31 15:36:06 2023 -0700

    Also log the error output from xcrun, if it fails. (#70716)
    
    In the rare case that an Xcode installation is damaged, this output
    could contain clues to further diagnose the issue.
    
    rdar://117698630
```
