### PR TITLE
[Dyld] Remove another `startswith`

### DIFF
--- a/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
+++ b/llvm/lib/ExecutionEngine/RuntimeDyld/RuntimeDyldCOFF.cpp
@@ -126,7 +126,7 @@ bool RuntimeDyldCOFF::relocationNeedsDLLImportStub(
   if (!TargetNameOrErr)
     return false;
 
-  return TargetNameOrErr->startswith(getImportSymbolPrefix());
+  return TargetNameOrErr->starts_with(getImportSymbolPrefix());
 }
 
 } // namespace llvm


### PR DESCRIPTION
This one was added in 4f2100b54f1f885dff4d21dc1b552f2bf9f5f51b - use `starts_with` instead.