### PR TITLE
[clang-cache] Report scan diagnostics from daemon

### DIFF
--- a/clang/test/CAS/cache-launcher-scan-diagnostics.c
+++ b/clang/test/CAS/cache-launcher-scan-diagnostics.c
@@ -1,0 +1,10 @@
+// REQUIRES: system-darwin, clang-cc1daemon
+
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN:   %clang -fsyntax-only -x c %s \
+// RUN:   2>&1 | FileCheck %s
+
+#include "missing.h"
+// CHECK: fatal error: 'missing.h' file not found

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -308,8 +308,11 @@ CC1DepScanDProtocol::getScanResult(llvm::StringSaver &Saver, ResultKind &Result,
   if (Error E = getResultKind(Result))
     return E;
 
-  if (Result == ErrorResult)
-    return getString(Saver, FailedReason);
+  if (Result == ErrorResult) {
+    if (Error E = getString(Saver, FailedReason))
+      return E;
+    return getString(Saver, DiagnosticOutput);
+  }
 
   if (Result == InvalidResult) {
     FailedReason = "invalid scan result";
@@ -334,10 +337,14 @@ llvm::Error CC1DepScanDProtocol::putScanResultSuccess(
   return putString(DiagnosticOutput);
 }
 
-llvm::Error CC1DepScanDProtocol::putScanResultFailed(StringRef Reason) {
+llvm::Error
+CC1DepScanDProtocol::putScanResultFailed(StringRef Reason,
+                                         StringRef DiagnosticOutput) {
   if (Error E = putResultKind(ErrorResult))
     return E;
-  return putString(Reason);
+  if (Error E = putString(Reason))
+    return E;
+  return putString(DiagnosticOutput);
 }
 
 #endif /* LLVM_ON_UNIX */

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -140,7 +140,7 @@ public:
   llvm::Error getCommand(llvm::StringSaver &Saver, StringRef &WorkingDirectory,
                          SmallVectorImpl<const char *> &Args);
 
-  llvm::Error putScanResultFailed(StringRef Reason);
+  llvm::Error putScanResultFailed(StringRef Reason, StringRef DiagnosticOutput);
   llvm::Error putScanResultSuccess(StringRef RootID,
                                    ArrayRef<const char *> Args,
                                    StringRef DiagnosticOutput);

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -369,7 +369,7 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
 static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
     const char *Exec, ArrayRef<const char *> OldArgs,
     StringRef WorkingDirectory, SmallVectorImpl<const char *> &NewArgs,
-    bool &DiagnosticErrorOccurred, StringRef Path,
+    StringRef &DiagnosticOutput, StringRef Path,
     const DepscanSharing &Sharing,
     llvm::function_ref<const char *(const Twine &)> SaveArg,
     llvm::cas::ObjectStore &CAS) {
@@ -393,7 +393,6 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
   SmallVector<const char *> RawNewArgs;
-  StringRef DiagnosticOutput;
   CC1DepScanDProtocol::ResultKind Result;
   StringRef FailedReason;
   StringRef RootID;
@@ -409,11 +408,6 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
   NewArgs.resize(RawNewArgs.size());
   for (int I = 0, E = RawNewArgs.size(); I != E; ++I)
     NewArgs[I] = SaveArg(RawNewArgs[I]);
-
-  DiagnosticErrorOccurred = !DiagnosticOutput.empty();
-  if (DiagnosticErrorOccurred) {
-    llvm::errs() << DiagnosticOutput;
-  }
 
   return CAS.parseID(RootID);
 }
@@ -509,19 +503,22 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
   if (ProduceIncludeTree)
     Sharing.CASArgs.push_back("-fdepscan-include-tree");
 
+  StringRef DiagnosticOutput;
   bool DiagnosticErrorOccurred = false;
   auto ScanAndUpdate = [&]() {
     if (std::optional<std::string> DaemonPath =
             makeDepscanDaemonPath(Mode, Sharing))
       return scanAndUpdateCC1UsingDaemon(Exec, OldArgs, WorkingDirectory,
-                                         NewArgs, DiagnosticErrorOccurred,
-                                         *DaemonPath, Sharing, SaveArg, *DB);
+                                         NewArgs, DiagnosticOutput, *DaemonPath,
+                                         Sharing, SaveArg, *DB);
     return scanAndUpdateCC1Inline(Exec, OldArgs, WorkingDirectory, NewArgs,
                                   ProduceIncludeTree, DiagnosticErrorOccurred,
                                   SaveArg, CASOpts, DB, Cache);
   };
   if (llvm::Error E = ScanAndUpdate().moveInto(RootID)) {
     Diag.Report(diag::err_cas_depscan_failed) << std::move(E);
+    if (!DiagnosticOutput.empty())
+      llvm::errs() << DiagnosticOutput;
     return 1;
   }
   return DiagnosticErrorOccurred;
@@ -958,7 +955,8 @@ int ScanServer::listen() {
           *Tool, *DiagsConsumer, &DiagsOS, Argv0, Args, WorkingDirectory,
           NewArgs, *CAS, [&](const Twine &T) { return Saver.save(T).data(); });
       if (!RootID) {
-        consumeError(Comms.putScanResultFailed(toString(RootID.takeError())));
+        consumeError(Comms.putScanResultFailed(toString(RootID.takeError()),
+                                               DiagsOS.str()));
         SharedOS.applyLocked([&](raw_ostream &OS) {
           printScannedCC1(OS);
           OS << I << ": failed to create compiler invocation\n";


### PR DESCRIPTION
Diagnostics from dependency scanning daemon aren't making their way to the end-user and the feedback is vague:
```
fatal error: CAS-based dependency scan failed: depscan daemon failed: failed to get include-tree
```

This patch extends the daemon protocol to send the diagnostics back and prints them to standard error output.

rdar://116549128