### PR TITLE
Clear the Clang type cache when new modules are loaded / Create non-null typerefs in field descriptors for Clang types

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -132,7 +132,7 @@ public:
     const swift::reflection::TypeRef *type_ref =
         GetTypeRefOrNull(dem, node, descriptor_finder);
     if (!type_ref)
-      LLDB_LOG(GetLog(LLDBLog::Types), "Could not find typeref for type: {0}",
+      LLDB_LOG(GetLog(LLDBLog::Types), "Could not find typeref for type {0}",
                mangled_type_name);
     return type_ref;
   }
@@ -197,8 +197,9 @@ public:
       std::stringstream ss;
       type_ref->dump(ss);
       LLDB_LOG(log,
-               "[TargetReflectionContext::getTypeInfo] Getting "
-               "type info for typeref:\n{0}", ss.str());
+               "[TargetReflectionContext[{0:x}]::getTypeInfo] Getting type "
+               "info for typeref {1}",
+               provider ? provider->getId() : 0, ss.str());
     }
 
     auto type_info = m_reflection_ctx.getTypeInfo(type_ref, provider);
@@ -207,7 +208,7 @@ public:
       type_ref->dump(ss);
       LLDB_LOG(log,
                "[TargetReflectionContext::getTypeInfo] Could not get "
-               "type info for typeref:\n{0}",
+               "type info for typeref {0}",
                ss.str());
     }
 
@@ -216,8 +217,8 @@ public:
       type_info->dump(ss);
       LLDB_LOG(log,
                "[TargetReflectionContext::getTypeInfo] Found "
-               "type info:\n{0}",
-                  ss.str());
+               "type info {0}",
+               ss.str());
     }
     return type_info;
   }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -353,6 +353,7 @@ public:
     ExecutionContext exe_ctx;
     process.CalculateExecutionContext(exe_ctx);
     auto *exe_scope = exe_ctx.GetBestExecutionContextScope();
+    TypeSystemSwiftTypeRef &typesystem = *m_reader->get();
     // Build a TypeInfo for the Clang type.
     auto size = clang_type.GetByteSize(exe_scope);
     auto bit_align = clang_type.GetTypeBitAlign(exe_scope);
@@ -372,11 +373,14 @@ public:
               "[LLDBTypeInfoProvider] bitfield support is not yet implemented");
           continue;
         }
+        CompilerType swift_type =
+            typesystem.ConvertClangTypeToSwiftType(field_type);
+        auto *typeref = m_runtime.GetTypeRef(swift_type, &typesystem);
         swift::reflection::FieldInfo field_info = {
-            name, (unsigned)bit_offset_ptr / 8, 0, nullptr,
+            name, (unsigned)bit_offset_ptr / 8, 0, typeref,
             *GetOrCreateTypeInfo(field_type)};
         fields.push_back(field_info);
-      }
+        }
     }
     return m_runtime.emplaceClangTypeInfo(clang_type, size, bit_align, fields);
   }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -197,6 +197,10 @@ public:
 
   bool IsABIStable();
 
+  /// Use the reflection context to build a TypeRef object.
+  const swift::reflection::TypeRef *
+  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder);
+
   void DumpTyperef(CompilerType type, TypeSystemSwiftTypeRef *module_holder,
                    Stream *s);
 
@@ -211,10 +215,6 @@ protected:
                           std::function<void(unsigned, unsigned)> callback) {
     SwiftLanguageRuntime::ForEachGenericParameter(node, callback);
   }
