### PR TITLE
Fix CAS errors related to moving of LinkerOptions amongst other things from MCAssember to MachObjectWriter

### DIFF
--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -112,11 +112,6 @@ private:
     bool operator<(const MachSymbolData &RHS) const;
   };
 
-  struct IndirectSymbolData {
-    MCSymbol *Symbol;
-    MCSection *Section;
-  };
-
   /// The target specific Mach-O writer instance.
   std::unique_ptr<MCMachObjectTargetWriter> TargetObjectWriter;
 
@@ -137,7 +132,6 @@ public:
 
 private:
   DenseMap<const MCSection *, std::vector<RelAndSymbol>> Relocations;
-  std::vector<IndirectSymbolData> IndirectSymbols;
   DenseMap<const MCSection *, unsigned> IndirectSymBase;
 
   SectionAddrMap SectionAddress;
@@ -200,9 +194,6 @@ public:
 
   bool isFixupKindPCRel(const MCAssembler &Asm, unsigned Kind);
 
-  std::vector<IndirectSymbolData> &getIndirectSymbols() {
-    return IndirectSymbols;
-  }
   const llvm::SmallVectorImpl<MCSection *> &getSectionOrder() const {
     return SectionOrder;
   }

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -86,12 +86,6 @@ public:
 
 class MachObjectWriter : public MCObjectWriter {
 public:
-  struct DataRegionData {
-    MachO::DataRegionType Kind;
-    MCSymbol *Start;
-    MCSymbol *End;
-  };
-
   // A Major version of 0 indicates that no version information was supplied
   // and so the corresponding load command should not be emitted.
   using VersionInfoType = struct {
@@ -145,8 +139,6 @@ private:
   DenseMap<const MCSection *, std::vector<RelAndSymbol>> Relocations;
   std::vector<IndirectSymbolData> IndirectSymbols;
   DenseMap<const MCSection *, unsigned> IndirectSymBase;
-
-  std::vector<DataRegionData> DataRegions;
 
   SectionAddrMap SectionAddress;
 
@@ -211,7 +203,6 @@ public:
   std::vector<IndirectSymbolData> &getIndirectSymbols() {
     return IndirectSymbols;
   }
-  std::vector<DataRegionData> &getDataRegions() { return DataRegions; }
   const llvm::SmallVectorImpl<MCSection *> &getSectionOrder() const {
     return SectionOrder;
   }

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -165,9 +165,6 @@ private:
 
   /// @}
 
-  // Used to communicate Linker Optimization Hint information.
-  MCLOHContainer LOHContainer;
-
   VersionInfoType VersionInfo{};
   VersionInfoType TargetVariantVersionInfo{};
 
@@ -219,7 +216,6 @@ public:
     return SectionOrder;
   }
   SectionAddrMap &getSectionAddressMap() { return SectionAddress; }
-  MCLOHContainer &getLOHContainer() { return LOHContainer; }
 
   uint64_t getSectionAddress(const MCSection *Sec) const {
     return SectionAddress.lookup(Sec);

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -174,9 +174,6 @@ private:
   std::optional<unsigned> PtrAuthABIVersion;
   bool PtrAuthKernelABIVersion;
 
-  // The list of linker options for LC_LINKER_OPTION.
-  std::vector<std::vector<std::string>> LinkerOptions;
-
   MachSymbolData *findSymbolData(const MCSymbol &Sym);
 
   void writeWithPadding(StringRef Str, uint64_t Size);
@@ -280,9 +277,6 @@ public:
   }
   void setPtrAuthKernelABIVersion(bool V) override {
     PtrAuthKernelABIVersion = V;
-  }
-  std::vector<std::vector<std::string>> &getLinkerOptions() {
-    return LinkerOptions;
   }
 
   /// @}

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -33,7 +33,16 @@ class MCValue;
 /// MCAssembler instance, which contains all the symbol and section data which
 /// should be emitted as part of writeObject().
 class MCObjectWriter {
+public:
+  struct DataRegionData {
+    unsigned Kind;
+    MCSymbol *Start;
+    MCSymbol *End;
+  };
+
 protected:
+  std::vector<DataRegionData> DataRegions;
+
   // The list of linker options for LC_LINKER_OPTION.
   std::vector<std::vector<std::string>> LinkerOptions;
 
@@ -73,6 +82,8 @@ public:
   }
 
   MCLOHContainer &getLOHContainer() { return LOHContainer; }
+
+  std::vector<DataRegionData> &getDataRegions() { return DataRegions; }
 
   /// Perform any late binding of symbols (for example, to assign symbol
   /// indices for use when generating relocations).

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -41,6 +41,13 @@ public:
   };
 
 protected:
