### PR TITLE
[DebugInfo] Emit specifiction_of and spare bits mask in debug info

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -630,6 +630,7 @@ HANDLE_DW_AT(0x3fee, APPLE_objc_direct, 0, APPLE)
 HANDLE_DW_AT(0x3fef, APPLE_sdk, 0, APPLE)
 HANDLE_DW_AT(0x3ff0, APPLE_origin, 0, APPLE)
 HANDLE_DW_AT(0x3ff1, APPLE_num_extra_inhabitants, 0, APPLE)
+HANDLE_DW_AT(0x3ff2, APPLE_spare_bits_mask, 0, APPLE)
 
 // Attribute form encodings.
 HANDLE_DW_FORM(0x01, addr, 2, DWARF)

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -500,13 +500,17 @@ namespace llvm {
     /// \param Discriminator Discriminant member
     /// \param Elements     Variant elements.
     /// \param UniqueIdentifier A unique identifier for the union.
-    DICompositeType *createVariantPart(DIScope *Scope, StringRef Name,
-				       DIFile *File, unsigned LineNumber,
-				       uint64_t SizeInBits, uint32_t AlignInBits,
-				       DINode::DIFlags Flags,
-				       DIDerivedType *Discriminator,
-				       DINodeArray Elements,
-				       StringRef UniqueIdentifier = "");
+    /// \param OffsetInBits The offset of the variant payload in the variant
+    /// type.
+    /// \param SpareBitMask A mask of spare bits of the payload, spare bits are
+    /// bits that aren't used in any of the variant's cases.
+    DICompositeType *
+    createVariantPart(DIScope *Scope, StringRef Name, DIFile *File,
+                      unsigned LineNumber, uint64_t SizeInBits,
+                      uint32_t AlignInBits, DINode::DIFlags Flags,
+                      DIDerivedType *Discriminator, DINodeArray Elements,
+                      StringRef UniqueIdentifier = "",
+                      uint64_t OffsetInBits = 0, APInt SpareBitsMask = APInt());
 
     /// Create debugging information for template
     /// type parameter.

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -458,6 +458,9 @@ namespace llvm {
     /// \param Elements     Struct elements.
     /// \param RunTimeLang  Optional parameter, Objective-C runtime version.
     /// \param UniqueIdentifier A unique identifier for the struct.
+    /// \param SpecificationOf The type that this type completes (is a
+    /// specification of). For example, this could be a templated type whose
+    /// template parameters have been substituted in.
     /// \param NumExtraInhabitants The number of extra inhabitants of the type.
     /// An extra inhabitant is a bit pattern that does not represent a valid
     /// value for objects of a given type.
@@ -465,8 +468,8 @@ namespace llvm {
         DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
         uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
         DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang = 0,
-        DIType *VTableHolder = nullptr, StringRef UniqueIdentifier = "", 
-        uint32_t NumExtraInhabitants = 0);
+        DIType *VTableHolder = nullptr, StringRef UniqueIdentifier = "",
+        DIType *SpecificationOf = nullptr, uint32_t NumExtraInhabitants = 0);
 
     /// Create debugging information entry for an union.
     /// \param Scope        Scope in which this union is defined.

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1155,15 +1155,16 @@ class DICompositeType : public DIType {
   friend class MDNode;
 
   unsigned RuntimeLang;
+  llvm::APInt SpareBitsMask;
 
   DICompositeType(LLVMContext &C, StorageType Storage, unsigned Tag,
                   unsigned Line, unsigned RuntimeLang, uint64_t SizeInBits,
                   uint32_t AlignInBits, uint64_t OffsetInBits,
-                  uint32_t NumExtraInhabitants, DIFlags Flags,
+                  uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags,
                   ArrayRef<Metadata *> Ops)
       : DIType(C, DICompositeTypeKind, Storage, Tag, Line, SizeInBits,
                AlignInBits, OffsetInBits, NumExtraInhabitants, Flags, Ops),
-        RuntimeLang(RuntimeLang) {}
+        RuntimeLang(RuntimeLang), SpareBitsMask(SpareBitsMask) {}
   ~DICompositeType() = default;
 
   /// Change fields in place.
@@ -1181,7 +1182,7 @@ class DICompositeType : public DIType {
   getImpl(LLVMContext &Context, unsigned Tag, StringRef Name, Metadata *File,
           unsigned Line, DIScope *Scope, DIType *BaseType, uint64_t SizeInBits,
           uint32_t AlignInBits, uint64_t OffsetInBits,
-          uint32_t NumExtraInhabitants, DIFlags Flags, DINodeArray Elements,
+          uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags, DINodeArray Elements,
           unsigned RuntimeLang, DIType *VTableHolder,
           DITemplateParameterArray TemplateParams, StringRef Identifier,
           DIDerivedType *Discriminator, Metadata *DataLocation,
@@ -1194,7 +1195,7 @@ class DICompositeType : public DIType {
                    TemplateParams.get(),
                    getCanonicalMDString(Context, Identifier), Discriminator,
                    DataLocation, Associated, Allocated, Rank, Annotations.get(),
-                   NumExtraInhabitants, Storage, ShouldCreate);
+                   NumExtraInhabitants, SpareBitsMask, Storage, ShouldCreate);
   }
   static DICompositeType *
   getImpl(LLVMContext &Context, unsigned Tag, MDString *Name, Metadata *File,
@@ -1204,7 +1205,7 @@ class DICompositeType : public DIType {
           Metadata *VTableHolder, Metadata *TemplateParams,
           MDString *Identifier, Metadata *Discriminator, Metadata *DataLocation,
           Metadata *Associated, Metadata *Allocated, Metadata *Rank,
-          Metadata *Annotations, uint32_t NumExtraInhabitants,
+          Metadata *Annotations, uint32_t NumExtraInhabitants, APInt SpareBitsMask,
           StorageType Storage, bool ShouldCreate = true);
 
   TempDICompositeType cloneImpl() const {
@@ -1214,7 +1215,7 @@ class DICompositeType : public DIType {
         getFlags(), getElements(), getRuntimeLang(), getVTableHolder(),
         getTemplateParams(), getIdentifier(), getDiscriminator(),
         getRawDataLocation(), getRawAssociated(), getRawAllocated(),
-        getRawRank(), getAnnotations(), getNumExtraInhabitants());
+        getRawRank(), getAnnotations(), getNumExtraInhabitants(), getSpareBitsMask());
   }
 
 public:
@@ -1228,9 +1229,9 @@ public:
        StringRef Identifier = "", DIDerivedType *Discriminator = nullptr,
        Metadata *DataLocation = nullptr, Metadata *Associated = nullptr,
        Metadata *Allocated = nullptr, Metadata *Rank = nullptr,
-       DINodeArray Annotations = nullptr, uint32_t NumExtraInhabitants = 0),
+       DINodeArray Annotations = nullptr, uint32_t NumExtraInhabitants = 0, APInt SpareBitsMask = APInt()),
       (Tag, Name, File, Line, Scope, BaseType, SizeInBits, AlignInBits,
-       OffsetInBits, NumExtraInhabitants, Flags, Elements, RuntimeLang,
+       OffsetInBits, NumExtraInhabitants, SpareBitsMask, Flags, Elements, RuntimeLang,
        VTableHolder, TemplateParams, Identifier, Discriminator, DataLocation,
        Associated, Allocated, Rank, Annotations))
   DEFINE_MDNODE_GET(
@@ -1243,11 +1244,11 @@ public:
        Metadata *Discriminator = nullptr, Metadata *DataLocation = nullptr,
        Metadata *Associated = nullptr, Metadata *Allocated = nullptr,
        Metadata *Rank = nullptr, Metadata *Annotations = nullptr,
-       uint32_t NumExtraInhabitants = 0),
+       uint32_t NumExtraInhabitants = 0, APInt SpareBitsMask = APInt()),
       (Tag, Name, File, Line, Scope, BaseType, SizeInBits, AlignInBits,
        OffsetInBits, Flags, Elements, RuntimeLang, VTableHolder, TemplateParams,
        Identifier, Discriminator, DataLocation, Associated, Allocated, Rank,
-       Annotations, NumExtraInhabitants))
+       Annotations, NumExtraInhabitants, SpareBitsMask))
 
   TempDICompositeType clone() const { return cloneImpl(); }
 
@@ -1262,8 +1263,9 @@ public:
   getODRType(LLVMContext &Context, MDString &Identifier, unsigned Tag,
              MDString *Name, Metadata *File, unsigned Line, Metadata *Scope,
              Metadata *BaseType, uint64_t SizeInBits, uint32_t AlignInBits,
-             uint64_t OffsetInBits, uint32_t NumExtraInhabitants, DIFlags Flags,
-             Metadata *Elements, unsigned RuntimeLang, Metadata *VTableHolder,
+             uint64_t OffsetInBits, uint32_t NumExtraInhabitants,
+             APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
+             unsigned RuntimeLang, Metadata *VTableHolder,
              Metadata *TemplateParams, Metadata *Discriminator,
              Metadata *DataLocation, Metadata *Associated, Metadata *Allocated,
              Metadata *Rank, Metadata *Annotations);
