### PR TITLE
[lldb][SwiftExpressionParser] Adapt SwiftExpressionParser to new DoPrepareForExecution API

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -2163,7 +2163,7 @@ static bool FindFunctionInModule(ConstString &mangled_name,
   return false;
 }
 
-Status SwiftExpressionParser::PrepareForExecution(
+Status SwiftExpressionParser::DoPrepareForExecution(
     lldb::addr_t &func_addr, lldb::addr_t &func_end,
     lldb::IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx,
     bool &can_interpret, ExecutionPolicy execution_policy) {

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -144,10 +144,10 @@ public:
   ///     Test with Success().
   //------------------------------------------------------------------
   Status
-  PrepareForExecution(lldb::addr_t &func_addr, lldb::addr_t &func_end,
-                      lldb::IRExecutionUnitSP &execution_unit_ap,
-                      ExecutionContext &exe_ctx, bool &can_interpret,
-                      lldb_private::ExecutionPolicy execution_policy) override;
+  DoPrepareForExecution(lldb::addr_t &func_addr, lldb::addr_t &func_end,
+                        lldb::IRExecutionUnitSP &execution_unit_ap,
+                        ExecutionContext &exe_ctx, bool &can_interpret,
+                        lldb_private::ExecutionPolicy execution_policy) override;
 
   const EvaluateExpressionOptions &GetOptions() const { return m_options; }
 


### PR DESCRIPTION
Adapts Swift plugin to the API refactoring in https://github.com/llvm/llvm-project/pull/96290