### PR TITLE
[stable/20240723][darwin] Upstream __isPlatformOrVariantPlatformVersionAtLeast()

### DIFF
--- a/compiler-rt/test/builtins/TestCases/Darwin/platform_version_check_test.c
+++ b/compiler-rt/test/builtins/TestCases/Darwin/platform_version_check_test.c
@@ -7,11 +7,22 @@ typedef unsigned int uint32_t;
 int32_t __isPlatformVersionAtLeast(uint32_t Platform, uint32_t Major,
                                    uint32_t Minor, uint32_t Subminor);
 
+int32_t __isPlatformOrVariantPlatformVersionAtLeast(
+    uint32_t Platform, uint32_t Major, uint32_t Minor, uint32_t Subminor,
+    uint32_t Platform2, uint32_t Major2, uint32_t Minor2, uint32_t Subminor2);
+
+void exit(int status);
+
 #define PLATFORM_MACOS 1
+#define PLATFORM_IOS 2
 
 int32_t check(uint32_t Major, uint32_t Minor, uint32_t Subminor) {
   int32_t Result =
       __isPlatformVersionAtLeast(PLATFORM_MACOS, Major, Minor, Subminor);
+  int32_t ResultVariant = __isPlatformOrVariantPlatformVersionAtLeast(
+      PLATFORM_MACOS, Major, Minor, Subminor, PLATFORM_IOS, 13, 0, 0);
+  if (Result != ResultVariant)
+    exit(-1);
   return Result;
 }
 


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/llvm-project/pull/9007 / https://github.com/llvm/llvm-project/pull/100605 to `stable/20240723`.