### PR TITLE
[CodeGen] Add typed error logic to  SwiftAggLowering

### DIFF
--- a/clang/include/clang/CodeGen/SwiftCallingConv.h
+++ b/clang/include/clang/CodeGen/SwiftCallingConv.h
@@ -88,6 +88,8 @@ public:
   ///   passed indirectly as an argument
   bool shouldPassIndirectly(bool asReturnValue) const;
 
+  bool shouldReturnTypedErrorIndirectly() const;
+
   using EnumerationCallback =
     llvm::function_ref<void(CharUnits offset, CharUnits end, llvm::Type *type)>;
 

--- a/clang/lib/CodeGen/ABIInfo.cpp
+++ b/clang/lib/CodeGen/ABIInfo.cpp
@@ -275,6 +275,15 @@ bool SwiftABIInfo::shouldPassIndirectly(ArrayRef<llvm::Type *> ComponentTys,
   return occupiesMoreThan(ComponentTys, /*total=*/4);
 }
 
+bool SwiftABIInfo::shouldReturnTypedErrorIndirectly(
+    ArrayRef<llvm::Type *> ComponentTys) const {
+  for (llvm::Type *type : ComponentTys) {
+    if (!type->isIntegerTy() && !type->isPointerTy())
+      return true;
+  }
+  return shouldPassIndirectly(ComponentTys, /*AsReturnValue=*/true);
+}
+
 bool SwiftABIInfo::isLegalVectorType(CharUnits VectorSize, llvm::Type *EltTy,
                                      unsigned NumElts) const {
   // The default implementation of this assumes that the target guarantees

--- a/clang/lib/CodeGen/ABIInfo.h
+++ b/clang/lib/CodeGen/ABIInfo.h
@@ -151,6 +151,9 @@ public:
 
   /// Returns true if swifterror is lowered to a register by the target ABI.
   bool isSwiftErrorInRegister() const { return SwiftErrorInRegister; };
+
+  virtual bool
+  shouldReturnTypedErrorIndirectly(ArrayRef<llvm::Type *> ComponentTys) const;
 };
 } // end namespace CodeGen
 } // end namespace clang

--- a/clang/lib/CodeGen/SwiftCallingConv.cpp
+++ b/clang/lib/CodeGen/SwiftCallingConv.cpp
@@ -644,6 +644,27 @@ bool SwiftAggLowering::shouldPassIndirectly(bool asReturnValue) const {
   return getSwiftABIInfo(CGM).shouldPassIndirectly(componentTys, asReturnValue);
 }
 
+bool SwiftAggLowering::shouldReturnTypedErrorIndirectly() const {
+  assert(Finished && "haven't yet finished lowering");
+
+  // Empty types don't need to be passed indirectly.
+  if (Entries.empty())
+    return false;
+
+  // Avoid copying the array of types when there's just a single element.
+  if (Entries.size() == 1) {
+    return getSwiftABIInfo(CGM).shouldReturnTypedErrorIndirectly(
+        Entries.back().Type);
+  }
+
+  SmallVector<llvm::Type *, 8> componentTys;
+  componentTys.reserve(Entries.size());
+  for (auto &entry : Entries) {
+    componentTys.push_back(entry.Type);
+  }
+  return getSwiftABIInfo(CGM).shouldReturnTypedErrorIndirectly(componentTys);
+}
+
 bool swiftcall::shouldPassIndirectly(CodeGenModule &CGM,
                                      ArrayRef<llvm::Type*> componentTys,
                                      bool asReturnValue) {


### PR DESCRIPTION
rdar://129359321

Adds SwiftAggLowerign::shouldReturnTypedErrorIndirectly, which checks if a typed error can be returned directly, similar to how shouldPassIndirectly works, but with the additional restriction of the type having to consist of only integers.