### PR TITLE
[lldb] Handle CFTimeZoneRef in NSTimeZoneSummaryProvider

### DIFF
--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -132,9 +132,29 @@ bool lldb_private::formatters::NSTimeZoneSummaryProvider(
       return true;
     }
   } else if (class_name == "_NSSwiftTimeZone") {
-    llvm::ArrayRef<llvm::StringRef> identifier_path = {"timeZone", "_timeZone",
-                                                       "some", "identifier"};
-    if (auto identifier_sp = valobj.GetChildAtNamePath(identifier_path)) {
+    // CFTimeZoneRef is declared as follows:
+    //     typedef const struct CF_BRIDGED_TYPE(NSTimeZone) __CFTimeZone *
+    //     CFTimeZoneRef;
+    // From the available debug info, this appears to lldb as pointer to an
+    // opaque type, not an ObjC object. As a result, lldb does not correctly
+    // determine the correct dynamic type (because it doesn't try ObjC). With no
+    // dynamic type, this summary provider cannot access the inner `identifier`
+    // property.
+    //
+    // The fix here is to explicitly cast the value as `id`, and get the dynamic
+    // value from there.
+    ValueObjectSP dyn_valobj_sp;
+    if (valobj.GetTypeName() == "CFTimeZoneRef") {
+      auto id_type =
+          valobj.GetCompilerType().GetBasicTypeFromAST(lldb::eBasicTypeObjCID);
+      dyn_valobj_sp = valobj.Cast(id_type)->GetDynamicValue(
+          DynamicValueType::eDynamicDontRunTarget);
+    }
+
+    ValueObject &time_zone = dyn_valobj_sp ? *dyn_valobj_sp : valobj;
+    llvm::ArrayRef<llvm::StringRef> identifier_path = {
+        "some", "timeZone", "_timeZone", "some", "identifier"};
+    if (auto identifier_sp = time_zone.GetChildAtNamePath(identifier_path)) {
       std::string desc;
       if (identifier_sp->GetSummaryAsCString(desc, options)) {
         stream.PutCString(desc);


### PR DESCRIPTION
`CFTimeZoneRef` is declared as follows:

```c++
typedef const struct CF_BRIDGED_TYPE(NSTimeZone) __CFTimeZone * CFTimeZoneRef;
```

From the available debug info, this appears to lldb as pointer to an opaque type, not an ObjC object. As a result, lldb does not correctly determine the dynamic type (because it doesn't try ObjC). With no dynamic type, this summary provider cannot access the inner `identifier` property.

The fix here is to explicitly cast the value as `id`, and get the dynamic value from there. 

rdar://114567512
