### PR TITLE
[lldb][test] XFAIL TestCCallingConventions.py on Linux

### DIFF
--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -66,7 +66,7 @@ class TestCase(TestBase):
     # any other architectures.
     @expectedFailureAll(
         triple=re.compile("^(x86|i386)"),
-        oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56084"
+        oslist=["freebsd", "linux"], bugnumber="github.com/llvm/llvm-project/issues/56084"
     )
     def test_vectorcall(self):
         if not self.build_and_run("vectorcall.c"):


### PR DESCRIPTION
The test-suite by default gets linked with LLD
on our Ubuntu Swift CI bots causing the vector_call test-case to fail. This is a known issue: https://github.com/llvm/llvm-project/issues/56084

Haven't found a good way to XFAIL a test based on
the linker used, so XFAIL it for all of Linux for now.

rdar://129208184