### PR TITLE
[Cherry-pick into next] Thread a SymbolContext through GetSwiftASTContext. (NFC)

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -191,9 +191,9 @@ swift::BraceStmt *SwiftASTManipulatorBase::GetUserBody() {
 
 SwiftASTManipulator::SwiftASTManipulator(
     SwiftASTContextForExpressions &swift_ast_ctx,
-    swift::SourceFile &source_file, bool repl,
+    swift::SourceFile &source_file, const SymbolContext &sc, bool repl,
     lldb::BindGenericTypes bind_generic_types)
-    : SwiftASTManipulatorBase(source_file, repl, bind_generic_types),
+    : SwiftASTManipulatorBase(source_file, sc, repl, bind_generic_types),
       m_swift_ast_ctx(swift_ast_ctx) {}
 
 void SwiftASTManipulator::FindSpecialNames(
@@ -889,7 +889,7 @@ llvm::Optional<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
   // When injecting a value pack or pack count into the outer
   // lldb_expr function, treat it as an opaque raw pointer.
   if (m_bind_generic_types == lldb::eDontBind && variable.IsUnboundPack()) {
-    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext();
+    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(&m_sc);
     if (swift_ast_ctx) {
       auto it = m_type_aliases.find("$__lldb_builtin_ptr_t");
       if (it == m_type_aliases.end())

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -146,9 +146,10 @@ public:
     VariableMetadataSP m_metadata;
   };
 
-  SwiftASTManipulatorBase(swift::SourceFile &source_file, bool repl,
+  SwiftASTManipulatorBase(swift::SourceFile &source_file,
+                          const SymbolContext &sc, bool repl,
                           lldb::BindGenericTypes bind_generic_types)
-      : m_source_file(source_file), m_variables(), m_repl(repl),
+      : m_source_file(source_file), m_sc(sc), m_repl(repl),
         m_bind_generic_types(bind_generic_types) {
     DoInitialization();
   }
@@ -168,7 +169,7 @@ private:
 protected:
   swift::SourceFile &m_source_file;
   llvm::SmallVector<VariableInfo, 1> m_variables;
-
+  const SymbolContext &m_sc;
   bool m_repl = false;
 
   lldb::BindGenericTypes m_bind_generic_types = lldb::eBindAuto;
@@ -196,8 +197,8 @@ protected:
 class SwiftASTManipulator : public SwiftASTManipulatorBase {
 public:
   SwiftASTManipulator(SwiftASTContextForExpressions &swift_ast_ctx,
-                      swift::SourceFile &source_file, bool repl,
-                      lldb::BindGenericTypes bind_generic_types);
+                      swift::SourceFile &source_file, const SymbolContext &sc,
+                      bool repl, lldb::BindGenericTypes bind_generic_types);
   SwiftASTContextForExpressions &GetScratchContext() { return m_swift_ast_ctx; }
 
   void FindSpecialNames(llvm::SmallVectorImpl<swift::Identifier> &names,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1416,7 +1416,8 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
   if (repl || !playground) {
     code_manipulator = std::make_unique<SwiftASTManipulator>(
-        swift_ast_context, *source_file, repl, options.GetBindGenericTypes());
+        swift_ast_context, *source_file, sc, repl,
+        options.GetBindGenericTypes());
 
     if (!playground) {
       code_manipulator->RewriteResult();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -563,13 +563,12 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
       llvm::consumeError(type_system_or_err.takeError());
       return;
     }
-
     auto *swift_ts =
         llvm::dyn_cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
             type_system_or_err->get());
     auto *target_swift_ast =
         llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-            swift_ts->GetSwiftASTContext());
+            swift_ts->GetSwiftASTContext(nullptr));
     m_swift_ast = target_swift_ast;
   }
   SwiftASTContextForExpressions *swift_ast = m_swift_ast;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -695,8 +695,10 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
     return error("could not create a Swift scratch context: ",
                  m_err.AsCString());
 
+  const SymbolContext *sc =
+      &frame->GetSymbolContext(lldb::eSymbolContextFunction);
   m_swift_ast_ctx = llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-      m_swift_scratch_ctx->get()->GetSwiftASTContext());
