### PR TITLE
[AVR] make the AVR ABI Swift compatible

### DIFF
--- a/clang/lib/CodeGen/Targets/AVR.cpp
+++ b/clang/lib/CodeGen/Targets/AVR.cpp
@@ -112,7 +112,10 @@ public:
 class AVRTargetCodeGenInfo : public TargetCodeGenInfo {
 public:
   AVRTargetCodeGenInfo(CodeGenTypes &CGT, unsigned NPR, unsigned NRR)
-      : TargetCodeGenInfo(std::make_unique<AVRABIInfo>(CGT, NPR, NRR)) {}
+       : TargetCodeGenInfo(std::make_unique<AVRABIInfo>(CGT, NPR, NRR)) {
+     SwiftInfo =
+         std::make_unique<SwiftABIInfo>(CGT, /*SwiftErrorInRegister=*/false);
+   }
 
   LangAS getGlobalVarAddressSpace(CodeGenModule &CGM,
                                   const VarDecl *D) const override {


### PR DESCRIPTION
This is a cherry-pick of https://github.com/swiftlang/llvm-project/pull/8945