### PR TITLE
Turn off implicit clang modules while importing CU dependencies.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -56,6 +56,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/TargetOptions.h"
 #include "clang/Driver/Driver.h"
+#include "clang/Frontend/CompilerInstance.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
@@ -1742,6 +1743,11 @@ void SwiftASTContext::AddExtraClangArgs(
   applyOverrideOptions(importer_options.ExtraArgs, overrideOpts);
   if (HasNonexistentExplicitModule(importer_options.ExtraArgs))
     RemoveExplicitModules(importer_options.ExtraArgs);
+
+  m_has_explicit_modules =
+      llvm::any_of(importer_options.ExtraArgs, [](const std::string &arg) {
+        return StringRef(arg).starts_with("-fmodule-file=");
+      });
 }
 
 void SwiftASTContext::AddUserClangArgs(TargetProperties &props) {
@@ -8968,13 +8974,11 @@ bool SwiftASTContextForExpressions::GetImplicitImports(
         &modules,
     Status &error) {
   LLDB_SCOPED_TIMER();
-  if (!GetCompileUnitImports(sc, process_sp, modules, error)) {
+  if (!GetCompileUnitImports(sc, process_sp, modules, error))
     return false;
-  }
 
   // Get the hand-loaded modules from the SwiftPersistentExpressionState.
   for (auto &module_pair : m_hand_loaded_modules) {
-
     auto &attributed_import = module_pair.second;
 
     // If the ImportedModule in the SwiftPersistentExpressionState has a
@@ -9137,6 +9141,7 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
         *modules,
     Status &error) {
   LLDB_SCOPED_TIMER();
+
   CompileUnit *compile_unit = sc.comp_unit;
   if (compile_unit && compile_unit->GetModule())
     // Check the cache if this compile unit's imports were previously
@@ -9170,6 +9175,44 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
   if (cu_imports.size() == 0)
     return true;
 
+  LOG_PRINTF(GetLog(LLDBLog::Types), "Importing dependencies of current CU");
+  
+  // Turn off implicit clang modules while importing CU dependencies.
+  // ModuleFileSharedCore::getTransitiveLoadingBehavior() has a
+  // best-effort mode that is enabled when debugger support is turned
+  // on that will try to import implementation-only imports of Swift
+  // modules, but won't treat import failures as errors. When explicit
+  // modules are on, this has the unwanted side-effect of potentially
+  // triggering an implicit Clang module build if one of the internal
+  // dependencies of a library was not used to build the target. To
+  // avoid these costly and potentially dangerous imports we turn off
+  // implicit modules while importing the CU imports only. If a user
+  // manually evaluates an expression that contains an import
+  // statement that can still trigger an implict import.  Implicit
+  // imports can be dangerous if an implicit module depends on a
+  // module that also exists as an explicit input: In this case, a
+  // subsequent explicit import of said dependency will error because
+  // Clang now knows about two versions of the same module.
+  clang::LangOptions *clang_lang_opts = nullptr;
+  auto reset = llvm::make_scope_exit([&] {
+    if (clang_lang_opts) {
+      LOG_PRINTF(GetLog(LLDBLog::Types), "Turning on implicit Clang modules");
+      clang_lang_opts->ImplicitModules = true;
+    }
+  });
+  if (auto *clang_importer = GetClangImporter()) {
+    if (m_has_explicit_modules) {
+      auto &clang_instance = const_cast<clang::CompilerInstance &>(
+          clang_importer->getClangInstance());
+      clang_lang_opts = &clang_instance.getLangOpts();
+      // AddExtraArgs is supposed to always turn implicit modules on.
+      assert(clang_lang_opts->ImplicitModules &&
+             "ClangImporter implicit module support is off");
+      LOG_PRINTF(GetLog(LLDBLog::Types), "Turning off implicit Clang modules");
+      clang_lang_opts->ImplicitModules = false;
+    }
+  }
+  
   std::string category = "Importing Swift module dependencies for ";
   category += compile_unit->GetPrimaryFile().GetFilename();
   Progress progress(category, "", cu_imports.size());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -964,6 +964,7 @@ protected:
   bool m_initialized_language_options = false;
   bool m_initialized_search_path_options = false;
   bool m_initialized_clang_importer_options = false;
+  bool m_has_explicit_modules = false;
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;
 

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Dylib.swift
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Dylib.swift
@@ -1,0 +1,6 @@
+@_implementationOnly internal import Hidden
+
+public struct Public {
+  let hidden = Hidden()
+  public init() {}
+}

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
@@ -1,0 +1,16 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_EXPLICIT_MODULES := YES
+SWIFTFLAGS_EXTRAS := -I.
+LD_EXTRAS = -L$(BUILDDIR) -lDylib
+
+all: libDylib a.out
+
+include Makefile.rules
+
+libDylib: Dylib.swift
+	mkdir -p $(BUILDDIR)/$(shell basename $< .swift)
+	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		DYLIB_NAME=Dylib DYLIB_SWIFT_SOURCES=Dylib.swift \
+		VPATH=$(SRCDIR) SWIFTFLAGS_EXTRAS=-I$(SRCDIR) \
+		-f $(MAKEFILE_RULES) all

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftClangImporterExplicitNoImplicit(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    # This triggers an infinite loop while completing types.
+    @skipIf(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'), bugnumber='rdar://128094135')
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """
+        Test flipping on/off implicit modules.
+        """
+        self.build()
+        self.expect('settings set symbols.clang-modules-cache-path '
+                    + self.getBuildArtifact("IMPLICIT-CLANG-MODULE-CACHE"))
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'),
+                                          extra_images=['Dylib'])
+        log = self.getBuildArtifact("types.log")
+        self.expect('log enable lldb types -f "%s"' % log)
+        self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
+                    substrs=["hidden"])
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK-NOT: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/SwiftShims-{{.*}}.pcm
+#       CHECK: Turning off implicit Clang modules
+#       CHECK: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/Hidden-{{.*}}.pcm
+#       CHECK: Turning on implicit Clang modules

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/hidden.h
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/hidden.h
@@ -1,0 +1,1 @@
+struct Hidden {};

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/main.swift
@@ -1,0 +1,3 @@
+import Dylib
+let obj = Public()
+print("break here \(obj)")

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/module.modulemap
@@ -1,0 +1,3 @@
+module Hidden {
+  header "hidden.h"
+}


### PR DESCRIPTION
ModuleFileSharedCore::getTransitiveLoadingBehavior() has a best-effort mode that is enabled when debugger support is turned on that will try to import implementation-only imports of Swift modules, but won't treat import failures as errors. When explicit modules are on, this has the unwanted side-effect of potentially triggering an implicit Clang module build if one of the internal dependencies of a library was not used to build the target. To avoid these costly and potentially dangerous imports we turn off implicit modules while importing the CU imports only. If a user manually evaluates an expression that contains an import statement that can still trigger an implict import.  Implicit imports can be dangerous if an implicit module depends on a module that also exists as an explicit input: In this case, a subsequent explicit import of said dependency will error because Clang now knows about two versions of the same module.

rdar://127455779