### PR TITLE
Implement precise compiler invocations for SwiftASTContext

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -66,6 +66,7 @@ public:
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);
 
+  bool GetUseSwiftPreciseCompilerInvocation() const;
   bool GetEnableSwiftMetadataCache() const;
   uint64_t GetSwiftMetadataCacheMaxByteSize();
   uint64_t GetSwiftMetadataCacheExpirationDays();

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -26,6 +26,9 @@ let Definition = "modulelist" in {
   def SwiftValidateTypeSystem: Property<"swift-validate-typesystem", "Boolean">,
     DefaultFalse,
     Desc<"Validate all Swift typesystem queries. Used for testing an asserts-enabled LLDB only.">;
+  def UseSwiftPreciseCompilerInvocation: Property<"swift-precise-compiler-invocation", "Boolean">,
+    DefaultFalse,
+    Desc<"In the Swift expression evaluator, create many Swift compiler instances with the precise invocation for the current context, instead of a single compiler instance that merges all flags from the entire project.">;
   def SwiftModuleLoadingMode: Property<"swift-module-loading-mode", "Enum">,
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,
     EnumValues<"OptionEnumValues(g_swift_module_loading_mode_enums)">,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -183,6 +183,12 @@ bool ModuleListProperties::GetSwiftValidateTypeSystem() const {
       idx, g_modulelist_properties[idx].default_uint_value != 0);
 }
 
+bool ModuleListProperties::GetUseSwiftPreciseCompilerInvocation() const {
+  const uint32_t idx = ePropertyUseSwiftPreciseCompilerInvocation;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
 bool ModuleListProperties::SetUseSwiftTypeRefTypeSystem(bool new_value) {
   const uint32_t idx = ePropertyUseSwiftTypeRefTypeSystem;
   return SetPropertyAtIndex(idx, new_value);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -191,9 +191,9 @@ swift::BraceStmt *SwiftASTManipulatorBase::GetUserBody() {
 
 SwiftASTManipulator::SwiftASTManipulator(
     SwiftASTContextForExpressions &swift_ast_ctx,
-    swift::SourceFile &source_file, bool repl,
+    swift::SourceFile &source_file, const SymbolContext &sc, bool repl,
     lldb::BindGenericTypes bind_generic_types)
-    : SwiftASTManipulatorBase(source_file, repl, bind_generic_types),
+    : SwiftASTManipulatorBase(source_file, sc, repl, bind_generic_types),
       m_swift_ast_ctx(swift_ast_ctx) {}
 
 void SwiftASTManipulator::FindSpecialNames(
@@ -889,7 +889,7 @@ llvm::Optional<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
   // When injecting a value pack or pack count into the outer
   // lldb_expr function, treat it as an opaque raw pointer.
   if (m_bind_generic_types == lldb::eDontBind && variable.IsUnboundPack()) {
-    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext();
+    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(&m_sc);
     if (swift_ast_ctx) {
       auto it = m_type_aliases.find("$__lldb_builtin_ptr_t");
       if (it == m_type_aliases.end())

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -146,9 +146,10 @@ public:
     VariableMetadataSP m_metadata;
   };
 
-  SwiftASTManipulatorBase(swift::SourceFile &source_file, bool repl,
+  SwiftASTManipulatorBase(swift::SourceFile &source_file,
+                          const SymbolContext &sc, bool repl,
                           lldb::BindGenericTypes bind_generic_types)
-      : m_source_file(source_file), m_variables(), m_repl(repl),
+      : m_source_file(source_file), m_sc(sc), m_repl(repl),
         m_bind_generic_types(bind_generic_types) {
     DoInitialization();
   }
@@ -168,7 +169,7 @@ private:
 protected:
   swift::SourceFile &m_source_file;
   llvm::SmallVector<VariableInfo, 1> m_variables;
-
+  const SymbolContext &m_sc;
   bool m_repl = false;
 
   lldb::BindGenericTypes m_bind_generic_types = lldb::eBindAuto;
@@ -196,8 +197,8 @@ protected:
 class SwiftASTManipulator : public SwiftASTManipulatorBase {
 public:
   SwiftASTManipulator(SwiftASTContextForExpressions &swift_ast_ctx,
-                      swift::SourceFile &source_file, bool repl,
-                      lldb::BindGenericTypes bind_generic_types);
+                      swift::SourceFile &source_file, const SymbolContext &sc,
+                      bool repl, lldb::BindGenericTypes bind_generic_types);
   SwiftASTContextForExpressions &GetScratchContext() { return m_swift_ast_ctx; }
 
   void FindSpecialNames(llvm::SmallVectorImpl<swift::Identifier> &names,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1416,7 +1416,8 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
   if (repl || !playground) {
     code_manipulator = std::make_unique<SwiftASTManipulator>(
-        swift_ast_context, *source_file, repl, options.GetBindGenericTypes());
+        swift_ast_context, *source_file, sc, repl,
+        options.GetBindGenericTypes());
 
     if (!playground) {
       code_manipulator->RewriteResult();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -625,7 +625,7 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     // If we are extending a generic class it's going to be a metatype,
     // and we have to grab the instance type:
     imported_self_type = swift_type_system->GetInstanceType(
-        imported_self_type.GetOpaqueQualType());
+        imported_self_type.GetOpaqueQualType(), stack_frame_sp.get());
     if (!imported_self_type)
       return Status(
           "Unable to add the aliases the expression needs because the Swift "

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -563,13 +563,12 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
       llvm::consumeError(type_system_or_err.takeError());
       return;
     }
-
     auto *swift_ts =
         llvm::dyn_cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
             type_system_or_err->get());
     auto *target_swift_ast =
         llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-            swift_ts->GetSwiftASTContext());
+            swift_ts->GetSwiftASTContext(nullptr));
     m_swift_ast = target_swift_ast;
   }
   SwiftASTContextForExpressions *swift_ast = m_swift_ast;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -695,8 +695,10 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
     return error("could not create a Swift scratch context: ",
                  m_err.AsCString());
 
+  const SymbolContext *sc =
+      &frame->GetSymbolContext(lldb::eSymbolContextFunction);
   m_swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-      m_swift_scratch_ctx->get()->GetSwiftASTContext());
+      m_swift_scratch_ctx->get()->GetSwiftASTContext(sc));
 
   if (!m_swift_ast_ctx)
     return error("could not create a Swift AST context");

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -145,7 +145,7 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
   // 4) If `self` is a metatype, get its instance type.
   if (Flags(info.type.GetTypeInfo())
           .AllSet(lldb::eTypeIsSwift | lldb::eTypeIsMetatype)) {
-    info.type = TypeSystemSwift::GetInstanceType(info.type);
+    info.type = TypeSystemSwift::GetInstanceType(info.type, &frame);
     info.is_metatype = true;
   }
 
@@ -686,9 +686,11 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
   if (!frame)
     return error("couldn't start parsing - no stack frame");
 
-  auto *exe_scope = exe_ctx.GetBestExecutionContextScope();
-  if (!exe_scope)
-    return error( "no execution context scope");
+  ExecutionContextScope *exe_scope =
+      m_options.GetREPLEnabled() ? static_cast<ExecutionContextScope *>(target)
+                                 : static_cast<ExecutionContextScope *>(frame);
+
+exe_scope = exe_ctx.GetBestExecutionContextScope();
 
   m_swift_scratch_ctx = target->GetSwiftScratchContext(m_err, *exe_scope);
   if (!m_swift_scratch_ctx)
@@ -697,8 +699,9 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
 
   const SymbolContext *sc =
       &frame->GetSymbolContext(lldb::eSymbolContextFunction);
-  m_swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-      m_swift_scratch_ctx->get()->GetSwiftASTContext(sc));
+  auto *swift_ast_ctx = m_swift_scratch_ctx->get()->GetSwiftASTContext(sc);
+  m_swift_ast_ctx =
+      llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(swift_ast_ctx);
 
   if (!m_swift_ast_ctx)
     return error("could not create a Swift AST context");

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -99,7 +99,10 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
   auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get());
   if (!ts)
     return "";
-  auto *ctx = ts->GetSwiftASTContext();
+  const SymbolContext *sc = nullptr;
+  if (swiftFrame)
+    sc = &swiftFrame->GetSymbolContext(eSymbolContextFunction);
+  auto *ctx = ts->GetSwiftASTContext(sc);
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1326,10 +1326,13 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
               llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
                   target->GetSwiftScratchContext(error, *exe_scope,
                                                  create_on_demand);
