### PR TITLE
Collect module import remarks in the types log.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -15,6 +15,7 @@
 
 #include "Plugins/ExpressionParser/Swift/SwiftDiagnostic.h"
 
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/StreamString.h"
 
 #include "swift/AST/DiagnosticEngine.h"
@@ -197,6 +198,13 @@ public:
       // str() implicitly flushes the stram.
       std::string &s = os.str();
       formatted_text = !s.empty() ? std::move(s) : std::string(text);
+    }
+    if (info.Kind == swift::DiagnosticKind::Remark &&
+        info.ID == swift::diag::module_loaded.ID) {
+      // Divert module import remarks into the logs.
+      LLDB_LOG(GetLog(LLDBLog::Types), "{0} Module import remark: {1}",
+               m_ast_context.GetDescription(), formatted_text);
+      return;
     }
     RawDiagnostic diagnostic(
         formatted_text, info.Kind, bufferName.str(), bufferID, line_col.first,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -979,7 +979,9 @@ SwiftASTContext::SwiftASTContext(std::string description,
   // Set the clang modules cache path.
   m_compiler_invocation_ap->setClangModuleCachePath(
       GetClangModulesCacheProperty());
+}
 
+void SwiftASTContext::SetCompilerInvocationLLDBOverrides() {
   swift::IRGenOptions &ir_gen_opts =
       m_compiler_invocation_ap->getIRGenOptions();
   ir_gen_opts.OutputKind = swift::IRGenOutputKind::Module;
@@ -1964,6 +1966,8 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(), resource_dir,
                         triple);
 
+  swift_ast_sp->SetCompilerInvocationLLDBOverrides();
+
   // Apply the working directory to all relative paths.
   std::vector<std::string> DeserializedArgs = swift_ast_sp->GetClangArguments();
   swift_ast_sp->GetClangImporterOptions().ExtraArgs.clear();
@@ -2490,6 +2494,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   // otherwise no modules will be found.
   swift_ast_sp->InitializeSearchPathOptions(module_search_paths,
                                             framework_search_paths);
+  swift_ast_sp->SetCompilerInvocationLLDBOverrides();
+
   if (!swift_ast_sp->GetClangImporter()) {
     logError("couldn't create a ClangImporter");
     return {};
@@ -2771,6 +2777,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   // otherwise no modules will be found.
   swift_ast_sp->InitializeSearchPathOptions(module_search_paths,
                                             framework_search_paths);
+  swift_ast_sp->SetCompilerInvocationLLDBOverrides();
+
   if (!swift_ast_sp->GetClangImporter()) {
     logError("couldn't create a ClangImporter");
     return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -999,6 +999,7 @@ void SwiftASTContext::SetCompilerInvocationLLDBOverrides() {
   // for the protocol conforming types.
   lang_opts.AllowModuleWithCompilerErrors = true;
   lang_opts.EnableTargetOSChecking = false;
+  lang_opts.EnableModuleLoadingRemarks = true;
 
   // Bypass deserialization safety to allow deserializing internal details from
   // swiftmodule files.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -211,6 +211,9 @@ public:
       std::set<lldb::LanguageType> &languages_for_types,
       std::set<lldb::LanguageType> &languages_for_expressions);
 
+  /// Set LangOpt overrides LLDB needs.
+  void SetCompilerInvocationLLDBOverrides();
+  
   bool SupportsLanguage(lldb::LanguageType language) override;
 
   SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override {

--- a/lldb/test/API/lang/swift/module_import/Makefile
+++ b/lldb/test/API/lang/swift/module_import/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
+++ b/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
@@ -1,0 +1,22 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftModuleImport(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        self.expect("expression -- 0")
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK: SwiftASTContextForExpressions{{.*}}Module import remark: loaded module 'a'

--- a/lldb/test/API/lang/swift/module_import/main.swift
+++ b/lldb/test/API/lang/swift/module_import/main.swift
@@ -1,0 +1,1 @@
+print("break here")

--- a/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -2,13 +2,12 @@ import lldb
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
-import os
 import unittest2
-
 
 class TestSwiftSystemFramework(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
+    NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
@@ -22,16 +21,7 @@ class TestSwiftSystemFramework(lldbtest.TestBase):
         self.runCmd('log enable lldb types -f "%s"' % log)
         self.expect("settings set target.use-all-compiler-flags true")
         self.expect("expression -- 0")
-        pos = 0
-        neg = 0
-        import io
-        with open(log, "r", encoding='utf-8') as logfile:
-            for line in logfile:
-                if "-- rejecting framework path " in line:
-                    pos += 1
-                elif ("reflection metadata" not in line) and \
-                     ("/System/Library/Frameworks" in line):
-                    neg += 1
-
-        self.assertGreater(pos, 0, "sanity check failed")
-        self.assertEqual(neg, 0, "found /System/Library/Frameworks in log")
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK: SwiftASTContextForExpressions{{.*}}-- rejecting framework path
+#       CHECK: SwiftASTContextForExpressions{{.*}}LogConfiguration()
+#       CHECK-NOT: LogConfiguration(){{.*}}/System/Library/Frameworks


### PR DESCRIPTION
This patch enables the module import remarks in the Swift LangOpts,
and sends them straight to the types log. Over the existing log entry
in LoadOneModule, this has the advantage that these remarks are
generated also for modules that are dependencies of other modules, not
just the top level imports. It works for Swift and Clang modules
imported by Swift modules.