### PR TITLE
[lldb][progress] Improve Swift progress reporting

### DIFF
--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -30,10 +30,9 @@ Progress::~Progress() {
   // Make sure to always report progress completed when this object is
   // destructed so it indicates the progress dialog/activity should go away.
   std::lock_guard<std::mutex> guard(m_mutex);
-  if (!m_completed) {
+  if (!m_completed)
     m_completed = m_total;
-    ReportProgress();
-  }
+  ReportProgress();
 }
 
 void Progress::Increment(uint64_t amount, std::string update) {

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -30,9 +30,10 @@ Progress::~Progress() {
   // Make sure to always report progress completed when this object is
   // destructed so it indicates the progress dialog/activity should go away.
   std::lock_guard<std::mutex> guard(m_mutex);
-  if (!m_completed)
+  if (!m_completed) {
     m_completed = m_total;
-  ReportProgress();
+    ReportProgress();
+  }
 }
 
 void Progress::Increment(uint64_t amount, std::string update) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -472,18 +472,14 @@ void SwiftLanguageRuntimeImpl::ProcessModulesToAdd() {
 
   auto &target = m_process.GetTarget();
   auto exe_module = target.GetExecutableModule();
-  Progress progress(
-      llvm::formatv("Setting up Swift reflection for '{0}'",
-                    exe_module->GetFileSpec().GetFilename().AsCString()),
-      modules_to_add_snapshot.GetSize());
-
+  Progress progress("Setting up Swift reflection");
   size_t completion = 0;
 
   // Add all defered modules to reflection context that were added to
   // the target since this SwiftLanguageRuntime was created.
   modules_to_add_snapshot.ForEach([&](const ModuleSP &module_sp) -> bool {
     AddModuleToReflectionContext(module_sp);
-    progress.Increment(++completion);
+    progress.Increment(++completion, module_sp->GetFileSpec().GetFilename().AsCString());
     return true;
   });
 }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -479,7 +479,8 @@ void SwiftLanguageRuntimeImpl::ProcessModulesToAdd() {
   // the target since this SwiftLanguageRuntime was created.
   modules_to_add_snapshot.ForEach([&](const ModuleSP &module_sp) -> bool {
     AddModuleToReflectionContext(module_sp);
-    progress.Increment(++completion, module_sp->GetFileSpec().GetFilename().AsCString());
+    progress.Increment(++completion,
+                       module_sp->GetFileSpec().GetFilename().AsCString());
     return true;
   });
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3917,7 +3917,7 @@ void SwiftASTContext::ValidateSectionModules(
   Status error;
 
   Progress progress(
-      llvm::formatv("Loading Swift module '{0}'. Submodule",
+      llvm::formatv("Loading Swift module '{0}' dependencies",
                     module.GetFileSpec().GetFilename().AsCString()),
       module_names.size());
   size_t completion = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1993,7 +1993,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 
     // Report progress on module importing by using a callback function in
     // swift::ASTContext
-    Progress progress("Importing Swift standard library modules");
+    Progress progress("Importing Swift standard library");
     swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
         [&progress](llvm::StringRef module_name, bool is_overlay) {
           progress.Increment(1, (is_overlay ? module_name.str() + " (overlay)"
@@ -2005,7 +2005,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     auto on_exit = llvm::make_scope_exit([&]() {
       swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
           [](llvm::StringRef module_name, bool is_overlay) {
-            Progress progress("Importing Swift modules");
+            Progress("Importing Swift modules");
           });
     });
 
@@ -2502,7 +2502,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
 
     // Report progress on module importing by using a callback function in
     // swift::ASTContext
-    Progress progress("Importing Swift standard library modules");
+    Progress progress("Importing Swift standard library");
     swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
         [&progress](llvm::StringRef module_name, bool is_overlay) {
           progress.Increment(1, (is_overlay ? module_name.str() + " (overlay)"
@@ -2514,7 +2514,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     auto on_exit = llvm::make_scope_exit([&]() {
       swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
           [](llvm::StringRef module_name, bool is_overlay) {
-            Progress progress("Importing Swift modules");
+            Progress("Importing Swift modules");
           });
     });
 
@@ -3306,7 +3306,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
   auto on_exit = llvm::make_scope_exit([&]() {
     ast->SetPreModuleImportCallback(
         [](llvm::StringRef module_name, bool is_overlay) {
-          Progress progress("Importing Swift modules");
+          Progress("Importing Swift modules");
         });
   });
 
@@ -3916,7 +3916,10 @@ void SwiftASTContext::ValidateSectionModules(
 
   Status error;
 
-  Progress progress("Loading Swift module", module_names.size());
+  Progress progress(
+      llvm::formatv("Loading Swift module '{0}'. Submodule",
+                    module.GetFileSpec().GetFilename().AsCString()),
+      module_names.size());
   size_t completion = 0;
 
   for (const std::string &module_name : module_names) {
@@ -3925,8 +3928,7 @@ void SwiftASTContext::ValidateSectionModules(
 
     // We have to increment the completion value even if we can't get the module
     // object to stay in-sync with the total progress reporting.
-    progress.Increment(++completion,
-                       module.GetFileSpec().GetFilename().AsCString());
+    progress.Increment(++completion, module_name);
     if (!GetModule(module_info, error))
       module.ReportWarning("unable to load swift module \"{0}\" ({1})",
                            module_name.c_str(), error.AsCString());
@@ -8363,7 +8365,7 @@ bool SwiftASTContextForExpressions::CacheUserImports(
 
   auto src_file_imports = source_file.getImports();
 
-  Progress progress("Importing module used in expression");
+  Progress progress("Importing modules used in expression");
   size_t completion = 0;
 
   /// Find all explicit imports in the expression.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -63,7 +63,6 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8356,7 +8356,7 @@ bool SwiftASTContextForExpressions::CacheUserImports(
   source_file.walk(import_finder);
   
   for (const auto &attributed_import : src_file_imports) {
-    progress.Increment(++completion, source_file.getFilename().str());
+    progress.Increment(++completion, attributed_import.module.importedModule->getModuleFilename().str());
     swift::ModuleDecl *module = attributed_import.module.importedModule;
     if (module && import_finder.imports.count(module)) {
       std::string module_name;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1991,13 +1991,14 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     LLDB_SCOPED_TIMERF("%s (getStdlibModule)", m_description.c_str());
     const bool can_create = true;
 
-    // Report progress on module importing by using a callback function in swift::ASTContext
+    // Report progress on module importing by using a callback function in
+    // swift::ASTContext
     Progress progress("Importing Swift standard library modules");
     swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
-      [&progress](llvm::StringRef module_name, bool is_overlay) {
-        progress.Increment(1, (is_overlay ? module_name.str() + " (overlay)" : module_name.str()));
-      }
-);
+        [&progress](llvm::StringRef module_name, bool is_overlay) {
+          progress.Increment(1, (is_overlay ? module_name.str() + " (overlay)"
+                                            : module_name.str()));
+        });
 
     // Clear the callback function on scope exit to prevent an out-of-scope access of the progress local variable
     auto on_exit = llvm::make_scope_exit([&](){
@@ -2495,13 +2496,14 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     LLDB_SCOPED_TIMERF("%s (getStdlibModule)", m_description.c_str());
     const bool can_create = true;
 
-    // Report progress on module importing by using a callback function in swift::ASTContext
+    // Report progress on module importing by using a callback function in
+    // swift::ASTContext
     Progress progress("Importing Swift standard library modules");
     swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
-      [&progress](llvm::StringRef module_name, bool is_overlay) {
-        progress.Increment(1, (is_overlay ? module_name.str() + " (overlay)" : module_name.str()));
-      }
-);
+        [&progress](llvm::StringRef module_name, bool is_overlay) {
+          progress.Increment(1, (is_overlay ? module_name.str() + " (overlay)"
+                                            : module_name.str()));
+        });
 
     // Clear the callback function on scope exit to prevent an out-of-scope access of the progress local variable
     auto on_exit = llvm::make_scope_exit([&](){
@@ -2952,7 +2954,6 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
       GetSymbolGraphOptions(), GetSourceManager(), GetDiagnosticEngine(),
       /*OutputBackend=*/nullptr));
 
-
   if (getenv("LLDB_SWIFT_DUMP_DIAGS")) {
     // NOTE: leaking a swift::PrintingDiagnosticConsumer() here, but
     // this only gets enabled when the above environment variable is
@@ -3283,13 +3284,14 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
   // Create a diagnostic consumer for the diagnostics produced by the import.
   auto import_diags = getScopedDiagnosticConsumer();
 
-  // Report progress on module importing by using a callback function in swift::ASTContext
+  // Report progress on module importing by using a callback function in
+  // swift::ASTContext
   Progress progress("Importing Swift modules");
-  ast->SetPreModuleImportCallback(
-    [&progress](llvm::StringRef module_name, bool is_overlay) {
-      progress.Increment(1, (is_overlay ? module_name.str() + " (overlay)" : module_name.str()));
-    }
-);
+  ast->SetPreModuleImportCallback([&progress](llvm::StringRef module_name,
+                                              bool is_overlay) {
+    progress.Increment(
+        1, (is_overlay ? module_name.str() + " (overlay)" : module_name.str()));
+  });
 
   // Clear the callback function on scope exit to prevent an out-of-scope access of the progress local variable
   auto on_exit = llvm::make_scope_exit([&](){
@@ -3298,7 +3300,6 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
 
   // Perform the import.
   swift::ModuleDecl *module_decl = ast->getModuleByName(module_basename_sref);
-
 
   // Error handling.
   if (import_diags->HasErrors()) {
@@ -3912,7 +3913,8 @@ void SwiftASTContext::ValidateSectionModules(
 
     // We have to increment the completion value even if we can't get the module
     // object to stay in-sync with the total progress reporting.
-    progress.Increment(++completion, module.GetFileSpec().GetFilename().AsCString());
+    progress.Increment(++completion,
+                       module.GetFileSpec().GetFilename().AsCString());
     if (!GetModule(module_info, error))
       module.ReportWarning("unable to load swift module \"{0}\" ({1})",
                            module_name.c_str(), error.AsCString());
@@ -8367,7 +8369,9 @@ bool SwiftASTContextForExpressions::CacheUserImports(
   source_file.walk(import_finder);
   
   for (const auto &attributed_import : src_file_imports) {
-    progress.Increment(++completion, attributed_import.module.importedModule->getModuleFilename().str());
+    progress.Increment(
+        ++completion,
+        attributed_import.module.importedModule->getModuleFilename().str());
     swift::ModuleDecl *module = attributed_import.module.importedModule;
     if (module && import_finder.imports.count(module)) {
       std::string module_name;
@@ -8483,7 +8487,8 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
   Progress progress("Importing module used by compile unit");
   size_t completion = 0;
   for (const SourceModule &module : cu_imports) {
-    progress.Increment(++completion, compile_unit->GetPrimaryFile().GetFilename().AsCString());
+    progress.Increment(
+        ++completion, compile_unit->GetPrimaryFile().GetFilename().AsCString());
     // When building the Swift stdlib with debug info these will
     // show up in "Swift.o", but we already imported them and
     // manually importing them will fail.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1998,6 +1998,12 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
         }
       }
 );
+
+    // Clear the callback function on scope exit to prevent an out-of-scope access of the progress local variable
+    auto on_exit = llvm::make_scope_exit([&](){
+      swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback([](llvm::StringRef module_name, bool is_overlay) {});
+    });
+
     swift::ModuleDecl *stdlib =
         swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create);
     if (!stdlib || IsDWARFImported(*stdlib)) {
@@ -2498,6 +2504,11 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
         }
       }
 );
+
+    // Clear the callback function on scope exit to prevent an out-of-scope access of the progress local variable
+    auto on_exit = llvm::make_scope_exit([&](){
+      swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback([](llvm::StringRef module_name, bool is_overlay) {});
+    });
 
     swift::ModuleDecl *stdlib =
         swift_ast_sp->m_ast_context_ap->getStdlibModule(can_create);
@@ -3285,8 +3296,14 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
     }
 );
 
+  // Clear the callback function on scope exit to prevent an out-of-scope access of the progress local variable
+  auto on_exit = llvm::make_scope_exit([&](){
+      ast->SetPreModuleImportCallback([](llvm::StringRef module_name, bool is_overlay) {});
+    });
+
   // Perform the import.
   swift::ModuleDecl *module_decl = ast->getModuleByName(module_basename_sref);
+
   progress.reset();
 
   // Error handling.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -293,12 +293,6 @@ public:
   swift::ModuleDecl *CreateModule(const SourceModule &module, Status &error,
                                   swift::ImplicitImportInfo importInfo);
 
-  /// Generic callback function used for progress reporting that gets
-  /// invoked by the Swift compiler and gets set upon scope exit when
-  /// a more detailed progress report was used as the callback
-  static bool ReportModuleLoadingProgress(llvm::StringRef module_name,
-                                          bool is_overlay);
-
   // This function should only be called when all search paths
   // for all items in a swift::ASTContext have been setup to
   // allow for imports to happen correctly. Use with caution,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -293,6 +293,9 @@ public:
   swift::ModuleDecl *CreateModule(const SourceModule &module, Status &error,
                                   swift::ImplicitImportInfo importInfo);
 
+  /// Generic callback function used for progress reporting that gets
+  /// invoked by the Swift compiler and gets set upon scope exit when
+  /// a more detailed progress report was used as the callback
   static bool ReportModuleLoadingProgress(llvm::StringRef module_name,
                                           bool is_overlay);
 

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -43,7 +43,7 @@ class TestSwiftProgressReporting(TestBase):
             "Setting up Swift reflection",
             "Getting Swift compile unit imports for",
             "Importing Swift modules",
-            "Importing Swift standard library modules",
+            "Importing Swift standard library",
         ]
 
         while len(beacons):

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -37,11 +37,14 @@ class TestSwiftProgressReporting(TestBase):
         self.runCmd("expr boo")
         self.runCmd("v s")
 
-        beacons = [ "Loading Swift module",
-                    "Importing module used in expression",
-                    "Setting up Swift reflection",
-                    "Importing module used by compile unit",
-                    "Importing Swift modules", "Importing Swift standard library modules"]
+        beacons = [
+            "Loading Swift module",
+            "Importing module used in expression",
+            "Setting up Swift reflection",
+            "Getting Swift compile unit imports for",
+            "Importing Swift modules",
+            "Importing Swift standard library modules",
+        ]
 
         while len(beacons):
             event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -39,7 +39,7 @@ class TestSwiftProgressReporting(TestBase):
 
         beacons = [
             "Loading Swift module",
-            "Importing module used in expression",
+            "Importing modules used in expression",
             "Setting up Swift reflection",
             "Getting Swift compile unit imports for",
             "Importing Swift modules",

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -8,28 +8,26 @@ import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
-
 class TestSwiftProgressReporting(TestBase):
+
     mydir = TestBase.compute_mydir(__file__)
 
     def setUp(self):
         TestBase.setUp(self)
         self.broadcaster = self.dbg.GetBroadcaster()
-        self.listener = lldbutil.start_listening_from(
-            self.broadcaster, lldb.SBDebugger.eBroadcastBitProgress
-        )
+        self.listener = lldbutil.start_listening_from(self.broadcaster,
+                                        lldb.SBDebugger.eBroadcastBitProgress)
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
-    @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin
     @swiftTest
     def test_swift_progress_report(self):
         """Test that we are able to fetch swift type-system progress events"""
         self.build()
 
-        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift")
-        )
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
 
         self.assertGreater(thread.GetNumFrames(), 0)
         frame = thread.GetSelectedFrame()
@@ -39,19 +37,16 @@ class TestSwiftProgressReporting(TestBase):
         self.runCmd("expr boo")
         self.runCmd("v s")
 
-        beacons = [
-            "Loading Swift module",
-            "Caching Swift user imports from",
-            "Setting up Swift reflection",
-            "Getting Swift compile unit imports",
-            "Importing Swift modules",
-            "Importing Swift standard library modules",
-        ]
+        beacons = [ "Loading Swift module",
+                    "Importing module used in expression",
+                    "Setting up Swift reflection",
+                    "Importing module used by compile unit",
+                    "Importing Swift modules", "Importing Swift standard library modules"]
 
         while len(beacons):
             event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
             ret_args = lldb.SBDebugger.GetProgressFromEvent(event)
-            self.trace((ret_args[0]))
+
             for beacon in beacons:
                 if beacon in ret_args[0]:
                     beacons.remove(beacon)


### PR DESCRIPTION
LLDB's progress reporting infrastructure has had the ability to add details to an overall progress report (added in
https://reviews.llvm.org/D143690) but this had yet to be implemented in existing progress reports. This commit adds this functionality to progress reports made for Swift operations (such as caching user imports) so that instead of sending several individual progress reports for each step in these operations, one progress report is created and then incrementally updated.

Importing Swift modules takes place in the Swift compiler which uses a callback function so that LLDB can perform its progress report. This originally called into a function in `lldb_private::SwiftASTContext` but will instead use a lambda function to increment a locally created progress report.

Related to https://github.com/apple/swift/pull/69730

rdar://105286354