### PR TITLE
[Cherry-pick into next] Strip out -fno-implicit-modules and friends from ClangImporter options

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1749,11 +1749,17 @@ void SwiftASTContext::FilterClangImporterOptions(
   // Copy back a filtered version of ExtraArgs.
   std::vector<std::string> orig_args(std::move(extra_args));
   for (auto &arg : orig_args) {
+    StringRef arg_sr(arg);
+    // LLDB wants to control implicit/explicit modules build flags.
+    if (arg_sr == "-fno-implicit-modules" ||
+        arg_sr == "-fno-implicit-module-maps")
+      continue;
+
     // The VFS options turn into fatal errors when the referenced file
     // is not found. Since the Xcode build system tends to create a
     // lot of VFS overlays by default, stat them and emit a warning if
     // the yaml file couldn't be found.
-    if (StringRef(arg).startswith("-ivfs")) {
+    if (arg_sr.startswith("-ivfs")) {
       // Stash the argument.
       ivfs_arg = arg;
       continue;

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -parse-stdlib -Xcc -DMARKER1 -Xcc -fno-implicit-modules -Xcc -fno-implicit-module-maps -Xcc -DMARKER2
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+class TestSwiftFModuleFlags(TestBase):
+    @skipIfDarwinEmbedded
+    @swiftTest
+    def test(self):
+        """Test that -fmodule flags get stripped out"""
+        self.build()
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
+            self, 'main')
+        self.expect("expression 1", substrs=["1"])
+
+        # Scan through the types log.
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK: -DMARKER1
+#       CHECK-NOT: -fno-implicit-modules
+#       CHECK-NOT: -fno-implicit-module-maps
+#       CHECK: -DMARKER2

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/main.swift
@@ -1,0 +1,1 @@
+// This space left intentionally blank.


### PR DESCRIPTION
```
commit 6fd0ca2272bf310b65886a163d55b303a5697cdd
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Apr 2 17:10:25 2024 -0700

    Strip out -fno-implicit-modules and friends from ClangImporter options
    
    LLDB would rather control this itself.
    
    rdar://124699949
```
