### PR TITLE
Resolve some doccomment and Swift interop warnings

### DIFF
--- a/clang/include/clang/AST/DependentDiagnostic.h
+++ b/clang/include/clang/AST/DependentDiagnostic.h
@@ -147,9 +147,11 @@ public:
     return tmp;
   }
 
+#ifndef __swift__
   bool operator==(ddiag_iterator Other) const {
     return Ptr == Other.Ptr;
   }
+#endif
 
   bool operator!=(ddiag_iterator Other) const {
     return Ptr != Other.Ptr;

--- a/clang/include/clang/Sema/CodeCompleteConsumer.h
+++ b/clang/include/clang/Sema/CodeCompleteConsumer.h
@@ -335,7 +335,7 @@ public:
     /// error and don't know which completions we should give.
     CCC_Recovery,
 
-    /// Code completion in a `@class` forward declaration.
+    /// Code completion in a \c \@class forward declaration.
     CCC_ObjCClassForwardDecl
   };
 

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -505,7 +505,7 @@ namespace llvm {
     /// \param UniqueIdentifier A unique identifier for the union.
     /// \param OffsetInBits The offset of the variant payload in the variant
     /// type.
-    /// \param SpareBitMask A mask of spare bits of the payload, spare bits are
+    /// \param SpareBitsMask A mask of spare bits of the payload, spare bits are
     /// bits that aren't used in any of the variant's cases.
     DICompositeType *
     createVariantPart(DIScope *Scope, StringRef Name, DIFile *File,

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -5623,7 +5623,9 @@ struct AAPointerInfo : public AbstractAttribute {
 
     unsigned size() const { return Ranges.size(); }
 
+#ifndef __swift__
     bool operator==(const RangeList &OI) const { return Ranges == OI.Ranges; }
+#endif
 
     /// Merge the ranges in \p RHS into the current ranges.
     /// - Merging a list of  unknown ranges makes the current list unknown.
@@ -5757,11 +5759,13 @@ struct AAPointerInfo : public AbstractAttribute {
     Access(const Access &Other) = default;
 
     Access &operator=(const Access &Other) = default;
+#ifndef __swift__
     bool operator==(const Access &R) const {
       return LocalI == R.LocalI && RemoteI == R.RemoteI && Ranges == R.Ranges &&
              Content == R.Content && Kind == R.Kind;
     }
     bool operator!=(const Access &R) const { return !(*this == R); }
+#endif
 
     Access &operator&=(const Access &R) {
       assert(RemoteI == R.RemoteI && "Expected same instruction!");

--- a/llvm/include/llvm/Transforms/IPO/SampleContextTracker.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleContextTracker.h
@@ -161,6 +161,7 @@ public:
       return *this;
     }
 
+#ifndef __swift__
     bool operator==(const Iterator &Other) const {
       if (NodeQueue.empty() && Other.NodeQueue.empty())
         return true;
@@ -168,6 +169,7 @@ public:
         return false;
       return NodeQueue.front() == Other.NodeQueue.front();
     }
+#endif
 
     ContextTrieNode *operator*() const {
       assert(!NodeQueue.empty() && "Invalid access to end iterator");


### PR DESCRIPTION
- Correct some doc comments to avoid warnings in downstream projects.
- Wrap some operators in `#ifndef __swift__` guards. Swift C++ interop has a bug where certain operator declarations cannot be imported successfully due to percieved circular references in the declarations. Since these declarations are already dropped by the ClangImporter, it's helpful to hide the declarations entirely from Swift to avoid spurious diagnostics that cannot be addressed. See https://github.com/apple/swift/pull/71032 for a similar workaround in the Swift compiler implementation.