### PR TITLE
[lldb] Fallback to implicit modules when explicit modules are missing (#8356)

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_EXPLICIT_MODULES := YES
+USE_PRIVATE_MODULE_CACHE := YES
+include Makefile.rules

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -1,0 +1,30 @@
+import shutil
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(lldbtest.TestBase):
+    @swiftTest
+    @skipIf(oslist=["linux"], bugnumber="rdar://124691219")
+    def test_missing_explicit_modules(self):
+        """Test missing explicit Swift modules and fallback to implicit modules."""
+        self.build()
+
+        # This test verifies the case where explicit modules are missing.
+        # Remove explicit modules from their place in the module cache.
+        mod_cache = self.getBuildArtifact("private-module-cache")
+        shutil.rmtree(mod_cache)
+
+        lldbutil.run_to_source_breakpoint(
+            self, "Set breakpoint here", lldb.SBFileSpec("main.swift")
+        )
+
+        log = self.getBuildArtifact("types.log")
+        self.runCmd(f"log enable lldb types -f '{log}'")
+
+        self.expect("expression c", substrs=["hello implicit fallback"])
+
+        self.filecheck(f"platform shell cat {log}", __file__)
+        # CHECK: Nonexistent explicit module file

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/main.swift
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/main.swift
@@ -1,0 +1,10 @@
+class Class {
+  var msg : String = "hello implicit fallback"
+}
+
+func main() {
+  let c = Class()
+  print(c) // Set breakpoint here
+}
+
+main()


### PR DESCRIPTION
Handle the case where an explicit module path does not exist, by falling back to 
implicit modules.

The initial logic is: If any one explicit module is nonexistent, then remove all 
references to explicit modules. Additionally, remove all explicit module maps.

(cherry-picked from commit 2abff47506bd4f2d03ce3d491d0c040be7c591d3)