### PR TITLE
[Cherry-pick into next] Improve logging.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -476,13 +476,10 @@ static bool HasReflectionInfo(ObjectFile *obj_file) {
   StringRef reflstr =
       obj_file_format_up->getSectionName(swift::ReflectionSectionKind::reflstr);
 
-  bool hasReflectionSection = false;
-  hasReflectionSection |= findSectionInObject(field_md);
-  hasReflectionSection |= findSectionInObject(assocty);
-  hasReflectionSection |= findSectionInObject(builtin);
-  hasReflectionSection |= findSectionInObject(capture);
-  hasReflectionSection |= findSectionInObject(typeref);
-  hasReflectionSection |= findSectionInObject(reflstr);
+  bool hasReflectionSection =
+      findSectionInObject(field_md) || findSectionInObject(assocty) ||
+      findSectionInObject(builtin) || findSectionInObject(capture) ||
+      findSectionInObject(typeref) || findSectionInObject(reflstr);
   return hasReflectionSection;
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -888,14 +888,14 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
 
   if (load_ptr == 0 || load_ptr == LLDB_INVALID_ADDRESS) {
     if (obj_file->GetType() != ObjectFile::eTypeJIT)
-      if (Log *log = GetLog(LLDBLog::Types))
-        log->Printf("%s: failed to get start address for %s.", __FUNCTION__,
-                    obj_file->GetFileSpec().GetFilename().GetCString());
+      LLDB_LOG(GetLog(LLDBLog::Types),
+               "{0}: failed to get start address for \"{1}\".", __FUNCTION__,
+               module_sp->GetObjectName());
     return false;
   }
   bool found = HasReflectionInfo(obj_file);
-  LLDB_LOGF(GetLog(LLDBLog::Types), "%s reflection metadata in \"%s\"",
-            found ? "Adding" : "No", obj_file->GetFileSpec().GetPath().c_str());
+  LLDB_LOG(GetLog(LLDBLog::Types), "{0} reflection metadata in \"{1}\"",
+            found ? "Adding" : "No", module_sp->GetObjectName());
   if (!found)
     return true;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -922,8 +922,14 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
                                likely_module_names);
   }
 
-  if (info_id)
-    if (auto *swift_metadata_cache = GetSwiftMetadataCache())
+  if (!info_id) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "Error while loading reflection metadata in \"{0}\"",
+             module_sp->GetObjectName());
+    return false;
+  }
+
+  if (auto *swift_metadata_cache = GetSwiftMetadataCache())
       swift_metadata_cache->registerModuleWithReflectionInfoID(module_sp,
                                                                *info_id);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -887,12 +887,16 @@ bool SwiftLanguageRuntimeImpl::AddModuleToReflectionContext(
     if (obj_file->GetType() != ObjectFile::eTypeJIT)
       LLDB_LOG(GetLog(LLDBLog::Types),
                "{0}: failed to get start address for \"{1}\".", __FUNCTION__,
-               module_sp->GetObjectName());
+               module_sp->GetObjectName()
+                   ? module_sp->GetObjectName()
+                   : obj_file->GetFileSpec().GetFilename());
     return false;
   }
   bool found = HasReflectionInfo(obj_file);
   LLDB_LOG(GetLog(LLDBLog::Types), "{0} reflection metadata in \"{1}\"",
-            found ? "Adding" : "No", module_sp->GetObjectName());
+           found ? "Adding" : "No",
+           module_sp->GetObjectName() ? module_sp->GetObjectName()
+                                      : obj_file->GetFileSpec().GetFilename());
   if (!found)
     return true;
 


### PR DESCRIPTION
```
commit bfbd76bb0cc02b00239e21252cced79565b09f47
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 13 15:40:34 2024 -0800

    Improve logging.
    
    In Core files the object file may not have a *file* name but still a name.

commit cdbce45329f887504914916009477a2b0645835c
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 13 16:17:51 2024 -0800

    Use early-exit short-circuit evaluation (NFC)

commit 895f7dabdc47a236abceeb5f576c612c0c437b13
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 13 16:56:45 2024 -0800

    Add error logging when reflection metadata loadign fails

commit 438950f8b371bfb02bae308060179b3de33d34bc
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Feb 14 08:50:45 2024 -0800

    Log GetObjectName or the Object filename, whichever is available.
```
