### PR TITLE
[clang] Fix build without `__APPLE__` defined

### DIFF
--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -449,7 +449,7 @@ bool ModuleManager::lookupModuleFile(StringRef FileName, off_t ExpectedSize,
     // On Linux ext4 FileManager's inode caching system does not
     // provide us correct behaviour for ModuleCache directories.
     // inode can be reused after PCM delete resulting in cache misleading.
-    File = FileMgr.getBypassFile(*FileOrErr);
+    File = FileMgr.getBypassFile(*File);
   }
 #endif
 


### PR DESCRIPTION
This fixes a build failure without `__APPLE__` defined after 8615ead9 and 231cacea.