### PR TITLE
[lldb][PDB] Fix test build after plugin namespace change

### DIFF
--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -53,7 +53,7 @@ public:
     FileSystem::Initialize();
     HostInfo::Initialize();
     ObjectFilePECOFF::Initialize();
-    SymbolFileDWARF::Initialize();
+    plugin::dwarf::SymbolFileDWARF::Initialize();
     TypeSystemClang::Initialize();
     SymbolFilePDB::Initialize();
 
@@ -64,7 +64,7 @@ public:
   void TearDown() override {
     SymbolFilePDB::Terminate();
     TypeSystemClang::Initialize();
-    SymbolFileDWARF::Terminate();
+    plugin::dwarf::SymbolFileDWARF::Terminate();
     ObjectFilePECOFF::Terminate();
     HostInfo::Terminate();
     FileSystem::Terminate();


### PR DESCRIPTION
This was failing to build on Windows after 1673a1ba5decd907d49e64ef705980a145b891d1.

(cherry picked from commit 3b23704f161c3dd89d4a0b637c9008f573cb87c8)