### PR TITLE
[lldb] Support breakpoints on specific property accessor blocks

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -148,7 +148,7 @@ SwiftLanguage::GetMethodNameVariants(ConstString method_name) const {
   // in type `A`). Second, it can refer the *getter* block for property `A`.
   // LLDB's baseline behavior handles the first case. The second case is
   // produced here as a variant name.
-  for (StringRef suffix : {".get", ".set", ".willSet", ".didSet"})
+  for (StringRef suffix : {".get", ".set", ".willset", ".didset"})
     if (method_name.GetStringRef().ends_with(suffix)) {
       // The method name, complete with suffix, *is* the variant.
       variant_names.emplace_back(method_name, eFunctionNameTypeFull |

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -143,7 +143,7 @@ SwiftLanguage::GetMethodNameVariants(ConstString method_name) const {
   // breakpoints on accessor blocks by name.
   //
   // By default, the name `A.B` is treated as a fully qualified name, where `B`
-  // is the basename. However, some names can be interpretted in two ways, for
+  // is the basename. However, some names can be interpreted in two ways, for
   // example `A.get`. First, it can refer to the name `get` (in module `A`, or
   // in type `A`). Second, it can refer the *getter* block for property `A`.
   // LLDB's baseline behavior handles the first case. The second case is

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/Makefile
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/Makefile
@@ -1,0 +1,4 @@
+
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestPropertyAccessorBreakpoints.py
@@ -1,6 +1,3 @@
-"""
-"""
-
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
@@ -19,5 +16,12 @@ class TestCase(TestBase):
             "observed.willset",
             "observed.didset",
         ):
-            bp = target.BreakpointCreateByName(name)
-            self.assertEqual(len(bp.locations), 1, name)
+            bp = target.BreakpointCreateByName(name, "a.out")
+            self.assertEqual(bp.num_locations, 1, f"{name} breakpoint failed")
+
+        # Setting a breakpoint on the name "get" should not create a breakpoint
+        # matching property getters. The other accerssor suffixes should also
+        # not succeed as bare names.
+        for name in ("get", "set", "willset", "didset"):
+            bp = target.BreakpointCreateByName(name, "a.out")
+            self.assertEqual(bp.num_locations, 0, f"{name} breakpoint unexpected")

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestPropertyAccessorBreakpoints.py
@@ -1,0 +1,23 @@
+"""
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target = self.dbg.CreateTarget(exe)
+        for name in (
+            "read_only.get",
+            "read_write.get",
+            "read_write.set",
+            "observed.willset",
+            "observed.didset",
+        ):
+            bp = target.BreakpointCreateByName(name)
+            self.assertEqual(len(bp.locations), 1, name)

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
@@ -6,6 +6,7 @@ from lldbsuite.test.decorators import *
 class TestCase(TestBase):
     @swiftTest
     def test(self):
+        """Test that a breakpoint on a property accessor can be set by name."""
         self.build()
         exe = self.getBuildArtifact("a.out")
         target = self.dbg.CreateTarget(exe)

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/main.swift
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/main.swift
@@ -1,0 +1,13 @@
+struct Thing {
+    var read_only: Int { 22 + 15 }
+
+    var read_write: Int {
+        get { 23 + 41 }
+        set { print("nothing") }
+    }
+
+    var observed: Int {
+        willSet { print("willSet") }
+        didSet { print("didSet") }
+    }
+}


### PR DESCRIPTION
Allows breakpoints to be set on computed properties, as well as other property accessor blocks including setters, and observers (`willSet`, `didSet`).

This change allows property accessor blocks to be set using the suffix generated for these by the compiler. They are:

* `.get`
* `.set`
* `.willset`
* `.didset`

In particular, this change allows the following command to work: `b computed_prop.get`. This will create a breakpoint on a computed property's getter – which is the motivation of this change. Currently, there's no way to set a breakpoint by name on computed properties.

Note that these suffixes are emitted by the compiler into debug info. Ex:

```
% dwarfdump main.dSYM | grep computed_prop
                    DW_AT_linkage_name	("$s4main1SV13computed_propSbvg")
                    DW_AT_name	("computed_prop.get")
```

rdar://125740294