### PR TITLE
[lldb] Initialize SwiftASTContext with embedded swift feature

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -823,6 +823,8 @@ public:
                                  std::optional<lldb::user_id_t> debugger_id);
 
   bool IsSwiftCxxInteropEnabled();
+
+  bool IsEmbeddedSwift();
 #endif
 
   // Return true if the file backing this module has changed since the module
@@ -1109,6 +1111,7 @@ private:
   void ReportErrorIfModifyDetected(const llvm::formatv_object_base &payload);
 #ifdef LLDB_ENABLE_SWIFT
   LazyBool m_is_swift_cxx_interop_enabled = eLazyBoolCalculate;
+  LazyBool m_is_embedded_swift = eLazyBoolCalculate;
 #endif
 };
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1289,6 +1289,8 @@ public:
   bool IsSwiftREPL();
 
   bool IsSwiftCxxInteropEnabled();
+
+  bool IsEmbeddedSwift();
 private:
   void DisplayFallbackSwiftContextErrors(
       SwiftASTContextForExpressions *swift_ast_ctx);

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1203,6 +1203,34 @@ bool Module::IsSwiftCxxInteropEnabled() {
   }
   return m_is_swift_cxx_interop_enabled == eLazyBoolYes;
 }
+
+bool Module::IsEmbeddedSwift() {
+  switch (m_is_embedded_swift) {
+  case eLazyBoolYes:
+    return true;
+  case eLazyBoolNo:
+    return false;
+  case eLazyBoolCalculate:
+    auto *sym_file = GetSymbolFile();
+    if (!sym_file)
+      return false;
+
+    m_is_embedded_swift = eLazyBoolNo;
+    auto options = sym_file->GetCompileOptions();
+    StringRef enable_embedded_swift("-enable-embedded-swift");
+    for (auto &[_, args] : options) {
+      for (const char *arg : args.GetArgumentArrayRef()) {
+        if (enable_embedded_swift == arg) {
+          m_is_embedded_swift = eLazyBoolYes;
+          return true;
+        }
+      }
+    }
+
+    return m_is_embedded_swift == eLazyBoolYes;
+  }
+}
+
 #endif
 
 void Module::ReportErrorIfModifyDetected(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1936,6 +1936,9 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   swift_ast_sp->GetLanguageOptions().EnableCXXInterop =
       module.IsSwiftCxxInteropEnabled();
 
+  if (module.IsEmbeddedSwift())
+    swift_ast_sp->GetLanguageOptions().enableFeature(swift::Feature::Embedded);
+
   bool found_swift_modules = false;
   SymbolFile *sym_file = module.GetSymbolFile();
 
@@ -2357,6 +2360,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
 
   swift_ast_sp->GetLanguageOptions().EnableCXXInterop =
       target.IsSwiftCxxInteropEnabled();
+
+  if (target.IsEmbeddedSwift())
+    swift_ast_sp->GetLanguageOptions().enableFeature(swift::Feature::Embedded);
+
   bool handled_sdk_path = false;
   const size_t num_images = target.GetImages().GetSize();
 
@@ -2651,6 +2658,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
 
   swift_ast_sp->GetLanguageOptions().EnableCXXInterop =
       target.IsSwiftCxxInteropEnabled();
+
+  if (target.IsEmbeddedSwift())
+    swift_ast_sp->GetLanguageOptions().enableFeature(swift::Feature::Embedded);
+
   bool handled_sdk_path = false;
   const size_t num_images = target.GetImages().GetSize();
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3188,6 +3188,14 @@ bool Target::IsSwiftCxxInteropEnabled() {
   return m_is_swift_cxx_interop_enabled == eLazyBoolYes;
 }
 
+bool Target::IsEmbeddedSwift() {
+  if (GetImages().IsEmpty())
+    return false;
+
+  // Embedded Swift cannot be mixed with non-embedded, so checking the first
+  // module should be enough.
+  return GetImages().GetModuleAtIndex(0)->IsEmbeddedSwift();
+}
 #endif // LLDB_ENABLE_SWIFT
 
 void Target::SettingsInitialize() { Process::SettingsInitialize(); }

--- a/lldb/test/API/lang/swift/embedded/expr/Makefile
+++ b/lldb/test/API/lang/swift/embedded/expr/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/expr/TestSwiftEmbeddedExpression.py
+++ b/lldb/test/API/lang/swift/embedded/expr/TestSwiftEmbeddedExpression.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftEmbeddedExpression(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("expr a.foo()", substrs=["(Int)", " = 16"])

--- a/lldb/test/API/lang/swift/embedded/expr/main.swift
+++ b/lldb/test/API/lang/swift/embedded/expr/main.swift
@@ -1,0 +1,15 @@
+struct A {
+  var field = 4
+
+  func foo() -> Int {
+    return field * field
+  }
+}
+
+
+let a = A()
+// Dummy statement to set breakpoint print can't be used in embedded Swift for now.
+let dummy = A() // break here
+let string = StaticString("Hello") 
+print(string) 
+


### PR DESCRIPTION
In order for expression evaluation to work when debugging embedded swift programs, the compiler instance needs to be initialized with the embedded feature. The compiler writes "-enable-embedded-swift" into the CU's debug info when compiling in embedded Swift.