### PR TITLE
[CodeGen] Add a CC1 option to evaluate function call arguments from right to left

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -189,6 +189,7 @@ CODEGENOPT(NullPointerIsValid , 1, 0) ///< Assume Null pointer deference is defi
 CODEGENOPT(OpenCLCorrectlyRoundedDivSqrt, 1, 0) ///< -cl-fp32-correctly-rounded-divide-sqrt
 CODEGENOPT(HIPCorrectlyRoundedDivSqrt, 1, 1) ///< -fno-hip-fp32-correctly-rounded-divide-sqrt
 CODEGENOPT(HIPSaveKernelArgName, 1, 0) ///< Set when -fhip-kernel-arg-name is enabled.
+CODEGENOPT(EvalArgsRightToLeft, 1, 0) ///< Set when -feval-args-right-to-left is enabled.
 CODEGENOPT(UniqueInternalLinkageNames, 1, 0) ///< Internal Linkage symbols get unique names.
 CODEGENOPT(SplitMachineFunctions, 1, 0) ///< Split machine functions using profile information.
 CODEGENOPT(PPCUseFullRegisterNames, 1, 0) ///< Print full register names in assembly

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1450,6 +1450,11 @@ defm hip_fp32_correctly_rounded_divide_sqrt : BoolFOption<"hip-fp32-correctly-ro
   BothFlags<[], [ClangOption], " that single precision floating-point divide and sqrt used in "
   "the program source are correctly rounded (HIP device compilation only)">>,
   ShouldParseIf<hip.KeyPath>;
+defm eval_args_right_to_left : BoolFOption<"eval-args-right-to-left",
+  CodeGenOpts<"EvalArgsRightToLeft">, DefaultFalse,
+  PosFlag<SetTrue, [], [CC1Option], "Evaluate">,
+  NegFlag<SetFalse, [], [CC1Option], "Don't evaluate">,
+  BothFlags<[], [CC1Option], " arguments right to left)">>;
 defm hip_kernel_arg_name : BoolFOption<"hip-kernel-arg-name",
   CodeGenOpts<"HIPSaveKernelArgName">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Specify">,

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -4541,7 +4541,8 @@ void CodeGenFunction::EmitCallArgs(
   // evaluation, and in those cases we consider the evaluation order requirement
   // to trump the "destruction order is reverse construction order" guarantee.
   bool LeftToRight =
-      CGM.getTarget().getCXXABI().areArgsDestroyedLeftToRightInCallee()
+      (CGM.getTarget().getCXXABI().areArgsDestroyedLeftToRightInCallee() ||
+       CGM.getCodeGenOpts().EvalArgsRightToLeft)
           ? Order == EvaluationOrder::ForceLeftToRight
           : Order != EvaluationOrder::ForceRightToLeft;
 

--- a/clang/test/CodeGenCXX/eval-args-right-to-left.cpp
+++ b/clang/test/CodeGenCXX/eval-args-right-to-left.cpp
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macosx14 -emit-llvm -feval-args-right-to-left -o - %s | FileCheck %s
+// RUN: %clang_cc1 -triple x86_64-windows-msvc -emit-llvm -feval-args-right-to-left -o - %s | FileCheck %s
+
+// CHECK: %[[STRUCT_S123:.*]] = type { i32, i32 }
+
+struct S123 {
+  S123(int, int);
+  int a, b;
+  S123(const S123 &);
+  ~S123();
+};
+
+int operator &&(S123 s, int b);
+int getInt();
+void func(int, int);
+
+// CHECK: define {{(dso_local )?}}void @{{.*}}test0{{.*}}()
+// CHECK: %[[CALL:.*]] = call noundef i32 @{{.*}}getInt{{.*}}()
+// CHECK: %[[CALL1:.*]] = call noundef i32 @{{.*}}getInt{{.*}}()
+// CHECK: call void @{{.*}}func{{.*}}(i32 noundef %[[CALL1]], i32 noundef %[[CALL]])
+void test0() {
+  func(getInt(), getInt());
+}
+
+// CHECK: define {{(dso_local )?}}void @{{.*}}test1{{.*}}()
+// CHECK: %[[S:.*]] = alloca %[[STRUCT_S123]], align 4
+// CHECK: %[[CALL:.*]] = call noundef i32 @{{.*}}getInt{{.*}}()
+// CHECK: %[[CALL1:.*]] = call noundef i32 @{{.*}}getInt{{.*}}()
+// CHECK: call {{.*}}@{{.*}}S123{{.*}}(ptr noundef nonnull align 4 dereferenceable(8) %[[S]], i32 noundef %[[CALL]], i32 noundef %[[CALL1]])
+void test1() {
+  S123 s{getInt(), getInt()};
+}
+
+
+// CHECK: define {{(dso_local )?}}void @{{.*}}test2{{.*}}()
+// CHECK: %[[AGG_TMP:.*]] = alloca %[[STRUCT_S123]], align 4
+// CHECK: call {{.*}}@{{.*}}S123{{.*}}(ptr noundef nonnull align 4 dereferenceable(8) %[[AGG_TMP]], i32 noundef 1, i32 noundef 2)
+// CHECK: %[[CALL:.*]] = call noundef i32 @{{.*}}getInt{{.*}}()
+// CHECK: call noundef i32 @{{.*}}S123{{.*}}(ptr noundef %[[AGG_TMP]], i32 noundef %[[CALL]])
+void test2() {
+  S123(1, 2) && getInt();
+}


### PR DESCRIPTION
The flag doesn't change the order of argument evaluation in cases where the standard requires left-to-right evaluation.

rdar://130110857