### PR TITLE
[ThinLTO] Extract optionality out of `ModuleCacheEntry`

### DIFF
--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -62,8 +62,8 @@ public:
   }
 
   virtual ~ModuleCacheEntry() {}
-protected:
-  std::optional<std::string> computeCacheKey(
+
+  static std::optional<std::string> computeCacheKey(
       const ModuleSummaryIndex &Index, StringRef ModuleID,
       const FunctionImporter::ImportMapTy &ImportList,
       const FunctionImporter::ExportSetTy &ExportList,

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -602,18 +602,13 @@ public:
       cas::remote::ClientServices &Service, StringRef OutputPath,
       std::string Key,
       std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger)
-      : Service(Service), OutputPath(OutputPath.str()),
-        Logger(std::move(Logger)) {
-    ID = Key;
-  }
+      : Service(Service), ID(std::move(Key)), OutputPath(OutputPath.str()),
+        Logger(std::move(Logger)) {}
 
   std::string getEntryPath() final { return ID; }
 
   // Try loading the buffer for this cache entry.
   ErrorOr<std::unique_ptr<MemoryBuffer>> tryLoadingBuffer() final {
-    if (ID.empty())
-      return std::error_code();
-
     // Lookup the output value from KVDB.
     std::optional<cas::remote::KeyValueDBClient::ValueTy> GetResponse;
     {
@@ -672,9 +667,6 @@ public:
 
   // Cache the Produced object file
   void write(const MemoryBuffer &OutputBuffer) final {
-    if (ID.empty())
-      return;
-
     if (!ProducedOutput)
       cantFail(ModuleCacheEntry::writeObject(OutputBuffer, OutputPath));
 

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -397,8 +397,8 @@ struct NullModuleCacheEntry : ModuleCacheEntry {
 
 class FileModuleCacheEntry : public ModuleCacheEntry {
 public:
-  static std::unique_ptr<ModuleCacheEntry> make(StringRef CachePath,
-                                                std::string Key) {
+  static std::unique_ptr<ModuleCacheEntry> create(StringRef CachePath,
+                                                  std::string Key) {
     if (CachePath.empty())
       return std::make_unique<NullModuleCacheEntry>();
     return std::make_unique<FileModuleCacheEntry>(CachePath, std::move(Key));
@@ -956,7 +956,7 @@ std::unique_ptr<ModuleCacheEntry> ThinLTOCodeGenerator::createModuleCacheEntry(
 
   switch (CacheOptions.Type) {
   case CachingOptions::CacheType::CacheDirectory:
-    return FileModuleCacheEntry::make(CacheOptions.Path, std::move(*Key));
+    return FileModuleCacheEntry::create(CacheOptions.Path, std::move(*Key));
   case CachingOptions::CacheType::CAS:
     return std::make_unique<CASModuleCacheEntry>(
         *CacheOptions.CAS, *CacheOptions.Cache, std::move(*Key),


### PR DESCRIPTION
All existing kinds of `ModuleCacheEntry` contain the same kind of optionality: their `getEntryPath()`, `tryLoadingBuffer()` and `write()` functions are no-op if the ThinLTO key could not be computed in their constructors.

This patch extracts the concept of no-op cache entry into `NullModuleCacheEntry`, simplifying the logic.