+      m_swift_scratch_ctx->get()->GetSwiftASTContext(sc));
 
   if (!m_swift_ast_ctx)
     return error("could not create a Swift AST context");

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -99,7 +99,10 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
   auto *ts = llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get());
   if (!ts)
     return "";
-  auto *ctx = ts->GetSwiftASTContext();
+  const SymbolContext *sc = nullptr;
+  if (swiftFrame)
+    sc = &swiftFrame->GetSymbolContext(eSymbolContextFunction);
+  auto *ctx = ts->GetSwiftASTContext(sc);
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1321,10 +1321,13 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
               llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
                   target->GetSwiftScratchContext(error, *exe_scope,
                                                  create_on_demand);
+              const SymbolContext *sc = nullptr;
+              if (auto frame_sp = exe_scope->CalculateStackFrame())
+                sc = &frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
               if (maybe_scratch_ctx)
                 if (auto scratch_ctx = maybe_scratch_ctx->get())
                   if (SwiftASTContext *ast_ctx =
-                          scratch_ctx->GetSwiftASTContext()) {
+                          scratch_ctx->GetSwiftASTContext(sc)) {
                     ConstString cs_input{input};
                     Mangled mangled(cs_input);
                     if (mangled.GuessLanguage() == eLanguageTypeSwift) {
@@ -1383,73 +1386,76 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
                 target->GetSwiftScratchContext(error, *exe_scope,
                                                create_on_demand);
-              if (maybe_scratch_ctx)
-                if (auto scratch_ctx = maybe_scratch_ctx->get())
-                  if (SwiftASTContext *ast_ctx =
-                          scratch_ctx->GetSwiftASTContext()) {
-                    auto iter = ast_ctx->GetModuleCache().begin(),
-                         end = ast_ctx->GetModuleCache().end();
+            const SymbolContext *sc = nullptr;
+            if (auto frame_sp = exe_scope->CalculateStackFrame())
+              sc = &frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
 
-                    std::vector<llvm::StringRef> name_parts;
-                    SplitDottedName(input, name_parts);
+            if (maybe_scratch_ctx)
+              if (auto scratch_ctx = maybe_scratch_ctx->get())
+                if (SwiftASTContext *ast_ctx =
+                        scratch_ctx->GetSwiftASTContext(sc)) {
+                  auto iter = ast_ctx->GetModuleCache().begin(),
+                       end = ast_ctx->GetModuleCache().end();
 
-                    std::function<void(swift::ModuleDecl *)> lookup_func =
-                        [&ast_ctx, input, name_parts,
-                         &results](swift::ModuleDecl *module) -> void {
-                      for (auto imported_module :
-                           swift::namelookup::getAllImports(module)) {
-                        auto module = imported_module.importedModule;
-                        TypesOrDecls local_results;
-                        ast_ctx->FindTypesOrDecls(input, module, local_results,
-                                                  false);
-                        llvm::Optional<TypeOrDecl> candidate;
-                        if (local_results.empty() && name_parts.size() > 1) {
-                          size_t idx_of_deeper = 1;
-                          // if you're looking for Swift.Int in module Swift,
-                          // try looking for Int
-                          if (name_parts.front() == module->getName().str()) {
-                            candidate = ast_ctx->FindTypeOrDecl(
-                                name_parts[1].str().c_str(), module);
-                            idx_of_deeper = 2;
-                          }
-                          // this is probably the top-level name of a nested
-                          // type String.UTF8View
-                          else {
-                            candidate = ast_ctx->FindTypeOrDecl(
-                                name_parts[0].str().c_str(), module);
-                          }
-                          if (candidate.has_value()) {
-                            TypesOrDecls candidates{candidate.value()};
-                            for (; idx_of_deeper < name_parts.size();
-                                 idx_of_deeper++) {
-                              TypesOrDecls new_candidates;
-                              for (auto candidate : candidates) {
-                                ast_ctx->FindContainedTypeOrDecl(
-                                    name_parts[idx_of_deeper], candidate,
-                                    new_candidates);
-                              }
-                              candidates = new_candidates;
-                            }
+                  std::vector<llvm::StringRef> name_parts;
+                  SplitDottedName(input, name_parts);
+
+                  std::function<void(swift::ModuleDecl *)> lookup_func =
+                      [&ast_ctx, input, name_parts,
+                       &results](swift::ModuleDecl *module) -> void {
+                    for (auto imported_module :
+                         swift::namelookup::getAllImports(module)) {
+                      auto module = imported_module.importedModule;
+                      TypesOrDecls local_results;
+                      ast_ctx->FindTypesOrDecls(input, module, local_results,
+                                                false);
+                      llvm::Optional<TypeOrDecl> candidate;
+                      if (local_results.empty() && name_parts.size() > 1) {
+                        size_t idx_of_deeper = 1;
+                        // if you're looking for Swift.Int in module Swift,
+                        // try looking for Int
+                        if (name_parts.front() == module->getName().str()) {
+                          candidate = ast_ctx->FindTypeOrDecl(
+                              name_parts[1].str().c_str(), module);
+                          idx_of_deeper = 2;
+                        }
+                        // this is probably the top-level name of a nested
+                        // type String.UTF8View
+                        else {
+                          candidate = ast_ctx->FindTypeOrDecl(
+                              name_parts[0].str().c_str(), module);
+                        }
+                        if (candidate.has_value()) {
+                          TypesOrDecls candidates{candidate.value()};
+                          for (; idx_of_deeper < name_parts.size();
+                               idx_of_deeper++) {
+                            TypesOrDecls new_candidates;
                             for (auto candidate : candidates) {
-                              if (candidate)
-                                results.insert(candidate);
+                              ast_ctx->FindContainedTypeOrDecl(
+                                  name_parts[idx_of_deeper], candidate,
+                                  new_candidates);
                             }
+                            candidates = new_candidates;
                           }
-                        } else if (local_results.size() > 0) {
-                          for (const auto &result : local_results)
-                            results.insert(result);
-                        } else if (local_results.empty() && module &&
-                                   name_parts.size() == 1 &&
-                                   name_parts.front() ==
-                                       module->getName().str())
-                          results.insert(
-                              ToCompilerType(swift::ModuleType::get(module)));
-                      }
-                    };
+                          for (auto candidate : candidates) {
+                            if (candidate)
+                              results.insert(candidate);
+                          }
+                        }
+                      } else if (local_results.size() > 0) {
+                        for (const auto &result : local_results)
+                          results.insert(result);
+                      } else if (local_results.empty() && module &&
+                                 name_parts.size() == 1 &&
+                                 name_parts.front() == module->getName().str())
+                        results.insert(
+                            ToCompilerType(swift::ModuleType::get(module)));
+                    }
+                  };
 
-                    for (; iter != end; iter++)
-                      lookup_func(iter->second);
-                  }
+                  for (; iter != end; iter++)
+                    lookup_func(iter->second);
+                }
           }
 
           return (results.size() - before);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1232,7 +1232,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
           target.GetSwiftScratchContext(error, frame);
       auto scratch_ctx = maybe_swift_ast->get();
       if (scratch_ctx) {
-        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext()) {
+        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext(&sc)) {
         CompilerType function_type = swift_ast->GetTypeFromMangledTypename(
             mangled_name.GetMangledName());
         if (error.Success()) {
@@ -1444,7 +1444,9 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   auto scratch_ctx = maybe_scratch_context->get();
   if (!scratch_ctx)
     return error_valobj_sp;
-  SwiftASTContext *ast_context = scratch_ctx->GetSwiftASTContext();
+
+  const SymbolContext *sc = &frame_sp->GetSymbolContext(eSymbolContextFunction);
+  SwiftASTContext *ast_context = scratch_ctx->GetSwiftASTContext(sc);
   if (!ast_context)
     return error_valobj_sp;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2672,7 +2672,8 @@ SwiftLanguageRuntimeImpl::GetConcreteType(ExecutionContextScope *exe_scope,
   if (!promise_sp)
     return CompilerType();
 
-  return promise_sp->FulfillTypePromise();
+  const SymbolContext *sc = &frame->GetSymbolContext(eSymbolContextFunction);
+  return promise_sp->FulfillTypePromise(sc);
 }
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -291,11 +291,13 @@ protected:
     llvm::Optional<CompilerType> m_compiler_type;
 
   public:
-    CompilerType FulfillTypePromise(Status *error = nullptr);
+    CompilerType FulfillTypePromise(const SymbolContext *sc,
+                                    Status *error = nullptr);
   };
   typedef std::shared_ptr<MetadataPromise> MetadataPromiseSP;
 
-  MetadataPromiseSP GetMetadataPromise(lldb::addr_t addr,
+  MetadataPromiseSP GetMetadataPromise(const SymbolContext *sc,
+                                       lldb::addr_t addr,
                                        ValueObject &for_object);
   MetadataPromiseSP
   GetPromiseForTypeNameAndFrame(const char *type_name, StackFrame *frame);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -207,8 +207,8 @@ public:
 
   bool SupportsLanguage(lldb::LanguageType language) override;
 
-  SwiftASTContext *GetSwiftASTContext() const override {
-    return const_cast<SwiftASTContext *>(this);
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override {
+    return GetTypeSystemSwiftTypeRef().GetSwiftASTContext(sc);
   }
 
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
@@ -69,10 +69,6 @@ void SwiftDWARFImporterForClangTypes::lookupValue(
   if (SwiftLanguageRuntime::IsSwiftMangledName(name_cs.GetStringRef()))
     return;
 
-  auto *swift_ast_ctx = m_swift_typesystem.GetSwiftASTContext();
-  if (!swift_ast_ctx)
-    return;
-
   // Find the type in the debug info.
   TypeSP clang_type_sp;
   // FIXME: LookupClangType won't work for nested C++ types.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -115,7 +115,7 @@ public:
 
   const std::string &GetDescription() const { return m_description; }
   static LanguageSet GetSupportedLanguagesForTypes();
-  virtual SwiftASTContext *GetSwiftASTContext() const = 0;
+  virtual SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const = 0;
   virtual TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() = 0;
   virtual const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const = 0;
   virtual void SetTriple(const llvm::Triple triple) = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1552,13 +1552,13 @@ TypeSystemSwiftTypeRef::GetMangledTypeName(opaque_compiler_type_t type) {
 
 void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type) {
   Status error;
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return swift_ast_context->ReconstructType(GetMangledTypeName(type), error);
   return {};
 }
 
 CompilerType TypeSystemSwiftTypeRef::ReconstructType(CompilerType type) {
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return {swift_ast_context->weak_from_this(),
             ReconstructType(type.GetOpaqueQualType())};
   return {};
@@ -1587,14 +1587,17 @@ bool TypeSystemSwiftTypeRef::SupportsLanguage(lldb::LanguageType language) {
 }
 
 Status TypeSystemSwiftTypeRef::IsCompatible() {
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  // This is called only from SBModule.
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return swift_ast_context->IsCompatible();
   return {};
 }
 
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               Module &module) const {
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull())
+  // This gets called only from Thread::FrameSelectedCallback(StackFrame)
+  // and is of limited usefuleness.
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull(nullptr))
     swift_ast_context->DiagnoseWarnings(process, module);
 }
 
@@ -1901,7 +1904,7 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
   do {                                                                         \
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetUseSwiftTypeRefTypeSystem()) {                                \
-      if (auto *swift_ast_context = GetSwiftASTContext())                      \
+      if (auto *swift_ast_context = GetSwiftASTContext(nullptr))               \
         return swift_ast_context->REFERENCE ARGS;                              \
       return {};                                                               \
     }                                                                          \
@@ -1915,9 +1918,9 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
-    if (!GetSwiftASTContext())                                                 \
+    if (!GetSwiftASTContext(nullptr))                                          \
       return result;                                                           \
-    assert((result == GetSwiftASTContext()->REFERENCE()) &&                    \
+    assert((result == GetSwiftASTContext(nullptr)->REFERENCE()) &&             \
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");            \
     return result;                                                             \
   } while (0)
@@ -1930,18 +1933,18 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
-    if (!GetSwiftASTContext())                                                 \
+    if (!GetSwiftASTContext(nullptr))                                          \
       return result;                                                           \
     if (ShouldSkipValidation(TYPE))                                            \
       return result;                                                           \
     if ((TYPE) && !ReconstructType(TYPE))                                      \
       return result;                                                           \
     ExecutionContext _exe_ctx(EXE_CTX);                                        \
-    auto swift_scratch_ctx_lock = SwiftScratchContextLock(                         \
+    auto swift_scratch_ctx_lock = SwiftScratchContextLock(                     \
         _exe_ctx == ExecutionContext() ? nullptr : &_exe_ctx);                 \
     bool equivalent =                                                          \
         !ReconstructType(TYPE) /* missing .swiftmodule */ ||                   \
-        (Equivalent(result, GetSwiftASTContext()->REFERENCE ARGS));            \
+        (Equivalent(result, GetSwiftASTContext(nullptr)->REFERENCE ARGS));     \
     if (!equivalent)                                                           \
       llvm::dbgs() << "failing type was " << (const char *)TYPE << "\n";       \
     assert(equivalent &&                                                       \
@@ -2367,11 +2370,11 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     NodePointer node = dem.demangleSymbol(AsMangledName(type));
     bool unresolved_typealias = false;
     uint32_t flags = CollectTypeInfo(dem, node, unresolved_typealias);
-    if (unresolved_typealias && GetSwiftASTContext()) {
+    if (unresolved_typealias && GetSwiftASTContext(nullptr)) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
-      return GetSwiftASTContext()->GetTypeInfo(ReconstructType(type),
-                                               pointee_or_element_clang_type);
+      return GetSwiftASTContext(nullptr)->GetTypeInfo(
+          ReconstructType(type), pointee_or_element_clang_type);
     }
     return flags;
   };
@@ -2498,7 +2501,7 @@ TypeSystemSwiftTypeRef::GetNumMemberFunctions(opaque_compiler_type_t type) {
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return swift_ast_context->GetNumMemberFunctions(ReconstructType(type));
   return {};
 }
@@ -2509,7 +2512,7 @@ TypeSystemSwiftTypeRef::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return swift_ast_context->GetMemberFunctionAtIndex(ReconstructType(type),
                                                        idx);
   return {};
@@ -2629,7 +2632,9 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
       LLDB_LOGF(GetLog(LLDBLog::Types),
                 "Couldn't compute size of type %s using SwiftLanguageRuntime.",
                 AsMangledName(type));
-      if (auto *swift_ast_context = GetSwiftASTContext())
+
+      if (auto *swift_ast_context =
+              GetSwiftASTContextFromExecutionScope(exe_scope))
         return swift_ast_context->GetBitSize(ReconstructType(type), exe_scope);
     }
 
@@ -2805,7 +2810,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
             "Using SwiftASTContext::GetNumChildren fallback for type %s",
             AsMangledName(type));
 
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
     return swift_ast_context->GetNumChildren(ReconstructType(type),
                                              omit_empty_base_classes, exe_ctx);
   return {};
@@ -2862,7 +2867,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
             "Using SwiftASTContext::GetNumFields fallback for type %s",
             AsMangledName(type));
 
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
     return swift_ast_context->GetNumFields(ReconstructType(type), exe_ctx);
   return {};
 }
@@ -2876,7 +2881,7 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
   LLDB_SCOPED_TIMER();
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return swift_ast_context->GetFieldAtIndex(
         ReconstructType(type), idx, name, bit_offset_ptr, bitfield_bit_size_ptr,
         is_bitfield_ptr);
@@ -2928,7 +2933,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     LLDB_LOGF(GetLog(LLDBLog::Types),
               "Had to engage SwiftASTContext fallback for type %s.",
               AsMangledName(type));
-    if (auto *swift_ast_context = GetSwiftASTContext())
+    if (auto *swift_ast_context =
+            GetSwiftASTContextFromExecutionContext(exe_ctx))
       return swift_ast_context->GetChildCompilerTypeAtIndex(
           ReconstructType(type), exe_ctx, idx, transparent_pointers,
           omit_empty_base_classes, ignore_array_bounds, child_name,
@@ -2947,7 +2953,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   auto get_ast_num_children = [&]() {
     if (ast_num_children)
       return *ast_num_children;
-    if (auto *swift_ast_context = GetSwiftASTContext())
+    if (auto *swift_ast_context =
+            GetSwiftASTContextFromExecutionContext(exe_ctx))
       ast_num_children = swift_ast_context->GetNumChildren(
           ReconstructType(type), omit_empty_base_classes, exe_ctx);
     return ast_num_children.value_or(0);
@@ -3152,7 +3159,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
 #ifndef NDEBUG
         // This block is a custom VALIDATE_AND_RETURN implementation to support
         // checking the return value, plus the by-ref `child_indexes`.
-        if (!GetSwiftASTContext())
+        if (!GetSwiftASTContextFromExecutionContext(exe_ctx))
           return index_size;
         auto swift_scratch_ctx_lock = SwiftScratchContextLock(exe_ctx);
         auto ast_type = ReconstructType(type);
@@ -3160,9 +3167,10 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
           return index_size;
         std::vector<uint32_t> ast_child_indexes;
         auto ast_index_size =
-            GetSwiftASTContext()->GetIndexOfChildMemberWithName(
-                ast_type, name, exe_ctx, omit_empty_base_classes,
-                ast_child_indexes);
+            GetSwiftASTContextFromExecutionContext(exe_ctx)
+                ->GetIndexOfChildMemberWithName(ast_type, name, exe_ctx,
+                                                omit_empty_base_classes,
+                                                ast_child_indexes);
         // The runtime has more info than the AST. No useful validation can be
         // done.
         if (index_size > ast_index_size)
@@ -3205,7 +3213,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
             "type %s",
             AsMangledName(type));
 
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
     return swift_ast_context->GetIndexOfChildMemberWithName(
         ReconstructType(type), name, exe_ctx, omit_empty_base_classes,
         child_indexes);
@@ -3507,7 +3515,7 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type) {
       // type alias isn't possible, or the user might have defined the
       // type alias in the REPL. In these cases, fallback to asking the AST
       // for the canonical type.
-      if (auto *swift_ast_context = GetSwiftASTContext())
+      if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
         return swift_ast_context->GetInstanceType(ReconstructType(type));
       return {};
     }
@@ -3632,9 +3640,11 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
   // is an inlined function-specific variation.
   FALLBACK(CreateTupleType, (elements));
 #ifndef NDEBUG
-  {
+  if (ModuleList::GetGlobalModuleListProperties()
+          .GetSwiftValidateTypeSystem()) {
     auto result = impl();
-    if (!GetSwiftASTContext())
+    SwiftASTContext *swift_ast_ctx = GetSwiftASTContext(nullptr);
+    if (!swift_ast_ctx)
       return result;
     std::vector<TupleElement> ast_elements;
     std::transform(elements.begin(), elements.end(),
@@ -3643,10 +3653,10 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
                                          ReconstructType(element.element_type));
                    });
     bool equivalent =
-        Equivalent(result, GetSwiftASTContext()->CreateTupleType(ast_elements));
+        Equivalent(result, swift_ast_ctx->CreateTupleType(ast_elements));
     if (!equivalent) {
       result.dump();
-      auto a = GetSwiftASTContext()->CreateTupleType(elements);
+      auto a = swift_ast_ctx->CreateTupleType(elements);
       llvm::dbgs() << "AST type: " << a.GetMangledTypeName() << "\n";
       llvm::dbgs() << "failing tuple type\n";
     }
@@ -3655,9 +3665,8 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");
     return result;
   }
-#else
-  return impl();
 #endif
+  return impl();
 }
 
 bool TypeSystemSwiftTypeRef::IsTupleType(lldb::opaque_compiler_type_t type) {
@@ -3745,7 +3754,8 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
 
   // Also dump the swift ast context info, as this functions should not be in
   // any critical path.
-  if (auto *swift_ast_context = GetSwiftASTContext()) {
+  if (auto *swift_ast_context =
+          GetSwiftASTContextFromExecutionScope(exe_scope)) {
     s->PutCString("Source code info:\n");
     swift_ast_context->DumpTypeDescription(
         ReconstructType(type), s, print_help_if_available,
@@ -3874,7 +3884,8 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
 
       // No result available from the runtime, fallback to the AST. This occurs
       // for some Clang imported enums
-      if (auto *swift_ast_context = GetSwiftASTContext())
+      if (auto *swift_ast_context =
+              GetSwiftASTContextFromExecutionScope(exe_scope))
         return swift_ast_context->DumpTypeValue(
             ReconstructType(type), s, format, data, data_offset, data_byte_size,
             bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
@@ -3886,7 +3897,8 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       // SwiftASTContext couldn't resolve. This happens for ObjC
       // typedefs such as CFString in the REPL. More investigation is
       // needed.
-      if (auto *swift_ast_context = GetSwiftASTContext())
+      if (auto *swift_ast_context =
+              GetSwiftASTContextFromExecutionScope(exe_scope))
         return swift_ast_context->DumpTypeValue(
             ReconstructType(type), s, format, data, data_offset, data_byte_size,
             bitfield_bit_size, bitfield_bit_offset, exe_scope, is_base_class);
@@ -3969,7 +3981,7 @@ TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
     // defined in the expression. In that case we don't have debug
     // info for it, so defer to SwiftASTContext.
     if (llvm::isa_and_nonnull<SwiftASTContextForExpressions>(
-            GetSwiftASTContext()))
+            GetSwiftASTContextFromExecutionScope(exe_scope)))
       return ReconstructType({weak_from_this(), type}).GetTypeBitAlign(exe_scope);
   }
 
@@ -4077,7 +4089,7 @@ TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return swift_ast_context->GetNumDirectBaseClasses(ReconstructType(type));
   return {};
 }
@@ -4087,7 +4099,7 @@ CompilerType TypeSystemSwiftTypeRef::GetDirectBaseClassAtIndex(
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext())
+  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
     return swift_ast_context->GetDirectBaseClassAtIndex(ReconstructType(type),
                                                         idx, bit_offset_ptr);
   return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -59,9 +59,15 @@ public:
   ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   /// Get the corresponding SwiftASTContext, and create one if necessary.
-  SwiftASTContext *GetSwiftASTContext() const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  /// Convenience helpers.
+  SwiftASTContext *
+  GetSwiftASTContextFromExecutionScope(ExecutionContextScope *exe_scope) const;
+  SwiftASTContext *
+  GetSwiftASTContextFromExecutionContext(const ExecutionContext *exe_ctx) const;
   /// Return SwiftASTContext, iff one has already been created.
-  SwiftASTContext *GetSwiftASTContextOrNull() const;
+  virtual SwiftASTContext *
+  GetSwiftASTContextOrNull(const SymbolContext *sc = nullptr) const;
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override { return *this; }
   const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const override {
     return *this;
@@ -476,7 +482,9 @@ public:
   TypeSystemSwiftTypeRefForExpressions(lldb::LanguageType language,
                                        Target &target, Module &module);
 
-  SwiftASTContext *GetSwiftASTContext() const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  SwiftASTContext *
+  GetSwiftASTContextOrNull(const SymbolContext *sc = nullptr) const override;
   lldb::TargetWP GetTargetWP() const override { return m_target_wp; }
 
   /// Forwards to SwiftASTContext.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2498,7 +2498,7 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                 type_system_or_err->get())) {
       auto *swift_ast_ctx =
           llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-              swift_scratch_ctx->GetSwiftASTContextOrNull());
+              swift_scratch_ctx->GetSwiftASTContextOrNull(nullptr));
       // Replace the scratch context if it contains fatal errors or
       // needs to be replaced because new lldb::Modules were loaded.
       if (swift_ast_ctx && (swift_ast_ctx->CheckProcessChanged() ||
@@ -2547,7 +2547,7 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                   message, llvm::inconvertibleErrorCode());
             };
             auto *new_swift_ast_ctx =
-                new_swift_scratch_ctx->GetSwiftASTContext();
+                new_swift_scratch_ctx->GetSwiftASTContext(nullptr);
             if (!new_swift_ast_ctx)
               report_error("Failed to construct SwiftASTContextForExpressions");
             else if (new_swift_ast_ctx->HasFatalErrors()) {
@@ -2769,12 +2769,13 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
   Log *log = GetLog(LLDBLog::Target | LLDBLog::Types | LLDBLog::Expressions);
   LLDB_SCOPED_TIMER();
 
+  const SymbolContext *sc = nullptr;
   Module *lldb_module = nullptr;
   if (lldb::StackFrameSP stack_frame = exe_scope.CalculateStackFrame()) {
-    auto sc = stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
-    lldb_module = sc.module_sp.get();
+    sc = &stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
+    lldb_module = sc->module_sp.get();
   }
-
+  
   // Opt into the per-module scratch context if we find incompatible triples.
   if (!m_use_scratch_typesystem_per_module) {
     TargetSP target_sp = exe_scope.CalculateTarget();
@@ -2817,7 +2818,7 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
     if (auto *cached_ts = get_cached_module_ts(lldb_module)) {
       auto *cached_ast_ctx =
           llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-              cached_ts->GetSwiftASTContext());
+              cached_ts->GetSwiftASTContext(sc));
       if (cached_ast_ctx && cached_ast_ctx->HasFatalErrors() &&
           !m_cant_make_scratch_type_system.count(lldb::eLanguageTypeSwift)) {
         DisplayFallbackSwiftContextErrors(cached_ast_ctx);
@@ -2880,12 +2881,12 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
                 type_system_or_err->get()))
       if (auto *swift_ast_ctx =
               llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-                  global_scratch_ctx->GetSwiftASTContext()))
+                  global_scratch_ctx->GetSwiftASTContext(sc)))
         DisplayFallbackSwiftContextErrors(swift_ast_ctx);
 
     auto typesystem_sp = std::make_shared<TypeSystemSwiftTypeRefForExpressions>(
         lldb::eLanguageTypeSwift, *this, *lldb_module);
-    typesystem_sp->GetSwiftASTContext();
+    typesystem_sp->GetSwiftASTContext(sc);
     m_scratch_typesystem_for_module.insert({key, typesystem_sp});
     if (log)
       log->PutCString("created module-wide scratch context");


### PR DESCRIPTION
```
commit 71e3bfa68ea0978425451df7a0f4717ff56c0c9e
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Nov 2 09:41:05 2023 -0700

    Thread a SymbolContext through GetSwiftASTContext. (NFC)
```
