### PR TITLE
[lldb] Handle @objc classes in Swift runtime

### DIFF
--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/App.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct Document {
+    var kind: Kind
+    var path: String
+
+    enum Kind {
+        case binary
+        case text
+    }
+}
+
+@objc(App)
+class App : NSObject {
+    var name: String = "Debugger"
+    var version: (Int, Int) = (1, 0)
+    var recentDocuments: [Document]? = [
+        Document(kind: .binary, path: "/path/to/something"),
+    ]
+}

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/Makefile
@@ -1,0 +1,5 @@
+OBJC_SOURCES := main.m
+SWIFT_SOURCES := App.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/TestObjCDynamicTypeSwift.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @skipUnlessFoundation
+    @swiftTest
+    def test(self):
+        """Verify printing of Swift implemented ObjC objects."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+
+        # For Swift implemented objects, it's assumed the ObjC runtime prints
+        # only a pointer, and cannot generate any child values.
+        self.expect("v -d no app", startstr="(App *) app = 0x")
+        self.expect(
+            "v -d no -P1 app",
+            matching=False,
+            substrs=["name", "version", "recentDocuments"],
+        )
+
+        # With dynamic typing, the Swift runtime produces Swift child values.
+        self.expect("v app", substrs=["App?) app = 0x"])
+        self.expect("v app.name", startstr='(String) app.name = "Debugger"')
+        self.expect(
+            "v app.version", startstr="((Int, Int)) app.version = (0 = 1, 1 = 0)"
+        )
+
+        documents = """\
+([a.Document]?) app.recentDocuments = 1 value {
+  [0] = {
+    kind = binary
+    path = "/path/to/something"
+  }
+}
+"""
+        self.expect("v app.recentDocuments", startstr=documents)

--- a/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
+++ b/lldb/test/API/lang/swift/objc/dynamic-swift-type/main.m
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+@interface App : NSObject
+@end
+
+int main() {
+  App *app = [App new];
+  printf("break here\n");
+  return 0;
+}


### PR DESCRIPTION
@objc classes can be used from ObjC. In those cases, the Swift runtime is used. This
change implements the handling of @objc classes in the Swift language runtime.

(cherry picked from commit b4e30b7fa589a490ef024581aaed69819c84666d)

(cherry-picked from commit 6e5a4b5a4f24cc0bda94ca0aa780172fb700ebff)