### PR TITLE
[Cherry-pick into swift/release/6.0] Bump the DWARF version number to 5 on Darwin. (#95164)

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1444,7 +1444,16 @@ unsigned DarwinClang::GetDefaultDwarfVersion() const {
   if ((isTargetMacOSBased() && isMacosxVersionLT(10, 11)) ||
       (isTargetIOSBased() && isIPhoneOSVersionLT(9)))
     return 2;
-  return 4;
+  // Default to use DWARF 4 on OS X 10.11 - macOS 14 / iOS 9 - iOS 17.
+  if ((isTargetMacOSBased() && isMacosxVersionLT(15)) ||
+      (isTargetIOSBased() && isIPhoneOSVersionLT(18)) ||
+      (isTargetWatchOSBased() && TargetVersion < llvm::VersionTuple(11)) ||
+      (isTargetXROS() && TargetVersion < llvm::VersionTuple(2)) ||
+      (isTargetDriverKit() && TargetVersion < llvm::VersionTuple(24)) ||
+      (isTargetMacOSBased() &&
+       TargetVersion.empty())) // apple-darwin, no version.
+    return 4;
+  return 5;
 }
 
 void MachO::AddLinkRuntimeLib(const ArgList &Args, ArgStringList &CmdArgs,

--- a/clang/test/Driver/debug-options.c
+++ b/clang/test/Driver/debug-options.c
@@ -69,7 +69,32 @@
 // RUN: %clang -### -c -g %s -target x86_64-apple-driverkit19.0 2>&1 \
 // RUN:             | FileCheck -check-prefix=G_STANDALONE \
 // RUN:                         -check-prefix=G_DWARF4 %s
-// RUN: %clang -### -c -fsave-optimization-record %s \
+// RUN: %clang -### -c -g %s -target x86_64-apple-macosx15 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF5 %s
+// RUN: %clang -### -c -g %s -target arm64-apple-ios17.0 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF4 %s
+// RUN: %clang -### -c -g %s -target arm64-apple-ios18.0 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF5 %s
+// RUN: %clang -### -c -g %s -target arm64_32-apple-watchos11 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF5 %s
+// RUN: %clang -### -c -g %s -target arm64-apple-tvos18.0 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF5 %s
+// RUN: %clang -### -c -g %s -target x86_64-apple-driverkit24.0 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF5 %s
+// RUN: %clang -### -c -g %s -target arm64-apple-xros1 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF4 %s
+// RUN: %clang -### -c -g %s -target arm64-apple-xros2 2>&1 \
+// RUN:             | FileCheck -check-prefix=G_STANDALONE \
+// RUN:                         -check-prefix=G_DWARF5 %s
+//
+// RUN: %clang -### -c -fsave-optimization-record %s    \
 // RUN:        -target x86_64-apple-darwin 2>&1 \
 // RUN:             | FileCheck -check-prefix=GLTO_ONLY %s
 // RUN: %clang -### -c -g -fsave-optimization-record %s \


### PR DESCRIPTION
```
commit 8f6acd973a38da6dce45faa676cbb51da37f72e5
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Jun 12 14:36:56 2024 -0700

    Bump the DWARF version number to 5 on Darwin. (#95164)
    
    The default debug info format for newer versions of Darwin is DWARF 5.
    
    
    https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes
    
    rdar://110925733
```
