### PR TITLE
[6.0][IncludeTreeFileSystem] Make dir_begin() work as expected in OverlayFileSystem

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -869,6 +869,11 @@ private:
 Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
 createIncludeTreeFileSystem(IncludeTreeRoot &Root);
 
+/// Create the same IncludeTreeFileSystem but from IncludeTree::FileList.
+Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+createIncludeTreeFileSystem(llvm::cas::ObjectStore &CAS,
+                            IncludeTree::FileList &List);
+
 } // namespace cas
 } // namespace clang
 


### PR DESCRIPTION
Explanation: Allow directory iteration with an overlay file system that has clang include tree file system as one of its layer. This is needed for swift caching support when swift compilation looks for swift cross import overlay in a CAS file system.
Scope: Needed for swift caching support with cross module import
Issue: rdar://127370903
Original PR: https://github.com/apple/llvm-project/pull/8675
Risk: Low. Affect swift caching only.
Testing: Unit tests.
Reviewer: @benlangmuir