### PR TITLE
[lldb] Add support for structs and tuple info lookup from DWARF

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -186,6 +186,8 @@ public:
 
   EnableSwiftCxxInterop GetEnableSwiftCxxInterop() const;
 
+  bool GetSwiftEnableFullDwarfDebugging() const;
+
   Args GetSwiftPluginServerForPath() const;
 
   bool GetSwiftAutoImportFrameworks() const;

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -629,6 +629,14 @@ ifeq "$(SWIFT_CXX_INTEROP)" "1"
 endif
 
 #----------------------------------------------------------------------
+# Check if we should compile in Swift embedded mode
+#----------------------------------------------------------------------
+ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
+	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -Xfrontend -disable-objc-interop -runtime-compatibility-version none
+	SWIFT_WMO = 1
+endif
+	
+#----------------------------------------------------------------------
 # Set up variables to run the Swift frontend directly.
 #----------------------------------------------------------------------
 SWIFT=$(shell dirname $(SWIFTC))/swift
@@ -678,9 +686,17 @@ endif
 
 VPATHSOURCES=$(patsubst %,$(VPATH)/%,$(SWIFT_SOURCES)) $(patsubst %,$(VPATH)/%,$(DYLIB_SWIFT_SOURCES))
 
+# Whole module optimization and primary file directives are at direct odds with each other. 
+# Either pick one or the other.
+ifeq "$(SWIFT_WMO)" "1"
+SWIFT_COMPILE_MODE_DIRECTIVE = "-wmo"
+else
+SWIFT_COMPILE_DIRECTIVE = "-primary-file"
+endif
+
 %.o: %.swift $(SWIFT_BRIDGING_PCH) $(SWIFT_OBJC_HEADER)
 	@echo "### Compiling" $<
-	$(SWIFT_FE) -c -primary-file $< \
+	$(SWIFT_FE) -c $(SWIFT_COMPILE_DIRECTIVE) $< \
 	  $(filter-out $(VPATH)/$<,$(filter-out $<,$(VPATHSOURCES))) \
 	  $(SWIFT_FEFLAGS) $(SWIFT_HFLAGS) $(PARSE_AS_LIBRARY) \
 	  -module-name $(MODULENAME)  -emit-module-path \

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -30,6 +30,7 @@ namespace Demangle {
 class Demangler;
 } // namespace Demangle
 namespace reflection {
+struct DescriptorFinder;
 class RecordTypeInfo;
 class TypeInfo;
 } // namespace reflection
