### PR TITLE
[lldb][progress] Mitigate non-specific LLDB progress reports in Swift

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2162,9 +2162,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     auto on_exit = llvm::make_scope_exit([&]() {
       swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
           [](llvm::StringRef module_name,
-             swift::ASTContext::ModuleImportKind kind) {
-            Progress("Importing Swift modules");
-          });
+             swift::ASTContext::ModuleImportKind kind) {});
     });
 
     swift::ModuleDecl *stdlib =
@@ -2718,9 +2716,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     auto on_exit = llvm::make_scope_exit([&]() {
       swift_ast_sp->m_ast_context_ap->SetPreModuleImportCallback(
           [](llvm::StringRef module_name,
-             swift::ASTContext::ModuleImportKind kind) {
-            Progress("Importing Swift modules");
-          });
+             swift::ASTContext::ModuleImportKind kind) {});
     });
 
     swift::ModuleDecl *stdlib =
@@ -3781,20 +3777,22 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
 
   // Report progress on module importing by using a callback function in
   // swift::ASTContext.
-  Progress progress("Importing Swift modules");
+  std::unique_ptr<Progress> progress;
   ast->SetPreModuleImportCallback(
       [&progress](llvm::StringRef module_name,
                   swift::ASTContext::ModuleImportKind kind) {
+        if (!progress)
+          progress = std::make_unique<Progress>("Importing Swift modules");
         switch (kind) {
         case swift::ASTContext::Module:
-          progress.Increment(1, module_name.str());
+          progress->Increment(1, module_name.str());
           break;
         case swift::ASTContext::Overlay:
-          progress.Increment(1, module_name.str() + " (overlay)");
+          progress->Increment(1, module_name.str() + " (overlay)");
           break;
         case swift::ASTContext::BridgingHeader:
-          progress.Increment(1,
-                             "Compiling bridging header: " + module_name.str());
+          progress->Increment(1, "Compiling bridging header: " +
+                                     module_name.str());
           break;
         }
       });
@@ -3804,9 +3802,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
   auto on_exit = llvm::make_scope_exit([&]() {
     ast->SetPreModuleImportCallback(
         [](llvm::StringRef module_name,
-           swift::ASTContext::ModuleImportKind kind) {
-          Progress("Importing Swift modules");
-        });
+           swift::ASTContext::ModuleImportKind kind) {});
   });
 
   // Perform the import.

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -45,11 +45,21 @@ class TestSwiftProgressReporting(TestBase):
             "Importing Swift standard library",
         ]
 
+        importing_swift_reports = []
         while len(beacons):
             event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
             ret_args = lldb.SBDebugger.GetProgressFromEvent(event)
             if self.TraceOn():
                 print(ret_args[0])
+
+            # When importing Swift modules, make sure that we don't get two reports
+            # in a row with the title "Importing Swift modules", i.e. there should be
+            # a report with that title followed by a report with that title and details
+            # attached.
+            if ret_args[0] == "Importing Swift modules":
+                next_event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
+                next_ret_args = lldb.SBDebugger.GetProgressFromEvent(next_event)
+                self.assertRegexpMatches(next_ret_args[0], r"Importing Swift modules:+")
 
             for beacon in beacons:
                 if beacon in ret_args[0]:


### PR DESCRIPTION
When LLDB reports progress on importing Swift modules, it was delivering non-specific progress reports with only the title of "Importing Swift modules" and no details. To report progress on activity within Swift, LLDB first creates a progress report then updates that progress report using a callback that LLDB sets and the Swift compiler invokes when performing a full import.

When LLDB triggers Swift to import modules that were already imported before, Swift will not perform a full import. Since the progress report would've already been displayed, but the callback is never invoked, this leads to the non-specific messages that were being displayed when importing Swift modules.

This commit sets a unique pointer to create a progress report from within the callback function instead of creating the report before setting the callback. It also clears the callback on scope exit instead of setting it to a new progress report.

rdar://122050052
https://github.com/apple/llvm-project/issues/8572