### PR TITLE
[lldb] Add Foundation._NSSwiftTimeZone support

### DIFF
--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -131,6 +131,16 @@ bool lldb_private::formatters::NSTimeZoneSummaryProvider(
       stream.Printf("%s", summary_stream.GetData());
       return true;
     }
+  } else if (class_name == "_NSSwiftTimeZone") {
+    llvm::ArrayRef<llvm::StringRef> identifier_path = {"timeZone", "_timeZone",
+                                                       "some", "identifier"};
+    if (auto identifier_sp = valobj.GetChildAtNamePath(identifier_path)) {
+      std::string desc;
+      if (identifier_sp->GetSummaryAsCString(desc, options)) {
+        stream.PutCString(desc);
+        return true;
+      }
+    }
   }
 
   return false;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -635,6 +635,11 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Decimal summary provider", ConstString("Foundation.Decimal"),
       TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
 
+  lldb_private::formatters::AddCXXSummary(
+      swift_category_sp, lldb_private::formatters::NSTimeZoneSummaryProvider,
+      "NSTimeZone summary provider", ConstString("Foundation._NSSwiftTimeZone"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
+
   lldb_private::formatters::AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::URLComponentsSyntheticFrontEndCreator,


### PR DESCRIPTION
`_NSSwiftTimeZone` is the new Swift implementation of `NSTimeZone`.

(cherry picked from commit 666003ec6803f19ba1e490fd6be944c5e12b0465)

(cherry-picked from commit 19a30350cfb0ecabaad5b0af3d0cb02e190c1a37)