### PR TITLE
Add strx and all it's variants to FormsToPartition.

### DIFF
--- a/llvm/lib/MCCAS/MCCASDebugV1.cpp
+++ b/llvm/lib/MCCAS/MCCASDebugV1.cpp
@@ -218,6 +218,11 @@ bool mccasformats::v1::doesntDedup(dwarf::Form Form, dwarf::Attribute Attr) {
             dwarf::Attribute::DW_AT_call_file}},
           {dwarf::Form::DW_FORM_addrx, {}},
           {dwarf::Form::DW_FORM_addr, {}},
+          {dwarf::Form::DW_FORM_strx, {}},
+          {dwarf::Form::DW_FORM_strx1, {}},
+          {dwarf::Form::DW_FORM_strx2, {}},
+          {dwarf::Form::DW_FORM_strx3, {}},
+          {dwarf::Form::DW_FORM_strx4, {}},
       };
 
   auto it = FormsToPartition.find(Form);


### PR DESCRIPTION
In DWARF 5, there are new string inderiction forms, which are strx, strx1, strx2, strx3, and strx4. These forms do not deduplicate in the CAS, and must be partitioned out when creating a CAS representation of the debug info section. Therefore, they need to be added to the FormsToPartition table. This patch addresses that.

(cherry picked from commit 2cdd722887f8b4a3d5548e3888f5d284193de4c0)