### PR TITLE
[libclang] Introduce an API to check whether a CASID is materialized

### DIFF
--- a/clang/include/clang-c/CAS.h
+++ b/clang/include/clang-c/CAS.h
@@ -153,6 +153,20 @@ CINDEX_LINKAGE
 CXError clang_experimental_cas_Databases_prune_ondisk_data(CXCASDatabases);
 
 /**
+ * Checks whether an object is materialized in the database using its printed
+ * \p CASID.
+ *
+ * \param CASID The printed CASID string for the object.
+ * \param[out] OutError The error object to pass back to client (if any).
+ * If non-null the object must be disposed using \c clang_Error_dispose.
+ *
+ * \returns whether the object is materialized in the database.
+ */
+CINDEX_LINKAGE bool clang_experimental_cas_isMaterialized(CXCASDatabases,
+                                                          const char *CASID,
+                                                          CXError *OutError);
+
+/**
  * Loads an object using its printed \p CASID.
  *
  * \param CASID The printed CASID string for the object.

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -493,6 +493,7 @@ LLVM_16 {
     clang_experimental_cas_Databases_set_size_limit;
     clang_experimental_cas_getCachedCompilation;
     clang_experimental_cas_getCachedCompilation_async;
+    clang_experimental_cas_isMaterialized;
     clang_experimental_cas_loadObjectByString;
     clang_experimental_cas_loadObjectByString_async;
     clang_experimental_cas_ObjectStore_dispose;


### PR DESCRIPTION
This PR adds an API that allows clients to check whether an object (represented by its printed CASID) is materialized in the database.