@@ -1279,14 +1281,16 @@ public:
   ///
   /// If not \a LLVMContext::isODRUniquingDebugTypes(), this function returns
   /// nullptr.
-  static DICompositeType *buildODRType(
-      LLVMContext &Context, MDString &Identifier, unsigned Tag, MDString *Name,
-      Metadata *File, unsigned Line, Metadata *Scope, Metadata *BaseType,
-      uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
-      uint32_t NumExtraInhabitants, DIFlags Flags, Metadata *Elements,
-      unsigned RuntimeLang, Metadata *VTableHolder, Metadata *TemplateParams,
-      Metadata *Discriminator, Metadata *DataLocation, Metadata *Associated,
-      Metadata *Allocated, Metadata *Rank, Metadata *Annotations);
+  static DICompositeType *
+  buildODRType(LLVMContext &Context, MDString &Identifier, unsigned Tag,
+               MDString *Name, Metadata *File, unsigned Line, Metadata *Scope,
+               Metadata *BaseType, uint64_t SizeInBits, uint32_t AlignInBits,
+               uint64_t OffsetInBits, uint32_t NumExtraInhabitants,
+               APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
+               unsigned RuntimeLang, Metadata *VTableHolder,
+               Metadata *TemplateParams, Metadata *Discriminator,
+               Metadata *DataLocation, Metadata *Associated,
+               Metadata *Allocated, Metadata *Rank, Metadata *Annotations);
 
   DIType *getBaseType() const { return cast_or_null<DIType>(getRawBaseType()); }
   DINodeArray getElements() const {
@@ -1300,6 +1304,7 @@ public:
   }
   StringRef getIdentifier() const { return getStringOperand(7); }
   unsigned getRuntimeLang() const { return RuntimeLang; }
+  const APInt &getSpareBitsMask() const { return SpareBitsMask; }
 
   Metadata *getRawBaseType() const { return getOperand(3); }
   Metadata *getRawElements() const { return getOperand(4); }

--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -1160,8 +1160,8 @@ class DICompositeType : public DIType {
   DICompositeType(LLVMContext &C, StorageType Storage, unsigned Tag,
                   unsigned Line, unsigned RuntimeLang, uint64_t SizeInBits,
                   uint32_t AlignInBits, uint64_t OffsetInBits,
-                  uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags,
-                  ArrayRef<Metadata *> Ops)
+                  uint32_t NumExtraInhabitants, APInt SpareBitsMask,
+                  DIFlags Flags, ArrayRef<Metadata *> Ops)
       : DIType(C, DICompositeTypeKind, Storage, Tag, Line, SizeInBits,
                AlignInBits, OffsetInBits, NumExtraInhabitants, Flags, Ops),
         RuntimeLang(RuntimeLang), SpareBitsMask(SpareBitsMask) {}
@@ -1181,21 +1181,21 @@ class DICompositeType : public DIType {
   static DICompositeType *
   getImpl(LLVMContext &Context, unsigned Tag, StringRef Name, Metadata *File,
           unsigned Line, DIScope *Scope, DIType *BaseType, uint64_t SizeInBits,
-          uint32_t AlignInBits, uint64_t OffsetInBits,
-          uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags, DINodeArray Elements,
-          unsigned RuntimeLang, DIType *VTableHolder,
+          uint32_t AlignInBits, uint64_t OffsetInBits, DIType *SpecificationOf,
+          uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags,
+          DINodeArray Elements, unsigned RuntimeLang, DIType *VTableHolder,
           DITemplateParameterArray TemplateParams, StringRef Identifier,
           DIDerivedType *Discriminator, Metadata *DataLocation,
           Metadata *Associated, Metadata *Allocated, Metadata *Rank,
           DINodeArray Annotations, StorageType Storage,
           bool ShouldCreate = true) {
-    return getImpl(Context, Tag, getCanonicalMDString(Context, Name), File,
-                   Line, Scope, BaseType, SizeInBits, AlignInBits, OffsetInBits,
-                   Flags, Elements.get(), RuntimeLang, VTableHolder,
-                   TemplateParams.get(),
-                   getCanonicalMDString(Context, Identifier), Discriminator,
-                   DataLocation, Associated, Allocated, Rank, Annotations.get(),
-                   NumExtraInhabitants, SpareBitsMask, Storage, ShouldCreate);
+    return getImpl(
+        Context, Tag, getCanonicalMDString(Context, Name), File, Line, Scope,
+        BaseType, SizeInBits, AlignInBits, OffsetInBits, Flags, Elements.get(),
+        RuntimeLang, VTableHolder, TemplateParams.get(),
+        getCanonicalMDString(Context, Identifier), Discriminator, DataLocation,
+        Associated, Allocated, Rank, Annotations.get(), SpecificationOf,
+        NumExtraInhabitants, SpareBitsMask, Storage, ShouldCreate);
   }
   static DICompositeType *
   getImpl(LLVMContext &Context, unsigned Tag, MDString *Name, Metadata *File,
@@ -1205,7 +1205,8 @@ class DICompositeType : public DIType {
           Metadata *VTableHolder, Metadata *TemplateParams,
           MDString *Identifier, Metadata *Discriminator, Metadata *DataLocation,
           Metadata *Associated, Metadata *Allocated, Metadata *Rank,
-          Metadata *Annotations, uint32_t NumExtraInhabitants, APInt SpareBitsMask,
+          Metadata *Annotations, Metadata *SpecificationOf,
+          uint32_t NumExtraInhabitants, APInt SpareBitsMask,
           StorageType Storage, bool ShouldCreate = true);
 
   TempDICompositeType cloneImpl() const {
@@ -1215,7 +1216,8 @@ class DICompositeType : public DIType {
         getFlags(), getElements(), getRuntimeLang(), getVTableHolder(),
         getTemplateParams(), getIdentifier(), getDiscriminator(),
         getRawDataLocation(), getRawAssociated(), getRawAllocated(),
-        getRawRank(), getAnnotations(), getNumExtraInhabitants(), getSpareBitsMask());
+        getRawRank(), getAnnotations(), getSpecificationOf(),
+        getNumExtraInhabitants(), getSpareBitsMask());
   }
 
 public:
@@ -1229,11 +1231,12 @@ public:
        StringRef Identifier = "", DIDerivedType *Discriminator = nullptr,
        Metadata *DataLocation = nullptr, Metadata *Associated = nullptr,
        Metadata *Allocated = nullptr, Metadata *Rank = nullptr,
-       DINodeArray Annotations = nullptr, uint32_t NumExtraInhabitants = 0, APInt SpareBitsMask = APInt()),
+       DINodeArray Annotations = nullptr, DIType *SpecificationOf = nullptr,
+       uint32_t NumExtraInhabitants = 0, APInt SpareBitsMask = APInt()),
       (Tag, Name, File, Line, Scope, BaseType, SizeInBits, AlignInBits,
-       OffsetInBits, NumExtraInhabitants, SpareBitsMask, Flags, Elements, RuntimeLang,
-       VTableHolder, TemplateParams, Identifier, Discriminator, DataLocation,
-       Associated, Allocated, Rank, Annotations))
+       OffsetInBits, SpecificationOf, NumExtraInhabitants, SpareBitsMask, Flags,
+       Elements, RuntimeLang, VTableHolder, TemplateParams, Identifier,
+       Discriminator, DataLocation, Associated, Allocated, Rank, Annotations))
   DEFINE_MDNODE_GET(
       DICompositeType,
       (unsigned Tag, MDString *Name, Metadata *File, unsigned Line,
@@ -1244,11 +1247,12 @@ public:
        Metadata *Discriminator = nullptr, Metadata *DataLocation = nullptr,
        Metadata *Associated = nullptr, Metadata *Allocated = nullptr,
        Metadata *Rank = nullptr, Metadata *Annotations = nullptr,
-       uint32_t NumExtraInhabitants = 0, APInt SpareBitsMask = APInt()),
+       Metadata *SpecificationOf = nullptr, uint32_t NumExtraInhabitants = 0,
+       APInt SpareBitsMask = APInt()),
       (Tag, Name, File, Line, Scope, BaseType, SizeInBits, AlignInBits,
        OffsetInBits, Flags, Elements, RuntimeLang, VTableHolder, TemplateParams,
        Identifier, Discriminator, DataLocation, Associated, Allocated, Rank,
-       Annotations, NumExtraInhabitants, SpareBitsMask))
+       Annotations, SpecificationOf, NumExtraInhabitants, SpareBitsMask))
 
   TempDICompositeType clone() const { return cloneImpl(); }
 
@@ -1263,9 +1267,9 @@ public:
   getODRType(LLVMContext &Context, MDString &Identifier, unsigned Tag,
              MDString *Name, Metadata *File, unsigned Line, Metadata *Scope,
              Metadata *BaseType, uint64_t SizeInBits, uint32_t AlignInBits,
-             uint64_t OffsetInBits, uint32_t NumExtraInhabitants,
-             APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
-             unsigned RuntimeLang, Metadata *VTableHolder,
+             uint64_t OffsetInBits, Metadata *SpecificationOf,
+             uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags,
+             Metadata *Elements, unsigned RuntimeLang, Metadata *VTableHolder,
              Metadata *TemplateParams, Metadata *Discriminator,
              Metadata *DataLocation, Metadata *Associated, Metadata *Allocated,
              Metadata *Rank, Metadata *Annotations);
