### PR TITLE
Update tests to account for new diagnostics syntax

### DIFF
--- a/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
+++ b/lldb/test/Shell/SwiftREPL/DiagnosticOptions.test
@@ -10,8 +10,8 @@
 
 
 _ = "An unterminated string
-// DIAGNOSTIC: error: unterminated string literal [lex_unterminated_string]{{$}}
-// LOCALIZED: error: chaîne non terminée littérale{{$}}
+// DIAGNOSTIC: unterminated string literal [lex_unterminated_string]{{$}}
+// LOCALIZED: chaîne non terminée littérale{{$}}
 :quit
 
 

--- a/lldb/test/Shell/SwiftREPL/ImportError.test
+++ b/lldb/test/Shell/SwiftREPL/ImportError.test
@@ -4,5 +4,5 @@
 // RUN: %lldb --repl < %s 2>&1 | FileCheck %s
 
 import ModuleThatDoesNotExist
-// CHECK: error: no such module 'ModuleThatDoesNotExist'
+// CHECK: no such module 'ModuleThatDoesNotExist'
 // CHECK-NOT: fixed expression suggested

--- a/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
+++ b/lldb/test/Shell/SwiftREPL/LookupAfterImport.test
@@ -8,7 +8,7 @@
 // RUN: %lldb --repl="-I%t -L%t -lA" < %s 2>&1 | FileCheck %s
 
 "".foo()
-// CHECK: error: value of type 'String' has no member 'foo'
+// CHECK: value of type 'String' has no member 'foo'
 
 import A
 

--- a/lldb/test/Shell/SwiftREPL/LookupWithAttributedImport.test
+++ b/lldb/test/Shell/SwiftREPL/LookupWithAttributedImport.test
@@ -15,7 +15,7 @@ let y = Bar(baz: 123)
 // CHECK: baz = 123
 
 let x = Foo(bar:42)
-// CHECK: error: repl.swift:{{.*}}: error: cannot find 'Foo' in scope
+// CHECK: repl.swift:{{.*}}: error: cannot find 'Foo' in scope
 
 @testable import Test
 

--- a/lldb/test/Shell/SwiftREPL/OpenClass.test
+++ b/lldb/test/Shell/SwiftREPL/OpenClass.test
@@ -26,4 +26,4 @@ class Baz: Foo {
   override func foo() -> Int { return 4 }
 }
 
-// CHECK: error: overriding non-open instance method outside of its defining module
+// CHECK: overriding non-open instance method outside of its defining module

--- a/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
+++ b/lldb/test/Shell/SwiftREPL/PropertyWrapperTopLevel.test
@@ -34,5 +34,5 @@
 
 @A var anA: Int = 1
 
-// CHECK: error: property wrappers are not yet supported in top-level code
+// CHECK: property wrappers are not yet supported in top-level code
 // CHECK-NEXT: @A var anA: Int = 1


### PR DESCRIPTION
(cherry picked from commit 2a265ba56d522d1c036579139b112945bfe6987c)