### PR TITLE
Introduce LockGuarded and make swift::ASTContext accesses thread safe

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1259,9 +1259,6 @@ SwiftExpressionParser::ParseAndImport(
   Log *log = GetLog(LLDBLog::Expressions);
   LLDB_SCOPED_TIMER();
 
-  ThreadSafeASTContext ast_context = GetASTContext(diagnostic_manager);
-  if (!ast_context)
-    return make_error<SwiftASTContextError>();
 
   bool repl = m_options.GetREPLEnabled();
   bool playground = m_options.GetPlaygroundTransformEnabled();
@@ -1317,22 +1314,28 @@ SwiftExpressionParser::ParseAndImport(
   for (auto &attributed_import : additional_imports)
     importInfo.AdditionalImports.emplace_back(attributed_import);
 
-  auto module_id = ast_context->getIdentifier(expr_name_buf);
-  auto &module =
-      *swift::ModuleDecl::create(module_id, **ast_context, importInfo);
+  swift::ModuleDecl *module = nullptr;
+  swift::SourceFile *source_file = nullptr;
+  {
+    ThreadSafeASTContext ast_context = GetASTContext(diagnostic_manager);
+    if (!ast_context)
+      return make_error<SwiftASTContextError>();
 
-  swift::SourceFileKind source_file_kind = swift::SourceFileKind::Library;
-  if (playground || repl) {
-    source_file_kind = swift::SourceFileKind::Main;
+    auto module_id = ast_context->getIdentifier(expr_name_buf);
+    module = swift::ModuleDecl::create(module_id, **ast_context, importInfo);
+
+    swift::SourceFileKind source_file_kind = swift::SourceFileKind::Library;
+    if (playground || repl) {
+      source_file_kind = swift::SourceFileKind::Main;
+    }
+
+    // Create the source file. Note, we disable delayed parsing for the
+    // swift expression parser.
+    source_file = new (**ast_context) swift::SourceFile(
+        *module, source_file_kind, buffer_id,
+        swift::SourceFile::ParsingFlags::DisableDelayedBodies);
+    module->addFile(*source_file);
   }
-
-  // Create the source file. Note, we disable delayed parsing for the
-  // swift expression parser.
-  swift::SourceFile *source_file = new (**ast_context)
-      swift::SourceFile(module, source_file_kind, buffer_id,
-                        swift::SourceFile::ParsingFlags::DisableDelayedBodies);
-  module.addFile(*source_file);
-
   // Swift Modules that rely on shared libraries (not frameworks)
   // don't record the link information in the swiftmodule file, so we
   // can't really make them work without outside information.
@@ -1487,8 +1490,7 @@ SwiftExpressionParser::ParseAndImport(
 
   ParsedExpression result = {
       std::move(code_manipulator),
-      std::move(ast_context),
-      module,
+      *module,
       *external_lookup,
       *source_file,
       std::move(main_filename),
@@ -2109,7 +2111,10 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // part of the parse from the staging area in the external lookup
   // object into the SwiftPersistentExpressionState.
   swift::ModuleDecl *module = &parsed_expr->module;
-  parsed_expr->ast_context->addLoadedModule(module);
+  {
+    ThreadSafeASTContext ast_context = GetASTContext(diagnostic_manager);
+    ast_context->addLoadedModule(module);
+  }
   m_swift_ast_ctx.CacheModule(module);
   if (m_sc.target_sp) {
     auto *persistent_state =

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -132,60 +132,46 @@ static CompilerDecl GetCompilerDecl(swift::Decl *decl) {
   return {SwiftASTContext::GetSwiftASTContext(&decl->getASTContext()), decl};
 }
 
-namespace {
-class LLDBNameLookup : public swift::SILDebuggerClient {
-public:
-  LLDBNameLookup(swift::SourceFile &source_file,
-                 SwiftExpressionParser::SILVariableMap &variable_map,
-                 SymbolContext &sc, ExecutionContextScope &exe_scope)
-      : SILDebuggerClient(source_file.getASTContext()),
-        m_log(GetLog(LLDBLog::Expressions)), m_source_file(source_file),
-        m_variable_map(variable_map), m_sc(sc) {
-    source_file.getParentModule()->setDebugClient(this);
+LLDBNameLookup::LLDBNameLookup(
+    swift::SourceFile &source_file,
+    SwiftExpressionParser::SILVariableMap &variable_map, SymbolContext &sc,
+    ExecutionContextScope &exe_scope)
+    : SILDebuggerClient(source_file.getASTContext()),
+      m_log(GetLog(LLDBLog::Expressions)), m_source_file(source_file),
+      m_variable_map(variable_map), m_sc(sc) {
+  source_file.getParentModule()->setDebugClient(this);
 
-    if (!m_sc.target_sp)
-      return;
-    m_persistent_vars =
-        m_sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
-  }
+  if (!m_sc.target_sp)
+    return;
+  m_persistent_vars =
+      m_sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
+}
 
-  swift::SILValue emitLValueForVariable(swift::VarDecl *var,
-                                        swift::SILBuilder &builder) override {
-    SwiftSILManipulator manipulator(builder);
+swift::SILValue LLDBNameLookup::emitLValueForVariable(
+    swift::VarDecl *var, swift::SILBuilder &builder) {
+  SwiftSILManipulator manipulator(builder);
 
-    swift::Identifier variable_name = var->getName();
-    ConstString variable_const_string(variable_name.get());
+  swift::Identifier variable_name = var->getName();
+  ConstString variable_const_string(variable_name.get());
 
-    SwiftExpressionParser::SILVariableMap::iterator vi =
-        m_variable_map.find(variable_const_string.AsCString());
+  SwiftExpressionParser::SILVariableMap::iterator vi =
+      m_variable_map.find(variable_const_string.AsCString());
 
-    if (vi == m_variable_map.end())
-      return swift::SILValue();
+  if (vi == m_variable_map.end())
+    return swift::SILValue();
 
-    return manipulator.emitLValueForVariable(var, vi->second);
-  }
+  return manipulator.emitLValueForVariable(var, vi->second);
+}
 
-  SwiftPersistentExpressionState::SwiftDeclMap &GetStagedDecls() {
-    return m_staged_decls;
-  }
+SwiftPersistentExpressionState::SwiftDeclMap &
+LLDBNameLookup::GetStagedDecls() {
+  return m_staged_decls;
+}
 
-  void RegisterTypeAliases(
-      llvm::SmallVectorImpl<swift::TypeAliasDecl *> &type_aliases) {
-    m_type_aliases.append(type_aliases.begin(), type_aliases.end());
-  }
-
-protected:
-  Log *m_log;
-  swift::SourceFile &m_source_file;
-  SwiftExpressionParser::SILVariableMap &m_variable_map;
-  SymbolContext m_sc;
-  SwiftPersistentExpressionState *m_persistent_vars = nullptr;
-
-  // Subclasses stage globalized decls in this map. They get copied
-  // over to the SwiftPersistentVariable store if the parse succeeds.
-  SwiftPersistentExpressionState::SwiftDeclMap m_staged_decls;
-  llvm::SmallVector<swift::TypeAliasDecl *> m_type_aliases;
-};
+void LLDBNameLookup::RegisterTypeAliases(
+    llvm::SmallVectorImpl<swift::TypeAliasDecl *> &type_aliases) {
+  m_type_aliases.append(type_aliases.begin(), type_aliases.end());
+}
 
 /// A name lookup class for debugger expr mode.
 class LLDBExprNameLookup : public LLDBNameLookup {
@@ -446,8 +432,6 @@ public:
     return swift::Identifier();
   }
 };
-}; // END Anonymous namespace
-
 
 /// Returns the Swift type for a ValueObject representing a variable.
 /// An invalid CompilerType is returned on error.
@@ -792,16 +776,14 @@ static void ResolveSpecialNames(
 
 /// Initialize the SwiftASTContext and return the wrapped
 /// swift::ASTContext when successful.
-static ThreadSafeASTContext
-SetupASTContext(SwiftASTContextForExpressions &swift_ast_context,
-                DiagnosticManager &diagnostic_manager,
-                std::function<bool()> disable_objc_runtime, bool repl,
-                bool playground) {
+ThreadSafeASTContext SwiftExpressionParser::SetupASTContext(
+    DiagnosticManager &diagnostic_manager,
+    std::function<bool()> disable_objc_runtime, bool repl, bool playground) {
   // Lazily get the clang importer if we can to make sure it exists in
   // case we need it.
-  if (!swift_ast_context.GetClangImporter()) {
+  if (!m_swift_ast_ctx.GetClangImporter()) {
     std::string swift_error =
-        swift_ast_context.GetFatalErrors().AsCString("error: unknown error.");
+        m_swift_ast_ctx.GetFatalErrors().AsCString("error: unknown error.");
     diagnostic_manager.PutString(eSeverityError, swift_error);
     diagnostic_manager.PutString(eSeverityInfo,
                                  "Couldn't initialize Swift expression "
@@ -809,13 +791,13 @@ SetupASTContext(SwiftASTContextForExpressions &swift_ast_context,
     return ThreadSafeASTContext();
   }
 
-  if (swift_ast_context.HasFatalErrors()) {
+  if (m_swift_ast_ctx.HasFatalErrors()) {
     diagnostic_manager.PutString(eSeverityError,
                                  "The AST context is in a fatal error state.");
     return ThreadSafeASTContext();
   }
 
-  ThreadSafeASTContext ast_context = swift_ast_context.GetASTContext();
+  ThreadSafeASTContext ast_context = m_swift_ast_ctx.GetASTContext();
   if (!ast_context) {
     diagnostic_manager.PutString(
         eSeverityError,
@@ -823,7 +805,7 @@ SetupASTContext(SwiftASTContextForExpressions &swift_ast_context,
     return ThreadSafeASTContext();
   }
 
-  if (swift_ast_context.HasFatalErrors()) {
+  if (m_swift_ast_ctx.HasFatalErrors()) {
     diagnostic_manager.PutString(eSeverityError,
                                  "The AST context is in a fatal error state.");
     return ThreadSafeASTContext();
@@ -834,33 +816,33 @@ SetupASTContext(SwiftASTContextForExpressions &swift_ast_context,
   // swift_ast_context.GetLanguageOptions().DebugConstraintSolver = true;
 
   // No longer part of debugger support, set it separately.
-  swift_ast_context.GetLanguageOptions().EnableDollarIdentifiers = true;
-  swift_ast_context.GetLanguageOptions().EnableAccessControl =
+  m_swift_ast_ctx.GetLanguageOptions().EnableDollarIdentifiers = true;
+  m_swift_ast_ctx.GetLanguageOptions().EnableAccessControl =
       (repl || playground);
-  swift_ast_context.GetLanguageOptions().EnableTargetOSChecking = false;
+  m_swift_ast_ctx.GetLanguageOptions().EnableTargetOSChecking = false;
 
   if (disable_objc_runtime())
-    swift_ast_context.GetLanguageOptions().EnableObjCInterop = false;
+    m_swift_ast_ctx.GetLanguageOptions().EnableObjCInterop = false;
 
-  swift_ast_context.GetLanguageOptions().Playground = repl || playground;
-  swift_ast_context.GetIRGenOptions().Playground = repl || playground;
+  m_swift_ast_ctx.GetLanguageOptions().Playground = repl || playground;
+  m_swift_ast_ctx.GetIRGenOptions().Playground = repl || playground;
 
   // For the expression parser and REPL we want to relax the
   // requirement that you put "try" in front of every expression that
   // might throw.
   if (repl || !playground)
-    swift_ast_context.GetLanguageOptions().EnableThrowWithoutTry = true;
+    m_swift_ast_ctx.GetLanguageOptions().EnableThrowWithoutTry = true;
 
-  swift_ast_context.GetIRGenOptions().OutputKind =
+  m_swift_ast_ctx.GetIRGenOptions().OutputKind =
       swift::IRGenOutputKind::Module;
-  swift_ast_context.GetIRGenOptions().OptMode =
+  m_swift_ast_ctx.GetIRGenOptions().OptMode =
       swift::OptimizationMode::NoOptimization;
   // Normally we'd like to verify, but unfortunately the verifier's
   // error mode is abort().
-  swift_ast_context.GetIRGenOptions().Verify = false;
-  swift_ast_context.GetIRGenOptions().ForcePublicLinkage = true;
+  m_swift_ast_ctx.GetIRGenOptions().Verify = false;
+  m_swift_ast_ctx.GetIRGenOptions().ForcePublicLinkage = true;
 
-  swift_ast_context.GetIRGenOptions().DisableRoundTripDebugTypes = true;
+  m_swift_ast_ctx.GetIRGenOptions().DisableRoundTripDebugTypes = true;
   return ast_context;
 }
 
@@ -1122,18 +1104,6 @@ struct ModuleImportError : public llvm::ErrorInfo<ModuleImportError> {
 char PropagatedError::ID = 0;
 char SwiftASTContextError::ID = 0;
 char ModuleImportError::ID = 0;
-
-/// This holds the result of ParseAndImport.
-struct ParsedExpression {
-  std::unique_ptr<SwiftASTManipulator> code_manipulator;
-  ThreadSafeASTContext ast_context;
-  swift::ModuleDecl &module;
-  LLDBNameLookup &external_lookup;
-  swift::SourceFile &source_file;
-  std::string main_filename;
-  unsigned buffer_id;
-};
-
 } // namespace
 
 /// Adds typealiases from the archetypes as they appear in the source code to
@@ -1268,23 +1238,16 @@ AddArchetypeTypeAliases(std::unique_ptr<SwiftASTManipulator> &code_manipulator,
   return type_aliases;
 }
 
-/// Attempt to parse an expression and import all the Swift modules
-/// the expression and its context depend on.
-static llvm::Expected<ParsedExpression> ParseAndImport(
-    SwiftASTContextForExpressions &swift_ast_context,
-    SwiftASTContext::ScopedDiagnostics &expr_diagnostics, Expression &expr,
+llvm::Expected<SwiftExpressionParser::ParsedExpression>
+SwiftExpressionParser::ParseAndImport(
+    SwiftASTContext::ScopedDiagnostics &expr_diagnostics,
     SwiftExpressionParser::SILVariableMap &variable_map, unsigned &buffer_id,
-    DiagnosticManager &diagnostic_manager,
-    SwiftExpressionParser &swift_expr_parser,
-    lldb::StackFrameWP &stack_frame_wp, SymbolContext &sc,
-    ExecutionContextScope &exe_scope,
-    llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
-    const EvaluateExpressionOptions &options, bool repl, bool playground) {
+    DiagnosticManager &diagnostic_manager, bool repl, bool playground) {
   Log *log = GetLog(LLDBLog::Expressions);
   LLDB_SCOPED_TIMER();
 
   auto should_disable_objc_runtime = [&]() {
-    lldb::StackFrameSP this_frame_sp(stack_frame_wp.lock());
+    lldb::StackFrameSP this_frame_sp(m_stack_frame_wp.lock());
     if (!this_frame_sp)
       return false;
     lldb::ProcessSP process_sp(this_frame_sp->CalculateProcess());
@@ -1293,9 +1256,8 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     return !ObjCLanguageRuntime::Get(*process_sp);
   };
 
-  ThreadSafeASTContext ast_context =
-      SetupASTContext(swift_ast_context, diagnostic_manager,
-                      should_disable_objc_runtime, repl, playground);
+  ThreadSafeASTContext ast_context = SetupASTContext(
+      diagnostic_manager, should_disable_objc_runtime, repl, playground);
   if (!ast_context)
     return make_error<SwiftASTContextError>();
 
@@ -1308,25 +1270,25 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     Status error;
     SourceModule module_info;
     module_info.path.emplace_back("Swift");
-    swift::ModuleDecl *module = swift_ast_context.GetModule(module_info, error);
+    swift::ModuleDecl *module = m_swift_ast_ctx.GetModule(module_info, error);
 
     if (error.Fail() || !module) {
       LLDB_LOG(log, "couldn't load Swift Standard Library");
       return error.ToError();
     }
 
-    swift_ast_context.AddHandLoadedModule(ConstString("Swift"),
-                                          swift::ImportedModule(module));
+    m_swift_ast_ctx.AddHandLoadedModule(ConstString("Swift"),
+                                        swift::ImportedModule(module));
   }
 
   std::string main_filename;
   std::tie(buffer_id, main_filename) = CreateMainFile(
-      swift_ast_context, repl ? "<REPL>" : "<EXPR>", expr.Text(), options);
+      m_swift_ast_ctx, repl ? "<REPL>" : "<EXPR>", m_expr.Text(), m_options);
 
   char expr_name_buf[32];
 
   snprintf(expr_name_buf, sizeof(expr_name_buf), "__lldb_expr_%u",
-           options.GetExpressionNumber());
+           m_options.GetExpressionNumber());
 
   // Gather the modules that need to be implicitly imported.
   // The Swift stdlib needs to be imported before the SwiftLanguageRuntime can
@@ -1335,11 +1297,11 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   llvm::SmallVector<swift::AttributedImport<swift::ImportedModule>, 16>
       additional_imports;
   lldb::ProcessSP process_sp;
-  if (lldb::StackFrameSP this_frame_sp = stack_frame_wp.lock())
+  if (lldb::StackFrameSP this_frame_sp = m_stack_frame_wp.lock())
     process_sp = this_frame_sp->CalculateProcess();
-  swift_ast_context.LoadImplicitModules(sc.target_sp, process_sp, exe_scope);
-  if (!swift_ast_context.GetImplicitImports(sc, process_sp, additional_imports,
-                                            implicit_import_error)) {
+  m_swift_ast_ctx.LoadImplicitModules(m_sc.target_sp, process_sp, *m_exe_scope);
+  if (!m_swift_ast_ctx.GetImplicitImports(m_sc, process_sp, additional_imports,
+                                          implicit_import_error)) {
     const char *msg = implicit_import_error.AsCString();
     if (!msg)
       msg = "error status positive, but import still failed";
@@ -1352,8 +1314,8 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     importInfo.AdditionalImports.emplace_back(attributed_import);
 
   auto module_id = ast_context->getIdentifier(expr_name_buf);
-  auto &module = *swift::ModuleDecl::create(module_id, **ast_context,
-                                            importInfo);
+  auto &module =
+      *swift::ModuleDecl::create(module_id, **ast_context, importInfo);
 
   swift::SourceFileKind source_file_kind = swift::SourceFileKind::Library;
   if (playground || repl) {
@@ -1374,34 +1336,34 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   // compiler startup, and we should dlopen anything that's been
   // stuffed on there and hope it will be useful later on.
   if (repl) {
-    lldb::StackFrameSP this_frame_sp(stack_frame_wp.lock());
+    lldb::StackFrameSP this_frame_sp(m_stack_frame_wp.lock());
 
     if (this_frame_sp) {
       lldb::ProcessSP process_sp(this_frame_sp->CalculateProcess());
       if (process_sp) {
         Status error;
-        swift_ast_context.LoadExtraDylibs(*process_sp.get(), error);
+        m_swift_ast_ctx.LoadExtraDylibs(*process_sp.get(), error);
       }
     }
   }
 
-  auto &invocation = swift_ast_context.GetCompilerInvocation();
+  auto &invocation = m_swift_ast_ctx.GetCompilerInvocation();
   invocation.getFrontendOptions().ModuleName = expr_name_buf;
   invocation.getIRGenOptions().ModuleName = expr_name_buf;
 
   bool enable_bare_slash_regex_literals =
-      sc.target_sp->GetSwiftEnableBareSlashRegex();
+      m_sc.target_sp->GetSwiftEnableBareSlashRegex();
   if (enable_bare_slash_regex_literals) {
     invocation.getLangOptions().enableFeature(
         swift::Feature::BareSlashRegexLiterals);
   }
-  if (uint32_t version = expr.Language().version) {
+  if (uint32_t version = m_expr.Language().version) {
     invocation.getLangOptions().EffectiveLanguageVersion =
         llvm::VersionTuple(version / 100, version % 100);
   }
 
   auto should_use_prestable_abi = [&]() {
-    lldb::StackFrameSP this_frame_sp(stack_frame_wp.lock());
+    lldb::StackFrameSP this_frame_sp(m_stack_frame_wp.lock());
     if (!this_frame_sp)
       return false;
     lldb::ProcessSP process_sp(this_frame_sp->CalculateProcess());
@@ -1415,18 +1377,18 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
       should_use_prestable_abi();
 
   LLDBNameLookup *external_lookup;
-  if (options.GetPlaygroundTransformEnabled() || options.GetREPLEnabled()) {
-    external_lookup = new LLDBREPLNameLookup(*source_file, variable_map, sc,
-                                             exe_scope);
+  if (m_options.GetPlaygroundTransformEnabled() || m_options.GetREPLEnabled()) {
+    external_lookup =
+        new LLDBREPLNameLookup(*source_file, variable_map, m_sc, *m_exe_scope);
   } else {
-    external_lookup = new LLDBExprNameLookup(*source_file, variable_map, sc,
-                                             exe_scope);
+    external_lookup =
+        new LLDBExprNameLookup(*source_file, variable_map, m_sc, *m_exe_scope);
   }
 
   // FIXME: This call is here just so that the we keep the
   //        DebuggerClients alive as long as the Module we are not
   //        inserting them in.
-  swift_ast_context.AddDebuggerClient(external_lookup);
+  m_swift_ast_ctx.AddDebuggerClient(external_lookup);
 
   if (expr_diagnostics.HasErrors())
     return make_error<SwiftASTContextError>();
@@ -1442,8 +1404,8 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
   if (repl || !playground) {
     code_manipulator = std::make_unique<SwiftASTManipulator>(
-        swift_ast_context, *source_file, sc, repl,
-        options.GetBindGenericTypes());
+        m_swift_ast_ctx, *source_file, m_sc, repl,
+        m_options.GetBindGenericTypes());
 
     if (!playground) {
       code_manipulator->RewriteResult();
@@ -1451,20 +1413,20 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   }
 
   if (!playground && !repl) {
-    lldb::StackFrameSP stack_frame_sp = stack_frame_wp.lock();
+    lldb::StackFrameSP stack_frame_sp = m_stack_frame_wp.lock();
 
     bool local_context_is_swift = true;
 
-    if (sc.block) {
-      Function *function = sc.block->CalculateSymbolContextFunction();
+    if (m_sc.block) {
+      Function *function = m_sc.block->CalculateSymbolContextFunction();
       if (function && function->GetLanguage() != lldb::eLanguageTypeSwift)
         local_context_is_swift = false;
     }
 
     if (local_context_is_swift) {
       llvm::Error error = AddRequiredAliases(
-          sc.block, stack_frame_sp, swift_ast_context, *code_manipulator,
-          options.GetUseDynamic(), options.GetBindGenericTypes());
+          m_sc.block, stack_frame_sp, m_swift_ast_ctx, *code_manipulator,
+          m_options.GetUseDynamic(), m_options.GetBindGenericTypes());
       if (error)
         return error;
     }
@@ -1477,13 +1439,13 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
 
     code_manipulator->FindSpecialNames(special_names, persistent_var_prefix);
 
-    ResolveSpecialNames(sc, exe_scope, swift_ast_context, special_names,
-                        local_variables);
+    ResolveSpecialNames(m_sc, *m_exe_scope, m_swift_ast_ctx, special_names,
+                        m_local_variables);
 
-    code_manipulator->AddExternalVariables(local_variables);
+    code_manipulator->AddExternalVariables(m_local_variables);
 
     auto type_aliases = AddArchetypeTypeAliases(
-        code_manipulator, *stack_frame_sp.get(), swift_ast_context);
+        code_manipulator, *stack_frame_sp.get(), m_swift_ast_ctx);
     if (!type_aliases)
       diagnostic_manager.PutString(eSeverityWarning,
                                    llvm::toString(type_aliases.takeError()));
@@ -1499,8 +1461,8 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
         IRExecutionUnit::GetLLVMGlobalContextMutex());
 
     Status auto_import_error;
-    if (!swift_ast_context.CacheUserImports(process_sp, *source_file,
-                                            auto_import_error)) {
+    if (!m_swift_ast_ctx.CacheUserImports(process_sp, *source_file,
+                                          auto_import_error)) {
       const char *msg = auto_import_error.AsCString();
       if (!msg) {
         // The import itself succeeded, but the AST context is in a
@@ -1741,9 +1703,8 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 
   // Parse the expression and import all nececssary swift modules.
   auto parsed_expr = ParseAndImport(
-      m_swift_ast_ctx, *expr_diagnostics, m_expr, variable_map, buffer_id,
-      diagnostic_manager, *this, m_stack_frame_wp, m_sc, *m_exe_scope,
-      m_local_variables, m_options, repl, playground);
+      *expr_diagnostics,  variable_map, buffer_id,
+      diagnostic_manager, repl, playground);
 
   if (!parsed_expr) {
     bool retry = false;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -792,7 +792,7 @@ static void ResolveSpecialNames(
 
 /// Initialize the SwiftASTContext and return the wrapped
 /// swift::ASTContext when successful.
-static swift::ASTContext *
+static ThreadSafeASTContext
 SetupASTContext(SwiftASTContextForExpressions &swift_ast_context,
                 DiagnosticManager &diagnostic_manager,
                 std::function<bool()> disable_objc_runtime, bool repl,
@@ -806,27 +806,27 @@ SetupASTContext(SwiftASTContextForExpressions &swift_ast_context,
     diagnostic_manager.PutString(eSeverityInfo,
                                  "Couldn't initialize Swift expression "
                                  "evaluator due to previous errors.");
-    return nullptr;
+    return ThreadSafeASTContext();
   }
 
   if (swift_ast_context.HasFatalErrors()) {
     diagnostic_manager.PutString(eSeverityError,
                                  "The AST context is in a fatal error state.");
-    return nullptr;
+    return ThreadSafeASTContext();
   }
 
-  swift::ASTContext *ast_context = swift_ast_context.GetASTContext();
+  ThreadSafeASTContext ast_context = swift_ast_context.GetASTContext();
   if (!ast_context) {
     diagnostic_manager.PutString(
         eSeverityError,
         "Couldn't initialize the AST context.  Please check your settings.");
-    return nullptr;
+    return ThreadSafeASTContext();
   }
 
   if (swift_ast_context.HasFatalErrors()) {
     diagnostic_manager.PutString(eSeverityError,
                                  "The AST context is in a fatal error state.");
-    return nullptr;
+    return ThreadSafeASTContext();
   }
 
   // TODO: Find a way to get contraint-solver output sent to a stream
@@ -1126,7 +1126,7 @@ char ModuleImportError::ID = 0;
 /// This holds the result of ParseAndImport.
 struct ParsedExpression {
   std::unique_ptr<SwiftASTManipulator> code_manipulator;
-  swift::ASTContext &ast_context;
+  ThreadSafeASTContext ast_context;
   swift::ModuleDecl &module;
   LLDBNameLookup &external_lookup;
   swift::SourceFile &source_file;
@@ -1293,7 +1293,7 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     return !ObjCLanguageRuntime::Get(*process_sp);
   };
 
-  swift::ASTContext *ast_context =
+  ThreadSafeASTContext ast_context =
       SetupASTContext(swift_ast_context, diagnostic_manager,
                       should_disable_objc_runtime, repl, playground);
   if (!ast_context)
@@ -1352,7 +1352,7 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
     importInfo.AdditionalImports.emplace_back(attributed_import);
 
   auto module_id = ast_context->getIdentifier(expr_name_buf);
-  auto &module = *swift::ModuleDecl::create(module_id, *ast_context,
+  auto &module = *swift::ModuleDecl::create(module_id, **ast_context,
                                             importInfo);
 
   swift::SourceFileKind source_file_kind = swift::SourceFileKind::Library;
@@ -1362,7 +1362,7 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
 
   // Create the source file. Note, we disable delayed parsing for the
   // swift expression parser.
-  swift::SourceFile *source_file = new (*ast_context)
+  swift::SourceFile *source_file = new (**ast_context)
       swift::SourceFile(module, source_file_kind, buffer_id,
                         swift::SourceFile::ParsingFlags::DisableDelayedBodies);
   module.addFile(*source_file);
@@ -1520,8 +1520,13 @@ static llvm::Expected<ParsedExpression> ParseAndImport(
   swift::verify(*source_file);
 
   ParsedExpression result = {
-    std::move(code_manipulator), *ast_context, module, *external_lookup,
-    *source_file, std::move(main_filename), /*buffer_id*/0,
+      std::move(code_manipulator),
+      std::move(ast_context),
+      module,
+      *external_lookup,
+      *source_file,
+      std::move(main_filename),
+      /*buffer_id*/ 0,
   };
   return std::move(result);
 }
@@ -2140,7 +2145,7 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // part of the parse from the staging area in the external lookup
   // object into the SwiftPersistentExpressionState.
   swift::ModuleDecl *module = &parsed_expr->module;
-  parsed_expr->ast_context.addLoadedModule(module);
+  parsed_expr->ast_context->addLoadedModule(module);
   m_swift_ast_ctx.CacheModule(module);
   if (m_sc.target_sp) {
     auto *persistent_state =

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -774,76 +774,79 @@ static void ResolveSpecialNames(
   }
 }
 
-/// Initialize the SwiftASTContext and return the wrapped
-/// swift::ASTContext when successful.
-ThreadSafeASTContext SwiftExpressionParser::SetupASTContext(
+ThreadSafeASTContext SwiftExpressionParser::GetASTContext(
     DiagnosticManager &diagnostic_manager,
     std::function<bool()> disable_objc_runtime, bool repl, bool playground) {
-  // Lazily get the clang importer if we can to make sure it exists in
-  // case we need it.
-  if (!m_swift_ast_ctx.GetClangImporter()) {
-    std::string swift_error =
-        m_swift_ast_ctx.GetFatalErrors().AsCString("error: unknown error.");
-    diagnostic_manager.PutString(eSeverityError, swift_error);
-    diagnostic_manager.PutString(eSeverityInfo,
-                                 "Couldn't initialize Swift expression "
-                                 "evaluator due to previous errors.");
-    return ThreadSafeASTContext();
-  }
+  llvm::call_once(m_ast_init_once_flag, [&] {
+    // Lazily get the clang importer if we can to make sure it exists in
+    // case we need it.
+    if (!m_swift_ast_ctx.GetClangImporter()) {
+      std::string swift_error =
+          m_swift_ast_ctx.GetFatalErrors().AsCString("error: unknown error.");
+      diagnostic_manager.PutString(eSeverityError, swift_error);
+      diagnostic_manager.PutString(eSeverityInfo,
+                                   "Couldn't initialize Swift expression "
+                                   "evaluator due to previous errors.");
+      return;
+    }
 
-  if (m_swift_ast_ctx.HasFatalErrors()) {
-    diagnostic_manager.PutString(eSeverityError,
-                                 "The AST context is in a fatal error state.");
-    return ThreadSafeASTContext();
-  }
+    if (m_swift_ast_ctx.HasFatalErrors()) {
+      diagnostic_manager.PutString(
+          eSeverityError, "The AST context is in a fatal error state.");
+      return;
+    }
 
-  ThreadSafeASTContext ast_context = m_swift_ast_ctx.GetASTContext();
-  if (!ast_context) {
-    diagnostic_manager.PutString(
-        eSeverityError,
-        "Couldn't initialize the AST context.  Please check your settings.");
-    return ThreadSafeASTContext();
-  }
+    ThreadSafeASTContext ast_context = m_swift_ast_ctx.GetASTContext();
+    if (!ast_context) {
+      diagnostic_manager.PutString(
+          eSeverityError,
+          "Couldn't initialize the AST context.  Please check your settings.");
+      return;
+    }
 
-  if (m_swift_ast_ctx.HasFatalErrors()) {
-    diagnostic_manager.PutString(eSeverityError,
-                                 "The AST context is in a fatal error state.");
-    return ThreadSafeASTContext();
-  }
+    if (m_swift_ast_ctx.HasFatalErrors()) {
+      diagnostic_manager.PutString(
+          eSeverityError, "The AST context is in a fatal error state.");
+      return;
+    }
 
-  // TODO: Find a way to get contraint-solver output sent to a stream
-  //       so we can log it.
-  // swift_ast_context.GetLanguageOptions().DebugConstraintSolver = true;
+    // TODO: Find a way to get contraint-solver output sent to a stream
+    //       so we can log it.
+    // swift_ast_context.GetLanguageOptions().DebugConstraintSolver = true;
 
-  // No longer part of debugger support, set it separately.
-  m_swift_ast_ctx.GetLanguageOptions().EnableDollarIdentifiers = true;
-  m_swift_ast_ctx.GetLanguageOptions().EnableAccessControl =
-      (repl || playground);
-  m_swift_ast_ctx.GetLanguageOptions().EnableTargetOSChecking = false;
+    // No longer part of debugger support, set it separately.
+    m_swift_ast_ctx.GetLanguageOptions().EnableDollarIdentifiers = true;
+    m_swift_ast_ctx.GetLanguageOptions().EnableAccessControl =
+        (repl || playground);
+    m_swift_ast_ctx.GetLanguageOptions().EnableTargetOSChecking = false;
 
-  if (disable_objc_runtime())
-    m_swift_ast_ctx.GetLanguageOptions().EnableObjCInterop = false;
+    if (disable_objc_runtime())
+      m_swift_ast_ctx.GetLanguageOptions().EnableObjCInterop = false;
 
-  m_swift_ast_ctx.GetLanguageOptions().Playground = repl || playground;
-  m_swift_ast_ctx.GetIRGenOptions().Playground = repl || playground;
+    m_swift_ast_ctx.GetLanguageOptions().Playground = repl || playground;
+    m_swift_ast_ctx.GetIRGenOptions().Playground = repl || playground;
 
-  // For the expression parser and REPL we want to relax the
-  // requirement that you put "try" in front of every expression that
-  // might throw.
-  if (repl || !playground)
-    m_swift_ast_ctx.GetLanguageOptions().EnableThrowWithoutTry = true;
+    // For the expression parser and REPL we want to relax the
+    // requirement that you put "try" in front of every expression that
+    // might throw.
+    if (repl || !playground)
+      m_swift_ast_ctx.GetLanguageOptions().EnableThrowWithoutTry = true;
 
-  m_swift_ast_ctx.GetIRGenOptions().OutputKind =
-      swift::IRGenOutputKind::Module;
-  m_swift_ast_ctx.GetIRGenOptions().OptMode =
-      swift::OptimizationMode::NoOptimization;
-  // Normally we'd like to verify, but unfortunately the verifier's
-  // error mode is abort().
-  m_swift_ast_ctx.GetIRGenOptions().Verify = false;
-  m_swift_ast_ctx.GetIRGenOptions().ForcePublicLinkage = true;
+    m_swift_ast_ctx.GetIRGenOptions().OutputKind =
+        swift::IRGenOutputKind::Module;
+    m_swift_ast_ctx.GetIRGenOptions().OptMode =
+        swift::OptimizationMode::NoOptimization;
+    // Normally we'd like to verify, but unfortunately the verifier's
+    // error mode is abort().
+    m_swift_ast_ctx.GetIRGenOptions().Verify = false;
+    m_swift_ast_ctx.GetIRGenOptions().ForcePublicLinkage = true;
 
-  m_swift_ast_ctx.GetIRGenOptions().DisableRoundTripDebugTypes = true;
-  return ast_context;
+    m_swift_ast_ctx.GetIRGenOptions().DisableRoundTripDebugTypes = true;
+    m_ast_init_successful = true;
+  });
+  if (m_ast_init_successful)
+    return m_swift_ast_ctx.GetASTContext();
+  return ThreadSafeASTContext();
 }
 
 /// Returns the buffer_id for the expression's source code.
@@ -1256,7 +1259,7 @@ SwiftExpressionParser::ParseAndImport(
     return !ObjCLanguageRuntime::Get(*process_sp);
   };
 
-  ThreadSafeASTContext ast_context = SetupASTContext(
+  ThreadSafeASTContext ast_context = GetASTContext(
       diagnostic_manager, should_disable_objc_runtime, repl, playground);
   if (!ast_context)
     return make_error<SwiftASTContextError>();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -185,7 +185,6 @@ private:
   /// This holds the result of ParseAndImport.
   struct ParsedExpression {
     std::unique_ptr<SwiftASTManipulator> code_manipulator;
-    ThreadSafeASTContext ast_context;
     swift::ModuleDecl &module;
     LLDBNameLookup &external_lookup;
     swift::SourceFile &source_file;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -201,10 +201,11 @@ private:
                  unsigned &buffer_id, DiagnosticManager &diagnostic_manager,
                  bool repl, bool playground);
 
-  ThreadSafeASTContext
-  SetupASTContext(DiagnosticManager &diagnostic_manager,
-                  std::function<bool()> disable_objc_runtime, bool repl,
-                  bool playground);
+  /// Initialize the SwiftASTContext and return the wrapped
+  /// ThreadSafeASTContext when successful.
+  ThreadSafeASTContext GetASTContext(DiagnosticManager &diagnostic_manager,
+                                     std::function<bool()> disable_objc_runtime,
+                                     bool repl, bool playground);
 
   /// The expression to be parsed.
   Expression &m_expr;
@@ -234,6 +235,12 @@ private:
 
   /// Indicates whether the call to Parse of this type is cacheable.
   bool m_is_cacheable;
+
+  /// Once token to initialize the swift::ASTContext.
+  llvm::once_flag m_ast_init_once_flag;
+
+  /// Indicates if the ThreadSafeASTContext was initialized correctly.
+  bool m_ast_init_successful;
 };
 
 class LLDBNameLookup : public swift::SILDebuggerClient {

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -198,14 +198,11 @@ private:
   llvm::Expected<ParsedExpression>
   ParseAndImport(SwiftASTContext::ScopedDiagnostics &expr_diagnostics,
                  SwiftExpressionParser::SILVariableMap &variable_map,
-                 unsigned &buffer_id, DiagnosticManager &diagnostic_manager,
-                 bool repl, bool playground);
+                 unsigned &buffer_id, DiagnosticManager &diagnostic_manager);
 
   /// Initialize the SwiftASTContext and return the wrapped
   /// ThreadSafeASTContext when successful.
-  ThreadSafeASTContext GetASTContext(DiagnosticManager &diagnostic_manager,
-                                     std::function<bool()> disable_objc_runtime,
-                                     bool repl, bool playground);
+  ThreadSafeASTContext GetASTContext(DiagnosticManager &diagnostic_manager);
 
   /// The expression to be parsed.
   Expression &m_expr;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -13,9 +13,11 @@
 #ifndef liblldb_SwiftExpressionParser_h_
 #define liblldb_SwiftExpressionParser_h_
 
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "SwiftASTManipulator.h"
 
 #include "Plugins/ExpressionParser/Clang/IRForTarget.h"
+#include "SwiftPersistentExpressionState.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Expression/ExpressionParser.h"
@@ -24,6 +26,7 @@
 #include "lldb/Target/Target.h"
 #include "lldb/lldb-public.h"
 
+#include "swift/SIL/SILDebuggerClient.h"
 #include <string>
 #include <vector>
 
@@ -31,6 +34,7 @@ namespace lldb_private {
 
 class IRExecutionUnit;
 class SwiftLanguageRuntime;
+class LLDBNameLookup;
 //----------------------------------------------------------------------
 /// @class SwiftExpressionParser SwiftExpressionParser.h
 /// "lldb/Expression/SwiftExpressionParser.h"
@@ -178,6 +182,30 @@ public:
   typedef std::map<const char *, SILVariableInfo> SILVariableMap;
 
 private:
+  /// This holds the result of ParseAndImport.
+  struct ParsedExpression {
+    std::unique_ptr<SwiftASTManipulator> code_manipulator;
+    ThreadSafeASTContext ast_context;
+    swift::ModuleDecl &module;
+    LLDBNameLookup &external_lookup;
+    swift::SourceFile &source_file;
+    std::string main_filename;
+    unsigned buffer_id;
+  };
+
+  /// Attempt to parse an expression and import all the Swift modules
+  /// the expression and its context depend on.
+  llvm::Expected<ParsedExpression>
+  ParseAndImport(SwiftASTContext::ScopedDiagnostics &expr_diagnostics,
+                 SwiftExpressionParser::SILVariableMap &variable_map,
+                 unsigned &buffer_id, DiagnosticManager &diagnostic_manager,
+                 bool repl, bool playground);
+
+  ThreadSafeASTContext
+  SetupASTContext(DiagnosticManager &diagnostic_manager,
+                  std::function<bool()> disable_objc_runtime, bool repl,
+                  bool playground);
+
   /// The expression to be parsed.
   Expression &m_expr;
   /// The context to use for IR generation.
@@ -207,6 +235,34 @@ private:
   /// Indicates whether the call to Parse of this type is cacheable.
   bool m_is_cacheable;
 };
+
+class LLDBNameLookup : public swift::SILDebuggerClient {
+public:
+  LLDBNameLookup(swift::SourceFile &source_file,
+                 SwiftExpressionParser::SILVariableMap &variable_map,
+                 SymbolContext &sc, ExecutionContextScope &exe_scope);
+
+  swift::SILValue emitLValueForVariable(swift::VarDecl *var,
+                                        swift::SILBuilder &builder) override;
+
+  SwiftPersistentExpressionState::SwiftDeclMap &GetStagedDecls();
+
+  void RegisterTypeAliases(
+      llvm::SmallVectorImpl<swift::TypeAliasDecl *> &type_aliases);
+
+protected:
+  Log *m_log;
+  swift::SourceFile &m_source_file;
+  SwiftExpressionParser::SILVariableMap &m_variable_map;
+  SymbolContext m_sc;
+  SwiftPersistentExpressionState *m_persistent_vars = nullptr;
+
+  // Subclasses stage globalized decls in this map. They get copied
+  // over to the SwiftPersistentVariable store if the parse succeeds.
+  SwiftPersistentExpressionState::SwiftDeclMap m_staged_decls;
+  llvm::SmallVector<swift::TypeAliasDecl *> m_type_aliases;
+};
+
 } // namespace lldb_private
 
 #endif // liblldb_SwiftExpressionParser_h_

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -574,7 +574,7 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
   SwiftASTContextForExpressions *swift_ast = m_swift_ast;
 
   if (swift_ast) {
-    swift::ASTContext *ast = swift_ast->GetASTContext();
+    ThreadSafeASTContext ast = swift_ast->GetASTContext();
     swift::REPLCompletions completions;
     SourceModule completion_module_info;
     completion_module_info.path.push_back(ConstString("repl"));
@@ -587,7 +587,7 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
       repl_module = swift_ast->CreateModule(completion_module_info, error,
                                             importInfo);
       std::optional<unsigned> bufferID;
-      swift::SourceFile *repl_source_file = new (*ast) swift::SourceFile(
+      swift::SourceFile *repl_source_file = new (**ast) swift::SourceFile(
           *repl_module, swift::SourceFileKind::Main, bufferID);
       repl_module->addFile(*repl_source_file);
       swift::performImportResolution(*repl_source_file);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -378,7 +378,7 @@ static llvm::Error AddVariableInfo(
       ss.flush();
       log->Printf("Adding injected self: type (%p) context(%p) is: %s",
                   static_cast<void *>(swift_type.getPointer()),
-                  static_cast<void *>(ast_context.GetASTContext()), s.c_str());
+                  static_cast<void *>(*ast_context.GetASTContext()), s.c_str());
     }
   // A one-off clone of variable_sp with the type replaced by target_type.
   auto patched_variable_sp = std::make_shared<lldb_private::Variable>(

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -150,7 +150,8 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
     }
   };
 
-  MyConsumer consumer(swift::ObjCSelector(*ctx->GetASTContext(), numArguments,
+  ThreadSafeASTContext ast_ctx = ctx->GetASTContext();
+  MyConsumer consumer(swift::ObjCSelector(**ast_ctx, numArguments,
                                           selectorIdentifiers));
   // FIXME(mracek): Switch to a new API that translates the Clang class name
   // to Swift class name, once this API exists. Now we assume they are the same.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
@@ -1,0 +1,39 @@
+//===----------------- LockGuarded.h ----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_SwiftLockGuarded_h_
+#define liblldb_SwiftLockGuarded_h_
+
+#include <mutex>
+
+namespace lldb_private {
+/// A generic wrapper around a resource which holds a lock to ensure
+/// exclusive access.
+template <typename Resource> struct LockGuarded {
+  LockGuarded(Resource *resource, std::recursive_mutex &mutex)
+      : m_resource(resource), m_lock(mutex, std::adopt_lock) {}
+
+  LockGuarded() = default;
+
+  Resource *operator->() const { return m_resource; }
+
+  Resource *operator*() const { return m_resource; }
+
+  operator bool() const { return m_resource != nullptr; }
+
+private:
+  Resource *m_resource;
+  std::unique_lock<std::recursive_mutex> m_lock;
+};
+
+} // namespace lldb_private
+#endif

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -235,7 +235,7 @@ public:
 
   ThreadSafeReflectionContext GetReflectionContext() {
     STUB_LOG();
-    return ThreadSafeReflectionContext::MakeInvalid();
+    return ThreadSafeReflectionContext();
   }
 
   bool GetDynamicTypeAndAddress(ValueObject &in_value,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -51,11 +51,14 @@ class TypeBase;
 } // namespace swift
 
 namespace lldb_private {
-struct ThreadSafeReflectionContext;
+template <typename T>
+struct LockGuarded;
 
 class SwiftLanguageRuntimeStub;
 class SwiftLanguageRuntimeImpl;
 class ReflectionContextInterface;
+
+using ThreadSafeReflectionContext = LockGuarded<ReflectionContextInterface>;
 
 class SwiftLanguageRuntime : public LanguageRuntime {
 protected:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -278,18 +278,18 @@ typedef std::shared_ptr<SwiftEnumDescriptor> SwiftEnumDescriptorSP;
 typedef llvm::DenseMap<opaque_compiler_type_t, SwiftEnumDescriptorSP>
     EnumInfoCache;
 typedef std::shared_ptr<EnumInfoCache> EnumInfoCacheSP;
-typedef llvm::DenseMap<const swift::ASTContext *, EnumInfoCacheSP>
+typedef llvm::DenseMap<const SwiftASTContext *, EnumInfoCacheSP>
     ASTEnumInfoCacheMap;
 
-static EnumInfoCache *GetEnumInfoCache(const swift::ASTContext *a) {
+static EnumInfoCache *GetEnumInfoCache(const SwiftASTContext *swift_ast_ctx) {
   static ASTEnumInfoCacheMap g_cache;
   static std::mutex g_mutex;
   std::lock_guard<std::mutex> locker(g_mutex);
-  ASTEnumInfoCacheMap::iterator pos = g_cache.find(a);
+  ASTEnumInfoCacheMap::iterator pos = g_cache.find(swift_ast_ctx);
   if (pos == g_cache.end()) {
-    g_cache.insert(
-        std::make_pair(a, std::shared_ptr<EnumInfoCache>(new EnumInfoCache())));
-    return g_cache.find(a)->second.get();
+    g_cache.insert(std::make_pair(
+        swift_ast_ctx, std::shared_ptr<EnumInfoCache>(new EnumInfoCache())));
+    return g_cache.find(swift_ast_ctx)->second.get();
   }
   return pos->second.get();
 }
@@ -357,12 +357,12 @@ public:
 
   virtual ~SwiftEnumDescriptor() = default;
 
-  static SwiftEnumDescriptor *CreateDescriptor(swift::ASTContext *ast,
+  static SwiftEnumDescriptor *CreateDescriptor(SwiftASTContext *swift_ast_ctx,
                                                swift::CanType swift_can_type,
                                                swift::EnumDecl *enum_decl);
 
 protected:
-  SwiftEnumDescriptor(swift::ASTContext *ast, swift::CanType swift_can_type,
+  SwiftEnumDescriptor(swift::CanType swift_can_type,
                       swift::EnumDecl *enum_decl, SwiftEnumDescriptor::Kind k)
       : m_kind(k), m_type_name() {
     if (swift_can_type.getPointer()) {
@@ -381,10 +381,9 @@ private:
 
 class SwiftEmptyEnumDescriptor : public SwiftEnumDescriptor {
 public:
-  SwiftEmptyEnumDescriptor(swift::ASTContext *ast,
-                           swift::CanType swift_can_type,
+  SwiftEmptyEnumDescriptor(swift::CanType swift_can_type,
                            swift::EnumDecl *enum_decl)
-      : SwiftEnumDescriptor(ast, swift_can_type, enum_decl,
+      : SwiftEnumDescriptor(swift_can_type, enum_decl,
                             SwiftEnumDescriptor::Kind::Empty) {}
 
   ElementInfo *GetElementFromData(const lldb_private::DataExtractor &data,
@@ -445,18 +444,15 @@ class SwiftCStyleEnumDescriptor : public SwiftEnumDescriptor {
   llvm::SmallString<32> m_description = {"SwiftCStyleEnumDescriptor"};
 
 public:
-  SwiftCStyleEnumDescriptor(swift::ASTContext *ast,
+  SwiftCStyleEnumDescriptor(SwiftASTContext *swift_ast_ctx,
                             swift::CanType swift_can_type,
                             swift::EnumDecl *enum_decl)
-      : SwiftEnumDescriptor(ast, swift_can_type, enum_decl,
+      : SwiftEnumDescriptor(swift_can_type, enum_decl,
                             SwiftEnumDescriptor::Kind::CStyle),
         m_nopayload_elems_bitmask(), m_elements(), m_element_indexes() {
     LOG_PRINTF(GetLog(LLDBLog::Types), "doing C-style enum layout for %s",
                GetTypeName().AsCString());
 
-    SwiftASTContext *swift_ast_ctx = SwiftASTContext::GetSwiftASTContext(ast);
-    if (!swift_ast_ctx)
-      return;
     swift::irgen::IRGenModule &irgen_module = swift_ast_ctx->GetIRGenModule();
     const swift::irgen::EnumImplStrategy &enum_impl_strategy =
         swift::irgen::getEnumImplStrategy(irgen_module, swift_can_type);
@@ -587,15 +583,14 @@ class SwiftAllPayloadEnumDescriptor : public SwiftEnumDescriptor {
   llvm::SmallString<32> m_description = {"SwiftAllPayloadEnumDescriptor"};
 
 public:
-  SwiftAllPayloadEnumDescriptor(swift::ASTContext *ast,
+  SwiftAllPayloadEnumDescriptor(SwiftASTContext *swift_ast_ctx,
                                 swift::CanType swift_can_type,
                                 swift::EnumDecl *enum_decl)
-      : SwiftEnumDescriptor(ast, swift_can_type, enum_decl,
+      : SwiftEnumDescriptor(swift_can_type, enum_decl,
                             SwiftEnumDescriptor::Kind::AllPayload) {
     LOG_PRINTF(GetLog(LLDBLog::Types), "doing ADT-style enum layout for %s",
                GetTypeName().AsCString());
 
-    SwiftASTContext *swift_ast_ctx = SwiftASTContext::GetSwiftASTContext(ast);
     swift::irgen::IRGenModule &irgen_module = swift_ast_ctx->GetIRGenModule();
     const swift::irgen::EnumImplStrategy &enum_impl_strategy =
         swift::irgen::getEnumImplStrategy(irgen_module, swift_can_type);
@@ -730,13 +725,13 @@ private:
 
 class SwiftMixedEnumDescriptor : public SwiftEnumDescriptor {
 public:
-  SwiftMixedEnumDescriptor(swift::ASTContext *ast,
+  SwiftMixedEnumDescriptor(SwiftASTContext *swift_ast_ctx,
                            swift::CanType swift_can_type,
                            swift::EnumDecl *enum_decl)
-      : SwiftEnumDescriptor(ast, swift_can_type, enum_decl,
+      : SwiftEnumDescriptor(swift_can_type, enum_decl,
                             SwiftEnumDescriptor::Kind::Mixed),
-        m_non_payload_cases(ast, swift_can_type, enum_decl),
-        m_payload_cases(ast, swift_can_type, enum_decl) {}
+        m_non_payload_cases(swift_ast_ctx, swift_can_type, enum_decl),
+        m_payload_cases(swift_ast_ctx, swift_can_type, enum_decl) {}
 
   ElementInfo *GetElementFromData(const lldb_private::DataExtractor &data,
                                   bool no_payload) override {
@@ -775,10 +770,9 @@ class SwiftResilientEnumDescriptor : public SwiftEnumDescriptor {
   llvm::SmallString<32> m_description = {"SwiftResilientEnumDescriptor"};
 
 public:
-  SwiftResilientEnumDescriptor(swift::ASTContext *ast,
-                               swift::CanType swift_can_type,
+  SwiftResilientEnumDescriptor(swift::CanType swift_can_type,
                                swift::EnumDecl *enum_decl)
-      : SwiftEnumDescriptor(ast, swift_can_type, enum_decl,
+      : SwiftEnumDescriptor(swift_can_type, enum_decl,
                             SwiftEnumDescriptor::Kind::Resilient) {
     LOG_PRINTF(GetLog(LLDBLog::Types), "doing resilient enum layout for %s",
                GetTypeName().AsCString());
@@ -803,13 +797,12 @@ public:
 };
 
 SwiftEnumDescriptor *
-SwiftEnumDescriptor::CreateDescriptor(swift::ASTContext *ast,
+SwiftEnumDescriptor::CreateDescriptor(SwiftASTContext *swift_ast_ctx,
                                       swift::CanType swift_can_type,
                                       swift::EnumDecl *enum_decl) {
-  assert(ast);
+  assert(swift_ast_ctx);
   assert(enum_decl);
   assert(swift_can_type.getPointer());
-  SwiftASTContext *swift_ast_ctx = SwiftASTContext::GetSwiftASTContext(ast);
   assert(swift_ast_ctx);
   swift::irgen::IRGenModule &irgen_module = swift_ast_ctx->GetIRGenModule();
   const swift::irgen::EnumImplStrategy &enum_impl_strategy =
@@ -820,32 +813,35 @@ SwiftEnumDescriptor::CreateDescriptor(swift::ASTContext *ast,
       elements_with_no_payload = enum_impl_strategy.getElementsWithNoPayload();
   swift::SILType swift_sil_type = irgen_module.getLoweredType(swift_can_type);
   if (!irgen_module.getTypeInfo(swift_sil_type).isFixedSize())
-    return new SwiftResilientEnumDescriptor(ast, swift_can_type, enum_decl);
+    return new SwiftResilientEnumDescriptor(swift_can_type, enum_decl);
   if (elements_with_no_payload.size() == 0) {
     // Nothing with no payload.. empty or all payloads?
     if (elements_with_payload.size() == 0)
-      return new SwiftEmptyEnumDescriptor(ast, swift_can_type, enum_decl);
-    return new SwiftAllPayloadEnumDescriptor(ast, swift_can_type, enum_decl);
+      return new SwiftEmptyEnumDescriptor(swift_can_type, enum_decl);
+    return new SwiftAllPayloadEnumDescriptor(swift_ast_ctx, swift_can_type,
+                                             enum_decl);
   }
 
   // Something with no payload.. mixed or C-style?
   if (elements_with_payload.size() == 0)
-    return new SwiftCStyleEnumDescriptor(ast, swift_can_type, enum_decl);
-  return new SwiftMixedEnumDescriptor(ast, swift_can_type, enum_decl);
+    return new SwiftCStyleEnumDescriptor(swift_ast_ctx, swift_can_type,
+                                         enum_decl);
+  return new SwiftMixedEnumDescriptor(swift_ast_ctx, swift_can_type, enum_decl);
 }
 
 static SwiftEnumDescriptor *
-GetEnumInfoFromEnumDecl(swift::ASTContext *ast, swift::CanType swift_can_type,
+GetEnumInfoFromEnumDecl(SwiftASTContext *swift_ast_ctx,
+                        swift::CanType swift_can_type,
                         swift::EnumDecl *enum_decl) {
-  return SwiftEnumDescriptor::CreateDescriptor(ast, swift_can_type, enum_decl);
+  return SwiftEnumDescriptor::CreateDescriptor(swift_ast_ctx, swift_can_type,
+                                               enum_decl);
 }
 
 SwiftEnumDescriptor *
 SwiftASTContext::GetCachedEnumInfo(opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, nullptr);
 
-  ThreadSafeASTContext ast_ctx = GetASTContext();
-  EnumInfoCache *enum_info_cache = GetEnumInfoCache(*ast_ctx);
+  EnumInfoCache *enum_info_cache = GetEnumInfoCache(this);
   EnumInfoCache::const_iterator pos = enum_info_cache->find(type);
   if (pos != enum_info_cache->end())
     return pos->second.get();
@@ -856,11 +852,11 @@ SwiftASTContext::GetCachedEnumInfo(opaque_compiler_type_t type) {
   SwiftEnumDescriptorSP enum_info_sp;
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
   if (auto *enum_type = swift_can_type->getAs<swift::EnumType>()) {
-    enum_info_sp.reset(GetEnumInfoFromEnumDecl(*ast_ctx, swift_can_type,
+    enum_info_sp.reset(GetEnumInfoFromEnumDecl(this, swift_can_type,
                                                enum_type->getDecl()));
   } else if (auto *bound_enum_type =
                  swift_can_type->getAs<swift::BoundGenericEnumType>()) {
-    enum_info_sp.reset(GetEnumInfoFromEnumDecl(*ast_ctx, swift_can_type,
+    enum_info_sp.reset(GetEnumInfoFromEnumDecl(this, swift_can_type,
                                                bound_enum_type->getDecl()));
   }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4845,8 +4845,7 @@ CompilerType SwiftASTContext::GetAnyObjectType() {
   return ToCompilerType({ast->getAnyObjectType()});
 }
 
-static CompilerType ValueDeclToType(swift::ValueDecl *decl,
-                                    swift::ASTContext *ast) {
+static CompilerType ValueDeclToType(swift::ValueDecl *decl) {
   if (decl) {
     switch (decl->getKind()) {
     case swift::DeclKind::TypeAlias: {
@@ -4875,15 +4874,14 @@ static CompilerType ValueDeclToType(swift::ValueDecl *decl,
   return CompilerType();
 }
 
-static CompilerType DeclToType(swift::Decl *decl, swift::ASTContext *ast) {
+static CompilerType DeclToType(swift::Decl *decl) {
   if (swift::ValueDecl *value_decl =
           swift::dyn_cast_or_null<swift::ValueDecl>(decl))
-    return ValueDeclToType(value_decl, ast);
+    return ValueDeclToType(value_decl);
   return {};
 }
 
-static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::ASTContext *ast,
-                                                    swift::Decl *decl) {
+static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::Decl *decl) {
   if (decl) {
     switch (decl->getKind()) {
     case swift::DeclKind::BuiltinTuple:
@@ -4963,12 +4961,10 @@ SwiftASTContext::FindContainedTypeOrDecl(llvm::StringRef name,
 
   CompilerType container_type = container_type_or_decl.Apply<CompilerType>(
       [](CompilerType type) -> CompilerType { return type; },
-      [this](swift::Decl *decl) -> CompilerType {
-        ThreadSafeASTContext ast_ctx = GetASTContext();
-        return DeclToType(decl, *ast_ctx);
+      [](swift::Decl *decl) -> CompilerType {
+        return DeclToType(decl);
       });
 
-  ThreadSafeASTContext ast_ctx = GetASTContext();
   if (!name.empty() &&
       container_type.GetTypeSystem().isa_and_nonnull<TypeSystemSwift>()) {
     swift::Type swift_type = GetSwiftTypeIgnoringErrors(container_type);
@@ -4983,7 +4979,7 @@ SwiftASTContext::FindContainedTypeOrDecl(llvm::StringRef name,
     llvm::ArrayRef<swift::ValueDecl *> decls = nominal_decl->lookupDirect(
         swift::DeclName(m_ast_context_ap->getIdentifier(name)));
     for (auto *decl : decls)
-      results.emplace(DeclToTypeOrDecl(*ast_ctx, decl));
+      results.emplace(DeclToTypeOrDecl(decl));
   }
   return results.size() - size_before;
 }
@@ -5060,7 +5056,6 @@ size_t SwiftASTContext::FindTypesOrDecls(const char *name,
 
   size_t before = results.size();
 
-  ThreadSafeASTContext ast_ctx = GetASTContext();
   if (name && name[0] && swift_module) {
     llvm::SmallVector<swift::ValueDecl *, 4> value_decls;
     swift::Identifier identifier(GetIdentifier(llvm::StringRef(name)));
@@ -5072,19 +5067,19 @@ size_t SwiftASTContext::FindTypesOrDecls(const char *name,
                                 value_decls);
     if (identifier.isOperator()) {
       if (auto *op = swift_module->lookupPrefixOperator(identifier))
-        results.emplace(DeclToTypeOrDecl(*ast_ctx, op));
+        results.emplace(DeclToTypeOrDecl(op));
 
       if (auto *op = swift_module->lookupInfixOperator(identifier).getSingle())
-        results.emplace(DeclToTypeOrDecl(*ast_ctx, op));
+        results.emplace(DeclToTypeOrDecl(op));
 
       if (auto *op = swift_module->lookupPostfixOperator(identifier))
-        results.emplace(DeclToTypeOrDecl(*ast_ctx, op));
+        results.emplace(DeclToTypeOrDecl(op));
     }
     if (auto *pg = swift_module->lookupPrecedenceGroup(identifier).getSingle())
-      results.emplace(DeclToTypeOrDecl(*ast_ctx, pg));
+      results.emplace(DeclToTypeOrDecl(pg));
 
     for (auto *decl : value_decls)
-      results.emplace(DeclToTypeOrDecl(*ast_ctx, decl));
+      results.emplace(DeclToTypeOrDecl(decl));
   }
 
   return results.size() - before;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -13,6 +13,7 @@
 #ifndef liblldb_SwiftASTContext_h_
 #define liblldb_SwiftASTContext_h_
 
+#include "Plugins/LanguageRuntime/Swift/LockGuarded.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 
@@ -120,6 +121,8 @@ template <> struct hash<lldb_private::detail::SwiftLibraryLookupRequest> {
 } // end namespace std
 
 namespace lldb_private {
+
+using ThreadSafeASTContext = LockGuarded<swift::ASTContext>;
 
 /// This "middle" class between TypeSystemSwiftTypeRef and
 /// SwiftASTContextForExpressions will eventually go away, as more and
@@ -257,7 +260,7 @@ public:
 
   swift::SILOptions &GetSILOptions();
 
-  swift::ASTContext *GetASTContext();
+  ThreadSafeASTContext GetASTContext();
 
   swift::IRGenDebugInfoLevel GetGenerateDebugInfo();
 
@@ -913,6 +916,7 @@ protected:
   // CompilerInvocation, SourceMgr, and DiagEngine must come before
   // the ASTContext, so they get deallocated *after* the ASTContext.
   std::unique_ptr<swift::ASTContext> m_ast_context_ap;
+  std::recursive_mutex m_ast_context_mutex;
   std::unique_ptr<llvm::TargetOptions> m_target_options_ap;
   std::unique_ptr<swift::irgen::IRGenerator> m_ir_generator_ap;
   std::unique_ptr<swift::irgen::IRGenModule> m_ir_gen_module_ap;


### PR DESCRIPTION
swift::ASTContext is not thread safe by default, wrap SwiftASTContext's swift::ASTContext in a LockGuarded.

rdar://121409294