### PR TITLE
Reland "[lldb][sbdebugger] Move SBDebugger Broadcast bit enum into ll…

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -98821,6 +98821,10 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eAddressMaskRangeAll",SWIG_From_int(static_cast< int >(lldb::eAddressMaskRangeAll)));
   SWIG_Python_SetConstant(d, "ChildCacheState_eRefetch",SWIG_From_int(static_cast< int >(lldb::ChildCacheState::eRefetch)));
   SWIG_Python_SetConstant(d, "ChildCacheState_eReuse",SWIG_From_int(static_cast< int >(lldb::ChildCacheState::eReuse)));
+  SWIG_Python_SetConstant(d, "eBroadcastBitProgress",SWIG_From_int(static_cast< int >(lldb::eBroadcastBitProgress)));
+  SWIG_Python_SetConstant(d, "eBroadcastBitWarning",SWIG_From_int(static_cast< int >(lldb::eBroadcastBitWarning)));
+  SWIG_Python_SetConstant(d, "eBroadcastBitError",SWIG_From_int(static_cast< int >(lldb::eBroadcastBitError)));
+  SWIG_Python_SetConstant(d, "eBroadcastBitProgressCategory",SWIG_From_int(static_cast< int >(lldb::eBroadcastBitProgressCategory)));
   SWIG_Python_SetConstant(d, "SBCommandInterpreter_eBroadcastBitThreadShouldExit",SWIG_From_int(static_cast< int >(lldb::SBCommandInterpreter::eBroadcastBitThreadShouldExit)));
   SWIG_Python_SetConstant(d, "SBCommandInterpreter_eBroadcastBitResetPrompt",SWIG_From_int(static_cast< int >(lldb::SBCommandInterpreter::eBroadcastBitResetPrompt)));
   SWIG_Python_SetConstant(d, "SBCommandInterpreter_eBroadcastBitQuitCommandReceived",SWIG_From_int(static_cast< int >(lldb::SBCommandInterpreter::eBroadcastBitQuitCommandReceived)));
@@ -98832,10 +98836,6 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "SBCommunication_eBroadcastBitReadThreadShouldExit",SWIG_From_int(static_cast< int >(lldb::SBCommunication::eBroadcastBitReadThreadShouldExit)));
   SWIG_Python_SetConstant(d, "SBCommunication_eBroadcastBitPacketAvailable",SWIG_From_int(static_cast< int >(lldb::SBCommunication::eBroadcastBitPacketAvailable)));
   SWIG_Python_SetConstant(d, "SBCommunication_eAllEventBits",SWIG_From_int(static_cast< int >(lldb::SBCommunication::eAllEventBits)));
-  SWIG_Python_SetConstant(d, "SBDebugger_eBroadcastBitProgress",SWIG_From_int(static_cast< int >(lldb::SBDebugger::eBroadcastBitProgress)));
-  SWIG_Python_SetConstant(d, "SBDebugger_eBroadcastBitWarning",SWIG_From_int(static_cast< int >(lldb::SBDebugger::eBroadcastBitWarning)));
-  SWIG_Python_SetConstant(d, "SBDebugger_eBroadcastBitError",SWIG_From_int(static_cast< int >(lldb::SBDebugger::eBroadcastBitError)));
-  SWIG_Python_SetConstant(d, "SBDebugger_eBroadcastBitProgressCategory",SWIG_From_int(static_cast< int >(lldb::SBDebugger::eBroadcastBitProgressCategory)));
   SWIG_Python_SetConstant(d, "SBProcess_eBroadcastBitStateChanged",SWIG_From_int(static_cast< int >(lldb::SBProcess::eBroadcastBitStateChanged)));
   SWIG_Python_SetConstant(d, "SBProcess_eBroadcastBitInterrupt",SWIG_From_int(static_cast< int >(lldb::SBProcess::eBroadcastBitInterrupt)));
   SWIG_Python_SetConstant(d, "SBProcess_eBroadcastBitSTDOUT",SWIG_From_int(static_cast< int >(lldb::SBProcess::eBroadcastBitSTDOUT)));

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -1777,6 +1777,14 @@ ChildCacheState_eRefetch = _lldb.ChildCacheState_eRefetch
 
 ChildCacheState_eReuse = _lldb.ChildCacheState_eReuse
 
