### PR TITLE
[lldb][embedded] Raise deployment target on macOS tests of Embedded Swift

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -646,6 +646,9 @@ endif
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
 	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -Xfrontend -disable-objc-interop -runtime-compatibility-version none
+	ifeq "$(OS)" "Darwin"
+		SWIFTFLAGS += -target $(ARCH)-apple-macos14
+	endif
 	SWIFT_WMO = 1
 endif
 


### PR DESCRIPTION
This is necessary to raise the deployment target of the embedded stdlib (https://github.com/apple/swift/pull/72716), which itself is necessary to unblock bringup of Swift Embedded Concurrency.