### PR TITLE
[clang][DepScan] Fix DependencyScanningService construction from merge

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -803,7 +803,7 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
   DependencyScanningAction Action(
       WorkingDirectory, DepsConsumer, Controller, DepFS, DepCASFS, CacheFS,
       Format,
-      ScanningOptimizations::None, /*DisableFree=*/false, EagerLoadModules,
+      ScanningOptimizations::Default, /*DisableFree=*/false, EagerLoadModules,
       /*EmitDependencyFile=*/!DepFile.empty(), DiagGenerationAsCompilation,
       getCASOpts(),
       /*ModuleName=*/std::nullopt, VerboseOS);

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -852,9 +852,7 @@ int ScanServer::listen() {
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, CAS, Cache, FS,
-      clang::tooling::dependencies::ScanningOptimizations::None,
-      /*SkipExcludedPPRanges=*/true);
+      CASOpts, CAS, Cache, FS);
 
   std::atomic<int> NumRunning(0);
 
@@ -1077,9 +1075,7 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1Inline(
       ProduceIncludeTree
           ? tooling::dependencies::ScanningOutputFormat::IncludeTree
           : tooling::dependencies::ScanningOutputFormat::Tree,
-      CASOpts, DB, Cache, FS,
-      clang::tooling::dependencies::ScanningOptimizations::None,
-      /*SkipExcludedPPRanges=*/true);
+      CASOpts, DB, Cache, FS);
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS =
       llvm::vfs::createPhysicalFileSystem();
   if (ProduceIncludeTree)

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -133,8 +133,7 @@ clang_experimental_DependencyScannerService_create_v0(CXDependencyMode Format) {
   IntrusiveRefCntPtr<llvm::cas::CachingOnDiskFileSystem> FS;
   return wrap(new DependencyScanningService(
       ScanningMode::DependencyDirectivesScan, unwrap(Format), CASOpts,
-      /*CAS=*/nullptr, /*ActionCache=*/nullptr, FS,
-      ScanningOptimizations::None));
+      /*CAS=*/nullptr, /*ActionCache=*/nullptr, FS));
 }
 
 ScanningOutputFormat DependencyScannerServiceOptions::getFormat() const {
@@ -172,8 +171,7 @@ clang_experimental_DependencyScannerService_create_v1(
   }
   return wrap(new DependencyScanningService(
       ScanningMode::DependencyDirectivesScan, Format, unwrap(Opts)->CASOpts,
-      std::move(CAS), std::move(Cache), std::move(FS),
-      ScanningOptimizations::None));
+      std::move(CAS), std::move(Cache), std::move(FS)));
 }
 
 void clang_experimental_DependencyScannerService_dispose_v0(


### PR DESCRIPTION
The merge of fb07d9cc096f into next used `ScanningOptimizations::None`, as that was the existing default, but part of the patch was also enabling them by default. It also kept a bug of passing `true` to `EagerLoadModules`, but it thought it was `SkipExcludedPPRanges`.

Fix both of these issues by using the default argument values where possible, and explicitly using `ScanningOptimizations::Default` elsewhere.