### PR TITLE
[IncludeTree] Don't callback on visibility only modules

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2099,16 +2099,16 @@ void Preprocessor::HandleIncludeDirective(SourceLocation HashLoc,
             /*IsIncludeDirective=*/true);
         if (!CheckLoadResult(Imported))
           return;
+        // PPCallback for IncludeDirective. Using the AST file as the FileEntry
+        // in the callback to indicate this is not a missing header. Note this
+        // is not the same behavior as non-include-tree build where the
+        // FileEntry is for the header file.
+        // FIXME: Need to clarify what `File` means in the callback, and if that
+        // can be the module file entry instead of header file entry.
+        Module *M = Imported;
+        InclusionCallback(M->getASTFile(), Imported);
       }
 
-      // PPCallback for IncludeDirective. Using the AST file as the FileEntry in
-      // the callback to indicate this is not a missing header. Note this is not
-      // the same behavior as non-include-tree build where the FileEntry is for
-      // the header file.
-      // FIXME: Need to clarify what `File` means in the callback, and if that
-      // can be the module file entry instead of header file entry.
-      Module *M = Imported;
-      InclusionCallback(M->getASTFile(), Imported);
       makeModuleVisible(Imported, EndLoc);
       if (IncludeTok.getIdentifierInfo()->getPPKeywordID() !=
           tok::pp___include_macros)

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation-private.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation-private.c
@@ -16,6 +16,13 @@
 // RUN: cat %t/tu.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/tu.casid
 // RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid | FileCheck %s -DPREFIX=%/t
 // RUN: %clang @%t/tu.rsp
+//
+// RUN: FileCheck %s -input-file=%t/tu.d -check-prefix DEPS
+
+// DEPS: dependencies:
+// DEPS-DAG: tu.m
+// DEPS-DAG: Mod.h
+// DEPS-DAG: Priv.h
 
 // CHECK: [[PREFIX]]/tu.m llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
@@ -43,7 +50,7 @@
 [{
   "file": "DIR/tu.m",
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/tu.m -F DIR -fmodule-name=Mod -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+  "command": "clang -fsyntax-only DIR/tu.m -F DIR -fmodule-name=Mod -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -MMD -MT dependencies -MF DIR/tu.d"
 }]
 
 //--- Mod.framework/Modules/module.modulemap


### PR DESCRIPTION
Avoid callback on a visibility only module imports which avoid callback with a nullptr as imported file. Visibility only imports already gets a callback for the included header file and it should not get a callback for module. This also matches the behavior for the implicit module build.

rdar://127615714