### PR TITLE
[lldb] Update python deprecated APIs.

### DIFF
--- a/lldb/scripts/use_lldb_suite.py
+++ b/lldb/scripts/use_lldb_suite.py
@@ -16,10 +16,12 @@ def find_lldb_root():
             return lldb_root
 
 lldb_root = find_lldb_root()
-import imp
-fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
-try:
-    imp.load_module("use_lldb_suite_root", fp, pathname, desc)
-finally:
-    if fp:
-        fp.close()
+
+import importlib.machinery
+import importlib.util
+
+path = os.path.join(lldb_root, "use_lldb_suite_root.py")
+loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
+spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)

--- a/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/PythonDataObjects.cpp
@@ -72,7 +72,9 @@ Expected<std::string> python::As<std::string>(Expected<PythonObject> &&obj) {
 }
 
 static bool python_is_finalizing() {
-#if PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 7
+#if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 13) || (PY_MAJOR_VERSION > 3)
+  return Py_IsFinalizing();
+#elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 7
   return _Py_Finalizing != nullptr;
 #else
   return _Py_IsFinalizing();

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -180,6 +180,8 @@ private:
 // Python 3.13. It has been returning `true` always since Python 3.7.
 #if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 9) || (PY_MAJOR_VERSION < 3)
     if (PyEval_ThreadsInitialized()) {
+#else
+    if (true) {
 #endif
       Log *log = GetLog(LLDBLog::Script);
 
@@ -196,6 +198,8 @@ private:
 
     // InitThreads acquires the GIL if it hasn't been called before.
     PyEval_InitThreads();
+#else
+    }
 #endif
   }
 

--- a/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
@@ -176,18 +176,27 @@ private:
       return;
 #endif
 
+// `PyEval_ThreadsInitialized` was deprecated in Python 3.9 and removed in
+// Python 3.13. It has been returning `true` always since Python 3.7.
+#if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 9) || (PY_MAJOR_VERSION < 3)
     if (PyEval_ThreadsInitialized()) {
+#endif
       Log *log = GetLog(LLDBLog::Script);
 
       m_was_already_initialized = true;
       m_gil_state = PyGILState_Ensure();
       LLDB_LOGV(log, "Ensured PyGILState. Previous state = {0}locked\n",
                 m_gil_state == PyGILState_UNLOCKED ? "un" : "");
+
+// `PyEval_InitThreads` was deprecated in Python 3.9 and removed in
+// Python 3.13.
+#if (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION < 9) || (PY_MAJOR_VERSION < 3)
       return;
     }
 
     // InitThreads acquires the GIL if it hasn't been called before.
     PyEval_InitThreads();
+#endif
   }
 
   PyGILState_STATE m_gil_state = PyGILState_UNLOCKED;

--- a/lldb/test/API/use_lldb_suite.py
+++ b/lldb/test/API/use_lldb_suite.py
@@ -20,11 +20,11 @@ def find_lldb_root():
 
 lldb_root = find_lldb_root()
 
-import imp
+import importlib.machinery
+import importlib.util
 
-fp, pathname, desc = imp.find_module("use_lldb_suite_root", [lldb_root])
-try:
-    imp.load_module("use_lldb_suite_root", fp, pathname, desc)
-finally:
-    if fp:
-        fp.close()
+path = os.path.join(lldb_root, "use_lldb_suite_root.py")
+loader = importlib.machinery.SourceFileLoader("use_lldb_suite_root", path)
+spec = importlib.util.spec_from_loader("use_lldb_suite_root", loader=loader)
+module = importlib.util.module_from_spec(spec)
+loader.exec_module(module)


### PR DESCRIPTION
This patch cherry-picks some patches from upstream to get rid of some deprecated python modules/APIs and replace them with their new equivalent.

rdar://117331497