### PR TITLE
[lldb] Add setting to disable PCM validation (from Swift)

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -188,6 +188,8 @@ public:
 
   bool GetSwiftAllowExplicitModules() const;
 
+  bool GetSwiftDisablePCMValidation() const;
+
   Args GetSwiftPluginServerForPath() const;
 
   bool GetSwiftAutoImportFrameworks() const;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4927,6 +4927,19 @@ bool TargetProperties::GetSwiftAllowExplicitModules() const {
   return true;
 }
 
+bool TargetProperties::GetSwiftDisablePCMValidation() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftDisablePCMValidation)
+        .value_or(true);
+
+  return true;
+}
+
 Args TargetProperties::GetSwiftPluginServerForPath() const {
   const uint32_t idx = ePropertySwiftPluginServerForPath;
 

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -26,6 +26,9 @@ let Definition = "target_experimental" in {
   def SwiftAllowExplicitModules: Property<"swift-allow-explicit-modules", "Boolean">,
     DefaultTrue,
     Desc<"Allows explicit module flags to be passed through to ClangImporter.">;
+  def SwiftDisablePCMValidation: Property<"swift-disable-pcm-validation", "Boolean">,
+    DefaultFalse,
+    Desc<"Disable validation when loading Clang PCM files (-fno-validate-pch).">;
 }
 
 let Definition = "target" in {


### PR DESCRIPTION
Allow users to disable PCM validation for clang modules loaded by Swift. This may be helpful for explicit swift module builds.