### PR TITLE
6.0: [Test] lldb: Updated consume operator breakpoints.

### DIFF
--- a/lldb/test/API/lang/swift/variables/consume_operator/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator/main.swift
@@ -34,7 +34,8 @@ public func copyableValueTest() {
     print("stop here") // Set breakpoint
     let k = Klass()
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething() // Set breakpoint
 }
 
@@ -76,7 +77,8 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 public func copyableValueArgTest(_ k: __owned Klass) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething() // Set breakpoint
 }
 
@@ -116,7 +118,8 @@ public func copyableValueCCFTrueTest() {
     let k = Klass() // Set breakpoint
     k.doSomething() // Set breakpoint
     if trueBoolValue {
-        let m = consume k // Set breakpoint
+        print("stop here") // Set breakpoint
+        let m = consume k
         m.doSomething() // Set breakpoint
     }
     // Set breakpoint
@@ -126,6 +129,7 @@ public func copyableValueCCFFalseTest() {
     let k = Klass() // Set breakpoint
     k.doSomething() // Set breakpoint
     if falseBoolValue {
+        print("stop here") // Set breakpoint
         let m = consume k
         m.doSomething()
     }

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
@@ -25,7 +25,8 @@ public func copyableValueTest() async {
     let k = Klass()
     k.doSomething()
     await forceSplit() // Set breakpoint 01
-    let m = consume k    // Set breakpoint 02
+    print("stop here") // Set breakpoint 02
+    let m = consume k
     m.doSomething()    // Set breakpoint 03
     await forceSplit()
     m.doSomething()    // Set breakpoint 04


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/llvm-project/pull/8836 to release/6.0.  Paired with https://github.com/apple/swift/pull/74134 .

