### PR TITLE
[lldb][NFCI] Remove ObjectFile::GetReflectionSectionIdentifier

### DIFF
--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -24,9 +24,6 @@
 #include "llvm/Support/VersionTuple.h"
 #include <optional>
 
-namespace swift {
-enum ReflectionSectionKind : uint8_t;
-}
 namespace lldb_private {
 
 /// \class ObjectFile ObjectFile.h "lldb/Symbol/ObjectFile.h"
@@ -720,9 +717,6 @@ public:
 
   /// Creates a plugin-specific call frame info
   virtual std::unique_ptr<CallFrameInfo> CreateCallFrameInfo();
-
-  virtual llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section);
 
   /// Load binaries listed in a corefile
   ///

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -45,10 +45,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/MipsABIFlags.h"
 
-#ifdef LLDB_ENABLE_SWIFT
-#include "swift/ABI/ObjectFile.h"
-#endif //LLDB_ENABLE_SWIFT
-
 #define CASE_AND_STREAM(s, def, width)                                         \
   case def:                                                                    \
     s->Printf("%-*s", width, #def);                                            \
@@ -3587,14 +3583,4 @@ ObjectFileELF::MapFileDataWritable(const FileSpec &file, uint64_t Size,
                                    uint64_t Offset) {
   return FileSystem::Instance().CreateWritableDataBuffer(file.GetPath(), Size,
                                                          Offset);
-}
-
-llvm::StringRef ObjectFileELF::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-#ifdef LLDB_ENABLE_SWIFT
-  swift::SwiftObjectFileFormatELF file_format_elf;
-  return file_format_elf.getSectionName(section);
-#else
-  llvm_unreachable("Swift support disabled");
-#endif //LLDB_ENABLE_SWIFT
 }

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -398,9 +398,6 @@ private:
   /// .gnu_debugdata section or \c nullptr if an error occured or if there's no
   /// section with that name.
   std::shared_ptr<ObjectFileELF> GetGnuDebugDataObjectFile();
-
-  llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
 };
 
 #endif // LLDB_SOURCE_PLUGINS_OBJECTFILE_ELF_OBJECTFILEELF_H

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -53,7 +53,6 @@
 
 #include "ObjectFileMachO.h"
 #ifdef LLDB_ENABLE_SWIFT
-#include "swift/ABI/ObjectFile.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #endif //LLDB_ENABLE_SWIFT
 
@@ -6944,16 +6943,6 @@ bool ObjectFileMachO::SaveCore(const lldb::ProcessSP &process_sp,
                  // this process
   }
   return false;
-}
-
-llvm::StringRef ObjectFileMachO::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-#ifdef LLDB_ENABLE_SWIFT
-  swift::SwiftObjectFileFormatMachO file_format_mach_o;
-  return file_format_mach_o.getSectionName(section);
-#else
-  llvm_unreachable("Swift support disabled");
-#endif //LLDB_ENABLE_SWIFT
 }
 
 ObjectFileMachO::MachOCorefileAllImageInfos

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -228,9 +228,6 @@ protected:
 
   bool SectionIsLoadable(const lldb_private::Section *section);
 
-  llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
-
   /// A corefile may include metadata about all of the binaries that were
   /// present in the process when the corefile was taken.  This is only
   /// implemented for Mach-O files for now; we'll generalize it when we

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -40,10 +40,6 @@
 #include "llvm/TargetParser/Host.h"
 #include <optional>
 
-#ifdef LLDB_ENABLE_SWIFT
-#include "swift/ABI/ObjectFile.h"
-#endif //LLDB_ENABLE_SWIFT
-
 #define IMAGE_DOS_SIGNATURE 0x5A4D    // MZ
 #define IMAGE_NT_SIGNATURE 0x00004550 // PE00
 #define OPT_HEADER_MAGIC_PE32 0x010b
@@ -1434,13 +1430,3 @@ ObjectFile::Type ObjectFilePECOFF::CalculateType() {
 }
 
 ObjectFile::Strata ObjectFilePECOFF::CalculateStrata() { return eStrataUser; }
-
-llvm::StringRef ObjectFilePECOFF::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-#ifdef LLDB_ENABLE_SWIFT
-  swift::SwiftObjectFileFormatCOFF file_format_coff;
-  return file_format_coff.getSectionName(section);
-#else
-  llvm_unreachable("Swift support disabled");
-#endif //LLDB_ENABLE_SWIFT
-}

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -265,9 +265,6 @@ protected:
                                           const section_header_t &sect);
   size_t GetSectionDataSize(lldb_private::Section *section) override;
 
-  llvm::StringRef
-  GetReflectionSectionIdentifier(swift::ReflectionSectionKind section) override;
-
   typedef std::vector<section_header_t> SectionHeaderColl;
   typedef SectionHeaderColl::iterator SectionHeaderCollIter;
   typedef SectionHeaderColl::const_iterator SectionHeaderCollConstIter;

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -732,13 +732,6 @@ void llvm::format_provider<ObjectFile::Strata>::format(
   }
 }
 
-llvm::StringRef ObjectFile::GetReflectionSectionIdentifier(
-    swift::ReflectionSectionKind section) {
-  assert(false &&
-         "Base class's GetReflectionSectionIdentifier should not be called");
-  return "";
-}
-
 Symtab *ObjectFile::GetSymtab() {
   ModuleSP module_sp(GetModule());
   if (module_sp) {


### PR DESCRIPTION
ObjectFile doesn't need to know what swift is. The only place this method got used was in SwiftLanguageRuntime, which already has functionality to replace this entirely (which I just moved up).