### PR TITLE
[Cherry-pick into next] Improve the data formatter UX if an array is uninitialized.

### DIFF
--- a/lldb/test/API/lang/swift/array_uninitialized/Makefile
+++ b/lldb/test/API/lang/swift/array_uninitialized/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
+++ b/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftArrayUninitialized(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test unitialized global arrays"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+        self.expect("target variable -- array_unused", substrs=['<uninitialized>'])
+        self.expect("target variable -- array_used_empty", substrs=['0 values'])

--- a/lldb/test/API/lang/swift/array_uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/array_uninitialized/main.swift
@@ -1,0 +1,8 @@
+var array_unused : [Int] = [1,2,3]
+var array_used_empty : [Int] = []
+@main struct Main {
+  static func main() {
+    print(array_used_empty)
+    print("break here")
+  }
+}

--- a/lldb/test/API/lang/swift/nsarray_code_running_formatter/main.swift
+++ b/lldb/test/API/lang/swift/nsarray_code_running_formatter/main.swift
@@ -23,7 +23,7 @@ func main() {
   var tb = Test() as Array + []
 
   print("second stop") //% self.expect('frame variable -d run -- t', substrs=['t = 0x', 'NSArray = {', 'NSObject = {'])
-                       //% self.expect('frame variable -d run -- ta', substrs=['ta = {', '_buffer = {', '_storage =', 'rawValue = 0x'])
+                       //% self.expect('frame variable -d run -- ta', substrs=['ta = <uninitialized>', '_buffer = {', '_storage =', 'rawValue = 0x'])
                        //% self.expect('frame variable -d run -- tb', substrs=['tb = 1 value {', '"abc"'])
                        //% self.expect('po t', substrs=['0 : abc'])
                        //% self.expect('po ta', substrs=['0 : abc'])


### PR DESCRIPTION
```
commit c84825025c18cb30a2a4eb519bb57813daa2abfa
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Jul 29 15:44:49 2024 -0700

    Improve the data formatter UX if an array is uninitialized.
    
    Global variables in Swift are lazy initialized and often zeroed out
    before the first access. This can be confusing to users, so this patch
    modifies the array dataformatter to recognize a null array.
    
    rdar://132736658
```
