### PR TITLE
[lldb] Skip null bytes in embedded type summaries

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1476,8 +1476,26 @@ static void LoadTypeSummariesForModule(ModuleSP module_sp) {
   auto section_size = summaries_sp->GetSectionData(extractor);
   lldb::offset_t offset = 0;
   while (offset < section_size) {
+    // Skip null bytes. Can happen with alignment padding.
+    while (true) {
+      auto next_offset = offset;
+      if (extractor.GetU8(&next_offset) != 0) {
+        break;
+      }
+      // Move past the null byte, using the advanced offset.
+      offset = next_offset;
+    }
+
     uint64_t version = extractor.GetULEB128(&offset);
     uint64_t record_size = extractor.GetULEB128(&offset);
+    if (record_size == 0) {
+      LLDB_LOGF(log,
+                "Skipping empty (malformed) embedded type summary of version "
+                "%llu in %s.",
+                version, module_name);
+      continue;
+    }
+
     if (version == 1) {
       uint64_t type_size = extractor.GetULEB128(&offset);
       llvm::StringRef type_name = extractor.GetCStr(&offset, type_size);

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
@@ -5,8 +5,7 @@ struct Player {
   int number;
 };
 
-__attribute__((aligned(1), used,
-               section("__DATA_CONST,__lldbsummaries"))) unsigned char
+__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
     _Player_type_summary[] = "\x01"     // version
                              "\x25"     // record size
                              "\x07"     // type name size
@@ -20,8 +19,7 @@ struct Layer {
 };
 
 // Near copy of the record for `Player`, using a regex type name (`^Layer`).
-__attribute__((aligned(1), used,
-               section("__DATA_CONST,__lldbsummaries"))) unsigned char
+__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
     _Layer_type_summary[] = "\x01"     // version
                             "\x25"     // record size
                             "\x07"     // type name size


### PR DESCRIPTION
Handle null padding that may exists between embedded type summary records. This can happen for example on x86-64 where the default alignment of `char[]` is 16 (p2align = 4).