### PR TITLE
[lldb] Fix custom alignments of clang types which are members of Swift types being printed incorrectly

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -58,7 +58,16 @@ using namespace clang::CodeGen;
 
 static uint32_t getTypeAlignIfRequired(const Type *Ty, const ASTContext &Ctx) {
   auto TI = Ctx.getTypeInfo(Ty);
-  return TI.isAlignRequired() ? TI.Align : 0;
+  if (TI.isAlignRequired())
+    return TI.Align;
+
+  // MaxFieldAlignmentAttr is the attribute added to types
+  // declared after #pragma pack(n).
+  if (auto *Decl = Ty->getAsRecordDecl())
+    if (Decl->hasAttr<MaxFieldAlignmentAttr>())
+      return TI.Align;
+
+  return 0;
 }
 
 static uint32_t getTypeAlignIfRequired(QualType Ty, const ASTContext &Ctx) {

--- a/clang/test/CodeGen/debug-info-packed-struct.c
+++ b/clang/test/CodeGen/debug-info-packed-struct.c
@@ -59,7 +59,7 @@ struct layout2 {
 #pragma pack()
 // CHECK: l2_ofs0
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "l2_ofs1",
-// CHECK-SAME:     {{.*}}size: 64, offset: 8)
+// CHECK-SAME:     {{.*}}size: 64, align: 8, offset: 8)
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "l2_ofs9",
 // CHECK-SAME:     {{.*}}size: 1, offset: 72, flags: DIFlagBitField, extraData: i64 72)
 
@@ -81,7 +81,7 @@ struct layout3 {
 #pragma pack()
 // CHECK: l3_ofs0
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "l3_ofs4",
-// CHECK-SAME:     {{.*}}size: 64, offset: 32)
+// CHECK-SAME:     {{.*}}size: 64, align: 32, offset: 32)
 // CHECK: !DIDerivedType(tag: DW_TAG_member, name: "l3_ofs12",
 // CHECK-SAME:     {{.*}}size: 1, offset: 96, flags: DIFlagBitField, extraData: i64 96)
 

--- a/clang/test/CodeGenCXX/debug-info-struct-align.cpp
+++ b/clang/test/CodeGenCXX/debug-info-struct-align.cpp
@@ -25,3 +25,11 @@ struct MyType2 {
 MyType2 mt2;
 
 static_assert(alignof(MyType2) == 1, "alignof MyType2 is wrong");
+
+#pragma pack(1)
+struct MyType3 {
+  int m;
+};
+MyType3 mt3;
+
+static_assert(alignof(MyType3) == 1, "alignof MyType3 is wrong");

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -327,6 +327,10 @@ ParsedDWARFTypeAttributes::ParsedDWARFTypeAttributes(const DWARFDIE &die) {
       byte_size = form_value.Unsigned();
       break;
 
+    case DW_AT_alignment:
+      alignment = form_value.Unsigned();
+      break;
+
     case DW_AT_byte_stride:
       byte_stride = form_value.Unsigned();
       break;
@@ -1945,17 +1949,21 @@ DWARFASTParserClang::ParseStructureLikeDIE(const SymbolContext &sc,
             die.GetOffset(), attrs.name.GetCString());
       }
 
-      // If the byte size of the record is specified then overwrite the size
-      // that would be computed by Clang. This is only needed as LLDB's
-      // TypeSystemClang is always in C++ mode, but some compilers such as
-      // GCC and Clang give empty structs a size of 0 in C mode (in contrast to
-      // the size of 1 for empty structs that would be computed in C++ mode).
-      if (attrs.byte_size) {
+      // Setting authority byte size and alignment for empty structures.
+      //
+      // If the byte size or alignmenet of the record is specified then
+      // overwrite the ones that would be computed by Clang.
+      // This is only needed as LLDB's TypeSystemClang is always in C++ mode,
+      // but some compilers such as GCC and Clang give empty structs a size of 0
+      // in C mode (in contrast to the size of 1 for empty structs that would be
+      // computed in C++ mode).
+      if (attrs.byte_size || attrs.alignment) {
         clang::RecordDecl *record_decl =
             TypeSystemClang::GetAsRecordDecl(clang_type);
         if (record_decl) {
           ClangASTImporter::LayoutInfo layout;
-          layout.bit_size = *attrs.byte_size * 8;
+          layout.bit_size = attrs.byte_size.value_or(0) * 8;
+          layout.alignment = attrs.alignment.value_or(0) * 8;
           GetClangASTImporter().SetRecordLayout(record_decl, layout);
         }
       }
@@ -2326,6 +2334,9 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
     if (layout_info.bit_size == 0)
       layout_info.bit_size =
           die.GetAttributeValueAsUnsigned(DW_AT_byte_size, 0) * 8;
+    if (layout_info.alignment == 0)
+      layout_info.alignment =
+          die.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_alignment, 0) * 8;
 
     GetClangASTImporter().SetRecordLayout(record_decl, layout_info);
   }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.h
@@ -434,6 +434,7 @@ struct ParsedDWARFTypeAttributes {
   lldb_private::plugin::dwarf::DWARFFormValue type;
   lldb::LanguageType class_language = lldb::eLanguageTypeUnknown;
   std::optional<uint64_t> byte_size;
+  std::optional<uint64_t> alignment;
   size_t calling_convention = llvm::dwarf::DW_CC_normal;
   uint32_t bit_stride = 0;
   uint32_t byte_stride = 0;

--- a/lldb/test/API/lang/cpp/alignas_base_class/TestAlignAsBaseClass.py
+++ b/lldb/test/API/lang/cpp/alignas_base_class/TestAlignAsBaseClass.py
@@ -12,3 +12,7 @@ class TestCase(TestBase):
 
         # The offset of f2 should be 8 because of `alignas(8)`.
         self.expect_expr("(intptr_t)&d3g.f2 - (intptr_t)&d3g", result_value="8")
+
+        # Verify specified class alignments.
+        self.expect_expr("alignof(B2)", result_value="8")
+        self.expect_expr("alignof(EmptyClassAlign8)", result_value="8")

--- a/lldb/test/API/lang/cpp/alignas_base_class/main.cpp
+++ b/lldb/test/API/lang/cpp/alignas_base_class/main.cpp
@@ -10,4 +10,7 @@ struct D : B1, B2 {};
 
 D d3g;
 
+struct alignas(8) EmptyClassAlign8 {
+} t;
+
 int main() {}

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR)
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
@@ -1,0 +1,47 @@
+# TestSwiftClangImporterCustomAlignment.py
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ------------------------------------------------------------------------------
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import unittest2
+
+
+class TestSwiftClangImporterCustomAlignment(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        v = frame.FindVariable("v")
+        s = v.GetChildMemberWithName("s")
+
+        field_1 = s.GetChildMemberWithName("field_64_1")
+        lldbutil.check_variable(self, field_1, False, value="100")
+
+        field_2 = s.GetChildMemberWithName("field_32_1")
+        lldbutil.check_variable(self, field_2, False, value="200")
+
+        field_3 = s.GetChildMemberWithName("field_32_2")
+        lldbutil.check_variable(self, field_3, False, value="300")
+
+        field_4 = s.GetChildMemberWithName("field_64_2")
+        lldbutil.check_variable(self, field_4, False, value="400")
+
+        x = v.GetChildMemberWithName("x")
+        lldbutil.check_variable(self, x, False, value="1")

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/header.h
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/header.h
@@ -1,0 +1,14 @@
+#include "stdlib.h"
+#include <stdint.h>
+
+#pragma pack(push, 4)
+
+struct Struct {
+ int64_t field_64_1;
+ int32_t field_32_1;
+ uint32_t field_32_2;
+ int64_t field_64_2;
+}; 
+
+#pragma pack(pop)
+

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/main.swift
@@ -1,0 +1,17 @@
+import Module
+
+struct Value {
+  var x: Int32 = 1
+  var s = Struct()
+}
+
+func f() {
+  var v = Value()
+  v.s.field_64_1 = 100;
+  v.s.field_32_1 = 200;
+  v.s.field_32_2 = 300;
+  v.s.field_64_2 = 400;
+  print(v) // break here
+}
+
+f()

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/module.modulemap
@@ -1,0 +1,4 @@
+module Module {
+  header "header.h"
+  export *
+}


### PR DESCRIPTION


This PR cherry-picks 2 changes from upstream LLVM ("Fix #pragma (packed, n) not emitting the alignment in debug info" and "[LLDB] Respect the DW_AT_alignment attribute.") and adds a test to ensure that Swift types who have a member which is a clang type with a custom alignment are printed correctly.

rdar://127785973