### PR TITLE
[lldb][progress] Fix format string in title

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4273,7 +4273,7 @@ void SwiftASTContext::ValidateSectionModules(
 
   Status error;
 
-  Progress progress("Loading Swift module '{0}' dependencies",
+  Progress progress("Loading Swift module dependencies",
                     module.GetFileSpec().GetFilename().AsCString(),
                     module_names.size());
   size_t completion = 0;


### PR DESCRIPTION
The title string for the progress report for loading Swift module dependencies had an unused formatter in its title string. Since the filename that was supposed to go in this formatter will now be reported as a detail, this commit removes the formatter from the title string.

rdar://122048954