### PR TITLE
[lldb][Type Completion] Fix various redecl-completion issues that stem from the `UseRedeclCompletion` setting split

### DIFF
--- a/clang/lib/AST/ASTImporter.cpp
+++ b/clang/lib/AST/ASTImporter.cpp
@@ -1878,7 +1878,7 @@ ASTNodeImporter::ImportDeclContext(DeclContext *FromDC, bool ForceImport) {
       continue;
     }
 
-    if (Importer.hasLLDBRedeclCompletion()) {
+    if (!Importer.hasLLDBRedeclCompletion()) {
       FieldDecl *FieldFrom = dyn_cast_or_null<FieldDecl>(From);
       Decl *ImportedDecl = *ImportedOrErr;
       FieldDecl *FieldTo = dyn_cast_or_null<FieldDecl>(ImportedDecl);

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1210,8 +1210,6 @@ ClangASTImporter::ASTImporterDelegate::ImportImpl(Decl *From) {
     DeclContext::lookup_result lr = dc->lookup(*dn_or_err);
     for (clang::Decl *candidate : lr) {
       if (candidate->getKind() == From->getKind()) {
-        RegisterImportedDecl(From, candidate);
-
         // If we're dealing with redecl chains. We want to find the definition,
         // so skip if the decl is actually just a forwad decl.
         if (TypeSystemClang::UseRedeclCompletion())
@@ -1219,6 +1217,7 @@ ClangASTImporter::ASTImporterDelegate::ImportImpl(Decl *From) {
               !tag_decl || !tag_decl->getDefinition())
             continue;
 
+        RegisterImportedDecl(From, candidate);
         m_decls_to_ignore.insert(candidate);
         return candidate;
       }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTSource.h
@@ -214,7 +214,7 @@ public:
   ///
   /// Clang AST contexts like to own their AST sources, so this is a state-
   /// free proxy object.
-  class ClangASTSourceProxy : public clang::ExternalASTSource {
+  class ClangASTSourceProxy : public ImporterBackedASTSource {
   public:
     ClangASTSourceProxy(ClangASTSource &original) : m_original(original) {}
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1788,6 +1788,8 @@ TypeSystemClang::CreateClassTemplateSpecializationDecl(
       static_cast<TagDecl::TagKind>(kind));
   class_template_specialization_decl->setDeclContext(decl_ctx);
   class_template_specialization_decl->setInstantiationOf(class_template_decl);
+  if (TypeSystemClang::UseRedeclCompletion())
+    ast.getTypeDeclType(class_template_specialization_decl, nullptr);
   class_template_specialization_decl->setTemplateArgs(
       TemplateArgumentList::CreateCopy(ast, args));
   class_template_specialization_decl->setDeclName(


### PR DESCRIPTION
Debugging larger programs with the redecl-completion setting enabled was causing various crashes. This patch series resolves these. All of them were caused by either missed cherry-picks or incorrect `UseRedeclCompletion` guards.

Follow-ups from https://github.com/apple/llvm-project/pull/8222