### PR TITLE
[lldb] Improve identification of Dlang mangled names

### DIFF
--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -59,11 +59,12 @@ Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
     return Mangled::eManglingSchemeRustV0;
 
   if (name.startswith("_D")) {
-    // A dlang mangled name begins with `_D`, followed by a numeric length.
+    // A dlang mangled name begins with `_D`, followed by a numeric length. One
+    // known exception is the symbol `_Dmain`.
     // See `SymbolName` and `LName` in
     // https://dlang.org/spec/abi.html#name_mangling
     llvm::StringRef buf = name.drop_front(2);
-    if (!buf.empty() && llvm::isDigit(buf.front()))
+    if (!buf.empty() && (llvm::isDigit(buf.front()) || name == "_Dmain"))
       return Mangled::eManglingSchemeD;
   }
 

--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -19,6 +19,7 @@
 #include "lldb/Utility/Stream.h"
 #include "lldb/lldb-enumerations.h"
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/Compiler.h"
@@ -57,8 +58,14 @@ Mangled::ManglingScheme Mangled::GetManglingScheme(llvm::StringRef const name) {
   if (name.startswith("_R"))
     return Mangled::eManglingSchemeRustV0;
 
-  if (name.startswith("_D"))
-    return Mangled::eManglingSchemeD;
+  if (name.startswith("_D")) {
+    // A dlang mangled name begins with `_D`, followed by a numeric length.
+    // See `SymbolName` and `LName` in
+    // https://dlang.org/spec/abi.html#name_mangling
+    llvm::StringRef buf = name.drop_front(2);
+    if (!buf.empty() && llvm::isDigit(buf.front()))
+      return Mangled::eManglingSchemeD;
+  }
 
   if (name.startswith("_Z"))
     return Mangled::eManglingSchemeItanium;

--- a/lldb/test/API/lang/c/non-mangled/Makefile
+++ b/lldb/test/API/lang/c/non-mangled/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
+++ b/lldb/test/API/lang/c/non-mangled/TestCNonMangled.py
@@ -1,0 +1,15 @@
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+
+
+class TestCase(TestBase):
+    def test_functions_having_dlang_mangling_prefix(self):
+        """
+        Ensure C functions with a '_D' prefix alone are not mistakenly treated
+        as a Dlang mangled name. A proper Dlang mangling will have digits
+        immediately following the '_D' prefix.
+        """
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_name_breakpoint(self, "_Dfunction")
+        symbol = thread.frame[0].symbol
+        self.assertEqual(symbol.GetDisplayName(), "_Dfunction")

--- a/lldb/test/API/lang/c/non-mangled/main.c
+++ b/lldb/test/API/lang/c/non-mangled/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+void _Dfunction() {}
+
+int main() {
+  _Dfunction();
+  return 0;
+}

--- a/lldb/unittests/Core/MangledTest.cpp
+++ b/lldb/unittests/Core/MangledTest.cpp
@@ -81,12 +81,12 @@ TEST(MangledTest, ResultForValidDLangName) {
   EXPECT_STREQ(expected_result.GetCString(), the_demangled.GetCString());
 }
 
-TEST(MangledTest, EmptyForInvalidDLangName) {
+TEST(MangledTest, SameForInvalidDLangPrefixedName) {
   ConstString mangled_name("_DDD");
   Mangled the_mangled(mangled_name);
   ConstString the_demangled = the_mangled.GetDemangledName();
 
-  EXPECT_STREQ("", the_demangled.GetCString());
+  EXPECT_STREQ("_DDD", the_demangled.GetCString());
 }
 
 TEST(MangledTest, BoolConversionOperator) {


### PR DESCRIPTION
See the commit messages of the cherry picked commits.

rdar://128242875