### PR TITLE
[CAS][Test] Fix downstream test failures

### DIFF
--- a/clang/test/CAS/availability-check.c
+++ b/clang/test/CAS/availability-check.c
@@ -3,14 +3,14 @@
 // RUN: %clang_cc1 -triple x86_64-apple-ios14-macabi -isysroot %S/Inputs/MacOSX11.0.sdk -fsyntax-only -verify %s
 
 // RUN: %clang -cc1depscan -o %t/cmd.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 -fcas-path %t/cas -triple x86_64-apple-ios14-macabi -isysroot %S/Inputs/MacOSX11.0.sdk %s
+// RUN:     -cc1 -fcas-path %t/cas -triple x86_64-apple-ios14-macabi -isysroot %S/Inputs/MacOSX11.0.sdk %s -fsyntax-only
 
 // RUN: %clang -cc1depscan -o %t/cmd-casfs.rsp -fdepscan=inline -cc1-args \
-// RUN:     -cc1 -fcas-path %t/cas -triple x86_64-apple-ios14-macabi -isysroot %S/Inputs/MacOSX11.0.sdk %s
+// RUN:     -cc1 -fcas-path %t/cas -triple x86_64-apple-ios14-macabi -isysroot %S/Inputs/MacOSX11.0.sdk %s -fsyntax-only
 
 // FIXME: `-verify` should work with a CAS invocation.
-// RUN: not %clang @%t/cmd.rsp -fsyntax-only 2> %t/out.txt
-// RUN: not %clang @%t/cmd-casfs.rsp -fsyntax-only 2> %t/out-casfs.txt
+// RUN: not %clang @%t/cmd.rsp 2> %t/out.txt
+// RUN: not %clang @%t/cmd-casfs.rsp 2> %t/out-casfs.txt
 // RUN: FileCheck -input-file %t/out.txt %s
 // RUN: FileCheck -input-file %t/out-casfs.txt %s
 // CHECK: error: 'fUnavail' is unavailable

--- a/clang/test/CAS/cmd-macro-and-pch.c
+++ b/clang/test/CAS/cmd-macro-and-pch.c
@@ -7,11 +7,11 @@
 
 // RUN: %clang -cc1depscan -o %t/pch.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
 // RUN:     -cc1 -x c-header %t/prefix.h -emit-pch -DSOME_MACRO=1 -fcas-path %t/cas -Werror
-// RUN: %clang @%t/pch.rsp -emit-pch -o %t/prefix2.pch
+// RUN: %clang @%t/pch.rsp -o %t/prefix2.pch
 
 // RUN: %clang -cc1depscan -o %t/tu.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 %t/t1.c -include-pch %t/prefix2.pch -DSOME_MACRO=1 -fcas-path %t/cas -Werror
-// RUN: %clang @%t/tu.rsp -fsyntax-only
+// RUN:     -cc1 %t/t1.c -fsyntax-only -include-pch %t/prefix2.pch -DSOME_MACRO=1 -fcas-path %t/cas -Werror
+// RUN: %clang @%t/tu.rsp
 
 //--- t1.c
 

--- a/clang/test/CAS/fcas-include-tree-with-pch.c
+++ b/clang/test/CAS/fcas-include-tree-with-pch.c
@@ -9,14 +9,14 @@
 // RUN: %clang_cc1 %t/t1.c -include-pch %t/prefix1.pch -emit-llvm -o %t/source.ll -I %t/inc -DCMD_MACRO=1
 
 // RUN: %clang -cc1depscan -o %t/pch.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 -x c-header %t/prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
-// RUN: %clang @%t/pch.rsp -emit-pch -o %t/prefix2.pch
+// RUN:     -cc1 -emit-pch -x c-header %t/prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: %clang @%t/pch.rsp -o %t/prefix2.pch
 
 // RUN: %clang -cc1depscan -o %t/tu.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 %t/t1.c -include-pch %t/prefix2.pch -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN:     -cc1 -emit-llvm %t/t1.c -include-pch %t/prefix2.pch -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
 // RUN: rm %t/prefix2.pch
 
-// RUN: %clang @%t/tu.rsp -emit-llvm -o %t/tree.ll
+// RUN: %clang @%t/tu.rsp -o %t/tree.ll
 // RUN: diff -u %t/source.ll %t/tree.ll
 
 // Check again with relative paths.
@@ -27,14 +27,14 @@
 // RUN: %clang_cc1 t1.c -include-pch prefix3.pch -emit-llvm -o source-rel.ll -I inc -DCMD_MACRO=1
 
 // RUN: %clang -cc1depscan -o pch2.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 -x c-header prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
-// RUN: %clang @pch2.rsp -emit-pch -o prefix4.pch
+// RUN:     -cc1 -emit-pch -x c-header prefix.h -I %t/inc -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN: %clang @pch2.rsp -o prefix4.pch
 
 // RUN: %clang -cc1depscan -o tu2.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 t1.c -include-pch prefix4.pch -I inc -DCMD_MACRO=1 -fcas-path %t/cas
+// RUN:     -cc1 -emit-llvm t1.c -include-pch prefix4.pch -I inc -DCMD_MACRO=1 -fcas-path %t/cas
 // RUN: rm %t/prefix4.pch
 
-// RUN: %clang @tu2.rsp -emit-llvm -o tree-rel.ll
+// RUN: %clang @tu2.rsp -o tree-rel.ll
 // RUN: diff -u source-rel.ll tree-rel.ll
 
 // Check that -coverage-notes-file and -coverage-data-file are stripped

