### PR TITLE
[lldb] Update for PrintOptions.PrintRegularClangComments removal

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4912,8 +4912,7 @@ swift::PrintOptions SwiftASTContext::GetUserVisibleTypePrintingOptions(
   print_options.FullyQualifiedTypesIfAmbiguous = true;
   print_options.FullyQualifiedTypes = true;
   print_options.ExplodePatternBindingDecls = false;
-  print_options.PrintDocumentationComments =
-      print_options.PrintRegularClangComments = print_help_if_available;
+  print_options.PrintDocumentationComments = print_help_if_available;
   return print_options;
 }
 


### PR DESCRIPTION
PrintRegularClangComments is being removed in swift.