### PR TITLE
[lldb][test] Add comment for skipping TestSwiftExprMissingType.py

### DIFF
--- a/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
+++ b/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExprMissingType(lldbtest.TestBase):
+    # rdar://125857402
     @skipIfDarwin
     @skipIfLinux
     @swiftTest


### PR DESCRIPTION
Adds a comment for why we're skipping this test.