### PR TITLE
[lldb] Implement check for potential Swift interop types in DWARF

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTMetadata.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTMetadata.cpp
@@ -31,5 +31,12 @@ void ClangASTMetadata::Dump(Stream *s) {
   if (m_is_dynamic_cxx) {
     s->Printf("is_dynamic_cxx=%i ", m_is_dynamic_cxx);
   }
+
+  // BEGIN SWIFT
+  if (m_is_potentially_swift_interop_type) {
+    s->Printf("is_swift_interop_type=%i ", m_is_potentially_swift_interop_type);
+  }
+  // END SWIFT
+
   s->EOL();
 }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTMetadata.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTMetadata.h
@@ -20,7 +20,15 @@ public:
   ClangASTMetadata()
       : m_user_id(0), m_union_is_user_id(false), m_union_is_isa_ptr(false),
         m_has_object_ptr(false), m_is_self(false), m_is_dynamic_cxx(true),
-        m_is_forcefully_completed(false) {}
+        m_is_forcefully_completed(false)
+        // BEGIN SWIFT
+        // This is initialized to true because in the off-chance we don't parse
+        // this type in debug info we should stil take the regular, expensive
+        // path to figure out if the type is a Swift interop type or not.
+        ,
+        m_is_potentially_swift_interop_type(true)
+  // END SWIFT
+  {}
 
   bool GetIsDynamicCXXType() const { return m_is_dynamic_cxx; }
 
@@ -93,6 +101,16 @@ public:
     m_is_forcefully_completed = true;
   }
 
+  // BEGIN SWIFT
+  bool GetIsPotentiallySwiftInteropType() {
+    return m_is_potentially_swift_interop_type;
+  }
+
+  void SetIsPotentiallySwiftInteropType(bool is_swift_interop_type) {
+    m_is_potentially_swift_interop_type = is_swift_interop_type;
+  }
+  // END SWIFT
+
   void Dump(Stream *s);
 
 private:
@@ -102,7 +120,12 @@ private:
   };
 
   bool m_union_is_user_id : 1, m_union_is_isa_ptr : 1, m_has_object_ptr : 1,
-      m_is_self : 1, m_is_dynamic_cxx : 1, m_is_forcefully_completed : 1;
+      m_is_self : 1, m_is_dynamic_cxx : 1,
+      m_is_forcefully_completed : 1
+      // BEGIN SWIFT
+      , m_is_potentially_swift_interop_type : 1
+      // END SWIFT
+      ;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -23,6 +23,7 @@
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/DataFormatters/StringPrinter.h"
 
+#include "Plugins/ExpressionParser/Clang/ClangASTMetadata.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -768,6 +769,10 @@ ExtractSwiftTypeNameFromCxxInteropType(CompilerType type) {
   }
 
   const clang::RecordDecl *record_decl = record_type->getDecl();
+  auto *metadata = tsc->GetMetadata(record_decl);
+  if (metadata && !metadata->GetIsPotentiallySwiftInteropType())
+    return {};
+
   for (auto *child_decl : record_decl->decls()) {
     auto *var_decl = llvm::dyn_cast<clang::VarDecl>(child_decl);
     if (!var_decl)

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1604,6 +1604,16 @@ DWARFASTParserClang::GetCPlusPlusQualifiedName(const DWARFDIE &die) {
   return qualified_name;
 }
 
+// BEGIN SWIFT  
+bool DWARFASTParserClang::IsSwiftInteropType(const DWARFDIE &die) {
+  for (DWARFDIE die : die.children())
+    if (die.Tag() == llvm::dwarf::DW_TAG_member &&
+        llvm::StringRef(die.GetName()) == "__swift_mangled_name")
+      return true;
+  return false;
+}
+// END SWIFT
+
 TypeSP
 DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
                                            const DWARFDIE &die,
@@ -1802,6 +1812,9 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
     ClangASTMetadata metadata;
     metadata.SetUserID(die.GetID());
     metadata.SetIsDynamicCXXType(dwarf->ClassOrStructIsVirtual(die));
+    // BEGIN SWIFT
+    metadata.SetIsPotentiallySwiftInteropType(IsSwiftInteropType(die));
+    // END SWIFT
 
     TypeSystemClang::TemplateParameterInfos template_param_infos;
     if (ParseTemplateParameterInfos(die, template_param_infos)) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -414,6 +414,13 @@ private:
                        lldb_private::CompilerType &class_clang_type,
                        const lldb::AccessType default_accesibility,
                        lldb_private::ClangASTImporter::LayoutInfo &layout_info);
+
+  // BEGIN SWIFT
+  /// Returns true if the C++ type is a compiler-generated wrapper around a
+  /// Swift type.
+  bool IsSwiftInteropType(const lldb_private::plugin::dwarf::DWARFDIE &die);
+  // END SWIFT
+
 };
 
 /// Parsed form of all attributes that are relevant for type reconstruction.


### PR DESCRIPTION
Add a cheaper pre-check for Swift/C++ interop types when parsing the type in DWARF.

(cherry picked from commit 7a6cdb2dbdd274dc76c7ff65b4de64797e26a83e)