### PR TITLE
[clangd] Fix indexed rename test after merging David’s implementation of ObjC selector rename

### DIFF
--- a/clang-tools-extra/clangd/refactor/Rename.h
+++ b/clang-tools-extra/clangd/refactor/Rename.h
@@ -125,9 +125,8 @@ llvm::Expected<Edit> buildRenameEdit(llvm::StringRef AbsFilePath,
 /// occurrence has the same length).
 /// REQUIRED: Indexed is sorted.
 std::optional<std::vector<SymbolRange>>
-adjustRenameRanges(llvm::StringRef DraftCode, llvm::StringRef Identifier,
-                   std::vector<Range> Indexed, const LangOptions &LangOpts,
-                   std::optional<Selector> Selector);
+adjustRenameRanges(llvm::StringRef DraftCode, const tooling::SymbolName &Name,
+                   std::vector<Range> Indexed, const LangOptions &LangOpts);
 
 /// Calculates the lexed occurrences that the given indexed occurrences map to.
 /// Returns std::nullopt if we don't find a mapping.

--- a/clang-tools-extra/clangd/unittests/RenameTests.cpp
+++ b/clang-tools-extra/clangd/unittests/RenameTests.cpp
@@ -2213,9 +2213,9 @@ TEST(CrossFileRenameTests, adjustRenameRanges) {
   for (const auto &T : Tests) {
     SCOPED_TRACE(T.DraftCode);
     Annotations Draft(T.DraftCode);
-    auto ActualRanges = adjustRenameRanges(Draft.code(), "x",
-                                           Annotations(T.IndexedCode).ranges(),
-                                           LangOpts, std::nullopt);
+    auto ActualRanges = adjustRenameRanges(
+        Draft.code(), tooling::SymbolName("x", /*IsObjectiveCSelector=*/false),
+        Annotations(T.IndexedCode).ranges(), LangOpts);
     if (!ActualRanges)
        EXPECT_THAT(Draft.ranges(), testing::IsEmpty());
     else
@@ -2501,7 +2501,6 @@ TEST(IndexedRename, IndexedRename) {
         }
       )cpp",
     },
-    #if 0 // // rdar://123113381
     {
       // Input
       R"cpp(
@@ -2534,7 +2533,6 @@ TEST(IndexedRename, IndexedRename) {
         @end
       )cpp",
     }
-    #endif
   };
   trace::TestTracer Tracer;
   for (const auto &T : Cases) {


### PR DESCRIPTION
Only the last commit is interesting after the merge conflict to `next` has been resolved.

rdar://123113381