### PR TITLE
[Cherry-pick into next] Turn off implicit clang modules while importing CU dependencies.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -960,6 +960,7 @@ protected:
   bool m_initialized_language_options = false;
   bool m_initialized_search_path_options = false;
   bool m_initialized_clang_importer_options = false;
+  bool m_has_explicit_modules = false;
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;
 

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Dylib.swift
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Dylib.swift
@@ -1,0 +1,6 @@
+@_implementationOnly internal import Hidden
+
+public struct Public {
+  let hidden = Hidden()
+  public init() {}
+}

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
@@ -1,0 +1,16 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_EXPLICIT_MODULES := YES
+SWIFTFLAGS_EXTRAS := -I.
+LD_EXTRAS = -L$(BUILDDIR) -lDylib
+
+all: libDylib a.out
+
+include Makefile.rules
+
+libDylib: Dylib.swift
+	mkdir -p $(BUILDDIR)/$(shell basename $< .swift)
+	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		DYLIB_NAME=Dylib DYLIB_SWIFT_SOURCES=Dylib.swift \
+		VPATH=$(SRCDIR) SWIFTFLAGS_EXTRAS=-I$(SRCDIR) \
+		-f $(MAKEFILE_RULES) all

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftClangImporterExplicitNoImplicit(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    
+    # Don't run ClangImporter tests if Clangimporter is disabled.
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    # This triggers an infinite loop while completing types.
+    @skipIf(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'), bugnumber='rdar://128094135')
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """
+        Test flipping on/off implicit modules.
+        """
+        self.build()
+        self.expect('settings set symbols.clang-modules-cache-path '
+                    + self.getBuildArtifact("IMPLICIT-CLANG-MODULE-CACHE"))
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'),
+                                          extra_images=['Dylib'])
+        log = self.getBuildArtifact("types.log")
+        self.expect('log enable lldb types -f "%s"' % log)
+        self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
+                    substrs=["hidden"])
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK-NOT: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/SwiftShims-{{.*}}.pcm
+#       CHECK: Turning off implicit Clang modules
+#       CHECK: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/Hidden-{{.*}}.pcm
+#       CHECK: Turning on implicit Clang modules

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/hidden.h
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/hidden.h
@@ -1,0 +1,1 @@
+struct Hidden {};

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/main.swift
@@ -1,0 +1,3 @@
+import Dylib
+let obj = Public()
+print("break here \(obj)")

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/module.modulemap
@@ -1,0 +1,3 @@
+module Hidden {
+  header "hidden.h"
+}


### PR DESCRIPTION
```
commit 4afab15af327f5ab51a4f087c5ad296c0547ab48
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri May 10 17:34:29 2024 -0700

    Turn off implicit clang modules while importing CU dependencies.
    
    ModuleFileSharedCore::getTransitiveLoadingBehavior() has a best-effort
    mode that is enabled when debugger support is turned on that will try
    to import implementation-only imports of Swift modules, but won't
    treat import failures as errors. When explicit modules are on, this
    has the unwanted side-effect of potentially triggering an implicit
    Clang module build if one of the internal dependencies of a library
    was not used to build the target. To avoid these costly and
    potentially dangerous imports we turn off implicit modules while
    importing the CU imports only. If a user manually evaluates an
    expression that contains an import statement that can still trigger an
    implict import.  Implicit imports can be dangerous if an implicit
    module depends on a module that also exists as an explicit input: In
    this case, a subsequent explicit import of said dependency will error
    because Clang now knows about two versions of the same module.
    
    rdar://127455779
```
