### PR TITLE
[lldb][Type Completion] Load C++ methods lazily from DWARF

### DIFF
--- a/clang/include/clang/AST/ExternalASTSource.h
+++ b/clang/include/clang/AST/ExternalASTSource.h
@@ -150,6 +150,11 @@ public:
   virtual bool
   FindExternalVisibleDeclsByName(const DeclContext *DC, DeclarationName Name);
 
+  virtual bool FindExternalVisibleMethodsByName(const DeclContext *DC,
+                                                DeclarationName Name) {
+    return false;
+  }
+
   /// Ensures that the table of all visible declarations inside this
   /// context is up to date.
   ///

--- a/clang/lib/Sema/SemaExprMember.cpp
+++ b/clang/lib/Sema/SemaExprMember.cpp
@@ -715,6 +715,13 @@ static bool LookupMemberExprInRecord(Sema &SemaRef, LookupResult &R,
     }
   }
 
+  if (ExternalASTSource *Source =
+          DC->getParentASTContext().getExternalSource()) {
+    if (auto LookupName = R.getLookupName()) {
+      Source->FindExternalVisibleMethodsByName(DC, LookupName);
+    }
+  }
+
   // The record definition is complete, now look up the member.
   SemaRef.LookupQualifiedName(R, DC, SS);
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
@@ -87,6 +87,9 @@ public:
   bool FindExternalVisibleDeclsByName(const clang::DeclContext *DC,
                                       clang::DeclarationName Name) override;
 
+  bool FindExternalVisibleMethodsByName(const clang::DeclContext *DC,
+                                        clang::DeclarationName Name) override;
+
   /// Enumerate all Decls in a given lexical context.
   ///
   /// \param[in] DC
@@ -197,6 +200,7 @@ public:
   /// \param[in] context
   ///     The NameSearchContext to use when filing results.
   virtual void FindExternalVisibleDecls(NameSearchContext &context);
+  virtual void FindExternalVisibleMethods(NameSearchContext &context);
 
   clang::Sema *getSema();
 
