### PR TITLE
Fix unused function warning

### DIFF
--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -124,7 +124,7 @@ struct CUInfo {
 };
 static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(
     MutableArrayRef<char> CUData, endianness Endian,
-    std::optional<uint32_t> NewOffset = std::nullopt);
+    std::optional<uint32_t> NewOffset, uint8_t AddressSize);
 Expected<cas::ObjectProxy>
 MCSchema::createFromMCAssemblerImpl(MachOCASWriter &ObjectWriter,
                                     MCAssembler &Asm, const MCAsmLayout &Layout,


### PR DESCRIPTION
Fix
`/Users/shubham/Development/llvm-project-cas/llvm-project/llvm/lib/MCCAS/MCCASObjectV1.cpp:125:25: warning: unused function 'getAndSetDebugAbbrevOffsetAndSkip' [-Wunused-function]
  125 | static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~`