### PR TITLE
[lldb] Skip null bytes in embedded type summaries (#8132)

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
@@ -5,8 +5,7 @@ struct Player {
   int number;
 };
 
-__attribute__((aligned(1), used,
-               section("__DATA_CONST,__lldbsummaries"))) unsigned char
+__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
     _Player_type_summary[] = "\x01"     // version
                              "\x25"     // record size
                              "\x07"     // type name size
@@ -20,8 +19,7 @@ struct Layer {
 };
 
 // Near copy of the record for `Player`, using a regex type name (`^Layer`).
-__attribute__((aligned(1), used,
-               section("__DATA_CONST,__lldbsummaries"))) unsigned char
+__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
     _Layer_type_summary[] = "\x01"     // version
                             "\x25"     // record size
                             "\x07"     // type name size


### PR DESCRIPTION
Handle null padding that may exists between embedded type summary records. This can 
happen for example on x86-64 where the default alignment of `char[]` is 16 (p2align = 
4).

(cherry-picked from commit 87ace14daa2139a1095d0be7bf5702c12c2befa8)