### PR TITLE
[lit] abs_path_preserve_drive - don't normalize path, leave this to t…

### DIFF
--- a/llvm/utils/lit/lit/discovery.py
+++ b/llvm/utils/lit/lit/discovery.py
@@ -57,7 +57,7 @@ def getTestSuite(item, litConfig, cache):
         config_map = litConfig.params.get("config_map")
         if config_map:
             cfgpath = util.abs_path_preserve_drive(cfgpath)
-            target = config_map.get(cfgpath)
+            target = config_map.get(os.path.normcase(cfgpath))
             if target:
                 cfgpath = target
 

--- a/llvm/utils/lit/lit/util.py
+++ b/llvm/utils/lit/lit/util.py
@@ -138,12 +138,12 @@ def abs_path_preserve_drive(path):
         # Since Python 3.8, os.path.realpath resolves sustitute drives,
         # so we should not use it. In Python 3.7, os.path.realpath
         # was implemented as os.path.abspath.
-        return os.path.normpath(os.path.abspath(path))
+        return os.path.abspath(path)
     else:
         # On UNIX, the current directory always has symbolic links resolved,
         # so any program accepting relative paths cannot preserve symbolic
         # links in paths and we should always use os.path.realpath.
-        return os.path.normpath(os.path.realpath(path))
+        return os.path.realpath(path)
 
 def mkdir(path):
     try:


### PR DESCRIPTION
…he caller

As noted on D154130, this was preventing path matching between normalized/unnormalized paths on some windows builds.

Cherry pick commit https://github.com/llvm/llvm-project/commit/5ccfa15681300323effe314348bb415f6a59c97f

This fixes the error in the LLVM unit test invocation `ninja check-llvm-unit` on Windows:
```
llvm-lit.py: C:\Users\hiroshi\llvmcas\llvm-project\llvm\utils\lit\lit\TestingConfig.py:155: fatal: unable to parse config file 'C:\\Users\\hiroshi\\llvmcas\\llvm-project\\llvm\\test\\Unit\\lit.cfg.py', traceback: Traceback (most recent call last):
  File "C:\Users\hiroshi\llvmcas\llvm-project\llvm\utils\lit\lit\TestingConfig.py", line 143, in load_from_path
    exec(compile(data, path, "exec"), cfg_globals, None)
  File "C:\Users\hiroshi\llvmcas\llvm-project\llvm\test\Unit\lit.cfg.py", line 38, in <module>
    config.test_exec_root = os.path.join(config.llvm_obj_root, "unittests")
AttributeError: 'TestingConfig' object has no attribute 'llvm_obj_root'
```

Note that this commit already exists in the `next` and the `stable/20240723` branches.