### PR TITLE
[Modules] Allow any client to use the upcoming new clang modules

### DIFF
--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -305,8 +305,11 @@ bool Module::directlyUses(const Module *Requested) {
     if (Requested->isSubModuleOf(Use))
       return true;
 
-  // Anyone is allowed to use our builtin stddef.h and its accompanying module.
-  if (!Requested->Parent && Requested->Name == "_Builtin_stddef_max_align_t")
+  // Anyone is allowed to use our builtin stdarg.h and stddef.h and their
+  // accompanying modules.
+  if (Requested->getTopLevelModuleName() == "_Builtin_stdarg" ||
+      Requested->getTopLevelModuleName() == "_Builtin_stddef" ||
+      (!Requested->Parent && Requested->Name == "_Builtin_stddef_max_align_t"))
     return true;
 
   if (NoUndeclaredIncludes)


### PR DESCRIPTION
In order to ease adoption of the new clang modules, allow them before they're actually introduced.
rdar://105819340