### PR TITLE
[lldb] Fix use-after-free of StringRefs in GetNominal

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -480,8 +480,7 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
 
 /// Return a pair of module name and type name, given a mangled name.
 static llvm::Optional<std::pair<StringRef, StringRef>>
-GetNominal(llvm::StringRef mangled_name) {
-  swift::Demangle::Demangler dem;
+GetNominal(llvm::StringRef mangled_name, swift::Demangle::Demangler &dem) {
   auto *node = GetDemangledType(dem, mangled_name);
   /// Builtin names belong to the builtin module, and are stored only with their
   /// mangled name.
@@ -1826,7 +1825,9 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
   auto *M = GetModule();
   if (!M)
     return {};
-  auto module_type = GetNominal(AsMangledName(opaque_type));
+
+  swift::Demangle::Demangler dem;
+  auto module_type = GetNominal(AsMangledName(opaque_type), dem);
   if (!module_type)
     return {};
   // DW_AT_linkage_name is not part of the accelerator table, so


### PR DESCRIPTION
GetNominal returns StringRefs tied to a Demangler local variable. Fix this by passing the Demangler as a parameter.

rdar://121464845