### PR TITLE
Fix ptrauth after merge

### DIFF
--- a/clang/lib/CodeGen/CGCXXABI.h
+++ b/clang/lib/CodeGen/CGCXXABI.h
@@ -471,6 +471,12 @@ public:
                                   BaseSubobject Base,
                                   const CXXRecordDecl *NearestVBase) = 0;
 
+  /// Get the address point of the vtable for the given base subobject while
+  /// building a constexpr.
+  virtual llvm::Constant *
+  getVTableAddressPointForConstExpr(BaseSubobject Base,
+                                    const CXXRecordDecl *VTableClass) = 0;
+
   /// Get the address of the vtable for the given record decl which should be
   /// used for the vptr at the given offset in RD.
   virtual llvm::GlobalVariable *getAddrOfVTable(const CXXRecordDecl *RD,

--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -801,8 +801,8 @@ bool ConstStructBuilder::Build(const APValue &Val, const RecordDecl *RD,
     // Add a vtable pointer, if we need one and it hasn't already been added.
     if (Layout.hasOwnVFPtr()) {
       llvm::Constant *VTableAddressPoint =
-          CGM.getCXXABI().getVTableAddressPoint(BaseSubobject(CD, Offset),
-                                                VTableClass);
+          CGM.getCXXABI().getVTableAddressPointForConstExpr(
+              BaseSubobject(CD, Offset), VTableClass);
       if (!AppendBytes(Offset, VTableAddressPoint))
         return false;
     }

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -308,6 +308,10 @@ public:
       CodeGenFunction &CGF, const CXXRecordDecl *VTableClass,
       BaseSubobject Base, const CXXRecordDecl *NearestVBase);
 
+  llvm::Constant *
+  getVTableAddressPointForConstExpr(BaseSubobject Base,
+                                    const CXXRecordDecl *VTableClass) override;
+
   llvm::GlobalVariable *getAddrOfVTable(const CXXRecordDecl *RD,
                                         CharUnits VPtrOffset) override;
 
@@ -2084,6 +2088,18 @@ llvm::Value *ItaniumCXXABI::getVTableAddressPointInStructorWithVTT(
                                                             QualType());
     AP = CGF.EmitPointerAuthAuth(PointerAuth, AP);
   }
+
+  return AP;
+}
+
+llvm::Constant *
+ItaniumCXXABI::getVTableAddressPointForConstExpr(BaseSubobject Base,
+                                    const CXXRecordDecl *VTableClass) {
+  auto AP = getVTableAddressPoint(Base, VTableClass);
+
+  if (auto &Schema = CGM.getCodeGenOpts().PointerAuth.CXXVTablePointers)
+    AP = CGM.getConstantSignedPointer(AP, Schema, nullptr, GlobalDecl(),
+                                      QualType());
 
   return AP;
 }

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -327,6 +327,10 @@ public:
       CodeGenFunction &CGF, const CXXRecordDecl *VTableClass,
       BaseSubobject Base, const CXXRecordDecl *NearestVBase) override;
 
+  llvm::Constant *
+  getVTableAddressPointForConstExpr(BaseSubobject Base,
+                                    const CXXRecordDecl *VTableClass) override;
+
   llvm::GlobalVariable *getAddrOfVTable(const CXXRecordDecl *RD,
                                         CharUnits VPtrOffset) override;
 
@@ -1786,6 +1790,13 @@ MicrosoftCXXABI::getVTableAddressPoint(BaseSubobject Base,
   (void)getAddrOfVTable(VTableClass, Base.getBaseOffset());
   VFTableIdTy ID(VTableClass, Base.getBaseOffset());
   return VFTablesMap[ID];
+}
+
+llvm::Constant *MicrosoftCXXABI::getVTableAddressPointForConstExpr(
+    BaseSubobject Base, const CXXRecordDecl *VTableClass) {
+  llvm::Constant *VFTable = getVTableAddressPoint(Base, VTableClass);
+  assert(VFTable && "Couldn't find a vftable for the given base?");
+  return VFTable;
 }
 
 llvm::GlobalVariable *MicrosoftCXXABI::getAddrOfVTable(const CXXRecordDecl *RD,

--- a/clang/test/CodeGen/ptrauth-debuginfo.c
+++ b/clang/test/CodeGen/ptrauth-debuginfo.c
@@ -8,7 +8,7 @@ extern int external_int;
 // CHECK: !DIDerivedType(tag: DW_TAG_LLVM_ptrauth_type,
 // CHECK-SAME:           ptrAuthKey: 1,
 // CHECK-SAME:           ptrAuthIsAddressDiscriminated: false,
-// CHECK-SAME:           ptrAuthExtraDiscriminator: 1234)
+// CHECK-SAME:           ptrAuthExtraDiscriminator: 1234,
 int * __ptrauth(1,0,1234) g1 = &external_int;
 
 struct A {
@@ -23,4 +23,4 @@ void f() {
 // CHECK: !DIDerivedType(tag: DW_TAG_LLVM_ptrauth_type,
 // CHECK-SAME:           ptrAuthKey: 1,
 // CHECK-SAME:           ptrAuthIsAddressDiscriminated: true,
-// CHECK-SAME:           ptrAuthExtraDiscriminator: 1)
+// CHECK-SAME:           ptrAuthExtraDiscriminator: 1,


### PR DESCRIPTION
Some ptrauth tests were failing after a recent merge. Two issues:

1. We do need a slightly different CodeGen path for vtables in static initializers, so I reinstated that function.
2. `next` emits more debug-info than the test was expecting, so allow other fields.