### PR TITLE
Add SwiftLanguageRuntime support for implicit enum members.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -310,9 +310,11 @@ public:
     return {};
   }
 
-  std::pair<bool, llvm::Optional<size_t>> GetIndexOfChildMemberWithName(
-      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+  std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes) {
     STUB_LOG();
     return {};
   }
@@ -2427,7 +2429,7 @@ llvm::Optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(
   FORWARD(GetEnumCaseName, type, data, exe_ctx);
 }
 
-std::pair<bool, llvm::Optional<size_t>>
+std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
 SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
     CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -323,6 +323,17 @@ public:
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 
+  enum LookupResult {
+    /// Failed due to missing reflection meatadata or unimplemented
+    /// functionality. Should retry with SwiftASTContext.
+    eError = 0,
+    /// Success.
+    eFound,
+    /// Found complete type info, lookup unsuccessful.
+    /// Do not waste time retrying.
+    eNotFound
+  };
+
   /// Behaves like the CompilerType::GetIndexOfChildMemberWithName()
   /// except for the more nuanced return value.
   ///
@@ -333,9 +344,11 @@ public:
   ///                     don't have an index.
   ///
   /// \returns {true, {num_idexes}} on success.
-  std::pair<bool, llvm::Optional<size_t>> GetIndexOfChildMemberWithName(
-      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+  std::pair<LookupResult, llvm::Optional<size_t>>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes);
 
   /// Ask Remote Mirrors about a child of a composite type.
   CompilerType GetChildCompilerTypeAtIndex(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -136,9 +136,11 @@ public:
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 
-  std::pair<bool, llvm::Optional<size_t>> GetIndexOfChildMemberWithName(
-      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+  std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes);
 
   CompilerType GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3413,7 +3413,10 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
       auto found_numidx = runtime->GetIndexOfChildMemberWithName(
           GetCanonicalType(type), name, exe_ctx, omit_empty_base_classes,
           child_indexes);
-      if (found_numidx.first) {
+      // Only use the SwiftASTContext fallback if there was an
+      // error. If the runtime had complete type info and couldn't
+      // find a result, don't waste time retrying.
+      if (found_numidx.first != SwiftLanguageRuntime::eError) {
         size_t index_size = found_numidx.second.value_or(0);
 #ifndef NDEBUG
         // This block is a custom VALIDATE_AND_RETURN implementation to support
@@ -3436,17 +3439,11 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
           return index_size;
 
         auto fail = [&]() {
-          auto join = [](const auto &v) {
-            std::ostringstream buf;
-            buf << "{";
-            for (const auto &item : v)
-              buf << item << ",";
-            buf.seekp(-1, std::ios_base::end);
-            buf << "}";
-            return buf.str();
-          };
-          llvm::dbgs() << join(child_indexes)
-                       << " != " << join(ast_child_indexes) << "\n";
+          llvm::dbgs() << "{";
+          llvm::interleaveComma(child_indexes, llvm::dbgs());
+          llvm::dbgs() << "} != {";
+          llvm::interleaveComma(ast_child_indexes, llvm::dbgs());
+          llvm::dbgs() << "}\n";
           llvm::dbgs() << "failing type was " << (const char *)type
                        << ", member was " << name << "\n";
           assert(false &&
@@ -4289,6 +4286,23 @@ TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
             "Couldn't compute alignment of type %s using static debug info.",
             AsMangledName(type));
   return {};
+}
+
+bool TypeSystemSwiftTypeRef::IsSIMDType(CompilerType type) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  swift::Demangle::NodePointer global =
+      dem.demangleSymbol(type.GetMangledTypeName().GetStringRef());
+  using Kind = swift::Demangle::Node::Kind;
+  auto *simd_storage = swift_demangle::nodeAtPath(
+      global, {Kind::TypeMangling, Kind::Type, Kind::Structure});
+  if (!simd_storage || simd_storage->getNumChildren() != 2)
+    return false;
+  auto base_type = simd_storage->getFirstChild();
+  auto wrapper = simd_storage->getLastChild();
+  return wrapper && wrapper->getKind() == Kind::Identifier &&
+         wrapper->hasText() && wrapper->getText().starts_with("SIMD") &&
+         base_type && base_type->getKind() == Kind::Structure;
 }
 
 #ifndef NDEBUG

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -282,6 +282,8 @@ public:
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp);
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
+  /// Determine whether this is a builtin SIMD type.
+  static bool IsSIMDType(CompilerType type);
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
   /// builtins (int <-> Swift.Int) as Clang types.
   CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,


### PR DESCRIPTION
To verify this I also added a new assertion that replaces the // FIXME unimplemented comments sprinkled over the code. This uncoverd a bunch mre bugs related to implicit fields that are also fixed in this patch. One issue with nested enums is described in a comment but not yet fixed.