### PR TITLE
[TextAPI] add missing platforms for translating triples to tapi targets

### DIFF
--- a/llvm/lib/TextAPI/Platform.cpp
+++ b/llvm/lib/TextAPI/Platform.cpp
@@ -49,7 +49,13 @@ PlatformType mapToPlatformType(const Triple &Target) {
   case Triple::WatchOS:
     return Target.isSimulatorEnvironment() ? PLATFORM_WATCHOSSIMULATOR
                                            : PLATFORM_WATCHOS;
-    // TODO: add bridgeOS & driverKit once in llvm::Triple
+  case Triple::BridgeOS:
+    return PLATFORM_BRIDGEOS;
+  case Triple::DriverKit:
+    return PLATFORM_DRIVERKIT;
+  case Triple::XROS:
+    return Target.isSimulatorEnvironment() ? PLATFORM_XROS_SIMULATOR
+                                           : PLATFORM_XROS;
   }
 }
 

--- a/llvm/lib/TextAPI/Platform.cpp
+++ b/llvm/lib/TextAPI/Platform.cpp
@@ -49,8 +49,6 @@ PlatformType mapToPlatformType(const Triple &Target) {
   case Triple::WatchOS:
     return Target.isSimulatorEnvironment() ? PLATFORM_WATCHOSSIMULATOR
                                            : PLATFORM_WATCHOS;
-  case Triple::BridgeOS:
-    return PLATFORM_BRIDGEOS;
   case Triple::DriverKit:
     return PLATFORM_DRIVERKIT;
   case Triple::XROS:


### PR DESCRIPTION
 (cherry picked from commit 06fea93341ae7d0d0faa82c4c8704591963c2d8c)
