### PR TITLE
Revert "[lldb][test] XFAIL TestCCallingConventions.py"

### DIFF
--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -63,8 +63,7 @@ class TestCase(TestBase):
         self.expect_expr("func(1, 2, 3, 4)", result_type="int", result_value="10")
 
     @expectedFailureAll(
-        triple=re.compile("^(x86|i386)"),
-        oslist=["freebsd", "linux"], bugnumber="github.com/llvm/llvm-project/issues/56084"
+        oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56084"
     )
     def test_vectorcall(self):
         if not self.build_and_run("vectorcall.c"):


### PR DESCRIPTION
Reverts apple/llvm-project#8859

The `release/6.0` and `main` branches of swift are using different linkers. It's only the linker in `main` that is problematic, so the test should only be xfailed in llvm's `stable/2023` branch.

rdar://129408996