### PR TITLE
[clangd] Follow-up changes after testing clangd rename of Objective-C symbols on `next`

### DIFF
--- a/clang-tools-extra/clangd/refactor/Rename.cpp
+++ b/clang-tools-extra/clangd/refactor/Rename.cpp
@@ -969,7 +969,8 @@ buildRenameEdit(llvm::StringRef AbsFilePath, llvm::StringRef InitialCode,
           SM.getLocForStartOfFile(SM.getMainFileID()).getLocWithOffset(R.first),
           OldName, tooling::ObjCSymbolSelectorKind::Unknown, PieceLocations);
       if (Error) {
-        // Ignore the error. We simply skip over all selectors that didn't match.
+        // Ignore the error. We simply skip over all selectors that didn't 
+        // match.
         consumeError(std::move(Error));
         continue;
       }

--- a/clang/unittests/Tooling/RefactoringActionRulesTest.cpp
+++ b/clang/unittests/Tooling/RefactoringActionRulesTest.cpp
@@ -211,9 +211,9 @@ TEST_F(RefactoringActionRulesTest, ReturnSymbolOccurrences) {
     Expected<SymbolOccurrences>
     findSymbolOccurrences(RefactoringRuleContext &) override {
       SymbolOccurrences Occurrences;
-      Occurrences.push_back(SymbolOccurrence(SymbolName("test"),
-                                             SymbolOccurrence::MatchingSymbol,
-                                             Selection.getBegin()));
+      Occurrences.push_back(SymbolOccurrence(
+          SymbolName("test", /*IsObjectiveCSelector=*/false),
+          SymbolOccurrence::MatchingSymbol, Selection.getBegin()));
       return std::move(Occurrences);
     }
   };


### PR DESCRIPTION
Fix one LLVM test failure and one formatting issue.