### PR TITLE
Fix an MSVC build issue

### DIFF
--- a/lldb/include/lldb/Utility/ConstString.h
+++ b/lldb/include/lldb/Utility/ConstString.h
@@ -435,6 +435,11 @@ protected:
 /// Stream the string value \a str to the stream \a s
 Stream &operator<<(Stream &s, ConstString str);
 
+inline std::string &operator+=(std::string &str, const lldb_private::ConstString &s) {
+  str += llvm::StringRef(s).str();
+  return str;
+}
+
 } // namespace lldb_private
 
 namespace llvm {


### PR DESCRIPTION
Add an operator+= for std::string and ConstString.

```
S:\SourceCache\llvm-project\lldb\source\Plugins\TypeSystem\Swift\SwiftASTContext.cpp(8846): error C2679: binary '+=': no operator found which takes a right-hand operand of type 'const lldb_private::ConstString' (or there is no acceptable conversion)
```