### PR TITLE
Display generic function type parameters in backtraces. 

### DIFF
--- a/lldb/include/lldb/Symbol/Function.h
+++ b/lldb/include/lldb/Symbol/Function.h
@@ -537,7 +537,7 @@ public:
 
   ConstString GetNameNoArguments(const SymbolContext *sc = nullptr) const;
 
-  ConstString GetDisplayName(const SymbolContext *sc = nullptr) const;
+  ConstString GetDisplayName() const;
 
   const Mangled &GetMangled() const { return m_mangled; }
 

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -45,23 +45,6 @@ static inline bool cstring_is_mangled(llvm::StringRef s) {
   return Mangled::GetManglingScheme(s) != Mangled::eManglingSchemeNone;
 }
 
-#ifdef LLDB_ENABLE_SWIFT
-#pragma mark DisplayDemangledNamesCache
-
-// make the key type be a const char* because that gives us usable
-// DenseMapInfo for free making DenseMap work for ConstString requires
-// us to provide two "invalid" values: the empty key and the tombstone
-// key; but for ConstString, we really don't have any well-known
-// invalid value other than ConstString(nullptr) so, just use const
-// char* as the key as LLVM knows how to do proper DenseMapInfo for
-// pointers
-static ThreadSafeDenseMap<const char *, ConstString>&
-GetDisplayDemangledNamesCache() {
-  static ThreadSafeDenseMap<const char *, ConstString> g_cache;
-  return g_cache;
-}
-#endif // LLDB_ENABLE_SWIFT
-
 #pragma mark Mangled
 
 Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
@@ -346,39 +329,15 @@ ConstString Mangled::GetDemangledName(// BEGIN SWIFT
 
 ConstString Mangled::GetDisplayDemangledName(
 // BEGIN SWIFT
-                                             const SymbolContext *sc
-                                             ) const {
-  ConstString demangled;
+    const SymbolContext *sc) const {
 #ifdef LLDB_ENABLE_SWIFT
-  if (m_mangled) {
-    do {
-      const char *mangled = m_mangled.GetCString();
-
-      if (mangled) {
-        if (SwiftLanguageRuntime::IsSwiftMangledName(m_mangled.GetStringRef())) {
-          auto& display_cache = ::GetDisplayDemangledNamesCache();
-          if (display_cache.Lookup(mangled, demangled) &&
-              demangled)
-            break;
-
-          std::string demangled_std =
-              SwiftLanguageRuntime::DemangleSymbolAsString(
-                  m_mangled.GetStringRef(), SwiftLanguageRuntime::eSimplified,
-                  sc);
-          if (!demangled_std.empty()) {
-            demangled.SetCString(demangled_std.c_str());
-            display_cache.Insert(mangled, demangled);
-            break;
-          }
-        }
-      }
-    } while (0);
-  }
+  if (m_mangled &&
+      SwiftLanguageRuntime::IsSwiftMangledName(m_mangled.GetStringRef()))
+    return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
+        m_mangled.GetStringRef(), SwiftLanguageRuntime::eSimplified, sc));
 #endif // LLDB_ENABLE_SWIFT
-  if (!demangled)
-    demangled = GetDemangledName();
-  return demangled ? demangled : m_mangled;
 // END SWIFT
