### PR TITLE
Remove MCCAS options in Scanner if not emitting Obj

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -26,11 +26,19 @@ void tooling::dependencies::configureInvocationForCaching(
   auto &FrontendOpts = CI.getFrontendOpts();
   FrontendOpts.CacheCompileJob = true;
   FrontendOpts.IncludeTimestamps = false;
+
   // Clear this otherwise it defeats the purpose of making the compilation key
   // independent of certain arguments.
-  CI.getCodeGenOpts().DwarfDebugFlags.clear();
+  auto &CodeGenOpts = CI.getCodeGenOpts();
+  if (CI.getFrontendOpts().ProgramAction != frontend::ActionKind::EmitObj) {
+    CodeGenOpts.UseCASBackend = false;
+    CodeGenOpts.EmitCASIDFile = false;
+    auto &LLVMArgs = FrontendOpts.LLVMArgs;
+    llvm::erase_value(LLVMArgs, "-cas-friendly-debug-info");
+  }
+  CodeGenOpts.DwarfDebugFlags.clear();
   resetBenignCodeGenOptions(FrontendOpts.ProgramAction, CI.getLangOpts(),
-                            CI.getCodeGenOpts());
+                            CodeGenOpts);
 
   HeaderSearchOptions &HSOpts = CI.getHeaderSearchOpts();
   // Avoid writing potentially volatile diagnostic options into pcms.
@@ -75,7 +83,7 @@ void tooling::dependencies::configureInvocationForCaching(
       // Disable `-gmodules` to avoid debug info referencing a non-existent PCH
       // filename.
       // FIXME: we should also allow -gmodules if there is no PCH involved.
-      CI.getCodeGenOpts().DebugTypeExtRefs = false;
+      CodeGenOpts.DebugTypeExtRefs = false;
       HSOpts.ModuleFormat = "raw";
     }
     // Clear APINotes options.

--- a/clang/test/CAS/depscan-update-mccas.c
+++ b/clang/test/CAS/depscan-update-mccas.c
@@ -1,0 +1,24 @@
+// RUN: %clang -cc1depscan -o - -cc1-args -cc1 -triple \
+// RUN:        x86_64-apple-darwin10 -debug-info-kind=standalone -dwarf-version=4 \
+// RUN:        -debugger-tuning=lldb -emit-obj -fcas-backend -fcas-path %t/cas \
+// RUN:        -fcas-emit-casid-file -mllvm -cas-friendly-debug-info %s | FileCheck %s --check-prefix=MCCAS_ON
+
+// MCCAS_ON: -mllvm
+// MCCAS_ON: -cas-friendly-debug-info
+// MCCAS_ON: -fcas-backend
+// MCCAS_ON: -fcas-emit-casid-file
+
+// RUN: %clang -cc1depscan -o - -cc1-args -cc1 -triple \
+// RUN:        x86_64-apple-darwin10 -debug-info-kind=standalone -dwarf-version=4 \
+// RUN:        -debugger-tuning=lldb -emit-llvm -fcas-backend -fcas-path %t/cas \
+// RUN:        -fcas-emit-casid-file -mllvm -cas-friendly-debug-info %s | FileCheck %s --check-prefix=MCCAS_OFF 
+
+// MCCAS_OFF-NOT: -mllvm
+// MCCAS_OFF-NOT: -cas-friendly-debug-info
+// MCCAS_OFF-NOT: -fcas-backend
+// MCCAS_OFF-NOT: -fcas-emit-casid-file
+
+
+int foo(int x) {
+    return x+1;
+}


### PR DESCRIPTION
Remove the MCCAS options in the dependency scanner if the FrontendAction is not EmitObj. MCCAS should only be turned on when the compiler is emitting an object file.

Cherry-pick https://github.com/apple/llvm-project/pull/8666 to swift/release/6.0

(cherry picked from commit 08b92a9ac7daabbd360fdfa2a54a1c3a2e834ac1)