### PR TITLE
Keep start and stop symbols linked through clang (Linux)

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -836,7 +836,7 @@ std::string ToolChain::GetLinkerPath(bool *LinkerIsLLD) const {
     if (llvm::sys::fs::can_execute(UseLinker))
       return std::string(UseLinker);
   } else {
-    llvm::SmallString<8> LinkerName;
+    llvm::SmallString<8> LinkerName = {};
     if (Triple.isOSDarwin())
       LinkerName.append("ld64.");
     else


### PR DESCRIPTION
Changes in https://reviews.llvm.org/D96914 taught LLD to remove `__start_##name` and `__stop_##name` symbol names. The Swift runtime uses these specially named symbols to unpack the runtime type metadata on Linux and WebAssembly systems, resulting in broken binaries when linked with `lld`. This change tells the Swift-paired Clang to force the `-z nostart-stop-gc` flag when compiling for Linux-y systems, including Musl, WASM, and Android. Swift and the clang-linker have to work with other existing toolchains, so we can't simply flip the CMake option in the LLVM build system to keep these symbols and get a working binary.