### PR TITLE
[Cherry-pick into stable/20230725] [LEB128] Don't initialize error on success

### DIFF
--- a/lld/COFF/Driver.cpp
+++ b/lld/COFF/Driver.cpp
@@ -1249,7 +1249,7 @@ static void findKeepUniqueSections(COFFLinkerContext &ctx) {
       const uint8_t *cur = contents.begin();
       while (cur != contents.end()) {
         unsigned size;
-        const char *err;
+        const char *err = nullptr;
         uint64_t symIndex = decodeULEB128(cur, &size, contents.end(), &err);
         if (err)
           fatal(toString(obj) + ": could not decode addrsig section: " + err);

--- a/lld/ELF/Driver.cpp
+++ b/lld/ELF/Driver.cpp
@@ -2229,7 +2229,7 @@ static void findKeepUniqueSections(opt::InputArgList &args) {
       const uint8_t *cur = contents.begin();
       while (cur != contents.end()) {
         unsigned size;
-        const char *err;
+        const char *err = nullptr;
         uint64_t symIndex = decodeULEB128(cur, &size, contents.end(), &err);
         if (err)
           fatal(toString(f) + ": could not decode addrsig section: " + err);

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -125,14 +125,15 @@ inline unsigned encodeULEB128(uint64_t Value, uint8_t *p,
 }
 
 /// Utility function to decode a ULEB128 value.
+///
+/// If \p error is non-null, it will point to a static error message,
+/// if an error occured. It will not be modified on success.
 inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
                               const uint8_t *end = nullptr,
                               const char **error = nullptr) {
   const uint8_t *orig_p = p;
   uint64_t Value = 0;
   unsigned Shift = 0;
-  if (error)
-    *error = nullptr;
   do {
     if (p == end) {
       if (error)
@@ -158,6 +159,9 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
 }
 
 /// Utility function to decode a SLEB128 value.
+///
+/// If \p error is non-null, it will point to a static error message,
+/// if an error occured. It will not be modified on success.
 inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
                              const uint8_t *end = nullptr,
                              const char **error = nullptr) {
@@ -165,8 +169,6 @@ inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
   int64_t Value = 0;
   unsigned Shift = 0;
   uint8_t Byte;
-  if (error)
-    *error = nullptr;
   do {
     if (p == end) {
       if (error)

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -135,15 +135,16 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
   uint64_t Value = 0;
   unsigned Shift = 0;
   do {
-    if (p == end) {
+    if (LLVM_UNLIKELY(p == end)) {
       if (error)
         *error = "malformed uleb128, extends past end";
       Value = 0;
       break;
     }
     uint64_t Slice = *p & 0x7f;
-    if (Shift >= 63 && ((Shift == 63 && (Slice << Shift >> Shift) != Slice) ||
-                        (Shift > 63 && Slice != 0))) {
+    if (LLVM_UNLIKELY(Shift >= 63) &&
+        ((Shift == 63 && (Slice << Shift >> Shift) != Slice) ||
+         (Shift > 63 && Slice != 0))) {
       if (error)
         *error = "uleb128 too big for uint64";
       Value = 0;
@@ -169,7 +170,7 @@ inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
   unsigned Shift = 0;
   uint8_t Byte;
   do {
-    if (p == end) {
+    if (LLVM_UNLIKELY(p == end)) {
       if (error)
         *error = "malformed sleb128, extends past end";
       if (n)
@@ -178,8 +179,9 @@ inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
     }
     Byte = *p;
     uint64_t Slice = Byte & 0x7f;
-    if ((Shift >= 63) && ((Shift == 63 && Slice != 0 && Slice != 0x7f) ||
-                          (Shift > 63 && Slice != (Value < 0 ? 0x7f : 0x00)))) {
+    if (LLVM_UNLIKELY(Shift >= 63) &&
+        ((Shift == 63 && Slice != 0 && Slice != 0x7f) ||
+         (Shift > 63 && Slice != (Value < 0 ? 0x7f : 0x00)))) {
       if (error)
         *error = "sleb128 too big for int64";
       if (n)

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -142,7 +142,8 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
       break;
     }
     uint64_t Slice = *p & 0x7f;
-    if ((Shift >= 64 && Slice != 0) || Slice << Shift >> Shift != Slice) {
+    if (Shift >= 63 && ((Shift == 63 && (Slice << Shift >> Shift) != Slice) ||
+                        (Shift > 63 && Slice != 0))) {
       if (error)
         *error = "uleb128 too big for uint64";
       Value = 0;
@@ -177,8 +178,8 @@ inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr,
     }
     Byte = *p;
     uint64_t Slice = Byte & 0x7f;
-    if ((Shift >= 64 && Slice != (Value < 0 ? 0x7f : 0x00)) ||
-        (Shift == 63 && Slice != 0 && Slice != 0x7f)) {
+    if ((Shift >= 63) && ((Shift == 63 && Slice != 0 && Slice != 0x7f) ||
+                          (Shift > 63 && Slice != (Value < 0 ? 0x7f : 0x00)))) {
       if (error)
         *error = "sleb128 too big for int64";
       if (n)

--- a/llvm/include/llvm/Support/LEB128.h
+++ b/llvm/include/llvm/Support/LEB128.h
@@ -138,17 +138,15 @@ inline uint64_t decodeULEB128(const uint8_t *p, unsigned *n = nullptr,
     if (p == end) {
       if (error)
         *error = "malformed uleb128, extends past end";
-      if (n)
-        *n = (unsigned)(p - orig_p);
-      return 0;
+      Value = 0;
+      break;
     }
     uint64_t Slice = *p & 0x7f;
     if ((Shift >= 64 && Slice != 0) || Slice << Shift >> Shift != Slice) {
       if (error)
         *error = "uleb128 too big for uint64";
-      if (n)
-        *n = (unsigned)(p - orig_p);
-      return 0;
+      Value = 0;
+      break;
     }
     Value += Slice << Shift;
     Shift += 7;

--- a/llvm/lib/Object/MachOObjectFile.cpp
+++ b/llvm/lib/Object/MachOObjectFile.cpp
@@ -2992,7 +2992,7 @@ void ExportEntry::pushNode(uint64_t offset) {
   ErrorAsOutParameter ErrAsOutParam(E);
   const uint8_t *Ptr = Trie.begin() + offset;
   NodeState State(Ptr);
-  const char *error;
+  const char *error = nullptr;
   uint64_t ExportInfoSize = readULEB128(State.Current, &error);
   if (error) {
     *E = malformedError("export info size " + Twine(error) +
@@ -3127,7 +3127,7 @@ void ExportEntry::pushNode(uint64_t offset) {
 
 void ExportEntry::pushDownUntilBottom() {
   ErrorAsOutParameter ErrAsOutParam(E);
-  const char *error;
+  const char *error = nullptr;
   while (Stack.back().NextChildIndex < Stack.back().ChildCount) {
     NodeState &Top = Stack.back();
     CumulativeString.resize(Top.ParentStringLength);

--- a/llvm/lib/Support/DataExtractor.cpp
+++ b/llvm/lib/Support/DataExtractor.cpp
@@ -202,7 +202,7 @@ static T getLEB128(StringRef Data, uint64_t *OffsetPtr, Error *Err,
   if (isError(Err))
     return T();
 
-  const char *error;
+  const char *error = nullptr;
   unsigned bytes_read;
   T result =
       Decoder(Bytes.data() + *OffsetPtr, &bytes_read, Bytes.end(), &error);

--- a/llvm/tools/llvm-readobj/COFFDumper.cpp
+++ b/llvm/tools/llvm-readobj/COFFDumper.cpp
@@ -2125,7 +2125,7 @@ void COFFDumper::printAddrsig() {
   const uint8_t *End = AddrsigContents.bytes_end();
   while (Cur != End) {
     unsigned Size;
-    const char *Err;
+    const char *Err = nullptr;
     uint64_t SymIndex = decodeULEB128(Cur, &Size, End, &Err);
     if (Err)
       reportError(createError(Err), Obj->getFileName());

--- a/llvm/tools/llvm-readobj/ELFDumper.cpp
+++ b/llvm/tools/llvm-readobj/ELFDumper.cpp
@@ -5002,7 +5002,7 @@ static Expected<std::vector<uint64_t>> toULEB128Array(ArrayRef<uint8_t> Data) {
   const uint8_t *End = Data.end();
   while (Cur != End) {
     unsigned Size;
-    const char *Err;
+    const char *Err = nullptr;
     Ret.push_back(decodeULEB128(Cur, &Size, End, &Err));
     if (Err)
       return createError(Err);


### PR DESCRIPTION
```
commit 545c8e009e2b649ef38f7e432ffbc06ba8a9b813
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Nov 27 10:42:57 2023 -0800

    [LEB128] Don't initialize error on success
    
    This change removes an unnecessary branch from a hot path. It's also
    questionable API to override any previous error unconditonally.

commit b96121c2e7de66154a70db5f202c9adce515aa45
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Nov 27 14:15:06 2023 -0800

    [LEB128] Factor out redundant code

commit 0cc2acc30b3d2f4e914fd49c599cfde8a17f26a6
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Nov 27 14:15:12 2023 -0800

    [LEB128] Don't handle edge cases in every loop iteration
    
    Previously the overflow check was done for every byte even though it
    is only needed for the case where Shift == 63.

commit 80fc872a24c4dca4820d2e7885b5ee9195bec42a
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Nov 27 14:46:57 2023 -0800

    [LEB128] Mark error condition with LLVM_UNLIKELY
```
