### PR TITLE
Fix bug with -fcas-emit-casid-file during replay.

### DIFF
--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -1048,8 +1048,11 @@ CodeGenAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
         BA == Backend_EmitObj && OutputFile != "-") {
       std::string OutputPathCASIDFile = std::string(OutputFile);
       OutputPathCASIDFile.append(".casid");
-      CasIDOS = CI.createOutputFile(OutputPathCASIDFile, true, true,
-                                    CI.getFrontendOpts().UseTemporary, false);
+      std::error_code EC;
+      CasIDOS = std::make_unique<raw_fd_ostream>(OutputPathCASIDFile, EC);
+      if (EC)
+        CI.getDiagnostics().Report(diag::err_fe_unable_to_open_output)
+            << EC.message();
     }
   }
 

--- a/clang/test/CAS/mccas-emit-casid-file.c
+++ b/clang/test/CAS/mccas-emit-casid-file.c
@@ -1,0 +1,16 @@
+// REQUIRES: x86-registered-target
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: %clang -cc1depscan -o %t/args.rsp  -cc1-args -cc1 -triple x86_64-apple-darwin10 \
+// RUN:    -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
+// RUN:    -emit-obj -fcas-backend  -fcas-path %t/cas  -fcas-emit-casid-file %s
+
+// RUN: %clang @%t/args.rsp -o %t/output1.o 
+
+// cat %t/output1.o.casid | FileCheck %s
+
+// CHECK: llvmcas://{{[a-z0-9]+}}
+
+int foo(int x) {
+    return x+1;
+}

--- a/llvm/lib/MC/MachOCASWriter.cpp
+++ b/llvm/lib/MC/MachOCASWriter.cpp
@@ -80,6 +80,10 @@ uint64_t MachOCASWriter::writeObject(MCAssembler &Asm,
 
     return Error::success();
   };
+
+  if (CasIDOS)
+    writeCASIDBuffer(CASObj.getID(), *CasIDOS);
+
   // If there is a callback, then just hand off the result through callback.
   if (ResultCallBack) {
     cantFail((*ResultCallBack)(CASObj.getID()));
@@ -114,9 +118,6 @@ uint64_t MachOCASWriter::writeObject(MCAssembler &Asm,
     break;
   }
   }
-
-  if (CasIDOS)
-    writeCASIDBuffer(CASObj.getID(), *CasIDOS);
 
   return OS.tell() - StartOffset;
 }


### PR DESCRIPTION
When using MCCAS replay with the option -fcas-emit-casid-file, we would see the error:
    
`fatal error: caching backend error: cached output file has unknown path <path-to-file>/file.casid`
    
This patch fixes that issue by just having a raw_fd_ostream in the CompilerInstance that points to the .casid file rather than having it be one of the outputs of the CompilerInstance.