+eBroadcastBitProgress = _lldb.eBroadcastBitProgress
+
+eBroadcastBitWarning = _lldb.eBroadcastBitWarning
+
+eBroadcastBitError = _lldb.eBroadcastBitError
+
+eBroadcastBitProgressCategory = _lldb.eBroadcastBitProgressCategory
+
 class SBAddress(object):
     r"""
     A section + offset based address class.
@@ -4369,14 +4377,6 @@ class SBDebugger(object):
     """
 
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
-    eBroadcastBitProgress = _lldb.SBDebugger_eBroadcastBitProgress
-    
-    eBroadcastBitWarning = _lldb.SBDebugger_eBroadcastBitWarning
-    
-    eBroadcastBitError = _lldb.SBDebugger_eBroadcastBitError
-    
-    eBroadcastBitProgressCategory = _lldb.SBDebugger_eBroadcastBitProgressCategory
-    
 
     def __init__(self, *args):
         r"""

--- a/lldb/include/lldb/API/SBDebugger.h
+++ b/lldb/include/lldb/API/SBDebugger.h
@@ -42,13 +42,6 @@ public:
 
 class LLDB_API SBDebugger {
 public:
-  FLAGS_ANONYMOUS_ENUM(){
-      eBroadcastBitProgress = (1 << 0),
-      eBroadcastBitWarning = (1 << 1),
-      eBroadcastBitError = (1 << 2),
-      eBroadcastBitProgressCategory = (1 << 3),
-  };
-
   SBDebugger();
 
   SBDebugger(const lldb::SBDebugger &rhs);

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1363,6 +1363,14 @@ enum class ChildCacheState {
               ///< re-use what we computed the last time we called Update.
 };
 
+/// Used by the debugger to indicate which events are being broadcasted.
+enum DebuggerBroadcastBit {
+  eBroadcastBitProgress = (1 << 0),
+  eBroadcastBitWarning = (1 << 1),
+  eBroadcastBitError = (1 << 2),
+  eBroadcastBitProgressCategory = (1 << 3),
+};
+
 } // namespace lldb
 
 #endif // LLDB_LLDB_ENUMERATIONS_H

--- a/lldb/test/API/functionalities/diagnostic_reporting/TestDiagnosticReporting.py
+++ b/lldb/test/API/functionalities/diagnostic_reporting/TestDiagnosticReporting.py
@@ -15,7 +15,7 @@ class TestDiagnosticReporting(TestBase):
         self.broadcaster = self.dbg.GetBroadcaster()
         self.listener = lldbutil.start_listening_from(
             self.broadcaster,
-            lldb.SBDebugger.eBroadcastBitWarning | lldb.SBDebugger.eBroadcastBitError,
+            lldb.eBroadcastBitWarning | lldb.eBroadcastBitError,
         )
 
     def test_dwarf_symbol_loading_diagnostic_report(self):

--- a/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/TestProgressReporting.py
@@ -13,7 +13,7 @@ class TestProgressReporting(TestBase):
         TestBase.setUp(self)
         self.broadcaster = self.dbg.GetBroadcaster()
         self.listener = lldbutil.start_listening_from(
-            self.broadcaster, lldb.SBDebugger.eBroadcastBitProgress
+            self.broadcaster, lldb.eBroadcastBitProgress
         )
 
     def test_dwarf_symbol_loading_progress_report(self):

--- a/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
+++ b/lldb/test/API/functionalities/progress_reporting/clang_modules/TestClangModuleBuildProgress.py
@@ -34,7 +34,7 @@ class TestCase(TestBase):
         # other unrelated progress events.
         broadcaster = self.dbg.GetBroadcaster()
         listener = lldbutil.start_listening_from(
-            broadcaster, lldb.SBDebugger.eBroadcastBitProgress
+            broadcaster, lldb.eBroadcastBitProgress
         )
 
         # Trigger module builds.

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -13,7 +13,7 @@ class TestSwiftProgressReporting(TestBase):
         TestBase.setUp(self)
         self.broadcaster = self.dbg.GetBroadcaster()
         self.listener = lldbutil.start_listening_from(self.broadcaster,
-                                        lldb.SBDebugger.eBroadcastBitProgress)
+                                        lldb.eBroadcastBitProgress)
 
     @skipIf(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/macosx/rosetta/TestRosetta.py
+++ b/lldb/test/API/macosx/rosetta/TestRosetta.py
@@ -49,7 +49,7 @@ class TestRosetta(TestBase):
         if rosetta_debugserver_installed():
             broadcaster = self.dbg.GetBroadcaster()
             listener = lldbutil.start_listening_from(
-                broadcaster, lldb.SBDebugger.eBroadcastBitWarning
+                broadcaster, lldb.eBroadcastBitWarning
             )
 
             target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -406,8 +406,8 @@ void SendStdOutStdErr(lldb::SBProcess &process) {
 
 void ProgressEventThreadFunction() {
   lldb::SBListener listener("lldb-dap.progress.listener");
-  g_dap.debugger.GetBroadcaster().AddListener(
-      listener, lldb::SBDebugger::eBroadcastBitProgress);
+  g_dap.debugger.GetBroadcaster().AddListener(listener,
+                                              lldb::eBroadcastBitProgress);
   g_dap.broadcaster.AddListener(listener, eBroadcastBitStopProgressThread);
   lldb::SBEvent event;
   bool done = false;


### PR DESCRIPTION
…… (#88331)

…db-enumerations.h" (#88324)"

This reverts commit 9f6d08f2566a26144ea1753f80aebb1f2ecfdc63. This broke the build because of a usage of one of the original SBDebugger broadcast bits that wasn't updated in the original commit.

(cherry picked from commit 8c3cb6b55b688b767e5d65bcc2891b17322e8d05)