### PR TITLE
Change `image list -r` so that it actually shows the ref count and whether the image is in the shared cache.

### DIFF
--- a/lldb/source/Commands/CommandObjectTarget.cpp
+++ b/lldb/source/Commands/CommandObjectTarget.cpp
@@ -3376,15 +3376,19 @@ protected:
 
       case 'r': {
         size_t ref_count = 0;
+        char in_shared_cache = 'Y';
+        
         ModuleSP module_sp(module->shared_from_this());
+        if (!ModuleList::ModuleIsInCache(module))
+          in_shared_cache = 'N';
         if (module_sp) {
           // Take one away to make sure we don't count our local "module_sp"
           ref_count = module_sp.use_count() - 1;
         }
         if (width)
-          strm.Printf("{%*" PRIu64 "}", width, (uint64_t)ref_count);
+          strm.Printf("{%c %*" PRIu64 "}", in_shared_cache, width, (uint64_t)ref_count);
         else
-          strm.Printf("{%" PRIu64 "}", (uint64_t)ref_count);
+          strm.Printf("{%c %" PRIu64 "}", in_shared_cache, (uint64_t)ref_count);
       } break;
 
       case 's':

--- a/lldb/source/Commands/Options.td
+++ b/lldb/source/Commands/Options.td
@@ -936,8 +936,8 @@ let Command = "target modules list" in {
     OptionalArg<"Width">, Desc<"Display the modification time with optional "
     "width of the module.">;
   def target_modules_list_ref_count : Option<"ref-count", "r">, Group<1>,
-    OptionalArg<"Width">, Desc<"Display the reference count if the module is "
-    "still in the shared module cache.">;
+    OptionalArg<"Width">, Desc<"Display whether the module is still in the "
+    "the shared module cache (Y/N), and its shared pointer use_count.">;
   def target_modules_list_pointer : Option<"pointer", "p">, Group<1>,
     OptionalArg<"None">, Desc<"Display the module pointer.">;
   def target_modules_list_global : Option<"global", "g">, Group<1>,


### PR DESCRIPTION
The docs for the `-r` argument for `image list` say:

       -r[<width>] ( --ref-count=[<width>] )
            Display the reference count if the module is still in the shared module cache.

but it doesn't actually do that.  It always displays the reference count regardless of whether the module is in the shared module cache, or if it only exists in the ModuleCollection and is waiting to get it's use_count to 0 so it can get destroyed.

I changed this to do:

       -r[<width>] ( --ref-count=[<width>] )
            Display whether the module is still in the the shared module cache (Y/N), and its shared pointer use_count.

So the display is goes from `{4}` to `{Y 4}` for a module with a use_count of 4 in the shared cache.

I didn't write any new tests because I'm not sure I how much we want to codify the shared cache behavior in tests.
