### PR TITLE
[lldb][NFCI] Remove Section::CanContainSwiftReflectionData

### DIFF
--- a/lldb/include/lldb/Core/Section.h
+++ b/lldb/include/lldb/Core/Section.h
@@ -209,8 +209,6 @@ public:
   ObjectFile *GetObjectFile() { return m_obj_file; }
   const ObjectFile *GetObjectFile() const { return m_obj_file; }
 
-  bool CanContainSwiftReflectionData() const;
-
   /// Read the section data from the object file that the section
   /// resides in.
   ///

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -25,7 +25,6 @@
 #include <optional>
 
 namespace swift {
-class SwiftObjectFileFormat;
 enum ReflectionSectionKind : uint8_t;
 }
 namespace lldb_private {
@@ -724,12 +723,6 @@ public:
 
   virtual llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
-
-#ifdef LLDB_ENABLE_SWIFT
-  virtual bool CanContainSwiftReflectionData(const Section &section) {
-    return false;
-  }
-#endif // LLDB_ENABLE_SWIFT
 
   /// Load binaries listed in a corefile
   ///

--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -375,14 +375,6 @@ void Section::SetPermissions(uint32_t permissions) {
   m_executable = (permissions & ePermissionsExecutable) != 0;
 }
 
-bool Section::CanContainSwiftReflectionData() const {
-#ifdef LLDB_ENABLE_SWIFT
-  return m_obj_file->CanContainSwiftReflectionData(*this);
-#else
-  return false;
-#endif // LLDB_ENABLE_SWIFT
-}
-
 lldb::offset_t Section::GetSectionData(void *dst, lldb::offset_t dst_len,
                                        lldb::offset_t offset) {
   if (m_obj_file)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -146,6 +146,27 @@ LLDBMemoryReader::getSymbolAddress(const std::string &name) {
   return swift::remote::RemoteAddress(load_addr);
 }
 
+static std::unique_ptr<swift::SwiftObjectFileFormat>
+GetSwiftObjectFileFormat(llvm::Triple::ObjectFormatType obj_format_type) {
+  std::unique_ptr<swift::SwiftObjectFileFormat> obj_file_format;
+  switch (obj_format_type) {
+  case llvm::Triple::MachO:
+    obj_file_format = std::make_unique<swift::SwiftObjectFileFormatMachO>();
+    break;
+  case llvm::Triple::ELF:
+    obj_file_format = std::make_unique<swift::SwiftObjectFileFormatELF>();
+    break;
+  case llvm::Triple::COFF:
+    obj_file_format = std::make_unique<swift::SwiftObjectFileFormatCOFF>();
+    break;
+  default:
+    LLDB_LOG(GetLog(LLDBLog::Types), "Could not determine swift reflection "
+                                     "section names for object format type");
+    break;
+  }
+  return obj_file_format;
+}
+
 llvm::Optional<swift::remote::RemoteAbsolutePointer>
 LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
   // If an address has a symbol, that symbol provides additional useful data to
@@ -173,8 +194,18 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
       return {};
   }
 
-  if (!addr.GetSection()->CanContainSwiftReflectionData())
-    return {};
+  if (auto section_sp = addr.GetSection()) {
+    if (auto *obj_file = section_sp->GetObjectFile()) {
+      auto obj_file_format_type =
+          obj_file->GetArchitecture().GetTriple().getObjectFormat();
+      if (auto swift_obj_file_format =
+              GetSwiftObjectFileFormat(obj_file_format_type)) {
+        if (!swift_obj_file_format->sectionContainsReflectionData(
+                section_sp->GetName().GetStringRef()))
+          return {};
+      }
+    }
+  }
 
   if (auto *symbol = addr.CalculateSymbolContextSymbol()) {
     auto mangledName = symbol->GetMangled().GetMangledName().GetStringRef();

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -3629,11 +3629,3 @@ llvm::StringRef ObjectFileELF::GetReflectionSectionIdentifier(
   llvm_unreachable("Swift support disabled");
 #endif //LLDB_ENABLE_SWIFT
 }
-
-#ifdef LLDB_ENABLE_SWIFT
-bool ObjectFileELF::CanContainSwiftReflectionData(const Section &section) {
-  swift::SwiftObjectFileFormatELF file_format;
-  return file_format.sectionContainsReflectionData(
-      section.GetName().GetStringRef());
-}
-#endif // LLDB_ENABLE_SWIFT

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -401,11 +401,6 @@ private:
 
   llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
-
-#ifdef LLDB_ENABLE_SWIFT
-  bool
-  CanContainSwiftReflectionData(const lldb_private::Section &section) override;
-#endif // LLDB_ENABLE_SWIFT
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_ELF_OBJECTFILEELF_H

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -6959,14 +6959,6 @@ llvm::StringRef ObjectFileMachO::GetReflectionSectionIdentifier(
 #endif //LLDB_ENABLE_SWIFT
 }
 
-#ifdef LLDB_ENABLE_SWIFT
-bool ObjectFileMachO::CanContainSwiftReflectionData(const Section &section) {
-  swift::SwiftObjectFileFormatMachO file_format;
-  return file_format.sectionContainsReflectionData(
-      section.GetName().GetStringRef());
-}
-#endif // LLDB_ENABLE_SWIFT
-
 ObjectFileMachO::MachOCorefileAllImageInfos
 ObjectFileMachO::GetCorefileAllImageInfos() {
   MachOCorefileAllImageInfos image_infos;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -231,11 +231,6 @@ protected:
   llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 
-#ifdef LLDB_ENABLE_SWIFT
-  bool
-  CanContainSwiftReflectionData(const lldb_private::Section &section) override;
-#endif // LLDB_ENABLE_SWIFT
-
   /// A corefile may include metadata about all of the binaries that were
   /// present in the process when the corefile was taken.  This is only
   /// implemented for Mach-O files for now; we'll generalize it when we

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -1442,11 +1442,3 @@ llvm::StringRef ObjectFilePECOFF::GetReflectionSectionIdentifier(
   llvm_unreachable("Swift support disabled");
 #endif //LLDB_ENABLE_SWIFT
 }
-
-#ifdef LLDB_ENABLE_SWIFT
-bool ObjectFilePECOFF::CanContainSwiftReflectionData(const Section &section) {
-  swift::SwiftObjectFileFormatCOFF file_format;
-  return file_format.sectionContainsReflectionData(
-      section.GetName().GetStringRef());
-}
-#endif // LLDB_ENABLE_SWIFT

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -268,11 +268,6 @@ protected:
   llvm::StringRef
   GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 
-#ifdef LLDB_ENABLE_SWIFT
-  bool
-  CanContainSwiftReflectionData(const lldb_private::Section &section) override;
-#endif // LLDB_ENABLE_SWIFT
-
   typedef std::vector<section_header_t> SectionHeaderColl;
   typedef SectionHeaderColl::iterator SectionHeaderCollIter;
   typedef SectionHeaderColl::const_iterator SectionHeaderCollConstIter;


### PR DESCRIPTION
Instead of giving Section swift-specific knowledge, I think it would make more sense for the Swift plugins that need this knowledge to compute it.

(cherry picked from commit 8eef4a0931edd7b880cb5b78e4153027c273a5bb)