### PR TITLE
[Cherry-pick into stable/20230725][Sanitizers][Darwin] Pass offset to __asan_set_shadow_xx (#71745)

### DIFF
--- a/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
+++ b/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
@@ -65,8 +65,8 @@ void __asan_handle_no_return(void) { __asan_abi_handle_no_return(); }
 
 // Variables concerning RTL state. These provisionally exist for completeness
 // but will likely move into the Stable ABI implementation and not in the shim.
-uptr __asan_shadow_memory_dynamic_address = (uptr)0xdeaddeaddeadbeaf;
-int __asan_option_detect_stack_use_after_return = 0;
+uptr __asan_shadow_memory_dynamic_address = (uptr)0L;
+int __asan_option_detect_stack_use_after_return = 1;
 
 // Functions concerning memory load and store reporting
 void __asan_report_load1(uptr addr) {


### PR DESCRIPTION
Normally, when __asan_option_detect_stack_use_after_return option is set,
the instrumentation passed the adress of the shadow memory bytes to be set, for detecting problems with local variables.
This can be a problem when the -fsanitize-stable-abi option is in effect,
since the ABI implementation doesn't have means to communicate the current shadow memory base address
back to its users.

This change addresses it simply by setting
__asan_shadow_memory_dynamic_address to zero. It means that __asan_set_shadow_xx will be now called with the offset relative to the current shadow memory
base, and the ABI implementation needs to adapt accordingly.

The other change here is to set
__asan_option_detect_stack_use_after_return to nonzer by default, which is needed for instrumentation to take paths using the __asan_shadow_memory_dynamic_address
and __asan_set_shadow_xx calls.

Co-authored-by: Mariusz Borsa <m_borsa@apple.com>
(cherry picked from commit c2205ab30917e2718e8863d905b52b5dc453bd96)