+              const SymbolContext *sc = nullptr;
+              if (auto frame_sp = exe_scope->CalculateStackFrame())
+                sc = &frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
               if (maybe_scratch_ctx)
                 if (auto scratch_ctx = maybe_scratch_ctx->get())
                   if (SwiftASTContext *ast_ctx =
-                          scratch_ctx->GetSwiftASTContext()) {
+                          scratch_ctx->GetSwiftASTContext(sc)) {
                     ConstString cs_input{input};
                     Mangled mangled(cs_input);
                     if (mangled.GuessLanguage() == eLanguageTypeSwift) {
@@ -1388,73 +1391,76 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
                 target->GetSwiftScratchContext(error, *exe_scope,
                                                create_on_demand);
-              if (maybe_scratch_ctx)
-                if (auto scratch_ctx = maybe_scratch_ctx->get())
-                  if (SwiftASTContext *ast_ctx =
-                          scratch_ctx->GetSwiftASTContext()) {
-                    auto iter = ast_ctx->GetModuleCache().begin(),
-                         end = ast_ctx->GetModuleCache().end();
+            const SymbolContext *sc = nullptr;
+            if (auto frame_sp = exe_scope->CalculateStackFrame())
+              sc = &frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
 
-                    std::vector<llvm::StringRef> name_parts;
-                    SplitDottedName(input, name_parts);
+            if (maybe_scratch_ctx)
+              if (auto scratch_ctx = maybe_scratch_ctx->get())
+                if (SwiftASTContext *ast_ctx =
+                        scratch_ctx->GetSwiftASTContext(sc)) {
+                  auto iter = ast_ctx->GetModuleCache().begin(),
+                       end = ast_ctx->GetModuleCache().end();
 
-                    std::function<void(swift::ModuleDecl *)> lookup_func =
-                        [&ast_ctx, input, name_parts,
-                         &results](swift::ModuleDecl *module) -> void {
-                      for (auto imported_module :
-                           swift::namelookup::getAllImports(module)) {
-                        auto module = imported_module.importedModule;
-                        TypesOrDecls local_results;
-                        ast_ctx->FindTypesOrDecls(input, module, local_results,
-                                                  false);
-                        llvm::Optional<TypeOrDecl> candidate;
-                        if (local_results.empty() && name_parts.size() > 1) {
-                          size_t idx_of_deeper = 1;
-                          // if you're looking for Swift.Int in module Swift,
-                          // try looking for Int
-                          if (name_parts.front() == module->getName().str()) {
-                            candidate = ast_ctx->FindTypeOrDecl(
-                                name_parts[1].str().c_str(), module);
-                            idx_of_deeper = 2;
-                          }
-                          // this is probably the top-level name of a nested
-                          // type String.UTF8View
-                          else {
-                            candidate = ast_ctx->FindTypeOrDecl(
-                                name_parts[0].str().c_str(), module);
-                          }
-                          if (candidate.has_value()) {
-                            TypesOrDecls candidates{candidate.value()};
-                            for (; idx_of_deeper < name_parts.size();
-                                 idx_of_deeper++) {
-                              TypesOrDecls new_candidates;
-                              for (auto candidate : candidates) {
-                                ast_ctx->FindContainedTypeOrDecl(
-                                    name_parts[idx_of_deeper], candidate,
-                                    new_candidates);
-                              }
-                              candidates = new_candidates;
-                            }
+                  std::vector<llvm::StringRef> name_parts;
+                  SplitDottedName(input, name_parts);
+
+                  std::function<void(swift::ModuleDecl *)> lookup_func =
+                      [&ast_ctx, input, name_parts,
+                       &results](swift::ModuleDecl *module) -> void {
+                    for (auto imported_module :
+                         swift::namelookup::getAllImports(module)) {
+                      auto module = imported_module.importedModule;
+                      TypesOrDecls local_results;
+                      ast_ctx->FindTypesOrDecls(input, module, local_results,
+                                                false);
+                      llvm::Optional<TypeOrDecl> candidate;
+                      if (local_results.empty() && name_parts.size() > 1) {
+                        size_t idx_of_deeper = 1;
+                        // if you're looking for Swift.Int in module Swift,
+                        // try looking for Int
+                        if (name_parts.front() == module->getName().str()) {
+                          candidate = ast_ctx->FindTypeOrDecl(
+                              name_parts[1].str().c_str(), module);
+                          idx_of_deeper = 2;
+                        }
+                        // this is probably the top-level name of a nested
+                        // type String.UTF8View
+                        else {
+                          candidate = ast_ctx->FindTypeOrDecl(
+                              name_parts[0].str().c_str(), module);
+                        }
+                        if (candidate.has_value()) {
+                          TypesOrDecls candidates{candidate.value()};
+                          for (; idx_of_deeper < name_parts.size();
+                               idx_of_deeper++) {
+                            TypesOrDecls new_candidates;
                             for (auto candidate : candidates) {
-                              if (candidate)
-                                results.insert(candidate);
+                              ast_ctx->FindContainedTypeOrDecl(
+                                  name_parts[idx_of_deeper], candidate,
+                                  new_candidates);
                             }
+                            candidates = new_candidates;
                           }
-                        } else if (local_results.size() > 0) {
-                          for (const auto &result : local_results)
-                            results.insert(result);
-                        } else if (local_results.empty() && module &&
-                                   name_parts.size() == 1 &&
-                                   name_parts.front() ==
-                                       module->getName().str())
-                          results.insert(
-                              ToCompilerType(swift::ModuleType::get(module)));
-                      }
-                    };
+                          for (auto candidate : candidates) {
+                            if (candidate)
+                              results.insert(candidate);
+                          }
+                        }
+                      } else if (local_results.size() > 0) {
+                        for (const auto &result : local_results)
+                          results.insert(result);
+                      } else if (local_results.empty() && module &&
+                                 name_parts.size() == 1 &&
+                                 name_parts.front() == module->getName().str())
+                        results.insert(
+                            ToCompilerType(swift::ModuleType::get(module)));
+                    }
+                  };
 
-                    for (; iter != end; iter++)
-                      lookup_func(iter->second);
-                  }
+                  for (; iter != end; iter++)
+                    lookup_func(iter->second);
+                }
           }
 
           return (results.size() - before);

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1369,8 +1369,16 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                 if (result_sp && result_sp->GetCompilerType().IsValid()) {
                   CompilerType result_type(result_sp->GetCompilerType());
                   if (Flags(result_type.GetTypeInfo())
-                          .AllSet(eTypeIsSwift | eTypeIsMetatype))
-                    result_type = TypeSystemSwift::GetInstanceType(result_type);
+                      .AllSet(eTypeIsSwift | eTypeIsMetatype)) {
+                    result_type = TypeSystemSwift::GetInstanceType(result_type,
+                                                                   exe_scope);
+                    if (auto swift_ast_ctx =
+                            result_type.GetTypeSystem()
+                                .dyn_cast_or_null<SwiftASTContext>())
+                      result_type = swift_ast_ctx->GetTypeSystemSwiftTypeRef()
+                                        .GetTypeFromMangledTypename(
+                                            result_type.GetMangledTypeName());
+                  }
                   results.insert(TypeOrDecl(result_type));
                 }
               }

