### PR TITLE
[lldb][Type Completion] Fix completion of ObjCObjectTypes

### DIFF
--- a/lldb/test/Shell/Expr/Inputs/objc-cast.cpp
+++ b/lldb/test/Shell/Expr/Inputs/objc-cast.cpp
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/lldb/test/Shell/Expr/TestObjCIDCast.test
+++ b/lldb/test/Shell/Expr/TestObjCIDCast.test
@@ -1,0 +1,9 @@
+// UNSUPPORTED: system-linux, system-windows
+//
+// RUN: %clangxx_host %p/Inputs/objc-cast.cpp -g -o %t
+// RUN: %lldb %t \
+// RUN:   -o "b main" -o run -o "expression --language objc -- *(id)0x1" \
+// RUN:   -b 2>&1 | FileCheck %s
+
+// CHECK: (lldb) expression --language objc -- *(id)0x1
+// CHECK: error: Couldn't apply expression side effects : Couldn't dematerialize a result variable: couldn't read its memory


### PR DESCRIPTION
The problem was introduced in:
```
commit e68f76a9e59104e2bfb972155af8ff04310cd078
Author: Michael Buch <michaelbuch12@gmail.com>
Date:   Fri Feb 16 14:35:34 2024 +0000

    [lldb][TypeSystemClang][NFCI] Factor completion logic out of GetCompleteQualType
```

This introduced an incorrect `llvm::dyn_cast_or_null` check causing us to incorrectly claim that we failed to complete a type.

This manifested in a crash when running following expression:
```
expr -l objc -- *(id)0x1234
```

rdar://129633122