### PR TITLE
[lldb] Handle diagnostics better around expression evaulation retries

### DIFF
--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -151,3 +151,8 @@ class TestSwiftPrivateGenericType(TestBase):
                     substrs=["Could not evaluate the expression without binding generic types."], 
                     error=True)
 
+        # Check that if both binding and not binding the generic type parameters fail, we report 
+        # the "bind generic params" error message, as that's the default case that runs first.
+        self.expect("e --bind-generic-types auto -- self", 
+                    substrs=["Couldn't realize Swift AST type of self."], 
+                    error=True)


### PR DESCRIPTION
The error message produced when expression evaluation parsing failed with automatic retries was not great, and would confuse many users. Change the logic around what diagnostics should be displayed to the user if expression evaluation parsing retry also fails to show the original error message.

rdar://118057664
(cherry picked from commit 5e4ece7ec10b0f64b496a60f5619f12ae2a876e0)