### PR TITLE
Thread llvm::Expected through SwiftASTContext::Reconstruct type 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1510,7 +1510,9 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
                          swift_ast_ctx->GetIdentifier(name.GetCString()),
                          module_decl);
       var_decl->setInterfaceType(
-          swift_ast_ctx->GetSwiftType(swift_ast_ctx->GetErrorType()));
+          llvm::expectedToStdOptional(
+              swift_ast_ctx->GetSwiftType(swift_ast_ctx->GetErrorType()))
+              .value_or(swift::Type()));
       var_decl->setDebuggerVar(true);
 
       SwiftPersistentExpressionState *persistent_state =

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1073,6 +1073,8 @@ static const char *getImportFailureString(swift::serialization::Status status) {
            "was required to do so.";
   case swift::serialization::Status::SDKMismatch:
     return "The module file was built with a different SDK version.";
+  case swift::serialization::Status::ChannelIncompatible:
+    return "The distribution channel doesn't match.";
   }
 }
 
@@ -8598,6 +8600,9 @@ static void DescribeFileUnit(Stream &s, const swift::FileUnit *file_unit) {
         break;
       case swift::SourceFileKind::Interface:
         s.PutCString("Interface");
+        break;
+      case swift::SourceFileKind::DefaultArgument:
+        s.PutCString("Default Argument");
         break;
       }
     }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -212,7 +212,8 @@ CompilerType SwiftASTContext::GetCompilerType(swift::TypeBase *swift_type) {
   return {weak_from_this(), swift_type};
 }
 
-swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
+llvm::Expected<swift::Type>
+SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
   if (compiler_type.GetTypeSystem().GetSharedPointer().get() == this)
     return reinterpret_cast<swift::TypeBase *>(
         compiler_type.GetOpaqueQualType());
@@ -222,12 +223,19 @@ swift::Type SwiftASTContext::GetSwiftType(CompilerType compiler_type) {
 swift::Type SwiftASTContext::GetSwiftType(opaque_compiler_type_t opaque_type) {
   assert(opaque_type && *reinterpret_cast<const char *>(opaque_type) != '$' &&
          "wrong type system");
-  return GetSwiftType(CompilerType(weak_from_this(), opaque_type));
+  return GetSwiftTypeIgnoringErrors(
+      CompilerType(weak_from_this(), opaque_type));
+}
+
+swift::Type
+SwiftASTContext::GetSwiftTypeIgnoringErrors(CompilerType compiler_type) {
+  return llvm::expectedToStdOptional(GetSwiftType(compiler_type))
+      .value_or(swift::Type());
 }
 
 swift::CanType
 SwiftASTContext::GetCanonicalSwiftType(CompilerType compiler_type) {
-  swift::Type swift_type = GetSwiftType(compiler_type);
+  swift::Type swift_type = GetSwiftTypeIgnoringErrors(compiler_type);
   return swift_type ? swift_type->getCanonicalType() : swift::CanType();
 }
 
@@ -936,8 +944,8 @@ llvm::Error SwiftASTContext::ScopedDiagnostics::GetAllErrors() const {
   // Retrieve the error message from the DiagnosticConsumer.
   DiagnosticManager diagnostic_manager;
   PrintDiagnostics(diagnostic_manager);
-  return llvm::make_error<llvm::StringError>(diagnostic_manager.GetString(),
-                                             llvm::inconvertibleErrorCode());
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 diagnostic_manager.GetString());
 }
 
 SwiftASTContext::ScopedDiagnostics::~ScopedDiagnostics() {
@@ -4425,7 +4433,9 @@ static swift::Type ConvertSILFunctionTypesToASTFunctionTypes(swift::Type t) {
 CompilerType
 SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename) {
   if (llvm::isa<SwiftASTContextForExpressions>(this))
-    return GetCompilerType(ReconstructType(mangled_typename));
+    return GetCompilerType(
+        llvm::expectedToStdOptional(ReconstructType(mangled_typename))
+            .value_or(nullptr));
   return GetCompilerType(mangled_typename);
 }
 
@@ -4482,25 +4492,27 @@ CompilerType SwiftASTContext::GetAsClangType(ConstString mangled_name) {
 }
 
 swift::TypeBase *
-SwiftASTContext::ReconstructType(ConstString mangled_typename) {
+SwiftASTContext::ReconstructTypeOrWarn(ConstString mangled_typename) {
   Status error;
 
-  auto reconstructed_type = ReconstructType(mangled_typename, error);
-  if (!error.Success())
-    AddDiagnostic(eDiagnosticSeverityWarning, error.AsCString());
-  return reconstructed_type;
+  auto reconstructed_type = ReconstructType(mangled_typename);
+  if (!reconstructed_type)
+    AddDiagnostic(eDiagnosticSeverityWarning,
+                  llvm::toString(reconstructed_type.takeError()));
+  return *reconstructed_type;
 }
 
-swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
-                                                  Status &error) {
+llvm::Expected<swift::TypeBase *>
+SwiftASTContext::ReconstructType(ConstString mangled_typename) {
   VALID_OR_RETURN(nullptr);
 
   const char *mangled_cstr = mangled_typename.AsCString();
-  if (mangled_typename.IsEmpty() ||
-      !SwiftLanguageRuntime::IsSwiftMangledName(mangled_typename.GetStringRef())) {
-    error.SetErrorStringWithFormat(
-        "typename \"%s\" is not a valid Swift mangled name", mangled_cstr);
-    return {};
+  if (mangled_typename.IsEmpty() || !SwiftLanguageRuntime::IsSwiftMangledName(
+                                        mangled_typename.GetStringRef())) {
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "typename \"" +
+                                       mangled_typename.GetStringRef() +
+                                       "\" is not a valid Swift mangled name");
   }
 
   LOG_VERBOSE_PRINTF(GetLog(LLDBLog::Types), "(\"%s\")", mangled_cstr);
@@ -4509,11 +4521,9 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
   if (!ast_ctx) {
     LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- null Swift AST Context",
                mangled_cstr);
-    error.SetErrorString("null Swift AST Context");
-    return {};
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "null Swift AST Context");
   }
-
-  error.Clear();
 
   // If we were to crash doing this, remember what type caused it.
   llvm::PrettyStackTraceFormat PST("error finding type for %s", mangled_cstr);
@@ -4528,7 +4538,10 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
   if (m_negative_type_cache.Lookup(mangled_cstr)) {
     LOG_PRINTF(GetLog(LLDBLog::Types),
                "(\"%s\") -- found in the negative cache", mangled_cstr);
-    return {};
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "type for typename \"" +
+                                       mangled_typename.GetString() +
+                                       "\" was not found (cached)");
   }
 
   LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- not cached, searching",
