### PR TITLE
Add error handling to GetChildCompilerTypeAtIndex()

### DIFF
--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -591,18 +591,18 @@ static bool ExtractBytesFromRegisters(
     bool child_is_base_class = false;
     bool child_is_deref_of_parent = false;
     uint64_t language_flags;
+    CompilerType field_clang_type;
     auto field_clang_type_or_err = clang_type.GetChildCompilerTypeAtIndex(
         &exe_ctx, idx, transparent_pointers, omit_empty_base_classes,
         ignore_array_bounds, name, child_byte_size, child_byte_offset,
         child_bitfield_bit_size, child_bitfield_bit_offset, child_is_base_class,
         child_is_deref_of_parent, nullptr, language_flags);
-    if (!field_clang_type_or_err) {
-      LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions),
+    if (!field_clang_type_or_err)
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types),
                      field_clang_type_or_err.takeError(),
-                     "Could not get child type: {0}");
-      return false;
-    }
-    CompilerType field_clang_type = *field_clang_type_or_err;
+                     "could not find child #{1}: {0}", idx);
+    else
+      field_clang_type = *field_clang_type_or_err;
 
     const uint64_t field_bit_offset = child_byte_offset * 8;
     const size_t field_bit_width =

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -353,7 +353,7 @@ public:
                                 std::vector<uint32_t> &child_indexes);
 
   /// Ask Remote Mirrors about a child of a composite type.
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,
       bool omit_empty_base_classes, bool ignore_array_bounds,
       std::string &child_name, uint32_t &child_byte_size,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -144,7 +144,7 @@ public:
                                 bool omit_empty_base_classes,
                                 std::vector<uint32_t> &child_indexes);
 
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       CompilerType type, size_t idx, bool transparent_pointers,
       bool omit_empty_base_classes, bool ignore_array_bounds,
       std::string &child_name, uint32_t &child_byte_size,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -714,7 +714,7 @@ public:
                                uint32_t *bitfield_bit_size_ptr,
                                bool *is_bitfield_ptr) override;
 
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -205,7 +205,7 @@ public:
                                std::string &name, uint64_t *bit_offset_ptr,
                                uint32_t *bitfield_bit_size_ptr,
                                bool *is_bitfield_ptr) override;
-  CompilerType GetChildCompilerTypeAtIndex(
+  llvm::Expected<CompilerType> GetChildCompilerTypeAtIndex(
       lldb::opaque_compiler_type_t type, ExecutionContext *exe_ctx, size_t idx,
       bool transparent_pointers, bool omit_empty_base_classes,
       bool ignore_array_bounds, std::string &child_name,


### PR DESCRIPTION
This was prompted by a crash report due to an out-of-bounds access of "fields" in

    return get_from_field_info(fields[idx], tuple, true);

which is now wrapped in an error. I don't know how to trigger this situation from a testcase.

rdar://128284599
(cherry picked from commit cc6b62c69dfe16548dafcd8f2fd5943c5d1531f8)

 Conflicts:
	lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
	lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp