### PR TITLE
Add zlib compression to the debug_str_offset section

### DIFF
--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.h
@@ -588,6 +588,8 @@ private:
 
   Expected<SmallVector<DebugStrRef, 0>> createDebugStringRefs();
 
+  std::optional<Expected<DebugStrOffsetsRef>> createDebugStrOffsetsRef();
+
   template <typename SectionTy>
   std::optional<Expected<SectionTy>> createGenericDebugRef(MCSection *Section);
 


### PR DESCRIPTION
In MCCAS, the DWARF5 size is larger than the DWARF4 size because of the presence of the debug_str_offset section. There is not much we can do to improve the deduplication rate of that section, so the only thing to do is to compress the data in that cas block, which is what this patch adds support for. 

The sizes in my testing were as follows:

DWARF4 Size: 11.377 GB
DWARF5 Size Baseline: 12.193 GB
DWARF5 Size Default compression (compression level 6): 11.457 GB
DWARF5 Size (compression level 7): 11.456 GB
DWARF5 Size (compression level 8): 11.455 GB
DWARF5 Size (compression level 9): 11.453 GB

Therefore I have elected to go with the default compression for now