@@ -4593,10 +4606,11 @@ swift::TypeBase *SwiftASTContext::ReconstructType(ConstString mangled_typename,
 
   LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- not found", mangled_cstr);
 
-  error.SetErrorStringWithFormat("type for typename \"%s\" was not found",
-                                 mangled_cstr);
   CacheDemangledTypeFailure(mangled_typename);
-  return {};
+  return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                 "type for typename \"" +
+                                     mangled_typename.GetString() +
+                                     "\" was not found");
 }
 
 CompilerType SwiftASTContext::GetAnyObjectType() {
@@ -4729,7 +4743,7 @@ SwiftASTContext::FindContainedTypeOrDecl(llvm::StringRef name,
 
   if (!name.empty() &&
       container_type.GetTypeSystem().isa_and_nonnull<TypeSystemSwift>()) {
-    swift::Type swift_type = GetSwiftType(container_type);
+    swift::Type swift_type = GetSwiftTypeIgnoringErrors(container_type);
     if (!swift_type)
       return 0;
     swift::CanType swift_can_type(swift_type->getCanonicalType());
@@ -5047,7 +5061,7 @@ SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements) {
   else {
     std::vector<swift::TupleTypeElt> tuple_elems;
     for (const TupleElement &element : elements) {
-      if (auto swift_type = GetSwiftType(element.element_type)) {
+      if (auto swift_type = GetSwiftTypeIgnoringErrors(element.element_type)) {
         if (element.element_name.IsEmpty())
           tuple_elems.push_back(swift::TupleTypeElt(swift_type));
         else
@@ -5602,7 +5616,8 @@ bool SwiftASTContext::IsVoidType(opaque_compiler_type_t type) {
 bool SwiftASTContext::IsGenericType(const CompilerType &compiler_type) {
   if (auto swift_ast_ctx =
           compiler_type.GetTypeSystem().dyn_cast_or_null<SwiftASTContext>()) {
-    if (swift::Type swift_type = swift_ast_ctx->GetSwiftType(compiler_type))
+    if (swift::Type swift_type =
+            swift_ast_ctx->GetSwiftTypeIgnoringErrors(compiler_type))
       return swift_type->hasTypeParameter();
   } else
     return compiler_type.GetTypeInfo() & eTypeIsGenericTypeParam;
@@ -6565,8 +6580,8 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
                                 bool omit_empty_base_classes,
                                 const ExecutionContext *exe_ctx) {
   VALID_OR_RETURN_CHECK_TYPE(
-      type, llvm::make_error<llvm::StringError>(
-                "invalid type", llvm::inconvertibleErrorCode()));
+      type,
+      llvm::createStringError(llvm::inconvertibleErrorCode(), "invalid type"));
   LLDB_SCOPED_TIMER();
 
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -7916,7 +7931,7 @@ CompilerType SwiftASTContext::GetUnboundGenericType(opaque_compiler_type_t type,
 
 CompilerType SwiftASTContext::GetGenericArgumentType(CompilerType ct,
                                                      size_t idx) {
-  swift::Type swift_type = GetSwiftType(ct);
+  swift::Type swift_type = GetSwiftTypeIgnoringErrors(ct);
   if (!swift_type)
     return {};
   auto *ast = GetSwiftASTContext(&swift_type->getASTContext());
@@ -8250,17 +8265,15 @@ SwiftASTContext::ConvertClangTypeToSwiftType(CompilerType clang_type) {
   if (!typeref_type)
     return {};
 
-  Status error;
-  auto *ast_type = ReconstructType(typeref_type.GetMangledTypeName(), error);
-  if (error.Fail()) {
-    LLDB_LOGF(GetLog(LLDBLog::Types),
-              "[SwiftASTContext::ConvertClangTypeToSwiftType] Could not "
-              "reconstruct type. Error: %s",
-              error.AsCString());
+  auto ast_type = ReconstructType(typeref_type.GetMangledTypeName());
+  if (!ast_type) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), ast_type.takeError(),
+                   "[SwiftASTContext::ConvertClangTypeToSwiftType] Could not "
+                   "reconstruct type. Error: {0}");
     return {};
   }
 
-  return {this->weak_from_this(), ast_type};
+  return {this->weak_from_this(), *ast_type};
 }
 
 CompilerType SwiftASTContext::GetBuiltinIntType() {
@@ -8269,7 +8282,7 @@ CompilerType SwiftASTContext::GetBuiltinIntType() {
 }
 
 bool SwiftASTContext::TypeHasArchetype(CompilerType type) {
-  auto swift_type = GetSwiftType(type);
+  auto swift_type = GetSwiftTypeIgnoringErrors(type);
   if (swift_type)
     return swift_type->hasArchetype();
   return false;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -241,7 +241,7 @@ SwiftASTContext::GetCanonicalSwiftType(opaque_compiler_type_t opaque_type) {
 ConstString SwiftASTContext::GetMangledTypeName(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(
       type, ConstString("<invalid Swift context or opaque type>"));
-  return GetMangledTypeName(GetSwiftType({weak_from_this(), type}).getPointer());
+  return GetMangledTypeName(GetSwiftType(type).getPointer());
 }
 
 typedef lldb_private::ThreadSafeDenseMap<swift::ASTContext *, SwiftASTContext *>
@@ -6248,7 +6248,7 @@ CompilerType SwiftASTContext::GetPointeeType(opaque_compiler_type_t type) {
 CompilerType SwiftASTContext::GetPointerType(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
-  auto swift_type = GetSwiftType({weak_from_this(), type});
+  auto swift_type = GetSwiftType(type);
   auto pointer_type =
       swift_type->wrapInPointer(swift::PointerTypeKind::PTK_UnsafePointer);
   if (pointer_type)
@@ -6260,7 +6260,7 @@ CompilerType SwiftASTContext::GetPointerType(opaque_compiler_type_t type) {
 CompilerType SwiftASTContext::GetTypedefedType(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
-  swift::Type swift_type(GetSwiftType({weak_from_this(), type}));
+  swift::Type swift_type(GetSwiftType(type));
   swift::TypeAliasType *name_alias_type =
       swift::dyn_cast<swift::TypeAliasType>(swift_type.getPointer());
   if (name_alias_type) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -362,9 +362,14 @@ public:
                   bool append = true);
 
   /// Reconstruct a Swift AST type from a mangled name by looking its
+  /// components up in Swift modules. Diagnose a warning on error.
+  swift::TypeBase *ReconstructTypeOrWarn(ConstString mangled_typename);
+  /// Reconstruct a Swift AST type from a mangled name by looking its
   /// components up in Swift modules.
-  swift::TypeBase *ReconstructType(ConstString mangled_typename);
-  swift::TypeBase *ReconstructType(ConstString mangled_typename, Status &error);
+  llvm::Expected<swift::TypeBase *>
+  ReconstructType(ConstString mangled_typename);
+  /// Reconstruct a Swift AST type from a mangled name by looking its
+  /// components up in Swift modules.
   CompilerType
   GetTypeFromMangledTypename(ConstString mangled_typename) override;
 
@@ -415,11 +420,12 @@ public:
   CompilerType GetCompilerType(swift::TypeBase *swift_type);
   CompilerType GetCompilerType(ConstString mangled_name);
   /// Import compiler_type into this context and return the swift::Type.
-  swift::Type GetSwiftType(CompilerType compiler_type);
+  llvm::Expected<swift::Type> GetSwiftType(CompilerType compiler_type);
   /// Import compiler_type into this context and return the swift::CanType.
   swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
 protected:
   swift::Type GetSwiftType(lldb::opaque_compiler_type_t opaque_type);
+  swift::Type GetSwiftTypeIgnoringErrors(CompilerType compiler_type);
   swift::CanType
   GetCanonicalSwiftType(lldb::opaque_compiler_type_t opaque_type);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1810,9 +1810,10 @@ TypeSystemSwiftTypeRef::GetMangledTypeName(opaque_compiler_type_t type) {
 
 void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
                                               const ExecutionContext *exe_ctx) {
-  Status error;
   if (auto *swift_ast_context = GetSwiftASTContextFromExecutionContext(exe_ctx))
-    return swift_ast_context->ReconstructType(GetMangledTypeName(type), error);
+    return llvm::expectedToStdOptional(
+               swift_ast_context->ReconstructType(GetMangledTypeName(type)))
+        .value_or(nullptr);
   return {};
 }
 
@@ -2049,8 +2050,9 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
   // See comments in SwiftASTContext::ReconstructType(). For
   // SILFunctionTypes the mapping isn't bijective.
   auto ast_ctx = r.GetTypeSystem().dyn_cast_or_null<SwiftASTContext>();
-  if (((void *)ast_ctx->ReconstructType(l.GetMangledTypeName())) ==
-      r.GetOpaqueQualType())
+  if (((void *)llvm::expectedToStdOptional(
+           ast_ctx->ReconstructType(l.GetMangledTypeName()))
+           .value_or(nullptr)) == r.GetOpaqueQualType())
     return true;
   ConstString lhs = l.GetMangledTypeName();
   ConstString rhs = r.GetMangledTypeName();

--- a/lldb/test/API/lang/swift/expression/missing_type/Makefile
+++ b/lldb/test/API/lang/swift/expression/missing_type/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -experimental-skip-non-inlinable-function-bodies-without-types
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
+++ b/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftExprMissingType(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("frame variable invisible", substrs=["1", "2"])
+        self.expect("expr invisible", error=True,
+                    substrs=["Missing type debug info", "invisible"])

--- a/lldb/test/API/lang/swift/expression/missing_type/main.swift
+++ b/lldb/test/API/lang/swift/expression/missing_type/main.swift
@@ -1,0 +1,8 @@
+func main() {
+  // This type is hidden due to the frontend flag in Makefile.
+  typealias Pair<T> = (T, T)
+  let invisible : Pair<Int> = (1, 2)
+  print("break here \(invisible)")
+}
+
+main()


### PR DESCRIPTION
[Thread llvm::Expected through SwiftASTContext::Reconstruct type all the way to the expression evaluator. Without this change a user would see a misleading
```
  error: <EXPR>:8:1: cannot find 'variable' in scope
```
instead of pointing at the missing debug info for variable's type.

rdar://125613361