### PR TITLE
[lldb] Build DeclContext vector from a Swift demangle tree

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -473,11 +473,109 @@ TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
   return pointee ? GetPointerTo(dem, nominal) : nominal;
 }
 
-/// Return a pair of modulename, type name for the outermost nominal type.
-static std::optional<std::pair<StringRef, StringRef>>
-GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
+bool 
+TypeSystemSwiftTypeRef::IsBuiltinType(CompilerType type) {
+  assert(type.GetTypeSystem().isa_and_nonnull<TypeSystemSwift>() &&
+         "Unexpected type system!");
+  Demangler dem;
+  auto *node = GetDemangledType(dem, type.GetMangledTypeName());
   if (!node)
+    return false;
+  return node->getKind() == Node::Kind::BuiltinTypeName;
+}
+
+std::optional<std::pair<NodePointer, NodePointer>>
+ExtractTypeNode(NodePointer node) {
+  // A type node is expected to have two children.
+  if (node->getNumChildren() != 2)
     return {};
+
+  auto *first = node->getChild(0);
+  auto *second = node->getChild(1);
+
+  // The second child of a type node is expected to be its identifier.
+  if (second->getKind() != Node::Kind::Identifier)
+    return {};
+  return {{first, second}};
+}
+
+static std::optional<llvm::StringRef>
+ExtractIdentifierFromLocalDeclName(NodePointer node) {
+  assert(node->getKind() == Node::Kind::LocalDeclName &&
+         "Expected LocalDeclName node!");
+
+  if (node->getNumChildren() != 2) {
+    assert(false && "Local decl name node should have 2 children!");
+    return {};
+  }
+
+  auto *first = node->getChild(0);
+  auto *second = node->getChild(1);
+
+  assert(first->getKind() == Node::Kind::Number && "Expected number node!");
+
+  if (second->getKind() == Node::Kind::Identifier) {
+    if (!second->hasText()) {
+      assert(false && "Identifier should have text!");
+      return {};
+    }
+    return second->getText();
+  }
+  assert(false && "Expected second child of local decl name to be its "
+                  "identifier!"); 
+  return {};
+}
+
+static std::optional<std::pair<StringRef, StringRef>>
+ExtractIdentifiersFromPrivateDeclName(NodePointer node) {
+  assert(node->getKind() == Node::Kind::PrivateDeclName && "Expected PrivateDeclName node!");
+
+  if (node->getNumChildren() != 2) {
+    assert(false && "Private decl name node should have 2 children!");
+    return {};
+  }
+
+  auto *private_discriminator = node->getChild(0);
+  auto *type_name = node->getChild(1);
+
+  if (private_discriminator->getKind() != Node::Kind::Identifier) {
+    assert(
+        false &&
+        "Expected first child of private decl name node to be an identifier!");
+    return {};
+  }
+  if (type_name->getKind() != Node::Kind::Identifier) {
+    assert(
+        false &&
+        "Expected second child of private decl name node to be an identifier!");
+    return {};
+  }
+
+  if (!private_discriminator->hasText() || !type_name->hasText()) {
+    assert(false && "Identifier nodes should have text!");
+    return {};
+  }
+
+  return {{private_discriminator->getText(), type_name->getText()}};
+}
+/// Builds the decl context of a given node. The decl context is the context in
+/// where this type is defined. For example, give a module A with the following 
+/// code:
+///
+/// struct B {
+///   class C {
+///     ...
+///   }
+/// }
+///
+/// The decl context of C would be:
+/// <Module A>
+///   <AnyType B>
+///     <AnyType C>
+static bool BuildDeclContext(swift::Demangle::NodePointer node,
+                             std::vector<CompilerContext> &context) {
+  if (!node)
+    return false;
   using namespace swift::Demangle;
   switch (node->getKind()) {
   case Node::Kind::Structure:
@@ -489,14 +587,34 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
   case Node::Kind::ProtocolListWithAnyObject:
   case Node::Kind::TypeAlias: {
     if (node->getNumChildren() != 2)
-      return {};
-    auto *m = node->getChild(0);
-    if (!m || m->getKind() != Node::Kind::Module || !m->hasText())
-      return {};
-    auto *n = node->getChild(1);
-    if (!n || n->getKind() != Node::Kind::Identifier || !n->hasText())
-      return {};
-    return {{m->getText(), n->getText()}};
+      return false;
+    auto *first = node->getChild(0);
+    if (!first)
+      return false;
+    if (first->getKind() == Node::Kind::Module) {
+      assert(first->hasText() && "Module node should have text!");
+      context.push_back(
+          {CompilerContextKind::Module, ConstString(first->getText())});
+    } else {
+      // If the node's kind is not a module, this is probably a nested type, so
+      // build the decl context for the parent type first.
+      if (!BuildDeclContext(first, context))
+        return false;
+    }
+
+    auto *second = node->getChild(1);
+    if (!second)
+      return false;
+
+    if (second->getKind() == Node::Kind::Identifier) {
+      assert(second->hasText() && "Identifier node should have text!");
+      context.push_back(
+          {CompilerContextKind::AnyType, ConstString(second->getText())});
+      return true;
+    }
+    // If the second child is not an identifier, it could be a private decl
+    // name or a local decl name.
+    return BuildDeclContext(second, context);
   }
   case Node::Kind::BoundGenericClass:
   case Node::Kind::BoundGenericEnum:
@@ -509,36 +627,91 @@ GetNominal(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node) {
     auto *type = node->getChild(0);
     if (!type || type->getKind() != Node::Kind::Type || !type->hasChildren())
       return {};
-    return GetNominal(dem, type->getFirstChild());
+    return BuildDeclContext(type->getFirstChild(), context);
+  }
+  case Node::Kind::Function: {
+    if (node->getNumChildren() != 3)
+      return false;
+
+    auto *first = node->getChild(0);
+    auto *second = node->getChild(1);
+
+    if (first->getKind() == Node::Kind::Module) {
+      if (!first->hasText()) {
+        assert(false && "Module should have text!");
+        return false;
+      }
+      context.push_back(
+          {CompilerContextKind::Module, ConstString(first->getText())});
+    } else if (!BuildDeclContext(first, context))
+      return false;
+
+    if (second->getKind() == Node::Kind::Identifier) {
+      if (!second->hasText()) {
+        assert(false && "Identifier should have text!");
+        return false;
+      }
+      context.push_back(
+          {CompilerContextKind::Function, ConstString(second->getText())});
+    } else if (!BuildDeclContext(second, context))
+      return false;
+
+    return true;
+  }
+  case Node::Kind::LocalDeclName: {
+    std::optional<llvm::StringRef> identifier =
+        ExtractIdentifierFromLocalDeclName(node);
+    if (!identifier)
+      return false;
+
+    context.push_back(
+        {CompilerContextKind::AnyDeclContext, ConstString(*identifier)});
+    return true;
+  }
+
+  case Node::Kind::PrivateDeclName: {
+    auto discriminator_and_type_name =
+        ExtractIdentifiersFromPrivateDeclName(node);
+
+    if (!discriminator_and_type_name)
+      return false;
+    auto &[private_discriminator, type_name] = *discriminator_and_type_name;
+
+    context.push_back(
+        {CompilerContextKind::Namespace, ConstString(private_discriminator)});
+    context.push_back(
+        {CompilerContextKind::AnyDeclContext, ConstString(type_name)});
+    return true;
   }
   default:
     break;
   }
+  return false;
+}
+
+/// Builds the decl context of a given swift type. See the documentation in the
+/// other implementation of BuildDeclContext for more details.
+static std::optional<std::vector<CompilerContext>>
+BuildDeclContext(llvm::StringRef mangled_name,
+                 swift::Demangle::Demangler &dem) {
+  std::vector<CompilerContext> context;
+  auto *node = GetDemangledType(dem, mangled_name);
+  
+  /// Builtin names belong to the builtin module, and are stored only with their
+  /// mangled name.
+  if (node->getKind() == Node::Kind::BuiltinTypeName) {
+    context.push_back({CompilerContextKind::Module, ConstString("Builtin")});
+    context.push_back(
+        {CompilerContextKind::AnyType, ConstString(mangled_name)});
+    return std::move(context);
+  }
+
+  auto success = BuildDeclContext(node, context);
+  if (success)
+    return std::move(context);
   return {};
 }
 
