### PR TITLE
[lldb] Remove -triple handing in SwiftASTContext::AddExtraClangArgs

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1490,8 +1490,8 @@ bool ConsumeIncludeOption(StringRef &arg, StringRef &prefix) {
 }
 
 std::array<StringRef, 2> macro_flags = { "-D", "-U" };
-std::array<StringRef, 6> multi_arg_flags = {
-    "-D", "-U", "-I", "-F", "-working-directory", "-triple"};
+std::array<StringRef, 5> multi_arg_flags = {"-D", "-U", "-I", "-F",
+                                            "-working-directory"};
 std::array<StringRef, 6> args_to_unique = {
     "-D", "-U", "-I", "-F", "-fmodule-file=", "-fmodule-map-file="};
 
@@ -1537,14 +1537,6 @@ void SwiftASTContext::AddExtraClangArgs(const std::vector<std::string> &source,
       llvm::find(source, "-fno-implicit-modules") != source.end();
 
   for (const std::string &arg : source) {
-    // Ignore the `-triple` flag. First, this is not a driver flag, and second,
-    // lldb has its own logic to determine the target. Ignore now, before
-    // appending the argument.
-    if (clang_argument == "-triple") {
-      clang_argument.clear();
-      continue;
-    }
-
     // Join multi-arg options for uniquing.
     clang_argument += arg;
     if (IsMultiArgClangFlag(clang_argument))


### PR DESCRIPTION
Instead of working around `-triple`, https://github.com/apple/swift/pull/71987 changes Swift to emit `--target=` instead, which does not need working around.