### PR TITLE
[libclang] Introduce an API to get the include-tree CASID

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -551,7 +551,19 @@ CINDEX_LINKAGE CXCStringArray
     clang_experimental_DepGraphModule_getBuildArguments(CXDepGraphModule);
 
 /**
+ * @returns the CASID of the include-tree for this module, if any.
+ *
+ * The string is only valid to use while the \c CXDepGraphModule object is
+ * valid.
+ */
+CINDEX_LINKAGE const char *
+    clang_experimental_DepGraphModule_getIncludeTreeID(CXDepGraphModule);
+
+/**
  * \returns the \c ActionCache key for this module, if any.
+ *
+ * The string is only valid to use while the \c CXDepGraphModule object is
+ * valid.
  */
 CINDEX_LINKAGE
 const char *clang_experimental_DepGraphModule_getCacheKey(CXDepGraphModule);
@@ -596,6 +608,9 @@ CINDEX_LINKAGE CXCStringArray
 
 /**
  * \returns the \c ActionCache key for this translation unit, if any.
+ *
+ * The string is only valid to use while the \c CXDepGraphTUCommand object is
+ * valid.
  */
 CINDEX_LINKAGE const char *
     clang_experimental_DepGraphTUCommand_getCacheKey(CXDepGraphTUCommand);
@@ -618,6 +633,14 @@ CXCStringArray clang_experimental_DepGraph_getTUFileDeps(CXDepGraph);
  */
 CINDEX_LINKAGE
 CXCStringArray clang_experimental_DepGraph_getTUModuleDeps(CXDepGraph);
+
+/**
+ * @returns the CASID of the include-tree for this TU, if any.
+ *
+ * The string is only valid to use while the \c CXDepGraph object is valid.
+ */
+CINDEX_LINKAGE
+const char *clang_experimental_DepGraph_getTUIncludeTreeID(CXDepGraph);
 
 /**
  * \returns the context hash of the C++20 module this translation unit exports.

--- a/clang/test/Index/Core/scan-deps-cas.m
+++ b/clang/test/Index/Core/scan-deps-cas.m
@@ -71,6 +71,7 @@
 // INCLUDE_TREE-NEXT:     name: ModA
 // INCLUDE_TREE-NEXT:     context-hash: [[HASH_MOD_A:[A-Z0-9]+]]
 // INCLUDE_TREE-NEXT:     module-map-path: [[PREFIX]]/Inputs/module/module.modulemap
+// INCLUDE_TREE-NEXT:     include-tree-id: [[ModA_INCLUDE_TREE_ID:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     cache-key: [[ModA_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     module-deps:
 // INCLUDE_TREE-NEXT:     file-deps:
@@ -81,12 +82,13 @@
 // INCLUDE_TREE-NEXT:     build-args:
 // INCLUDE_TREE-SAME:       -cc1
 // INCLUDE_TREE-SAME:       -fcas-path
-// INCLUDE_TREE-SAME:       -fcas-include-tree llvmcas://{{[[:xdigit:]]+}}
+// INCLUDE_TREE-SAME:       -fcas-include-tree [[ModA_INCLUDE_TREE_ID]]
 // INCLUDE_TREE-SAME:       -fcache-compile-job
 
 // INCLUDE_TREE:      dependencies:
 // INCLUDE_TREE-NEXT:   command 0:
 // INCLUDE_TREE-NEXT:     context-hash: [[HASH_TU:[A-Z0-9]+]]
+// INCLUDE_TREE-NEXT:     include-tree-id: [[INC_TU_INCLUDE_TREE_ID:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     cache-key: [[INC_TU_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     module-deps:
 // INCLUDE_TREE-NEXT:       ModA:[[HASH_MOD_A]]
@@ -95,7 +97,7 @@
 // INCLUDE_TREE-NEXT:     build-args:
 // INCLUDE_TREE-SAME:       -cc1
 // INCLUDE_TREE-SAME:       -fcas-path
-// INCLUDE_TREE-SAME:       -fcas-include-tree llvmcas://{{[[:xdigit:]]+}}
+// INCLUDE_TREE-SAME:       -fcas-include-tree [[INC_TU_INCLUDE_TREE_ID]]
 // INCLUDE_TREE-SAME:       -fcache-compile-job
 // INCLUDE_TREE-SAME:       -fmodule-file-cache-key [[PCM:.*ModA_.*pcm]] [[ModA_CACHE_KEY]]
 // INCLUDE_TREE-SAME:       -fmodule-file={{(ModA=)?}}[[PCM]]

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -597,6 +597,14 @@ clang_experimental_DepGraphModule_getBuildArguments(CXDepGraphModule CXDepMod) {
 }
 
 const char *
+clang_experimental_DepGraphModule_getIncludeTreeID(CXDepGraphModule CXDepMod) {
+  ModuleDeps &ModDeps = *unwrap(CXDepMod)->ModDeps;
+  if (ModDeps.IncludeTreeID)
+    return ModDeps.IncludeTreeID->c_str();
+  return nullptr;
+}
+
+const char *
 clang_experimental_DepGraphModule_getCacheKey(CXDepGraphModule CXDepMod) {
   ModuleDeps &ModDeps = *unwrap(CXDepMod)->ModDeps;
   if (ModDeps.ModuleCacheKey)
@@ -651,6 +659,13 @@ CXCStringArray clang_experimental_DepGraph_getTUModuleDeps(CXDepGraph Graph) {
   for (const ModuleID &MID : TUDeps.ClangModuleDeps)
     Modules.push_back(MID.ModuleName + ":" + MID.ContextHash);
   return unwrap(Graph)->StrMgr.createCStringsOwned(std::move(Modules));
+}
+
+const char *clang_experimental_DepGraph_getTUIncludeTreeID(CXDepGraph Graph) {
+  TranslationUnitDeps &TUDeps = unwrap(Graph)->TUDeps;
+  if (TUDeps.IncludeTreeID)
+    return TUDeps.IncludeTreeID->c_str();
+  return nullptr;
 }
 
 const char *clang_experimental_DepGraph_getTUContextHash(CXDepGraph Graph) {

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -523,12 +523,14 @@ LLVM_16 {
     clang_experimental_DepGraph_getTUCommand;
     clang_experimental_DepGraph_getTUContextHash;
     clang_experimental_DepGraph_getTUFileDeps;
+    clang_experimental_DepGraph_getTUIncludeTreeID;
     clang_experimental_DepGraph_getTUModuleDeps;
     clang_experimental_DepGraphModule_dispose;
     clang_experimental_DepGraphModule_getBuildArguments;
     clang_experimental_DepGraphModule_getCacheKey;
     clang_experimental_DepGraphModule_getContextHash;
     clang_experimental_DepGraphModule_getFileDeps;
+    clang_experimental_DepGraphModule_getIncludeTreeID;
     clang_experimental_DepGraphModule_getModuleDeps;
     clang_experimental_DepGraphModule_getModuleMapPath;
     clang_experimental_DepGraphModule_getName;


### PR DESCRIPTION
The include-tree is a CAS object stored in the database and it's essentially an output of the dependency scan and an input to the compilation. This object may get pruned out of the database like any other. This means that before an incremental build, the build system needs to be able to check whether this object still exists. Exposing an API that returns the CAS ID of the include-tree object is a necessary stepping stone for implementing that.

Cherry-pick of https://github.com/swiftlang/llvm-project/pull/8975