### PR TITLE
[lldb] Fix unsafe pointer type determination logic

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -383,8 +383,11 @@ std::unique_ptr<SwiftUnsafeType> SwiftUnsafeType::Create(ValueObject &valobj) {
   }
 
   llvm::StringRef valobj_type_name(type.GetTypeName().GetCString());
-  bool is_raw = valobj_type_name.contains("Raw");
-  bool is_buffer_ptr = valobj_type_name.contains("BufferPointer");
+  valobj_type_name.consume_front("Swift.");
+  valobj_type_name.consume_front("Unsafe");
+  valobj_type_name.consume_front("Mutable");
+  bool is_raw = valobj_type_name.consume_front("Raw");
+  bool is_buffer_ptr = valobj_type_name.consume_front("Buffer");
   UnsafePointerKind kind =
       static_cast<UnsafePointerKind>(is_buffer_ptr << 1 | is_raw);
 

--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/main.swift
@@ -35,6 +35,12 @@ class Number<T:Numeric> {
   }
 }
 
+// Ensure "Raw" in the name doesn't confuse the data formatters into thinking
+// it's a raw value.
+struct NotRaw {
+  var x: Int
+}
+
 func main() {
   // UnsafeBufferPointer
   let structArray = [ IntPair(1), IntPair(-2), IntPair(3) ]
@@ -204,6 +210,16 @@ func main() {
     //%            substrs=['(UInt8) [0] = 1'])
   }
 
+  let cooked: [NotRaw] = [.init(x: 1), .init(x: 2), .init(x: 4)]
+  cooked.withUnsafeBufferPointer { buffer in
+    //% self.expect("frame variable buffer",
+    //%            patterns=[
+    //%            '\(UnsafeBufferPointer<a.NotRaw>\) buffer = 3 values \(0[xX][0-9a-fA-F]+\) {',
+    //%            '\[0\] = \(x = 1\)',
+    //%            '\[1\] = \(x = 2\)',
+    //%            '\[2\] = \(x = 4\)',
+    //%            ])
+  }
 }
 
 main()


### PR DESCRIPTION
(cherry-picked from commit 048ba28fe970a1259920921e76296bd54bbf5f3f)