### PR TITLE
[Cherry-pick into next] Precise compiler invocations: Set C++ interoperability per SymbolContext

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1185,7 +1185,9 @@ bool Module::IsSwiftCxxInteropEnabled() {
     auto *sym_file = GetSymbolFile();
     if (sym_file) {
       auto options = sym_file->GetCompileOptions();
-      for (auto &[_, args] : options) {
+      for (auto &[cu, args] : options) {
+        if (cu->GetLanguage() != eLanguageTypeSwift)
+          continue;
         for (const char *arg : args.GetArgumentArrayRef()) {
           if (strcmp(arg, "-enable-experimental-cxx-interop") == 0) {
             m_is_swift_cxx_interop_enabled = eLazyBoolYes;

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/Dylib.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/Dylib.swift
@@ -1,0 +1,3 @@
+public func f() {
+  print("break here")
+}

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/Makefile
@@ -1,0 +1,21 @@
+SWIFT_SOURCES := main.swift
+SWIFT_CXX_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -I.
+LD_EXTRAS = -L$(BUILDDIR) -lDylib
+
+all: libDylib.dylib a.out
+
+include Makefile.rules
+
+libDylib.dylib: Dylib.swift
+	$(MAKE) MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(THIS_FILE_DIR)/Makefile.rules \
+		DYLIB_SWIFT_SOURCES=Dylib.swift \
+		DYLIB_NAME=Dylib \
+		DYLIB_ONLY=YES \
+		SWIFT_SOURCES= \
+		SWIFT_CXX_INTEROP=0 \
+		SWIFT_BRIDGING_HEADER= \
+		all

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
@@ -1,0 +1,32 @@
+
+"""
+Test that a C++ class is visible in Swift.
+"""
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSwiftForwardInteropCxxLangOpt(TestBase):
+
+    @swiftTest
+    @expectedFailureAll(setting=('symbols.swift-precise-compiler-invocation', 'false'))
+    def test_class(self):
+        """
+        Test that C++ interoperability is enabled on a per-CU basis.
+        """
+        self.build()
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'),
+            extra_images=['Dylib'])
+        dylib_bkpt = target.BreakpointCreateBySourceRegex(
+            'break here', lldb.SBFileSpec('Dylib.swift'))
+        self.assertGreater(dylib_bkpt.GetNumLocations(), 0, VALID_BREAKPOINT)
+        self.expect('expr 0')
+        lldbutil.continue_to_breakpoint(process, dylib_bkpt)
+        self.expect('expr 1')
+        self.filecheck('platform shell cat ""%s"' % log, __file__)
+#       CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Swift/C++ interop : on
+#       CHECK:  SwiftASTContextForExpressions(module: "Dylib", cu: "Dylib.swift")::LogConfiguration(){{.*}}Swift/C++ interop : off
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/bridging.h
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/bridging.h
@@ -1,0 +1,10 @@
+
+struct CxxClass {
+  long long a1 = 10;
+  long long a2 = 20;
+  long long a3 = 30;
+};
+
+struct InheritedCxxClass: CxxClass {
+  long long a4 = 40;
+};

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/main.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/main.swift
@@ -1,0 +1,4 @@
+import Dylib
+
+print("break here")
+f()


### PR DESCRIPTION
```
commit 90e1467a618b0a4fb78ce5b16641cf5813477330
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Apr 17 12:44:31 2024 -0700

    Precise compiler invocations: Set C++ interoperability per SymbolContext
    
    rdar://125182583
```
