### PR TITLE
[llvm][cas] Fix thread safety issues with MappedFileRegionBumpPtr

### DIFF
--- a/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
@@ -50,21 +50,6 @@ public:
   create(const Twine &Path, uint64_t Capacity, int64_t BumpPtrOffset,
          function_ref<Error(MappedFileRegionBumpPtr &)> NewFileConstructor);
 
-  /// Create a \c MappedFileRegionBumpPtr., shared across the process via a
-  /// singleton map.
-  ///
-  /// FIXME: Singleton map should be based on sys::fs::UniqueID, but currently
-  /// it is just based on \p Path.
-  ///
-  /// \param Path the path to open the mapped region.
-  /// \param Capacity the maximum size for the mapped file region.
-  /// \param BumpPtrOffset the offset at which to store the bump pointer.
-  /// \param NewFileConstructor is for constructing new files. It has exclusive
-  /// access to the file. Must call \c initializeBumpPtr.
-  static Expected<std::shared_ptr<MappedFileRegionBumpPtr>> createShared(
-      const Twine &Path, uint64_t Capacity, int64_t BumpPtrOffset,
-      function_ref<Error(MappedFileRegionBumpPtr &)> NewFileConstructor);
-
   /// Finish initializing the bump pointer. Must be called by
   /// \c NewFileConstructor.
   void initializeBumpPtr(int64_t BumpPtrOffset);

--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -12,6 +12,16 @@
 #include "llvm/Support/Process.h"
 #include <mutex>
 #include <optional>
+#include <thread>
+
+#if __has_include(<sys/file.h>)
+#include <sys/file.h>
+#ifdef LOCK_SH
+#define HAVE_FLOCK 1
+#else
+#define HAVE_FLOCK 0
+#endif
+#endif
 
 using namespace llvm;
 
@@ -45,4 +55,56 @@ Expected<std::optional<uint64_t>> cas::ondisk::getOverriddenMaxMappingSize() {
 
 void cas::ondisk::setMaxMappingSize(uint64_t Size) {
   OnDiskCASMaxMappingSize = Size;
+}
+
+std::error_code cas::ondisk::lockFileThreadSafe(int FD, bool Exclusive) {
+#if HAVE_FLOCK
+  if (flock(FD, Exclusive ? LOCK_EX : LOCK_SH) == 0)
+    return std::error_code();
+  return std::error_code(errno, std::generic_category());
+#elif defined(_WIN32)
+  // On Windows this implementation is thread-safe.
+  return sys::fs::lockFile(FD, Exclusive);
+#else
+  return make_error_code(std::errc::no_lock_available);
+#endif
+}
+
+std::error_code cas::ondisk::unlockFileThreadSafe(int FD) {
+#if HAVE_FLOCK
+  if (flock(FD, LOCK_UN) == 0)
+    return std::error_code();
+  return std::error_code(errno, std::generic_category());
+#elif defined(_WIN32)
+  // On Windows this implementation is thread-safe.
+  return sys::fs::unlockFile(FD);
+#else
+  return make_error_code(std::errc::no_lock_available);
+#endif
+}
+
+std::error_code
+cas::ondisk::tryLockFileThreadSafe(int FD, std::chrono::milliseconds Timeout,
+                                   bool Exclusive) {
+#if HAVE_FLOCK
+  auto Start = std::chrono::steady_clock::now();
+  auto End = Start + Timeout;
+  do {
+    if (flock(FD, (Exclusive ? LOCK_EX : LOCK_SH) | LOCK_NB) == 0)
+      return std::error_code();
+    int Error = errno;
+    if (Error == EWOULDBLOCK) {
+      // Match sys::fs::tryLockFile, which sleeps for 1 ms per attempt.
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      continue;
+    }
+    return std::error_code(Error, std::generic_category());
+  } while (std::chrono::steady_clock::now() < End);
+  return make_error_code(std::errc::no_lock_available);
+#elif defined(_WIN32)
+  // On Windows this implementation is thread-safe.
+  return sys::fs::tryLockFile(FD, Timeout, Exclusive);
+#else
+  return make_error_code(std::errc::no_lock_available);
+#endif
 }

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -10,6 +10,7 @@
 #define LLVM_LIB_CAS_ONDISKCOMMON_H
 
 #include "llvm/Support/Error.h"
+#include <chrono>
 #include <optional>
 
 namespace llvm::cas::ondisk {
@@ -24,6 +25,23 @@ Expected<std::optional<uint64_t>> getOverriddenMaxMappingSize();
 /// should be set before creaing any ondisk CAS and does not affect CAS already
 /// created. Set value 0 to use default size.
 void setMaxMappingSize(uint64_t Size);
+
+/// Thread-safe alternative to \c sys::fs::lockFile. This does not support all
+/// the platforms that \c sys::fs::lockFile does, so keep it in the CAS library
+/// for now.
+std::error_code lockFileThreadSafe(int FD, bool Exclusive = true);
+
+/// Thread-safe alternative to \c sys::fs::unlockFile. This does not support all
+/// the platforms that \c sys::fs::lockFile does, so keep it in the CAS library
+/// for now.
+std::error_code unlockFileThreadSafe(int FD);
+
+/// Thread-safe alternative to \c sys::fs::tryLockFile. This does not support
+/// all the platforms that \c sys::fs::lockFile does, so keep it in the CAS
+/// library for now.
+std::error_code tryLockFileThreadSafe(
+    int FD, std::chrono::milliseconds Timeout = std::chrono::milliseconds(0),
+    bool Exclusive = true);
 
 } // namespace llvm::cas::ondisk
 

--- a/llvm/test/check-lock-files.ll
+++ b/llvm/test/check-lock-files.ll
@@ -1,0 +1,6 @@
+# REQUIRES: ondisk_cas
+
+# Multi-threaded test that CAS lock files protecting the shared data are working.
+
+# RUN: rm -rf %t/cas
+# RUN: llvm-cas -cas %t/cas -check-lock-files


### PR DESCRIPTION
`llvm::sys::fs::lockFile` and friends, which are implemented with `fcntl F_SETLK`, are only safe to use across processes and not across threads. We were attempting to workaround that using `createShared`, which tries to unique the mapped file per process, but (a) that only works if you have a single copy of llvm in your process, which may not always be true, and (b) we had a race in the implementation between closing one CAS and opening a new one at the same path.  Replace these with an flock-based implementation. Since this is not available on all platforms LLVM supports we use a separate implementation for the on-disk CAS rather than change llvm::sys::fs::lockFile.

rdar://126882843