### PR TITLE
[IncludeTreeFileSystem] Make dir_begin() work as expected in OverlayFileSystem

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -869,6 +869,11 @@ private:
 Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
 createIncludeTreeFileSystem(IncludeTreeRoot &Root);
 
+/// Create the same IncludeTreeFileSystem but from IncludeTree::FileList.
+Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+createIncludeTreeFileSystem(llvm::cas::ObjectStore &CAS,
+                            IncludeTree::FileList &List);
+
 } // namespace cas
 } // namespace clang
 


### PR DESCRIPTION
Make `dir_begin()` in IncludeTreeFileSystem to return no_such_file_or_directory instead of operation_not_permitted. This allows OverlayFileSystem to correctly ignore IncludeTreeFileSystem layer and continue to search the layer below.

rdar://127370903