@@ -1285,9 +1289,9 @@ public:
   buildODRType(LLVMContext &Context, MDString &Identifier, unsigned Tag,
                MDString *Name, Metadata *File, unsigned Line, Metadata *Scope,
                Metadata *BaseType, uint64_t SizeInBits, uint32_t AlignInBits,
-               uint64_t OffsetInBits, uint32_t NumExtraInhabitants,
-               APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
-               unsigned RuntimeLang, Metadata *VTableHolder,
+               uint64_t OffsetInBits, Metadata *SpecificationOf,
+               uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags,
+               Metadata *Elements, unsigned RuntimeLang, Metadata *VTableHolder,
                Metadata *TemplateParams, Metadata *Discriminator,
                Metadata *DataLocation, Metadata *Associated,
                Metadata *Allocated, Metadata *Rank, Metadata *Annotations);
@@ -1351,6 +1355,10 @@ public:
     return cast_or_null<MDTuple>(getRawAnnotations());
   }
 
+  Metadata *getRawSpecificationOf() const { return getOperand(14); }
+  DIType *getSpecificationOf() const {
+    return cast_or_null<DIType>(getRawSpecificationOf());
+  }
   /// Replace operands.
   ///
   /// If this \a isUniqued() and not \a isResolved(), on a uniquing collision

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -4301,6 +4301,10 @@ struct MDAPSIntField : public MDFieldImpl<APSInt> {
   MDAPSIntField() : ImplTy(APSInt()) {}
 };
 
+struct MDAPIntField : public MDFieldImpl<APInt> {
+  MDAPIntField() : ImplTy(APInt()) {}
+};
+
 struct MDSignedField : public MDFieldImpl<int64_t> {
   int64_t Min = INT64_MIN;
   int64_t Max = INT64_MAX;
@@ -5074,7 +5078,8 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
   OPTIONAL(allocated, MDField, );                                              \
   OPTIONAL(rank, MDSignedOrMDField, );                                         \
   OPTIONAL(annotations, MDField, );                                            \
-  OPTIONAL(num_extra_inhabitants, MDUnsignedField, (0, UINT32_MAX));           
+  OPTIONAL(num_extra_inhabitants, MDUnsignedField, (0, UINT32_MAX));           \
+  OPTIONAL(spare_bits_mask, MDAPSIntField, );                                  
   PARSE_MD_FIELDS();
 #undef VISIT_MD_FIELDS
 
@@ -5090,10 +5095,10 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
     if (auto *CT = DICompositeType::buildODRType(
             Context, *identifier.Val, tag.Val, name.Val, file.Val, line.Val,
             scope.Val, baseType.Val, size.Val, align.Val, offset.Val,
-            num_extra_inhabitants.Val, flags.Val, elements.Val, runtimeLang.Val,
-            vtableHolder.Val, templateParams.Val, discriminator.Val,
-            dataLocation.Val, associated.Val, allocated.Val, Rank,
-            annotations.Val)) {
+            num_extra_inhabitants.Val, spare_bits_mask.Val, flags.Val, elements.Val,
+            runtimeLang.Val, vtableHolder.Val, templateParams.Val,
+            discriminator.Val, dataLocation.Val, associated.Val, allocated.Val,
+            Rank, annotations.Val)) {
       Result = CT;
       return false;
     }
@@ -5106,7 +5111,7 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
        size.Val, align.Val, offset.Val, flags.Val, elements.Val,
        runtimeLang.Val, vtableHolder.Val, templateParams.Val, identifier.Val,
        discriminator.Val, dataLocation.Val, associated.Val, allocated.Val, Rank,
-       annotations.Val, num_extra_inhabitants.Val));
+       annotations.Val, num_extra_inhabitants.Val, spare_bits_mask.Val));
   return false;
 }
 

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -5079,6 +5079,7 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
   OPTIONAL(rank, MDSignedOrMDField, );                                         \
   OPTIONAL(annotations, MDField, );                                            \
   OPTIONAL(num_extra_inhabitants, MDUnsignedField, (0, UINT32_MAX));           \
+  OPTIONAL(specification_of, MDField, );                                       \
   OPTIONAL(spare_bits_mask, MDAPSIntField, );                                  
   PARSE_MD_FIELDS();
 #undef VISIT_MD_FIELDS
@@ -5095,10 +5096,11 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
     if (auto *CT = DICompositeType::buildODRType(
             Context, *identifier.Val, tag.Val, name.Val, file.Val, line.Val,
             scope.Val, baseType.Val, size.Val, align.Val, offset.Val,
-            num_extra_inhabitants.Val, spare_bits_mask.Val, flags.Val, elements.Val,
-            runtimeLang.Val, vtableHolder.Val, templateParams.Val,
-            discriminator.Val, dataLocation.Val, associated.Val, allocated.Val,
-            Rank, annotations.Val)) {
+            specification_of.Val, num_extra_inhabitants.Val,
+            spare_bits_mask.Val, flags.Val, elements.Val, runtimeLang.Val,
+            vtableHolder.Val, templateParams.Val, discriminator.Val,
+            dataLocation.Val, associated.Val, allocated.Val, Rank,
+            annotations.Val)) {
       Result = CT;
       return false;
     }
@@ -5111,7 +5113,8 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
        size.Val, align.Val, offset.Val, flags.Val, elements.Val,
        runtimeLang.Val, vtableHolder.Val, templateParams.Val, identifier.Val,
        discriminator.Val, dataLocation.Val, associated.Val, allocated.Val, Rank,
-       annotations.Val, num_extra_inhabitants.Val, spare_bits_mask.Val));
+       annotations.Val, specification_of.Val, num_extra_inhabitants.Val,
+       spare_bits_mask.Val));
   return false;
 }
 

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1604,6 +1604,7 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     Metadata *Allocated = nullptr;
     Metadata *Rank = nullptr;
     Metadata *Annotations = nullptr;
+    Metadata *SpecificationOf = nullptr;
     auto *Identifier = getMDString(Record[15]);
     // If this module is being parsed so that it can be ThinLTO imported
     // into another module, composite types only need to be imported
@@ -1647,19 +1648,22 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
       if (Record.size() > 21) {
         Annotations = getMDOrNull(Record[21]);
       }
+      if (Record.size() > 23) {
+        SpecificationOf = getMDOrNull(Record[23]);
+      }
     }
     DICompositeType *CT = nullptr;
     APInt SpareBitsMask;
     // SpareBitsMask is an optional field so the metadata loader has to check if
     // it was emitted before accessing it.
-    if (Record.size() > 23) {
+    if (Record.size() > 24) {
       if (IsBigInt) {
-        const uint64_t BitWidth = Record[23];
+        const uint64_t BitWidth = Record[24];
         const size_t NumWords = Record.size() - 3;
         SpareBitsMask =
-            readWideAPInt(ArrayRef(&Record[24], NumWords), BitWidth);
+            readWideAPInt(ArrayRef(&Record[25], NumWords), BitWidth);
       } else {
-        const uint64_t IntValue = Record[23];
+        const uint64_t IntValue = Record[24];
         SpareBitsMask = APInt(64, IntValue);
       }
     }
@@ -1667,10 +1671,10 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     if (Identifier)
       CT = DICompositeType::buildODRType(
           Context, *Identifier, Tag, Name, File, Line, Scope, BaseType,
-          SizeInBits, AlignInBits, OffsetInBits, NumExtraInhabitants,
-          SpareBitsMask, Flags, Elements, RuntimeLang, VTableHolder,
-          TemplateParams, Discriminator, DataLocation, Associated, Allocated,
-          Rank, Annotations);
+          SizeInBits, AlignInBits, OffsetInBits, SpecificationOf,
+          NumExtraInhabitants, SpareBitsMask, Flags, Elements, RuntimeLang,
+          VTableHolder, TemplateParams, Discriminator, DataLocation, Associated,
+          Allocated, Rank, Annotations);
 
     // Create a node if we didn't get a lazy ODR type.
     if (!CT)
@@ -1679,8 +1683,8 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
                             SizeInBits, AlignInBits, OffsetInBits, Flags,
                             Elements, RuntimeLang, VTableHolder, TemplateParams,
                             Identifier, Discriminator, DataLocation, Associated,
-                            Allocated, Rank, Annotations, NumExtraInhabitants,
-                            SpareBitsMask));
+                            Allocated, Rank, Annotations, SpecificationOf,
+                            NumExtraInhabitants, SpareBitsMask));
     if (!IsNotUsedInTypeRef && Identifier)
       MetadataList.addTypeRef(*Identifier, *cast<DICompositeType>(CT));
 

