### PR TITLE
[clang][CAS] Fix the "CAS/driver-cache-launcher.c" test

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -124,7 +124,7 @@
 
 // Unused option warning should only be emitted once.
 // RUN: touch %t.o
-// RUN: %clang-cache %clang -target arm64-apple-macosx12 -fsyntax-only %s -Wl,-ObjC 2>&1 | FileCheck %s -check-prefix=UNUSED_OPT
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target arm64-apple-macosx12 -fsyntax-only %s -Wl,-ObjC 2>&1 | FileCheck %s -check-prefix=UNUSED_OPT
 // UNUSED_OPT-NOT: warning:
 // UNUSED_OPT: warning: -Wl,-ObjC: 'linker' input unused
 // UNUSED_OPT-NOT: warning:


### PR DESCRIPTION
The test failed because it didn't have the CAS path set, even though it attempted to perform caching.

rdar://119440920