### PR TITLE
[IncludeTree] Suppot `export_as` field in ModuleMap

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -462,16 +462,24 @@ public:
     bool InferSubmodules : 1;
     bool InferExplicitSubmodules : 1;
     bool InferExportWildcard : 1;
+    bool UseExportAsModuleLinkName: 1;
     ModuleFlags()
         : IsFramework(false), IsExplicit(false), IsExternC(false),
           IsSystem(false), InferSubmodules(false),
-          InferExplicitSubmodules(false), InferExportWildcard(false) {}
+          InferExplicitSubmodules(false), InferExportWildcard(false),
+          UseExportAsModuleLinkName(false) {}
   };
 
   ModuleFlags getFlags() const;
 
   /// The name of the current (sub)module.
-  StringRef getName() const { return dataAfterFlags(); }
+  StringRef getName() const {
+    return dataAfterFlags().split('\0').first;
+  }
+
+  StringRef getExportAsModule() const {
+    return dataAfterFlags().split('\0').second;
+  }
 
   size_t getNumSubmodules() const;
 
@@ -505,7 +513,7 @@ public:
   llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
 
   static Expected<Module> create(ObjectStore &DB, StringRef ModuleName,
-                                 ModuleFlags Flags,
+                                 StringRef ExportAs, ModuleFlags Flags,
                                  ArrayRef<ObjectRef> Submodules,
                                  std::optional<ObjectRef> ExportList,
                                  std::optional<ObjectRef> LinkLibraries);

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -579,6 +579,8 @@ static Expected<Module *> makeIncludeTreeModule(CompilerInstance &CI,
   M->InferSubmodules = Flags.InferSubmodules;
   M->InferExplicitSubmodules = Flags.InferExplicitSubmodules;
   M->InferExportWildcard = Flags.InferExportWildcard;
+  M->UseExportAsModuleLinkName = Flags.UseExportAsModuleLinkName;
+  M->ExportAsModule = Mod.getExportAsModule();
 
   auto ExportList = Mod.getExports();
   if (!ExportList)

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -546,6 +546,7 @@ getIncludeTreeModule(cas::ObjectStore &DB, Module *M) {
   Flags.InferSubmodules = M->InferSubmodules;
   Flags.InferExplicitSubmodules = M->InferExplicitSubmodules;
   Flags.InferExportWildcard = M->InferExportWildcard;
+  Flags.UseExportAsModuleLinkName = M->UseExportAsModuleLinkName;
 
   bool GlobalWildcardExport = false;
   SmallVector<ITModule::ExportList::Export> Exports;
@@ -579,8 +580,8 @@ getIncludeTreeModule(cas::ObjectStore &DB, Module *M) {
     LinkLibraries = LL->getRef();
   }
 
-  return ITModule::create(DB, M->Name, Flags, Submodules, ExportList,
-                          LinkLibraries);
+  return ITModule::create(DB, M->Name, M->ExportAsModule, Flags, Submodules,
+                          ExportList, LinkLibraries);
 }
 
 Expected<cas::IncludeTreeRoot>

--- a/clang/test/ClangScanDeps/modules-include-tree-export-as.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-export-as.c
@@ -1,0 +1,67 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Extract the include-tree commands
+// RUN: %deps-to-rsp %t/deps.json --module-name Top > %t/Top.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name Left > %t/Left.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// Extract include-tree casids
+// RUN: cat %t/Top.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Top.casid
+// RUN: cat %t/Left.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Left.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Top.casid | FileCheck %s -check-prefix=TOP
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Left.casid | FileCheck %s -check-prefix=LEFT
+
+// TOP: Module Map:
+// TOP-NEXT: Top
+// TOP-NEXT: export_as Left
+// LEFT: Module Map:
+// LEFT-NEXT Left
+// LEFT-NOT: export_as
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -fapinotes-modules -iapinotes-modules DIR"
+}]
+
+//--- module.modulemap
+module Top {
+  header "Top.h"
+  export_as Left
+  export *
+}
+module Left {
+  header "Left.h"
+  export *
+}
+
+//--- Top.h
+#pragma once
+struct Top {
+  int x;
+};
+void top(void);
+
+//--- Left.h
+#include "Top.h"
+void left(void);
+
+//--- tu.m
+#import "Left.h"
+
+void tu(void) {
+  top(); // expected-error {{'top' is unavailable: don't use this}}
+  left();
+}
+// expected-note@Top.h:5{{'top' has been explicitly marked unavailable here}}
+


### PR DESCRIPTION
Add support for `export_as` in module map for include-tree.

rdar://125421391