### PR TITLE
[cherry-pick][stable/20230725] [clang][CodeCompletion] Allow debuggers to code-complete reserved identifiers

### DIFF
--- a/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/clang/lib/Sema/SemaCodeComplete.cpp
@@ -700,6 +700,10 @@ ResultBuilder::ShadowMapEntry::end() const {
 // Filter out names reserved for the implementation if they come from a
 // system header.
 static bool shouldIgnoreDueToReservedName(const NamedDecl *ND, Sema &SemaRef) {
+  // Debuggers want access to all identifiers, including reserved ones.
+  if (SemaRef.getLangOpts().DebuggerSupport)
+    return false;
+
   ReservedIdentifierStatus Status = ND->isReserved(SemaRef.getLangOpts());
   // Ignore reserved names for compiler provided decls.
   if (isReservedInAllContexts(Status) && ND->getLocation().isInvalid())

--- a/clang/test/CodeCompletion/ordinary-name.c
+++ b/clang/test/CodeCompletion/ordinary-name.c
@@ -5,6 +5,7 @@ typedef struct t _TYPEDEF;
 void foo() {
   int y;
   // RUN: %clang_cc1 -isystem %S/Inputs -fsyntax-only -code-completion-at=%s:%(line-1):9 %s -o - | FileCheck -check-prefix=CHECK-CC1 %s
+  // CHECK-CC1-NOT: __builtin_va_list
   // CHECK-CC1-NOT: __INTEGER_TYPE
   // CHECK-CC1: _Imaginary
   // CHECK-CC1: _MyPrivateType
@@ -15,4 +16,8 @@ void foo() {
   // CHECK-CC1: y
 
   // PR8744
-  // RUN: %clang_cc1 -isystem %S/Inputs -fsyntax-only -code-completion-at=%s:%(line-17):11 %s
+  // RUN: %clang_cc1 -isystem %S/Inputs -fsyntax-only -code-completion-at=%s:%(line-18):11 %s
+  
+  // RUN: %clang_cc1 -isystem %S/Inputs -fsyntax-only -fdebugger-support -code-completion-at=%s:%(line-15):9 %s -o - | FileCheck -check-prefix=CHECK-DBG %s
+  // CHECK-DBG: __builtin_va_list
+  // CHECK-DBG: __INTEGER_TYPE

--- a/lldb/test/API/commands/expression/completion/Makefile
+++ b/lldb/test/API/commands/expression/completion/Makefile
@@ -1,3 +1,4 @@
 CXX_SOURCES := main.cpp other.cpp
+CXXFLAGS += -isystem $(SRCDIR)/sys
 
 include Makefile.rules

--- a/lldb/test/API/commands/expression/completion/TestExprCompletion.py
+++ b/lldb/test/API/commands/expression/completion/TestExprCompletion.py
@@ -246,6 +246,11 @@ class CommandLineExprCompletionTestCase(TestBase):
             "expr some_expr.Self(). FooNoArgs", "expr some_expr.Self(). FooNoArgsBar()"
         )
 
+        self.complete_from_to("expr myVec.__f", "expr myVec.__func()")
+        self.complete_from_to("expr myVec._F", "expr myVec._Func()")
+        self.complete_from_to("expr myVec.__m", "expr myVec.__mem")
+        self.complete_from_to("expr myVec._M", "expr myVec._Mem")
+
     def test_expr_completion_with_descriptions(self):
         self.build()
         self.main_source = "main.cpp"

--- a/lldb/test/API/commands/expression/completion/main.cpp
+++ b/lldb/test/API/commands/expression/completion/main.cpp
@@ -1,3 +1,5 @@
+#include <reserved.h>
+
 namespace LongNamespaceName { class NestedClass { long m; }; }
 
 // Defined in other.cpp, we only have a forward declaration here.
@@ -31,5 +33,8 @@ int main()
     some_expr.FooNumbersBar1();
     Expr::StaticMemberMethodBar();
     ForwardDecl *fwd_decl_ptr = &fwd_decl;
+    MyVec myVec;
+    myVec.__func();
+    myVec._Func();
     return 0; // Break here
 }

--- a/lldb/test/API/commands/expression/completion/sys/reserved.h
+++ b/lldb/test/API/commands/expression/completion/sys/reserved.h
@@ -1,0 +1,8 @@
+class MyVec {
+  int __mem;
+  int _Mem;
+
+public:
+  void __func() {}
+  void _Func() {}
+};


### PR DESCRIPTION
It is not uncommon for LLDB users to dig into internal implementation details of system types (including the STL). LLDB's expression evaluator makes use of Clang's code-completion facilities but currently reserved identifeirs are filtered out (clang::Decls created in LLDB don't have valid locations, so we would also fail to code-complete any identifiers with reserved prefixes, not just ones from system headers).

This patch permits Clang to code-complete reserved identifiers iff we're in the debugger.

The associated LLDB tests: https://github.com/llvm/llvm-project/pull/84890

rdar://124098023