### PR TITLE
Fix some tests that recent upstream changes had broken

### DIFF
--- a/clang/test/CodeGen/ptrauth-function-init-fail.c
+++ b/clang/test/CodeGen/ptrauth-function-init-fail.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls %s -verify -emit-llvm -S -o -
+// RUN: %clang_cc1 -triple arm64e-apple-ios -fptrauth-calls %s -verify -emit-llvm -o -
 
 void f(void);
 

--- a/clang/test/CodeGenCXX/ptrauth-member-function-pointer.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-member-function-pointer.cpp
@@ -102,7 +102,7 @@ typedef void (Derived0::*MethodTy1)();
 // CHECK-NEXT: store { i64, i64 } { i64 ptrtoint (ptr @_ZN5Base08virtual1Ev_vfpthunk_.ptrauth.4 to i64), i64 0 }, ptr %[[METHOD7]], align 8
 // CHECK: ret void
 
-// CHECK: define linkonce_odr hidden void @_ZN5Base08virtual1Ev_vfpthunk_(ptr noundef %[[THIS:.*]]) {{.*}}align 2
+// CHECK: define linkonce_odr hidden void @_ZN5Base08virtual1Ev_vfpthunk_(ptr noundef %[[THIS:.*]])
 // CHECK: %[[THIS_ADDR:.*]] = alloca ptr, align 8
 // CHECK: store ptr %[[THIS]], ptr %[[THIS_ADDR]], align 8
 // CHECK: %[[THIS1:.*]] = load ptr, ptr %[[THIS_ADDR]], align 8
@@ -118,7 +118,7 @@ typedef void (Derived0::*MethodTy1)();
 // CHECK-NEXT: musttail call void %[[V5]](ptr noundef nonnull align {{[0-9]+}} dereferenceable(8) %[[V0]]) [ "ptrauth"(i32 0, i64 %[[V7]]) ]
 // CHECK-NEXT: ret void
 
-// CHECK: define linkonce_odr hidden void @_ZN5Base08virtual3Ev_vfpthunk_(ptr noundef %{{.*}}) {{.*}}align 2
+// CHECK: define linkonce_odr hidden void @_ZN5Base08virtual3Ev_vfpthunk_(ptr noundef %{{.*}})
 // CHECK: load ptr, ptr %{{.*}}, align 8
 // CHECK: load ptr, ptr %{{.*}}, align 8
 // CHECK: %[[VTABLE:.*]] = load ptr, ptr %{{.*}}, align 8
@@ -128,7 +128,7 @@ typedef void (Derived0::*MethodTy1)();
 // CHECK: getelementptr inbounds ptr, ptr %[[V4]], i64 1
 // CHECK: call i64 @llvm.ptrauth.blend(i64 %{{.*}}, i64 53007)
 
-// CHECK: define linkonce_odr hidden void @_ZN5Base016virtual_variadicEiz_vfpthunk_(ptr noundef %[[THIS:.*]], i32 noundef %0, ...){{.*}} align 2
+// CHECK: define linkonce_odr hidden void @_ZN5Base016virtual_variadicEiz_vfpthunk_(ptr noundef %[[THIS:.*]], i32 noundef %0, ...)
 // CHECK: %[[THIS_ADDR:.*]] = alloca ptr, align 8
 // CHECK-NEXT: %[[_ADDR:.*]] = alloca i32, align 4
 // CHECK-NEXT: store ptr %[[THIS]], ptr %[[THIS_ADDR]], align 8

--- a/clang/test/CodeGenCXX/ptrauth-thunks.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-thunks.cpp
@@ -21,7 +21,7 @@ namespace Test1 {
   }
 }
 
-// CHECK-LABEL: define linkonce_odr void @_ZTv0_n24_N5Test11DD0Ev(ptr noundef %this){{.*}} align 2
+// CHECK-LABEL: define linkonce_odr void @_ZTv0_n24_N5Test11DD0Ev(ptr noundef %this)
 // CHECK: %[[This:.*]] = load ptr
 // CHECK: %[[SignedVTable:.*]] = load ptr, ptr %[[This]], align 8
 // CHECK: %[[SignedVTableAsInt:.*]] = ptrtoint ptr %[[SignedVTable]] to i64

--- a/llvm/test/tools/lto/opt-level.ll
+++ b/llvm/test/tools/lto/opt-level.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.o
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O0 -o %t.dylib %t.o -lSystem
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.13 -dylib -mllvm -O0 -o %t.dylib %t.o -lSystem
 ; RUN: llvm-nm --no-llvm-bc %t.dylib | FileCheck --check-prefix=CHECK-O0 %s
-; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -dylib -mllvm -O2 -o %t.dylib %t.o -lSystem
+; RUN: %ld64 -lto_library %llvmshlibdir/libLTO.dylib -arch x86_64 -macosx_version_min 10.13 -dylib -mllvm -O2 -o %t.dylib %t.o -lSystem
 ; RUN: llvm-nm --no-llvm-bc %t.dylib | FileCheck --check-prefix=CHECK-O2 %s
 
 target triple = "x86_64-apple-macosx10.8.0"


### PR DESCRIPTION
Three main categories:

1. The default AArch64 function alignment is now 4 bytes (nothing less is even remotely valid anyway) but some ptrauth tests were checking for the explicit attribute. Drop that.
2. Clang now diagnoses conflicting & duplicate actions on `-cc1` invocations. Some tests hadn't caught up.
3. Some ld64 linkers assume bad things like KernelKit if they aren't provided with an explicit platform & version and then error when that leads to problems. So give a mostly meaningless one to shut them up.