### PR TITLE
Add error handling to GetChildCompilerTypeAtIndex() 

### DIFF
--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -381,7 +381,7 @@ public:
                                    uint32_t *bitfield_bit_size_ptr = nullptr,
                                    bool *is_bitfield_ptr = nullptr) const;
 
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       ExecutionContext *exe_ctx, size_t idx, bool transparent_pointers,
       bool omit_empty_base_classes, bool ignore_array_bounds,
       std::string &child_name, uint32_t &child_byte_size,

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -362,7 +362,7 @@ public:
   GetVirtualBaseClassAtIndex(lldb::opaque_compiler_type_t type, size_t idx,
                              uint32_t *bit_offset_ptr) = 0;
 
-  virtual CompilerType GetChildCompilerTypeAtIndex(
+  virtual llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,

--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -600,15 +600,23 @@ ValueObject *ValueObject::CreateChildAtIndex(size_t idx,
   uint64_t language_flags = 0;
 
   const bool transparent_pointers = !synthetic_array_member;
-  CompilerType child_compiler_type;
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
-  child_compiler_type = GetCompilerType().GetChildCompilerTypeAtIndex(
-      &exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
-      ignore_array_bounds, child_name_str, child_byte_size, child_byte_offset,
-      child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
-      child_is_deref_of_parent, this, language_flags);
+  auto child_compiler_type_or_err =
+      GetCompilerType().GetChildCompilerTypeAtIndex(
+          &exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
+          ignore_array_bounds, child_name_str, child_byte_size,
+          child_byte_offset, child_bitfield_bit_size, child_bitfield_bit_offset,
+          child_is_base_class, child_is_deref_of_parent, this, language_flags);
+  CompilerType child_compiler_type;
+  if (!child_compiler_type_or_err)
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types),
+                   child_compiler_type_or_err.takeError(),
+                   "could not find child: {0}");
+  else
+    child_compiler_type = *child_compiler_type_or_err;
+
   if (child_compiler_type) {
     if (synthetic_index)
       child_byte_offset += child_byte_size * synthetic_index;
@@ -2735,16 +2743,23 @@ ValueObjectSP ValueObject::Dereference(Status &error) {
     bool child_is_deref_of_parent = false;
     const bool transparent_pointers = false;
     CompilerType compiler_type = GetCompilerType();
-    CompilerType child_compiler_type;
     uint64_t language_flags = 0;
 
     ExecutionContext exe_ctx(GetExecutionContextRef());
 
-    child_compiler_type = compiler_type.GetChildCompilerTypeAtIndex(
+    CompilerType child_compiler_type;
+    auto child_compiler_type_or_err = compiler_type.GetChildCompilerTypeAtIndex(
         &exe_ctx, 0, transparent_pointers, omit_empty_base_classes,
         ignore_array_bounds, child_name_str, child_byte_size, child_byte_offset,
         child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
         child_is_deref_of_parent, this, language_flags);
+    if (!child_compiler_type_or_err)
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types),
+                     child_compiler_type_or_err.takeError(),
+                     "could not find child: {0}");
+    else
+      child_compiler_type = *child_compiler_type_or_err;
+
     if (child_compiler_type && child_byte_size) {
       ConstString child_name;
       if (!child_name_str.empty())

--- a/lldb/source/Core/ValueObjectConstResultImpl.cpp
+++ b/lldb/source/Core/ValueObjectConstResultImpl.cpp
@@ -17,6 +17,8 @@
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/Endian.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/Scalar.h"
 
 #include <string>
@@ -66,15 +68,21 @@ ValueObject *ValueObjectConstResultImpl::CreateChildAtIndex(
 
   const bool transparent_pointers = !synthetic_array_member;
   CompilerType compiler_type = m_impl_backend->GetCompilerType();
-  CompilerType child_compiler_type;
 
   ExecutionContext exe_ctx(m_impl_backend->GetExecutionContextRef());
 
-  child_compiler_type = compiler_type.GetChildCompilerTypeAtIndex(
+  auto child_compiler_type_or_err = compiler_type.GetChildCompilerTypeAtIndex(
       &exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
       ignore_array_bounds, child_name_str, child_byte_size, child_byte_offset,
       child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
       child_is_deref_of_parent, m_impl_backend, language_flags);
+  CompilerType child_compiler_type;
+  if (!child_compiler_type_or_err)
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types),
+                   child_compiler_type_or_err.takeError(),
+                   "could not find child: {0}");
+  else
+    child_compiler_type = *child_compiler_type_or_err;
 
   // One might think we should check that the size of the children
   // is always strictly positive, hence we could avoid creating a

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc64.cpp
@@ -903,7 +903,8 @@ private:
   }
 
   // get child
-  CompilerType GetChildType(uint32_t i, std::string &name, uint32_t &size) {
+  llvm::Expected<CompilerType> GetChildType(uint32_t i, std::string &name,
+                                            uint32_t &size) {
     // GetChild constant inputs
     const bool transparent_pointers = false;
     const bool omit_empty_base_classes = true;

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -591,11 +591,18 @@ static bool ExtractBytesFromRegisters(
     bool child_is_base_class = false;
     bool child_is_deref_of_parent = false;
     uint64_t language_flags;
-    CompilerType field_clang_type = clang_type.GetChildCompilerTypeAtIndex(
+    CompilerType field_clang_type;
+    auto field_clang_type_or_err = clang_type.GetChildCompilerTypeAtIndex(
         &exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
         ignore_array_bounds, name, child_byte_size, child_byte_offset,
         child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
         child_is_deref_of_parent, nullptr, language_flags);
+    if (!field_clang_type_or_err)
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types),
+                     field_clang_type_or_err.takeError(),
+                     "could not find child #{1}: {0}", idx);
+    else
+      field_clang_type = *field_clang_type_or_err;
 
     const uint64_t field_bit_offset = child_byte_offset * 8;
     const size_t field_bit_width =

--- a/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/BlockPointer.cpp
@@ -12,6 +12,7 @@
 #include "Plugins/ExpressionParser/Clang/ClangPersistentVariables.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "lldb/Core/ValueObject.h"
+#include "lldb/Core/ValueObjectConstResult.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/TypeSystem.h"
@@ -105,13 +106,16 @@ public:
     bool child_is_deref_of_parent = false;
     uint64_t language_flags = 0;
 
-    const CompilerType child_type =
-        m_block_struct_type.GetChildCompilerTypeAtIndex(
-            &exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
-            ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
-            child_bitfield_bit_size, child_bitfield_bit_offset,
-            child_is_base_class, child_is_deref_of_parent, value_object,
-            language_flags);
+    auto child_type_or_err = m_block_struct_type.GetChildCompilerTypeAtIndex(
+        &exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
+        ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
+        child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
+        child_is_deref_of_parent, value_object, language_flags);
+    if (!child_type_or_err)
+      return ValueObjectConstResult::Create(
+          exe_ctx.GetBestExecutionContextScope(),
+          Status(child_type_or_err.takeError()));
+    CompilerType child_type = *child_type_or_err;
 
     ValueObjectSP struct_pointer_sp =
         m_backend.Cast(m_block_struct_type.GetPointerType());

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxMap.cpp
@@ -295,13 +295,13 @@ void lldb_private::formatters::LibcxxStdMapSyntheticFrontEnd::GetValueOffset(
     bool child_is_base_class;
     bool child_is_deref_of_parent;
     uint64_t language_flags;
-    if (tree_node_type
-            .GetChildCompilerTypeAtIndex(
-                nullptr, 4, true, true, true, child_name, child_byte_size,
-                child_byte_offset, child_bitfield_bit_size,
-                child_bitfield_bit_offset, child_is_base_class,
-                child_is_deref_of_parent, nullptr, language_flags)
-            .IsValid())
+    auto child_type =
+        llvm::expectedToStdOptional(tree_node_type.GetChildCompilerTypeAtIndex(
+            nullptr, 4, true, true, true, child_name, child_byte_size,
+            child_byte_offset, child_bitfield_bit_size,
+            child_bitfield_bit_offset, child_is_base_class,
+            child_is_deref_of_parent, nullptr, language_flags));
+    if (child_type && child_type->IsValid())
       m_skip_size = (uint32_t)child_byte_offset;
   }
 }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -356,7 +356,7 @@ public:
                                 std::vector<uint32_t> &child_indexes);
 
   /// Ask Remote Mirrors about a child of a composite type.
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,
       bool omit_empty_base_classes, bool ignore_array_bounds,
       std::string &child_name, uint32_t &child_byte_size,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -144,7 +144,7 @@ public:
                                 bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes);
 
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,
       bool omit_empty_base_classes, bool ignore_array_bounds,
       std::string &child_name, uint32_t &child_byte_size,

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -6245,7 +6245,7 @@ uint32_t TypeSystemClang::GetNumPointeeChildren(clang::QualType type) {
   return 0;
 }
 
