### PR TITLE
Frontend: sink vendor definitions from Basic to Frontend

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -266,7 +266,6 @@ ArrayRef<Builtin::Info> AMDGPUTargetInfo::getTargetBuiltins() const {
 
 void AMDGPUTargetInfo::getTargetDefines(const LangOptions &Opts,
                                         MacroBuilder &Builder) const {
-  Builder.defineMacro("__AMD__");
   Builder.defineMacro("__AMDGPU__");
 
   if (isAMDGCN(getTriple()))

--- a/clang/lib/Basic/Targets/OSTargets.cpp
+++ b/clang/lib/Basic/Targets/OSTargets.cpp
@@ -23,7 +23,6 @@ void getDarwinDefines(MacroBuilder &Builder, const LangOptions &Opts,
                       const llvm::Triple &Triple, StringRef &PlatformName,
                       VersionTuple &PlatformMinVersion) {
   Builder.defineMacro("__APPLE_CC__", "6000");
-  Builder.defineMacro("__APPLE__");
   Builder.defineMacro("__STDC_NO_THREADS__");
 
   // AddressSanitizer doesn't play well with source fortification, which is on

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -804,6 +804,11 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
     }
   }
 
+  if (TI.getTriple().getVendor() == Triple::AMD)
+    Builder.defineMacro("__AMD__");
+  if (TI.getTriple().getVendor() == Triple::Apple)
+    Builder.defineMacro("__APPLE__");
+
   // Define macros for the C11 / C++11 memory orderings
   Builder.defineMacro("__ATOMIC_RELAXED", "0");
   Builder.defineMacro("__ATOMIC_CONSUME", "1");


### PR DESCRIPTION
The vendor specific macro definitions are based on the vendor rather than the target specific information. This ensures that `__APPLE__` is always defined for `*-apple-*` targets. Take the opportunity to do likewise with the `__AMD__` vendor macro.