### PR TITLE
[lldb] Be more precise when copying over Swift resources

### DIFF
--- a/lldb/cmake/modules/LLDBFramework.cmake
+++ b/lldb/cmake/modules/LLDBFramework.cmake
@@ -135,11 +135,32 @@ if(NOT APPLE_EMBEDDED)
   )
 
   if(LLDB_FRAMEWORK_COPY_SWIFT_RESOURCES)
+    # To run the LLDB test suite, we need to be able to find some of the Swift
+    # compiler resources. When part of a toolchain, LLDB knows where to find
+    # those. For at-desk builds, it copies over the resources from the Swift
+    # build directory into LLDB.framework.
+    set(RESOURCE_DIRS
+      FrameworkABIBaseline
+      apinotes
+      clang
+      embedded
+      macosx
+      shims
+      swiftToCxx
+    )
+    foreach(DIR ${RESOURCE_DIRS})
+      add_custom_command(TARGET liblldb POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+                ${SWIFT_BINARY_DIR}/lib/swift/${DIR}/
+                $<TARGET_FILE_DIR:liblldb>/Resources/Swift/${DIR}
+        COMMENT "LLDB.framework: copy Swift compiler resource: ${DIR}"
+      )
+    endforeach()
     add_custom_command(TARGET liblldb POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy_directory
-              ${SWIFT_BINARY_DIR}/lib/swift
-              $<TARGET_FILE_DIR:liblldb>/Resources/Swift
-      COMMENT "LLDB.framework: copy Swift vendor-specific headers"
+      COMMAND ${CMAKE_COMMAND} -E copy
+              ${SWIFT_BINARY_DIR}/lib/swift/module.modulemap
+              $<TARGET_FILE_DIR:liblldb>/Resources/Swift/
+      COMMENT "LLDB.framework: copy Swift compiler resource: module.modulemap"
     )
   endif()
 endif()


### PR DESCRIPTION
To run the LLDB test suite, we need to be able to find some of the Swift compiler resources. When part of a toolchain, LLDB knows where to find those. For at-desk builds, it copies over the resources from the Swift build directory into LLDB.framework.

Right now we copy over the whole lib/swift directory from the Swift build root. This contains much more than we need, such as dylibs and dSYMs. This patch modifies LLDB to be more precise in what it copies over.

rdar://124975526

(cherry picked from commit 32e2b5433c9445064c8e9401ab0cfa23c944c211) (cherry picked from commit 7c170520e42bd74fa3c5aaae3ac80491757443bd) (cherry picked from commit b1ff623bd1527d4072f8cd957fc112f62f193dfd)