### PR TITLE
[lldb] Fix embedded type summary regex handling

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1452,7 +1452,7 @@ static void LoadTypeSummariesForModule(ModuleSP module_sp) {
     return;
 
   Log *log = GetLog(LLDBLog::DataFormatters);
-  const char *module_name = module_sp->GetObjectName().GetCString();
+  const char *module_name = module_sp->GetFileSpec().GetFilename().GetCString();
 
   TypeCategoryImplSP category;
   DataVisualization::Categories::GetCategory(ConstString("default"), category);
@@ -1488,7 +1488,7 @@ static void LoadTypeSummariesForModule(ModuleSP module_sp) {
         auto summary_sp =
             std::make_shared<StringSummaryFormat>(flags, summary_string.data());
         FormatterMatchType match_type = eFormatterMatchExact;
-        if (summary_string.front() == '^' && summary_string.back() == '$')
+        if (type_name.front() == '^')
           match_type = eFormatterMatchRegex;
         category->AddTypeSummary(type_name, match_type, summary_sp);
         LLDB_LOGF(log, "Loaded embedded type summary for '%s' from %s.",

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
@@ -10,3 +10,4 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
         self.expect("v player", substrs=['"Dirk" (41)'])
+        self.expect("v layer", substrs=['"crust" (3)'])

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
@@ -7,10 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @skipUnlessDarwin
     def test(self):
-        self.runCmd("log enable lldb formatters")
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
         self.expect("v player", substrs=['"Dirk" (41)'])
-        self.runCmd("type summary list", trace=True)
-        self.runCmd("type summary info layer", trace=True)
         self.expect("v layer", substrs=['"crust" (3)'])

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
@@ -10,4 +10,6 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
         self.expect("v player", substrs=['"Dirk" (41)'])
+        self.runCmd("type summary list")
+        self.runCmd("type summary info layer")
         self.expect("v layer", substrs=['"crust" (3)'])

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
@@ -10,6 +10,6 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
         self.expect("v player", substrs=['"Dirk" (41)'])
-        self.runCmd("type summary list")
-        self.runCmd("type summary info layer")
+        self.runCmd("type summary list", trace=True)
+        self.runCmd("type summary info layer", trace=True)
         self.expect("v layer", substrs=['"crust" (3)'])

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @skipUnlessDarwin
     def test(self):
+        self.runCmd("log enable lldb formatters")
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
         self.expect("v player", substrs=['"Dirk" (41)'])

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
@@ -5,7 +5,8 @@ struct Player {
   int number;
 };
 
-__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
+__attribute__((aligned(1), used,
+               section("__DATA_CONST,__lldbsummaries"))) unsigned char
     _Player_type_summary[] = "\x01"     // version
                              "\x25"     // record size
                              "\x07"     // type name size
@@ -19,7 +20,8 @@ struct Layer {
 };
 
 // Near copy of the record for `Player`, using a regex type name (`^Layer`).
-__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
+__attribute__((aligned(1), used,
+               section("__DATA_CONST,__lldbsummaries"))) unsigned char
     _Layer_type_summary[] = "\x01"     // version
                             "\x25"     // record size
                             "\x07"     // type name size

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
@@ -13,10 +13,27 @@ __attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
                              "\x1c"     // summary string size
                              "${var.name} (${var.number})"; // summary string
 
+struct Layer {
+  char *name;
+  int number;
+};
+
+// Near copy of the record for `Player`, using a regex type name (`^Layer`).
+__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
+    _Lawyer_type_summary[] = "\x01"     // version
+                             "\x25"     // record size
+                             "\x07"     // type name size
+                             "^Layer\0" // type name
+                             "\x1c"     // summary string size
+                             "${var.name} (${var.number})"; // summary string
+
 int main() {
   struct Player player;
   player.name = "Dirk";
   player.number = 41;
+  struct Layer layer;
+  layer.name = "crust";
+  layer.number = 3;
   puts("break here");
   return 0;
 }

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
@@ -20,12 +20,12 @@ struct Layer {
 
 // Near copy of the record for `Player`, using a regex type name (`^Layer`).
 __attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
-    _Lawyer_type_summary[] = "\x01"     // version
-                             "\x25"     // record size
-                             "\x07"     // type name size
-                             "^Layer\0" // type name
-                             "\x1c"     // summary string size
-                             "${var.name} (${var.number})"; // summary string
+    _Layer_type_summary[] = "\x01"     // version
+                            "\x25"     // record size
+                            "\x07"     // type name size
+                            "^Layer\0" // type name
+                            "\x1c"     // summary string size
+                            "${var.name} (${var.number})"; // summary string
 
 int main() {
   struct Player player;


### PR DESCRIPTION
Fixes a logic error when determining if a type is a regex. Look for a leading `^` in the type name, not the summary string.

Adds a test to verify regex handling.

Fixes a log message to help debugging.