### PR TITLE
[lldb] Make GetClangTypeNode aware of SIMD types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -283,6 +283,28 @@ GetPointerTo(swift::Demangle::Demangler &dem,
   return bgs;
 }
 
+NodePointer TypeSystemSwiftTypeRef::CreateBoundGenericStruct(
+    llvm::StringRef name, llvm::StringRef module_name,
+    llvm::ArrayRef<NodePointer> type_list_elements,
+    swift::Demangle::Demangler &dem) {
+  NodePointer type_list = dem.createNode(Node::Kind::TypeList);
+  for (auto *type_list_element : type_list_elements)
+    type_list->addChild(type_list_element, dem);
+  NodePointer identifier = dem.createNode(Node::Kind::Identifier, name);
+  NodePointer module = dem.createNode(Node::Kind::Module, module_name);
+  NodePointer structure = dem.createNode(Node::Kind::Structure);
+  structure->addChild(module, dem);
+  structure->addChild(identifier, dem);
+  NodePointer type = dem.createNode(Node::Kind::Type);
+  type->addChild(structure, dem);
+  NodePointer signature = dem.createNode(Node::Kind::BoundGenericStructure);
+  signature->addChild(type, dem);
+  signature->addChild(type_list, dem);
+  NodePointer outer_type = dem.createNode(Node::Kind::Type);
+  outer_type->addChild(signature, dem);
+  return outer_type;
+}
+
 /// Return a demangle tree leaf node representing \p clang_type.
 swift::Demangle::NodePointer
 TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
@@ -378,6 +400,28 @@ TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
     kind = Node::Kind::TypeAlias;
     pointee = {};
     break;
+  case eTypeClassVector: {
+    CompilerType element_type;
+    uint64_t size;
+    bool is_vector = clang_type.IsVectorType(&element_type, &size);
+    if (!is_vector)
+      break;
+
+    auto qual_type = ClangUtil::GetQualType(clang_type); 
+    const auto *ptr = qual_type.getTypePtrOrNull();
+    if (!ptr)
+      break;
+
+    // Check if this is an extended vector type.
+    if (!llvm::isa<clang::DependentSizedExtVectorType>(ptr) &&
+        !llvm::isa<clang::ExtVectorType>(ptr))
+      break;
+
+    NodePointer element_type_node = GetClangTypeNode(element_type, dem);
+    llvm::SmallVector<NodePointer, 1> elements({element_type_node});
+    return CreateBoundGenericStruct("SIMD" + std::to_string(size),
+                                    swift::STDLIB_NAME, elements, dem);
+  }
   default:
     break;
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -320,6 +320,13 @@ public:
   CompilerType CreateGenericTypeParamType(unsigned int depth,
                                     unsigned int index) override;
 
+  /// Builds a bound generic struct demangle tree with the name, module name,
+  /// and the struct's elements.
+  static swift::Demangle::NodePointer CreateBoundGenericStruct(
+      llvm::StringRef name, llvm::StringRef module_name,
+      llvm::ArrayRef<swift::Demangle::NodePointer> type_list_elements,
+      swift::Demangle::Demangler &dem);
+
   /// Get the Swift raw pointer type.
   CompilerType GetRawPointerType();
   /// Determine whether \p type is a protocol.

--- a/lldb/test/Shell/SwiftREPL/SIMD.test
+++ b/lldb/test/Shell/SwiftREPL/SIMD.test
@@ -170,6 +170,9 @@ simd_quatf(vector: colf4)
 simd_quatd(vector: cold4)
 // CHECK: $R{{.*}}: simd_quatd = (1.500000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00)
 
+simd_quaternion(1.0, 0.5, 0.3, 0.1)
+// CHECK: $R{{.*}}: simd_quatd = (1.000000e+00, 5.000000e-01, 3.000000e-01, 1.000000e-01)
+
 // Test the new SIMD types
 let tinky = SIMD2<Int>(1, 2)
 // CHECK: {{tinky}}: SIMD2<Int> = (1, 2)


### PR DESCRIPTION
The compiler has some special handling for SIMD types, implement the same rules on TypeSystemSwiftTypeRef::GetClangTypeNode.

rdar://78567209
(cherry picked from commit 9c4b291eebf3d35b5b010803754450ee5b420fcd)