### PR TITLE
Skip 32 bit relocation addend partitioning in MCCAS.

### DIFF
--- a/llvm/test/CAS/test-reloc-mccas-32bit-arm.s
+++ b/llvm/test/CAS/test-reloc-mccas-32bit-arm.s
@@ -1,0 +1,9 @@
+# This test tests to make sure mccas can handle scattered relocations properly on 32 bit arm
+
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc --cas=%t/cas --cas-backend --mccas-verify -triple=armv7-apple-darwin10  -filetype=obj -o %t/reloc.o %s
+
+    movw  r0, :lower16:(fn2-L1)
+L1:
+fn2:
+

--- a/llvm/test/CAS/test-reloc-mccas-32bit.s
+++ b/llvm/test/CAS/test-reloc-mccas-32bit.s
@@ -1,0 +1,6 @@
+# This test tests to make sure mccas can handle scattered relocations properly on 32 bit x86
+
+# RUN: rm -rf %t && mkdir -p %t
+# RUN: llvm-mc --cas=%t/cas --cas-backend --mccas-verify  -triple=i386-apple-macosx10.4 -filetype=obj -o %t/reloc.o %s
+        movl    y+4, %ecx
+.zerofill __DATA,__common,y,8,3


### PR DESCRIPTION
Relocations addednds do not deduplicate, to improve deduplication in MCCAS, we store those addends in an AddendsRef block. This is much more complicated to do in 32 bit architectures because of various corner cases and complexities with the MachO 32-bit relocation format Therefore we skip relocation partitioning for 32-bit architectures in MCCAS.