### PR TITLE
LTO: repair the build after 554ebcc6179b0

### DIFF
--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -1781,7 +1781,7 @@ void ThinLTOCodeGenerator::run() {
     };
     struct ModuleInfo {
       std::unique_ptr<AsyncModuleCacheEntry> Entry;
-      std::atomic<unsigned> State = MS_Empty;
+      std::atomic<unsigned> State = ModuleState::MS_Empty;
       std::unique_ptr<MemoryBuffer> ComputedBuffer;
       std::unique_ptr<MemoryBuffer> CachedBuffer;
     };


### PR DESCRIPTION
The `MS_Empty` enumerator needs to be qualified for lookup with MSVC. Tested with MSVC 10.17.11.