### PR TITLE
[TSAN] fix module map of main executable on darwin platforms

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_procmaps_mac.cpp
@@ -433,7 +433,7 @@ void MemoryMappingLayout::DumpListOfModules(
   MemoryMappedSegmentData data;
   segment.data_ = &data;
   while (Next(&segment)) {
-    if (segment.filename[0] == '\0') continue;
+    if (segment.filename[0] == '\0' || internal_strcmp(data.name, "__PAGEZERO") == 0) continue;
     LoadedModule *cur_module = nullptr;
     if (!modules->empty() &&
         0 == internal_strcmp(segment.filename, modules->back().full_name())) {


### PR DESCRIPTION
there is a segment named `__PAGEZERO` in the main executable on darwin platforms, it's vmaddr and vmsize are both 0. we will get a wrong start address of main executable if we don't skip that segment.