### PR TITLE
[lldb] Check if interop is enabled only on compile unit

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2264,7 +2264,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 }
 
 /// Determine whether this CU was compiled with C++ interop enabled.
-static bool ShouldEnableCXXInterop(CompileUnit *cu) {
+bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
   AutoBool interop_enabled =
     ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
   switch (interop_enabled) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -208,6 +208,9 @@ public:
   CreateInstance(const SymbolContext &sc,
                  TypeSystemSwiftTypeRefForExpressions &typeref_typesystem);
 
+  /// Returns true if Swift C++ interop is enabled for the given compiler unit.
+  static bool ShouldEnableCXXInterop(CompileUnit *cu);
+
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,
       std::set<lldb::LanguageType> &languages_for_expressions);


### PR DESCRIPTION
When deciding whether to format a C++ type as a Swiftified type or not, checking if Swift/C++ interop is enabled on the entire target can be very expensive for big projects, and may not swiftify types that should be.

rdar://117708944