### PR TITLE
[Cherry-pick into stable/20240723] Disable the import of private dependencies when using precise invocations.

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -30,6 +30,4 @@ class TestSwiftClangImporterExplicitNoImplicit(TestBase):
                     substrs=["hidden"])
         self.filecheck('platform shell cat "%s"' % log, __file__)
 #       CHECK-NOT: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/SwiftShims-{{.*}}.pcm
-#       CHECK: Turning off implicit Clang modules
 #       CHECK: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/Hidden-{{.*}}.pcm
-#       CHECK: Turning on implicit Clang modules


### PR DESCRIPTION
```
commit 534c7a95698429947177f8ec486f5318dfde6dba
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Aug 2 14:21:17 2024 -0700

    Disable the import of private dependencies when using precise invocations.
    
    ModuleFileSharedCore::getTransitiveLoadingBehavior() has a
    best-effort mode that is enabled when debugger support is turned
    on that will try to import implementation-only imports of Swift
    modules, but won't treat import failures as errors. When explicit
    modules are on, this has the unwanted side-effect of potentially
    triggering an implicit Clang module build if one of the internal
    dependencies of a library was not used to build the target.
    
    I previously fixed this problem by turning off implicit modules while
    loading the context dependencies. However, we discovered that the
    transitive loading of private dependencies can also lead to additional
    Swift modules being pulled in that through their dependencies can lead
    to dependency cycles that were not a problem at build time.
    
    Therefore, a simpler solution to both problem is turning of private
    dependency import altogether when using precise compiler invocations.
    
    Note that private dependencies can still sneak into a context via type
    reconstruction, which can also trigger module imports.
    
    rdar://132360374
```
