### PR TITLE
[stable] Add missing link dependency clangToolingRefactoring -> clangToolingSyntax

### DIFF
--- a/clang/lib/Tooling/Refactoring/CMakeLists.txt
+++ b/clang/lib/Tooling/Refactoring/CMakeLists.txt
@@ -24,6 +24,7 @@ add_clang_library(clangToolingRefactoring
   clangLex
   clangRewrite
   clangToolingCore
+  clangToolingSyntax
 
   DEPENDS
   omp_gen


### PR DESCRIPTION
`clang/include/clang/tTooling/Refactoring/Rename/RefactoringAction.h` includes `clang/Tooling/Syntax/Tokens.h` and thus `clangToolingRefactoring` needs to link against `clangToolingSyntax` so that the symbols defined in `Tokens.h` are actually present at link time.