### PR TITLE
[Explicit Module Builds] Fallback on implicit module builds by filtering out Explicit Module clang arguments from invocation

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/TestSwiftExplicitModules.py
@@ -9,7 +9,6 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @swiftTest
     @skipUnlessDarwin # FIXME.
-    @expectedFailureAll(bugnumber='rdar://121078994')
     def test_any_type(self):
         """Test explicit Swift modules"""
         self.build()


### PR DESCRIPTION
When loading compilation flags from a serialized AST, filter out explicit module build commands for the time being and fallback on implicit module loading. In the future, we will utilize explicit dependency info, but for the time being the module loaders are not configured to take advantage of them.

Resolves rdar://121078994