--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1570,9 +1570,13 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
     break;
   }
   case bitc::METADATA_COMPOSITE_TYPE: {
-    if (Record.size() < 16 || Record.size() > 23)
+    // The last field is a variable sized APInt, so the metadata loader can't
+    // reliably check the end for this record.
+    if (Record.size() < 16)
       return error("Invalid record");
 
+    IsDistinct = Record[0] & 1;
+    bool IsBigInt = (Record[0] >> 3) & 1;
     // If we have a UUID and this is not a forward declaration, lookup the
     // mapping.
     IsDistinct = Record[0] & 0x1;
@@ -1645,12 +1649,28 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
       }
     }
     DICompositeType *CT = nullptr;
+    APInt SpareBitsMask;
+    // SpareBitsMask is an optional field so the metadata loader has to check if
+    // it was emitted before accessing it.
+    if (Record.size() > 23) {
+      if (IsBigInt) {
+        const uint64_t BitWidth = Record[23];
+        const size_t NumWords = Record.size() - 3;
+        SpareBitsMask =
+            readWideAPInt(ArrayRef(&Record[24], NumWords), BitWidth);
+      } else {
+        const uint64_t IntValue = Record[23];
+        SpareBitsMask = APInt(64, IntValue);
+      }
+    }
+
     if (Identifier)
       CT = DICompositeType::buildODRType(
           Context, *Identifier, Tag, Name, File, Line, Scope, BaseType,
-          SizeInBits, AlignInBits, OffsetInBits, NumExtraInhabitants, Flags,
-          Elements, RuntimeLang, VTableHolder, TemplateParams, Discriminator,
-          DataLocation, Associated, Allocated, Rank, Annotations);
+          SizeInBits, AlignInBits, OffsetInBits, NumExtraInhabitants,
+          SpareBitsMask, Flags, Elements, RuntimeLang, VTableHolder,
+          TemplateParams, Discriminator, DataLocation, Associated, Allocated,
+          Rank, Annotations);
 
     // Create a node if we didn't get a lazy ODR type.
     if (!CT)
@@ -1659,7 +1679,8 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
                             SizeInBits, AlignInBits, OffsetInBits, Flags,
                             Elements, RuntimeLang, VTableHolder, TemplateParams,
                             Identifier, Discriminator, DataLocation, Associated,
