### PR TITLE
Fix swift async frames unwinding unwinding

### DIFF
--- a/lldb/include/lldb/Symbol/UnwindPlan.h
+++ b/lldb/include/lldb/Symbol/UnwindPlan.h
@@ -68,7 +68,8 @@ public:
         isAFAPlusOffset,   // reg = AFA + offset
         inOtherRegister,   // reg = other reg
         atDWARFExpression, // reg = deref(eval(dwarf_expr))
-        isDWARFExpression  // reg = eval(dwarf_expr)
+        isDWARFExpression, // reg = eval(dwarf_expr)
+        isConstant         // reg = constant
       };
 
       RegisterLocation() : m_location() {}
@@ -104,6 +105,15 @@ public:
       bool IsAtDWARFExpression() const { return m_type == atDWARFExpression; }
 
       bool IsDWARFExpression() const { return m_type == isDWARFExpression; }
+
+      bool IsConstant() const { return m_type == isConstant; }
+
+      void SetIsConstant(uint64_t value) {
+        m_type = isConstant;
+        m_location.constant_value = value;
+      }
+
+      uint64_t GetConstant() const { return m_location.constant_value; }
 
       void SetAtCFAPlusOffset(int32_t offset) {
         m_type = atCFAPlusOffset;
@@ -192,6 +202,8 @@ public:
           const uint8_t *opcodes;
           uint16_t length;
         } expr;
+        // For m_type == isConstant
+        uint64_t constant_value;
       } m_location;
     };
 
@@ -361,6 +373,10 @@ public:
     bool SetRegisterLocationToIsDWARFExpression(uint32_t reg_num,
                                                 const uint8_t *opcodes,
                                                 uint32_t len, bool can_replace);
+
+    bool SetRegisterLocationToIsConstant(uint32_t reg_num, uint64_t constant,
+                                         bool can_replace);
+
     // When this UnspecifiedRegistersAreUndefined mode is
     // set, any register that is not specified by this Row will
     // be described as Undefined.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -490,6 +490,13 @@ private:
   GetFollowAsyncContextUnwindPlan(lldb::ProcessSP process_sp,
                                   RegisterContext *regctx, ArchSpec &arch,
                                   bool &behaves_like_zeroth_frame);
+
+  /// Given the async register of a funclet, extract its continuation pointer,
+  /// compute the prologue size of the continuation function, and return the
+  /// address of the first non-prologue instruction.
+  std::optional<lldb::addr_t>
+  TrySkipVirtualParentProlog(lldb::addr_t async_reg_val, Process &process,
+                             unsigned num_indirections);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -482,6 +482,14 @@ protected:
   bool GetTargetOfPartialApply(SymbolContext &curr_sc, ConstString &apply_name,
                                SymbolContext &sc);
   AppleObjCRuntimeV2 *GetObjCRuntime();
+
+private:
+  /// Creates an UnwindPlan for following the AsyncContext chain up the stack,
+  /// from a current AsyncContext frame.
+  lldb::UnwindPlanSP
+  GetFollowAsyncContextUnwindPlan(lldb::ProcessSP process_sp,
+                                  RegisterContext *regctx, ArchSpec &arch,
+                                  bool &behaves_like_zeroth_frame);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Symbol/UnwindPlan.cpp
+++ b/lldb/source/Symbol/UnwindPlan.cpp
@@ -46,6 +46,8 @@ operator==(const UnwindPlan::Row::RegisterLocation &rhs) const {
         return !memcmp(m_location.expr.opcodes, rhs.m_location.expr.opcodes,
                        m_location.expr.length);
       break;
+    case isConstant:
+      return m_location.constant_value == rhs.m_location.constant_value;
     }
   }
   return false;
@@ -153,6 +155,9 @@ void UnwindPlan::Row::RegisterLocation::Dump(Stream &s,
     if (m_type == atDWARFExpression)
       s.PutChar(']');
   } break;
+  case isConstant:
+    s.Printf("=0x%" PRIx64, m_location.constant_value);
+    break;
   }
 }
 
@@ -362,6 +367,17 @@ bool UnwindPlan::Row::SetRegisterLocationToIsDWARFExpression(
   return true;
 }
 
