### PR TITLE
Properly disable `clang/test/Driver/lld-repro.c`

### DIFF
--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -3,7 +3,7 @@
 
 // Swift LLVM fork downstream change start
 // lld from the Swift LLVM fork does not support linking Darwin Mach-O files
-// UNSUPPORTED: *
+// UNSUPPORTED: target={{.*}}
 // Swift LLVM fork downstream change end
 
 // RUN: echo "-nostartfiles -nostdlib -fuse-ld=lld -gen-reproducer=error -fcrash-diagnostics-dir=%t" \


### PR DESCRIPTION
The test was failing as a result of a malformed glob in the UNSUPPORTED directive.

Replace with `UNSUPPORTED target={{.*}}` to disable the test on all platforms, which I assume was the intent.

Before:

```
UNRESOLVED: Clang :: Driver/lld-repro.c (1 of 1)
******************** TEST 'Clang :: Driver/lld-repro.c' FAILED ********************
Exception during script execution:
Traceback (most recent call last):
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/BooleanExpression.py", line 32, in evaluate
    return parser.parseAll()
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/BooleanExpression.py", line 151, in parseAll
    self.token = next(self.tokens)
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/BooleanExpression.py", line 62, in tokenize
    raise ValueError("couldn't parse text: %r" % string)
ValueError: couldn't parse text: '*'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/Test.py", line 406, in getUnsupportedFeatures
    return [
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/Test.py", line 409, in <listcomp>
    if BooleanExpression.evaluate(item, features)
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/BooleanExpression.py", line 34, in evaluate
    raise ValueError(str(e) + ("\nin expression: %r" % string))
ValueError: couldn't parse text: '*'
in expression: '*'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/worker.py", line 76, in _execute_test_handle_errors
    result = test.config.test_format.execute(test, lit_config)
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/formats/shtest.py", line 29, in execute
    return lit.TestRunner.executeShTest(
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/TestRunner.py", line 2096, in executeShTest
    parsed = parseIntegratedTestScript(test, require_script=not script)
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/TestRunner.py", line 2014, in parseIntegratedTestScript
    unsupported_features = test.getUnsupportedFeatures()
  File "/home/nuriamari/git/swift-project/llvm-project/llvm/utils/lit/lit/Test.py", line 412, in getUnsupportedFeatures
    raise ValueError("Error in UNSUPPORTED list:\n%s" % str(e))
ValueError: Error in UNSUPPORTED list:
couldn't parse text: '*'
in expression: '*'

```