### PR TITLE
[ClangModuleManager] Extend the ext4 file system workaround

### DIFF
--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -483,7 +483,7 @@ OptionalFileEntryRef FileManager::getBypassFile(FileEntryRef VF) {
 
   // If we've already bypassed just use the existing one.
   auto Insertion = SeenBypassFileEntries->insert(
-      {VF.getName(), std::errc::no_such_file_or_directory});
+      {VF.getNameAsRequested(), std::errc::no_such_file_or_directory});
   if (!Insertion.second)
     return FileEntryRef(*Insertion.first);
 

--- a/clang/lib/Frontend/Rewrite/FrontendActions.cpp
+++ b/clang/lib/Frontend/Rewrite/FrontendActions.cpp
@@ -213,8 +213,14 @@ public:
 
   void visitModuleFile(StringRef Filename,
                        serialization::ModuleKind Kind) override {
-    auto File = CI.getFileManager().getFile(Filename);
+    auto File = CI.getFileManager().getOptionalFileRef(Filename);
     assert(File && "missing file for loaded module?");
+
+#if !defined(__APPLE__)
+    // Workaround for ext4 file system.
+    if (auto Bypass = CI.getFileManager().getBypassFile(*File))
+      File = *Bypass;
+#endif
 
     // Only rewrite each module file once.
     if (!Rewritten.insert(*File).second)

--- a/clang/test/Modules/explicit-build-relpath.cpp
+++ b/clang/test/Modules/explicit-build-relpath.cpp
@@ -1,3 +1,6 @@
+/// Due to module bypass workaround in https://reviews.llvm.org/D97850 for ext4 FS, relative and absolute path do not match after bypass.
+// REQUIRES: system-darwin
+
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cd %t


### PR DESCRIPTION
Extend the ext4 file system workaround so it covers `lookupByFileName`. This doesn't fix all the problems from the workaround, but it allows correct lookup of the previously added module/PCH files.

rdar://119269472