### PR TITLE
🍒 [clang][ExtractAPI] Update availability serialization in SGF (#71418)

### DIFF
--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -172,11 +172,11 @@ Optional<Array> serializeAvailability(const AvailabilitySet &Availabilities) {
     if (AvailInfo.Unavailable)
       Availability["isUnconditionallyUnavailable"] = true;
     else {
-      serializeObject(Availability, "introducedVersion",
+      serializeObject(Availability, "introduced",
                       serializeSemanticVersion(AvailInfo.Introduced));
-      serializeObject(Availability, "deprecatedVersion",
+      serializeObject(Availability, "deprecated",
                       serializeSemanticVersion(AvailInfo.Deprecated));
-      serializeObject(Availability, "obsoletedVersion",
+      serializeObject(Availability, "obsoleted",
                       serializeSemanticVersion(AvailInfo.Obsoleted));
     }
     AvailabilityArray.emplace_back(std::move(Availability));

--- a/clang/test/ExtractAPI/availability.c
+++ b/clang/test/ExtractAPI/availability.c
@@ -127,7 +127,7 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       "availability": [
         {
           "domain": "macos",
-          "introducedVersion": {
+          "introduced": {
             "major": 12,
             "minor": 0,
             "patch": 0
@@ -200,18 +200,18 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       "accessLevel": "public",
       "availability": [
         {
-          "deprecatedVersion": {
+          "deprecated": {
             "major": 12,
             "minor": 0,
             "patch": 0
           },
           "domain": "macos",
-          "introducedVersion": {
+          "introduced": {
             "major": 11,
             "minor": 0,
             "patch": 0
           },
-          "obsoletedVersion": {
+          "obsoleted": {
             "major": 20,
             "minor": 0,
             "patch": 0
@@ -284,18 +284,18 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       "accessLevel": "public",
       "availability": [
         {
-          "deprecatedVersion": {
+          "deprecated": {
             "major": 12,
             "minor": 0,
             "patch": 0
           },
           "domain": "macos",
-          "introducedVersion": {
+          "introduced": {
             "major": 11,
             "minor": 0,
             "patch": 0
           },
-          "obsoletedVersion": {
+          "obsoleted": {
             "major": 20,
             "minor": 0,
             "patch": 0
@@ -303,7 +303,7 @@ void e(void) __attribute__((availability(tvos, unavailable)));
         },
         {
           "domain": "ios",
-          "introducedVersion": {
+          "introduced": {
             "major": 13,
             "minor": 0,
             "patch": 0
@@ -311,7 +311,7 @@ void e(void) __attribute__((availability(tvos, unavailable)));
         },
         {
           "domain": "tvos",
-          "introducedVersion": {
+          "introduced": {
             "major": 15,
             "minor": 0,
             "patch": 0
@@ -389,7 +389,7 @@ void e(void) __attribute__((availability(tvos, unavailable)));
         },
         {
           "domain": "macos",
-          "introducedVersion": {
+          "introduced": {
             "major": 11,
             "minor": 0,
             "patch": 0


### PR DESCRIPTION
The prevailing symbol graph parsing library expects availability attributes to just be "introduced" instead of "introducedVersion"

rdar://117823923