### PR TITLE
[lldb] Change GetSwiftASTContext call to take exe_scope in GetByteStride

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2860,7 +2860,8 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
     LLDB_LOGF(GetLog(LLDBLog::Types),
               "Couldn't compute stride of type %s using SwiftLanguageRuntime.",
               AsMangledName(type));
-    if (auto *swift_ast_context = GetSwiftASTContext())
+    if (auto *swift_ast_context =
+            GetSwiftASTContextFromExecutionScope(exe_scope))
       return swift_ast_context->GetByteStride(ReconstructType(type), exe_scope);
     return {};
   };


### PR DESCRIPTION
GetSwiftASTContext now has a symbol context parameter, change the call site in GetByteStride to call one of GetSwiftASTContext's helper functions (GetSwiftASTContextFromExecutionScope)

rdar://118524643
(cherry picked from commit d6c79377ab272c788381f4a6f53f5cd6368ebb67)