### PR TITLE
Revert "Revert "[lldb][test] XFAIL TestCCallingConventions.py""

### DIFF
--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -63,7 +63,8 @@ class TestCase(TestBase):
         self.expect_expr("func(1, 2, 3, 4)", result_type="int", result_value="10")
 
     @expectedFailureAll(
-        oslist=["freebsd"], bugnumber="github.com/llvm/llvm-project/issues/56084"
+        triple=re.compile("^(x86|i386)"),
+        oslist=["freebsd", "linux"], bugnumber="github.com/llvm/llvm-project/issues/56084"
     )
     def test_vectorcall(self):
         if not self.build_and_run("vectorcall.c"):


### PR DESCRIPTION
This reverts commit 4df496533ac1e3b2272388c2a55fbb1d65a51a18.

This test should be Xfailed on configurations using LLD as linker. The stable branch is one such configuration.