### PR TITLE
[lldb] Fix macros in noasserts after #8793

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2497,8 +2497,10 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
   FALLBACK(REFERENCE, FALLBACK_ARGS, {});                                      \
   return IMPL();
 #define VALIDATE_AND_RETURN_EXPECTED(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS,     \
-                                     FALLBACK_ARGS, DEFAULT)                   \
-  FALLBACK(REFERENCE, FALLBACK_ARGS, DEFAULT);                                 \
+                                     FALLBACK_ARGS)                            \
+  FALLBACK(REFERENCE, FALLBACK_ARGS,                                           \
+           llvm::createStringError(llvm::inconvertibleErrorCode(),             \
+                                   "incomplete AST type information"));        \
   return IMPL();
 #endif
 


### PR DESCRIPTION
In #8793 the macro in the modified file is changed to remove the last parameter, but the original change fails to realize that the macro is only the asserts/NDEBUG version of the macro, and the code will fail to compile when building in noasserts mode.

Remove the last argument in the other macro, and use the same default when invoking the `FALLBACK` macro.