### PR TITLE
[lldb] Handle new suffix casing in TestSwiftPropertyAccessorBreakpoints

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
@@ -10,19 +10,23 @@ class TestCase(TestBase):
         self.build()
         exe = self.getBuildArtifact("a.out")
         target = self.dbg.CreateTarget(exe)
-        for name in (
-            "read_only.get",
-            "read_write.get",
-            "read_write.set",
-            "observed.willset",
-            "observed.didset",
+
+        for name, alt_name in (
+            ("read_only.get", None),
+            ("read_write.get", None),
+            ("read_write.set", None),
+            ("observed.willSet", "observed.willset"),
+            ("observed.didSet", "observed.didset"),
         ):
             bp = target.BreakpointCreateByName(name, "a.out")
-            self.assertEqual(bp.num_locations, 1, f"{name} breakpoint failed")
+            if not bp.IsValid() and alt_name:
+                bp = target.BreakpointCreateByName(alt_name, "a.out")
+            self.assertTrue(bp.IsValid(), f"{name} breakpoint failed")
+            self.assertEqual(bp.num_locations, 1)
 
         # Setting a breakpoint on the name "get" should not create a breakpoint
         # matching property getters. The other accerssor suffixes should also
         # not succeed as bare names.
-        for name in ("get", "set", "willset", "didset"):
+        for name in ("get", "set", "willSet", "didSet", "willset", "didset"):
             bp = target.BreakpointCreateByName(name, "a.out")
             self.assertEqual(bp.num_locations, 0, f"{name} breakpoint unexpected")


### PR DESCRIPTION
This change supports casing changes in Swift https://github.com/apple/swift/pull/73085