### PR TITLE
[lldb] Skip lldb-server unit tests when building with ASan

### DIFF
--- a/lldb/unittests/tools/CMakeLists.txt
+++ b/lldb/unittests/tools/CMakeLists.txt
@@ -1,3 +1,5 @@
 if(LLDB_TOOL_LLDB_SERVER_BUILD)
-  add_subdirectory(lldb-server)
+  if (NOT LLVM_USE_SANITIZER MATCHES ".*Address.*")
+    add_subdirectory(lldb-server)
+  endif()
 endif()


### PR DESCRIPTION
The lldb-server unit tests are failing on swift-ci and we haven't been able to figure out why. We've made several attempts to blindly address the issue but we've reached a point where we need to disable them to get signal out of this bot.