### PR TITLE
[lldb][test] Fix PythonDataObjectsTest

### DIFF
--- a/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
+++ b/lldb/unittests/ScriptInterpreter/Python/PythonDataObjectsTests.cpp
@@ -11,6 +11,7 @@
 
 #include "Plugins/ScriptInterpreter/Python/PythonDataObjects.h"
 #include "Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.h"
+#include "TestingSupport/SubsystemRAII.h"
 #include "lldb/Host/File.h"
 #include "lldb/Host/FileSystem.h"
 #include "lldb/Host/HostInfo.h"
@@ -27,6 +28,8 @@ using llvm::Error;
 using llvm::Expected;
 
 class PythonDataObjectsTest : public PythonTestSuite {
+  SubsystemRAII<FileSystem> subsystems;
+
 public:
   void SetUp() override {
     PythonTestSuite::SetUp();
@@ -210,8 +213,8 @@ TEST_F(PythonDataObjectsTest, TestPythonBoolean) {
   };
 
   // Test PythonBoolean constructed from long integer values.
-  test_from_long(0); // Test 'false' value.
-  test_from_long(1); // Test 'true' value.
+  test_from_long(0);  // Test 'false' value.
+  test_from_long(1);  // Test 'true' value.
   test_from_long(~0); // Any value != 0 is 'true'.
 }
 
@@ -809,7 +812,8 @@ main = foo
                                 testing::ContainsRegex("line 7, in baz"),
                                 testing::ContainsRegex("ZeroDivisionError")))));
 
-#if !((defined(_WIN32) || defined(_WIN64)) && (defined(__aarch64__) || defined(_M_ARM64)))
+#if !((defined(_WIN32) || defined(_WIN64)) &&                                  \
+      (defined(__aarch64__) || defined(_M_ARM64)))
 
   static const char script2[] = R"(
 class MyError(Exception):


### PR DESCRIPTION
This is using `FileSystem::Instance()` w/o calling `FileSystem::Initialize()`. Use `SubsystemRAII` to do that.

This cherry-pick fixes the swift-ci LLDB ubuntu `ScriptInterpreterTests` crash: https://ci.swift.org/view/LLDB/job/oss-lldb-linux-ubuntu-22_04/9528/execution/node/387/log/

Which locally reproduced in a Linux VM looks as follows:
```
/usr/lib/gcc/aarch64-linux-gnu/11/../../../../include/c++/11/optional:439: _Tp &std::_Optional_base_impl<lldb_private::FileSystem, std::_Optional_base<lldb_private::FileSystem, false, false>>::_M_get() [_Tp = lldb_private::FileSystem, _Dp = std::_Optional_base<lldb_private::FileSystem, false, false>]: Assertion 'this->_M_is_engaged()' failed.
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  ScriptInterpreterPythonTests 0x0000aaaaca63504c
1  ScriptInterpreterPythonTests 0x0000aaaaca633008
2  ScriptInterpreterPythonTests 0x0000aaaaca635b00
3  linux-vdso.so.1              0x0000ffff8d11e7ac __kernel_rt_sigreturn + 0
4  libc.so.6                    0x0000ffff8a8bf200
5  libc.so.6                    0x0000ffff8a87a67c raise + 28
6  libc.so.6                    0x0000ffff8a867130 abort + 228
7  ScriptInterpreterPythonTests 0x0000aaaaca5fc4e4
8  ScriptInterpreterPythonTests 0x0000aaaaca700e6c
9  ScriptInterpreterPythonTests 0x0000aaaaca6ffe4c
10 ScriptInterpreterPythonTests 0x0000aaaaca6fdb18
11 ScriptInterpreterPythonTests 0x0000aaaaca5ef29c
12 ScriptInterpreterPythonTests 0x0000aaaaca6c93c4
13 ScriptInterpreterPythonTests 0x0000aaaaca6cae04
14 ScriptInterpreterPythonTests 0x0000aaaaca6cb63c
15 ScriptInterpreterPythonTests 0x0000aaaaca6da580
16 ScriptInterpreterPythonTests 0x0000aaaaca6d9df0
17 ScriptInterpreterPythonTests 0x0000aaaaca6b947c
18 libc.so.6                    0x0000ffff8a8673fc
19 libc.so.6                    0x0000ffff8a8674cc __libc_start_main + 152
20 ScriptInterpreterPythonTests 0x0000aaaaca5e7bf0
zsh: abort      
```

(cherry picked from commit 675791335285fa86434dc46e5c92f543e0e79d19)