### PR TITLE
[lldb] [NFC] Update TestEarlyProcessLaunch to work on macOS 15

### DIFF
--- a/lldb/test/API/macosx/early-process-launch/TestEarlyProcessLaunch.py
+++ b/lldb/test/API/macosx/early-process-launch/TestEarlyProcessLaunch.py
@@ -1,6 +1,5 @@
 """Test that we don't read objc class tables early in process startup."""
 
-
 import time
 import lldb
 from lldbsuite.test.decorators import *
@@ -30,7 +29,14 @@ class TestEarlyProcessLaunch(TestBase):
         ###
         ### Use the types logging to detect the difference.
 
-        target, process, _, bkpt = lldbutil.run_to_name_breakpoint(self, "malloc")
+        exe = self.getBuildArtifact("a.out")
+        target = self.dbg.CreateTarget(exe)
+        self.assertTrue(target.IsValid())
+        bkpt = target.BreakpointCreateByRegex("alloc", None)
+        self.assertTrue(bkpt.IsValid())
+        (target, process, thread, bkpt) = lldbutil.run_to_breakpoint_do_run(
+            self, target, bkpt
+        )
 
         target.DisableAllBreakpoints()
         target.BreakpointCreateByName("main")


### PR DESCRIPTION
This test sets a breakpoint on malloc, as a way to stop early in dyld's setting up code, before the system libraries are initialized so we can confirm that we don't fetch the Objective-C class table before it's initialized.

In macOS 15 (macOS Sonoma), dyld doesn't call malloc any longer, so this heuristic/trick isn't working.  It does call other things called *alloc though, so I'm changing this to use a regex breakpoint on that, to keep the test working.

(cherry picked from commit 1988c27e5f4dbcf42c9a80f44bdee7ccd208a0ac)