### PR TITLE
[RuntimeDyld][Windows] Allocate space for dllimport things.

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyld.cpp
@@ -690,9 +690,12 @@ unsigned RuntimeDyldImpl::computeSectionStubBufSize(const ObjectFile &Obj,
     if (!(RelSecI == Section))
       continue;
 
-    for (const RelocationRef &Reloc : SI->relocations())
+    for (const RelocationRef &Reloc : SI->relocations()) {
       if (relocationNeedsStub(Reloc))
         StubBufSize += StubSize;
+      if (relocationNeedsDLLImportStub(Reloc))
+        StubBufSize = sizeAfterAddingDLLImportStub(StubBufSize);
+    }
   }
 
   // Get section data size and alignment

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
@@ -119,4 +119,15 @@ bool RuntimeDyldCOFF::isCompatibleFile(const object::ObjectFile &Obj) const {
   return Obj.isCOFF();
 }
 
+bool RuntimeDyldCOFF::relocationNeedsDLLImportStub(const RelocationRef &R) const {
+  object::symbol_iterator Symbol = R.getSymbol();
+  Expected<StringRef> TargetNameOrErr = Symbol->getName();
+  if (!TargetNameOrErr)
+    return false;
+
+  StringRef TargetName = *TargetNameOrErr;
+
+  return TargetName.startswith(getImportSymbolPrefix());
+}
+
 } // namespace llvm

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
@@ -119,15 +119,14 @@ bool RuntimeDyldCOFF::isCompatibleFile(const object::ObjectFile &Obj) const {
   return Obj.isCOFF();
 }
 
-bool RuntimeDyldCOFF::relocationNeedsDLLImportStub(const RelocationRef &R) const {
+bool RuntimeDyldCOFF::relocationNeedsDLLImportStub(
+    const RelocationRef &R) const {
   object::symbol_iterator Symbol = R.getSymbol();
   Expected<StringRef> TargetNameOrErr = Symbol->getName();
   if (!TargetNameOrErr)
     return false;
 
-  StringRef TargetName = *TargetNameOrErr;
-
-  return TargetName.startswith(getImportSymbolPrefix());
+  return TargetNameOrErr->startswith(getImportSymbolPrefix());
 }
 
 } // namespace llvm

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.h
@@ -14,6 +14,7 @@
 #define LLVM_RUNTIME_DYLD_COFF_H
 
 #include "RuntimeDyldImpl.h"
+#include "llvm/Support/MathExtras.h"
 
 #define DEBUG_TYPE "dyld"
 
@@ -48,6 +49,12 @@ protected:
                               StringRef Name, bool SetSectionIDMinus1 = false);
 
   static constexpr StringRef getImportSymbolPrefix() { return "__imp_"; }
+
+  bool relocationNeedsDLLImportStub(const RelocationRef &R) const;
+
+  unsigned sizeAfterAddingDLLImportStub(unsigned Size) const {
+    return alignTo(Size, PointerSize) + PointerSize;
+  }
 
 private:
   unsigned PointerSize;

--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldImpl.h
@@ -455,6 +455,16 @@ protected:
     return true;    // Conservative answer
   }
 
+  // Return true if the relocation R may require allocating a DLL import stub.
+  virtual bool relocationNeedsDLLImportStub(const RelocationRef &R) const {
+    return false;
+  }
+
+  // Add the size of a DLL import stub to the buffer size
+  virtual unsigned sizeAfterAddingDLLImportStub(unsigned Size) const {
+    return Size;
+  }
+
 public:
   RuntimeDyldImpl(RuntimeDyld::MemoryManager &MemMgr,
                   JITSymbolResolver &Resolver)


### PR DESCRIPTION
We weren't taking account of the space we require in the stubs for things that are dllimported, and as a result we could hit the assertion failure for running out of stub space. Fix that.

rdar://133473673