### PR TITLE
[5.10] build: support multiple architectures on Windows

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -202,8 +202,13 @@ function(add_properties_for_swift_modules target reldir)
       set_property(TARGET ${target} APPEND PROPERTY BUILD_RPATH "${SWIFT_BUILD_RPATH}")
       set_property(TARGET ${target} APPEND PROPERTY INSTALL_RPATH "${SWIFT_INSTALL_RPATH}")
     elseif(CMAKE_SYSTEM_NAME MATCHES Windows)
-      target_link_directories(${target} PRIVATE
-        ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/Windows/x86_64)
+      if(CMAKE_SYSTEM_PROCESSOR MATCHES AMD64|amd64|x86_64)
+        target_link_directories(${target} PRIVATE
+          ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/windows/x86_64)
+      elseif(CMAKE_SYSTEM_PROCESSOR MATCHES ARM64|arm64|aarch64)
+        target_link_directories(${target} PRIVATE
+          ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/windows/aarch64)
+      endif()
     endif()
 
     if (SWIFT_BUILD_SWIFT_SYNTAX)


### PR DESCRIPTION
Swift on Windows only supports 64-bit hosts.  Add support for x64 and ARM64 toolchains to be built.