### PR TITLE
[clang][modules] Only compute affecting module maps with implicit search

### DIFF
--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -161,8 +161,13 @@ static TypeCode getTypeCodeForTypeClass(Type::TypeClass id) {
 
 namespace {
 
-std::set<const FileEntry *> GetAffectingModuleMaps(const Preprocessor &PP,
-                                                   Module *RootModule) {
+std::optional<std::set<const FileEntry *>>
+GetAffectingModuleMaps(const Preprocessor &PP, Module *RootModule) {
+  // Without implicit module map search, there's no good reason to know about
+  // any module maps that are not affecting.
+  if (!PP.getHeaderSearchInfo().getHeaderSearchOpts().ImplicitModuleMaps)
+    return std::nullopt;
+
   SmallVector<const Module *> ModulesToProcess{RootModule};
 
   const HeaderSearch &HS = PP.getHeaderSearchInfo();
@@ -4682,8 +4687,16 @@ void ASTWriter::computeNonAffectingInputFiles() {
     if (!Cache->OrigEntry)
       continue;
 
-    if (!isModuleMap(File.getFileCharacteristic()) ||
-        llvm::is_contained(AffectingModuleMaps, *Cache->OrigEntry))
+    // Don't prune anything other than module maps.
+    if (!isModuleMap(File.getFileCharacteristic()))
+      continue;
+
+    // Don't prune module maps if all are guaranteed to be affecting.
+    if (!AffectingModuleMaps)
+      continue;
+
+    // Don't prune module maps that are affecting.
+    if (llvm::is_contained(*AffectingModuleMaps, *Cache->OrigEntry))
       continue;
 
     IsSLocAffecting[I] = false;


### PR DESCRIPTION
Cherry-pick of https://github.com/llvm/llvm-project/pull/87849
----------------------------------------
**Explanation**:

When writing out a PCM, we compute the set of module maps that did affect the compilation and we strip the rest to make the output independent of them. The most common way to read a module map that is not affecting is with implicit module map search. The other option is to pass a bunch of unnecessary `-fmodule-map-file=<path>` arguments on the command-line, in which case the client should probably not give those to Clang anyway.

This makes serialization of explicit modules faster, mostly due to reduced file system traffic.

**Risk**: Low. This change only affects explicitly-built modules that have implicit module map search disabled and all known module map files are affecting anyway.

**Testing**: Existing test suite coverage exercises the relevant code-paths affected by this functional change.

**Reviewed By**: @benlangmuir @Bigcheese