### PR TITLE
NCGenerics: handle new parameter when validating serialized AST

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1065,6 +1065,10 @@ static const char *getImportFailureString(swift::serialization::Status status) {
   case swift::serialization::Status::NotInOSSA:
     return "The module file was not compiled with -enable-ossa-modules when it "
            "was required to do so.";
+  case swift::serialization::Status::NotUsingNoncopyableGenerics:
+    return "The module file was not compiled with "
+           "-enable-experimental-feature NoncopyableGenerics when it "
+           "was required to do so.";
   case swift::serialization::Status::SDKMismatch:
     return "The module file was built with a different SDK version.";
   }
@@ -1248,8 +1252,10 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
     for (; !buf.empty(); buf = buf.substr(info.bytes)) {
       llvm::SmallVector<swift::serialization::SearchPath> searchPaths;
       swift::serialization::ExtendedValidationInfo extended_validation_info;
+      auto &langOpts = invocation.getLangOptions();
       info = swift::serialization::validateSerializedAST(
           buf, invocation.getSILOptions().EnableOSSAModules,
+          langOpts.hasFeature(swift::Feature::NoncopyableGenerics),
           /*requiredSDK*/ StringRef(), &extended_validation_info,
           /*dependencies*/ nullptr, &searchPaths);
       bool invalid_ast = info.status != swift::serialization::Status::Valid;
@@ -3383,7 +3389,8 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
     std::make_unique<swift::ModuleInterfaceCheckerImpl>(*m_ast_context_ap,
       moduleCachePath, prebuiltModuleCachePath,
       swift::ModuleInterfaceLoaderOptions(),
-      swift::RequireOSSAModules_t(GetSILOptions())));
+      swift::RequireOSSAModules_t(GetSILOptions()),
+      swift::RequireNoncopyableGenerics_t(GetLanguageOptions())));
 
   // 2. Create and install the module interface loader.
   //


### PR DESCRIPTION
paired with https://github.com/apple/swift/pull/70866

that PR adds a new way that modules can be considered mis-matched: if one is compiled with or without noncopyable generics.