### PR TITLE
ExtractAPI: use zero-based indices for line/column in symbol graph

### DIFF
--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -101,8 +101,8 @@ Object serializeSourcePosition(const PresumedLoc &Loc) {
   assert(Loc.isValid() && "invalid source position");
 
   Object SourcePosition;
-  SourcePosition["line"] = Loc.getLine();
-  SourcePosition["character"] = Loc.getColumn();
+  SourcePosition["line"] = Loc.getLine() - 1;
+  SourcePosition["character"] = Loc.getColumn() - 1;
 
   return SourcePosition;
 }

--- a/clang/test/ExtractAPI/anonymous_record_no_typedef.c
+++ b/clang/test/ExtractAPI/anonymous_record_no_typedef.c
@@ -105,12 +105,12 @@ struct Vehicle {
           {
             "range": {
               "end": {
-                "character": 29,
-                "line": 3
+                "character": 28,
+                "line": 2
               },
               "start": {
-                "character": 9,
-                "line": 3
+                "character": 8,
+                "line": 2
               }
             },
             "text": "The type of vehicle."
@@ -127,8 +127,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 4
+          "character": 4,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -163,8 +163,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -206,8 +206,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 6
+          "character": 8,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -256,12 +256,12 @@ struct Vehicle {
           {
             "range": {
               "end": {
-                "character": 14,
-                "line": 1
+                "character": 13,
+                "line": 0
               },
               "start": {
-                "character": 5,
-                "line": 1
+                "character": 4,
+                "line": 0
               }
             },
             "text": "A Vehicle"
@@ -278,8 +278,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 2
+          "character": 7,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -328,8 +328,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 7
+          "character": 6,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -379,8 +379,8 @@ struct Vehicle {
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 13
+          "character": 6,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/availability.c
+++ b/clang/test/ExtractAPI/availability.c
@@ -98,8 +98,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -172,8 +172,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 3
+          "character": 5,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -256,8 +256,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 5
+          "character": 5,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -356,8 +356,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 7
+          "character": 5,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -438,8 +438,8 @@ void e(void) __attribute__((availability(tvos, unavailable)));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 9
+          "character": 5,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/emit-symbol-graph/multi_file.c
+++ b/clang/test/ExtractAPI/emit-symbol-graph/multi_file.c
@@ -183,8 +183,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 7
+          "character": 4,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -247,8 +247,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 8
+          "character": 5,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -311,8 +311,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 3
+          "character": 4,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/main.c"
       },
@@ -361,8 +361,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -411,8 +411,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -571,8 +571,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 7
+          "character": 4,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -635,8 +635,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 8
+          "character": 5,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -685,8 +685,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -735,8 +735,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/test.h"
       },

--- a/clang/test/ExtractAPI/emit-symbol-graph/single_file.c
+++ b/clang/test/ExtractAPI/emit-symbol-graph/single_file.c
@@ -85,8 +85,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 4
+          "character": 4,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/main.c"
       },
@@ -135,8 +135,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/main.c"
       },
@@ -185,8 +185,8 @@ int main ()
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 2
+          "character": 8,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/main.c"
       },

--- a/clang/test/ExtractAPI/enum.c
+++ b/clang/test/ExtractAPI/enum.c
@@ -164,12 +164,12 @@ enum {
           {
             "range": {
               "end": {
-                "character": 22,
-                "line": 1
+                "character": 21,
+                "line": 0
               },
               "start": {
-                "character": 5,
-                "line": 1
+                "character": 4,
+                "line": 0
               }
             },
             "text": "Kinds of vehicles"
@@ -186,8 +186,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 2
+          "character": 5,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -228,8 +228,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 3
+          "character": 2,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -271,8 +271,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 4
+          "character": 2,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -309,12 +309,12 @@ enum {
           {
             "range": {
               "end": {
-                "character": 45,
-                "line": 5
+                "character": 44,
+                "line": 4
               },
               "start": {
-                "character": 15,
-                "line": 5
+                "character": 14,
+                "line": 4
               }
             },
             "text": "Move this to the top! -Sheldon"
@@ -331,8 +331,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 5
+          "character": 2,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -374,8 +374,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 6
+          "character": 2,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -417,8 +417,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 7
+          "character": 2,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -481,8 +481,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 10
+          "character": 5,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -523,8 +523,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 11
+          "character": 2,
+          "line": 10
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -566,8 +566,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 12
+          "character": 2,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -609,8 +609,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 13
+          "character": 2,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -652,8 +652,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 14
+          "character": 2,
+          "line": 13
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -708,8 +708,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 17
+          "character": 0,
+          "line": 16
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -744,8 +744,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 18
+          "character": 2,
+          "line": 17
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -800,8 +800,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 21
+          "character": 0,
+          "line": 20
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -836,8 +836,8 @@ enum {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 22
+          "character": 2,
+          "line": 21
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_record.c
+++ b/clang/test/ExtractAPI/global_record.c
@@ -80,8 +80,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 1
+          "character": 4,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -197,12 +197,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 3
+                "character": 3,
+                "line": 2
               },
               "start": {
-                "character": 4,
-                "line": 3
+                "character": 3,
+                "line": 2
               }
             },
             "text": ""
@@ -210,12 +210,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 27,
-                "line": 4
+                "character": 26,
+                "line": 3
               },
               "start": {
-                "character": 3,
-                "line": 4
+                "character": 2,
+                "line": 3
               }
             },
             "text": " \\brief Add two numbers."
@@ -223,12 +223,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 30,
-                "line": 5
+                "character": 29,
+                "line": 4
               },
               "start": {
-                "character": 3,
-                "line": 5
+                "character": 2,
+                "line": 4
               }
             },
             "text": " \\param [in]  x   A number."
