### PR TITLE
[lldb] Support reconstructing types compiled with a different abi name

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1959,8 +1959,14 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
         auto var_info = MaterializeVariable(
             variable, swift_expr, *materializer, *parsed_expr->code_manipulator,
             m_stack_frame_wp, diagnostic_manager, log, repl);
-        if (!var_info)
+        if (!var_info) {
+          auto error_string = llvm::toString(var_info.takeError());
+          LLDB_LOG(log, "Variable info failzed to materialize with error: {0}",
+              error_string);
+                    
+
           return ParseResult::unrecoverable_error;
+        }
 
         const char *name = ConstString(variable.GetName().get()).GetCString();
         variable_map[name] = *var_info;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3768,6 +3768,29 @@ void SwiftASTContext::CacheModule(swift::ModuleDecl *module) {
   m_swift_module_cache.insert({ID, module});
 }
 
+void SwiftASTContext::RegisterModuleABINameToRealName(
+    swift::ModuleDecl *module) {
+  if (module->getABIName() == module->getName())
+    return;
+
+  // Ignore _Concurrency, which is hardcoded in the compiler and should be
+  // looked up using its ABI name "Swift"
+  if (module->getName().str() == swift::SWIFT_CONCURRENCY_NAME)
+    return;
+
+  // Also ignore modules with the special "Compiler" prefix.
+  if (module->getABIName().str().starts_with(
+          swift::SWIFT_MODULE_ABI_NAME_PREFIX))
+    return;
+
+  LOG_PRINTF(GetLog(LLDBLog::Types),
+             "Mapping module ABI name \"%s\" to its regular name \"%s\"",
+             module->getABIName().str().str().c_str(),
+             module->getName().str().str().c_str());
+  m_module_abi_to_regular_name.insert({module->getABIName().str(),
+                                      module->getName().str()});
+}
+
 swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
                                               Status &error, bool *cached) {
   if (cached)
@@ -3877,6 +3900,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
              module.path.front().GetCString(),
              module_decl->getName().str().str().c_str());
 
+  RegisterModuleABINameToRealName(module_decl);
   m_swift_module_cache[module.path.front().GetStringRef()] = module_decl;
   return module_decl;
 }
@@ -3931,6 +3955,7 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const FileSpec &module_spec,
                    module_spec.GetPath().c_str(),
                    module->getName().str().str().c_str());
 
+        RegisterModuleABINameToRealName(module);
         m_swift_module_cache[module_basename.GetCString()] = module;
         return module;
       } else {
@@ -4599,7 +4624,7 @@ SwiftASTContext::ReconstructTypeOrWarn(ConstString mangled_typename) {
 }
 
 llvm::Expected<swift::TypeBase *>
-SwiftASTContext::ReconstructType(ConstString mangled_typename) {
+SwiftASTContext::ReconstructTypeImpl(ConstString mangled_typename) {
   VALID_OR_RETURN(nullptr);
 
   const char *mangled_cstr = mangled_typename.AsCString();
@@ -4707,6 +4732,43 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
                                  "type for typename \"" +
                                      mangled_typename.GetString() +
                                      "\" was not found");
+}
+
+llvm::Expected<swift::TypeBase *>
+SwiftASTContext::ReconstructType(ConstString mangled_typename) {
+  VALID_OR_RETURN(nullptr);
+
+  // Mangled names are encoded with the ABI module name in debug info, but with
+  // the regular module name in the swift module. When reconstructing these
+  // types, SwiftASTContext must first substitute the ABI module name with the
+  // regular one on the type's mangled name before attempting to reconstruct
+  // them.
+  auto mangling = TypeSystemSwiftTypeRef::TransformModuleName(
+      mangled_typename, m_module_abi_to_regular_name);
+  ConstString module_adjusted_mangled_typename;
+  if (mangling.isSuccess())
+    module_adjusted_mangled_typename = ConstString(mangling.result());
+
+  if (mangled_typename == module_adjusted_mangled_typename)
+    return ReconstructTypeImpl(mangled_typename);
+
+  // If the mangles names don't match, try the one with the module's regular
+  // name first.
+  auto result = ReconstructTypeImpl(module_adjusted_mangled_typename);
+
+  if (result)
+    return result;
+
+  auto error = llvm::toString(result.takeError());
+  LOG_PRINTF(
+      GetLog(LLDBLog::Types),
+      "Reconstruct type failed for adjusted type: \"%s\" with error: \"%s\"",
+      module_adjusted_mangled_typename.GetCString(), error.c_str());
+
+  // If the mangled name with the regular name fails, try the one with the ABI
+  // name. This could happen if a module's ABI name is the same as another
+  // module's regular name.
+  return ReconstructTypeImpl(mangled_typename);
 }
 
 CompilerType SwiftASTContext::GetAnyObjectType() {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -423,6 +423,12 @@ public:
   llvm::Expected<swift::Type> GetSwiftType(CompilerType compiler_type);
   /// Import compiler_type into this context and return the swift::CanType.
   swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
+private:
+  /// Reconstruct a Swift AST type from a mangled name by looking its
+  /// components up in Swift modules.
+  llvm::Expected<swift::TypeBase *>
+  ReconstructTypeImpl(ConstString mangled_typename);
+
 protected:
   swift::Type GetSwiftType(lldb::opaque_compiler_type_t opaque_type);
   swift::Type GetSwiftTypeIgnoringErrors(CompilerType compiler_type);
@@ -892,6 +898,10 @@ protected:
 
   CompilerType GetAsClangType(ConstString mangled_name);
 
+  /// Inserts the mapping from the module's ABI name to it's regular name into
+  /// m_module_abi_to_regular_name if they're different.
+  void RegisterModuleABINameToRealName(swift::ModuleDecl *module);
+
   /// Data members.
   /// @{
   // Always non-null outside of unit tests.
@@ -953,6 +963,9 @@ protected:
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;
 
+  /// Holds the source module name (value) for all modules with a custom ABI
+  /// name (key).
+  llvm::StringMap<llvm::StringRef> m_module_abi_to_regular_name;
   /// Whether this is a scratch or a module AST context.
   bool m_is_scratch_context = false;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -147,6 +147,31 @@ TypeSystemSwiftTypeRef::CanonicalizeSugar(swift::Demangle::Demangler &dem,
   });
 }
 
