### PR TITLE
[lldb] Display breakpoint locations using display name

### DIFF
--- a/lldb/include/lldb/Symbol/Function.h
+++ b/lldb/include/lldb/Symbol/Function.h
@@ -537,7 +537,7 @@ public:
 
   ConstString GetNameNoArguments(const SymbolContext *sc = nullptr) const;
 
-  ConstString GetDisplayName() const;
+  ConstString GetDisplayName(const SymbolContext *sc = nullptr) const;
 
   const Mangled &GetMangled() const { return m_mangled; }
 

--- a/lldb/include/lldb/Symbol/Symbol.h
+++ b/lldb/include/lldb/Symbol/Symbol.h
@@ -130,7 +130,7 @@ public:
 
   ConstString GetNameNoArguments() const;
 
-  ConstString GetDisplayName() const;
+  ConstString GetDisplayName(const SymbolContext *sc = nullptr) const;
 
   uint32_t GetID() const { return m_uid; }
 

--- a/lldb/include/lldb/Symbol/SymbolContext.h
+++ b/lldb/include/lldb/Symbol/SymbolContext.h
@@ -151,7 +151,8 @@ public:
                        const Address &so_addr, bool show_fullpaths,
                        bool show_module, bool show_inlined_frames,
                        bool show_function_arguments,
-                       bool show_function_name) const;
+                       bool show_function_name,
+                       bool show_function_display_name = false) const;
 
   /// Get the address range contained within a symbol context.
   ///

--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -270,6 +270,10 @@ public:
     return mangled.GetMangledName();
   }
 
+  virtual ConstString GetDisplayDemangledName(Mangled mangled) const {
+    return mangled.GetDemangledName();
+  }
+
   virtual void GetExceptionResolverDescription(bool catch_on, bool throw_on,
                                                Stream &s);
 

--- a/lldb/source/Breakpoint/BreakpointLocation.cpp
+++ b/lldb/source/Breakpoint/BreakpointLocation.cpp
@@ -515,7 +515,7 @@ void BreakpointLocation::GetDescription(Stream *s,
       else
         s->PutCString("where = ");
       sc.DumpStopContext(s, m_owner.GetTarget().GetProcessSP().get(), m_address,
-                         false, true, false, true, true);
+                         false, true, false, true, true, true);
     } else {
       if (sc.module_sp) {
         s->EOL();

--- a/lldb/source/Core/Address.cpp
+++ b/lldb/source/Core/Address.cpp
@@ -643,7 +643,7 @@ bool Address::Dump(Stream *s, ExecutionContextScope *exe_scope, DumpStyle style,
                     pointer_sc.symbol != nullptr) {
                   s->PutCString(": ");
                   pointer_sc.DumpStopContext(s, exe_scope, so_addr, true, false,
-                                             false, true, true);
+                                             false, true, true, false);
                 }
               }
             }
@@ -682,7 +682,8 @@ bool Address::Dump(Stream *s, ExecutionContextScope *exe_scope, DumpStyle style,
               // address.
               sc.DumpStopContext(s, exe_scope, *this, show_fullpaths,
                                  show_module, show_inlined_frames,
-                                 show_function_arguments, show_function_name);
+                                 show_function_arguments, show_function_name,
+                                 false);
             } else {
               // We found a symbol but it was in a different section so it
               // isn't the symbol we should be showing, just show the section

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -337,6 +337,8 @@ ConstString Mangled::GetDisplayDemangledName(
         m_mangled.GetStringRef(), SwiftLanguageRuntime::eSimplified, sc));
 #endif // LLDB_ENABLE_SWIFT
 // END SWIFT
+  if (Language *lang = Language::FindPlugin(GuessLanguage()))
+    return lang->GetDisplayDemangledName(*this);
   return GetDemangledName();
 }
 

--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -498,10 +498,10 @@ bool Function::IsTopLevelFunction() {
   return result;
 }
 
