### PR TITLE
[Support] Use all_read | all_write for createTemporaryFile (#83360)

### DIFF
--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -850,7 +850,7 @@ createTemporaryFile(const Twine &Model, int &ResultFD,
          "Model must be a simple filename.");
   // Use P.begin() so that createUniqueEntity doesn't need to recreate Storage.
   return createUniqueEntity(P.begin(), ResultFD, ResultPath, true, Type, Flags,
-                            owner_read | owner_write);
+                            all_read | all_write);
 }
 
 static std::error_code


### PR DESCRIPTION
In a04879ce7dd6, dsymutil switched from using TempFile to createTemporaryFile. This caused a regression because the two use different permissions:

 - TempFile opens the file as all_read | all_write
 - createTemporaryFile opens the file as owner_read | owner_write

The latter turns out to be problematic for dsymutil because it either promotes the temporary to a proper output file, or it would pass it to `lipo` to create a universal binary and `lipo` preserves the permissions of the input files. Either way, this caused issues when the build system was run as a different user than the one ingesting the resulting binaries.

I did some version control archeology and I couldn't find evidence that these permissions were chosen purposely. Both could be considered reasonable default.

This patch changes the permissions to `all read | all write` to make the two consistent and match the one currently used by the higher level abstraction (TempFile).

rdar://123722848
(cherry picked from commit 310ed337092d6afc78594e1d8e32e6f44fff5568)