### PR TITLE
Revert "[Clang] Don't use crtbegin/crtend when building for musl."

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -385,16 +385,14 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   const llvm::Triple::ArchType Arch = ToolChain.getArch();
   const bool isOHOSFamily = ToolChain.getTriple().isOHOSFamily();
   const bool isAndroid = ToolChain.getTriple().isAndroid();
-  const bool isMusl = ToolChain.getTriple().isMusl();
   const bool IsIAMCU = ToolChain.getTriple().isOSIAMCU();
   const bool IsVE = ToolChain.getTriple().isVE();
   const bool IsPIE = getPIE(Args, ToolChain);
   const bool IsStaticPIE = getStaticPIE(Args, ToolChain);
   const bool IsStatic = getStatic(Args);
   const bool HasCRTBeginEndFiles =
-    !isMusl && (ToolChain.getTriple().hasEnvironment() ||
-                (ToolChain.getTriple().getVendor()
-                 != llvm::Triple::MipsTechnologies));
+      ToolChain.getTriple().hasEnvironment() ||
+      (ToolChain.getTriple().getVendor() != llvm::Triple::MipsTechnologies);
 
   ArgStringList CmdArgs;
 


### PR DESCRIPTION
Reverts apple/llvm-project#8254

Talking to upstream folks, there are people relying on the existing behaviour, so regardless of whether that’s right or not, this is the wrong solution to the problem I was trying to fix.

Plus it breaks a test (apparently we don’t run the LLVM tests as part of PR testing here?)