### PR TITLE
LLDB CMake: add option to link Swift content from Darwin toolchain

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -244,6 +244,11 @@ function(add_properties_for_swift_modules target reldir)
           APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")
         set_property(TARGET ${target}
           APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host")
+        if(SWIFT_ALLOW_LINKING_SWIFT_CONTENT_IN_DARWIN_TOOLCHAIN)
+          get_filename_component(TOOLCHAIN_BIN_DIR ${CMAKE_Swift_COMPILER} DIRECTORY)
+          get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/macosx" ABSOLUTE)
+          target_link_directories(${target} BEFORE PUBLIC ${TOOLCHAIN_LIB_DIR})
+        endif()
       elseif (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD")
         set_property(TARGET ${target}
           APPEND PROPERTY BUILD_RPATH "$ORIGIN/${build_reldir}lib/swift/host")


### PR DESCRIPTION
This is a companion to https://github.com/apple/swift/pull/73255, and it's needed in some Apple internal configurations.

Addresses rdar://127113448