@@ -217,6 +221,12 @@ public:
     bool FindExternalVisibleDeclsByName(const clang::DeclContext *DC,
                                         clang::DeclarationName Name) override {
       return m_original.FindExternalVisibleDeclsByName(DC, Name);
+    }
+
+    bool
+    FindExternalVisibleMethodsByName(const clang::DeclContext *DC,
+                                     clang::DeclarationName Name) override {
+      return m_original.FindExternalVisibleMethodsByName(DC, Name);
     }
 
     void FindExternalLexicalDecls(
@@ -288,6 +298,9 @@ protected:
   void FindExternalVisibleDecls(NameSearchContext &context,
                                 lldb::ModuleSP module,
                                 CompilerDeclContext &namespace_decl);
+  void FindExternalVisibleMethods(NameSearchContext &context,
+                                  lldb::ModuleSP module,
+                                  CompilerDeclContext &namespace_decl);
 
   /// Find all Objective-C methods matching a given selector.
   ///
@@ -363,6 +376,10 @@ private:
   bool FindObjCPropertyAndIvarDeclsWithOrigin(
       NameSearchContext &context,
       DeclFromUser<const clang::ObjCInterfaceDecl> &origin_iface_decl);
+
+  bool CompilerDeclContextsMatch(CompilerDeclContext candidate_decl_ctx,
+                                 clang::DeclContext const *context,
+                                 TypeSystemClang &ts);
 
 protected:
   bool FindObjCMethodDeclsWithOrigin(

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.cpp
@@ -1337,6 +1337,13 @@ void ClangExpressionDeclMap::LookupFunction(
   }
 }
 
+void ClangExpressionDeclMap::FindExternalVisibleMethods(
+    NameSearchContext &context) {
+  assert(m_ast_context);
+
+  ClangASTSource::FindExternalVisibleMethods(context);
+}
+
 void ClangExpressionDeclMap::FindExternalVisibleDecls(
     NameSearchContext &context, lldb::ModuleSP module_sp,
     const CompilerDeclContext &namespace_decl) {

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionDeclMap.h
@@ -18,6 +18,7 @@
 #include "ClangASTSource.h"
 #include "ClangExpressionVariable.h"
 
+#include "Plugins/ExpressionParser/Clang/NameSearchContext.h"
 #include "lldb/Core/Value.h"
 #include "lldb/Expression/Materializer.h"
 #include "lldb/Symbol/SymbolContext.h"
@@ -266,6 +267,7 @@ public:
   /// \param[in] context
   ///     The NameSearchContext that can construct Decls for this name.
   void FindExternalVisibleDecls(NameSearchContext &context) override;
+  void FindExternalVisibleMethods(NameSearchContext &context) override;
 
   /// Find all entities matching a given name in a given module/namespace,
   /// using a NameSearchContext to make Decls for them.

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.h
@@ -37,6 +37,11 @@ public:
   bool FindExternalVisibleDeclsByName(const clang::DeclContext *DC,
                                       clang::DeclarationName Name) override;
 
+  bool FindExternalVisibleMethodsByName(const clang::DeclContext *DC,
+                                        clang::DeclarationName Name) override {
+    return false;
+  }
+
   void CompleteType(clang::TagDecl *tag_decl) override;
 
   void CompleteType(clang::ObjCInterfaceDecl *objc_decl) override;

--- a/lldb/test/API/commands/expression/completion/TestExprCompletion.py
+++ b/lldb/test/API/commands/expression/completion/TestExprCompletion.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 class CommandLineExprCompletionTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @expectedFailureAll(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     def test_expr_completion(self):
         self.build()
         self.main_source = "main.cpp"

--- a/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/empty-module/TestEmptyStdModule.py
@@ -15,6 +15,7 @@ class ImportStdModule(TestBase):
     @add_test_categories(["libc++"])
     @skipIfRemote
     @skipIf(compiler=no_match("clang"))
+    @expectedFailureAll(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/pr35310/TestExprsBug35310.py
+++ b/lldb/test/API/commands/expression/pr35310/TestExprsBug35310.py
@@ -12,6 +12,7 @@ class ExprBug35310(TestBase):
         self.main_source = "main.cpp"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
+    @expectedFailureAll(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     def test_issue35310(self):
         """Test invoking functions with non-standard linkage names.
 

--- a/lldb/test/API/lang/cpp/function-ref-qualifiers/TestCppFunctionRefQualifiers.py
+++ b/lldb/test/API/lang/cpp/function-ref-qualifiers/TestCppFunctionRefQualifiers.py
@@ -34,11 +34,11 @@ class TestFunctionRefQualifiers(TestBase):
         self.expect_expr("Foo{}.func()", result_type="int64_t", result_value="3")
 
         self.filecheck("target modules dump ast", __file__)
-        # CHECK:      |-CXXMethodDecl {{.*}} func 'uint32_t () const &'
-        # CHECK-NEXT: | `-AsmLabelAttr {{.*}}
-        # CHECK-NEXT: |-CXXMethodDecl {{.*}} func 'int64_t () const &&'
-        # CHECK-NEXT: | `-AsmLabelAttr {{.*}}
-        # CHECK-NEXT: |-CXXMethodDecl {{.*}} func 'uint32_t () &'
-        # CHECK-NEXT: | `-AsmLabelAttr {{.*}}
-        # CHECK-NEXT: `-CXXMethodDecl {{.*}} func 'int64_t () &&'
-        # CHECK-NEXT:   `-AsmLabelAttr {{.*}}
+        # CHECK-DAG: CXXMethodDecl {{.*}} func 'uint32_t () const &'
+        # CHECK-DAG: `-AsmLabelAttr {{.*}}
+        # CHECK-DAG: CXXMethodDecl {{.*}} func 'int64_t () const &&'
+        # CHECK-DAG: `-AsmLabelAttr {{.*}}
+        # CHECK-DAG: CXXMethodDecl {{.*}} func 'uint32_t () &'
+        # CHECK-DAG: `-AsmLabelAttr {{.*}}
+        # CHECK-DAG: CXXMethodDecl {{.*}} func 'int64_t () &&'
+        # CHECK-DAG: `-AsmLabelAttr {{.*}}

--- a/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
+++ b/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
@@ -19,6 +19,7 @@ class SBTypeMemberFunctionsTest(TestBase):
         self.source = "main.mm"
         self.line = line_number(self.source, "// set breakpoint here")
 
+    @expectedFailureAll(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     @skipUnlessDarwin
     def test(self):
         """Test SBType APIs to fetch member function types."""


### PR DESCRIPTION
Note, this is a no-op when the LLDB setting
`plugin.typesystem.clang.experimental-redecl-completion` is not set (which is currently the default). So this patch has no effect unless the user explicitly opts into it.

The type-completion rework (aka redecl-completion) implemented in https://github.com/apple/llvm-project/pull/8222 comes with a large performance penalty, since we now eagerly complete `RecordType`s. Completing a `RecordType` previously unconditionally resolved all member function of said type. With redecl-completion completion, however, this meant we were now pulling in many more definitions than needed. Without redecl-completion, this isn't a problem, since importing method parameters is cheap (they are imported minimally), so we wouldn't notice that we always resolved all member functions.

This patch tries to load methods lazily when in redecl-completion mode. We do this by introducing a new `ExternalASTSource::FindExternalVisibleMethods` API which Clang calls when it parses a member access expression. The callback into LLDB will do a `FindFunctions` call for all methods with the method name we're looking for, filters out any mismatches, and lets Clang continue with it's parsing. We still load following methods eagerly:
1. virtual functions: currently overrides are resolved in `CompleteRecordType`
2. operators: currently I couldn't find a point at which Clang can call into LLDB here to facilitate lazy loading
3. ctors/dtors: same reason as (2)

In our benchmark harness, we saw this patch bring down redecl-completion expression evaluation on-par with top-of-tree expression evaluation.