### PR TITLE
[DebugInfo] Update ptrauth metadata storage after upstream DIType change.

### DIFF
--- a/llvm/test/Assembler/debug-info.ll
+++ b/llvm/test/Assembler/debug-info.ll
@@ -100,5 +100,5 @@
 !41 = !DIBasicType(name: "u64.be", size: 64, align: 1, encoding: DW_ATE_unsigned, flags: DIFlagBigEndian)
 !42 = !DIBasicType(name: "u64.le", size: 64, align: 1, encoding: DW_ATE_unsigned, flags: DIFlagLittleEndian)
 
-; CHECK: !DIDerivedType(tag: DW_TAG_LLVM_ptrauth_type, baseType: !13, align: 19754, ptrAuthKey: 2, ptrAuthIsAddressDiscriminated: true, ptrAuthExtraDiscriminator: 1234)
+; CHECK: !DIDerivedType(tag: DW_TAG_LLVM_ptrauth_type, baseType: !13, ptrAuthKey: 2, ptrAuthIsAddressDiscriminated: true, ptrAuthExtraDiscriminator: 1234)
 !43 = !DIDerivedType(tag: DW_TAG_LLVM_ptrauth_type, baseType: !15, ptrAuthKey: 2, ptrAuthIsAddressDiscriminated: true, ptrAuthExtraDiscriminator: 1234)


### PR DESCRIPTION
Following 102f7fce8d82, DIType uses the SubclassData32 MDNode field to store the type alignment.  This conflicts with DIDerivedType's usage of SubclassData32 for ptrauth metadata.

Store the ptrauth metadata separately in DIDerivedType.  We're now paying a price for ptrauth support even when it's not used, but refactoring the type hierarchy to isolate ptrauth is far from trivial and may not even make sense.