@@ -236,12 +236,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 36,
-                "line": 6
+                "character": 35,
+                "line": 5
               },
               "start": {
-                "character": 3,
-                "line": 6
+                "character": 2,
+                "line": 5
               }
             },
             "text": " \\param [in]  y   Another number."
@@ -249,12 +249,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 41,
-                "line": 7
+                "character": 40,
+                "line": 6
               },
               "start": {
-                "character": 3,
-                "line": 7
+                "character": 2,
+                "line": 6
               }
             },
             "text": " \\param [out] res The result of x + y."
@@ -262,12 +262,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 8
+                "character": 3,
+                "line": 7
               },
               "start": {
-                "character": 1,
-                "line": 8
+                "character": 0,
+                "line": 7
               }
             },
             "text": " "
@@ -365,8 +365,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 9
+          "character": 5,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/global_record_multifile.c
+++ b/clang/test/ExtractAPI/global_record_multifile.c
@@ -82,8 +82,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 1
+          "character": 4,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input1.h"
       },
@@ -199,12 +199,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 1
+                "character": 3,
+                "line": 0
               },
               "start": {
-                "character": 4,
-                "line": 1
+                "character": 3,
+                "line": 0
               }
             },
             "text": ""
@@ -212,12 +212,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 27,
-                "line": 2
+                "character": 26,
+                "line": 1
               },
               "start": {
-                "character": 3,
-                "line": 2
+                "character": 2,
+                "line": 1
               }
             },
             "text": " \\brief Add two numbers."
@@ -225,12 +225,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 30,
-                "line": 3
+                "character": 29,
+                "line": 2
               },
               "start": {
-                "character": 3,
-                "line": 3
+                "character": 2,
+                "line": 2
               }
             },
             "text": " \\param [in]  x   A number."
@@ -238,12 +238,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 36,
-                "line": 4
+                "character": 35,
+                "line": 3
               },
               "start": {
-                "character": 3,
-                "line": 4
+                "character": 2,
+                "line": 3
               }
             },
             "text": " \\param [in]  y   Another number."
@@ -251,12 +251,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 41,
-                "line": 5
+                "character": 40,
+                "line": 4
               },
               "start": {
-                "character": 3,
-                "line": 5
+                "character": 2,
+                "line": 4
               }
             },
             "text": " \\param [out] res The result of x + y."
@@ -264,12 +264,12 @@ char unavailable __attribute__((unavailable));
           {
             "range": {
               "end": {
-                "character": 4,
-                "line": 6
+                "character": 3,
+                "line": 5
               },
               "start": {
-                "character": 1,
-                "line": 6
+                "character": 0,
+                "line": 5
               }
             },
             "text": " "
@@ -367,8 +367,8 @@ char unavailable __attribute__((unavailable));
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 7
+          "character": 5,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input2.h"
       },

--- a/clang/test/ExtractAPI/known_files_only.c
+++ b/clang/test/ExtractAPI/known_files_only.c
@@ -78,8 +78,8 @@ struct Foo { int a; };
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 1
+          "character": 4,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input1.h"
       },

