### PR TITLE
[lldb] Implement DLQ_GetObjCInteropIsEnabled in LLDBMemoryReader

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -76,6 +76,11 @@ bool LLDBMemoryReader::queryDataLayout(DataLayoutQueryType type, void *inBuffer,
       *result = 0x1000;
     return true;
   }
+  case DLQ_GetObjCInteropIsEnabled: {
+    auto *result = (bool *)outBuffer;
+    *result = SwiftLanguageRuntime::GetObjCRuntime(m_process) != nullptr;
+    return true;
+  }
   }
 }
 


### PR DESCRIPTION
DLQ_GetObjCInteropIsEnabled was added as a query to queryDataLayout. Implement this query type.