### PR TITLE
[DebugInfo] Fix test to force InstrRef in x86

### DIFF
--- a/llvm/test/DebugInfo/X86/DW_OP_LLVM_extract_bits.ll
+++ b/llvm/test/DebugInfo/X86/DW_OP_LLVM_extract_bits.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=x86_64-unknown-linux-gnu %s -o %t -filetype=obj
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu %s -o %t -filetype=obj -experimental-debug-variable-locations=true
 ; RUN: llvm-dwarfdump --debug-info %t | FileCheck %s
 
 %struct.struct_t = type { i8 }


### PR DESCRIPTION
This is necessary since we changed the default implementation of LDV in x86 for the time being.