### PR TITLE
[next] Cherry missing commits from stable/20240625

### DIFF
--- a/clang/lib/Index/IndexRecordHasher.cpp
+++ b/clang/lib/Index/IndexRecordHasher.cpp
@@ -367,6 +367,10 @@ static hash_code computeHash(const TemplateArgument &Arg,
   case TemplateArgument::Integral:
     COMBINE_HASH('V', Hasher.hash(Arg.getIntegralType()), Arg.getAsIntegral());
     break;
+
+  case TemplateArgument::StructuralValue:
+    // FIXME: Hash structural values
+    break;
   }
 
   return Hash;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -70,11 +70,11 @@ public:
       lldb_private::CompilerDeclContext decl_context) override {}
 
   // FIXME: What should this do?
-  lldb_private::ConstString
+  std::string
   GetDIEClassTemplateParams(const DWARFDIE &die) override {
     assert(false && "DWARFASTParserSwift::GetDIEClassTemplateParams has not "
                     "yet been implemented");
-    return lldb_private::ConstString();
+    return {};
   }
 
   static bool classof(const DWARFASTParser *Parser) {


### PR DESCRIPTION
Couple of commits from stable/20240625 that need to be on `next`.