-CompilerType TypeSystemClang::GetChildCompilerTypeAtIndex(
+llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
     lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
     bool transparent_pointers, bool omit_empty_base_classes,
     bool ignore_array_bounds, std::string &child_name,
@@ -6271,11 +6271,8 @@ CompilerType TypeSystemClang::GetChildCompilerTypeAtIndex(
 
   auto num_children_or_err =
       GetNumChildren(type, omit_empty_base_classes, exe_ctx);
-  if (!num_children_or_err) {
-    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), num_children_or_err.takeError(),
-                    "{0}");
-    return {};
-  }
+  if (!num_children_or_err)
+    return num_children_or_err.takeError();
 
   const bool idx_is_valid = idx < *num_children_or_err;
   int32_t bit_offset;
@@ -6357,7 +6354,10 @@ CompilerType TypeSystemClang::GetChildCompilerTypeAtIndex(
             std::optional<uint64_t> size =
                 base_class_clang_type.GetBitSize(get_exe_scope());
             if (!size)
-              return {};
+              return llvm::make_error<llvm::StringError>(
+                  "no size info for base class",
+                  llvm::inconvertibleErrorCode());
+
             uint64_t base_class_clang_type_bit_size = *size;
 
             // Base classes bit sizes should be a multiple of 8 bits in size
@@ -6389,7 +6389,9 @@ CompilerType TypeSystemClang::GetChildCompilerTypeAtIndex(
           std::optional<uint64_t> size =
               field_clang_type.GetByteSize(get_exe_scope());
           if (!size)
-            return {};
+            return llvm::make_error<llvm::StringError>(
+                "no size info for field", llvm::inconvertibleErrorCode());
+
           child_byte_size = *size;
           const uint32_t child_bit_size = child_byte_size * 8;
 

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -942,7 +942,7 @@ public:
 
   static uint32_t GetNumPointeeChildren(clang::QualType type);
 
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -7527,7 +7527,7 @@ GetInstanceVariableOffset(ValueObject *valobj, ExecutionContext *exe_ctx,
                                             ivar_name, ivar_type);
 }
 
-CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
+llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
     opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
     bool transparent_pointers, bool omit_empty_base_classes,
     bool ignore_array_bounds, std::string &child_name,
@@ -7614,7 +7614,9 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
           cached_enum_info->GetElementWithPayloadAtIndex(idx);
       child_name.assign(element_info->name.GetCString());
       if (!get_type_size(child_byte_size, element_info->payload_type))
-        return {};
+        return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                       "could not get size for enum element " +
+                                           llvm::Twine(idx));
       child_byte_offset = 0;
       child_bitfield_bit_size = 0;
       child_bitfield_bit_offset = 0;