--- a/lldb/source/Plugins/Language/Swift/SwiftMetatype.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftMetatype.cpp
@@ -25,8 +25,9 @@ bool lldb_private::formatters::swift::SwiftMetatype_SummaryProvider(
   lldb::addr_t metadata_ptr = valobj.GetPointerValue();
   if (metadata_ptr == LLDB_INVALID_ADDRESS || metadata_ptr == 0) {
     CompilerType compiler_metatype_type(valobj.GetCompilerType());
-    CompilerType instancetype =
-      TypeSystemSwift::GetInstanceType(compiler_metatype_type);
+    ExecutionContext exe_ctx = valobj.GetExecutionContextRef();
+    CompilerType instancetype = TypeSystemSwift::GetInstanceType(
+        compiler_metatype_type, exe_ctx.GetBestExecutionContextScope());
     name = instancetype.GetDisplayTypeName();
   } else if (CompilerType meta_type = valobj.GetCompilerType()) {
     name = meta_type.GetDisplayTypeName();

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.h
@@ -41,7 +41,7 @@ private:
   const SwiftOptionSetSummaryProvider &
   operator=(const SwiftOptionSetSummaryProvider &) = delete;
 
-  void FillCasesIfNeeded();
+  void FillCasesIfNeeded(const ExecutionContext *);
 
   CompilerType m_type;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1232,7 +1232,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
           target.GetSwiftScratchContext(error, frame);
       auto scratch_ctx = maybe_swift_ast->get();
       if (scratch_ctx) {
-        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext()) {
+        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext(&sc)) {
         CompilerType function_type = swift_ast->GetTypeFromMangledTypename(
             mangled_name.GetMangledName());
         if (error.Success()) {
@@ -1444,7 +1444,9 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   auto scratch_ctx = maybe_scratch_context->get();
   if (!scratch_ctx)
     return error_valobj_sp;
-  SwiftASTContext *ast_context = scratch_ctx->GetSwiftASTContext();
+
+  const SymbolContext *sc = &frame_sp->GetSymbolContext(eSymbolContextFunction);
+  SwiftASTContext *ast_context = scratch_ctx->GetSwiftASTContext(sc);
   if (!ast_context)
     return error_valobj_sp;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2780,7 +2780,8 @@ SwiftLanguageRuntimeImpl::GetConcreteType(ExecutionContextScope *exe_scope,
   if (!promise_sp)
     return CompilerType();
 
-  return promise_sp->FulfillTypePromise();
+  const SymbolContext *sc = &frame->GetSymbolContext(eSymbolContextFunction);
+  return promise_sp->FulfillTypePromise(sc);
 }
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -506,8 +506,10 @@ llvm::Optional<uint64_t> SwiftLanguageRuntimeImpl::GetMemberVariableOffset(
             .GetSwiftValidateTypeSystem()) {
       // Convert to an AST type, if necessary.
       if (auto ts = instance_type.GetTypeSystem()
-                        .dyn_cast_or_null<TypeSystemSwiftTypeRef>())
-        instance_type = ts->ReconstructType(instance_type);
+                        .dyn_cast_or_null<TypeSystemSwiftTypeRef>()) {
+        ExecutionContext exe_ctx = instance->GetExecutionContextRef().Lock(false);
+        instance_type = ts->ReconstructType(instance_type, &exe_ctx);
+      }
       auto reference = GetMemberVariableOffsetRemoteAST(instance_type, instance,
                                                         member_name);
       if (reference.has_value() && offset != reference) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -291,11 +291,13 @@ protected:
     llvm::Optional<CompilerType> m_compiler_type;
 
   public:
-    CompilerType FulfillTypePromise(Status *error = nullptr);
+    CompilerType FulfillTypePromise(const SymbolContext *sc,
+                                    Status *error = nullptr);
   };
   typedef std::shared_ptr<MetadataPromise> MetadataPromiseSP;
 
-  MetadataPromiseSP GetMetadataPromise(lldb::addr_t addr,
+  MetadataPromiseSP GetMetadataPromise(const SymbolContext *sc,
+                                       lldb::addr_t addr,
                                        ValueObject &for_object);
   MetadataPromiseSP
   GetPromiseForTypeNameAndFrame(const char *type_name, StackFrame *frame);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1156,6 +1156,7 @@ static std::string GetPluginServerForSDK(llvm::StringRef sdk_path) {
 /// \returns true if an error was encountered.
 static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
                                         llvm::StringRef module_name,
+                                        llvm::StringRef module_filter,
                                         llvm::ArrayRef<StringRef> buffers,
                                         const PathMappingList &path_map,
                                         bool discover_implicit_search_paths,
@@ -1258,6 +1259,15 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
         // If there's a size error, quit the loop early, otherwise try the next.
         if (invalid_size)
           break;
+        continue;
+      }
+
+      // Skip over this module if filtering and the filter matches.
+      if (!module_filter.empty() && module_filter != info.name) {
+        LOG_PRINTF(GetLog(LLDBLog::Types),
+                   "Skipping compiler options from %s, filter=%s",
+                   extended_validation_info.getModuleABIName().str().c_str(),
+                   module_filter.str().c_str());
         continue;
       }
 
@@ -1893,17 +1903,17 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     bool discover_implicit_search_paths = false;
     auto ast_file_datas = module.GetASTData(eLanguageTypeSwift);
     std::string module_name = module.GetSpecificationDescription();
+    StringRef module_filter;
     std::vector<llvm::StringRef> buffers =
         GetASTBuffersFromModule(m_description, ast_file_datas, module_name);
 
     // If no N_AST symbols exist, this is not an error.
     if (!buffers.empty())
       if (DeserializeAllCompilerFlags(
-              swift_ast_sp->GetCompilerInvocation(),
-              module_name, buffers,
-              module.GetSourceMappingList(), discover_implicit_search_paths,
-              m_description, errs, got_serialized_options,
-              found_swift_modules)) {
+              swift_ast_sp->GetCompilerInvocation(), module_name, module_filter,
+              buffers, module.GetSourceMappingList(),
+              discover_implicit_search_paths, m_description, errs,
+              got_serialized_options, found_swift_modules)) {
         // Validation errors are not fatal for the context.
         swift_ast_sp->AddDiagnostic(eDiagnosticSeverityError, errs.str());
       }
@@ -2085,14 +2095,14 @@ static lldb::ModuleSP GetUnitTestModule(lldb_private::ModuleList &modules) {
 
 /// Scan a newly added lldb::Module for Swift modules and report any errors in
 /// its module SwiftASTContext to Target.
-static void ProcessModule(
-    ModuleSP module_sp, std::string m_description,
-    bool discover_implicit_search_paths, bool use_all_compiler_flags,
-    Target &target, llvm::Triple triple,
-    std::vector<swift::PluginSearchOption> &plugin_search_options,
-    std::vector<std::string> &module_search_paths,
-    std::vector<std::pair<std::string, bool>> &framework_search_paths,
-    std::vector<std::string> &extra_clang_args) {
+static void
+ProcessModule(ModuleSP module_sp, std::string m_description,
+              bool discover_implicit_search_paths, bool use_all_compiler_flags,
+              StringRef module_filter, Target &target, llvm::Triple triple,
+              std::vector<swift::PluginSearchOption> &plugin_search_options,
+              std::vector<std::string> &module_search_paths,
+              std::vector<std::pair<std::string, bool>> &framework_search_paths,
+              std::vector<std::string> &extra_clang_args) {
   {
     llvm::raw_string_ostream ss(m_description);
     ss << "::ProcessModule(" << '"';
@@ -2208,9 +2218,9 @@ static void ProcessModule(
   // If no N_AST symbols exist, this is not an error.
   if (!buffers.empty())
     if (DeserializeAllCompilerFlags(
-            invocation, module_name, buffers, module_sp->GetSourceMappingList(),
-            discover_implicit_search_paths, m_description, errs,
-            got_serialized_options, found_swift_modules)) {
+            invocation, module_name, module_filter, buffers,
+            module_sp->GetSourceMappingList(), discover_implicit_search_paths,
+            m_description, errs, got_serialized_options, found_swift_modules)) {
       // TODO: After removing DeserializeAllCompilerFlags from
       //       CreateInstance(per-Module), errs will need to be
       //       collected here and surfaced.
@@ -2412,9 +2422,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
 
   for (ModuleSP module_sp : target.GetImages().Modules())
     if (module_sp) {
+      StringRef module_filter;
       std::vector<std::string> extra_clang_args;
       ProcessModule(module_sp, m_description, discover_implicit_search_paths,
-                    use_all_compiler_flags, target, triple,
+                    use_all_compiler_flags, module_filter, target, triple,
                     plugin_search_options, module_search_paths,
                     framework_search_paths, extra_clang_args);
       swift_ast_sp->AddExtraClangArgs(extra_clang_args);
@@ -2443,6 +2454,268 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
                                   swift_ast_sp->GetDiagnosticEngine());
   }
 
+  swift_ast_sp->ApplyDiagnosticOptions();
+
+  // Apply source path remappings found in each module's dSYM.
+  for (ModuleSP module : target.GetImages().Modules())
+    if (module)
+      swift_ast_sp->RemapClangImporterOptions(module->GetSourceMappingList());
+
+  // Apply source path remappings found in the target settings.
+  swift_ast_sp->RemapClangImporterOptions(target.GetSourcePathMap());
+  swift_ast_sp->FilterClangImporterOptions(
+      swift_ast_sp->GetClangImporterOptions().ExtraArgs, swift_ast_sp.get());
+
+  // This needs to happen once all the import paths are set, or
+  // otherwise no modules will be found.
+  swift_ast_sp->InitializeSearchPathOptions(module_search_paths,
+                                            framework_search_paths);
+  if (!swift_ast_sp->GetClangImporter()) {
+    logError("couldn't create a ClangImporter");
+    return {};
+  }
+
+  // Initialize the compiler plugin search paths.
+  auto &opts = swift_ast_sp->GetSearchPathOptions();
+  opts.PluginSearchOpts.insert(opts.PluginSearchOpts.end(),
+                               plugin_search_options.begin(),
+                               plugin_search_options.end());
+
+  for (size_t mi = 0; mi != num_images; ++mi) {
+    std::vector<std::string> module_names;
+    auto module_sp = target.GetImages().GetModuleAtIndex(mi);
+    swift_ast_sp->RegisterSectionModules(*module_sp, module_names);
+  }
+
+  LOG_PRINTF(GetLog(LLDBLog::Types), "((Target*)%p) = %p",
+             static_cast<void *>(&target),
+             static_cast<void *>(swift_ast_sp.get()));
+
+  if (swift_ast_sp->HasFatalErrors()) {
+    logError(swift_ast_sp->GetFatalErrors().AsCString());
+    return {};
+  }
+
+  {
+    LLDB_SCOPED_TIMERF("%s (getStdlibModule)", m_description.c_str());
+    const bool can_create = true;
+    swift::ModuleDecl *stdlib =
+        swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create);
+    if (!stdlib || IsDWARFImported(*stdlib)) {
+      logError("couldn't load the Swift stdlib");
+      return {};
+    }
+  }
+
+  return swift_ast_sp;
+}
+
+
+lldb::TypeSystemSP SwiftASTContext::CreateInstance(
+    const SymbolContext &sc,
+    TypeSystemSwiftTypeRefForExpressions &typeref_typesystem) {
+  LLDB_SCOPED_TIMER();
+
+  CompileUnit *cu = sc.comp_unit;
+  StringRef swift_module_name = TypeSystemSwiftTypeRef::GetSwiftModuleFor(&sc);
+  std::string m_description;
+  {
+    StreamString ss;
+    ss << "SwiftASTContextForExpressions"
+       << "(module: " << '"' << swift_module_name << "\", "
+       << "cu: " << '"' << cu->GetPrimaryFile().GetFilename() << '"'
+       << ')';
+    m_description = ss.GetString();
+  }
+
+  TargetSP target_sp = typeref_typesystem.GetTargetWP().lock();
+  if (!target_sp)
+    return {};
+  Target &target = *target_sp;
+
+  // Make an AST but don't set the triple yet. We need to
+  // try and detect if we have a iOS simulator.
+  std::shared_ptr<SwiftASTContextForExpressions> swift_ast_sp(
+      new SwiftASTContextForExpressions(m_description, typeref_typesystem));
+  auto defer_log = llvm::make_scope_exit(
+      [swift_ast_sp] { swift_ast_sp->LogConfiguration(); });
+
+  LOG_PRINTF(GetLog(LLDBLog::Types), "(Target)");
+  auto logError = [&](const char *message) {
+    LOG_PRINTF(GetLog(LLDBLog::Types), "Failed to create scratch context - %s",
+               message);
+    if (StreamSP errs_sp = target.GetDebugger().GetAsyncErrorStream())
+      errs_sp->Printf("Cannot create Swift scratch context (%s)", message);
+  };
+
+  ArchSpec arch = target.GetArchitecture();
+  if (!arch.IsValid()) {
+    logError("invalid target architecture");
+    return {};
+  }
+
+  // This is a scratch AST context, mark it as such.
+  swift_ast_sp->m_is_scratch_context = true;
+
+  swift_ast_sp->GetLanguageOptions().EnableCXXInterop =
+      target.IsSwiftCxxInteropEnabled();
+  bool handled_sdk_path = false;
+  const size_t num_images = target.GetImages().GetSize();
+
+  // Set the SDK path prior to doing search paths.  Otherwise when we
+  // create search path options we put in the wrong SDK path.
+  FileSpec &target_sdk_spec = target.GetSDKPath();
+  if (target_sdk_spec && FileSystem::Instance().Exists(target_sdk_spec)) {
+    swift_ast_sp->SetPlatformSDKPath(target_sdk_spec.GetPath());
+    handled_sdk_path = true;
+  }
+
+  if (!handled_sdk_path) {
+    for (size_t mi = 0; mi != num_images; ++mi) {
+      ModuleSP module_sp = target.GetImages().GetModuleAtIndex(mi);
+      if (!HasSwiftModules(*module_sp))
+        continue;
+
+      std::string sdk_path = GetSDKPathFromDebugInfo(m_description, *module_sp);
+
+      if (sdk_path.empty())
+        continue;
+
+      handled_sdk_path = true;
+      swift_ast_sp->SetPlatformSDKPath(sdk_path);
+      break;
+    }
+  }
+
+  // First, prime the compiler with the options from the main executable:
+  bool got_serialized_options = false;
+  ModuleSP exe_module_sp(target.GetExecutableModule());
+
+  // If we're debugging a testsuite, then treat the main test bundle
+  // as the executable.
+  if (exe_module_sp && IsUnitTestExecutable(*exe_module_sp)) {
+    ModuleSP unit_test_module = GetUnitTestModule(target.GetImages());
+
+    if (unit_test_module) {
+      exe_module_sp = unit_test_module;
+    }
+  }
+
+  {
+    auto get_executable_triple = [&]() -> llvm::Triple {
+      if (!exe_module_sp)
+        return {};
+      return exe_module_sp->GetArchitecture().GetTriple();
+    };
+
+    llvm::Triple computed_triple;
+    llvm::Triple target_triple = target.GetArchitecture().GetTriple();
+
+    if (target.GetArchitecture().IsFullySpecifiedTriple()) {
+      // If a fully specified triple was passed in, for example
+      // through CreateTargetWithFileAndTargetTriple(), prefer that.
+      LOG_PRINTF(GetLog(LLDBLog::Types), "Fully specified target triple %s.",
+                 target_triple.str().c_str());
+      computed_triple = target_triple;
+    } else {
+      // Underspecified means that one or more of vendor, os, or os
+      // version (Darwin only) is missing.
+      LOG_PRINTF(GetLog(LLDBLog::Types), "Underspecified target triple %s.",
+                 target_triple.str().c_str());
+      llvm::VersionTuple platform_version;
+      PlatformSP platform_sp(target.GetPlatform());
+      if (platform_sp)
+        platform_version =
+            platform_sp->GetOSVersion(target.GetProcessSP().get());
+      LOG_PRINTF(GetLog(LLDBLog::Types), "Platform version is %s",
+                 platform_version.empty()
+                     ? "<empty>"
+                     : platform_version.getAsString().c_str());
+      // Try to fill in the platform OS version. The idea behind using
+      // the platform version is to let the expression evaluator mark
+      // the expressions with the highest supported availability
+      // attribute. Don't use the platform when an environment is
+      // present, since there might be some ambiguity about the
+      // plaform (e.g., ios-macabi runs on the macOS, but uses iOS
+      // version numbers).
+      if (!platform_version.empty() &&
+          target_triple.getEnvironment() == llvm::Triple::UnknownEnvironment) {
+        LOG_PRINTF(GetLog(LLDBLog::Types), "Completing triple based on platform.");
+
+        llvm::SmallString<32> buffer;
+        {
+          llvm::raw_svector_ostream os(buffer);
+          os << target_triple.getArchName() << '-';
+          os << target_triple.getVendorName() << '-';
+          os << llvm::Triple::getOSTypeName(target_triple.getOS());
+          os << platform_version.getAsString();
+        }
+        computed_triple = llvm::Triple(buffer);
+      } else {
+        LOG_PRINTF(GetLog(LLDBLog::Types),
+                   "Completing triple based on main binary load commands.");
+        computed_triple = get_executable_triple();
+      }
+    }
+
+    if (computed_triple.getOS() == llvm::Triple::MacOSX) {
+      // Handle the case where an apparent macOS binary has been
+      // force-loaded as a macCatalyst process. The Xcode test
+      // runner works this way.
+      llvm::Triple exe_triple = get_executable_triple();
+      if (exe_triple.getOS() == llvm::Triple::IOS &&
+          exe_triple.getEnvironment() == llvm::Triple::MacABI) {
+        LOG_PRINTF(GetLog(LLDBLog::Types), "Adjusting triple to macCatalyst.");
+        computed_triple.setOSAndEnvironmentName(
+            exe_triple.getOSAndEnvironmentName());
+      }
+    }
+    if (computed_triple == llvm::Triple()) {
+      LOG_PRINTF(GetLog(LLDBLog::Types), "Failed to compute triple.");
+      return {};
+    }
+    swift_ast_sp->SetTriple(computed_triple);
+  }
+
+  llvm::Triple triple = swift_ast_sp->GetTriple();
+  std::string resource_dir = HostInfo::GetSwiftResourceDir(
+      triple, swift_ast_sp->GetPlatformSDKPath());
+  ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(), resource_dir,
+                        triple);
+
+  std::vector<swift::PluginSearchOption> plugin_search_options;
+  std::vector<std::string> module_search_paths;
+  std::vector<std::pair<std::string, bool>> framework_search_paths;
+  std::vector<std::string> extra_clang_args;
+  
+  const bool discover_implicit_search_paths =
+      target.GetSwiftDiscoverImplicitSearchPaths();
+
+  const bool use_all_compiler_flags =
+      !got_serialized_options || target.GetUseAllCompilerFlags();
+
+  for (const FileSpec &path : target.GetSwiftModuleSearchPaths())
+    module_search_paths.push_back(path.GetPath());
+
+  for (const FileSpec &path : target.GetSwiftFrameworkSearchPaths())
+    framework_search_paths.push_back({path.GetPath(),
+                                      /*is_system*/ false});
+  ModuleSP module_sp = sc.module_sp;
+  if (module_sp) {
+    StringRef module_filter = swift_module_name;
+    std::vector<std::string> extra_clang_args;
+    ProcessModule(module_sp, m_description, discover_implicit_search_paths,
+                  use_all_compiler_flags, module_filter, target, triple,
+                  plugin_search_options, module_search_paths,
+                  framework_search_paths, extra_clang_args);
+    swift_ast_sp->AddExtraClangArgs(extra_clang_args);
+  }
+
+  // Now fold any extra options we were passed. This has to be done
+  // BEFORE the ClangImporter is made by calling GetClangImporter or
+  // these options will be ignored.
+
+  swift_ast_sp->AddUserClangArgs(target);
   swift_ast_sp->ApplyDiagnosticOptions();
 
   // Apply source path remappings found in each module's dSYM.
@@ -4763,9 +5036,10 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
     std::vector<std::pair<std::string, bool>> framework_search_paths;
     std::vector<std::string> extra_clang_args;
     lldb::ModuleSP module_sp = module_list.GetModuleAtIndex(mi);
+    StringRef module_filter;
     ProcessModule(module_sp, m_description, discover_implicit_search_paths,
-                  use_all_compiler_flags, *target_sp, GetTriple(),
-                  plugin_search_options, module_search_paths,
+                  use_all_compiler_flags, module_filter, *target_sp,
+                  GetTriple(), plugin_search_options, module_search_paths,
                   framework_search_paths, extra_clang_args);
     // If the use-all-compiler-flags setting is enabled, the
     // expression context is supposed to merge all search paths
@@ -5627,7 +5901,9 @@ CompilerType SwiftASTContext::GetCanonicalType(opaque_compiler_type_t type) {
   return ToCompilerType({GetCanonicalSwiftType(type).getPointer()});
 }
 
-CompilerType SwiftASTContext::GetInstanceType(opaque_compiler_type_t type) {
+CompilerType
+SwiftASTContext::GetInstanceType(opaque_compiler_type_t type,
+                                 ExecutionContextScope *exe_scope) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -7675,8 +7951,9 @@ bool SwiftASTContext::DumpTypeValue(
   case swift::TypeKind::Protocol:
     return false;
 
-  case swift::TypeKind::ExistentialMetatype:
-  case swift::TypeKind::Metatype: {
+    
+  case swift::TypeKind::Metatype:
+  case swift::TypeKind::ExistentialMetatype: {
     return DumpDataExtractor(data, &s, byte_offset, eFormatPointer, byte_size, 1,
                              UINT32_MAX, LLDB_INVALID_ADDRESS,
                              bitfield_bit_size, bitfield_bit_offset, exe_scope);
@@ -8361,15 +8638,17 @@ bool SwiftASTContextForExpressions::CacheUserImports(
               llvm::raw_svector_ostream errs(error);
               bool discover_implicit_search_paths = false;
               swift::CompilerInvocation &invocation = GetCompilerInvocation();
+              StringRef module_filter;
 
               LOG_PRINTF(GetLog(LLDBLog::Types),
                          "Scanning for search paths in %s",
                          ast_file.str().c_str());
               if (DeserializeAllCompilerFlags(
-                      invocation, ast_file, {file_or_err->get()->getBuffer()},
-                      path_remap, discover_implicit_search_paths,
-                      m_description.str().str(), errs, got_serialized_options,
-                      found_swift_modules, /*search_paths_only = */true)) {
+                      invocation, ast_file, module_filter,
+                      {file_or_err->get()->getBuffer()}, path_remap,
+                      discover_implicit_search_paths, m_description.str().str(),
+                      errs, got_serialized_options, found_swift_modules,
+                      /*search_paths_only = */ true)) {
                 LOG_PRINTF(GetLog(LLDBLog::Types), "Could not parse %s: %s",
                            ast_file.str().c_str(), error.str().str().c_str());
               }
@@ -8387,15 +8666,16 @@ bool SwiftASTContextForExpressions::CacheUserImports(
 }
 
 bool SwiftASTContext::GetCompileUnitImports(
-    SymbolContext &sc, ProcessSP process_sp,
+    const SymbolContext &sc, ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
   return GetCompileUnitImportsImpl(sc, process_sp, &modules, error);
 }
 
-void SwiftASTContext::PerformCompileUnitImports(
-    SymbolContext &sc, lldb::ProcessSP process_sp, Status &error) {
+void SwiftASTContext::PerformCompileUnitImports(const SymbolContext &sc,
+                                                lldb::ProcessSP process_sp,
+                                                Status &error) {
   GetCompileUnitImportsImpl(sc, process_sp, nullptr, error);
 }
 
@@ -8405,7 +8685,7 @@ GetCUSignature(CompileUnit &compile_unit) {
 }
 
 bool SwiftASTContext::GetCompileUnitImportsImpl(
-    SymbolContext &sc, lldb::ProcessSP process_sp,
+    const SymbolContext &sc, lldb::ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         *modules,
     Status &error) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -207,8 +207,8 @@ public:
 
   bool SupportsLanguage(lldb::LanguageType language) override;
 
-  SwiftASTContext *GetSwiftASTContext() const override {
-    return const_cast<SwiftASTContext *>(this);
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override {
+    return GetTypeSystemSwiftTypeRef().GetSwiftASTContext(sc);
   }
 
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -201,6 +201,12 @@ public:
                  TypeSystemSwiftTypeRefForExpressions &typeref_typesystem,
                  const char *extra_options);
 
+  /// Create a SwiftASTContextForExpressions taylored to a specific symbol
+  /// context.
+  static lldb::TypeSystemSP
+  CreateInstance(const SymbolContext &sc,
+                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem);
+
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,
       std::set<lldb::LanguageType> &languages_for_expressions);
@@ -643,7 +649,8 @@ public:
 
   CompilerType GetCanonicalType(lldb::opaque_compiler_type_t type) override;
 
-  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type,
+                               ExecutionContextScope *exe_scope) override;
 
   // Returns -1 if this isn't a function of if the function doesn't have a
   // prototype. Returns a value >override if there is a prototype.
@@ -814,18 +821,18 @@ public:
   /// Retrieve/import the modules imported by the compilation
   /// unit. Early-exists with false if there was an import failure.
   bool GetCompileUnitImports(
-      SymbolContext &sc, lldb::ProcessSP process_sp,
+      const SymbolContext &sc, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
           &modules,
       Status &error);
 
   /// Perform all the implicit imports for the current frame.
-  void PerformCompileUnitImports(SymbolContext &sc, lldb::ProcessSP process_sp,
+  void PerformCompileUnitImports(const SymbolContext &sc, lldb::ProcessSP process_sp,
                                  Status &error);
 
 protected:
   bool GetCompileUnitImportsImpl(
-      SymbolContext &sc, lldb::ProcessSP process_sp,
+      const SymbolContext &sc, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
           *modules,
       Status &error);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
@@ -69,10 +69,6 @@ void SwiftDWARFImporterForClangTypes::lookupValue(
   if (SwiftLanguageRuntime::IsSwiftMangledName(name_cs.GetStringRef()))
     return;
 
-  auto *swift_ast_ctx = m_swift_typesystem.GetSwiftASTContext();
-  if (!swift_ast_ctx)
-    return;
-
   // Find the type in the debug info.
   TypeSP clang_type_sp;
   // FIXME: LookupClangType won't work for nested C++ types.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
@@ -195,13 +195,13 @@ void SwiftDWARFImporterDelegate::lookupValue(
     // Import the type into SwiftASTContext's ClangImporter's clang::ASTContext.
     clang::ASTContext &to_ctx = clang_importer->getClangASTContext();
     clang::ASTContext &from_ctx = type_system->getASTContext();
-
     clang::QualType qual_type = ClangUtil::GetQualType(compiler_type);
     importType(qual_type, from_ctx, to_ctx, kind, results);
 
-    LLDB_LOG(GetLog(LLDBLog::Types),
-             "{0}::lookupValue() -- imported {1} types from debug info.",
-             m_description.c_str(), results.size());
   }
+  LLDB_LOG(GetLog(LLDBLog::Types),
+           "{0}::lookupValue() -- imported {1} types from debug info.",
+           m_description.c_str(), results.size());
 }
-}
+
+} // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -115,7 +115,7 @@ public:
 
   const std::string &GetDescription() const { return m_description; }
   static LanguageSet GetSupportedLanguagesForTypes();
-  virtual SwiftASTContext *GetSwiftASTContext() const = 0;
+  virtual SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const = 0;
   virtual TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() = 0;
   virtual const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const = 0;
   virtual void SetTriple(const llvm::Triple triple) = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -127,8 +127,10 @@ public:
   virtual bool IsErrorType(lldb::opaque_compiler_type_t type) = 0;
   virtual CompilerType GetErrorType() = 0;
   virtual CompilerType GetReferentType(lldb::opaque_compiler_type_t type) = 0;
-  static CompilerType GetInstanceType(CompilerType ct);
-  virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) = 0;
+  static CompilerType GetInstanceType(CompilerType ct,
+                                      ExecutionContextScope *exe_scope);
+  virtual CompilerType GetInstanceType(lldb::opaque_compiler_type_t type,
+                                       ExecutionContextScope *exe_scope) = 0;
   /// Return the static type if this is a DynamicSelf type else the input type.
   virtual CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) = 0;
   enum class TypeAllocationStrategy { eInline, ePointer, eDynamic, eUnknown };

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -22,6 +22,7 @@
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "lldb/Core/Debugger.h"
 #include "lldb/Core/DumpDataExtractor.h"
 #include "lldb/Core/StreamFile.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -1343,12 +1344,14 @@ TypeSystemSwiftTypeRef::CollectTypeInfo(swift::Demangle::Demangler &dem,
   return swift_flags;
 }
 
-CompilerType TypeSystemSwift::GetInstanceType(CompilerType compiler_type) {
+CompilerType
+TypeSystemSwift::GetInstanceType(CompilerType compiler_type,
+                                 ExecutionContextScope *exe_scope) {
   auto ts = compiler_type.GetTypeSystem();
   if (auto tr = ts.dyn_cast_or_null<TypeSystemSwiftTypeRef>())
-    return tr->GetInstanceType(compiler_type.GetOpaqueQualType());
+    return tr->GetInstanceType(compiler_type.GetOpaqueQualType(), exe_scope);
   if (auto ast = ts.dyn_cast_or_null<SwiftASTContext>())
-    return ast->GetInstanceType(compiler_type.GetOpaqueQualType());
+    return ast->GetInstanceType(compiler_type.GetOpaqueQualType(), exe_scope);
   return {};
 }
 
@@ -1376,12 +1379,11 @@ TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "%s::TypeSystemSwiftTypeRefForExpressions()",
             m_description.c_str());
-  m_swift_ast_context_initialized = true;
-  m_swift_ast_context_sp = SwiftASTContext::CreateInstance(
-      LanguageType::eLanguageTypeSwift, module,
-      *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this), true);
-  m_swift_ast_context =
-      llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
+  m_swift_ast_context_map.insert(
+      {nullptr,
+       SwiftASTContext::CreateInstance(
+           LanguageType::eLanguageTypeSwift, module,
+           *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this), true)});
 }
 
 TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
@@ -1393,27 +1395,49 @@ TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
             "%s::TypeSystemSwiftTypeRefForExpressions()",
             m_description.c_str());
   // Is this a REPL?
