### PR TITLE
[lldb] Move two settings from target.experimental to symbols

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -92,6 +92,9 @@ public:
   uint64_t GetSwiftMetadataCacheExpirationDays();
   FileSpec GetSwiftMetadataCachePath() const;
   bool SetSwiftMetadataCachePath(const FileSpec &path);
+
+  AutoBool GetSwiftEnableCxxInterop() const;
+  AutoBool GetSwiftEnableFullDwarfDebugging() const;
   // END SWIFT
 
   FileSpec GetClangModulesCachePath() const;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -184,10 +184,6 @@ public:
 
   bool GetSwiftEnableBareSlashRegex() const;
 
-  AutoBool GetEnableSwiftCxxInterop() const;
-
-  AutoBool GetSwiftEnableFullDwarfDebugging() const;
-
   bool GetSwiftAllowExplicitModules() const;
 
   Args GetSwiftPluginServerForPath() const;

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -54,6 +54,16 @@ let Definition = "modulelist" in {
     Global,
     DefaultUnsignedValue<7>,
     Desc<"The expiration time in days for a Swift reflection cache file. When a file hasn't been accessed for the specified amount of days, it is removed from the cache. A value of 0 disables the expiration-based pruning.">;
+  def SwiftEnableCxxInterop: Property<"swift-enable-cxx-interop", "Enum">,
+    Global,
+    DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,
+    EnumValues<"OptionEnumValues(g_enable_swift_cxx_interop_values)">,
+    Desc<"Passes the -enable-cxx-interop flag to the swift compiler.">;
+  def SwiftEnableFullDwarfDebugging: Property<"swift-enable-full-dwarf-debugging", "Enum">,
+    Global,
+    DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,
+    EnumValues<"OptionEnumValues(g_enable_full_dwarf_debugging)">,
+    Desc<"Read full debug information from DWARF for Swift debugging. By default LLDB will use DWARF debug information if it cannot use reflection metadata.">;
 // END SWIFT
   def SymLinkPaths: Property<"debug-info-symlink-paths", "FileSpecList">,
     Global,

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1172,7 +1172,7 @@ bool Module::IsSwiftCxxInteropEnabled() {
     break;
   }
   AutoBool interop_enabled =
-      Target::GetGlobalProperties().GetEnableSwiftCxxInterop();
+    ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
   switch (interop_enabled) {
   case AutoBool::True:
     m_is_swift_cxx_interop_enabled = eLazyBoolYes;

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -82,6 +82,25 @@ static constexpr OptionEnumValueElement g_swift_module_loading_mode_enums[] = {
   {eSwiftModuleLoadingModeOnlySerialized, "only-serialized",
     "Only load Swift modules via their .swiftmodule file - ignore "
     ".swiftinterface files."} };
+
+
+static constexpr OptionEnumValueElement g_enable_swift_cxx_interop_values[] = {
+    {llvm::to_underlying(AutoBool::Auto), "auto",
+     "Automatically detect if C++ interop mode should be enabled."},
+    {llvm::to_underlying(AutoBool::True), "true", "Enable C++ interop."},
+    {llvm::to_underlying(AutoBool::False), "false", "Disable C++ interop."},
+};
+
+static constexpr OptionEnumValueElement g_enable_full_dwarf_debugging[] = {
+    {llvm::to_underlying(AutoBool::Auto), "auto",
+     "Automatically detect if full DWARF debugging should be enabled. Full "
+     "DWARF debugging is enabled if no reflection metadata is added to the "
+     "debugger."},
+    {llvm::to_underlying(AutoBool::True), "true",
+     "Enable full DWARF debugging."},
+    {llvm::to_underlying(AutoBool::False), "false",
+     "Disable full DWARF debugging."},
+};
 // END SWIFT
 
 #define LLDB_PROPERTIES_modulelist
@@ -238,6 +257,22 @@ uint64_t ModuleListProperties::GetSwiftMetadataCacheExpirationDays() {
   const uint32_t idx = ePropertySwiftMetadataCacheExpirationDays;
   return GetPropertyAtIndexAs<uint64_t>(
       idx, g_modulelist_properties[idx].default_uint_value);
+}
+
+
+AutoBool ModuleListProperties::GetSwiftEnableCxxInterop() const {
+  const uint32_t idx = ePropertySwiftEnableCxxInterop;
+
+  return GetPropertyAtIndexAs<AutoBool>(
+      idx, static_cast<AutoBool>(
+               g_modulelist_properties[idx].default_uint_value));
+}
+
+AutoBool ModuleListProperties::GetSwiftEnableFullDwarfDebugging() const {
+  const uint32_t idx = ePropertySwiftEnableFullDwarfDebugging;
+  return GetPropertyAtIndexAs<AutoBool>(
+      idx, static_cast<AutoBool>(
+               g_modulelist_properties[idx].default_uint_value));
 }
 // END SWIFT
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -63,7 +63,8 @@ struct DescriptorFinderForwarder : public swift::reflection::DescriptorFinder {
 
 private:
   bool shouldConsultDescriptorFinder() {
-    switch (Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging()) {
+    switch (ModuleList::GetGlobalModuleListProperties()
+                .GetSwiftEnableFullDwarfDebugging()) {
     case lldb_private::AutoBool::True:
       return true;
     case lldb_private::AutoBool::False:

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -147,7 +147,8 @@ public:
 
   std::vector<std::unique_ptr<swift::reflection::FieldRecordBase>>
   getFieldRecords() override {
-    assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+    assert(ModuleList::GetGlobalModuleListProperties()
+                   .GetSwiftEnableFullDwarfDebugging() !=
                lldb_private::AutoBool::False &&
            "Full DWARF debugging for Swift is disabled!");
 
@@ -305,7 +306,8 @@ public:
 std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
 DWARFASTParserSwift::getBuiltinTypeDescriptor(
     const swift::reflection::TypeRef *TR) {
-  assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+  assert(ModuleList::GetGlobalModuleListProperties()
+                 .GetSwiftEnableFullDwarfDebugging() !=
              lldb_private::AutoBool::False &&
          "Full DWARF debugging for Swift is disabled!");
 
@@ -347,7 +349,8 @@ DWARFASTParserSwift::getBuiltinTypeDescriptor(
 std::unique_ptr<swift::reflection::MultiPayloadEnumDescriptorBase>
 DWARFASTParserSwift::getMultiPayloadEnumDescriptor(
     const swift::reflection::TypeRef *TR) {
-  assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+  assert(ModuleList::GetGlobalModuleListProperties()
+                 .GetSwiftEnableFullDwarfDebugging() !=
              lldb_private::AutoBool::False &&
          "Full DWARF debugging for Swift is disabled!");
 
@@ -453,7 +456,8 @@ NodePointer DWARFASTParserSwift::GetCanonicalDemangleTree(DWARFDIE &die) {
 
 std::unique_ptr<swift::reflection::FieldDescriptorBase>
 DWARFASTParserSwift::getFieldDescriptor(const swift::reflection::TypeRef *TR) {
-  assert(Target::GetGlobalProperties().GetSwiftEnableFullDwarfDebugging() !=
+  assert(ModuleList::GetGlobalModuleListProperties()
+                 .GetSwiftEnableFullDwarfDebugging() !=
              lldb_private::AutoBool::False &&
          "Full DWARF debugging for Swift is disabled!");
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -3162,8 +3162,8 @@ bool Target::IsSwiftCxxInteropEnabled() {
   case eLazyBoolCalculate:
     break;
   }
-
-  AutoBool interop_enabled = GetEnableSwiftCxxInterop();
+  AutoBool interop_enabled =
+      ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
   switch (interop_enabled) {
   case AutoBool::True:
     m_is_swift_cxx_interop_enabled = eLazyBoolYes;
@@ -4695,23 +4695,6 @@ static constexpr OptionEnumValueElement g_memory_module_load_level_values[] = {
     },
 };
 
-static constexpr OptionEnumValueElement g_enable_swift_cxx_interop_values[] = {
-    {llvm::to_underlying(AutoBool::Auto), "auto",
-     "Automatically detect if C++ interop mode should be enabled."},
-    {llvm::to_underlying(AutoBool::True), "true", "Enable C++ interop."},
-    {llvm::to_underlying(AutoBool::False), "false", "Disable C++ interop."},
-};
-
-static constexpr OptionEnumValueElement g_enable_full_dwarf_debugging[] = {
-    {llvm::to_underlying(AutoBool::Auto), "auto",
-     "Automatically detect if full DWARF debugging should be enabled. Full "
-     "DWARF debugging is enabled if no reflection metadata is added to the "
-     "debugger."},
-    {llvm::to_underlying(AutoBool::True), "true",
-     "Enable full DWARF debugging."},
-    {llvm::to_underlying(AutoBool::False), "false",
-     "Disable full DWARF debugging."},
-};
 
 #define LLDB_PROPERTIES_target
 #include "TargetProperties.inc"
@@ -4936,27 +4919,6 @@ bool TargetProperties::GetSwiftEnableBareSlashRegex() const {
         .value_or(true);
 
   return true;
-}
-
-AutoBool TargetProperties::GetEnableSwiftCxxInterop() const {
-  const uint32_t idx = ePropertySwiftEnableCxxInterop;
-
-  AutoBool enable_interop =
-      (AutoBool)m_experimental_properties_up->GetValueProperties()
-          ->GetPropertyAtIndexAs<AutoBool>(idx)
-          .value_or(static_cast<AutoBool>(
-              g_target_properties[idx].default_uint_value));
-  return enable_interop;
-}
-
-AutoBool TargetProperties::GetSwiftEnableFullDwarfDebugging() const {
-  const uint32_t idx = ePropertySwiftEnableCxxInterop;
-  AutoBool enable_dwarf_debugging =
-      (AutoBool)m_experimental_properties_up->GetValueProperties()
-          ->GetPropertyAtIndexAs<AutoBool>(idx)
-          .value_or(static_cast<AutoBool>(
-              g_target_properties[idx].default_uint_value));
-  return enable_dwarf_debugging;
 }
 
 bool TargetProperties::GetSwiftAllowExplicitModules() const {

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -19,18 +19,10 @@ let Definition = "target_experimental" in {
   def SwiftEnableBareSlashRegex: Property<"swift-enable-bare-slash-regex", "Boolean">,
     DefaultFalse,
     Desc<"Passes the -enable-bare-slash-regex compiler flag to the swift compiler.">;
-  def SwiftEnableCxxInterop: Property<"swift-enable-cxx-interop", "Enum">,
-    DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,
-    EnumValues<"OptionEnumValues(g_enable_swift_cxx_interop_values)">,
-    Desc<"Passes the -enable-cxx-interop flag to the swift compiler.">;
   def SwiftPluginServerForPath: Property<"swift-plugin-server-for-path",
       "Dictionary">,
     ElementType<"String">,
     Desc<"A dictionary of plugin paths as keys and swift-plugin-server binaries as values">;
-  def SwiftEnableFullDwarfDebugging: Property<"swift-enable-full-dwarf-debugging", "Enum">,
-    DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,
-    EnumValues<"OptionEnumValues(g_enable_full_dwarf_debugging)">,
-    Desc<"Read full debug information from DWARF for Swift debugging. By default LLDB will use DWARF debug information if it cannot use reflection metadata.">;
   def SwiftAllowExplicitModules: Property<"swift-allow-explicit-modules", "Boolean">,
     DefaultTrue,
     Desc<"Allows explicit module flags to be passed through to ClangImporter.">;


### PR DESCRIPTION
SwiftEnableCxxInterop and SwiftEnableFullDwarfDebugging are meant to be global properties. They also can already be stabilized, so move them from target.experimental to symbols