### PR TITLE
Pass UseCASBackend flag to replayCachedResult (cherry-pick https://github.com/apple/llvm-project/pull/8002 to stable/20230725 branch)

### DIFF
--- a/clang/include/clang/Frontend/CompileJobCache.h
+++ b/clang/include/clang/Frontend/CompileJobCache.h
@@ -81,12 +81,13 @@ public:
   /// \returns true if finished successfully.
   bool finishComputedResult(CompilerInstance &Clang, bool Success);
 
-  static llvm::Expected<std::optional<int>> replayCachedResult(
-      std::shared_ptr<CompilerInvocation> Invok, StringRef WorkingDir,
-      const llvm::cas::CASID &CacheKey,
-      cas::CompileJobCacheResult &CachedResult, SmallVectorImpl<char> &DiagText,
-      bool WriteOutputAsCASID = false, bool UseCASBackend = false,
-      std::optional<llvm::cas::CASID> *MCOutputID = nullptr);
+  static llvm::Expected<std::optional<int>>
+  replayCachedResult(std::shared_ptr<CompilerInvocation> Invok,
+                     StringRef WorkingDir, const llvm::cas::CASID &CacheKey,
+                     cas::CompileJobCacheResult &CachedResult,
+                     SmallVectorImpl<char> &DiagText,
+                     bool WriteOutputAsCASID = false,
+                     std::optional<llvm::cas::CASID> *MCOutputID = nullptr);
 
   class CachingOutputs;
 

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -542,7 +542,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
     std::shared_ptr<CompilerInvocation> Invok, StringRef WorkingDir,
     const llvm::cas::CASID &CacheKey, cas::CompileJobCacheResult &CachedResult,
     SmallVectorImpl<char> &DiagText, bool WriteOutputAsCASID,
-    bool UseCASBackend, std::optional<llvm::cas::CASID> *OutMCOutputID) {
+    std::optional<llvm::cas::CASID> *OutMCOutputID) {
   CompilerInstance Clang;
   Clang.setInvocation(std::move(Invok));
   llvm::raw_svector_ostream DiagOS(DiagText);
@@ -573,7 +573,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
   std::optional<llvm::cas::CASID> MCOutputID;
   ObjectStoreCachingOutputs CachingOutputs(
       Clang, WorkingDir, std::move(PrefixMapper), WriteOutputAsCASID,
-      UseCASBackend, MCOutputID,
+      Clang.getInvocation().getCodeGenOpts().UseCASBackend, MCOutputID,
       /*CAS*/ nullptr, /*Cache*/ nullptr);
   if (OutMCOutputID)
     *OutMCOutputID = std::move(MCOutputID);

--- a/clang/test/CAS/mccas-replay.c
+++ b/clang/test/CAS/mccas-replay.c
@@ -1,0 +1,20 @@
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: %clang -cc1depscan -o %t/args.rsp  -cc1-args -cc1 \
+// RUN:    -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
+// RUN:    -emit-obj -fcas-backend  -fcas-path %t/cas       %s -o - > /dev/null
+
+// RUN: %clang @%t/args.rsp -o %t/output1.o -Rcompile-job-cache 2> %t/output1.txt
+
+// RUN: cat %t/output1.txt | grep llvmcas | sed \
+// RUN:       -e "s/^.*miss for '//" \
+// RUN:       -e "s/' .*$//" > %t/cache-key 
+
+// RUN: c-index-test core -replay-cached-job -cas-path %t/cas @%t/cache-key \
+// RUN:       -working-dir %t  -- @%t/args.rsp -o %t/output2.o
+
+// RUN: diff %t/output1.o %t/output2.o 
+
+int foo(int x) {
+    return x+1;
+}


### PR DESCRIPTION
When using MCCAS, the replay on a cache hit needs to materialize the object file by calling into MCCAS's serializeObjectFile function. Pass the UseCASBackend flag from the CodeGenOpts to replayCachedResult to make sure it knows when to invoke MCCAS serialization.

(cherry picked from commit 1fe3f3ae2d7b794da3e6b25cfda862023be4d565)