### PR TITLE
[lldb] Ignore swig warnings about shadowed overloads

### DIFF
--- a/lldb/bindings/CMakeLists.txt
+++ b/lldb/bindings/CMakeLists.txt
@@ -23,7 +23,11 @@ endif()
 
 set(SWIG_COMMON_FLAGS
   -c++
-  -w361,362 # Ignore warnings about ignored operator overloads
+  # Ignored warnings:
+  # 361: operator! ignored.
+  # 362: operator= ignored.
+  # 509: Overloaded method declaration effectively ignored, shadowed by previous declaration.
+  -w361,362,509
   -features autodoc
   -I${LLDB_SOURCE_DIR}/include
   -I${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
This specifically addresses the warnings:
$LLVM/lldb/include/lldb/API/SBCommandReturnObject.h:119: Warning 509: Overloaded method lldb::SBCommandReturnObject::PutCString(char const *) effectively ignored, $LLVM/lldb/include/lldb/API/SBCommandReturnObject.h:119: Warning 509: as it is shadowed by lldb::SBCommandReturnObject::PutCString(char const *,int).

There is exactly one declaration of SBCommandReturnObject::PutCString. The second parameter (of type `int`) has default value `-1`. Without investigating why SWIG believes there are 2 method declarations, I believe it is safe to ignore this warning. It does not appear to actually impact functionality in any way.

rdar://117744660