### PR TITLE
[am] Disable building compiler-rt in the merge build.

### DIFF
--- a/apple-ci/clang/am/build.sh
+++ b/apple-ci/clang/am/build.sh
@@ -31,7 +31,7 @@ xcrun cmake -G Ninja \
  -DCMAKE_C_COMPILER_LAUNCHER=$HOST_COMPILER_PATH/clang-cache \
  -DCMAKE_CXX_COMPILER_LAUNCHER=$HOST_COMPILER_PATH/clang-cache \
  -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
- -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lldb" \
+ -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;lldb" \
  -DLLDB_ENABLE_SWIFT_SUPPORT=OFF \
  -DLLDB_INCLUDE_TESTS=OFF \
  $SRC_DIR/llvm && $NINJA


### PR DESCRIPTION
It takes too long for the benefit it gives (it doesn't utilize CAS either).