### PR TITLE
[6.0][clang][cas] Ingest the plist output of the clang analyzer action when caching is enabled

### DIFF
--- a/clang/include/clang/Frontend/CompileJobCache.h
+++ b/clang/include/clang/Frontend/CompileJobCache.h
@@ -92,6 +92,10 @@ public:
   class CachingOutputs;
 
 private:
+  /// \returns true if the output from the compilation is not supported for
+  /// caching.
+  Expected<bool>
+  maybeIngestNonVirtualOutputFromFileSystem(CompilerInstance &Clang);
   int reportCachingBackendError(DiagnosticsEngine &Diag, llvm::Error &&E);
 
   bool CacheCompileJob = false;

--- a/clang/test/CAS/analyze-action-remote-service.c
+++ b/clang/test/CAS/analyze-action-remote-service.c
@@ -1,0 +1,40 @@
+// REQUIRES: remote-cache-service
+
+// Need a short path for the unix domain socket (and unique for this test file).
+// RUN: rm -f %{remote-cache-dir}/%basename_t
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang_cc1 -cc1 -triple x86_64-apple-macosx12 -analyze -analyzer-checker=deadcode -analyzer-output plist %s -o %t/regular.plist 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-DIAG
+// RUN: FileCheck %s --input-file=%t/regular.plist --check-prefix=CHECK-PLIST
+
+// CHECK-DIAG: Value stored to 'v' during its initialization is never read
+// CHECK-PLIST: Value stored to &apos;v&apos; during its initialization is never read
+
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macosx12 --analyze --analyzer-output plist %s -o %t/cached.plist
+// RUN: rm %t/cached.plist
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macosx12 --analyze --analyzer-output plist %s -o %t/cached.plist -Rcompile-job-cache \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-HIT
+
+// CHECK-HIT: remark: compile job cache hit
+// CHECK-HIT: Value stored to 'v' during its initialization is never read
+
+// RUN: diff -u %t/regular.plist %t/cached.plist
+
+// Check cache is skipped for analyzer html output.
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macosx12 --analyze --analyzer-output html %s -o %t/analysis -Rcompile-job-cache -Wclang-cache \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-HTML
+// RUN: llvm-remote-cache-test -socket-path=%{remote-cache-dir}/%basename_t -cache-path=%t/cache -- env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macosx12 --analyze --analyzer-output html %s -o %t/analysis -Rcompile-job-cache -Wclang-cache \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CHECK-HTML
+
+// CHECK-HTML: remark: compile job cache miss
+// CHECK-HTML: remark: compile job cache skipped
+// FIXME: `analyse` action passes `-w` for `-cc1` args and the "caching disabled" warning doesn't show up.
+
+void foo(int *p) {
+  int v = p[0];
+}

--- a/clang/test/CAS/analyze-action.c
+++ b/clang/test/CAS/analyze-action.c
@@ -1,0 +1,37 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang_cc1 -cc1 -triple x86_64-apple-macosx12 -analyze -analyzer-checker=deadcode -analyzer-output plist %s -o %t/regular.plist 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-DIAG
+// RUN: FileCheck %s --input-file=%t/regular.plist --check-prefix=CHECK-PLIST
+
+// CHECK-DIAG: Value stored to 'v' during its initialization is never read
+// CHECK-PLIST: Value stored to &apos;v&apos; during its initialization is never read
+
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macosx12 -fcas-path %t/cas -analyze -analyzer-checker=deadcode -analyzer-output plist %s -o %t/cached.plist
+// RUN: %clang @%t/t.rsp
+
+// RUN: rm %t/cached.plist
+// RUN: %clang @%t/t.rsp -Rcompile-job-cache 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-HIT
+
+// CHECK-HIT: remark: compile job cache hit
+// CHECK-HIT: Value stored to 'v' during its initialization is never read
+
+// RUN: diff -u %t/regular.plist %t/cached.plist
+
+// Check cache is skipped for analyzer html output.
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t2.rsp -cc1-args \
+// RUN:   -cc1 -triple x86_64-apple-macosx12 -fcas-path %t/cas -analyze -analyzer-checker=deadcode -analyzer-output html %s -o %t/analysis
+// RUN: %clang @%t/t2.rsp -Rcompile-job-cache 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-HTML
+// RUN: %clang @%t/t2.rsp -Rcompile-job-cache 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=CHECK-HTML
+
+// CHECK-HTML: remark: compile job cache miss
+// CHECK-HTML: warning: caching disabled because analyzer output is not supported
+// CHECK-HTML: remark: compile job cache skipped
+
+void foo(int *p) {
+  int v = p[0];
+}

--- a/llvm/include/llvm/CAS/CASOutputBackend.h
+++ b/llvm/include/llvm/CAS/CASOutputBackend.h
@@ -33,7 +33,7 @@ public:
   SmallVector<OutputFile> takeOutputs() { return std::move(Outputs); }
 
   /// Add a CAS object to the path in the output backend.
-  Error addObject(StringRef Path, const CASID &Object);
+  void addObject(StringRef Path, ObjectRef Object);
 
 private:
   Expected<std::unique_ptr<vfs::OutputFileImpl>>

--- a/llvm/lib/CAS/CASOutputBackend.cpp
+++ b/llvm/lib/CAS/CASOutputBackend.cpp
@@ -60,8 +60,12 @@ CASOutputBackend::createFileImpl(StringRef ResolvedPath,
         if (Error E =
                 CAS.storeFromString(std::nullopt, Bytes).moveInto(BytesRef))
           return E;
-        // FIXME: Should there be a lock taken before modifying Outputs?
-        Outputs.push_back({std::string(Path), *BytesRef});
+        addObject(Path, *BytesRef);
         return Error::success();
       });
+}
+
+void CASOutputBackend::addObject(StringRef Path, ObjectRef Object) {
+  // FIXME: Should there be a lock taken before modifying Outputs?
+  Outputs.push_back({std::string(Path), Object});
 }


### PR DESCRIPTION
The ingestion happens directly from the file-system when the analyzer action is used. This is a simpler approach that having the analyzer infrastructure adopt `VirtualOutputBackend`, which would be intrusive and require constant maintenance of such code out-of-tree.

Once `VirtualOutputBackend` gets upstreamed we should also change the analyzer to adopt it on the upstream repo, then the direct ingestion code can be removed.

rdar://129021951
(cherry picked from commit 768f97e2a278fd5e52543864b0f3d0eaa5b38af3)