### PR TITLE
Follow swift test naming convention; add test method docstring

### DIFF
--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
@@ -6,6 +6,7 @@ from lldbsuite.test.decorators import *
 class TestCase(TestBase):
     @swiftTest
     def test(self):
+        """Test that a breakpoint on a property accessor can be set by name."""
         self.build()
         exe = self.getBuildArtifact("a.out")
         target = self.dbg.CreateTarget(exe)


### PR DESCRIPTION
(cherry-picked from commit 0f35b80cdefe2cc29e3a57421bb613048f6318c1)