+  struct IndirectSymbolData {
+    MCSymbol *Symbol;
+    MCSection *Section;
+  };
+
+  std::vector<IndirectSymbolData> IndirectSymbols;
+
   std::vector<DataRegionData> DataRegions;
 
   // The list of linker options for LC_LINKER_OPTION.
@@ -79,6 +86,10 @@ public:
 
   std::vector<std::vector<std::string>> &getLinkerOptions() {
     return LinkerOptions;
+  }
+
+  std::vector<IndirectSymbolData> &getIndirectSymbols() {
+    return IndirectSymbols;
   }
 
   MCLOHContainer &getLOHContainer() { return LOHContainer; }

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -10,6 +10,7 @@
 #define LLVM_MC_MCOBJECTWRITER_H
 
 #include "llvm/MC/MCDirectives.h"
+#include "llvm/MC/MCLinkerOptimizationHint.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstdint>
@@ -35,6 +36,9 @@ class MCObjectWriter {
 protected:
   // The list of linker options for LC_LINKER_OPTION.
   std::vector<std::vector<std::string>> LinkerOptions;
+
+  // Used to communicate Linker Optimization Hint information.
+  MCLOHContainer LOHContainer;
 
   /// List of declared file names
   SmallVector<std::pair<std::string, size_t>, 0> FileNames;
@@ -67,6 +71,8 @@ public:
   std::vector<std::vector<std::string>> &getLinkerOptions() {
     return LinkerOptions;
   }
+
+  MCLOHContainer &getLOHContainer() { return LOHContainer; }
 
   /// Perform any late binding of symbols (for example, to assign symbol
   /// indices for use when generating relocations).

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -33,6 +33,9 @@ class MCValue;
 /// should be emitted as part of writeObject().
 class MCObjectWriter {
 protected:
+  // The list of linker options for LC_LINKER_OPTION.
+  std::vector<std::vector<std::string>> LinkerOptions;
+
   /// List of declared file names
   SmallVector<std::pair<std::string, size_t>, 0> FileNames;
   // XCOFF specific: Optional compiler version.
@@ -60,6 +63,10 @@ public:
 
   /// \name High-Level API
   /// @{
+
+  std::vector<std::vector<std::string>> &getLinkerOptions() {
+    return LinkerOptions;
+  }
 
   /// Perform any late binding of symbols (for example, to assign symbol
   /// indices for use when generating relocations).

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -124,7 +124,7 @@ public:
   }
 
   void emitLOHDirective(MCLOHType Kind, const MCLOHArgs &Args) override {
-    getWriter().getLOHContainer().addDirective(Kind, Args);
+    getMCObjectWriter().getLOHContainer().addDirective(Kind, Args);
   }
   void emitCGProfileEntry(const MCSymbolRefExpr *From,
                           const MCSymbolRefExpr *To, uint64_t Count) override {

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -129,7 +129,7 @@ public:
   void emitCGProfileEntry(const MCSymbolRefExpr *From,
                           const MCSymbolRefExpr *To, uint64_t Count) override {
     if (!From->getSymbol().isTemporary() && !To->getSymbol().isTemporary())
-      getWriter().getCGProfile().push_back({From, To, Count});
+      getMCObjectWriter().getCGProfile().push_back({From, To, Count});
   }
 
   void finishImpl() override;
@@ -277,8 +277,8 @@ void MCMachOStreamer::emitDarwinTargetVariantBuildVersion(
 
 void MCMachOStreamer::EmitPtrAuthABIVersion(unsigned PtrAuthABIVersion,
                                             bool PtrAuthKernelABIVersion) {
-  getWriter().setPtrAuthABIVersion(PtrAuthABIVersion);
-  getWriter().setPtrAuthKernelABIVersion(PtrAuthKernelABIVersion);
+  getMCObjectWriter().setPtrAuthABIVersion(PtrAuthABIVersion);
+  getMCObjectWriter().setPtrAuthKernelABIVersion(PtrAuthKernelABIVersion);
 }
 
 void MCMachOStreamer::emitThumbFunc(MCSymbol *Symbol) {
@@ -518,7 +518,7 @@ void MCMachOStreamer::finalizeCGProfileEntry(const MCSymbolRefExpr *&SRE) {
 
 void MCMachOStreamer::finalizeCGProfile() {
   MCAssembler &Asm = getAssembler();
-  MCObjectWriter &W = getWriter();
+  MCObjectWriter &W = getMCObjectWriter();
   if (W.getCGProfile().empty())
     return;
   for (auto &E : W.getCGProfile()) {

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -232,7 +232,7 @@ void MCMachOStreamer::emitAssemblerFlag(MCAssemblerFlag Flag) {
 }
 
 void MCMachOStreamer::emitLinkerOptions(ArrayRef<std::string> Options) {
-  getWriter().getLinkerOptions().push_back(Options);
+  getMCObjectWriter().getLinkerOptions().push_back(Options);
 }
 
 void MCMachOStreamer::emitDataRegion(MCDataRegionType Kind) {

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -297,7 +297,7 @@ bool MCMachOStreamer::emitSymbolAttribute(MCSymbol *Sym,
   if (Attribute == MCSA_IndirectSymbol) {
     // Note that we intentionally cannot use the symbol data here; this is
     // important for matching the string table that 'as' generates.
-    getWriter().getIndirectSymbols().push_back(
+    getMCObjectWriter().getIndirectSymbols().push_back(
         {Symbol, getCurrentSectionOnly()});
     return true;
   }

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -203,11 +203,11 @@ void MCMachOStreamer::emitDataRegion(MachO::DataRegionType Kind) {
   MCSymbol *Start = getContext().createTempSymbol();
   emitLabel(Start);
   // Record the region for the object writer to use.
-  getWriter().getDataRegions().push_back({Kind, Start, nullptr});
+  getMCObjectWriter().getDataRegions().push_back({Kind, Start, nullptr});
 }
 
 void MCMachOStreamer::emitDataRegionEnd() {
-  auto &Regions = getWriter().getDataRegions();
+  auto &Regions = getMCObjectWriter().getDataRegions();
   assert(!Regions.empty() && "Mismatched .end_data_region!");
   auto &Data = Regions.back();
   assert(!Data.End && "Mismatched .end_data_region!");

--- a/llvm/lib/MC/MCMachOStreamer.cpp
+++ b/llvm/lib/MC/MCMachOStreamer.cpp
@@ -78,9 +78,12 @@ public:
     MCObjectStreamer::reset();
   }
 
-  MachObjectWriter &getWriter() {
-    return static_cast<MachObjectWriter &>(getAssembler().getWriter());
-  }
+  // This function is commented out downstream because it is unsafe to use a
+  // MachObjectWriter in the McMachOStreamer which may hold a MachOCASWriter
+  // instead.
+  // MachObjectWriter &getWriter() {
+  //   return static_cast<MachObjectWriter &>(getAssembler().getWriter());
+  // }
 
   MCObjectWriter &getMCObjectWriter() {
     return static_cast<MCObjectWriter &>(getAssembler().getWriter());

--- a/llvm/lib/MC/MCObjectWriter.cpp
+++ b/llvm/lib/MC/MCObjectWriter.cpp
@@ -27,6 +27,7 @@ void MCObjectWriter::reset() {
   CGProfile.clear();
   LinkerOptions.clear();
   LOHContainer.reset();
+  DataRegions.clear();
 }
 
 bool MCObjectWriter::isSymbolRefDifferenceFullyResolved(

--- a/llvm/lib/MC/MCObjectWriter.cpp
+++ b/llvm/lib/MC/MCObjectWriter.cpp
@@ -28,6 +28,7 @@ void MCObjectWriter::reset() {
   LinkerOptions.clear();
   LOHContainer.reset();
   DataRegions.clear();
+  IndirectSymbols.clear();
 }
 
 bool MCObjectWriter::isSymbolRefDifferenceFullyResolved(

--- a/llvm/lib/MC/MCObjectWriter.cpp
+++ b/llvm/lib/MC/MCObjectWriter.cpp
@@ -26,6 +26,7 @@ void MCObjectWriter::reset() {
   SubsectionsViaSymbols = false;
   CGProfile.clear();
   LinkerOptions.clear();
+  LOHContainer.reset();
 }
 
 bool MCObjectWriter::isSymbolRefDifferenceFullyResolved(

--- a/llvm/lib/MC/MCObjectWriter.cpp
+++ b/llvm/lib/MC/MCObjectWriter.cpp
@@ -25,6 +25,7 @@ void MCObjectWriter::reset() {
   EmitAddrsigSection = false;
   SubsectionsViaSymbols = false;
   CGProfile.clear();
+  LinkerOptions.clear();
 }
 
 bool MCObjectWriter::isSymbolRefDifferenceFullyResolved(

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -63,7 +63,6 @@ void MachObjectWriter::reset() {
   TargetVariantVersionInfo.SDKVersion = VersionTuple();
   PtrAuthABIVersion = std::nullopt;
   PtrAuthKernelABIVersion = false;
-  LinkerOptions.clear();
   MCObjectWriter::reset();
 }
 

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -49,14 +49,12 @@ void MachObjectWriter::reset() {
   Relocations.clear();
   IndirectSymBase.clear();
   IndirectSymbols.clear();
-  DataRegions.clear();
   SectionAddress.clear();
   SectionOrder.clear();
   StringTable.clear();
   LocalSymbolData.clear();
   ExternalSymbolData.clear();
   UndefinedSymbolData.clear();
-  LOHContainer.reset();
   VersionInfo.Major = 0;
   VersionInfo.SDKVersion = VersionTuple();
   TargetVariantVersionInfo.Major = 0;
@@ -1096,10 +1094,11 @@ void MachObjectWriter::writeDataInCodeRegion(MCAssembler &Asm) {
     else
       report_fatal_error("Data region not terminated");
 
-    LLVM_DEBUG(dbgs() << "data in code region-- kind: " << Data.Kind
-                      << "  start: " << Start << "(" << Data.Start->getName()
-                      << ")" << "  end: " << End << "(" << Data.End->getName()
-                      << ")" << "  size: " << End - Start << "\n");
+    LLVM_DEBUG(dbgs() << "data in code region-- kind: "
+                      << (MachO::DataRegionType)Data.Kind << "  start: "
+                      << Start << "(" << Data.Start->getName() << ")"
+                      << "  end: " << End << "(" << Data.End->getName() << ")"
+                      << "  size: " << End - Start << "\n");
     W.write<uint32_t>(Start);
     W.write<uint16_t>(End - Start);
     W.write<uint16_t>(Data.Kind);

--- a/llvm/test/MC/MachO/linker-options.ll
+++ b/llvm/test/MC/MachO/linker-options.ll
@@ -6,6 +6,8 @@
 
 ; RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj -o - %s | llvm-readobj --macho-linker-options - > %t
 ; RUN: FileCheck --check-prefix=CHECK-OBJ < %t %s
+; RUN: mkdir -p %t.dir/cas
+; RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj --cas %t.dir/cas -cas-backend -o - %s | llvm-readobj --macho-linker-options - > %t
 
 ; CHECK-OBJ: Linker Options {
 ; CHECK-OBJ:   Size: 16


### PR DESCRIPTION
This patch fixes any MCCAS errors we have from the work that Fangrui has done upstream to move major components from MCAssembler to MachObjectWriter