### PR TITLE
[Cherry-pick into next] Add a missing check for nullptr

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -317,17 +317,16 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
           diagnostic_manager.Clear();
           user_expression_sp = fixed_expression_sp;
           break;
+        }
+        // The fixed expression also didn't parse. Let's check for any new
+        // fixits we could try.
+        if (!fixed_expression_sp->GetFixedText().empty()) {
+          *fixed_expression = fixed_expression_sp->GetFixedText().str();
         } else {
-          // The fixed expression also didn't parse. Let's check for any new
-          // Fix-Its we could try.
-          if (!fixed_expression_sp->GetFixedText().empty()) {
-            *fixed_expression = fixed_expression_sp->GetFixedText().str();
-          } else {
-            // Fixed expression didn't compile without a fixit, don't retry and
-            // don't tell the user about it.
-            fixed_expression->clear();
-            break;
-          }
+          // Fixed expression didn't compile without a fixit, don't retry and
+          // don't tell the user about it.
+          fixed_expression->clear();
+          break;
         }
       }
     }

--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -307,6 +307,8 @@ UserExpression::Evaluate(ExecutionContext &exe_ctx,
             target->GetUserExpressionForLanguage(
                 fixed_expression->c_str(), full_prefix, language, desired_type,
                 options, ctx_obj, error));
+        if (!fixed_expression_sp)
+          break;
         DiagnosticManager fixed_diagnostic_manager;
         parse_success = fixed_expression_sp->Parse(
             fixed_diagnostic_manager, exe_ctx, execution_policy,


### PR DESCRIPTION
```
commit bb015b862c31b4b36fc412c3a7dffccca41d539b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue May 7 12:58:20 2024 -0700

    Add a missing check for nullptr
    
    This can't happen with Clang, but I've seen a crash report from the
    Swift plugin where this happened.
    
    rdar://126564844
    (cherry picked from commit 8c4d7989c2b4a7e251afc3b13002611646de90b6)

commit e218833185f36a2ca63aa2e5b80ffc4727ee5e87
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue May 7 12:57:43 2024 -0700

    Remove else-after-break (NFC)
    
    (cherry picked from commit 272ea28bdec93b33527dc54edbdef8f43c51df47)
```
