### PR TITLE
[Cherrypick] Add asan tests for libsanitizers for swift.

### DIFF
--- a/lldb/test/API/functionalities/asan/swift/Makefile
+++ b/lldb/test/API/functionalities/asan/swift/Makefile
@@ -2,8 +2,11 @@
 SWIFT_SOURCES := main.swift
 
 # Note the lazy variable setting - needs to use CLANG_RT_DIR, defined in Makefile.rules
-LD_EXTRAS = -lclang_rt.asan_osx_dynamic -L$(CLANG_RT_DIR)
+asan: LD_EXTRAS = -lclang_rt.asan_osx_dynamic -L$(CLANG_RT_DIR)
+asan: SWIFTFLAGS += -sanitize=address
+asan: all
+
+libsanitizers: SWIFTFLAGS += -sanitize=address -sanitize-stable-abi
+libsanitizers: all
 
 include Makefile.rules
-
-SWIFTFLAGS += -sanitize=address


### PR DESCRIPTION
This patch tests LLDB integration with libsanitizers for ASan for swift.

rdar://126704110