### PR TITLE
[lldb] Add support for class info lookup from DWARF

### DIFF
--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -62,6 +62,18 @@ class SubSub: Sub {
   var subSubField = A()
 }
 
+class Sup {
+  var supField: Int8 = 42
+}
+
+class Sub: Sup {
+  var subField = B()
+}
+
+class SubSub: Sub {
+  var subSubField = A()
+}
+
 let varB = B()
 let tuple = (A(), B())
 let trivial = TrivialEnum.theCase


### PR DESCRIPTION
This patch expands the DWARFASTParserSwift's implementation of the DescriptorFinder interface to lookup classes debug information from DWARF.

(cherry picked from commit ff077c5aa6fd28e7c8ac8137fbae2f63dc72ebee)