### PR TITLE
[lldb][test] XFAIL TestCCallingConventions.py

### DIFF
--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -63,7 +63,8 @@ class TestCase(TestBase):
         self.expect_expr("func(1, 2, 3, 4)", result_type="int", result_value="10")
 
     @expectedFailureAll(
-        oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56084"
+        triple=re.compile("^(x86|i386)"),
+        oslist=["freebsd", "linux"], bugnumber="github.com/llvm/llvm-project/issues/56084"
     )
     def test_vectorcall(self):
         if not self.build_and_run("vectorcall.c"):


### PR DESCRIPTION
The test-suite by default gets linked with LLD
on our Ubuntu Swift CI bots causing the vector_call test-case to fail. This is a known issue: https://github.com/llvm/llvm-project/issues/56084

Haven't found a good way to XFAIL a test-case based on
the linker used, so XFAIL it for all of Linux for now.

rdar://129208184
(cherry picked from commit 685dd5ec0764f52224e97e4d9085a5090eb8a744)