### PR TITLE
[llvm][cas] Fix thread safety issues with MappedFileRegionBumpPtr

### DIFF
--- a/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
@@ -50,21 +50,6 @@ public:
   create(const Twine &Path, uint64_t Capacity, int64_t BumpPtrOffset,
          function_ref<Error(MappedFileRegionBumpPtr &)> NewFileConstructor);
 
-  /// Create a \c MappedFileRegionBumpPtr., shared across the process via a
-  /// singleton map.
-  ///
-  /// FIXME: Singleton map should be based on sys::fs::UniqueID, but currently
-  /// it is just based on \p Path.
-  ///
-  /// \param Path the path to open the mapped region.
-  /// \param Capacity the maximum size for the mapped file region.
-  /// \param BumpPtrOffset the offset at which to store the bump pointer.
-  /// \param NewFileConstructor is for constructing new files. It has exclusive
-  /// access to the file. Must call \c initializeBumpPtr.
-  static Expected<std::shared_ptr<MappedFileRegionBumpPtr>> createShared(
-      const Twine &Path, uint64_t Capacity, int64_t BumpPtrOffset,
-      function_ref<Error(MappedFileRegionBumpPtr &)> NewFileConstructor);
-
   /// Finish initializing the bump pointer. Must be called by
   /// \c NewFileConstructor.
   void initializeBumpPtr(int64_t BumpPtrOffset);

--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -12,6 +12,16 @@
 #include "llvm/Support/Process.h"
 #include <mutex>
 #include <optional>
+#include <thread>
+
+#if __has_include(<sys/file.h>)
+#include <sys/file.h>
+#ifdef LOCK_SH
+#define HAVE_FLOCK 1
+#else
+#define HAVE_FLOCK 0
+#endif
+#endif
 
 using namespace llvm;
 
