### PR TITLE
[lldb][test] Force dwarf4 usage in test requiring it (#95449)

### DIFF
--- a/lldb/test/Shell/SymbolFile/DWARF/x86/apple-index-is-used.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/apple-index-is-used.cpp
@@ -1,5 +1,5 @@
 // Test that we use the apple indexes.
-// RUN: %clang %s -g -c -o %t --target=x86_64-apple-macosx
+// RUN: %clang %s -g -c -o %t --target=x86_64-apple-macosx -gdwarf-4
 // RUN: lldb-test symbols %t | FileCheck %s
 
 // CHECK: .apple_names index present


### PR DESCRIPTION
This test is explicitly checking for dwarf 4 behavior on Apple platforms, so we should explicitly use the dwarf4 flag.

Related to https://github.com/llvm/llvm-project/pull/95164

(cherry picked from commit 445fc51800d391d0c912d8c6c918b016e0604319)