--- a/clang/test/CAS/fcas-include-tree.c
+++ b/clang/test/CAS/fcas-include-tree.c
@@ -5,10 +5,12 @@
 // RUN: %clang_cc1 %t/t1.c -emit-llvm -o %t/source.ll -isystem %t -DCMD_MACRO=1 -Werror -dependency-file %t/t1-source.d -MT deps
 
 // RUN: %clang -cc1depscan -o %t/inline.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 %t/t1.c -isystem %t -DCMD_MACRO=1 -fcas-path %t/cas
-// RUN: %clang @%t/inline.rsp -E -P -o %t/tree.i -Werror
+// RUN:     -cc1 -E -P %t/t1.c -isystem %t -DCMD_MACRO=1 -fcas-path %t/cas -Werror
+// RUN: %clang @%t/inline.rsp -o %t/tree.i
 // RUN: diff -u %t/source.i %t/tree.i
-// RUN: %clang @%t/inline.rsp -emit-llvm -o %t/tree.ll -Werror -dependency-file %t/t1-tree.d -MT deps
+// RUN: %clang -cc1depscan -o %t/inline2.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
+// RUN:     -cc1 -emit-llvm %t/t1.c -isystem %t -DCMD_MACRO=1 -fcas-path %t/cas -Werror -dependency-file %t/t1-tree.d -MT deps
+// RUN: %clang @%t/inline2.rsp -o %t/tree.ll
 // RUN: diff -u %t/source.ll %t/tree.ll
 // RUN: diff -u %t/t1-source.d %t/t1-tree.d
 

--- a/clang/test/CAS/include-tree-with-include-next.c
+++ b/clang/test/CAS/include-tree-with-include-next.c
@@ -5,8 +5,8 @@
 // RUN: %clang_cc1 %t/t.c -I %t/inc -I %t/inc2 -fsyntax-only -Werror
 
 // RUN: %clang -cc1depscan -o %t/tu.rsp -fdepscan=inline -fdepscan-include-tree -cc1-args \
-// RUN:     -cc1 -fcas-path %t/cas %t/t.c -I %t/inc -I %t/inc2 -Werror
-// RUN: %clang @%t/tu.rsp -fsyntax-only -Werror
+// RUN:     -cc1 -fsyntax-only -Werror -fcas-path %t/cas %t/t.c -I %t/inc -I %t/inc2 -Werror
+// RUN: %clang @%t/tu.rsp
 
 //--- t.c
 #include "t.h"

--- a/clang/test/CAS/plugin-cas.c
+++ b/clang/test/CAS/plugin-cas.c
@@ -3,31 +3,31 @@
 // RUN: rm -rf %t && mkdir -p %t
 
 // RUN: %clang -cc1depscan -o %t/t1.rsp -fdepscan=inline -cc1-args \
-// RUN:   -cc1 %s -fcas-path %t/cas \
+// RUN:   -cc1 -emit-obj %s -fcas-path %t/cas \
 // RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option first-prefix=myfirst- -fcas-plugin-option second-prefix=mysecond- \
 // RUN:   -fcas-plugin-option upstream-path=%t/cas-upstream
-// RUN: %clang @%t/t1.rsp -emit-obj -o %t/t1.o -Rcompile-job-cache 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
+// RUN: %clang @%t/t1.rsp -o %t/t1.o -Rcompile-job-cache 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
 
 // Clear the CAS and check the outputs can still be "downloaded" from upstream.
 // RUN: rm -rf %t/cas
 // RUN: %clang -cc1depscan -o %t/t2.rsp -fdepscan=inline -cc1-args \
-// RUN:   -cc1 %s -fcas-path %t/cas \
+// RUN:   -cc1 -emit-obj %s -fcas-path %t/cas \
 // RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option first-prefix=myfirst- -fcas-plugin-option second-prefix=mysecond- \
 // RUN:   -fcas-plugin-option upstream-path=%t/cas-upstream
-// RUN: %clang @%t/t2.rsp -emit-obj -o %t/t2.o -Rcompile-job-cache 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+// RUN: %clang @%t/t2.rsp -o %t/t2.o -Rcompile-job-cache 2>&1 | FileCheck %s --check-prefix=CACHE-HIT
 // RUN: diff %t/t1.o %t/t2.o
 
 // Check that it's a cache miss if outputs are not found in the upstream CAS.
 // RUN: rm -rf %t/cas
 // RUN: %clang -cc1depscan -o %t/t3.rsp -fdepscan=inline -cc1-args \
-// RUN:   -cc1 %s -fcas-path %t/cas \
+// RUN:   -cc1 -emit-obj %s -fcas-path %t/cas \
 // RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option first-prefix=myfirst- -fcas-plugin-option second-prefix=mysecond- \
 // RUN:   -fcas-plugin-option upstream-path=%t/cas-upstream \
 // RUN:   -fcas-plugin-option simulate-missing-objects
-// RUN: %clang @%t/t3.rsp -emit-obj -o %t/t.o -Rcompile-job-cache 2>&1 | FileCheck %s --check-prefix=CACHE-NOTFOUND
+// RUN: %clang @%t/t3.rsp -o %t/t.o -Rcompile-job-cache 2>&1 | FileCheck %s --check-prefix=CACHE-NOTFOUND
 
 // CACHE-MISS: remark: compile job cache miss for 'myfirst-mysecond-
 // CACHE-MISS: warning: some warning


### PR DESCRIPTION
Now clang errors out when it receives more than one compile job kind. Make sure the compile job action is passed to the scanner so there is no overwritten needed when running the args returned by scanner.

rdar://127798678