### PR TITLE
[Cherry-pick into next] Remove side effect from SetPlaygroundTransformEnabled()

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -458,8 +458,6 @@ public:
 
   void SetPlaygroundTransformEnabled(bool b) {
     m_playground = b;
-    if (b)
-      m_language = lldb::eLanguageTypeSwift;
   }
 
   lldb::BindGenericTypes GetBindGenericTypes() const {


### PR DESCRIPTION
```
commit aa3bf5d484f29653885f9e704626be0aa1f521ad
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Jun 17 09:45:57 2024 -0700

    Remove side effect from SetPlaygroundTransformEnabled()
    
    The function was also setting the language to Swift, which can (after
    the API change have the unwanted side-effect of also resetting the
    language version to the default.
```
