### PR TITLE
[lldb] Add fallback to TypeSystemSwiftTypeRef::GetByteStride

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2829,8 +2829,15 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
   auto impl = [&]() -> llvm::Optional<uint64_t> {
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
-      return runtime->GetByteStride(GetCanonicalType(type));
+      if (auto stride = runtime->GetByteStride(GetCanonicalType(type)))
+        return stride;
     }
+    // Runtime failed, fallback to SwiftASTContext.
+    LLDB_LOGF(GetLog(LLDBLog::Types),
+              "Couldn't compute stride of type %s using SwiftLanguageRuntime.",
+              AsMangledName(type));
+    if (auto *swift_ast_context = GetSwiftASTContext())
+      return swift_ast_context->GetByteStride(ReconstructType(type), exe_scope);
     return {};
   };
   VALIDATE_AND_RETURN(impl, GetByteStride, type, exe_scope,


### PR DESCRIPTION
If TypeSystemSwiftTypeRef::GetByteStride fails, we should fallback to SwiftASTContext, much like the other functions in the typeref typesystem.

rdar://105124851
(cherry picked from commit e2b3e9a6f4b453071232c3cf91ec10bcb53d7f2a)