### PR TITLE
Add REQUIRES to 32-bit relocation tests in MCCAS

### DIFF
--- a/llvm/test/CAS/test-reloc-mccas-32bit-arm.s
+++ b/llvm/test/CAS/test-reloc-mccas-32bit-arm.s
@@ -1,5 +1,5 @@
 # This test tests to make sure mccas can handle scattered relocations properly on 32 bit arm
-
+# REQUIRES: arm-registered-target
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: llvm-mc --cas=%t/cas --cas-backend --mccas-verify -triple=armv7-apple-darwin10  -filetype=obj -o %t/reloc.o %s
 

--- a/llvm/test/CAS/test-reloc-mccas-32bit.s
+++ b/llvm/test/CAS/test-reloc-mccas-32bit.s
@@ -1,5 +1,5 @@
 # This test tests to make sure mccas can handle scattered relocations properly on 32 bit x86
-
+# REQUIRES: x86-registered-target
 # RUN: rm -rf %t && mkdir -p %t
 # RUN: llvm-mc --cas=%t/cas --cas-backend --mccas-verify  -triple=i386-apple-macosx10.4 -filetype=obj -o %t/reloc.o %s
         movl    y+4, %ecx


### PR DESCRIPTION
cherry-pick https://github.com/apple/llvm-project/pull/8616 to swift/release/6.0