### PR TITLE
Fix extra inhabitants count for Clang-imported pointers. 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -397,9 +397,7 @@ SwiftLanguageRuntimeImpl::emplaceClangTypeInfo(
   // The stride is the size rounded up to alignment.
   const size_t byte_stride = llvm::alignTo(*byte_size, byte_align);
   unsigned extra_inhabitants = 0;
-  if (clang_type.IsPointerType() &&
-      TypeSystemSwiftTypeRef::IsKnownSpecialImportedType(
-          clang_type.GetDisplayTypeName().GetStringRef()))
+  if (clang_type.IsPointerType())
     extra_inhabitants = swift::swift_getHeapObjectExtraInhabitantCount();
 
   if (fields.empty()) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -177,11 +177,6 @@ TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
   }
 }
 
-bool TypeSystemSwiftTypeRef::IsKnownSpecialImportedType(llvm::StringRef name) {
-  return name == "NSNotificationName" ||
-         swift::ClangImporter::isKnownCFTypeName(name);
-}
-
 /// Create a mangled name for a type node.
 static swift::Demangle::ManglingErrorOr<std::string>
 GetMangledName(swift::Demangle::Demangler &dem,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -359,9 +359,6 @@ public:
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
 
-  /// Return whether the type is known to be specially handled by the compiler.
-  static bool IsKnownSpecialImportedType(llvm::StringRef name);
-
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/Foo/Foo.h
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/Foo/Foo.h
@@ -1,0 +1,5 @@
+typedef struct {} *StructPtr;
+// Simulates the CoreFoundation CF_BRIDGED_TYPE(id) macro.
+typedef struct  __attribute__((objc_bridge(id))) {} *BridgedPtr;
+typedef id OpaqueObj;
+typedef void *VoidPtr;

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/Foo/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+  header "Foo.h"
+}

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/Makefile
@@ -1,0 +1,4 @@
+SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR)/Foo
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/TestSwiftClangImporterExtraInhabitants.py
@@ -1,0 +1,41 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftClangImporterExtraInhabitants(TestBase):
+    @swiftTest
+    @skipUnlessDarwin
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    def test(self):
+        """Test that the extra inhabitants are correctly computed for various
+           kinds of Objective-C pointers, by using them in enums."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+        var = self.frame().FindVariable("mystruct")
+        check = lldbutil.check_variable
+
+        check(self, var.GetChildAtIndex(0), value="0")
+        check(self, var.GetChildAtIndex(1),
+              typename="Swift.Optional<Swift.OpaquePointer>",
+              summary="nil")
+
+        check(self, var.GetChildAtIndex(2), value="2")
+        check(self, var.GetChildAtIndex(3),
+              typename="Swift.Optional<Foo.BridgedPtr>",
+              summary="nil")
+
+        check(self, var.GetChildAtIndex(4), value="4")
+        check(self, var.GetChildAtIndex(5),
+              typename="Swift.Optional<Swift.AnyObject>",
+              summary="nil")
+
+        check(self, var.GetChildAtIndex(6), value="6")
+        check(self, var.GetChildAtIndex(7),
+              typename="Swift.Optional<Swift.UnsafeMutableRawPointer>",
+              summary="nil")
+
+        check(self, var.GetChildAtIndex(8), value="8")

--- a/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/extra_inhabitants/main.swift
@@ -1,0 +1,23 @@
+import Foo
+
+class MyStruct {
+  let m0 : Int  = 0
+  let pointer : StructPtr? = nil
+  let m2 : Int = 2
+  let bridged : BridgedPtr? = nil
+  let m4 : Int = 4
+  let opaque : OpaqueObj? = nil
+  let m6 : Int = 6
+  let void : VoidPtr? = nil
+  let m8 : Int = 8
+  init() {}    
+}
+
+func use<T>(_ t: T) {}
+
+func main() {
+  let mystruct = MyStruct()
+  use(mystruct) // break here
+}
+
+main()


### PR DESCRIPTION
This patch effectively just removes a special condition that was placed there without any tests and that was thought to be correct because it was in an assertion. This commit adds the missing test and counterexample to the condition.

rdar://121225616