### PR TITLE
Add libclang API to store and query CAS objects

### DIFF
--- a/clang/include/clang-c/CAS.h
+++ b/clang/include/clang-c/CAS.h
@@ -186,6 +186,35 @@ CINDEX_LINKAGE void clang_experimental_cas_loadObjectByString_async(
     CXCASCancellationToken *OutToken);
 
 /**
+ * Stores an object in the CAS.
+ *
+ * \param Refs The refs of the object to be stored.
+ * \param RefsCount The number of refs.
+ * \param Data The data of the object to be stored.
+ * \param DataSize The size of \Data.
+ * \param[out] OutError The error object to pass back to client (if any).
+ * If non-null the object must be disposed using \c clang_Error_dispose.
+ * \returns The CAS ID of the stored object, or an empty string if an
+ * error occurred. The ID should be disposed using
+ * \c clang_disposeString.
+ */
+CINDEX_LINKAGE CXString clang_experimental_cas_storeObject(
+    CXCASDatabases, const char *const *Refs, size_t RefsCount, const char *Data,
+    size_t DataSize, CXError *OutError);
+
+/**
+ * \returns the CAS object's refs.
+ */
+CINDEX_LINKAGE CXStringSet *
+    clang_experimental_cas_CASObject_getRefs(CXCASObject);
+
+/**
+ * \returns the CAS object's data, which is valid for the lifetime of the
+ * CXCASObject.
+ */
+CINDEX_LINKAGE CXString clang_experimental_cas_CASObject_getData(CXCASObject);
+
+/**
  * Dispose of a \c CXCASObject object.
  */
 CINDEX_LINKAGE void clang_experimental_cas_CASObject_dispose(CXCASObject);

--- a/clang/test/CAS/libclang-cas-api.c
+++ b/clang/test/CAS/libclang-cas-api.c
@@ -1,0 +1,19 @@
+// RUN: rm -rf %t && mkdir %t
+
+// RUN: c-index-test core -cas-store -cas-path %t/cas -cas-object-data aGVsbG8sIHdvcmxkIQo= 1> %t/obj1.txt
+
+// RUN: c-index-test core -cas-load -cas-path %t/cas @%t/obj1.txt 1> %t/out1.txt
+// RUN: FileCheck %s -input-file %t/out1.txt -check-prefix=OBJECTONE
+//
+// OBJECTONE: Data:
+// OBJECTONE: aGVsbG8sIHdvcmxkIQo=
+
+// RUN: c-index-test core -cas-store -cas-path %t/cas -cas-object-data Zm9vCg== --cas-object-ref @%t/obj1.txt 1> %t/obj2.txt
+
+// RUN: c-index-test core -cas-load -cas-path %t/cas @%t/obj2.txt 1> %t/out2.txt
+// RUN: FileCheck %s -input-file %t/out2.txt -check-prefix=OBJECTTWO
+//
+// OBJECTTWO: Refs:
+// OBJECTTWO: llvmcas://{{[a-z0-9]+}}
+// OBJECTTWO: Data:
+// OBJECTTWO: Zm9vCg==

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -484,6 +484,8 @@ LLVM_16 {
     clang_experimental_cas_CancellationToken_cancel;
     clang_experimental_cas_CancellationToken_dispose;
     clang_experimental_cas_CASObject_dispose;
+    clang_experimental_cas_CASObject_getData;
+    clang_experimental_cas_CASObject_getRefs;
     clang_experimental_cas_Databases_create;
     clang_experimental_cas_Databases_dispose;
     clang_experimental_cas_Databases_get_storage_size;
@@ -504,6 +506,7 @@ LLVM_16 {
     clang_experimental_cas_replayCompilation;
     clang_experimental_cas_ReplayResult_dispose;
     clang_experimental_cas_ReplayResult_getStderr;
+    clang_experimental_cas_storeObject;
     clang_experimental_DependencyScannerService_create_v1;
     clang_experimental_DependencyScannerServiceOptions_create;
     clang_experimental_DependencyScannerServiceOptions_dispose;


### PR DESCRIPTION
Allow libclang clients to directly access data and refs of CAS objects, and store new CAS objects