### PR TITLE
[clang] implement common sugared type of inst-dependent DecltypeType (#67739)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -743,6 +743,9 @@ Bug Fixes in This Version
 - Clang now accepts anonymous members initialized with designated initializers
   inside templates.
   Fixes (`#65143 <https://github.com/llvm/llvm-project/issues/65143>`_)
+- Fixes crash when trying to obtain the common sugared type of
+  `decltype(instantiation-dependent-expr)`.
+  Fixes (`#67603 <https://github.com/llvm/llvm-project/issues/67603>`_)
 
 Bug Fixes to Compiler Builtins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -12632,7 +12632,6 @@ static QualType getCommonNonSugarTypeNode(ASTContext &Ctx, const Type *X,
 
 #define SUGAR_FREE_TYPE(Class) UNEXPECTED_TYPE(Class, "sugar-free")
     SUGAR_FREE_TYPE(Builtin)
-    SUGAR_FREE_TYPE(Decltype)
     SUGAR_FREE_TYPE(DeducedTemplateSpecialization)
     SUGAR_FREE_TYPE(DependentBitInt)
     SUGAR_FREE_TYPE(Enum)
@@ -12861,6 +12860,14 @@ static QualType getCommonNonSugarTypeNode(ASTContext &Ctx, const Type *X,
         ::getCommonTemplateNameChecked(Ctx, TX->getTemplateName(),
                                        TY->getTemplateName()),
         As, X->getCanonicalTypeInternal());
+  }
+  case Type::Decltype: {
+    const auto *DX = cast<DecltypeType>(X), *DY = cast<DecltypeType>(Y);
+    assert(DX->isDependentType());
+    assert(DY->isDependentType());
+    assert(Ctx.hasSameExpr(DX->getUnderlyingExpr(), DY->getUnderlyingExpr()));
+    // As Decltype is not uniqued, building a common type would be wasteful.
+    return QualType(DX, 0);
   }
   case Type::DependentName: {
     const auto *NX = cast<DependentNameType>(X),

--- a/clang/test/SemaCXX/sugar-common-types.cpp
+++ b/clang/test/SemaCXX/sugar-common-types.cpp
@@ -142,3 +142,14 @@ namespace PR61419 {
   extern const pair<id, id> p;
   id t = false ? p.first : p.second;
 } // namespace PR61419
+
+namespace GH67603 {
+  template <class> using A = long;
+  template <class B> void h() {
+    using C = B;
+    using D = B;
+    N t = 0 ? A<decltype(C())>() : A<decltype(D())>();
+    // expected-error@-1 {{rvalue of type 'A<decltype(C())>' (aka 'long')}}
+  }
+  template void h<int>();
+} // namespace GH67603


### PR DESCRIPTION
While a DecltypeType node itself is not uniqued, an instantiation dependent DecltypeType will have a
DependentDecltypeType as an underlying type, which is uniqued.

In that case, there can be non-identical non-sugar DecltypeTypes nodes which nonetheless represent the same type.

Fixes https://github.com/llvm/llvm-project/issues/67603

(cherry picked from commit 06721bb8b4a95efaf0d0b2d6d1bd2256f8e24c60)

Conflicts:
	clang/docs/ReleaseNotes.rst