### PR TITLE
[embedded] Produce armv6, armv6m, armv7, armv7m, armv7em builtins for Embedded Swift

### DIFF
--- a/compiler-rt/cmake/builtin-config-ix.cmake
+++ b/compiler-rt/cmake/builtin-config-ix.cmake
@@ -231,6 +231,15 @@ if(APPLE)
     endif()
   endforeach()
 
+  # Cross-compilation builtins for Mach-O supported archs that Darwin systems don't use, but embedded baremetal use cases might need.
+  if(COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS)
+    # Typically, COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS is something like "armv6 armv6m armv7 armv7m armv7em"
+    foreach(arch ${COMPILER_RT_FORCE_BUILD_BAREMETAL_MACHO_BUILTINS_ARCHS})
+      list(APPEND COMPILER_RT_SUPPORTED_ARCH ${arch})
+      set(CAN_TARGET_${arch} 1)
+    endforeach()
+  endif()
+
   list_intersect(BUILTIN_SUPPORTED_ARCH ALL_BUILTIN_SUPPORTED_ARCH COMPILER_RT_SUPPORTED_ARCH)
 
 else()


### PR DESCRIPTION
The builtins build today only produces slides that either macOS or other Darwin OS's actually use in their userspace. To support Embedded Swift and possibly other baremetal usecases that want to use Mach-O files and link with the Apple linker, we should build builtins (unconditionally) for other common ARM based ISAs.

Addresses this issue: https://github.com/apple/swift-embedded-examples/issues/5
