### PR TITLE
[lldb] Fix embedded type summary regex handling (#8121)

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1491,7 +1491,7 @@ static void LoadTypeSummariesForModule(ModuleSP module_sp) {
     return;
 
   Log *log = GetLog(LLDBLog::DataFormatters);
-  const char *module_name = module_sp->GetObjectName().GetCString();
+  const char *module_name = module_sp->GetFileSpec().GetFilename().GetCString();
 
   TypeCategoryImplSP category;
   DataVisualization::Categories::GetCategory(ConstString("default"), category);
@@ -1527,7 +1527,7 @@ static void LoadTypeSummariesForModule(ModuleSP module_sp) {
         auto summary_sp =
             std::make_shared<StringSummaryFormat>(flags, summary_string.data());
         FormatterMatchType match_type = eFormatterMatchExact;
-        if (summary_string.front() == '^' && summary_string.back() == '$')
+        if (type_name.front() == '^')
           match_type = eFormatterMatchRegex;
         category->AddTypeSummary(type_name, match_type, summary_sp);
         LLDB_LOGF(log, "Loaded embedded type summary for '%s' from %s.",

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/TestEmbeddedTypeSummary.py
@@ -10,3 +10,4 @@ class TestCase(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.c"))
         self.expect("v player", substrs=['"Dirk" (41)'])
+        self.expect("v layer", substrs=['"crust" (3)'])

--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
@@ -5,7 +5,8 @@ struct Player {
   int number;
 };
 
-__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
+__attribute__((aligned(1), used,
+               section("__DATA_CONST,__lldbsummaries"))) unsigned char
     _Player_type_summary[] = "\x01"     // version
                              "\x25"     // record size
                              "\x07"     // type name size
@@ -13,10 +14,28 @@ __attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
                              "\x1c"     // summary string size
                              "${var.name} (${var.number})"; // summary string
 
+struct Layer {
+  char *name;
+  int number;
+};
+
+// Near copy of the record for `Player`, using a regex type name (`^Layer`).
+__attribute__((aligned(1), used,
+               section("__DATA_CONST,__lldbsummaries"))) unsigned char
+    _Layer_type_summary[] = "\x01"     // version
+                            "\x25"     // record size
+                            "\x07"     // type name size
+                            "^Layer\0" // type name
+                            "\x1c"     // summary string size
+                            "${var.name} (${var.number})"; // summary string
+
 int main() {
   struct Player player;
   player.name = "Dirk";
   player.number = 41;
+  struct Layer layer;
+  layer.name = "crust";
+  layer.number = 3;
   puts("break here");
   return 0;
 }


### PR DESCRIPTION
Fixes a logic error when determining if a type is a regex. Look for a leading `^` in 
the type name, not the summary string.

Adds a test to verify regex handling.

Fixes a log message to help debugging.

(cherry-picked from commit 81ae1b5a2907cdf8b9ea52c9c585302de1770dd4)