### PR TITLE
🍒 [Sanitizers][Darwin] Bump up DEFAULT_SANITIZER_MIN_OSX_VERSION (#86035)

### DIFF
--- a/compiler-rt/cmake/config-ix.cmake
+++ b/compiler-rt/cmake/config-ix.cmake
@@ -446,7 +446,7 @@ if(APPLE)
 
   # Note: In order to target x86_64h on OS X the minimum deployment target must
   # be 10.8 or higher.
-  set(DEFAULT_SANITIZER_MIN_OSX_VERSION 10.10)
+  set(DEFAULT_SANITIZER_MIN_OSX_VERSION 10.13)
   set(DARWIN_osx_MIN_VER_FLAG "-mmacosx-version-min")
   if(NOT SANITIZER_MIN_OSX_VERSION)
     string(REGEX MATCH "${DARWIN_osx_MIN_VER_FLAG}=([.0-9]+)"


### PR DESCRIPTION
The greendragon was recently moved and now it runs on somewhat newer
macOS
version - which breaks some sanitizers tests

rdar://125052915

Co-authored-by: Mariusz Borsa <m_borsa@apple.com>
(cherry picked from commit 19268ac55106834701b1c41acded4d413a3502e9)
