### PR TITLE
[Cherry-pick into next] Work around flaky test by moving code around

### DIFF
--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/main.swift
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/main.swift
@@ -1,5 +1,7 @@
 import CoreGraphics
 
+func use<T>(_ t: T) {}
+
 public class MyClass {
   // CGImage is consulted through the external info provider.
   // This field is here to test that LLDB correctly calculates 
@@ -8,7 +10,11 @@ public class MyClass {
 	public var unused: CGImage? = nil
 	public var size: CGSize? = nil
 }
-let object = MyClass()
-object.size = CGSize(width:10, height:20)
-print(1) // Set breakpoint here.
+func f() {
+  let object = MyClass()
+  object.size = CGSize(width:10, height:20)
+  use(object)
+  print("Set breakpoint here.")
+}
 
+f()


### PR DESCRIPTION
```
commit a25c350c23a880fe079dd180a12c94e1e8d4144e
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Jan 29 14:34:57 2024 -0800

    Work around flaky test by moving code around
    
    There is an LLVM MIR bug that caused a non-sequential linetable that is being investigated spearately.
```
