### PR TITLE
Cherry-pick PR #7911 into stable/20230725

### DIFF
--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -3107,27 +3107,6 @@ struct DIEVisitor {
     SmallVector<AbbrevContent> AbbrevContents;
   };
 
-  DIEVisitor() = delete;
-
-  DIEVisitor(ArrayRef<StringRef> AbbrevEntries,
-             BinaryStreamReader DistinctReader, StringRef DistinctData,
-             std::function<void(StringRef)> HeaderCallback,
-             std::function<void(dwarf::Tag, uint64_t)> StartTagCallback,
-             std::function<void(dwarf::Attribute, dwarf::Form, StringRef, bool)>
-                 AttrCallback,
-             std::function<void(bool)> EndTagCallback,
-             std::function<void(StringRef)> NewBlockCallback)
-      : AbbrevEntries(AbbrevEntries), DistinctReader(DistinctReader),
-        DistinctData(DistinctData), HeaderCallback(HeaderCallback),
-        StartTagCallback(StartTagCallback), AttrCallback(AttrCallback),
-        EndTagCallback(EndTagCallback), NewBlockCallback(NewBlockCallback) {
-    AbbrevEntryCache.reserve(AbbrevEntries.size());
-    for (unsigned I = 0; I < AbbrevEntries.size(); I++) {
-      if (Error E = materializeAbbrevDIE(encodeAbbrevIndex(I)))
-        report_fatal_error(std::move(E));
-    }
-  }
-
   Error visitDIERef(DIEDedupeTopLevelRef Ref);
   Error visitDIERef(ArrayRef<DIEDataRef> &DIEChildrenStack);
   Error visitDIEAttrs(BinaryStreamReader &DataReader, StringRef DIEData,
@@ -3312,6 +3291,10 @@ static void popStack(BinaryStreamReader &Reader, StringRef &Data,
 // Visit DIERef CAS objects and materialize them.
 Error DIEVisitor::visitDIERef(ArrayRef<DIEDataRef> &DIEChildrenStack) {
 
+  for (unsigned I = 0; I < AbbrevEntries.size(); I++)
+    if (Error E = materializeAbbrevDIE(encodeAbbrevIndex(I)))
+      return E;
+
   std::stack<std::pair<StringRef, unsigned>> StackOfNodes;
   auto Data = DIEChildrenStack.empty() ? StringRef()
                                        : DIEChildrenStack.front().getData();
@@ -3439,9 +3422,14 @@ Error mccasformats::v1::visitDebugInfo(
   HeaderCallback(toStringRef(HeaderData));
 
   append_range(TotAbbrevEntries, LoadedTopRef->AbbrevEntries);
-  DIEVisitor Visitor{TotAbbrevEntries,         DistinctReader,
-                     UncompressedDistinctData, HeaderCallback,
-                     StartTagCallback,         AttrCallback,
-                     EndTagCallback,           NewBlockCallback};
+  DIEVisitor Visitor{{},
+                     TotAbbrevEntries,
+                     DistinctReader,
+                     UncompressedDistinctData,
+                     HeaderCallback,
+                     StartTagCallback,
+                     AttrCallback,
+                     EndTagCallback,
+                     NewBlockCallback};
   return Visitor.visitDIERef(LoadedTopRef->RootDIE);
 }


### PR DESCRIPTION
This patch cherry-picks https://github.com/apple/llvm-project/pull/7911 to stable/20230725 and depends on https://github.com/apple/llvm-project/pull/7910