### PR TITLE
[Cherry-pick into next] Revert "Filter out -g from custom link command to avoid generating a dsym"

### DIFF
--- a/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
+++ b/lldb/source/Breakpoint/BreakpointResolverFileLine.cpp
@@ -293,9 +293,6 @@ Searcher::CallbackReturn BreakpointResolverFileLine::SearchCallback(
   for (size_t i = 0; i < num_comp_units; i++) {
     CompUnitSP cu_sp(context.module_sp->GetCompileUnitAtIndex(i));
     if (cu_sp) {
-      StreamString s;
-      cu_sp->GetDescription(&s, eDescriptionLevelBrief);
-      llvm::errs()<<s.GetString()<<"\n";
       if (filter.CompUnitPasses(*cu_sp))
         cu_sp->ResolveSymbolContext(m_location_spec, eSymbolContextEverything,
                                     sc_list);

--- a/lldb/test/API/lang/swift/static_linking/macOS/Makefile
+++ b/lldb/test/API/lang/swift/static_linking/macOS/Makefile
@@ -17,7 +17,7 @@ SWIFTFLAGS+=-sdk "$(SWIFTSDKROOT)"
 
 $(EXE): objc_main.m A.o B.o
 	$(CC) $(CFLAGS) -c -I. $< -fobjc-arc -o $(BUILDDIR)/objc_main.o
-	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) -o $@ $(BUILDDIR)/objc_main.o $(BUILDDIR)/A.o $(BUILDDIR)/B.o -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker A.swiftmodule -Xlinker -add_ast_path -Xlinker B.swiftmodule
+	$(SWIFTC) $(SWIFTFLAGS) -o $@ $(BUILDDIR)/objc_main.o $(BUILDDIR)/A.o $(BUILDDIR)/B.o -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker A.swiftmodule -Xlinker -add_ast_path -Xlinker B.swiftmodule
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif

--- a/lldb/test/API/lang/swift/static_linking/macOS/Makefile
+++ b/lldb/test/API/lang/swift/static_linking/macOS/Makefile
@@ -17,7 +17,7 @@ SWIFTFLAGS+=-sdk "$(SWIFTSDKROOT)"
 
 $(EXE): objc_main.m A.o B.o
 	$(CC) $(CFLAGS) -c -I. $< -fobjc-arc -o $(BUILDDIR)/objc_main.o
-	$(SWIFTC) $(SWIFTFLAGS) -o $@ $(BUILDDIR)/objc_main.o $(BUILDDIR)/A.o $(BUILDDIR)/B.o -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker A.swiftmodule -Xlinker -add_ast_path -Xlinker B.swiftmodule
+	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) -o $@ $(BUILDDIR)/objc_main.o $(BUILDDIR)/A.o $(BUILDDIR)/B.o -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker A.swiftmodule -Xlinker -add_ast_path -Xlinker B.swiftmodule
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$@"
 endif


### PR DESCRIPTION
```
commit 69b97aac1f764481665e9c64ec5bb482c08b944e
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jan 18 12:12:45 2024 -0800

    Revert "Filter out -g from custom link command to avoid generating a dsym"
    
    This reverts commit 0750e0d1de5cf7b5d1164c6b9a15a8e6c4eefa9b.

commit e8f75fac782ccd6302e871e26d3c789f2c82a2c4
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jan 18 12:12:52 2024 -0800

    Filter out -g from custom link command to avoid generating a dsym
```
