### PR TITLE
[clang] Update ptrauth c++ test to avoid VLA warnings.

### DIFF
--- a/clang/test/SemaCXX/ptrauth.cpp
+++ b/clang/test/SemaCXX/ptrauth.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios -std=c++17 -fsyntax-only -verify -fptrauth-intrinsics -fptrauth-calls %s
+// RUN: %clang_cc1 -triple arm64-apple-ios -std=c++17 -Wno-vla -fsyntax-only -verify -fptrauth-intrinsics -fptrauth-calls %s
 
 struct Incomplete0; // expected-note 3 {{forward declaration of 'Incomplete0'}}
 


### PR DESCRIPTION
With 84a3aadf0f24 we now diagnose VLAs in c++ by default.

rdar://118145293