### PR TITLE
Fix regex & startsWith name lookup in SBTarget::FindGlobalVariables

### DIFF
--- a/lldb/source/API/SBTarget.cpp
+++ b/lldb/source/API/SBTarget.cpp
@@ -2005,7 +2005,7 @@ SBValueList SBTarget::FindGlobalVariables(const char *name,
                                                  max_matches, variable_list);
       break;
     case eMatchTypeStartsWith:
-      regexstr = llvm::Regex::escape(name) + ".*";
+      regexstr = "^" + llvm::Regex::escape(name) + ".*";
       target_sp->GetImages().FindGlobalVariables(RegularExpression(regexstr),
                                                  max_matches, variable_list);
       break;

--- a/lldb/source/Plugins/SymbolFile/DWARF/HashedNameToDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/HashedNameToDIE.cpp
@@ -9,6 +9,8 @@
 #include "HashedNameToDIE.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "lldb/Core/Mangled.h"
+
 using namespace lldb_private::dwarf;
 
 bool DWARFMappedHash::ExtractDIEArray(
@@ -422,7 +424,11 @@ DWARFMappedHash::MemoryTable::AppendHashDataForRegularExpression(
       count * m_header.header_data.GetMinimumHashDataByteSize();
   if (count > 0 && m_data.ValidOffsetForDataOfSize(*hash_data_offset_ptr,
                                                    min_total_hash_data_size)) {
-    const bool match = regex.Execute(llvm::StringRef(strp_cstr));
+    // The name in the name table may be a mangled name, in which case we
+    // should also compare against the demangled version.  The simplest way to
+    // do that is to use the Mangled class:
+    lldb_private::Mangled mangled_name((llvm::StringRef(strp_cstr)));
+    const bool match = mangled_name.NameMatches(regex);
 
     if (!match && m_header.header_data.HashDataHasFixedByteSize()) {
       // If the regex doesn't match and we have fixed size data, we can just

--- a/lldb/test/API/lang/cpp/class_static/main.cpp
+++ b/lldb/test/API/lang/cpp/class_static/main.cpp
@@ -21,16 +21,29 @@ public:
     static PointType g_points[];
 };
 
+// Make sure similar names don't confuse us:
+
+class AA
+{
+public:
+  static PointType g_points[];
+};
+
 PointType A::g_points[] = 
 {
     {    1,    2 },
     {   11,   22 }
 };
-
 static PointType g_points[] = 
 {
     {    3,    4 },
     {   33,   44 }
+};
+
+PointType AA::g_points[] = 
+{
+    {    5,    6 },
+    {   55,   66 }
 };
 
 int
@@ -38,6 +51,7 @@ main (int argc, char const *argv[])
 {
     const char *hello_world = "Hello, world!";
     printf ("A::g_points[1].x = %i\n", A::g_points[1].x); // Set break point at this line.
+    printf ("AA::g_points[1].x = %i\n", AA::g_points[1].x);
     printf ("::g_points[1].x = %i\n", g_points[1].x);
     printf ("%s\n", hello_world);
     return 0;


### PR DESCRIPTION
There were two bugs here.

eMatchTypeStartsWith searched for "symbol_name" by adding ".*" to the end of the symbol name and treating that as a regex, which isn't actually a regex for "starts with". The ".*" is in fact a no-op.  When we finally get to comparing the name, we compare against whatever form of the name was in the accelerator table. But for C++ that might be the mangled name. We should also try demangled names here, since most users are going the see demangled not mangled names.  I fixed these two bugs and added a bunch of tests for FindGlobalVariables.

This change is in the DWARF parser code, so there may be a similar bug in PDB, but the test for this was already skipped for Windows, so I don't know about this.

You might theoretically need to do this Mangled comparison in

DWARFMappedHash::MemoryTable::FindByName

except when we have names we always chop them before looking them up so I couldn't see any code paths that fail without that change. So I didn't add that to this patch.

Differential Revision: https://reviews.llvm.org/D151940

(cherry picked from commit 22667e3220de5ead353a2148265d841644b63824)