### PR TITLE
[lldb] Add forward declaration for SBWatchpointOptions in SBDefines.h

### DIFF
--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -126,6 +126,7 @@ class LLDB_API SBValue;
 class LLDB_API SBValueList;
 class LLDB_API SBVariablesOptions;
 class LLDB_API SBWatchpoint;
+class LLDB_API SBWatchpointOptions;
 class LLDB_API SBUnixSignals;
 
 typedef bool (*SBBreakpointHitCallback)(void *baton, SBProcess &process,


### PR DESCRIPTION
(cherry picked from commit a322d50804c5248f9e2981f3733bcb598fa13d51)