### PR TITLE
[lldb] Handle diagnostics better around expression evaulation retries

### DIFF
--- a/lldb/include/lldb/Expression/DiagnosticManager.h
+++ b/lldb/include/lldb/Expression/DiagnosticManager.h
@@ -118,6 +118,15 @@ public:
       m_diagnostics.push_back(std::move(diagnostic));
   }
 
+  /// Moves over the contents of a second diagnostic manager over. Leaves other
+  /// diagnostic manager in an empty state.
+  void Consume(DiagnosticManager &&other) {
+    std::move(other.m_diagnostics.begin(), other.m_diagnostics.end(),
+              std::back_inserter(m_diagnostics));
+    m_fixed_expression = std::move(other.m_fixed_expression);
+    other.Clear();
+  }
+
   size_t Printf(DiagnosticSeverity severity, const char *format, ...)
       __attribute__((format(printf, 3, 4)));
   void PutString(DiagnosticSeverity severity, llvm::StringRef str);

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -151,3 +151,8 @@ class TestSwiftPrivateGenericType(TestBase):
                     substrs=["Could not evaluate the expression without binding generic types."], 
                     error=True)
 
+        # Check that if both binding and not binding the generic type parameters fail, we report 
+        # the "bind generic params" error message, as that's the default case that runs first.
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)


### PR DESCRIPTION
The error message produced when expression evaluation parsing failed with automatic retries was not great, and would confuse many users. Change the logic around what diagnostics should be displayed to the user if expression evaluation parsing retry also fails to show the original error message.

rdar://118057664