### PR TITLE
[Cherry-pick into next] Remove redundant round-trip through SwiftASTContext (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -547,9 +547,7 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
       types.Insert(cached);
     else if (auto *M = GetModule())
       M->FindTypes({mangled}, false, 1, searched_symbol_files, types);
-    else if (TargetSP target_sp = GetSwiftASTContext()
-                                      ? GetSwiftASTContext()->GetTargetWP().lock()
-                                      : nullptr)
+    else if (TargetSP target_sp = GetTargetWP().lock())
       target_sp->GetImages().FindTypes(nullptr, {mangled}, false, 1,
                                        searched_symbol_files, types);
     else {


### PR DESCRIPTION
```
commit dc8729dd7d650e4e07f098caeaf6f2c9bd94e147
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Oct 31 16:40:50 2023 -0700

    Remove redundant round-trip through SwiftASTContext (NFC)
    
    The implementation there calls back into TypeSystemSwiftTypeRef.
```