@@ -7642,7 +7644,9 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
 
     CompilerType child_type = ToCompilerType(child.getType().getPointer());
     if (!get_type_size(child_byte_size, child_type))
-      return {};
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "could not get size of tuple element " +
+                                         child_name);
     child_is_base_class = false;
     child_is_deref_of_parent = false;
 
@@ -7650,7 +7654,9 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     std::optional<uint64_t> offset = GetInstanceVariableOffset(
         valobj, exe_ctx, compiler_type, printed_idx.c_str(), child_type);
     if (!offset)
-      return {};
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "could not get offset for tuple element " +
+                                         child_name);
 
     child_byte_offset = *offset;
     child_bitfield_bit_size = 0;
@@ -7671,7 +7677,8 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
 
         child_name = GetSuperclassName(superclass_type);
         if (!get_type_size(child_byte_size, superclass_type))
-          return {};
+          return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                         "could not get size of super class");
         child_is_base_class = true;
         child_is_deref_of_parent = false;
 
@@ -7711,7 +7718,10 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
                 ToCompilerType(VD->getTypeInContext().getPointer());
             child_name = VD->getNameStr().str();
             if (!get_type_size(child_byte_size, child_type))
-              return {};
+              return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                             "could not get size of field " +
+                                                 child_name);
+
             child_is_base_class = false;
             child_is_deref_of_parent = false;
             child_byte_offset = 0;
@@ -7719,7 +7729,9 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
             child_bitfield_bit_offset = 0;
             return child_type;
           }
