### PR TITLE
Remove side effect from SetPlaygroundTransformEnabled()

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -454,8 +454,6 @@ public:
 
   void SetPlaygroundTransformEnabled(bool b) {
     m_playground = b;
-    if (b)
-      m_language = lldb::eLanguageTypeSwift;
   }
 
   lldb::BindGenericTypes GetBindGenericTypes() const {


### PR DESCRIPTION
The function was also setting the langiage to Swift, which can (after the API change have the unwanted side-effect of also resetting the language version to the default.