### PR TITLE
[lldb] Skip TestExecutableFirst.test_executable_is_first_before_run on ELF

### DIFF
--- a/lldb/test/API/functionalities/executable_first/TestExecutableFirst.py
+++ b/lldb/test/API/functionalities/executable_first/TestExecutableFirst.py
@@ -10,6 +10,9 @@ from lldbsuite.test import lldbutil
 class TestExecutableIsFirst(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    # ELF does not have a hard distinction between shared libraries and
+    # (position-independent) executables
+    @skipIf(oslist=no_match(lldbplatformutil.getDarwinOSTriples()+["windows"]))
     def test_executable_is_first_before_run(self):
         self.build()
 


### PR DESCRIPTION
ELF does not have a hard distinction between shared libraries (and position-independent) executables. It is possible to create a shared library that will also be executable.

(cherry picked from commit 15311d5822f5fcaf53bc7cfc728ad2b477a430e4)