### PR TITLE
Cherrypick two upstream commits for SymbolFilePDBTests.cpp

### DIFF
--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -414,10 +414,11 @@ TEST_F(SymbolFilePDBTests, TestNestedClassTypes) {
   // (with the same compiler type) because the symbols have different IDs.
 
   auto ClassCompilerDeclCtx = CompilerDeclContext(clang_ast_ctx, ClassDeclCtx);
-  TypeResults query_results;
-  symfile->FindTypes(TypeQuery(ClassCompilerDeclCtx, "NestedClass"),
-                     query_results);
-  TypeMap &more_results = query_results.GetTypeMap();
+  TypeResults query_results_nested;
+  symfile->FindTypes(
+      TypeQuery(ClassCompilerDeclCtx, ConstString("NestedClass")),
+      query_results_nested);
+  TypeMap &more_results = query_results_nested.GetTypeMap();
   EXPECT_LE(1u, more_results.GetSize());
 
   lldb::TypeSP udt_type = more_results.GetTypeAtIndex(0);
@@ -459,7 +460,7 @@ TEST_F(SymbolFilePDBTests, TestClassInNamespace) {
   EXPECT_TRUE(ns_namespace_decl_ctx.IsValid());
 
   TypeResults query_results;
-  symfile->FindTypes(TypeQuery(ns_namespace_decl_ctx, "NSClass"),
+  symfile->FindTypes(TypeQuery(ns_namespace_decl_ctx, ConstString("NSClass")),
                      query_results);
   TypeMap &results = query_results.GetTypeMap();
   EXPECT_EQ(1u, results.GetSize());


### PR DESCRIPTION
Increase the MSVC buildability.

Cherrypick commit https://github.com/llvm/llvm-project/commit/f59fed261e30ddeecb6c6bfb53e47ecd4b124e7a
Cherrypick commit https://github.com/llvm/llvm-project/commit/e34c35a21ccc215ce507a1e19b4ff2a1ce9906f3