### PR TITLE
[ThinLTO] Re-commit termination handling

### DIFF
--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -2027,9 +2027,10 @@ void ThinLTOCodeGenerator::run() {
       WrittenObjects.wait(AllModules);
 
       {
-        CacheLogOS.applyLocked([&](raw_ostream &OS) {
-          OS << "Waiting for outstanding cache requests...\n";
-        });
+        if (CacheLogging)
+          CacheLogOS.applyLocked([&](raw_ostream &OS) {
+            OS << "Waiting for outstanding cache requests...\n";
+          });
         ScopedDurationTimer T([&](double Seconds) {
           if (CacheLogging)
             CacheLogOS.applyLocked([&](raw_ostream &OS) {

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -2023,6 +2023,46 @@ void ThinLTOCodeGenerator::run() {
           }
         });
       }
+
+      WrittenObjects.wait(AllModules);
+
+      {
+        CacheLogOS.applyLocked([&](raw_ostream &OS) {
+          OS << "Waiting for outstanding cache requests...\n";
+        });
+        ScopedDurationTimer T([&](double Seconds) {
+          if (CacheLogging)
+            CacheLogOS.applyLocked([&](raw_ostream &OS) {
+              OS << "Handled outstanding cache requests in "
+                 << llvm::format("%.6fs", Seconds) << "\n";
+            });
+        });
+        auto Start = std::chrono::steady_clock::now();
+        auto CacheTimeout = DeterministicCheck
+                                ? std::chrono::milliseconds::max()
+                                : std::chrono::milliseconds(5000);
+
+        if (!HandledCacheReads.waitFor(CacheTimeout, AllModules)) {
+          // If we were unable to finish all cache reads in time, just request
+          // their cancellation (we already have all objects written) and don't
+          // bother writing to the cache (that would probably be even slower
+          // than reading form it).
+          GetCancelTok->requestCancellation();
+        } else {
+          auto Now = std::chrono::steady_clock::now();
+          auto RemainingCacheTimeout = CacheTimeout - (Now - Start);
+          // If we finished all cache reads in time, request writes.
+          if (!HandledCacheWrites.waitFor(RemainingCacheTimeout, AllModules)) {
+            // If we were unable to finish all cache writes in time, request
+            // their cancellation. We don't want to hold up the link any longer.
+            PutCancelTok->requestCancellation();
+          }
+        }
+
+        if (DeterministicCheck)
+          for (int count : ModulesOrdering)
+            (void)Infos[count].Entry->areLoadedAndWrittenResultsIdentical();
+      }
     }
 
     pruneCache(CacheOptions.Path, CacheOptions.Policy, ProducedBinaries);


### PR DESCRIPTION
Asynchronous ThinLTO caching was originally implemented in https://github.com/apple/llvm-project/pull/8236 (and cherry-picked into the release branch in https://github.com/apple/llvm-project/pull/8614), but the [Make the async code more self-contained](https://github.com/apple/llvm-project/pull/8236/commits/8fc16874fab1c941ce95fc9c6e911b2f6d26b23a) commit accidentally dropped termination handling. This resulted in a crash in the "LLVM.CAS.thinlto-remote-cache.ll" test. This PR fixes that.