### PR TITLE
[lldb][test] Fix SymbolFilePDBTests

### DIFF
--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -382,7 +382,6 @@ TEST_F(SymbolFilePDBTests, TestNestedClassTypes) {
   SymbolFilePDB *symfile =
       static_cast<SymbolFilePDB *>(module->GetSymbolFile());
   llvm::pdb::IPDBSession &session = symfile->GetPDBSession();
-  TypeMap results;
 
   auto clang_ast_ctx_or_err =
       symfile->GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);

--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -578,15 +578,15 @@ TEST_F(SymbolFilePDBTests, TestMaxMatches) {
       static_cast<SymbolFilePDB *>(module->GetSymbolFile());
 
   // Make a type query object we can use for all types and for one type
-  TypeQuery query("ClassTypedef");
+  TypeQuery query("NestedClass");
   {
     // Find all types that match
     TypeResults query_results;
     symfile->FindTypes(query, query_results);
     TypeMap &results = query_results.GetTypeMap();
-    EXPECT_GT(results.GetSize(), 1u);
+    // We expect to find Class::NestedClass and ClassTypedef::NestedClass.
+    EXPECT_EQ(results.GetSize(), 2u);
   }
-
   {
     // Find a single type that matches
     query.SetFindOne(true);


### PR DESCRIPTION
These tests are currently broken on Windows x86_64 due a type mismatch and outdated test assertion. Both of which have since been fixed upstream.