### PR TITLE
[Triple] Add "swift" as a vendor.

### DIFF
--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -180,7 +180,8 @@ public:
     Mesa,
     SUSE,
     OpenEmbedded,
-    LastVendorType = OpenEmbedded
+    Swift,
+    LastVendorType = Swift
   };
   enum OSType {
     UnknownOS,

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -226,6 +226,7 @@ StringRef Triple::getVendorTypeName(VendorType Kind) {
   case PC: return "pc";
   case SCEI: return "scei";
   case SUSE: return "suse";
+  case Swift: return "swift";
   }
 
   llvm_unreachable("Invalid VendorType!");
@@ -599,6 +600,7 @@ static Triple::VendorType parseVendor(StringRef VendorName) {
     .Case("amd", Triple::AMD)
     .Case("mesa", Triple::Mesa)
     .Case("suse", Triple::SUSE)
+    .Case("swift", Triple::Swift)
     .Case("oe", Triple::OpenEmbedded)
     .Default(Triple::UnknownVendor);
 }


### PR DESCRIPTION
We want this so we can uniquely identify our fully-static Linux target using a triple (since we wish to make decisions about it in the compiler driver that wouldn't be appropriate for an "unknown" triple).

rdar://123436421