### PR TITLE
[lldb][test] XFAIL TestCppReferenceToOuterClass.py for now

### DIFF
--- a/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/TestDbgInfoContentDequeFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/TestDbgInfoContentDequeFromStdModule.py
@@ -11,6 +11,7 @@ class TestDbgInfoContentDeque(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "12.0"])
+    @skipIf(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/cpp/reference-to-outer-type/TestCppReferenceToOuterClass.py
+++ b/lldb/test/API/lang/cpp/reference-to-outer-type/TestCppReferenceToOuterClass.py
@@ -5,7 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    @expectedFailureAll(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'false'))
+    @expectedFailure("The fix for this was reverted due to llvm.org/PR52257")
     def test(self):
         self.build()
         self.dbg.CreateTarget(self.getBuildArtifact("a.out"))


### PR DESCRIPTION
The intention was to only fail this test when
`plugin.typesystem.clang.experimental-redecl-completion=false`, but it seems like when the setting is not passed explicitly to `dotest` the decorator is a no-op.

XFAIL this again until we figure out the decoartor properly.