### PR TITLE
[Cherry-pick into next] Rewrite test to not depend on a compiler bug

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -769,6 +769,9 @@ $(EXE): $(OBJECTS)
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$(EXE)"
 endif
+ifneq "$(HIDE_SWIFTMODULE)" ""
+	rm -f $(MODULENAME).swiftmodule
+endif
 else # OS = Linux
 ifeq "$(HIDE_SWIFTMODULE)" ""
 WRAPPED_SWIFTMODULE = $(MODULENAME).o
@@ -777,7 +780,9 @@ endif
 $(EXE): $(OBJECTS)
 	@echo "### Linking" $(EXE)
 	$(SWIFTC) $(LD_EXTRAS) $(LD_SWIFTFLAGS) $(WRAPPED_SWIFTMODULE) $^ $(patsubst -g,,$(SWIFTFLAGS)) -o "$(EXE)"
-
+ifneq "$(HIDE_SWIFTMODULE)" ""
+	rm -f $(MODULENAME).swiftmodule
+endif
 endif
 
 else # USESWIFTDRIVER = 0

--- a/lldb/test/API/lang/swift/expression/missing_type/Makefile
+++ b/lldb/test/API/lang/swift/expression/missing_type/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -experimental-skip-non-inlinable-function-bodies-without-types
+HIDE_SWIFTMODULE := YES
 include Makefile.rules


### PR DESCRIPTION
```
commit b97c8a7619430ca5e5d2804389e7319c321befe0
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Apr 3 09:08:51 2024 -0700

    Rewrite test to not depend on a compiler bug
```
