### PR TITLE
[lldb] Remove invalid SWIFT_FLAGS_EXTRAS build flag from test (NFC) (#8382)

### DIFF
--- a/lldb/test/API/lang/swift/system_framework/Makefile
+++ b/lldb/test/API/lang/swift/system_framework/Makefile
@@ -1,5 +1,3 @@
 SWIFT_SOURCES := main.swift
 
-SWIFT_FLAGS_EXTRAS := -framwork CoreGraphics
-
 include Makefile.rules


### PR DESCRIPTION
(cherry-picked from commit d4830139e0df980fe44aedb612b47e210335f25f)