### PR TITLE
[ThinLTO] Re-commit termination handling

### DIFF
--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -2024,9 +2024,10 @@ void ThinLTOCodeGenerator::run() {
       WrittenObjects.wait(AllModules);
 
       {
-        CacheLogOS.applyLocked([&](raw_ostream &OS) {
-          OS << "Waiting for outstanding cache requests...\n";
-        });
+        if (CacheLogging)
+          CacheLogOS.applyLocked([&](raw_ostream &OS) {
+            OS << "Waiting for outstanding cache requests...\n";
+          });
         ScopedDurationTimer T([&](double Seconds) {
           if (CacheLogging)
             CacheLogOS.applyLocked([&](raw_ostream &OS) {


### PR DESCRIPTION
Asynchronous ThinLTO caching was originally implemented in #8236, but the [Make the async code more self-contained](https://github.com/apple/llvm-project/pull/8236/commits/8fc16874fab1c941ce95fc9c6e911b2f6d26b23a) commit accidentally dropped termination handling. This resulted in a crash in the "LLVM.CAS.thinlto-remote-cache.ll" test. This PR fixes that.