### PR TITLE
[lldb][test] Remove unnecessary mydir assignments (NFC)

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftErrorBreakpoint(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @decorators.skipIfLinux  # <rdar://problem/30909618>
     @swiftTest
     def test_swift_error_no_typename(self):

--- a/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -20,9 +20,6 @@ import os
 
 
 class TestSwiftTypeAliasFormatters(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_type_alias_formatters(self):
         """Test that Swift typealiases get formatted properly"""

--- a/lldb/test/API/functionalities/mtc/swift-property/TestMTCSwiftProperty.py
+++ b/lldb/test/API/functionalities/mtc/swift-property/TestMTCSwiftProperty.py
@@ -13,9 +13,6 @@ import json
 
 
 class MTCSwiftPropertyTestCase(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @expectedFailureAll(bugnumber="rdar://60396797",
                         setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/functionalities/mtc/swift/TestMTCSwift.py
+++ b/lldb/test/API/functionalities/mtc/swift/TestMTCSwift.py
@@ -13,9 +13,6 @@ import json
 
 
 class MTCSwiftTestCase(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @expectedFailureAll(bugnumber="rdar://60396797",
                         setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -9,9 +9,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 class TestSwiftProgressReporting(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def setUp(self):
         TestBase.setUp(self)
         self.broadcaster = self.dbg.GetBroadcaster()

--- a/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftAnyObjectType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_any_object_type(self):
         """Test the AnyObject type"""

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftArchetypeResolution(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_archetype_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftArchetypeResolution(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_associated_type_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""

--- a/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
@@ -33,8 +33,6 @@ def getOlderVersion(major, minor):
 
 class TestAvailability(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class SwiftPartialBreakTest(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_partial_break(self):
         """Tests that we can break on a partial name of a Swift function"""

--- a/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
+++ b/lldb/test/API/lang/swift/bridged_metatype/TestSwiftBridgedMetatype.py
@@ -10,9 +10,6 @@ import unittest2
 
 
 class TestSwiftBridgedMetatype(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipUnlessFoundation
     def test_swift_bridged_metatype(self):

--- a/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class TestSwiftBacktracePrinting(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_backtrace_printing(self):
         """Test printing Swift backtrace"""

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftWerror(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
+++ b/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/TestSwiftBridgingHeaderHeadermap.py
@@ -20,7 +20,6 @@ import shutil
 
 class TestSwiftBridgingHeaderHeadermap(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
@@ -6,8 +6,6 @@ import unittest2
 
 class TestSwiftExtraClangFlags(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
     
     def setUp(self):

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -18,9 +18,6 @@ import os
 import unittest2
 
 class TestSwiftDedupMacros(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/TestSwiftDynamicTypeResolutionImportConflict.py
@@ -19,9 +19,6 @@ import unittest2
 import shutil
 
 class TestSwiftDynamicTypeResolutionImportConflict(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -5,9 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 import unittest2
 
 class TestSwiftExprImport(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-    
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))

--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -5,9 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 import unittest2
 
 class TestSwiftExtraClangFlags(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(oslist=['windows'])

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -19,9 +19,6 @@ import unittest2
 import shutil
 
 class TestSwiftHeadermapConflict(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipIf(bugnumber="rdar://60396797",
             setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -19,9 +19,6 @@ import unittest2
 import shutil
 
 class TestSwiftIncludeConflict(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -19,9 +19,6 @@ import unittest2
 import shutil
 
 class TestSwiftMacroConflict(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))

--- a/lldb/test/API/lang/swift/clangimporter/missing_pch/TestSwiftMissingPCH.py
+++ b/lldb/test/API/lang/swift/clangimporter/missing_pch/TestSwiftMissingPCH.py
@@ -6,7 +6,6 @@ import unittest2
 import os
 
 class TestSwiftMissingVFSOverlay(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
 
     NO_DEBUG_INFO_TESTCASE = True
 

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/TestSwiftMissingVFSOverlay.py
@@ -6,8 +6,6 @@ import unittest2
 
 class TestSwiftMissingVFSOverlay(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
     
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs/TestSwiftObjCMainConflictingDylibs.py
@@ -19,9 +19,6 @@ import unittest2
 import shutil
 
 class TestSwiftObjCMainConflictingDylibs(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -19,9 +19,6 @@ import unittest2
 import shutil
 
 class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -21,7 +21,6 @@ import shutil
 class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
-    mydir = TestBase.compute_mydir(__file__)
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -6,9 +6,6 @@ import os
 import unittest2
 
 class TestSwiftRewriteClangPaths(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @skipIfDarwinEmbedded
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/TestSwiftRemoteASTImport.py
@@ -18,9 +18,6 @@ import os
 import unittest2
 
 class TestSwiftRemoteASTImport(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-    
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -19,9 +19,6 @@ import unittest2
 import shutil
 
 class TestSwiftRewriteClangPaths(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/TestSwiftStaticArchiveTwoSwiftmodules.py
@@ -18,9 +18,6 @@ import os
 import unittest2
 
 class TestSwiftStaticArchiveTwoSwiftmodules(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/closures/TestSwiftClosures.py
+++ b/lldb/test/API/lang/swift/closures/TestSwiftClosures.py
@@ -15,9 +15,6 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestPassedClosures(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
 
     @expectedFailureAll(bugnumber="rdar://31816998")

--- a/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
+++ b/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
@@ -5,9 +5,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.lldbpexpect import PExpectTest
 
 class SwiftCompletionTest(PExpectTest):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # PExpect uses many timeouts internally and doesn't play well
     # under ASAN on a loaded machine..
     @skipIfAsan

--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class TestSwiftConditionalBreakpoint(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_conditional_breakpoint(self):
         """Tests that we can set a conditional breakpoint in Swift code"""

--- a/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
+++ b/lldb/test/API/lang/swift/cross_module_extension/TestSwiftCrossModuleExtension.py
@@ -21,9 +21,6 @@ import os.path
 import unittest2
 
 class TestSwiftCrossModuleExtension(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_cross_module_extension(self):

--- a/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
+++ b/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
@@ -23,9 +23,6 @@ import unittest2
 
 
 class TestSwiftDebugPrefixMap(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_debug_prefix_map(self):
         self.do_test()

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -21,8 +21,6 @@ import os
 
 
 class TestSwiftDeploymentTarget(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
+++ b/lldb/test/API/lang/swift/deserialization_failure/TestSwiftDeserializationFailure.py
@@ -6,9 +6,6 @@ import unittest2
 
 
 class TestSwiftDeserializationFailure(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def prepare(self):
         import shutil
         copied_source = self.getBuildArtifact("main.swift")

--- a/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
+++ b/lldb/test/API/lang/swift/different_clang_flags/TestSwiftDifferentClangFlags.py
@@ -36,9 +36,6 @@ def execute_command(command):
 
 
 class TestSwiftDifferentClangFlags(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     @skipIf(

--- a/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
+++ b/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class SwiftDynamicValueTest(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_dynamic_value(self):
         """Tests that dynamic values work correctly for Swift"""

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -14,9 +14,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
 class TestClassConstrainedProtocol(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_extension_weak_self(self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""

--- a/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/lldb/test/API/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestExpressionsInSwiftMethodsFromObjC(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_expressions_from_objc(self):

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestExpressionsInSwiftMethodsPureSwift(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -33,9 +33,6 @@ def execute_command(command):
 
 
 class TestUnitTests(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]), bugnumber="This test is building a dSYM")
     @expectedFailureAll(

--- a/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestExpressionErrors(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_CanThrowError(self):
         """Tests that swift expressions resolve scoped variables correctly"""

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -30,9 +30,6 @@ def execute_command(command):
     return exit_status
 
 class TestExclusivitySuppression(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
     # a failure due to exclusivity
     @swiftTest

--- a/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
+++ b/lldb/test/API/lang/swift/expression/no_calculator/TestSwiftNoProcess.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftNoProcess(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def setUp(self):
         TestBase.setUp(self)
         self.main_source = "main.swift"

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -18,9 +18,6 @@ import os
 import unittest2
 
 class TestSwiftExpressionObjCContext(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -15,9 +15,6 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestOptionalAmbiguity(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_sample_rename_this(self):
         self.build()

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestDefiningOverloadedFunctions(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_simple_overload_expressions(self):
         """Test defining overloaded functions"""

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftExprInProtocolExtension(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def continue_to_bkpt(self, process, bkpt):
         threads = lldbutil.continue_to_breakpoint(process, bkpt)
         self.assertTrue(len(threads) == 1)

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -4,9 +4,6 @@ from lldbsuite.test.decorators import *
 
 
 class TestSwiftProtocolExtensionSelf(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test(self):
         """Test that the generic self in a protocol extension works in the expression evaluator.

--- a/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftExpressionScopes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_expression_scopes(self):
         """Tests that swift expressions resolve scoped variables correctly"""

--- a/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSimpleExpressions.py
@@ -22,9 +22,6 @@ import unittest2
 
 
 class TestSimpleSwiftExpressions(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftExpressionsInClassFunctions(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_expressions_in_class_functions(self):
         """Test expressions in class func contexts"""

--- a/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -20,9 +20,6 @@ import os
 
 
 class TestSwiftSubmoduleImport(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Have to find some submodule that is present on both Darwin & Linux for this
     # test to run on both systems...
 

--- a/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
+++ b/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
@@ -20,9 +20,6 @@ import os
 
 
 class TestFilePrivate(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def setUp(self):
         TestBase.setUp(self)
         self.a_source = "a.swift"

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class TestSwiftFixIts(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_fixits(self):
         """Test applying fixits to expressions"""

--- a/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/global/TestSwiftFoundationTypeGlobal.py
@@ -6,9 +6,6 @@ import os
 import unittest2
 
 class TestSwiftFoundationValueTypeGlobal(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipUnlessFoundation
     def test(self):

--- a/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
+++ b/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
@@ -6,9 +6,6 @@ import unittest2
 
 
 class SwiftGenericClassTest(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test(self):
         """Tests that a generic class type can be resolved from the instance metadata alone"""

--- a/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class SwiftDynamicTypeGenericsTest(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_genericresolution_commands(self):
         """Check that we can correctly figure out the dynamic type of generic things"""

--- a/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class SwiftGetValueAsUnsignedAPITest(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_get_value_as_unsigned_sbapi(self):
         """Tests that the SBValue::GetValueAsUnsigned() API works for Swift types"""

--- a/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -12,9 +12,6 @@ import os
 import unittest2
 
 class TestSwiftHashedContainerEnum(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_any_object_type(self):
         """Test combinations of hashed swift containers with enums"""

--- a/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftHideRuntimeSupport(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_hide_runtime_support(self):
         """Test that we hide runtime support values"""

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -22,9 +22,6 @@ import time
 import unittest2
 
 class TestLibraryIndirect(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def launch_info(self):
         info = self.target.GetLaunchInfo()
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -22,9 +22,6 @@ import time
 import unittest2
 
 class TestLibraryResilient(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def launch_info(self):
         info = lldb.SBLaunchInfo([])
         info.SetLaunchFlags(lldb.eLaunchFlagInheritTCCFromParent)

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -23,9 +23,6 @@ import unittest2
 
 @skipIfDarwin # rdar://problem/54322424 Sometimes failing, sometimes truncated output.
 class TestMainExecutable(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def launch_info(self):
         info = lldb.SBLaunchInfo([])
 

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftCGImportedTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_cg_imported_types(self):

--- a/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
+++ b/lldb/test/API/lang/swift/late_dylib/TestSwiftLateDylib.py
@@ -3,9 +3,6 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateDylib(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded 

--- a/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_dylib_clangdeps/TestSwiftLateDylibClangDeps.py
@@ -3,9 +3,6 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLateDylibClangDeps(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded 

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -4,8 +4,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftLateDylib(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
+++ b/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftLetIntSupport(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_let_int(self):
         """Test that a 'let' Int is formatted properly"""

--- a/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
+++ b/lldb/test/API/lang/swift/macCatalyst/TestSwiftMacCatalyst.py
@@ -7,9 +7,6 @@ import unittest2
 
 
 class TestSwiftMacCatalyst(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipIf(macos_version=["<", "10.15"])
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftMetatype(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_metatype(self):
         """Test the formatting of Swift metatypes"""

--- a/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
+++ b/lldb/test/API/lang/swift/missing_sdk/TestMissingSDK.py
@@ -9,9 +9,6 @@ from lldbsuite.test.lldbtest import *
 import unittest2
 
 class TestSwiftMissingSDK(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
+++ b/lldb/test/API/lang/swift/mix_any_object/TestSwiftMixAnyObjectType.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftMixAnyObjectType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_any_object_type(self):

--- a/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -20,9 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 import unittest2
 
 class TestSwiftModuleSearchPaths(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def setUp(self):
         TestBase.setUp(self)
         self.main_source = "main.swift"

--- a/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
+++ b/lldb/test/API/lang/swift/multilang_category/TestMultilangFormatterCategories.py
@@ -9,9 +9,6 @@ import os
 
 
 class TestMultilangFormatterCategories(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipUnlessDarwin
     def test_multilang_formatter_categories(self):

--- a/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftMultipayloadEnum(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_multipayload_enum(self):
         """Test that LLDB understands generic enums with more than one payload type"""

--- a/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
+++ b/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
@@ -33,9 +33,6 @@ def check_for_C(child, idx):
 
 
 class TestSwiftNestedArray(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def setUp(self):
         TestBase.setUp(self)
         self.main_source = "main.swift"

--- a/lldb/test/API/lang/swift/nserror/TestNSError.py
+++ b/lldb/test/API/lang/swift/nserror/TestNSError.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class SwiftNSErrorTest(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_nserror(self):

--- a/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
+++ b/lldb/test/API/lang/swift/objc_inherited_ivars/TestSwiftAtObjCIvars.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftAtObjCIvars(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def check_foo(self, theFoo):
         x = theFoo.GetChildMemberWithName("x")
         y = theFoo.GetChildMemberWithName("y")

--- a/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
+++ b/lldb/test/API/lang/swift/objc_runtime_ivars/TestObjCIvarDiscovery.py
@@ -23,9 +23,6 @@ import unittest2
 import shutil
 
 class TestObjCIVarDiscovery(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @skipIf(debug_info=no_match("dsym"))
     @swiftTest

--- a/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftOneCaseEnum(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_one_case_enum(self):
         """Test that an enum with only one case does not crash LLDB"""

--- a/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
+++ b/lldb/test/API/lang/swift/optional_of_resilient/TestResilientObjectInOptional.py
@@ -19,9 +19,6 @@ import lldbsuite.test.lldbutil as lldbutil
 import unittest2
 
 class TestResilientObjectInOptional(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_optional_of_resilient(self):

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -19,8 +19,6 @@ import unittest2
 
 
 class TestSwiftInterfaceDSYM(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -27,8 +27,6 @@ import unittest2
 
 
 class TestSwiftInterfaceNoDebugInfo(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -27,8 +27,6 @@ import unittest2
 
 
 class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""

--- a/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
+++ b/lldb/test/API/lang/swift/path_with_colons/TestSwiftPathWithColons.py
@@ -25,9 +25,6 @@ import unittest2
 # this should be a perfectly general feature but I could not
 # cause the failure to reproduce against clang, so put it here
 class TestSwiftPathWithColon(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipIf(oslist=['windows'])
     @skipIfiOSSimulator
     @swiftTest

--- a/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
+++ b/lldb/test/API/lang/swift/playgrounds-repl/old_playground/TestNonREPLPlayground.py
@@ -32,9 +32,6 @@ def execute_command(command):
 
 
 class TestNonREPLPlayground(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     @skipIf(

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -36,9 +36,6 @@ def execute_command(command):
 
 
 class TestSwiftPlaygrounds(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def get_build_triple(self):
         """We want to build the file with a deployment target earlier than the
            availability set in the source file."""

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftTypeLookup(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""

--- a/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
+++ b/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftPrivateDeclName(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def setUp(self):
         TestBase.setUp(self)
         self.a_source = "a.swift"

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -4,9 +4,6 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftPrivateImport(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_private_import(self):

--- a/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
+++ b/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftPrivateTypeAlias(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_private_typealias(self):
         """Test that we can correctly print variables whose types are private type aliases"""

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
@@ -7,8 +7,6 @@ from lldbsuite.test.decorators import *
 
 
 class TestDefaultProtocolExtensionNoSelfReference(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_protocol_default_extension_no_self_reference(self):
         """

--- a/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftRangeType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_range_type(self):
         """Test the Swift.Range<T> type"""

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftReferenceStorageTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
     @skipIf(oslist=["linux"], bugnumber="rdar://76592966")

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -19,8 +19,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftRegex(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
-
     def setUp(self):
         TestBase.setUp(self)
         self.main_source = "main.swift"

--- a/lldb/test/API/lang/swift/repl_in_c/TestSwiftReplInC.py
+++ b/lldb/test/API/lang/swift/repl_in_c/TestSwiftReplInC.py
@@ -15,7 +15,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftReplInC(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest

--- a/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
+++ b/lldb/test/API/lang/swift/resilience/TestSwiftResilience.py
@@ -23,9 +23,6 @@ def execute_command(command):
 
 
 class TestSwiftResilience(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     # Because we rename the .swiftmodule files after building the

--- a/lldb/test/API/lang/swift/return/TestSwiftReturns.py
+++ b/lldb/test/API/lang/swift/return/TestSwiftReturns.py
@@ -21,8 +21,6 @@ import unittest2
 
 class TestSwiftReturns(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest

--- a/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
+++ b/lldb/test/API/lang/swift/static_linking/macOS/TestSwiftStaticLinkingMacOS.py
@@ -17,8 +17,6 @@ from lldbsuite.test import lldbtest, lldbutil
 
 class SwiftStaticLinkingMacOSTestCase(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     NO_DEBUG_INFO_TESTCASE = True
 
     def expect_self_var_available_at_breakpoint(

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -22,9 +22,6 @@ import unittest2
 
 
 class TestSwiftStructChangeRerun(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_struct_change_rerun(self):
         """Test that we display self correctly for an inline-initialized struct"""

--- a/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
+++ b/lldb/test/API/lang/swift/struct_init_display/TestSwiftStructInit.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftStructInit(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipIf(oslist=['windows'])
     def test_swift_struct_init(self):

--- a/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
+++ b/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
@@ -8,7 +8,6 @@ import unittest2
 class TestSwiftHealthCheck(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
-    mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
+++ b/lldb/test/API/lang/swift/swift_version/TestSwiftVersion.py
@@ -22,9 +22,6 @@ import time
 import unittest2
 
 class TestSwiftVersion(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_cross_module_extension(self):

--- a/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
+++ b/lldb/test/API/lang/swift/swiftieformatting/TestSwiftieFormatting.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftieFormatting(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swiftie_formatting(self):

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -8,7 +8,6 @@ import unittest2
 class TestSwiftTripleDetection(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
-    mydir = TestBase.compute_mydir(__file__)
 
     @swiftTest
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftTuple(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class SwiftTypeMetadataTest(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_type_metadata(self):
         """Test that LLDB can effectively use the type metadata to reconstruct dynamic types for Swift"""

--- a/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
+++ b/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
@@ -3,9 +3,6 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTypeAlias(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test(self):
         """Test type aliases are only searched in the debug info once"""

--- a/lldb/test/API/lang/swift/unit-tests/TestSwiftUnitTests.py
+++ b/lldb/test/API/lang/swift/unit-tests/TestSwiftUnitTests.py
@@ -14,9 +14,6 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftUnitTests(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     # The creation of the .xctest framework messes with the AST search path.

--- a/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
+++ b/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
@@ -10,9 +10,6 @@ import unittest2
 
 
 class TestSwiftActorTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_class_types(self):
         """Test swift Actor types"""

--- a/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
+++ b/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftBool(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_bool(self):
         """Test that we can inspect various Swift bools"""

--- a/lldb/test/API/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
+++ b/lldb/test/API/lang/swift/variables/bridged_array/TestSwiftBridgedArray.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftBridgedArray(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     @expectedFailureAll(bugnumber="<rdar://problem/32024572>")

--- a/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -24,9 +24,6 @@ import unittest2
 
 
 class TestSwiftBridgedStringVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_swift_bridged_string_variables(self):

--- a/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestBulkyEnumVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_bulky_enum_variables(self):
         """Tests that large-size Enum variables display correctly"""

--- a/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
+++ b/lldb/test/API/lang/swift/variables/cgtypes/TestCGTypes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftCoreGraphicsTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipUnlessDarwin
     def test_swift_coregraphics_types(self):

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftClassTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_class_types(self):
         """Test swift Class types"""

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftMetadataSymbols.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftMetadataSymbols.py
@@ -20,9 +20,6 @@ import os
 
 
 class TestSwiftMetadataSymbols(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @expectedFailureAll(bugnumber="<rdar://problem/31066543>")
     def test_swift_metadata_symbols(self):

--- a/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
@@ -25,9 +25,6 @@ def stderr_print(line):
     sys.stderr.write(line + "\n")
 
 class TestSwiftConsumeOperatorType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=['aarch64'], oslist=['linux'])
     @swiftTest

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -25,9 +25,6 @@ def stderr_print(line):
     sys.stderr.write(line + "\n")
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while

--- a/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
+++ b/lldb/test/API/lang/swift/variables/dict_nsobj_anyobj/TestSwiftDictionaryNSObjectAnyObject.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestDictionaryNSObjectAnyObject(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @skipUnlessDarwin
     @swiftTest
     def test_dictionary_nsobject_any_object(self):

--- a/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftStdlibDictionary(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def get_variable(self, name):
         var = self.frame().FindVariable(
             name).GetDynamicValue(lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/lang/swift/variables/enums/TestEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/enums/TestEnumVariables.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestEnumVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_enum_variables(self):
         """Tests that Enum variables display correctly"""

--- a/lldb/test/API/lang/swift/variables/func/TestFunctionVariables.py
+++ b/lldb/test/API/lang/swift/variables/func/TestFunctionVariables.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestFunctionVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_function_variables(self):
         """Tests that function type variables display correctly"""

--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftGenericEnumTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     def get_variable(self, name):
         var = self.frame().FindVariable(
             name).GetDynamicValue(lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
+++ b/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftGenericTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_generic_types(self):
         """Test support for generic types"""

--- a/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftGlobals(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_globals(self):
         """Check that we can examine module globals in the expression parser"""

--- a/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestIndirectEnumVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_indirect_cases_variables(self):
         """Tests that indirect Enum variables display correctly when cases are indirect"""

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestInOutVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_in_out_variables(self):
         """Test that @inout variables display reasonably"""

--- a/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
+++ b/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
@@ -6,8 +6,6 @@ import unittest2
 
 
 class TestSwiftLetConstants(TestBase):
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_let_constants(self):
         """Test that let constants aren't writeable"""

--- a/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
+++ b/lldb/test/API/lang/swift/variables/objc/TestSwiftObjCImportedTypes.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftObjCImportedTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_imported_types(self):

--- a/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
+++ b/lldb/test/API/lang/swift/variables/objc_optionals/TestSwiftObjCOptionals.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftObjCOptionalType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     @skipUnlessDarwin
     def test_swift_objc_optional_type(self):

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftOptionalType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_optional_type(self):
         """Check formatting for T? and T!"""

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class TestSwiftProtocolTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_protocol_types(self):
         """Test support for protocol types"""

--- a/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftStdlibSet(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_stdlib_set(self):
         """Tests that we properly vend synthetic children for Swift.Set"""

--- a/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -24,9 +24,6 @@ import unittest2
 
 
 class TestSwiftStaticStringVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_static_string_variables(self):
         """Test that Swift.String formats properly"""

--- a/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -24,9 +24,6 @@ import unittest2
 
 
 class TestSwiftStringVariables(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_string_variables(self):
         """Test that Swift.String formats properly"""

--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -21,9 +21,6 @@ import platform
 
 
 class TestSwiftTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""

--- a/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -20,9 +20,6 @@ import unittest2
 
 
 class TestSwiftTupleTypes(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_tuple_types(self):
         """Test support for tuple types"""

--- a/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
+++ b/lldb/test/API/lang/swift/variables/value_of_optionals/TestSwiftValueOfOptionals.py
@@ -21,9 +21,6 @@ import unittest2
 
 
 class TestSwiftValueOfOptionalType(TestBase):
-
-    mydir = TestBase.compute_mydir(__file__)
-
     @swiftTest
     def test_swift_value_optional_type(self):
         """Check that trying to read an optional's numeric value doesn't crash LLDB"""

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -18,8 +18,6 @@ from lldbsuite.test import decorators
 
 class TestSwiftREPLExceptions(TestBase):
 
-    mydir = TestBase.compute_mydir(__file__)
-
     # If your test case doesn't stress debug info, the 
     # set this to true.  That way it won't be run once for
     # each debug info format.


### PR DESCRIPTION
The default location of `mydir` is determined in `lldbtest.py`. Tests only need to define it if they need a custom location. Each of these `TestBase.compute_mydir(__file__)` definitions is redundant. This PR changes Swift specific tests.