### PR TITLE
[lldb] Add test dependency on the `runtimes` instead of the `cxx` target

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -139,6 +139,10 @@ if(NOT LLDB_BUILT_STANDALONE)
   )
 endif()
 
+if (LLVM_ENABLE_RUNTIMES)
+  add_lldb_test_dependency(runtimes)
+endif()
+
 # Add dependencies if we test with the in-tree clang.
 # This works with standalone builds as they import the clang target.
 if(TARGET clang)
@@ -157,12 +161,10 @@ if(TARGET clang)
       set(LIBCXX_LIBRARY_DIR ${CMAKE_BINARY_DIR}/lib${LIBCXX_LIBDIR_SUFFIX})
       set(LIBCXX_GENERATED_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include/c++/v1")
     endif()
-    add_lldb_test_dependency(cxx)
   endif()
 
   if (TARGET compiler-rt OR "compiler-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
     set(LLDB_HAS_COMPILER_RT ON)
-    add_lldb_test_dependency(compiler-rt)
   endif()
 
   if(APPLE AND NOT LLVM_TARGET_IS_CROSSCOMPILE_HOST)


### PR DESCRIPTION
Instead of adding individual dependencies on the enabled runtimes, make the `lldb-test-depends` target depend on the `runtimes` target. The `cxx` target broke after 0fc8f0b.

(cherry picked from commit dfa357026be3d9ecacc910abb8d55b8fe2d8d01d)