+  return GetDemangledName();
 }
 
 bool Mangled::NameMatches(const RegularExpression &regex) const {

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1207,7 +1207,8 @@ bool SwiftLanguage::IsSourceFile(llvm::StringRef file_path) const {
   return file_path.endswith(".swift");
 }
 
-std::vector<FormattersMatchCandidate> SwiftLanguage::GetPossibleFormattersMatches(
+std::vector<FormattersMatchCandidate>
+SwiftLanguage::GetPossibleFormattersMatches(
     ValueObject &valobj, lldb::DynamicValueType use_dynamic) {
   std::vector<FormattersMatchCandidate> result;
 
@@ -1643,10 +1644,12 @@ bool SwiftLanguage::GetFunctionDisplayName(
       return false;
     if (sc->function->GetLanguage() != eLanguageTypeSwift)
       return false;
-    ConstString cs = sc->function->GetDisplayName(sc);
-    if (!cs)
+    std::string display_name = SwiftLanguageRuntime::DemangleSymbolAsString(
+        sc->function->GetMangled().GetMangledName().GetStringRef(),
+        SwiftLanguageRuntime::eSimplified, sc, exe_ctx);
+    if (display_name.empty())
       return false;
-    s.Printf("%s", cs.AsCString());
+    s << display_name;
     return true;
   }
   case Language::FunctionNameRepresentation::eNameWithArgs: {
@@ -1654,10 +1657,11 @@ bool SwiftLanguage::GetFunctionDisplayName(
       return false;
     if (sc->function->GetLanguage() != eLanguageTypeSwift)
       return false;
-    ConstString cs = sc->function->GetDisplayName(sc);
-    if (!cs)
+    std::string display_name = SwiftLanguageRuntime::DemangleSymbolAsString(
+        sc->function->GetMangled().GetMangledName().GetStringRef(),
+        SwiftLanguageRuntime::eSimplified, sc, exe_ctx);
+    if (display_name.empty())
       return false;
-    const char *cstr = cs.AsCString();
     ExecutionContextScope *exe_scope =
         exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL;
     const InlineFunctionInfo *inline_info = NULL;
@@ -1680,9 +1684,9 @@ bool SwiftLanguage::GetFunctionDisplayName(
     }
 
     if (inline_info) {
-      s.PutCString(cstr);
+      s << display_name;
       s.PutCString(" [inlined] ");
-      cstr = inline_info->GetName().GetCString();
+      display_name = inline_info->GetName();
     }
 
     VariableList args;
@@ -1690,15 +1694,16 @@ bool SwiftLanguage::GetFunctionDisplayName(
       variable_list_sp->AppendVariablesWithScope(eValueTypeVariableArgument,
                                                  args);
     if (args.GetSize() == 0) {
-      s.PutCString(cstr);
+      s << display_name;
       return true;
     }
+    const char *cstr = display_name.data();
     const char *open_paren = strchr(cstr, '(');
     const char *close_paren = nullptr;
     const char *generic = strchr(cstr, '<');
-    // if before the arguments list begins there is a template sign
+    // If before the arguments list begins there is a template sign
     // then scan to the end of the generic args before you try to find
-    // the arguments list
+    // the arguments list.
     if (generic && open_paren && generic < open_paren) {
       int generic_depth = 1;
       ++generic;
@@ -1720,7 +1725,7 @@ bool SwiftLanguage::GetFunctionDisplayName(
     if (open_paren)
       s.Write(cstr, open_paren - cstr + 1);
     else {
-      s.PutCString(cstr);
+      s << display_name;
       s.PutChar('(');
     }
     const size_t num_args = args.GetSize();
@@ -1730,6 +1735,8 @@ bool SwiftLanguage::GetFunctionDisplayName(
       VariableSP var_sp(args.GetVariableAtIndex(arg_idx));
       ValueObjectSP var_value_sp(
           ValueObjectVariable::Create(exe_scope, var_sp));
+      if (!var_sp || !var_value_sp || var_sp->IsArtificial())
+        continue;
       StreamString ss;
       const char *var_representation = nullptr;
       const char *var_name = var_value_sp->GetName().GetCString();

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1636,152 +1636,148 @@ bool SwiftLanguage::GetFunctionDisplayName(
   SwiftScratchContextLock scratch_ctx_lock(exe_ctx);
   switch (representation) {
   case Language::FunctionNameRepresentation::eName:
-    break; // no need to customize this
+    // No need to customize this.
+    return false;
   case Language::FunctionNameRepresentation::eNameWithNoArgs: {
-    if (sc->function) {
-      if (sc->function->GetLanguage() == eLanguageTypeSwift) {
-        if (ConstString cs = sc->function->GetDisplayName(sc)) {
-          s.Printf("%s", cs.AsCString());
-          return true;
-        }
-      }
-    }
-    break;
+    if (!sc->function)
+      return false;
+    if (sc->function->GetLanguage() != eLanguageTypeSwift)
+      return false;
+    ConstString cs = sc->function->GetDisplayName(sc);
+    if (!cs)
+      return false;
+    s.Printf("%s", cs.AsCString());
+    return true;
   }
   case Language::FunctionNameRepresentation::eNameWithArgs: {
-    if (sc->function) {
-      if (sc->function->GetLanguage() == eLanguageTypeSwift) {
-        if (const char *cstr = sc->function->GetDisplayName(sc).AsCString()) {
-          ExecutionContextScope *exe_scope =
-              exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL;
-          const InlineFunctionInfo *inline_info = NULL;
-          VariableListSP variable_list_sp;
-          bool get_function_vars = true;
-          if (sc->block) {
-            Block *inline_block = sc->block->GetContainingInlinedBlock();
+    if (!sc->function)
+      return false;
+    if (sc->function->GetLanguage() != eLanguageTypeSwift)
+      return false;
+    ConstString cs = sc->function->GetDisplayName(sc);
+    if (!cs)
+      return false;
+    const char *cstr = cs.AsCString();
+    ExecutionContextScope *exe_scope =
+        exe_ctx ? exe_ctx->GetBestExecutionContextScope() : NULL;
+    const InlineFunctionInfo *inline_info = NULL;
+    VariableListSP variable_list_sp;
+    bool get_function_vars = true;
+    if (sc->block) {
+      Block *inline_block = sc->block->GetContainingInlinedBlock();
 
-            if (inline_block) {
-              get_function_vars = false;
-              inline_info = sc->block->GetInlinedFunctionInfo();
-              if (inline_info)
-                variable_list_sp = inline_block->GetBlockVariableList(true);
-            }
-          }
-
-          if (get_function_vars) {
-            variable_list_sp =
-                sc->function->GetBlock(true).GetBlockVariableList(true);
-          }
-
-          if (inline_info) {
-            s.PutCString(cstr);
-            s.PutCString(" [inlined] ");
-            cstr = inline_info->GetName().GetCString();
-          }
-
-          VariableList args;
-          if (variable_list_sp)
-            variable_list_sp->AppendVariablesWithScope(
-                eValueTypeVariableArgument, args);
-          if (args.GetSize() > 0) {
-            const char *open_paren = strchr(cstr, '(');
-            const char *close_paren = nullptr;
-            const char *generic = strchr(cstr, '<');
-            // if before the arguments list begins there is a template sign
-            // then scan to the end of the generic args before you try to find
-            // the arguments list
-            if (generic && open_paren && generic < open_paren) {
-              int generic_depth = 1;
-              ++generic;
-              for (; *generic && generic_depth > 0; generic++) {
-                if (*generic == '<')
-                  generic_depth++;
-                if (*generic == '>')
-                  generic_depth--;
-              }
-              if (*generic)
-                open_paren = strchr(generic, '(');
-              else
-                open_paren = nullptr;
-            }
-            if (open_paren) {
-              close_paren = strchr(open_paren, ')');
-            }
-
-            if (open_paren)
-              s.Write(cstr, open_paren - cstr + 1);
-            else {
-              s.PutCString(cstr);
-              s.PutChar('(');
-            }
-            const size_t num_args = args.GetSize();
-            for (size_t arg_idx = 0; arg_idx < num_args; ++arg_idx) {
-              std::string buffer;
-
-              VariableSP var_sp(args.GetVariableAtIndex(arg_idx));
-              ValueObjectSP var_value_sp(
-                  ValueObjectVariable::Create(exe_scope, var_sp));
-              StreamString ss;
-              const char *var_representation = nullptr;
-              const char *var_name = var_value_sp->GetName().GetCString();
-              if (var_value_sp->GetCompilerType().IsValid()) {
-                if (var_value_sp && exe_scope->CalculateTarget())
-                  var_value_sp =
-                      var_value_sp->GetQualifiedRepresentationIfAvailable(
-                          exe_scope->CalculateTarget()
-                              ->TargetProperties::GetPreferDynamicValue(),
-                          exe_scope->CalculateTarget()
-                              ->TargetProperties::GetEnableSyntheticValue());
-                if (var_value_sp->GetCompilerType().IsAggregateType() &&
-                    DataVisualization::ShouldPrintAsOneLiner(
-                        *var_value_sp.get())) {
-                  static StringSummaryFormat format(
-                      TypeSummaryImpl::Flags()
-                          .SetHideItemNames(false)
-                          .SetShowMembersOneLiner(true),
-                      "");
-                  format.FormatObject(var_value_sp.get(), buffer,
-                                      TypeSummaryOptions());
-                  var_representation = buffer.c_str();
-                } else
-                  var_value_sp->DumpPrintableRepresentation(
-                      ss,
-                      ValueObject::ValueObjectRepresentationStyle::
-                          eValueObjectRepresentationStyleSummary,
-                      eFormatDefault,
-                      ValueObject::PrintableRepresentationSpecialCases::eAllow,
-                      false);
-              }
-              if (ss.GetData() && ss.GetSize())
-                var_representation = ss.GetData();
-              if (arg_idx > 0)
-                s.PutCString(", ");
-              if (var_value_sp->GetError().Success()) {
-                if (var_representation)
-                  s.Printf("%s=%s", var_name, var_representation);
-                else
-                  s.Printf("%s=%s at %s", var_name,
-                           var_value_sp->GetTypeName().GetCString(),
-                           var_value_sp->GetLocationAsCString());
-              } else
-                s.Printf("%s=<unavailable>", var_name);
-            }
-
-            if (close_paren)
-              s.PutCString(close_paren);
-            else
-              s.PutChar(')');
-
-          } else {
-            s.PutCString(cstr);
-          }
-          return true;
-        }
+      if (inline_block) {
+        get_function_vars = false;
+        inline_info = sc->block->GetInlinedFunctionInfo();
+        if (inline_info)
+          variable_list_sp = inline_block->GetBlockVariableList(true);
       }
     }
-  }
-  }
 
+    if (get_function_vars) {
+      variable_list_sp =
+          sc->function->GetBlock(true).GetBlockVariableList(true);
+    }
+
+    if (inline_info) {
+      s.PutCString(cstr);
+      s.PutCString(" [inlined] ");
+      cstr = inline_info->GetName().GetCString();
+    }
+
+    VariableList args;
+    if (variable_list_sp)
+      variable_list_sp->AppendVariablesWithScope(eValueTypeVariableArgument,
+                                                 args);
+    if (args.GetSize() == 0) {
+      s.PutCString(cstr);
+      return true;
+    }
+    const char *open_paren = strchr(cstr, '(');
+    const char *close_paren = nullptr;
+    const char *generic = strchr(cstr, '<');
+    // if before the arguments list begins there is a template sign
+    // then scan to the end of the generic args before you try to find
+    // the arguments list
+    if (generic && open_paren && generic < open_paren) {
+      int generic_depth = 1;
+      ++generic;
+      for (; *generic && generic_depth > 0; generic++) {
+        if (*generic == '<')
+          generic_depth++;
+        if (*generic == '>')
+          generic_depth--;
+      }
+      if (*generic)
+        open_paren = strchr(generic, '(');
+      else
+        open_paren = nullptr;
+    }
+    if (open_paren) {
+      close_paren = strchr(open_paren, ')');
+    }
+
+    if (open_paren)
+      s.Write(cstr, open_paren - cstr + 1);
+    else {
+      s.PutCString(cstr);
+      s.PutChar('(');
+    }
+    const size_t num_args = args.GetSize();
+    for (size_t arg_idx = 0; arg_idx < num_args; ++arg_idx) {
+      std::string buffer;
+
+      VariableSP var_sp(args.GetVariableAtIndex(arg_idx));
+      ValueObjectSP var_value_sp(
+          ValueObjectVariable::Create(exe_scope, var_sp));
+      StreamString ss;
+      const char *var_representation = nullptr;
+      const char *var_name = var_value_sp->GetName().GetCString();
+      if (var_value_sp->GetCompilerType().IsValid()) {
+        if (var_value_sp && exe_scope->CalculateTarget())
+          var_value_sp = var_value_sp->GetQualifiedRepresentationIfAvailable(
+              exe_scope->CalculateTarget()
+                  ->TargetProperties::GetPreferDynamicValue(),
+              exe_scope->CalculateTarget()
+                  ->TargetProperties::GetEnableSyntheticValue());
+        if (var_value_sp->GetCompilerType().IsAggregateType() &&
+            DataVisualization::ShouldPrintAsOneLiner(*var_value_sp.get())) {
+          static StringSummaryFormat format(TypeSummaryImpl::Flags()
+                                                .SetHideItemNames(false)
+                                                .SetShowMembersOneLiner(true),
+                                            "");
+          format.FormatObject(var_value_sp.get(), buffer, TypeSummaryOptions());
+          var_representation = buffer.c_str();
+        } else
+          var_value_sp->DumpPrintableRepresentation(
+              ss,
+              ValueObject::ValueObjectRepresentationStyle::
+                  eValueObjectRepresentationStyleSummary,
+              eFormatDefault,
+              ValueObject::PrintableRepresentationSpecialCases::eAllow, false);
+      }
+      if (ss.GetData() && ss.GetSize())
+        var_representation = ss.GetData();
+      if (arg_idx > 0)
+        s.PutCString(", ");
+      if (var_value_sp->GetError().Success()) {
+        if (var_representation)
+          s.Printf("%s=%s", var_name, var_representation);
+        else
+          s.Printf("%s=%s at %s", var_name,
+                   var_value_sp->GetTypeName().GetCString(),
+                   var_value_sp->GetLocationAsCString());
+      } else
+        s.Printf("%s=<unavailable>", var_name);
+    }
+
+    if (close_paren)
+      s.PutCString(close_paren);
+    else
+      s.PutChar(')');
+    } 
+    return true;
+  }
   return false;
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -141,9 +141,10 @@ public:
   IsSwiftAsyncAwaitResumePartialFunctionSymbol(llvm::StringRef name);
 
   enum DemangleMode { eSimplified, eTypeName, eDisplayTypeName };
-  static std::string DemangleSymbolAsString(llvm::StringRef symbol,
-                                            DemangleMode mode,
-                                            const SymbolContext *sc = nullptr);
+  static std::string
+  DemangleSymbolAsString(llvm::StringRef symbol, DemangleMode mode,
+                         const SymbolContext *sc = nullptr,
+                         const ExecutionContext *exe_ctx = nullptr);
 
   /// Demangle a symbol to a swift::Demangle node tree.
   ///
@@ -246,7 +247,7 @@ public:
   /// Populate a map with the names of all archetypes in a function's generic
   /// context.
   static void GetGenericParameterNamesForFunction(
-      const SymbolContext &sc,
+      const SymbolContext &sc, const ExecutionContext *exe_ctx,
       llvm::DenseMap<ArchetypePath, llvm::StringRef> &dict);
 
   /// Invoke callback for each DependentGenericParamType.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6004,7 +6004,8 @@ GetArchetypeNames(swift::Type swift_type, swift::ASTContext &ast_ctx,
     return dict;
 
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, StringRef> names;
-  SwiftLanguageRuntime::GetGenericParameterNamesForFunction(*sc, names);
+  SwiftLanguageRuntime::GetGenericParameterNamesForFunction(*sc, nullptr,
+                                                            names);
   swift_type.visit([&](swift::Type type) {
     if (!type->isTypeParameter() || dict.count(type->getCanonicalType()))
       return;

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -498,10 +498,10 @@ bool Function::IsTopLevelFunction() {
   return result;
 }
 
-ConstString Function::GetDisplayName(const SymbolContext *sc) const {
+ConstString Function::GetDisplayName() const {
   if (!m_mangled)
     return GetName();
-  return m_mangled.GetDisplayDemangledName(sc);
+  return m_mangled.GetDisplayDemangledName();
 }
 
 CompilerDeclContext Function::GetDeclContext() {

--- a/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -24,35 +24,11 @@ class TestSwiftBacktracePrinting(TestBase):
     def test_swift_backtrace_printing(self):
         """Test printing Swift backtrace"""
         self.build()
-        self.do_test()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
 
-    def setUp(self):
-        TestBase.setUp(self)
-        self.main_source = "main.swift"
-        self.main_source_spec = lldb.SBFileSpec(self.main_source)
-
-    def do_test(self):
-        """Test printing Swift backtrace"""
-        exe_name = "a.out"
-        exe = self.getBuildArtifact(exe_name)
-
-        # Create the target
-        target = self.dbg.CreateTarget(exe)
-        self.assertTrue(target, VALID_TARGET)
-
-        # Set the breakpoints
-        breakpoint = target.BreakpointCreateBySourceRegex(
-            'break here', self.main_source_spec)
-        self.assertTrue(breakpoint.GetNumLocations() > 0, VALID_BREAKPOINT)
-
-        # Launch the process, and do not stop at the entry point.
-        process = target.LaunchSimple(None, None, os.getcwd())
-
-        self.assertTrue(process, PROCESS_IS_VALID)
-
-        self.expect("bt", substrs=['h<T>',
-                                   # FIXME: rdar://65956239 U and T are not resolved!
-                                   'g<U, T>', 'pair', # '12', "Hello world",
+        self.expect("bt", substrs=['h<Int>',
+                                   'g<String, Int>', 'pair', # FIXME: values are still wrong!
                                    'arg1=12', 'arg2="Hello world"'])
         self.expect("breakpoint set -p other", substrs=['g<U, T>'])
 

--- a/lldb/test/API/lang/swift/expression/generic_function_name/Makefile
+++ b/lldb/test/API/lang/swift/expression/generic_function_name/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/generic_function_name/TestSwiftGenericFunctionName.py
+++ b/lldb/test/API/lang/swift/expression/generic_function_name/TestSwiftGenericFunctionName.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftGenericFunction(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test display of generic function names"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
+            self, 'f')
+
+        # Live process:
+        stream = lldb.SBStream()
+        self.frame().GetDescription(stream)
+        desc = stream.GetData()
+        # It's debatable whether C's generic parameter should be displayed here.
+        self.assertIn("C.f<Int>(t=1, u=2)", desc)
+
+        # Dead process + debug info:
+        process.Kill()
+        stream = lldb.SBStream()
+        bkpt.GetLocationAtIndex(0).GetDescription(stream, 1)
+        desc = stream.GetData()
+        self.assertIn("C.f<T>(T, U) -> ()", desc)
+
+        # Demangling only:
+        fs = target.FindFunctions("f")
+        self.assertTrue(fs)
+        desc = fs[0].GetFunction().GetDisplayName()
+        self.assertIn("C.f<τ_0_0>(_:_:)", desc)
+

--- a/lldb/test/API/lang/swift/expression/generic_function_name/main.swift
+++ b/lldb/test/API/lang/swift/expression/generic_function_name/main.swift
@@ -1,0 +1,8 @@
+class C<T>
+{
+  func f<U> (_ t: T, _ u: U) {
+    print("break here")
+  }
+}
+
+C<Int>().f(1, 2 as Float)


### PR DESCRIPTION
This patch changes the behavior of SwiftLanguage::GetFunctionDisplayName()
so it now:
- (if exe_ctx && sc available) does generic parameter binding
- (if only sc availble) shows the archetype name
- the letter τ will now only appear if neither no context whatsover is available
- (drive by) omits self

rdar://126883922