### PR TITLE
[next] Disable lld Mach-O tests in the Swift LLVM fork

### DIFF
--- a/lld/test/COFF/gc-dwarf-eh.s
+++ b/lld/test/COFF/gc-dwarf-eh.s
@@ -1,5 +1,10 @@
 # REQUIRES: x86
 
+# Swift LLVM fork downstream change start
+# Disable failing test
+# XFAIL: *
+# Swift LLVM fork downstream change end
+
 # RUN: llvm-mc -triple=i686-windows-gnu %s -filetype=obj -o %t.obj
 # RUN: lld-link -lldmingw -lldmap:%t.map -out:%t.exe -opt:ref -entry:main %t.obj -verbose 2>&1 | FileCheck %s
 # RUN: FileCheck %s --check-prefix=MAP --input-file=%t.map

--- a/lld/test/COFF/gc-dwarf-eh.s
+++ b/lld/test/COFF/gc-dwarf-eh.s
@@ -1,10 +1,5 @@
 # REQUIRES: x86
 
-# Swift LLVM fork downstream change start
-# Disable failing test
-# XFAIL: *
-# Swift LLVM fork downstream change end
-
 # RUN: llvm-mc -triple=i686-windows-gnu %s -filetype=obj -o %t.obj
 # RUN: lld-link -lldmingw -lldmap:%t.map -out:%t.exe -opt:ref -entry:main %t.obj -verbose 2>&1 | FileCheck %s
 # RUN: FileCheck %s --check-prefix=MAP --input-file=%t.map

--- a/lld/test/MachO/lit.local.cfg
+++ b/lld/test/MachO/lit.local.cfg
@@ -8,6 +8,11 @@ import os
 if sys.byteorder == "big":
     config.unsupported = True
 
+# Swift LLVM fork downstream change start
+# The Swift LLVM fork of lld does not support linking Mach-O for userspace Darwin, let's disable Mach-O tests
+config.unsupported = True
+# Swift LLVM fork downstream change end
+
 # We specify the most commonly-used archs and platform versions in our tests
 # here. Tests which need different settings can just append to this, as only
 # the last value will be used.


### PR DESCRIPTION
next version of https://github.com/apple/llvm-project/pull/8511