### PR TITLE
Fixing Debian 11: llvm::Error deleted constructor

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -545,7 +545,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
                     .replayCachedResult(CacheKey, CachedResult,
                                         /*JustComputedResult*/ false)
                     .moveInto(Ret))
-    return E;
+    return std::move(E);
 
   if (Clang.getDiagnostics().hasErrorOccurred())
     return llvm::createStringError(llvm::inconvertibleErrorCode(),


### PR DESCRIPTION
Fixing another instance of calling the deleted copy constructor of `llvm::Error`.