### PR TITLE
Revert "[lldb] Add actionable feedback when overwriting a command fails"

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -1172,9 +1172,7 @@ Status CommandInterpreter::AddUserCommand(llvm::StringRef name,
 
   if (UserCommandExists(name)) {
     if (!can_replace) {
-      result.SetErrorString(
-          "user command exists and force replace not set by --overwrite or "
-          "'settings set interpreter.require-overwrite false'");
+      result.SetErrorString("user command exists and force replace not set");
       return result;
     }
     if (cmd_sp->IsMultiwordObject()) {

--- a/lldb/test/API/commands/command/script/TestCommandScript.py
+++ b/lldb/test/API/commands/command/script/TestCommandScript.py
@@ -161,17 +161,6 @@ class CmdPythonTestCase(TestBase):
         )
         self.expect("my_command", substrs=["a.out"])
 
-        # Test that without --overwrite we are not allowed to redefine the command.
-        self.expect(
-            "command script add my_command --class welcome.TargetnameCommand",
-            substrs=[
-                "cannot add command: user command exists and force replace not set",
-                "--overwrite",
-                "settings set interpreter.require-overwrite false",
-            ],
-            error=True,
-        )
-
         self.runCmd("command script clear")
 
         self.expect(


### PR DESCRIPTION
Reverts apple/llvm-project#7897

This was meant to go upstream.