### PR TITLE
[lldb] Build DeclContext vector from a Swift demangle tree

### DIFF
--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -180,4 +180,34 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         lldbutil.check_variable(self, second, False, value="315")
         u = right.GetChildMemberWithName("u")
         two = u.GetChildMemberWithName("two")
-        lldbutil.check_variable(self, two, False, value="one")
+        lldbutil.check_variable(self, two, False, value='one')
+
+        inner = frame.FindVariable("inner")
+        value = inner.GetChildMemberWithName("value")
+        lldbutil.check_variable(self, value, False, value='99')
+
+        innerer = frame.FindVariable("innerer")
+        innererValue = innerer.GetChildMemberWithName("innererValue")
+        lldbutil.check_variable(self, innererValue, False, value='101')
+
+        privateType = frame.FindVariable("privateType")
+        privateField = privateType.GetChildMemberWithName("privateField")
+        lldbutil.check_variable(self, privateField, False, value='100')
+
+        specializedInner = frame.FindVariable("specializedInner")
+        t = specializedInner.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value='837')
+
+        genericInner = frame.FindVariable("genericInner")
+        t = genericInner.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value='647')
+        u = genericInner.GetChildMemberWithName("u")
+        lldbutil.check_variable(self, u, False, value='674.5')
+
+        functionType = frame.FindVariable("functionType")
+        funcField = functionType.GetChildMemberWithName("funcField")
+        lldbutil.check_variable(self, funcField, False, value='67')
+
+        innerFunctionType = frame.FindVariable("innerFunctionType")
+        innerFuncField = innerFunctionType.GetChildMemberWithName("innerFuncField")
+        lldbutil.check_variable(self, innerFuncField, False, value='8479')

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -83,42 +83,88 @@ enum Either<Left, Right> {
   case right(Right)
 }
 