-  if (extra_options) {
-    m_swift_ast_context_initialized = true;
-    m_swift_ast_context_sp = SwiftASTContext::CreateInstance(
-        LanguageType::eLanguageTypeSwift,
-        *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this),
-        extra_options);
-    m_swift_ast_context =
-        llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
+  if (extra_options)
+    m_swift_ast_context_map.insert(
+        {nullptr, SwiftASTContext::CreateInstance(
+                      LanguageType::eLanguageTypeSwift,
+                      *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this),
+                      extra_options)});
+}
+
+void TypeSystemSwiftTypeRef::NotifyAllTypeSystems(
+    std::function<void(lldb::TypeSystemSP)> fn) {
+  // Grab the list of typesystems while holding the lock.
+  std::vector<TypeSystemSP> typesystems;
+  {
+    std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
+    for (auto it : m_swift_ast_context_map)
+      typesystems.push_back(it.second);
   }
+  // Notify all SwiftASTContexts.
+  for (auto ts_sp : typesystems)
+    fn(ts_sp);
+}
+
+void TypeSystemSwiftTypeRefForExpressions::ModulesDidLoad(
+    ModuleList &module_list) {
+  NotifyAllTypeSystems([&](TypeSystemSP ts_sp) {
+    if (auto swift_ast_ctx =
+            llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(ts_sp.get()))
+      swift_ast_ctx->ModulesDidLoad(module_list);
+  });
 }
 
 Status TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