-          return {};
+          return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                         "could not get size of field " +
+                                             child_name);
         }
 
     auto stored_properties = GetStoredProperties(nominal);
@@ -7734,7 +7746,9 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     CompilerType child_type = ToCompilerType(child_swift_type.getPointer());
     child_name = property->getBaseName().userFacingName().str();
     if (!get_type_size(child_byte_size, child_type))
-      return {};
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "could not get size of field " +
+                                         child_name);
     child_is_base_class = false;
     child_is_deref_of_parent = false;
 
@@ -7742,8 +7756,9 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     std::optional<uint64_t> offset = GetInstanceVariableOffset(
         valobj, exe_ctx, compiler_type, child_name.c_str(), child_type);
     if (!offset)
-      return {};
-
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "could not get offset of field " +
+                                         child_name);
     child_byte_offset = *offset;
     child_bitfield_bit_size = 0;
     child_bitfield_bit_offset = 0;
@@ -7763,11 +7778,15 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
     CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
     CompilerType child_type;
     if (!ast_ctx)
-      return {};
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "no ast context");
+
     std::tie(child_type, child_name) = GetExistentialTypeChild(
         *this, **ast_ctx, compiler_type, protocol_info, idx);
     if (!get_type_size(child_byte_size, child_type))
-      return {};
+      return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                     "could not get size of field " +
+                                         llvm::Twine(idx));
     child_byte_offset = idx * child_byte_size;
     child_bitfield_bit_size = 0;
     child_bitfield_bit_offset = 0;
@@ -7804,7 +7823,8 @@ CompilerType SwiftASTContext::GetChildCompilerTypeAtIndex(
       // We have a pointer to a simple type
       if (idx == 0) {
         if (!get_type_size(child_byte_size, pointee_clang_type))
-          return {};
+          return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                         "could not get size of lvalue");
         child_byte_offset = 0;
         return pointee_clang_type;
       }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -720,7 +720,7 @@ public:
                                uint32_t *bitfield_bit_size_ptr,
                                bool *is_bitfield_ptr) override;
 
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2229,8 +2229,11 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
 #else
   // We allow the typeref typesystem to return a type where
   // SwiftASTContext fails.
-  if (!l)
+  if (!l) {
+    llvm::dbgs() << l.GetMangledTypeName() << " != " << r.GetMangledTypeName()
+                 << "\n";
     return !r;
+  }
   if (!r)
     return true;
 #endif
@@ -2257,8 +2260,12 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
       TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, l_node));
   auto r_mangling = swift::Demangle::mangleNode(
       TypeSystemSwiftTypeRef::CanonicalizeSugar(dem, r_node));
-  if (!l_mangling.isSuccess() || !r_mangling.isSuccess())
+  if (!l_mangling.isSuccess() || !r_mangling.isSuccess()) {
+    llvm::dbgs() << "TypeSystemSwiftTypeRef diverges from SwiftASTContext "
+                    "(mangle error): "
+                 << lhs.GetStringRef() << " != " << rhs.GetStringRef() << "\n";
     return false;
+  }
 
   if (l_mangling.result() == r_mangling.result())
     return true;
@@ -2282,6 +2289,7 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
                << lhs.GetStringRef() << " != " << rhs.GetStringRef() << "\n";
   return false;
 }
+
 /// This one is particularly taylored for GetTypeName() and
 /// GetDisplayTypeName().
 ///
@@ -2351,6 +2359,20 @@ bool Equivalent(std::optional<T> l, std::optional<T> r) {
     return true;
   llvm::dbgs() << l << " != " << r << "\n";
   return false;
+}
+
+template <>
+bool Equivalent(std::optional<CompilerType> l, std::optional<CompilerType> r) {
+  if (l == r)
+    return true;
+  // Assume that any value is "better" than none.
+  if (l.has_value() && !r.has_value())
+    return true;
+  if (!l.has_value() && r.has_value()) {
+    llvm::dbgs() << "{} != <some value>\n";
+    return false;
+  }
+  return Equivalent(*l, *r);
 }
 
 // Introduced for `GetNumChildren`.
@@ -2425,9 +2447,11 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
   } while (0)
 
 #define VALIDATE_AND_RETURN_EXPECTED(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS,     \
