### PR TITLE
[lldb] Disable linux test failing on bots

### DIFF
--- a/lldb/test/API/terminal/TestEditline.py
+++ b/lldb/test/API/terminal/TestEditline.py
@@ -48,6 +48,7 @@ class EditlineTest(PExpectTest):
     @skipIfAsan
     @skipIfEditlineSupportMissing
     @skipIfEditlineWideCharSupportMissing
+    @skipIf(oslist=["linux"])
     def test_prompt_unicode(self):
         """Test that we can use Unicode in the LLDB prompt."""
         self.launch(use_colors=True, encoding="utf-8")


### PR DESCRIPTION
While we investigate it: rdar://117690727