### PR TITLE
[lldb] Detect when full DWARF debugging should be enabled

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -184,9 +184,9 @@ public:
 
   bool GetSwiftEnableBareSlashRegex() const;
 
-  EnableSwiftCxxInterop GetEnableSwiftCxxInterop() const;
+  AutoBool GetEnableSwiftCxxInterop() const;
 
-  bool GetSwiftEnableFullDwarfDebugging() const;
+  AutoBool GetSwiftEnableFullDwarfDebugging() const;
 
   bool GetSwiftAllowExplicitModules() const;
 

--- a/lldb/include/lldb/lldb-private-enumerations.h
+++ b/lldb/include/lldb/lldb-private-enumerations.h
@@ -172,10 +172,10 @@ typedef enum SwiftModuleLoadingMode {
 } SwiftModuleLoadingMode;
 
 // BEGIN SWIFT
-enum EnableSwiftCxxInterop {
-  eAutoDetectSwiftCxxInterop,
-  eEnableSwiftCxxInterop,
-  eDisableSwiftCxxInterop
+enum class AutoBool {
+  Auto,
+  True,
+  False
 };
 // END SWIFT
 

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1171,16 +1171,16 @@ bool Module::IsSwiftCxxInteropEnabled() {
   case eLazyBoolCalculate:
     break;
   }
-  EnableSwiftCxxInterop interop_enabled =
+  AutoBool interop_enabled =
       Target::GetGlobalProperties().GetEnableSwiftCxxInterop();
   switch (interop_enabled) {
-  case eEnableSwiftCxxInterop:
+  case AutoBool::True:
     m_is_swift_cxx_interop_enabled = eLazyBoolYes;
     break;
-  case eDisableSwiftCxxInterop:
+  case AutoBool::False:
     m_is_swift_cxx_interop_enabled = eLazyBoolNo;
     break;
-  case eAutoDetectSwiftCxxInterop: {
+  case AutoBool::Auto: {
     // Look for the "-enable-experimental-cxx-interop" compile flag in the args
     // of the compile units this module is composed of.
     auto *sym_file = GetSymbolFile();

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -147,8 +147,10 @@ public:
 
   std::vector<std::unique_ptr<swift::reflection::FieldRecordBase>>
   getFieldRecords() override {
-    if (!Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging())
-      return {};
+    assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+               lldb_private::AutoBool::False &&
+           "Full DWARF debugging for Swift is disabled!");
+
     auto *dwarf =
         llvm::dyn_cast<SymbolFileDWARF>(m_type_system.GetSymbolFile());
     auto *dwarf_parser = m_type_system.GetDWARFParser();
@@ -303,8 +305,9 @@ public:
 std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
 DWARFASTParserSwift::getBuiltinTypeDescriptor(
     const swift::reflection::TypeRef *TR) {
-  if (!Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging())
-    return nullptr;
+  assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+             lldb_private::AutoBool::False &&
+         "Full DWARF debugging for Swift is disabled!");
 
   auto pair = getTypeAndDie(m_swift_typesystem, TR);
   if (!pair)
@@ -344,8 +347,9 @@ DWARFASTParserSwift::getBuiltinTypeDescriptor(
 std::unique_ptr<swift::reflection::MultiPayloadEnumDescriptorBase>
 DWARFASTParserSwift::getMultiPayloadEnumDescriptor(
     const swift::reflection::TypeRef *TR) {
-  if (!Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging())
-    return nullptr;
+  assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+             lldb_private::AutoBool::False &&
+         "Full DWARF debugging for Swift is disabled!");
 
   auto pair = getTypeAndDie(m_swift_typesystem, TR);
   if (!pair)
@@ -449,8 +453,10 @@ NodePointer DWARFASTParserSwift::GetCanonicalDemangleTree(DWARFDIE &die) {
 
 std::unique_ptr<swift::reflection::FieldDescriptorBase>
 DWARFASTParserSwift::getFieldDescriptor(const swift::reflection::TypeRef *TR) {
-  if (!Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging())
-    return nullptr;
+  assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+             lldb_private::AutoBool::False &&
+         "Full DWARF debugging for Swift is disabled!");
+
 
   auto pair = getTypeAndDie(m_swift_typesystem, TR);
   if (!pair)

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3161,15 +3161,15 @@ bool Target::IsSwiftCxxInteropEnabled() {
     break;
   }
 
-  EnableSwiftCxxInterop interop_enabled = GetEnableSwiftCxxInterop();
+  AutoBool interop_enabled = GetEnableSwiftCxxInterop();
   switch (interop_enabled) {
-  case eEnableSwiftCxxInterop:
+  case AutoBool::True:
     m_is_swift_cxx_interop_enabled = eLazyBoolYes;
     break;
-  case eDisableSwiftCxxInterop:
+  case AutoBool::False:
     m_is_swift_cxx_interop_enabled = eLazyBoolNo;
     break;
-  case eAutoDetectSwiftCxxInterop: {
+  case AutoBool::Auto: {
     if (GetImages().IsEmpty())
       m_is_swift_cxx_interop_enabled = eLazyBoolNo;
     else
@@ -4694,10 +4694,21 @@ static constexpr OptionEnumValueElement g_memory_module_load_level_values[] = {
 };
 
 static constexpr OptionEnumValueElement g_enable_swift_cxx_interop_values[] = {
-    {eAutoDetectSwiftCxxInterop, "auto",
+    {llvm::to_underlying(AutoBool::Auto), "auto",
      "Automatically detect if C++ interop mode should be enabled."},
-    {eEnableSwiftCxxInterop, "true", "Enable C++ interop."},
-    {eDisableSwiftCxxInterop, "false", "Disable C++ interop."},
+    {llvm::to_underlying(AutoBool::True), "true", "Enable C++ interop."},
+    {llvm::to_underlying(AutoBool::False), "false", "Disable C++ interop."},
+};
+
+static constexpr OptionEnumValueElement g_enable_full_dwarf_debugging[] = {
+    {llvm::to_underlying(AutoBool::Auto), "auto",
+     "Automatically detect if full DWARF debugging should be enabled. Full "
+     "DWARF debugging is enabled if no reflection metadata is added to the "
+     "debugger."},
+    {llvm::to_underlying(AutoBool::True), "true",
+     "Enable full DWARF debugging."},
+    {llvm::to_underlying(AutoBool::False), "false",
+     "Disable full DWARF debugging."},
 };
 
 #define LLDB_PROPERTIES_target
@@ -4925,28 +4936,25 @@ bool TargetProperties::GetSwiftEnableBareSlashRegex() const {
   return true;
 }
 
-EnableSwiftCxxInterop TargetProperties::GetEnableSwiftCxxInterop() const {
+AutoBool TargetProperties::GetEnableSwiftCxxInterop() const {
   const uint32_t idx = ePropertySwiftEnableCxxInterop;
 
-  EnableSwiftCxxInterop enable_interop =
-      (EnableSwiftCxxInterop)m_experimental_properties_up->GetValueProperties()
-          ->GetPropertyAtIndexAs<EnableSwiftCxxInterop>(idx)
-          .value_or(static_cast<EnableSwiftCxxInterop>(
+  AutoBool enable_interop =
+      (AutoBool)m_experimental_properties_up->GetValueProperties()
+          ->GetPropertyAtIndexAs<AutoBool>(idx)
+          .value_or(static_cast<AutoBool>(
               g_target_properties[idx].default_uint_value));
   return enable_interop;
 }
 
-bool TargetProperties::GetSwiftEnableFullDwarfDebugging() const {
-  const Property *exp_property =
-      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
-  OptionValueProperties *exp_values =
-      exp_property->GetValue()->GetAsProperties();
-  if (exp_values)
-    return exp_values
-        ->GetPropertyAtIndexAs<bool>(ePropertySwiftEnableFullDwarfDebugging)
-        .value_or(false);
-
-  return false;
+AutoBool TargetProperties::GetSwiftEnableFullDwarfDebugging() const {
+  const uint32_t idx = ePropertySwiftEnableCxxInterop;
+  AutoBool enable_dwarf_debugging =
+      (AutoBool)m_experimental_properties_up->GetValueProperties()
+          ->GetPropertyAtIndexAs<AutoBool>(idx)
+          .value_or(static_cast<AutoBool>(
+              g_target_properties[idx].default_uint_value));
+  return enable_dwarf_debugging;
 }
 
 bool TargetProperties::GetSwiftAllowExplicitModules() const {

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -20,16 +20,17 @@ let Definition = "target_experimental" in {
     DefaultFalse,
     Desc<"Passes the -enable-bare-slash-regex compiler flag to the swift compiler.">;
   def SwiftEnableCxxInterop: Property<"swift-enable-cxx-interop", "Enum">,
-    DefaultEnumValue<"eAutoDetectSwiftCxxInterop">,
+    DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,
     EnumValues<"OptionEnumValues(g_enable_swift_cxx_interop_values)">,
     Desc<"Passes the -enable-cxx-interop flag to the swift compiler.">;
   def SwiftPluginServerForPath: Property<"swift-plugin-server-for-path",
       "Dictionary">,
     ElementType<"String">,
     Desc<"A dictionary of plugin paths as keys and swift-plugin-server binaries as values">;
-  def SwiftEnableFullDwarfDebugging: Property<"swift-enable-full-dwarf-debugging", "Boolean">,
-    DefaultFalse,
-    Desc<"Read full debug information from DWARF for Swift debugging, whenever possible">;
+  def SwiftEnableFullDwarfDebugging: Property<"swift-enable-full-dwarf-debugging", "Enum">,
+    DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,
+    EnumValues<"OptionEnumValues(g_enable_full_dwarf_debugging)">,
+    Desc<"Read full debug information from DWARF for Swift debugging. By default LLDB will use DWARF debug information if it cannot use reflection metadata.">;
   def SwiftAllowExplicitModules: Property<"swift-allow-explicit-modules", "Boolean">,
     DefaultTrue,
     Desc<"Allows explicit module flags to be passed through to ClangImporter.">;


### PR DESCRIPTION
Automatically turn on full DWARF debugging if reflection metadata isn't available.

rdar://122711892