-                            Allocated, Rank, Annotations, NumExtraInhabitants));
+                            Allocated, Rank, Annotations, NumExtraInhabitants,
+                            SpareBitsMask));
     if (!IsNotUsedInTypeRef && Identifier)
       MetadataList.addTypeRef(*Identifier, *cast<DICompositeType>(CT));
 

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1754,8 +1754,15 @@ void ModuleBitcodeWriter::writeDIDerivedType(const DIDerivedType *N,
 void ModuleBitcodeWriter::writeDICompositeType(
     const DICompositeType *N, SmallVectorImpl<uint64_t> &Record,
     unsigned Abbrev) {
+
+  APInt SpareBitsMask = N->getSpareBitsMask();
+  unsigned IsWideAPInt = 0;;
+  if (!SpareBitsMask.isZero() && SpareBitsMask.getBitWidth() > 64) 
+    IsWideAPInt = 1 << 3;
+
   const unsigned IsNotUsedInOldTypeRef = 0x2;
-  Record.push_back(IsNotUsedInOldTypeRef | (unsigned)N->isDistinct());
+  Record.push_back(IsWideAPInt | IsNotUsedInOldTypeRef |
+                   (unsigned)N->isDistinct());
   Record.push_back(N->getTag());
   Record.push_back(VE.getMetadataOrNullID(N->getRawName()));
   Record.push_back(VE.getMetadataOrNullID(N->getFile()));
@@ -1778,6 +1785,17 @@ void ModuleBitcodeWriter::writeDICompositeType(
   Record.push_back(VE.getMetadataOrNullID(N->getRawRank()));
   Record.push_back(VE.getMetadataOrNullID(N->getAnnotations().get()));
   Record.push_back(N->getNumExtraInhabitants());
+
+
+  if (!SpareBitsMask.isZero()) {
+    if (IsWideAPInt) {
+      Record.push_back(SpareBitsMask.getBitWidth());
+      emitWideAPInt(Record, SpareBitsMask);
+    } else {
+        uint64_t V = SpareBitsMask.getZExtValue();
+        Record.push_back(V);
+    }
+  }
 
   Stream.EmitRecord(bitc::METADATA_COMPOSITE_TYPE, Record, Abbrev);
   Record.clear();

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1785,6 +1785,7 @@ void ModuleBitcodeWriter::writeDICompositeType(
   Record.push_back(VE.getMetadataOrNullID(N->getRawRank()));
   Record.push_back(VE.getMetadataOrNullID(N->getAnnotations().get()));
   Record.push_back(N->getNumExtraInhabitants());
+  Record.push_back(VE.getMetadataOrNullID(N->getRawSpecificationOf()));
 
 
   if (!SpareBitsMask.isZero()) {

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1012,6 +1012,11 @@ void DwarfUnit::constructTypeDIE(DIE &Buffer, const DICompositeType *CTy) {
         addUInt(Buffer, dwarf::DW_AT_calling_convention, dwarf::DW_FORM_data1,
                 CC);
     }
+
+    if (auto *SpecifiedFrom = CTy->getSpecificationOf())
+      addDIEEntry(Buffer, dwarf::DW_AT_specification,
+                  *getOrCreateContextDIE(SpecifiedFrom));
+
     break;
   }
   default:

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -456,30 +456,31 @@ void DwarfUnit::addConstantFPValue(DIE &Die, const ConstantFP *CFP) {
 }
 
 void DwarfUnit::addConstantValue(DIE &Die, const ConstantInt *CI,
-                                 const DIType *Ty) {
-  addConstantValue(Die, CI->getValue(), Ty);
+                                 const DIType *Ty, dwarf::Attribute Attribute) {
+  addConstantValue(Die, CI->getValue(), Ty, Attribute);
 }
 
-void DwarfUnit::addConstantValue(DIE &Die, uint64_t Val, const DIType *Ty) {
-  addConstantValue(Die, DD->isUnsignedDIType(Ty), Val);
+void DwarfUnit::addConstantValue(DIE &Die, uint64_t Val, const DIType *Ty, dwarf::Attribute Attribute) {
+  addConstantValue(Die, DD->isUnsignedDIType(Ty), Val, Attribute);
 }
 
-void DwarfUnit::addConstantValue(DIE &Die, bool Unsigned, uint64_t Val) {
+void DwarfUnit::addConstantValue(DIE &Die, bool Unsigned, uint64_t Val, dwarf::Attribute Attribute) {
   // FIXME: This is a bit conservative/simple - it emits negative values always
   // sign extended to 64 bits rather than minimizing the number of bytes.
-  addUInt(Die, dwarf::DW_AT_const_value,
+  addUInt(Die, Attribute,
           Unsigned ? dwarf::DW_FORM_udata : dwarf::DW_FORM_sdata, Val);
 }
 
-void DwarfUnit::addConstantValue(DIE &Die, const APInt &Val, const DIType *Ty) {
-  addConstantValue(Die, Val, DD->isUnsignedDIType(Ty));
+void DwarfUnit::addConstantValue(DIE &Die, const APInt &Val, const DIType *Ty, dwarf::Attribute Attribute) {
+  addConstantValue(Die, Val, DD->isUnsignedDIType(Ty), Attribute);
 }
 
-void DwarfUnit::addConstantValue(DIE &Die, const APInt &Val, bool Unsigned) {
+void DwarfUnit::addConstantValue(DIE &Die, const APInt &Val, bool Unsigned, dwarf::Attribute Attribute) {
   unsigned CIBitWidth = Val.getBitWidth();
   if (CIBitWidth <= 64) {
     addConstantValue(Die, Unsigned,
-                     Unsigned ? Val.getZExtValue() : Val.getSExtValue());
+                     Unsigned ? Val.getZExtValue() : Val.getSExtValue(),
+                     Attribute);
     return;
   }
 
@@ -501,7 +502,7 @@ void DwarfUnit::addConstantValue(DIE &Die, const APInt &Val, bool Unsigned) {
     addUInt(*Block, dwarf::DW_FORM_data1, c);
   }
 
-  addBlock(Die, dwarf::DW_AT_const_value, Block);
+  addBlock(Die, Attribute, Block);
 }
 
 void DwarfUnit::addLinkageName(DIE &Die, StringRef LinkageName) {
@@ -1065,6 +1066,14 @@ void DwarfUnit::constructTypeDIE(DIE &Buffer, const DICompositeType *CTy) {
     if (uint32_t NumExtraInhabitants = CTy->getNumExtraInhabitants())
       addUInt(Buffer, dwarf::DW_AT_APPLE_num_extra_inhabitants,
             std::nullopt, NumExtraInhabitants);
+
+  } else if (Tag == dwarf::DW_TAG_variant_part) {
+    auto SpareBitsMask = CTy->getSpareBitsMask();
+    if (!SpareBitsMask.isZero())
+      addConstantValue(Buffer, SpareBitsMask, false,
+                       dwarf::DW_AT_APPLE_spare_bits_mask);
+    if (auto OffsetInBits = CTy->getOffsetInBits()) 
+      addUInt(Buffer, dwarf::DW_AT_bit_offset, std::nullopt, OffsetInBits);
   }
 }
 

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.h
@@ -218,11 +218,16 @@ public:
   void addSourceLine(DIE &Die, const DIObjCProperty *Ty);
 
   /// Add constant value entry in variable DIE.
-  void addConstantValue(DIE &Die, const ConstantInt *CI, const DIType *Ty);
-  void addConstantValue(DIE &Die, const APInt &Val, const DIType *Ty);
-  void addConstantValue(DIE &Die, const APInt &Val, bool Unsigned);
-  void addConstantValue(DIE &Die, uint64_t Val, const DIType *Ty);
-  void addConstantValue(DIE &Die, bool Unsigned, uint64_t Val);
+  void addConstantValue(DIE &Die, const ConstantInt *CI, const DIType *Ty,
+                        dwarf::Attribute = dwarf::DW_AT_const_value);
+  void addConstantValue(DIE &Die, const APInt &Val, const DIType *Ty,
+                        dwarf::Attribute = dwarf::DW_AT_const_value);
+  void addConstantValue(DIE &Die, const APInt &Val, bool Unsigned,
+                        dwarf::Attribute = dwarf::DW_AT_const_value);
+  void addConstantValue(DIE &Die, uint64_t Val, const DIType *Ty,
+                        dwarf::Attribute = dwarf::DW_AT_const_value);
+  void addConstantValue(DIE &Die, bool Unsigned, uint64_t Val,
+                        dwarf::Attribute = dwarf::DW_AT_const_value);
 
   /// Add constant value entry in variable DIE.
   void addConstantFPValue(DIE &Die, const ConstantFP *CFP);

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2084,6 +2084,8 @@ static void writeDICompositeType(raw_ostream &Out, const DICompositeType *N,
   else
     Printer.printMetadata("rank", N->getRawRank(), /*ShouldSkipNull */ true);
   Printer.printMetadata("annotations", N->getRawAnnotations());
+  if (auto *SpecificationOf = N->getRawSpecificationOf())
+    Printer.printMetadata("specification_of", SpecificationOf);
   Out << ")";
 }
 

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2065,6 +2065,8 @@ static void writeDICompositeType(raw_ostream &Out, const DICompositeType *N,
   Printer.printInt("align", N->getAlignInBits());
   Printer.printInt("offset", N->getOffsetInBits());
   Printer.printInt("num_extra_inhabitants", N->getNumExtraInhabitants());
+  if (!N->getSpareBitsMask().isZero())
+    Printer.printAPInt("spare_bits_mask", N->getSpareBitsMask(), true, false);
   Printer.printDIFlags("flags", N->getFlags());
   Printer.printMetadata("elements", N->getRawElements());
   Printer.printDwarfEnum("runtimeLang", N->getRuntimeLang(),

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -532,16 +532,16 @@ DICompositeType *DIBuilder::createUnionType(
   return R;
 }
 
-DICompositeType *
-DIBuilder::createVariantPart(DIScope *Scope, StringRef Name, DIFile *File,
-                             unsigned LineNumber, uint64_t SizeInBits,
-                             uint32_t AlignInBits, DINode::DIFlags Flags,
-                             DIDerivedType *Discriminator, DINodeArray Elements,
-                             StringRef UniqueIdentifier) {
+DICompositeType *DIBuilder::createVariantPart(
+    DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
+    uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
+    DIDerivedType *Discriminator, DINodeArray Elements,
+    StringRef UniqueIdentifier, uint64_t OffsetInBits, APInt SpareBitsMask) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_variant_part, Name, File, LineNumber,
-      getNonCompileUnitScope(Scope), nullptr, SizeInBits, AlignInBits, 0, Flags,
-      Elements, 0, nullptr, nullptr, UniqueIdentifier, 0, Discriminator);
+      getNonCompileUnitScope(Scope), nullptr, SizeInBits, AlignInBits,
+      OffsetInBits, Flags, Elements, 0, nullptr, nullptr, UniqueIdentifier, 0,
+      Discriminator, nullptr, nullptr, nullptr, {}, {}, SpareBitsMask);
   trackIfUnresolved(R);
   return R;
 }

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -508,13 +508,13 @@ DICompositeType *DIBuilder::createStructType(
     DIScope *Context, StringRef Name, DIFile *File, unsigned LineNumber,
     uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
     DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang,
-    DIType *VTableHolder, StringRef UniqueIdentifier,
+    DIType *VTableHolder, StringRef UniqueIdentifier, DIType *SpecificationOf,
     uint32_t NumExtraInhabitants) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_structure_type, Name, File, LineNumber,
       getNonCompileUnitScope(Context), DerivedFrom, SizeInBits, AlignInBits, 0,
       Flags, Elements, RunTimeLang, VTableHolder, nullptr, UniqueIdentifier,
-      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, SpecificationOf,
       NumExtraInhabitants);
   trackIfUnresolved(R);
   return R;
@@ -540,8 +540,9 @@ DICompositeType *DIBuilder::createVariantPart(
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_variant_part, Name, File, LineNumber,
       getNonCompileUnitScope(Scope), nullptr, SizeInBits, AlignInBits,
-      OffsetInBits, Flags, Elements, 0, nullptr, nullptr, UniqueIdentifier, 0,
-      Discriminator, nullptr, nullptr, nullptr, {}, {}, SpareBitsMask);
+      OffsetInBits, Flags, Elements, 0, nullptr, nullptr, UniqueIdentifier,
+      nullptr, 0, Discriminator, nullptr, nullptr, nullptr, {}, {},
+      SpareBitsMask);
   trackIfUnresolved(R);
   return R;
 }

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -752,23 +752,24 @@ DICompositeType *DICompositeType::getImpl(
     Metadata *TemplateParams, MDString *Identifier, Metadata *Discriminator,
     Metadata *DataLocation, Metadata *Associated, Metadata *Allocated,
     Metadata *Rank, Metadata *Annotations, uint32_t NumExtraInhabitants,
-    StorageType Storage, bool ShouldCreate) {
+    APInt SpareBitsMask, StorageType Storage, bool ShouldCreate) {
   assert(isCanonical(Name) && "Expected canonical MDString");
 
   // Keep this in sync with buildODRType.
-  DEFINE_GETIMPL_LOOKUP(DICompositeType,
-                        (Tag, Name, File, Line, Scope, BaseType, SizeInBits,
-                         AlignInBits, OffsetInBits, Flags, Elements,
-                         RuntimeLang, VTableHolder, TemplateParams, Identifier,
-                         Discriminator, DataLocation, Associated, Allocated,
-                         Rank, Annotations, NumExtraInhabitants));
+  DEFINE_GETIMPL_LOOKUP(
+      DICompositeType,
+      (Tag, Name, File, Line, Scope, BaseType, SizeInBits, AlignInBits,
+       OffsetInBits, Flags, Elements, RuntimeLang, VTableHolder, TemplateParams,
+       Identifier, Discriminator, DataLocation, Associated, Allocated, Rank,
+       Annotations, NumExtraInhabitants, SpareBitsMask));
   Metadata *Ops[] = {File,          Scope,        Name,           BaseType,
                      Elements,      VTableHolder, TemplateParams, Identifier,
                      Discriminator, DataLocation, Associated,     Allocated,
                      Rank,          Annotations};
   DEFINE_GETIMPL_STORE(DICompositeType,
                        (Tag, Line, RuntimeLang, SizeInBits, AlignInBits,
-                        OffsetInBits, NumExtraInhabitants, Flags),
+                        OffsetInBits, NumExtraInhabitants, SpareBitsMask,
+                        Flags),
                        Ops);
 }
 
@@ -776,7 +777,7 @@ DICompositeType *DICompositeType::buildODRType(
     LLVMContext &Context, MDString &Identifier, unsigned Tag, MDString *Name,
     Metadata *File, unsigned Line, Metadata *Scope, Metadata *BaseType,
     uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
-    uint32_t NumExtraInhabitants, DIFlags Flags, Metadata *Elements,
+    uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
     unsigned RuntimeLang, Metadata *VTableHolder, Metadata *TemplateParams,
     Metadata *Discriminator, Metadata *DataLocation, Metadata *Associated,
     Metadata *Allocated, Metadata *Rank, Metadata *Annotations) {
@@ -790,7 +791,7 @@ DICompositeType *DICompositeType::buildODRType(
                AlignInBits, OffsetInBits, Flags, Elements, RuntimeLang,
                VTableHolder, TemplateParams, &Identifier, Discriminator,
                DataLocation, Associated, Allocated, Rank, Annotations,
-               NumExtraInhabitants);
+               NumExtraInhabitants, SpareBitsMask);
 
   if (CT->getTag() != Tag)
     return nullptr;
@@ -819,10 +820,11 @@ DICompositeType *DICompositeType::getODRType(
     LLVMContext &Context, MDString &Identifier, unsigned Tag, MDString *Name,
     Metadata *File, unsigned Line, Metadata *Scope, Metadata *BaseType,
     uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
-    uint32_t NumExtraInhabitants, DIFlags Flags, Metadata *Elements,
-    unsigned RuntimeLang, Metadata *VTableHolder, Metadata *TemplateParams,
-    Metadata *Discriminator, Metadata *DataLocation, Metadata *Associated,
-    Metadata *Allocated, Metadata *Rank, Metadata *Annotations) {
+    uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags,
+    Metadata *Elements, unsigned RuntimeLang, Metadata *VTableHolder,
+    Metadata *TemplateParams, Metadata *Discriminator, Metadata *DataLocation,
+    Metadata *Associated, Metadata *Allocated, Metadata *Rank,
+    Metadata *Annotations) {
   assert(!Identifier.getString().empty() && "Expected valid identifier");
   if (!Context.isODRUniquingDebugTypes())
     return nullptr;
@@ -832,7 +834,7 @@ DICompositeType *DICompositeType::getODRType(
         Context, Tag, Name, File, Line, Scope, BaseType, SizeInBits,
         AlignInBits, OffsetInBits, Flags, Elements, RuntimeLang, VTableHolder,
         TemplateParams, &Identifier, Discriminator, DataLocation, Associated,
-        Allocated, Rank, Annotations, NumExtraInhabitants);
+        Allocated, Rank, Annotations, NumExtraInhabitants, SpareBitsMask);
   } else {
     if (CT->getTag() != Tag)
       return nullptr;

--- a/llvm/lib/IR/DebugInfoMetadata.cpp
+++ b/llvm/lib/IR/DebugInfoMetadata.cpp
@@ -751,8 +751,9 @@ DICompositeType *DICompositeType::getImpl(
     Metadata *Elements, unsigned RuntimeLang, Metadata *VTableHolder,
     Metadata *TemplateParams, MDString *Identifier, Metadata *Discriminator,
     Metadata *DataLocation, Metadata *Associated, Metadata *Allocated,
-    Metadata *Rank, Metadata *Annotations, uint32_t NumExtraInhabitants,
-    APInt SpareBitsMask, StorageType Storage, bool ShouldCreate) {
+    Metadata *Rank, Metadata *Annotations, Metadata *SpecificationOf,
+    uint32_t NumExtraInhabitants, APInt SpareBitsMask, StorageType Storage,
+    bool ShouldCreate) {
   assert(isCanonical(Name) && "Expected canonical MDString");
 
   // Keep this in sync with buildODRType.
@@ -761,11 +762,11 @@ DICompositeType *DICompositeType::getImpl(
       (Tag, Name, File, Line, Scope, BaseType, SizeInBits, AlignInBits,
        OffsetInBits, Flags, Elements, RuntimeLang, VTableHolder, TemplateParams,
        Identifier, Discriminator, DataLocation, Associated, Allocated, Rank,
-       Annotations, NumExtraInhabitants, SpareBitsMask));
+       Annotations, SpecificationOf, NumExtraInhabitants, SpareBitsMask));
   Metadata *Ops[] = {File,          Scope,        Name,           BaseType,
                      Elements,      VTableHolder, TemplateParams, Identifier,
                      Discriminator, DataLocation, Associated,     Allocated,
-                     Rank,          Annotations};
+                     Rank,          Annotations,  SpecificationOf};
   DEFINE_GETIMPL_STORE(DICompositeType,
                        (Tag, Line, RuntimeLang, SizeInBits, AlignInBits,
                         OffsetInBits, NumExtraInhabitants, SpareBitsMask,
@@ -777,7 +778,8 @@ DICompositeType *DICompositeType::buildODRType(
     LLVMContext &Context, MDString &Identifier, unsigned Tag, MDString *Name,
     Metadata *File, unsigned Line, Metadata *Scope, Metadata *BaseType,
     uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
-    uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
+    Metadata *SpecificationOf, uint32_t NumExtraInhabitants,
+    APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
     unsigned RuntimeLang, Metadata *VTableHolder, Metadata *TemplateParams,
     Metadata *Discriminator, Metadata *DataLocation, Metadata *Associated,
     Metadata *Allocated, Metadata *Rank, Metadata *Annotations) {
@@ -791,7 +793,7 @@ DICompositeType *DICompositeType::buildODRType(
                AlignInBits, OffsetInBits, Flags, Elements, RuntimeLang,
                VTableHolder, TemplateParams, &Identifier, Discriminator,
                DataLocation, Associated, Allocated, Rank, Annotations,
-               NumExtraInhabitants, SpareBitsMask);
+               SpecificationOf, NumExtraInhabitants, SpareBitsMask);
 
   if (CT->getTag() != Tag)
     return nullptr;
@@ -820,11 +822,11 @@ DICompositeType *DICompositeType::getODRType(
     LLVMContext &Context, MDString &Identifier, unsigned Tag, MDString *Name,
     Metadata *File, unsigned Line, Metadata *Scope, Metadata *BaseType,
     uint64_t SizeInBits, uint32_t AlignInBits, uint64_t OffsetInBits,
-    uint32_t NumExtraInhabitants, APInt SpareBitsMask, DIFlags Flags,
-    Metadata *Elements, unsigned RuntimeLang, Metadata *VTableHolder,
-    Metadata *TemplateParams, Metadata *Discriminator, Metadata *DataLocation,
-    Metadata *Associated, Metadata *Allocated, Metadata *Rank,
-    Metadata *Annotations) {
+    Metadata *SpecificationOf, uint32_t NumExtraInhabitants,
+    APInt SpareBitsMask, DIFlags Flags, Metadata *Elements,
+    unsigned RuntimeLang, Metadata *VTableHolder, Metadata *TemplateParams,
+    Metadata *Discriminator, Metadata *DataLocation, Metadata *Associated,
+    Metadata *Allocated, Metadata *Rank, Metadata *Annotations) {
   assert(!Identifier.getString().empty() && "Expected valid identifier");
   if (!Context.isODRUniquingDebugTypes())
     return nullptr;
@@ -834,7 +836,8 @@ DICompositeType *DICompositeType::getODRType(
         Context, Tag, Name, File, Line, Scope, BaseType, SizeInBits,
         AlignInBits, OffsetInBits, Flags, Elements, RuntimeLang, VTableHolder,
         TemplateParams, &Identifier, Discriminator, DataLocation, Associated,
-        Allocated, Rank, Annotations, NumExtraInhabitants, SpareBitsMask);
+        Allocated, Rank, Annotations, SpecificationOf, NumExtraInhabitants,
+        SpareBitsMask);
   } else {
     if (CT->getTag() != Tag)
       return nullptr;

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -654,6 +654,7 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
   Metadata *Rank;
   Metadata *Annotations;
   uint32_t NumExtraInhabitants;
+  APInt SpareBitsMask;
 
   MDNodeKeyImpl(unsigned Tag, MDString *Name, Metadata *File, unsigned Line,
                 Metadata *Scope, Metadata *BaseType, uint64_t SizeInBits,
@@ -663,7 +664,7 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
                 MDString *Identifier, Metadata *Discriminator,
                 Metadata *DataLocation, Metadata *Associated,
                 Metadata *Allocated, Metadata *Rank, Metadata *Annotations,
-                uint32_t NumExtraInhabitants)
+                uint32_t NumExtraInhabitants, APInt SpareBitsMask)
       : Tag(Tag), Name(Name), File(File), Line(Line), Scope(Scope),
         BaseType(BaseType), SizeInBits(SizeInBits), OffsetInBits(OffsetInBits),
         AlignInBits(AlignInBits), Flags(Flags), Elements(Elements),
@@ -671,7 +672,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
         TemplateParams(TemplateParams), Identifier(Identifier),
         Discriminator(Discriminator), DataLocation(DataLocation),
         Associated(Associated), Allocated(Allocated), Rank(Rank),
-        Annotations(Annotations), NumExtraInhabitants(NumExtraInhabitants) {}
+        Annotations(Annotations), NumExtraInhabitants(NumExtraInhabitants),
+        SpareBitsMask(SpareBitsMask) {}
   MDNodeKeyImpl(const DICompositeType *N)
       : Tag(N->getTag()), Name(N->getRawName()), File(N->getRawFile()),
         Line(N->getLine()), Scope(N->getRawScope()),
@@ -685,7 +687,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
         DataLocation(N->getRawDataLocation()),
         Associated(N->getRawAssociated()), Allocated(N->getRawAllocated()),
         Rank(N->getRawRank()), Annotations(N->getRawAnnotations()),
-        NumExtraInhabitants(N->getNumExtraInhabitants()) {}
+        NumExtraInhabitants(N->getNumExtraInhabitants()),
+        SpareBitsMask(N->getSpareBitsMask()) {}
 
   bool isKeyOf(const DICompositeType *RHS) const {
     return Tag == RHS->getTag() && Name == RHS->getRawName() &&
@@ -704,7 +707,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
            Associated == RHS->getRawAssociated() &&
            Allocated == RHS->getRawAllocated() && Rank == RHS->getRawRank() &&
            Annotations == RHS->getRawAnnotations() &&
-           NumExtraInhabitants == RHS->getNumExtraInhabitants();
+           NumExtraInhabitants == RHS->getNumExtraInhabitants() &&
+           SpareBitsMask == RHS->getSpareBitsMask();
   }
 
   unsigned getHashValue() const {

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -653,6 +653,7 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
   Metadata *Allocated;
   Metadata *Rank;
   Metadata *Annotations;
+  Metadata *SpecificationOf;
   uint32_t NumExtraInhabitants;
   APInt SpareBitsMask;
 
@@ -664,7 +665,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
                 MDString *Identifier, Metadata *Discriminator,
                 Metadata *DataLocation, Metadata *Associated,
                 Metadata *Allocated, Metadata *Rank, Metadata *Annotations,
-                uint32_t NumExtraInhabitants, APInt SpareBitsMask)
+                Metadata *SpecificationOf, uint32_t NumExtraInhabitants,
+                APInt SpareBitsMask)
       : Tag(Tag), Name(Name), File(File), Line(Line), Scope(Scope),
         BaseType(BaseType), SizeInBits(SizeInBits), OffsetInBits(OffsetInBits),
         AlignInBits(AlignInBits), Flags(Flags), Elements(Elements),
@@ -672,8 +674,9 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
         TemplateParams(TemplateParams), Identifier(Identifier),
         Discriminator(Discriminator), DataLocation(DataLocation),
         Associated(Associated), Allocated(Allocated), Rank(Rank),
-        Annotations(Annotations), NumExtraInhabitants(NumExtraInhabitants),
-        SpareBitsMask(SpareBitsMask) {}
+        Annotations(Annotations), SpecificationOf(SpecificationOf),
+        NumExtraInhabitants(NumExtraInhabitants), SpareBitsMask(SpareBitsMask) {
+  }
   MDNodeKeyImpl(const DICompositeType *N)
       : Tag(N->getTag()), Name(N->getRawName()), File(N->getRawFile()),
         Line(N->getLine()), Scope(N->getRawScope()),
@@ -687,6 +690,7 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
         DataLocation(N->getRawDataLocation()),
         Associated(N->getRawAssociated()), Allocated(N->getRawAllocated()),
         Rank(N->getRawRank()), Annotations(N->getRawAnnotations()),
+        SpecificationOf(N->getSpecificationOf()),
         NumExtraInhabitants(N->getNumExtraInhabitants()),
         SpareBitsMask(N->getSpareBitsMask()) {}
 
@@ -707,6 +711,7 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
            Associated == RHS->getRawAssociated() &&
            Allocated == RHS->getRawAllocated() && Rank == RHS->getRawRank() &&
            Annotations == RHS->getRawAnnotations() &&
+           SpecificationOf == RHS->getSpecificationOf() &&
            NumExtraInhabitants == RHS->getNumExtraInhabitants() &&
            SpareBitsMask == RHS->getSpareBitsMask();
   }

--- a/llvm/test/Assembler/debug-info.ll
+++ b/llvm/test/Assembler/debug-info.ll
@@ -1,8 +1,8 @@
 ; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
 ; RUN: verify-uselistorder %s
 
-; CHECK: !named = !{!0, !0, !1, !2, !3, !4, !5, !6, !7, !8, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42}
-!named = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45}
+; CHECK: !named = !{!0, !0, !1, !2, !3, !4, !5, !6, !7, !8, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49}
+!named = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49, !50, !51, !52}
 
 ; CHECK:      !0 = !DISubrange(count: 3, lowerBound: 0)
 ; CHECK-NEXT: !1 = !DISubrange(count: 3, lowerBound: 4)
