### PR TITLE
[TEST] Remove XFAIL for passing test

### DIFF
--- a/compiler-rt/test/asan/TestCases/printf-5.c
+++ b/compiler-rt/test/asan/TestCases/printf-5.c
@@ -7,8 +7,6 @@
 // FIXME: printf is not intercepted on Windows yet.
 // XFAIL: target={{.*windows-(msvc.*|gnu)}}
 
-// XFAIL: !rdar109379358
-
 // FIXME: The test is flaky after build bot upgrade. #97515
 // UNSUPPORTED: android
 


### PR DESCRIPTION
Remove XFAIL for passing test
Looks like there was some merge conflicts between apple's internal repos. When a recent change to this file went through, it seems this XFAIL got re-added due to some conflicts.
This test was XFAIL'd then the XFAIL was reverted a year ago, but the XFAIL was not reverted in the github. So a recent merge conflict was resolved incorrectly. THis should not be XFAILed and the initial issue was reverted and fixed promptly in open source.

Relevant: 8dbb99ccabf841fc06dd61be050418211a13248c
Conflict: https://github.com/swiftlang/llvm-project/commit/353ab60e4fd6e11d33ff41183b036f39733f76a2

rdar://132838354