### PR TITLE
Pass the linker version to libfuzzer tests on darwin (#87719)

### DIFF
--- a/compiler-rt/test/fuzzer/lit.cfg.py
+++ b/compiler-rt/test/fuzzer/lit.cfg.py
@@ -89,6 +89,12 @@ def generate_compiler_cmd(is_cpp=True, fuzzer_enabled=True, msan_enabled=False):
     if fuzzer_enabled:
         sanitizers.append("fuzzer")
     sanitizers_cmd = "-fsanitize=%s" % ",".join(sanitizers)
+
+    if "darwin" in config.available_features and getattr(
+        config, "darwin_linker_version", None
+    ):
+        extra_cmd = extra_cmd + " -mlinker-version=" + config.darwin_linker_version
+
     return " ".join(
         [
             compiler_cmd,


### PR DESCRIPTION
The HOST_LINK_VERSION is a hardcoded string in Darwin clang that detects the linker version at configure time. The driver uses this information to build the correct set of arguments for the linker. This patch detects the linker version again during compiler-rt configuration and passes it to the libfuzzer tests. This allows a clang built on a machine with a new linker to run compiler-rt tests on a machine with an old linker.

rdar://125932376