### PR TITLE
[lldb] Only use Swift remark diagnostics for logging (#8371)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -199,11 +199,12 @@ public:
       std::string &s = os.str();
       formatted_text = !s.empty() ? std::move(s) : std::string(text);
     }
-    if (info.Kind == swift::DiagnosticKind::Remark &&
-        info.ID == swift::diag::module_loaded.ID) {
-      // Divert module import remarks into the logs.
-      LLDB_LOG(GetLog(LLDBLog::Types), "{0} Module import remark: {1}",
-               m_ast_context.GetDescription(), formatted_text);
+    if (info.Kind == swift::DiagnosticKind::Remark) {
+      if (info.ID == swift::diag::module_loaded.ID) {
+        // Divert module import remarks into the logs.
+        LLDB_LOG(GetLog(LLDBLog::Types), "{0} Module import remark: {1}",
+                 m_ast_context.GetDescription(), formatted_text);
+      }
       return;
     }
     RawDiagnostic diagnostic(


### PR DESCRIPTION
In `handleDiagnostics`, early exit from all Swift remarks. Remark diagnostics should 
not be handled as warnings/errors.

At most, lldb should use remark diagnostics for logging, or progress events.

By setting `EnableModuleLoadingRemarks` to true 
(https://github.com/apple/llvm-project/pull/7857) there are remarks other than 
`module_loaded` that are emitted. These other remarks should be ignored in 
`handleDiagnostics`.

rdar://121611925

(cherry-picked from commit b7ab93809c4cc92e27115c9595622eb25972b9cc)