### PR TITLE
[lldb][progress] Fix format string in title (#8314)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4236,7 +4236,7 @@ void SwiftASTContext::ValidateSectionModules(
 
   Status error;
 
-  Progress progress("Loading Swift module '{0}' dependencies",
+  Progress progress("Loading Swift module dependencies",
                     module.GetFileSpec().GetFilename().AsCString(),
                     module_names.size());
 


### PR DESCRIPTION
The title string for the progress report for loading Swift module dependencies had an unused formatter in its title string. Since the filename that was supposed to go in this formatter will now be reported as a detail, this commit removes the formatter from the title string.
rdar://122048954

(cherry picked from commit 1bf6b0eb71227245cf2bf7dccb38bbb5c8864433)