### PR TITLE
[lldb] Add lldb-dap to Linux distribution

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-Linux.cmake
+++ b/lldb/cmake/caches/Apple-lldb-Linux.cmake
@@ -5,6 +5,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   lldb
   liblldb
   lldb-argdumper
+  lldb-dap
   lldb-server
   lldb-python-scripts
   repl_swift


### PR DESCRIPTION
In #8176 lldb-dap was added to the macOS distribution

This PR does the same but for Linux