### PR TITLE
[lldb][debugger][NFC] Add broadcast bit for category-based progress e…

### DIFF
--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -46,6 +46,7 @@ public:
       eBroadcastBitProgress = (1 << 0),
       eBroadcastBitWarning = (1 << 1),
       eBroadcastBitError = (1 << 2),
+      eBroadcastBitProgressCategory = (1 << 3),
   };
 
   SBDebugger();

--- a/lldb/include/lldb/Core/Debugger.h
+++ b/lldb/include/lldb/Core/Debugger.h
@@ -84,6 +84,7 @@ public:
     eBroadcastBitWarning = (1 << 1),
     eBroadcastBitError = (1 << 2),
     eBroadcastSymbolChange = (1 << 3),
+    eBroadcastBitProgressCategory = (1 << 4),
   };
 
   using DebuggerList = std::vector<lldb::DebuggerSP>;


### PR DESCRIPTION
…vents. (#81169)

This commit adds a new broadcast bit to the debugger. When in use, it will be listened to for progress events that will be delivered and kept track of by category as opposed to the current behaviour of coming in one by one.

(cherry picked from commit ab4a793e8bc78f50f9f104c9c732e2dd91bf70a2)