### PR TITLE
Add lldb-dap to Swift distributions (#88482)

### DIFF
--- a/lldb/cmake/caches/Apple-lldb-Linux.cmake
+++ b/lldb/cmake/caches/Apple-lldb-Linux.cmake
@@ -4,6 +4,7 @@ set(LLVM_DISTRIBUTION_COMPONENTS
   lldb
   liblldb
   lldb-argdumper
+  lldb-dap
   lldb-server
   lldb-python-scripts
   repl_swift


### PR DESCRIPTION
This includes the lldb-dap executable in the MacOS and Linux distributions of Swift. Currently there is a commit in the Apple repo to do this for just MacOS https://github.com/apple/llvm-project/pull/8176. This PR extends this to both Linux and MacOS and brings the change upstream.

(Cherry-pick of 2c2377d3a9305b86ab110a4f8390b2d16bff9510)