+swift::Demangle::ManglingErrorOr<std::string>
+TypeSystemSwiftTypeRef::TransformModuleName(
+    llvm::StringRef mangled_name,
+    const llvm::StringMap<llvm::StringRef> &module_name_map) {
+  swift::Demangle::Demangler dem;
+  auto *node = dem.demangleSymbol(mangled_name);
+  auto *adjusted_node = TypeSystemSwiftTypeRef::Transform(
+      dem, node, [&](swift::Demangle::NodePointer node) {
+        if (node->getKind() == Node::Kind::Module) {
+          auto module_name = node->getText();
+          if (module_name_map.contains(module_name)) {
+            auto real_name = module_name_map.lookup(module_name);
+            auto *adjusted_module_node =
+                dem.createNodeWithAllocatedText(Node::Kind::Module, real_name);
+            return adjusted_module_node;
+          }
+        }
+
+        return node;
+      });
+
+  auto mangling = mangleNode(adjusted_node);
+  return mangling;
+}
+
 llvm::StringRef
 TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
   if (!node)

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -29,6 +29,8 @@ namespace Demangle {
 class Node;
 using NodePointer = Node *;
 class Demangler;
+template <typename T>
+class ManglingErrorOr;
 } // namespace Demangle
 namespace reflection {
 struct DescriptorFinder;
@@ -361,6 +363,12 @@ public:
   static swift::Demangle::NodePointer
   CanonicalizeSugar(swift::Demangle::Demangler &dem,
                     swift::Demangle::NodePointer node);
+
+  /// Transforms the module name in the mangled type name using module_name_map
+  /// as the mapping source.
+  static swift::Demangle::ManglingErrorOr<std::string>
+  TransformModuleName(llvm::StringRef mangled_name,
+                      const llvm::StringMap<llvm::StringRef> &module_name_map);
 
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   swift::Demangle::NodePointer

--- a/lldb/test/API/lang/swift/different_abi_name/Makefile
+++ b/lldb/test/API/lang/swift/different_abi_name/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -module-abi-name OtherName
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
+++ b/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
@@ -1,0 +1,20 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftDifferentABIName(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+
+        _, _, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("frame variable s", 
+                    substrs=["Struct", "s = ", "field = 42"])
+        self.expect("expr s", substrs=["Struct", "field = 42"])
+        self.expect("expr -O -- s", substrs=["Struct", "- field : 42"])

--- a/lldb/test/API/lang/swift/different_abi_name/main.swift
+++ b/lldb/test/API/lang/swift/different_abi_name/main.swift
@@ -1,0 +1,6 @@
+struct Struct {
+  let field = 42
+}
+
+let s = Struct()
+print(s) // break here


### PR DESCRIPTION
Support expression evaluation for types in modules that were compiled with the -module-abi-name flag. These types have have the ABI module name serialized in debug information and the regular module name in the swift module.

rdar://126719253
(cherry picked from commit d19cadc947ffe2f0aa4a3fb2f7dafe6d7afab455)