### PR TITLE
[-Wunsafe-buffer-usage][NFC] Add testcase for not-unsafe pointer

### DIFF
--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-fixits-pointer-access.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-fixits-pointer-access.cpp
@@ -85,6 +85,7 @@ void unsafe_method_invocation_single_param() {
 
 void safe_method_invocation_single_param() {
   int* p = new int[10];
+  // CHECK-NOT: fix-it:"{{.*}}":{[[@LINE-1]]:{{.*}}-[[@LINE-1]]:{{.*}}}
   foo(p);
 }
 


### PR DESCRIPTION
(cherry picked from commit ea06ed298ffd5552e98caa2739115bc0ded22ebf)