### PR TITLE
[clang] Fix clang.ClangScanDeps.diagnostics.c

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -220,6 +220,7 @@ static void sanitizeDiagOpts(DiagnosticOptions &DiagOpts) {
   llvm::erase_if(DiagOpts.Warnings, [](StringRef Warning) {
     return llvm::StringSwitch<bool>(Warning)
         .Cases("pch-vfs-diff", "error=pch-vfs-diff", false)
+        .StartsWith("no-error=", false)
         .Default(true);
   });
 }


### PR DESCRIPTION
This change got missed from the upstream commit: de3b2c293b8bf

rdar://124036657