### PR TITLE
Enable MCCAS by default in clang-cache

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -45,6 +45,40 @@
 // PLUGIN: "-fcas-plugin-option" "some-opt=value"
 // PLUGIN: "-fcas-plugin-option" "opt2=val2"
 
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
+// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS -DPREFIX=%t
+// ENABLE-MCCAS: "-fcas-path" "[[PREFIX]]/cas"
+// ENABLE-MCCAS: "-fcas-backend"
+// ENABLE-MCCAS: "-mllvm"
+// ENABLE-MCCAS: "-cas-friendly-debug-info"
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_VERIFY_MCCAS=1 \
+// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS-VERIFY -DPREFIX=%t
+// ENABLE-MCCAS-VERIFY: "-fcas-path" "[[PREFIX]]/cas"
+// ENABLE-MCCAS-VERIFY: "-fcas-backend"
+// ENABLE-MCCAS-VERIFY: "-fcas-backend-mode=verify"
+// ENABLE-MCCAS-VERIFY: "-mllvm"
+// ENABLE-MCCAS-VERIFY: "-cas-friendly-debug-info"
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 \
+// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote \
+// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote CLANG_CACHE_DISABLE_MCCAS=1 \
+// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote CLANG_CACHE_DISABLE_MCCAS=1 CLANG_CACHE_VERIFY_MCCAS=1 \
+// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// DISABLE-MCCAS-NOT: "-fcas-backend"
+// DISABLE-MCCAS-NOT: "-fcas-backend-mode=verify"
+// DISABLE-MCCAS-NOT: "-mllvm"
+// DISABLE-MCCAS-NOT: "-cas-friendly-debug-info"
+
+
+
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=REMOTE -DPREFIX=%t
 // REMOTE: "-fcompilation-caching-service-path" "[[PREFIX]]/ccremote"
 


### PR DESCRIPTION
Enable MCCAS in clang-cache by default, disable it if environment variable DISABLE_MCCAS is set or a remote cache is used.

(cherry picked from commit 124ddd0d3fc70a0ec7df4921df943029d31c89fd)

Cherry-pick https://github.com/apple/llvm-project/pull/8542 to swift/release/6.0