-ConstString Function::GetDisplayName() const {
+ConstString Function::GetDisplayName(const SymbolContext *sc) const {
   if (!m_mangled)
     return GetName();
-  return m_mangled.GetDisplayDemangledName();
+  return m_mangled.GetDisplayDemangledName(sc);
 }
 
 CompilerDeclContext Function::GetDeclContext() {

--- a/lldb/source/Symbol/Symbol.cpp
+++ b/lldb/source/Symbol/Symbol.cpp
@@ -168,8 +168,8 @@ bool Symbol::ValueIsAddress() const {
   return (bool)m_addr_range.GetBaseAddress().GetSection();
 }
 
-ConstString Symbol::GetDisplayName() const {
-  return GetMangled().GetDisplayDemangledName();
+ConstString Symbol::GetDisplayName(const SymbolContext *sc) const {
+  return GetMangled().GetDisplayDemangledName(sc);
 }
 
 ConstString Symbol::GetReExportedSymbolName() const {

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -71,7 +71,8 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
                                     const Address &addr, bool show_fullpaths,
                                     bool show_module, bool show_inlined_frames,
                                     bool show_function_arguments,
-                                    bool show_function_name) const {
+                                    bool show_function_name,
+                                    bool show_function_display_name) const {
   bool dumped_something = false;
   if (show_module && module_sp) {
     if (show_fullpaths)
@@ -92,6 +93,8 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
       ConstString name;
       if (!show_function_arguments)
         name = function->GetNameNoArguments(this);
+      if (!name && show_function_display_name)
+        name = function->GetDisplayName();
       if (!name)
         name = function->GetName(this);
       if (name)
@@ -145,7 +148,8 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
         const bool show_function_name = true;
         return inline_parent_sc.DumpStopContext(
             s, exe_scope, inline_parent_addr, show_fullpaths, show_module,
-            show_inlined_frames, show_function_arguments, show_function_name);
+            show_inlined_frames, show_function_arguments, show_function_name,
+            show_function_display_name);
       }
     } else {
       if (line_entry.IsValid()) {
@@ -163,7 +167,12 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
       dumped_something = true;
       if (symbol->GetType() == eSymbolTypeTrampoline)
         s->PutCString("symbol stub for: ");
-      symbol->GetName().Dump(s);
+      ConstString name;
+      if (show_function_display_name)
+        name = symbol->GetDisplayName();
+      if (!name)
+        name = symbol->GetName();
+      name.Dump(s);
     }
 
     if (addr.IsValid() && symbol->ValueIsAddress()) {

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -94,7 +94,7 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
       if (!show_function_arguments)
         name = function->GetNameNoArguments(this);
       if (!name && show_function_display_name)
-        name = function->GetDisplayName();
+        name = function->GetDisplayName(this);
       if (!name)
         name = function->GetName(this);
       if (name)
@@ -169,7 +169,7 @@ bool SymbolContext::DumpStopContext(Stream *s, ExecutionContextScope *exe_scope,
         s->PutCString("symbol stub for: ");
       ConstString name;
       if (show_function_display_name)
-        name = symbol->GetDisplayName();
+        name = symbol->GetDisplayName(this);
       if (!name)
         name = symbol->GetName();
       name.Dump(s);

--- a/lldb/test/API/lang/swift/expression/generic_function_name/TestSwiftGenericFunctionName.py
+++ b/lldb/test/API/lang/swift/expression/generic_function_name/TestSwiftGenericFunctionName.py
@@ -25,7 +25,7 @@ class TestSwiftGenericFunction(lldbtest.TestBase):
         stream = lldb.SBStream()
         bkpt.GetLocationAtIndex(0).GetDescription(stream, 1)
         desc = stream.GetData()
-        self.assertIn("C.f<T>(T, U) -> ()", desc)
+        self.assertIn("C.f<T>(_:_:)", desc)
 
         # Demangling only:
         fs = target.FindFunctions("f")

--- a/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
+++ b/lldb/test/Shell/SwiftREPL/BreakpointSimple.test
@@ -7,7 +7,7 @@ func foo() -> Int {
 }
 
 :b foo
-// CHECK: Breakpoint 1: {{.*}}foo() -> Swift.Int {{.*}} repl.swift:6:3, address = 0x
+// CHECK: Breakpoint 1: {{.*}}foo() {{.*}} repl.swift:6:3, address = 0x
 
 // CHECK: Execution stopped at breakpoint
 foo()


### PR DESCRIPTION
Adds a `show_function_display_name` parameter to `SymbolContext::DumpStopContext`. This parameter defaults to false, but `BreakpointLocation::GetDescription` sets it to true.