### PR TITLE
[cas] Add cc1 option -finclude-tree-preserve-pch-path

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -794,12 +794,12 @@ public:
     return IncludeTree::FileList(std::move(*Node));
   }
 
-  Expected<std::optional<StringRef>> getPCHBuffer() {
+  Expected<std::optional<IncludeTree::File>> getPCH() {
     if (std::optional<ObjectRef> Ref = getPCHRef()) {
       auto Node = getCAS().getProxy(*Ref);
       if (!Node)
         return Node.takeError();
-      return Node->getData();
+      return IncludeTree::File(std::move(*Node));
     }
     return std::nullopt;
   }

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8215,6 +8215,11 @@ defm casid_output : BoolFOption<"casid-output",
                          " write a CASID for the output file.">,
     NegFlag<SetFalse>>;
 
+defm include_tree_preserve_pch_path : BoolFOption<"include-tree-preserve-pch-path",
+    FrontendOpts<"IncludeTreePreservePCHPath">, DefaultFalse,
+    PosFlag<SetTrue, [], [], "Keep the original PCH path in include-tree rather than canonicalizing">,
+    NegFlag<SetFalse>>;
+
 /// BEGIN MCCAS
 defm cas_backend : BoolFOption<"cas-backend",
     CodeGenOpts<"UseCASBackend">, DefaultFalse,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -415,6 +415,11 @@ public:
   /// caching of compilation outputs. This is used for testing purposes.
   unsigned DisableCachedCompileJobReplay : 1;
 
+  /// Whether to preserve the original PCH path in the include-tree, or to
+  /// canonicalize it to a fixed value. Setting this to \c true allows the use
+  /// of gmodules with PCH and include tree.
+  unsigned IncludeTreePreservePCHPath : 1;
+
   /// Keep the diagnostic client open for receiving diagnostics after the source
   /// files have been processed.
   unsigned MayEmitDiagnosticsAfterProcessingSourceFiles : 1;
@@ -642,6 +647,7 @@ public:
         BuildingImplicitModuleUsesLock(true), ModulesEmbedAllFiles(false),
         IncludeTimestamps(true), UseTemporary(true), CacheCompileJob(false),
         ForIncludeTreeScan(false), DisableCachedCompileJobReplay(false),
+        IncludeTreePreservePCHPath(false),
         MayEmitDiagnosticsAfterProcessingSourceFiles(false), WriteOutputAsCASID(false),
         AllowPCMWithCompilerErrors(false), ModulesShareFileManager(true),
         EmitSymbolGraph(false), EmitExtensionSymbolGraphs(false),

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -832,10 +832,13 @@ llvm::Error IncludeTree::APINotes::forEachAPINotes(
 }
 
 llvm::Error IncludeTreeRoot::print(llvm::raw_ostream &OS, unsigned Indent) {
-  if (std::optional<ObjectRef> PCHRef = getPCHRef()) {
+  std::optional<IncludeTree::File> PCH;
+  if (llvm::Error E = getPCH().moveInto(PCH))
+    return E;
+  if (PCH) {
     OS.indent(Indent) << "(PCH) ";
-    getCAS().getID(*PCHRef).print(OS);
-    OS << '\n';
+    if (llvm::Error E = PCH->print(OS))
+      return E;
   }
   std::optional<cas::IncludeTree> MainTree;
   if (llvm::Error E = getMainFileTree().moveInto(MainTree))

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -58,9 +58,12 @@ void tooling::dependencies::configureInvocationForCaching(
     HSOpts.ResourceDir = std::move(OriginalHSOpts.ResourceDir);
     // Preserve fmodule-file options.
     HSOpts.PrebuiltModuleFiles = std::move(OriginalHSOpts.PrebuiltModuleFiles);
+    // Preserve -gmodules (see below for caveats).
+    HSOpts.ModuleFormat = OriginalHSOpts.ModuleFormat;
     HSOpts.UseBuiltinIncludes = false;
     HSOpts.UseStandardSystemIncludes = false;
     HSOpts.UseStandardCXXIncludes = false;
+
     auto &PPOpts = CI.getPreprocessorOpts();
     // We don't need this because we save the contents of the PCH file in the
     // include tree root.
@@ -75,12 +78,13 @@ void tooling::dependencies::configureInvocationForCaching(
       PPOpts.MacroIncludes.clear();
       PPOpts.Includes.clear();
     }
-    // Disable `-gmodules` to avoid debug info referencing a non-existent PCH
-    // filename.
-    // NOTE: We'd have to preserve \p HeaderSearchOptions::ModuleFormat (code
-    // above resets \p HeaderSearchOptions) when properly supporting
-    // `-gmodules`.
-    CI.getCodeGenOpts().DebugTypeExtRefs = false;
+    if (!FrontendOpts.IncludeTreePreservePCHPath) {
+      // Disable `-gmodules` to avoid debug info referencing a non-existent PCH
+      // filename.
+      // FIXME: we should also allow -gmodules if there is no PCH involved.
+      CI.getCodeGenOpts().DebugTypeExtRefs = false;
+      HSOpts.ModuleFormat = "raw";
+    }
     // Clear APINotes options.
     CI.getAPINotesOpts().ModuleSearchPaths = {};
   } else {

--- a/clang/test/ClangScanDeps/include-tree-preserve-pch-path.c
+++ b/clang/test/ClangScanDeps/include-tree-preserve-pch-path.c
@@ -1,0 +1,63 @@
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb_pch.json.template > %t/cdb_pch.json
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb_no_preserve.json.template > %t/cdb_no_preserve.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb_pch.json -format experimental-include-tree-full -cas-path %t/cas > %t/deps_pch.json
+// RUN: FileCheck %s -input-file %t/deps_pch.json -DPREFIX=%/t
+
+// CHECK: "-fmodule-format=obj"
+// CHECK: "-dwarf-ext-refs"
+
+// RUN: %deps-to-rsp %t/deps_pch.json --tu-index 0 > %t/pch.rsp
+// RUN: %clang @%t/pch.rsp
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree-full -cas-path %t/cas > %t/deps_tu.json
+// RUN: FileCheck %s -input-file %t/deps_tu.json -DPREFIX=%/t
+
+// RUN: %deps-to-rsp %t/deps_tu.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/tu.rsp
+
+// RUN: cat %t/tu.ll | FileCheck %s -check-prefix=LLVMIR -DPREFIX=%/t
+// LLVMIR: !DICompileUnit({{.*}}, splitDebugFilename: "prefix.pch"
+
+// Extract include-tree casid
+// RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
+
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid | FileCheck %s -check-prefix=INCLUDE_TREE -DPREFIX=%/t
+// INCLUDE_TREE: (PCH) [[PREFIX]]/prefix.pch llvmcas://
+
+// RUN: clang-scan-deps -compilation-database %t/cdb_no_preserve.json -format experimental-include-tree-full -cas-path %t/cas > %t/deps_no_preserve.json
+// RUN: FileCheck %s -input-file %t/deps_no_preserve.json -DPREFIX=%/t -check-prefix=NO_PRESERVE
+
+// Note: "raw" is the default format, so it will not show up in the arguments.
+// NO_PRESERVE-NOT: "-fmodule-format=
+// NO_PRESERVE-NOT: "-dwarf-ext-refs"
+
+
+//--- cdb_pch.json.template
+[{
+  "directory": "DIR",
+  "command": "clang -x c-header DIR/prefix.h -target x86_64-apple-macos12 -o DIR/prefix.pch -gmodules -g -Xclang -finclude-tree-preserve-pch-path",
+  "file": "DIR/prefix.h"
+}]
+
+//--- cdb.json.template
+[{
+  "directory": "DIR",
+  "command": "clang -S -emit-llvm DIR/tu.c -o DIR/tu.ll -include-pch DIR/prefix.pch -target x86_64-apple-macos12 -gmodules -g -Xclang -finclude-tree-preserve-pch-path",
+  "file": "DIR/tu.c"
+}]
+
+//--- cdb_no_preserve.json.template
+[{
+  "directory": "DIR",
+  "command": "clang -S -emit-llvm DIR/tu.c -o DIR/tu.ll -include-pch DIR/prefix.pch -target x86_64-apple-macos12 -gmodules -g",
+  "file": "DIR/tu.c"
+}]
+
+//--- prefix.h
+struct S {};
+
+//--- tu.c
+struct S s;

--- a/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
@@ -47,7 +47,7 @@
 // CHECK-NOT: Bar
 
 // CHECK-LABEL: TRANSLATION UNIT
-// CHECK: (PCH) llvmcas://
+// CHECK: (PCH) <PCH> llvmcas://
 // CHECK: [[PREFIX]]/tu.c llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
 // CHECK: 2:1 (Spurious import) (Module) Foo.Bar [[PREFIX]]/Foo.framework/Headers/Bar.h llvmcas://

--- a/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
@@ -53,7 +53,7 @@
 // CHECK:   3:1 (Module) Mod_Private
 
 // CHECK-LABEL: TRANSLATION UNIT
-// CHECK: (PCH) llvmcas://
+// CHECK: (PCH) <PCH> llvmcas://
 // CHECK: [[PREFIX]]/tu.m llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
 // CHECK: 2:1 (Module) Mod_Private


### PR DESCRIPTION
Add the PCH path to the include tree, and add a way to control whether we use the original PCH path, or if we canonicalize it away to <PCH>. For now, keep the default being to canonicalize it to <PCH> as this improves canonicalization. However, a client (e.g. Swift) that knows its PCH path will be stable can use this option to allow enabling -gmodules, which requires a real path.

rdar://126370706