### PR TITLE
[lldb] Replace assertEquals with assertEqual (NFC)

### DIFF
--- a/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
+++ b/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
@@ -58,8 +58,8 @@ class SwiftRuntimeReportingExclusivityViolationTestCase(lldbtest.TestBase):
         frame = thread.GetSelectedFrame()
 
         frame_variables = frame.GetVariables(True, False, False, False)
-        self.assertEquals(frame_variables.GetSize(), 1)
-        self.assertEquals(frame_variables.GetValueAtIndex(0).GetName(), "p")
+        self.assertEqual(frame_variables.GetSize(), 1)
+        self.assertEqual(frame_variables.GetValueAtIndex(0).GetName(), "p")
 
         addr = frame_variables.GetValueAtIndex(0).GetValueAsUnsigned()
 

--- a/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
+++ b/lldb/test/API/lang/swift/imported_types/cgtypes/TestCGImportedTypes.py
@@ -39,4 +39,4 @@ class TestSwiftCGImportedTypes(TestBase):
         self.assertTrue(
             x_native.IsValid(),
             "Got valid native from cgrect.origin.x")
-        self.assertEquals(x_native.GetValue(), "10", "Value of x is correct")
+        self.assertEqual(x_native.GetValue(), "10", "Value of x is correct")

--- a/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -39,7 +39,7 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
 
         self.assertTrue(value.IsValid(),
                         "expr " + var_name + " returned a valid value")
-        self.assertEquals(value.GetValue(), expected_val)
+        self.assertEqual(value.GetValue(), expected_val)
 
     def do_test(self):
         """Test the split debug info"""

--- a/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
+++ b/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
@@ -22,7 +22,7 @@ class TestSwiftHealthCheck(TestBase):
         result = lldb.SBCommandReturnObject()
         ret_val = self.dbg.GetCommandInterpreter().HandleCommand("swift-healthcheck", result)
         log = result.GetOutput()[:-1].split(" ")[-1]
-        self.assertEquals(log[-4:], ".log")
+        self.assertEqual(log[-4:], ".log")
         import io, re
         logfile = io.open(log, "r", encoding='utf-8')
         good = 0
@@ -35,7 +35,7 @@ class TestSwiftHealthCheck(TestBase):
                 bad += 1
                 break
         self.assertGreater(good, 1)
-        self.assertEquals(bad, 0)
+        self.assertEqual(bad, 0)
 
     @swiftTest
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -40,4 +40,4 @@ class TestSwiftTripleDetection(TestBase):
             if found == 1 and re.search('SwiftASTContextForExpressions.*setting to ".*-apple-macos.[0-9.]+"', line):
                found += 1
                break
-        self.assertEquals(found, 2)
+        self.assertEqual(found, 2)

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -1,6 +1,4 @@
-# TestInOutVariables.py
-#
-# This source file is part of the Swift.org open source project
+# TestInOutVariables.py This source file is part of the Swift.org open source project
 #
 # Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
@@ -69,18 +67,18 @@ class TestInOutVariables(TestBase):
 
         ivar = x_actual.GetChildAtIndex(0).GetChildAtIndex(0)
         ovar = x_actual.GetChildAtIndex(1)
-        self.assertEquals(
+        self.assertEqual(
             ivar.GetName(), "ivar", "Name: %s is not ivar %s" %
             (ivar.GetName(), message_end))
-        self.assertEquals(
+        self.assertEqual(
             ovar.GetName(), "ovar",
             "ovar is not ovar %s" %
             (message_end))
-        self.assertEquals(
+        self.assertEqual(
             ivar.GetValue(), ivar_value,
             "ivar wrong %s" %
             (message_end))
-        self.assertEquals(
+        self.assertEqual(
             ovar.GetValue(), ovar_value,
             "ovar wrong %s" %
             (message_end))


### PR DESCRIPTION
assertEquals is a deprecated alias for assertEqual and has been removed in Python 3.12. This wasn't an issue previously because we used a vendored version of the unittest module. Now that we use the built-in version this gets updated together with the Python version used to run the test suite.

This is the equivalent of 80fcecb13c388ff087a27a4b0e7ca3dd8c98eaa4 upstream but for the Swift tests.

(cherry picked from commit 7c6f381858aafc3e040bebcaeab55684041b4a7a)