### PR TITLE
[Cherry-pick into stable/20230725] Avoid a potential exit(1) in LLVMContext::diagnose()  (#84992)

### DIFF
--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -233,18 +233,17 @@ struct IRExecDiagnosticHandler : public llvm::DiagnosticHandler {
   Status *err;
   IRExecDiagnosticHandler(Status *err) : err(err) {}
   bool handleDiagnostics(const llvm::DiagnosticInfo &DI) override {
-    if (DI.getKind() == llvm::DK_SrcMgr) {
+    if (DI.getSeverity() == llvm::DS_Error) {
       const auto &DISM = llvm::cast<llvm::DiagnosticInfoSrcMgr>(DI);
       if (err && err->Success()) {
         err->SetErrorToGenericError();
         err->SetErrorStringWithFormat(
-            "Inline assembly error: %s",
+            "IRExecution error: %s",
             DISM.getSMDiag().getMessage().str().c_str());
       }
-      return true;
     }
 
-    return false;
+    return true;
   }
 };
 } // namespace


### PR DESCRIPTION
```
commit c3eccf03b365a705bc8dc043217478a82bc37a4d
Author: Adrian Prantl <adrian-prantl@users.noreply.github.com>
Date:   Wed Mar 13 08:53:13 2024 -0700

    Avoid a potential exit(1) in LLVMContext::diagnose()  (#84992)
    
    by handling *all* errors in IRExecDiagnosticHandler. The function that
    call this handles all unhandled errors with an `exit(1)`.
    
    rdar://124459751
    
    I don't really have a testcase for this, since the crash report I got
    for this involved the Swift language plugin.
```
