### PR TITLE
[cherry-pick stable/20230725] Revert "[ClangScanDeps] Fix cas dependency scanning test after D159064"

### DIFF
--- a/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
@@ -21,24 +21,20 @@
 // RUN:  > %t/dir2.txt
 
 // Extract individual commands.
-// RUN: %deps-to-rsp %t/dir1.txt --module-name=_Builtin_stdarg > %t/dir1/stdarg.cc1.rsp
 // RUN: %deps-to-rsp %t/dir1.txt --module-name=B > %t/dir1/B.cc1.rsp
 // RUN: %deps-to-rsp %t/dir1.txt --module-name=A > %t/dir1/A.cc1.rsp
 // RUN: %deps-to-rsp %t/dir1.txt --tu-index 0 > %t/dir1/tu.cc1.rsp
 
-// RUN: %deps-to-rsp %t/dir2.txt --module-name=_Builtin_stdarg > %t/dir2/stdarg.cc1.rsp
 // RUN: %deps-to-rsp %t/dir2.txt --module-name=B > %t/dir2/B.cc1.rsp
 // RUN: %deps-to-rsp %t/dir2.txt --module-name=A > %t/dir2/A.cc1.rsp
 // RUN: %deps-to-rsp %t/dir2.txt --tu-index 0 > %t/dir2/tu.cc1.rsp
 
-// RUN: (cd %t/dir1; %clang @stdarg.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: (cd %t/dir1; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: (cd %t/dir1; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: (cd %t/dir1; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 
 // CACHE-MISS: compile job cache miss
 
-// RUN: (cd %t/dir2; %clang @stdarg.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: (cd %t/dir2; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: (cd %t/dir2; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: (cd %t/dir2; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT

--- a/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-prefix-mapping.c
@@ -16,7 +16,6 @@
 // RUN: FileCheck %s -input-file %t/full_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
 
 // Extract individual commands.
-// RUN: %deps-to-rsp %t/full_result.txt --module-name=_Builtin_stdarg > %t/stdarg.cc1.rsp
 // RUN: %deps-to-rsp %t/full_result.txt --module-name=B > %t/B.cc1.rsp
 // RUN: %deps-to-rsp %t/full_result.txt --module-name=A > %t/A.cc1.rsp
 // RUN: %deps-to-rsp %t/full_result.txt --tu-index 0 > %t/tu.cc1.rsp
@@ -42,7 +41,6 @@
 // FS: file llvmcas://{{.*}} /^tc/lib/clang/{{.*}}/include/stdarg.h
 
 // Check that it builds.
-// RUN: %clang @%t/stdarg.cc1.rsp
 // RUN: %clang @%t/B.cc1.rsp
 // RUN: %clang @%t/A.cc1.rsp
 // RUN: %clang @%t/tu.cc1.rsp
@@ -91,11 +89,7 @@
 // CHECK:          }
 // CHECK:          {
 // CHECK:            "casfs-root-id": "[[B_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
-// CHECK:            "clang-module-deps": [
-// CHECK:              {
-// CHECK:                "module-name": "_Builtin_stdarg"
-// CHECK:              }
-// CHECK:            ],
+// CHECK:            "clang-module-deps": [],
 // CHECK:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
 // CHECK:            "command-line": [
 // CHECK:              "-fcas-path"

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
@@ -22,22 +22,18 @@
 // RUN:  > %t/pch_dir2.txt
 
 // == Build PCH
-// RUN: %deps-to-rsp %t/pch_dir1.txt --module-name=_Builtin_stdarg > %t/dir1/stdarg.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir1.txt --module-name=B > %t/dir1/B.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir1.txt --module-name=A > %t/dir1/A.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir1.txt --tu-index 0 > %t/dir1/pch.cc1.rsp
-// RUN: (cd %t/dir1; %clang @stdarg.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: (cd %t/dir1; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: (cd %t/dir1; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: (cd %t/dir1; %clang @pch.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 
 // CACHE-MISS: compile job cache miss
 
-// RUN: %deps-to-rsp %t/pch_dir2.txt --module-name=_Builtin_stdarg > %t/dir2/stdarg.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir2.txt --module-name=B > %t/dir2/B.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir2.txt --module-name=A > %t/dir2/A.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir2.txt --tu-index 0 > %t/dir2/pch.cc1.rsp
-// RUN: (cd %t/dir2; %clang @stdarg.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: (cd %t/dir2; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: (cd %t/dir2; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: (cd %t/dir2; %clang @pch.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
@@ -18,11 +18,9 @@
 // RUN: FileCheck %s -input-file %t/pch_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK -check-prefix=PCH
 
 // == Build PCH
-// RUN: %deps-to-rsp %t/pch_result.txt --module-name=_Builtin_stdarg > %t/stdarg.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_result.txt --module-name=B > %t/B.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_result.txt --module-name=A > %t/A.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_result.txt --tu-index 0 > %t/pch.cc1.rsp
-// RUN: %clang @%t/stdarg.cc1.rsp
 // RUN: %clang @%t/B.cc1.rsp
 // RUN: %clang @%t/A.cc1.rsp
 // Ensure we load pcms from action cache
@@ -121,11 +119,7 @@
 // PCH:          }
 // PCH:          {
 // PCH:            "casfs-root-id": "[[B_ROOT_ID:llvmcas://[[:xdigit:]]+]]"
-// PCH:            "clang-module-deps": [
-// PCH:               {
-// PCH:                 "module-name": "_Builtin_stdarg"
-// PCH:               }
-// PCH:             ],
+// PCH:            "clang-module-deps": [],
 // PCH:            "clang-modulemap-file": "[[PREFIX]]/module.modulemap"
 // PCH:            "command-line": [
 // PCH:              "-fcas-path"


### PR DESCRIPTION


https://github.com/apple/llvm-project/commit/ab562edba8719e61d3d2e307e2c451bf8d80cffb (https://github.com/llvm/llvm-project/pull/84127) reverses the part of D159064 that originally broke these tests.

This reverts commit 33825dadd075c273adaa617125b8a865fcfea6f6.

rdar://124628894
(cherry picked from commit a92be41b41b8d9dd4d72f72da6a75723fca15105)

This patch needs to be cherry-picked to swift/release/6.0 because it no longer merges from stable/20230725