### PR TITLE
[clang] fix -Wnullability-completeness false-positive in dependent code

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -4722,7 +4722,8 @@ static bool shouldHaveNullability(QualType T) {
          // It's unclear whether the pragma's behavior is useful for C++.
          // e.g. treating type-aliases and template-type-parameters differently
          // from types of declarations can be surprising.
-         !isa<RecordType>(T->getCanonicalTypeInternal());
+         !isa<RecordType, TemplateSpecializationType>(
+             T->getCanonicalTypeInternal());
 }
 
 static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,

--- a/clang/test/SemaObjCXX/Inputs/nullability-consistency-smart.h
+++ b/clang/test/SemaObjCXX/Inputs/nullability-consistency-smart.h
@@ -5,3 +5,7 @@ void f1(int * _Nonnull);
 void f2(Smart); // OK, not required on smart-pointer types
 using Alias = Smart;
 void f3(Alias);
+
+template <class T> class _Nullable SmartTmpl;
+void f2(SmartTmpl<int>);
+template <class T> void f2(SmartTmpl<T>);


### PR DESCRIPTION
The intent was that smart-pointers do not participate in completeness checks, but we failed to capture dependent `unique_ptr<T>`, which is not a RecordType but a TemplateSpecializationType.

(cherry picked from commit 7257c37357ee4540d6a63e5d2854b97f43ae2c49)