### PR TITLE
[lldb] Ignore -triple flag for ClangImporter

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1544,8 +1544,10 @@ void SwiftASTContext::AddExtraClangArgs(const std::vector<std::string> &source,
   llvm::SmallString<128> cur_working_dir;
   llvm::SmallString<128> clang_argument;
   for (const std::string &arg : source) {
-    if (clang_argument == "-triple")
+    if (clang_argument == "-triple") {
+      clang_argument.clear();
       continue;
+    }
 
     // Join multi-arg options for uniquing.
     clang_argument += arg;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1544,6 +1544,9 @@ void SwiftASTContext::AddExtraClangArgs(const std::vector<std::string> &source,
   llvm::SmallString<128> cur_working_dir;
   llvm::SmallString<128> clang_argument;
   for (const std::string &arg : source) {
+    // Ignore the `-triple` flag. First, this is not a driver flag, and second,
+    // lldb has its own logic to determine the target. Ignore now, before
+    // appending the argument.
     if (clang_argument == "-triple") {
       clang_argument.clear();
       continue;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1507,8 +1507,8 @@ bool ConsumeIncludeOption(StringRef &arg, StringRef &prefix) {
 }
 
 std::array<StringRef, 2> macro_flags = { "-D", "-U" };
-std::array<StringRef, 5> multi_arg_flags =
-    { "-D", "-U", "-I", "-F", "-working-directory" };
+std::array<StringRef, 6> multi_arg_flags = {
+    "-D", "-U", "-I", "-F", "-working-directory", "-triple"};
 std::array<StringRef, 6> args_to_unique = {
     "-D", "-U", "-I", "-F", "-fmodule-file=", "-fmodule-map-file="};
 
@@ -1544,6 +1544,9 @@ void SwiftASTContext::AddExtraClangArgs(const std::vector<std::string> &source,
   llvm::SmallString<128> cur_working_dir;
   llvm::SmallString<128> clang_argument;
   for (const std::string &arg : source) {
+    if (clang_argument == "-triple")
+      continue;
+
     // Join multi-arg options for uniquing.
     clang_argument += arg;
     if (IsMultiArgClangFlag(clang_argument))


### PR DESCRIPTION
This change is in support of explicit swift modules (apple/llvm-project#8017).

With explicit modules, the resulting clang flags include the `-triple` flag, which has not been supported by `SwiftASTContext::AddExtraClangArgs`. This change ignores any found triple, relying on lldb's existing triple/target discovery functionality.