### PR TITLE
[lldb] Avoid eager loading of SwiftASTContext from TSSwiftTypeRef::SetTriple

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1455,6 +1455,8 @@ SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContext() const {
         *const_cast<TypeSystemSwiftTypeRef *>(this));
     m_swift_ast_context =
         llvm::dyn_cast_or_null<SwiftASTContext>(m_swift_ast_context_sp.get());
+    if (m_swift_ast_context && !m_swift_ast_context_triple.str().empty())
+      m_swift_ast_context->SetTriple(m_swift_ast_context_triple);
   }
   return m_swift_ast_context;
 }
@@ -1524,8 +1526,10 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
 }
 
 void TypeSystemSwiftTypeRef::SetTriple(const llvm::Triple triple) {
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull())
     swift_ast_context->SetTriple(triple);
+  else
+    m_swift_ast_context_triple = triple;
 }
 
 void TypeSystemSwiftTypeRef::ClearModuleDependentCaches() {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -434,6 +434,7 @@ protected:
 #endif
 
   /// The sibling SwiftASTContext.
+  llvm::Triple m_swift_ast_context_triple;
   mutable bool m_swift_ast_context_initialized = false;
   mutable lldb::TypeSystemSP m_swift_ast_context_sp;
   mutable SwiftASTContext *m_swift_ast_context = nullptr;


### PR DESCRIPTION
(cherry-picked from commit 9aa46a4d6cb62560fc59ebcd12e5682cb9e3851d)