### PR TITLE
[lldb] Add a setting to allow Swift AST context instantiations

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -95,6 +95,7 @@ public:
 
   AutoBool GetSwiftEnableCxxInterop() const;
   AutoBool GetSwiftEnableFullDwarfDebugging() const;
+  bool GetSwiftEnableASTContext() const;
   // END SWIFT
 
   FileSpec GetClangModulesCachePath() const;

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -64,6 +64,10 @@ let Definition = "modulelist" in {
     DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,
     EnumValues<"OptionEnumValues(g_enable_full_dwarf_debugging)">,
     Desc<"Read full debug information from DWARF for Swift debugging. By default LLDB will use DWARF debug information if it cannot use reflection metadata.">;
+  def SwiftEnableASTContext: Property<"swift-enable-ast-context", "Boolean">,
+    Global,
+    DefaultTrue,
+    Desc<"Enable instantiating Swift AST contexts.">;
 // END SWIFT
   def SymLinkPaths: Property<"debug-info-symlink-paths", "FileSpecList">,
     Global,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -274,6 +274,12 @@ AutoBool ModuleListProperties::GetSwiftEnableFullDwarfDebugging() const {
       idx, static_cast<AutoBool>(
                g_modulelist_properties[idx].default_uint_value));
 }
+
+bool ModuleListProperties::GetSwiftEnableASTContext() const {
+  const uint32_t idx = ePropertySwiftEnableASTContext;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
 // END SWIFT
 
 FileSpec ModuleListProperties::GetLLDBIndexCachePath() const {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -976,6 +976,10 @@ SwiftASTContext::SwiftASTContext(std::string description,
     : TypeSystemSwift(), m_typeref_typesystem(&typeref_typesystem),
       m_compiler_invocation_ap(new swift::CompilerInvocation()),
       m_diagnostic_consumer_ap(new StoringDiagnosticConsumer(*this)) {
+  assert(
+      ModuleList::GetGlobalModuleListProperties().GetSwiftEnableASTContext() &&
+      "Swift AST context instantiation is disabled!");
+
   m_description = description;
 
   // Set the clang modules cache path.
@@ -1884,6 +1888,10 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   if (!SwiftASTContextSupportsLanguage(language))
     return lldb::TypeSystemSP();
 
+  if (!ModuleList::GetGlobalModuleListProperties()
+           .GetSwiftEnableASTContext())
+    return lldb::TypeSystemSP();
+
   std::string m_description;
   {
     llvm::raw_string_ostream ss(m_description);
@@ -2359,6 +2367,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   if (!SwiftASTContextSupportsLanguage(language))
     return lldb::TypeSystemSP();
 
+  if (!ModuleList::GetGlobalModuleListProperties()
+           .GetSwiftEnableASTContext())
+    return lldb::TypeSystemSP();
+
   LLDB_SCOPED_TIMER();
   std::string m_description = "SwiftASTContextForExpressions";
   std::vector<swift::PluginSearchOption> plugin_search_options;
@@ -2649,6 +2661,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     const SymbolContext &sc,
     TypeSystemSwiftTypeRefForExpressions &typeref_typesystem) {
   LLDB_SCOPED_TIMER();
+
+  if (!ModuleList::GetGlobalModuleListProperties()
+           .GetSwiftEnableASTContext())
+    return lldb::TypeSystemSP();
 
   CompileUnit *cu = sc.comp_unit;
   StringRef swift_module_name = TypeSystemSwiftTypeRef::GetSwiftModuleFor(&sc);


### PR DESCRIPTION
For testing purposes, it's useful to have a setting to disable the instantiation of SwiftASTContext, to ensure that
TypeSystemSwiftTypeRef, which by default falls back to it on failure, is working independently.

This setting might also be useful for end users, as when debugging a program that was built with a different compiler version versus what is embedded in LLDB instantiation of Swift AST contexts would be moot.