### PR TITLE
Just apply `musttail` in swiftasynccall functions

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5728,9 +5728,6 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
   if (llvm::CallInst *Call = dyn_cast<llvm::CallInst>(CI)) {
     if (TargetDecl && TargetDecl->hasAttr<NotTailCalledAttr>())
       Call->setTailCallKind(llvm::CallInst::TCK_NoTail);
-    else if (CallInfo.getASTCallingConvention() == CC_SwiftAsync &&
-             CurFnInfo->getASTCallingConvention() == CC_SwiftAsync)
-      Call->setTailCallKind(llvm::CallInst::TCK_Tail);
     else if (IsMustTail)
       Call->setTailCallKind(llvm::CallInst::TCK_MustTail);
   }


### PR DESCRIPTION
Commit 7c190e7f5cb673787eb88785c6e3db0ccfe735d3 from the Apple LLVM fork was rolled into 92dcb1d2db8c4de48df0af806dca631523cd4169 when it was upstreamed, and LLVM already had support for `musttail`, so this little bit of logic was not needed.   The logic was preserved on the `next` branch, but it had no overall effect because we overwrote it later with `musttail`.  When I changed upstream to rely on applying the attribute correctly instead of using that override, the logic was exposed and broke the tests.  Just remove the logic and apply `musttail`.

Fixes rdar://125426110