### PR TITLE
[ThinLTO] Asynchronous caching

### DIFF
--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -259,6 +259,10 @@ public:
 
   /// Asynchronous version of \c getProxyIfExists using a callback.
   void getProxyAsync(
+      const CASID &ID,
+      unique_function<void(Expected<std::optional<ObjectProxy>>)> Callback);
+  /// Asynchronous version of \c getProxyIfExists using a callback.
+  void getProxyAsync(
       ObjectRef Ref,
       unique_function<void(Expected<std::optional<ObjectProxy>>)> Callback);
 

--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -62,8 +62,8 @@ public:
   }
 
   virtual ~ModuleCacheEntry() {}
-protected:
-  std::optional<std::string> computeCacheKey(
+
+  static std::optional<std::string> computeCacheKey(
       const ModuleSummaryIndex &Index, StringRef ModuleID,
       const FunctionImporter::ImportMapTy &ImportList,
       const FunctionImporter::ExportSetTy &ExportList,

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -128,6 +128,15 @@ std::future<AsyncProxyValue> ObjectStore::getProxyFuture(ObjectRef Ref) {
 }
 
 void ObjectStore::getProxyAsync(
+    const CASID &ID,
+    unique_function<void(Expected<std::optional<ObjectProxy>>)> Callback) {
+  std::optional<ObjectRef> Ref = getReference(ID);
+  if (!Ref)
+    return Callback(createUnknownObjectError(ID));
+  return getProxyAsync(*Ref, std::move(Callback));
+}
+
+void ObjectStore::getProxyAsync(
     ObjectRef Ref,
     unique_function<void(Expected<std::optional<ObjectProxy>>)> Callback) {
   // FIXME: there is potential for use-after-free for the 'this' pointer.

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -1920,7 +1920,7 @@ void ThinLTOCodeGenerator::run() {
 
     // Parallel optimizer + codegen
     {
-      DefaultThreadPool Pool(heavyweight_hardware_concurrency(ThreadCount));
+      ThreadPool Pool(heavyweight_hardware_concurrency(ThreadCount));
       for (auto count : ModulesOrdering) {
         auto ModuleEntryPath = Infos[count].Entry->getEntryPath();
         Pool.async([&, count, ModuleEntryPath, GetCancelTok] {

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -386,48 +386,42 @@ std::unique_ptr<MemoryBuffer> codegenModule(Module &TheModule,
       std::move(OutputBuffer), /*RequiresNullTerminator=*/false);
 }
 
+struct NullModuleCacheEntry : ModuleCacheEntry {
+  std::string getEntryPath() override { return "<null>"; }
+  ErrorOr<std::unique_ptr<MemoryBuffer>> tryLoadingBuffer() override {
+    return std::error_code();
+  }
+  void write(const MemoryBuffer &OutputBuffer) override {}
+};
+
 class FileModuleCacheEntry : public ModuleCacheEntry {
 public:
+  static std::unique_ptr<ModuleCacheEntry> create(StringRef CachePath,
+                                                  std::string Key) {
+    if (CachePath.empty())
+      return std::make_unique<NullModuleCacheEntry>();
+    return std::make_unique<FileModuleCacheEntry>(CachePath, std::move(Key));
+  }
+
   // Create a cache entry. This compute a unique hash for the Module considering
   // the current list of export/import, and offer an interface to query to
   // access the content in the cache.
-  FileModuleCacheEntry(
-      StringRef CachePath, const ModuleSummaryIndex &Index, StringRef ModuleID,
-      const FunctionImporter::ImportMapTy &ImportList,
-      const FunctionImporter::ExportSetTy &ExportList,
-      const std::map<GlobalValue::GUID, GlobalValue::LinkageTypes> &ResolvedODR,
-      const GVSummaryMapTy &DefinedGVSummaries, unsigned OptLevel,
-      bool Freestanding, const TargetMachineBuilder &TMBuilder) {
-    if (CachePath.empty())
-      return;
-
-    std::optional<std::string> Key =
-        computeCacheKey(Index, ModuleID, ImportList, ExportList, ResolvedODR,
-                        DefinedGVSummaries, OptLevel, Freestanding, TMBuilder);
-
-    if (!Key)
-      return;
-
+  FileModuleCacheEntry(StringRef CachePath, std::string Key) {
+    assert(!CachePath.empty());
     // This choice of file name allows the cache to be pruned (see pruneCache()
     // in include/llvm/Support/CachePruning.h).
-    sys::path::append(EntryPath, CachePath, "llvmcache-" + *Key);
+    sys::path::append(EntryPath, CachePath, "llvmcache-" + Key);
   }
 
   std::string getEntryPath() final { return EntryPath.str().str(); }
 
   // Try loading the buffer for this cache entry.
   ErrorOr<std::unique_ptr<MemoryBuffer>> tryLoadingBuffer() final {
-    if (EntryPath.empty())
-      return std::error_code();
-
     return MemoryBuffer::getFile(EntryPath);
   }
 
   // Cache the Produced object file
   void write(const MemoryBuffer &OutputBuffer) final {
-    if (EntryPath.empty())
-      return;
-
     if (auto Err = llvm::writeToOutput(
             EntryPath, [&OutputBuffer](llvm::raw_ostream &OS) -> llvm::Error {
               OS << OutputBuffer.getBuffer();
@@ -442,30 +436,24 @@ public:
                     StringRef OutputPath) final {
     // Clear output file if exists for hard-linking.
     sys::fs::remove(OutputPath);
-    // Cache is enabled, hard-link the entry (or copy if hard-link fails).
-    std::string CacheEntryPath = getEntryPath();
-    if (!CacheEntryPath.empty()) {
-      auto Err = sys::fs::create_hard_link(CacheEntryPath, OutputPath);
-      if (!Err)
-        return Error::success();
-      // Hard linking failed, try to copy.
-      Err = sys::fs::copy_file(CacheEntryPath, OutputPath);
-      if (!Err)
-        return Error::success();
-      // Copy failed (could be because the CacheEntry was removed from the cache
-      // in the meantime by another process), fall back and try to write down
-      // the buffer to the output.
-      errs() << "remark: can't link or copy from cached entry '"
-             << CacheEntryPath << "' to '" << OutputPath << "'\n";
-    }
+    // Hard-link the entry (or copy if hard-link fails).
+    auto Err = sys::fs::create_hard_link(EntryPath, OutputPath);
+    if (!Err)
+      return Error::success();
+    // Hard linking failed, try to copy.
+    Err = sys::fs::copy_file(EntryPath, OutputPath);
+    if (!Err)
+      return Error::success();
+    // Copy failed (could be because the CacheEntry was removed from the cache
+    // in the meantime by another process), fall back and try to write down
+    // the buffer to the output.
+    errs() << "remark: can't link or copy from cached entry '" << EntryPath
+           << "' to '" << OutputPath << "'\n";
     // Fallback to default.
     return ModuleCacheEntry::writeObject(OutputBuffer, OutputPath);
   }
 
   std::optional<std::unique_ptr<MemoryBuffer>> getMappedBuffer() final {
-    if (getEntryPath().empty())
-      return std::nullopt;
-
     auto ReloadedBufferOrErr = tryLoadingBuffer();
     if (auto EC = ReloadedBufferOrErr.getError()) {
       // On error, keep the preexisting buffer and print a diagnostic.
@@ -498,54 +486,34 @@ static void handleCASError(
     consumeError(std::move(E));
 }
 
+static cas::CASID createCASProxyOrAbort(cas::ObjectStore &CAS, StringRef Key) {
+  // Create the key by inserting cache key (SHA1) into CAS to create an ID for
+  // the correct context.
+  // TODO: We can have an alternative hashing function that doesn't need to
+  // store the key into CAS to get the CacheKey.
+  auto CASKey = CAS.createProxy(std::nullopt, Key);
+  if (!CASKey)
+    report_fatal_error(CASKey.takeError());
+  return CASKey->getID();
+}
+
 class CASModuleCacheEntry : public ModuleCacheEntry {
 public:
   // Create a cache entry. This compute a unique hash for the Module considering
   // the current list of export/import, and offer an interface to query to
   // access the content in the cache.
   CASModuleCacheEntry(
-      cas::ObjectStore &CAS, cas::ActionCache &Cache,
-      const ModuleSummaryIndex &Index, StringRef ModuleID,
-      const FunctionImporter::ImportMapTy &ImportList,
-      const FunctionImporter::ExportSetTy &ExportList,
-      const std::map<GlobalValue::GUID, GlobalValue::LinkageTypes> &ResolvedODR,
-      const GVSummaryMapTy &DefinedGVSummaries, unsigned OptLevel,
-      bool Freestanding, const TargetMachineBuilder &TMBuilder,
+      cas::ObjectStore &CAS, cas::ActionCache &Cache, std::string Key,
       std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger)
-      : CAS(CAS), Cache(Cache), Logger(std::move(Logger)) {
-    std::optional<std::string> Key =
-        computeCacheKey(Index, ModuleID, ImportList, ExportList, ResolvedODR,
-                        DefinedGVSummaries, OptLevel, Freestanding, TMBuilder);
-
-    if (!Key)
-      return;
-
-    // Create the key by inserting cache key (SHA1) into CAS to create a ID for
-    // the correct context.
-    // TODO: We can have an alternative hashing function that doesn't
-    // need to store the key into CAS to get the CacheKey.
-    auto CASKey = CAS.createProxy(std::nullopt, *Key);
-    if (!CASKey) {
-      handleCASError(CASKey.takeError(), this->Logger);
-      // return as if the key doesn't exist, which will be treated as miss.
-      return;
-    }
-
-    ID = CASKey->getID();
-  }
+      : CAS(CAS), Cache(Cache), ID(createCASProxyOrAbort(CAS, Key)),
+        Logger(std::move(Logger)) {}
 
   std::string getEntryPath() final {
-    if (!ID)
-      return "";
-
-    return ID->toString();
+    return ID.toString();
   }
 
   // Try loading the buffer for this cache entry.
   ErrorOr<std::unique_ptr<MemoryBuffer>> tryLoadingBuffer() final {
-    if (!ID)
-      return std::error_code();
-
     std::optional<cas::CASID> MaybeKeyID;
     {
       ScopedDurationTimer ScopedTime([&](double Seconds) {
@@ -557,7 +525,7 @@ public:
         }
       });
 
-      if (Error E = Cache.get(*ID, /*Globally=*/true).moveInto(MaybeKeyID)) {
+      if (Error E = Cache.get(ID, /*Globally=*/true).moveInto(MaybeKeyID)) {
         handleCASError(std::move(E), Logger);
         // If handleCASError didn't abort, treat as miss.
         return std::error_code();
@@ -586,11 +554,8 @@ public:
     return MaybeObject->getMemoryBuffer("", /*NullTerminated=*/true);
   }
 
-  // Cache the Produced object file
+  // Cache the computed object file.
   void write(const MemoryBuffer &OutputBuffer) final {
-    if (!ID)
-      return;
-
     std::optional<cas::ObjectProxy> Proxy;
     {
       ScopedDurationTimer ScopedTime([&](double Seconds) {
@@ -616,14 +581,14 @@ public:
       }
     });
 
-    if (auto Err = Cache.put(*ID, Proxy->getID(), /*Globally=*/true))
+    if (auto Err = Cache.put(ID, Proxy->getID(), /*Globally=*/true))
       handleCASError(std::move(Err), Logger);
   }
 
 private:
   cas::ObjectStore &CAS;
   cas::ActionCache &Cache;
-  std::optional<cas::CASID> ID;
+  cas::CASID ID;
   std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger;
 };
 
@@ -633,33 +598,16 @@ public:
   // the current list of export/import, and offer an interface to query to
   // access the content in the cache.
   RemoteModuleCacheEntry(
-      cas::remote::ClientServices &Service, const ModuleSummaryIndex &Index,
-      StringRef ModuleID, StringRef OutputPath,
-      const FunctionImporter::ImportMapTy &ImportList,
-      const FunctionImporter::ExportSetTy &ExportList,
-      const std::map<GlobalValue::GUID, GlobalValue::LinkageTypes> &ResolvedODR,
-      const GVSummaryMapTy &DefinedGVSummaries, unsigned OptLevel,
-      bool Freestanding, const TargetMachineBuilder &TMBuilder,
+      cas::remote::ClientServices &Service, StringRef OutputPath,
+      std::string Key,
       std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger)
-      : Service(Service), OutputPath(OutputPath.str()),
-        Logger(std::move(Logger)) {
-    std::optional<std::string> Key =
-        computeCacheKey(Index, ModuleID, ImportList, ExportList, ResolvedODR,
-                        DefinedGVSummaries, OptLevel, Freestanding, TMBuilder);
-
-    if (!Key)
-      return;
-
-    ID = *Key;
-  }
+      : Service(Service), ID(std::move(Key)), OutputPath(OutputPath.str()),
+        Logger(std::move(Logger)) {}
 
   std::string getEntryPath() final { return ID; }
 
   // Try loading the buffer for this cache entry.
   ErrorOr<std::unique_ptr<MemoryBuffer>> tryLoadingBuffer() final {
-    if (ID.empty())
-      return std::error_code();
-
     // Lookup the output value from KVDB.
     std::optional<cas::remote::KeyValueDBClient::ValueTy> GetResponse;
     {
@@ -718,9 +666,6 @@ public:
 
   // Cache the Produced object file
   void write(const MemoryBuffer &OutputBuffer) final {
-    if (ID.empty())
-      return;
-
     if (!ProducedOutput)
       cantFail(ModuleCacheEntry::writeObject(OutputBuffer, OutputPath));
 
@@ -1001,21 +946,23 @@ std::unique_ptr<ModuleCacheEntry> ThinLTOCodeGenerator::createModuleCacheEntry(
     const GVSummaryMapTy &DefinedGVSummaries, unsigned OptLevel,
     bool Freestanding, const TargetMachineBuilder &TMBuilder,
     std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger) {
+  std::optional<std::string> Key = ModuleCacheEntry::computeCacheKey(
+      Index, ModuleID, ImportList, ExportList, ResolvedODR, DefinedGVSummaries,
+      OptLevel, Freestanding, TMBuilder);
+
+  if (!Key)
+    return std::make_unique<NullModuleCacheEntry>();
+
   switch (CacheOptions.Type) {
   case CachingOptions::CacheType::CacheDirectory:
-    return std::make_unique<FileModuleCacheEntry>(
-        CacheOptions.Path, Index, ModuleID, ImportList, ExportList, ResolvedODR,
-        DefinedGVSummaries, OptLevel, Freestanding, TMBuilder);
+    return FileModuleCacheEntry::create(CacheOptions.Path, std::move(*Key));
   case CachingOptions::CacheType::CAS:
     return std::make_unique<CASModuleCacheEntry>(
-        *CacheOptions.CAS, *CacheOptions.Cache, Index, ModuleID, ImportList,
-        ExportList, ResolvedODR, DefinedGVSummaries, OptLevel, Freestanding,
-        TMBuilder, std::move(Logger));
+        *CacheOptions.CAS, *CacheOptions.Cache, std::move(*Key),
+        std::move(Logger));
   case CachingOptions::CacheType::RemoteService:
     return std::make_unique<RemoteModuleCacheEntry>(
-        *CacheOptions.Service, Index, ModuleID, OutputPath, ImportList,
-        ExportList, ResolvedODR, DefinedGVSummaries, OptLevel, Freestanding,
-        TMBuilder, std::move(Logger));
+        *CacheOptions.Service, OutputPath, std::move(*Key), std::move(Logger));
   }
 }
 
@@ -1714,7 +1661,7 @@ void ThinLTOCodeGenerator::run() {
             OS << "Update cached result for " << ModuleIdentifier << "\n";
           });
 
-        // Commit to the cache (if enabled)
+        // Commit to the cache.
         CacheEntry->write(*OutputBuffer);
 
         if (UseBufferAPI) {

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -68,6 +68,7 @@
 
 #include <memory>
 #include <numeric>
+#include <queue>
 
 #if !defined(_MSC_VER) && !defined(__MINGW32__)
 #include <unistd.h>
@@ -467,6 +468,39 @@ private:
   SmallString<128> EntryPath;
 };
 
+struct CancellationToken {
+  std::atomic<bool> WantsToExit{false};
+  std::mutex Mutex;
+  std::condition_variable CondVar;
+  unsigned ExitBlockers{0};
+
+  void requestCancellation() {
+    WantsToExit = true;
+    std::unique_lock Lock(Mutex);
+    CondVar.wait(Lock, [&]() { return ExitBlockers == 0; });
+  }
+
+  [[nodiscard]] auto acquireHandle() {
+    auto ReleaseHandleOnScopeExit = llvm::make_scope_exit([this]() {
+      std::unique_lock Lock(Mutex);
+      --ExitBlockers;
+      CondVar.notify_one();
+    });
+
+    using RetTy = std::optional<decltype(ReleaseHandleOnScopeExit)>;
+
+    if (WantsToExit) {
+      ReleaseHandleOnScopeExit.release();
+      return RetTy{};
+    }
+
+    std::unique_lock Lock(Mutex);
+    ++ExitBlockers;
+
+    return RetTy{std::move(ReleaseHandleOnScopeExit)};
+  }
+};
+
 static void handleCASError(
     Error E, llvm::function_ref<void(llvm::function_ref<void(raw_ostream &OS)>)>
                  Logger) {
@@ -497,7 +531,59 @@ static cas::CASID createCASProxyOrAbort(cas::ObjectStore &CAS, StringRef Key) {
   return CASKey->getID();
 }
 
-class CASModuleCacheEntry : public ModuleCacheEntry {
+// ThinLTOCacheEntry: manage caching for a single Module.
+class AsyncModuleCacheEntry {
+public:
+  // Access the path to this entry in the cache.
+  virtual std::string getEntryPath() = 0;
+
+  /// Attempt to asynchronously load the cached buffer and invoke the callback.
+  /// Cache miss is represented as std::error_code().
+  virtual void tryLoadingBuffer(
+      std::function<void(ErrorOr<std::unique_ptr<MemoryBuffer>>)> Cb) = 0;
+
+  /// Attempt to asynchronously write the computed buffer and invoke the
+  /// callback.
+  virtual void write(const MemoryBuffer &OutputBuffer,
+                     std::function<void()> Cb) = 0;
+
+  virtual Error writeObject(const MemoryBuffer &OutputBuffer,
+                            StringRef OutputPath) {
+    std::error_code Err;
+    raw_fd_ostream OS(OutputPath, Err, sys::fs::CD_CreateAlways);
+    if (Err)
+      return createStringError(Err, Twine("Can't open output '") + OutputPath);
+    OS << OutputBuffer.getBuffer();
+    return Error::success();
+  }
+
+  virtual std::optional<std::unique_ptr<MemoryBuffer>> getMappedBuffer() {
+    return std::nullopt;
+  }
+
+  /// Check whether the loaded and written results of this entry are identical.
+  /// This is only called when DeterministicCheck is enabled, and after both
+  /// \c tryLoadingBuffer() and \c write() have finished.
+  virtual bool areLoadedAndWrittenResultsIdentical() const { return true; }
+
+  virtual ~AsyncModuleCacheEntry() {}
+};
+
+struct NullAsyncModuleCacheEntry : AsyncModuleCacheEntry {
+  std::string getEntryPath() override { return "<null>"; }
+
+  void tryLoadingBuffer(
+      std::function<void(ErrorOr<std::unique_ptr<MemoryBuffer>>)> Cb) override {
+    return Cb(std::error_code());
+  }
+
+  void write(const MemoryBuffer &OutputBuffer,
+             std::function<void()> Cb) override {
+    return Cb();
+  }
+};
+
+class CASModuleCacheEntry : public AsyncModuleCacheEntry {
 public:
   // Create a cache entry. This compute a unique hash for the Module considering
   // the current list of export/import, and offer an interface to query to
@@ -512,77 +598,76 @@ public:
     return ID.toString();
   }
 
-  // Try loading the buffer for this cache entry.
-  ErrorOr<std::unique_ptr<MemoryBuffer>> tryLoadingBuffer() final {
-    std::optional<cas::CASID> MaybeKeyID;
-    {
-      ScopedDurationTimer ScopedTime([&](double Seconds) {
-        if (Logger) {
-          Logger([&](raw_ostream &OS) {
-            OS << "LTO cache lookup '" << ID << "' in "
-               << llvm::format("%.6fs", Seconds) << "\n";
-          });
-        }
-      });
-
-      if (Error E = Cache.get(ID, /*Globally=*/true).moveInto(MaybeKeyID)) {
-        handleCASError(std::move(E), Logger);
-        // If handleCASError didn't abort, treat as miss.
-        return std::error_code();
-      }
-    }
-
-    if (!MaybeKeyID)
-      return std::error_code();
-
-    ScopedDurationTimer ScopedTime([&](double Seconds) {
+  void tryLoadingBuffer(
+      std::function<void(ErrorOr<std::unique_ptr<MemoryBuffer>>)> Cb) final {
+    auto LookupStart = std::chrono::steady_clock::now();
+    Cache.getAsync(ID, /*Globally=*/true, [=](auto KeyID) {
       if (Logger) {
+        auto LookupEnd = std::chrono::steady_clock::now();
+        auto Seconds =
+            std::chrono::duration<double>(LookupEnd - LookupStart).count();
         Logger([&](raw_ostream &OS) {
-          OS << "LTO cache load '" << ID << "' in "
+          OS << "LTO cache lookup '" << ID << "' in "
              << llvm::format("%.6fs", Seconds) << "\n";
         });
       }
-    });
 
-    auto MaybeObject = CAS.getProxy(*MaybeKeyID);
-    if (!MaybeObject) {
-      handleCASError(MaybeObject.takeError(), Logger);
-      // If handleCASError didn't abort, treat as miss.
-      return std::error_code();
-    }
+      std::optional<cas::CASID> MaybeKeyID;
+      if (auto E = std::move(KeyID).moveInto(MaybeKeyID)) {
+        handleCASError(std::move(E), Logger);
+        // If handleCASError didn't abort, treat as miss.
+        return Cb(std::error_code());
+      }
 
-    return MaybeObject->getMemoryBuffer("", /*NullTerminated=*/true);
-  }
+      if (!MaybeKeyID)
+        return Cb(std::error_code());
 
-  // Cache the computed object file.
-  void write(const MemoryBuffer &OutputBuffer) final {
-    std::optional<cas::ObjectProxy> Proxy;
-    {
-      ScopedDurationTimer ScopedTime([&](double Seconds) {
+      auto LoadStart = std::chrono::steady_clock::now();
+      CAS.getProxyAsync(*MaybeKeyID, [=](auto MaybeObject) {
         if (Logger) {
+          auto LoadEnd = std::chrono::steady_clock::now();
+          auto Seconds =
+              std::chrono::duration<double>(LoadEnd - LoadStart).count();
           Logger([&](raw_ostream &OS) {
-            OS << "LTO cache save '" << ID << "' in "
+            OS << "LTO cache load '" << ID << "' in "
                << llvm::format("%.6fs", Seconds) << "\n";
           });
         }
-      });
 
-      if (Error E = CAS.createProxy(std::nullopt, OutputBuffer.getBuffer())
-                        .moveInto(Proxy))
-        return handleCASError(std::move(E), Logger);
+        if (!MaybeObject) {
+          handleCASError(MaybeObject.takeError(), Logger);
+          // If handleCASError didn't abort, treat as miss.
+          return Cb(std::error_code());
+        }
+        return Cb((*MaybeObject)->getMemoryBuffer("", /*NullTerminated=*/true));
+      });
+    });
+  }
+
+  void write(const MemoryBuffer &OutputBuffer, std::function<void()> Cb) final {
+    std::optional<cas::ObjectProxy> Proxy;
+    if (Error E =
+            CAS.createProxy({}, OutputBuffer.getBuffer()).moveInto(Proxy)) {
+      handleCASError(std::move(E), Logger);
+      return Cb();
     }
 
-    ScopedDurationTimer ScopedTime([&](double Seconds) {
+    auto UpdateStart = std::chrono::steady_clock::now();
+    Cache.putAsync(ID, Proxy->getID(), /*Globally=*/true, [=](auto Err) {
       if (Logger) {
+        auto UpdateEnd = std::chrono::steady_clock::now();
+        auto Seconds =
+            std::chrono::duration<double>(UpdateEnd - UpdateStart).count();
         Logger([&](raw_ostream &OS) {
           OS << "LTO cache update '" << ID << "' in "
              << llvm::format("%.6fs", Seconds) << "\n";
         });
       }
-    });
 
-    if (auto Err = Cache.put(ID, Proxy->getID(), /*Globally=*/true))
-      handleCASError(std::move(Err), Logger);
+      if (Err)
+        report_fatal_error(std::move(Err));
+      Cb();
+    });
   }
 
 private:
@@ -592,147 +677,200 @@ private:
   std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger;
 };
 
-class RemoteModuleCacheEntry : public ModuleCacheEntry {
+class RemoteModuleCacheEntry : public AsyncModuleCacheEntry {
 public:
   // Create a cache entry. This compute a unique hash for the Module considering
   // the current list of export/import, and offer an interface to query to
   // access the content in the cache.
   RemoteModuleCacheEntry(
-      cas::remote::ClientServices &Service, StringRef OutputPath,
-      std::string Key,
+      std::shared_ptr<CancellationToken> GetCancelTok,
+      std::shared_ptr<CancellationToken> PutCancelTok,
+      cas::remote::ClientServices &Service,
+      StringRef OutputPath, std::string Key,
       std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger)
-      : Service(Service), ID(std::move(Key)), OutputPath(OutputPath.str()),
-        Logger(std::move(Logger)) {}
+      : GetCancelTok(GetCancelTok), PutCancelTok(PutCancelTok), Service(Service), ID(std::move(Key)),
+        OutputPath(OutputPath.str()), Logger(std::move(Logger)) {}
 
   std::string getEntryPath() final { return ID; }
 
-  // Try loading the buffer for this cache entry.
-  ErrorOr<std::unique_ptr<MemoryBuffer>> tryLoadingBuffer() final {
-    // Lookup the output value from KVDB.
-    std::optional<cas::remote::KeyValueDBClient::ValueTy> GetResponse;
-    {
-      ScopedDurationTimer ScopedTime([&](double Seconds) {
-        if (Logger) {
-          Logger([&](raw_ostream &OS) {
-            OS << "LTO cache lookup '" << ID << "' in "
-               << llvm::format("%.6fs", Seconds) << "\n";
-          });
-        }
-      });
+  void tryLoadingBuffer(
+      std::function<void(ErrorOr<std::unique_ptr<MemoryBuffer>>)> Cb) final {
+    auto LookupStart = std::chrono::steady_clock::now();
+    Service.KVDB->getValueAsync(ID, [=, GetCancelTok = GetCancelTok](auto ErrOrGetResponse) {
+      auto CancelTokHandle = GetCancelTok->acquireHandle();
+      if (!CancelTokHandle) {
+        (void)expectedToOptional(std::move(ErrOrGetResponse));
+        return;
+      }
 
-      if (Error E = Service.KVDB->getValueSync(ID).moveInto(GetResponse)) {
+      if (Logger) {
+        auto LookupEnd = std::chrono::steady_clock::now();
+        auto Seconds =
+            std::chrono::duration<double>(LookupEnd - LookupStart).count();
+        Logger([&](raw_ostream &OS) {
+          OS << "LTO cache lookup '" << ID << "' in "
+             << llvm::format("%.6fs", Seconds) << "\n";
+        });
+      }
+
+      // Use the KVDB to map the ThinLTO key onto the CAS ID.
+      std::optional<cas::remote::KeyValueDBClient::ValueTy> GetResponse;
+      if (Error E = std::move(ErrOrGetResponse).moveInto(GetResponse)) {
         handleCASError(std::move(E), Logger);
         // If handleCASError didn't abort, treat as miss.
-        return std::error_code();
+        return Cb(std::error_code());
       }
-    }
 
-    // Cache Miss.
-    if (!GetResponse)
-      return std::error_code();
+      // Cache Miss.
+      if (!GetResponse)
+        return Cb(std::error_code());
 
-    // Malformed output. Error.
-    auto Result = GetResponse->find("Output");
-    if (Result == GetResponse->end())
-      return std::make_error_code(std::errc::message_size);
+      // Malformed output. Error.
+      auto Result = GetResponse->find("Output");
+      if (Result == GetResponse->end())
+        return Cb(std::make_error_code(std::errc::message_size));
 
-    if (DeterministicCheck)
-      PresumedOutput = Result->getValue();
+      LoadedCASID = Result->getValue();
 
-    ScopedDurationTimer ScopedTime([&](double Seconds) {
-      if (Logger) {
-        Logger([&](raw_ostream &OS) {
-          OS << "LTO cache load '" << ID << "' in "
-             << llvm::format("%.6fs", Seconds) << "\n";
-        });
-      }
-    });
+      std::string TmpPath = OutputPath + ".downloaded.tmp";
 
-    // Request the output buffer.
-    auto LoadResponse = Service.CASDB->loadSync(Result->getValue(), OutputPath);
-    if (!LoadResponse) {
-      handleCASError(LoadResponse.takeError(), Logger);
-      // If handleCASError didn't abort, treat as miss.
-      return std::error_code();
-    }
+      // Request the output buffer.
+      auto LoadStart = std::chrono::steady_clock::now();
+      Service.CASDB->loadAsync(
+          *LoadedCASID, TmpPath, [=, GetCancelTok = GetCancelTok](auto LoadResponse) {
+            auto CancelTokHandle = GetCancelTok->acquireHandle();
+            if (!CancelTokHandle) {
+              (void)expectedToOptional(std::move(LoadResponse));
+              return;
+            }
 
-    // Object not found. Treat it as a miss.
-    if (LoadResponse->KeyNotFound)
-      return std::error_code();
+            if (Logger) {
+              auto LoadEnd = std::chrono::steady_clock::now();
+              auto Seconds =
+                  std::chrono::duration<double>(LoadEnd - LoadStart).count();
+              Logger([&](raw_ostream &OS) {
+                OS << "LTO cache load '" << ID << "' in "
+                   << llvm::format("%.6fs", Seconds) << "\n";
+              });
+            }
 
-    ProducedOutput = true;
-    return MemoryBuffer::getFile(OutputPath);
-  }
+            if (!LoadResponse) {
+              handleCASError(LoadResponse.takeError(), Logger);
+              // If handleCASError didn't abort, treat as miss.
+              return Cb(std::error_code());
+            }
 
-  // Cache the Produced object file
-  void write(const MemoryBuffer &OutputBuffer) final {
-    if (!ProducedOutput)
-      cantFail(ModuleCacheEntry::writeObject(OutputBuffer, OutputPath));
+            // Object not found. Treat it as a miss.
+            if (LoadResponse->KeyNotFound)
+              return Cb(std::error_code());
 
-    ProducedOutput = true;
-    std::optional<std::string> SaveResponse;
-    {
-      ScopedDurationTimer ScopedTime([&](double Seconds) {
-        if (Logger) {
-          Logger([&](raw_ostream &OS) {
-            OS << "LTO cache save '" << ID << "' in "
-               << llvm::format("%.6fs", Seconds) << "\n";
+            sys::fs::rename(TmpPath, OutputPath);
+            // Note: This might pick up the file created by rename in \c
+            // write().
+            return Cb(MemoryBuffer::getFile(OutputPath));
           });
-        }
-      });
-
-      if (Error E =
-              Service.CASDB->saveFileSync(OutputPath).moveInto(SaveResponse))
-        return handleCASError(std::move(E), Logger);
-    }
-
-    // Only check determinism when the cache lookup succeeded before.
-    if (DeterministicCheck && PresumedOutput) {
-      if (*PresumedOutput != *SaveResponse)
-        report_fatal_error(
-            (Twine) "ThinLTO deterministic check failed: " + *PresumedOutput +
-            " (expected) vs. " + *SaveResponse + " (actual)");
-    }
-
-    ScopedDurationTimer ScopedTime([&](double Seconds) {
-      if (Logger) {
-        Logger([&](raw_ostream &OS) {
-          OS << "LTO cache update '" << ID << "' in "
-             << llvm::format("%.6fs", Seconds) << "\n";
-        });
-      }
     });
-
-    cas::remote::KeyValueDBClient::ValueTy CompResult;
-    CompResult["Output"] = *SaveResponse;
-    if (auto Err = Service.KVDB->putValueSync(ID, CompResult))
-      handleCASError(std::move(Err), Logger);
   }
 
   Error writeObject(const MemoryBuffer &OutputBuffer,
                     StringRef OutputPath) final {
-    // There is nothing to do here.
+    std::string TmpPath = this->OutputPath + ".computed.tmp";
+
+    if (Error E = AsyncModuleCacheEntry::writeObject(OutputBuffer, TmpPath))
+      return E;
+
+    if (auto EC = sys::fs::rename(TmpPath, OutputPath)) {
+      (void)sys::fs::remove(TmpPath); // Attempt to clean up.
+      return createStringError(
+          EC, "renaming of computed module object file failed");
+    }
+
     return Error::success();
   }
 
-  std::optional<std::unique_ptr<MemoryBuffer>> getMappedBuffer() final {
-    if (!ProducedOutput)
-      return std::nullopt;
+  void write(const MemoryBuffer &OutputBuffer, std::function<void()> Cb) final {
+    std::string TmpPath = OutputPath + ".uploaded.tmp";
 
-    ErrorOr<std::unique_ptr<MemoryBuffer>> MBOrErr =
-        MemoryBuffer::getFile(OutputPath);
-    if (!MBOrErr)
-      return std::nullopt;
+    if (Error E = AsyncModuleCacheEntry::writeObject(OutputBuffer, TmpPath)) {
+      handleCASError(std::move(E), Logger);
+      return;
+    }
 
-    return std::move(*MBOrErr);
+    auto SaveStart = std::chrono::steady_clock::now();
+    // FIXME: Consider passing the buffer contents this in a string instead of file.
+    Service.CASDB->saveFileAsync(TmpPath, [=, PutCancelTok = PutCancelTok](auto MaybeWrittenCASID) {
+      sys::fs::remove(TmpPath);
+
+      auto CancelTokHandle = PutCancelTok->acquireHandle();
+      if (!CancelTokHandle) {
+        (void)expectedToOptional(std::move(MaybeWrittenCASID));
+        return;
+      }
+
+      if (Logger) {
+        auto SaveEnd = std::chrono::steady_clock::now();
+        auto Seconds =
+            std::chrono::duration<double>(SaveEnd - SaveStart).count();
+        Logger([&](raw_ostream &OS) {
+          OS << "LTO cache save '" << ID << "' in "
+             << llvm::format("%.6fs", Seconds) << "\n";
+        });
+      }
+
+      if (Error E = std::move(MaybeWrittenCASID).moveInto(WrittenCASID)) {
+        handleCASError(std::move(E), Logger);
+        return Cb();
+      }
+
+      cas::remote::KeyValueDBClient::ValueTy CompResult;
+      CompResult["Output"] = *WrittenCASID;
+
+      auto UpdateStart = std::chrono::steady_clock::now();
+      Service.KVDB->putValueAsync(ID, CompResult, [=, PutCancelTok = PutCancelTok](auto Err) {
+        auto CancelTokHandle = PutCancelTok->acquireHandle();
+        if (!CancelTokHandle) {
+          (void)consumeError(std::move(Err));
+          return;
+        }
+
+        if (Logger) {
+          auto UpdateEnd = std::chrono::steady_clock::now();
+          auto Seconds =
+              std::chrono::duration<double>(UpdateEnd - UpdateStart).count();
+          Logger([&](raw_ostream &OS) {
+            OS << "LTO cache update '" << ID << "' in "
+               << llvm::format("%.6fs", Seconds) << "\n";
+          });
+        }
+
+        if (Err)
+          handleCASError(std::move(Err), Logger);
+
+        return Cb();
+      });
+    });
+  }
+
+  bool areLoadedAndWrittenResultsIdentical() const override {
+    if (LoadedCASID && WrittenCASID && *LoadedCASID != *WrittenCASID) {
+      Error E = createStringError(
+          inconvertibleErrorCode(),
+          "ThinLTO deterministic check failed: " + *LoadedCASID +
+              " (expected) vs. " + *WrittenCASID + " (actual)");
+      handleCASError(std::move(E), Logger);
+      return false;
+    }
+    return true;
   }
 
 private:
+  std::shared_ptr<CancellationToken> GetCancelTok;
+  std::shared_ptr<CancellationToken> PutCancelTok;
   cas::remote::ClientServices &Service;
   std::string ID;
   std::string OutputPath;
-  bool ProducedOutput = false;
-  std::optional<std::string> PresumedOutput;
+  std::optional<std::string> LoadedCASID;
+  std::optional<std::string> WrittenCASID;
   std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger;
 };
 
@@ -946,6 +1084,8 @@ std::unique_ptr<ModuleCacheEntry> ThinLTOCodeGenerator::createModuleCacheEntry(
     const GVSummaryMapTy &DefinedGVSummaries, unsigned OptLevel,
     bool Freestanding, const TargetMachineBuilder &TMBuilder,
     std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger) {
+  assert(CacheOptions.Type == CachingOptions::CacheType::CacheDirectory);
+
   std::optional<std::string> Key = ModuleCacheEntry::computeCacheKey(
       Index, ModuleID, ImportList, ExportList, ResolvedODR, DefinedGVSummaries,
       OptLevel, Freestanding, TMBuilder);
@@ -953,16 +1093,38 @@ std::unique_ptr<ModuleCacheEntry> ThinLTOCodeGenerator::createModuleCacheEntry(
   if (!Key)
     return std::make_unique<NullModuleCacheEntry>();
 
+  return FileModuleCacheEntry::create(CacheOptions.Path, std::move(*Key));
+}
+
+static std::unique_ptr<AsyncModuleCacheEntry> createAsyncModuleCacheEntry(
+    std::shared_ptr<CancellationToken> GetCancelTok,
+    std::shared_ptr<CancellationToken> PutCancelTok,
+    ThinLTOCodeGenerator::CachingOptions &CacheOptions,
+    const ModuleSummaryIndex &Index, StringRef ModuleID, StringRef OutputPath,
+    const FunctionImporter::ImportMapTy &ImportList,
+    const FunctionImporter::ExportSetTy &ExportList,
+    const std::map<GlobalValue::GUID, GlobalValue::LinkageTypes> &ResolvedODR,
+    const GVSummaryMapTy &DefinedGVSummaries, unsigned OptLevel,
+    bool Freestanding, const TargetMachineBuilder &TMBuilder,
+    std::function<void(llvm::function_ref<void(raw_ostream &OS)>)> Logger) {
+  std::optional<std::string> Key = ModuleCacheEntry::computeCacheKey(
+      Index, ModuleID, ImportList, ExportList, ResolvedODR, DefinedGVSummaries,
+      OptLevel, Freestanding, TMBuilder);
+
+  if (!Key)
+    return std::make_unique<NullAsyncModuleCacheEntry>();
+
   switch (CacheOptions.Type) {
-  case CachingOptions::CacheType::CacheDirectory:
-    return FileModuleCacheEntry::create(CacheOptions.Path, std::move(*Key));
-  case CachingOptions::CacheType::CAS:
+  case ThinLTOCodeGenerator::CachingOptions::CacheType::CAS:
     return std::make_unique<CASModuleCacheEntry>(
         *CacheOptions.CAS, *CacheOptions.Cache, std::move(*Key),
         std::move(Logger));
-  case CachingOptions::CacheType::RemoteService:
+  case ThinLTOCodeGenerator::CachingOptions::CacheType::RemoteService:
     return std::make_unique<RemoteModuleCacheEntry>(
-        *CacheOptions.Service, OutputPath, std::move(*Key), std::move(Logger));
+        GetCancelTok, PutCancelTok, *CacheOptions.Service, OutputPath,
+        std::move(*Key), std::move(Logger));
+  case ThinLTOCodeGenerator::CachingOptions::CacheType::CacheDirectory:
+    llvm_unreachable("creating async module cache entry in sync context");
   }
 }
 
@@ -1373,6 +1535,48 @@ ThinLTOCodeGenerator::writeGeneratedObject(StringRef OutputPath,
   return std::string(OutputPath.str());
 }
 
+template <class T>
+class Awaitable {
+  T Value;
+  std::mutex Mutex;
+  std::condition_variable Channel;
+
+public:
+  explicit Awaitable(T Value) : Value(std::move(Value)) {}
+
+  bool check(llvm::function_ref<bool(const T &)> Cond) {
+    std::lock_guard Lock{Mutex};
+    return Cond(Value);
+  }
+
+  void wait(llvm::function_ref<bool(const T &)> Cond) {
+    std::unique_lock Lock{Mutex};
+    if (Cond(Value))
+      return;
+
+    Channel.wait(Lock, [&]() { return Cond(Value); });
+  }
+
+  template <class Duration>
+  bool waitFor(Duration MaxDuration, llvm::function_ref<bool(const T &)> Cond) {
+    std::unique_lock Lock{Mutex};
+    if (Cond(Value))
+      return true;
+
+    return Channel.wait_for(Lock, MaxDuration, [&]() { return Cond(Value); });
+  }
+
+  T apply(llvm::function_ref<void(T &)> Modifier) {
+    T Result = [&]() {
+      std::lock_guard Lock{Mutex};
+      Modifier(Value);
+      return Value;
+    }();
+    Channel.notify_one();
+    return Result;
+  }
+};
+
 // Main entry point for the ThinLTO processing
 void ThinLTOCodeGenerator::run() {
   timeTraceProfilerBegin("ThinLink", StringRef(""));
@@ -1562,6 +1766,273 @@ void ThinLTOCodeGenerator::run() {
 
   TimeTraceScopeExit.release();
   LoggingStream CacheLogOS(llvm::errs());
+
+  // We can try running cache queries asynchronously.
+  if (CacheOptions.Type == CachingOptions::CacheType::CAS ||
+      CacheOptions.Type == CachingOptions::CacheType::RemoteService) {
+    enum ModuleState {
+      // Initial state, no guarantees.
+      MS_Empty = 0b0000,
+      // Computation is done, ComputedBuffer is valid.
+      MS_ComputationDone = 0b0001,
+      // Cache lookup is done, no other guarantees.
+      MS_CacheLookupDone = 0b0010,
+      // Cache lookup is done, CachedBuffer is valid.
+      MS_CacheLookupHit = 0b0100,
+    };
+    struct ModuleInfo {
+      std::unique_ptr<AsyncModuleCacheEntry> Entry;
+      std::atomic<unsigned> State = MS_Empty;
+      std::unique_ptr<MemoryBuffer> ComputedBuffer;
+      std::unique_ptr<MemoryBuffer> CachedBuffer;
+    };
+    std::vector<ModuleInfo> Infos(ModuleCount);
+
+    auto GetCancelTok = std::make_shared<CancellationToken>();
+    auto PutCancelTok = std::make_shared<CancellationToken>();
+
+    Awaitable<std::size_t> WrittenObjects{0};
+    Awaitable<std::size_t> HandledCacheReads{0};
+    Awaitable<std::size_t> HandledCacheWrites{0};
+    auto AllModules = [ModuleCount](std::size_t V) { return V == ModuleCount; };
+    auto Increment = [](std::size_t &V) { ++V; };
+
+    auto WriteObject = [&](int count, bool CacheHit) {
+      auto &Buffer =
+          CacheHit ? Infos[count].CachedBuffer : Infos[count].ComputedBuffer;
+
+      if (UseBufferAPI) {
+        ProducedBinaries[count] = std::move(Buffer);
+      } else {
+        std::string OutputPath = computeThinLTOOutputPath(
+            count, SavedObjectsDirectoryPath, TMBuilder);
+
+        Error Err = Infos[count].Entry->writeObject(*Buffer, OutputPath);
+        if (Err)
+          report_fatal_error(std::move(Err));
+        ProducedBinaryFiles[count] = std::string(OutputPath);
+      }
+
+      WrittenObjects.apply(Increment);
+    };
+
+    auto WriteCache = [&, PutCancelTok](int count) {
+      if (count == -1) {
+        HandledCacheWrites.apply(Increment);
+        return;
+      }
+
+      auto &OutputBuffer =
+          UseBufferAPI ? ProducedBinaries[count] : Infos[count].ComputedBuffer;
+
+      // Commit to the cache.
+      Infos[count].Entry->write(*OutputBuffer, [&, PutCancelTok]() {
+        auto CancelTokHandle = PutCancelTok->acquireHandle();
+        if (!CancelTokHandle)
+          return;
+
+        // TODO: With UseBufferAPI, we could try replacing ProducedBinaries[count]
+        //  with the buffer that's now cached on disk.
+
+        HandledCacheWrites.apply(Increment);
+      });
+    };
+
+    std::mutex WriteQueueMutex;
+    std::queue<int> WriteQueue;
+    auto EnqueueCacheWrite = [&](int count) {
+      std::scoped_lock Lock(WriteQueueMutex);
+      WriteQueue.push(count);
+      if (HandledCacheReads.check(AllModules)) {
+        while (!WriteQueue.empty()) {
+          WriteCache(WriteQueue.front());
+          WriteQueue.pop();
+        }
+      }
+    };
+
+    // Query the cache.
+    for (auto IndexCount : ModulesOrdering) {
+      auto &Mod = Modules[IndexCount];
+      auto ModuleIdentifier = Mod->getName();
+
+      std::string OutputPath = computeThinLTOOutputPath(
+          IndexCount, SavedObjectsDirectoryPath, TMBuilder);
+
+      auto &CacheEntry = Infos[IndexCount].Entry = createAsyncModuleCacheEntry(
+          GetCancelTok, PutCancelTok, CacheOptions, *Index, ModuleIdentifier,
+          OutputPath, ImportLists[ModuleIdentifier],
+          ExportLists[ModuleIdentifier], ResolvedODR[ModuleIdentifier],
+          ModuleToDefinedGVSummaries[ModuleIdentifier], OptLevel, Freestanding,
+          TMBuilder,
+          [&CacheLogOS](llvm::function_ref<void(raw_ostream & OS)> Log) {
+            if (CacheLogging)
+              CacheLogOS.applyLocked(Log);
+            else {
+              raw_null_ostream OS;
+              Log(OS);
+            }
+          });
+
+      CacheEntry->tryLoadingBuffer([&, IndexCount,
+                                    GetCancelTok](auto ErrOrBuffer) {
+        auto CancelTokHandle = GetCancelTok->acquireHandle();
+        if (!CancelTokHandle)
+          return;
+
+        bool CacheHit{ErrOrBuffer};
+        unsigned CacheBits = MS_CacheLookupDone;
+
+        if (CacheHit) {
+          Infos[IndexCount].CachedBuffer = std::move(ErrOrBuffer.get());
+          CacheBits |= MS_CacheLookupHit;
+        }
+
+        unsigned ComputationState = Infos[IndexCount].State.fetch_or(CacheBits);
+
+        // Consider writing the object file.
+        if (DeterministicCheck) {
+          // With deterministic checks, writing the object file is always
+          // responsibility of the compute task.
+        } else {
+          // Without deterministic checks, writing the object file is
+          // responsibility of whoever comes up with usable result first.
+          if (!(ComputationState & MS_ComputationDone) && CacheHit)
+            WriteObject(IndexCount, /*CacheHit=*/true);
+        }
+
+        HandledCacheReads.apply(Increment);
+
+        // Enqueueing cache write is responsibility of whoever lost the race.
+        if (DeterministicCheck) {
+          if (ComputationState & MS_ComputationDone)
+            EnqueueCacheWrite(IndexCount);
+        } else {
+          if (ComputationState & MS_ComputationDone) {
+            if (!CacheHit)
+              EnqueueCacheWrite(IndexCount);
+            else
+              EnqueueCacheWrite(-1);
+          }
+        }
+      });
+    }
+
+    // Parallel optimizer + codegen
+    {
+      DefaultThreadPool Pool(heavyweight_hardware_concurrency(ThreadCount));
+      for (auto count : ModulesOrdering) {
+        auto ModuleEntryPath = Infos[count].Entry->getEntryPath();
+        Pool.async([&, count, ModuleEntryPath, GetCancelTok] {
+          auto CancelTokHandle = GetCancelTok->acquireHandle();
+          if (!CancelTokHandle) {
+            if (CacheLogging)
+              CacheLogOS.applyLocked([&](raw_ostream &OS) {
+                OS << "LTO compute '" << ModuleEntryPath
+                   << "' skipped due to completion\n";
+              });
+            return;
+          }
+
+          auto &Mod = Modules[count];
+          StringRef ModuleIdentifier = Mod->getName();
+
+          if (!DeterministicCheck) {
+            unsigned CacheState = Infos[count].State;
+            if (CacheState & MS_CacheLookupHit) {
+              if (CacheLogging)
+                CacheLogOS.applyLocked([&](raw_ostream &OS) {
+                  OS << "LTO compute '" << Infos[count].Entry->getEntryPath()
+                     << "' skipped due to cache hit\n";
+                });
+              EnqueueCacheWrite(-1);
+              return;
+            }
+          }
+
+          if (CacheLogging)
+            CacheLogOS.applyLocked([&](raw_ostream &OS) {
+              OS << "LTO compute '" << Infos[count].Entry->getEntryPath()
+                 << "' started\n";
+            });
+          ScopedDurationTimer T([&](double Seconds) {
+            if (CacheLogging)
+              CacheLogOS.applyLocked([&](raw_ostream &OS) {
+                OS << "LTO compute '" << Infos[count].Entry->getEntryPath()
+                   << "' in " << llvm::format("%.6fs", Seconds) << "\n";
+              });
+          });
+
+          LLVMContext Context;
+          Context.setDiscardValueNames(LTODiscardValueNames);
+          Context.enableDebugTypeODRUniquing();
+          auto DiagFileOrErr = lto::setupLLVMOptimizationRemarks(
+              Context, RemarksFilename, RemarksPasses, RemarksFormat,
+              RemarksWithHotness, RemarksHotnessThreshold, count);
+          if (!DiagFileOrErr) {
+            errs() << "Error: " << toString(DiagFileOrErr.takeError()) << "\n";
+            report_fatal_error("ThinLTO: Can't get an output file for the "
+                               "remarks");
+          }
+
+          // Parse module now
+          auto TheModule = loadModuleFromInput(Mod.get(), Context, false,
+                                               /*IsImporting*/ false);
+
+          // Save temps: original file.
+          saveTempBitcode(*TheModule, SaveTempsDir, count, ".0.original.bc");
+
+          // Run the main process now, and generates a binary
+          auto OutputBuffer = ProcessThinLTOModule(
+              *TheModule, *Index, ModuleMap, *TMBuilder.create(),
+              ImportLists[ModuleIdentifier], ExportLists[ModuleIdentifier],
+              GUIDPreservedSymbols,
+              ModuleToDefinedGVSummaries[ModuleIdentifier], CacheOptions,
+              DisableCodeGen, SaveTempsDir, Freestanding, OptLevel, count,
+              DebugPassManager);
+
+          Infos[count].ComputedBuffer = std::move(OutputBuffer);
+
+          unsigned CacheState = Infos[count].State.fetch_or(MS_ComputationDone);
+          bool CacheHit = CacheState & MS_CacheLookupHit;
+
+          // Consider writing the object file.
+          if (DeterministicCheck) {
+            // With deterministic checks, writing the object file is always our
+            // responsibility.
+            WriteObject(count, /*CacheHit=*/false);
+          } else {
+            // Without deterministic checks, writing the object file is
+            // responsibility of whoever comes up with usable result first.
+            if (!(CacheState & MS_CacheLookupDone) || !CacheHit)
+              WriteObject(count, /*CacheHit=*/false);
+          }
+
+          // Enqueueing cache write is responsibility of whoever lost the race.
+          if (DeterministicCheck) {
+            if (CacheState & MS_CacheLookupDone)
+              EnqueueCacheWrite(count);
+          } else {
+            if (CacheState & MS_CacheLookupDone) {
+              if (!CacheHit)
+                EnqueueCacheWrite(count);
+              else
+                EnqueueCacheWrite(-1);
+            }
+          }
+        });
+      }
+    }
+
+    pruneCache(CacheOptions.Path, CacheOptions.Policy, ProducedBinaries);
+
+    // If statistics were requested, print them out now.
+    if (llvm::AreStatisticsEnabled())
+      llvm::PrintStatistics();
+    reportAndResetTimings();
+
+    return;
+  }
 
   // Parallel optimizer + codegen
   {

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -1782,9 +1782,10 @@ void ThinLTOCodeGenerator::run() {
     };
     struct ModuleInfo {
       std::unique_ptr<AsyncModuleCacheEntry> Entry;
-      std::atomic<unsigned> State = MS_Empty;
+      std::atomic<unsigned> State;
       std::unique_ptr<MemoryBuffer> ComputedBuffer;
       std::unique_ptr<MemoryBuffer> CachedBuffer;
+      ModuleInfo() : State(MS_Empty) {}
     };
     std::vector<ModuleInfo> Infos(ModuleCount);
 


### PR DESCRIPTION
Cherry-pick of #8236.
----------------------------------------
**Explanation:** ThinLTO performs cache operations synchronously on a thread pool. If they happen to be slow (e.g. using a remote cache with poor latency/throughput), the requests can block threads for a long period of time and slow down the build. This patch makes cache requests asynchronous and starts performing codegen locally, avoiding unnecessary waits on slow cache.

**Risk:** Moderate. The changes are non-trivial and the asynchronous nature makes it hard to programatically test.

**Testing:** Existing tests exercise the affected code path, manual testing with fault injection was performed but not easy to replicate in automated tests.

Reviewed By: @akyrtzi