### PR TITLE
[lldb] Validate type infos produced by DWARF vs reflection metadata

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -188,6 +188,8 @@ public:
 
   bool GetSwiftEnableFullDwarfDebugging() const;
 
+  bool GetSwiftValidateFullDwarf() const;
+
   Args GetSwiftPluginServerForPath() const;
 
   bool GetSwiftAutoImportFrameworks() const;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4896,6 +4896,19 @@ bool TargetProperties::GetSwiftEnableFullDwarfDebugging() const {
   return false;
 }
 
+bool TargetProperties::GetSwiftValidateFullDwarf() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftValidateFullDwarf)
+        .value_or(false);
+
+  return false;
+}
+
 Args TargetProperties::GetSwiftPluginServerForPath() const {
   const uint32_t idx = ePropertySwiftPluginServerForPath;
 

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -30,6 +30,9 @@ let Definition = "target_experimental" in {
   def SwiftEnableFullDwarfDebugging: Property<"swift-enable-full-dwarf-debugging", "Boolean">,
   DefaultFalse,
   Desc<"Read full debug information from DWARF for Swift debugging, whenever possible">;
+  def SwiftValidateFullDwarf: Property<"swift-validate-full-dwarf", "Boolean">,
+    DefaultFalse,
+    Desc<"Validate full DWARF against reflection metadata. Used for testing an asserts-enabled LLDB only.">;
 }
 
 let Definition = "target" in {


### PR DESCRIPTION
Add a setting available only on debug to validate all the type infos that are produced by DWARF vs those produced by reflection metadata.