### PR TITLE
Add total argument to Progress object for Swift reflection setup

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -502,7 +502,7 @@ void SwiftLanguageRuntimeImpl::ProcessModulesToAdd() {
 
   auto &target = m_process.GetTarget();
   auto exe_module = target.GetExecutableModule();
-  Progress progress("Setting up Swift reflection");
+  Progress progress("Setting up Swift reflection", {}, modules_to_add_snapshot.GetSize());
   size_t completion = 0;
 
   // Add all defered modules to reflection context that were added to


### PR DESCRIPTION
The total for this Progress object is well known at construction time, so by adding it the Progress object is no longer "indeterminate" and will complete successfully.

(cherry picked from commit 68e9d5703df04942381d413dec6c5e544d1db912)