### PR TITLE
[Cherry-pick into next] Remove obsolete calls to MemoryPressureDetected

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -57,7 +57,6 @@ class TestSwiftMacroConflict(TestBase):
                         bar_value.GetError().Success())
 
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
-        lldb.SBDebugger.MemoryPressureDetected()
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
@@ -86,4 +85,3 @@ class TestSwiftMacroConflict(TestBase):
         process.Continue()
         self.expect("v foo", substrs=["42"])
         self.assertTrue(os.path.isdir(mod_cache), "module cache exists")
-        lldb.SBDebugger.MemoryPressureDetected()


### PR DESCRIPTION
```
commit 605a997e3bcc9be0a44d00dfbbaff7ba937741c9
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Jan 24 12:42:59 2024 -0800

    Remove obsolete calls to MemoryPressureDetected
```
