### PR TITLE
[bazel] Add CAS headers to `//llvm:Support`

### DIFF
--- a/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
+++ b/utils/bazel/llvm-project-overlay/llvm/BUILD.bazel
@@ -251,6 +251,7 @@ cc_library(
     hdrs = glob([
         "include/llvm/Support/**/*.h",
         "include/llvm/ADT/*.h",
+        "include/llvm/CAS/*.h",
     ]) + [
         "include/llvm-c/Core.h",
         "include/llvm-c/DataTypes.h",


### PR DESCRIPTION
Without these we get compile errors with Bazel:

```
external/llvm-project/llvm/lib/Support/VirtualFileSystem.cpp:26:10: fatal error: 'llvm/CAS/CASReference.h' file not found
#include "llvm/CAS/CASReference.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```