+bool UnwindPlan::Row::SetRegisterLocationToIsConstant(uint32_t reg_num,
+                                                      uint64_t constant,
+                                                      bool can_replace) {
+  if (!can_replace &&
+      m_register_locations.find(reg_num) != m_register_locations.end())
+    return false;
+  RegisterLocation reg_loc;
+  reg_loc.SetIsConstant(constant);
+  m_register_locations[reg_num] = reg_loc;
+  return true;
+}
 
 bool UnwindPlan::Row::operator==(const UnwindPlan::Row &rhs) const {
   return m_offset == rhs.m_offset && m_cfa_value == rhs.m_cfa_value &&

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -1692,6 +1692,15 @@ RegisterContextUnwind::SavedLocationForRegister(
     return UnwindLLDB::RegisterSearchResult::eRegisterNotFound;
   }
 
+  if (unwindplan_regloc.IsConstant()) {
+    regloc.type = UnwindLLDB::RegisterLocation::eRegisterValueInferred;
+    regloc.location.inferred_value = unwindplan_regloc.GetConstant();
+    m_registers[regnum.GetAsKind(eRegisterKindLLDB)] = regloc;
+    UnwindLogMsg("supplying caller's register %s (%d) via constant value",
+                 regnum.GetName(), regnum.GetAsKind(eRegisterKindLLDB));
+    return UnwindLLDB::RegisterSearchResult::eRegisterFound;
+  }
+
   UnwindLogMsg("no save location for %s (%d) in this stack frame",
                regnum.GetName(), regnum.GetAsKind(eRegisterKindLLDB));
 

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
@@ -44,7 +44,7 @@ class TestCase(lldbtest.TestBase):
             lldbutil.check_variable(self, myvar, False, value=expected_value)
 
     @swiftTest
-    @skipIf(oslist=["windows", "linux", "macos"])
+    @skipIf(oslist=["windows", "linux"])
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
@@ -1,0 +1,78 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    # Check that the CFA chain is correctly built
+    def check_cfas(self, async_frames, process):
+        async_cfas = list(map(lambda frame: frame.GetCFA(), async_frames))
+        expected_cfas = [async_cfas[0]]
+        # The CFA chain ends in nullptr.
+        while expected_cfas[-1] != 0:
+            error = lldb.SBError()
+            expected_cfas.append(
+                process.ReadPointerFromMemory(expected_cfas[-1], error)
+            )
+            self.assertSuccess(error, "Managed to read cfa memory")
+
+        self.assertEqual(async_cfas, expected_cfas[:-1])
+
+    def check_pcs(self, async_frames, process, target):
+        for idx, frame in enumerate(async_frames[:-1]):
+            # Read the continuation pointer from the second field of the CFA.
+            error = lldb.SBError()
+            continuation_ptr = process.ReadPointerFromMemory(
+                frame.GetCFA() + target.addr_size, error
+            )
+            self.assertSuccess(error, "Managed to read context memory")
+
+            # The PC of the previous frame should be the continuation pointer
+            # with the funclet's prologue skipped.
+            parent_frame = async_frames[idx + 1]
+            prologue_to_skip = parent_frame.GetFunction().GetPrologueByteSize()
+            self.assertEqual(continuation_ptr + prologue_to_skip, parent_frame.GetPC())
+
+
+    def check_variables(self, async_frames, expected_values):
+        for (frame, expected_value) in zip(async_frames, expected_values):
+            myvar = frame.FindVariable("myvar")
+            lldbutil.check_variable(self, myvar, False, value=expected_value)
+
+    @swiftTest
+    @skipIf(oslist=["windows", "linux", "macos"])
+    def test(self):
+        """Test `frame variable` in async functions"""
+        self.build()
+
+        source_file = lldb.SBFileSpec("main.swift")
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "breakpoint1", source_file
+        )
+
+        async_frames = process.GetSelectedThread().frames
+        self.check_cfas(async_frames, process)
+        self.check_pcs(async_frames, process, target)
+        self.check_variables(async_frames, ["222", "333", "444", "555"])
+
+        target.DeleteAllBreakpoints()
+        target.BreakpointCreateBySourceRegex("breakpoint2", source_file)
+        process.Continue()
+        # First frame is from a synchronous function
+        frames = process.GetSelectedThread().frames
+        async_frames = frames[1:]
+        self.check_cfas(async_frames, process)
+        self.check_pcs(async_frames, process, target)
+        self.check_variables(async_frames, ["111", "222", "333", "444", "555"])
+
+        target.DeleteAllBreakpoints()
+        target.BreakpointCreateBySourceRegex("breakpoint3", source_file)
+        process.Continue()
+        async_frames = process.GetSelectedThread().frames
+        self.check_cfas(async_frames, process)
+        self.check_pcs(async_frames, process, target)
+        self.check_variables(async_frames, ["222", "333", "444", "555"])

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/main.swift
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/main.swift
@@ -1,0 +1,49 @@
+func work() {
+  print("working") // breakpoint2
+}
+
+func ASYNC___1___() async -> Int {
+  var myvar = 111;
+  work()
+  myvar += 1;
+  return myvar
+}
+
+func ASYNC___2___() async -> Int {
+  var myvar = 222;
+  let result = await ASYNC___1___() // breakpoint1
+  work() // breakpoint3
+  myvar += result;
+  return myvar
+}
+
+func ASYNC___3___() async -> Int {
+  var myvar = 333;
+  let result = await ASYNC___2___()
+  work()
+  myvar += result
+  return myvar
+}
+
+func ASYNC___4___() async -> Int {
+  var myvar = 444;
+  let result = await ASYNC___3___()
+  work()
+  myvar += result
+  return myvar
+}
+
+func ASYNC___5___() async -> Int {
+  var myvar = 555;
+  let result = await ASYNC___4___()
+  work()
+  myvar += result
+  return myvar
+}
+
+@main struct Main {
+  static func main() async {
+    let result = await ASYNC___5___()
+    print(result)
+  }
+}

--- a/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
+++ b/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
@@ -76,8 +76,9 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
                     error = lldb.SBError()
                     ret_addr = process.ReadPointerFromMemory(
                         cfa[fibonacci_number-1] + target.addr_size, error)
+                    prologue_to_skip = frame.GetFunction().GetPrologueByteSize()
                     self.assertSuccess(error, "Managed to read context memory")
-                    self.assertEqual(ret_addr, frame.GetPC())
+                    self.assertEqual(ret_addr + prologue_to_skip, frame.GetPC())
 
             self.assertIn("Main.main", thread.GetFrameAtIndex(n+1).GetFunctionName())
 


### PR DESCRIPTION
This series of patches aims to solve the problem where LLDB is unable to print variables in backtraces involving swift async functions. The _only_ frame where this works today is the first async frame, which is a real frame and is physically on the stack. We fail to do so for all virtual frames.

The underlying problem is simple: when unwinding the PC, we use the first instruction of the continuation funclets. This instruction is part of the prologue, where no variables are in scope.

The solution is similarly simple: we just offset the PC by the size of the prologue of the continuation funclet.

These commits are meant to be reviewed independently, please the commit messages too.

The first commit is a cherry-pick from: https://github.com/llvm/llvm-project/pull/100624