### PR TITLE
🍒 [clang-cache] Report scan diagnostics (#9035)

### DIFF
--- a/clang/test/CAS/cache-launcher-scan-diagnostics.c
+++ b/clang/test/CAS/cache-launcher-scan-diagnostics.c
@@ -1,0 +1,10 @@
+// REQUIRES: system-darwin, clang-cc1daemon
+
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache \
+// RUN:   %clang -fsyntax-only -x c %s \
+// RUN:   2>&1 | FileCheck %s
+
+#include "missing.h"
+// CHECK: fatal error: 'missing.h' file not found

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -308,8 +308,11 @@ CC1DepScanDProtocol::getScanResult(llvm::StringSaver &Saver, ResultKind &Result,
   if (Error E = getResultKind(Result))
     return E;
 
-  if (Result == ErrorResult)
-    return getString(Saver, FailedReason);
+  if (Result == ErrorResult) {
+    if (Error E = getString(Saver, FailedReason))
+      return E;
+    return getString(Saver, DiagnosticOutput);
+  }
 
   if (Result == InvalidResult) {
     FailedReason = "invalid scan result";
@@ -334,10 +337,14 @@ llvm::Error CC1DepScanDProtocol::putScanResultSuccess(
   return putString(DiagnosticOutput);
 }
 
-llvm::Error CC1DepScanDProtocol::putScanResultFailed(StringRef Reason) {
+llvm::Error
+CC1DepScanDProtocol::putScanResultFailed(StringRef Reason,
+                                         StringRef DiagnosticOutput) {
   if (Error E = putResultKind(ErrorResult))
     return E;
-  return putString(Reason);
+  if (Error E = putString(Reason))
+    return E;
+  return putString(DiagnosticOutput);
 }
 
 #endif /* LLVM_ON_UNIX */

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -140,7 +140,7 @@ public:
   llvm::Error getCommand(llvm::StringSaver &Saver, StringRef &WorkingDirectory,
                          SmallVectorImpl<const char *> &Args);
 
-  llvm::Error putScanResultFailed(StringRef Reason);
+  llvm::Error putScanResultFailed(StringRef Reason, StringRef DiagnosticOutput);
   llvm::Error putScanResultSuccess(StringRef RootID,
                                    ArrayRef<const char *> Args,
                                    StringRef DiagnosticOutput);


### PR DESCRIPTION
Diagnostics from dependency scanning daemon aren't making their way to the end-user and the feedback is vague:
```
fatal error: CAS-based dependency scan failed: depscan daemon failed: failed to get include-tree
```

This patch extends the daemon protocol to send the diagnostics back and prints them to standard error output.

rdar://116549128
(cherry picked from commit 2fdda439c91853b0ba149c466d14ffa9f1ea5d3b)