### PR TITLE
[Cherry-pick into next] Surface errors in GetNumChildren.

### DIFF
--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -131,12 +131,12 @@ bool lldb_private::formatters::swift::IndexPath_SummaryProvider(
     stream.PutCString("2 indices");
   else if (value == g_array)
   {
-    if (underlying_enum_sp->GetNumChildren() != 1) 
+    if (underlying_enum_sp->GetNumChildrenIgnoringErrors() != 1)
       return false;
   
     underlying_enum_sp = underlying_enum_sp->GetChildAtIndex(0, true)
        ->GetQualifiedRepresentationIfAvailable(lldb::eDynamicDontRunTarget, true);
-    size_t num_children = underlying_enum_sp->GetNumChildren();
+    size_t num_children = underlying_enum_sp->GetNumChildrenIgnoringErrors();
     stream.Printf("%zu indices", num_children);
   }
   return true;
@@ -214,7 +214,7 @@ bool lldb_private::formatters::swift::UUID_SummaryProvider(
   if (!uuid_sp)
     return false;
 
-  if (uuid_sp->GetNumChildren() < 16)
+  if (uuid_sp->GetNumChildrenIgnoringErrors() < 16)
     return false;
 
   ValueObjectSP children[] = {
@@ -300,7 +300,7 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
     // Do nothing; count is already 0.
   } else if (representation_case == g_inline) {
     // Grab the associated value from `case inline(InlineData)`.
-    if (representation_enum_sp->GetNumChildren() != 1)
+    if (representation_enum_sp->GetNumChildrenIgnoringErrors() != 1)
       return false;
 
     ValueObjectSP inline_data_sp =
@@ -330,7 +330,7 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
     }
   } else if (representation_case == g_slice) {
     // Grab the associated value from `case slice(InlineSlice)`.
-    if (representation_enum_sp->GetNumChildren() != 1)
+    if (representation_enum_sp->GetNumChildrenIgnoringErrors() != 1)
       return false;
 
     ValueObjectSP slice_data_sp =
@@ -392,7 +392,7 @@ bool lldb_private::formatters::swift::Data_SummaryProvider(
     count = upperBound - lowerBound;
   } else if (representation_case == g_large) {
     // Grab the associated value from `case large(LargeSlice)`.
-    if (representation_enum_sp->GetNumChildren() != 1)
+    if (representation_enum_sp->GetNumChildrenIgnoringErrors() != 1)
       return false;
 
     ValueObjectSP large_data_sp =
@@ -521,7 +521,7 @@ bool lldb_private::formatters::swift::Decimal_SummaryProvider(
 
   // Mantissa is represented as a tuple of 8 UInt16.
   const uint8_t num_children = 8;
-  if (mantissa_sp->GetNumChildren() != num_children)
+  if (mantissa_sp->GetNumChildrenIgnoringErrors() != num_children)
     return false;
 
   std::vector<double> mantissa_elements;
@@ -570,13 +570,13 @@ public:
 
   ~URLComponentsSyntheticChildrenFrontEnd() override = default;
 
-  size_t CalculateNumChildren() override {
+  llvm::Expected<uint32_t> CalculateNumChildren() override {
     if (IsValid())
       return 9;
     return 0;
   }
 
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override {
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override {
     if (IsValid()) {
       switch (idx) {
 #define COMPONENT(Name, PrettyName, ID)                                        \

--- a/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
+++ b/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
@@ -34,9 +34,10 @@ size_t ObjCRuntimeSyntheticProvider::FrontEnd::GetNumBases() {
   return m_provider->m_descriptor_sp->GetSuperclass().get() ? 1 : 0;
 }
 
-size_t ObjCRuntimeSyntheticProvider::FrontEnd::CalculateNumChildren() {
-  size_t ivars = m_provider->GetNumIVars();
-  size_t bases = GetNumBases();
+llvm::Expected<uint32_t>
+ObjCRuntimeSyntheticProvider::FrontEnd::CalculateNumChildren() {
+  uint32_t ivars = m_provider->GetNumIVars();
+  uint32_t bases = GetNumBases();
   return bases + ivars;
 }
 
@@ -59,9 +60,9 @@ ObjCRuntimeSyntheticProvider::FrontEnd::FrontEnd(
       m_root_sp(::GetSuitableRootObject(backend.GetSP())) {}
 
 lldb::ValueObjectSP
-ObjCRuntimeSyntheticProvider::FrontEnd::GetChildAtIndex(size_t idx) {
+ObjCRuntimeSyntheticProvider::FrontEnd::GetChildAtIndex(uint32_t idx) {
   lldb::ValueObjectSP child_sp(nullptr);
-  if (idx < CalculateNumChildren()) {
+  if (idx < CalculateNumChildrenIgnoringErrors()) {
     if (GetNumBases() == 1) {
       if (idx == 0) {
         do {
@@ -117,7 +118,7 @@ ObjCRuntimeSyntheticProvider::FrontEnd::GetChildAtIndex(size_t idx) {
 
 size_t ObjCRuntimeSyntheticProvider::FrontEnd::GetIndexOfChildWithName(
     ConstString name) {
-  for (size_t idx = 0; idx < CalculateNumChildren(); idx++) {
+  for (size_t idx = 0; idx < CalculateNumChildrenIgnoringErrors(); idx++) {
     const auto &ivar_info(m_provider->GetIVarAtIndex(idx));
     if (name == ivar_info.m_name)
       return idx + GetNumBases();

--- a/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.h
+++ b/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.h
@@ -48,8 +48,8 @@ public:
   public:
     FrontEnd(ObjCRuntimeSyntheticProvider *prv, ValueObject &backend);
 
-    size_t CalculateNumChildren() override;
-    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+    llvm::Expected<uint32_t> CalculateNumChildren() override;
+    lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
     lldb::ChildCacheState Update() override {
       return lldb::ChildCacheState::eRefetch;
     }

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.h
@@ -164,8 +164,8 @@ bool Array_SummaryProvider(ValueObject &valobj, Stream &stream,
 class ArraySyntheticFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   ArraySyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
-  size_t CalculateNumChildren() override;
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+  llvm::Expected<uint32_t> CalculateNumChildren() override;
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
   size_t GetIndexOfChildWithName(ConstString name) override;

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -711,8 +711,8 @@ class EnumSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   EnumSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
 
-  size_t CalculateNumChildren() override;
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+  llvm::Expected<uint32_t> CalculateNumChildren() override;
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
   size_t GetIndexOfChildWithName(ConstString name) override;
@@ -734,14 +734,14 @@ lldb_private::formatters::swift::EnumSyntheticFrontEnd::EnumSyntheticFrontEnd(
     Update();
 }
 
-size_t
+llvm::Expected<uint32_t>
 lldb_private::formatters::swift::EnumSyntheticFrontEnd::CalculateNumChildren() {
   return m_child_index != UINT32_MAX ? 1 : 0;
 }
 
 lldb::ValueObjectSP
 lldb_private::formatters::swift::EnumSyntheticFrontEnd::GetChildAtIndex(
-    size_t idx) {
+    uint32_t idx) {
   if (idx)
     return ValueObjectSP();
   if (m_child_index == UINT32_MAX)

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -134,8 +134,8 @@ public:
   HashedSyntheticChildrenFrontEnd(const HashedCollectionConfig &config,
                                   lldb::ValueObjectSP valobj_sp);
 
-  size_t CalculateNumChildren() override;
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+  llvm::Expected<uint32_t> CalculateNumChildren() override;
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
   size_t GetIndexOfChildWithName(ConstString name) override;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -839,11 +839,9 @@ class ValueObjectWrapperSyntheticChildren : public SyntheticChildren {
     ValueObjectWrapperFrontEndProvider(ValueObject &backend)
         : SyntheticChildrenFrontEnd(backend) {}
 
-    size_t CalculateNumChildren() override {
-      return 1;
-    }
+    llvm::Expected<uint32_t> CalculateNumChildren() override { return 1; }
 
-    lldb::ValueObjectSP GetChildAtIndex(size_t idx) override {
+    lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override {
       return idx == 0 ? m_backend.GetSP() : nullptr;
     }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -189,11 +189,9 @@ bool lldb_private::formatters::swift::SwiftOptionalSummaryProvider::
   if (!summary_sp) {
     if (lldb_private::DataVisualization::ShouldPrintAsOneLiner(*some))
       return false;
-    else
-      return (some->GetNumChildren() > 0);
-  } else
-    return (some->GetNumChildren() > 0) &&
-           (summary_sp->DoesPrintChildren(some));
+    return some->HasChildren();
+  }
+  return some->HasChildren() && summary_sp->DoesPrintChildren(some);
 }
 
 bool lldb_private::formatters::swift::SwiftOptionalSummaryProvider::
@@ -211,15 +209,15 @@ bool lldb_private::formatters::swift::SwiftOptionalSyntheticFrontEnd::IsEmpty()
   return (m_is_none == true || m_children == false || m_some == nullptr);
 }
 
-size_t lldb_private::formatters::swift::SwiftOptionalSyntheticFrontEnd::
-    CalculateNumChildren() {
+llvm::Expected<uint32_t> lldb_private::formatters::swift::
+    SwiftOptionalSyntheticFrontEnd::CalculateNumChildren() {
   if (IsEmpty())
     return 0;
   return m_some->GetNumChildren();
 }
 
 lldb::ValueObjectSP lldb_private::formatters::swift::
-    SwiftOptionalSyntheticFrontEnd::GetChildAtIndex(size_t idx) {
+    SwiftOptionalSyntheticFrontEnd::GetChildAtIndex(uint32_t idx) {
   if (IsEmpty())
     return nullptr;
   auto child = m_some->GetChildAtIndex(idx, true);
@@ -243,7 +241,7 @@ lldb::ChildCacheState lldb_private::formatters::swift::SwiftOptionalSyntheticFro
 
   m_is_none = false;
 
-  m_children = (m_some->GetNumChildren() > 0);
+  m_children = m_some->HasChildren();
 
   return ChildCacheState::eRefetch;
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.h
@@ -82,8 +82,8 @@ class SwiftOptionalSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   SwiftOptionalSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
 
-  size_t CalculateNumChildren() override;
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+  llvm::Expected<uint32_t> CalculateNumChildren() override;
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
   size_t GetIndexOfChildWithName(ConstString name) override;

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -514,8 +514,8 @@ class UnsafeTypeSyntheticFrontEnd : public SwiftBasicTypeSyntheticFrontEnd {
 public:
   UnsafeTypeSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
 
-  size_t CalculateNumChildren() override;
-  lldb::ValueObjectSP GetChildAtIndex(size_t idx) override;
+  llvm::Expected<uint32_t> CalculateNumChildren() override;
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
   size_t GetIndexOfChildWithName(ConstString name) override;
@@ -547,15 +547,15 @@ lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
     Update();
 }
 
-size_t lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
-    CalculateNumChildren() {
+llvm::Expected<uint32_t> lldb_private::formatters::swift::
+    UnsafeTypeSyntheticFrontEnd::CalculateNumChildren() {
   return m_unsafe_ptr->GetCount();
 }
 
 lldb::ValueObjectSP
 lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::GetChildAtIndex(
-    size_t idx) {
-  const size_t num_children = CalculateNumChildren();
+    uint32_t idx) {
+  const uint32_t num_children = CalculateNumChildrenIgnoringErrors();
 
   if (idx >= num_children || idx >= m_children.size())
     return lldb::ValueObjectSP();
@@ -575,7 +575,7 @@ lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::Update() {
   if (m_unsafe_ptr->Update() == ChildCacheState::eRefetch)
     return ChildCacheState::eRefetch;
 
-  const size_t num_children = CalculateNumChildren();
+  const uint32_t num_children = CalculateNumChildrenIgnoringErrors();
   m_children = ::ExtractChildrenFromSwiftPointerValueObject(valobj_sp,
                                                           *m_unsafe_ptr.get());
   return m_children.size() == num_children ? ChildCacheState::eReuse

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -315,7 +315,7 @@ public:
                                                    Status *error = nullptr);
 
   /// Ask Remote Mirrors about the children of a composite type.
-  std::optional<unsigned> GetNumChildren(CompilerType type,
+  llvm::Expected<uint32_t> GetNumChildren(CompilerType type,
                                           ExecutionContextScope *exe_scope);
 
   /// Determine the enum case name for the \p data value of the enum \p type.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -128,7 +128,7 @@ public:
                                                    llvm::StringRef member_name,
                                                    Status *error);
 
-  std::optional<unsigned> GetNumChildren(CompilerType type,
+  llvm::Expected<uint32_t> GetNumChildren(CompilerType type,
                                           ExecutionContextScope *exe_scope);
 
   std::optional<unsigned> GetNumFields(CompilerType type,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -688,9 +688,10 @@ public:
   lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                              uint64_t &count) override;
 
-  uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
-                          bool omit_empty_base_classes,
-                          const ExecutionContext *exe_ctx) override;
+  llvm::Expected<uint32_t>
+  GetNumChildren(lldb::opaque_compiler_type_t type,
+                 bool omit_empty_base_classes,
+                 const ExecutionContext *exe_ctx) override;
 
   uint32_t GetNumFields(lldb::opaque_compiler_type_t type,
                         ExecutionContext *exe_ctx = nullptr) override;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -193,9 +193,10 @@ public:
                 ExecutionContextScope *exe_scope) override;
   lldb::Encoding GetEncoding(lldb::opaque_compiler_type_t type,
                              uint64_t &count) override;
-  uint32_t GetNumChildren(lldb::opaque_compiler_type_t type,
-                          bool omit_empty_base_classes,
-                          const ExecutionContext *exe_ctx) override;
+  llvm::Expected<uint32_t>
+  GetNumChildren(lldb::opaque_compiler_type_t type,
+                 bool omit_empty_base_classes,
+                 const ExecutionContext *exe_ctx) override;
   uint32_t GetNumFields(lldb::opaque_compiler_type_t type,
                         ExecutionContext *exe_ctx = nullptr) override;
   CompilerType GetFieldAtIndex(lldb::opaque_compiler_type_t type, size_t idx,

--- a/lldb/test/API/lang/swift/error_handling_missing_type/Makefile
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/Makefile
@@ -1,0 +1,5 @@
+SWIFT_SOURCES := main.swift
+SWIFT_BRIDGING_HEADER := bridging.h
+SWIFT_PRECOMPILE_BRIDGING_HEADER := NO
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftLateSymbols(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'true'))
+    def test_any_object_type(self):
+        """Test the AnyObject type"""
+        self.build()
+        self.expect('settings set symbols.use-swift-clangimporter false')
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+        frame = thread.frames[0]
+        var_object = frame.FindVariable("object", lldb.eNoDynamicValues)
+        val = var_object.GetChildAtIndex(1)
+        # FIXME: Should be True, for now it's just a string
+        self.assertFalse(val.GetError().Fail())
+        self.expect('v object', substrs=['missing Clang debug info', 'FromC'])

--- a/lldb/test/API/lang/swift/error_handling_missing_type/bridging.h
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/bridging.h
@@ -1,0 +1,3 @@
+struct FromC {
+  int i;
+};

--- a/lldb/test/API/lang/swift/error_handling_missing_type/main.swift
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/main.swift
@@ -1,0 +1,6 @@
+func use<T>(_ t: T) {}
+func main() {
+  var object = (1, FromC(i: 23), 2)
+  use(object) // break here
+}
+main()


### PR DESCRIPTION
```
commit 54bd0478e0802451b0f566d893d172778b39d0e7
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Feb 28 16:30:31 2024 -0800

    Surface errors in GetNumChildren.
    
    This patch will allow displaying unresolved types in composite types
    as errors instead of "{}" empty types.
    
    rdar://123794838
```
