### PR TITLE
[lldb] Log module after bindExtensions

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1755,10 +1755,11 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     LLDB_LOG(log, "\n{0}\n\n{1}\n", msg, s);
   };
 
+  swift::bindExtensions(parsed_expr->module);
+
   if (log)
     dumpModule("Module before type checking:");
 
-  swift::bindExtensions(parsed_expr->module);
   swift::performTypeChecking(parsed_expr->source_file);
 
   if (log)


### PR DESCRIPTION
The expressions logs was crashing in ExtensionDecl::getExtendedNominal because it was reaching an llvm_unreachable with the following message:
"Extension must have already been bound (by bindExtensions)".

Move the log call to right after the call to bindExtensions.

rdar://128095039
(cherry picked from commit 06a49a53e16fef8e6acf5c3cc9b6f10fdb835186)