### PR TITLE
disable flaky macro test

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -22,6 +22,7 @@ class TestSwiftMacroConflict(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
+    @skipIf(bugnumber="rdar://121539666")
     @skipUnlessDarwin
     @swiftTest
     def test(self):
@@ -58,6 +59,7 @@ class TestSwiftMacroConflict(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(bugnumber="rdar://121539666")
     @skipUnlessDarwin
     @swiftTest
     def test_with_dwarfimporter(self):


### PR DESCRIPTION
rdar://121539666 (Failing CI test -- lldb-api :: lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py)