-bool 
-TypeSystemSwiftTypeRef::IsBuiltinType(CompilerType type) {
-  assert(type.GetTypeSystem().isa_and_nonnull<TypeSystemSwift>() &&
-         "Unexpected type system!");
-  Demangler dem;
-  auto *node = GetDemangledType(dem, type.GetMangledTypeName());
-  if (!node)
-    return false;
-  return node->getKind() == Node::Kind::BuiltinTypeName;
-}
-
-/// Return a pair of module name and type name, given a mangled name.
-static std::optional<std::pair<StringRef, StringRef>>
-GetNominal(llvm::StringRef mangled_name, swift::Demangle::Demangler &dem) {
-  auto *node = GetDemangledType(dem, mangled_name);
-  /// Builtin names belong to the builtin module, and are stored only with their
-  /// mangled name.
-  if (node->getKind() == Node::Kind::BuiltinTypeName) 
-    return {{"Builtin", mangled_name}};
-
-  return GetNominal(dem, node);
-}
 /// Detect the AnyObject type alias.
 static bool IsAnyObjectTypeAlias(swift::Demangle::NodePointer node) {
   using namespace swift::Demangle;
@@ -630,10 +803,6 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
   ConstString mangled(mangling.result());
 
   auto resolve_clang_type = [&]() -> CompilerType {
-    auto maybe_module_and_type_names = GetNominal(dem, node);
-    if (!maybe_module_and_type_names)
-      return {};
-
     // This is an imported Objective-C type; look it up in the debug info.
     llvm::SmallVector<CompilerContext, 2> decl_context;
     if (!IsClangImportedType(node, decl_context))
@@ -1885,20 +2054,14 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
     return {};
 
   swift::Demangle::Demangler dem;
-  auto module_type = GetNominal(AsMangledName(opaque_type), dem);
-  if (!module_type)
+  auto context = BuildDeclContext(AsMangledName(opaque_type), dem);
+  if (!context)
     return {};
   // DW_AT_linkage_name is not part of the accelerator table, so
-  // we need to search by module+name.
-  ConstString module(module_type->first);
-  ConstString type(module_type->second);
-  llvm::SmallVector<CompilerContext, 2> decl_context;
-  if (!module.IsEmpty())
-    decl_context.push_back({CompilerContextKind::Module, module});
-  decl_context.push_back({CompilerContextKind::AnyType, type});
+  // we need to search by decl context.
 
-  TypeQuery query(decl_context, TypeQueryOptions::e_find_one |
-                                    TypeQueryOptions::e_module_search);
+  TypeQuery query(*context, TypeQueryOptions::e_find_one |
+                                TypeQueryOptions::e_module_search);
   query.SetLanguages(TypeSystemSwift::GetSupportedLanguagesForTypes());
 
   TypeResults results;

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -178,4 +178,34 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         lldbutil.check_variable(self, second, False, value="315")
         u = right.GetChildMemberWithName("u")
         two = u.GetChildMemberWithName("two")
-        lldbutil.check_variable(self, two, False, value="one")
+        lldbutil.check_variable(self, two, False, value='one')
+
+        inner = frame.FindVariable("inner")
+        value = inner.GetChildMemberWithName("value")
+        lldbutil.check_variable(self, value, False, value='99')
+
+        innerer = frame.FindVariable("innerer")
+        innererValue = innerer.GetChildMemberWithName("innererValue")
+        lldbutil.check_variable(self, innererValue, False, value='101')
+
+        privateType = frame.FindVariable("privateType")
+        privateField = privateType.GetChildMemberWithName("privateField")
+        lldbutil.check_variable(self, privateField, False, value='100')
+
+        specializedInner = frame.FindVariable("specializedInner")
+        t = specializedInner.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value='837')
+
+        genericInner = frame.FindVariable("genericInner")
+        t = genericInner.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value='647')
+        u = genericInner.GetChildMemberWithName("u")
+        lldbutil.check_variable(self, u, False, value='674.5')
+
+        functionType = frame.FindVariable("functionType")
+        funcField = functionType.GetChildMemberWithName("funcField")
+        lldbutil.check_variable(self, funcField, False, value='67')
+
+        innerFunctionType = frame.FindVariable("innerFunctionType")
+        innerFuncField = innerFunctionType.GetChildMemberWithName("innerFuncField")
+        lldbutil.check_variable(self, innerFuncField, False, value='8479')

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -83,42 +83,88 @@ enum Either<Left, Right> {
   case right(Right)
 }
 
