### PR TITLE
Deal with DIComposite types which aren't enums in isUnsignedDIType

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
@@ -189,10 +189,10 @@ bool DebugHandlerBase::isUnsignedDIType(const DIType *Ty) {
         // FIXME: Enums without a fixed underlying type have unknown signedness
         // here, leading to incorrectly emitted constants.
         return false;
-    } else
-      // (Pieces of) aggregate types that get hacked apart by SROA may be
-      // represented by a constant. Encode them as unsigned bytes.
-      return true;
+    }
+    // (Pieces of) aggregate types that get hacked apart by SROA may be
+    // represented by a constant. Encode them as unsigned bytes.
+    return true;
   }
 
   if (auto *DTy = dyn_cast<DIDerivedType>(Ty)) {


### PR DESCRIPTION
(cherry picked from commit bfa4eb235f94cbec497c2b79d412c6ad76002066)