### PR TITLE
[lldb] Replace -triple with --target= in clang extra args

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1491,7 +1491,7 @@ bool ConsumeIncludeOption(StringRef &arg, StringRef &prefix) {
 
 std::array<StringRef, 2> macro_flags = { "-D", "-U" };
 std::array<StringRef, 6> multi_arg_flags = {
-    "-D", "-U", "-I", "-F", "-working-directory", "-triple"};
+    "-D", "-U", "-I", "-F", "-working-directory", "--target="};
 std::array<StringRef, 6> args_to_unique = {
     "-D", "-U", "-I", "-F", "-fmodule-file=", "-fmodule-map-file="};
 
@@ -1537,16 +1537,15 @@ void SwiftASTContext::AddExtraClangArgs(const std::vector<std::string> &source,
       llvm::find(source, "-fno-implicit-modules") != source.end();
 
   for (const std::string &arg : source) {
-    // Ignore the `-triple` flag. First, this is not a driver flag, and second,
-    // lldb has its own logic to determine the target. Ignore now, before
-    // appending the argument.
-    if (clang_argument == "-triple") {
-      clang_argument.clear();
-      continue;
+    if (arg == "-triple") {
+      // Clang extra args are for driver flags. Replace the frontend `-triple`
+      // flag with a `--target=` driver flag.
+      clang_argument = "--target=";
+    } else {
+      // Join multi-arg options for uniquing.
+      clang_argument += arg;
     }
 
-    // Join multi-arg options for uniquing.
-    clang_argument += arg;
     if (IsMultiArgClangFlag(clang_argument))
       continue;
 


### PR DESCRIPTION
Instead of ignoring the serialized `-triple` flag (because it's a frontend flag), convert it to the correct driver flag: `--target=`. See also https://github.com/apple/swift/pull/71987 for a fix in the compiler.