### PR TITLE
[next] Migrate remaining llvm::Optional to std::optional

### DIFF
--- a/clang/include/clang/Basic/PointerAuthOptions.h
+++ b/clang/include/clang/Basic/PointerAuthOptions.h
@@ -15,10 +15,10 @@
 #define LLVM_CLANG_BASIC_POINTERAUTHOPTIONS_H
 
 #include "clang/Basic/LLVM.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/Target/TargetOptions.h"
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 #include "llvm/Support/ErrorHandling.h"

--- a/clang/include/clang/Tooling/Refactor/RefactoringOperation.h
+++ b/clang/include/clang/Tooling/Refactor/RefactoringOperation.h
@@ -15,8 +15,8 @@
 #include "clang/Tooling/Refactor/RefactoringOptionSet.h"
 #include "clang/Tooling/Refactor/RefactoringReplacement.h"
 #include "clang/Tooling/Refactor/SymbolOperation.h"
-#include "llvm/ADT/None.h"
 #include "llvm/Support/Error.h"
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/clang/lib/Tooling/Refactor/RefactoringContinuations.h
+++ b/clang/lib/Tooling/Refactor/RefactoringContinuations.h
@@ -267,9 +267,9 @@ private:
   ConsumerFn Consumer;
   std::unique_ptr<ASTQueryType> ASTQuery;
   /// Inputs store state that's dependent on the original TU.
-  llvm::Optional<std::tuple<QueryOrState...>> Inputs;
+  std::optional<std::tuple<QueryOrState...>> Inputs;
   /// State contains TU-independent values.
-  llvm::Optional<
+  std::optional<
       std::tuple<typename StateTraits<QueryOrState>::PersistentType...>>
       State;
 