@@ -45,4 +55,56 @@ Expected<std::optional<uint64_t>> cas::ondisk::getOverriddenMaxMappingSize() {
 
 void cas::ondisk::setMaxMappingSize(uint64_t Size) {
   OnDiskCASMaxMappingSize = Size;
+}
+
+std::error_code cas::ondisk::lockFileThreadSafe(int FD, bool Exclusive) {
+#if HAVE_FLOCK
+  if (flock(FD, Exclusive ? LOCK_EX : LOCK_SH) == 0)
+    return std::error_code();
+  return std::error_code(errno, std::generic_category());
+#elif defined(_WIN32)
+  // On Windows this implementation is thread-safe.
+  return sys::fs::lockFile(FD, Exclusive);
+#else
+  return make_error_code(std::errc::no_lock_available);
+#endif
+}
+
+std::error_code cas::ondisk::unlockFileThreadSafe(int FD) {
+#if HAVE_FLOCK
+  if (flock(FD, LOCK_UN) == 0)
+    return std::error_code();
+  return std::error_code(errno, std::generic_category());
+#elif defined(_WIN32)
+  // On Windows this implementation is thread-safe.
+  return sys::fs::unlockFile(FD);
+#else
+  return make_error_code(std::errc::no_lock_available);
+#endif
+}
+
+std::error_code
+cas::ondisk::tryLockFileThreadSafe(int FD, std::chrono::milliseconds Timeout,
+                                   bool Exclusive) {
+#if HAVE_FLOCK
+  auto Start = std::chrono::steady_clock::now();
+  auto End = Start + Timeout;
+  do {
+    if (flock(FD, (Exclusive ? LOCK_EX : LOCK_SH) | LOCK_NB) == 0)
+      return std::error_code();
+    int Error = errno;
+    if (Error == EWOULDBLOCK) {
+      // Match sys::fs::tryLockFile, which sleeps for 1 ms per attempt.
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      continue;
+    }
+    return std::error_code(Error, std::generic_category());
+  } while (std::chrono::steady_clock::now() < End);
+  return make_error_code(std::errc::no_lock_available);
+#elif defined(_WIN32)
+  // On Windows this implementation is thread-safe.
+  return sys::fs::tryLockFile(FD, Timeout, Exclusive);
+#else
+  return make_error_code(std::errc::no_lock_available);
+#endif
 }

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -10,6 +10,7 @@
 #define LLVM_LIB_CAS_ONDISKCOMMON_H
 
 #include "llvm/Support/Error.h"
+#include <chrono>
 #include <optional>
 
 namespace llvm::cas::ondisk {
@@ -24,6 +25,23 @@ Expected<std::optional<uint64_t>> getOverriddenMaxMappingSize();
 /// should be set before creaing any ondisk CAS and does not affect CAS already
 /// created. Set value 0 to use default size.
 void setMaxMappingSize(uint64_t Size);
+
+/// Thread-safe alternative to \c sys::fs::lockFile. This does not support all
+/// the platforms that \c sys::fs::lockFile does, so keep it in the CAS library
+/// for now.
+std::error_code lockFileThreadSafe(int FD, bool Exclusive = true);
+
+/// Thread-safe alternative to \c sys::fs::unlockFile. This does not support all
+/// the platforms that \c sys::fs::lockFile does, so keep it in the CAS library
+/// for now.
+std::error_code unlockFileThreadSafe(int FD);
+
+/// Thread-safe alternative to \c sys::fs::tryLockFile. This does not support
+/// all the platforms that \c sys::fs::lockFile does, so keep it in the CAS
+/// library for now.
+std::error_code tryLockFileThreadSafe(
+    int FD, std::chrono::milliseconds Timeout = std::chrono::milliseconds(0),
+    bool Exclusive = true);
 
 } // namespace llvm::cas::ondisk
 

--- a/llvm/test/check-lock-files.ll
+++ b/llvm/test/check-lock-files.ll
@@ -1,0 +1,6 @@
+# REQUIRES: ondisk_cas
+
+# Multi-threaded test that CAS lock files protecting the shared data are working.
+
+# RUN: rm -rf %t/cas
+# RUN: llvm-cas -cas %t/cas -check-lock-files

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
 #include <system_error>
@@ -64,6 +65,7 @@ static int putCacheKey(ObjectStore &CAS, ActionCache &AC,
 static int getCacheResult(ObjectStore &CAS, ActionCache &AC, const CASID &ID);
 static int validateObject(ObjectStore &CAS, const CASID &ID);
 static int ingestCasIDFile(cas::ObjectStore &CAS, ArrayRef<std::string> CASIDs);
+static int checkLockFiles(StringRef CASPath);
 
 int main(int Argc, char **Argv) {
   InitLLVM X(Argc, Argv);
@@ -101,6 +103,7 @@ int main(int Argc, char **Argv) {
     Import,
     PutCacheKey,
     GetCacheResult,
+    CheckLockFiles,
     Validate,
   };
   cl::opt<CommandKind> Command(
@@ -126,6 +129,8 @@ int main(int Argc, char **Argv) {
                      "set a value for a cache key"),
           clEnumValN(GetCacheResult, "get-cache-result",
                      "get the result value from a cache key"),
+          clEnumValN(CheckLockFiles, "check-lock-files",
+                     "Test file locking behaviour of on-disk CAS"),
           clEnumValN(Validate, "validate", "validate the object for CASID")),
       cl::init(CommandKind::Invalid));
 
@@ -140,6 +145,9 @@ int main(int Argc, char **Argv) {
   if (CASPath.empty())
     ExitOnErr(
         createStringError(inconvertibleErrorCode(), "missing --cas=<path>"));
+
+  if (Command == CheckLockFiles)
+    return checkLockFiles(CASPath);
 
   std::shared_ptr<ObjectStore> CAS;
   std::shared_ptr<ActionCache> AC;
@@ -656,6 +664,45 @@ static int getCacheResult(ObjectStore &CAS, ActionCache &AC, const CASID &ID) {
     return 1;
   }
   outs() << *Result << "\n";
+  return 0;
+}
+
+static int checkLockFiles(StringRef CASPath) {
+  ExitOnError ExitOnErr("llvm-cas: check-lock-files: ");
+
+  SmallString<128> DataPoolPath(CASPath);
+  sys::path::append(DataPoolPath, "v1.1/v8.data");
+
+  auto OpenCASAndGetDataPoolSize = [&]() -> Expected<uint64_t> {
+    auto Result = createOnDiskUnifiedCASDatabases(CASPath);
+    if (!Result)
+      return Result.takeError();
+
+    sys::fs::file_status DataStat;
+    if (std::error_code EC = sys::fs::status(DataPoolPath, DataStat))
+      ExitOnErr(createFileError(DataPoolPath, EC));
+    return DataStat.getSize();
+  };
+
+  // Get the normal size of an open CAS data pool to compare against later.
+  uint64_t OpenSize = ExitOnErr(OpenCASAndGetDataPoolSize());
+
+  ThreadPool Pool;
+  for (int i = 0; i < 1000; ++i) {
+    Pool.async([&, i] {
+      uint64_t DataPoolSize = ExitOnErr(OpenCASAndGetDataPoolSize());
+      if (DataPoolSize < OpenSize)
+        ExitOnErr(createStringError(
+            inconvertibleErrorCode(),
+            StringRef("CAS data file size (" + std::to_string(DataPoolSize) +
+                      ") is smaller than expected (" +
+                      std::to_string(OpenSize) + ") in iteration " +
+                      std::to_string(i))));
+    });
+  }
+
+  Pool.wait();
+
   return 0;
 }
 


### PR DESCRIPTION
* Explanation: Opening and closing the CAS uses file locks to ensure only one process and thread will resize the CAS files. We already knew of a potential hole if multiple libclangs are loaded into a single process and open/close the same CAS on different threads. We recently discovered another thread-safety issue with a race between open/close within a single process.  This fixes both issues by replacing `fcntl F_SETLK`, which is not thread safe, with `flock`, which is. 
* Scope: Fixes two races in caching builds. We are not 100% sure if these races were happening in practice, but stress testing shows they can cause a crash and we think they can lead to a corrupted CAS in the right circumstances.
* Issue: rdar://126882843
* Original PR: #8621
* Risk: Impacts caching builds. Change is in core CAS file locking, so if my changes are buggy it could blow up in all kinds of nasty ways (crashes, corrupted CAS). But it's a fairly clean swap of one implementation for another using well-known primitives, so we don't anticipate any issues.
* Testing: Added a regression test based on stress-testing our file locks. I also manually ran this test for longer periods across multiple threads and processes. I also manually tested that flock and fcntl interoperate correctly, as is stated in the man page, to ensure this will not break when there are processes using the old CAS.
* Reviewer: @cachemeifyoucan 