### PR TITLE
[clang][include-tree] Load even spurious modular dependencies

### DIFF
--- a/clang/include/clang/Lex/PPCachedActions.h
+++ b/clang/include/clang/Lex/PPCachedActions.h
@@ -43,6 +43,12 @@ public:
     // Whether this module should only be "marked visible" rather than imported.
     bool VisibilityOnly;
   };
+  /// The module that is loaded and discarded for an \c #include directive, and
+  /// the file that is included instead.
+  struct SpuriousImport {
+    IncludeModule IM;
+    IncludeFile IF;
+  };
 
   virtual ~PPCachedActions() = default;
 
@@ -56,7 +62,8 @@ public:
   /// \returns the file that should be entered or module that should be imported
   /// for an \c #include directive. \c {} indicates that the directive
   /// should be skipped.
-  virtual std::variant<std::monostate, IncludeFile, IncludeModule>
+  virtual std::variant<std::monostate, IncludeFile, IncludeModule,
+                       SpuriousImport>
   handleIncludeDirective(Preprocessor &PP, SourceLocation IncludeLoc,
                          SourceLocation AfterDirectiveLoc) = 0;
 

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -36,6 +36,12 @@ Expected<NodeT> IncludeTreeBase<NodeT>::create(ObjectStore &DB,
   return NodeT(*Proxy);
 }
 
+Expected<IncludeTree::SpuriousImport>
+IncludeTree::SpuriousImport::create(ObjectStore &DB, ObjectRef ImportRef,
+                                    ObjectRef TreeRef) {
+  return IncludeTreeBase::create(DB, {ImportRef, TreeRef}, {});
+}
+
 Expected<IncludeTree::File> IncludeTree::File::create(ObjectStore &DB,
                                                       StringRef Filename,
                                                       ObjectRef Contents) {
@@ -138,7 +144,9 @@ Expected<IncludeTree> IncludeTree::create(
     assert((Include.Kind == NodeKind::Tree &&
             IncludeTree::isValid(DB, Include.Ref)) ||
            (Include.Kind == NodeKind::ModuleImport &&
-            ModuleImport::isValid(DB, Include.Ref)));
+            ModuleImport::isValid(DB, Include.Ref)) ||
+           (Include.Kind == NodeKind::SpuriousImport &&
+            SpuriousImport::isValid(DB, Include.Ref)));
     Refs.push_back(Include.Ref);
     Writer.write(Include.Offset);
     static_assert(sizeof(uint8_t) == sizeof(Kind));
@@ -671,12 +679,27 @@ llvm::Error IncludeTree::FileList::print(llvm::raw_ostream &OS,
 }
 
 llvm::Error IncludeTree::ModuleImport::print(llvm::raw_ostream &OS,
-                                             unsigned Indent) {
+                                             unsigned Indent, char End) {
   if (visibilityOnly())
     OS << "(Module for visibility only) ";
   else
     OS << "(Module) ";
-  OS << getModuleName() << '\n';
+  OS << getModuleName() << End;
+  return llvm::Error::success();
+}
+
+llvm::Error IncludeTree::SpuriousImport::print(llvm::raw_ostream &OS,
+                                               unsigned Indent) {
+  auto MI = getModuleImport();
+  if (!MI)
+    return MI.takeError();
+  auto IT = getIncludeTree();
+  if (!IT)
+    return IT.takeError();
+  if (llvm::Error E = MI->print(OS, Indent, /*End=*/' '))
+    return E;
+  if (llvm::Error E = IT->print(OS, Indent))
+    return E;
   return llvm::Error::success();
 }
 
