### PR TITLE
[CAS] Fix Windows build for CAS unittest

### DIFF
--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -9,18 +9,40 @@
 #include "OnDiskCommon.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/Process.h"
+#include <mutex>
+#include <optional>
 
 using namespace llvm;
 
+static uint64_t OnDiskCASMaxMappingSize = 0;
+
 Expected<std::optional<uint64_t>> cas::ondisk::getOverriddenMaxMappingSize() {
-  constexpr const char *EnvVar = "LLVM_CAS_MAX_MAPPING_SIZE";
-  const char *Value = getenv(EnvVar);
-  if (!Value)
+  static std::once_flag Flag;
+  Error Err = Error::success();
+  std::call_once(Flag, [&Err] {
+    ErrorAsOutParameter EAO(&Err);
+    constexpr const char *EnvVar = "LLVM_CAS_MAX_MAPPING_SIZE";
+    auto Value = sys::Process::GetEnv(EnvVar);
+    if (!Value)
+      return;
+
+    uint64_t Size;
+    if (StringRef(*Value).getAsInteger(/*auto*/ 0, Size))
+      Err = createStringError(inconvertibleErrorCode(),
+                              "invalid value for %s: expected integer", EnvVar);
+    OnDiskCASMaxMappingSize = Size;
+  });
+
+  if (Err)
+    return std::move(Err);
+
+  if (OnDiskCASMaxMappingSize == 0)
     return std::nullopt;
 
-  uint64_t Size;
-  if (StringRef(Value).getAsInteger(/*auto*/ 0, Size))
-    return createStringError(inconvertibleErrorCode(),
-                             "invalid value for %s: expected integer", EnvVar);
-  return Size;
+  return OnDiskCASMaxMappingSize;
+}
+
+void cas::ondisk::setMaxMappingSize(uint64_t Size) {
+  OnDiskCASMaxMappingSize = Size;
 }

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -14,10 +14,16 @@
 
 namespace llvm::cas::ondisk {
 
-/// Retrieves an overridden maximum mapping size for CAS files, if any, by
-/// checking LLVM_CAS_MAX_MAPPING_SIZE in the environment. If the value is
-/// unreadable, returns an error.
+/// Retrieves an overridden maximum mapping size for CAS files, if any,
+/// speicified by LLVM_CAS_MAX_MAPPING_SIZE in the environment or set by
+/// `setMaxMappingSize()`. If the value from environment is unreadable, returns
+/// an error.
 Expected<std::optional<uint64_t>> getOverriddenMaxMappingSize();
+
+/// Set MaxMappingSize for ondisk CAS. This function is not thread-safe and
+/// should be set before creaing any ondisk CAS and does not affect CAS already
+/// created. Set value 0 to use default size.
+void setMaxMappingSize(uint64_t Size);
 
 } // namespace llvm::cas::ondisk
 

--- a/llvm/unittests/CAS/CASTestConfig.h
+++ b/llvm/unittests/CAS/CASTestConfig.h
@@ -33,6 +33,8 @@ struct TestingAndDir {
   std::optional<llvm::unittest::TempDir> Temp;
 };
 
+void setMaxOnDiskCASMappingSize();
+
 class CASTest
     : public testing::TestWithParam<std::function<TestingAndDir(int)>> {
 protected:
@@ -58,7 +60,10 @@ protected:
       Envs.emplace_back(std::move(TD.Env));
     return std::move(TD.Cache);
   }
-  void SetUp() { NextCASIndex = 0; }
+  void SetUp() {
+    NextCASIndex = 0;
+    setMaxOnDiskCASMappingSize();
+  }
   void TearDown() {
     NextCASIndex = std::nullopt;
     Dirs.clear();

--- a/llvm/unittests/CAS/ObjectStoreTest.cpp
+++ b/llvm/unittests/CAS/ObjectStoreTest.cpp
@@ -416,6 +416,7 @@ TEST(OnDiskCASTest, BlobsBigParallelMultiCAS) {
 
 #ifndef _WIN32 // FIXME: resize support on Windows.
 TEST(OnDiskCASTest, DiskSize) {
+  setMaxOnDiskCASMappingSize();
   unittest::TempDir Temp("on-disk-cas", /*Unique=*/true);
   std::unique_ptr<ObjectStore> CAS;
   ASSERT_THAT_ERROR(createOnDiskCAS(Temp.path()).moveInto(CAS), Succeeded());


### PR DESCRIPTION
Fix the CAS unit-test build for windows which doesn't have the same setenv function and constructor attributes. Implement the default ondisk cas differently so it can be overwritten from environmental variable, using command-line opts or overwrite the value in process directly.

Fix: https://github.com/apple/llvm-project/issues/7883