### PR TITLE
[Cherry-pick into stable/20230725] Improve and modernize logging for Process::CompleteAttach() (#82717)

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -3091,14 +3091,11 @@ void Process::CompleteAttach() {
   DidAttach(process_arch);
 
   if (process_arch.IsValid()) {
+    LLDB_LOG(log,
+             "Process::{0} replacing process architecture with DidAttach() "
+             "architecture: \"{1}\"",
+             __FUNCTION__, process_arch.GetTriple().getTriple());
     GetTarget().SetArchitecture(process_arch);
-    if (log) {
-      const char *triple_str = process_arch.GetTriple().getTriple().c_str();
-      LLDB_LOGF(log,
-                "Process::%s replacing process architecture with DidAttach() "
-                "architecture: %s",
-                __FUNCTION__, triple_str ? triple_str : "<null>");
-    }
   }
 
   // We just attached.  If we have a platform, ask it for the process


### PR DESCRIPTION
```
commit 55bc0488af077acb47be70542718d1bc17f3de4f
Author: Adrian Prantl <adrian-prantl@users.noreply.github.com>
Date:   Fri Feb 23 08:00:58 2024 -0800

    Improve and modernize logging for Process::CompleteAttach() (#82717)
    
    Target::SetArchitecture() does not necessarily set the triple that is
    being passed in, and will unconditionally log the real architecture to
    the log channel. By flipping the order between the log outputs, the
    resulting combined log makes a lot more sense to read.
```