-func f() {
-  let varB = B()
-  let tuple = (A(), B())
-  let trivial = TrivialEnum.theCase
-  let nonPayload1 = NonPayloadEnum.one
-  let nonPayload2 = NonPayloadEnum.two
-  let singlePayload = SinglePayloadEnum.payload(B())
-  let emptySinglePayload = SinglePayloadEnum.nonPayloadTwo
-  let smallMultipayloadEnum1 = SmallMultipayloadEnum.one(.two)
-  let smallMultipayloadEnum2 = SmallMultipayloadEnum.two(.one)
-  let e1 = Sup()
-  let e2 = Sup()
-  e2.supField = 43
-  let e3 = Sup()
-  e3.supField = 44
-  let bigMultipayloadEnum1 = BigMultipayloadEnum.one(e1, e2, e3)
-  let fullMultipayloadEnum1 = FullMultipayloadEnum.one(120)
-  let fullMultipayloadEnum2 = FullMultipayloadEnum.two(9.5)
-  let bigFullMultipayloadEnum1 = BigFullMultipayloadEnum.one(209, 315)
-  let bigFullMultipayloadEnum2 = BigFullMultipayloadEnum.two(452.5, 753.5)
-  let sup = Sup()
-  let sub = Sub()
-  let subSub = SubSub()
-  let sup2: Sup = SubSub()
-  let gsp = GenericStructPair(t: 42, u: 94.5)
-  let gsp2 = GenericStructPair(t: Sup(), u: B())
-  let gsp3 = GenericStructPair(t: bigFullMultipayloadEnum1, u: smallMultipayloadEnum2)
-  let gcp = GenericClassPair(t: 55.5, u: 9348)
-  let either = Either<Int, Double>.left(1234)
-  let either2 = Either<Sup, _>.right(gsp3)
 
-  // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
-  let dummy = A() // break here
-  let string = StaticString("Hello") 
-  print(string) 
+struct Outer {
+  struct Inner {
+    let value = 99
+    struct Innerer {
+      let innererValue = 101
+    }
+  }
 }
 
-f()
+private struct PrivateType {
+  let privateField = 100
+}
 
+
+struct OuterGeneric<T> {
+  struct SpecializedInner {
+    let t: T
+  }
+
+  struct GenericInner<U> {
+    let t: T
+    let u: U
+  }
+}
+
+func g() {
+  struct FunctionType {
+    let funcField = 67
+  }
+  func f() {
+    struct InnerFunctionType {
+      let innerFuncField = 8479
+    }
+
+    let varB = B()
+    let tuple = (A(), B())
+    let trivial = TrivialEnum.theCase
+    let nonPayload1 = NonPayloadEnum.one
+    let nonPayload2 = NonPayloadEnum.two
+    let singlePayload = SinglePayloadEnum.payload(B())
+    let emptySinglePayload = SinglePayloadEnum.nonPayloadTwo
+    let smallMultipayloadEnum1 = SmallMultipayloadEnum.one(.two)
+    let smallMultipayloadEnum2 = SmallMultipayloadEnum.two(.one)
+    let e1 = Sup()
+    let e2 = Sup()
+    e2.supField = 43
+    let e3 = Sup()
+    e3.supField = 44
+    let bigMultipayloadEnum1 = BigMultipayloadEnum.one(e1, e2, e3)
+    let fullMultipayloadEnum1 = FullMultipayloadEnum.one(120)
+    let fullMultipayloadEnum2 = FullMultipayloadEnum.two(9.5)
+    let bigFullMultipayloadEnum1 = BigFullMultipayloadEnum.one(209, 315)
+    let bigFullMultipayloadEnum2 = BigFullMultipayloadEnum.two(452.5, 753.5)
+    let sup = Sup()
+    let sub = Sub()
+    let subSub = SubSub()
+    let sup2: Sup = SubSub()
+    let gsp = GenericStructPair(t: 42, u: 94.5)
+    let gsp2 = GenericStructPair(t: Sup(), u: B())
+    let gsp3 = GenericStructPair(t: bigFullMultipayloadEnum1, u: smallMultipayloadEnum2)
+    let gcp = GenericClassPair(t: 55.5, u: 9348)
+    let either = Either<Int, Double>.left(1234)
+    let either2 = Either<Sup, _>.right(gsp3)
+    // FIXME: remove the instantiation of Outer (rdar://125258124)
+    let outer = Outer()
+    let inner = Outer.Inner()
+    let innerer = Outer.Inner.Innerer()
+    let privateType = PrivateType()
+    // FIXME: remove the instantiation of OuterGeneric (rdar://125258124)
+    let outerGeneric = OuterGeneric<Int>()
+    let specializedInner = OuterGeneric<Int>.SpecializedInner(t: 837)
+    let genericInner = OuterGeneric<Int>.GenericInner(t: 647, u: 674.5)
+    let functionType = FunctionType()
+    let innerFunctionType = InnerFunctionType()
+
+    // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
+    let dummy = A() // break here
+    let string = StaticString("Hello") 
+    print(string) 
+  }
+  f()
+}
+
+g()

--- a/lldb/test/API/lang/swift/embedded/nested_frame_variable/Makefile
+++ b/lldb/test/API/lang/swift/embedded/nested_frame_variable/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/nested_frame_variable/TestSwiftEmbeddedNestedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/nested_frame_variable/TestSwiftEmbeddedNestedFrameVariable.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftEmbeddedNestedFrameVariable(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.implementation()
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_without_ast(self):
+        """Run the test turning off instantion of  Swift AST contexts in order to ensure that all type information comes from DWARF"""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        self.implementation()
+
+    def implementation(self):
+        self.runCmd("setting set symbols.swift-enable-full-dwarf-debugging true")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        s4 = frame.FindVariable("s4")
+        t = s4.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value='839')
+

--- a/lldb/test/API/lang/swift/embedded/nested_frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/nested_frame_variable/main.swift
@@ -1,0 +1,27 @@
+private struct S {
+  func s1() {
+    class S2 {
+      func s2() {
+        func s2_2() {
+          enum S3 {
+            case theCase
+            func s3() {
+              struct S4<T> {
+                let t: T
+              }
+
+              let s4 = S4<Int>(t: 839)
+              let string = StaticString("Hello") // break here
+              print(string) 
+            }
+          }
+          S3.theCase.s3()
+        }
+        s2_2()
+      }
+    }
+    S2().s2()
+  }
+}
+
+S().s1()


### PR DESCRIPTION
Replace the current GetNominal function, which would only handle finding
a module + a type with a more complete BuildDeclContext function, which
will recursively build a DeclContext, taking into account nested and
private types.

rdar://125044318