### PR TITLE
[rebranch][cxx-interop] Workaround a Swift compiler bug

### DIFF
--- a/clang/include/clang/AST/StmtIterator.h
+++ b/clang/include/clang/AST/StmtIterator.h
@@ -133,10 +133,10 @@ struct StmtIterator : public StmtIteratorImpl<StmtIterator, Stmt*&> {
   StmtIterator(const VariableArrayType *t)
       : StmtIteratorImpl<StmtIterator, Stmt*&>(t) {}
 
-private:
   StmtIterator(const StmtIteratorBase &RHS)
       : StmtIteratorImpl<StmtIterator, Stmt *&>(RHS) {}
 
+private:
   inline friend StmtIterator
   cast_away_const(const ConstStmtIterator &RHS);
 };


### PR DESCRIPTION
The swift compiler issue is fixed in https://github.com/apple/swift/pull/67775, but this is too recent for our `hosttools` builds. This works around the issue by making the constructor public.

(cherry picked from commit f7b421ff1fe19c0453f072dcfcddda7d0a77df5a)