### PR TITLE
[cmake] Use Windows-specific LLDB test args on Windows

### DIFF
--- a/lldb/test/API/CMakeLists.txt
+++ b/lldb/test/API/CMakeLists.txt
@@ -40,11 +40,19 @@ option(LLDB_TEST_SWIFT "Use in-tree swift when testing lldb" On)
 if(LLDB_TEST_SWIFT)
   set(LLDB_SWIFTC ${SWIFT_BINARY_DIR}/bin/swiftc CACHE STRING "Path to swift compiler")
   set(LLDB_SWIFT_LIBS ${SWIFT_LIBRARY_DIR}/swift CACHE STRING "Path to swift libraries")
+
   # Prefer the just-built stdlib over the system one.
-  set(SWIFT_TEST_ARGS
-    --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx:${LLVM_LIBRARY_OUTPUT_INTDIR}/lldb/clang/lib/darwin\\\""
-    --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/${CMAKE_SYSTEM_PROCESSOR}\\\""
-    --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\"")
+  if ( CMAKE_SYSTEM_NAME MATCHES "Windows" )
+    set(SWIFT_TEST_ARGS
+      --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/windows:${LLVM_LIBRARY_OUTPUT_INTDIR}/lldb/clang/lib/${LLVM_HOST_TRIPLE}\\\""
+      --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/${CMAKE_SYSTEM_PROCESSOR}\\\""
+      --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/windows\\\"")
+  else()
+    set(SWIFT_TEST_ARGS
+      --inferior-env "DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx:${LLVM_LIBRARY_OUTPUT_INTDIR}/lldb/clang/lib/darwin\\\""
+      --inferior-env "LD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/${CMAKE_SYSTEM_PROCESSOR}\\\""
+      --inferior-env "SIMCTL_CHILD_DYLD_LIBRARY_PATH=\\\"${LLDB_SWIFT_LIBS}/macosx\\\"")
+  endif()
 endif()
 # END - Swift Mods
 


### PR DESCRIPTION
This PR avoids hardcoding `macosx` and `darwin` into `DYLD_LIBRARY_PATH`, which becomes part of `LLDB_TEST_COMMON_ARGS` and breaks the LLDB test build on Windows.

Related to https://github.com/swiftlang/llvm-project/issues/9141