### PR TITLE
[Support] Add option to print SMDiagnostic into a buffer without the filename and location info (#92050)

### DIFF
--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -329,7 +329,7 @@ public:
   ArrayRef<SMFixIt> getFixIts() const { return FixIts; }
 
   void print(const char *ProgName, raw_ostream &S, bool ShowColors = true,
-             bool ShowKindLabel = true) const;
+             bool ShowKindLabel = true, bool ShowLocation = true) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Support/SourceMgr.cpp
+++ b/llvm/lib/Support/SourceMgr.cpp
@@ -498,7 +498,7 @@ static void printSourceLine(raw_ostream &S, StringRef LineContents) {
 static bool isNonASCII(char c) { return c & 0x80; }
 
 void SMDiagnostic::print(const char *ProgName, raw_ostream &OS, bool ShowColors,
-                         bool ShowKindLabel) const {
+                         bool ShowKindLabel, bool ShowLocation) const {
   ColorMode Mode = ShowColors ? ColorMode::Auto : ColorMode::Disable;
 
   {
@@ -507,7 +507,7 @@ void SMDiagnostic::print(const char *ProgName, raw_ostream &OS, bool ShowColors,
     if (ProgName && ProgName[0])
       S << ProgName << ": ";
 
-    if (!Filename.empty()) {
+    if (ShowLocation && !Filename.empty()) {
       if (Filename == "-")
         S << "<stdin>";
       else

--- a/llvm/unittests/Support/SourceMgrTest.cpp
+++ b/llvm/unittests/Support/SourceMgrTest.cpp
@@ -580,3 +580,15 @@ TEST_F(SourceMgrTest, AddIncludedFile) {
             "Included from //path/to/includes/search-path-file:3:\n",
             Output);
 }
+
+TEST_F(SourceMgrTest, PrintWithoutLoc) {
+  raw_string_ostream OS(Output);
+  auto Diag =
+      llvm::SMDiagnostic("file.in", llvm::SourceMgr::DK_Error, "message");
+  Diag.print(nullptr, OS);
+  OS.flush();
+  EXPECT_EQ("file.in: error: message\n", Output);
+  Output.clear();
+  Diag.print(nullptr, OS, false, false, false);
+  EXPECT_EQ("message\n", Output);
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/llvm/llvm-project/pull/92050
--------------------------------------------------