### PR TITLE
Update the test to use the types log

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
+++ b/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
@@ -12,7 +12,7 @@ class TestCase(lldbtest.TestBase):
         self.build()
 
         log = self.getBuildArtifact("lldb.log")
-        self.runCmd(f"log enable lldb expr -f '{log}'")
+        self.runCmd(f"log enable lldb types -f '{log}'")
         self.runCmd("settings set target.swift-clang-override-options x-DDELETEME=1")
 
         lldbutil.run_to_name_breakpoint(self, "main", bkpt_module="a.out")


### PR DESCRIPTION
(cherry-picked from commit b9a971157f448b6b492dc81712babf58ed07d793)