### PR TITLE
[Tests] Fix broken tests on `next`

### DIFF
--- a/clang/test/CodeGen/ptrauth-init-fini.c
+++ b/clang/test/CodeGen/ptrauth-init-fini.c
@@ -1,18 +1,18 @@
 // REQUIRES: aarch64-registered-target
 
-// RUN: %clang -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fptrauth-init-fini    \
+// RUN: %clang -mllvm -ptrauth-emit-wrapper-globals=0 -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fptrauth-init-fini    \
 // RUN:   -S -emit-llvm %s -o - | FileCheck --check-prefix=SIGNED %s
 
-// RUN: %clang -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fptrauth-init-fini    \
+// RUN: %clang -mllvm -ptrauth-emit-wrapper-globals=0 -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fptrauth-init-fini    \
 // RUN:   -fptrauth-init-fini-address-discrimination -S -emit-llvm %s -o - | FileCheck --check-prefix=ADDRDISC %s
 
-// RUN: %clang -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fno-ptrauth-init-fini \
+// RUN: %clang -mllvm -ptrauth-emit-wrapper-globals=0 -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fno-ptrauth-init-fini \
 // RUN:   -S -emit-llvm %s -o - | FileCheck --check-prefix=UNSIGNED %s
 
-// RUN: %clang -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fptrauth-init-fini-address-discrimination \
+// RUN: %clang -mllvm -ptrauth-emit-wrapper-globals=0 -target aarch64-elf -march=armv8.3-a+pauth -fptrauth-calls -fptrauth-init-fini-address-discrimination \
 // RUN:   -S -emit-llvm %s -o - | FileCheck --check-prefix=UNSIGNED %s
 
-// RUN: %clang -target aarch64-elf -march=armv8.3-a+pauth                 -fptrauth-init-fini    \
+// RUN: %clang -mllvm -ptrauth-emit-wrapper-globals=0 -target aarch64-elf -march=armv8.3-a+pauth                 -fptrauth-init-fini    \
 // RUN:   -S -emit-llvm %s -o - | FileCheck --check-prefix=UNSIGNED %s
 
 // SIGNED: @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr ptrauth (ptr @foo, i32 0, i64 55764), ptr null }]

--- a/clang/test/Modules/pch-in-module-units.cppm
+++ b/clang/test/Modules/pch-in-module-units.cppm
@@ -6,7 +6,7 @@
 // RUN: split-file %s %t
 //
 // RUN: %clang_cc1 -std=c++20 -emit-reduced-module-interface %t/A.cppm \
-// RUN:   -o %t/A.pcm -fskip-odr-check-in-gmf
+// RUN:   -o %t/A.pcm -fskip-odr-check-in-gmf -fmodule-related-to-pch
 // RUN: %clang_cc1 -std=c++20 -DDIFF -x c++-header %t/foo.h \
 // RUN:   -emit-pch -o %t/foo.pch -fskip-odr-check-in-gmf
 // RUN: %clang_cc1 -std=c++20 %t/B.cppm -fmodule-file=A=%t/A.pcm -include-pch \


### PR DESCRIPTION
Fix following test cases:
clang/test/Modules/pch-in-module-units.cppm
clang/test/CodeGen/ptrauth-init-fini.c