### PR TITLE
[lldb] Fix LLDB_LOG with format specifier argument

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -667,7 +667,7 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
 
   auto error = [&](const char *error_msg, const char *detail = nullptr) {
     if (detail)
-      LLDB_LOG(log, "%s: %s", error_msg, detail);
+      LLDB_LOG(log, "{0}: {1}", error_msg, detail);
     else
       LLDB_LOG(log, error_msg);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -611,7 +611,7 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
   }
   NodePointer n = GetDemangledType(dem, desugared_name.GetStringRef());
   if (!n) {
-    LLDB_LOG(GetLog(LLDBLog::Types), "Unrecognized demangling %s",
+    LLDB_LOG(GetLog(LLDBLog::Types), "Unrecognized demangling {0}",
              desugared_name.AsCString());
     return {{}, {}};
   }


### PR DESCRIPTION
LLDB_LOG formats strings by specifying the positions of the argument ({0}, {1}, etc), and not with format specifiers (%s, %i, etc).

rdar://117504055
(cherry picked from commit be390308c18a4eb0a445e6423cbf24e224d5ed85)