### PR TITLE
[lldb] Change GetSwiftASTContext call to take exe_scope in GetByteStride

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2836,7 +2836,8 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
     LLDB_LOGF(GetLog(LLDBLog::Types),
               "Couldn't compute stride of type %s using SwiftLanguageRuntime.",
               AsMangledName(type));
-    if (auto *swift_ast_context = GetSwiftASTContext())
+    if (auto *swift_ast_context =
+            GetSwiftASTContextFromExecutionScope(exe_scope))
       return swift_ast_context->GetByteStride(ReconstructType(type), exe_scope);
     return {};
   };

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2829,8 +2829,15 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
   auto impl = [&]() -> llvm::Optional<uint64_t> {
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
-      return runtime->GetByteStride(GetCanonicalType(type));
+      if (auto stride = runtime->GetByteStride(GetCanonicalType(type)))
+        return stride;
     }
+    // Runtime failed, fallback to SwiftASTContext.
+    LLDB_LOGF(GetLog(LLDBLog::Types),
+              "Couldn't compute stride of type %s using SwiftLanguageRuntime.",
+              AsMangledName(type));
+    if (auto *swift_ast_context = GetSwiftASTContext())
+      return swift_ast_context->GetByteStride(ReconstructType(type), exe_scope);
     return {};
   };
   VALIDATE_AND_RETURN(impl, GetByteStride, type, exe_scope,


### PR DESCRIPTION
GetSwiftASTContext now has a symbol context parameter, change the call
site in GetByteStride to call one of GetSwiftASTContext's helper
functions (GetSwiftASTContextFromExecutionScope)

rdar://118524643
