### PR TITLE
[llvm/Support/VirtualOutputBackends] Don't create unbuffered streams when the `MirroringOutputBackend` is used

### DIFF
--- a/llvm/lib/Support/VirtualOutputBackends.cpp
+++ b/llvm/lib/Support/VirtualOutputBackends.cpp
@@ -123,11 +123,7 @@ vfs::makeMirroringOutputBackend(IntrusiveRefCntPtr<OutputBackend> Backend1,
                     std::unique_ptr<OutputFileImpl> F2)
         : PreferredBufferSize(std::max(F1->getOS().GetBufferSize(),
                                        F1->getOS().GetBufferSize())),
-          F1(std::move(F1)), F2(std::move(F2)) {
-      // Don't double buffer.
-      this->F1->getOS().SetUnbuffered();
-      this->F2->getOS().SetUnbuffered();
-    }
+          F1(std::move(F1)), F2(std::move(F2)) {}
     size_t PreferredBufferSize;
     std::unique_ptr<OutputFileImpl> F1;
     std::unique_ptr<OutputFileImpl> F2;


### PR DESCRIPTION
`MirroringOutputBackend` was forcing the `raw_ostream`s to be unbuffered, causing significant slowdown due to I/O. When enabling Clang caching for building Clang or WebKit, the "from scratch" (all cache misses) build was slower than the regular non-caching build. For building debug Clang the overhead was ~22%, and for debug build of WebKit, it was ~15%.

The overhead went away after removing the `SetUnbuffered()` calls.

rdar://130514092