### PR TITLE
[lldb][DWARFASTParserClang] Fix build failure following mismerge

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -278,7 +278,7 @@ static void PrepareContextToReceiveMembers(TypeSystemClang &ast,
 
   // We have already completed the type, or we have found its definition and are
   // ready to complete it later (cf. ParseStructureLikeDIE).
-  bool hasDef = ast.UseRedeclCompletion()
+  bool hasDef = m_ast.UseRedeclCompletion()
                     ? tag_decl_ctx->getDefinition() != nullptr
                     : tag_decl_ctx->isCompleteDefinition();
   if (hasDef || tag_decl_ctx->isBeingDefined())
@@ -290,7 +290,7 @@ static void PrepareContextToReceiveMembers(TypeSystemClang &ast,
 
   // If this type was not imported from an external AST, there's nothing to do.
   if (ast_importer.CanImport(tag_decl_ctx)) {
-    CompilerType type = ast.GetTypeForDecl(tag_decl_ctx);
+    CompilerType type = m_ast.GetTypeForDecl(tag_decl_ctx);
     auto qual_type = ClangUtil::GetQualType(type);
     if (ast_importer.RequireCompleteType(qual_type))
       return;
@@ -302,7 +302,7 @@ static void PrepareContextToReceiveMembers(TypeSystemClang &ast,
 
   // We don't have a type definition and/or the import failed. We must
   // forcefully complete the type to avoid crashes.
-  ForcefullyCompleteType(ast.GetTypeForDecl(tag_decl_ctx));
+  ForcefullyCompleteType(m_ast.GetTypeForDecl(tag_decl_ctx));
 }
 
 void DWARFASTParserClang::RegisterDIE(DWARFDebugInfoEntry *die,
@@ -1134,8 +1134,7 @@ DWARFASTParserClang::ParseSubroutine(const DWARFDIE &die,
       containing_decl_ctx->getDeclKind();
 
   if (TypeSystemClang::UseRedeclCompletion())
-    PrepareContextToReceiveMembers(m_ast, GetClangASTImporter(),
-                                   containing_decl_ctx, die,
+    PrepareContextToReceiveMembers(containing_decl_ctx, decl_ctx_die, die,
                                    attrs.name.GetCString());
 
   bool is_cxx_method = DeclKindIsCXXClass(containing_decl_kind);


### PR DESCRIPTION
Mismerge in:
```
commit 316c3c38494e0590ccfa13a7a5798a804a5acc1b
Merge: 44e9a6cbc649 9a7262c26018
Author: Michael Buch <michaelbuch12@gmail.com>

    Merge commit '9a7262c26018' from llvm.org/main into next
```