### PR TITLE
Revert "[CodeGen] Add public function to emit C++ constructor/destructor"

### DIFF
--- a/clang/include/clang/CodeGen/CodeGenABITypes.h
+++ b/clang/include/clang/CodeGen/CodeGenABITypes.h
@@ -81,9 +81,6 @@ const CGFunctionInfo &arrangeFreeFunctionCall(CodeGenModule &CGM,
                                               FunctionType::ExtInfo info,
                                               RequiredArgs args);
 
-const CGFunctionInfo &arrangeCXXStructorDeclaration(CodeGenModule &CGM,
-                                                    GlobalDecl GD);
-
 /// Returns the implicit arguments to add to a complete, non-delegating C++
 /// constructor call.
 ImplicitCXXConstructorArgs

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -367,11 +367,6 @@ CodeGenTypes::arrangeCXXStructorDeclaration(GlobalDecl GD) {
                                  argTypes, extInfo, paramInfos, required);
 }
 
-const CGFunctionInfo &CodeGen::arrangeCXXStructorDeclaration(CodeGenModule &CGM,
-                                                             GlobalDecl GD) {
-  return CGM.getTypes().arrangeCXXStructorDeclaration(GD);
-}
-
 static SmallVector<CanQualType, 16>
 getArgTypesForCall(ASTContext &ctx, const CallArgList &args) {
   SmallVector<CanQualType, 16> argTypes;


### PR DESCRIPTION
This reverts commit 16df02a03e39d7a0f9980bb3212d580774b55ffc.

The API was needed to get the correct return type for C++ constructors, but it's not needed anymore.