### PR TITLE
[swift/release/6.0] [lldb][test] un-XFAIL TestCoroutineHandle.py for libstdc++

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
@@ -139,7 +139,6 @@ class TestCoroutineHandle(TestBase):
             )
 
     @add_test_categories(["libstdcxx"])
-    @expectedFailureAll(oslist=["linux"])
     def test_libstdcpp(self):
         self.do_test(USE_LIBSTDCPP)
 


### PR DESCRIPTION
This XPASSes on the Swift 6.0 Linux buildbots. I suspect we XFAILed it in the past because the bots were on an incompatible libstdc++ version (though this is just speculation).