### PR TITLE
[Cherry-pick into next] Produce a summary for non-decodable strings.

### DIFF
--- a/lldb/test/API/lang/swift/string/Makefile
+++ b/lldb/test/API/lang/swift/string/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/string/TestSwiftString.py
+++ b/lldb/test/API/lang/swift/string/TestSwiftString.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import unittest2
+
+class TestSwiftTuple(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    def test(self):
+        """Test the String formatter under adverse conditions"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        # FIXME: It would be even better if this were an error.
+        self.expect("frame variable zero", substrs=['<uninitialized>'])
+        self.expect("frame variable random", substrs=['cannot decode string'])

--- a/lldb/test/API/lang/swift/string/main.swift
+++ b/lldb/test/API/lang/swift/string/main.swift
@@ -1,0 +1,19 @@
+func main() {
+  var zero : String = "zero"
+  withUnsafeMutablePointer(to: &zero) {
+    $0.withMemoryRebound(to: UInt64.self, capacity: 2) { raw in
+      raw[0] = 0
+      raw[1] = 0
+    }
+  }
+  var random : String = "random"
+  withUnsafeMutablePointer(to: &random) {
+    $0.withMemoryRebound(to: UInt64.self, capacity: 2) { raw in
+      raw[0] = 0xfefefefefefefefe
+      raw[1] = 0xfefefefefefefefe
+    }
+  }
+  print("break here")
+}
+
+main()


### PR DESCRIPTION
```
commit 22968c8d18590bace891738365455102011c0c08
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue May 28 12:50:50 2024 -0700

    Produce a summary for non-decodable strings.
    
    Currently when LLDB encounters an uninitialized string the summary
    formatter will fail and the user sees something like:
    
    ```
    (String) s = {
      _guts = {
        _object = (_countAndFlagsBits = 18374403900871474942, _object = 0xfefefefefefefefe)
      }
    }
    ```
    
    with this patch this becomes
    
    (String) s = <could not decode string: unexpected discriminator>
```