-    SymbolContext &sc) {
+    const SymbolContext &sc) {
   Status status;
   lldb::ProcessSP process_sp;
   if (auto target_sp = sc.target_sp)
     process_sp = target_sp->GetProcessSP();
-  if (!m_swift_ast_context_initialized)
-    // Stash sc, the import will happen lazily when SwiftASTContext is created.
-    m_initial_symbol_context_up = std::make_unique<SymbolContext>(sc);
-  else if (auto *swift_ast_ctx = GetSwiftASTContext())
+  if (!ModuleList::GetGlobalModuleListProperties()
+           .GetUseSwiftPreciseCompilerInvocation())
+    if (!GetSwiftASTContextOrNull(nullptr))
+      m_initial_symbol_context_up = std::make_unique<SymbolContext>(sc);
+
+  if (auto *swift_ast_ctx = GetSwiftASTContextOrNull(&sc))
     swift_ast_ctx->PerformCompileUnitImports(sc, process_sp, status);
   return status;
 }
@@ -1442,55 +1466,172 @@ TypeSystemSwiftTypeRefForExpressions::GetPersistentExpressionState() {
   return m_persistent_state_up.get();
 }
 
-SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContext() const {
-  if (m_swift_ast_context_initialized)
-    return m_swift_ast_context;
+ConstString TypeSystemSwiftTypeRef::GetSwiftModuleFor(const SymbolContext *sc) {
+  if (!sc)
+    return {};
+  if (!sc->function)
+    return {};
+  std::vector<CompilerContext> decl_ctx = sc->function->GetCompilerContext();
+  for (auto &ctx : decl_ctx)
+    if (ctx.kind == CompilerContextKind::Module)
+      return ctx.name;
+  return {};
+}
 
-  // SwiftASTContext::CreateInstance() returns a nullptr on failure,
-  // there is no point in trying to initialize when that happens.
-  m_swift_ast_context_initialized = true;
-  if (auto *module = GetModule()) {
-    m_swift_ast_context_sp = SwiftASTContext::CreateInstance(
-        LanguageType::eLanguageTypeSwift, *module,
-        *const_cast<TypeSystemSwiftTypeRef *>(this));
-    m_swift_ast_context =
-        llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
+SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextFromExecutionScope(
+    ExecutionContextScope *exe_scope) const {
+  const SymbolContext *sc = nullptr;
+  if (exe_scope) {
+    // The SymbolContext is a Function, which outlives the stack
+    // frame, so not holding on to the shared pointer is safe here.
+    auto stack_frame_sp = exe_scope->CalculateStackFrame();
+    if (stack_frame_sp)
+      sc = &stack_frame_sp->GetSymbolContext(eSymbolContextFunction);
   }
-  return m_swift_ast_context;
+  return GetSwiftASTContext(sc);
+}
+
+SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextFromExecutionContext(
+    const ExecutionContext *exe_ctx) const {
+  const SymbolContext *sc = nullptr;
+  if (exe_ctx) {
+    // The SymbolContext is a Function, which outlives the stack
+    // frame, so not holding on to the shared pointer is safe here.
+    auto stack_frame = exe_ctx->GetFramePtr();
+    if (stack_frame)
+      sc = &stack_frame->GetSymbolContext(eSymbolContextFunction);
+  }
+  return GetSwiftASTContext(sc);
 }
 
 SwiftASTContext *
-TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext() const {
-  if (m_swift_ast_context_initialized)
-    return m_swift_ast_context;
+TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext *sc) const {
+  std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
+  // There is only one per-module context.
+  const char *key = nullptr;
 
-  // SwiftASTContext::CreateInstance() returns a nullptr on failure,
-  // there is no point in trying to initialize when that happens.
-  m_swift_ast_context_initialized = true;
-  m_swift_ast_context_sp = SwiftASTContext::CreateInstance(
-      LanguageType::eLanguageTypeSwift,
-      *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this), nullptr);
-  m_swift_ast_context =
-      llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
-  if (!m_swift_ast_context)
-    return nullptr;
-
-  assert(llvm::isa<SwiftASTContextForExpressions>(m_swift_ast_context));
-  if (m_initial_symbol_context_up) {
-    Status error;
-    lldb::ProcessSP process_sp;
-    if (TargetSP target_sp = GetTargetWP().lock())
-      process_sp = target_sp->GetProcessSP();
-    m_swift_ast_context->PerformCompileUnitImports(*m_initial_symbol_context_up,
-                                                   process_sp, error);
-    m_initial_symbol_context_up.reset();
+  // Look up the SwiftASTContext in the cache.
+  auto it = m_swift_ast_context_map.find(key);
+  if (it != m_swift_ast_context_map.end()) {
+    // SwiftASTContext::CreateInstance() returns a nullptr on failure,
+    // there is no point in trying to initialize when that happens.
+    if (!it->second)
+      return nullptr;
+    return llvm::cast<SwiftASTContext>(it->second.get());
   }
 
-  return m_swift_ast_context;
+  // Create a new SwiftASTContextForExpressions.
+  TypeSystemSP ts = SwiftASTContext::CreateInstance(
+      LanguageType::eLanguageTypeSwift, *m_module,
+      *const_cast<TypeSystemSwiftTypeRef *>(this));
+  m_swift_ast_context_map.insert({key, ts});
+
+  auto *swift_ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(ts.get());
+  return swift_ast_context;
 }
 
-SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull() const {
-  return m_swift_ast_context;
+SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
+    const SymbolContext *sc) const {
+  // SwiftASTContext::CreateInstance() returns a nullptr on failure,
+  // there is no point in trying to initialize when that happens.
+  bool precise = false;
+  // Compute the cache key.
+  const char *key = nullptr;
+  if (sc && ModuleList::GetGlobalModuleListProperties()
+                .GetUseSwiftPreciseCompilerInvocation()) {
+    ConstString module = GetSwiftModuleFor(sc);
+    key = module.GetCString();
+    precise = true;
+  }
+
+  // Look up the SwiftASTContext in the cache.
+  TypeSystemSP ts;
+  {
+    std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
+    auto it = m_swift_ast_context_map.find(key);
+    if (it != m_swift_ast_context_map.end()) {
+      // SwiftASTContext::CreateInstance() returns a nullptr on failure,
+      // there is no point in trying to initialize when that happens.
+      if (!it->second)
+        return nullptr;
+      auto *swift_ast_ctx = llvm::cast<SwiftASTContext>(it->second.get());
+      if (!swift_ast_ctx->HasFatalErrors())
+        return swift_ast_ctx;
+      // Recreate the SwiftASTContext if it has developed fatal errors. Any
+      // clients holding on to the old context via a CompilerType will keep its
+      // shared_ptr alive.
+      m_swift_ast_context_map.erase(key);
+    }
+
+    // Create a new SwiftASTContextForExpressions.
+    ts = precise
+             ? SwiftASTContext::CreateInstance(
+                   *sc,
+                   *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this))
+             : SwiftASTContext::CreateInstance(
+                   LanguageType::eLanguageTypeSwift,
+                   *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this),
+                   nullptr);
+    m_swift_ast_context_map.insert({key, ts});
+  }
+
+  // Now perform the initial imports. This step can be very expensive.
+  auto *swift_ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(ts.get());
+  if (!swift_ast_context)
+    return nullptr;
+  assert(llvm::isa<SwiftASTContextForExpressions>(swift_ast_context));
+
+  auto perform_initial_import = [&](const SymbolContext &sc) {
+    Status error;
+    lldb::ProcessSP process_sp;
+    TargetSP target_sp = GetTargetWP().lock();
+    if (target_sp)
+      process_sp = target_sp->GetProcessSP();
+    swift_ast_context->PerformCompileUnitImports(sc, process_sp, error);
+    if (error.Fail() && target_sp)
+      if (StreamSP errs_sp = target_sp->GetDebugger().GetAsyncErrorStream())
+        errs_sp->Printf(
+            "Could not import Swift modules for translation unit: %s",
+            error.AsCString());
+  };
+
+  if (precise && sc) {
+    perform_initial_import(*sc);
+  } else {
+    if (m_initial_symbol_context_up) {
+      perform_initial_import(*m_initial_symbol_context_up);
+      m_initial_symbol_context_up.reset();
+    }
+  }
+  return swift_ast_context;
+}
+
+SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull(
+    const SymbolContext *sc) const {
+  std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
+
+  const char *key = nullptr;
+  auto it = m_swift_ast_context_map.find(key);
+  if (it != m_swift_ast_context_map.end())
+    return llvm::cast_or_null<SwiftASTContext>(it->second.get());
+  return nullptr;
+}
+
+SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContextOrNull(
+    const SymbolContext *sc) const {
+  std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
+
+  const char *key = nullptr;
+  if (sc && ModuleList::GetGlobalModuleListProperties()
+                .GetUseSwiftPreciseCompilerInvocation()) {
+    ConstString module = GetSwiftModuleFor(sc);
+    key = module.GetCString();
+  }
+
+  auto it = m_swift_ast_context_map.find(key);
+  if (it != m_swift_ast_context_map.end())
+    return llvm::cast_or_null<SwiftASTContext>(it->second.get());
+  return nullptr;
 }
 
 SwiftDWARFImporterForClangTypes &
