### PR TITLE
Try to figure out why this test is failing on CentOS and no other Linux.

### DIFF
--- a/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
+++ b/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
@@ -11,9 +11,29 @@ class SwiftAddressExpressionTest(TestBase):
         """Test that you can use register names in image lookup in a swift frame."""
         self.build()
         (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(self, 
-                "break here to check image lookup", lldb.SBFileSpec("main.swift"))
+            "break here to check image lookup", lldb.SBFileSpec("main.swift"))
         # I don't want to be too specific in what we print for image lookup,
         # we're testing that the address expression for the pc worked.
         self.expect("image lookup -va $pc", substrs=["doSomething"])
         self.expect("image lookup -va $pc+4", substrs=["doSomething"])
+
+    def test_using_alias(self):
+        """Test that you can use register names in image lookup in a swift frame."""
+        self.build()
+        (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(self, 
+            "break here to check image lookup", lldb.SBFileSpec("main.swift"))
+        # I don't want to be too specific in what we print for image lookup,
+        # we're testing that the address expression for the pc worked.
+        self.expect("target modules lookup -va $pc", substrs=["doSomething"])
+        self.expect("target modules lookup -va $pc+4", substrs=["doSomething"])
+        
+    def test_using_separate_options(self):
+        """Test that you can use register names in image lookup in a swift frame."""
+        self.build()
+        (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(self, 
+            "break here to check image lookup", lldb.SBFileSpec("main.swift"))
+        # I don't want to be too specific in what we print for image lookup,
+        # we're testing that the address expression for the pc worked.
+        self.expect("target modules lookup -v -a $pc", substrs=["doSomething"])
+        self.expect("target modules lookup -v -a $pc+4", substrs=["doSomething"])
         


### PR DESCRIPTION
This test is failing at the command-line argument parsing stage on CentOS but no other Linux so far as I can tell.  This looks like a problem with the option parsing (we use the system opt parse to do this, so that is certainly possible).

I dialed up the command I want in a couple different ways, let's see if they all fail on CentOS.