### PR TITLE
[Cherry-pick into swift/release/5.10] Fix DWARF parsing for (some) opaque Swift types.

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -164,7 +164,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
           m_swift_typesystem.GetTypeFromMangledTypename(mangled_name);
   }
 
-  if (!compiler_type && name) {
+  if (!compiler_type && die.Tag() == DW_TAG_typedef) {
     // Handle Archetypes, which are typedefs to RawPointerType.
     llvm::StringRef typedef_name = GetTypedefName(die);
     if (typedef_name.startswith("$sBp")) {

--- a/lldb/test/API/lang/swift/opaque_type/Makefile
+++ b/lldb/test/API/lang/swift/opaque_type/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
+++ b/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
@@ -1,0 +1,17 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftOpaque(TestBase):
+
+    @swiftTest
+    def test(self):
+        """Test opaque types in parameter positions"""         
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec("main.swift"))
+        self.expect("v p", substrs=["C", "23"])
+

--- a/lldb/test/API/lang/swift/opaque_type/main.swift
+++ b/lldb/test/API/lang/swift/opaque_type/main.swift
@@ -1,0 +1,11 @@
+protocol P {}
+
+class C: P {
+  let i = 23
+}
+
+func f(_ p : some P) {
+  print("break here")
+}
+
+f(C())


### PR DESCRIPTION
```
commit 9f94c54f25c997b5e9f8b767aaf70330891336c3
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Nov 17 12:50:49 2023 -0800

    Fix DWARF parsing for (some) opaque Swift types.
    
    The only thing that prevented this test from working was the fact that
    DWARFASTParserSwift expected an Archetype name in the typedef.
    
    rdar://115997836
```
