### PR TITLE
[LLDBTypeInfoProvider] Store anonymous clang types in a side table

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -170,6 +170,11 @@ public:
   CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
                                          CompilerType base_type);
 
+  /// Enter an anonymous Clang type with a name key into a side table.
+  void RegisterAnonymousClangType(const char *key, CompilerType clang_type);
+  /// Look up an anonymous Clang type with a name key into a side table.
+  CompilerType LookupAnonymousClangType(const char *key);
+
   CompilerType GetConcreteType(ExecutionContextScope *exe_scope,
                                ConstString abstract_type_name);
 
@@ -434,6 +439,8 @@ private:
   llvm::DenseMap<lldb::opaque_compiler_type_t,
                  std::optional<swift::reflection::RecordTypeInfo>>
       m_clang_record_type_info;
+  llvm::DenseMap<const char *, CompilerType> m_anonymous_clang_types;
+  unsigned m_num_anonymous_clang_types = 0;
   std::recursive_mutex m_clang_type_info_mutex;
   /// \}
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -321,6 +321,22 @@ NodePointer TypeSystemSwiftTypeRef::CreateBoundGenericStruct(
   return outer_type;
 }
 
+CompilerType
+TypeSystemSwiftTypeRef::CreateClangStructType(llvm::StringRef name) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodePointer module = dem.createNodeWithAllocatedText(
+      Node::Kind::Module, swift::MANGLING_MODULE_OBJC);
+  NodePointer identifier =
+      dem.createNodeWithAllocatedText(Node::Kind::Identifier, name);
+  NodePointer nominal = dem.createNode(Node::Kind::Structure);
+  nominal->addChild(module, dem);
+  nominal->addChild(identifier, dem);
+  NodePointer type = dem.createNode(Node::Kind::Type);
+  type->addChild(nominal, dem);
+  return RemangleAsType(dem, type);
+}
+
 /// Return a demangle tree leaf node representing \p clang_type.
 swift::Demangle::NodePointer
 TypeSystemSwiftTypeRef::GetClangTypeNode(CompilerType clang_type,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -327,6 +327,9 @@ public:
   CompilerType CreateGenericTypeParamType(unsigned int depth,
                                     unsigned int index) override;
 
+  /// Create a __C imported struct type.
+  CompilerType CreateClangStructType(llvm::StringRef name);
+
   /// Builds a bound generic struct demangle tree with the name, module name,
   /// and the struct's elements.
   static swift::Demangle::NodePointer CreateBoundGenericStruct(

--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
@@ -9,28 +9,43 @@ class TestSwiftAnonymousClangTypes(lldbtest.TestBase):
     def test(self):
         self.build()
 
-        lldbutil.run_to_source_breakpoint(
+        target, _, _, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
-        self.expect(
-            "frame variable twoStructs",
-            substrs=[
-                "(TwoAnonymousStructs) twoStructs = {",
-                "= (x = 1, y = 2, z = 3)",
-                "= (a = 4)",
-            ],
-        )
+        def check(field, value):
+            self.assertTrue(field.IsValid())
+            lldbutil.check_variable(self, field, False, value=value)       
 
-        self.expect(
-            "frame variable twoUnions",
-            substrs=[
-                "(TwoAnonymousUnions) twoUnions = {",
-                "   = {",
-                "     = (x = 2)",
-                "     = (y = 2, z = 3)",
-                "  }",
-                "   = {",
-                "     = (a = 4, b = 5, c = 6)",
-                "     = (d = 4, e = 5)",
-            ],
-        )
+        twoStructs = target.FindFirstGlobalVariable("twoStructs")
+        self.assertTrue(twoStructs.IsValid())
+
+        field0 = twoStructs.GetChildAtIndex(0)
+        self.assertTrue(field0.IsValid())
+        check(field0.GetChildMemberWithName("x"), value="1")
+        check(field0.GetChildMemberWithName("y"), value="2")
+        check(field0.GetChildMemberWithName("z"), value="3")
+
+        field1 = twoStructs.GetChildAtIndex(1)
+        self.assertTrue(field1.IsValid())
+        check(field1.GetChildMemberWithName("a"), value="4")
+
+
+        twoUnions = target.FindFirstGlobalVariable("twoUnions")
+        self.assertTrue(twoUnions.IsValid())
+        field0 = twoUnions.GetChildAtIndex(0)
+        self.assertTrue(field0.IsValid())
+        field0_0 = field0.GetChildAtIndex(0)
+        check(field0_0.GetChildMemberWithName("x"), value="2")
+        field0_1 = field0.GetChildAtIndex(1)
+        check(field0_1.GetChildMemberWithName("y"), value="2")
+        check(field0_1.GetChildMemberWithName("z"), value="3")
+
+        field1 = twoUnions.GetChildAtIndex(1)
+        self.assertTrue(field1.IsValid())
+        field1_0 = field1.GetChildAtIndex(0)
+        check(field1_0.GetChildMemberWithName("a"), value="4")
+        check(field1_0.GetChildMemberWithName("b"), value="5")
+        check(field1_0.GetChildMemberWithName("c"), value="6")
+        field1_1 = field1.GetChildAtIndex(1)
+        check(field1_1.GetChildMemberWithName("d"), value="4")
+        check(field1_1.GetChildMemberWithName("e"), value="5")


### PR DESCRIPTION
so they can be found again when their TypeInfo is requested.

This changes the behavior of the modified test such that it now uses TypeSystemSwiftTypeRef, which slightly alters the textual output. I took this as an opportunity to convert it to check_variable.

(cherry picked from commit 851bb55480c34809a57c4bed398fcb84afb2db68)