### PR TITLE
amtool: print the whole sha after 'Successfully pushed '

### DIFF
--- a/apple-ci/amtool
+++ b/apple-ci/amtool
@@ -328,7 +328,7 @@ def main():
             pass
 
         # Save the commit sha so that we can include it in the output message.
-        merge_commit = git('rev-parse', '--short', 'HEAD')
+        merge_commit = git('rev-parse', 'HEAD')
 
         # Perform the push.
         merge_id = MergeId(content)


### PR DESCRIPTION
... as `git fetch` requires the whole thing whenever the patch isn't already available on a branch locally.