@@ -1524,14 +1665,17 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
 }
 
 void TypeSystemSwiftTypeRef::SetTriple(const llvm::Triple triple) {
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  // This function appears to be only called via Module::SetArchitecture(ArchSpec).
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull(nullptr))
     swift_ast_context->SetTriple(triple);
 }
 
 void TypeSystemSwiftTypeRef::ClearModuleDependentCaches() {
-  // There is no need to notify a not-yet created SwiftASTContext to reset.
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull())
-    swift_ast_context->ClearModuleDependentCaches();
+  NotifyAllTypeSystems([&](TypeSystemSP ts_sp) {
+    if (auto swift_ast_ctx =
+            llvm::dyn_cast_or_null<SwiftASTContext>(ts_sp.get()))
+      swift_ast_ctx->ClearModuleDependentCaches();
+  });
 }
 
 const char *TypeSystemSwiftTypeRef::AsMangledName(opaque_compiler_type_t type) {
@@ -1546,17 +1690,29 @@ TypeSystemSwiftTypeRef::GetMangledTypeName(opaque_compiler_type_t type) {
   return ConstString(AsMangledName(type));
 }
 
-void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type) {
+void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
+                                              const ExecutionContext *exe_ctx) {
   Status error;
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
+  if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
     return swift_ast_context->ReconstructType(GetMangledTypeName(type), error);
   return {};
 }
 
-CompilerType TypeSystemSwiftTypeRef::ReconstructType(CompilerType type) {
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
+void *TypeSystemSwiftTypeRef::ReconstructType(
+    opaque_compiler_type_t type,  ExecutionContextScope *exe_scope) {
+  ExecutionContext exe_ctx;
+  if (exe_scope)
+    exe_scope->CalculateExecutionContext(exe_ctx);
+  return ReconstructType(type, &exe_ctx);
+}
+
+CompilerType
+TypeSystemSwiftTypeRef::ReconstructType(CompilerType type,
+                                        const ExecutionContext *exe_ctx) {
+  assert(type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>());
+  if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
     return {swift_ast_context->weak_from_this(),
-            ReconstructType(type.GetOpaqueQualType())};
+            ReconstructType(type.GetOpaqueQualType(), exe_ctx)};
   return {};
 }
 
@@ -1940,7 +2096,8 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
         _exe_ctx == ExecutionContext() ? nullptr : &_exe_ctx);                 \
     bool equivalent =                                                          \
         !ReconstructType(TYPE) /* missing .swiftmodule */ ||                   \
-        (Equivalent(result, GetSwiftASTContext(nullptr)->REFERENCE ARGS));     \
+        (Equivalent(result, GetSwiftASTContextFromExecutionContext(&_exe_ctx)  \
+                                ->REFERENCE ARGS));                            \
     if (!equivalent)                                                           \
       llvm::dbgs() << "failing type was " << (const char *)TYPE << "\n";       \
     assert(equivalent &&                                                       \
@@ -2358,6 +2515,7 @@ TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
   VALIDATE_AND_RETURN(impl, GetDisplayTypeName, type, g_no_exe_ctx,
                       (ReconstructType(type), sc), (ReconstructType(type), sc));
 }
+
 uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     opaque_compiler_type_t type, CompilerType *pointee_or_element_clang_type) {
   auto impl = [&]() {
@@ -2421,8 +2579,8 @@ TypeSystemSwiftTypeRef::GetArrayElementType(opaque_compiler_type_t type,
     return element_type;
   };
   VALIDATE_AND_RETURN(impl, GetArrayElementType, type, exe_scope,
-                      (ReconstructType(type), exe_scope),
-                      (ReconstructType(type), exe_scope));
+                      (ReconstructType(type, exe_scope), exe_scope),
+                      (ReconstructType(type, exe_scope), exe_scope));
 }
 
 CompilerType
@@ -2434,7 +2592,8 @@ TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
     if (ContainsUnresolvedTypeAlias(canonical)) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
-      CompilerType ast_type = ReconstructType({weak_from_this(), type}).GetCanonicalType();
+      CompilerType ast_type =
+        ReconstructType({weak_from_this(), type}, nullptr).GetCanonicalType();
       return GetTypeFromMangledTypename(ast_type.GetMangledTypeName());
     }
     auto mangling = mangleNode(canonical);
@@ -2631,9 +2790,9 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
 
       if (auto *swift_ast_context =
               GetSwiftASTContextFromExecutionScope(exe_scope))
-        return swift_ast_context->GetBitSize(ReconstructType(type), exe_scope);
+        return swift_ast_context->GetBitSize(ReconstructType(type, exe_scope),
+                                             exe_scope);
     }
-
 
     // FIXME: Move this to the top. Currently this causes VALIDATE
     // errors on resilient types, and Foundation overlay types. These
@@ -2655,11 +2814,11 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
               AsMangledName(type));
     return {};
   };
-  FALLBACK(GetBitSize, (ReconstructType(type), exe_scope));
+  FALLBACK(GetBitSize, (ReconstructType(type, exe_scope), exe_scope));
   if (exe_scope && exe_scope->CalculateProcess()) {
     VALIDATE_AND_RETURN(impl, GetBitSize, type, exe_scope,
-                        (ReconstructType(type), exe_scope),
-                        (ReconstructType(type), exe_scope));
+                        (ReconstructType(type, exe_scope), exe_scope),
+                        (ReconstructType(type, exe_scope), exe_scope));
   } else
     return impl();
 }
@@ -2676,8 +2835,8 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
     return {};
   };
   VALIDATE_AND_RETURN(impl, GetByteStride, type, exe_scope,
-                      (ReconstructType(type), exe_scope),
-                      (ReconstructType(type), exe_scope));
+                      (ReconstructType(type, exe_scope), exe_scope),
+                      (ReconstructType(type, exe_scope), exe_scope));
 }
 
 lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
@@ -2762,7 +2921,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        const ExecutionContext *exe_ctx) {
   LLDB_SCOPED_TIMER();
   FALLBACK(GetNumChildren,
-           (ReconstructType(type), omit_empty_base_classes, exe_ctx));
+           (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx));
 
   auto impl = [&]() -> llvm::Optional<uint32_t> {
     if (exe_ctx)
@@ -2790,8 +2949,8 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
         exe_ctx_obj = *exe_ctx;
       VALIDATE_AND_RETURN(
           impl, GetNumChildren, type, exe_ctx_obj,
-          (ReconstructType(type), omit_empty_base_classes, exe_ctx),
-          (ReconstructType(type), omit_empty_base_classes, exe_ctx));
+          (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx),
+          (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx));
     }()
                         .value_or(0);
 
@@ -2800,7 +2959,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
             AsMangledName(type));
 
   if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
-    return swift_ast_context->GetNumChildren(ReconstructType(type),
+    return swift_ast_context->GetNumChildren(ReconstructType(type, exe_ctx),
                                              omit_empty_base_classes, exe_ctx);
   return {};
 }
@@ -2808,7 +2967,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
 uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
                                               ExecutionContext *exe_ctx) {
   LLDB_SCOPED_TIMER();
-  FALLBACK(GetNumFields, (ReconstructType(type), exe_ctx));
+  FALLBACK(GetNumFields, (ReconstructType(type, exe_ctx), exe_ctx));
 
   auto impl = [&]() -> llvm::Optional<uint32_t> {
     if (exe_ctx)
@@ -2846,8 +3005,8 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
       if (exe_ctx)
         exe_ctx_obj = *exe_ctx;
       VALIDATE_AND_RETURN(impl, GetNumFields, type, exe_ctx_obj,
-                          (ReconstructType(type), exe_ctx),
-                          (ReconstructType(type), exe_ctx));
+                          (ReconstructType(type, exe_ctx), exe_ctx),
+                          (ReconstructType(type, exe_ctx), exe_ctx));
     }()
                         .value_or(0);
   }
@@ -2857,7 +3016,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
             AsMangledName(type));
 
   if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
-    return swift_ast_context->GetNumFields(ReconstructType(type), exe_ctx);
+    return swift_ast_context->GetNumFields(ReconstructType(type, exe_ctx), exe_ctx);
   return {};
 }
 