-
-  /// Use the reflection context to build a TypeRef object.
-  const swift::reflection::TypeRef *
-  GetTypeRef(CompilerType type, TypeSystemSwiftTypeRef *module_holder);
 
   /// If \p instance points to a Swift object, retrieve its
   /// RecordTypeInfo and pass it to the callback \p fn. Repeat the

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1490,6 +1490,7 @@ void TypeSystemSwiftTypeRef::NotifyAllTypeSystems(
 void TypeSystemSwiftTypeRefForExpressions::ModulesDidLoad(
     ModuleList &module_list) {
   ++m_generation;
+  m_clang_type_cache.Clear();
   NotifyAllTypeSystems([&](TypeSystemSP ts_sp) {
     if (auto swift_ast_ctx =
             llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(ts_sp.get()))

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -46,6 +46,7 @@
 
 #include <algorithm>
 #include <sstream>
+#include <type_traits>
 
 using namespace lldb;
 using namespace lldb_private;
@@ -330,6 +331,8 @@ TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
       return optional;
     }
   }
+  if (clang_type.IsAnonymousType())
+    return nullptr;
   llvm::StringRef clang_name = clang_type.GetTypeName().GetStringRef();
 #define MAP_TYPE(C_TYPE_NAME, C_TYPE_KIND, C_TYPE_BITWIDTH, SWIFT_MODULE_NAME, \
                  SWIFT_TYPE_NAME, CAN_BE_MISSING, C_NAME_MAPPING)              \
@@ -382,6 +385,8 @@ TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
     auto *tuple = dem.createNode(Node::Kind::Tuple);
     NodePointer element_type = GetClangTypeNode(
         {clang_type.GetTypeSystem(), elem_type.getAsOpaquePtr()}, dem);
+    if (!element_type)
+      return nullptr;
     for (unsigned i = 0; i < size; ++i) {
       NodePointer tuple_element = dem.createNode(Node::Kind::TupleElement);
       NodePointer type = dem.createNode(Node::Kind::Type);
@@ -413,6 +418,8 @@ TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,
       break;
 
     NodePointer element_type_node = GetClangTypeNode(element_type, dem);
+    if (!element_type_node)
+      return nullptr;
     llvm::SmallVector<NodePointer, 1> elements({element_type_node});
     return CreateBoundGenericStruct("SIMD" + std::to_string(size),
                                     swift::STDLIB_NAME, elements, dem);
@@ -818,8 +825,12 @@ TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
     case Node::Kind::BoundGenericTypeAlias:
     case Node::Kind::TypeAlias: {
       auto node_clangtype = ResolveTypeAlias(dem, node);
-      if (CompilerType clang_type = node_clangtype.second)
-        return GetClangTypeNode(clang_type, dem);
+      if (CompilerType clang_type = node_clangtype.second) {
+        if (auto result = GetClangTypeNode(clang_type, dem))
+          return result;
+        else
+          return node;
+      }
       if (node_clangtype.first)
         return node_clangtype.first;
       return node;
@@ -3180,8 +3191,11 @@ TypeSystemSwiftTypeRef::GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
   assert(clang_type.GetTypeSystem().isa_and_nonnull<TypeSystemClang>() &&
          "expected a clang type");
   using namespace swift::Demangle;
+  NodePointer node = GetClangTypeNode(clang_type, dem);
+  if (!node)
+    return nullptr;
   NodePointer type = dem.createNode(Node::Kind::Type);
-  type->addChild(GetClangTypeNode(clang_type, dem), dem);
+  type->addChild(node, dem);
   return type;
 }
 
@@ -3358,6 +3372,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
         swift::Demangle::Demangler dem;
         swift::Demangle::NodePointer node =
             GetClangTypeTypeNode(dem, clang_child_type);
+        if (!node)
+          return {};
         switch (node->getChild(0)->getKind()) {
         case swift::Demangle::Node::Kind::Class:
           prefix = "ObjectiveC.";
@@ -3440,6 +3456,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
       ast_child_name = suffix.str();
     assert((llvm::StringRef(child_name).contains('.') ||
             llvm::StringRef(ast_child_name).contains('.') ||
+            llvm::StringRef(ast_child_name).starts_with("_") ||
             Equivalent(child_name, ast_child_name)));
     assert(ast_language_flags ||
            (Equivalent(std::optional<uint64_t>(child_byte_size),
@@ -4457,6 +4474,8 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
     } else {
       NodePointer clang_node =
           GetClangTypeNode(std::get<CompilerType>(pair), dem);
+      if (!clang_node)
+        return {};
       type_node->addChild(clang_node, dem);
     }
     return RemangleAsType(dem, type_node);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -386,7 +386,8 @@ public:
   /// context.
   virtual lldb::TypeSP
   LookupClangType(llvm::StringRef name_ref,
-                  llvm::ArrayRef<CompilerContext> decl_context);
+                  llvm::ArrayRef<CompilerContext> decl_context,
+                  ExecutionContext *exe_ctx = nullptr);
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.
@@ -538,9 +539,11 @@ public:
   /// Returns how often ModulesDidLoad was called.
   unsigned GetGeneration() const { return m_generation; }
   /// Performs a target-wide search.
+  /// \param exe_ctx is a hint for where to look first.
   lldb::TypeSP
   LookupClangType(llvm::StringRef name_ref,
-                  llvm::ArrayRef<CompilerContext> decl_context) override;
+                  llvm::ArrayRef<CompilerContext> decl_context,
+                  ExecutionContext *exe_ctx) override;
 
 
   friend class SwiftASTContextForExpressions;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -383,9 +383,10 @@ public:
   lldb::TypeSP LookupClangType(llvm::StringRef name_ref);
 
   /// Search the debug info for a Clang type with the specified name and decl
-  /// context, and cache the result.
-  lldb::TypeSP LookupClangType(llvm::StringRef name_ref,
-                               llvm::ArrayRef<CompilerContext> decl_context);
+  /// context.
+  virtual lldb::TypeSP
+  LookupClangType(llvm::StringRef name_ref,
+                  llvm::ArrayRef<CompilerContext> decl_context);
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.
@@ -491,8 +492,6 @@ protected:
 
   /// All lldb::Type pointers produced by DWARFASTParser Swift go here.
   ThreadSafeDenseMap<const char *, lldb::TypeSP> m_swift_type_map;
-  /// Map ConstString Clang type identifiers to Clang types.
-  ThreadSafeDenseMap<const char *, lldb::TypeSP> m_clang_type_cache;
 };
 
 /// This one owns a SwiftASTContextForExpressions.
@@ -535,8 +534,13 @@ public:
   /// Forwards to SwiftASTContext.
   PersistentExpressionState *GetPersistentExpressionState() override;
   Status PerformCompileUnitImports(const SymbolContext &sc);
-  /// Returns how often ModulesDidLoad was called/
+  /// Returns how often ModulesDidLoad was called.
   unsigned GetGeneration() const { return m_generation; }
+  /// Performs a target-wide search.
+  lldb::TypeSP
+  LookupClangType(llvm::StringRef name_ref,
+                  llvm::ArrayRef<CompilerContext> decl_context) override;
+
 
   friend class SwiftASTContextForExpressions;
 protected:
@@ -553,6 +557,8 @@ protected:
   /// Perform all the implicit imports for the current frame.
   mutable std::unique_ptr<SymbolContext> m_initial_symbol_context_up;
   std::unique_ptr<SwiftPersistentExpressionState> m_persistent_state_up;
+  /// Map ConstString Clang type identifiers to Clang types.
+  ThreadSafeDenseMap<const char *, lldb::TypeSP> m_clang_type_cache;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -398,6 +398,7 @@ public:
 
   /// Lookup a type in the debug info.
   lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);
+
 protected:
   /// Helper that creates an AST type from \p type.
   void *ReconstructType(lldb::opaque_compiler_type_t type,

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/ClangHeader.h
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/ClangHeader.h
@@ -1,0 +1,3 @@
+struct FromClang {
+  int x;
+};

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/ClangMod.h
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/ClangMod.h
@@ -1,0 +1,3 @@
+struct FromClang {
+  int x;
+};

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/Makefile
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/Makefile
@@ -1,0 +1,27 @@
+# This Makefile recursively calls itself, hence the ?=.
+EXE ?= a.out
+SWIFT_SOURCES ?= loader.swift
+SWIFT_BRIDGING_HEADER ?= ClangHeader.h
+SWIFT_PRECOMPILE_BRIDGING_HEADER ?= NO
+SWIFTFLAGS_EXTRAS ?= -enable-bare-slash-regex
+
+all: dylib $(EXE)
+
+include Makefile.rules
+
+.PHONY: dylib
+dylib:
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(SRCDIR)/Makefile \
+		DYLIB_FILENAME=dylib.dylib \
+		DYLIB_SWIFT_SOURCES=dylib.swift \
+		DYLIB_NAME=dylib \
+		DYLIB_ONLY=YES \
+		SWIFTFLAGS_EXTRAS="-Xcc -I$(SRCDIR)" \
+		SWIFT_SOURCES= \
+		SWIFT_BRIDGING_HEADER= \
+		LD_EXTRAS="-lSwiftCore -Xlinker -exported_symbol -Xlinker _f" \
+		dylib.dylib
+

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
@@ -1,0 +1,27 @@
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftLateSwiftDylibClangDeps(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    @skipIfDarwinEmbedded 
+    def test(self):
+        """Test that the reflection metadata cache is invalidated
+        when new DWARF debug info is available"""
+        self.build()
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("loader.swift"))
+
+        # Initialize SwiftASTContext before loading the dylib.
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        self.expect("v fromClang",
+                    substrs=["missing debug info", "FromClang"])
+
+        bkpt = target.BreakpointCreateByLocation(
+            lldb.SBFileSpec('dylib.swift'), 5)
+        threads = lldbutil.continue_to_breakpoint(process, bkpt)
+
+        self.expect("v x", substrs=['42'])
+        self.expect("frame select 1")
+        self.expect("v fromClang", substrs=['23'])

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/dylib.swift
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/dylib.swift
@@ -1,0 +1,6 @@
+import ClangMod
+
+@_silgen_name("f") public func f() {
+  let x = FromClang(x: 42)
+  print(x) // line 5
+}

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/loader.swift
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/loader.swift
@@ -1,0 +1,14 @@
+import Darwin
+
+// This lookup should fail in debugger.
+let fromClang = FromClang(x: 23)
+print(fromClang) // break here
+
+// Now load the dylib.
+let arg0 = CommandLine.arguments[0]
+let dylibName = arg0.replacing(/a\.out$/, with: "dylib.dylib")
+let dylib = dlopen(dylibName, Darwin.RTLD_NOW)
+let fsym = dlsym(dylib!, "f")
+typealias voidTy = @convention(c) () -> ()
+let f = unsafeBitCast(fsym, to: voidTy.self)
+f()

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/module.modulemap
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/module.modulemap
@@ -1,0 +1,3 @@
+module ClangMod {
+  header "ClangMod.h"
+}


### PR DESCRIPTION
This series of commits fixes a number of closely related issues when parsing Clang types from DWARF and creating reflection metadata records for it.

rdar://121758809