### PR TITLE
[lldb] Handle formatting C anonymous struct and unions in Swift

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/Makefile
@@ -1,0 +1,5 @@
+SWIFT_SOURCES := main.swift
+C_SOURCES := source.c
+SWIFT_BRIDGING_HEADER := bridging-header.h
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
@@ -1,0 +1,36 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftAnonymousClangTypes(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame variable twoStructs",
+            substrs=[
+                "(TwoAnonymousStructs) twoStructs = {",
+                "= (x = 1, y = 2, z = 3)",
+                "= (a = 4)",
+            ],
+        )
+
+        self.expect(
+            "frame variable twoUnions",
+            substrs=[
+                "(TwoAnonymousUnions) twoUnions = {",
+                "   = {",
+                "     = (x = 2)",
+                "     = (y = 2, z = 3)",
+                "  }",
+                "   = {",
+                "     = (a = 4, b = 5, c = 6)",
+                "     = (d = 4, e = 5)",
+            ],
+        )

--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/bridging-header.h
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/bridging-header.h
@@ -1,0 +1,37 @@
+
+typedef struct TwoAnonymousStructs {
+        struct {
+            float x;
+            float y;
+            float z;
+        };
+        struct {
+          int a;
+        };
+} TwoAnonymousStructs;
+
+typedef struct TwoAnonymousUnions {
+        union {
+          struct {
+            int x;
+          };
+          struct {
+            int y;
+            int z;
+          };
+        };
+        union {
+          struct {
+            int a;
+            int b;
+            int c;
+          };
+          struct {
+            int d;
+            int e;
+          };
+        };
+} TwoAnonymousUnions;
+
+TwoAnonymousStructs makeTwoAnonymousStructs();
+TwoAnonymousUnions makeTwoAnonymousUnions();

--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/main.swift
@@ -1,0 +1,3 @@
+let twoStructs = makeTwoAnonymousStructs()
+let twoUnions = makeTwoAnonymousUnions()
+print("break here")

--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/source.c
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/source.c
@@ -1,0 +1,21 @@
+#include "bridging-header.h"
+
+TwoAnonymousStructs makeTwoAnonymousStructs() {
+    TwoAnonymousStructs anon_struct;
+    anon_struct.x = 1;
+    anon_struct.y = 2;
+    anon_struct.z = 3;
+    anon_struct.a = 4;
+    return anon_struct;
+}
+
+
+TwoAnonymousUnions makeTwoAnonymousUnions() {
+  TwoAnonymousUnions anon_unions;
+  anon_unions.y = 2;
+  anon_unions.z = 3;
+  anon_unions.a = 4;
+  anon_unions.b = 5;
+  anon_unions.c = 6;
+  return anon_unions;
+}


### PR DESCRIPTION
TypeSystemSwiftTypeRef handles Clang types by looking them up in debug information. This doesn't work for anonymous structs and unions, as: 1) they don't have a mangled name emitted in debug information 2) it's not possible to differentiate between multiple sibling
   anonymous structs/unions inside the same parent type.

For these reasons, when encountering an anonymous type, return the clang type directly, instead of trying to convert it to Swift.

rdar://96453293
(cherry picked from commit 8f297ca830fd2fb984ae7957ce5ad7ce9e82b585)