### PR TITLE
Fix MCCAS dropping LC_BUILD_VERSION

### DIFF
--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -91,6 +91,43 @@ public:
     MOW.writeDataInCodeRegion(Asm);
   }
 
+  void setVersionMin(MCVersionMinType Type, unsigned Major, unsigned Minor,
+                     unsigned Update,
+                     VersionTuple SDKVersion = VersionTuple()) override {
+    MOW.setVersionMin(Type, Major, Minor, Update, SDKVersion);
+  }
+  void setBuildVersion(unsigned Platform, unsigned Major, unsigned Minor,
+                       unsigned Update,
+                       VersionTuple SDKVersion = VersionTuple()) override {
+    MOW.setBuildVersion(Platform, Major, Minor, Update, SDKVersion);
+  }
+  void setTargetVariantBuildVersion(unsigned Platform, unsigned Major,
+                                    unsigned Minor, unsigned Update,
+                                    VersionTuple SDKVersion) override {
+    MOW.setTargetVariantBuildVersion(Platform, Major, Minor, Update,
+                                     SDKVersion);
+  }
+
+  std::optional<unsigned> getPtrAuthABIVersion() const override {
+    return MOW.getPtrAuthABIVersion();
+  }
+  void setPtrAuthABIVersion(unsigned V) override {
+    MOW.setPtrAuthABIVersion(V);
+  }
+  bool getPtrAuthKernelABIVersion() const override {
+    return MOW.getPtrAuthKernelABIVersion();
+  }
+  void setPtrAuthKernelABIVersion(bool V) override {
+    MOW.setPtrAuthKernelABIVersion(V);
+  }
+
+  bool getSubsectionsViaSymbols() const override {
+    return MOW.getSubsectionsViaSymbols();
+  }
+  void setSubsectionsViaSymbols(bool Value) override {
+    MOW.setSubsectionsViaSymbols(Value);
+  }
+
   void writeSymbolTable(MCAssembler &Asm) { MOW.writeSymbolTable(Asm); }
 
   uint64_t writeObject(MCAssembler &Asm) override;

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -241,7 +241,7 @@ public:
   /// Mach-O deployment target version information.
   void setVersionMin(MCVersionMinType Type, unsigned Major, unsigned Minor,
                      unsigned Update,
-                     VersionTuple SDKVersion = VersionTuple()) {
+                     VersionTuple SDKVersion = VersionTuple()) override {
     VersionInfo.EmitBuildVersion = false;
     VersionInfo.TypeOrPlatform.Type = Type;
     VersionInfo.Major = Major;
@@ -249,33 +249,38 @@ public:
     VersionInfo.Update = Update;
     VersionInfo.SDKVersion = SDKVersion;
   }
