### PR TITLE
[lldb] Change embedded swift test to use "clean" doubles

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -41,19 +41,19 @@ using namespace lldb_private::plugin::dwarf;
 /// Double>), with a link back to the unsubstituted type. When looking up one of
 /// the specialized generics, return the unsubstituted version instead.
 static std::optional<std::pair<CompilerType, DWARFDIE>>
-findUnsubstitutedGenericTypeAndDie(TypeSystemSwiftTypeRef &ts,
+findUnsubstitutedGenericTypeAndDIE(TypeSystemSwiftTypeRef &ts,
                                    const DWARFDIE &die) {
-  auto specified_die =
+  auto unsubstituted_die =
       die.GetAttributeValueAsReferenceDIE(llvm::dwarf::DW_AT_specification);
-  if (!specified_die)
+  if (!unsubstituted_die)
     return {};
 
-  const auto *mangled_name = specified_die.GetAttributeValueAsString(
+  const auto *mangled_name = unsubstituted_die.GetAttributeValueAsString(
       llvm::dwarf::DW_AT_linkage_name, nullptr);
   assert(mangled_name);
-  auto specified_type =
+  auto unsubstituted_type =
       ts.GetTypeFromMangledTypename(ConstString(mangled_name));
-  return {{specified_type, specified_die}};
+  return {{unsubstituted_type, unsubstituted_die}};
 }
 /// Given a type system and a typeref, return the compiler type and die of the
 /// type that matches that mangled name, looking up the in the type system's
@@ -86,7 +86,7 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
   }
   auto die = dwarf->GetDIE(lldb_type->GetID());
 
-  if (auto unsubstituted_pair = findUnsubstitutedGenericTypeAndDie(ts, die))
+  if (auto unsubstituted_pair = findUnsubstitutedGenericTypeAndDIE(ts, die))
     return unsubstituted_pair;
 
   return {{type, die}};

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -17,15 +17,15 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
 
         self.expect(
             "frame variable varB",
-            substrs=["varB = ", "a = (field = 4.2000000000000002)", "b = 123456"],
+            substrs=["varB = ", "a = (field = 4.5)", "b = 123456"],
         )
         self.expect(
             "frame variable tuple",
             substrs=[
                 "(a.A, a.B) tuple = {",
-                "0 = (field = 4.2000000000000002)",
+                "0 = (field = 4.5)",
                 "1 = {",
-                "a = (field = 4.2000000000000002)",
+                "a = (field = 4.5)",
                 "b = 123456",
             ],
         )
@@ -41,7 +41,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
             substrs=[
                 "SinglePayloadEnum) singlePayload = ",
                 "payload {",
-                "a = (field = 4.2000000000000002)",
+                "a = (field = 4.5)",
                 "b = 123456",
             ],
         )
@@ -85,7 +85,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
             "frame variable fullMultipayloadEnum2",
             substrs=[
                 "FullMultipayloadEnum) fullMultipayloadEnum2 = ",
-                "(two = 9.2100000000000008)",
+                "(two = 9.5)",
             ],
         )
 
@@ -100,7 +100,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
             "frame variable bigFullMultipayloadEnum2",
             substrs=[
                 "a.BigFullMultipayloadEnum) bigFullMultipayloadEnum2 = two {",
-                "two = (0 = 452.19999999999999, 1 = 753.89999999999998)",
+                "two = (0 = 452.5, 1 = 753.5)",
             ],
         )
 
@@ -112,7 +112,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
                 "Sup = {",
                 "supField = 42",
                 "subField = {",
-                "a = (field = 4.2000000000000002",
+                "a = (field = 4.5",
                 "b = 123456",
             ],
         )
@@ -124,9 +124,9 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
                 "a.Sup = {",
                 "supField = 42",
                 "subField = {",
-                "a = (field = 4.2000000000000002",
+                "a = (field = 4.5",
                 "b = 123456",
-                "subSubField = (field = 4.2000000000000002)",
+                "subSubField = (field = 4.5)",
             ],
         )
 
@@ -134,7 +134,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
             "frame variable gsp",
             substrs=[
                 "GenericStructPair<Int, Double>) gsp =",
-                "(t = 42, u = 94.299999999999997)",
+                "(t = 42, u = 94.5)",
             ],
         )
 
@@ -145,7 +145,7 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
                 "t = ",
                 "(supField = 42)",
                 "u = {",
-                "a = (field = 4.2000000000000002)",
+                "a = (field = 4.5)",
                 "b = 123456",
             ],
         )

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -1,5 +1,5 @@
 struct A {
-  let field = 4.2
+  let field = 4.5
 }
 
 struct B {
@@ -99,14 +99,14 @@ let e3 = Sup()
 e3.supField = 44
 let bigMultipayloadEnum1 = BigMultipayloadEnum.one(e1, e2, e3)
 let fullMultipayloadEnum1 = FullMultipayloadEnum.one(120)
-let fullMultipayloadEnum2 = FullMultipayloadEnum.two(9.21)
+let fullMultipayloadEnum2 = FullMultipayloadEnum.two(9.5)
 let bigFullMultipayloadEnum1 = BigFullMultipayloadEnum.one(209, 315)
-let bigFullMultipayloadEnum2 = BigFullMultipayloadEnum.two(452.2, 753.9)
+let bigFullMultipayloadEnum2 = BigFullMultipayloadEnum.two(452.5, 753.5)
 let sup = Sup()
 let sub = Sub()
 let subSub = SubSub()
 let sup2: Sup = SubSub()
-let gsp = GenericStructPair(t: 42, u: 94.3)
+let gsp = GenericStructPair(t: 42, u: 94.5)
 let gsp2 = GenericStructPair(t: Sup(), u: B())
 let gsp3 = GenericStructPair(t: bigFullMultipayloadEnum1, u: smallMultipayloadEnum2)
 let gcp = GenericClassPair(t: 43.8, u: 9348)


### PR DESCRIPTION
(cherry picked from commit 75a08e36298018cb6cddcca92f9faf26679d0394)