@@ -686,6 +709,8 @@ llvm::Error IncludeTree::Node::print(llvm::raw_ostream &OS, unsigned Indent) {
     return getIncludeTree().print(OS, Indent);
   case NodeKind::ModuleImport:
     return getModuleImport().print(OS, Indent);
+  case NodeKind::SpuriousImport:
+    return getSpuriousImport().print(OS, Indent);
   }
 }
 

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -696,6 +696,7 @@ llvm::Error IncludeTree::SpuriousImport::print(llvm::raw_ostream &OS,
   auto IT = getIncludeTree();
   if (!IT)
     return IT.takeError();
+  OS << "(Spurious import) ";
   if (llvm::Error E = MI->print(OS, Indent, /*End=*/' '))
     return E;
   if (llvm::Error E = IT->print(OS, Indent))

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -20,6 +20,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/TokenKinds.h"
+#include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Lex/CodeCompletionHandler.h"
 #include "clang/Lex/HeaderSearch.h"
 #include "clang/Lex/HeaderSearchOptions.h"
@@ -1999,7 +2000,7 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
     auto Include = CActions->handleIncludeDirective(
         *this, IncludePos, CurLexer->getSourceLocation());
 
-    if (auto *File = std::get_if<PPCachedActions::IncludeFile>(&Include)) {
+    auto HandleIncludeFile = [&](const PPCachedActions::IncludeFile *File) {
       OptionalFileEntryRef FE = SourceMgr.getFileEntryRefForID(File->FID);
       bool IsImport =
           IncludeTok.getIdentifierInfo()->getPPKeywordID() == tok::pp_import;
@@ -2017,9 +2018,32 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
         EnterAnnotationToken(SourceRange(HashLoc, EndLoc),
                              tok::annot_module_begin, SM);
       }
-      return;
-    }
-    if (auto *Import = std::get_if<PPCachedActions::IncludeModule>(&Include)) {
+    };
+
+    auto LoadModule = [&](const PPCachedActions::IncludeModule *Import) {
+      auto Imported = TheModuleLoader.loadModule(
+            IncludeTok.getLocation(), ArrayRef(Import->ImportPath).take_front(),
+            Module::Hidden, /*IsInclusionDirective=*/true);
+      if (!Imported) {
+        assert(hadModuleLoaderFatalFailure() && "unexpected failure kind");
+        if (hadModuleLoaderFatalFailure()) {
+          IncludeTok.setKind(tok::eof);
+          CurLexer->cutOffLexing();
+        }
+        return;
+      }
+
+      auto Path = Import->ImportPath;
+      std::string PathStr = Path.front().first->getName().str();
+      for (unsigned I = 1; I != Path.size(); ++I)
+        PathStr += ("." + Path[I].first->getName()).str();
+
+      getDiagnostics().Report(IncludeTok.getLocation(),
+                              diag::warn_missing_submodule)
+          << PathStr << SourceRange(Path.front().second, Path.back().second);
+    };
+
+    auto HandleIncludeMod = [&](const PPCachedActions::IncludeModule *Import) {
       ModuleLoadResult Imported;
       if (Import->VisibilityOnly) {
         ModuleMap &MMap = getHeaderSearchInfo().getModuleMap();
@@ -2055,8 +2079,18 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
           tok::pp___include_macros)
         EnterAnnotationToken(SourceRange(HashLoc, EndLoc),
                              tok::annot_module_include, Imported);
+    };
+
+    if (auto *SpuriousImport =
+            std::get_if<PPCachedActions::SpuriousImport>(&Include)) {
+      LoadModule(&SpuriousImport->IM);
+      HandleIncludeFile(&SpuriousImport->IF);
       return;
     }
+    if (auto *File = std::get_if<PPCachedActions::IncludeFile>(&Include))
+      return HandleIncludeFile(File);
+    if (auto *Import = std::get_if<PPCachedActions::IncludeModule>(&Include))
+      return HandleIncludeMod(Import);
     assert(std::holds_alternative<std::monostate>(Include));
     // FIXME: Report \p Callbacks->FileSkipped? Note that it currently
     // requires the resolved FileEntry for this particular #include.

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation-transitive.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation-transitive.c
@@ -1,0 +1,74 @@
+// REQUIRES: ondisk_cas
+
+// This test checks that we correctly handle situations where a spurious modular
+// dependency (1) turns otherwise textual dependency into modular (2).
+//
+// (1) For example #include <Spurious/Missing.h>, where the framework Spurious
+// has an umbrella header that does not include Missing.h, making it a textual
+// include instead.
+//
+// (2) For example when compiling the implementation file of a module Mod,
+// #included headers belonging to Mod are treated textually, unless some other
+// module already depends on Mod in its modular form.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
+
+//--- cdb.json.in
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -c DIR/tu.m -o DIR/tu.o -F DIR/frameworks -I DIR/include -fmodule-name=Mod -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- frameworks/Spurious.framework/Modules/module.modulemap
+framework module Spurious {
+  umbrella header "Spurious.h"
+  module * { export * }
+}
+//--- frameworks/Spurious.framework/Headers/Spurious.h
+#include <Mod.h>
+//--- frameworks/Spurious.framework/Headers/Missing.h
+
+//--- include/module.modulemap
+module Mod { header "Mod.h" }
+//--- include/Mod.h
+typedef int mod_int;
+
+//--- tu.m
+#include <Spurious/Missing.h>
+#include <Mod.h>
+static mod_int x;
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-full \
+// RUN:   -module-files-dir %t/outputs > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name=Mod      > %t/Mod.cc1.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name=Spurious > %t/Spurious.cc1.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index=0           > %t/tu.rsp
+
+// RUN: %clang @%t/Mod.cc1.rsp
+// RUN: %clang @%t/Spurious.cc1.rsp
+// RUN: %clang @%t/tu.rsp
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   -module-files-dir %t/cas-outputs > %t/cas-deps.json
+
+// RUN: %deps-to-rsp %t/cas-deps.json --module-name=Mod      > %t/cas-Mod.cc1.rsp
+// RUN: %deps-to-rsp %t/cas-deps.json --module-name=Spurious > %t/cas-Spurious.cc1.rsp
+// RUN: %deps-to-rsp %t/cas-deps.json --tu-index=0           > %t/cas-tu.rsp
+
+// RUN: cat %t/cas-tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid > %t/tu-include-tree.txt
+// RUN: FileCheck %s -input-file %t/tu-include-tree.txt -DPREFIX=%/t
+// CHECK:      [[PREFIX]]/tu.m llvmcas://
+// CHECK-NEXT: 1:1 <built-in> llvmcas://
+// CHECK-NEXT: 2:1 (Module) Spurious.Missing [[PREFIX]]/frameworks/Spurious.framework/Headers/Missing.h llvmcas://
+// CHECK-NEXT: 3:1 (Module for visibility only) Mod
+
+// RUN: %clang @%t/cas-Mod.cc1.rsp
+// RUN: %clang @%t/cas-Spurious.cc1.rsp
+// RUN: %clang @%t/cas-tu.rsp

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation-transitive.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation-transitive.c
@@ -66,7 +66,7 @@ static mod_int x;
 // RUN: FileCheck %s -input-file %t/tu-include-tree.txt -DPREFIX=%/t
 // CHECK:      [[PREFIX]]/tu.m llvmcas://
 // CHECK-NEXT: 1:1 <built-in> llvmcas://
-// CHECK-NEXT: 2:1 (Module) Spurious.Missing [[PREFIX]]/frameworks/Spurious.framework/Headers/Missing.h llvmcas://
+// CHECK-NEXT: 2:1 (Spurious import) (Module) Spurious.Missing [[PREFIX]]/frameworks/Spurious.framework/Headers/Missing.h llvmcas://
 // CHECK-NEXT: 3:1 (Module for visibility only) Mod
 
 // RUN: %clang @%t/cas-Mod.cc1.rsp

--- a/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
@@ -50,7 +50,7 @@
 // CHECK: (PCH) llvmcas://
 // CHECK: [[PREFIX]]/tu.c llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
-// CHECK: 2:1 [[PREFIX]]/Foo.framework/Headers/Bar.h llvmcas://
+// CHECK: 2:1 (Module) Foo.Bar [[PREFIX]]/Foo.framework/Headers/Bar.h llvmcas://
 
 // RUN: %clang @%t/tu.rsp
 

--- a/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
@@ -50,7 +50,7 @@
 // CHECK: (PCH) llvmcas://
 // CHECK: [[PREFIX]]/tu.c llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
-// CHECK: 2:1 (Module) Foo.Bar [[PREFIX]]/Foo.framework/Headers/Bar.h llvmcas://
+// CHECK: 2:1 (Spurious import) (Module) Foo.Bar [[PREFIX]]/Foo.framework/Headers/Bar.h llvmcas://
 
 // RUN: %clang @%t/tu.rsp
 


### PR DESCRIPTION
With implicit modules, some modular dependencies can be "spurious". By that I mean that `#include "Header.h"` results in a PCM file load, but the header ends up being included textually anyways. (This can happen in situations that would trigger the `-Wincomplete-umbrella` warning.)

This patch ensures this behavior is preserved with include-tree. Previously, include-tree would simply textually include the header file and skip the PCM file load. This now ensures consistent behavior in edge-cases like the one in the attached test case (with `-fmodule-name=X`).

rdar://121220983