@@ -2925,7 +3084,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     if (auto *swift_ast_context =
             GetSwiftASTContextFromExecutionContext(exe_ctx))
       return swift_ast_context->GetChildCompilerTypeAtIndex(
-          ReconstructType(type), exe_ctx, idx, transparent_pointers,
+          ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
           omit_empty_base_classes, ignore_array_bounds, child_name,
           child_byte_size, child_byte_offset, child_bitfield_bit_size,
           child_bitfield_bit_offset, child_is_base_class,
@@ -2933,7 +3092,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     return {};
   };
   FALLBACK(GetChildCompilerTypeAtIndex,
-           (ReconstructType(type), exe_ctx, idx, transparent_pointers,
+           (ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
             omit_empty_base_classes, ignore_array_bounds, child_name,
             child_byte_size, child_byte_offset, child_bitfield_bit_size,
             child_bitfield_bit_offset, child_is_base_class,
@@ -2945,7 +3104,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     if (auto *swift_ast_context =
             GetSwiftASTContextFromExecutionContext(exe_ctx))
       ast_num_children = swift_ast_context->GetNumChildren(
-          ReconstructType(type), omit_empty_base_classes, exe_ctx);
+          ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx);
     return ast_num_children.value_or(0);
   };
   auto impl = [&]() -> CompilerType {
@@ -3118,12 +3277,12 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
 #endif
   VALIDATE_AND_RETURN(
       impl, GetChildCompilerTypeAtIndex, type, exe_ctx,
-      (ReconstructType(type), exe_ctx, idx, transparent_pointers,
+      (ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
        omit_empty_base_classes, ignore_array_bounds, ast_child_name,
        ast_child_byte_size, ast_child_byte_offset, ast_child_bitfield_bit_size,
        ast_child_bitfield_bit_offset, ast_child_is_base_class,
        ast_child_is_deref_of_parent, valobj, ast_language_flags),
-      (ReconstructType(type), exe_ctx, idx, transparent_pointers,
+      (ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
        omit_empty_base_classes, ignore_array_bounds, child_name,
        child_byte_size, child_byte_offset, child_bitfield_bit_size,
        child_bitfield_bit_offset, child_is_base_class, child_is_deref_of_parent,
@@ -3135,7 +3294,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   LLDB_SCOPED_TIMER();
   FALLBACK(GetIndexOfChildMemberWithName,
-           (ReconstructType(type), name, exe_ctx, omit_empty_base_classes,
+           (ReconstructType(type, exe_ctx), name, exe_ctx, omit_empty_base_classes,
             child_indexes));
   if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
     if (auto *runtime =
@@ -3151,7 +3310,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
         if (!GetSwiftASTContextFromExecutionContext(exe_ctx))
           return index_size;
         auto swift_scratch_ctx_lock = SwiftScratchContextLock(exe_ctx);
-        auto ast_type = ReconstructType(type);
+        auto ast_type = ReconstructType(type, exe_ctx);
         if (!ast_type)
           return index_size;
         std::vector<uint32_t> ast_child_indexes;
@@ -3204,7 +3363,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
 
   if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
     return swift_ast_context->GetIndexOfChildMemberWithName(
-        ReconstructType(type), name, exe_ctx, omit_empty_base_classes,
+        ReconstructType(type, exe_ctx), name, exe_ctx, omit_empty_base_classes,
         child_indexes);
   return {};
 }
@@ -3490,22 +3649,23 @@ TypeSystemSwiftTypeRef::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
 }
 
 CompilerType
-TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type) {
+TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type,
+                                        ExecutionContextScope *exe_scope) {
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = DemangleCanonicalType(dem, type);
 
-    if (!node)
-      return {};
-    if (ContainsUnresolvedTypeAlias(node)) {
+    if (!node || ContainsUnresolvedTypeAlias(node)) {
       // If we couldn't resolve all type aliases, we might be in a REPL session
       // where getting to the debug information necessary for resolving that
       // type alias isn't possible, or the user might have defined the
       // type alias in the REPL. In these cases, fallback to asking the AST
       // for the canonical type.
-      if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
-        return swift_ast_context->GetInstanceType(ReconstructType(type));
+      if (auto *swift_ast_context =
+              GetSwiftASTContextFromExecutionScope(exe_scope))
+        return swift_ast_context->GetInstanceType(
+            ReconstructType(type, exe_scope), exe_scope);
       return {};
     }
 
@@ -3517,8 +3677,9 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type) {
     }
     return {weak_from_this(), type};
   };
-  VALIDATE_AND_RETURN(impl, GetInstanceType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+  VALIDATE_AND_RETURN(impl, GetInstanceType, type, exe_scope,
+                      (ReconstructType(type, exe_scope), exe_scope),
+                      (ReconstructType(type, exe_scope), exe_scope));
 }
 
 CompilerType TypeSystemSwiftTypeRef::CreateSILPackType(CompilerType type,
@@ -3638,8 +3799,9 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
     std::vector<TupleElement> ast_elements;
     std::transform(elements.begin(), elements.end(),
                    std::back_inserter(ast_elements), [&](TupleElement element) {
-                     return TupleElement(element.element_name,
-                                         ReconstructType(element.element_type));
+                     return TupleElement(
+                         element.element_name,
+                         ReconstructType(element.element_type, nullptr));
                    });
     bool equivalent =
         Equivalent(result, swift_ast_ctx->CreateTupleType(ast_elements));
@@ -3747,7 +3909,7 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
           GetSwiftASTContextFromExecutionScope(exe_scope)) {
     s->PutCString("Source code info:\n");
     swift_ast_context->DumpTypeDescription(
-        ReconstructType(type), s, print_help_if_available,
+        ReconstructType(type, exe_scope), s, print_help_if_available,
         print_extensions_if_available, level);
   }
 }
@@ -3773,8 +3935,10 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       return false;
 
     using namespace swift::Demangle;
-    Demangler dem;
+    Demangler dem;    
     auto *node = DemangleCanonicalType(dem, type);
+    if (!node)
+      return false;
     switch (node->getKind()) {
     case Node::Kind::Class:
     case Node::Kind::BoundGenericClass:
@@ -3874,10 +4038,14 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       // No result available from the runtime, fallback to the AST. This occurs
       // for some Clang imported enums
       if (auto *swift_ast_context =
-              GetSwiftASTContextFromExecutionScope(exe_scope))
+              GetSwiftASTContextFromExecutionScope(exe_scope)) {
+        ExecutionContext exe_ctx;
+        exe_scope->CalculateExecutionContext(exe_ctx);
         return swift_ast_context->DumpTypeValue(
-            ReconstructType(type), s, format, data, data_offset, data_byte_size,
-            bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+            ReconstructType(type, &exe_ctx), s, format, data, data_offset,
+            data_byte_size, bitfield_bit_size, bitfield_bit_offset, exe_scope,
+            is_base_class);
+      }
       return {};
     }
     case Node::Kind::TypeAlias:
@@ -3889,8 +4057,9 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       if (auto *swift_ast_context =
               GetSwiftASTContextFromExecutionScope(exe_scope))
         return swift_ast_context->DumpTypeValue(
-            ReconstructType(type), s, format, data, data_offset, data_byte_size,
-            bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
+            ReconstructType(type, exe_scope), s, format, data, data_offset,
+            data_byte_size, bitfield_bit_size, bitfield_bit_offset, exe_scope,
+            is_base_class);
       return {};
     }
     default:
@@ -3902,10 +4071,28 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     }
   };
 
+  {
+    // If this is a typealias defined in the expression evaluator,
+    // then we don't have debug info to resolve it from.
+    using namespace swift::Demangle;
+    Demangler dem;
+    auto *node = DemangleCanonicalType(dem, type);
+    bool unresolved_typealias = false;
+    CollectTypeInfo(dem, node, unresolved_typealias);
+    if (!node || unresolved_typealias) {
+      if (auto swift_ast_ctx = GetSwiftASTContextFromExecutionScope(exe_scope))
+        return swift_ast_ctx->DumpTypeValue(
+            ReconstructType(type, exe_scope), s, format, data, data_offset,
+            data_byte_size, bitfield_bit_size, bitfield_bit_offset, exe_scope,
+            is_base_class);
+      return false;
+    }
+  }
+
 #ifndef NDEBUG
