### PR TITLE
[Swift][MSVC] Temporary force -fbuiltin-headers-in-system-modules in the MSVC driver/toolchain

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -1019,4 +1019,9 @@ void MSVCToolChain::addClangTargetOptions(
   if (DriverArgs.hasFlag(options::OPT_fno_rtti, options::OPT_frtti,
                          /*Default=*/false))
     CC1Args.push_back("-D_HAS_STATIC_RTTI=0");
+
+  // Temporary workaround for Swift not perfectly propagating this
+  // flag throughout their module interface loaders. All currently
+  // known msvc module maps require this flag anyway.
+  CC1Args.push_back("-fbuiltin-headers-in-system-modules");
 }


### PR DESCRIPTION
Swift doesn't perfectly propagate -fbuiltin-headers-in-system-modules throughout its module interface loaders. Temporary force that flag in the driver/toolchain. Once Darwin doesn't require -fbuiltin-headers-in-system-modules, it will be much easier for us to debug/fix Swift. Alternatively we could fix the ucrt module in Swift to not require -fbuiltin-headers-in-system-modules. When either of those things happen we can remove this workaround.

rdar://105819340