### PR TITLE
[lldb] Skip delay-init test when run on pre-macOS 15

### DIFF
--- a/lldb/test/API/macosx/delay-init-dependency/TestDelayInitDependency.py
+++ b/lldb/test/API/macosx/delay-init-dependency/TestDelayInitDependency.py
@@ -11,6 +11,7 @@ class TestDelayInitDependencies(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessDarwin
+    @skipIf(macos_version=["<", "15.0"])
     def test_delay_init_dependency(self):
         TestBase.setUp(self)
         out = subprocess.run(


### PR DESCRIPTION
The test has a check that the static linker supports the new option, but it assumed the Xcode 16 linker also meant it was running on macOS 15 and the dynamic linker would honor dependencies flagged this way.  But Xcode 16 can be run on macOS 14.5, so we need to skip the test in that combination.

(cherry picked from commit 45927d730bcd2aa3380834ca8db96e32a8b2f2b1)