### PR TITLE
[lldb][progress] Mitigate non-specific LLDB progress reports in Swift

### DIFF
--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -45,11 +45,21 @@ class TestSwiftProgressReporting(TestBase):
             "Importing Swift standard library",
         ]
 
+        importing_swift_reports = []
         while len(beacons):
             event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
             ret_args = lldb.SBDebugger.GetProgressFromEvent(event)
             if self.TraceOn():
                 print(ret_args[0])
+
+            # When importing Swift modules, make sure that we don't get two reports
+            # in a row with the title "Importing Swift modules", i.e. there should be
+            # a report with that title followed by a report with that title and details
+            # attached.
+            if ret_args[0] == "Importing Swift modules":
+                next_event = lldbutil.fetch_next_event(self, self.listener, self.broadcaster)
+                next_ret_args = lldb.SBDebugger.GetProgressFromEvent(next_event)
+                self.assertRegexpMatches(next_ret_args[0], r"Importing Swift modules:+")
 
             for beacon in beacons:
                 if beacon in ret_args[0]:


### PR DESCRIPTION
When LLDB reports progress on importing Swift modules, it was delivering non-specific progress reports with only the title of "Importing Swift modules" and no details. To report progress on activity within Swift, LLDB first creates a progress report then updates that progress report using a callback that LLDB sets and the Swift compiler invokes when performing a full import.

When LLDB triggers Swift to import modules that were already imported before, Swift will not perform a full import. Since the progress report would've already been displayed, but the callback is never invoked, this leads to the non-specific messages that were being displayed when importing Swift modules.

This commit sets a unique pointer to create a progress report from within the callback function instead of creating the report before setting the callback. It also clears the callback on scope exit instead of setting it to a new progress report.

(cherry picked from commit 84e7e51b3a87823198d0283f4b1e83ee651c34bb)