### PR TITLE
[-Wunsafe-buffer-usage] Fix AST matcher of UUCAddAssignGadget

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1185,11 +1185,16 @@ public:
   }
 
   static Matcher matcher() {
+    // clang-format off
     return stmt(isInUnspecifiedUntypedContext(expr(ignoringImpCasts(
         binaryOperator(hasOperatorName("+="),
-                       hasLHS(declRefExpr(toSupportedVariable())),
+                       hasLHS(
+                        declRefExpr(
+                          hasPointerType(),
+                          toSupportedVariable())),
                        hasRHS(expr().bind(OffsetTag)))
             .bind(UUCAddAssignTag)))));
+    // clang-format on
   }
 
   virtual std::optional<FixItList> getFixits(const Strategy &S) const override;


### PR DESCRIPTION
We are not interested in nonpointers being added to.

(cherry picked from commit dcc2b0c07681b57dbd5a82ce83f5166bb3b9ee09)