@@ -79,47 +80,56 @@ public:
   ReadELF(swift::remote::RemoteAddress ImageStart,
           llvm::Optional<llvm::sys::MemoryBlock> FileBuffer,
           llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
-  virtual const swift::reflection::TypeRef *
-  GetTypeRefOrNull(llvm::StringRef mangled_type_name) = 0;
-  virtual const swift::reflection::TypeRef *
-  GetTypeRefOrNull(swift::Demangle::Demangler &dem,
-                   swift::Demangle::NodePointer node) = 0;
-  virtual const swift::reflection::TypeInfo *
-  GetClassInstanceTypeInfo(const swift::reflection::TypeRef *type_ref,
-                           swift::remote::TypeInfoProvider *provider) = 0;
-  virtual const swift::reflection::TypeInfo *
-  GetTypeInfo(const swift::reflection::TypeRef *type_ref,
-              swift::remote::TypeInfoProvider *provider) = 0;
-  virtual const swift::reflection::TypeInfo *
-  GetTypeInfoFromInstance(lldb::addr_t instance,
-                          swift::remote::TypeInfoProvider *provider) = 0;
+  virtual const swift::reflection::TypeRef *GetTypeRefOrNull(
+      llvm::StringRef mangled_type_name,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  virtual const swift::reflection::TypeRef *GetTypeRefOrNull(
+      swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  virtual const swift::reflection::TypeInfo *GetClassInstanceTypeInfo(
+      const swift::reflection::TypeRef *type_ref,
+      swift::remote::TypeInfoProvider *provider,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  virtual const swift::reflection::TypeInfo *GetTypeInfo(
+      const swift::reflection::TypeRef *type_ref,
+      swift::remote::TypeInfoProvider *provider,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  virtual const swift::reflection::TypeInfo *GetTypeInfoFromInstance(
+      lldb::addr_t instance, swift::remote::TypeInfoProvider *provider,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual swift::remote::MemoryReader &GetReader() = 0;
-  virtual const swift::reflection::TypeRef *
-  LookupSuperclass(const swift::reflection::TypeRef *tr) = 0;
-  virtual bool
-  ForEachSuperClassType(swift::remote::TypeInfoProvider *tip,
-                        lldb::addr_t pointer,
-                        std::function<bool(SuperClassType)> fn) = 0;
+  virtual const swift::reflection::TypeRef *LookupSuperclass(
+      const swift::reflection::TypeRef *tr,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  virtual bool ForEachSuperClassType(
+      swift::remote::TypeInfoProvider *tip,
+      swift::reflection::DescriptorFinder *descriptor_finder,
+      lldb::addr_t pointer, std::function<bool(SuperClassType)> fn) = 0;
   virtual llvm::Optional<std::pair<const swift::reflection::TypeRef *,
                                    swift::remote::RemoteAddress>>
   ProjectExistentialAndUnwrapClass(
       swift::remote::RemoteAddress existential_addess,
-      const swift::reflection::TypeRef &existential_tr) = 0;
-  virtual llvm::Optional<int32_t>
-  ProjectEnumValue(swift::remote::RemoteAddress enum_addr,
-                   const swift::reflection::TypeRef *enum_type_ref,
-                   swift::remote::TypeInfoProvider *provider) = 0;
-  virtual const swift::reflection::TypeRef *
-  ReadTypeFromMetadata(lldb::addr_t metadata_address,
-                       bool skip_artificial_subclasses = false) = 0;
-  virtual const swift::reflection::TypeRef *
-  ReadTypeFromInstance(lldb::addr_t instance_address,
-                       bool skip_artificial_subclasses = false) = 0;
+      const swift::reflection::TypeRef &existential_tr,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  virtual llvm::Optional<int32_t> ProjectEnumValue(
+      swift::remote::RemoteAddress enum_addr,
+      const swift::reflection::TypeRef *enum_type_ref,
+      swift::remote::TypeInfoProvider *provider,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  virtual const swift::reflection::TypeRef *ReadTypeFromMetadata(
+      lldb::addr_t metadata_address,
+      swift::reflection::DescriptorFinder *descriptor_finder,
+      bool skip_artificial_subclasses = false) = 0;
+  virtual const swift::reflection::TypeRef *ReadTypeFromInstance(
+      lldb::addr_t instance_address,
+      swift::reflection::DescriptorFinder *descriptor_finder,
+      bool skip_artificial_subclasses = false) = 0;
   virtual llvm::Optional<bool> IsValueInlinedInExistentialContainer(
       swift::remote::RemoteAddress existential_address) = 0;
-  virtual const swift::reflection::TypeRef *
-  ApplySubstitutions(const swift::reflection::TypeRef *type_ref,
-                     swift::reflection::GenericArgumentMap substitutions) = 0;
+  virtual const swift::reflection::TypeRef *ApplySubstitutions(
+      const swift::reflection::TypeRef *type_ref,
+      swift::reflection::GenericArgumentMap substitutions,
+      swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
 };

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -657,7 +657,8 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
       return {};
 
     LLDBTypeInfoProvider tip(*this, *ts);
-    auto *cti = reflection_ctx->GetClassInstanceTypeInfo(tr, &tip);
+    auto *cti = reflection_ctx->GetClassInstanceTypeInfo(
+        tr, &tip, ts->GetDescriptorFinder());
     if (auto *rti =
             llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(cti)) {
       LLDB_LOG(GetLog(LLDBLog::Types),
@@ -665,7 +666,8 @@ SwiftLanguageRuntimeImpl::GetNumChildren(CompilerType type,
                type.GetMangledTypeName().GetCString(), rti->getNumFields());
 
       // The superclass, if any, is an extra child.
-      if (reflection_ctx->LookupSuperclass(tr))
+      if (reflection_ctx->LookupSuperclass(tr,
+                                           ts->GetDescriptorFinder()))
         return rti->getNumFields() + 1;
       return rti->getNumFields();
     }
@@ -733,7 +735,8 @@ SwiftLanguageRuntimeImpl::GetNumFields(CompilerType type,
         return {};
 
       LLDBTypeInfoProvider tip(*this, *ts);
-      auto *cti = reflection_ctx->GetClassInstanceTypeInfo(tr, &tip);
+      auto *cti = reflection_ctx->GetClassInstanceTypeInfo(
+          tr, &tip, ts->GetDescriptorFinder());
       if (auto *rti = llvm::dyn_cast_or_null<RecordTypeInfo>(cti)) {
         return rti->getNumFields();
       }
@@ -873,10 +876,12 @@ SwiftLanguageRuntimeImpl::GetIndexOfChildMemberWithName(
       auto *current_tr = tr;
       while (current_tr) {
         auto *record_ti = llvm::dyn_cast_or_null<RecordTypeInfo>(
-            reflection_ctx->GetClassInstanceTypeInfo(current_tr, &tip));
+            reflection_ctx->GetClassInstanceTypeInfo(
+                current_tr, &tip, ts->GetDescriptorFinder()));
         if (!record_ti)
           break;
-        auto *super_tr = reflection_ctx->LookupSuperclass(current_tr);
+        auto *super_tr = reflection_ctx->LookupSuperclass(
+            current_tr, ts->GetDescriptorFinder());
         uint32_t offset = super_tr ? 1 : 0;
         auto found_size = findFieldWithName(record_ti->getFields(), name, false,
                                             child_indexes, offset);
@@ -966,7 +971,8 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
       // The indirect enum field should point to a closure context.
       LLDBTypeInfoProvider tip(*this, *ts);
       lldb::addr_t instance = MaskMaybeBridgedPointer(m_process, pointer);
-      auto *ti = reflection_ctx->GetTypeInfoFromInstance(instance, &tip);
+      auto *ti = reflection_ctx->GetTypeInfoFromInstance(
+          instance, &tip, ts->GetDescriptorFinder());
       if (!ti)
         return {};
       auto *rti = llvm::dyn_cast_or_null<swift::reflection::RecordTypeInfo>(ti);
@@ -1077,7 +1083,8 @@ CompilerType SwiftLanguageRuntimeImpl::GetChildCompilerTypeAtIndex(
     llvm::SmallVector<SuperClassType, 2> supers;
     LLDBTypeInfoProvider tip(*this, *instance_ts);
     reflection_ctx->ForEachSuperClassType(
-        &tip, pointer, [&](SuperClassType sc) -> bool {
+        &tip, ts->GetDescriptorFinder(), pointer,
+        [&](SuperClassType sc) -> bool {
           // If the typeref is invalid, we don't want to process it (for
           // example, this could be an artifical ObjC class).
           if (!sc.get_typeref())
@@ -1192,7 +1199,9 @@ bool SwiftLanguageRuntimeImpl::ForEachSuperClassType(
 
   LLDBTypeInfoProvider tip(*this, *ts);
   lldb::addr_t pointer = instance.GetPointerValue();
-  return reflection_ctx->ForEachSuperClassType(&tip, pointer, fn);
+  return reflection_ctx->ForEachSuperClassType(
+      &tip, ts->GetTypeSystemSwiftTypeRef().GetDescriptorFinder(),
+      pointer, fn);
 }
 
 bool SwiftLanguageRuntime::IsSelf(Variable &variable) {
@@ -1380,7 +1389,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Pack(
           return {};
         }
 
-        auto *type_ref = reflection_ctx->ReadTypeFromMetadata(md);
+        auto *type_ref = reflection_ctx->ReadTypeFromMetadata(
+            md, ts->GetDescriptorFinder());
         if (!type_ref) {
           LLDB_LOGF(log,
                     "cannot decode pack_expansion type: failed to decode type "
@@ -1406,13 +1416,14 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Pack(
           });
 
       // Build a TypeRef from the demangle tree.
-      auto type_ref = reflection_ctx->GetTypeRefOrNull(dem, pack_element);
+      auto type_ref = reflection_ctx->GetTypeRefOrNull(
+          dem, pack_element, ts->GetDescriptorFinder());
       if (!type_ref)
         return {};
 
       // Apply the substitutions.
-      auto bound_typeref =
-          reflection_ctx->ApplySubstitutions(type_ref, substitutions);
+      auto bound_typeref = reflection_ctx->ApplySubstitutions(
+          type_ref, substitutions, ts->GetDescriptorFinder());
       swift::Demangle::NodePointer node = bound_typeref->getDemangling(dem);
       CompilerType type = ts->RemangleAsType(dem, node);
 
@@ -1567,8 +1578,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Class(
   if (!reflection_ctx)
     return false;
 
-  const auto *typeref =
-      reflection_ctx->ReadTypeFromInstance(instance_ptr, true);
+  const auto *typeref = reflection_ctx->ReadTypeFromInstance(
+      instance_ptr, ts.GetDescriptorFinder(), true);
   if (!typeref) {
     LLDB_LOGF(log,
               "could not read typeref for type: %s (instance_ptr = 0x%" PRIx64
@@ -1723,7 +1734,8 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol(
     return false;
 
   auto pair = reflection_ctx->ProjectExistentialAndUnwrapClass(
-      remote_existential, *protocol_typeref);
+      remote_existential, *protocol_typeref,
+      tss->GetTypeSystemSwiftTypeRef().GetDescriptorFinder());
   if (use_local_buffer)
     PopLocalBuffer();
 
@@ -1778,13 +1790,13 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ExistentialMetatype(
   if (!reflection_ctx)
     return false;
 
-  const swift::reflection::TypeRef *type_ref =
-      reflection_ctx->ReadTypeFromMetadata(ptr);
-
   auto tss = meta_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!tss)
     return false;
-  auto &ts = tss->GetTypeSystemSwiftTypeRef();
+
+  const swift::reflection::TypeRef *type_ref =
+      reflection_ctx->ReadTypeFromMetadata(
+          ptr, tss->GetTypeSystemSwiftTypeRef().GetDescriptorFinder());
 
   using namespace swift::Demangle;
   Demangler dem;
@@ -1798,7 +1810,7 @@ bool SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ExistentialMetatype(
   meta->addChild(node, dem);
   wrapped->addChild(meta,dem);
 
-  meta_type = ts.GetTypeSystemSwiftTypeRef().RemangleAsType(dem, wrapped);
+  meta_type = tss->GetTypeSystemSwiftTypeRef().RemangleAsType(dem, wrapped);
   class_type_or_name.SetCompilerType(meta_type);
   address.SetRawAddress(ptr);
   return true;
@@ -1815,7 +1827,8 @@ CompilerType SwiftLanguageRuntimeImpl::GetTypeFromMetadata(TypeSystemSwift &ts,
     return {};
 
   const swift::reflection::TypeRef *type_ref =
-      reflection_ctx->ReadTypeFromMetadata(ptr);
+      reflection_ctx->ReadTypeFromMetadata(
+          ptr, ts.GetTypeSystemSwiftTypeRef().GetDescriptorFinder());
 
   using namespace swift::Demangle;
   Demangler dem;
@@ -1892,7 +1905,9 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParameters(
   Demangler dem;
   NodePointer unbound_node =
       dem.demangleSymbol(unbound_type.GetMangledTypeName().GetStringRef());
-  auto type_ref = reflection_ctx->GetTypeRefOrNull(dem, unbound_node);
+  auto type_ref = reflection_ctx->GetTypeRefOrNull(
+      dem, unbound_node,
+      ts->GetTypeSystemSwiftTypeRef().GetDescriptorFinder());
   if (!type_ref) {
     LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
              "Couldn't get TypeRef of unbound type");
@@ -1915,8 +1930,9 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParameters(
       return;
     }
 
-    auto type_ref = reflection_ctx->GetTypeRefOrNull(
-        type.GetMangledTypeName().GetStringRef());
+    const auto *type_ref = reflection_ctx->GetTypeRefOrNull(
+        type.GetMangledTypeName().GetStringRef(),
+        ts->GetTypeSystemSwiftTypeRef().GetDescriptorFinder());
     if (!type_ref) {
       LLDB_LOG(GetLog(LLDBLog::Expressions | LLDBLog::Types),
                "Couldn't get TypeRef when binding generic type parameters.");
@@ -1932,7 +1948,9 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParameters(
 
   // Apply the substitutions.
   const swift::reflection::TypeRef *bound_type_ref =
-      reflection_ctx->ApplySubstitutions(type_ref, substitutions);
+      reflection_ctx->ApplySubstitutions(
+          type_ref, substitutions,
+          ts->GetTypeSystemSwiftTypeRef().GetDescriptorFinder());
   NodePointer node = bound_type_ref->getDemangling(dem);
   return ts->GetTypeSystemSwiftTypeRef().RemangleAsType(dem, node);
 }
@@ -1970,7 +1988,8 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
     if (!metadata_location)
       return;
     const swift::reflection::TypeRef *type_ref =
-        reflection_ctx->ReadTypeFromMetadata(*metadata_location);
+        reflection_ctx->ReadTypeFromMetadata(*metadata_location,
+                                             ts.GetDescriptorFinder());
     if (!type_ref)
       return;
     substitutions.insert({{depth, index}, type_ref});
@@ -1987,14 +2006,15 @@ SwiftLanguageRuntimeImpl::BindGenericTypeParameters(StackFrame &stack_frame,
     return get_canonical();
 
   // Build a TypeRef from the demangle tree.
-  const swift::reflection::TypeRef *type_ref =
-      reflection_ctx->GetTypeRefOrNull(dem, canonical);
+  const swift::reflection::TypeRef *type_ref = reflection_ctx->GetTypeRefOrNull(
+      dem, canonical, ts.GetDescriptorFinder());
   if (!type_ref)
     return get_canonical();
 
   // Apply the substitutions.
   const swift::reflection::TypeRef *bound_type_ref =
-      reflection_ctx->ApplySubstitutions(type_ref, substitutions);
+      reflection_ctx->ApplySubstitutions(type_ref, substitutions,
+                                         ts.GetDescriptorFinder());
   NodePointer node = bound_type_ref->getDemangling(dem);
 
   // Import the type into the scratch context. Subsequent conversions
@@ -2665,7 +2685,8 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
   if (!reflection_ctx)
     return nullptr;
 
-  auto type_ref = reflection_ctx->GetTypeRefOrNull(dem, node);
+  const auto *type_ref = reflection_ctx->GetTypeRefOrNull(
+      dem, node, module_holder->GetDescriptorFinder());
   if (!type_ref)
     return nullptr;
   if (log && log->GetVerbose()) {
@@ -2725,7 +2746,9 @@ SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
     return nullptr;
 
   LLDBTypeInfoProvider provider(*this, *ts);
-  return reflection_ctx->GetTypeInfo(type_ref, &provider);
+  return reflection_ctx->GetTypeInfo(
+      type_ref, &provider,
+      ts->GetTypeSystemSwiftTypeRef().GetDescriptorFinder());
 }
 
 bool SwiftLanguageRuntimeImpl::IsStoredInlineInBuffer(CompilerType type) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/DWARF/CMakeLists.txt
@@ -6,7 +6,7 @@ lldb_tablegen(SymbolFileDWARFPropertiesEnum.inc -gen-lldb-property-enum-defs
   SOURCE SymbolFileDWARFProperties.td
   TARGET LLDBPluginSymbolFileDWARFPropertiesEnumGen)
 
-set(SWIFT_SOURCES DWARFASTParserSwift.cpp)
+set(SWIFT_SOURCES DWARFASTParserSwift.cpp DWARFASTParserSwiftDescriptorFinder.cpp)
 set(LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
 if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
   unset(SWIFT_SOURCES)

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -15,10 +15,22 @@
 
 #include "DWARFASTParser.h"
 #include "DWARFDIE.h"
+#include "swift/RemoteInspection/DescriptorFinder.h"
+#include "swift/RemoteInspection/TypeRef.h"
+
+namespace swift {
+namespace reflection {
+class TypeInfo;
+} // namespace reflection
+namespace remote {
+struct TypeInfoProvider;
+} // namespace remote
+} // namespace swift
 
 namespace lldb_private { class TypeSystemSwiftTypeRef; }
 
-class DWARFASTParserSwift : public lldb_private::plugin::dwarf::DWARFASTParser {
+class DWARFASTParserSwift : public lldb_private::plugin::dwarf::DWARFASTParser,
+                            public swift::reflection::DescriptorFinder {
 public:
   using DWARFDIE = lldb_private::plugin::dwarf::DWARFDIE;
   DWARFASTParserSwift(lldb_private::TypeSystemSwiftTypeRef &swift_typesystem);
@@ -68,6 +80,14 @@ public:
   static bool classof(const DWARFASTParser *Parser) {
     return Parser->GetKind() == Kind::DWARFASTParserSwift;
   }
+
+  /// Returns a field descriptor constructed from DWARF info.
+  std::unique_ptr<swift::reflection::FieldDescriptorBase>
+  getFieldDescriptor(const swift::reflection::TypeRef *TR) override;
+
+  /// Returns a builtin descriptor constructed from DWARF info.
+  std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
+  getBuiltinTypeDescriptor(const swift::reflection::TypeRef *TR) override;
 
 protected:
   lldb_private::TypeSystemSwiftTypeRef &m_swift_typesystem;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -1,0 +1,224 @@
+//===-- DWARFASTParserSwiftDescriptorFinder.cpp ---------------------------===//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Implements DWARFASTParserSwift's Descriptor finder interface
+//
+//===----------------------------------------------------------------------===//
+
+#include "DWARFASTParserSwift.h"
+
+#include "DWARFDIE.h"
+#include "DWARFDebugInfo.h"
+
+#include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+
+#include "swift/RemoteInspection/TypeLowering.h"
+
+
+using namespace lldb;
+using namespace lldb_private;
+using namespace lldb_private::dwarf;
+using namespace lldb_private::plugin::dwarf;
+
+/// Given a type system and a typeref, return the compiler type and die of the
+/// type that matches that mangled name, looking up the in the type system's
+/// module's debug information.
+static std::optional<std::pair<CompilerType, DWARFDIE>>
+getTypeAndDie(TypeSystemSwiftTypeRef &ts,
+              const swift::reflection::TypeRef *TR) {
+  swift::Demangle::Demangler dem;
+  swift::Demangle::NodePointer node = TR->getDemangling(dem);
+  auto type = ts.RemangleAsType(dem, node);
+  if (!type)
+    return {};
+
+  auto *dwarf = llvm::cast_or_null<SymbolFileDWARF>(ts.GetSymbolFile());
+  if (!dwarf)
+    return {};
+  auto lldb_type = ts.FindTypeInModule(type.GetOpaqueQualType());
+  if (!lldb_type)
+    // TODO: for embedded Swift this is fine but consult other modules here for
+    // general case?
+    return {};
+  auto die = dwarf->GetDIE(lldb_type->GetID());
+  return {{type, die}};
+}
+
+static std::optional<swift::reflection::FieldDescriptorKind>
+getFieldDescriptorKindForDie(DWARFDIE &die) {
+  if (die.Tag() == DW_TAG_structure_type)
+    return swift::reflection::FieldDescriptorKind::Struct;
+  // TODO: handle more cases, for now we only support structs.
+  return {};
+}
+
+namespace {
+// Class that implements the same layout as a builtin type descriptor, only it's
+// built from DWARF instead.
+class DWARFBuiltinTypeDescriptorImpl
+    : public swift::reflection::BuiltinTypeDescriptorBase {
+  ConstString m_type_name;
+
+public:
+  DWARFBuiltinTypeDescriptorImpl(uint32_t size, uint32_t alignment,
+                                 uint32_t stride,
+                                 uint32_t num_extra_inhabitants,
+                                 bool is_bitwise_takable, ConstString type_name)
+      : swift::reflection::BuiltinTypeDescriptorBase(
+            size, alignment, stride, num_extra_inhabitants, is_bitwise_takable),
+        m_type_name(type_name) {}
+  ~DWARFBuiltinTypeDescriptorImpl() override = default;
+
+  llvm::StringRef getMangledTypeName() override { return m_type_name; }
+};
+
+class DWARFFieldRecordImpl : public swift::reflection::FieldRecordBase {
+  ConstString m_field_name;
+  ConstString m_type_name;
+  swift::Demangle::Demangler m_dem;
+
+public:
+  DWARFFieldRecordImpl(bool is_indirect_case, bool is_var,
+                       ConstString field_name, ConstString type_name)
+      : swift::reflection::FieldRecordBase(is_indirect_case, is_var,
+                                           !type_name.IsEmpty()),
+        m_field_name(field_name), m_type_name(type_name) {}
+
+  ~DWARFFieldRecordImpl() override = default;
+  llvm::StringRef getFieldName() override { return m_field_name; }
+
+  NodePointer getDemangledTypeName() override {
+    return m_dem.demangleSymbol(m_type_name);
+  }
+};
+
+class DWARFFieldDescriptorImpl : public swift::reflection::FieldDescriptorBase {
+  TypeSystemSwiftTypeRef &m_type_system;
+  ConstString m_mangled_name;
+  DIERef m_die_ref;
+
+public:
+  DWARFFieldDescriptorImpl(swift::reflection::FieldDescriptorKind kind,
+                           bool has_superclass,
+                           TypeSystemSwiftTypeRef &type_system,
+                           ConstString mangled_name, DIERef die_ref)
+      : swift::reflection::FieldDescriptorBase(kind, has_superclass),
+        m_type_system(type_system), m_mangled_name(mangled_name),
+        m_die_ref(die_ref) {}
+
+  ~DWARFFieldDescriptorImpl() override = default;
+
+  // TODO: implement this.
+  swift::Demangle::NodePointer demangleSuperclass() override { return nullptr; }
+
+  std::vector<std::unique_ptr<swift::reflection::FieldRecordBase>>
+  getFieldRecords() override {
+    if (!Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging())
+      return {};
+    auto *dwarf =
+        llvm::dyn_cast<SymbolFileDWARF>(m_type_system.GetSymbolFile());
+    auto *dwarf_parser = m_type_system.GetDWARFParser();
+    if (!dwarf || !dwarf_parser)
+      return {};
+
+    auto die = dwarf->GetDIE(m_die_ref);
+    if (!die)
+      return {};
+
+    // For now we only support structs.
+    if (Kind != swift::reflection::FieldDescriptorKind::Struct)
+      return {};
+
+    std::vector<std::unique_ptr<swift::reflection::FieldRecordBase>> fields;
+    for (DWARFDIE child_die : die.children()) {
+      auto tag = child_die.Tag();
+      if (tag != DW_TAG_member)
+        continue;
+      const auto *member_field_name =
+          child_die.GetAttributeValueAsString(llvm::dwarf::DW_AT_name, "");
+      auto *member_type = dwarf_parser->GetTypeForDIE(child_die);
+      auto member_mangled_typename =
+          member_type->GetForwardCompilerType().GetMangledTypeName();
+
+      // Only matters for enums, so set to false for structs.
+      bool is_indirect_case = false;
+      // Unused by type info construction.
+      bool is_var = false;
+      fields.emplace_back(std::make_unique<DWARFFieldRecordImpl>(
+          is_indirect_case, is_var, ConstString(member_field_name),
+          member_mangled_typename));
+    }
+    return fields;
+  }
+};
+} // namespace
+
+/// Constructs a builtin type descriptor from DWARF information.
+std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
+DWARFASTParserSwift::getBuiltinTypeDescriptor(
+    const swift::reflection::TypeRef *TR) {
+  if (!Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging())
+    return nullptr;
+
+  auto pair = getTypeAndDie(m_swift_typesystem, TR);
+  if (!pair)
+    return nullptr;
+  auto &[type, die] = *pair;
+
+  if (die.Tag() == llvm::dwarf::DW_TAG_structure_type) {
+    auto child = die.GetFirstChild();
+    if (child.Tag() != llvm::dwarf::DW_TAG_variant_part)
+      return nullptr;
+  } else if (die.Tag() != llvm::dwarf::DW_TAG_base_type)
+    return nullptr;
+
+  auto byte_size =
+      die.GetAttributeValueAsUnsigned(DW_AT_byte_size, LLDB_INVALID_ADDRESS);
+  if (byte_size == LLDB_INVALID_ADDRESS)
+    return {};
+  auto alignment = die.GetAttributeValueAsUnsigned(
+      DW_AT_alignment, byte_size == 0 ? 1 : byte_size);
+
+  // TODO: this seems simple to calculate but maybe we should encode the stride
+  // in DWARF? That's what reflection metadata does.
+  unsigned stride = ((byte_size + alignment - 1) & ~(alignment - 1));
+
+  auto num_extra_inhabitants =
+      die.GetAttributeValueAsUnsigned(DW_AT_APPLE_num_extra_inhabitants, 0);
+
+  auto is_bitwise_takable = true; // TODO: encode it in DWARF
+
+  return std::make_unique<DWARFBuiltinTypeDescriptorImpl>(
+      byte_size, alignment, stride, num_extra_inhabitants, is_bitwise_takable,
+      type.GetMangledTypeName());
+}
+
+std::unique_ptr<swift::reflection::FieldDescriptorBase>
+DWARFASTParserSwift::getFieldDescriptor(const swift::reflection::TypeRef *TR) {
+  if (!Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging())
+    return nullptr;
+
+  auto pair = getTypeAndDie(m_swift_typesystem, TR);
+  if (!pair)
+    return nullptr;
+  auto [type, die] = *pair;
+  if (!die)
+    return nullptr;
+  auto kind = getFieldDescriptorKindForDie(die);
+  if (!kind)
+    return nullptr;
+// TODO: encode this in DWARF, maybe as a DW_AT_containing_type?
+  bool has_superclass = false; 
+  return std::make_unique<DWARFFieldDescriptorImpl>(
+      *kind, has_superclass, m_swift_typesystem, type.GetMangledTypeName(),
+      *die.GetDIERef());
+}

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -403,13 +403,7 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
   case Node::Kind::ProtocolList:
   case Node::Kind::ProtocolListWithClass:
   case Node::Kind::ProtocolListWithAnyObject:
-  case Node::Kind::TypeAlias:
-  case Node::Kind::BoundGenericClass:
-  case Node::Kind::BoundGenericEnum:
-  case Node::Kind::BoundGenericStructure:
-  case Node::Kind::BoundGenericProtocol:
-  case Node::Kind::BoundGenericOtherNominalType:
-  case Node::Kind::BoundGenericTypeAlias: {
+  case Node::Kind::TypeAlias: {
     if (node->getNumChildren() != 2)
       return {};
     auto *m = node->getChild(0);
@@ -420,12 +414,37 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
       return {};
     return {{m->getText(), n->getText()}};
   }
+  case Node::Kind::BoundGenericClass:
+  case Node::Kind::BoundGenericEnum:
+  case Node::Kind::BoundGenericStructure:
+  case Node::Kind::BoundGenericProtocol:
+  case Node::Kind::BoundGenericOtherNominalType:
+  case Node::Kind::BoundGenericTypeAlias: {
+    if (node->getNumChildren() != 2)
+      return {};
+    auto *type = node->getChild(0);
+    if (!type || type->getKind() != Node::Kind::Type || !type->hasChildren())
+      return {};
+    return GetNominal(dem, type->getFirstChild());
+  }
   default:
     break;
   }
   return {};
 }
 
+/// Return a pair of module name and type name, given a mangled name.
+static llvm::Optional<std::pair<StringRef, StringRef>>
+GetNominal(llvm::StringRef mangled_name) {
+  swift::Demangle::Demangler dem;
+  auto *node = GetDemangledType(dem, mangled_name);
+  /// Builtin names belong to the builtin module, and are stored only with their
+  /// mangled name.
+  if (node->getKind() == Node::Kind::BuiltinTypeName) 
+    return {{"Builtin", mangled_name}};
+
+  return GetNominal(dem, node);
+}
 /// Detect the AnyObject type alias.
 static bool IsAnyObjectTypeAlias(swift::Demangle::NodePointer node) {
   using namespace swift::Demangle;
@@ -1605,9 +1624,7 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
   auto *M = GetModule();
   if (!M)
     return {};
-  swift::Demangle::Demangler dem;
-  auto *node = GetDemangledType(dem, AsMangledName(opaque_type));
-  auto module_type = GetNominal(dem, node);
+  auto module_type = GetNominal(AsMangledName(opaque_type));
   if (!module_type)
     return {};
   // DW_AT_linkage_name is not part of the accelerator table, so
@@ -2870,6 +2887,11 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
         ReconstructType(type), idx, name, bit_offset_ptr, bitfield_bit_size_ptr,
         is_bitfield_ptr);
   return {};
+}
+
+swift::reflection::DescriptorFinder *
+TypeSystemSwiftTypeRef::GetDescriptorFinder() {
+  return llvm::cast<DWARFASTParserSwift>(GetDWARFParser());
 }
 
 swift::Demangle::NodePointer

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -30,6 +30,13 @@ class Node;
 using NodePointer = Node *;
 class Demangler;
 } // namespace Demangle
+namespace reflection {
+struct DescriptorFinder;
+class TypeInfo;
+} // namespace reflection
+namespace remote {
+struct TypeInfoProvider;
+} // namespace remote
 } // namespace swift
 
 namespace lldb_private {
@@ -361,14 +368,18 @@ public:
   /// For example, int is converted to Int32.
   CompilerType ConvertClangTypeToSwiftType(CompilerType clang_type) override;
 
+  /// Gets the descriptor finder belonging to this instance's
+  /// module.
+  swift::reflection::DescriptorFinder *GetDescriptorFinder();
+
+  /// Lookup a type in the debug info.
+  lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);
 protected:
   /// Helper that creates an AST type from \p type.
   void *ReconstructType(lldb::opaque_compiler_type_t type);
   /// Cast \p opaque_type as a mangled name.
   static const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
-  /// Lookup a type in the debug info.
-  lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);
 
   /// Demangle the mangled name of the canonical type of \p type and
   /// drill into the Global(TypeMangling(Type())).

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4887,6 +4887,19 @@ EnableSwiftCxxInterop TargetProperties::GetEnableSwiftCxxInterop() const {
   return enable_interop;
 }
 
+bool TargetProperties::GetSwiftEnableFullDwarfDebugging() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftEnableFullDwarfDebugging)
+        .value_or(false);
+
+  return false;
+}
+
 Args TargetProperties::GetSwiftPluginServerForPath() const {
   const uint32_t idx = ePropertySwiftPluginServerForPath;
 

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -27,6 +27,9 @@ let Definition = "target_experimental" in {
       "Dictionary">,
     ElementType<"String">,
     Desc<"A dictionary of plugin paths as keys and swift-plugin-server binaries as values">;
+  def SwiftEnableFullDwarfDebugging: Property<"swift-enable-full-dwarf-debugging", "Boolean">,
+  DefaultFalse,
+  Desc<"Read full debug information from DWARF for Swift debugging, whenever possible">;
 }
 
 let Definition = "target" in {

--- a/lldb/test/API/lang/swift/embedded/frame_variable/Makefile
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -1,0 +1,31 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftEmbeddedFrameVariable(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable varB",
+            substrs=["varB = ", "a = (field = 4.2000000000000002)", "b = 123456"],
+        )
+        self.expect(
+            "frame variable tuple",
+            substrs=[
+                "(a.A, a.B) tuple = {",
+                "0 = (field = 4.2000000000000002)",
+                "1 = {",
+                "a = (field = 4.2000000000000002)",
+                "b = 123456",
+            ],
+        )

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -1,0 +1,14 @@
+struct A {
+  let field = 4.2
+}
+
+struct B {
+  let a = A()
+  let b = 123456
+}
+
+let varB = B()
+let tuple = (A(), B())
+// Dummy statement to set breakpoint print can't be used in embedded Swift for now.
+let dummy = A() // break here
+


### PR DESCRIPTION
To support embedded Swift, lldb will need to support reading type information from DWARF instead of reflection metadata (whivh it corrently relies on). This patch implements the DescriptorFinder interface by DWARFASTParserSwift, which allows it to provide the data necessary for type info reconstruction without relying on reflection metadata.