### PR TITLE
[lldb] Add color support to StreamString (cherry pick)

### DIFF
--- a/lldb/include/lldb/Utility/StreamString.h
+++ b/lldb/include/lldb/Utility/StreamString.h
@@ -22,7 +22,7 @@ namespace lldb_private {
 
 class StreamString : public Stream {
 public:
-  StreamString();
+  StreamString(bool colors = false);
 
   StreamString(uint32_t flags, uint32_t addr_size, lldb::ByteOrder byte_order);
 

--- a/lldb/source/Utility/StreamString.cpp
+++ b/lldb/source/Utility/StreamString.cpp
@@ -11,7 +11,7 @@
 using namespace lldb;
 using namespace lldb_private;
 
-StreamString::StreamString() : Stream(0, 4, eByteOrderBig) {}
+StreamString::StreamString(bool colors) : Stream(0, 4, eByteOrderBig, colors) {}
 
 StreamString::StreamString(uint32_t flags, uint32_t addr_size,
                            ByteOrder byte_order)


### PR DESCRIPTION
This change just adds a `bool colors` parameter to the `StreamString` class's constructor, which it passes up to its superclass’s constructor.

I'm working on another patch that prints out error messages using a `StreamString` but I wasn't getting colorized text because of this missing implementation detail.

Original PR:
https://github.com/llvm/llvm-project/pull/77380

rdar://120671168


**Note**
I renamed my branch to `apple/misc/streamstring-gets-color-cherrypick`.
You can now find it here:
https://github.com/PortalPete/llvm-project/tree/apple/misc/streamstring-gets-color-cherrypick
