### PR TITLE
[llvm] Fix for upstream ThreadPool rename

### DIFF
--- a/llvm/unittests/CAS/ThreadSafeAllocatorTest.cpp
+++ b/llvm/unittests/CAS/ThreadSafeAllocatorTest.cpp
@@ -15,7 +15,7 @@ using namespace llvm;
 
 TEST(ThreadSafeAllocatorTest, AllocWithAlign) {
   cas::ThreadSafeAllocator<BumpPtrAllocator> Alloc;
-  ThreadPool Threads;
+  DefaultThreadPool Threads;
 
   for (unsigned Index = 1; Index < 100; ++Index)
     Threads.async(
@@ -34,7 +34,7 @@ TEST(ThreadSafeAllocatorTest, AllocWithAlign) {
 
 TEST(ThreadSafeAllocatorTest, SpecificBumpPtrAllocator) {
   cas::ThreadSafeAllocator<SpecificBumpPtrAllocator<int>> Alloc;
-  ThreadPool Threads;
+  DefaultThreadPool Threads;
 
   for (unsigned Index = 1; Index < 100; ++Index)
     Threads.async(


### PR DESCRIPTION
716042a63f26c changed from ThreadPool to DefaultThreadPool.