### PR TITLE
Fix test failure

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -74,8 +74,7 @@
 
 // DISABLE-MCCAS-NOT: "-fcas-backend"
 // DISABLE-MCCAS-NOT: "-fcas-backend-mode=verify"
-// DISABLE-MCCAS-NOT: "-mllvm"
-// DISABLE-MCCAS-NOT: "-cas-friendly-debug-info"
+// DISABLE-MCCAS-NOT: "-mllvm" "-cas-friendly-debug-info"
 
 
 


### PR DESCRIPTION
rdar://127869147
(Clang.CAS.driver-cache-launcher.c failing on internal/clang/1600)

/Users/local/jenkins/workspace/stage1-RA_internal_clang_1600_13/llvm-project/clang/test/CAS/driver-cache-launcher.c:77:23: error: DISABLE-MCCAS-NOT: excluded string found in input
// DISABLE-MCCAS-NOT: "-mllvm"