### PR TITLE
Add asan tests for libsanitizers. (#88349) (#88962)

### DIFF
--- a/lldb/test/API/functionalities/asan/Makefile
+++ b/lldb/test/API/functionalities/asan/Makefile
@@ -1,4 +1,8 @@
 C_SOURCES := main.c
-CFLAGS_EXTRAS := -fsanitize=address -g -gcolumn-info
+asan: CFLAGS_EXTRAS := -fsanitize=address -g -gcolumn-info
+asan: all
+
+libsanitizers: CFLAGS_EXTRAS := -fsanitize=address -fsanitize-stable-abi -g -gcolumn-info
+libsanitizers: all
 
 include Makefile.rules


### PR DESCRIPTION
The previous patch was reverted because the test fails to build when libsanitizers is not present. This patch catches the BuildError exception and skips the test appropriately.

This patch tests LLDB integration with libsanitizers for ASan.

rdar://111856681