### PR TITLE
[lldb][Target] Refactor Target::FindLoadAddr

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1362,6 +1362,12 @@ public:
       const EvaluateExpressionOptions &options = EvaluateExpressionOptions(),
       std::string *fixed_expression = nullptr, ValueObject *ctx_obj = nullptr);
 
+  lldb::addr_t FindLoadAddrForNameInSymbols(
+      ConstString name_const_str, lldb::SymbolType symbol_type);
+
+  lldb::addr_t FindLoadAddrForNameInPersistentVariables(
+    ConstString name_const_str, lldb::SymbolType symbol_type);
+
   // Look up a symbol by name and type in both the target's symbols and the
   // persistent symbols from the
   // expression parser.  The symbol_type is ignored in that case, for now we

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -183,19 +183,9 @@ FindSymbolForSwiftObject(Process &process, RuntimeKind runtime_kind,
     return {};
   }
 
-  SymbolContextList sc_list;
-  image->FindSymbolsWithNameAndType(ConstString(object), sym_type, sc_list);
-  if (sc_list.GetSize() != 1)
-    return {};
-
-  SymbolContext SwiftObject_Class;
-  if (!sc_list.GetContextAtIndex(0, SwiftObject_Class))
-    return {};
-  if (!SwiftObject_Class.symbol)
-    return {};
   lldb::addr_t addr =
-      SwiftObject_Class.symbol->GetAddress().GetLoadAddress(&target);
-  if (addr && addr != LLDB_INVALID_ADDRESS)
+      target.FindLoadAddrForNameInSymbols(ConstString(object), sym_type);
+  if (addr != LLDB_INVALID_ADDRESS)
     return addr;
 
   return {};


### PR DESCRIPTION
`Target::FindLoadAddrForNameInSymbolsAndPersistentVariables` has been split into `Target::FindLoadAddrForNameInSymbols` and `Target::FindLoadAddrForNameInPersistentVariables`. Instead of performing both searches in one function,
`Target::FindLoadAddrForNameInSymbolsAndPersistentVariables` will call its constituent functions.

This allows `SwiftLanguageRuntime::FindSymbolForSwiftObject` to look for symbols with `Target::FindLoadAddrForNameInSymbols` instead of performing this search on its own.

rdar://32228544
(cherry picked from commit 2542856f5b7c61f2389a0cbe6ade25f5b5ac8ae6)