### PR TITLE
[Cherry-pick into next] Register the symbol context's module's AST files first.

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -837,18 +837,17 @@ DYLIB_SWIFT_FLAGS=  \
         -Xlinker -install_name -Xlinker "$(DYLIB_INSTALL_NAME)" \
         $(LD_EXTRAS)
 ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
-DYLIB_SWIFT_FLAGS+= -Xlinker -add_ast_path -Xlinker $(DYLIB_NAME).swiftmodule
+DYLIB_SWIFT_FLAGS+= -Xlinker -add_ast_path -Xlinker $(MODULENAME).swiftmodule
 endif
 else
 DYLIB_SWIFT_FLAGS=$(LD_EXTRAS)
+ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
+DYLIB_OBJECTS += $(BUILDDIR)/$(MODULENAME).o
 endif
+endif
+
 $(DYLIB_FILENAME) : $(DYLIB_OBJECTS) $(MODULE_INTERFACE)
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
-ifneq "$(DYLIB_HIDE_SWIFTMODULE)" ""
-	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
-            -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ \
-            $(patsubst %.swiftmodule.o,,$(DYLIB_OBJECTS))
-else
 ifneq "$(FRAMEWORK)" ""
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Headers
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules
@@ -865,7 +864,6 @@ endif
 endif
 	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
             -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ $(DYLIB_OBJECTS)
-endif
 ifneq "$(CODESIGN)" ""
 	$(CODESIGN) -s - "$(DYLIB_FILENAME)"
 endif

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -65,4 +65,4 @@ class TestSwiftDeploymentTarget(TestBase):
         self.expect("expression f", substrs=["i = 23"])
         self.filecheck('platform shell cat ""%s"' % log, __file__)
 #       CHECK: SwiftASTContextForExpressions::SetTriple({{.*}}apple-macosx11.0.0
-#       CHECK:  SwiftASTContextForExpressions::RegisterSectionModules("a.out") retrieved 0 AST Data blobs
+#       CHECK-NOT: SwiftASTContextForExpressions::RegisterSectionModules("a.out"){{.*}} AST Data blobs


### PR DESCRIPTION
```
commit 7dbd6b79448f6d7abf672025cf08022cf3e7d249
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Apr 17 16:36:46 2024 -0700

    Register the symbol context's module's AST files first.
    
    This makes it more likely that compatible AST blobs are found first,
    since then the local AST blobs overwrite any ones with the same import
    path from another dylib. The AST blobs are registered in a DFS
    following the dynamic library dependencies in the binary.
```
