### PR TITLE
[llvm/Support] Make `llvm::sys::RWMutex` Lockable (#90667)

### DIFF
--- a/llvm/include/llvm/Support/RWMutex.h
+++ b/llvm/include/llvm/Support/RWMutex.h
@@ -66,6 +66,10 @@ public:
   /// Unconditionally release the lock in reader mode.
   bool unlock_shared();
 
+  /// Attempts to acquire the lock in reader mode. Returns immediately.
+  /// @returns true on successful lock acquisition, false otherwise.
+  bool try_lock_shared();
+
   /// Attempts to unconditionally acquire the lock in reader mode. If the
   /// lock is held by any readers, this method will wait until it can
   /// acquire the lock.
@@ -77,6 +81,10 @@ public:
   /// @returns false if any kind of error occurs, true otherwise.
   /// Unconditionally release the lock in write mode.
   bool unlock();
+
+  /// Attempts to acquire the lock in writer mode. Returns immediately.
+  /// @returns true on successful lock acquisition, false otherwise.
+  bool try_lock();
 
   //@}
   /// @name Platform Dependent Data
@@ -126,6 +134,8 @@ public:
     return true;
   }
 
+  bool try_lock_shared() { return impl.try_lock_shared(); }
+
   bool lock() {
     if (!mt_only || llvm_is_multithreaded()) {
       impl.lock();
@@ -151,6 +161,8 @@ public:
     --writers;
     return true;
   }
+
+  bool try_lock() { return impl.try_lock(); }
 };
 
 typedef SmartRWMutex<false> RWMutex;

--- a/llvm/lib/Support/RWMutex.cpp
+++ b/llvm/lib/Support/RWMutex.cpp
@@ -26,8 +26,10 @@ RWMutexImpl::~RWMutexImpl() = default;
 
 bool RWMutexImpl::lock_shared() { return true; }
 bool RWMutexImpl::unlock_shared() { return true; }
+bool RWMutexImpl::try_lock_shared() { return true; }
 bool RWMutexImpl::lock() { return true; }
 bool RWMutexImpl::unlock() { return true; }
+bool RWMutexImpl::try_lock() { return true; }
 
 #else
 
@@ -87,6 +89,14 @@ RWMutexImpl::unlock_shared()
   return errorcode == 0;
 }
 
+bool RWMutexImpl::try_lock_shared() {
+  pthread_rwlock_t *rwlock = static_cast<pthread_rwlock_t *>(data_);
+  assert(rwlock != nullptr);
+
+  int errorcode = pthread_rwlock_tryrdlock(rwlock);
+  return errorcode == 0;
+}
+
 bool
 RWMutexImpl::lock()
 {
@@ -107,6 +117,14 @@ RWMutexImpl::unlock()
   return errorcode == 0;
 }
 
+bool RWMutexImpl::try_lock() {
+  pthread_rwlock_t *rwlock = static_cast<pthread_rwlock_t *>(data_);
+  assert(rwlock != nullptr);
+
+  int errorcode = pthread_rwlock_trywrlock(rwlock);
+  return errorcode == 0;
+}
+
 #else
 
 RWMutexImpl::RWMutexImpl() : data_(new MutexImpl(false)) { }
@@ -123,12 +141,20 @@ bool RWMutexImpl::unlock_shared() {
   return static_cast<MutexImpl *>(data_)->release();
 }
 
+bool RWMutexImpl::try_lock_shared() {
+  return static_cast<MutexImpl *>(data_)->tryacquire();
+}
+
 bool RWMutexImpl::lock() {
   return static_cast<MutexImpl *>(data_)->acquire();
 }
 
 bool RWMutexImpl::unlock() {
   return static_cast<MutexImpl *>(data_)->release();
+}
+
+bool RWMutexImpl::try_lock() {
+  return static_cast<MutexImpl *>(data_)->tryacquire();
 }
 
 #endif


### PR DESCRIPTION
This patch extends the `llvm::sys::RWMutex` class to fullfill the `Lockable` requirement to include attempted locking, by implementing a `bool try_lock` member function.

As the name suggests, this method will try to acquire to lock in a non-blocking fashion and release it immediately. If it managed to acquire the lock, returns `true`, otherwise returns `false`.

Signed-off-by: Med Ismail Bennani <ismail@bennani.ma>
(cherry picked from commit bf447e27d2ac7a81ea714ceca932eecaac6db77b)