### PR TITLE
[🍒 stable/20230725] Handle new `delete_pending` error code when stating index unit files

### DIFF
--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -242,7 +242,7 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
 
   llvm::sys::fs::file_status UnitStat;
   if (std::error_code EC = llvm::sys::fs::status(UnitPath.c_str(), UnitStat)) {
-    if (EC != llvm::errc::no_such_file_or_directory) {
+    if (EC != llvm::errc::no_such_file_or_directory && EC != llvm::errc::delete_pending) {
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << UnitPath
           << "': " << EC.message();
@@ -256,7 +256,7 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
 
   llvm::sys::fs::file_status CompareStat;
   if (std::error_code EC = llvm::sys::fs::status(*TimeCompareFilePath, CompareStat)) {
-    if (EC != llvm::errc::no_such_file_or_directory) {
+    if (EC != llvm::errc::no_such_file_or_directory && EC != llvm::errc::delete_pending) {
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << *TimeCompareFilePath
           << "': " << EC.message();


### PR DESCRIPTION
**Explanation**: Fixes a common compiler crash on Windows when generating the index while building.
**Scope**: This crash happens frequently when building large projects on Windows when indexing while building. The `delete_pending` error code is only generated on Windows when the `status` function is called against a path that has been marked for deletion.
**Issue**: This issue tracked the addition of the new error code, which was done in support of the fix here: https://github.com/llvm/llvm-project/issues/89137
**Risk**: Very low risk, this change introduces handling for a new error code that can only be generated under specific conditions on Windows.
**Testing**: Tested through LLVM CI and locally.
**Reviewer**: @compnerd

Multiple clang processes race to write out the same index file via renaming a newly generated index file ontop of the stale one. On Windows, there is a small window where the destination path is marked for deletion, and querying the file at this time would return a misleading `permission_denied` error (which is the Win32 error mapping from the underlying NTSTATUS code `STATUS_DELETE_PENDING`). An upstream change has modified the `fs::status` function on Windows to detect this case and return a more accurate `delete_pending` error code, which can be handled here as if the file is already deleted (i.e. `no_such_file_or_directory`)

(cherry picked from commit dd2cc940551f22c732803ccedda467bbf7228de6)