### PR TITLE
[Cherry-pick into next] Add SwiftLanguageRuntime support for implicit enum members.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -310,9 +310,11 @@ public:
     return {};
   }
 
-  std::pair<bool, llvm::Optional<size_t>> GetIndexOfChildMemberWithName(
-      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
+  std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes) {
     STUB_LOG();
     return {};
   }
@@ -2427,7 +2429,7 @@ llvm::Optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(
   FORWARD(GetEnumCaseName, type, data, exe_ctx);
 }
 
-std::pair<bool, llvm::Optional<size_t>>
+std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
 SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
     CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -323,6 +323,17 @@ public:
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 
+  enum LookupResult {
+    /// Failed due to missing reflection meatadata or unimplemented
+    /// functionality. Should retry with SwiftASTContext.
+    eError = 0,
+    /// Success.
+    eFound,
+    /// Found complete type info, lookup unsuccessful.
+    /// Do not waste time retrying.
+    eNotFound
+  };
+
   /// Behaves like the CompilerType::GetIndexOfChildMemberWithName()
   /// except for the more nuanced return value.
   ///
@@ -333,9 +344,11 @@ public:
   ///                     don't have an index.
   ///
   /// \returns {true, {num_idexes}} on success.
-  std::pair<bool, llvm::Optional<size_t>> GetIndexOfChildMemberWithName(
-      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+  std::pair<LookupResult, llvm::Optional<size_t>>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes);
 
   /// Ask Remote Mirrors about a child of a composite type.
   CompilerType GetChildCompilerTypeAtIndex(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -136,9 +136,11 @@ public:
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 
-  std::pair<bool, llvm::Optional<size_t>> GetIndexOfChildMemberWithName(
-      CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
-      bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes);
+  std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
+  GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
+                                ExecutionContext *exe_ctx,
+                                bool omit_empty_base_classes,
+                                std::vector<uint32_t> &child_indexes);
 
   CompilerType GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -282,6 +282,8 @@ public:
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp);
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
+  /// Determine whether this is a builtin SIMD type.
+  static bool IsSIMDType(CompilerType type);
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
   /// builtins (int <-> Swift.Int) as Clang types.
   CompilerType GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,


### PR DESCRIPTION
```
commit aeb25ee6358f1df1a96faaabea81a03562729f07
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 6 17:23:53 2024 -0800

    Add SwiftLanguageRuntime support for implicit enum members.
    
    To verify this I also added a new assertion that replaces the // FIXME
    unimplemented comments sprinkled over the code. This uncoverd a bunch
    mre bugs related to implicit fields that are also fixed in this
    patch. One issue with nested enums is described in a comment but not
    yet fixed.
```
