### PR TITLE
Register the symbol context's module first.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -818,18 +818,17 @@ DYLIB_SWIFT_FLAGS=  \
         -Xlinker -install_name -Xlinker "$(DYLIB_INSTALL_NAME)" \
         $(LD_EXTRAS)
 ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
-DYLIB_SWIFT_FLAGS+= -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule
+DYLIB_SWIFT_FLAGS+= -Xlinker -add_ast_path -Xlinker $(MODULENAME).swiftmodule
 endif
 else
 DYLIB_SWIFT_FLAGS=$(LD_EXTRAS)
+ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
+DYLIB_OBJECTS += $(BUILDDIR)/$(MODULENAME).o
 endif
+endif
+
 $(DYLIB_FILENAME) : $(DYLIB_OBJECTS) $(MODULE_INTERFACE)
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
-ifneq "$(DYLIB_HIDE_SWIFTMODULE)" ""
-	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
-            -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ \
-            $(patsubst %.swiftmodule.o,,$(DYLIB_OBJECTS))
-else
 ifneq "$(FRAMEWORK)" ""
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Headers
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules
@@ -846,7 +845,6 @@ endif
 endif
 	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
             -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ $(DYLIB_OBJECTS)
-endif
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$(DYLIB_FILENAME)"
 endif

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2981,10 +2981,56 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
                                plugin_search_options.begin(),
                                plugin_search_options.end());
 
+  // Register the symbol context's module first. This makes it more
+  // likely that compatible AST blobs are found first, since then the
+  // local AST blobs overwrite any ones with the same import path from
+  // another dylib.
+  llvm::DenseSet<Module *> visited_modules;
+  llvm::StringMap<ModuleSP> all_modules;
   for (size_t mi = 0; mi != num_images; ++mi) {
-    std::vector<std::string> module_names;
-    auto module_sp = target.GetImages().GetModuleAtIndex(mi);
-    swift_ast_sp->RegisterSectionModules(*module_sp, module_names);
+    auto image_sp = target.GetImages().GetModuleAtIndex(mi);
+    std::string path = image_sp->GetSpecificationDescription();
+    all_modules.insert({path, image_sp});
+    all_modules.insert({llvm::sys::path::filename(path), image_sp});
+  }
+  std::vector<std::string> module_names;
+  std::function<void(ModuleSP, unsigned)> scan_module =
+      [&](ModuleSP cur_module_sp, unsigned indent) {
+        if (!cur_module_sp ||
+            !visited_modules.insert(cur_module_sp.get()).second)
+          return;
+        swift_ast_sp->RegisterSectionModules(*cur_module_sp, module_names);
+        if (GetLog(LLDBLog::Types)) {
+          std::string spacer(indent, '-');
+          LOG_PRINTF(GetLog(LLDBLog::Types), "+%s Dependency scan: %s",
+                     spacer.c_str(),
+                     cur_module_sp->GetSpecificationDescription().c_str());
+        }
+        if (auto object = cur_module_sp->GetObjectFile()) {
+          FileSpecList file_list;
+          object->GetDependentModules(file_list);
+          for (auto &fs : file_list) {
+            if (ModuleSP dependency = all_modules.lookup(fs.GetPath())) {
+              scan_module(dependency, indent + 1);
+            } else if (ModuleSP dependency =
+                           all_modules.lookup(fs.GetFilename())) {
+              scan_module(dependency, indent + 1);
+            } else {
+              if (GetLog(LLDBLog::Types)) {
+                std::string spacer(indent, '-');
+                LOG_PRINTF(GetLog(LLDBLog::Types),
+                           "+%s Could not find %s in images", spacer.c_str(),
+                           fs.GetPath().c_str());
+              }
+            }
+          }
+        }
+      };
+  scan_module(module_sp, 0);
+  for (size_t mi = 0; mi != num_images; ++mi) {
+    auto image_sp = target.GetImages().GetModuleAtIndex(mi);
+    if (!visited_modules.count(image_sp.get()))
+      swift_ast_sp->RegisterSectionModules(*image_sp, module_names);
   }
 
   LOG_PRINTF(GetLog(LLDBLog::Types), "((Target*)%p) = %p",
@@ -4372,6 +4418,7 @@ void SwiftASTContext::RegisterSectionModules(
 
   // Grab all the AST blobs from the symbol vendor.
   auto ast_file_datas = module.GetASTData(eLanguageTypeSwift);
+    if (ast_file_datas.size())
   LOG_PRINTF(GetLog(LLDBLog::Types),
              "(\"%s\") retrieved %zu AST Data blobs from the symbol vendor "
              "(filter=\"%s\").",

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -65,4 +65,4 @@ class TestSwiftDeploymentTarget(TestBase):
         self.expect("expression f", substrs=["i = 23"])
         self.filecheck('platform shell cat ""%s"' % log, __file__)
 #       CHECK: SwiftASTContextForExpressions::SetTriple({{.*}}apple-macosx11.0.0
-#       CHECK:  SwiftASTContextForExpressions::RegisterSectionModules("a.out") retrieved 0 AST Data blobs
+#       CHECK-NOT: SwiftASTContextForExpressions::RegisterSectionModules("a.out"){{.*}} AST Data blobs


### PR DESCRIPTION
This makes it more likely that compatible AST blobs are found first, since then the local AST blobs overwrite any ones with the same import path from another dylib.