### PR TITLE
Move GetUserExpression to TypeSystemSwiftTypeRef (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8086,25 +8086,6 @@ lldb::TargetWP SwiftASTContextForExpressions::GetTargetWP() const {
   return ts->m_target_wp;
 }
 
-UserExpression *SwiftASTContextForExpressions::GetUserExpression(
-    llvm::StringRef expr, llvm::StringRef prefix, lldb::LanguageType language,
-    Expression::ResultType desired_type,
-    const EvaluateExpressionOptions &options, ValueObject *ctx_obj) {
-  TargetSP target_sp = GetTargetWP().lock();
-  if (!target_sp)
-    return nullptr;
-  if (ctx_obj != nullptr) {
-    lldb_assert(0,
-                "Swift doesn't support 'evaluate in the context"
-                " of an object'.",
-                __FUNCTION__, __FILE__, __LINE__);
-    return nullptr;
-  }
-
-  return new SwiftUserExpression(*target_sp.get(), expr, prefix, language,
-                                 desired_type, options);
-}
-
 PersistentExpressionState *
 SwiftASTContextForExpressions::GetPersistentExpressionState() {
   return GetTypeSystemSwiftTypeRef().GetPersistentExpressionState();

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -1013,7 +1013,10 @@ public:
                                     lldb::LanguageType language,
                                     Expression::ResultType desired_type,
                                     const EvaluateExpressionOptions &options,
-                                    ValueObject *ctx_obj) override;
+                                    ValueObject *ctx_obj) override {
+    return m_typeref_typesystem->GetUserExpression(
+        expr, prefix, language, desired_type, options, ctx_obj);
+  }
 
   PersistentExpressionState *GetPersistentExpressionState() override;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -14,7 +14,13 @@
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 
+#include "Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.h"
+#include "Plugins/ExpressionParser/Clang/ClangUtil.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
+#include "Plugins/ExpressionParser/Swift/SwiftUserExpression.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
+#include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
+#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "lldb/Core/DumpDataExtractor.h"
 #include "lldb/Core/StreamFile.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -24,12 +30,6 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/RegularExpression.h"
 #include "lldb/Utility/Timer.h"
-
-#include "Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.h"
-#include "Plugins/ExpressionParser/Clang/ClangUtil.h"
-#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
-#include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
-#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/../../lib/ClangImporter/ClangAdapter.h"
@@ -1430,11 +1430,19 @@ UserExpression *TypeSystemSwiftTypeRefForExpressions::GetUserExpression(
     llvm::StringRef expr, llvm::StringRef prefix, lldb::LanguageType language,
     Expression::ResultType desired_type,
     const EvaluateExpressionOptions &options, ValueObject *ctx_obj) {
-  auto *swift_ast_ctx = GetSwiftASTContext();
-  if (!swift_ast_ctx)
+  TargetSP target_sp = GetTargetWP().lock();
+  if (!target_sp)
     return nullptr;
-  return swift_ast_ctx->GetUserExpression(expr, prefix, language, desired_type,
-                                          options, ctx_obj);
+  if (ctx_obj != nullptr) {
+    lldb_assert(0,
+                "Swift doesn't support 'evaluate in the context"
+                " of an object'.",
+                __FUNCTION__, __FILE__, __LINE__);
+    return nullptr;
+  }
+
+  return new SwiftUserExpression(*target_sp.get(), expr, prefix, language,
+                                 desired_type, options);
 }
 
 PersistentExpressionState *


### PR DESCRIPTION
(cherry picked from commit ebb46203bebb6b786cde7e09337b62518c9be9db)

 Conflicts:
	lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp