### PR TITLE
[Sanitizers][ABI] Remove too strong assert in asan_abi_shim (#81696)

### DIFF
--- a/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
+++ b/compiler-rt/lib/asan_abi/asan_abi_shim.cpp
@@ -54,7 +54,7 @@ void *__asan_memmove(void *dest, const void *src, uptr n) {
 
 // Functions concerning RTL startup and initialization
 void __asan_init(void) {
-  static_assert(sizeof(uptr) == 8);
+  static_assert(sizeof(uptr) == 8 || sizeof(uptr) == 4);
   static_assert(sizeof(u64) == 8);
   static_assert(sizeof(u32) == 4);
 


### PR DESCRIPTION
Recently we enabled building the shim for arm64_32 arch. On this arch, sizeof(uptr) == sizeof(unsigned long) == 4 - so this assert will fail in runtime.

Need to just remove this assert

rdar://122927166

Co-authored-by: Mariusz Borsa <m_borsa@apple.com>
(cherry picked from commit 3f738a4c55dfb6476c47cab30e878cf5f0643351)