### PR TITLE
Re-expose GTest for now

### DIFF
--- a/third-party/unittest/CMakeLists.txt
+++ b/third-party/unittest/CMakeLists.txt
@@ -42,7 +42,11 @@ endif()
 # by unittests if these are built.
 
 set(BUILDTREE_ONLY BUILDTREE_ONLY)
-set(EXCLUDE_FROM_ALL ON)
+# TODO: Swift does not build as part of the LLVM unified build, so it can't find
+#       GTest when LLVM doesn't export it. Swift should be built in the unified
+#       build, but we're not there yet. Put this back once Swift gets cleaned up
+#       a bit. rdar://113340971
+# set(EXCLUDE_FROM_ALL ON)
 if (LLVM_INSTALL_GTEST)
   set(EXCLUDE_FROM_ALL OFF)
   set(BUILDTREE_ONLY "")


### PR DESCRIPTION
LLVM hid GTest from folks that aren't building as part of LLVM, or that aren't installing GTest. While this is the right thing to do and is totally sensible, it doesn't work with Swift, which does neither. Re-expose GTest for now. This should get cleaned up once Swift builds things reasonably.

(cherry picked from commit ade5638923f1506496a390308a5725bdcbe23697)