@@ -108,3 +108,18 @@
 
 ;CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "ExtraInhabitantCompositeType", file: !10, size: 64, num_extra_inhabitants: 66, identifier: "MangledExtraInhabitantCompositeType")
 !45 = !DICompositeType(tag: DW_TAG_structure_type, name: "ExtraInhabitantCompositeType", file: !12, size: 64, num_extra_inhabitants: 66, identifier: "MangledExtraInhabitantCompositeType")
+
+;CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "SmallSpareBitsMaskType", file: !10, size: 64, elements: !44, identifier: "SmallSpareBitsMaskType")
+!46 = !DICompositeType(tag: DW_TAG_structure_type, name: "SmallSpareBitsMaskType", file: !12, size: 64, elements: !47, identifier: "SmallSpareBitsMaskType")
+!47 = !{!48}
+
+; CHECK: !DICompositeType(tag: DW_TAG_variant_part, file: !10, line: 3, size: 64, offset: 56, spare_bits_mask: 1152921504606846982, elements: !46)
+!48 = !DICompositeType(tag: DW_TAG_variant_part, file: !12, line: 3, size: 64, offset: 56, spare_bits_mask: 1152921504606846982, elements: !49)
+!49 = !{}
+
+!50 = !DICompositeType(tag: DW_TAG_structure_type, name: "BigSpareBitsMaskType", file: !12, size: 64, elements: !51, num_extra_inhabitants: 66, identifier: "BigSpareBitsMaskType")
+!51 = !{!52}
+
+; CHECK: !DICompositeType(tag: DW_TAG_variant_part, file: !10, line: 3, size: 64, offset: 56, spare_bits_mask: 108555083659983933259422293470276692178088180458183830018690888325426562727942)
+!52 = !DICompositeType(tag: DW_TAG_variant_part, file: !12, line: 3, size: 64, offset: 56, spare_bits_mask: 108555083659983933259422293470276692178088180458183830018690888325426562727942)
+