-func f() {
-  let varB = B()
-  let tuple = (A(), B())
-  let trivial = TrivialEnum.theCase
-  let nonPayload1 = NonPayloadEnum.one
-  let nonPayload2 = NonPayloadEnum.two
-  let singlePayload = SinglePayloadEnum.payload(B())
-  let emptySinglePayload = SinglePayloadEnum.nonPayloadTwo
-  let smallMultipayloadEnum1 = SmallMultipayloadEnum.one(.two)
-  let smallMultipayloadEnum2 = SmallMultipayloadEnum.two(.one)
-  let e1 = Sup()
-  let e2 = Sup()
-  e2.supField = 43
-  let e3 = Sup()
-  e3.supField = 44
-  let bigMultipayloadEnum1 = BigMultipayloadEnum.one(e1, e2, e3)
-  let fullMultipayloadEnum1 = FullMultipayloadEnum.one(120)
-  let fullMultipayloadEnum2 = FullMultipayloadEnum.two(9.5)
-  let bigFullMultipayloadEnum1 = BigFullMultipayloadEnum.one(209, 315)
-  let bigFullMultipayloadEnum2 = BigFullMultipayloadEnum.two(452.5, 753.5)
-  let sup = Sup()
-  let sub = Sub()
-  let subSub = SubSub()
-  let sup2: Sup = SubSub()
-  let gsp = GenericStructPair(t: 42, u: 94.5)
-  let gsp2 = GenericStructPair(t: Sup(), u: B())
-  let gsp3 = GenericStructPair(t: bigFullMultipayloadEnum1, u: smallMultipayloadEnum2)
-  let gcp = GenericClassPair(t: 55.5, u: 9348)
-  let either = Either<Int, Double>.left(1234)
-  let either2 = Either<Sup, _>.right(gsp3)
 
-  // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
-  let dummy = A() // break here
-  let string = StaticString("Hello") 
-  print(string) 
+struct Outer {
+  struct Inner {
+    let value = 99
+    struct Innerer {
+      let innererValue = 101
+    }
+  }
 }
 
-f()
+private struct PrivateType {
+  let privateField = 100
+}
 
+
+struct OuterGeneric<T> {
+  struct SpecializedInner {
+    let t: T
+  }
+
+  struct GenericInner<U> {
+    let t: T
+    let u: U
+  }
+}
+
+func g() {
+  struct FunctionType {
+    let funcField = 67
+  }
+  func f() {
+    struct InnerFunctionType {
+      let innerFuncField = 8479
+    }
+
+    let varB = B()
+    let tuple = (A(), B())
+    let trivial = TrivialEnum.theCase
+    let nonPayload1 = NonPayloadEnum.one
+    let nonPayload2 = NonPayloadEnum.two
+    let singlePayload = SinglePayloadEnum.payload(B())
+    let emptySinglePayload = SinglePayloadEnum.nonPayloadTwo
+    let smallMultipayloadEnum1 = SmallMultipayloadEnum.one(.two)
+    let smallMultipayloadEnum2 = SmallMultipayloadEnum.two(.one)
+    let e1 = Sup()
+    let e2 = Sup()
+    e2.supField = 43
+    let e3 = Sup()
+    e3.supField = 44
+    let bigMultipayloadEnum1 = BigMultipayloadEnum.one(e1, e2, e3)
+    let fullMultipayloadEnum1 = FullMultipayloadEnum.one(120)
+    let fullMultipayloadEnum2 = FullMultipayloadEnum.two(9.5)
+    let bigFullMultipayloadEnum1 = BigFullMultipayloadEnum.one(209, 315)
+    let bigFullMultipayloadEnum2 = BigFullMultipayloadEnum.two(452.5, 753.5)
+    let sup = Sup()
+    let sub = Sub()
+    let subSub = SubSub()
+    let sup2: Sup = SubSub()
+    let gsp = GenericStructPair(t: 42, u: 94.5)
+    let gsp2 = GenericStructPair(t: Sup(), u: B())
+    let gsp3 = GenericStructPair(t: bigFullMultipayloadEnum1, u: smallMultipayloadEnum2)
+    let gcp = GenericClassPair(t: 55.5, u: 9348)
+    let either = Either<Int, Double>.left(1234)
+    let either2 = Either<Sup, _>.right(gsp3)
+    // FIXME: remove the instantiation of Outer (rdar://125258124)
+    let outer = Outer()
+    let inner = Outer.Inner()
+    let innerer = Outer.Inner.Innerer()
+    let privateType = PrivateType()
+    // FIXME: remove the instantiation of OuterGeneric (rdar://125258124)
+    let outerGeneric = OuterGeneric<Int>()
+    let specializedInner = OuterGeneric<Int>.SpecializedInner(t: 837)
+    let genericInner = OuterGeneric<Int>.GenericInner(t: 647, u: 674.5)
+    let functionType = FunctionType()
+    let innerFunctionType = InnerFunctionType()
+
+    // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
+    let dummy = A() // break here
+    let string = StaticString("Hello") 
+    print(string) 
+  }
+  f()
+}
+
+g()

--- a/lldb/test/API/lang/swift/embedded/nested_frame_variable/Makefile
+++ b/lldb/test/API/lang/swift/embedded/nested_frame_variable/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/nested_frame_variable/TestSwiftEmbeddedNestedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/nested_frame_variable/TestSwiftEmbeddedNestedFrameVariable.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftEmbeddedNestedFrameVariable(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.implementation()
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_without_ast(self):
+        """Run the test turning off instantion of  Swift AST contexts in order to ensure that all type information comes from DWARF"""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        self.implementation()
+
+    def implementation(self):
+        self.runCmd("setting set symbols.swift-enable-full-dwarf-debugging true")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        s4 = frame.FindVariable("s4")
+        t = s4.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value='839')
+

--- a/lldb/test/API/lang/swift/embedded/nested_frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/nested_frame_variable/main.swift
@@ -1,0 +1,27 @@
+private struct S {
+  func s1() {
+    class S2 {
+      func s2() {
+        func s2_2() {
+          enum S3 {
+            case theCase
+            func s3() {
+              struct S4<T> {
+                let t: T
+              }
+
+              let s4 = S4<Int>(t: 839)
+              let string = StaticString("Hello") // break here
+              print(string) 
+            }
+          }
+          S3.theCase.s3()
+        }
+        s2_2()
+      }
+    }
+    S2().s2()
+  }
+}
+
+S().s1()


### PR DESCRIPTION
Replace the current GetNominal function, which would only handle finding a module + a type with a more complete BuildDeclContext function, which will recursively build a DeclContext, taking into account nested and private types.

rdar://125044318
(cherry picked from commit 08e70a22febda63af8076c664511180a86982e25)