### PR TITLE
Add an include to xtr1common in ADL.h

### DIFF
--- a/llvm/include/llvm/ADT/ADL.h
+++ b/llvm/include/llvm/ADT/ADL.h
@@ -9,6 +9,9 @@
 #ifndef LLVM_ADT_ADL_H
 #define LLVM_ADT_ADL_H
 
+#if defined(_MSC_VER) && _MSC_VER < 1937
+#include <xtr1common>
+#endif
 #include <type_traits>
 #include <iterator>
 #include <utility>


### PR DESCRIPTION
When including ADL.h in a header that is used from Swift using C++ interop, MSVC complains about a missing definition of `remove_reference_t` in ADL.h.
Explicitly including `<xtr1common>` fixes the issue.