### PR TITLE
[swift/6.0][lldb] Update for PrintOptions.PrintRegularClangComments removal

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4928,8 +4928,7 @@ swift::PrintOptions SwiftASTContext::GetUserVisibleTypePrintingOptions(
   print_options.FullyQualifiedTypesIfAmbiguous = true;
   print_options.FullyQualifiedTypes = true;
   print_options.ExplodePatternBindingDecls = false;
-  print_options.PrintDocumentationComments =
-      print_options.PrintRegularClangComments = print_help_if_available;
+  print_options.PrintDocumentationComments = print_help_if_available;
   return print_options;
 }
 


### PR DESCRIPTION
Cherry-pick https://github.com/apple/llvm-project/pull/8443 into `swift/release/6.0`

(Copied from corresponding `swift` repo PR https://github.com/apple/swift/pull/72574)
* **Explanation**: Generated interfaces for Clang modules used to try printing normal comments and whitespaces between decls extracted from the header text. That's was getting confusing mainly because of "import as member" which  reorders decls in the header files. So stop printing normal comments for Clang decls.
* **Scope**: Generated interface in SourceKit
* **Risk**: Low. Changes are simple. Nobody should rely on the comments/whitespaces in generated interfaces
* **Testing**: Updated regression test cases
* **Issues**: rdar://93731287
* **Reviewers**: Alex Hoppen (@ahoppen) Hamish Knight (@hamishknight)