### PR TITLE
[lldb] reenable swift benchmark test

### DIFF
--- a/lldb/test/Shell/Stepper/TestSwiftBenchmarkOnone.1.test
+++ b/lldb/test/Shell/Stepper/TestSwiftBenchmarkOnone.1.test
@@ -1,9 +1,5 @@
 # REQUIRES: swift_Benchmark_Onone
 #
-# The test has regressed, tracked by: rdar://73760364
-# The regression only appears when compiling with -disable-copy-propagation.
-# REQUIRES: rdar73760364
-#
 # - Don't capture a reproducer (it can easily exceed 1GB).
 # - Skip `po` testing for now (until we can un-XFAIL `frame var` testing).
 # - Just run benchmark #1 for now (there are more; --list lists all of them). 


### PR DESCRIPTION
This test now passes.

(cherry picked from commit 940795bc396b5a8a6a465e988b4e0bbbf92eca14)