### PR TITLE
[lldb] Diagnose expressions that evaluate to ~Copyable types

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -687,6 +687,23 @@ void SwiftASTManipulator::InsertError(swift::VarDecl *error_var,
   m_catch_stmt->setBody(body_stmt);
 }
 
+
+bool SwiftASTManipulator::IsExpressionResultNonCopyable() {
+  VariableInfo *result_var =
+      llvm::find_if(m_variables, [&](const VariableInfo &var) {
+        return var.GetName().str() == GetResultName();
+      });
+  if (result_var == m_variables.end())
+    return false;
+
+  swift::VarDecl *decl = result_var->GetDecl();
+  if (!decl)
+    return false;
+
+  swift::Type type = decl->getTypeInContext();
+  return type->isNoncopyable();
+}
+
 llvm::Error SwiftASTManipulator::FixupResultAfterTypeChecking() {
   if (!IsValid())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -250,6 +250,12 @@ public:
                 bool make_private = true,
                 swift::DeclContext *decl_ctx = nullptr);
 
+  /// Returns true if $__lldb_result is a non copyable type.
+  /// Currently LLDB cannot deal with expressions whose result is a non copyable
+  /// type, this function exists so LLDB can diagnose this situation and provide
+  /// a proper error message.
+  bool IsExpressionResultNonCopyable();
+
   llvm::Error FixupResultAfterTypeChecking();
 
   static const char *GetArgumentName() { return "$__lldb_arg"; }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1843,6 +1843,17 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
         m_options.GetPlaygroundTransformHighPerformance());
   }
 
+  /// Currently LLDB cannot deal with expressions whose result is a non copyable
+  /// type, because there's no easy way to assign $__lldb_result to the result
+  /// of the expression.
+  if (parsed_expr->code_manipulator &&
+      parsed_expr->code_manipulator->IsExpressionResultNonCopyable()) {
+    diagnostic_manager.PutString(
+        eSeverityError,
+        "Cannot evaluate an expression that results in a ~Copyable type");
+    return ParseResult::unrecoverable_error;
+  }
+
   // FIXME: We now should have to do the name binding and type
   //        checking again, but there should be only the result
   //        variable to bind up at this point.

--- a/lldb/test/API/lang/swift/noncopyable/Makefile
+++ b/lldb/test/API/lang/swift/noncopyable/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/noncopyable/TestSwiftNonCopyableTypeError.py
+++ b/lldb/test/API/lang/swift/noncopyable/TestSwiftNonCopyableTypeError.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+
+class TestSwiftNonCopyableTypeError(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("expression s", substrs=["Cannot evaluate an expression that results in a ~Copyable type"], error=True)
+

--- a/lldb/test/API/lang/swift/noncopyable/main.swift
+++ b/lldb/test/API/lang/swift/noncopyable/main.swift
@@ -1,0 +1,10 @@
+struct S: ~Copyable {
+  let i = 42
+}
+
+func f() {
+  let s = S()
+  print("break here")
+}
+
+f()


### PR DESCRIPTION
Currently lldb's expression evaluator does not support ~Copyable types. Diagnose this and provide a better error message for the user.

rdar://126943358
(cherry picked from commit 11c0285a2c40df8f7c21b763982daff877fd6a58)