-                                     FALLBACK_ARGS, DEFAULT)                   \
+                                     FALLBACK_ARGS)                            \
   do {                                                                         \
-    FALLBACK(REFERENCE, FALLBACK_ARGS, DEFAULT);                               \
+    FALLBACK(REFERENCE, FALLBACK_ARGS,                                         \
+             llvm::createStringError(llvm::inconvertibleErrorCode(),           \
+                                     "incomplete AST type information"));      \
     auto result = IMPL();                                                      \
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
@@ -2446,12 +2470,17 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
         return result;                                                         \
     auto swift_scratch_ctx_lock = SwiftScratchContextLock(                     \
         _exe_ctx == ExecutionContext() ? nullptr : &_exe_ctx);                 \
-    bool equivalent =                                                          \
-        !ReconstructType(TYPE) /* missing .swiftmodule */ ||                   \
-        (Equivalent(llvm::expectedToStdOptional(std::move(result)),            \
-                    llvm::expectedToStdOptional(                               \
-                        GetSwiftASTContextFromExecutionContext(&_exe_ctx)      \
-                            ->REFERENCE ARGS)));                               \
+    bool equivalent = true;                                                    \
+    if (ReconstructType(TYPE)) {                                               \
+      equivalent =                                                             \
+          (Equivalent(llvm::expectedToStdOptional(std::move(result)),          \
+                      llvm::expectedToStdOptional(                             \
+                          GetSwiftASTContextFromExecutionContext(&_exe_ctx)    \
+                              ->REFERENCE ARGS)));                             \
+    } else { /* missing .swiftmodule */                                        \
+      if (!result)                                                             \
+        llvm::consumeError(result.takeError());                                \
+    }                                                                          \
     if (!equivalent)                                                           \
       llvm::dbgs() << "failing type was " << (const char *)TYPE << "\n";       \
     assert(equivalent &&                                                       \
@@ -3301,8 +3330,8 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
         return 1;
       return clang_type.GetNumChildren(omit_empty_base_classes, exe_ctx);
     }
-    return llvm::make_error<llvm::StringError>("incomplete type information",
-                                               llvm::inconvertibleErrorCode());
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "incomplete type information");
   };
   llvm::Expected<uint32_t> num_children = impl();
   if (num_children) {
@@ -3312,9 +3341,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
     VALIDATE_AND_RETURN_EXPECTED(
         impl, GetNumChildren, type, exe_ctx_obj,
         (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx),
-        (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx),
-        llvm::make_error<llvm::StringError>("incomplete AST type information",
-                                            llvm::inconvertibleErrorCode()));
+        (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx));
   }
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "Using SwiftASTContext::GetNumChildren fallback for type %s",
@@ -3438,7 +3465,8 @@ TypeSystemSwiftTypeRef::ConvertClangTypeToSwiftType(CompilerType clang_type) {
   return RemangleAsType(dem, node);
 }
 
-CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
+llvm::Expected<CompilerType>
+TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
     bool transparent_pointers, bool omit_empty_base_classes,
     bool ignore_array_bounds, std::string &child_name,
@@ -3455,7 +3483,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   child_is_base_class = false;
   child_is_deref_of_parent = false;
   language_flags = 0;
-  auto fallback = [&]() -> CompilerType {
+  auto fallback = [&]() -> llvm::Expected<CompilerType> {
     LLDB_LOG(GetLog(LLDBLog::Types),
              "Had to engage SwiftASTContext fallback for type {0}, field #{1}.",
              AsMangledName(type), idx);
@@ -3467,7 +3495,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
           child_byte_size, child_byte_offset, child_bitfield_bit_size,
           child_bitfield_bit_offset, child_is_base_class,
           child_is_deref_of_parent, valobj, language_flags);
-    return {};
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "no SwiftASTContext");
   };
   FALLBACK(GetChildCompilerTypeAtIndex,
            (ReconstructType(type), exe_ctx, idx, transparent_pointers,
@@ -3475,7 +3504,8 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
             child_byte_size, child_byte_offset, child_bitfield_bit_size,
             child_bitfield_bit_offset, child_is_base_class,
             child_is_deref_of_parent, valobj, language_flags),
-           {});
+           llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "no SwiftASTContext"));
   std::optional<unsigned> ast_num_children;
   auto get_ast_num_children = [&]() {
     if (ast_num_children)
@@ -3487,26 +3517,27 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
                                             omit_empty_base_classes, exe_ctx));
     return ast_num_children.value_or(0);
   };
