### PR TITLE
[lldb][Progress] Separate title and details (#77547) (#7978)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4166,11 +4166,9 @@ void SwiftASTContext::ValidateSectionModules(
 
   Status error;
 
-  Progress progress(
-      llvm::formatv("Loading Swift module {0}",
-                    module.GetFileSpec().GetFilename().AsCString()),
-      module_names.size());
-
+  Progress progress("Loading Swift module '{0}' dependencies",
+                    module.GetFileSpec().GetFilename().AsCString(),
+                    module_names.size());
   size_t completion = 0;
 
   for (const std::string &module_name : module_names) {
@@ -8748,11 +8746,9 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
   if (cu_imports.size() == 0)
     return true;
 
-  Progress progress(
-      llvm::formatv("Getting Swift compile unit imports for '{0}'",
-                    compile_unit->GetPrimaryFile().GetFilename()),
-      cu_imports.size());
-
+  Progress progress("Getting Swift compile unit imports",
+                    compile_unit->GetPrimaryFile().GetFilename().GetCString(),
+                    cu_imports.size());
   size_t completion = 0;
   for (const SourceModule &module : cu_imports) {
     progress.Increment(++completion);

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -37,11 +37,14 @@ class TestSwiftProgressReporting(TestBase):
         self.runCmd("expr boo")
         self.runCmd("v s")
 
-        beacons = [ "Loading Swift module",
-                    "Caching Swift user imports from",
-                    "Setting up Swift reflection for",
-                    "Getting Swift compile unit imports for",
-                    "Importing module", "Importing overlay module"]
+        beacons = [
+            "Loading Swift module",
+            "Importing modules used in expression",
+            "Setting up Swift reflection",
+            "Getting Swift compile unit imports",
+            "Importing Swift modules",
+            "Importing Swift standard library",
+        ]
 
         while len(beacons):
             event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)


### PR DESCRIPTION
Per this RFC:
https://discourse.llvm.org/t/rfc-improve-lldb-progress-reporting/75717 on improving progress reports, this commit separates the title field and details field so that the title specifies the category that the progress report falls under. The details field is added as a part of the constructor for progress reports and by default is an empty string. In addition, changes the total amount of progress completed into a std::optional. Also updates the test to check for details being correctly reported from the event structured data dictionary.

Some changes were made to Swift progress reports to match the upstream changes to `Progress`.
(cherry picked from commit f1ef910b97d6acb80480b79a4144541311369cc9) (cherry picked from commit 342d11d5df54940f1aaa5d8a21eef8a85ca4ac6e)