### PR TITLE
[cherry-pick swift/release/6.0][Headers] Don't declare unreachable() from stddef.h in C++

### DIFF
--- a/clang/lib/Headers/__stddef_unreachable.h
+++ b/clang/lib/Headers/__stddef_unreachable.h
@@ -7,6 +7,8 @@
  *===-----------------------------------------------------------------------===
  */
 
+#ifndef __cplusplus
+
 /*
  * When -fbuiltin-headers-in-system-modules is set this is a non-modular header
  * and needs to behave as if it was textual.
@@ -14,4 +16,6 @@
 #if !defined(unreachable) ||                                                   \
     (__has_feature(modules) && !__building_module(_Builtin_stddef))
 #define unreachable() __builtin_unreachable()
+#endif
+
 #endif


### PR DESCRIPTION
Even if __need_unreachable is set, stddef.h should not declare unreachable() in C++ because it conflicts with the declaration in <utility>.

rdar://125937171
(cherry picked from commit d23b9186615ad3d482ba130a565fd6053c5c591c)