### PR TITLE
[lldb] Support frame variable for generic types in embedded Swift

### DIFF
--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -129,3 +129,61 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
                 "subSubField = (field = 4.2000000000000002)",
             ],
         )
+
+        self.expect(
+            "frame variable gsp",
+            substrs=[
+                "GenericStructPair<Int, Double>) gsp =",
+                "(t = 42, u = 94.299999999999997)",
+            ],
+        )
+
+        self.expect(
+            "frame variable gsp2",
+            substrs=[
+                "a.GenericStructPair<a.Sup, a.B>) gsp2 = {",
+                "t = ",
+                "(supField = 42)",
+                "u = {",
+                "a = (field = 4.2000000000000002)",
+                "b = 123456",
+            ],
+        )
+
+        self.expect(
+            "frame variable gsp3",
+            substrs=[
+                "(a.GenericStructPair<a.BigFullMultipayloadEnum,",
+                "a.SmallMultipayloadEnum>) gsp3 = {",
+                "t = one {",
+                "one = (0 = 209, 1 = 315)",
+                "u = two {",
+            ],
+        )
+
+        self.expect(
+            "frame variable gcp",
+            substrs=[
+                "GenericClassPair<Double, Int>) gcp =",
+                "(t = 43.799999999999997, u = 9348)",
+            ],
+        )
+
+        self.expect(
+            "frame variable either",
+            substrs=["(a.Either<Int, Double>) either =", "left (left = 1234)"],
+        )
+
+        self.expect(
+            "frame variable either2",
+            substrs=[
+                "(a.Either<a.Sup, a.GenericStructPair<a.BigFullMultipayloadEnum,",
+                "a.SmallMultipayloadEnum>>)",
+                "either2 = right {",
+                "right = {",
+                "t = one {",
+                "one = (0 = 209, 1 = 315)",
+                "u = two {",
+                "two = one",
+            ],
+        )

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -62,6 +62,27 @@ class SubSub: Sub {
   var subSubField = A()
 }
 
+
+struct GenericStructPair<T, U> {
+  let t: T
+  let u: U
+}
+
+class GenericClassPair<T, U> {
+  let t: T
+  let u: U
+
+  init(t: T, u: U) {
+    self.t = t
+    self.u = u
+  }
+}
+
+enum Either<Left, Right> {
+  case left(Left)
+  case right(Right)
+}
+
 let varB = B()
 let tuple = (A(), B())
 let trivial = TrivialEnum.theCase
@@ -85,6 +106,12 @@ let sup = Sup()
 let sub = Sub()
 let subSub = SubSub()
 let sup2: Sup = SubSub()
+let gsp = GenericStructPair(t: 42, u: 94.3)
+let gsp2 = GenericStructPair(t: Sup(), u: B())
+let gsp3 = GenericStructPair(t: bigFullMultipayloadEnum1, u: smallMultipayloadEnum2)
+let gcp = GenericClassPair(t: 43.8, u: 9348)
+let either = Either<Int, Double>.left(1234)
+let either2 = Either<Sup, _>.right(gsp3)
 
 // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
 let dummy = A() // break here


### PR DESCRIPTION
Support finding generic types when debugging embedded Swift by following the DW_AT_linkage_name attribute emitted by the compiler that connects the substituted generic type back to the non-substituted one.

(cherry picked from commit 257d4606bc7568b11f54de802f3e69b062ad211e)