### PR TITLE
🍒[next] Set Swift clang-linker path

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -616,6 +616,7 @@ ifeq "$(USESWIFTDRIVER)" "1"
 	ifeq "$(OS)" "Darwin"
 		SWIFTFLAGS += -sdk "$(SWIFTSDKROOT)"
 	endif
+	SWIFTFLAGS += -tools-directory "$(shell dirname $(CC))"
 endif
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
The swift driver is picking up the system clang instead of using the clang set in `CC`. The system clang is attempting to use bfd to link Swift, which doesn't work due to Swift's protected symbol usage.

(cherry picked from commit 1f6bd5557207f61d5da4c66b657c12468fa4e9aa)