### PR TITLE
[clang][ExtractAPI][NFC] Remove some nullptr dereference problems (#98914)

### DIFF
--- a/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
+++ b/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
@@ -174,22 +174,25 @@ protected:
       // skip classes not inherited as public
       if (BaseSpecifier.getAccessSpecifier() != AccessSpecifier::AS_public)
         continue;
-      SymbolReference BaseClass;
-      if (BaseSpecifier.getType().getTypePtr()->isTemplateTypeParmType()) {
-        BaseClass.Name = API.copyString(BaseSpecifier.getType().getAsString());
-        if (auto *TTPTD = BaseSpecifier.getType()
-                              ->getAs<TemplateTypeParmType>()
-                              ->getDecl()) {
-          SmallString<128> USR;
-          index::generateUSRForDecl(TTPTD, USR);
-          BaseClass.USR = API.copyString(USR);
-          BaseClass.Source = API.copyString(getOwningModuleName(*TTPTD));
-        }
+      if (auto *BaseDecl = BaseSpecifier.getType()->getAsTagDecl()) {
+        Bases.emplace_back(createSymbolReferenceForDecl(*BaseDecl));
       } else {
-        BaseClass = createSymbolReferenceForDecl(
-            *BaseSpecifier.getType().getTypePtr()->getAsCXXRecordDecl());
+        SymbolReference BaseClass;
+        BaseClass.Name = API.copyString(BaseSpecifier.getType().getAsString(
+            Decl->getASTContext().getPrintingPolicy()));
+
+        if (BaseSpecifier.getType().getTypePtr()->isTemplateTypeParmType()) {
+          if (auto *TTPTD = BaseSpecifier.getType()
+                                ->getAs<TemplateTypeParmType>()
+                                ->getDecl()) {
+            SmallString<128> USR;
+            index::generateUSRForDecl(TTPTD, USR);
+            BaseClass.USR = API.copyString(USR);
+            BaseClass.Source = API.copyString(getOwningModuleName(*TTPTD));
+          }
+        }
+        Bases.emplace_back(BaseClass);
       }
-      Bases.emplace_back(BaseClass);
     }
     return Bases;
   }
@@ -326,7 +329,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitFunctionDecl(
     return true;
 
   // Collect symbol information.
-  StringRef Name = Decl->getName();
+  auto Name = Decl->getNameAsString();
   SmallString<128> USR;
   index::generateUSRForDecl(Decl, USR);
   PresumedLoc Loc =
@@ -639,8 +642,8 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXMethodDecl(
   if (FunctionTemplateDecl *TemplateDecl =
           Decl->getDescribedFunctionTemplate()) {
     API.createRecord<CXXMethodTemplateRecord>(
-        USR, Decl->getName(), createHierarchyInformationForDecl(*Decl), Loc,
-        AvailabilityInfo::createFromDecl(Decl), Comment,
+        USR, Decl->getNameAsString(), createHierarchyInformationForDecl(*Decl),
+        Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::getFragmentsForFunctionTemplate(
             TemplateDecl),
         SubHeading, DeclarationFragmentsBuilder::getFunctionSignature(Decl),
@@ -648,8 +651,8 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXMethodDecl(
         Template(TemplateDecl), isInSystemHeader(Decl));
   } else if (Decl->getTemplateSpecializationInfo())
     API.createRecord<CXXMethodTemplateSpecializationRecord>(
-        USR, Decl->getName(), createHierarchyInformationForDecl(*Decl), Loc,
-        AvailabilityInfo::createFromDecl(Decl), Comment,
+        USR, Decl->getNameAsString(), createHierarchyInformationForDecl(*Decl),
+        Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::
             getFragmentsForFunctionTemplateSpecialization(Decl),
         SubHeading, Signature, Access, isInSystemHeader(Decl));
@@ -661,14 +664,14 @@ bool ExtractAPIVisitorBase<Derived>::VisitCXXMethodDecl(
         SubHeading, Signature, Access, isInSystemHeader(Decl));
   else if (Decl->isStatic())
     API.createRecord<CXXStaticMethodRecord>(
-        USR, Decl->getName(), createHierarchyInformationForDecl(*Decl), Loc,
-        AvailabilityInfo::createFromDecl(Decl), Comment,
+        USR, Decl->getNameAsString(), createHierarchyInformationForDecl(*Decl),
+        Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::getFragmentsForCXXMethod(Decl), SubHeading,
         Signature, Access, isInSystemHeader(Decl));
   else
     API.createRecord<CXXInstanceMethodRecord>(
-        USR, Decl->getName(), createHierarchyInformationForDecl(*Decl), Loc,
-        AvailabilityInfo::createFromDecl(Decl), Comment,
+        USR, Decl->getNameAsString(), createHierarchyInformationForDecl(*Decl),
+        Loc, AvailabilityInfo::createFromDecl(Decl), Comment,
         DeclarationFragmentsBuilder::getFragmentsForCXXMethod(Decl), SubHeading,
         Signature, Access, isInSystemHeader(Decl));
 
@@ -950,7 +953,7 @@ bool ExtractAPIVisitorBase<Derived>::VisitFunctionTemplateDecl(
     return true;
 
   // Collect symbol information.
-  StringRef Name = Decl->getName();
+  auto Name = Decl->getNameAsString();
   SmallString<128> USR;
   index::generateUSRForDecl(Decl, USR);
   PresumedLoc Loc =

--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -708,7 +708,8 @@ DeclarationFragmentsBuilder::getFragmentsForFunction(const FunctionDecl *Func) {
 
   Fragments.append(std::move(ReturnValueFragment))
       .appendSpace()
-      .append(Func->getName(), DeclarationFragments::FragmentKind::Identifier);
+      .append(Func->getNameAsString(),
+              DeclarationFragments::FragmentKind::Identifier);
 
   if (Func->getTemplateSpecializationInfo()) {
     Fragments.append("<", DeclarationFragments::FragmentKind::Text);
@@ -1592,8 +1593,11 @@ DeclarationFragmentsBuilder::getSubHeading(const NamedDecl *Decl) {
              cast<CXXMethodDecl>(Decl)->isOverloadedOperator()) {
     Fragments.append(Decl->getNameAsString(),
                      DeclarationFragments::FragmentKind::Identifier);
-  } else if (!Decl->getName().empty())
+  } else if (Decl->getIdentifier()) {
     Fragments.append(Decl->getName(),
+                     DeclarationFragments::FragmentKind::Identifier);
+  } else
+    Fragments.append(Decl->getDeclName().getAsString(),
                      DeclarationFragments::FragmentKind::Identifier);
   return Fragments;
 }


### PR DESCRIPTION
A places try to get a NamedDecl's name using getName when it isn't a simple identifier, migrate these areas to getNameAsString.

rdar://125315602