### PR TITLE
NFC: Fix a bunch of doccomments

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -721,7 +721,6 @@ private:
   /// Read options from the specified file.
   ///
   /// \param [in] FileName File to read.
-  /// \param [in] Search and expansion options.
   /// \returns true, if error occurred while reading.
   bool readConfigFile(StringRef FileName, llvm::cl::ExpansionContext &ExpCtx);
 

--- a/clang/include/clang/Lex/HeaderSearch.h
+++ b/clang/include/clang/Lex/HeaderSearch.h
@@ -670,9 +670,6 @@ public:
 
   /// Retrieve all the modules corresponding to the given file.
   ///
-  /// \param AllowCreation Whether to allow inference of a new submodule, or to
-  ///        only return existing known modules.
-  ///
   /// \ref findModuleForHeader should typically be used instead of this.
   ArrayRef<ModuleMap::KnownHeader>
   findAllModulesForHeader(FileEntryRef File) const;

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3341,8 +3341,8 @@ private:
   /// Parses clauses for directive.
   ///
   /// \param DKind Kind of current directive.
-  /// \param clauses for current directive.
-  /// \param start location for clauses of current directive
+  /// \param Clauses for current directive.
+  /// \param Loc location for clauses of current directive
   void ParseOpenMPClauses(OpenMPDirectiveKind DKind,
                           SmallVectorImpl<clang::OMPClause *> &Clauses,
                           SourceLocation Loc);

--- a/clang/include/clang/Sema/CodeCompleteConsumer.h
+++ b/clang/include/clang/Sema/CodeCompleteConsumer.h
@@ -335,7 +335,7 @@ public:
     /// error and don't know which completions we should give.
     CCC_Recovery,
 
-    /// Code completion in a @class forward declaration.
+    /// Code completion in a `@class` forward declaration.
     CCC_ObjCClassForwardDecl
   };
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -8488,8 +8488,8 @@ public:
   /// intentionally partial, e.g., because we're checking just the initial
   /// set of template arguments.
   ///
-  /// \param Converted Will receive the converted, canonicalized template
-  /// arguments.
+  /// \param CanonicalConverted Will receive the converted, canonicalized
+  /// template arguments.
   ///
   /// \param UpdateArgsWithConversions If \c true, update \p TemplateArgs to
   /// contain the converted forms of the template arguments as written.

--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningTool.h
@@ -116,7 +116,7 @@ public:
   /// dependency information by `-MD -MF <dep_file>`.
   ///
   /// \param MakeformatOutputPath The output parameter for the path to
-  /// \param MakeformatOutput.
+  /// \p MakeformatOutput.
   ///
   /// \returns A \c StringError with the diagnostic output if clang errors
   /// occurred, P1689 dependency format rules otherwise.

--- a/llvm/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/llvm/include/llvm/CodeGen/BasicTTIImpl.h
@@ -2361,7 +2361,6 @@ public:
   }
 
   /// Try to calculate op costs for min/max reduction operations.
-  /// \param CondTy Conditional type for the Select instruction.
   InstructionCost getMinMaxReductionCost(Intrinsic::ID IID, VectorType *Ty,
                                          FastMathFlags FMF,
                                          TTI::TargetCostKind CostKind) {

--- a/llvm/include/llvm/IRReader/IRReader.h
+++ b/llvm/include/llvm/IRReader/IRReader.h
@@ -50,7 +50,6 @@ getLazyIRFileModule(StringRef Filename, SMDiagnostic &Err, LLVMContext &Context,
 /// If the given MemoryBuffer holds a bitcode image, return a Module
 /// for it.  Otherwise, attempt to parse it as LLVM Assembly and return
 /// a Module for it.
-/// \param DataLayoutCallback Override datalayout in the llvm assembly.
 std::unique_ptr<Module> parseIR(MemoryBufferRef Buffer, SMDiagnostic &Err,
                                 LLVMContext &Context,
                                 ParserCallbacks Callbacks = {});
@@ -58,7 +57,6 @@ std::unique_ptr<Module> parseIR(MemoryBufferRef Buffer, SMDiagnostic &Err,
 /// If the given file holds a bitcode image, return a Module for it.
 /// Otherwise, attempt to parse it as LLVM Assembly and return a Module
 /// for it.
-/// \param DataLayoutCallback Override datalayout in the llvm assembly.
 std::unique_ptr<Module> parseIRFile(StringRef Filename, SMDiagnostic &Err,
                                     LLVMContext &Context,
                                     ParserCallbacks Callbacks = {});

--- a/llvm/include/llvm/TextAPI/Symbol.h
+++ b/llvm/include/llvm/TextAPI/Symbol.h
@@ -172,7 +172,7 @@ struct SimpleSymbol {
 
 /// Determine SymbolKind from Flags and parsing Name.
 ///
-/// \param Name The name of symbol.
+/// \param SymName The name of symbol.
 /// \param Flags The flags pre-determined for the symbol.
 SimpleSymbol parseSymbol(StringRef SymName,
                          const SymbolFlags Flags = SymbolFlags::None);


### PR DESCRIPTION
Address mistakes in doccomments in clang and llvm headers that are causing warnings for downstream clients.