### PR TITLE
[swift/6.0][lldb] Update for _CompilerSwiftSyntax libraries

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -241,9 +241,9 @@ function(add_properties_for_swift_modules target reldir)
     if (SWIFT_BUILD_SWIFT_SYNTAX)
       if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
         set_property(TARGET ${target}
-          APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host")
+          APPEND PROPERTY BUILD_RPATH "@loader_path/${build_reldir}lib/swift/host/compiler")
         set_property(TARGET ${target}
-          APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host")
+          APPEND PROPERTY INSTALL_RPATH "@loader_path/${reldir}lib/swift/host/compiler")
         if(SWIFT_ALLOW_LINKING_SWIFT_CONTENT_IN_DARWIN_TOOLCHAIN)
           get_filename_component(TOOLCHAIN_BIN_DIR ${CMAKE_Swift_COMPILER} DIRECTORY)
           get_filename_component(TOOLCHAIN_LIB_DIR "${TOOLCHAIN_BIN_DIR}/../lib/swift/macosx" ABSOLUTE)
@@ -251,9 +251,9 @@ function(add_properties_for_swift_modules target reldir)
         endif()
       elseif (CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD")
         set_property(TARGET ${target}
-          APPEND PROPERTY BUILD_RPATH "$ORIGIN/${build_reldir}lib/swift/host")
+          APPEND PROPERTY BUILD_RPATH "$ORIGIN/${build_reldir}lib/swift/host/compiler")
         set_property(TARGET ${target}
-          APPEND PROPERTY INSTALL_RPATH "$ORIGIN/${reldir}lib/swift/host")
+          APPEND PROPERTY INSTALL_RPATH "$ORIGIN/${reldir}lib/swift/host/compiler")
       endif()
     endif()
   endif()


### PR DESCRIPTION
Cherry-pick #8855 into `swift/release/6.0`

(copied from https://github.com/swiftlang/swift/pull/74740)
* **Explanation**: swift-syntax libraries in compiler has been complied with `-enable-library-evolution` because the toolchain provides them as a public interface for building plugins (i.e. `lib/swift/host/*.swiftmodule`). But that was not great for the performance in the compiler. This PR changes that by separating swift-syntax libs for the compiler from the one for the plugins. So the compiler and the plugin now can use different version/ABI of swift-syntax libraries from the compiler. Now swift-syntax for the compiler are compiled without library evolution.
* **Scope**: Macro plugins
* **Risk**: Mid. This changes the mechanism of in-process plugins significantly. Now in-process plugins are communicate with the compiler using the same messaging serialization with other plugins (i.e. `swift-plugin-server`, and other executable plugins), instead of directly calling the `Macro.Type` expansion method. Also, to separate the swift-syntax libraries, this introduces another set of shared swift-syntax libraries in the toolchain.
* **Testing**: Passes current test suite.
* **Issue**: rdar://130532628
* **Reviewer**: Hamish Knight (@hamishknight) Alex Hoppen (@ahoppen) Ben Barham (@bnbarham)