### PR TITLE
[lldb][ClangASTImporter] Fix mismerge in LayoutRecordType

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -785,6 +785,7 @@ bool ClangASTImporter::LayoutRecordType(
     field_offsets.swap(pos->second.field_offsets);
     base_offsets.swap(pos->second.base_offsets);
     vbase_offsets.swap(pos->second.vbase_offsets);
+    return true;
   }
 
   // It's possible that we calculated the layout in a different


### PR DESCRIPTION
The return statement was dropped when resolving merge conflicts in https://github.com/apple/llvm-project/pull/8306.