### PR TITLE
[Tests] Fix a nondeterministic failure in cas-case-sensitivity.c

### DIFF
--- a/clang/test/ClangScanDeps/cas-case-sensitivity.c
+++ b/clang/test/ClangScanDeps/cas-case-sensitivity.c
@@ -53,10 +53,6 @@ void bar2(void) {
   foo();
 }
 
-//--- header.h
-#pragma once
-void foo(void);
-
 //--- Header.h
 #pragma once
 void foo(void);


### PR DESCRIPTION
It seems that `split-file` doesn't guarantee which file will be kept if multiple files are written to the same location. Avoid writing two files into the same location in a case-insensitive file system.

rdar://131898412