### PR TITLE
[next] Remove makeArrayRef functions and references

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2168,7 +2168,7 @@ public:
     }
 
     llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
-      return llvm::makeArrayRef(g_swift_demangle_options);
+      return llvm::ArrayRef(g_swift_demangle_options);
     }
 
     // Options table: Required for subclasses of Options.


### PR DESCRIPTION
Use the corresponding template deduction guides instead, as in upstream.

(cherry picked from commit 0a2d0d74f859e7213f5491faaa9ec4c7ea3eef5f)