### PR TITLE
[Cherry-pick into next] Add a testcase that implicitly imports a module in an explicit module build project

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -8,10 +8,24 @@ import unittest2
 class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @swiftTest
-    def test_any_type(self):
+    def test(self):
         """Test explicit Swift modules"""
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
         self.expect("expression c", substrs=['hello explicit'])
+
+    @swiftTest
+    @skipUnlessDarwin
+    def test_import(self):
+        """Test an implicit import inside an explicit build"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
+
+        self.expect('expression URL(string: "https://lldb.llvm.org")',
+                    error=True)
+        self.expect("expression import Foundation")
+        self.expect('expression URL(string: "https://lldb.llvm.org")',
+                    substrs=["https://lldb.llvm.org"])


### PR DESCRIPTION
```
commit e89165f9bce469f150de6cf9d668c3bb47484de7
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu May 30 13:57:43 2024 -0700

    Add a testcase that implicitly imports a module in an explicit module build project
```