--- a/llvm/test/Assembler/debug-info.ll
+++ b/llvm/test/Assembler/debug-info.ll
@@ -1,8 +1,8 @@
 ; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
 ; RUN: verify-uselistorder %s
 
-; CHECK: !named = !{!0, !0, !1, !2, !3, !4, !5, !6, !7, !8, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49}
-!named = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49, !50, !51, !52}
+; CHECK: !named = !{!0, !0, !1, !2, !3, !4, !5, !6, !7, !8, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49, !50, !51}
+!named = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49, !50, !51, !52, !53, !54}
 
 ; CHECK:      !0 = !DISubrange(count: 3, lowerBound: 0)
 ; CHECK-NEXT: !1 = !DISubrange(count: 3, lowerBound: 4)
@@ -123,3 +123,7 @@
 ; CHECK: !DICompositeType(tag: DW_TAG_variant_part, file: !10, line: 3, size: 64, offset: 56, spare_bits_mask: 108555083659983933259422293470276692178088180458183830018690888325426562727942)
 !52 = !DICompositeType(tag: DW_TAG_variant_part, file: !12, line: 3, size: 64, offset: 56, spare_bits_mask: 108555083659983933259422293470276692178088180458183830018690888325426562727942)
 
+!53 = !DICompositeType(tag: DW_TAG_structure_type, name: "BaseType", file: !12, size: 64, identifier: "BaseType")
+
+; CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "SpecificationType", file: !10, size: 64, identifier: "SpecificationType", specification_of: !50)
+!54 = !DICompositeType(tag: DW_TAG_structure_type, name: "SpecificationType", file: !12, size: 64, identifier: "SpecificationType", specification_of: !53)

--- a/llvm/test/DebugInfo/AArch64/spare_bits_mask.ll
+++ b/llvm/test/DebugInfo/AArch64/spare_bits_mask.ll
@@ -1,0 +1,45 @@
+; RUN: llc %s -filetype=obj -mtriple arm64e-apple-darwin -o - \
+; RUN:   | llvm-dwarfdump - | FileCheck %s
+
+; CHECK: DW_TAG_structure_type
+; CHECK: DW_AT_name	("SmallSpareBitsMaskType")
+; CHECK: DW_TAG_variant_part
+; CHECK: DW_AT_APPLE_spare_bits_mask	(-1152921504606846970)
+; CHECK: DW_AT_bit_offset	(0x38)
+
+; CHECK: DW_TAG_structure_type
+; CHECK: DW_AT_name	("BigSpareBitsMaskType")
+; CHECK: DW_TAG_variant_part
+; CHECK: DW_AT_APPLE_spare_bits_mask	(<0x20> 06 00 00 00 00 00 00 f0 07 00 00 00 00 00 00 f0 07 00 00 00 00 00 00 f0 07 00 00 00 00 00 00 f0 )
+; CHECK: DW_AT_bit_offset	(0x38)
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+
+@p = common global i8* null, align 8, !dbg !0
+@q = common global i8* null, align 8, !dbg !8
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!6, !7}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "p", scope: !2, file: !3, line: 1, type: !10, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, emissionKind: FullDebug, globals: !5)
+!3 = !DIFile(filename: "/tmp/p.c", directory: "/")
+!4 = !{}
+!5 = !{!0, !8}
+!6 = !{i32 2, !"Dwarf Version", i32 4}
+!7 = !{i32 2, !"Debug Info Version", i32 3}
+
+!8 = !DIGlobalVariableExpression(var: !9, expr: !DIExpression())
+!9 = distinct !DIGlobalVariable(name: "q", scope: !2, file: !3, line: 1, type: !14, isLocal: false, isDefinition: true)
+
+!10 = !DICompositeType(tag: DW_TAG_structure_type, name: "SmallSpareBitsMaskType", file: !3, size: 64, elements: !11, identifier: "SmallSpareBitsMaskType")
+!11 = !{!12}
+
+!12 = !DICompositeType(tag: DW_TAG_variant_part, file: !3, line: 3, size: 64, offset: 56, spare_bits_mask: 1152921504606846982, elements: !13)
+!13 = !{}
+
+!14 = !DICompositeType(tag: DW_TAG_structure_type, name: "BigSpareBitsMaskType", file: !3, size: 64, elements: !15, num_extra_inhabitants: 66, identifier: "BigSpareBitsMaskType")
+!15 = !{!16}
+
+!16 = !DICompositeType(tag: DW_TAG_variant_part, file: !3, line: 3, size: 64, offset: 56, spare_bits_mask: 108555083659983933259422293470276692178088180458183830018690888325426562727942)
+

