### PR TITLE
Update swift language plugin's address mask handling

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -27,12 +27,8 @@ bool LLDBMemoryReader::queryDataLayout(DataLayoutQueryType type, void *inBuffer,
                                        void *outBuffer) {
   switch (type) {
   case DLQ_GetPtrAuthMask: {
-    // The MemoryReader API doesn't distinguish between the two, so
-    // this configuration is not yet supported.
-    if (m_process.GetCodeAddressMask() != m_process.GetDataAddressMask())
-      return false;
-    lldb::addr_t ptrauth_mask = m_process.GetCodeAddressMask();
-    if (!ptrauth_mask)
+    lldb::addr_t ptrauth_mask = m_process.GetDataAddressMask();
+    if (ptrauth_mask == LLDB_INVALID_ADDRESS_MASK)
       return false;
     // The mask returned by the process masks out the non-addressable bits.
     uint64_t mask_pattern = ~ptrauth_mask;


### PR DESCRIPTION
to match the new style I introduced in
`[lldb] Address mask sbprocess apis and new mask invalid const (#83663)`