### PR TITLE
[lldb] Make GetClangTypeNode aware of SIMD types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -320,6 +320,13 @@ public:
   CompilerType CreateGenericTypeParamType(unsigned int depth,
                                     unsigned int index) override;
 
+  /// Builds a bound generic struct demangle tree with the name, module name,
+  /// and the struct's elements.
+  static swift::Demangle::NodePointer CreateBoundGenericStruct(
+      llvm::StringRef name, llvm::StringRef module_name,
+      llvm::ArrayRef<swift::Demangle::NodePointer> type_list_elements,
+      swift::Demangle::Demangler &dem);
+
   /// Get the Swift raw pointer type.
   CompilerType GetRawPointerType();
   /// Determine whether \p type is a protocol.

--- a/lldb/test/Shell/SwiftREPL/SIMD.test
+++ b/lldb/test/Shell/SwiftREPL/SIMD.test
@@ -170,6 +170,9 @@ simd_quatf(vector: colf4)
 simd_quatd(vector: cold4)
 // CHECK: $R{{.*}}: simd_quatd = (1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00)
 
+simd_quaternion(1.0, 0.5, 0.3, 0.1)
+// CHECK: $R{{.*}}: simd_quatd = (1.000000e+00, 5.000000e-01, 3.000000e-01, 1.000000e-01)
+
 // Test the new SIMD types
 let tinky = SIMD2<Int>(1, 2)
 // CHECK: {{tinky}}: SIMD2<Int> = (1, 2)


### PR DESCRIPTION
The compiler has some special handling for SIMD types, implement the same rules on TypeSystemSwiftTypeRef::GetClangTypeNode.

rdar://78567209