### PR TITLE
[clang][cas] Don't include PGO-related files in the include-tree when they are not used

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -14,8 +14,7 @@ def err_cas_cannot_be_initialized : Error<
 def err_cas_cannot_parse_root_id : Error<
   "CAS cannot parse root-id '%0' specified by -fcas-fs">, DefaultFatal;
 def err_cas_filesystem_cannot_be_initialized : Error<
-  "CAS filesystem cannot be initialized from root-id '%0' specified by"
-  " -fcas-fs">, DefaultFatal;
+  "CAS filesystem cannot be initialized from root-id '%0': %1">, DefaultFatal;
 def err_cas_filesystem_cannot_set_working_directory : Error<
   "CAS filesystem cannot set working directory to '%0' specified by"
   " -fcas-fs-working-directory">, DefaultFatal;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1553,9 +1553,8 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
   auto ExpectedFS = IsIncludeTreeFS ? makeIncludeTreeFS(std::move(CAS), *RootID)
                                     : makeCASFS(std::move(CAS), *RootID);
   if (!ExpectedFS) {
-    llvm::consumeError(ExpectedFS.takeError());
     Diags.Report(diag::err_cas_filesystem_cannot_be_initialized)
-        << RootIDString;
+        << RootIDString << llvm::toString(ExpectedFS.takeError());
     return makeEmptyCASFS();
   }
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS = std::move(*ExpectedFS);

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -941,7 +941,6 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
 
   // Adjust the invocation.
   auto &Frontend = Invocation->getFrontendOpts();
-  Frontend.ProgramAction = frontend::RunPreprocessorOnly;
   Frontend.OutputFile = "/dev/null";
   Frontend.DisableFree = false;
 

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -381,6 +381,10 @@ Error IncludeTreeActionController::finalizeModuleBuild(
     CompilerInstance &ModuleScanInstance) {
   // FIXME: the scan invocation is incorrect here; we need the `NewInvocation`
   // from `finalizeModuleInvocation` to finish the tree.
+  resetBenignCodeGenOptions(
+      frontend::GenerateModule,
+      ModuleScanInstance.getInvocation().getLangOpts(),
+      ModuleScanInstance.getInvocation().getCodeGenOpts());
   auto Builder = BuilderStack.pop_back_val();
   auto Tree = Builder->finishIncludeTree(ModuleScanInstance,
                                          ModuleScanInstance.getInvocation());
@@ -594,6 +598,8 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
 
   auto addFile = [&](StringRef FilePath,
                      bool IgnoreFileError = false) -> Error {
+    if (FilePath.empty())
+      return Error::success();
     llvm::Expected<FileEntryRef> FE = FM.getFileRef(FilePath);
     if (!FE) {
       auto Err = FE.takeError();

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -29,12 +29,8 @@ void tooling::dependencies::configureInvocationForCaching(
   // Clear this otherwise it defeats the purpose of making the compilation key
   // independent of certain arguments.
   CI.getCodeGenOpts().DwarfDebugFlags.clear();
-  if (FrontendOpts.ProgramAction == frontend::GeneratePCH) {
-    // Clear paths that are emitted into binaries; they do not affect PCH.
-    // For modules this is handled in ModuleDepCollector.
-    CI.getCodeGenOpts().CoverageDataFile.clear();
-    CI.getCodeGenOpts().CoverageNotesFile.clear();
-  }
+  resetBenignCodeGenOptions(FrontendOpts.ProgramAction, CI.getLangOpts(),
+                            CI.getCodeGenOpts());
 
   HeaderSearchOptions &HSOpts = CI.getHeaderSearchOpts();
   // Avoid writing potentially volatile diagnostic options into pcms.

--- a/clang/test/CAS/modules-include-tree-pgo-option.c
+++ b/clang/test/CAS/modules-include-tree-pgo-option.c
@@ -1,0 +1,42 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: llvm-profdata merge -o %t/instrumentation.profdata %S/Inputs/pgo.profraw
+// RUN: clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module-name Top > %t/Top.rsp
+// RUN: FileCheck %s --input-file=%t/Top.rsp
+
+// RUN: cat %t/Top.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Top.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Top.casid | FileCheck %s
+// CHECK-NOT: instrumentation.profdata
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.m",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.m -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -fprofile-instr-use=DIR/instrumentation.profdata"
+}]
+
+//--- module.modulemap
+module Top { header "Top.h" export *}
+
+//--- Top.h
+#pragma once
+struct Top {
+  int x;
+};
+void top(void);
+
+//--- tu.m
+#import "Top.h"
+
+void tu(void) {
+  top();
+}

--- a/clang/test/CAS/pgo-profile-with-pch.c
+++ b/clang/test/CAS/pgo-profile-with-pch.c
@@ -1,0 +1,28 @@
+// RUN: rm -rf %t.dir && mkdir -p %t.dir
+
+// Check that use of profile data for PCH is ignored
+
+// RUN: llvm-profdata merge -o %t.profdata %S/Inputs/pgo.profraw
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t-pch.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-pch -O3 -Rcompile-job-cache \
+// RUN:   -x c-header %s -o %t.h.pch -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.profdata
+// RUN: %clang @%t-pch.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: FileCheck %s -check-prefix=PCHPROF -input-file %t-pch.rsp
+// PCHPROF-NOT: -fprofile-instrument-use-path
+
+// Update profdata file contents
+// RUN: llvm-profdata merge -o %t.profdata %S/Inputs/pgo2.profraw
+
+// Use the modified profdata file for the main file along with the PCH.
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache \
+// RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.profdata -include-pch %t.h.pch
+// RUN: %clang @%t.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: FileCheck %s -check-prefix=TUPROF -input-file %t.rsp
+// TUPROF: -fprofile-instrument-use-path
+
+// Check that the modified profdata is ignored when re-scanning for the PCH.
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t-pch2.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-pch -O3 -Rcompile-job-cache \
+// RUN:   -x c-header %s -o %t.h.pch -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.profdata
+// RUN: diff -u %t-pch.rsp %t-pch2.rsp
+
+// CACHE-MISS: remark: compile job cache miss
+// CACHE-HIT: remark: compile job cache hit


### PR DESCRIPTION
PGO options are ignored for PCH invocations and may not be treated as dependencies from the build system, so don't add them in the include-tree. Otherwise we may get in a situation where such a file gets updated and an incremental build fails because of mismatched files in the include-tree of the PCH and the translation unit that uses it.

rdar://125629656