### PR TITLE
[cherry-pick][swift/release/6.0] [clang][PGO] Apply artificial DebugLoc to llvm.instrprof.increment instructions 

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -1534,8 +1534,10 @@ public:
   void incrementProfileCounter(const Stmt *S, llvm::Value *StepV = nullptr) {
     if (CGM.getCodeGenOpts().hasProfileClangInstr() &&
         !CurFn->hasFnAttribute(llvm::Attribute::NoProfile) &&
-        !CurFn->hasFnAttribute(llvm::Attribute::SkipProfile))
+        !CurFn->hasFnAttribute(llvm::Attribute::SkipProfile)) {
+      auto AL = ApplyDebugLocation::CreateArtificial(*this);
       PGO.emitCounterIncrement(Builder, S, StepV);
+    }
     PGO.setCurrentStmt(S);
   }
 

--- a/clang/test/Profile/debug-info-instr_profile_switch.cpp
+++ b/clang/test/Profile/debug-info-instr_profile_switch.cpp
@@ -1,0 +1,40 @@
+// Tests that we don't attach misleading debug locations to llvm.instrprof.increment
+// counters.
+
+// RUN: %clang_cc1 -x c++ %s -debug-info-kind=standalone -triple %itanium_abi_triple -main-file-name debug-info-instr_profile_switch.cpp -std=c++11 -o - -emit-llvm -fprofile-instrument=clang | FileCheck %s
+
+int main(int argc, const char *argv[]) {
+  switch(argc) {
+    case 0:
+      return 0;
+    case 1:
+      return 1;
+  }
+}
+
+// CHECK: define {{.*}} @main(i32 noundef %argc, ptr noundef %argv) #0 !dbg ![[MAIN_SCOPE:[0-9]+]]
+
+// CHECK:        switch i32 {{.*}}, label {{.*}} [
+// CHECK-NEXT:     i32 0, label %[[CASE1_LBL:[a-z0-9.]+]]
+// CHECK-NEXT:     i32 1, label %[[CASE2_LBL:[a-z0-9.]+]]
+// CHECK-NEXT:   ], !dbg ![[SWITCH_LOC:[0-9]+]]
+
+// CHECK:       [[CASE1_LBL]]:
+// CHECK-NEXT:     %{{.*}} = load i64, ptr getelementptr inbounds ({{.*}}, ptr @__profc_main, {{.*}}), align {{.*}}, !dbg ![[CTR_LOC:[0-9]+]]
+// CHECK-NEXT:     %{{.*}} = add {{.*}}, !dbg ![[CTR_LOC]]
+// CHECK-NEXT:     store i64 {{.*}}, ptr getelementptr inbounds ({{.*}}, ptr @__profc_main, {{.*}}), align {{.*}}, !dbg ![[CTR_LOC]]
+// CHECK-NEXT:     store i32 0, {{.*}} !dbg ![[CASE1_LOC:[0-9]+]]
+// CHECK-NEXT:     br label {{.*}}, !dbg ![[CASE1_LOC]]
+
+// CHECK:       [[CASE2_LBL]]:
+// CHECK-NEXT:     %{{.*}} = load i64, ptr getelementptr inbounds ({{.*}}, ptr @__profc_main, {{.*}}), align {{.*}}, !dbg ![[CTR_LOC]]
+// CHECK-NEXT:     %{{.*}} = add {{.*}}, !dbg ![[CTR_LOC]]
+// CHECK-NEXT:     store i64 {{.*}}, ptr getelementptr inbounds ({{.*}}, ptr @__profc_main, {{.*}}), align {{.*}}, !dbg ![[CTR_LOC]]
+// CHECK-NEXT:     store i32 1, {{.*}} !dbg ![[CASE2_LOC:[0-9]+]]
+// CHECK-NEXT:     br label {{.*}}, !dbg ![[CASE2_LOC]]
+
+// CHECK: ![[SWITCH_LOC]] = !DILocation({{.*}}, scope: ![[MAIN_SCOPE]])
+// CHECK: ![[CTR_LOC]] = !DILocation(line: 0, scope: ![[BLOCK_SCOPE:[0-9]+]])
+// CHECK: ![[BLOCK_SCOPE]] = distinct !DILexicalBlock(scope: ![[MAIN_SCOPE]]
+// CHECK: ![[CASE1_LOC]] = !DILocation(line: {{.*}}, column: {{.*}}, scope: ![[BLOCK_SCOPE]])
+// CHECK: ![[CASE2_LOC]] = !DILocation(line: {{.*}}, column: {{.*}}, scope: ![[BLOCK_SCOPE]])


### PR DESCRIPTION
Prior to this change the debug-location for the
`llvm.instrprof.increment` intrinsic was set to whatever the current
DIBuilder's current debug location was set to. This meant that for
switch-statements, a counter's location was set to the previous case's
debug-location, causing confusing stepping behaviour in debuggers. This
patch makes sure we attach a dummy debug-location for the increment
instructions.

rdar://123050737
(cherry picked from commit https://github.com/apple/llvm-project/commit/4113e15153d5af39a12c6bcf16e6b35614dc13a2)