-  FALLBACK(DumpTypeValue,
-           (ReconstructType(type), s, format, data, data_offset, data_byte_size,
-            bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class));
+  FALLBACK(DumpTypeValue, (ReconstructType(type, exe_scope), s, format, data,
+                           data_offset, data_byte_size, bitfield_bit_size,
+                           bitfield_bit_offset, exe_scope, is_base_class));
   StreamString ast_s;
   auto defer = llvm::make_scope_exit([&] {
     assert(Equivalent(ConstString(ast_s.GetString()),
@@ -3913,12 +4100,13 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
   });
 #endif
-  VALIDATE_AND_RETURN(
-      impl, DumpTypeValue, type, exe_scope,
-      (ReconstructType(type), ast_s, format, data, data_offset, data_byte_size,
-       bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class),
-      (ReconstructType(type), s, format, data, data_offset, data_byte_size,
-       bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class));
+  VALIDATE_AND_RETURN(impl, DumpTypeValue, type, exe_scope,
+                      (ReconstructType(type, exe_scope), ast_s, format, data,
+                       data_offset, data_byte_size, bitfield_bit_size,
+                       bitfield_bit_offset, exe_scope, is_base_class),
+                      (ReconstructType(type, exe_scope), s, format, data,
+                       data_offset, data_byte_size, bitfield_bit_size,
+                       bitfield_bit_offset, exe_scope, is_base_class));
 }
 
 bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
@@ -3935,7 +4123,7 @@ llvm::Optional<size_t>
 TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
                                         ExecutionContextScope *exe_scope) {
   LLDB_SCOPED_TIMER();
-  FALLBACK(GetTypeBitAlign, (ReconstructType(type), exe_scope));
+  FALLBACK(GetTypeBitAlign, (ReconstructType(type, exe_scope), exe_scope));
   // This method doesn't use VALIDATE_AND_RETURN because except for
   // fixed-size types the SwiftASTContext implementation forwards to
   // SwiftLanguageRuntime anyway and for many fixed-size types the
@@ -3970,8 +4158,12 @@ TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
     // defined in the expression. In that case we don't have debug
     // info for it, so defer to SwiftASTContext.
     if (llvm::isa_and_nonnull<SwiftASTContextForExpressions>(
-            GetSwiftASTContextFromExecutionScope(exe_scope)))
-      return ReconstructType({weak_from_this(), type}).GetTypeBitAlign(exe_scope);
+            GetSwiftASTContextFromExecutionScope(exe_scope))) {
+      ExecutionContext exe_ctx;
+      if (exe_scope)exe_scope->CalculateExecutionContext(exe_ctx);
+      return ReconstructType({weak_from_this(), type}, &exe_ctx)
+          .GetTypeBitAlign(exe_scope);
+    }
   }
 
   // If there is no process, we can still try to get the static

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1509,7 +1509,6 @@ TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext *sc) const {
   std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
   // There is only one per-module context.
   const char *key = nullptr;
-
   // Look up the SwiftASTContext in the cache.
   auto it = m_swift_ast_context_map.find(key);
   if (it != m_swift_ast_context_map.end()) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -59,9 +59,15 @@ public:
   ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   /// Get the corresponding SwiftASTContext, and create one if necessary.
-  SwiftASTContext *GetSwiftASTContext() const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  /// Convenience helpers.
+  SwiftASTContext *
+  GetSwiftASTContextFromExecutionScope(ExecutionContextScope *exe_scope) const;
+  SwiftASTContext *
+  GetSwiftASTContextFromExecutionContext(const ExecutionContext *exe_ctx) const;
   /// Return SwiftASTContext, iff one has already been created.
-  SwiftASTContext *GetSwiftASTContextOrNull() const;
+  virtual SwiftASTContext *
+  GetSwiftASTContextOrNull(const SymbolContext *sc = nullptr) const;
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override { return *this; }
   const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const override {
     return *this;
@@ -475,7 +481,9 @@ public:
   TypeSystemSwiftTypeRefForExpressions(lldb::LanguageType language,
                                        Target &target, Module &module);
 
-  SwiftASTContext *GetSwiftASTContext() const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  SwiftASTContext *
+  GetSwiftASTContextOrNull(const SymbolContext *sc = nullptr) const override;
   lldb::TargetWP GetTargetWP() const override { return m_target_wp; }
 
   /// Forwards to SwiftASTContext.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -67,7 +67,7 @@ public:
   GetSwiftASTContextFromExecutionContext(const ExecutionContext *exe_ctx) const;
   /// Return SwiftASTContext, iff one has already been created.
   virtual SwiftASTContext *
-  GetSwiftASTContextOrNull(const SymbolContext *sc = nullptr) const;
+  GetSwiftASTContextOrNull(const SymbolContext *sc) const;
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override { return *this; }
   const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const override {
     return *this;
@@ -79,7 +79,9 @@ public:
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
 
-  CompilerType ReconstructType(CompilerType type);
+  /// Return a SwiftASTContext type for type.
+  CompilerType ReconstructType(CompilerType type,
+                               const ExecutionContext *exe_ctx);
   CompilerType
   GetTypeFromMangledTypename(ConstString mangled_typename) override;
 
@@ -119,6 +121,9 @@ public:
   }
 
   Module *GetModule() const { return m_module; }
+
+  /// Return the owning Swift module for a function.
+  static ConstString GetSwiftModuleFor(const SymbolContext *sc);
 
   // Tests
 #ifndef NDEBUG
@@ -277,7 +282,8 @@ public:
   bool IsErrorType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetErrorType() override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
-  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type) override;
+  CompilerType GetInstanceType(lldb::opaque_compiler_type_t type,
+                               ExecutionContextScope *exe_scope) override;
   CompilerType GetStaticSelfType(lldb::opaque_compiler_type_t type) override;
   static swift::Demangle::NodePointer
   GetStaticSelfType(swift::Demangle::Demangler &dem,
@@ -369,7 +375,10 @@ public:
 
 protected:
   /// Helper that creates an AST type from \p type.
-  void *ReconstructType(lldb::opaque_compiler_type_t type);
+  void *ReconstructType(lldb::opaque_compiler_type_t type,
+                        const ExecutionContext *exe_ctx = nullptr);
+  void *ReconstructType(lldb::opaque_compiler_type_t type,
+                        ExecutionContextScope *exe_scope);
   /// Cast \p opaque_type as a mangled name.
   static const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
@@ -439,10 +448,15 @@ protected:
   bool ShouldSkipValidation(lldb::opaque_compiler_type_t type);
 #endif
 
-  /// The sibling SwiftASTContext.
-  mutable bool m_swift_ast_context_initialized = false;
-  mutable lldb::TypeSystemSP m_swift_ast_context_sp;
-  mutable SwiftASTContext *m_swift_ast_context = nullptr;
+  /// Perform an action on all subling SwiftASTContexts.
+  void NotifyAllTypeSystems(std::function<void(lldb::TypeSystemSP)> fn);
+  
+  mutable std::mutex m_swift_ast_context_lock;
+  /// The "precise" SwiftASTContexts managed by this scratch context. There
+  /// exists one per Swift module. The keys in this map are module names.
+  mutable llvm::DenseMap<const char *, lldb::TypeSystemSP>
+      m_swift_ast_context_map;
+
   mutable std::unique_ptr<SwiftDWARFImporterForClangTypes>
       m_dwarf_importer_for_clang_types_up;
   mutable std::unique_ptr<ClangNameImporter> m_name_importer_up;
@@ -483,8 +497,10 @@ public:
 
   SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
   SwiftASTContext *
-  GetSwiftASTContextOrNull(const SymbolContext *sc = nullptr) const override;
+  GetSwiftASTContextOrNull(const SymbolContext *sc) const override;
   lldb::TargetWP GetTargetWP() const override { return m_target_wp; }
+
+  void ModulesDidLoad(ModuleList &module_list);
 
   /// Forwards to SwiftASTContext.
   UserExpression *GetUserExpression(llvm::StringRef expr,
@@ -496,7 +512,7 @@ public:
 
   /// Forwards to SwiftASTContext.
   PersistentExpressionState *GetPersistentExpressionState() override;
-  Status PerformCompileUnitImports(SymbolContext &sc);
+  Status PerformCompileUnitImports(const SymbolContext &sc);
 
   friend class SwiftASTContextForExpressions;
 protected:

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1689,12 +1689,7 @@ void Target::ModulesDidLoad(ModuleList &module_list) {
               type_system.get());
       if (!swift_scratch_ctx)
         return true;
-      auto *swift_ast_ctx =
-          llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-              swift_scratch_ctx->GetSwiftASTContextOrNull());
-      if (!swift_ast_ctx)
-        return true;
-      swift_ast_ctx->ModulesDidLoad(module_list);
+      swift_scratch_ctx->ModulesDidLoad(module_list);
 #endif // LLDB_ENABLE_SWIFT
       return true;
     };

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -10,6 +10,7 @@ class TestSwiftWerror(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -23,6 +23,7 @@ class TestSwiftDedupMacros(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     # NOTE: rdar://44201206 - This test may sporadically segfault. It's likely
     # that the underlying memory corruption issue has been addressed, but due
     # to the difficulty of reproducing the crash, we are not sure. If a crash

--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -10,6 +10,7 @@ class TestSwiftExprImport(TestBase):
     
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @swiftTest
     def test(self):
         """Test error handling if the expression evaluator

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -12,6 +12,7 @@ class TestSwiftHardMacroConflict(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -24,6 +24,7 @@ class TestSwiftHeadermapConflict(TestBase):
 
     @skipIf(bugnumber="rdar://60396797",
             setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -24,6 +24,7 @@ class TestSwiftIncludeConflict(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -24,6 +24,7 @@ class TestSwiftMacroConflict(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -24,6 +24,7 @@ class TestSwiftRewriteClangPaths(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
@@ -32,6 +33,7 @@ class TestSwiftRewriteClangPaths(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -16,7 +16,10 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
         
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
-
+        # FIXME: TypeSystemSwiftTypeRef::GetCanonicalType() doesn't
+        # take an execution context, so the validation happens in the
+        # wrong SwiftASTContext.
+        self.expect('settings set symbols.swift-validate-typesystem false')
         self.expect('v map', substrs=['CxxMap', 'first = 1, second = 3', 
             'first = 2, second = 2', 'first = 3, second = 3'])
         self.expect('expr map', substrs=['CxxMap', 'first = 1, second = 3', 

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -9,6 +9,7 @@ class TestSwiftLateDylib(TestBase):
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     def test(self):
         """Test that a late loaded Swift dylib is debuggable"""
         arch = self.getArchitecture()

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -13,6 +13,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     def test_system_framework(self):
         """Test that a framework that is registered as autolinked in a Swift
            module used in the target, but not linked against the target is

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -35,7 +35,6 @@ class TestSwiftMacro(lldbtest.TestBase):
         """Test Swift macros"""
         self.build(dictionary={'SWIFT_SOURCES': 'main.swift'})
         self.setupPluginServerForTesting()
-
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
@@ -70,6 +69,6 @@ class TestSwiftMacro(lldbtest.TestBase):
         self.expect('expression -- #stringify(1)', substrs=['0 = 1', '1 = "1"'])
         self.filecheck('platform shell cat "%s"' % types_log, __file__)
 #       CHECK: CacheUserImports(){{.*}}: Macro.
-#       CHECK: SwiftASTContextForExpressions::LoadOneModule(){{.*}}Imported module Macro from {kind = Serialized Swift AST, filename = "{{.*}}Macro.swiftmodule";}
+#       CHECK: SwiftASTContextForExpressions{{.*}}::LoadOneModule(){{.*}}Imported module Macro from {kind = Serialized Swift AST, filename = "{{.*}}Macro.swiftmodule";}
 #       CHECK: CacheUserImports(){{.*}}Scanning for search paths in{{.*}}Macro.swiftmodule
-#       CHECK: SwiftASTContextForExpressions::LogConfiguration(){{.*}} -external-plugin-path {{.*}}/lang/swift/macro/{{.*}}#{{.*}}/swift-plugin-server
+#       CHECK: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}} -external-plugin-path {{.*}}/lang/swift/macro/{{.*}}#{{.*}}/swift-plugin-server

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -206,4 +206,4 @@ class TestSwiftPlaygrounds(TestBase):
                and 'Versions/A/Dylib' in line \
                and 'ClangImporter needs to be reinitialized' in line:
                     found += 1
-        self.assertEqual(found, 2)
+        self.assertGreater(found, 1)

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -137,19 +137,20 @@ class TestSwiftPlaygrounds(TestBase):
         self.expect('settings set target.swift-framework-search-paths "%s"' %
                     self.getBuildDir())
 
-        self.options = lldb.SBExpressionOptions()
-        self.options.SetLanguage(lldb.eLanguageTypeSwift)
-        self.options.SetPlaygroundTransformEnabled()
-        # The concurrency expressions will spawn multiple threads.
-        self.options.SetOneThreadTimeoutInMicroSeconds(1)
-        self.options.SetTryAllThreads(True)
-
-
     def execute_code(self, input_file, expect_error=False):
         contents = "syntax error"
         with open(input_file, 'r') as contents_file:
             contents = contents_file.read()
-        res = self.frame().EvaluateExpression(contents, self.options)
+
+        options = lldb.SBExpressionOptions()
+        options.SetLanguage(lldb.eLanguageTypeSwift)
+        options.SetPlaygroundTransformEnabled()
+        # The concurrency expressions will spawn multiple threads.
+        options.SetOneThreadTimeoutInMicroSeconds(1)
+        options.SetTryAllThreads(True)
+        options.SetAutoApplyFixIts(False)
+
+        res = self.frame().EvaluateExpression(contents, options)
         ret = self.frame().EvaluateExpression("get_output()")
         is_error = res.GetError().Fail() and not (
                      res.GetError().GetType() == 1 and
@@ -198,12 +199,5 @@ class TestSwiftPlaygrounds(TestBase):
         self.assertIn("Hello from the Dylib", playground_output)
 
         # Scan through the types log to make sure the SwiftASTContext was poisoned.
-        import io
-        logfile = io.open(log, "r", encoding='utf-8')
-        found = 0
-        for line in logfile:
-            if 'New Swift image added' in line \
-               and 'Versions/A/Dylib' in line \
-               and 'ClangImporter needs to be reinitialized' in line:
-                    found += 1
-        self.assertGreater(found, 1)
+        self.filecheck('platform shell cat ""%s"' % log, __file__)
+#       CHECK: New Swift image added{{.*}}Versions/A/Dylib{{.*}}ClangImporter needs to be reinitialized

--- a/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
+++ b/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
@@ -12,8 +12,12 @@ class TestSwiftTaggedPointer(lldbtest.TestBase):
     # This test depends on NSObject, so it is not available on non-Darwin
     # platforms.
     @skipUnlessDarwin
+    # This test exposes a bug in DWARFImporterForClangTypes, which
+    # doesn't do type completion correctly. (rdar://118337109)
+    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     def test(self):
         self.build()
+        self.expect('log enable lldb types')
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -673,7 +673,7 @@ TEST_F(TestTypeSystemSwiftTypeRef, GetInstanceType) {
 
     CompilerType t = GetCompilerType(b.Mangle(n));
     CompilerType instance_type =
-        m_swift_ts->GetInstanceType(t.GetOpaqueQualType());
+      m_swift_ts->GetInstanceType(t.GetOpaqueQualType(), nullptr);
     ASSERT_EQ(instance_type.GetMangledTypeName(), "$sSSD");
   };
   {
@@ -683,7 +683,7 @@ TEST_F(TestTypeSystemSwiftTypeRef, GetInstanceType) {
 
     CompilerType t = GetCompilerType(b.Mangle(n));
     CompilerType instance_type =
-        m_swift_ts->GetInstanceType(t.GetOpaqueQualType());
+      m_swift_ts->GetInstanceType(t.GetOpaqueQualType(), nullptr);
     ASSERT_EQ(instance_type.GetMangledTypeName(), "$sSSD");
   };
 };


### PR DESCRIPTION
To deal with the growing number of incompatible Swift language flags,
LLDB's expression evaluator can now precisely match the compiler flags
from the current breakpoint instead of attempting to build a single
compiler invocation for the entire project.

This is now possible for the first time thanks to dwim-print and the
generic expression evaluator. The feature can be controlled via
a new "symbols.swift-precise-compiler-invocation" setting.

rdar://115188886