### PR TITLE
[LiveDebugValues] Remove unused static function

### DIFF
--- a/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
+++ b/llvm/lib/CodeGen/LiveDebugValues/VarLocBasedImpl.cpp
@@ -2203,33 +2203,6 @@ void VarLocBasedLDV::recordEntryValue(const MachineInstr &MI,
   OpenRanges.insert(EntryValLocIDs, EntryValLocAsBackup);
 }
 
-static bool isSwiftAsyncContext(const MachineInstr &MI) {
-  const llvm::MachineFunction *MF = MI.getParent()->getParent();
-  const llvm::Function &F = MF->getFunction();
-  // FIXME: Missing patch.
-  //if (F.getCallingConv() != CallingConv::SwiftTail)
-  //  return false;
-  for (const MachineOperand &Op : MI.debug_operands()) {
-    if (!Op.isReg())
-      return false;
-    bool found = false;
-    unsigned Reg = Op.getReg();
-    unsigned I = 0;
-    if (MF->getProperties().hasProperty(
-            MachineFunctionProperties::Property::TracksLiveness))
-      for (auto R : MF->getRegInfo().liveins()) {
-        if (R.first == Reg && F.hasParamAttribute(I, Attribute::SwiftAsync)) {
-          found = true;
-          break;
-        }
-        ++I;
-      }
-    if (!found)
-      return false;
-  }
-  return true;
-}
-
 /// Calculate the liveness information for the given machine function and
 /// extend ranges across basic blocks.
 bool VarLocBasedLDV::ExtendRanges(MachineFunction &MF,


### PR DESCRIPTION
Last use removed in https://github.com/apple/llvm-project/pull/7715

(cherry picked from commit 999a07394ce71f9f090793a190c0721f964852b0)