### PR TITLE
[Cherry-pick][debug info] Add DW_TAG_label entries to the accelerator table

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfCompileUnit.cpp
@@ -1439,9 +1439,18 @@ void DwarfCompileUnit::finishEntityDefinition(const DbgEntity *Entity) {
       llvm_unreachable("DbgEntity must be DbgVariable or DbgLabel.");
   }
 
-  if (Label)
-    if (const auto *Sym = Label->getSymbol())
-      addLabelAddress(*Die, dwarf::DW_AT_low_pc, Sym);
+  if (!Label)
+    return;
+
+  const auto *Sym = Label->getSymbol();
+  if (!Sym)
+    return;
+
+  addLabelAddress(*Die, dwarf::DW_AT_low_pc, Sym);
+
+  // A TAG_label with a name and an AT_low_pc must be placed in debug_names.
+  if (StringRef Name = Label->getName(); !Name.empty())
+    getDwarfDebug().addAccelName(*CUNode, Name, *Die);
 }
 
 DbgEntity *DwarfCompileUnit::getExistingAbstractEntity(const DINode *Node) {

--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -635,7 +635,7 @@ std::optional<uint64_t> DWARFDebugNames::Entry::getCUOffset() const {
 }
 
 void DWARFDebugNames::Entry::dump(ScopedPrinter &W) const {
-  W.printHex("Abbrev", Abbr->Code);
+  W.startLine() << formatv("Abbrev: {0:x}\n", Abbr->Code);
   W.startLine() << formatv("Tag: {0}\n", Abbr->Tag);
   assert(Abbr->Attributes.size() == Values.size());
   for (auto Tuple : zip_first(Abbr->Attributes, Values)) {

--- a/llvm/test/DebugInfo/X86/debug-names-dwarf64.ll
+++ b/llvm/test/DebugInfo/X86/debug-names-dwarf64.ll
@@ -26,11 +26,11 @@
 ; CHECK-NEXT:     CU[0]: 0x00000000
 ; CHECK-NEXT:   ]
 ; CHECK-NEXT:   Abbreviations [
-; CHECK-NEXT:     Abbreviation 0x34 {
+; CHECK-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; CHECK-NEXT:       Tag: DW_TAG_variable
 ; CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 ; CHECK-NEXT:     }
-; CHECK-NEXT:     Abbreviation 0x24 {
+; CHECK-NEXT:     Abbreviation [[ABBREV:0x[0-9a-f]*]] {
 ; CHECK-NEXT:       Tag: DW_TAG_base_type
 ; CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 ; CHECK-NEXT:     }
@@ -40,7 +40,7 @@
 ; CHECK-NEXT:       Hash: 0xB888030
 ; CHECK-NEXT:       String: {{.+}} "int"
 ; CHECK-NEXT:       Entry @ {{.+}} {
-; CHECK-NEXT:         Abbrev: 0x24
+; CHECK-NEXT:         Abbrev: [[ABBREV]]
 ; CHECK-NEXT:         Tag: DW_TAG_base_type
 ; CHECK-NEXT:         DW_IDX_die_offset: [[TYPEDIE]]
 ; CHECK-NEXT:       }
@@ -51,7 +51,7 @@
 ; CHECK-NEXT:       Hash: 0xB887389
 ; CHECK-NEXT:       String: {{.+}} "foo"
 ; CHECK-NEXT:       Entry @ {{.+}} {
-; CHECK-NEXT:         Abbrev: 0x34
+; CHECK-NEXT:         Abbrev: [[ABBREV1]]
 ; CHECK-NEXT:         Tag: DW_TAG_variable
 ; CHECK-NEXT:         DW_IDX_die_offset: [[VARDIE]]
 ; CHECK-NEXT:       }

--- a/llvm/test/DebugInfo/X86/debug-names-dwarf64.ll
+++ b/llvm/test/DebugInfo/X86/debug-names-dwarf64.ll
@@ -10,6 +10,10 @@
 ; CHECK-NEXT:                   DW_AT_name ("foo")
 ; CHECK:      [[TYPEDIE:.+]]: DW_TAG_base_type
 ; CHECK-NEXT:                   DW_AT_name ("int")
+; CHECK:      [[SPDIE:.+]]:   DW_TAG_subprogram
+; CHECK:                        DW_AT_name ("func")
+; CHECK:      [[LABELDIE:.+]]: DW_TAG_label
+; CHECK-NEXT:                   DW_AT_name ("MyLabel")
 
 ; CHECK:      .debug_names contents:
 ; CHECK-NEXT: Name Index @ 0x0 {
@@ -19,8 +23,8 @@
 ; CHECK-NEXT:     CU count: 1
 ; CHECK-NEXT:     Local TU count: 0
 ; CHECK-NEXT:     Foreign TU count: 0
-; CHECK-NEXT:     Bucket count: 2
-; CHECK-NEXT:     Name count: 2
+; CHECK-NEXT:     Bucket count: 4
+; CHECK-NEXT:     Name count: 4
 ; CHECK:        }
 ; CHECK-NEXT:   Compilation Unit offsets [
 ; CHECK-NEXT:     CU[0]: 0x00000000
@@ -28,6 +32,14 @@
 ; CHECK-NEXT:   Abbreviations [
 ; CHECK-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 ; CHECK-NEXT:       Tag: DW_TAG_variable
+; CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; CHECK-NEXT:     }
+; CHECK-NEXT:     Abbreviation [[ABBREV_SP:0x[0-9a-f]*]] {
+; CHECK-NEXT:       Tag: DW_TAG_subprogram
+; CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
+; CHECK-NEXT:     }
+; CHECK-NEXT:     Abbreviation [[ABBREV_LABEL:0x[0-9a-f]*]] {
+; CHECK-NEXT:       Tag: DW_TAG_label
 ; CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 ; CHECK-NEXT:     }
 ; CHECK-NEXT:     Abbreviation [[ABBREV:0x[0-9a-f]*]] {
@@ -56,6 +68,29 @@
 ; CHECK-NEXT:         DW_IDX_die_offset: [[VARDIE]]
 ; CHECK-NEXT:       }
 ; CHECK-NEXT:     }
+; CHECK-NEXT:     Name 3 {
+; CHECK-NEXT:       Hash: 0x7C96FE71
+; CHECK-NEXT:       String: {{.+}} "func"
+; CHECK-NEXT:       Entry @ {{.+}} {
+; CHECK-NEXT:         Abbrev: [[ABBREV_SP]]
+; CHECK-NEXT:         Tag: DW_TAG_subprogram
+; CHECK-NEXT:         DW_IDX_die_offset: [[SPDIE]]
+; CHECK-NEXT:       }
+; CHECK-NEXT:     }
+; CHECK-NEXT:   ]
+; CHECK-NEXT:   Bucket 2 [
+; CHECK-NEXT:     EMPTY
+; CHECK-NEXT:   ]
+; CHECK-NEXT:   Bucket 3 [
+; CHECK-NEXT:     Name 4 {
+; CHECK-NEXT:       Hash: 0xEC64E52B
+; CHECK-NEXT:       String: {{.+}} "MyLabel"
+; CHECK-NEXT:       Entry @ {{.+}} {
+; CHECK-NEXT:         Abbrev: [[ABBREV_LABEL]]
+; CHECK-NEXT:         Tag: DW_TAG_label
+; CHECK-NEXT:         DW_IDX_die_offset: [[LABELDIE]]
+; CHECK-NEXT:       }
+; CHECK-NEXT:     }
 ; CHECK-NEXT:   ]
 ; CHECK-NEXT: }
 
@@ -64,11 +99,24 @@
 ; IR generated and reduced from:
 ; $ cat foo.c
 ; int foo;
+; void func() {
+;   goto MyLabel;
+;
+; MyLabel:
+;   return 1;
+; }
 ; $ clang -g -gpubnames -S -emit-llvm foo.c -o foo.ll
 
 target triple = "x86_64-unknown-linux-gnu"
 
 @foo = dso_local global i32 0, align 4, !dbg !0
+
+define void @func() !dbg !11 {
+  call void @llvm.dbg.label(metadata !15), !dbg !14
+  ret void, !dbg !14
+}
+
+declare void @llvm.dbg.label(metadata)
 
 !llvm.dbg.cu = !{!2}
 !llvm.module.flags = !{!7, !8, !9}
@@ -85,3 +133,8 @@ target triple = "x86_64-unknown-linux-gnu"
 !8 = !{i32 2, !"Debug Info Version", i32 3}
 !9 = !{i32 1, !"wchar_size", i32 4}
 !10 = !{!"clang version 12.0.0"}
+!11 = distinct !DISubprogram(name: "func", linkageName: "func", scope: !3, file: !3, line: 2, type: !12,  unit: !2)
+!12 = !DISubroutineType(types: !13)
+!13 = !{null}
+!14 = !DILocation(line: 2, column: 13, scope: !11)
+!15 = !DILabel(scope: !11, name: "MyLabel", file: !3, line: 5)

--- a/llvm/test/DebugInfo/X86/dwarfdump-debug-names.s
+++ b/llvm/test/DebugInfo/X86/dwarfdump-debug-names.s
@@ -151,7 +151,7 @@
 # CHECK-NEXT:     CU[0]: 0x00000000
 # CHECK-NEXT:   ]
 # CHECK-NEXT:   Abbreviations [
-# CHECK-NEXT:     Abbreviation 0x2e {
+# CHECK-NEXT:     Abbreviation [[ABBREV:0x[0-9a-f]*]] {
 # CHECK-NEXT:       Tag: DW_TAG_subprogram
 # CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 # CHECK-NEXT:     }
@@ -164,7 +164,7 @@
 # CHECK-NEXT:       Hash: 0xB887389
 # CHECK-NEXT:       String: 0x00000000 "foo"
 # CHECK-NEXT:       Entry @ 0x4f {
-# CHECK-NEXT:         Abbrev: 0x2E
+# CHECK-NEXT:         Abbrev: [[ABBREV]]
 # CHECK-NEXT:         Tag: DW_TAG_subprogram
 # CHECK-NEXT:         DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:       }
@@ -173,7 +173,7 @@
 # CHECK-NEXT:       Hash: 0xB5063D0B
 # CHECK-NEXT:       String: 0x00000004 "_Z3foov"
 # CHECK-NEXT:       Entry @ 0x58 {
-# CHECK-NEXT:         Abbrev: 0x2E
+# CHECK-NEXT:         Abbrev: [[ABBREV]]
 # CHECK-NEXT:         Tag: DW_TAG_subprogram
 # CHECK-NEXT:         DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:       }
@@ -197,7 +197,7 @@
 # CHECK-NEXT:     CU[0]: 0x00000002
 # CHECK-NEXT:   ]
 # CHECK-NEXT:   Abbreviations [
-# CHECK-NEXT:     Abbreviation 0x34 {
+# CHECK-NEXT:     Abbreviation [[ABBREV1:0x[0-9a-f]*]] {
 # CHECK-NEXT:       Tag: DW_TAG_variable
 # CHECK-NEXT:       DW_IDX_die_offset: DW_FORM_ref4
 # CHECK-NEXT:     }
@@ -207,7 +207,7 @@
 # CHECK-NEXT:       Hash: 0xB8860BA
 # CHECK-NEXT:       String: 0x0000000c "bar"
 # CHECK-NEXT:       Entry @ 0xa3 {
-# CHECK-NEXT:         Abbrev: 0x34
+# CHECK-NEXT:         Abbrev: [[ABBREV1]]
 # CHECK-NEXT:         Tag: DW_TAG_variable
 # CHECK-NEXT:         DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:       }
@@ -237,7 +237,7 @@
 # CHECK-NEXT:     ForeignTU[0]: 0xffffff00ffffffff
 # CHECK-NEXT:   ]
 # CHECK-NEXT:   Abbreviations [
-# CHECK-NEXT:     Abbreviation 0x1 {
+# CHECK-NEXT:     Abbreviation [[ABBREV2:0x[0-9a-f]*]] {
 # CHECK-NEXT:       Tag: DW_TAG_base_type
 # CHECK-NEXT:       DW_IDX_type_unit: DW_FORM_data4
 # CHECK-NEXT:       DW_IDX_type_hash: DW_FORM_data8
@@ -248,7 +248,7 @@
 # CHECK-NEXT:       Hash: 0xB887389
 # CHECK-NEXT:       String: 0x00000000 "foo"
 # CHECK-NEXT:       Entry @ 0x111 {
-# CHECK-NEXT:         Abbrev: 0x1
+# CHECK-NEXT:         Abbrev: [[ABBREV2]]
 # CHECK-NEXT:         Tag: DW_TAG_base_type
 # CHECK-NEXT:         DW_IDX_type_unit: 0x00000001
 # CHECK-NEXT:         DW_IDX_type_hash: 0x0000ff03ffffffff

--- a/llvm/test/tools/llvm-dwarfdump/X86/debug-names-misaligned.s
+++ b/llvm/test/tools/llvm-dwarfdump/X86/debug-names-misaligned.s
@@ -84,7 +84,7 @@
 # CHECK:       Name 1 {
 # CHECK-NEXT:    String: 0x00000000 "foo"
 # CHECK-NEXT:    Entry @ 0x37 {
-# CHECK-NEXT:      Abbrev: 0x2E
+# CHECK-NEXT:      Abbrev: 0x2e
 # CHECK-NEXT:      Tag: DW_TAG_subprogram
 # CHECK-NEXT:      DW_IDX_die_offset: 0x00000001
 # CHECK-NEXT:    }


### PR DESCRIPTION
This PR cherry-picks a fix to AsmPrinter so that it enters DW_TAG_label entries to the accelerator table appropriately.
It also includes another upstream change to a related test to remove hard-coded offsets.