### PR TITLE
[lldb] Restore upstream implementation of ClangPersistentVariables::RemovePersistentVariable

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangPersistentVariables.h
@@ -120,8 +120,6 @@ private:
   uint32_t m_next_user_file_id = 0;
   // The counter used by GetNextPersistentVariableName
   uint32_t m_next_persistent_variable_id = 0;
-  /// The counter used by GetNextResultName when is_error is true.
-  uint32_t m_next_persistent_error_id;
 
   typedef llvm::DenseMap<const char *, clang::TypeDecl *>
       ClangPersistentTypeMap;


### PR DESCRIPTION
(cherry-picked from commit 6c939332a2ce85f9f4ed6d03fd85433454fd20be)