### PR TITLE
[lldb] XFAIL tests that are failing on CI

### DIFF
--- a/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
+++ b/lldb/test/API/lang/c/tls_globals/TestTlsGlobals.py
@@ -42,6 +42,7 @@ class TlsGlobalTestCase(TestBase):
         bugnumber="llvm.org/pr28392",
         oslist=no_match(lldbplatformutil.getDarwinOSTriples()),
     )
+    @expectedFailureDarwin("rdar://120676969")
     def test(self):
         """Test thread-local storage."""
         self.build()

--- a/lldb/test/API/lang/cpp/thread_local/TestThreadLocal.py
+++ b/lldb/test/API/lang/cpp/thread_local/TestThreadLocal.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbtest
 
 class PlatformProcessCrashInfoTestCase(TestBase):
     @expectedFailureAll(oslist=["windows", "linux", "freebsd", "netbsd"])
+    @expectedFailureDarwin("rdar://120676969")
     def test_thread_local(self):
         # Set a breakpoint on the first instruction of the main function,
         # before the TLS initialization has run.

--- a/lldb/test/API/macosx/indirect_symbol/TestIndirectSymbols.py
+++ b/lldb/test/API/macosx/indirect_symbol/TestIndirectSymbols.py
@@ -16,6 +16,7 @@ class TestIndirectFunctions(TestBase):
 
     @skipUnlessDarwin
     @add_test_categories(["pyapi"])
+    @expectedFailureDarwin("rdar://120796553")
     def test_with_python_api(self):
         """Test stepping and setting breakpoints in indirect and re-exported symbols."""
         self.build()

--- a/lldb/test/Shell/Unwind/eh-frame-dwarf-unwind.test
+++ b/lldb/test/Shell/Unwind/eh-frame-dwarf-unwind.test
@@ -3,6 +3,8 @@
 
 # UNSUPPORTED: system-windows
 # REQUIRES: target-x86_64, native
+# XFAIL: system-darwin
+# See: rdar://120797300
 
 # RUN: %clang_host %p/Inputs/call-asm.c %p/Inputs/eh-frame-dwarf-unwind.s -o %t
 # RUN: %lldb %t -s %s -o exit | FileCheck %s

--- a/lldb/test/Shell/Unwind/thread-step-out-ret-addr-check.test
+++ b/lldb/test/Shell/Unwind/thread-step-out-ret-addr-check.test
@@ -3,6 +3,8 @@
 
 # REQUIRES: target-x86_64
 # UNSUPPORTED: system-windows
+# XFAIL: system-darwin
+# See: rdar://120797300
 
 # RUN: %clang_host %p/Inputs/call-asm.c -x assembler-with-cpp %p/Inputs/thread-step-out-ret-addr-check.s -o %t
 # RUN: not %lldb %t -s %s -b 2>&1 | FileCheck %s


### PR DESCRIPTION
These tests are failing on CI. To unblock PRs, we are going to investigate and fix these offline. They are being tracked internally at Apple.