### PR TITLE
[lldb] Use __TEXT segment in embedded summary test (#8245)

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
+++ b/lldb/test/API/functionalities/data-formatter/embedded-summary/main.c
@@ -1,17 +1,19 @@
 #include <stdio.h>
 
+#define LLDBSUMMARY __attribute__((section("__TEXT,__lldbsummaries"), used))
+
 struct Player {
   char *name;
   int number;
 };
 
-__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
-    _Player_type_summary[] = "\x01"     // version
-                             "\x25"     // record size
-                             "\x07"     // type name size
-                             "Player\0" // type name
-                             "\x1c"     // summary string size
-                             "${var.name} (${var.number})"; // summary string
+LLDBSUMMARY unsigned char _Player_type_summary[] =
+    "\x01"                         // version
+    "\x25"                         // record size
+    "\x07"                         // type name size
+    "Player\0"                     // type name
+    "\x1c"                         // summary string size
+    "${var.name} (${var.number})"; // summary string
 
 struct Layer {
   char *name;
@@ -19,13 +21,13 @@ struct Layer {
 };
 
 // Near copy of the record for `Player`, using a regex type name (`^Layer`).
-__attribute__((used, section("__DATA_CONST,__lldbsummaries"))) unsigned char
-    _Layer_type_summary[] = "\x01"     // version
-                            "\x25"     // record size
-                            "\x07"     // type name size
-                            "^Layer\0" // type name
-                            "\x1c"     // summary string size
-                            "${var.name} (${var.number})"; // summary string
+LLDBSUMMARY unsigned char _Layer_type_summary[] =
+    "\x01"                         // version
+    "\x25"                         // record size
+    "\x07"                         // type name size
+    "^Layer\0"                     // type name
+    "\x1c"                         // summary string size
+    "${var.name} (${var.number})"; // summary string
 
 int main() {
   struct Player player;


### PR DESCRIPTION
These test fixtures are true constants and can be placed in the `__TEXT` segment.

(cherry-picked from commit 807f7ada4ce16a42b2214917edcbaa9a59f76592)