### PR TITLE
[clang][ASTImporter] Fix LLDB crash when declaration chain contains decls without TypeForDecls

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3031,8 +3031,8 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
           InjSpec = ToDescribed->getInjectedClassNameSpecialization();
         for (auto *R : Redecls) {
           auto *RI = cast<CXXRecordDecl>(R);
-          auto *TFD = RI->getTypeForDecl();
-          if (R != Redecls.front() || (TFD && !isa<InjectedClassNameType>(TFD)))
+          if (R != Redecls.front() ||
+              !isa_and_nonnull<InjectedClassNameType>(RI->getTypeForDecl()))
             RI->setTypeForDecl(nullptr);
           // This function tries to get the injected type from getTypeForDecl,
           // then from the previous declaration if possible. If not, it creates

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3009,11 +3009,10 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         SmallVector<Decl *, 2> Redecls =
             getCanonicalForwardRedeclChain(D2CXX);
 
-        // FIXME: This is an LLDB-specific fix for crashes
-        // related to rdar://120862220, where the redeclaration
-        // chain can contain decls that don't have a TypeForDecl.
-        // In such cases we want to grab the TypeForDecl from some
-        // other declaration on the chain.
+        // This is an LLDB-specific fix for crashes where the
+        // redeclaration chain can contain decls that don't have a
+        // TypeForDecl. In such cases we want to grab the TypeForDecl
+        // from some other declaration on the chain.
         const Type *FrontTy = nullptr;
         for (auto const &Redecl : Redecls) {
           FrontTy = cast<CXXRecordDecl>(Redecl)->getTypeForDecl();

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3015,13 +3015,14 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         // In such cases we want to grab the TypeForDecl from some
         // other declaration on the chain.
         const Type *FrontTy = nullptr;
-        for (auto const& Redecl : Redecls) {
+        for (auto const &Redecl : Redecls) {
           FrontTy = cast<CXXRecordDecl>(Redecl)->getTypeForDecl();
           if (FrontTy)
             break;
         }
 
-        assert (FrontTy != nullptr);
+        assert(FrontTy != nullptr &&
+               "TypeForDecl not set on any decl of the redecl chain");
 
         QualType InjSpec;
         if (auto *InjTy = FrontTy->getAs<InjectedClassNameType>())

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3009,11 +3009,6 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         SmallVector<Decl *, 2> Redecls =
             getCanonicalForwardRedeclChain(D2CXX);
 
-        // This is an LLDB-specific fix for crashes where the
-        // redeclaration chain can contain decls that don't have a
-        // TypeForDecl. In such cases we want to grab the TypeForDecl
-        // from some other declaration on the chain.
-
         InjectedClassNameType const *ICNT = nullptr;
         for (auto const *Redecl : Redecls) {
           const Type *Ty = cast<CXXRecordDecl>(Redecl)->getTypeForDecl();

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3014,13 +3014,16 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         // TypeForDecl. In such cases we want to grab the TypeForDecl
         // from some other declaration on the chain.
         const Type *FrontTy = nullptr;
+        const Decl *DeclWithTypeForDecl = nullptr;
         for (auto const &Redecl : Redecls) {
           FrontTy = cast<CXXRecordDecl>(Redecl)->getTypeForDecl();
-          if (FrontTy)
+          if (FrontTy) {
+            DeclWithTypeForDecl = Redecl;
             break;
+          }
         }
 
-        assert(FrontTy != nullptr &&
+        assert(FrontTy != nullptr && DeclWithTypeForDecl != nullptr &&
                "TypeForDecl not set on any decl of the redecl chain");
 
         QualType InjSpec;
@@ -3030,7 +3033,7 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
           InjSpec = ToDescribed->getInjectedClassNameSpecialization();
         for (auto *R : Redecls) {
           auto *RI = cast<CXXRecordDecl>(R);
-          if (R != Redecls.front() ||
+          if (R != DeclWithTypeForDecl ||
               !isa_and_nonnull<InjectedClassNameType>(RI->getTypeForDecl()))
             RI->setTypeForDecl(nullptr);
           // This function tries to get the injected type from getTypeForDecl,

--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -3012,7 +3012,6 @@ ExpectedDecl ASTNodeImporter::VisitRecordDecl(RecordDecl *D) {
         InjectedClassNameType const *ICNT = nullptr;
         for (auto const *Redecl : Redecls) {
           const Type *Ty = cast<CXXRecordDecl>(Redecl)->getTypeForDecl();
-
           ICNT = llvm::dyn_cast_if_present<InjectedClassNameType>(Ty);
           if (ICNT)
             break;


### PR DESCRIPTION
This works around a frequent LLDB crash we've been seeing (when debugging projects that use precompiled headers) where `getTypeForDecl() == nullptr` for the canonical decl on a declaration chain of a `CXXRecordDecl` describing a template.

This patch simply iterates over the redecl chain until we find a valid `TypeForDecl` and use that as the injected class name instead.

rdar://120862220
rdar://109876539