### PR TITLE
[Tests][LoopDistribute] Re-adding target triple in a test that was removed earlier to fix build errors

### DIFF
--- a/llvm/test/Transforms/LoopDistribute/basic-with-memchecks.ll
+++ b/llvm/test/Transforms/LoopDistribute/basic-with-memchecks.ll
@@ -1,3 +1,4 @@
+; REQUIRES: x86-registered-target
 ; RUN: opt -aa-pipeline=basic-aa -passes=loop-distribute -enable-loop-distribute -verify-loop-info -verify-dom-info -S \
 ; RUN:   < %s | FileCheck %s
 
@@ -18,6 +19,7 @@
 ;   }
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-apple-macosx10.10.0"
 
 @B = common global ptr null, align 8
 @A = common global ptr null, align 8
@@ -77,6 +79,7 @@ entry:
 ; CHECK: for.end:
 
 
+; VECTORIZE: mul <4 x i32>
 ; VECTORIZE: mul <4 x i32>
 ; VECTORIZE-NOT: mul <4 x i32>
 


### PR DESCRIPTION
This triple was removed earlier to fix build errors because of target-specific cost model. It seems more correct to add target requirement for the test than remove it. 