### PR TITLE
(Cherrypick) [lldb] Remove workaround in InstrumentationRuntimeASan

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/ASan/InstrumentationRuntimeASan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/ASan/InstrumentationRuntimeASan.cpp
@@ -152,12 +152,10 @@ StructuredData::ObjectSP InstrumentationRuntimeASan::RetrieveReportData() {
 
   addr_t pc =
       return_value_sp->GetValueForExpressionPath(".pc")->GetValueAsUnsigned(0);
-  /* commented out because rdar://problem/18533301
   addr_t bp =
   return_value_sp->GetValueForExpressionPath(".bp")->GetValueAsUnsigned(0);
   addr_t sp =
-  return_value_sp->GetValueForExpressionPath(".sp")->GetValueAsUnsigned(0);
-  */
+      return_value_sp->GetValueForExpressionPath(".sp")->GetValueAsUnsigned(0);
   addr_t address = return_value_sp->GetValueForExpressionPath(".address")
                        ->GetValueAsUnsigned(0);
   addr_t access_type =
@@ -177,10 +175,8 @@ StructuredData::ObjectSP InstrumentationRuntimeASan::RetrieveReportData() {
   dict->AddStringItem("instrumentation_class", "AddressSanitizer");
   dict->AddStringItem("stop_type", "fatal_error");
   dict->AddIntegerItem("pc", pc);
-  /* commented out because rdar://problem/18533301
   dict->AddIntegerItem("bp", bp);
   dict->AddIntegerItem("sp", sp);
-  */
   dict->AddIntegerItem("address", address);
   dict->AddIntegerItem("access_type", access_type);
   dict->AddIntegerItem("access_size", access_size);


### PR DESCRIPTION
The code was commented out because it would trigger an assert in the source manager. I can no longer reproduce the assert and none of the ASan tests are failing with the code re-enabled.