### PR TITLE
[clang] Sema::isSimpleTypeSpecifier return true for _Bool in c99

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -147,6 +147,9 @@ bool Sema::isSimpleTypeSpecifier(tok::TokenKind Kind) const {
   case tok::kw___auto_type:
     return true;
 
+  case tok::kw__Bool:
+    return getLangOpts().C99;
+
   case tok::annot_typename:
   case tok::kw_char16_t:
   case tok::kw_char32_t:


### PR DESCRIPTION
Currently returns false for _Bool, regardless of C dialect.

Fixes https://github.com/llvm/llvm-project/issues/72203.

Will take a more complicated approach in the upstream repository but this patch on apple/llvm-project might be useful in the short term.