### PR TITLE
[lldb] Uncomment LogUnimplementedTypeKind in GetEnumCaseName

### DIFF
--- a/lldb/source/Core/ValueObject.cpp
+++ b/lldb/source/Core/ValueObject.cpp
@@ -232,7 +232,7 @@ bool ValueObject::UpdateFormatsIfNeeded() {
     m_last_format_mgr_revision = DataVisualization::GetCurrentRevision();
     any_change = true;
 
-    SetValueFormat(DataVisualization::GetFormat(*this, eNoDynamicValues));
+    SetValueFormat(DataVisualization::GetFormat(*this, GetDynamicValueType()));
     SetSummaryFormat(
         DataVisualization::GetSummaryFormat(*this, GetDynamicValueType()));
 #if LLDB_ENABLE_PYTHON

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -957,12 +957,7 @@ std::optional<std::string> SwiftLanguageRuntimeImpl::GetEnumCaseName(
   if (eti->projectEnumValue(*GetMemoryReader(), addr, &case_index))
     return eti->getCases()[case_index].Name;
 
-  // FIXME: Enabling this fails TestSwiftNestedCEnums.py: The test
-  // nests a C-style enum inside of a payload-carrying enum and most
-  // likely we're not stripping off the outer enum's discriminator
-  // before reading the value of the inner one.
-  
-  // LogUnimplementedTypeKind(__FUNCTION__, type);
+  LogUnimplementedTypeKind(__FUNCTION__, type);
   return {};
 }
 


### PR DESCRIPTION
There are two commits in this PR:

    [lldb] Uncomment LogUnimplementedTypeKind in GetEnumCaseName

    GetEnumCaseName now passes the test suite without failing. Uncomment the
    log in it.

    rdar://122506593

-------

    [lldb] UpdateFormatsIfNeeded should respect the dynamic value type

    UpdateFormatsIfNeeded has hardcoded the call to GetFormat with no
    dynamic values. GetFormat will try to find the synthetic children of the
    ValueObject, and passing the wrong one can fail, which can be bad for
    performance but should not be user visible. Fix the performace bug by
    passing the dynamic value type of the ValueObject.

    rdar://122506593
    (cherry picked from commit d698ba1ce41d04526dfc2d8abe69c673d524afa4)