### PR TITLE
[Cherry-pick into next] Make the user code range detection more robust.

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.h
@@ -38,7 +38,7 @@ public:
   // passed to CreateWrapped. Return true if the bounds could be found.  This
   // will also work on text with FixItHints applied.
   static bool GetOriginalBodyBounds(std::string transformed_text,
-                                    size_t &start_loc, size_t &end_loc);
+                                    uint32_t &start_loc, uint32_t &end_loc);
 
   uint32_t GetNumBodyLines();
 
@@ -51,8 +51,8 @@ public:
       llvm::ArrayRef<SwiftASTManipulator::VariableInfo> local_variables) const;
 
 private:
-  SwiftExpressionSourceCode(const char *name, const char *prefix, const char *body,
-                       Wrapping wrap)
+  SwiftExpressionSourceCode(const char *name, const char *prefix,
+                            const char *body, Wrapping wrap)
       : ExpressionSourceCode(name, prefix, body, wrap) {}
   uint32_t m_num_body_lines = 0;
 };

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -828,8 +828,8 @@ exe_scope = exe_ctx.GetBestExecutionContextScope();
       // If fixits are enabled, calculate the fixed expression string.
       if (m_options.GetAutoApplyFixIts() && diagnostic_manager.HasFixIts()) {
         if (m_parser->RewriteExpression(diagnostic_manager)) {
-          size_t fixed_start;
-          size_t fixed_end;
+          uint32_t fixed_start;
+          uint32_t fixed_end;
           const std::string &fixed_expression =
               diagnostic_manager.GetFixedExpression();
           if (SwiftExpressionSourceCode::GetOriginalBodyBounds(

--- a/lldb/test/API/lang/swift/expression/error_reporting/Makefile
+++ b/lldb/test/API/lang/swift/expression/error_reporting/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -1,0 +1,33 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftExpressionErrorReportingy(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    def test(self):
+        """Test error reporting in expressions reports
+        only diagnostics in user code"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        options = lldb.SBExpressionOptions()
+        value = self.frame().EvaluateExpression(
+            "ceciNestPasUnVar", options)
+        def check(value):
+            lines = str(value.GetError()).split('\n')
+            self.assertTrue(lines[0].startswith('error:'))
+            self.assertIn('ceciNestPasUnVar', lines[0])
+            for line in lines[1:]:
+                self.assertFalse(line.startswith('error:'))
+                self.assertFalse(line.startswith('warning:'))
+
+        check(value)
+        process.Continue()
+        value = self.frame().EvaluateExpression(
+            "ceciNestPasUnVar", options)
+        check(value)

--- a/lldb/test/API/lang/swift/expression/error_reporting/main.swift
+++ b/lldb/test/API/lang/swift/expression/error_reporting/main.swift
@@ -1,0 +1,15 @@
+class State {
+  init(x: Int) {
+    number = x
+    print("in class") // break here
+  }
+
+  var number:Int
+}
+
+func f() {
+  print("in function") // break here
+}
+
+f()
+State(x: 20)


### PR DESCRIPTION
```
commit fa9fea903840f434114b01ff9a1b63587f887eab
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri May 3 16:36:41 2024 -0700

    Make the user code range detection more robust.
    
    While it could be determined statically, it's more future-proof to
    calculate it every time, since some substituions might intrroduce
    extra newlines.
    
    rdar://127123509
```
