### PR TITLE
[Cherry-pick into next] Retire DynamicValueTypeInfoNeedsUpdate() (NFC)

### DIFF
--- a/lldb/include/lldb/Core/ValueObjectDynamicValue.h
+++ b/lldb/include/lldb/Core/ValueObjectDynamicValue.h
@@ -106,10 +106,6 @@ protected:
 
   bool HasDynamicValueTypeInfo() override { return true; }
 
-  /// Determine whether the scratch AST context has been replaced
-  /// since this dynamic type has been created.
-  bool DynamicValueTypeInfoNeedsUpdate();
-
   CompilerType GetCompilerTypeImpl() override;
 
   Address m_address; ///< The variable that this value object is based upon

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -129,17 +129,6 @@ bool ValueObject::UpdateValueIfNeeded(bool update_format) {
 
   bool did_change_formats = false;
 
-  // BEGIN SWIFT
-  // Swift: Check whether the dynamic type system became stale.
-  if (m_dynamic_value) {
-    auto *dyn_val = static_cast<ValueObjectDynamicValue *>(m_dynamic_value);
-    if (dyn_val->DynamicValueTypeInfoNeedsUpdate()) {
-      dyn_val->SetNeedsUpdate();
-      SetNeedsUpdate();
-    }
-  }
-  // END SWIFT
-
   if (update_format)
     did_change_formats = UpdateFormatsIfNeeded();
 

--- a/lldb/source/Core/ValueObjectDynamicValue.cpp
+++ b/lldb/source/Core/ValueObjectDynamicValue.cpp
@@ -440,23 +440,3 @@ void ValueObjectDynamicValue::SetLanguageFlags(uint64_t flags) {
   else
     this->ValueObject::SetLanguageFlags(flags);
 }
-
-bool ValueObjectDynamicValue::DynamicValueTypeInfoNeedsUpdate() {
-  if (GetPreferredDisplayLanguage() != eLanguageTypeSwift)
-    return false;
-
-  if (!m_dynamic_type_info.HasType())
-    return false;
-
-#ifdef LLDB_ENABLE_SWIFT
-  auto cached_ctx = m_value.GetCompilerType().GetTypeSystem();
-  std::optional<SwiftScratchContextReader> scratch_ctx(
-      GetSwiftScratchContext());
-
-  if (!scratch_ctx || !cached_ctx)
-    return true;
-  return (void*)cached_ctx.GetSharedPointer().get() != (void*)scratch_ctx->get();
-#else // !LLDB_ENABLE_SWIFT
-  return false;
-#endif // LLDB_ENABLE_SWIFT
-}


### PR DESCRIPTION
```
commit e472464f09ca33671344d43ce9236faf96be55eb
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Mar 12 17:43:47 2024 -0700

    Retire DynamicValueTypeInfoNeedsUpdate() (NFC)
    
    This function was introduced to detect a stale Swift scratch
    context. Today it doesn't make much sense, since all ValueObjects
    prefer to store their types as TypeSystemSwiftTypeRef types, and
    dynamic type resolution is done using type metadata, and not in
    SwiftASTContext space. This avoids a very costly initialization of the
    Swift compiler triggered by ValueObjectDynamicValue.
    
    rdar://124487859
```
