### PR TITLE
[lldb][swift] Fix zeroth frame detection in async functions

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2766,7 +2766,6 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   plan->SetSourcedFromCompiler(eLazyBoolNo);
   plan->SetUnwindPlanValidAtAllInstructions(eLazyBoolYes);
   plan->SetUnwindPlanForSignalTrap(eLazyBoolYes);
-  behaves_like_zeroth_frame = true;
   return plan;
 }
 

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -32,3 +32,22 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
         # to see that this is really the async unwinder.
         self.assertIn(thread.GetFrameAtIndex(1).GetRegisters().GetSize(), [2,3,4])
         self.assertIn(thread.GetFrameAtIndex(2).GetRegisters().GetSize(), [2,3,4])
+
+        # Delete the old breakpoint, otherwise it would be reached again.
+        target.BreakpointDelete(bkpt.GetID())
+        lldbutil.continue_to_source_breakpoint(
+            self, process, "break synchronous hello", src
+        )
+
+        self.assertTrue(
+            "synchronousSayHelo" in thread.GetFrameAtIndex(0).GetFunctionName(),
+        )
+        frame1 = thread.GetFrameAtIndex(1)
+        self.assertTrue(
+            "callSyncHello" in frame1.GetFunctionName(),
+        )
+        location = frame1.GetLineEntry()
+        # Check that the callsite location is on the correct line.
+        self.assertEqual(
+            location.GetLine(), lldbtest.line_number("main.swift", "frame 1 line")
+        )

--- a/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/main.swift
@@ -20,9 +20,18 @@ func sayGeneric<T>(_ msg: T) async {
   print("\(str) after calls - arg \(msg)")
 }
 
+func synchronousSayHelo() {
+  print("synchronously saying hello") // break synchronous hello
+}
+
+func callSyncHello() async {
+  synchronousSayHelo() // frame 1 line
+}
+
 @main struct Main {
   static func main() async {
     await sayGeneric("world")
     await sayHello()
+    await callSyncHello()
   }
 }


### PR DESCRIPTION
In all frames except for the zero-th frame, we subtract one from the address before looking up line number information. This is to account for the fact that such address is normally the return address of a call.

In async backtraces (async function awaiting another async function), however, we don't do that: this address is usually the continuation address, which is in a different low level function, even though it's "the same" source level function.

The current implementation was also applying this behavior (of not subtracting one) to async functions calling a synchronous function. To fix this, we remove the hardcoded "behaves like zeroth frame" from the thread plan responsible for this type of unwinding.

rdar://128679048