### PR TITLE
next: [Test] lldb: Updated consume operator breakpoints.

### DIFF
--- a/lldb/test/API/lang/swift/variables/consume_operator/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator/main.swift
@@ -34,7 +34,8 @@ public func copyableValueTest() {
     print("stop here") // Set breakpoint
     let k = Klass()
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething() // Set breakpoint
 }
 
@@ -76,7 +77,8 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 public func copyableValueArgTest(_ k: __owned Klass) {
     print("stop here") // Set breakpoint
     k.doSomething()
-    let m = consume k // Set breakpoint
+    print("stop here") // Set breakpoint
+    let m = consume k
     m.doSomething() // Set breakpoint
 }
 
@@ -116,7 +118,8 @@ public func copyableValueCCFTrueTest() {
     let k = Klass() // Set breakpoint
     k.doSomething() // Set breakpoint
     if trueBoolValue {
-        let m = consume k // Set breakpoint
+        print("stop here") // Set breakpoint
+        let m = consume k
         m.doSomething() // Set breakpoint
     }
     // Set breakpoint
@@ -126,6 +129,7 @@ public func copyableValueCCFFalseTest() {
     let k = Klass() // Set breakpoint
     k.doSomething() // Set breakpoint
     if falseBoolValue {
+        print("stop here") // Set breakpoint
         let m = consume k
         m.doSomething()
     }

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/main.swift
@@ -25,7 +25,8 @@ public func copyableValueTest() async {
     let k = Klass()
     k.doSomething()
     await forceSplit() // Set breakpoint 01
-    let m = consume k    // Set breakpoint 02
+    print("stop here") // Set breakpoint 02
+    let m = consume k
     m.doSomething()    // Set breakpoint 03
     await forceSplit()
     m.doSomething()    // Set breakpoint 04


### PR DESCRIPTION
Use the same breakpoints for `let`s as for `var`s.  Now that value lifetimes in the face of `consume` are fixed to behave just like address lifetimes (rather than not actually ending at `consume`s), the breakpoint locations used to inspect a `let x` must occur before the `consume x` just as is the case for `var x`.

Paired with https://github.com/apple/swift/pull/74109 .

rdar://113142446
(cherry picked from commit 2cd0c0f64c7f40c2e852d1607049a1b99c78cfb4)