### PR TITLE
Fix error message for CAS ingestion

### DIFF
--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -535,7 +535,7 @@ Error checkCASIngestPath(StringRef CASPath, StringRef DataPath) {
   if (std::error_code EC = sys::fs::real_path(StringRef(CASPath), RealCAS))
     return createFileError(CASPath, EC);
   if (std::error_code EC = sys::fs::real_path(StringRef(DataPath), RealData))
-    return createFileError(CASPath, EC);
+    return createFileError(DataPath, EC);
   if (RealCAS.startswith(RealData) &&
       (RealCAS.size() == RealData.size() ||
        sys::path::is_separator(RealCAS[RealData.size()])))


### PR DESCRIPTION
The code is checking if the DataPath is valid, but the error message is printing the CASPath.

(cherry picked from commit ef74121888977a6ccc917d2c50a477bff9ec602c)