### PR TITLE
[lldb][progress] Add progress manager class (#81319)

### DIFF
--- a/lldb/include/lldb/Core/Progress.h
+++ b/lldb/include/lldb/Core/Progress.h
@@ -11,6 +11,7 @@
 
 #include "lldb/Utility/ConstString.h"
 #include "lldb/lldb-types.h"
+#include "llvm/ADT/StringMap.h"
 #include <atomic>
 #include <mutex>
 #include <optional>
@@ -117,6 +118,26 @@ private:
   /// to ensure that we don't send progress updates after progress has
   /// completed.
   bool m_complete = false;
+};
+
+/// A class used to group progress reports by category. This is done by using a
+/// map that maintains a refcount of each category of progress reports that have
+/// come in. Keeping track of progress reports this way will be done if a
+/// debugger is listening to the eBroadcastBitProgressByCategory broadcast bit.
+class ProgressManager {
+public:
+  ProgressManager();
+  ~ProgressManager();
+
+  /// Control the refcount of the progress report category as needed.
+  void Increment(std::string category);
+  void Decrement(std::string category);
+
+  static ProgressManager &Instance();
+
+private:
+  llvm::StringMap<uint64_t> m_progress_category_map;
+  std::mutex m_progress_map_mutex;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Core/Progress.cpp
+++ b/lldb/source/Core/Progress.cpp
@@ -11,6 +11,7 @@
 #include "lldb/Core/Debugger.h"
 #include "lldb/Utility/StreamString.h"
 
+#include <mutex>
 #include <optional>
 
 using namespace lldb;
@@ -65,4 +66,36 @@ void Progress::ReportProgress() {
     Debugger::ReportProgress(m_id, m_title, m_details, m_completed, m_total,
                              m_debugger_id);
   }
+}
+
+ProgressManager::ProgressManager() : m_progress_category_map() {}
+
+ProgressManager::~ProgressManager() {}
+
+ProgressManager &ProgressManager::Instance() {
+  static std::once_flag g_once_flag;
+  static ProgressManager *g_progress_manager = nullptr;
+  std::call_once(g_once_flag, []() {
+    // NOTE: known leak to avoid global destructor chain issues.
+    g_progress_manager = new ProgressManager();
+  });
+  return *g_progress_manager;
+}
+
+void ProgressManager::Increment(std::string title) {
+  std::lock_guard<std::mutex> lock(m_progress_map_mutex);
+  m_progress_category_map[title]++;
+}
+
+void ProgressManager::Decrement(std::string title) {
+  std::lock_guard<std::mutex> lock(m_progress_map_mutex);
+  auto pos = m_progress_category_map.find(title);
+
+  if (pos == m_progress_category_map.end())
+    return;
+
+  if (pos->second <= 1)
+    m_progress_category_map.erase(title);
+  else
+    --pos->second;
 }


### PR DESCRIPTION
Per discussions from https://github.com/llvm/llvm-project/pull/81026, it was decided that having a class that manages a map of progress reports would be beneficial in order to categorize them. This class is a part of the overall `Progress` class and utilizes a map that keeps a count of how many times a progress report category has been sent. This would be used with the new debugger broadcast bit added in
https://github.com/llvm/llvm-project/pull/81169 so that a user listening with that bit will receive grouped progress reports.

(cherry picked from commit 327d2f8c6cee019d4f915036f40041b5369b61e5)