### PR TITLE
Add TypeSystemSwiftTypeRef suport for protocol composition types.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6804,16 +6804,9 @@ static std::pair<CompilerType, std::string> GetExistentialTypeChild(
   // The instance for a class-bound existential.
   if (idx == 0 && protocol_info.m_is_class_only) {
     CompilerType class_type;
-    // FIXME: Remove this comment once the TypeSystemSwiftTyperef
-    // transition is complete.
-    //
-    // There is not enough data available to support this in
-    // TypeSystemSwiftTypeRef, but there is also notuser-visible
-    // feature affected by this apart from the --raw-types output, so
-    // this was removed to match TypeSystemSwiftTyperef:
-    /* if (protocol_info.m_superclass) {
+    if (protocol_info.m_superclass) {
       class_type = protocol_info.m_superclass;
-      } else */ {
+    } else {
       auto raw_pointer = ast.TheRawPointerType;
       class_type = ToCompilerType(raw_pointer.getPointer());
     }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1590,8 +1590,6 @@ TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext *sc) const {
 
 SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
     const SymbolContext *sc) const {
-  // SwiftASTContext::CreateInstance() returns a nullptr on failure,
-  // there is no point in trying to initialize when that happens.
   bool precise = false;
   // Compute the cache key.
   const char *key = nullptr;

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/Makefile
@@ -1,0 +1,3 @@
+SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftProtocolComposition.py
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftProtocolComposition.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftProtocolComposition(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test that the extra inhabitants are correctly computed for various
+           kinds of Objective-C pointers, by using them in enums."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+        obj = self.frame().FindVariable("obj", lldb.eDynamicDontRunTarget)
+        p = obj.GetChildAtIndex(0, lldb.eDynamicDontRunTarget, False)
+        some = p.GetChildAtIndex(0, lldb.eDynamicDontRunTarget, False)
+        synth_obj = p.GetChildMemberWithName('object', lldb.eDynamicDontRunTarget)
+        i = synth_obj.GetChildMemberWithName('i', lldb.eDynamicDontRunTarget)
+        lldbutil.check_variable(self, i, value="23")

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftProtocolComposition.py
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftProtocolComposition.py
@@ -8,8 +8,8 @@ class TestSwiftProtocolComposition(TestBase):
     @skipUnlessDarwin
     @swiftTest
     def test(self):
-        """Test that the extra inhabitants are correctly computed for various
-           kinds of Objective-C pointers, by using them in enums."""
+        """Test that protocol composition types can be resolved
+           through the Swift language runtime"""
         self.build()
         lldbutil.run_to_source_breakpoint(self, 'break here',
                                           lldb.SBFileSpec('main.swift'))

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/main.swift
@@ -1,0 +1,22 @@
+import Foundation
+@objc public protocol MyProtocol : NSObjectProtocol {}
+
+@objc class C : NSObject {
+  let i = 23
+}
+
+extension C : MyProtocol {
+}
+
+class D {
+  let p : MyProtocol = C()
+}
+
+func use<T>(_ t: T) {}
+
+func main() {
+  let obj = D()
+  use(obj) // break here
+}
+
+main()

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -82,9 +82,8 @@ class TestSwiftProtocolTypes(TestBase):
         self.expect("expression --dynamic-type no-dynamic-values"
                     " --raw-output --show-types -- loc3dSuper",
                     substrs=['(a.PointSuperclass & a.PointUtils) $R',
-#                             Only supported by SwiftASTContext and of little usefulness.
-#                             '(a.PointSuperclass) object = 0x',
-#                             '(Swift.Int) superData = ',
+                             '(a.PointSuperclass) object = 0x',
+                             '(Swift.Int) superData = ',
                              '(Builtin.RawPointer) wtable = 0x'])
 
         self.expect("expression -- loc3dSuper",


### PR DESCRIPTION
plus assorted other performance improvements that eliminate SwiftASTContext fallback paths.