### PR TITLE
[Cherry-pick into swift/release/6.0] Disable target mismatch check when precise compiler invocations are on (NFCish)

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2929,7 +2929,9 @@ std::optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
   }
   
   // Opt into the per-module scratch context if we find incompatible triples.
-  if (!m_use_scratch_typesystem_per_module) {
+  if (!m_use_scratch_typesystem_per_module &&
+      !ModuleList::GetGlobalModuleListProperties()
+           .GetUseSwiftPreciseCompilerInvocation()) {
     TargetSP target_sp = exe_scope.CalculateTarget();
     if (lldb_module) {
       auto module_arch = lldb_module->GetArchitecture();

--- a/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
+++ b/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
@@ -33,21 +33,7 @@ class TestSwiftOtherArchDylib(TestBase):
         self.expect("expression 1", substrs=['1'])
 
         # Check the types log.
-        import re
-        import io
-        types_logfile = io.open(types_log, "r", encoding='utf-8')
-        re0 = re.compile(r'SwiftASTContextForExpressions::LogConfiguration().*arm64-apple-macosx')
-        re1 = re.compile(r'Enabling per-module Swift scratch context')
-        re2 = re.compile(r'wiftASTContextForExpressions..OtherArch..::LogConfiguration().*arm64e-apple-macosx')
-        found = 0
-        for line in types_logfile:
-            if self.TraceOn():
-                print(line[:-1])
-            if found == 0 and re0.search(line):
-                found = 1
-            elif found == 1 and re1.search(line):
-                found = 2
-            elif found == 2 and re2.search(line):
-                found = 3
-                break
-        self.assertEquals(found, 3)
+        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        # CHECK: SwiftASTContextForExpressions::LogConfiguration() arm64-apple-macosx
+        # CHECK: Enabling per-module Swift scratch context
+        # CHECK: {{SwiftASTContextForExpressions..OtherArch..}}::LogConfiguration() arm64e-apple-macosx


### PR DESCRIPTION
```
commit fbc7f328596e8c4b6400a5de72f934405e42bb37
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Mar 14 12:59:32 2024 -0700

    Disable target mismatch check when precise compiler invocations are on (NFCish)
    
    Precise compiler invocations already create a scratch context per
    module, so this fallback path doesn't add much there.
    
    rdar://109227800

commit a74ed32a3ae16a5aa223ec6f5f64ca835c000143
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Mar 14 13:01:07 2024 -0700

    modernize testcase
```
