### PR TITLE
[cherry-pick][swift/release/6.0] [lldb][DataFormatter] unordered_map: account for new libc++ __hash_node layout

### DIFF
--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxUnorderedMap.cpp
@@ -147,10 +147,27 @@ lldb::ValueObjectSP lldb_private::formatters::
       if (!node_sp || error.Fail())
           return nullptr;
 
-      value_sp = node_sp->GetChildMemberWithName("__value_");
       hash_sp = node_sp->GetChildMemberWithName("__hash_");
-      if (!value_sp || !hash_sp)
+      if (!hash_sp)
         return nullptr;
+
+      value_sp = node_sp->GetChildMemberWithName("__value_");
+      if (!value_sp) {
+        // clang-format off
+        // Since D101206 (ba79fb2e1f), libc++ wraps the `__value_` in an
+        // anonymous union.
+        // Child 0: __hash_node_base base class
+        // Child 1: __hash_
+        // Child 2: anonymous union
+        // clang-format on
+        auto anon_union_sp = node_sp->GetChildAtIndex(2);
+        if (!anon_union_sp)
+          return nullptr;
+
+        value_sp = anon_union_sp->GetChildMemberWithName("__value_");
+        if (!value_sp)
+          return nullptr;
+      }
     }
     m_elements_cache.push_back(
         {value_sp.get(), hash_sp->GetValueAsUnsigned(0)});


### PR DESCRIPTION
Since D101206 (`ba79fb2e1ff7130cde02fbbd325f0f96f8a522ca`) the `__hash_node::__value_` member is wrapped in an anonymous union. `ValueObject::GetChildMemberWithName` doesn't see through the union.

This patch accounts for this possible new layout by getting a handle to the union before doing the by-name `__value_` lookup.

(cherry picked from commit 7493d45408c3469568ff4b23ae71c435384a830d)