### PR TITLE
[5.10] Remove a bogus assertion.

### DIFF
--- a/clang/include/clang/AST/PropertiesBase.td
+++ b/clang/include/clang/AST/PropertiesBase.td
@@ -517,20 +517,16 @@ let Class = PropertyTypeCase<APValue, "LValue"> in {
   def : Creator<[{
     (void)ctx;
     APValue::LValueBase base;
-    QualType elemTy;
     if (hasBase) {
       if (isTypeInfo) {
         base = APValue::LValueBase::getTypeInfo(
             TypeInfoLValue(typeInfo.value().getTypePtr()), type.value());
-        elemTy = base.getTypeInfoType();
       } else if (isExpr) {
         base = APValue::LValueBase(cast<Expr>(stmt.value()),
                                    callIndex.value(), version.value());
-        elemTy = base.get<const Expr *>()->getType();
       } else {
         base = APValue::LValueBase(cast<ValueDecl>(decl.value()),
                                    callIndex.value(), version.value());
-        elemTy = base.get<const ValueDecl *>()->getType();
       }
     }
     CharUnits offset = CharUnits::fromQuantity(offsetQuantity);
@@ -543,7 +539,6 @@ let Class = PropertyTypeCase<APValue, "LValue"> in {
     auto pathLength = lvaluePath->Path.size();
     APValue::LValuePathEntry *path = result.setLValueUninit(
         base, offset, pathLength, isLValueOnePastTheEnd, isNullPtr).data();
-    assert(lvaluePath->getType() == elemTy && "Unexpected type reference!");
     llvm::copy(lvaluePath->Path, path);
     return result;
   }]>;


### PR DESCRIPTION
The result of recomputing the type of an LValue may be different from the type we find serialized with that LValue, either due to differing type sugar in a redeclaration, or more significantly due to a later declaration of a variable having an array bound that a prior declaration did not have. Therefore this assertion was attempting to verify a property that isn't necessarily true.

(cherry-picked commit 2009f2450532)

Needed to build Arc browser with Swift 5.10