### PR TITLE
Remove lldb support for Swift "MPE descriptors"

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -44,13 +44,6 @@ struct DescriptorFinderForwarder : public swift::reflection::DescriptorFinder {
     return nullptr;
   }
 
-  std::unique_ptr<swift::reflection::MultiPayloadEnumDescriptorBase>
-  getMultiPayloadEnumDescriptor(const swift::reflection::TypeRef *TR) override {
-    if (!m_descriptor_finders.empty() && shouldConsultDescriptorFinder())
-      return m_descriptor_finders.back()->getMultiPayloadEnumDescriptor(TR);
-    return nullptr;
-  }
-
   void PushExternalDescriptorFinder(
       swift::reflection::DescriptorFinder *descriptor_finder) {
     m_descriptor_finders.push_back(descriptor_finder);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -89,10 +89,6 @@ public:
   std::unique_ptr<swift::reflection::BuiltinTypeDescriptorBase>
   getBuiltinTypeDescriptor(const swift::reflection::TypeRef *TR) override;
 
-  /// Returns a builtin descriptor constructed from DWARF info.
-  std::unique_ptr<swift::reflection::MultiPayloadEnumDescriptorBase>
-  getMultiPayloadEnumDescriptor(const swift::reflection::TypeRef *TR) override;
-
 private:
   /// Returns the canonical demangle tree of a die's type.
   NodePointer GetCanonicalDemangleTree(DWARFDIE &die);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -281,52 +281,6 @@ public:
   }
 };
 
-class DWARFMultiPayloadEnumDescriptorImpl
-    : public swift::reflection::MultiPayloadEnumDescriptorBase {
-  ConstString m_mangled_name;
-  DIERef m_die_ref;
-  std::vector<uint8_t> m_spare_bits_mask;
-  uint64_t m_byte_offset;
-
-public:
-  ~DWARFMultiPayloadEnumDescriptorImpl() override = default;
-
-  DWARFMultiPayloadEnumDescriptorImpl(ConstString mangled_name, DIERef die_ref,
-                                      std::vector<uint8_t> &&spare_bits_mask,
-                                      uint64_t byte_offset)
-      : swift::reflection::MultiPayloadEnumDescriptorBase(),
-        m_mangled_name(mangled_name), m_die_ref(die_ref),
-        m_spare_bits_mask(std::move(spare_bits_mask)),
-        m_byte_offset(byte_offset) {}
-
-  llvm::StringRef getMangledTypeName() override {
-    return m_mangled_name.GetStringRef();
-  }
-
-  uint32_t getContentsSizeInWords() const override {
-    return m_spare_bits_mask.size() / 4;
-  }
-
-  size_t getSizeInBytes() const override { return m_spare_bits_mask.size(); }
-
-  uint32_t getFlags() const override { return usesPayloadSpareBits(); }
-
-  bool usesPayloadSpareBits() const override {
-    return !m_spare_bits_mask.empty();
-  }
-
-  uint32_t getPayloadSpareBitMaskByteOffset() const override {
-    return m_byte_offset;
-  }
-
-  uint32_t getPayloadSpareBitMaskByteCount() const override {
-    return getSizeInBytes();
-  }
-
-  const uint8_t *getPayloadSpareBits() const override {
-    return m_spare_bits_mask.data();
-  }
-};
 } // namespace
 
 /// Constructs a builtin type descriptor from DWARF information.
@@ -372,85 +326,6 @@ DWARFASTParserSwift::getBuiltinTypeDescriptor(
   return std::make_unique<DWARFBuiltinTypeDescriptorImpl>(
       byte_size, alignment, stride, num_extra_inhabitants, is_bitwise_takable,
       type.GetMangledTypeName());
-}
-
-std::unique_ptr<swift::reflection::MultiPayloadEnumDescriptorBase>
-DWARFASTParserSwift::getMultiPayloadEnumDescriptor(
-    const swift::reflection::TypeRef *TR) {
-  assert(ModuleList::GetGlobalModuleListProperties()
-                 .GetSwiftEnableFullDwarfDebugging() !=
-             lldb_private::AutoBool::False &&
-         "Full DWARF debugging for Swift is disabled!");
-
-  auto pair = getTypeAndDie(m_swift_typesystem, TR);
-  if (!pair)
-    return nullptr;
-
-  auto [type, die] = *pair;
-  if (!die)
-    return nullptr;
-
-  auto kind = getFieldDescriptorKindForDie(type);
-  if (!kind)
-    return nullptr;
-
-  auto child_die = die.GetFirstChild();
-  auto bit_offset =
-      child_die.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_bit_offset, 0);
-
-  auto byte_offset = (bit_offset + 7) / 8;
-
-  const auto &attributes = child_die.GetAttributes();
-  auto spare_bits_mask_idx =
-      attributes.FindAttributeIndex(llvm::dwarf::DW_AT_APPLE_spare_bits_mask);
-  if (spare_bits_mask_idx == UINT32_MAX)
-    return nullptr;
-
-  DWARFFormValue form_value;
-  attributes.ExtractFormValueAtIndex(spare_bits_mask_idx, form_value);
-
-  if (!form_value.IsValid()) {
-    if (auto *log = GetLog(LLDBLog::Types)) {
-      std::stringstream ss;
-      TR->dump(ss);
-      LLDB_LOG(log,
-               "Could not produce MultiPayloadEnumTypeInfo for typeref: {0}",
-               ss.str());
-    }
-    return nullptr;
-  }
-  // If there's a block data, this is a number bigger than 64 bits already
-  // encoded as an array.
-  if (form_value.BlockData()) {
-    uint64_t block_length = form_value.Unsigned();
-    std::vector<uint8_t> bytes(form_value.BlockData(),
-                             form_value.BlockData() + block_length);
-    return std::make_unique<DWARFMultiPayloadEnumDescriptorImpl>(
-        type.GetMangledTypeName(), *die.GetDIERef(),
-        std::move(bytes), byte_offset);
-  }
-
-  // If there is no block data, the spare bits mask is encoded as a single 64
-  // bit number. Convert this to a byte array with only the amount of bytes
-  // necessary to cover the whole number (see
-  // MultiPayloadEnumDescriptorBuilder::layout on GenReflection.cpp for a
-  // similar calculation when emitting this into metadata).
-  llvm::APInt bits(64, form_value.Unsigned());
-  auto bitsInMask = bits.getActiveBits(); 
-  uint32_t bytesInMask = (bitsInMask + 7) / 8;
-  auto wordsInMask = (bytesInMask + 3) / 4;
-  bits = bits.zextOrTrunc(wordsInMask * 32);
-
-  std::vector<uint8_t> bytes;
-  for (size_t i = 0; i < bytesInMask; ++i) {
-    uint8_t byte = bits.extractBitsAsZExtValue(8, 0);
-    bytes.push_back(byte);
-    bits.lshrInPlace(8);
-  }
-
-  return std::make_unique<DWARFMultiPayloadEnumDescriptorImpl>(
-      type.GetMangledTypeName(), *die.GetDIERef(), std::move(bytes),
-      byte_offset);
 }
 
 namespace {


### PR DESCRIPTION
The RemoteMirror library used by LLDB to inspect Swift values no longer requires these MPE descriptors. As the next step in fully removing the related code, this removes the LLDB code to look up such descriptors from the DWARF data.

The Swift compiler will continue to emit these descriptors for a while in order to support debugging with older versions of LLDB, but that code will also eventually be deleted.