### PR TITLE
[libclang] Introduce an API to check whether a cached compilation is materialized

### DIFF
--- a/clang/include/clang-c/CAS.h
+++ b/clang/include/clang-c/CAS.h
@@ -299,6 +299,20 @@ CINDEX_LINKAGE void clang_experimental_cas_CachedCompilation_makeGlobal(
     CXCASCancellationToken *OutToken);
 
 /**
+ * Looks up the cache key and returns true if all of the associated compilation
+ * outputs are materialized.
+ *
+ * \param CacheKey The printed compilation cache key string.
+ * \param[out] OutError The error object to pass back to client (if any).
+ * If non-null the object must be disposed using \c clang_Error_dispose.
+ *
+ * \returns whether the compilation is present in the cache and its outputs are
+ * materialized in the database.
+ */
+CINDEX_LINKAGE bool clang_experimental_cas_isCachedCompilationMaterialized(
+    CXCASDatabases, const char *CacheKey, CXError *OutError);
+
+/**
  * Replays a cached compilation by writing the cached outputs to the filesystem
  * and/or stderr based on the given compilation arguments.
  *

--- a/clang/tools/libclang/CCAS.cpp
+++ b/clang/tools/libclang/CCAS.cpp
@@ -540,6 +540,41 @@ void clang_experimental_cas_CachedCompilation_makeGlobal(
   }
 }
 
+bool clang_experimental_cas_isCachedCompilationMaterialized(
+    CXCASDatabases CDBs, const char *CacheKey, CXError *OutError) {
+  WrappedCASDatabases &DBs = *unwrap(CDBs);
+
+  if (OutError)
+    *OutError = nullptr;
+
+  auto Failure = [OutError](Error &&E) {
+    passAsCXError(std::move(E), OutError);
+    return false;
+  };
+
+  Expected<CASID> KeyID = DBs.CAS->parseID(CacheKey);
+  if (!KeyID)
+    return Failure(KeyID.takeError());
+
+  auto CacheValueOrErr = DBs.Cache->get(*KeyID);
+  if (!CacheValueOrErr)
+    return Failure(CacheValueOrErr.takeError());
+
+  auto MaybeCacheValue = *CacheValueOrErr;
+  if (!MaybeCacheValue)
+    return false;
+
+  auto MaybeRef = DBs.CAS->getReference(*MaybeCacheValue);
+  if (!MaybeRef)
+    return false;
+
+  auto ResultOrErr = DBs.CAS->isMaterialized(*MaybeRef);
+  if (!ResultOrErr)
+    return Failure(ResultOrErr.takeError());
+
+  return *ResultOrErr;
+}
+
 CXCASReplayResult clang_experimental_cas_replayCompilation(
     CXCASCachedCompilation CComp, int argc, const char *const *argv,
     const char *WorkingDirectory, void * /*reserved*/, CXError *OutError) {

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -493,6 +493,7 @@ LLVM_16 {
     clang_experimental_cas_Databases_set_size_limit;
     clang_experimental_cas_getCachedCompilation;
     clang_experimental_cas_getCachedCompilation_async;
+    clang_experimental_cas_isCachedCompilationMaterialized;
     clang_experimental_cas_isMaterialized;
     clang_experimental_cas_loadObjectByString;
     clang_experimental_cas_loadObjectByString_async;


### PR DESCRIPTION
This PR adds new libclang API that allows clients to ask whether a cached compilation and its outputs are materialized in the CAS database. This is necessary during incremental builds, where other tasks may depend on the CAS outputs of the compilation at hand. Until now, the only way to implement this check was with:

```c
CXCASCachedCompilation CachedCompilation = clang_experimental_cas_getCachedCompilation(/*...*/);
size_t NumOutputs = clang_experimental_cas_CachedCompilation_getNumOutputs(CachedCompilation);
for (size_t I = 0; I != NumOutputs; ++I)
  if (!clang_experimental_cas_CachedCompilation_isOutputMaterialized(CachedCompilation, I))
    return false;
return true;
```

This is problematic due to the fact that `getCachedCompilation()` actually loads the compilation object. If the database is an `OnDiskGraphDB` with `FaultInPolicy::FullTree`, all referenced objects (i.e. the outputs) are eagerly loaded too. This means that just performing this "is materialized" check will prevent those object ever being marked as garbage and pruned when the size limit is reached, which is not desirable. The new API never loads the objects - it instead uses the narrower `ObjectStore::isMaterialized()` API.