### PR TITLE
[lldb] [test] Disable TestTypealiasExpressionParser.py for all platforms

### DIFF
--- a/lldb/test/API/lang/swift/typealias_expression_parser/TestTypealiasExpressionParser.py
+++ b/lldb/test/API/lang/swift/typealias_expression_parser/TestTypealiasExpressionParser.py
@@ -2,4 +2,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 # FIXME! The Swift driver insists on passing -experimental-skip-non-inlinable-function-bodies-without-types to -emit-module.
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, expectedFailureDarwin(bugnumber="rdar://120928396")])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipIf(bugnumber="rdar://120928396")])


### PR DESCRIPTION
This is failing on Linux https://ci.swift.org/job/oss-swift-RA-linux-ubuntu-18_04/5759/