### PR TITLE
[CAS] Add missing TargetParser dependency to MCCAS & cas-dump.

### DIFF
--- a/llvm/lib/MCCAS/CMakeLists.txt
+++ b/llvm/lib/MCCAS/CMakeLists.txt
@@ -12,4 +12,5 @@ add_llvm_component_library(LLVMMCCAS
   DebugInfoCodeView
   DebugInfoDWARF
   MC
+  TargetParser
   )

--- a/llvm/tools/llvm-cas-dump/CMakeLists.txt
+++ b/llvm/tools/llvm-cas-dump/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   CASUtil
   BinaryFormat
   Object
+  TargetParser
   )
 
 add_llvm_tool(llvm-cas-dump


### PR DESCRIPTION
This unbreaks the shared library build of LLVM.