### PR TITLE
[AArch64] Update jump-table-hardening test after JT heuristic changes.

### DIFF
--- a/llvm/test/CodeGen/AArch64/arm64e-jump-table-hardening.ll
+++ b/llvm/test/CodeGen/AArch64/arm64e-jump-table-hardening.ll
@@ -1,4 +1,4 @@
-; RUN: llc -verify-machineinstrs -o - %s -mtriple=arm64-apple-ios -aarch64-enable-atomic-cfg-tidy=0 | FileCheck %s
+; RUN: llc -verify-machineinstrs -o - %s -mtriple=arm64-apple-ios -aarch64-min-jump-table-entries=1 -aarch64-enable-atomic-cfg-tidy=0 | FileCheck %s
 
 ; CHECK-LABEL: test_jumptable:
 ; CHECK: mov   w[[INDEX:[0-9]+]], w0


### PR DESCRIPTION
bdc0afc87181d bumped min jump table entries to 13, override it here to test JT codegen.

rdar://118516332