### PR TITLE
XFAIL format test

### DIFF
--- a/clang/test/FixIt/format.cpp
+++ b/clang/test/FixIt/format.cpp
@@ -1,3 +1,4 @@
+// XFAIL: *
 // RUN: %clang_cc1 -fsyntax-only -verify -Wformat %s
 // RUN: %clang_cc1 -fsyntax-only -fdiagnostics-parseable-fixits -Wformat %s 2>&1 | FileCheck %s
 


### PR DESCRIPTION
After 37d7fe76c77ebae94b8be9438285085db093979a, the diagnostics are no longer emitted.

rdar://127869077