--- a/clang/tools/IndexStore/IndexStore.cpp
+++ b/clang/tools/IndexStore/IndexStore.cpp
@@ -19,7 +19,6 @@
 #include "clang/Index/IndexUnitWriter.h"
 #include "clang/DirectoryWatcher/DirectoryWatcher.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/ManagedStatic.h"

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -486,7 +486,7 @@ static std::string findRecordNameForFile(indexstore::IndexStore &store,
 }
 
 static int printStoreFileRecord(StringRef storePath, StringRef filePath,
-                                Optional<unsigned> lineStart, unsigned lineCount,
+                                std::optional<unsigned> lineStart, unsigned lineCount,
                                 PathRemapper remapper, raw_ostream &OS) {
   std::string error;
   indexstore::IndexStore store(storePath, remapper, error);
@@ -698,7 +698,7 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
                     bool SerializeDiags, bool DependencyFile,
                     ArrayRef<std::string> DepTargets, std::string OutputPath,
                     CXCASDatabases DBs,
-                    Optional<std::string> ModuleName = std::nullopt) {
+                    std::optional<std::string> ModuleName = std::nullopt) {
   CXDependencyScannerServiceOptions Opts =
       clang_experimental_DependencyScannerServiceOptions_create();
   auto CleanupOpts = llvm::make_scope_exit([&] {
@@ -1193,7 +1193,7 @@ static int watchDirectory(StringRef dirPath) {
 
 bool deconstructPathAndRange(StringRef input,
                              std::string &filepath,
-                             Optional<unsigned> &lineStart,
+                             std::optional<unsigned> &lineStart,
                              unsigned &lineCount) {
   StringRef path, start, end;
   std::tie(path, end) = input.rsplit(':');
@@ -1272,7 +1272,7 @@ int indextest_core_main(int argc, const char **argv) {
   if (options::Action == ActionType::PrintRecord) {
     if (!options::FilePathAndRange.empty()) {
       std::string filepath;
-      Optional<unsigned> lineStart;
+      std::optional<unsigned> lineStart;
       unsigned lineCount;
       if (deconstructPathAndRange(options::FilePathAndRange,
                                   filepath, lineStart, lineCount))
@@ -1330,9 +1330,9 @@ int indextest_core_main(int argc, const char **argv) {
     return aggregateDataAsJSON(storePath, PathRemapper, OS);
   }
 
-  Optional<std::string> CASPath = options::CASPath.empty()
+  std::optional<std::string> CASPath = options::CASPath.empty()
                                       ? std::nullopt
-                                      : Optional<std::string>(options::CASPath);
+                                      : std::optional<std::string>(options::CASPath);
 
   CXCASOptions CASOpts = nullptr;
   CXCASDatabases DBs = nullptr;

--- a/clang/tools/libclang/CIndexDiagnostic.h
+++ b/clang/tools/libclang/CIndexDiagnostic.h
@@ -16,7 +16,6 @@
 #include "clang-c/Index.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 #include <assert.h>
 #include <memory>

--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -31,7 +31,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/Optional.h"
+#include <optional>
 #include "llvm/Support/Chrono.h"
 
 #include <atomic>
@@ -819,7 +819,7 @@ public:
 #ifdef LLDB_ENABLE_SWIFT
   void
   ReportWarningToolchainMismatch(CompileUnit &comp_unit,
-                                 llvm::Optional<lldb::user_id_t> debugger_id);
+                                 std::optional<lldb::user_id_t> debugger_id);
 
   bool IsSwiftCxxInteropEnabled();
 #endif

--- a/lldb/include/lldb/Core/ValueObject.h
+++ b/lldb/include/lldb/Core/ValueObject.h
@@ -585,7 +585,7 @@ public:
   virtual bool HasSyntheticValue();
 
 #ifdef LLDB_ENABLE_SWIFT
-  llvm::Optional<SwiftScratchContextReader> GetSwiftScratchContext();
+  std::optional<SwiftScratchContextReader> GetSwiftScratchContext();
 #endif // LLDB_ENABLE_SWIFT
 
   virtual bool IsSynthetic() { return false; }

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -45,7 +45,7 @@
 #include "lldb/Utility/Timeout.h"
 #include "lldb/lldb-public.h"
 
-#include "llvm/ADT/Optional.h"
+#include <optional>
 
 namespace lldb_private {
 
@@ -1286,7 +1286,7 @@ public:
     return m_scratch_typesystem_lock;
   }
 
-  llvm::Optional<SwiftScratchContextReader>
+  std::optional<SwiftScratchContextReader>
   GetSwiftScratchContext(Status &error, ExecutionContextScope &exe_scope,
                          bool create_on_demand = true);
 

--- a/lldb/include/lldb/Utility/Either.h
+++ b/lldb/include/lldb/Utility/Either.h
@@ -9,7 +9,7 @@
 #ifndef liblldb_Either_h_
 #define liblldb_Either_h_
 
-#include "llvm/ADT/Optional.h"
+#include <optional>
 
 #include <functional>
 
@@ -51,23 +51,23 @@ public:
 
   template <class X, typename std::enable_if<std::is_same<T1, X>::value>::type
                          * = nullptr>
-  llvm::Optional<T1> GetAs() const {
+  std::optional<T1> GetAs() const {
     switch (m_selected) {
     case Selected::One:
       return m_t1;
     default:
-      return llvm::Optional<T1>();
+      return std::optional<T1>();
     }
   }
 
   template <class X, typename std::enable_if<std::is_same<T2, X>::value>::type
                          * = nullptr>
-  llvm::Optional<T2> GetAs() const {
+  std::optional<T2> GetAs() const {
     switch (m_selected) {
     case Selected::Two:
       return m_t2;
     default:
-      return llvm::Optional<T2>();
+      return std::optional<T2>();
     }
   }
 

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1140,7 +1140,7 @@ static llvm::VersionTuple GetAdjustedVersion(llvm::VersionTuple version) {
 }
 
 void Module::ReportWarningToolchainMismatch(
-    CompileUnit &comp_unit, llvm::Optional<lldb::user_id_t> debugger_id) {
+    CompileUnit &comp_unit, std::optional<lldb::user_id_t> debugger_id) {
   if (SymbolFile *sym_file = GetSymbolFile()) {
     llvm::VersionTuple sym_file_version =
         GetAdjustedVersion(sym_file->GetProducerVersion(comp_unit));

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -1605,10 +1605,10 @@ bool ValueObject::GetDeclaration(Declaration &decl) {
 }
 
 #ifdef LLDB_ENABLE_SWIFT
-llvm::Optional<SwiftScratchContextReader> ValueObject::GetSwiftScratchContext() {
+std::optional<SwiftScratchContextReader> ValueObject::GetSwiftScratchContext() {
   lldb::TargetSP target_sp(GetTargetSP());
   if (!target_sp)
-    return llvm::None;
+    return std::nullopt;
   Status error;
   ExecutionContext ctx = GetExecutionContextRef().Lock(false);
   auto *exe_scope = ctx.GetBestExecutionContextScope();

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -447,7 +447,7 @@ bool ValueObjectDynamicValue::DynamicValueTypeInfoNeedsUpdate() {
 
 #ifdef LLDB_ENABLE_SWIFT
   auto cached_ctx = m_value.GetCompilerType().GetTypeSystem();
-  llvm::Optional<SwiftScratchContextReader> scratch_ctx(
+  std::optional<SwiftScratchContextReader> scratch_ctx(
       GetSwiftScratchContext());
 
   if (!scratch_ctx || !cached_ctx)

--- a/lldb/source/Expression/DWARFExpression.cpp
+++ b/lldb/source/Expression/DWARFExpression.cpp
@@ -758,7 +758,7 @@ static bool Evaluate_DW_OP_entry_value(std::vector<Value> &stack,
   }
 #ifdef LLDB_ENABLE_SWIFT
   }
-  llvm::Optional<DWARFExpressionList> subexpr;
+  std::optional<DWARFExpressionList> subexpr;
   if (!matched_param) {
     auto *ctx_func = parent_func ? parent_func : current_func;
     subexpr.emplace(ctx_func->CalculateSymbolContextModule(),

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -1058,7 +1058,7 @@ public:
     if (m_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
 #ifdef LLDB_ENABLE_SWIFT
       Status status;
-      llvm::Optional<SwiftScratchContextReader> maybe_type_system =
+      std::optional<SwiftScratchContextReader> maybe_type_system =
           target_sp->GetSwiftScratchContext(status, *exe_scope);
       if (!maybe_type_system) {
         err.SetErrorStringWithFormat("Couldn't dematerialize a result variable: "

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -878,7 +878,7 @@ swift::FuncDecl *SwiftASTManipulator::GetFunctionToInjectVariableInto(
   return m_function_decl;
 }
 
-llvm::Optional<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
+std::optional<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
     const SwiftASTManipulator::VariableInfo &variable) const {
   auto type_system_swift =
       variable.m_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 
+#include <optional>
 
 namespace swift {
 class CaseStmt;
@@ -213,7 +214,7 @@ public:
   swift::VarDecl *GetVarDeclForVariableInFunction(
       const SwiftASTManipulator::VariableInfo &variable,
       swift::FuncDecl *containing_function);
-  llvm::Optional<swift::Type> GetSwiftTypeForVariable(
+  std::optional<swift::Type> GetSwiftTypeForVariable(
       const SwiftASTManipulator::VariableInfo &variable) const;
 
   bool AddExternalVariables(llvm::MutableArrayRef<VariableInfo> variables);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -875,7 +875,7 @@ CreateMainFile(SwiftASTContextForExpressions &swift_ast_context,
 }
 
 /// Attempt to materialize one variable.
-static llvm::Optional<SwiftExpressionParser::SILVariableInfo>
+static std::optional<SwiftExpressionParser::SILVariableInfo>
 MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
                     SwiftUserExpression &user_expression,
                     Materializer &materializer,
@@ -925,7 +925,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       swift::Type actual_swift_type =
           manipulator.GetScratchContext().GetSwiftType(actual_type);
       if (!actual_swift_type)
-        return llvm::None;
+        return std::nullopt;
 
       auto transformed_type =
           actual_swift_type.transform([](swift::Type t) -> swift::Type {
@@ -939,7 +939,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
           });
 
       if (!transformed_type)
-        return llvm::None;
+        return std::nullopt;
 
       actual_type =
           ToCompilerType(transformed_type->mapTypeOutOfContext().getPointer());
@@ -962,7 +962,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       diagnostic_manager.Printf(
           eDiagnosticSeverityError, "couldn't add %s variable to struct: %s.\n",
           is_result ? "result" : "error", error.AsCString());
-      return llvm::None;
+      return std::nullopt;
     }
 
     LLDB_LOG(log, "Added {0} variable to struct at offset {1}",
@@ -978,7 +978,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       diagnostic_manager.Printf(eDiagnosticSeverityError,
                                 "couldn't add variable to struct: %s.\n",
                                 error.AsCString());
-      return llvm::None;
+      return std::nullopt;
     }
 
     LLDB_LOG(log, "Added variable {0} to struct at offset {1}",
@@ -1000,7 +1000,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
     // this check scattered in several places in the codebase, we should at
     // some point centralize it.
     lldb::StackFrameSP stack_frame_sp = stack_frame_wp.lock();
-    llvm::Optional<uint64_t> size =
+    std::optional<uint64_t> size =
         variable.GetType().GetByteSize(stack_frame_sp.get());
     if (repl && size && *size == 0) {
       auto &repl_mat = *llvm::cast<SwiftREPLMaterializer>(&materializer);
@@ -1026,7 +1026,7 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
       diagnostic_manager.Printf(eDiagnosticSeverityError,
                                 "couldn't add variable to struct: %s.\n",
                                 error.AsCString());
-      return llvm::None;
+      return std::nullopt;
     }
 
     LLDB_LOGF(

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -25,7 +25,7 @@ using namespace lldb;
 using namespace lldb_private;
 
 namespace lldb_private {
-llvm::Optional<std::pair<unsigned, unsigned>>
+std::optional<std::pair<unsigned, unsigned>>
 ParseSwiftGenericParameter(llvm::StringRef name) {
   if (!name.consume_front("$τ_"))
     return {};
@@ -136,7 +136,7 @@ struct CallsAndArgs {
 ///           $τ_0_0, $τ_0_1, ..., $τ_0_n)
 static llvm::Expected<CallsAndArgs> MakeGenericSignaturesAndCalls(
     llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables,
-    const llvm::Optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
+    const std::optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
     bool needs_object_ptr) {
   llvm::SmallVector<SwiftASTManipulator::VariableInfo> metadata_variables;
   for (auto &var : local_variables)
@@ -256,7 +256,7 @@ static Status WrapExpression(
     const EvaluateExpressionOptions &options, llvm::StringRef os_version,
     uint32_t &first_body_line,
     llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables,
-    const llvm::Optional<SwiftLanguageRuntime::GenericSignature> &generic_sig) {
+    const std::optional<SwiftLanguageRuntime::GenericSignature> &generic_sig) {
   Status status;
   first_body_line = 0; // set to invalid
   // TODO make the extension private so we're not polluting the class
@@ -556,7 +556,7 @@ Status SwiftExpressionSourceCode::GetText(
     std::string &text, lldb::LanguageType wrapping_language,
     bool needs_object_ptr, bool static_method, bool is_class, bool weak_self,
     const EvaluateExpressionOptions &options,
-    const llvm::Optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
+    const std::optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
     ExecutionContext &exe_ctx, uint32_t &first_body_line,
     llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) const {
   Status status;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
@@ -18,7 +18,7 @@
 namespace lldb_private {
 
 /// Parse a name such as "$τ_0_0".
-llvm::Optional<std::pair<unsigned, unsigned>>
+std::optional<std::pair<unsigned, unsigned>>
 ParseSwiftGenericParameter(llvm::StringRef name);
 
 class SwiftExpressionSourceCode : public ExpressionSourceCode {
@@ -46,7 +46,7 @@ public:
       std::string &text, lldb::LanguageType wrapping_language,
       bool needs_object_ptr, bool static_method, bool is_class, bool weak_self,
       const EvaluateExpressionOptions &options,
-      const llvm::Optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
+      const std::optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
       ExecutionContext &exe_ctx, uint32_t &first_body_line,
       llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) const;
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.cpp
@@ -84,10 +84,10 @@ void SwiftPersistentExpressionState::RemovePersistentVariable(
   }
 }
 
-llvm::Optional<CompilerType>
+std::optional<CompilerType>
 SwiftPersistentExpressionState::GetCompilerTypeFromPersistentDecl(
     ConstString type_name) {
-  return llvm::None;
+  return std::nullopt;
 }
 
 bool SwiftPersistentExpressionState::SwiftDeclMap::DeclsAreEquivalent(

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h
@@ -84,7 +84,7 @@ public:
 
   ConstString GetNextPersistentVariableName(bool is_error = false) override;
 
-  llvm::Optional<CompilerType>
+  std::optional<CompilerType>
   GetCompilerTypeFromPersistentDecl(ConstString type_name) override;
 
   void RegisterSwiftPersistentDecl(CompilerDecl value_decl);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -586,7 +586,7 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
       importInfo.StdlibKind = swift::ImplicitStdlibKind::Stdlib;
       repl_module = swift_ast->CreateModule(completion_module_info, error,
                                             importInfo);
-      llvm::Optional<unsigned> bufferID;
+      std::optional<unsigned> bufferID;
       swift::SourceFile *repl_source_file = new (*ast) swift::SourceFile(
           *repl_module, swift::SourceFileKind::Main, bufferID);
       repl_module->addFile(*repl_source_file);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPLMaterializer.cpp
@@ -224,7 +224,7 @@ public:
       demangle_ctx.clear();
     }
 
-    llvm::Optional<uint64_t> size =
+    std::optional<uint64_t> size =
         m_type.GetByteSize(execution_unit->GetBestExecutionContextScope());
     if (size && *size == 0) {
       MakeREPLResult(*execution_unit, err, nullptr);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -122,7 +122,7 @@ struct SwiftSelfInfo {
 };
 
 /// Find information about `self` in the frame.
-static llvm::Optional<SwiftSelfInfo>
+static std::optional<SwiftSelfInfo>
 findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
   SwiftSelfInfo info;
 
@@ -371,7 +371,7 @@ static bool AddVariableInfo(
       std::make_shared<lldb_private::SymbolFileType>(
           *variable_sp->GetType()->GetSymbolFile(),
           variable_sp->GetType()->GetSymbolFile()->MakeType(
-              0, variable_sp->GetType()->GetName(), llvm::None,
+              0, variable_sp->GetType()->GetName(), std::nullopt,
               variable_sp->GetType()->GetSymbolContextScope(), LLDB_INVALID_UID,
               Type::eEncodingIsUID, variable_sp->GetType()->GetDeclaration(),
               target_type, lldb_private::Type::ResolveState::Full,
@@ -488,7 +488,7 @@ GetPersistentState(Target *target, ExecutionContext &exe_ctx) {
 /// - The Self type has to be the outermost type with unbound generics.
 static bool CanEvaluateExpressionWithoutBindingGenericParams(
     const llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &variables,
-    const llvm::Optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
+    const std::optional<SwiftLanguageRuntime::GenericSignature> &generic_sig,
     SwiftASTContextForExpressions &scratch_ctx, Block *block,
     StackFrame &stack_frame) {
   // First, find the compiler type of self with the generic parameters not

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -189,11 +189,11 @@ private:
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
   };
 
-  llvm::Optional<SwiftScratchContextReader> m_swift_scratch_ctx;
+  std::optional<SwiftScratchContextReader> m_swift_scratch_ctx;
   SwiftASTContextForExpressions *m_swift_ast_ctx;
   PersistentVariableDelegate m_persistent_variable_delegate;
   std::unique_ptr<SwiftExpressionParser> m_parser;
-  llvm::Optional<SwiftLanguageRuntime::GenericSignature> m_generic_signature;
+  std::optional<SwiftLanguageRuntime::GenericSignature> m_generic_signature;
   Status m_err;
   bool m_runs_in_playground_or_repl;
   bool m_needs_object_ptr = false;

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -24,9 +24,8 @@
 #include "lldb/Utility/Timer.h"
 #include "swift/AST/Types.h"
 #include "swift/Demangling/ManglingMacros.h"
-#include "llvm/ADT/None.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
+#include <optional>
 
 // FIXME: we should not need this
 #include "Plugins/Language/CPlusPlus/CxxStringTypes.h"
@@ -79,7 +78,7 @@ struct StringSlice {
 
 template <typename AddrT>
 static void applySlice(AddrT &address, uint64_t &length,
-                       Optional<StringSlice> slice) {
+                       std::optional<StringSlice> slice) {
   if (!slice)
     return;
 
@@ -128,7 +127,7 @@ static bool makeStringGutsSummary(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options,
-    Optional<StringSlice> slice = None) {
+    std::optional<StringSlice> slice = std::nullopt) {
   LLDB_SCOPED_TIMER();
 
   static ConstString g__object("_object");
@@ -428,20 +427,20 @@ bool lldb_private::formatters::swift::Substring_SummaryProvider(
     return false;
 
   auto get_index =
-      [&slice_sp](ConstString index_name) -> Optional<StringIndex> {
+      [&slice_sp](ConstString index_name) -> std::optional<StringIndex> {
     auto raw_bits_sp = slice_sp->GetChildAtNamePath({index_name, g__rawBits});
     if (!raw_bits_sp)
-      return None;
+      return std::nullopt;
     bool success = false;
     StringIndex index =
         raw_bits_sp->GetSyntheticValue()->GetValueAsUnsigned(0, &success);
     if (!success)
-      return None;
+      return std::nullopt;
     return index;
   };
 
-  Optional<StringIndex> start_index = get_index(g__startIndex);
-  Optional<StringIndex> end_index = get_index(g__endIndex);
+  std::optional<StringIndex> start_index = get_index(g__startIndex);
+  std::optional<StringIndex> end_index = get_index(g__endIndex);
   if (!start_index || !end_index)
     return false;
 
@@ -1041,12 +1040,12 @@ public:
 };
 
 /// Read a vector from a buffer target.
-llvm::Optional<std::vector<std::string>>
+std::optional<std::vector<std::string>>
 ReadVector(const SIMDElementFormatter &formatter, const uint8_t *buffer,
            unsigned len, unsigned offset, unsigned num_elements) {
   unsigned elt_size = formatter.getElementSize();
   if ((offset + num_elements * elt_size) > len)
-    return llvm::None;
+    return std::nullopt;
   std::vector<std::string> elements;
   for (unsigned I = 0; I < num_elements; ++I)
     elements.emplace_back(formatter.Format(buffer + offset + (I * elt_size)));
@@ -1054,7 +1053,7 @@ ReadVector(const SIMDElementFormatter &formatter, const uint8_t *buffer,
 }
 
 /// Read a SIMD vector from the target.
-llvm::Optional<std::vector<std::string>>
+std::optional<std::vector<std::string>>
 ReadVector(Process &process, ValueObject &valobj,
            const SIMDElementFormatter &formatter, unsigned num_elements) {
   Status error;
@@ -1062,21 +1061,21 @@ ReadVector(Process &process, ValueObject &valobj,
   static ConstString g_value("_value");
   ValueObjectSP value_sp = valobj.GetChildAtNamePath({g_storage, g_value});
   if (!value_sp)
-    return llvm::None;
+    return std::nullopt;
 
   // The layout of the vector is the same as what you'd expect for a C-style
   // array. It's a contiguous bag of bytes with no padding.
   lldb_private::DataExtractor data;
   uint64_t len = value_sp->GetData(data, error);
   if (error.Fail())
-    return llvm::None;
+    return std::nullopt;
 
   const uint8_t *buffer = data.GetDataStart();
   return ReadVector(formatter, buffer, len, 0, num_elements);
 }
 
 /// Print a vector of elements as a row, if possible.
-bool PrintRow(Stream &stream, llvm::Optional<std::vector<std::string>> vec) {
+bool PrintRow(Stream &stream, std::optional<std::vector<std::string>> vec) {
   if (!vec)
     return false;
 
@@ -1126,7 +1125,7 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
     return false;
 
   ExecutionContext exe_ctx = valobj.GetExecutionContextRef().Lock(true);
-  llvm::Optional<uint64_t> opt_type_size =
+  std::optional<uint64_t> opt_type_size =
     simd_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
   if (!opt_type_size)
     return false;
@@ -1141,7 +1140,7 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   if (!arg_type)
     return false;
 
-  llvm::Optional<uint64_t> opt_arg_size =
+  std::optional<uint64_t> opt_arg_size =
       arg_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
   if (!opt_arg_size)
     return false;
@@ -1209,7 +1208,7 @@ bool lldb_private::formatters::swift::LegacySIMD_SummaryProvider(
   bool is_vector = !is_matrix && !is_quaternion;
 
   // Get the kind of SIMD element inside of this object.
-  llvm::Optional<SIMDElementKind> kind = llvm::None;
+  std::optional<SIMDElementKind> kind = std::nullopt;
   if (type_name.startswith("int"))
     kind = SIMDElementKind::Int32;
   else if (type_name.startswith("uint"))

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -290,7 +290,7 @@ HashedCollectionConfig::StorageObjectAtAddress(
   // same address.
   Status error;
   ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
-  llvm::Optional<SwiftScratchContextReader> reader =
+  std::optional<SwiftScratchContextReader> reader =
     process_sp->GetTarget().GetSwiftScratchContext(error, *exe_scope);
   if (!reader)
     return nullptr;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1030,7 +1030,7 @@ SwiftLanguage::GetHardcodedSynthetics() {
         LLDB_LOGV(log, "[Matching CxxBridgedSyntheticChildProvider] - "
                        "Could not get the swift runtime.");
 
-      llvm::Optional<SwiftScratchContextReader> scratch_ctx_reader =
+      std::optional<SwiftScratchContextReader> scratch_ctx_reader =
           valobj.GetSwiftScratchContext();
       if (!scratch_ctx_reader || !scratch_ctx_reader->get()) {
         LLDB_LOGV(log, "[Matching CxxBridgedSyntheticChildProvider] - "
@@ -1328,7 +1328,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             if (target) {
               const bool create_on_demand = false;
               Status error;
-              llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
+              std::optional<SwiftScratchContextReader> maybe_scratch_ctx =
                   target->GetSwiftScratchContext(error, *exe_scope,
                                                  create_on_demand);
               const SymbolContext *sc = nullptr;
@@ -1401,7 +1401,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             Target *target = exe_scope->CalculateTarget().get();
             const bool create_on_demand = false;
             Status error;
-            llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
+            std::optional<SwiftScratchContextReader> maybe_scratch_ctx =
                 target->GetSwiftScratchContext(error, *exe_scope,
                                                create_on_demand);
             const SymbolContext *sc = nullptr;
@@ -1427,7 +1427,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                       TypesOrDecls local_results;
                       ast_ctx->FindTypesOrDecls(input, module, local_results,
                                                 false);
-                      llvm::Optional<TypeOrDecl> candidate;
+                      std::optional<TypeOrDecl> candidate;
                       if (local_results.empty() && name_parts.size() > 1) {
                         size_t idx_of_deeper = 1;
                         // if you're looking for Swift.Int in module Swift,

--- a/lldb/source/Plugins/Language/Swift/SwiftOptionSet.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptionSet.h
@@ -20,7 +20,7 @@
 #include "lldb/Symbol/CompilerType.h"
 
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/Optional.h"
+#include <optional>
 
 #include <vector>
 
@@ -48,7 +48,7 @@ private:
   typedef std::vector<std::pair<llvm::APInt, lldb_private::ConstString>>
       CasesVector;
 
-  llvm::Optional<CasesVector> m_cases;
+  std::optional<CasesVector> m_cases;
 };
 
 bool SwiftOptionSet_SummaryProvider(ValueObject &valobj, Stream &stream);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -167,7 +167,7 @@ GetSwiftObjectFileFormat(llvm::Triple::ObjectFormatType obj_format_type) {
   return obj_file_format;
 }
 
-llvm::Optional<swift::remote::RemoteAbsolutePointer>
+std::optional<swift::remote::RemoteAbsolutePointer>
 LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
   // If an address has a symbol, that symbol provides additional useful data to
   // MetadataReader. Without the symbol, MetadataReader can derive the symbol
@@ -178,7 +178,7 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
   if (!target.GetSwiftUseReflectionSymbols())
     return {};
 
-  llvm::Optional<Address> maybeAddr =
+  std::optional<Address> maybeAddr =
       resolveRemoteAddress(address.getAddressData());
   // This is not an assert, but should never happen.
   if (!maybeAddr)
@@ -332,7 +332,7 @@ bool LLDBMemoryReader::readBytes(swift::remote::RemoteAddress address,
 
   LLDB_LOGV(log, "[MemoryReader] asked to read {0} bytes at address {1:x}",
             size, address.getAddressData());
-  llvm::Optional<Address> maybeAddr =
+  std::optional<Address> maybeAddr =
       resolveRemoteAddressFromSymbolObjectFile(address.getAddressData());
 
   if (!maybeAddr)
@@ -409,7 +409,7 @@ bool LLDBMemoryReader::readString(swift::remote::RemoteAddress address,
   LLDB_LOGV(log, "[MemoryReader] asked to read string data at address {0:x}",
             address.getAddressData());
 
-  llvm::Optional<Address> maybeAddr =
+  std::optional<Address> maybeAddr =
       resolveRemoteAddressFromSymbolObjectFile(address.getAddressData());
 
   if (!maybeAddr)
@@ -464,7 +464,7 @@ void LLDBMemoryReader::popLocalBuffer() {
   m_local_buffer_size = 0;
 }
 
-llvm::Optional<std::pair<uint64_t, uint64_t>>
+std::optional<std::pair<uint64_t, uint64_t>>
 LLDBMemoryReader::addModuleToAddressMap(ModuleSP module,
                                         bool register_symbol_obj_file) {
   if (!readMetadataFromFileCacheEnabled())
@@ -547,7 +547,7 @@ LLDBMemoryReader::addModuleToAddressMap(ModuleSP module,
   return {{module_start_address, module_end_address}};
 }
 
-llvm::Optional<std::pair<uint64_t, lldb::ModuleSP>>
+std::optional<std::pair<uint64_t, lldb::ModuleSP>>
 LLDBMemoryReader::getFileAddressAndModuleForTaggedAddress(
     uint64_t tagged_address) const {
   Log *log(GetLog(LLDBLog::Types));
@@ -600,7 +600,7 @@ LLDBMemoryReader::getFileAddressAndModuleForTaggedAddress(
   return {{file_address, module}};
 }
 
-llvm::Optional<Address>
+std::optional<Address>
 LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
   Log *log(GetLog(LLDBLog::Types));
   auto maybe_pair = getFileAddressAndModuleForTaggedAddress(address);
@@ -633,7 +633,7 @@ LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
   return resolved;
 }
 
-llvm::Optional<Address>
+std::optional<Address>
 LLDBMemoryReader::resolveRemoteAddressFromSymbolObjectFile(
     uint64_t address) const {
   Log *log(GetLog(LLDBLog::Types));

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -43,7 +43,7 @@ public:
   swift::remote::RemoteAddress
   getSymbolAddress(const std::string &name) override;
 
-  llvm::Optional<swift::remote::RemoteAbsolutePointer>
+  std::optional<swift::remote::RemoteAbsolutePointer>
   resolvePointerAsSymbol(swift::remote::RemoteAddress address) override;
 
   swift::remote::RemoteAbsolutePointer
@@ -64,7 +64,7 @@ public:
   /// addresses, so we can read memory from the file cache whenever possible.
   /// \return a pair of addresses indicating the start and end of this image in
   /// the tagged address space. None on failure.
-  llvm::Optional<std::pair<uint64_t, uint64_t>>
+  std::optional<std::pair<uint64_t, uint64_t>>
   addModuleToAddressMap(lldb::ModuleSP module, bool register_symbol_obj_file);
 
   /// Returns whether the filecache optimization is enabled or not.
@@ -73,7 +73,7 @@ public:
 private:
   /// Gets the file address and module that were mapped to a given tagged
   /// address.
-  llvm::Optional<std::pair<uint64_t, lldb::ModuleSP>>
+  std::optional<std::pair<uint64_t, lldb::ModuleSP>>
   getFileAddressAndModuleForTaggedAddress(uint64_t tagged_address) const;
 
   /// Resolves the address by either mapping a tagged address back to an LLDB
@@ -83,18 +83,18 @@ private:
   /// tagged address back, an Address with just an offset if the address was not
   /// tagged, and None if the address was tagged but we couldn't convert it back
   /// to an Address.
-  llvm::Optional<Address> resolveRemoteAddress(uint64_t address) const;
+  std::optional<Address> resolveRemoteAddress(uint64_t address) const;
 
   /// Reads memory from the symbol rich binary from the address into dest.
   /// \return true if it was able to successfully read memory.
-  llvm::Optional<Address>
+  std::optional<Address>
   resolveRemoteAddressFromSymbolObjectFile(uint64_t address) const;
 
 private:
   Process &m_process;
   size_t m_max_read_amount;
 
-  llvm::Optional<uint64_t> m_local_buffer;
+  std::optional<uint64_t> m_local_buffer;
   uint64_t m_local_buffer_size = 0;
 
   std::function<swift::remote::RemoteAbsolutePointer(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -71,7 +71,7 @@ public:
       : m_reflection_ctx(reader, swift_metadata_cache, &m_forwader),
         m_type_converter(m_reflection_ctx.getBuilder()) {}
 
-  llvm::Optional<uint32_t> AddImage(
+  std::optional<uint32_t> AddImage(
       llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
           swift::ReflectionSectionKind)>
           find_section,
@@ -79,15 +79,15 @@ public:
     return m_reflection_ctx.addImage(find_section, likely_module_names);
   }
 
-  llvm::Optional<uint32_t>
+  std::optional<uint32_t>
   AddImage(swift::remote::RemoteAddress image_start,
            llvm::SmallVector<llvm::StringRef, 1> likely_module_names) override {
     return m_reflection_ctx.addImage(image_start, likely_module_names);
   }
 
-  llvm::Optional<uint32_t> ReadELF(
+  std::optional<uint32_t> ReadELF(
       swift::remote::RemoteAddress ImageStart,
-      llvm::Optional<llvm::sys::MemoryBlock> FileBuffer,
+      std::optional<llvm::sys::MemoryBlock> FileBuffer,
       llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) override {
     return m_reflection_ctx.readELF(ImageStart, FileBuffer,
                                     likely_module_names);
@@ -261,7 +261,7 @@ public:
     return false;
   }
 
-  llvm::Optional<int32_t> ProjectEnumValue(
+  std::optional<int32_t> ProjectEnumValue(
       swift::remote::RemoteAddress enum_addr,
       const swift::reflection::TypeRef *enum_type_ref,
       swift::remote::TypeInfoProvider *provider,
@@ -274,7 +274,7 @@ public:
     return {};
   }
 
-  llvm::Optional<std::pair<const swift::reflection::TypeRef *,
+  std::optional<std::pair<const swift::reflection::TypeRef *,
                            swift::reflection::RemoteAddress>>
   ProjectExistentialAndUnwrapClass(
       swift::reflection::RemoteAddress existential_address,
@@ -312,7 +312,7 @@ public:
                                                  skip_artificial_subclasses);
   }
 
-  llvm::Optional<bool> IsValueInlinedInExistentialContainer(
+  std::optional<bool> IsValueInlinedInExistentialContainer(
       swift::remote::RemoteAddress existential_address) override {
     return m_reflection_ctx.isValueInlinedInExistentialContainer(
         existential_address);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -19,7 +19,7 @@
 #include "swift/ABI/ObjectFile.h"
 #include "swift/Remote/RemoteAddress.h"
 #include "swift/RemoteInspection/TypeRef.h"
-#include "llvm/ADT/Optional.h"
+#include <optional>
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -68,17 +68,17 @@ public:
 
   virtual ~ReflectionContextInterface() = default;
 
-  virtual llvm::Optional<uint32_t> AddImage(
+  virtual std::optional<uint32_t> AddImage(
       llvm::function_ref<std::pair<swift::remote::RemoteRef<void>, uint64_t>(
           swift::ReflectionSectionKind)>
           find_section,
       llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
-  virtual llvm::Optional<uint32_t>
+  virtual std::optional<uint32_t>
   AddImage(swift::remote::RemoteAddress image_start,
            llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
-  virtual llvm::Optional<uint32_t>
+  virtual std::optional<uint32_t>
   ReadELF(swift::remote::RemoteAddress ImageStart,
-          llvm::Optional<llvm::sys::MemoryBlock> FileBuffer,
+          std::optional<llvm::sys::MemoryBlock> FileBuffer,
           llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
   virtual const swift::reflection::TypeRef *GetTypeRefOrNull(
       llvm::StringRef mangled_type_name,
@@ -117,13 +117,13 @@ public:
                         const swift::reflection::TypeRef *tr,
                         std::function<bool(SuperClassType)> fn) = 0;
 
-  virtual llvm::Optional<std::pair<const swift::reflection::TypeRef *,
-                                   swift::remote::RemoteAddress>>
+  virtual std::optional<std::pair<const swift::reflection::TypeRef *,
+                                  swift::remote::RemoteAddress>>
   ProjectExistentialAndUnwrapClass(
       swift::remote::RemoteAddress existential_addess,
       const swift::reflection::TypeRef &existential_tr,
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
-  virtual llvm::Optional<int32_t> ProjectEnumValue(
+  virtual std::optional<int32_t> ProjectEnumValue(
       swift::remote::RemoteAddress enum_addr,
       const swift::reflection::TypeRef *enum_type_ref,
       swift::remote::TypeInfoProvider *provider,
@@ -136,7 +136,7 @@ public:
       lldb::addr_t instance_address,
       swift::reflection::DescriptorFinder *descriptor_finder,
       bool skip_artificial_subclasses = false) = 0;
-  virtual llvm::Optional<bool> IsValueInlinedInExistentialContainer(
+  virtual std::optional<bool> IsValueInlinedInExistentialContainer(
       swift::remote::RemoteAddress existential_address) = 0;
   virtual const swift::reflection::TypeRef *ApplySubstitutions(
       const swift::reflection::TypeRef *type_ref,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -161,7 +161,7 @@ static ModuleSP findRuntime(Process &process, RuntimeKind runtime_kind) {
   return runtime_image;
 }
 
-static llvm::Optional<lldb::addr_t>
+static std::optional<lldb::addr_t>
 FindSymbolForSwiftObject(Process &process, RuntimeKind runtime_kind,
                          StringRef object, const SymbolType sym_type) {
   ModuleSP image = findRuntime(process, runtime_kind);
@@ -290,7 +290,7 @@ public:
     STUB_LOG();
   }
 
-  llvm::Optional<uint64_t> GetMemberVariableOffset(CompilerType instance_type,
+  std::optional<uint64_t> GetMemberVariableOffset(CompilerType instance_type,
                                                    ValueObject *instance,
                                                    llvm::StringRef member_name,
                                                    Status *error) {
@@ -298,20 +298,20 @@ public:
     return {};
   }
 
-  llvm::Optional<unsigned> GetNumChildren(CompilerType type,
+  std::optional<unsigned> GetNumChildren(CompilerType type,
                                           ExecutionContextScope *exe_scopej) {
     STUB_LOG();
     return {};
   }
 
-  llvm::Optional<std::string> GetEnumCaseName(CompilerType type,
+  std::optional<std::string> GetEnumCaseName(CompilerType type,
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx) {
     STUB_LOG();
     return {};
   }
 
-  std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
+  std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>
   GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
                                 ExecutionContext *exe_ctx,
                                 bool omit_empty_base_classes,
@@ -332,7 +332,7 @@ public:
     return {};
   }
 
-  llvm::Optional<unsigned> GetNumFields(CompilerType type,
+  std::optional<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx) {
     STUB_LOG();
     return {};
@@ -370,18 +370,18 @@ public:
     return {};
   }
 
-  llvm::Optional<uint64_t> GetBitSize(CompilerType type,
+  std::optional<uint64_t> GetBitSize(CompilerType type,
                                       ExecutionContextScope *exe_scope) {
     STUB_LOG();
     return {};
   }
 
-  llvm::Optional<uint64_t> GetByteStride(CompilerType type) {
+  std::optional<uint64_t> GetByteStride(CompilerType type) {
     STUB_LOG();
     return {};
   }
 
-  llvm::Optional<size_t> GetBitAlignment(CompilerType type,
+  std::optional<size_t> GetBitAlignment(CompilerType type,
                                          ExecutionContextScope *exe_scope) {
     STUB_LOG();
     return {};
@@ -583,7 +583,7 @@ void SwiftLanguageRuntimeImpl::SetupSwiftError() {
                                "__SwiftNativeNSError", eSymbolTypeObjCClass);
 }
 
-llvm::Optional<lldb::addr_t>
+std::optional<lldb::addr_t>
 SwiftLanguageRuntimeImpl::GetSwiftNativeNSErrorISA() {
   return m_SwiftNativeNSErrorISA;
 }
@@ -599,7 +599,7 @@ void SwiftLanguageRuntimeImpl::SetupExclusivity() {
         m_dynamic_exclusivity_flag_addr ? *m_dynamic_exclusivity_flag_addr : 0);
 }
 
-llvm::Optional<lldb::addr_t>
+std::optional<lldb::addr_t>
 SwiftLanguageRuntimeImpl::GetDynamicExclusivityFlagAddr() {
   return m_dynamic_exclusivity_flag_addr;
 }
@@ -718,7 +718,7 @@ bool SwiftLanguageRuntimeImpl::AddJitObjectFileToReflectionContext(
   return reflection_info_id.has_value();
 }
 
-llvm::Optional<uint32_t>
+std::optional<uint32_t>
 SwiftLanguageRuntimeImpl::AddObjectFileToReflectionContext(
     ModuleSP module,
     llvm::SmallVector<llvm::StringRef, 1> likely_module_names) {
@@ -739,7 +739,7 @@ SwiftLanguageRuntimeImpl::AddObjectFileToReflectionContext(
     if (!sym_obj_file)
       return false;
 
-    llvm::Optional<llvm::StringRef> maybe_segment_name =
+    std::optional<llvm::StringRef> maybe_segment_name =
         obj_file_format->getSymbolRichSegmentName();
     if (!maybe_segment_name)
       return false;
@@ -764,8 +764,8 @@ SwiftLanguageRuntimeImpl::AddObjectFileToReflectionContext(
     return section_iter != segment->GetChildren().end();
   }();
 
-  llvm::Optional<llvm::StringRef> maybe_segment_name;
-  llvm::Optional<llvm::StringRef> maybe_secondary_segment_name;
+  std::optional<llvm::StringRef> maybe_segment_name;
+  std::optional<llvm::StringRef> maybe_secondary_segment_name;
   ObjectFile *object_file;
   if (should_register_with_symbol_obj_file) {
     maybe_segment_name = obj_file_format->getSymbolRichSegmentName();
@@ -902,7 +902,7 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
   auto read_from_file_cache =
       GetMemoryReader()->readMetadataFromFileCacheEnabled();
 
-  llvm::Optional<uint32_t> info_id;
+  std::optional<uint32_t> info_id;
   // When dealing with ELF, we need to pass in the contents of the on-disk
   // file, since the Section Header Table is not present in the child process
   if (obj_file->GetPluginName().equals("elf")) {
@@ -912,7 +912,7 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
     llvm::sys::MemoryBlock file_buffer((void *)file_data, size);
     info_id = m_reflection_ctx->ReadELF(
         swift::remote::RemoteAddress(load_ptr),
-        llvm::Optional<llvm::sys::MemoryBlock>(file_buffer),
+        std::optional<llvm::sys::MemoryBlock>(file_buffer),
         likely_module_names);
   } else if (read_from_file_cache &&
              obj_file->GetPluginName().equals("mach-o")) {
@@ -1237,7 +1237,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
       Status error;
       Target &target = frame.GetThread()->GetProcess()->GetTarget();
       ExecutionContext exe_ctx(frame);
-      llvm::Optional<SwiftScratchContextReader> maybe_swift_ast =
+      std::optional<SwiftScratchContextReader> maybe_swift_ast =
           target.GetSwiftScratchContext(error, frame);
       auto scratch_ctx = maybe_swift_ast->get();
       if (scratch_ctx) {
@@ -1434,7 +1434,7 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   if (!runtime)
     return error_valobj_sp;
 
-  llvm::Optional<Value> arg0 =
+  std::optional<Value> arg0 =
       runtime->GetErrorReturnLocationAfterReturn(frame_sp);
   if (!arg0)
     return error_valobj_sp;
@@ -1446,7 +1446,7 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   if (!exe_scope)
     return error_valobj_sp;
 
-  llvm::Optional<SwiftScratchContextReader> maybe_scratch_context =
+  std::optional<SwiftScratchContextReader> maybe_scratch_context =
       target->GetSwiftScratchContext(error, *frame_sp);
   if (!maybe_scratch_context || error.Fail())
     return error_valobj_sp;
@@ -1910,7 +1910,7 @@ void SwiftLanguageRuntimeImpl::WillStartExecutingUserExpression(
     return;
   }
   ConstString BoolName("bool");
-  llvm::Optional<uint64_t> bool_size =
+  std::optional<uint64_t> bool_size =
       ts->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
   if (!bool_size)
     return;
@@ -1985,7 +1985,7 @@ void SwiftLanguageRuntimeImpl::DidFinishExecutingUserExpression(
     return;
   }
   ConstString BoolName("bool");
-  llvm::Optional<uint64_t> bool_size =
+  std::optional<uint64_t> bool_size =
       ts->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
   if (!bool_size)
     return;
@@ -2008,9 +2008,9 @@ void SwiftLanguageRuntimeImpl::DidFinishExecutingUserExpression(
              m_original_dynamic_exclusivity_flag_state);
 }
 
-llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationAfterReturn(
+std::optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationAfterReturn(
     lldb::StackFrameSP frame_sp) {
-  llvm::Optional<Value> error_val;
+  std::optional<Value> error_val;
 
   llvm::StringRef error_reg_name;
   ArchSpec arch_spec(GetTargetRef().GetArchitecture());
@@ -2058,9 +2058,9 @@ llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationAfterReturn(
   return error_val;
 }
 
-llvm::Optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationBeforeReturn(
+std::optional<Value> SwiftLanguageRuntime::GetErrorReturnLocationBeforeReturn(
     lldb::StackFrameSP frame_sp, bool &need_to_check_after_return) {
-  llvm::Optional<Value> error_val;
+  std::optional<Value> error_val;
 
   if (!frame_sp) {
     need_to_check_after_return = false;
@@ -2217,7 +2217,7 @@ private:
     eReferenceWeak,
   };
 
-  llvm::Optional<uint32_t> getReferenceCount(StringRef ObjName,
+  std::optional<uint32_t> getReferenceCount(StringRef ObjName,
                                              ReferenceCountType Type,
                                              ExecutionContext &exe_ctx,
                                              StackFrameSP &Frame) {
@@ -2245,13 +2245,13 @@ private:
     bool evalStatus = exe_ctx.GetTargetSP()->EvaluateExpression(
         Expr, Frame.get(), result_valobj_sp, eval_options);
     if (evalStatus != eExpressionCompleted)
-      return llvm::None;
+      return std::nullopt;
 
     bool success = false;
     uint32_t count = result_valobj_sp->GetSyntheticValue()->GetValueAsUnsigned(
         UINT32_MAX, &success);
     if (!success)
-      return llvm::None;
+      return std::nullopt;
     return count;
   }
 
@@ -2293,11 +2293,11 @@ protected:
 
     // Ask swift debugger support in the compiler about the objects
     // reference counts, and return them to the user.
-    llvm::Optional<uint32_t> strong = getReferenceCount(
+    std::optional<uint32_t> strong = getReferenceCount(
         command, ReferenceCountType::eReferenceStrong, m_exe_ctx, frame_sp);
-    llvm::Optional<uint32_t> unowned = getReferenceCount(
+    std::optional<uint32_t> unowned = getReferenceCount(
         command, ReferenceCountType::eReferenceUnowned, m_exe_ctx, frame_sp);
-    llvm::Optional<uint32_t> weak = getReferenceCount(
+    std::optional<uint32_t> weak = getReferenceCount(
         command, ReferenceCountType::eReferenceWeak, m_exe_ctx, frame_sp);
 
     std::string unavailable = "<unavailable>";
@@ -2411,24 +2411,24 @@ bool SwiftLanguageRuntime::IsStoredInlineInBuffer(CompilerType type) {
   FORWARD(IsStoredInlineInBuffer, type);
 }
 
-llvm::Optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
+std::optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
     CompilerType instance_type, ValueObject *instance,
     llvm::StringRef member_name, Status *error) {
   FORWARD(GetMemberVariableOffset, instance_type, instance, member_name, error);
 }
 
-llvm::Optional<unsigned>
+std::optional<unsigned>
 SwiftLanguageRuntime::GetNumChildren(CompilerType type,
                                      ExecutionContextScope *exe_scope) {
   FORWARD(GetNumChildren, type, exe_scope);
 }
 
-llvm::Optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(
+std::optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(
     CompilerType type, const DataExtractor &data, ExecutionContext *exe_ctx) {
   FORWARD(GetEnumCaseName, type, data, exe_ctx);
 }
 
-std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
+std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>
 SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
     CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
@@ -2452,7 +2452,7 @@ CompilerType SwiftLanguageRuntime::GetChildCompilerTypeAtIndex(
           language_flags);
 }
 
-llvm::Optional<unsigned>
+std::optional<unsigned>
 SwiftLanguageRuntime::GetNumFields(CompilerType type,
                                    ExecutionContext *exe_ctx) {
   FORWARD(GetNumFields, type, exe_ctx);
@@ -2490,18 +2490,18 @@ SwiftLanguageRuntime::GetConcreteType(ExecutionContextScope *exe_scope,
   FORWARD(GetConcreteType, exe_scope, abstract_type_name);
 }
 
-llvm::Optional<uint64_t>
+std::optional<uint64_t>
 SwiftLanguageRuntime::GetBitSize(CompilerType type,
                                  ExecutionContextScope *exe_scope) {
   FORWARD(GetBitSize, type, exe_scope);
 }
 
-llvm::Optional<uint64_t>
+std::optional<uint64_t>
 SwiftLanguageRuntime::GetByteStride(CompilerType type) {
   FORWARD(GetByteStride, type);
 }
 
-llvm::Optional<size_t>
+std::optional<size_t>
 SwiftLanguageRuntime::GetBitAlignment(CompilerType type,
                                       ExecutionContextScope *exe_scope) {
   FORWARD(GetBitAlignment, type, exe_scope);
@@ -2544,7 +2544,7 @@ struct AsyncUnwindRegisterNumbers {
 };
 } // namespace
 
-static llvm::Optional<AsyncUnwindRegisterNumbers>
+static std::optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple) {
   switch (triple) {
   case llvm::Triple::x86_64: {
@@ -2594,7 +2594,7 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
 
   Target &target(process_sp->GetTarget());
   auto arch = target.GetArchitecture();
-  llvm::Optional<AsyncUnwindRegisterNumbers> regnums =
+  std::optional<AsyncUnwindRegisterNumbers> regnums =
       GetAsyncUnwindRegisterNumbers(arch.GetMachine());
   if (!regnums)
     return UnwindPlanSP();
@@ -2772,7 +2772,7 @@ GetFollowAsyncContextUnwindPlan(RegisterContext *regctx, ArchSpec &arch,
   const int32_t ptr_size = 8;
   row->SetOffset(0);
 
-  llvm::Optional<AsyncUnwindRegisterNumbers> regnums =
+  std::optional<AsyncUnwindRegisterNumbers> regnums =
       GetAsyncUnwindRegisterNumbers(arch.GetMachine());
   if (!regnums)
     return UnwindPlanSP();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -21,7 +21,7 @@
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/lldb-private.h"
 
-#include "llvm/ADT/Optional.h"
+#include <optional>
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
 
@@ -292,7 +292,7 @@ public:
     unsigned GetCountForTypePack(unsigned i) { return count_for_type_pack[i]; }
   };
   /// Extract the generic signature out of a mangled Swift function name.
-  static llvm::Optional<GenericSignature>
+  static std::optional<GenericSignature>
   GetGenericSignature(llvm::StringRef function_name,
                       TypeSystemSwiftTypeRef &ts);
 
@@ -309,18 +309,18 @@ public:
   /// of the given type.
   ///
   /// \param instance_type
-  llvm::Optional<uint64_t> GetMemberVariableOffset(CompilerType instance_type,
+  std::optional<uint64_t> GetMemberVariableOffset(CompilerType instance_type,
                                                    ValueObject *instance,
                                                    llvm::StringRef member_name,
                                                    Status *error = nullptr);
 
   /// Ask Remote Mirrors about the children of a composite type.
-  llvm::Optional<unsigned> GetNumChildren(CompilerType type,
+  std::optional<unsigned> GetNumChildren(CompilerType type,
                                           ExecutionContextScope *exe_scope);
 
   /// Determine the enum case name for the \p data value of the enum \p type.
   /// This is performed using Swift reflection.
-  llvm::Optional<std::string> GetEnumCaseName(CompilerType type,
+  std::optional<std::string> GetEnumCaseName(CompilerType type,
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 
@@ -345,7 +345,7 @@ public:
   ///                     don't have an index.
   ///
   /// \returns {true, {num_idexes}} on success.
-  std::pair<LookupResult, llvm::Optional<size_t>>
+  std::pair<LookupResult, std::optional<size_t>>
   GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
                                 ExecutionContext *exe_ctx,
                                 bool omit_empty_base_classes,
@@ -362,18 +362,18 @@ public:
       uint64_t &language_flags);
 
   /// Ask Remote Mirrors about the fields of a composite type.
-  llvm::Optional<unsigned> GetNumFields(CompilerType type,
+  std::optional<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);
 
   /// Ask Remote Mirrors for the size of a Swift type.
-  llvm::Optional<uint64_t> GetBitSize(CompilerType type,
+  std::optional<uint64_t> GetBitSize(CompilerType type,
                                       ExecutionContextScope *exe_scope);
 
   /// Ask Remote mirrors for the stride of a Swift type.
-  llvm::Optional<uint64_t> GetByteStride(CompilerType type);
+  std::optional<uint64_t> GetByteStride(CompilerType type);
 
   /// Ask Remote mirrors for the alignment of a Swift type.
-  llvm::Optional<size_t> GetBitAlignment(CompilerType type,
+  std::optional<size_t> GetBitAlignment(CompilerType type,
                                          ExecutionContextScope *exe_scope);
 
   /// Release the RemoteASTContext associated with the given swift::ASTContext.
@@ -428,10 +428,10 @@ public:
                                                          ConstString name,
                                                          bool persistent);
 
-  llvm::Optional<Value>
+  std::optional<Value>
   GetErrorReturnLocationAfterReturn(lldb::StackFrameSP frame_sp);
 
-  llvm::Optional<Value>
+  std::optional<Value>
   GetErrorReturnLocationBeforeReturn(lldb::StackFrameSP frame_sp,
                                      bool &need_to_check_after_return);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -93,52 +93,52 @@ public:
   GetSwiftRuntimeTypeInfo(CompilerType type, ExecutionContextScope *exe_scope,
                           swift::reflection::TypeRef const **out_tr = nullptr);
 
-  llvm::Optional<const swift::reflection::TypeInfo *>
+  std::optional<const swift::reflection::TypeInfo *>
   lookupClangTypeInfo(CompilerType clang_type);
 
   const swift::reflection::TypeInfo *emplaceClangTypeInfo(
-      CompilerType clang_type, llvm::Optional<uint64_t> byte_size,
-      llvm::Optional<size_t> bit_align,
+      CompilerType clang_type, std::optional<uint64_t> byte_size,
+      std::optional<size_t> bit_align,
       llvm::ArrayRef<swift::reflection::FieldInfo> fields);
 
   bool IsStoredInlineInBuffer(CompilerType type);
 
   /// Ask Remote Mirrors for the size of a Swift type.
-  llvm::Optional<uint64_t> GetBitSize(CompilerType type,
+  std::optional<uint64_t> GetBitSize(CompilerType type,
                                       ExecutionContextScope *exe_scope);
 
   /// Ask Remote mirrors for the stride of a Swift type.
-  llvm::Optional<uint64_t> GetByteStride(CompilerType type);
+  std::optional<uint64_t> GetByteStride(CompilerType type);
 
   /// Ask Remote mirrors for the alignment of a Swift type.
-  llvm::Optional<size_t> GetBitAlignment(CompilerType type,
+  std::optional<size_t> GetBitAlignment(CompilerType type,
                                          ExecutionContextScope *exe_scope);
 
   CompilerType GetTypeFromMetadata(TypeSystemSwift &tss, Address address);
 
-  llvm::Optional<uint64_t>
+  std::optional<uint64_t>
   GetMemberVariableOffsetRemoteAST(CompilerType instance_type,
                                    ValueObject *instance,
                                    llvm::StringRef member_name);
-  llvm::Optional<uint64_t> GetMemberVariableOffsetRemoteMirrors(
+  std::optional<uint64_t> GetMemberVariableOffsetRemoteMirrors(
       CompilerType instance_type, ValueObject *instance,
       llvm::StringRef member_name, Status *error);
-  llvm::Optional<uint64_t> GetMemberVariableOffset(CompilerType instance_type,
+  std::optional<uint64_t> GetMemberVariableOffset(CompilerType instance_type,
                                                    ValueObject *instance,
                                                    llvm::StringRef member_name,
                                                    Status *error);
 
-  llvm::Optional<unsigned> GetNumChildren(CompilerType type,
+  std::optional<unsigned> GetNumChildren(CompilerType type,
                                           ExecutionContextScope *exe_scope);
 
-  llvm::Optional<unsigned> GetNumFields(CompilerType type,
+  std::optional<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);
 
-  llvm::Optional<std::string> GetEnumCaseName(CompilerType type,
+  std::optional<std::string> GetEnumCaseName(CompilerType type,
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 
-  std::pair<SwiftLanguageRuntime::LookupResult, llvm::Optional<size_t>>
+  std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>
   GetIndexOfChildMemberWithName(CompilerType type, llvm::StringRef name,
                                 ExecutionContext *exe_ctx,
                                 bool omit_empty_base_classes,
@@ -252,7 +252,7 @@ protected:
                                          TypeAndOrName &class_type_or_name,
                                          Address &address);
 #ifndef NDEBUG
-  llvm::Optional<std::pair<CompilerType, Address>>
+  std::optional<std::pair<CompilerType, Address>>
   GetDynamicTypeAndAddress_ProtocolRemoteAST(ValueObject &in_value,
                                              CompilerType protocol_type,
                                              bool use_local_buffer,
@@ -291,8 +291,8 @@ protected:
     lldb::ValueObjectSP m_for_object_sp;
     SwiftLanguageRuntimeImpl &m_swift_runtime;
     lldb::addr_t m_metadata_location;
-    llvm::Optional<swift::MetadataKind> m_metadata_kind;
-    llvm::Optional<CompilerType> m_compiler_type;
+    std::optional<swift::MetadataKind> m_metadata_kind;
+    std::optional<CompilerType> m_compiler_type;
 
   public:
     CompilerType FulfillTypePromise(const SymbolContext *sc,
@@ -306,7 +306,7 @@ protected:
   MetadataPromiseSP
   GetPromiseForTypeNameAndFrame(const char *type_name, StackFrame *frame);
 
-  llvm::Optional<lldb::addr_t>
+  std::optional<lldb::addr_t>
   GetTypeMetadataForTypeNameAndFrame(llvm::StringRef mdvar_name,
                                      StackFrame &frame);
 
@@ -368,14 +368,14 @@ private:
   bool m_initialized_reflection_ctx = false;
 
   /// Lazily initialize and return \p m_dynamic_exclusivity_flag_addr.
-  llvm::Optional<lldb::addr_t> GetDynamicExclusivityFlagAddr();
+  std::optional<lldb::addr_t> GetDynamicExclusivityFlagAddr();
 
   // Add the modules in m_modules_to_add to the Reflection Context. The
   // ModulesDidLoad() callback appends to m_modules_to_add.
   void ProcessModulesToAdd();
 
   /// Lazily initialize and return \p m_SwiftNativeNSErrorISA.
-  llvm::Optional<lldb::addr_t> GetSwiftNativeNSErrorISA();
+  std::optional<lldb::addr_t> GetSwiftNativeNSErrorISA();
 
   SwiftMetadataCache *GetSwiftMetadataCache();
 
@@ -389,7 +389,7 @@ private:
   uint32_t m_active_user_expr_count = 0;
 
   bool m_original_dynamic_exclusivity_flag_state = false;
-  llvm::Optional<lldb::addr_t> m_dynamic_exclusivity_flag_addr;
+  std::optional<lldb::addr_t> m_dynamic_exclusivity_flag_addr;
   /// \}
 
   /// Reflection context.
@@ -421,24 +421,24 @@ private:
   /// Add the reflections sections to the reflection context by extracting
   /// the directly from the object file.
   /// \return the info id of the newly registered reflection info on success, or
-  /// llvm::None otherwise.
-  llvm::Optional<uint32_t> AddObjectFileToReflectionContext(
+  /// std::nullopt otherwise.
+  std::optional<uint32_t> AddObjectFileToReflectionContext(
       lldb::ModuleSP module,
       llvm::SmallVector<llvm::StringRef, 1> likely_module_names);
 
   /// Cache for the debug-info-originating type infos.
   /// \{
   llvm::DenseMap<lldb::opaque_compiler_type_t,
-                 llvm::Optional<swift::reflection::TypeInfo>>
+                 std::optional<swift::reflection::TypeInfo>>
       m_clang_type_info;
   llvm::DenseMap<lldb::opaque_compiler_type_t,
-                 llvm::Optional<swift::reflection::RecordTypeInfo>>
+                 std::optional<swift::reflection::RecordTypeInfo>>
       m_clang_record_type_info;
   std::recursive_mutex m_clang_type_info_mutex;
   /// \}
 
   /// Swift native NSError isa.
-  llvm::Optional<lldb::addr_t> m_SwiftNativeNSErrorISA;
+  std::optional<lldb::addr_t> m_SwiftNativeNSErrorISA;
 
 #ifndef NDEBUG
   /// Assert helper to determine if the scratch SwiftASTContext is locked.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -365,7 +365,7 @@ private:
    return site_sp->IsBreakpointAtThisSite(m_async_breakpoint_sp->GetID());
   }
 
-  llvm::Optional<lldb::addr_t> GetBreakpointAsyncContext() {
+  std::optional<lldb::addr_t> GetBreakpointAsyncContext() {
     if (m_breakpoint_async_ctx)
       return m_breakpoint_async_ctx;
 
@@ -428,8 +428,8 @@ private:
 
   ThreadPlanSP m_step_in_plan_sp;
   BreakpointSP m_async_breakpoint_sp;
-  llvm::Optional<lldb::addr_t> m_initial_async_ctx;
-  llvm::Optional<lldb::addr_t> m_breakpoint_async_ctx;
+  std::optional<lldb::addr_t> m_initial_async_ctx;
+  std::optional<lldb::addr_t> m_breakpoint_async_ctx;
 };
 
 static lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
@@ -1187,7 +1187,7 @@ SwiftLanguageRuntime::GetStepThroughTrampolinePlan(Thread &thread,
   return ::GetStepThroughTrampolinePlan(thread, stop_others);
 }
 
-llvm::Optional<SwiftLanguageRuntime::GenericSignature>
+std::optional<SwiftLanguageRuntime::GenericSignature>
 SwiftLanguageRuntime::GetGenericSignature(StringRef function_name,
                                           TypeSystemSwiftTypeRef &ts) {
   GenericSignature signature;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -78,7 +78,7 @@ void SwiftLanguageRuntimeImpl::ReleaseAssociatedRemoteASTContext(
   m_remote_ast_contexts.erase(ctx);
 }
 
-llvm::Optional<uint64_t>
+std::optional<uint64_t>
 SwiftLanguageRuntimeImpl::GetMemberVariableOffsetRemoteAST(
     CompilerType instance_type, ValueObject *instance,
     llvm::StringRef member_name) {
@@ -182,7 +182,7 @@ ConstString SwiftLanguageRuntimeImpl::GetDynamicTypeName_ClassRemoteAST(
   // Dynamic type resolution in RemoteAST might pull in other Swift modules, so
   // use the scratch context where such operations are legal and safe.
 
-  llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
+  std::optional<SwiftScratchContextReader> maybe_scratch_ctx =
       in_value.GetSwiftScratchContext();
   if (!maybe_scratch_ctx)
     return {};
@@ -216,14 +216,14 @@ ConstString SwiftLanguageRuntimeImpl::GetDynamicTypeName_ClassRemoteAST(
   return {};
 }
 
-llvm::Optional<std::pair<CompilerType, Address>>
+std::optional<std::pair<CompilerType, Address>>
 SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ProtocolRemoteAST(
     ValueObject &in_value, CompilerType protocol_type, bool use_local_buffer,
     lldb::addr_t existential_address) {
   // Dynamic type resolution in RemoteAST might pull in other Swift
   // modules, so use the scratch context where such operations are
   // legal and safe.
-  llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
+  std::optional<SwiftScratchContextReader> maybe_scratch_ctx =
       in_value.GetSwiftScratchContext();
   if (!maybe_scratch_ctx)
     return {};
@@ -284,7 +284,7 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
   // that module context.  Binding archetypes can trigger an import of
   // another module, so switch to a scratch context where such an
   // operation is safe.
-  llvm::Optional<SwiftScratchContextReader> maybe_scratch_ctx =
+  std::optional<SwiftScratchContextReader> maybe_scratch_ctx =
       target.GetSwiftScratchContext(error, stack_frame);
   if (!maybe_scratch_ctx)
     return base_type;
@@ -458,7 +458,7 @@ CompilerType SwiftLanguageRuntimeImpl::MetadataPromise::FulfillTypePromise(
   if (m_compiler_type.has_value())
     return m_compiler_type.value();
 
-  llvm::Optional<SwiftScratchContextReader> maybe_swift_scratch_ctx =
+  std::optional<SwiftScratchContextReader> maybe_swift_scratch_ctx =
       m_for_object_sp->GetSwiftScratchContext();
   if (!maybe_swift_scratch_ctx) {
     error->SetErrorString("couldn't get Swift scratch context");
@@ -501,7 +501,7 @@ SwiftLanguageRuntimeImpl::MetadataPromiseSP
 SwiftLanguageRuntimeImpl::GetMetadataPromise(const SymbolContext *sc,
                                              lldb::addr_t addr,
                                              ValueObject &for_object) {
-  llvm::Optional<SwiftScratchContextReader> maybe_swift_scratch_ctx =
+  std::optional<SwiftScratchContextReader> maybe_swift_scratch_ctx =
       for_object.GetSwiftScratchContext();
   if (!maybe_swift_scratch_ctx)
     return nullptr;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.cpp
@@ -148,7 +148,7 @@ static bool areMangledNamesAndFieldSectionSameSize(
   return field_descriptors_size == mangled_names.size();
 }
 
-llvm::Optional<std::pair<uint32_t, llvm::SmallString<32>>>
+std::optional<std::pair<uint32_t, llvm::SmallString<32>>>
 SwiftMetadataCache::generateHashTableBlob(
     uint64_t info_id, const swift::reflection::FieldSection &field_descriptors,
     const std::vector<std::string> &mangled_names) {
@@ -233,7 +233,7 @@ void SwiftMetadataCache::cacheFieldDescriptors(
             module->GetFileSpec().GetFilename());
 }
 
-llvm::Optional<swift::remote::FieldDescriptorLocator>
+std::optional<swift::remote::FieldDescriptorLocator>
 SwiftMetadataCache::getFieldDescriptorLocator(const std::string &Name) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
   Log *log = GetLog(LLDBLog::Types);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.h
@@ -140,7 +140,7 @@ public:
       const swift::reflection::FieldSection &field_descriptors,
       llvm::ArrayRef<std::string> mangled_names) override;
 
-  llvm::Optional<swift::remote::FieldDescriptorLocator>
+  std::optional<swift::remote::FieldDescriptorLocator>
   getFieldDescriptorLocator(const std::string &mangled_name) override;
 
   bool isReflectionInfoCached(uint64_t info_id) override;
@@ -148,7 +148,7 @@ public:
 private:
   /// Generate the on disk hash table data structure into a blob. Returns
   /// the start on the hash table's control structure and the blob itself.
-  llvm::Optional<std::pair<uint32_t, llvm::SmallString<32>>>
+  std::optional<std::pair<uint32_t, llvm::SmallString<32>>>
   generateHashTableBlob(
       uint64_t info_id,
       const swift::reflection::FieldSection &field_descriptors,
@@ -181,7 +181,7 @@ private:
 
   std::recursive_mutex m_mutex;
 
-  llvm::Optional<DataFileCache> m_data_file_cache;
+  std::optional<DataFileCache> m_data_file_cache;
 };
 } // namespace lldb_private
 #endif

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -69,7 +69,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
   ConstString name;
   ConstString preferred_name;
 
-  llvm::Optional<uint64_t> dwarf_byte_size;
+  std::optional<uint64_t> dwarf_byte_size;
 
   DWARFAttributes attributes = die.GetAttributes();
   const size_t num_attributes = attributes.Size();

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -827,7 +827,7 @@ public:
   std::optional<uint64_t> GetBitSize(lldb::opaque_compiler_type_t type,
                                      ExecutionContextScope *exe_scope) override;
 
-  llvm::Optional<uint64_t>
+  std::optional<uint64_t>
   GetByteStride(lldb::opaque_compiler_type_t type,
                 ExecutionContextScope *exe_scope) override {
     return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1693,7 +1693,7 @@ void SwiftASTContext::FilterClangImporterOptions(
 }
 
 /// Retrieve the .dSYM bundle for \p module.
-static llvm::Optional<StringRef> GetDSYMBundle(Module &module) {
+static std::optional<StringRef> GetDSYMBundle(Module &module) {
   auto sym_file = module.GetSymbolFile();
   if (!sym_file)
     return {};
@@ -2870,7 +2870,7 @@ Status SwiftASTContext::GetAllDiagnostics() const {
 }
 
 void SwiftASTContext::StreamAllDiagnostics(
-    llvm::Optional<lldb::user_id_t> debugger_id) const {
+    std::optional<lldb::user_id_t> debugger_id) const {
   Status error = m_fatal_errors;
   if (!error.Success()) {
     Debugger::ReportWarning(error.AsCString(), debugger_id,
@@ -3322,7 +3322,7 @@ swift::ASTContext *SwiftASTContext::GetASTContext() {
   // Compute the prebuilt module cache path to use:
   // <resource-dir>/<platform>/prebuilt-modules/<version>
   llvm::Triple triple(GetTriple());
-  llvm::Optional<llvm::VersionTuple> sdk_version =
+  std::optional<llvm::VersionTuple> sdk_version =
       m_ast_context_ap->LangOpts.SDKVersion;
   if (!sdk_version) {
     auto SDKInfoOrErr = clang::parseDarwinSDKInfo(
@@ -4650,17 +4650,17 @@ CompilerType SwiftASTContext::FindType(const char *name,
     return *search_results.begin();
 }
 
-llvm::Optional<SwiftASTContext::TypeOrDecl>
+std::optional<SwiftASTContext::TypeOrDecl>
 SwiftASTContext::FindTypeOrDecl(const char *name,
                                 swift::ModuleDecl *swift_module) {
-  VALID_OR_RETURN(llvm::Optional<SwiftASTContext::TypeOrDecl>());
+  VALID_OR_RETURN(std::optional<SwiftASTContext::TypeOrDecl>());
 
   TypesOrDecls search_results;
 
   FindTypesOrDecls(name, swift_module, search_results, false);
 
   if (search_results.empty())
-    return llvm::Optional<SwiftASTContext::TypeOrDecl>();
+    return std::optional<SwiftASTContext::TypeOrDecl>();
   else
     return *search_results.begin();
 }
@@ -4899,7 +4899,7 @@ swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
         "",        // features
         *getTargetOptions(),
         llvm::Reloc::Static, // TODO verify with Sean, Default went away
-        llvm::None, optimization_level);
+        std::nullopt, optimization_level);
     if (target_machine) {
       // Set the module's string representation.
       const llvm::DataLayout data_layout = target_machine->createDataLayout();
@@ -4961,7 +4961,7 @@ bool SwiftASTContext::IsTupleType(lldb::opaque_compiler_type_t type) {
   return llvm::isa<::swift::TupleType>(swift_type);
 }
 
-llvm::Optional<TypeSystemSwift::NonTriviallyManagedReferenceKind>
+std::optional<TypeSystemSwift::NonTriviallyManagedReferenceKind>
 SwiftASTContext::GetNonTriviallyManagedReferenceKind(
     lldb::opaque_compiler_type_t type) {
   VALID_OR_RETURN({});
@@ -6201,10 +6201,10 @@ bool SwiftASTContext::IsFixedSize(CompilerType compiler_type) {
   return false;
 }
 
-llvm::Optional<uint64_t>
+std::optional<uint64_t>
 SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {
-  VALID_OR_RETURN_CHECK_TYPE(type, llvm::None);
+  VALID_OR_RETURN_CHECK_TYPE(type, std::nullopt);
   LLDB_SCOPED_TIMER();
 
   // If the type has type parameters, bind them first.
@@ -6251,10 +6251,10 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
   return {};
 }
 
-llvm::Optional<uint64_t>
+std::optional<uint64_t>
 SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
                                ExecutionContextScope *exe_scope) {
-  VALID_OR_RETURN_CHECK_TYPE(type, llvm::None);
+  VALID_OR_RETURN_CHECK_TYPE(type, std::nullopt);
   LLDB_SCOPED_TIMER();
 
   // If the type has type parameters, bind them first.
@@ -6294,10 +6294,10 @@ SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
   return {};
 }
 
-llvm::Optional<size_t>
+std::optional<size_t>
 SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
                                  ExecutionContextScope *exe_scope) {
-  VALID_OR_RETURN_CHECK_TYPE(type, llvm::None);
+  VALID_OR_RETURN_CHECK_TYPE(type, std::nullopt);
   LLDB_SCOPED_TIMER();
 
   // If the type has type parameters, bind them first.
@@ -6960,7 +6960,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
     std::tie(child_type, name) = GetExistentialTypeChild(
         *this, *GetASTContext(), compiler_type, protocol_info, idx);
 
-    llvm::Optional<uint64_t> child_size = child_type.GetByteSize(nullptr);
+    std::optional<uint64_t> child_size = child_type.GetByteSize(nullptr);
     if (!child_size)
       return {};
     if (bit_offset_ptr)
@@ -7094,7 +7094,7 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   return 0;
 }
 
-static llvm::Optional<uint64_t> GetInstanceVariableOffset_Metadata(
+static std::optional<uint64_t> GetInstanceVariableOffset_Metadata(
     ValueObject *valobj, ExecutionContext *exe_ctx, const CompilerType &type,
     StringRef ivar_name, const CompilerType &ivar_type) {
   llvm::SmallString<1> m_description;
@@ -7114,7 +7114,7 @@ static llvm::Optional<uint64_t> GetInstanceVariableOffset_Metadata(
   }
 
   Status error;
-  llvm::Optional<uint64_t> offset =
+  std::optional<uint64_t> offset =
       runtime->GetMemberVariableOffset(type, valobj, ivar_name, &error);
   if (offset)
     LOG_PRINTF(GetLog(LLDBLog::Types), "for %s: %llu", ivar_name.str().c_str(),
@@ -7126,7 +7126,7 @@ static llvm::Optional<uint64_t> GetInstanceVariableOffset_Metadata(
   return offset;
 }
 
-static llvm::Optional<uint64_t>
+static std::optional<uint64_t>
 GetInstanceVariableOffset(ValueObject *valobj, ExecutionContext *exe_ctx,
                           const CompilerType &class_type, StringRef ivar_name,
                           const CompilerType &ivar_type) {
@@ -7158,7 +7158,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
   auto get_type_size = [&exe_ctx](uint32_t &result, CompilerType type) {
     auto *exe_scope =
         exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr;
-    llvm::Optional<uint64_t> size = type.GetByteSize(exe_scope);
+    std::optional<uint64_t> size = type.GetByteSize(exe_scope);
     if (!size)
       return false;
     result = *size;
@@ -7263,7 +7263,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     child_is_deref_of_parent = false;
 
     CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
-    llvm::Optional<uint64_t> offset = GetInstanceVariableOffset(
+    std::optional<uint64_t> offset = GetInstanceVariableOffset(
         valobj, exe_ctx, compiler_type, printed_idx.c_str(), child_type);
     if (!offset)
       return {};
@@ -7355,7 +7355,7 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     child_is_deref_of_parent = false;
 
     CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
-    llvm::Optional<uint64_t> offset = GetInstanceVariableOffset(
+    std::optional<uint64_t> offset = GetInstanceVariableOffset(
         valobj, exe_ctx, compiler_type, child_name.c_str(), child_type);
     if (!offset)
       return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -342,7 +342,7 @@ public:
 
   CompilerType FindType(const char *name, swift::ModuleDecl *swift_module);
 
-  llvm::Optional<SwiftASTContext::TypeOrDecl>
+  std::optional<SwiftASTContext::TypeOrDecl>
   FindTypeOrDecl(const char *name, swift::ModuleDecl *swift_module);
 
   size_t FindTypes(const char *name, swift::ModuleDecl *swift_module,
@@ -434,7 +434,7 @@ public:
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
   bool IsTupleType(lldb::opaque_compiler_type_t type) override;
-  llvm::Optional<NonTriviallyManagedReferenceKind>
+  std::optional<NonTriviallyManagedReferenceKind>
   GetNonTriviallyManagedReferenceKind(
       lldb::opaque_compiler_type_t type) override;
 
@@ -674,11 +674,11 @@ public:
 
   // Exploring the type
 
-  llvm::Optional<uint64_t>
+  std::optional<uint64_t>
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
 
-  llvm::Optional<uint64_t>
+  std::optional<uint64_t>
   GetByteStride(lldb::opaque_compiler_type_t type,
                 ExecutionContextScope *exe_scope) override;
 
@@ -784,7 +784,7 @@ public:
   bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
                                 CompilerType *pointee_type) override;
 
-  llvm::Optional<size_t>
+  std::optional<size_t>
   GetTypeBitAlign(lldb::opaque_compiler_type_t type,
                   ExecutionContextScope *exe_scope) override;
 
@@ -851,7 +851,7 @@ protected:
   void LogFatalErrors() const;
   Status GetAllDiagnostics() const;
   /// Stream all diagnostics to the Debugger and clear them.
-  void StreamAllDiagnostics(llvm::Optional<lldb::user_id_t> debugger_id) const;
+  void StreamAllDiagnostics(std::optional<lldb::user_id_t> debugger_id) const;
 
   llvm::TargetOptions *getTargetOptions();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
@@ -58,7 +58,7 @@ SwiftDWARFImporterForClangTypes::SwiftDWARFImporterForClangTypes(
 }
 
 void SwiftDWARFImporterForClangTypes::lookupValue(
-    StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
+    StringRef name, std::optional<swift::ClangTypeKind> kind,
     StringRef inModule, llvm::SmallVectorImpl<CompilerType> &results) {
   LLDB_SCOPED_TIMER();
   LLDB_LOG(GetLog(LLDBLog::Types), "{0}::lookupValue(\"{1}\")", m_description,
@@ -121,7 +121,7 @@ void SwiftDWARFImporterForClangTypes::lookupValue(
 
 void SwiftDWARFImporterDelegate::importType(
     clang::QualType qual_type, clang::ASTContext &from_ctx,
-    clang::ASTContext &to_ctx, llvm::Optional<swift::ClangTypeKind> kind,
+    clang::ASTContext &to_ctx, std::optional<swift::ClangTypeKind> kind,
     llvm::SmallVectorImpl<clang::Decl *> &results) {
   clang::ASTImporter importer(
       to_ctx, to_ctx.getSourceManager().getFileManager(), from_ctx,
@@ -174,7 +174,7 @@ SwiftDWARFImporterDelegate::SwiftDWARFImporterDelegate(SwiftASTContext &ts)
       m_description(ts.GetDescription() + "::SwiftDWARFImporterDelegate") {}
 
 void SwiftDWARFImporterDelegate::lookupValue(
-    StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
+    StringRef name, std::optional<swift::ClangTypeKind> kind,
     StringRef inModule, llvm::SmallVectorImpl<clang::Decl *> &results) {
   LLDB_LOG(GetLog(LLDBLog::Types), "{0}::lookupValue(\"{1}\")", m_description,
            name.str());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.h
@@ -42,7 +42,7 @@ class SwiftDWARFImporterForClangTypes {
 
 public:
   SwiftDWARFImporterForClangTypes(TypeSystemSwiftTypeRef &ts);
-  void lookupValue(StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
+  void lookupValue(StringRef name, std::optional<swift::ClangTypeKind> kind,
                    StringRef inModule,
                    llvm::SmallVectorImpl<CompilerType> &results);
 };
@@ -65,7 +65,7 @@ class SwiftDWARFImporterDelegate : public swift::DWARFImporterDelegate {
   /// add it to \p results if successful.
   void importType(clang::QualType qual_type, clang::ASTContext &from_ctx,
                   clang::ASTContext &to_ctx,
-                  llvm::Optional<swift::ClangTypeKind> kind,
+                  std::optional<swift::ClangTypeKind> kind,
                   llvm::SmallVectorImpl<clang::Decl *> &results);
 
   clang::Decl *GetDeclForTypeAndKind(clang::QualType qual_type,
@@ -128,7 +128,7 @@ public:
   /// ║  └─────────────────────────┘                                         ║
   /// ╚══════════════════════════════════════════════════════════════════════╝
   /// \endverbatim
-  void lookupValue(StringRef name, llvm::Optional<swift::ClangTypeKind> kind,
+  void lookupValue(StringRef name, std::optional<swift::ClangTypeKind> kind,
                    StringRef inModule,
                    llvm::SmallVectorImpl<clang::Decl *> &results) override;
 };

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -151,7 +151,7 @@ public:
     eUnowned,
     eUnmanaged
   };
-  virtual llvm::Optional<NonTriviallyManagedReferenceKind>
+  virtual std::optional<NonTriviallyManagedReferenceKind>
   GetNonTriviallyManagedReferenceKind(lldb::opaque_compiler_type_t type) = 0;
 
   /// Creates a GenericTypeParamType with the desired depth and index.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -431,7 +431,7 @@ TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
 }
 
 /// Return a pair of modulename, type name for the outermost nominal type.
-static llvm::Optional<std::pair<StringRef, StringRef>>
+static std::optional<std::pair<StringRef, StringRef>>
 GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
   if (!node)
     return {};
@@ -475,7 +475,7 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
 }
 
 /// Return a pair of module name and type name, given a mangled name.
-static llvm::Optional<std::pair<StringRef, StringRef>>
+static std::optional<std::pair<StringRef, StringRef>>
 GetNominal(llvm::StringRef mangled_name) {
   swift::Demangle::Demangler dem;
   auto *node = GetDemangledType(dem, mangled_name);
@@ -657,7 +657,7 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
   return {n, {}};
 }
 
-llvm::Optional<TypeSystemSwift::TupleElement>
+std::optional<TypeSystemSwift::TupleElement>
 TypeSystemSwiftTypeRef::GetTupleElement(lldb::opaque_compiler_type_t type,
                                         size_t idx) {
   TupleElement result;
@@ -2089,7 +2089,7 @@ template <> bool Equivalent<ConstString>(ConstString l, ConstString r) {
 
 /// Version tailored to GetBitSize & friends.
 template <typename T>
-bool Equivalent(llvm::Optional<T> l, llvm::Optional<T> r) {
+bool Equivalent(std::optional<T> l, std::optional<T> r) {
   if (l == r)
     return true;
   // There are situations where SwiftASTContext incorrectly returns
@@ -2105,8 +2105,8 @@ bool Equivalent(llvm::Optional<T> l, llvm::Optional<T> r) {
 }
 
 // Introduced for `GetNumChildren`.
-template <typename T> bool Equivalent(llvm::Optional<T> l, T r) {
-  return Equivalent(l, llvm::Optional<T>(r));
+template <typename T> bool Equivalent(std::optional<T> l, T r) {
+  return Equivalent(l, std::optional<T>(r));
 }
 
 } // namespace
@@ -2792,12 +2792,12 @@ CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
 }
 
 // Exploring the type
-llvm::Optional<uint64_t>
+std::optional<uint64_t>
 TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                                    ExecutionContextScope *exe_scope) {
   LLDB_SCOPED_TIMER();
-  auto impl = [&]() -> llvm::Optional<uint64_t> {
-    auto get_static_size = [&](bool cached_only) -> llvm::Optional<uint64_t> {
+  auto impl = [&]() -> std::optional<uint64_t> {
+    auto get_static_size = [&](bool cached_only) -> std::optional<uint64_t> {
       if (IsMeaninglessWithoutDynamicResolution(type))
         return {};
 
@@ -2810,7 +2810,7 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
       struct SwiftType : public Type {
         /// Avoid a potential infinite recursion because
         /// Type::GetByteSize() may call into this function again.
-        llvm::Optional<uint64_t> GetStaticByteSize() {
+        std::optional<uint64_t> GetStaticByteSize() {
           if (m_byte_size_has_value)
             return uint64_t(m_byte_size);
           return {};
@@ -2892,11 +2892,11 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
     return impl();
 }
 
-llvm::Optional<uint64_t>
+std::optional<uint64_t>
 TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
                                       ExecutionContextScope *exe_scope) {
   LLDB_SCOPED_TIMER();
-  auto impl = [&]() -> llvm::Optional<uint64_t> {
+  auto impl = [&]() -> std::optional<uint64_t> {
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
       if (auto stride = runtime->GetByteStride(GetCanonicalType(type)))
@@ -3000,7 +3000,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
   FALLBACK(GetNumChildren,
            (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx));
 
-  auto impl = [&]() -> llvm::Optional<uint32_t> {
+  auto impl = [&]() -> std::optional<uint32_t> {
     if (exe_ctx)
       if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
         if (auto *runtime =
@@ -3016,10 +3016,10 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
     }
     return {};
   };
-  if (llvm::Optional<uint32_t> num_children = impl())
+  if (std::optional<uint32_t> num_children = impl())
     // Use a lambda to intercept and unwrap the `Optional` return value.
     // Optional<uint32_t> uses more lax equivalency function.
-    return [&]() -> llvm::Optional<uint32_t> {
+    return [&]() -> std::optional<uint32_t> {
       auto impl = [&]() { return num_children; };
       ExecutionContext exe_ctx_obj;
       if (exe_ctx)
@@ -3046,7 +3046,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
   LLDB_SCOPED_TIMER();
   FALLBACK(GetNumFields, (ReconstructType(type, exe_ctx), exe_ctx));
 
-  auto impl = [&]() -> llvm::Optional<uint32_t> {
+  auto impl = [&]() -> std::optional<uint32_t> {
     if (exe_ctx)
       if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP()))
         if (auto num_fields =
@@ -3076,7 +3076,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
   if (auto num_fields = impl()) {
     // Use a lambda to intercept and unwrap the `Optional` return value.
     // Optional<uint32_t> uses more lax equivalency function.
-    return [&]() -> llvm::Optional<uint32_t> {
+    return [&]() -> std::optional<uint32_t> {
       auto impl = [&]() { return num_fields; };
       ExecutionContext exe_ctx_obj;
       if (exe_ctx)
@@ -3179,7 +3179,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
             child_byte_size, child_byte_offset, child_bitfield_bit_size,
             child_bitfield_bit_offset, child_is_base_class,
             child_is_deref_of_parent, valobj, language_flags));
-  llvm::Optional<unsigned> ast_num_children;
+  std::optional<unsigned> ast_num_children;
   auto get_ast_num_children = [&]() {
     if (ast_num_children)
       return *ast_num_children;
@@ -3381,10 +3381,10 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
             llvm::StringRef(ast_child_name).contains('.') ||
             Equivalent(child_name, ast_child_name)));
     assert(ast_language_flags ||
-           (Equivalent(llvm::Optional<uint64_t>(child_byte_size),
-                       llvm::Optional<uint64_t>(ast_child_byte_size))));
-    assert(Equivalent(llvm::Optional<uint64_t>(child_byte_offset),
-                      llvm::Optional<uint64_t>(ast_child_byte_offset)));
+           (Equivalent(std::optional<uint64_t>(child_byte_size),
+                       std::optional<uint64_t>(ast_child_byte_size))));
+    assert(Equivalent(std::optional<uint64_t>(child_byte_offset),
+                      std::optional<uint64_t>(ast_child_byte_offset)));
     assert(
         Equivalent(child_bitfield_bit_offset, ast_child_bitfield_bit_offset));
     assert(Equivalent(child_bitfield_bit_size, ast_child_bitfield_bit_size));
@@ -3815,7 +3815,7 @@ CompilerType TypeSystemSwiftTypeRef::CreateSILPackType(CompilerType type,
   return RemangleAsType(dem, type_node);
 }
 
-static llvm::Optional<TypeSystemSwiftTypeRef::PackTypeInfo>
+static std::optional<TypeSystemSwiftTypeRef::PackTypeInfo>
 decodeSILPackType(swift::Demangle::Demangler &dem, CompilerType type,
                   swift::Demangle::NodePointer &node) {
   TypeSystemSwiftTypeRef::PackTypeInfo info;
@@ -3844,7 +3844,7 @@ decodeSILPackType(swift::Demangle::Demangler &dem, CompilerType type,
   return info;
 }
 
-llvm::Optional<TypeSystemSwiftTypeRef::PackTypeInfo>
+std::optional<TypeSystemSwiftTypeRef::PackTypeInfo>
 TypeSystemSwiftTypeRef::IsSILPackType(CompilerType type) {
   NodePointer node;
   swift::Demangle::Demangler dem;
@@ -3948,11 +3948,11 @@ bool TypeSystemSwiftTypeRef::IsTupleType(lldb::opaque_compiler_type_t type) {
                       (ReconstructType(type)), (ReconstructType(type)));
 }
 
-llvm::Optional<TypeSystemSwift::NonTriviallyManagedReferenceKind>
+std::optional<TypeSystemSwift::NonTriviallyManagedReferenceKind>
 TypeSystemSwiftTypeRef::GetNonTriviallyManagedReferenceKind(
     lldb::opaque_compiler_type_t type) {
   auto impl = [&]()
-      -> llvm::Optional<TypeSystemSwift::NonTriviallyManagedReferenceKind> {
+      -> std::optional<TypeSystemSwift::NonTriviallyManagedReferenceKind> {
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = GetDemangledType(dem, AsMangledName(type));
@@ -4242,7 +4242,7 @@ bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
                       (ReconstructType(type), nullptr),
                       (ReconstructType(type), pointee_type));
 }
-llvm::Optional<size_t>
+std::optional<size_t>
 TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
                                         ExecutionContextScope *exe_scope) {
   LLDB_SCOPED_TIMER();

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -185,10 +185,10 @@ public:
   CompilerType GetVoidFunctionType();
 
   // Exploring the type
-  llvm::Optional<uint64_t>
+  std::optional<uint64_t>
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
-  llvm::Optional<uint64_t>
+  std::optional<uint64_t>
   GetByteStride(lldb::opaque_compiler_type_t type,
                 ExecutionContextScope *exe_scope) override;
   lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
@@ -258,7 +258,7 @@ public:
 
   bool IsPointerOrReferenceType(lldb::opaque_compiler_type_t type,
                                 CompilerType *pointee_type) override;
-  llvm::Optional<size_t>
+  std::optional<size_t>
   GetTypeBitAlign(lldb::opaque_compiler_type_t type,
                   ExecutionContextScope *exe_scope) override;
   CompilerType GetBuiltinTypeForEncodingAndBitSize(lldb::Encoding encoding,
@@ -305,17 +305,17 @@ public:
     bool indirect = false;
     bool expanded = false;
   };
-  llvm::Optional<PackTypeInfo> IsSILPackType(CompilerType type);
+  std::optional<PackTypeInfo> IsSILPackType(CompilerType type);
   CompilerType GetSILPackElementAtIndex(CompilerType type, unsigned i);
   CompilerType
   CreateTupleType(const std::vector<TupleElement> &elements) override;
   bool IsTupleType(lldb::opaque_compiler_type_t type) override;
-  llvm::Optional<NonTriviallyManagedReferenceKind>
+  std::optional<NonTriviallyManagedReferenceKind>
   GetNonTriviallyManagedReferenceKind(
       lldb::opaque_compiler_type_t type) override;
 
   /// Return the nth tuple element's type and name, if it has one.
-  llvm::Optional<TupleElement>
+  std::optional<TupleElement>
   GetTupleElement(lldb::opaque_compiler_type_t type, size_t idx);
 
   /// Creates a GenericTypeParamType with the desired depth and index.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2841,7 +2841,7 @@ Target::CreateUtilityFunction(std::string expression, std::string name,
 }
 
 #ifdef LLDB_ENABLE_SWIFT
-llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
+std::optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
     Status &error, ExecutionContextScope &exe_scope, bool create_on_demand) {
   Log *log = GetLog(LLDBLog::Target | LLDBLog::Types | LLDBLog::Expressions);
   LLDB_SCOPED_TIMER();
@@ -2970,7 +2970,7 @@ llvm::Optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
     return;
   };
 
-  llvm::Optional<SwiftScratchContextReader> reader;
+  std::optional<SwiftScratchContextReader> reader;
   if (lldb_module && m_use_scratch_typesystem_per_module) {
     maybe_create_fallback_context();
     std::shared_lock<std::shared_mutex> lock(GetSwiftScratchContextLock());

--- a/llvm/include/llvm/IR/GlobalPtrAuthInfo.h
+++ b/llvm/include/llvm/IR/GlobalPtrAuthInfo.h
@@ -15,10 +15,10 @@
 #define LLVM_IR_GLOBALPTRAUTHINFO_H
 
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/Support/Error.h"
+#include <optional>
 
 namespace llvm {
 
@@ -47,7 +47,7 @@ public:
 
   /// Try to analyze \p V as an authenticated global reference, and return its
   /// information if successful.
-  static Optional<GlobalPtrAuthInfo> analyze(const Value *V);
+  static std::optional<GlobalPtrAuthInfo> analyze(const Value *V);
 
   /// Try to analyze \p V as an authenticated global reference, and return its
   /// information if successful, or an error explaining the failure if not.

--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -11,12 +11,12 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/MC/MCDirectives.h"
 #include "llvm/MC/MCMachOCASWriter.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/Support/Endian.h"
 #include <cstdint>
+#include <optional>
 
 namespace llvm {
 

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -10,7 +10,6 @@
 #define LLVM_MC_MCMACHOBJECTWRITER_H
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/MC/MCExpr.h"
@@ -20,6 +19,7 @@
 #include "llvm/Support/EndianStream.h"
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -194,7 +194,7 @@ public:
 
   void writeHeader(MachO::HeaderFileType Type, unsigned NumLoadCommands,
                    unsigned LoadCommandsSize, bool SubsectionsViaSymbols,
-                   Optional<unsigned> PtrAuthABIVersion,
+                   std::optional<unsigned> PtrAuthABIVersion,
                    bool PtrAuthKernelABIVersion);
 
   /// Write a segment load command.

--- a/llvm/lib/IR/GlobalPtrAuthInfo.cpp
+++ b/llvm/lib/IR/GlobalPtrAuthInfo.cpp
@@ -66,7 +66,7 @@ Expected<GlobalPtrAuthInfo> GlobalPtrAuthInfo::tryAnalyze(const Value *V) {
   return GlobalPtrAuthInfo(GV);
 }
 
-Optional<GlobalPtrAuthInfo> GlobalPtrAuthInfo::analyze(const Value *V) {
+std::optional<GlobalPtrAuthInfo> GlobalPtrAuthInfo::analyze(const Value *V) {
   if (auto PAIOrErr = tryAnalyze(V)) {
     return *PAIOrErr;
   } else {

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCAsmBackend.h"
-#include "llvm/ADT/None.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/MC/MCDXContainerWriter.h"
 #include "llvm/MC/MCELFObjectWriter.h"
@@ -23,6 +22,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 using namespace llvm;
 

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -137,7 +137,7 @@ void MachObjectWriter::writeHeader(MachO::HeaderFileType Type,
                                    unsigned NumLoadCommands,
                                    unsigned LoadCommandsSize,
                                    bool SubsectionsViaSymbols,
-                                   Optional<unsigned> PtrAuthABIVersion,
+                                   std::optional<unsigned> PtrAuthABIVersion,
                                    bool PtrAuthKernelABIVersion) {
   uint32_t Flags = 0;
 
@@ -896,7 +896,7 @@ void MachObjectWriter::writeMachOHeader(MCAssembler &Asm,
   SectionDataFileSize += SectionDataPadding;
 
   // The ptrauth ABI version is limited to 4 bits.
-  Optional<unsigned> PtrAuthABIVersion = Asm.getPtrAuthABIVersion();
+  std::optional<unsigned> PtrAuthABIVersion = Asm.getPtrAuthABIVersion();
   if (PtrAuthABIVersion && *PtrAuthABIVersion > 63) {
     Asm.getContext().reportError(SMLoc(), "invalid ptrauth ABI version: " +
                                               utostr(*PtrAuthABIVersion));

--- a/llvm/lib/Transforms/Instrumentation/SoftPointerAuth.cpp
+++ b/llvm/lib/Transforms/Instrumentation/SoftPointerAuth.cpp
@@ -45,10 +45,10 @@
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/ModuleUtils.h"
 
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include <map>
+#include <optional>
 
 #define DEBUG_TYPE "soft-ptrauth"
 
@@ -90,7 +90,7 @@ class SoftPointerAuth {
   FunctionCallee BlendDiscriminatorFn = nullptr;
   FunctionCallee SignGenericFn = nullptr;
 
-  Optional<IRBuilderTy> GlobalConstructorBuilder;
+  std::optional<IRBuilderTy> GlobalConstructorBuilder;
 
 public:
   SoftPointerAuth() {}

--- a/llvm/tools/dsymutil/MachOUtils.cpp
+++ b/llvm/tools/dsymutil/MachOUtils.cpp
@@ -410,7 +410,7 @@ bool generateDsymCompanion(
   MachO::symtab_command SymtabCmd = InputBinary.getSymtabLoadCommand();
 
   // Get the ptrauth ABI version (for arm64 subtypes).
-  Optional<unsigned> PtrAuthABIVersion;
+  std::optional<unsigned> PtrAuthABIVersion;
   bool PtrAuthKernelABIVersion = false;
   unsigned CPUType = InputBinary.getHeader().cputype;
   unsigned CPUSubTypeField = InputBinary.getHeader().cpusubtype;

--- a/mlir/include/mlir/Support/LLVM.h
+++ b/mlir/include/mlir/Support/LLVM.h
@@ -20,7 +20,6 @@
 
 // We include these two headers because they cannot be practically forward
 // declared, and are effectively language features.
-#include "llvm/ADT/None.h"
 #include "llvm/Support/Casting.h"
 #include <vector>
 
@@ -58,7 +57,6 @@ class DenseSet;
 class MallocAllocator;
 template <typename T>
 class MutableArrayRef;
-template <typename T> using Optional = std::optional<T>;
 template <typename... PT>
 class PointerUnion;
 template <typename T, typename Vector, typename Set, unsigned N>
@@ -130,7 +128,6 @@ using SetVector = llvm::SetVector<T, Vector, Set, N>;
 template <typename AllocatorTy = llvm::MallocAllocator>
 using StringSet = llvm::StringSet<AllocatorTy>;
 using llvm::MutableArrayRef;
-using llvm::Optional;
 using llvm::PointerUnion;
 using llvm::SmallPtrSet;
 using llvm::SmallPtrSetImpl;


### PR DESCRIPTION
This has mostly been done, there's just a few left overs (namely LLDB). Leave removing `Optional.h` and `None.h` so that this can be merged irrespective of the Swift changes.

(cherry picked from commit 97468059920f06c9966f0b0890302e26479e53eb)