### PR TITLE
[lldb] Add lldb-dap to LLVM_DISTRIBUTION_COMPONENTS

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-macOS.cmake
+++ b/lldb/cmake/caches/Apple-lldb-macOS.cmake
@@ -22,6 +22,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   lldb
   liblldb
   lldb-argdumper
+  lldb-dap
   darwin-debug
   debugserver
   repl_swift


### PR DESCRIPTION
(cherry picked from commit ba6db14ac21145f7868faccdb0e3d965c83c5c88)