### PR TITLE
[lldb] Disable one test from TestStaticVariables on Linux

### DIFF
--- a/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
+++ b/lldb/test/API/lang/cpp/class_static/TestStaticVariables.py
@@ -120,6 +120,7 @@ class StaticVariableTestCase(TestBase):
 
         return value_check
 
+    @skipUnlessDarwin
     @expectedFailureAll(
         compiler=["gcc"], bugnumber="Compiler emits incomplete debug info"
     )


### PR DESCRIPTION
This was never enabled in ToT, but due to some cherry-pick interactions the "skip" clause was left out.