### PR TITLE
Modify gmlt.test to XFAIL on apple platforms correctly. (#90779)

### DIFF
--- a/llvm/test/DebugInfo/Generic/gmlt.test
+++ b/llvm/test/DebugInfo/Generic/gmlt.test
@@ -1,4 +1,4 @@
 ; RUN: %llc_dwarf -O0 -filetype=obj < %S/../Inputs/gmlt.ll | llvm-dwarfdump -v - | FileCheck %S/../Inputs/gmlt.ll
 
 ; There's a darwin specific test in X86/gmlt, so it's okay to XFAIL this here.
-; XFAIL: target={{.*}}-darwin{{.*}}
+; XFAIL: target={{.*}}-apple{{.*}}


### PR DESCRIPTION
(cherry picked from commit 37277d8da8afd3291240a14a19193024065cf7ca)