### PR TITLE
[AArch64] Gate uses of ptrauth-returns on macho vs not.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64FrameLowering.cpp
@@ -474,7 +474,9 @@ bool AArch64FrameLowering::shouldAuthenticateLR(
     const MachineFunction &MF) const {
   // Return address authentication can be enabled at the function level, using
   // the "ptrauth-returns" attribute.
-  return MF.getFunction().hasFnAttribute("ptrauth-returns");
+  const AArch64Subtarget &Subtarget = MF.getSubtarget<AArch64Subtarget>();
+  return Subtarget.isTargetMachO() &&
+         MF.getFunction().hasFnAttribute("ptrauth-returns");
 }
 
 /// hasFP - Return true if the specified function should have a dedicated frame

--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -11264,7 +11264,8 @@ SDValue AArch64TargetLowering::LowerRETURNADDR(SDValue Op,
   }
 
   // If we're doing LR signing, we need to fixup ReturnAddr: strip it.
-  if (MF.getFunction().hasFnAttribute("ptrauth-returns"))
+  if (Subtarget->isTargetMachO() &&
+      MF.getFunction().hasFnAttribute("ptrauth-returns"))
     return DAG.getNode(ISD::INTRINSIC_WO_CHAIN, DL, VT,
                        DAG.getConstant(Intrinsic::ptrauth_strip, DL, MVT::i32),
                        ReturnAddress,

--- a/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64MachineFunctionInfo.cpp
@@ -37,8 +37,10 @@ void AArch64FunctionInfo::initializeBaseYamlFields(
     HasRedZone = YamlMFI.HasRedZone;
 }
 
-static std::pair<bool, bool> GetSignReturnAddress(const Function &F) {
-  if (F.hasFnAttribute("ptrauth-returns"))
+static std::pair<bool, bool> GetSignReturnAddress(const Function &F,
+                                                  const AArch64Subtarget &STI) {
+  if (!STI.getTargetTriple().isOSBinFormatMachO() &&
+      F.hasFnAttribute("ptrauth-returns"))
     return {true, false}; // non-leaf
   // The function should be signed in the following situations:
   // - sign-return-address=all
@@ -58,7 +60,8 @@ static std::pair<bool, bool> GetSignReturnAddress(const Function &F) {
 }
 
 static bool ShouldSignWithBKey(const Function &F, const AArch64Subtarget &STI) {
-  if (F.hasFnAttribute("ptrauth-returns"))
+  if (!STI.getTargetTriple().isOSBinFormatMachO() &&
+      F.hasFnAttribute("ptrauth-returns"))
     return true;
   if (!F.hasFnAttribute("sign-return-address-key")) {
     if (STI.getTargetTriple().isOSWindows())
@@ -78,7 +81,8 @@ AArch64FunctionInfo::AArch64FunctionInfo(const Function &F,
   // HasRedZone here.
   if (F.hasFnAttribute(Attribute::NoRedZone))
     HasRedZone = false;
-  std::tie(SignReturnAddress, SignReturnAddressAll) = GetSignReturnAddress(F);
+  std::tie(SignReturnAddress, SignReturnAddressAll) =
+      GetSignReturnAddress(F, *STI);
   SignWithBKey = ShouldSignWithBKey(F, *STI);
   // TODO: skip functions that have no instrumented allocas for optimization
   IsMTETagged = F.hasFnAttribute(Attribute::SanitizeMemTag);

--- a/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
+++ b/llvm/lib/Target/AArch64/AArch64Subtarget.cpp
@@ -569,7 +569,8 @@ AArch64PAuth::AuthCheckMethod AArch64Subtarget::getAuthenticatedLRCheckMethod(
     const MachineFunction &MF) const {
   // TODO: Check subtarget for the scheme. Present variant is a default for
   // pauthtest ABI.
-  if (MF.getFunction().hasFnAttribute("ptrauth-returns") &&
+  if (!getTargetTriple().isOSBinFormatMachO() &&
+      MF.getFunction().hasFnAttribute("ptrauth-returns") &&
       MF.getFunction().hasFnAttribute("ptrauth-auth-traps"))
     return AArch64PAuth::AuthCheckMethod::HighBitsNoTBI;
   if (AuthenticatedLRCheckMethod.getNumOccurrences())


### PR DESCRIPTION
Upstream contributors took over our ptrauth-returns attribute, which we use to denote LR signing for arm64e.
It now also enables the non-arm64e PACRET signing paths.

There's actual work needed to unify both.
For now, gate the two paths on !MachO vs MachO.

rdar://132779718