### PR TITLE
Disable Clang's lld-repro.c test in the Swift LLVM fork

### DIFF
--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -1,6 +1,11 @@
 // REQUIRES: lld
 // UNSUPPORTED: target={{.*-(ps4|ps5)}}
 
+// Swift LLVM fork downstream change start
+// lld from the Swift LLVM fork does not support linking Darwin Mach-O files
+// UNSUPPORTED: *
+// Swift LLVM fork downstream change end
+
 // RUN: echo "-nostartfiles -nostdlib -fuse-ld=lld -gen-reproducer=error -fcrash-diagnostics-dir=%t" \
 // RUN:   | sed -e 's/\\/\\\\/g' > %t.rsp
 


### PR DESCRIPTION
One more test to disable in the Swift LLVM fork because its lld doesn't support Darwin Mach-O linking. See https://github.com/apple/llvm-project/pull/8511 and https://github.com/apple/llvm-project/pull/8119.