### PR TITLE
[Cherry-pick into next] Remove redundant compiler flag from test

### DIFF
--- a/lldb/test/API/lang/swift/macro/Makefile
+++ b/lldb/test/API/lang/swift/macro/Makefile
@@ -2,7 +2,7 @@ SWIFTFLAGS_EXTRAS = -I.
 
 ifneq "$(SWIFT_SOURCES)" "empty.swift"
 
-SWIFTFLAGS_EXTRAS += -load-plugin-library $(BUILDDIR)/libMacroImpl.dylib
+SWIFTFLAGS_EXTRAS += -load-plugin-library $(BUILDDIR)/libMacroImpl.dylib -dwarf-version=5
 LD_EXTRAS = -L$(BUILDDIR) -lMacro
 
 endif

--- a/lldb/test/API/lang/swift/macro/main.swift
+++ b/lldb/test/API/lang/swift/macro/main.swift
@@ -2,8 +2,8 @@ import Macro
 
 func testStringify(a: Int, b: Int) {
   print("break here")
-  let s = #stringify(a + b)
+  let s = #stringify(a / b)
   print(s.1)
 }
 
-testStringify(a: 23, b: 42)
+testStringify(a: 23, b: 0)

--- a/lldb/test/API/lang/swift/runtime_failure_recognizer/Makefile
+++ b/lldb/test/API/lang/swift/runtime_failure_recognizer/Makefile
@@ -1,4 +1,3 @@
 SWIFT_SOURCES := RuntimeFailure.swift
-SWIFTFLAGS_EXTRAS += -Xllvm -enable-trap-debug-info
 
 include Makefile.rules


### PR DESCRIPTION
```
commit dbbf0f10feffa917f4f04a87d10d8ae1f38a9063
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Mar 20 14:18:47 2024 -0700

    Remove redundant compiler flag from test
```