--- a/clang/test/ExtractAPI/language.c
+++ b/clang/test/ExtractAPI/language.c
@@ -82,8 +82,8 @@ char objc;
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/c.h"
       },
@@ -162,8 +162,8 @@ char objc;
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/objc.h"
       },

--- a/clang/test/ExtractAPI/macro_undefined.c
+++ b/clang/test/ExtractAPI/macro_undefined.c
@@ -89,8 +89,8 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 3
+          "character": 0,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -241,8 +241,8 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 4
+          "character": 0,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -291,8 +291,8 @@ FUNC_GEN(bar, const int *, unsigned);
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/macros.c
+++ b/clang/test/ExtractAPI/macros.c
@@ -74,8 +74,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -124,8 +124,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 2
+          "character": 8,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -186,8 +186,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 3
+          "character": 8,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -264,8 +264,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -326,8 +326,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 5
+          "character": 8,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -388,8 +388,8 @@
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 6
+          "character": 8,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_category.m
+++ b/clang/test/ExtractAPI/objc_category.m
@@ -103,8 +103,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 3
+          "character": 11,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -171,8 +171,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 8
+          "character": 0,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -244,8 +244,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 9
+          "character": 0,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -308,8 +308,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 7
+          "character": 14,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_id_protocol.m
+++ b/clang/test/ExtractAPI/objc_id_protocol.m
@@ -87,8 +87,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 4
+          "character": 11,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -162,8 +162,8 @@
       },
       "location": {
         "position": {
-          "character": 43,
-          "line": 5
+          "character": 42,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -230,8 +230,8 @@
       },
       "location": {
         "position": {
-          "character": 38,
-          "line": 6
+          "character": 37,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -281,8 +281,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_instancetype.m
+++ b/clang/test/ExtractAPI/objc_instancetype.m
@@ -84,8 +84,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 1
+          "character": 11,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -150,8 +150,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 2
+          "character": 0,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -221,8 +221,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 3
+          "character": 0,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_interface.m
+++ b/clang/test/ExtractAPI/objc_interface.m
@@ -124,8 +124,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 3
+          "character": 11,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -231,8 +231,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 5
+          "character": 0,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -392,8 +392,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 6
+          "character": 0,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -480,8 +480,8 @@
       },
       "location": {
         "position": {
-          "character": 50,
-          "line": 4
+          "character": 49,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -540,8 +540,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 9
+          "character": 11,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -591,8 +591,8 @@
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 10
+          "character": 7,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -660,8 +660,8 @@
       },
       "location": {
         "position": {
-          "character": 1,
-          "line": 12
+          "character": 0,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_property.m
+++ b/clang/test/ExtractAPI/objc_property.m
@@ -122,8 +122,8 @@
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 6
+          "character": 11,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -189,8 +189,8 @@
       },
       "location": {
         "position": {
-          "character": 22,
-          "line": 7
+          "character": 21,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -249,8 +249,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 8
+          "character": 14,
+          "line": 7
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -317,8 +317,8 @@
       },
       "location": {
         "position": {
-          "character": 22,
-          "line": 12
+          "character": 21,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -377,8 +377,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 13
+          "character": 14,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -428,8 +428,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -495,8 +495,8 @@
       },
       "location": {
         "position": {
-          "character": 22,
-          "line": 2
+          "character": 21,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -555,8 +555,8 @@
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 3
+          "character": 14,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/objc_protocol.m
+++ b/clang/test/ExtractAPI/objc_protocol.m
@@ -80,8 +80,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 1
+          "character": 10,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -143,8 +143,8 @@
       },
       "location": {
         "position": {
-          "character": 11,
-          "line": 4
+          "character": 10,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/relative_include.m
+++ b/clang/test/ExtractAPI/relative_include.m
@@ -114,8 +114,8 @@ int OtherInt;
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 2
+          "character": 4,
+          "line": 1
         },
         "uri": "file://SRCROOT/MyHeader.h"
       },
@@ -165,8 +165,8 @@ int OtherInt;
       },
       "location": {
         "position": {
-          "character": 6,
-          "line": 1
+          "character": 5,
+          "line": 0
         },
         "uri": "file://SRCROOT/QuotedHeader.h"
       },

--- a/clang/test/ExtractAPI/struct.c
+++ b/clang/test/ExtractAPI/struct.c
@@ -100,12 +100,12 @@ struct Color {
           {
             "range": {
               "end": {
-                "character": 18,
-                "line": 1
+                "character": 17,
+                "line": 0
               },
               "start": {
-                "character": 5,
-                "line": 1
+                "character": 4,
+                "line": 0
               }
             },
             "text": "Color in RGBA"
@@ -122,8 +122,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 2
+          "character": 7,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -173,8 +173,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 3
+          "character": 11,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -225,8 +225,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 4
+          "character": 11,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -277,8 +277,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 5
+          "character": 11,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -324,12 +324,12 @@ struct Color {
           {
             "range": {
               "end": {
-                "character": 37,
-                "line": 6
+                "character": 36,
+                "line": 5
               },
               "start": {
-                "character": 7,
-                "line": 6
+                "character": 6,
+                "line": 5
               }
             },
             "text": "Alpha channel for transparency"
@@ -346,8 +346,8 @@ struct Color {
       },
       "location": {
         "position": {
-          "character": 12,
-          "line": 7
+          "character": 11,
+          "line": 6
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef.c
+++ b/clang/test/ExtractAPI/typedef.c
@@ -82,8 +82,8 @@ typedef int MyInt;
       },
       "location": {
         "position": {
-          "character": 13,
-          "line": 1
+          "character": 12,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef_anonymous_record.c
+++ b/clang/test/ExtractAPI/typedef_anonymous_record.c
@@ -91,8 +91,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 4
+          "character": 8,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -127,8 +127,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 16,
-          "line": 4
+          "character": 15,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -190,8 +190,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 1
+          "character": 8,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -247,8 +247,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 18,
-          "line": 2
+          "character": 17,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -311,8 +311,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 24,
-          "line": 3
+          "character": 23,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -375,8 +375,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 16,
-          "line": 5
+          "character": 15,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -439,8 +439,8 @@ typedef MyEnumEnum MyEnumEnumEnum;
       },
       "location": {
         "position": {
-          "character": 20,
-          "line": 6
+          "character": 19,
+          "line": 5
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef_chain.c
+++ b/clang/test/ExtractAPI/typedef_chain.c
@@ -84,8 +84,8 @@ typedef MyIntInt MyIntIntInt;
       },
       "location": {
         "position": {
-          "character": 13,
-          "line": 1
+          "character": 12,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -148,8 +148,8 @@ typedef MyIntInt MyIntIntInt;
       },
       "location": {
         "position": {
-          "character": 15,
-          "line": 2
+          "character": 14,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -212,8 +212,8 @@ typedef MyIntInt MyIntIntInt;
       },
       "location": {
         "position": {
-          "character": 18,
-          "line": 3
+          "character": 17,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/typedef_struct_enum.c
+++ b/clang/test/ExtractAPI/typedef_struct_enum.c
@@ -122,8 +122,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 14,
-          "line": 4
+          "character": 13,
+          "line": 3
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -164,8 +164,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 3,
-          "line": 5
+          "character": 2,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -235,8 +235,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 16,
-          "line": 1
+          "character": 15,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -289,8 +289,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 10
+          "character": 7,
+          "line": 9
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -340,8 +340,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 11
+          "character": 8,
+          "line": 10
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -412,8 +412,8 @@ struct Foo {
       },
       "location": {
         "position": {
-          "character": 20,
-          "line": 9
+          "character": 19,
+          "line": 8
         },
         "uri": "file://INPUT_DIR/input.h"
       },

--- a/clang/test/ExtractAPI/underscored.c
+++ b/clang/test/ExtractAPI/underscored.c
@@ -97,8 +97,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 5,
-          "line": 5
+          "character": 4,
+          "line": 4
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -151,8 +151,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 12
+          "character": 7,
+          "line": 11
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -202,8 +202,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 7,
-          "line": 13
+          "character": 6,
+          "line": 12
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -253,8 +253,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 9,
-          "line": 23
+          "character": 8,
+          "line": 22
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -316,8 +316,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 13,
-          "line": 18
+          "character": 12,
+          "line": 17
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -380,8 +380,8 @@ typedef _HiddenTypedef ExposedTypedefToHidden;
       },
       "location": {
         "position": {
-          "character": 24,
-          "line": 19
+          "character": 23,
+          "line": 18
         },
         "uri": "file://INPUT_DIR/input.h"
       },


### PR DESCRIPTION
Other implementations of the symbol graph format use zero-based indices for source locations, which causes problems when combined with clang's current one-based indices. This commit sets ExtractAPI's symbol graph output to use zero-based indices to align with other implementations.

Cherry-picked from llvm#71753.

rdar://107639783