### PR TITLE
[next][lldb] Remove duplicate `DoPlanExplainsStop`

### DIFF
--- a/lldb/source/Target/ThreadPlanStepOverRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepOverRange.cpp
@@ -337,37 +337,6 @@ bool ThreadPlanStepOverRange::ShouldStop(Event *event_ptr) {
     return false;
 }
 
-bool ThreadPlanStepRange::DoPlanExplainsStop(Event *event_ptr) {
-  // For crashes, breakpoint hits, signals, etc,cd  let the base plan (or some
-  // plan above us) handle the stop.  That way the user can see the stop, step
-  // around, and then when they are done, continue and have their step
-  // complete.  The exception is if we've hit our "run to next branch"
-  // breakpoint. Note, unlike the step in range plan, we don't mark ourselves
-  // complete if we hit an unexplained breakpoint/crash.
-
-  Log *log = GetLog(LLDBLog::Step);
-  StopInfoSP stop_info_sp = GetPrivateStopInfo();
-  bool return_value;
-
-  if (stop_info_sp) {
-    StopReason reason = stop_info_sp->GetStopReason();
-
-    if (reason == eStopReasonTrace) {
-      return_value = true;
-    } else if (reason == eStopReasonBreakpoint) {
-      return_value = NextRangeBreakpointExplainsStop(stop_info_sp);
-    } else {
-      if (log)
-        log->PutCString("ThreadPlanStepOverRange got asked if it explains the "
-                        "stop for some reason other than step.");
-      return_value = false;
-    }
-  } else
-    return_value = true;
-
-  return return_value;
-}
-
 bool ThreadPlanStepOverRange::DoWillResume(lldb::StateType resume_state,
                                            bool current_plan) {
   if (resume_state != eStateSuspended && m_first_resume) {


### PR DESCRIPTION
`ThreadPlanStepOverRange::DoPlanExplainsStop` was moved to `ThreadPlanStepRange::DoPlanExplansStop` in
3dcce7c312f3240fb1f3d476d49c1888b386e3cd. This resulted in a merge conflict, which renamed this method instead of removing it.

(cherry picked from commit 0b4c4c017fe45e31929f66d03a4a12e3f6bbec02)