### PR TITLE
Drop DIAssign for outlined cold function.

### DIFF
--- a/llvm/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/llvm/lib/Transforms/Utils/CodeExtractor.cpp
@@ -1619,6 +1619,8 @@ static void fixupDebugInfoPostExtraction(Function &OldFunc, Function &NewFunc,
       return MD;
     };
     updateLoopMetadataDebugLocations(I, updateLoopInfoLoc);
+    if (auto *ID = I.getMetadata(LLVMContext::MD_DIAssignID))
+      I.setMetadata(LLVMContext::MD_DIAssignID, nullptr);
   }
   if (!TheCall.getDebugLoc())
     TheCall.setDebugLoc(DILocation::get(Ctx, 0, 0, OldSP));


### PR DESCRIPTION
Fix for rdar://128178601
(Swift 6.0: Debian 12: Clang --  inst not in same function as dbg.assign)

The bug occurs because we need to fix up the DIAssign for an instruction that has been outlined due to hot cold splitting. That change exists in llvm trunk, but would require cherry-picking over 100 commits, so a compromise for this release is to drop the debug info instead.