--- a/llvm/test/DebugInfo/AArch64/specification.ll
+++ b/llvm/test/DebugInfo/AArch64/specification.ll
@@ -1,0 +1,31 @@
+; RUN: llc %s -filetype=obj -mtriple arm64e-apple-darwin -o - \
+; RUN:   | llvm-dwarfdump - | FileCheck %s
+
+; CHECK:   DW_TAG_structure_type
+; CHECK: DW_AT_specification	({{.*}} "BaseType")
+; CHECK: DW_AT_name	("SpecificationType")
+; CHECK: DW_AT_byte_size	(0x08)
+
+; CHECK: DW_TAG_structure_type
+; CHECK: DW_AT_name	("BaseType")
+; CHECK: DW_AT_byte_size	(0x08)
+
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+
+@p = common global i8* null, align 8, !dbg !0
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!6, !7}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "p", scope: !2, file: !3, line: 1, type: !11, isLocal: false, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, emissionKind: FullDebug, globals: !5)
+!3 = !DIFile(filename: "/tmp/p.c", directory: "/")
+!4 = !{}
+!5 = !{!0}
+!6 = !{i32 2, !"Dwarf Version", i32 4}
+!7 = !{i32 2, !"Debug Info Version", i32 3}
+
+!10 = !DICompositeType(tag: DW_TAG_structure_type, name: "BaseType", file: !3, size: 64, identifier: "BaseType")
+
+!11 = !DICompositeType(tag: DW_TAG_structure_type, name: "SpecificationType", file: !3, size: 64, identifier: "SpecificationType", specification_of: !10)

--- a/llvm/unittests/IR/DebugTypeODRUniquingTest.cpp
+++ b/llvm/unittests/IR/DebugTypeODRUniquingTest.cpp
@@ -30,7 +30,7 @@ TEST(DebugTypeODRUniquingTest, getODRType) {
   // Without a type map, this should return null.
   EXPECT_FALSE(DICompositeType::getODRType(
       Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, 0, DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
+      nullptr, 0, 0, 0, 0, APInt(), DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
       nullptr, nullptr, nullptr, nullptr, nullptr));
 
   // Enable the mapping.  There still shouldn't be a type.
@@ -40,7 +40,7 @@ TEST(DebugTypeODRUniquingTest, getODRType) {
   // Create some ODR-uniqued type.
   auto &CT = *DICompositeType::getODRType(
       Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, 0, DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
+      nullptr, 0, 0, 0, 0, APInt(), DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
       nullptr, nullptr, nullptr, nullptr, nullptr);
   EXPECT_EQ(UUID.getString(), CT.getIdentifier());
 
@@ -49,13 +49,13 @@ TEST(DebugTypeODRUniquingTest, getODRType) {
   EXPECT_EQ(&CT,
             DICompositeType::getODRType(
                 Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0,
-                nullptr, nullptr, 0, 0, 0, 0, DINode::FlagZero, nullptr, 0,
+                nullptr, nullptr, 0, 0, 0, 0, APInt(), DINode::FlagZero, nullptr, 0,
                 nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                 nullptr));
   EXPECT_EQ(&CT, DICompositeType::getODRType(
                      Context, UUID, dwarf::DW_TAG_class_type,
                      MDString::get(Context, "name"), nullptr, 0, nullptr,
-                     nullptr, 0, 0, 0, 0, DINode::FlagZero, nullptr, 0, nullptr,
+                     nullptr, 0, 0, 0, 0, APInt(), DINode::FlagZero, nullptr, 0, nullptr,
                      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                      nullptr));
 
@@ -76,7 +76,7 @@ TEST(DebugTypeODRUniquingTest, buildODRType) {
   MDString &UUID = *MDString::get(Context, "Type");
   auto &CT = *DICompositeType::buildODRType(
       Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, 0, DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr,
+      nullptr, 0, 0, 0, 0, APInt(),  DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr,
       nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   EXPECT_EQ(&CT, DICompositeType::getODRTypeIfExists(Context, UUID));
   EXPECT_EQ(dwarf::DW_TAG_class_type, CT.getTag());
@@ -84,19 +84,19 @@ TEST(DebugTypeODRUniquingTest, buildODRType) {
   // Update with another forward decl.  This should be a no-op.
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     0, nullptr, nullptr, 0, 0, 0, 0, DINode::FlagFwdDecl, nullptr,
+                     0, nullptr, nullptr, 0, 0, 0, 0, APInt(), DINode::FlagFwdDecl, nullptr,
                      0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                      nullptr, nullptr));
 
   EXPECT_FALSE(DICompositeType::buildODRType(
       Context, UUID, dwarf::DW_TAG_structure_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, 0, DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr,
+      nullptr, 0, 0, 0, 0, APInt(), DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr,
       nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
 
   // Update with a definition.  This time we should see a change.
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     0, nullptr, nullptr, 0, 0, 0, 0, DINode::FlagZero, nullptr, 0,
+                     0, nullptr, nullptr, 0, 0, 0, 0, APInt(), DINode::FlagZero, nullptr, 0,
                      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                      nullptr, nullptr));
   EXPECT_FALSE(CT.isForwardDecl());
@@ -104,13 +104,13 @@ TEST(DebugTypeODRUniquingTest, buildODRType) {
   // Further updates should be ignored.
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     0, nullptr, nullptr, 0, 0, 0, 0, DINode::FlagFwdDecl, nullptr,
+                     0, nullptr, nullptr, 0, 0, 0, 0, APInt(), DINode::FlagFwdDecl, nullptr,
                      0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                      nullptr, nullptr));
   EXPECT_FALSE(CT.isForwardDecl());
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     111u, nullptr, nullptr, 0, 0, 0, 0, DINode::FlagZero, nullptr,
+                     111u, nullptr, nullptr, 0, 0, 0, 0, APInt(), DINode::FlagZero, nullptr,
                      0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                      nullptr, nullptr));
   EXPECT_NE(111u, CT.getLine());
@@ -123,7 +123,7 @@ TEST(DebugTypeODRUniquingTest, buildODRTypeFields) {
   // Build an ODR type that's a forward decl with no other fields set.
   MDString &UUID = *MDString::get(Context, "UUID");
   auto &CT = *DICompositeType::buildODRType(
-      Context, UUID, 0, nullptr, nullptr, 0, nullptr, nullptr, 0, 0, 0, 0,
+      Context, UUID, 0, nullptr, nullptr, 0, nullptr, nullptr, 0, 0, 0, 0, APInt(),
       DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr, nullptr, nullptr,
       nullptr, nullptr, nullptr, nullptr);
 
@@ -156,7 +156,7 @@ TEST(DebugTypeODRUniquingTest, buildODRTypeFields) {
   // Replace all the fields with new values that are distinct from each other.
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, 0, Name, File, Line, Scope, BaseType,
-                     SizeInBits, AlignInBits, OffsetInBits, NumExtraInhabitants,
+                     SizeInBits, AlignInBits, OffsetInBits, NumExtraInhabitants, APInt(),
                      DINode::FlagArtificial, Elements, RuntimeLang,
                      VTableHolder, TemplateParams, nullptr, nullptr, nullptr,
                      nullptr, nullptr, nullptr));


### PR DESCRIPTION
Commit 1:

    [DebugInfo] Emit spare bits mask in debug info

    The spare bits mask is a mask of the unused bits that a type may have.
    Swift uses these on enums to pack extra data when wrapping these enums
    in other types. Emit this field in LLVM-IR and DWARF.

Commit 2:

    [DebugInfo] Add an specification_of attribute to LLVM DebugInfo

    Add a specification_of attribute to LLVM DebugInfo, which is analogous
    to DWARF's DW_AT_specification. According to the DWARF spec:
    "A debugging information entry that represents a declaration that
    completes another (earlier) non-defining declaration may have a
    DW_AT_specification attribute whose value is a reference to the
    debugging information entry representing the non-defining declaration."

    This patch allows types to be specifications of other types. For
    example, a templated type where the template parameters are substituted
    in could be a specification of the non-substituted template type.