### PR TITLE
[Cherry-pick into swift/release/6.0] [lldb] Provide a better error message for missing symbols (#89433)

### DIFF
--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -476,7 +476,9 @@ void IRExecutionUnit::GetRunnableInfo(Status &error, lldb::addr_t &func_addr,
     }
 
     m_failed_lookups.clear();
-
+    ss.PutCString(
+        "\nHint: The expression tried to call a function that is not present "
+        "in the target, perhaps because it was optimized out by the compiler.");
     error.SetErrorString(ss.GetString());
 
     return;

--- a/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
+++ b/lldb/test/API/lang/cpp/constructors/TestCppConstructors.py
@@ -47,7 +47,7 @@ class TestCase(TestBase):
         self.expect(
             "expr ClassWithDeletedDefaultCtor().value",
             error=True,
-            substrs=["Couldn't look up symbols:"],
+            substrs=["Couldn't look up symbols:", "function", "optimized out"],
         )
 
     @skipIfWindows  # Can't find operator new.


### PR DESCRIPTION
```
commit 08163cd9d82690e808c28515523b5fd0923d7b38
Author: Adrian Prantl <adrian-prantl@users.noreply.github.com>
Date:   Fri Apr 19 22:14:55 2024 +0200

    [lldb] Provide a better error message for missing symbols (#89433)
    
    This adds a hint to the missing symbols error message to make it easier
    to understand what this means to users.
```
