### PR TITLE
SwiftExpressionParser: link swiftrt to liblldb on linux

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -49,6 +49,15 @@ if(BOOTSTRAPPING_MODE)
   target_link_libraries(lldbPluginExpressionParserSwift
     PRIVATE
       swiftCompilerModules)
+
+  if (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD|Windows")
+    # The swiftCompilerModules need swiftrt to work properly.
+    string(REGEX MATCH "^[^-]*" arch ${LLVM_TARGET_TRIPLE})
+    string(TOLOWER ${CMAKE_SYSTEM_NAME} platform)
+    target_link_libraries(lldbPluginExpressionParserSwift
+      PRIVATE
+        "${LLDB_SWIFT_LIBS}/${platform}/${arch}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
+  endif()
 else()
   target_link_libraries(lldbPluginExpressionParserSwift
     PRIVATE


### PR DESCRIPTION
This is need to let the swiftCompilerModules work properly.

Cherry-pick of https://github.com/apple/llvm-project/pull/8244