### PR TITLE
Add a frame recognizer for Swift runtime error with instrumentation.

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftRuntimeFailureRecognizer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftRuntimeFailureRecognizer.cpp
@@ -10,6 +10,9 @@
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "swift/Strings.h"
+
 using namespace llvm;
 using namespace lldb;
 using namespace lldb_private;
@@ -21,12 +24,19 @@ SwiftRuntimeFailureRecognizedStackFrame::
   m_stop_desc = std::string(stop_desc);
 }
 
+lldb::StackFrameSP
+SwiftRuntimeFailureRecognizedStackFrame::GetMostRelevantFrame() {
+  return m_most_relevant_frame;
+}
+
 lldb::RecognizedStackFrameSP SwiftRuntimeFailureFrameRecognizer::RecognizeFrame(
     lldb::StackFrameSP frame_sp) {
   if (frame_sp->GetFrameIndex())
     return {};
 
   ThreadSP thread_sp = frame_sp->GetThread();
+  if (!thread_sp)
+    return {};
   ProcessSP process_sp = thread_sp->GetProcess();
 
   StackFrameSP most_relevant_frame_sp = thread_sp->GetStackFrameAtIndex(1);
@@ -67,23 +77,72 @@ lldb::RecognizedStackFrameSP SwiftRuntimeFailureFrameRecognizer::RecognizeFrame(
                                                   runtime_error));
 }
 
-lldb::StackFrameSP
-SwiftRuntimeFailureRecognizedStackFrame::GetMostRelevantFrame() {
-  return m_most_relevant_frame;
+lldb::RecognizedStackFrameSP
+SwiftRuntimeInstrumentedFrameRecognizer::RecognizeFrame(
+    lldb::StackFrameSP frame_sp) {
+  if (frame_sp->GetFrameIndex())
+    return {};
+
+  ThreadSP thread_sp = frame_sp->GetThread();
+  if (!thread_sp)
+    return {};
+
+  StackFrameSP most_relevant_frame_sp;
+  // Unwind until we leave the standard library.
+  unsigned max_depth = 16;
+  for (unsigned i = 1; i < max_depth; ++i) {
+    most_relevant_frame_sp = thread_sp->GetStackFrameAtIndex(i);
+    if (!most_relevant_frame_sp) {
+      Log *log = GetLog(LLDBLog::Unwind);
+      LLDB_LOG(log,
+               "Swift Runtime Instrumentation Failure Recognizer: Hit "
+               "unwinding bound ({0} frames)!",
+               i);
+      return {};
+    }
+    auto &sc =
+        most_relevant_frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
+    ConstString module_name = TypeSystemSwiftTypeRef::GetSwiftModuleFor(&sc);
+    if (!module_name)
+      continue;
+    if (module_name == swift::STDLIB_NAME)
+      continue;
+    if (i + 1 == max_depth)
+      return {};
+
+    break;
+  }
+
+  std::string runtime_error = thread_sp->GetStopDescriptionRaw();
+  return lldb::RecognizedStackFrameSP(
+      new SwiftRuntimeFailureRecognizedStackFrame(most_relevant_frame_sp,
+                                                  runtime_error));
 }
 
 namespace lldb_private {
 
 void RegisterSwiftRuntimeFailureRecognizer(Process &process) {
-    RegularExpressionSP module_regex_sp = nullptr;
-    RegularExpressionSP symbol_regex_sp(
-        new RegularExpression("Swift runtime failure"));
+  RegularExpressionSP module_regex_sp = nullptr;
+  {
+    auto symbol_regex_sp =
+        std::make_shared<RegularExpression>("Swift runtime failure");
 
     StackFrameRecognizerSP srf_recognizer_sp =
         std::make_shared<SwiftRuntimeFailureFrameRecognizer>();
 
     process.GetTarget().GetFrameRecognizerManager().AddRecognizer(
         srf_recognizer_sp, module_regex_sp, symbol_regex_sp, false);
+  }
+  {
+    auto symbol_regex_sp =
+        std::make_shared<RegularExpression>("_swift_runtime_on_report");
+
+    StackFrameRecognizerSP srf_recognizer_sp =
+        std::make_shared<SwiftRuntimeInstrumentedFrameRecognizer>();
+
+    process.GetTarget().GetFrameRecognizerManager().AddRecognizer(
+        srf_recognizer_sp, module_regex_sp, symbol_regex_sp, false);
+  }
 }
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/Language/Swift/SwiftRuntimeFailureRecognizer.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftRuntimeFailureRecognizer.h
@@ -30,7 +30,7 @@ private:
 /// When a thread stops, it checks the current frame contains a swift runtime
 /// failure diagnostic. If so, it returns a \a
 /// SwiftRuntimeFailureRecognizedStackFrame holding the diagnostic a stop reason
-/// description with  and the parent frame as the most relavant frame.
+/// description with  and the parent frame as the most relevant frame.
 class SwiftRuntimeFailureFrameRecognizer : public StackFrameRecognizer {
 public:
   std::string GetName() override {
@@ -40,6 +40,17 @@ public:
   RecognizeFrame(lldb::StackFrameSP frame) override;
 };
 
+/// Detect when a thread stops in _swift_runtime_on_report.
+class SwiftRuntimeInstrumentedFrameRecognizer : public StackFrameRecognizer {
+public:
+  std::string GetName() override {
+    return "Swift Runtime Instrumentation StackFrame Recognizer";
+  }
+  lldb::RecognizedStackFrameSP
+  RecognizeFrame(lldb::StackFrameSP frame) override;
+};
+
+  
 } // namespace lldb_private
 
 #endif // liblldb_SwiftRuntimeFailureRegognizer_h_

--- a/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/Makefile
+++ b/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := RuntimeError.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/RuntimeError.swift
+++ b/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/RuntimeError.swift
@@ -1,0 +1,5 @@
+func testit(_ a: Int) -> Int {
+  return 1 / a
+}
+
+print(testit(0))

--- a/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
+++ b/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftRuntimeInstrumentationRecognizer(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test Swift Runtime Instrumentation Recognizer"""
+        self.build()
+        self.runCmd("file " + self.getBuildArtifact("a.out"))
+        self.runCmd("process launch")
+
+        self.expect("frame recognizer list",
+                    substrs=['Swift Runtime Instrumentation StackFrame Recognizer, symbol _swift_runtime_on_report (regexp)'])
+
+        self.expect("frame recognizer info 0",
+                    substrs=['frame 0 is recognized by Swift Runtime Instrumentation StackFrame Recognizer'])
+
+        self.expect("thread info",
+                    substrs=['stop reason = Fatal error: Division by zero'])
+
+        self.expect('bt')
+        self.expect("frame info",
+                    patterns=['frame #(.*)`testit(.*)at RuntimeError\.swift'])


### PR DESCRIPTION
Certain errors are correctly detected by the Swift Runtime Instrumentation plugin, however, there is no frame recognizer to point the debugger to user code. This patch adds one.

rdar://125125193