### PR TITLE
[clang] Remove `IdentifierInfo::FEChangedAfterLoad`

### DIFF
--- a/clang/include/clang/Basic/IdentifierTable.h
+++ b/clang/include/clang/Basic/IdentifierTable.h
@@ -156,11 +156,6 @@ class alignas(IdentifierInfoAlignment) IdentifierInfo {
   LLVM_PREFERRED_TYPE(bool)
   unsigned ChangedAfterLoad : 1;
 
-  // True if the identifier's frontend information has changed from the
-  // definition loaded from an AST file.
-  LLVM_PREFERRED_TYPE(bool)
-  unsigned FEChangedAfterLoad : 1;
-
   // True if revertTokenIDToIdentifier was called.
   LLVM_PREFERRED_TYPE(bool)
   unsigned RevertedTokenID : 1;


### PR DESCRIPTION
This field was originally introduced upstream in d79514e, later removed downstream in c43f3fbc, and most recently accidentally re-introduced in e3b1368 (merge of 5e09c4e).

This commit reinstates c43f3fbc, which is the intended state of things.