### PR TITLE
[lldb] Remove linux disable in TestSwiftExplicitModulesImplicitFallback (#8446)

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(lldbtest.TestBase):
     @swiftTest
-    @skipIf(oslist=["linux"], bugnumber="rdar://124691219")
     def test_missing_explicit_modules(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
         self.build()


### PR DESCRIPTION
(cherry-picked from commit ee64cff09701ac2c2dc6a8ea3f0dd398637de0f0)