### PR TITLE
[lldb] Include SBFormat.h in LLDB.h (#79194)

### DIFF
--- a/lldb/include/lldb/API/LLDB.h
+++ b/lldb/include/lldb/API/LLDB.h
@@ -33,6 +33,7 @@
 #include "lldb/API/SBFile.h"
 #include "lldb/API/SBFileSpec.h"
 #include "lldb/API/SBFileSpecList.h"
+#include "lldb/API/SBFormat.h"
 #include "lldb/API/SBFrame.h"
 #include "lldb/API/SBFunction.h"
 #include "lldb/API/SBHostOS.h"


### PR DESCRIPTION
This was likely overlooked when SBFormat was added.

(cherry picked from commit 7ca8feb1b89dfe62c9c3a06aa0585adbcd019eff)