### PR TITLE
[Cherry-pick into next] Delete dead code

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1274,7 +1274,6 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
     for (; !buf.empty(); buf = buf.substr(info.bytes)) {
       llvm::SmallVector<swift::serialization::SearchPath> searchPaths;
       swift::serialization::ExtendedValidationInfo extended_validation_info;
-      auto &langOpts = invocation.getLangOptions();
       info = swift::serialization::validateSerializedAST(
           buf, invocation.getSILOptions().EnableOSSAModules,
           /*requiredSDK*/ StringRef(), &extended_validation_info,

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -71,5 +71,6 @@ class TestSwiftMacro(lldbtest.TestBase):
 #       CHECK: CacheUserImports(){{.*}}: Macro.
 #       CHECK: SwiftASTContextForExpressions{{.*}}::LoadOneModule(){{.*}}Imported module Macro from {kind = Serialized Swift AST, filename = "{{.*}}Macro.swiftmodule";}
 #       CHECK: CacheUserImports(){{.*}}Scanning for search paths in{{.*}}Macro.swiftmodule
-#       CHECK: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}} -external-plugin-path {{.*}}/Developer/Platforms/{{.*}}.platform/Developer/usr/local/lib/swift/host/plugins{{.*}}#{{.*}}/swift-plugin-server
+#       The bots have too old an Xcode for this.
+#       DISABLED: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}} -external-plugin-path {{.*}}/Developer/Platforms/{{.*}}.platform/Developer/usr/local/lib/swift/host/plugins{{.*}}#{{.*}}/swift-plugin-server
 #       CHECK: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}} -external-plugin-path {{.*}}/lang/swift/macro/{{.*}}#{{.*}}/swift-plugin-server

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -71,4 +71,5 @@ class TestSwiftMacro(lldbtest.TestBase):
 #       CHECK: CacheUserImports(){{.*}}: Macro.
 #       CHECK: SwiftASTContextForExpressions{{.*}}::LoadOneModule(){{.*}}Imported module Macro from {kind = Serialized Swift AST, filename = "{{.*}}Macro.swiftmodule";}
 #       CHECK: CacheUserImports(){{.*}}Scanning for search paths in{{.*}}Macro.swiftmodule
+#       CHECK: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}} -external-plugin-path {{.*}}/Developer/Platforms/{{.*}}.platform/Developer/usr/local/lib/swift/host/plugins{{.*}}#{{.*}}/swift-plugin-server
 #       CHECK: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}} -external-plugin-path {{.*}}/lang/swift/macro/{{.*}}#{{.*}}/swift-plugin-server


### PR DESCRIPTION
```
commit 242f12fd8b2d5da0d9192a0eb2046cc19890c6c1
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Apr 5 13:50:31 2024 -0700

    Delete dead code

commit bce2fc2a2199e73468fe9f39a501c2c98ddb7d1f
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Apr 5 13:50:37 2024 -0700

    Add platform plugin path to Swift compiler invocation.
    
    In actual invocations of the Swift compiler, the Swift driver computes
    and adds this search path, in standalone LLDB applications, like the
    REPL, we need to do this manually.
    
    rdar://124965889

commit 892383ded09555cd260b1ace3437f37bcaaf5550
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Apr 17 17:13:08 2024 -0700

    Disable part of test for the bots sake.
```
