### PR TITLE
Fixup some Swift specific code in ValueObjectPrinter.

### DIFF
--- a/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
+++ b/lldb/include/lldb/DataFormatters/DumpValueObjectOptions.h
@@ -34,7 +34,7 @@ public:
     bool CanAllowExpansion() const;
 
     bool CanAllowExpansion(bool is_root, TypeSummaryImpl *entry,
-                          ValueObject *valobj, const std::string &summary);
+                          ValueObject &valobj, const std::string &summary);
   };
 
   struct PointerAsArraySettings {

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -492,7 +492,7 @@ bool ValueObjectPrinter::PrintObjectDescriptionIfNeeded(bool value_printed,
 }
 
 bool DumpValueObjectOptions::PointerDepth::CanAllowExpansion(
-    bool is_root, TypeSummaryImpl *entry, ValueObject *valobj,
+    bool is_root, TypeSummaryImpl *entry, ValueObject &valobj,
     const std::string &summary) {
   switch (m_mode) {
   case Mode::Always:
@@ -504,7 +504,7 @@ bool DumpValueObjectOptions::PointerDepth::CanAllowExpansion(
       m_count = std::min<decltype(m_count)>(m_count, 1);
     return m_count > 0;
   case Mode::Formatters:
-    if (!entry || entry->DoesPrintChildren(valobj) || summary.empty())
+    if (!entry || entry->DoesPrintChildren(&valobj) || summary.empty())
       return m_count > 0;
     return false;
   }


### PR DESCRIPTION
I changed llvm.org to not pass as pointers values that cannot be null, but there were a couple swift specific usages that also need fixing.

(cherry picked from commit a32c9d96be311bbf891564d4a485aae546efa347)