### PR TITLE
[lldb][test] Turn ObjC string literals to C-style literals (NFC)

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
@@ -53,12 +53,12 @@ class ObjCDataFormatterNSDate(ObjCDataFormatterTestCase):
 
         self.expect(
             "frame variable cupertino home europe",
-            substrs=['@"America/Los_Angeles"', '@"Europe/Rome"', '@"Europe/Paris"'],
+            substrs=['"America/Los_Angeles"', '"Europe/Rome"', '"Europe/Paris"'],
         )
 
         self.expect(
             "frame variable cupertino_ns home_ns europe_ns",
-            substrs=['@"America/Los_Angeles"', '@"Europe/Rome"', '@"Europe/Paris"'],
+            substrs=['"America/Los_Angeles"', '"Europe/Rome"', '"Europe/Paris"'],
         )
 
         self.expect(


### PR DESCRIPTION
The underlying timezone classes are being reimplemented in Swift, and these
strings will be Swift strings, without the ObjC `@` prefix. Leaving off the `@`
makes these tests usable both before and after the reimplmentation of
Foundation in Swift.

Original: https://github.com/llvm/llvm-project/pull/69793

(cherry picked from commit 3b5d59ab55f885f1e12a9d306de351b798552426)
