### PR TITLE
[lldb][unittests] Add once_flag to initialization of debugger in testing support

### DIFF
--- a/lldb/unittests/Core/DiagnosticEventTest.cpp
+++ b/lldb/unittests/Core/DiagnosticEventTest.cpp
@@ -11,6 +11,7 @@
 #include "Plugins/Platform/MacOSX/PlatformMacOSX.h"
 #include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
 #include "TestingSupport/SubsystemRAII.h"
+#include "TestingSupport/TestUtilities.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/DebuggerEvents.h"
 #include "lldb/Host/FileSystem.h"
@@ -26,8 +27,6 @@ using namespace lldb_private::repro;
 static const constexpr std::chrono::seconds TIMEOUT(0);
 static const constexpr size_t DEBUGGERS = 3;
 
-static std::once_flag debugger_initialize_flag;
-
 namespace {
 class DiagnosticEventTest : public ::testing::Test {
 public:
@@ -35,7 +34,7 @@ public:
     FileSystem::Initialize();
     HostInfo::Initialize();
     PlatformMacOSX::Initialize();
-    std::call_once(debugger_initialize_flag,
+    std::call_once(TestUtilities::g_debugger_initialize_flag,
                    []() { Debugger::Initialize(nullptr); });
     ArchSpec arch("x86_64-apple-macosx-");
     Platform::SetHostPlatform(

--- a/lldb/unittests/TestingSupport/TestUtilities.cpp
+++ b/lldb/unittests/TestingSupport/TestUtilities.cpp
@@ -19,6 +19,7 @@ using namespace lldb_private;
 
 extern const char *TestMainArgv0;
 
+std::once_flag TestUtilities::g_debugger_initialize_flag;
 std::string lldb_private::GetInputFilePath(const llvm::Twine &name) {
   llvm::SmallString<128> result = llvm::sys::path::parent_path(TestMainArgv0);
   llvm::sys::fs::make_absolute(result);

--- a/lldb/unittests/TestingSupport/TestUtilities.h
+++ b/lldb/unittests/TestingSupport/TestUtilities.h
@@ -31,6 +31,11 @@
 namespace lldb_private {
 std::string GetInputFilePath(const llvm::Twine &name);
 
+class TestUtilities {
+public:
+  static std::once_flag g_debugger_initialize_flag;
+};
+
 class TestFile {
 public:
   static llvm::Expected<TestFile> fromYaml(llvm::StringRef Yaml);
@@ -51,6 +56,6 @@ private:
 
   std::string Buffer;
 };
-}
+} // namespace lldb_private
 
 #endif


### PR DESCRIPTION
This is a cherry-pick of 8a62124d06c495601cb135c9584f8604328717ba and 135b95c3cf9f2a7ed9c350f47a60efddcee322ea from LLVM main that combines 2 PRs (https://github.com/llvm/llvm-project/pull/80786 and https://github.com/llvm/llvm-project/pull/80788). The former adds a once_flag to `TestingSupport` in the unit testing framework to prevent 2 tests from trying to initialize the debugger (as this hits an assertion) and the latter uses this once_flag to initialize the debugger in its test.