### PR TITLE
[lldb] Use canonical QualTypes to determine SwiftOptionSet formatter eligibility

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.cpp
@@ -50,8 +50,8 @@ GetAsEnumDecl(CompilerType swift_type) {
   if (!clang_ts)
     return {nullptr, nullptr};
 
-  auto qual_type =
-      clang::QualType::getFromOpaquePtr(clang_type.GetOpaqueQualType());
+  auto qual_type = clang::QualType::getFromOpaquePtr(
+      clang_type.GetCanonicalType().GetOpaqueQualType());
   if (qual_type->getTypeClass() != clang::Type::TypeClass::Enum)
     return {nullptr, nullptr};
 


### PR DESCRIPTION
When we lookup a clang type from DWARF by name, we use the first one we find. In this test we have two entities with the name `ComparisonResult`, en enum and a typedef to the enum. So if we happened to find the typedef first, we would fail to apply the `OptionSet` formatter to it because it explicitly wants a QualType whose type-class is an enum.

This fixes `lang/swift/enum_objc/TestEnumObjC.py` when using the new `FindTypes` `TypeQuery` APIs (see
https://github.com/apple/llvm-project/pull/7885)

The fix simply gets the canonical type before we check its type-class.