-  void setBuildVersion(MachO::PlatformType Platform, unsigned Major,
-                       unsigned Minor, unsigned Update,
-                       VersionTuple SDKVersion = VersionTuple()) {
+  void setBuildVersion(unsigned Platform, unsigned Major, unsigned Minor,
+                       unsigned Update,
+                       VersionTuple SDKVersion = VersionTuple()) override {
     VersionInfo.EmitBuildVersion = true;
-    VersionInfo.TypeOrPlatform.Platform = Platform;
+    VersionInfo.TypeOrPlatform.Platform = (MachO::PlatformType)Platform;
     VersionInfo.Major = Major;
     VersionInfo.Minor = Minor;
     VersionInfo.Update = Update;
     VersionInfo.SDKVersion = SDKVersion;
   }
-  void setTargetVariantBuildVersion(MachO::PlatformType Platform,
-                                    unsigned Major, unsigned Minor,
-                                    unsigned Update, VersionTuple SDKVersion) {
+  void setTargetVariantBuildVersion(unsigned Platform, unsigned Major,
+                                    unsigned Minor, unsigned Update,
+                                    VersionTuple SDKVersion) override {
     TargetVariantVersionInfo.EmitBuildVersion = true;
-    TargetVariantVersionInfo.TypeOrPlatform.Platform = Platform;
+    TargetVariantVersionInfo.TypeOrPlatform.Platform =
+        (MachO::PlatformType)Platform;
     TargetVariantVersionInfo.Major = Major;
     TargetVariantVersionInfo.Minor = Minor;
     TargetVariantVersionInfo.Update = Update;
     TargetVariantVersionInfo.SDKVersion = SDKVersion;
   }
 
-  std::optional<unsigned> getPtrAuthABIVersion() const {
+  std::optional<unsigned> getPtrAuthABIVersion() const override {
     return PtrAuthABIVersion;
   }
-  void setPtrAuthABIVersion(unsigned V) { PtrAuthABIVersion = V; }
-  bool getPtrAuthKernelABIVersion() const { return PtrAuthKernelABIVersion; }
-  void setPtrAuthKernelABIVersion(bool V) { PtrAuthKernelABIVersion = V; }
+  void setPtrAuthABIVersion(unsigned V) override { PtrAuthABIVersion = V; }
+  bool getPtrAuthKernelABIVersion() const override {
+    return PtrAuthKernelABIVersion;
+  }
+  void setPtrAuthKernelABIVersion(bool V) override {
+    PtrAuthKernelABIVersion = V;
+  }
   std::vector<std::vector<std::string>> &getLinkerOptions() {
     return LinkerOptions;
   }

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_MC_MCOBJECTWRITER_H
 #define LLVM_MC_MCOBJECTWRITER_H
 
+#include "llvm/MC/MCDirectives.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstdint>
@@ -116,8 +117,12 @@ public:
   SmallVector<CGProfileEntry, 0> &getCGProfile() { return CGProfile; }
 
   // Mach-O specific: Whether .subsections_via_symbols is enabled.
-  bool getSubsectionsViaSymbols() const { return SubsectionsViaSymbols; }
-  void setSubsectionsViaSymbols(bool Value) { SubsectionsViaSymbols = Value; }
+  virtual bool getSubsectionsViaSymbols() const {
+    return SubsectionsViaSymbols;
+  }
+  virtual void setSubsectionsViaSymbols(bool Value) {
+    SubsectionsViaSymbols = Value;
+  }
 
   /// Write the object file and returns the number of bytes written.
   ///
@@ -126,6 +131,22 @@ public:
   /// generated.
   virtual uint64_t writeObject(MCAssembler &Asm) = 0;
 
+  virtual void setVersionMin(MCVersionMinType Type, unsigned Major,
+                             unsigned Minor, unsigned Update,
+                             VersionTuple SDKVersion = VersionTuple()) {}
+  virtual void setBuildVersion(unsigned Platform, unsigned Major,
+                               unsigned Minor, unsigned Update,
+                               VersionTuple SDKVersion = VersionTuple()) {}
+
+  virtual void setTargetVariantBuildVersion(unsigned Platform, unsigned Major,
+                                            unsigned Minor, unsigned Update,
+                                            VersionTuple SDKVersion) {}
+  virtual std::optional<unsigned> getPtrAuthABIVersion() const {
+    return std::nullopt;
+  }
+  virtual void setPtrAuthABIVersion(unsigned V) {}
+  virtual bool getPtrAuthKernelABIVersion() const { return false; }
+  virtual void setPtrAuthKernelABIVersion(bool V) {}
   /// @}
 };
 

--- a/llvm/include/llvm/MC/MCSPIRVObjectWriter.h
+++ b/llvm/include/llvm/MC/MCSPIRVObjectWriter.h
@@ -45,6 +45,10 @@ public:
 
   void setBuildVersion(unsigned Major, unsigned Minor, unsigned Bound);
 
+  void setBuildVersion(unsigned Platform, unsigned Major, unsigned Minor,
+                       unsigned Update,
+                       VersionTuple SDKVersion = VersionTuple()) override {}
+
 private:
   void recordRelocation(MCAssembler &Asm, const MCFragment *Fragment,
                         const MCFixup &Fixup, MCValue Target,

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -82,6 +82,10 @@ public:
     return static_cast<MachObjectWriter &>(getAssembler().getWriter());
   }
 
+  MCObjectWriter &getMCObjectWriter() {
+    return static_cast<MCObjectWriter &>(getAssembler().getWriter());
+  }
+
   /// @name MCStreamer Interface
   /// @{
 
@@ -222,7 +226,7 @@ void MCMachOStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {
   case MCAF_Code32: return; // Change parsing mode; no-op here.
   case MCAF_Code64: return; // Change parsing mode; no-op here.
   case MCAF_SubsectionsViaSymbols:
-    getWriter().setSubsectionsViaSymbols(true);
+    getMCObjectWriter().setSubsectionsViaSymbols(true);
     return;
   }
 }
@@ -254,21 +258,21 @@ void MCMachOStreamer::emitDataRegion(MCDataRegionType Kind) {
 void MCMachOStreamer::emitVersionMin(MCVersionMinType Kind, unsigned Major,
                                      unsigned Minor, unsigned Update,
                                      VersionTuple SDKVersion) {
-  getWriter().setVersionMin(Kind, Major, Minor, Update, SDKVersion);
+  getMCObjectWriter().setVersionMin(Kind, Major, Minor, Update, SDKVersion);
 }
 
 void MCMachOStreamer::emitBuildVersion(unsigned Platform, unsigned Major,
                                        unsigned Minor, unsigned Update,
                                        VersionTuple SDKVersion) {
-  getWriter().setBuildVersion((MachO::PlatformType)Platform, Major, Minor,
-                              Update, SDKVersion);
+  getMCObjectWriter().setBuildVersion((MachO::PlatformType)Platform, Major,
+                                      Minor, Update, SDKVersion);
 }
 
 void MCMachOStreamer::emitDarwinTargetVariantBuildVersion(
     unsigned Platform, unsigned Major, unsigned Minor, unsigned Update,
     VersionTuple SDKVersion) {
-  getWriter().setTargetVariantBuildVersion((MachO::PlatformType)Platform, Major,
-                                           Minor, Update, SDKVersion);
+  getMCObjectWriter().setTargetVariantBuildVersion(
+      (MachO::PlatformType)Platform, Major, Minor, Update, SDKVersion);
 }
 
 void MCMachOStreamer::EmitPtrAuthABIVersion(unsigned PtrAuthABIVersion,


### PR DESCRIPTION
rdar://133001453

This bug is a result of the work that has been done upstream rewriting the MachO MC code, and moves the VersionInfo from the MCAssembler to the MachObjectWriter/

(cherry picked from commit e260972e733e66361a8584d611940d7a09c9a2b3)