### PR TITLE
[cherry-pick][swift/release/6.0] [lldb] Fix type lookup in DWARF .o files via debug map (#87177)

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1244,7 +1244,7 @@ void SymbolFileDWARFDebugMap::FindTypes(const TypeQuery &query,
   std::lock_guard<std::recursive_mutex> guard(GetModuleMutex());
   ForEachSymbolFile([&](SymbolFileDWARF *oso_dwarf) -> bool {
     oso_dwarf->FindTypes(query, results);
-    return !results.Done(query); // Keep iterating if we aren't done.
+    return results.Done(query); // Keep iterating if we aren't done.
   });
 }
 
@@ -1376,7 +1376,7 @@ void SymbolFileDWARFDebugMap::ParseDeclsForContext(
     lldb_private::CompilerDeclContext decl_ctx) {
   ForEachSymbolFile([&](SymbolFileDWARF *oso_dwarf) -> bool {
     oso_dwarf->ParseDeclsForContext(decl_ctx);
-    return true; // Keep iterating
+    return false; // Keep iterating
   });
 }
 

--- a/lldb/test/API/functionalities/type_find_first/Makefile
+++ b/lldb/test/API/functionalities/type_find_first/Makefile
@@ -1,2 +1,2 @@
-CXX_SOURCES := main.cpp
+CXX_SOURCES := main.cpp other.cpp
 include Makefile.rules

--- a/lldb/test/API/functionalities/type_find_first/TestFindFirstType.py
+++ b/lldb/test/API/functionalities/type_find_first/TestFindFirstType.py
@@ -8,31 +8,31 @@ from lldbsuite.test import lldbutil
 
 
 class TypeFindFirstTestCase(TestBase):
-
-    NO_DEBUG_INFO_TESTCASE = True
-
     def test_find_first_type(self):
         """
-            Test SBTarget::FindFirstType() and SBModule::FindFirstType() APIs.
+        Test SBTarget::FindFirstType() and SBModule::FindFirstType() APIs.
 
-            This function had regressed after some past modification of the type
-            lookup internal code where if we had multiple types with the same
-            basename, FindFirstType() could end up failing depending on which
-            type was found first in the debug info indexes. This test will
-            ensure this doesn't regress in the future.
+        This function had regressed after some past modification of the type
+        lookup internal code where if we had multiple types with the same
+        basename, FindFirstType() could end up failing depending on which
+        type was found first in the debug info indexes. This test will
+        ensure this doesn't regress in the future.
+
+        The test also looks for a type defined in a different compilation unit
+        to verify that SymbolFileDWARFDebugMap searches each symbol file in a
+        module.
         """
         self.build()
         target = self.createTestTarget()
-        # Test the SBTarget APIs for FindFirstType
-        integer_type = target.FindFirstType("Integer::Point")
-        self.assertTrue(integer_type.IsValid())
-        float_type = target.FindFirstType("Float::Point")
-        self.assertTrue(float_type.IsValid())
-
-        # Test the SBModule APIs for FindFirstType
         exe_module = target.GetModuleAtIndex(0)
         self.assertTrue(exe_module.IsValid())
-        integer_type = exe_module.FindFirstType("Integer::Point")
-        self.assertTrue(integer_type.IsValid())
-        float_type = exe_module.FindFirstType("Float::Point")
-        self.assertTrue(float_type.IsValid())
+        # Test the SBTarget and SBModule APIs for FindFirstType
+        for api in [target, exe_module]:
+            integer_type = api.FindFirstType("Integer::Point")
+            self.assertTrue(integer_type.IsValid())
+            float_type = api.FindFirstType("Float::Point")
+            self.assertTrue(float_type.IsValid())
+            external_type = api.FindFirstType("OtherCompilationUnit::Type")
+            self.assertTrue(external_type.IsValid())
+            nonexistent_type = api.FindFirstType("NonexistentType")
+            self.assertFalse(nonexistent_type.IsValid())

--- a/lldb/test/API/functionalities/type_find_first/main.cpp
+++ b/lldb/test/API/functionalities/type_find_first/main.cpp
@@ -10,8 +10,13 @@ struct Point {
 };
 } // namespace Float
 
+namespace OtherCompilationUnit {
+void Function();
+} // namespace OtherCompilationUnit
+
 int main(int argc, char const *argv[]) {
   Integer::Point ip = {2, 3};
   Float::Point fp = {2.0, 3.0};
+  OtherCompilationUnit::Function();
   return 0;
 }

--- a/lldb/test/API/functionalities/type_find_first/other.cpp
+++ b/lldb/test/API/functionalities/type_find_first/other.cpp
@@ -1,0 +1,4 @@
+namespace OtherCompilationUnit {
+struct Type {};
+void Function() { Type typeIsActuallyUsed; }
+} // namespace OtherCompilationUnit


### PR DESCRIPTION
An inverted condition causes `SymbolFileDWARFDebugMap::FindTypes` to bail out after inspecting the first .o file in each module.

The same kind of bug is found in
`SymbolFileDWARFDebugMap::ParseDeclsForContext`.

Correct both early exit conditions and add a regression test for lookup of up a type defined in a secondary compilation unit.

Fixes #87176

(cherry picked from commit 154cea46732f4014bb409f1bcac9b39ac56df193)