### PR TITLE
[cherrypick swift/release/6.0] Return `errc::no_such_file_or_directory` in `fs::access` if `GetFileAttributesW` fails

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -630,6 +630,10 @@ std::error_code access(const Twine &Path, AccessMode Mode) {
   DWORD Attributes = ::GetFileAttributesW(PathUtf16.begin());
 
   if (Attributes == INVALID_FILE_ATTRIBUTES) {
+    // Avoid returning unexpected error codes when querying for existence.
+    if (Mode == AccessMode::Exist)
+      return errc::no_such_file_or_directory;
+
     // See if the file didn't actually exist.
     DWORD LastError = ::GetLastError();
     if (LastError != ERROR_FILE_NOT_FOUND && LastError != ERROR_PATH_NOT_FOUND)


### PR DESCRIPTION
Cherry picking this fix for https://github.com/apple/llvm-project/issues/8224 into the `swift/release/6.0` branch

(cherry picked from commit 9961c03e9ec2fc47cb42fd16141b89dd8d8e2c01)