### PR TITLE
[lldb][Type Completion] Fix completion of ObjCObjectTypes

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2794,13 +2794,9 @@ static clang::Type const *GetCompleteEnumType(clang::ASTContext *ast,
 }
 
 static clang::Type const *
-GetCompleteObjCInterfaceType(clang::ASTContext *ast, clang::QualType qual_type,
+GetCompleteObjCInterfaceType(clang::ASTContext *ast,
+                             clang::ObjCObjectType const *objc_class_type,
                              bool allow_completion = true) {
-  const clang::ObjCObjectType *objc_class_type =
-      llvm::dyn_cast<clang::ObjCObjectType>(qual_type);
-  if (!objc_class_type)
-    return nullptr;
-
   clang::ObjCInterfaceDecl *class_interface_decl =
       objc_class_type->getInterface();
   // We currently can't complete objective C types through the newly added
@@ -2861,8 +2857,13 @@ static bool GetCompleteQualType(clang::ASTContext *ast,
   } break;
   case clang::Type::ObjCObject:
   case clang::Type::ObjCInterface: {
-    if (auto const *ty = llvm::dyn_cast_or_null<ObjCInterfaceType>(
-            GetCompleteObjCInterfaceType(ast, qual_type, allow_completion)))
+    const clang::ObjCObjectType *objc_class_type =
+        llvm::dyn_cast<clang::ObjCObjectType>(qual_type);
+    if (!objc_class_type)
+      return true;
+
+    if (auto const *ty = GetCompleteObjCInterfaceType(ast, objc_class_type,
+                                                      allow_completion))
       return TypeSystemClang::UseRedeclCompletion() || !ty->isIncompleteType();
 
     return false;

--- a/lldb/test/Shell/Expr/Inputs/objc-cast.cpp
+++ b/lldb/test/Shell/Expr/Inputs/objc-cast.cpp
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/lldb/test/Shell/Expr/TestObjCIDCast.test
+++ b/lldb/test/Shell/Expr/TestObjCIDCast.test
@@ -1,0 +1,9 @@
+// UNSUPPORTED: system-linux, system-windows
+//
+// RUN: %clangxx_host %p/Inputs/objc-cast.cpp -g -o %t
+// RUN: %lldb %t \
+// RUN:   -o "b main" -o run -o "expression --language objc -- *(id)0x1" \
+// RUN:   2>&1 | FileCheck %s
+
+// CHECK: (lldb) expression --language objc -- *(id)0x1
+// CHECK: error: Couldn't apply expression side effects : Couldn't dematerialize a result variable: couldn't read its memory


### PR DESCRIPTION
The problem was introduced in:
```
commit e68f76a9e59104e2bfb972155af8ff04310cd078
Author: Michael Buch <michaelbuch12@gmail.com>
Date:   Fri Feb 16 14:35:34 2024 +0000

    [lldb][TypeSystemClang][NFCI] Factor completion logic out of GetCompleteQualType
```

This introduced an incorrect `llvm::dyn_cast_or_null` check causing us to incorrectly claim that we failed to complete a type.

This manifested in a crash when running following expression:
```
expr -l objc -- *(id)0x1234
```

rdar://129633122