### PR TITLE
[lldb] Log node kind when encoding is undetermined (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3265,8 +3265,8 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
       return referent_type.GetEncoding(count);
     }
     default:
-      LLDB_LOGF(GetLog(LLDBLog::Types), "No encoding for type %s",
-                AsMangledName(type));
+      LLDB_LOGF(GetLog(LLDBLog::Types), "No encoding for type %s of kind %s",
+                AsMangledName(type), getNodeKindString(kind));
       break;
     }
 


### PR DESCRIPTION
Make this log a little more convenient.