### PR TITLE
[lldb][debugserver] Fix build after libcxx removed generic char_traits implementation

### DIFF
--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -2585,7 +2585,7 @@ void register_value_in_hex_fixed_width(std::ostream &ostrm, nub_process_t pid,
       // fail value. If it does, return this instead in case some of
       // the registers are not available on the current system.
       if (reg->nub_info.size > 0) {
-        std::basic_string<uint8_t> zeros(reg->nub_info.size, '\0');
+        std::vector<uint8_t> zeros(reg->nub_info.size, '\0');
         append_hex_value(ostrm, zeros.data(), zeros.size(), false);
       }
     }
@@ -4224,7 +4224,7 @@ rnb_err_t RNBRemote::HandlePacket_p(const char *p) {
     ostrm << "00000000";
   } else if (reg_entry->nub_info.reg == (uint32_t)-1) {
     if (reg_entry->nub_info.size > 0) {
-      std::basic_string<uint8_t> zeros(reg_entry->nub_info.size, '\0');
+      std::vector<uint8_t> zeros(reg_entry->nub_info.size, '\0');
       append_hex_value(ostrm, zeros.data(), zeros.size(), false);
     }
   } else {


### PR DESCRIPTION
Which was done in https://reviews.llvm.org/D157058. This follows the fix for lldb-server in https://reviews.llvm.org/D157589.

Reviewed By: mstorsjo

Differential Revision: https://reviews.llvm.org/D158391

(cherry picked from commit 7549cde6bd5243570da8480c8580674a30024a71)