### PR TITLE
[lldb][test] TestObjCIDCast.test: remove batch mode

### DIFF
--- a/lldb/test/Shell/Expr/TestObjCIDCast.test
+++ b/lldb/test/Shell/Expr/TestObjCIDCast.test
@@ -3,7 +3,7 @@
 // RUN: %clangxx_host %p/Inputs/objc-cast.cpp -g -o %t
 // RUN: %lldb %t \
 // RUN:   -o "b main" -o run -o "expression --language objc -- *(id)0x1" \
-// RUN:   -b 2>&1 | FileCheck %s
+// RUN:   2>&1 | FileCheck %s
 
 // CHECK: (lldb) expression --language objc -- *(id)0x1
 // CHECK: error: Couldn't apply expression side effects : Couldn't dematerialize a result variable: couldn't read its memory


### PR DESCRIPTION
This caused the error running the expression to propagate and mark the test as failed