### PR TITLE
[lldb][Progress] Report progress when parsing forward declarations from DWARF

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -25,6 +25,7 @@
 #include "Plugins/ExpressionParser/Clang/ClangUtil.h"
 #include "Plugins/Language/ObjC/ObjCLanguage.h"
 #include "lldb/Core/Module.h"
+#include "lldb/Core/Progress.h"
 #include "lldb/Core/Value.h"
 #include "lldb/Host/Host.h"
 #include "lldb/Symbol/CompileUnit.h"
@@ -1773,6 +1774,11 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
   }
 
   if (attrs.is_forward_declaration) {
+    Progress progress(llvm::formatv(
+        "Parsing type in {0}: '{1}'",
+        dwarf->GetObjectFile()->GetFileSpec().GetFilename().GetString(),
+        attrs.name.GetString()));
+
     // We have a forward declaration to a type and we need to try and
     // find a full declaration. We look in the current type index just in
     // case we have a forward declaration followed by an actual


### PR DESCRIPTION
This is an attempt at displaying the work that's being done by LLDB when waiting on type-completion events, e.g., when running an expression. This patch adds a single new progress event for cases where we search for the definition DIE of a forward declaration, which can be an expensive operation in the presence of many object files.

(cherry picked from commit d32afb39fd90a305fc116a7161a2b4c4556117d4)