### PR TITLE
arm64_32: extend @llvm.stackguard call to in-DAG 64-bits before handing off

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -6881,11 +6881,13 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
   case Intrinsic::stackguard: {
     MachineFunction &MF = DAG.getMachineFunction();
     const Module &M = *MF.getFunction().getParent();
+    EVT PtrTy = TLI.getValueType(DAG.getDataLayout(), I.getType());
     SDValue Chain = getRoot();
     if (TLI.useLoadStackGuardNode()) {
       Res = getLoadStackGuard(DAG, sdl, Chain);
+      if (Res.getValueType() != PtrTy)
+        Res = DAG.getPtrExtOrTrunc(Res, sdl, PtrTy);
     } else {
-      EVT PtrTy = TLI.getValueType(DAG.getDataLayout(), I.getType());
       const Value *Global = TLI.getSDagStackGuard(M);
       Align Align = DAG.getDataLayout().getPrefTypeAlign(Global->getType());
       Res = DAG.getLoad(PtrTy, sdl, Chain, getValue(Global),

--- a/llvm/test/CodeGen/AArch64/arm64_32.ll
+++ b/llvm/test/CodeGen/AArch64/arm64_32.ll
@@ -758,5 +758,19 @@ define void @test_bzero(i64 %in)  {
 
 declare void @llvm.memset.p0.i32(ptr nocapture writeonly, i8, i32, i1)
 
+define i1 @test_stackguard(ptr %p1) {
+; CHECK-LABEL: test_stackguard:
+; CHECK: adrp x[[TMP:[0-9]+]], ___stack_chk_guard@GOTPAGE
+; CHECK: ldr [[GUARD:w[0-9]+]], [x[[TMP]], ___stack_chk_guard@GOTPAGEOFF]
+; CHECK: cmp [[GUARD]], w
+
+  %p2 = call ptr @llvm.stackguard()
+  %res = icmp ne ptr %p2, %p1
+  ret i1 %res
+}
+declare ptr @llvm.stackguard()
+@__stack_chk_guard = external global i32
+
+
 !llvm.module.flags = !{!0}
 !0 = !{i32 7, !"PIC Level", i32 2}


### PR DESCRIPTION
Pointers are 64-bits in the DAG, so we need to extend the result of loading the cookie when building the DAG.