### PR TITLE
[lldb] Add support for class info lookup from DWARF

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -89,8 +89,13 @@ public:
   std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
   getBuiltinTypeDescriptor(const swift::reflection::TypeRef *TR) override;
 
+private:
+  /// Returns the canonical demangle tree of a die's type.
+  NodePointer GetCanonicalDemangleTree(DWARFDIE &die);
+
 protected:
   lldb_private::TypeSystemSwiftTypeRef &m_swift_typesystem;
+  swift::Demangle::Demangler m_dem;
 };
 
 #endif // SymbolFileDWARF_DWARFASTParserSwift_h_

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -318,6 +318,10 @@ public:
   llvm::Optional<TupleElement>
   GetTupleElement(lldb::opaque_compiler_type_t type, size_t idx);
 
+  /// Returns true if the compiler type is a Builtin (belongs to the "Builtin
+  /// module").
+  static bool IsBuiltinType(CompilerType type);
+
   /// Creates a GenericTypeParamType with the desired depth and index.
   CompilerType CreateGenericTypeParamType(unsigned int depth,
                                     unsigned int index) override;

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -31,3 +31,8 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         )
 
         # TODO: test enums when "rdar://119343683 (Embedded Swift trivial case enum fails to link)" is solved
+
+        self.expect("frame variable sup", substrs=["Sup) sup = ", "supField = 42"])
+        self.expect("frame variable sub", substrs=["Sub) sub = ", "Sup = {", "supField = 42", "subField = {", "a = (field = 4.2000000000000002", "b = 123456"])
+        self.expect("frame variable subSub", substrs=["SubSub) subSub =", "a.Sub = {", "a.Sup = {", "supField = 42", "subField = {", "a = (field = 4.2000000000000002", "b = 123456", "subSubField = (field = 4.2000000000000002)"])
+

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -26,6 +26,18 @@ struct B {
 //   case nonPayloadTwo
 // }
 
+class Sup {
+  var supField: Int8 = 42
+}
+
+class Sub: Sup {
+  var subField = B()
+}
+
+class SubSub: Sub {
+  var subSubField = A()
+}
+
 let varB = B()
 let tuple = (A(), B())
 // let trivial = TrivialEnum.theCase
@@ -33,6 +45,10 @@ let tuple = (A(), B())
 // let nonPayload2 = NonPayloadEnum.two
 // let singlePayload = SinglePayloadEnum.payload(B())
 // let emptySinglePayload = SinglePayloadEnum.nonPayloadTwo
+let sup = Sup()
+let sub = Sub()
+let subSub = SubSub()
+let sup2: Sup = SubSub()
 
 // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
 let dummy = A() // break here


### PR DESCRIPTION
This patch expands the DWARFASTParserSwift's implementation of the DescriptorFinder interface to lookup classes debug information from DWARF.