### PR TITLE
[lldb] Use function in TestSwiftEmbeddedExpression so its not deleted

### DIFF
--- a/lldb/test/API/lang/swift/embedded/expr/main.swift
+++ b/lldb/test/API/lang/swift/embedded/expr/main.swift
@@ -1,7 +1,7 @@
-struct A {
+public struct A {
   var field = 4
 
-  func foo() -> Int {
+  public func foo() -> Int {
     return field * field
   }
 }


### PR DESCRIPTION
The compiler will not keep functions only for the debugger when compiling in embedded Swift mode. Change TestSwiftEmbeddedExpression so the function being called is not optimized out.