### PR TITLE
[Driver] Disable -fsanitize=function for all MachO (except x86)

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -563,7 +563,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
 
   Kinds |= Default;
 
-  if (TC.getTriple().isOSDarwin() && !TC.getTriple().isX86())
+  if (TC.getTriple().isOSBinFormatMachO() && !TC.getTriple().isX86())
     Kinds &= ~SanitizerKind::Function;
 
   // We disable the vptr sanitizer if it was enabled by group expansion but RTTI


### PR DESCRIPTION
Some embedded platforms don't fall into the Darwin category.

(cherry picked from commit 216dbd9c94fef54ce96756bb828e3ef5d750fea3)

 Conflicts:
	clang/test/CodeGen/ubsan-function.cpp