### PR TITLE
[lldb] Print mangled names with verbose break list

### DIFF
--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -524,6 +524,9 @@ void BreakpointLocation::GetDescription(Stream *s,
           s->EOL();
           s->Indent("function = ");
           s->PutCString(sc.function->GetName().AsCString("<unknown>"));
+          s->EOL();
+          s->Indent("mangled function = ");
+          s->PutCString(sc.function->GetMangled().GetMangledName().AsCString("<unknown>"));
         }
 
         if (sc.line_entry.line > 0) {

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
@@ -90,6 +90,15 @@ class BreakpointOptionsTestCase(TestBase):
             num_expected_locations=1,
         )
 
+        self.expect(
+            "breakpoint list -v",
+            "Verbose breakpoint list contains mangled names",
+            substrs=[
+                "function = ns::func"
+                "mangled function ="
+            ],
+        )
+
         # This should create a breakpoint with 0 locations.
         lldbutil.run_break_set_by_symbol(
             self,


### PR DESCRIPTION
When debugging LLDB itself, it can often be useful to know the mangled name of the function where a breakpoint is set. Since the `--verbose` setting of `break --list` is aimed at debugging LLDB, this patch makes it so that the mangled name is also printed in that mode.

Note about testing: since mangling is not the same on Windows and Linux, the test refrains from hardcoding mangled names.