### PR TITLE
Reapply "[llvm] Fix assertion error where we didn't check fixed point…

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DebugHandlerBase.cpp
@@ -226,12 +226,15 @@ bool DebugHandlerBase::isUnsignedDIType(const DIType *Ty) {
             Encoding == dwarf::DW_ATE_float || Encoding == dwarf::DW_ATE_UTF ||
             Encoding == dwarf::DW_ATE_boolean ||
             Encoding == dwarf::DW_ATE_complex_float ||
+            Encoding == dwarf::DW_ATE_signed_fixed ||
+            Encoding == dwarf::DW_ATE_unsigned_fixed ||
             (Ty->getTag() == dwarf::DW_TAG_unspecified_type &&
              Ty->getName() == "decltype(nullptr)")) &&
            "Unsupported encoding");
     return Encoding == dwarf::DW_ATE_unsigned ||
            Encoding == dwarf::DW_ATE_unsigned_char ||
            Encoding == dwarf::DW_ATE_UTF || Encoding == dwarf::DW_ATE_boolean ||
+           Encoding == llvm::dwarf::DW_ATE_unsigned_fixed ||
            Ty->getTag() == dwarf::DW_TAG_unspecified_type;
   }
   // FIXME: the signedness should come from the expression where the type is


### PR DESCRIPTION
…… (#82412)

… types." (#82285)

This reverts commit d9f9775ac6289271d57671c55166fa0cad61075b.

The test was missing a `REQUIRES: object-emission`.

(cherry picked from commit 0b2b91ee9cf92d08e5eec159545ce4147b8d908e)