### PR TITLE
[Cherry-pick into next] lldb: Link swiftrt from the host toolchain on Windows

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -50,16 +50,16 @@ if(BOOTSTRAPPING_MODE)
     PRIVATE
       swiftCompilerModules)
 
+  # The swiftCompilerModules need swiftrt to work properly.
+  string(REGEX MATCH "^[^-]*" arch ${LLVM_TARGET_TRIPLE})
   if (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD")
-    # The swiftCompilerModules need swiftrt to work properly.
-    string(REGEX MATCH "^[^-]*" arch ${LLVM_TARGET_TRIPLE})
     string(TOLOWER ${CMAKE_SYSTEM_NAME} platform)
     target_link_libraries(lldbPluginExpressionParserSwift
       PRIVATE
         "${LLDB_SWIFT_LIBS}/${platform}/${arch}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(swiftrt_obj
-        ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/windows/${SWIFT_HOST_VARIANT_ARCH}/swiftrt${CMAKE_C_OUTPUT_EXTENSION})
+        ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/windows/${arch}/swiftrt${CMAKE_C_OUTPUT_EXTENSION})
     target_link_libraries(lldbPluginExpressionParserSwift PRIVATE ${swiftrt_obj})
   endif()
 else()

--- a/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/ExpressionParser/Swift/CMakeLists.txt
@@ -50,13 +50,17 @@ if(BOOTSTRAPPING_MODE)
     PRIVATE
       swiftCompilerModules)
 
-  if (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD|Windows")
+  if (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD")
     # The swiftCompilerModules need swiftrt to work properly.
     string(REGEX MATCH "^[^-]*" arch ${LLVM_TARGET_TRIPLE})
     string(TOLOWER ${CMAKE_SYSTEM_NAME} platform)
     target_link_libraries(lldbPluginExpressionParserSwift
       PRIVATE
         "${LLDB_SWIFT_LIBS}/${platform}/${arch}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    set(swiftrt_obj
+        ${SWIFT_PATH_TO_SWIFT_SDK}/usr/lib/swift/windows/${SWIFT_HOST_VARIANT_ARCH}/swiftrt${CMAKE_C_OUTPUT_EXTENSION})
+    target_link_libraries(lldbPluginExpressionParserSwift PRIVATE ${swiftrt_obj})
   endif()
 else()
   target_link_libraries(lldbPluginExpressionParserSwift


### PR DESCRIPTION
This is required for enabling SwiftCompilerSources for lldb on Windows

This is a cherry-pick of https://github.com/apple/llvm-project/pull/8683 and https://github.com/apple/llvm-project/pull/8697

rdar://127567242