### PR TITLE
Revert "Disable TestSwiftExprMissingType.py"

### DIFF
--- a/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
+++ b/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
@@ -4,8 +4,6 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExprMissingType(lldbtest.TestBase):
-    @skipIfDarwin
-    @skipIfLinux
     @swiftTest
     def test(self):
         self.build()


### PR DESCRIPTION
Reverts apple/llvm-project#8528