### PR TITLE
[lldb] Properly namespace Severity enum values

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -243,12 +243,12 @@ public:
   static lldb::Severity SeverityForKind(swift::DiagnosticKind kind) {
     switch (kind) {
     case swift::DiagnosticKind::Error:
-      return eSeverityError;
+      return lldb::eSeverityError;
     case swift::DiagnosticKind::Warning:
-      return eSeverityWarning;
+      return lldb::eSeverityWarning;
     case swift::DiagnosticKind::Note:
     case swift::DiagnosticKind::Remark:
-      return eSeverityInfo;
+      return lldb::eSeverityInfo;
     }
 
     llvm_unreachable("Unhandled DiagnosticKind in switch.");


### PR DESCRIPTION
This means there must be a header that contains "using namespace lldb" transitively included.

(cherry picked from commit d4a96504c704648813a1718461198080722bd021)