### PR TITLE
[CodeGen][arm4e] Don't try to initialize a class with a constant if any of its base class cannot be initialized with a constant

### DIFF
--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -824,8 +824,9 @@ bool ConstStructBuilder::Build(const APValue &Val, const RecordDecl *RD,
       BaseInfo &Base = Bases[I];
 
       bool IsPrimaryBase = Layout.getPrimaryBase() == Base.Decl;
-      Build(Val.getStructBase(Base.Index), Base.Decl, IsPrimaryBase,
-            VTableClass, Offset + Base.Offset);
+      if (!Build(Val.getStructBase(Base.Index), Base.Decl, IsPrimaryBase,
+                 VTableClass, Offset + Base.Offset))
+        return false;
     }
   }
 


### PR DESCRIPTION
This fixes a bug where memset was called to initialize a class with a base class that has an address-discriminated field or a vtable.

This happens because ConstStructBuilder::Build leaves early with an empty Elems after failing to initialize the address-discriminated field or the vtable field with a constant, which causes
ConstantAggregateBuilder::buildFrom to return undef.

rdar://117175834