-  auto impl = [&]() -> CompilerType {
+  auto impl = [&]() -> llvm::Expected<CompilerType> {
     ExecutionContextScope *exe_scope = nullptr;
     if (exe_ctx)
       exe_scope = exe_ctx->GetBestExecutionContextScope();
     if (exe_scope) {
       if (auto *runtime =
-              SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
-        if (CompilerType result = runtime->GetChildCompilerTypeAtIndex(
-                {weak_from_this(), type}, idx, transparent_pointers,
-                omit_empty_base_classes, ignore_array_bounds, child_name,
-                child_byte_size, child_byte_offset, child_bitfield_bit_size,
-                child_bitfield_bit_offset, child_is_base_class,
-                child_is_deref_of_parent, valobj, language_flags)) {
+              SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
+        auto result = runtime->GetChildCompilerTypeAtIndex(
+            {weak_from_this(), type}, idx, transparent_pointers,
+            omit_empty_base_classes, ignore_array_bounds, child_name,
+            child_byte_size, child_byte_offset, child_bitfield_bit_size,
+            child_bitfield_bit_offset, child_is_base_class,
+            child_is_deref_of_parent, valobj, language_flags);
+        if (result && *result) {
           // This type is treated specially by ClangImporter.  It's really a
           // typedef to NSString *, but ClangImporter introduces an extra
           // layer of indirection that we simulate here.
           if (llvm::StringRef(AsMangledName(type))
                   .endswith("sSo18NSNotificationNameaD"))
             return GetTypeFromMangledTypename(ConstString("$sSo8NSStringCD"));
-          if (result.GetMangledTypeName().GetStringRef().count('$') > 1 &&
+          if (result->GetMangledTypeName().GetStringRef().count('$') > 1 &&
               get_ast_num_children() ==
                   llvm::expectedToStdOptional(runtime->GetNumChildren(
                       {weak_from_this(), type}, exe_scope)))
@@ -3519,103 +3550,110 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
               return ast_type;
           return result;
         }
-    }
-    // Clang types can be resolved even without a process.
-    bool is_signed;
-    if (CompilerType clang_type = GetAsClangTypeOrNull(type)) {
-      if (clang_type.IsEnumerationType(is_signed) && idx == 0)
-        // C enums get imported into Swift as structs with a "rawValue" field.
-        if (auto ts =
-                clang_type.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>())
-          if (clang::EnumDecl *enum_decl = ts->GetAsEnumDecl(clang_type)) {
-            swift::Demangle::Demangler dem;
-            CompilerType raw_value =
-                CompilerType(ts, enum_decl->getIntegerType().getAsOpaquePtr());
-            child_name = "rawValue";
-            auto bit_size = raw_value.GetBitSize(
-                exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr);
-            child_byte_size = bit_size.value_or(0) / 8;
-            child_byte_offset = 0;
-            child_bitfield_bit_size = 0;
-            child_bitfield_bit_offset = 0;
-            child_is_base_class = false;
-            child_is_deref_of_parent = false;
-            language_flags = 0;
-            return RemangleAsType(dem, GetClangTypeTypeNode(dem, raw_value));
-          }
-      // Otherwise defer to TypeSystemClang.
-      //
-      // Swift skips bitfields when counting children. Unfortunately
-      // this means we need to do this inefficient linear search here.
-      CompilerType clang_child_type;
-      for (size_t clang_idx = 0, swift_idx = 0; swift_idx <= idx; ++clang_idx) {
-        child_bitfield_bit_size = 0;
-        child_bitfield_bit_offset = 0;
-        clang_child_type = clang_type.GetChildCompilerTypeAtIndex(
-            exe_ctx, clang_idx, transparent_pointers, omit_empty_base_classes,
-            ignore_array_bounds, child_name, child_byte_size, child_byte_offset,
-            child_bitfield_bit_size, child_bitfield_bit_offset,
-            child_is_base_class, child_is_deref_of_parent, valobj,
-            language_flags);
-        if (!child_bitfield_bit_size && !child_bitfield_bit_offset)
-          ++swift_idx;
-        // FIXME: Why is this necessary?
-        if (clang_child_type.IsTypedefType() &&
-            clang_child_type.GetTypeName() ==
-                clang_child_type.GetTypedefedType().GetTypeName())
-          clang_child_type = clang_child_type.GetTypedefedType();
+        if (!result)
+          llvm::consumeError(result.takeError());
       }
-      if (clang_child_type) {
-        // TypeSystemSwiftTypeRef can't properly handle C anonymous types, as
-        // the only identifier CompilerTypes backed by this type system carry is
-        // the type's mangled name. This is problematic for anonymous types, as
-        // sibling anonymous types will share the exact same mangled name,
-        // making it impossible to diferentiate between them. For example, the
-        // following two anonymous structs in "MyStruct" share the same name
-        // (which is MyStruct::(anonymous struct)):
+      // Clang types can be resolved even without a process.
+      bool is_signed;
+      if (CompilerType clang_type = GetAsClangTypeOrNull(type)) {
+        if (clang_type.IsEnumerationType(is_signed) && idx == 0)
+          // C enums get imported into Swift as structs with a "rawValue" field.
+          if (auto ts = clang_type.GetTypeSystem()
+                            .dyn_cast_or_null<TypeSystemClang>())
+            if (clang::EnumDecl *enum_decl = ts->GetAsEnumDecl(clang_type)) {
+              swift::Demangle::Demangler dem;
+              CompilerType raw_value = CompilerType(
+                  ts, enum_decl->getIntegerType().getAsOpaquePtr());
+              child_name = "rawValue";
+              auto bit_size = raw_value.GetBitSize(
+                  exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr);
+              child_byte_size = bit_size.value_or(0) / 8;
+              child_byte_offset = 0;
+              child_bitfield_bit_size = 0;
+              child_bitfield_bit_offset = 0;
+              child_is_base_class = false;
+              child_is_deref_of_parent = false;
+              language_flags = 0;
+              return RemangleAsType(dem, GetClangTypeTypeNode(dem, raw_value));
+            }
+        // Otherwise defer to TypeSystemClang.
         //
-        // struct MyStruct {
-        //         struct {
-        //             float x;
-        //             float y;
-        //             float z;
-        //         };
-        //         struct {
-        //           int a;
-        //         };
-        // };
-        //
-        // For this reason, forward any lookups of anonymous types to
-        // TypeSystemClang instead, as that type system carries enough
-        // information to handle anonymous types properly.
-        auto ts_clang = clang_child_type.GetTypeSystem()
-                            .dyn_cast_or_null<TypeSystemClang>();
-        if (ts_clang &&
-            ts_clang->IsAnonymousType(clang_child_type.GetOpaqueQualType()))
-          return clang_child_type;
-
-        std::string prefix;
-        swift::Demangle::Demangler dem;
-        swift::Demangle::NodePointer node =
-            GetClangTypeTypeNode(dem, clang_child_type);
-        if (!node)
-          return {};
-        switch (node->getChild(0)->getKind()) {
-        case swift::Demangle::Node::Kind::Class:
-          prefix = "ObjectiveC.";
-          break;
-        default:
-          break;
+        // Swift skips bitfields when counting children. Unfortunately
+        // this means we need to do this inefficient linear search here.
+        CompilerType clang_child_type;
+        for (size_t clang_idx = 0, swift_idx = 0; swift_idx <= idx;
+             ++clang_idx) {
+          child_bitfield_bit_size = 0;
+          child_bitfield_bit_offset = 0;
+          auto clang_child_type_or_err = clang_type.GetChildCompilerTypeAtIndex(
+              exe_ctx, clang_idx, transparent_pointers, omit_empty_base_classes,
+              ignore_array_bounds, child_name, child_byte_size,
+              child_byte_offset, child_bitfield_bit_size,
+              child_bitfield_bit_offset, child_is_base_class,
+              child_is_deref_of_parent, valobj, language_flags);
+          if (!clang_child_type_or_err)
+            LLDB_LOG_ERROR(
+                GetLog(LLDBLog::Types), clang_child_type_or_err.takeError(),
+                "could not find child {1} using clang: {0}", clang_idx);
+          else
+            clang_child_type = *clang_child_type_or_err;
+          if (!child_bitfield_bit_size && !child_bitfield_bit_offset)
+            ++swift_idx;
+          // FIXME: Why is this necessary?
+          if (clang_child_type.IsTypedefType() &&
+              clang_child_type.GetTypeName() ==
+                  clang_child_type.GetTypedefedType().GetTypeName())
+            clang_child_type = clang_child_type.GetTypedefedType();
         }
-        child_name = prefix + child_name;
-        return RemangleAsType(dem, node);
+        if (clang_child_type) {
+          // TypeSystemSwiftTypeRef can't properly handle C anonymous types, as
+          // the only identifier CompilerTypes backed by this type system carry
+          // is the type's mangled name. This is problematic for anonymous
+          // types, as sibling anonymous types will share the exact same mangled
+          // name, making it impossible to diferentiate between them. For
+          // example, the following two anonymous structs in "MyStruct" share
+          // the same name (which is MyStruct::(anonymous struct)):
+          //
+          // struct MyStruct {
+          //         struct {
+          //             float x;
+          //             float y;
+          //             float z;
+          //         };
+          //         struct {
+          //           int a;
+          //         };
+          // };
+          //
+          // For this reason, forward any lookups of anonymous types to
+          // TypeSystemClang instead, as that type system carries enough
+          // information to handle anonymous types properly.
+          auto ts_clang = clang_child_type.GetTypeSystem()
+                              .dyn_cast_or_null<TypeSystemClang>();
+          if (ts_clang &&
+              ts_clang->IsAnonymousType(clang_child_type.GetOpaqueQualType()))
+            return clang_child_type;
+
+          std::string prefix;
+          swift::Demangle::Demangler dem;
+          swift::Demangle::NodePointer node =
+              GetClangTypeTypeNode(dem, clang_child_type);
+          if (!node)
+            return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                           "object has no address");
+
+          switch (node->getChild(0)->getKind()) {
+          case swift::Demangle::Node::Kind::Class:
+            prefix = "ObjectiveC.";
+            break;
+          default:
+            break;
+          }
+          child_name = prefix + child_name;
+          return RemangleAsType(dem, node);
+        }
       }
     }
-    // FIXME: SwiftASTContext can sometimes find more Clang types because it
-    // imports Clang modules from source. We should be able to replicate this
-    // and remove this fallback.
-    return fallback();
-
     if (!exe_scope)
       LLDB_LOGF(GetLog(LLDBLog::Types),
                 "Cannot compute the children of type %s without an execution "
@@ -3625,7 +3663,11 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
       LLDB_LOGF(GetLog(LLDBLog::Types),
                 "Couldn't compute size of type %s without a process.",
                 AsMangledName(type));
-    return {};
+
+    // FIXME: SwiftASTContext can sometimes find more Clang types because it
+    // imports Clang modules from source. We should be able to replicate this
+    // and remove this fallback.
+    return fallback();
   };
   // Skip validation when there is no process, because then we also
   // don't have a runtime.
@@ -3660,10 +3702,13 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   // GetChildCompilerTypeAtIndex will return the clang type directly. In this
   // case validation will fail as it can't correctly compare the mangled 
   // clang and Swift names, so return early.
-  if (auto ts_clang =
-          result.GetTypeSystem().dyn_cast_or_null<TypeSystemClang>()) {
-    if (ts_clang->IsAnonymousType(result.GetOpaqueQualType()))
-      return result;
+  if (result) {
+    if (auto ts_clang =
+            result->GetTypeSystem().dyn_cast_or_null<TypeSystemClang>())
+      if (ts_clang->IsAnonymousType(result->GetOpaqueQualType()))
+        return result;
+  } else {
+    llvm::consumeError(result.takeError());
   }
   std::string ast_child_name;
   uint32_t ast_child_byte_size = 0;
@@ -3699,7 +3744,7 @@ CompilerType TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     assert(Equivalent(language_flags, ast_language_flags));
   });
 #endif
-  VALIDATE_AND_RETURN(
+  VALIDATE_AND_RETURN_EXPECTED(
       impl, GetChildCompilerTypeAtIndex, type, exe_ctx,
       (ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
        omit_empty_base_classes, ignore_array_bounds, ast_child_name,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -205,7 +205,7 @@ public:
                                std::string &name, uint64_t *bit_offset_ptr,
                                uint32_t *bitfield_bit_size_ptr,
                                bool *is_bitfield_ptr) override;
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -707,7 +707,7 @@ uint32_t CompilerType::GetIndexOfFieldWithName(
   return UINT32_MAX;
 }
 
-CompilerType CompilerType::GetChildCompilerTypeAtIndex(
+llvm::Expected<CompilerType> CompilerType::GetChildCompilerTypeAtIndex(
     ExecutionContext *exe_ctx, size_t idx, bool transparent_pointers,
     bool omit_empty_base_classes, bool ignore_array_bounds,
     std::string &child_name, uint32_t &child_byte_size,


### PR DESCRIPTION
This was prompted by a crash report due to an out-of-bounds access of "fields" in

    return get_from_field_info(fields[idx], tuple, true);

which is now wrapped in an error. I don't know how to trigger this
situation from a testcase.

rdar://128284599