### PR TITLE
[lldb] Be more precise when copying over Swift resources

### DIFF
--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -139,7 +139,15 @@ if(NOT APPLE_EMBEDDED)
     # compiler resources. When part of a toolchain, LLDB knows where to find
     # those. For at-desk builds, it copies over the resources from the Swift
     # build directory into LLDB.framework.
-    set(RESOURCE_DIRS "clang;embedded;macosx;shims;swiftToCxx")
+    set(RESOURCE_DIRS
+      FrameworkABIBaseline
+      apinotes
+      clang
+      embedded
+      macosx
+      shims
+      swiftToCxx
+    )
     foreach(DIR ${RESOURCE_DIRS})
       add_custom_command(TARGET liblldb POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -135,11 +135,20 @@ if(NOT APPLE_EMBEDDED)
   )
 
   if(LLDB_FRAMEWORK_COPY_SWIFT_RESOURCES)
+    set(RESOURCE_DIRS "clang;embedded;macosx;shims;swiftToCxx")
+    foreach(DIR ${RESOURCE_DIRS})
+      add_custom_command(TARGET liblldb POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${SWIFT_BINARY_DIR}/lib/swift/${DIR}/
+                $<TARGET_FILE_DIR:liblldb>/Resources/Swift/${DIR}
+        COMMENT "LLDB.framework: copy Swift compiler resource: ${DIR}"
+      )
+    endforeach()
     add_custom_command(TARGET liblldb POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_directory
-              ${SWIFT_BINARY_DIR}/lib/swift
-              $<TARGET_FILE_DIR:liblldb>/Resources/Swift
-      COMMENT "LLDB.framework: copy Swift vendor-specific headers"
+      COMMAND ${CMAKE_COMMAND} -E copy
+              ${SWIFT_BINARY_DIR}/lib/swift/module.modulemap
+              $<TARGET_FILE_DIR:liblldb>/Resources/Swift/
+      COMMENT "LLDB.framework: copy Swift compiler resource: module.modulemap"
     )
   endif()
 endif()

--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -135,6 +135,10 @@ if(NOT APPLE_EMBEDDED)
   )
 
   if(LLDB_FRAMEWORK_COPY_SWIFT_RESOURCES)
+    # To run the LLDB test suite, we need to be able to find some of the Swift
+    # compiler resources. When part of a toolchain, LLDB knows where to find
+    # those. For at-desk builds, it copies over the resources from the Swift
+    # build directory into LLDB.framework.
     set(RESOURCE_DIRS "clang;embedded;macosx;shims;swiftToCxx")
     foreach(DIR ${RESOURCE_DIRS})
       add_custom_command(TARGET liblldb POST_BUILD


### PR DESCRIPTION
To run the LLDB test suite, we need to be able to find some of the Swift compiler resources. When part of a toolchain, LLDB knows where to find those. For at-desk builds, it copies over the resources from the Swift build directory into LLDB.framework.

Right now we copy over the whole lib/swift directory from the Swift build root. This contains much more than we need, such as dylibs and dSYMs. This patch modifies LLDB to be more precise in what it copies over.

rdar://124975526