### PR TITLE
[clang][deps][cas] Fix include-tree contents with -working-directory

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -420,7 +420,7 @@ public:
   }
 
   bool runInvocation(std::shared_ptr<CompilerInvocation> Invocation,
-                     FileManager *FileMgr,
+                     FileManager *DriverFileMgr,
                      std::shared_ptr<PCHContainerOperations> PCHContainerOps,
                      DiagnosticConsumer *DiagConsumer) override {
     // Make a deep copy of the original Clang invocation.
@@ -476,12 +476,13 @@ public:
     ScanInstance.getHeaderSearchOpts().ModulesIncludeVFSUsage =
         any(OptimizeArgs & ScanningOptimizations::VFS);
 
-    ScanInstance.setFileManager(FileMgr);
     // Support for virtual file system overlays.
-    FileMgr->setVirtualFileSystem(createVFSFromCompilerInvocation(
+    auto FS = createVFSFromCompilerInvocation(
         ScanInstance.getInvocation(), ScanInstance.getDiagnostics(),
-        FileMgr->getVirtualFileSystemPtr()));
+        DriverFileMgr->getVirtualFileSystemPtr());
 
+    // Create a new FileManager to match the invocation's FileSystemOptions.
+    auto *FileMgr = ScanInstance.createFileManager(FS);
     ScanInstance.createSourceManager(*FileMgr);
 
     // Store the list of prebuilt module files into header search options. This
@@ -868,9 +869,8 @@ bool DependencyScanningWorker::computeDependencies(
       ModifiedCommandLine ? *ModifiedCommandLine : CommandLine;
   auto &FinalFS = ModifiedFS ? ModifiedFS : BaseFS;
 
-  FileSystemOptions FSOpts;
-  FSOpts.WorkingDir = WorkingDirectory.str();
-  auto FileMgr = llvm::makeIntrusiveRefCnt<FileManager>(FSOpts, FinalFS);
+  auto FileMgr =
+      llvm::makeIntrusiveRefCnt<FileManager>(FileSystemOptions{}, FinalFS);
 
   std::vector<const char *> FinalCCommandLine(FinalCommandLine.size(), nullptr);
   llvm::transform(FinalCommandLine, FinalCCommandLine.begin(),

--- a/clang/test/ClangScanDeps/include-tree-working-directory.c
+++ b/clang/test/ClangScanDeps/include-tree-working-directory.c
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/other
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   > %t/deps.json
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/tu.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: ls %t/t.o
+
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-HIT: remark: compile job cache hit
+
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid | FileCheck %s -DPREFIX=%/t
+
+// CHECK: [[PREFIX]]/t.c llvmcas://
+// CHECK: 1:1 <built-in> llvmcas://
+// CHECK: 2:1 [[PREFIX]]/relative/h1.h llvmcas://
+// CHECK: Files:
+// CHECK: [[PREFIX]]/t.c llvmcas://
+// CHECK: [[PREFIX]]/relative/h1.h llvmcas://
+
+//--- cdb.json.template
+[{
+  "directory": "DIR/other",
+  "command": "clang -c t.c -I relative -working-directory DIR -o t.o",
+  "file": "DIR/t.c"
+}]
+
+//--- relative/h1.h
+
+//--- t.c
+#include "h1.h"

--- a/clang/test/ClangScanDeps/modules-include-tree-working-directory.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-working-directory.c
@@ -1,0 +1,41 @@
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/other
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   > %t/deps.json
+
+// Build the include-tree command
+// RUN: %deps-to-rsp %t/deps.json --module H > %t/H.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/H.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/H.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: %clang @%t/tu.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang @%t/tu.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-HIT: remark: compile job cache hit
+
+// RUN: cat %t/H.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/H.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/H.casid | FileCheck %s -DPREFIX=%/t
+
+// CHEK:C <module-includes>
+// CHECK: 2:1 [[PREFIX]]/relative/h1.h llvmcas://
+// CHECK: Files:
+// CHECK: [[PREFIX]]/relative/h1.h llvmcas://
+
+//--- cdb.json.template
+[{
+  "directory": "DIR/other",
+  "command": "clang -fsyntax-only t.c -I relative -working-directory DIR -fmodules -fimplicit-modules -fimplicit-module-maps",
+  "file": "DIR/t.c"
+}]
+
+//--- relative/h1.h
+
+//--- relative/module.modulemap
+module H { header "h1.h" }
+
+//--- t.c
+#include "h1.h"

--- a/clang/test/ClangScanDeps/working-directory-option.c
+++ b/clang/test/ClangScanDeps/working-directory-option.c
@@ -1,0 +1,30 @@
+// Test that -working-directory works even when it differs from the working
+// directory of the filesystem.
+
+// RUN: rm -rf %t
+// RUN: mkdir -p %t/other
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full \
+// RUN:   > %t/deps.json
+
+// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t
+
+// CHECK:      "file-deps": [
+// CHECK-NEXT:   "[[PREFIX]]/cwd/t.c"
+// CHECK-NEXT:   "[[PREFIX]]/cwd/relative/h1.h"
+// CHECK-NEXT: ]
+// CHECK-NEXT: "input-file": "[[PREFIX]]/cwd/t.c"
+
+//--- cdb.json.template
+[{
+  "directory": "DIR/other",
+  "command": "clang -c t.c -I relative -working-directory DIR/cwd",
+  "file": "DIR/cwd/t.c"
+}]
+
+//--- cwd/relative/h1.h
+
+//--- cwd/t.c
+#include "h1.h"

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -355,5 +355,5 @@ TEST(DependencyScanner, ScanDepsWithModuleLookup) {
 
   EXPECT_TRUE(llvm::find(InterceptFS->StatPaths, OtherPath) ==
               InterceptFS->StatPaths.end());
-  EXPECT_EQ(InterceptFS->ReadFiles, std::vector<std::string>{"/root/test.m"});
+  EXPECT_EQ(InterceptFS->ReadFiles, std::vector<std::string>{"test.m"});
 }


### PR DESCRIPTION
The first commit is https://github.com/llvm/llvm-project/pull/84525 and will be rebased before merging.

---
When using -working-directory we were inconsistent about using relativeor absolute paths, which was causing failures to find files in the include-tree filesystem. Now we should be consistently using theabsolute path.

Note: this changes behaviour of things like `__FILE__`, which would normally have a relative path even with -working-directory. In the future we may want to find a way to preserve the relative paths, but that has been much harder and the current change at fixes the compilation failures.
    
rdar://116135029