### PR TITLE
[SwiftExpressionParser] Suppress spurious variable lookup errors 

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1775,8 +1775,9 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
           "Missing type debug information for variable \"%s\": %s",
           var.GetName().str().str().c_str(),
           llvm::toString(std::move(error)).c_str());
+      return ParseResult::unrecoverable_error;
     }
-
+    // Otherwise print the diagnostics from the Swift compiler.
     DiagnoseSwiftASTContextError();
     return ParseResult::unrecoverable_error;
   }

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -8,7 +8,7 @@ class TestSwiftExpressionErrorReportingy(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    def test(self):
+    def test_missing_var(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""
         self.build()
@@ -30,4 +30,25 @@ class TestSwiftExpressionErrorReportingy(TestBase):
         process.Continue()
         value = self.frame().EvaluateExpression(
             "ceciNestPasUnVar", options)
+        check(value)
+
+    @swiftTest
+    def test_missing_type(self):
+        """Test error reporting in expressions reports
+        only diagnostics in user code"""
+        self.build(dictionary={'HIDE_SWIFTMODULE': 'YES'})
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        options = lldb.SBExpressionOptions()
+        value = self.frame().EvaluateExpression("strct", options)
+        def check(value):
+            lines = str(value.GetError()).split('\n')
+            self.assertTrue(lines[0].startswith('error:'))
+            self.assertIn('Missing type', lines[0])
+            self.assertIn('strct', lines[0])
+            for line in lines[1:]:
+                self.assertFalse(line.startswith('error:'))
+                self.assertFalse(line.startswith('warning:'))
+
         check(value)

--- a/lldb/test/API/lang/swift/expression/error_reporting/main.swift
+++ b/lldb/test/API/lang/swift/expression/error_reporting/main.swift
@@ -4,12 +4,14 @@ class State {
     print("in class") // break here
   }
 
-  var number:Int
+  var number : Int
 }
 
-func f() {
+struct S {}
+
+func f(_ strct : S) {
   print("in function") // break here
 }
 
-f()
+f(S())
 State(x: 20)


### PR DESCRIPTION
If a variable's type cannot be found, LLDB produces a diagnostic to that end, but the Swift compiler will also produce a spurious diagnostic that the identifier couldn't be found. This patch suppresses Swift diagnostics when there was a type lookup error.

rdar://125613361