### PR TITLE
[lldb] Drop LOG_CONS from openlog call.

### DIFF
--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -93,9 +93,8 @@ using namespace lldb_private;
 #include <syslog.h>
 void Host::SystemLog(Severity severity, llvm::StringRef message) {
   static llvm::once_flag g_openlog_once;
-  llvm::call_once(g_openlog_once, [] {
-    openlog("lldb", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_USER);
-  });
+  llvm::call_once(g_openlog_once,
+                  [] { openlog("lldb", LOG_PID | LOG_NDELAY, LOG_USER); });
   int level = LOG_DEBUG;
   switch (severity) {
   case lldb::eSeverityInfo:


### PR DESCRIPTION
Don't pass `LOG_CONS` to the openlog call.

> Write directly to the system console if there is an error while
> sending to the system logger.

This seemed like a good idea at the time, but it turns out to be extremely annoying when this happens and LLDB is overwhelmed by log messages in the console.

rdar://132243490
(cherry picked from commit 34e67ffe1947b399f57002f8cf60340a391ce8c0)