### PR TITLE
[Support] Do not use `llvm::size` in `getLoopPreheader`

### DIFF
--- a/llvm/include/llvm/Support/GenericLoopInfoImpl.h
+++ b/llvm/include/llvm/Support/GenericLoopInfoImpl.h
@@ -208,7 +208,10 @@ BlockT *LoopBase<BlockT, LoopT>::getLoopPreheader() const {
     return nullptr;
 
   // Make sure there is only one exit out of the preheader.
-  if (llvm::size(llvm::children<BlockT *>(Out)) != 1)
+  typedef GraphTraits<BlockT *> BlockTraits;
+  typename BlockTraits::ChildIteratorType SI = BlockTraits::child_begin(Out);
+  ++SI;
+  if (SI != BlockTraits::child_end(Out))
     return nullptr; // Multiple exits from the block, must not be a preheader.
 
   // The predecessor has exactly one successor, so it is a preheader.


### PR DESCRIPTION
There's no reason to require random access on downstream clients here.