### PR TITLE
🍒[APINotes] For a re-exported module, look for APINotes in the re-exporting module's apinotes file

### DIFF
--- a/clang/lib/APINotes/APINotesManager.cpp
+++ b/clang/lib/APINotes/APINotesManager.cpp
@@ -251,6 +251,7 @@ llvm::SmallVector<const FileEntry *, 2> APINotesManager::getCurrentModuleAPINote
     Module *module, bool lookInModule, ArrayRef<std::string> searchPaths) {
   FileManager &fileMgr = SourceMgr.getFileManager();
   auto moduleName = module->getTopLevelModuleName();
+  auto ExportedModuleName = module->getTopLevelModule()->ExportAsModule;
   llvm::SmallVector<const FileEntry *, 2> APINotes;
 
   // First, look relative to the module itself.
@@ -263,6 +264,10 @@ llvm::SmallVector<const FileEntry *, 2> APINotesManager::getCurrentModuleAPINote
 
         APINotes.push_back(file);
       }
+      // If module FooCore is re-exported through module Foo, try Foo.apinotes.
+      if (!ExportedModuleName.empty())
+        if (auto File = findAPINotesFile(dir, ExportedModuleName, wantPublic))
+          APINotes.push_back(File);
     };
 
     if (module->IsFramework) {

--- a/clang/test/APINotes/Inputs/Headers/ExportAs.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/ExportAs.apinotes
@@ -1,0 +1,5 @@
+Name: ExportAs
+Globals:
+  - Name: globalInt
+    Availability: none
+    AvailabilityMsg: "oh no"

--- a/clang/test/APINotes/Inputs/Headers/ExportAs.h
+++ b/clang/test/APINotes/Inputs/Headers/ExportAs.h
@@ -1,0 +1,1 @@
+#include "ExportAsCore.h"

--- a/clang/test/APINotes/Inputs/Headers/ExportAsCore.h
+++ b/clang/test/APINotes/Inputs/Headers/ExportAsCore.h
@@ -1,0 +1,1 @@
+static int globalInt = 123;

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -2,6 +2,16 @@ module ExternCtx {
   header "ExternCtx.h"
 }
 
+module ExportAsCore {
+  header "ExportAsCore.h"
+  export_as ExportAs
+}
+
+module ExportAs {
+  header "ExportAs.h"
+  export *
+}
+
 module HeaderLib {
   header "HeaderLib.h"
 }

--- a/clang/test/APINotes/export-as.c
+++ b/clang/test/APINotes/export-as.c
@@ -1,0 +1,8 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers %s -ast-dump -ast-dump-filter globalInt -x c | FileCheck %s
+
+#include "ExportAs.h"
+
+// CHECK: Dumping globalInt:
+// CHECK: VarDecl {{.+}} imported in ExportAsCore globalInt 'int'
+// CHECK: UnavailableAttr {{.+}} <<invalid sloc>> "oh no"


### PR DESCRIPTION
If module FooCore is re-exported through module Foo (by using `export_as` in the modulemap), look for attributes of FooCore symbols in Foo.apinotes file.

Swift bundles `std.apinotes` file that adds Swift-specific attributes to the C++ stdlib symbols. In recent versions of libc++, module std got split into multiple top-level modules, each of them is re-exported through std. This change allows us to keep using a single modulemap file for all supported C++ stdlibs.

rdar://121680760

(cherry picked from commit 5084e0e79231bdc145cb73b82695ef8a58e710cf)