### PR TITLE
[lldb] Remove redundant severity substring within a diagnostic message

### DIFF
--- a/lldb/source/Expression/DiagnosticManager.cpp
+++ b/lldb/source/Expression/DiagnosticManager.cpp
@@ -46,11 +46,20 @@ static const char *StringForSeverity(DiagnosticSeverity severity) {
 
 std::string DiagnosticManager::GetString(char separator) {
   std::string ret;
+  llvm::raw_string_ostream stream(ret);
 
   for (const auto &diagnostic : Diagnostics()) {
-    ret.append(StringForSeverity(diagnostic->GetSeverity()));
-    ret.append(std::string(diagnostic->GetMessage()));
-    ret.push_back(separator);
+    llvm::StringRef severity = StringForSeverity(diagnostic->GetSeverity());
+    stream << severity;
+
+    llvm::StringRef message = diagnostic->GetMessage();
+    std::string searchable_message = message.lower();
+    auto severity_pos = message.find(severity);
+    stream << message.take_front(severity_pos);
+
+    if (severity_pos != llvm::StringRef::npos)
+      stream << message.drop_front(severity_pos + severity.size());
+    stream << separator;
   }
 
   return ret;

--- a/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
+++ b/lldb/test/API/lang/objc/modules-compile-error/TestModulesCompileError.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             "expr @import LLDBTestModule",
             error=True,
             substrs=[
-                "module.h:4:1: error: unknown type name 'syntax_error_for_lldb_to_find'",
+                "module.h:4:1: unknown type name 'syntax_error_for_lldb_to_find'",
                 "syntax_error_for_lldb_to_find // comment that tests source printing",
                 "could not build module 'LLDBTestModule'",
             ],

--- a/lldb/test/API/lang/swift/playgrounds-repl/invalid_input/TestInvalidInput.py
+++ b/lldb/test/API/lang/swift/playgrounds-repl/invalid_input/TestInvalidInput.py
@@ -47,7 +47,7 @@ class TestInvalidInput(repl.PlaygroundREPLTest):
         self.assertTrue(is_error)
         error = self.get_stream_data(result)
         self.assertIn("left side of mutating operator", error, "Error messages do not match")
-        self.assertIn(":15:3: error: left side of mutating operator", error, "Error line number does not match")
+        self.assertIn(":15:3: left side of mutating operator", error, "Error line number does not match")
 
         # Execute revised block
         result, output = self.execute_code("Input3.swift")

--- a/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
+++ b/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
@@ -10,8 +10,8 @@
 
 
 _ = "An unterminated string
-// DIAGNOSTIC: error: unterminated string literal [lex_unterminated_string]{{$}}
-// LOCALIZED: error: chaîne non terminée littérale{{$}}
+// DIAGNOSTIC: unterminated string literal [lex_unterminated_string]{{$}}
+// LOCALIZED: chaîne non terminée littérale{{$}}
 :quit
 
 

--- a/lldb/test/Shell/SwiftREPL/ImportError.test
+++ b/lldb/test/Shell/SwiftREPL/ImportError.test
@@ -4,5 +4,5 @@
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 
 import ModuleThatDoesNotExist
-// CHECK: error: no such module 'ModuleThatDoesNotExist'
+// CHECK: no such module 'ModuleThatDoesNotExist'
 // CHECK-NOT: fixed expression suggested

--- a/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
+++ b/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
@@ -8,7 +8,7 @@
 // RUN: %lldb --repl="-I%t -L%t -lA" < %s 2>&1 | FileCheck %s
 
 "".foo()
-// CHECK: error: value of type 'String' has no member 'foo'
+// CHECK: value of type 'String' has no member 'foo'
 
 import A
 

--- a/lldb/test/Shell/SwiftREPL/LookupWithAttributedImport.test
+++ b/lldb/test/Shell/SwiftREPL/LookupWithAttributedImport.test
@@ -15,7 +15,7 @@ let y = Bar(baz: 123)
 // CHECK: baz = 123
 
 let x = Foo(bar:42)
-// CHECK: error: repl.swift:{{.*}}: error: cannot find 'Foo' in scope
+// CHECK: error: repl.swift:{{.*}}: cannot find 'Foo' in scope
 
 @testable import Test
 

--- a/lldb/test/Shell/SwiftREPL/OpenClass.test
+++ b/lldb/test/Shell/SwiftREPL/OpenClass.test
@@ -26,4 +26,4 @@ class Baz: Foo {
   override func foo() -> Int { return 4 }
 }
 
-// CHECK: error: overriding non-open instance method outside of its defining module
+// CHECK: overriding non-open instance method outside of its defining module

--- a/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
+++ b/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
@@ -34,5 +34,5 @@
 
 @A var anA: Int = 1
 
-// CHECK: error: property wrappers are not yet supported in top-level code
+// CHECK: property wrappers are not yet supported in top-level code
 // CHECK-NEXT: @A var anA: Int = 1


### PR DESCRIPTION
This is a cherry-pick from llvm/llvm-project:
- https://github.com/llvm/llvm-project/pull/76111

For example, the following message has the severity string "error: " twice.
> "error: <EXPR>:3:1: error: cannot find 'bogus' in scope

This method already appends the severity string in the beginning, but with this fix, it also removes a secondary instance, if applicable.

Note that this change only removes the *first* redundant substring. I considered putting the removal logic in a loop, but I decided that if something is generating more than one redundant severity substring, then that's a problem the message's source should probably fix.

rdar://114203423