### PR TITLE
test: adjust the test for the earlier snapshot

### DIFF
--- a/llvm/test/DebugInfo/codeview-bit-slice-fragments.ll
+++ b/llvm/test/DebugInfo/codeview-bit-slice-fragments.ll
@@ -25,7 +25,7 @@ entryresume.0:
 
 declare void @llvm.dbg.value(metadata %0, metadata %1, metadata %2) #0
 
-attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}


### PR DESCRIPTION
The memory attribute was added later and this branch does not support it.  It somehow passed the testing in CI, remove it as it was reported as causing a failure.