### PR TITLE
[stable/20230725][clang] Fix clang tests that use darwin features for Linux

### DIFF
--- a/clang/test/CAS/mccas-replay.c
+++ b/clang/test/CAS/mccas-replay.c
@@ -1,6 +1,7 @@
+// REQUIRES: x86-registered-target
 // RUN: rm -rf %t && mkdir %t
 
-// RUN: %clang -cc1depscan -o %t/args.rsp  -cc1-args -cc1 \
+// RUN: %clang -cc1depscan -o %t/args.rsp  -cc1-args -cc1 -triple x86_64-apple-darwin10 \
 // RUN:    -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
 // RUN:    -emit-obj -fcas-backend  -fcas-path %t/cas       %s -o - > /dev/null
 

--- a/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
@@ -1,4 +1,5 @@
 // REQUIRES: ondisk_cas
+// REQUIRES: x86-registered-target
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t/dir1
@@ -314,7 +315,7 @@
 [{
   "file": "DIR/tu.m",
   "directory": "DIR",
-  "command": "CLANG -fsyntax-only DIR/tu.m -I DIR -isystem DIR/System -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache"
+  "command": "CLANG -target x86_64-apple-darwin10 -fsyntax-only DIR/tu.m -I DIR -isystem DIR/System -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache"
 }]
 
 //--- module.modulemap

--- a/clang/test/Index/Store/handle-prebuilt-module.m
+++ b/clang/test/Index/Store/handle-prebuilt-module.m
@@ -1,8 +1,9 @@
+// REQUIRES: x86-registered-target
 // RUN: rm -rf %t
 // RUN: mkdir %t
-// RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -fsyntax-only %s -o %t.o -index-store-path %t/idx1 -fmodules -fmodules-cache-path=%t/mcp -I %S/Inputs/module -Rindex-store 2> %t.err1
-// RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -fsyntax-only %s -o %t.o -index-store-path %t/idx2 -fmodules -fmodules-cache-path=%t/mcp -I %S/Inputs/module -Rindex-store 2> %t.err2
-// RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -fsyntax-only %s -o %t.o -index-store-path %t/idx2 -fmodules -fmodules-cache-path=%t/mcp -I %S/Inputs/module -Rindex-store 2> %t.err3
+// RUN: %clang -target x86_64-apple-macos10.7 -fsyntax-only %s -o %t.o -index-store-path %t/idx1 -fmodules -fmodules-cache-path=%t/mcp -I %S/Inputs/module -Rindex-store 2> %t.err1
+// RUN: %clang -target x86_64-apple-macos10.7 -fsyntax-only %s -o %t.o -index-store-path %t/idx2 -fmodules -fmodules-cache-path=%t/mcp -I %S/Inputs/module -Rindex-store 2> %t.err2
+// RUN: %clang -target x86_64-apple-macos10.7 -fsyntax-only %s -o %t.o -index-store-path %t/idx2 -fmodules -fmodules-cache-path=%t/mcp -I %S/Inputs/module -Rindex-store 2> %t.err3
 // RUN: FileCheck -input-file=%t.err1 -check-prefix=CREATING_MODULES %s -allow-empty
 // RUN: FileCheck -input-file=%t.err2 -check-prefix=CREATING_INDEX_DATA_FROM_MODULE_FILES %s
 // RUN: FileCheck -input-file=%t.err3 -check-prefix=EXISTING_INDEX_DATA_FROM_MODULE_FILES %s -allow-empty

--- a/clang/test/Index/Store/print-units-with-modules.m
+++ b/clang/test/Index/Store/print-units-with-modules.m
@@ -1,5 +1,6 @@
+// REQUIRES: x86-registered-target
 // RUN: rm -rf %t.idx %t.mcp
-// RUN: %clang -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t.o -index-store-path %t.idx -fmodules -fmodules-cache-path=%t.mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
+// RUN: %clang -target x86_64-apple-macos10.7 -c %s -o %t.o -index-store-path %t.idx -fmodules -fmodules-cache-path=%t.mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
 // RUN: c-index-test core -print-unit %t.idx | FileCheck %s
 
 @import ModDep;


### PR DESCRIPTION
Fixes tests on the "next" branch that were implicitly depending on Darwin platform behaviours in the driver by explicitly setting a Darwin target triple.

(cherry picked from commit d7095426cadfc5e82e926dd7b52fe6d067a098bc)