### PR TITLE
[clang][DependencyScanner] Remove unused -fmodule-map-file arguments

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -192,6 +192,10 @@ ModuleDepCollector::getInvocationAdjustedForModuleBuildWithoutOutputs(
       ScanInstance.getFileManager().getFile(Deps.ClangModuleMapFile);
   assert(CurrentModuleMapEntry && "module map file entry not found");
 
+  // Remove directly passed modulemap files. They will get added back if they
+  // were actually used.
+  CI.getMutFrontendOpts().ModuleMapFiles.clear();
+
   auto DepModuleMapFiles = collectModuleMapFiles(Deps.ClangModuleDeps);
   for (StringRef ModuleMapFile : Deps.ModuleMapFileDeps) {
     // TODO: Track these as `FileEntryRef` to simplify the equality check below.

--- a/clang/test/ClangScanDeps/optimize-fmodulemap.m
+++ b/clang/test/ClangScanDeps/optimize-fmodulemap.m
@@ -1,0 +1,66 @@
+// Check that unused directly passed -fmodule-map-file options get dropped.
+
+// RUN: rm -rf %t && split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/build/cdb.json.in > %t/build/cdb.json
+// RUN: clang-scan-deps -compilation-database %t/build/cdb.json \
+// RUN:   -format experimental-full > %t/deps.json
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t
+
+// CHECK:      {
+// CHECK-NEXT:   "modules": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "clang-module-deps": [
+// CHECK-NEXT:         {
+// CHECK-NEXT:           "context-hash": "{{.*}}",
+// CHECK-NEXT:           "module-name": "B"
+// CHECK-NEXT:         }
+// CHECK-NEXT:       ],
+// CHECK-NEXT:       "clang-modulemap-file": "[[PREFIX]]/modules/A/module.modulemap",
+// CHECK-NEXT:       "command-line": [
+// CHECK-NOT:          "-fmodule-map-file=[[PREFIX]]/modules/A/module.modulemap"
+// CHECK:              "-fmodule-map-file=[[PREFIX]]/modules/B/module.modulemap"
+// CHECK-NOT:          "-fmodule-map-file=[[PREFIX]]/modules/A/module.modulemap"
+// CHECK:            ],
+// CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "file-deps": [
+// CHECK:            ],
+// CHECK-NEXT:       "name": "A"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "clang-module-deps": [],
+// CHECK-NEXT:       "clang-modulemap-file": "[[PREFIX]]/modules/B/module.modulemap",
+// CHECK-NEXT:       "command-line": [
+// CHECK-NOT:          "-fmodule-map-file=
+// CHECK:            ],
+// CHECK-NEXT:       "context-hash": "{{.*}}",
+// CHECK-NEXT:       "file-deps": [
+// CHECK:            ],
+// CHECK-NEXT:       "name": "B"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "translation-units": [
+// CHECK:        ]
+// CHECK:      }
+
+//--- build/cdb.json.in
+[{
+  "directory": "DIR",
+  "command": "clang -c DIR/tu.m -I DIR/modules/B -fmodule-map-file=DIR/modules/A/module.modulemap -fmodules -fmodules-cache-path=DIR/cache -fimplicit-module-maps",
+  "file": "DIR/tu.m"
+}]
+
+//--- build/vfs.yaml.in
+
+//--- tu.m
+@import A;
+
+//--- modules/A/module.modulemap
+module A { header "A.h" }
+
+//--- modules/A/A.h
+#include <B.h>
+
+//--- modules/B/module.modulemap
+module B { header "B.h" }
+
+//--- modules/B/B.h


### PR DESCRIPTION
Since we already add a `-fmodule-map-file=` argument for every used modulemap, we can remove all `ModuleMapFiles` entries before adding them.

This reduces the number of module variants when `-fmodule-map-file=` appears on the original command line.

https://github.com/llvm/llvm-project/pull/80090
rdar://121945037

(cherry picked from commit c003d851f5cc1476774153fa9ed02fda725e9d57)