### PR TITLE
Log clang errors to swift-healthcheck

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
@@ -26,5 +26,10 @@ class TestSwiftExtraClangFlags(TestBase):
                     '"-DBREAK_STUFF"')
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'))
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
+
         self.expect("expr 0", error=True,
                     substrs=['failed to import bridging header'])
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+        # CHECK: Clang error: {{.*}}bridging-header.h


### PR DESCRIPTION
Any errors from clang could be related module import issues, which shoud be surfaced in the health log channel.