### PR TITLE
[LLDB] Don't cache module sp when Activate() fails. (#95586)

### DIFF
--- a/lldb/source/Target/InstrumentationRuntime.cpp
+++ b/lldb/source/Target/InstrumentationRuntime.cpp
@@ -60,6 +60,8 @@ void InstrumentationRuntime::ModulesDidLoad(
       if (CheckIfRuntimeIsValid(module_sp)) {
         SetRuntimeModuleSP(module_sp);
         Activate();
+        if (!IsActive())
+          SetRuntimeModuleSP({}); // Don't cache module if activation failed.
         return false; // Stop iterating, we're done.
       }
     }


### PR DESCRIPTION
Currently, the instrumentation runtime is caching a library the first time it sees it in the module list. However, in some rare cases on Darwin, the cached pre-run unloaded modules are different from the runtime module that is loaded at runtime. This patch removes the cached module if the plugin fails to activate, ensuring that on subsequent calls we don't try to activate using the unloaded cached module.

There are a few related bugs to fix in a follow up: CheckIfRuntimeValid should have a stronger check to ensure the module is loaded and can be activated. Further investigation in
UpdateSpecialBinariesFromNewImageInfos calling ModulesDidLoad when the module list may have unloaded modules.

I have not included a test for the following reasons:
1. This is an incredibly rare occurance and is only observed in a specific circumstance on Darwin. It is tied to behavior in the DynamicLoader thai is not commonly encountered.

2. It is difficult to reproduce -- this bug requires precise conditions on darwin and it is unclear how we'd reproduce that in a controlled testing environment.

rdar://128971453