### PR TITLE
[DebugNames] Use hashes to quickly filter false positives

### DIFF
--- a/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFAcceleratorTable.cpp
@@ -937,9 +937,11 @@ DWARFDebugNames::ValueIterator::findEntryOffsetInCurrentIndex() {
     return std::nullopt; // Empty bucket
 
   for (; Index <= Hdr.NameCount; ++Index) {
-    uint32_t Hash = CurrentIndex->getHashArrayEntry(Index);
-    if (Hash % Hdr.BucketCount != Bucket)
+    uint32_t HashAtIndex = CurrentIndex->getHashArrayEntry(Index);
+    if (HashAtIndex % Hdr.BucketCount != Bucket)
       return std::nullopt; // End of bucket
+    if (HashAtIndex != Hash)
+      continue;
 
     NameTableEntry NTE = CurrentIndex->getNameTableEntry(Index);
     if (NTE.getString() == Key)


### PR DESCRIPTION
The current implementation of DebugNames is _only_ using hashes to compute the bucket number. Once inside the bucket, it reverts back to string comparisons, even though not all hashes inside a bucket are identical.

This commit changes the behavior so that we check the hash before comparing strings. Such check is so important that it speeds up a simple benchmark by 20%. In other words, the following expression evaluation time goes from 1100ms to 850ms.

```
bin/lldb \
		--batch \
		-o "b CodeGenFunction::GenerateCode" \
		-o run \
		-o "expr Fn" \
		-- \
		clang++ -c -g test.cpp -o /dev/null &> output
```

(Note, these numbers are considering the usage of IDX_parent)