### PR TITLE
Rewrite MachOCASWriter to be a derived class of MachObjectWriter 

### DIFF
--- a/clang/test/CAS/path-independent-cas-outputs.c
+++ b/clang/test/CAS/path-independent-cas-outputs.c
@@ -44,9 +44,9 @@
 
 // Baseline to check we got expected outputs.
 // RUN: %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -MMD -MT dependencies -MF %t/t.d --serialize-diagnostics %t/t.dia
-// RUN: env LLVM_CACHE_CAS_PATH=%t/a/cas %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/a/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/a/t1.o -MMD -MT dependencies -MF %t/a/t1.d --serialize-diagnostics %t/a/t1.dia
-// RUN: env LLVM_CACHE_CAS_PATH=%t/b/cas %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/b/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/b/t2.o -MMD -MT dependencies -MF %t/b/t2.d --serialize-diagnostics %t/b/t2.dia
 
 // RUN: diff %t/a/t1.o %t/b/t2.o

--- a/clang/test/CAS/path-independent-cas-outputs.c
+++ b/clang/test/CAS/path-independent-cas-outputs.c
@@ -44,9 +44,9 @@
 
 // Baseline to check we got expected outputs.
 // RUN: %clang -target x86_64-apple-macos11 -c %s -o %t/t.o -MMD -MT dependencies -MF %t/t.d --serialize-diagnostics %t/t.dia
-// RUN: env LLVM_CACHE_CAS_PATH=%t/a/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/a/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/a/t1.o -MMD -MT dependencies -MF %t/a/t1.d --serialize-diagnostics %t/a/t1.dia
-// RUN: env LLVM_CACHE_CAS_PATH=%t/b/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/b/cas %clang-cache \
 // RUN:   %clang -target x86_64-apple-macos11 -c %s -o %t/b/t2.o -MMD -MT dependencies -MF %t/b/t2.d --serialize-diagnostics %t/b/t2.dia
 
 // RUN: diff %t/a/t1.o %t/b/t2.o

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -34,7 +34,7 @@ class ObjectStore;
 class CASID;
 } // namespace cas
 
-class MachOCASWriter : public MCObjectWriter {
+class MachOCASWriter : public MachObjectWriter {
 public:
   /// ObjectStore
   const Triple Target;
@@ -57,52 +57,11 @@ public:
 
   uint8_t getAddressSize() { return Target.isArch32Bit() ? 4 : 8; }
 
-  void recordRelocation(MCAssembler &Asm, const MCFragment *Fragment,
-                                const MCFixup &Fixup, MCValue Target,
-                                uint64_t &FixedValue) override {
-    MOW.recordRelocation(Asm, Fragment, Fixup, Target, FixedValue);
-  }
-
-  void executePostLayoutBinding(MCAssembler &Asm) override {
-    MOW.executePostLayoutBinding(Asm);
-  }
-
-  bool isSymbolRefDifferenceFullyResolvedImpl(const MCAssembler &Asm,
-                                              const MCSymbol &SymA,
-                                              const MCFragment &FB, bool InSet,
-                                              bool IsPCRel) const override {
-    return MOW.isSymbolRefDifferenceFullyResolvedImpl(Asm, SymA, FB, InSet,
-                                                      IsPCRel);
-  }
-
-  uint64_t getPaddingSize(MCAssembler &Asm, const MCSection *SD) const {
-    return MOW.getPaddingSize(Asm, SD);
-  }
-
-  void prepareObject(MCAssembler &Asm) { MOW.prepareObject(Asm); }
-
-  void writeMachOHeader(MCAssembler &Asm) { MOW.writeMachOHeader(Asm); }
-
-  void writeSectionData(MCAssembler &Asm) { MOW.writeSectionData(Asm); }
-
-  void writeRelocations(MCAssembler &Asm) { MOW.writeRelocations(Asm); }
-
-  void writeDataInCodeRegion(MCAssembler &Asm) {
-    MOW.writeDataInCodeRegion(Asm);
-  }
-
-  void writeSymbolTable(MCAssembler &Asm) { MOW.writeSymbolTable(Asm); }
-
   uint64_t writeObject(MCAssembler &Asm) override;
 
   void resetBuffer() { OSOffset = InternalOS.tell(); }
 
   StringRef getContent() const { return InternalBuffer.substr(OSOffset); }
-
-  DenseMap<const MCSection *, std::vector<MachObjectWriter::RelAndSymbol>> &
-  getRelocations() {
-    return MOW.getRelocations();
-  }
 
 private:
   raw_pwrite_stream &OS;
@@ -110,8 +69,6 @@ private:
 
   SmallString<512> InternalBuffer;
   raw_svector_ostream InternalOS;
-
-  MachObjectWriter MOW;
 
   uint64_t OSOffset = 0;
 

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -91,43 +91,6 @@ public:
     MOW.writeDataInCodeRegion(Asm);
   }
 
-  void setVersionMin(MCVersionMinType Type, unsigned Major, unsigned Minor,
-                     unsigned Update,
-                     VersionTuple SDKVersion = VersionTuple()) override {
-    MOW.setVersionMin(Type, Major, Minor, Update, SDKVersion);
-  }
-  void setBuildVersion(unsigned Platform, unsigned Major, unsigned Minor,
-                       unsigned Update,
-                       VersionTuple SDKVersion = VersionTuple()) override {
-    MOW.setBuildVersion(Platform, Major, Minor, Update, SDKVersion);
-  }
-  void setTargetVariantBuildVersion(unsigned Platform, unsigned Major,
-                                    unsigned Minor, unsigned Update,
-                                    VersionTuple SDKVersion) override {
-    MOW.setTargetVariantBuildVersion(Platform, Major, Minor, Update,
-                                     SDKVersion);
-  }
-
-  std::optional<unsigned> getPtrAuthABIVersion() const override {
-    return MOW.getPtrAuthABIVersion();
-  }
-  void setPtrAuthABIVersion(unsigned V) override {
-    MOW.setPtrAuthABIVersion(V);
-  }
-  bool getPtrAuthKernelABIVersion() const override {
-    return MOW.getPtrAuthKernelABIVersion();
-  }
-  void setPtrAuthKernelABIVersion(bool V) override {
-    MOW.setPtrAuthKernelABIVersion(V);
-  }
-
-  bool getSubsectionsViaSymbols() const override {
-    return MOW.getSubsectionsViaSymbols();
-  }
-  void setSubsectionsViaSymbols(bool Value) override {
-    MOW.setSubsectionsViaSymbols(Value);
-  }
-
   void writeSymbolTable(MCAssembler &Asm) { MOW.writeSymbolTable(Asm); }
 
   uint64_t writeObject(MCAssembler &Asm) override;

--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -86,6 +86,12 @@ public:
 
 class MachObjectWriter : public MCObjectWriter {
 public:
+  struct DataRegionData {
+    MachO::DataRegionType Kind;
+    MCSymbol *Start;
+    MCSymbol *End;
+  };
+
   // A Major version of 0 indicates that no version information was supplied
   // and so the corresponding load command should not be emitted.
   using VersionInfoType = struct {
@@ -112,6 +118,11 @@ private:
     bool operator<(const MachSymbolData &RHS) const;
   };
 
+  struct IndirectSymbolData {
+    MCSymbol *Symbol;
+    MCSection *Section;
+  };
+
   /// The target specific Mach-O writer instance.
   std::unique_ptr<MCMachObjectTargetWriter> TargetObjectWriter;
 
@@ -132,7 +143,10 @@ public:
 
 private:
   DenseMap<const MCSection *, std::vector<RelAndSymbol>> Relocations;
+  std::vector<IndirectSymbolData> IndirectSymbols;
   DenseMap<const MCSection *, unsigned> IndirectSymBase;
+
+  std::vector<DataRegionData> DataRegions;
 
   SectionAddrMap SectionAddress;
 
@@ -151,11 +165,17 @@ private:
 
   /// @}
 
+  // Used to communicate Linker Optimization Hint information.
+  MCLOHContainer LOHContainer;
+
   VersionInfoType VersionInfo{};
   VersionInfoType TargetVariantVersionInfo{};
 
   std::optional<unsigned> PtrAuthABIVersion;
   bool PtrAuthKernelABIVersion;
+
+  // The list of linker options for LC_LINKER_OPTION.
+  std::vector<std::vector<std::string>> LinkerOptions;
 
   MachSymbolData *findSymbolData(const MCSymbol &Sym);
 
@@ -194,10 +214,15 @@ public:
 
   bool isFixupKindPCRel(const MCAssembler &Asm, unsigned Kind);
 
+  std::vector<IndirectSymbolData> &getIndirectSymbols() {
+    return IndirectSymbols;
+  }
+  std::vector<DataRegionData> &getDataRegions() { return DataRegions; }
   const llvm::SmallVectorImpl<MCSection *> &getSectionOrder() const {
     return SectionOrder;
   }
   SectionAddrMap &getSectionAddressMap() { return SectionAddress; }
+  MCLOHContainer &getLOHContainer() { return LOHContainer; }
 
   uint64_t getSectionAddress(const MCSection *Sec) const {
     return SectionAddress.lookup(Sec);
@@ -216,7 +241,7 @@ public:
   /// Mach-O deployment target version information.
   void setVersionMin(MCVersionMinType Type, unsigned Major, unsigned Minor,
                      unsigned Update,
-                     VersionTuple SDKVersion = VersionTuple()) override {
+                     VersionTuple SDKVersion = VersionTuple()) {
     VersionInfo.EmitBuildVersion = false;
     VersionInfo.TypeOrPlatform.Type = Type;
     VersionInfo.Major = Major;
@@ -224,37 +249,35 @@ public:
     VersionInfo.Update = Update;
     VersionInfo.SDKVersion = SDKVersion;
   }
-  void setBuildVersion(unsigned Platform, unsigned Major, unsigned Minor,
-                       unsigned Update,
-                       VersionTuple SDKVersion = VersionTuple()) override {
+  void setBuildVersion(MachO::PlatformType Platform, unsigned Major,
+                       unsigned Minor, unsigned Update,
+                       VersionTuple SDKVersion = VersionTuple()) {
     VersionInfo.EmitBuildVersion = true;
-    VersionInfo.TypeOrPlatform.Platform = (MachO::PlatformType)Platform;
+    VersionInfo.TypeOrPlatform.Platform = Platform;
     VersionInfo.Major = Major;
     VersionInfo.Minor = Minor;
     VersionInfo.Update = Update;
     VersionInfo.SDKVersion = SDKVersion;
   }
-  void setTargetVariantBuildVersion(unsigned Platform, unsigned Major,
-                                    unsigned Minor, unsigned Update,
-                                    VersionTuple SDKVersion) override {
+  void setTargetVariantBuildVersion(MachO::PlatformType Platform,
+                                    unsigned Major, unsigned Minor,
+                                    unsigned Update, VersionTuple SDKVersion) {
     TargetVariantVersionInfo.EmitBuildVersion = true;
-    TargetVariantVersionInfo.TypeOrPlatform.Platform =
-        (MachO::PlatformType)Platform;
+    TargetVariantVersionInfo.TypeOrPlatform.Platform = Platform;
     TargetVariantVersionInfo.Major = Major;
     TargetVariantVersionInfo.Minor = Minor;
     TargetVariantVersionInfo.Update = Update;
     TargetVariantVersionInfo.SDKVersion = SDKVersion;
   }
 
-  std::optional<unsigned> getPtrAuthABIVersion() const override {
+  std::optional<unsigned> getPtrAuthABIVersion() const {
     return PtrAuthABIVersion;
   }
-  void setPtrAuthABIVersion(unsigned V) override { PtrAuthABIVersion = V; }
-  bool getPtrAuthKernelABIVersion() const override {
-    return PtrAuthKernelABIVersion;
-  }
-  void setPtrAuthKernelABIVersion(bool V) override {
-    PtrAuthKernelABIVersion = V;
+  void setPtrAuthABIVersion(unsigned V) { PtrAuthABIVersion = V; }
+  bool getPtrAuthKernelABIVersion() const { return PtrAuthKernelABIVersion; }
+  void setPtrAuthKernelABIVersion(bool V) { PtrAuthKernelABIVersion = V; }
+  std::vector<std::vector<std::string>> &getLinkerOptions() {
+    return LinkerOptions;
   }
 
   /// @}

--- a/llvm/include/llvm/MC/MCObjectWriter.h
+++ b/llvm/include/llvm/MC/MCObjectWriter.h
@@ -9,8 +9,6 @@
 #ifndef LLVM_MC_MCOBJECTWRITER_H
 #define LLVM_MC_MCOBJECTWRITER_H
 
-#include "llvm/MC/MCDirectives.h"
-#include "llvm/MC/MCLinkerOptimizationHint.h"
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cstdint>
@@ -33,29 +31,7 @@ class MCValue;
 /// MCAssembler instance, which contains all the symbol and section data which
 /// should be emitted as part of writeObject().
 class MCObjectWriter {
-public:
-  struct DataRegionData {
-    unsigned Kind;
-    MCSymbol *Start;
-    MCSymbol *End;
-  };
-
 protected:
-  struct IndirectSymbolData {
-    MCSymbol *Symbol;
-    MCSection *Section;
-  };
-
-  std::vector<IndirectSymbolData> IndirectSymbols;
-
-  std::vector<DataRegionData> DataRegions;
-
-  // The list of linker options for LC_LINKER_OPTION.
-  std::vector<std::vector<std::string>> LinkerOptions;
-
-  // Used to communicate Linker Optimization Hint information.
-  MCLOHContainer LOHContainer;
-
   /// List of declared file names
   SmallVector<std::pair<std::string, size_t>, 0> FileNames;
   // XCOFF specific: Optional compiler version.
@@ -83,18 +59,6 @@ public:
 
   /// \name High-Level API
   /// @{
-
-  std::vector<std::vector<std::string>> &getLinkerOptions() {
-    return LinkerOptions;
-  }
-
-  std::vector<IndirectSymbolData> &getIndirectSymbols() {
-    return IndirectSymbols;
-  }
-
-  MCLOHContainer &getLOHContainer() { return LOHContainer; }
-
-  std::vector<DataRegionData> &getDataRegions() { return DataRegions; }
 
   /// Perform any late binding of symbols (for example, to assign symbol
   /// indices for use when generating relocations).
@@ -152,12 +116,8 @@ public:
   SmallVector<CGProfileEntry, 0> &getCGProfile() { return CGProfile; }
 
   // Mach-O specific: Whether .subsections_via_symbols is enabled.
-  virtual bool getSubsectionsViaSymbols() const {
-    return SubsectionsViaSymbols;
-  }
-  virtual void setSubsectionsViaSymbols(bool Value) {
-    SubsectionsViaSymbols = Value;
-  }
+  bool getSubsectionsViaSymbols() const { return SubsectionsViaSymbols; }
+  void setSubsectionsViaSymbols(bool Value) { SubsectionsViaSymbols = Value; }
 
   /// Write the object file and returns the number of bytes written.
   ///
@@ -166,22 +126,6 @@ public:
   /// generated.
   virtual uint64_t writeObject(MCAssembler &Asm) = 0;
 
-  virtual void setVersionMin(MCVersionMinType Type, unsigned Major,
-                             unsigned Minor, unsigned Update,
-                             VersionTuple SDKVersion = VersionTuple()) {}
-  virtual void setBuildVersion(unsigned Platform, unsigned Major,
-                               unsigned Minor, unsigned Update,
-                               VersionTuple SDKVersion = VersionTuple()) {}
-
-  virtual void setTargetVariantBuildVersion(unsigned Platform, unsigned Major,
-                                            unsigned Minor, unsigned Update,
-                                            VersionTuple SDKVersion) {}
-  virtual std::optional<unsigned> getPtrAuthABIVersion() const {
-    return std::nullopt;
-  }
-  virtual void setPtrAuthABIVersion(unsigned V) {}
-  virtual bool getPtrAuthKernelABIVersion() const { return false; }
-  virtual void setPtrAuthKernelABIVersion(bool V) {}
   /// @}
 };
 

--- a/llvm/include/llvm/MC/MCSPIRVObjectWriter.h
+++ b/llvm/include/llvm/MC/MCSPIRVObjectWriter.h
@@ -45,10 +45,6 @@ public:
 
   void setBuildVersion(unsigned Major, unsigned Minor, unsigned Bound);
 
-  void setBuildVersion(unsigned Platform, unsigned Major, unsigned Minor,
-                       unsigned Update,
-                       VersionTuple SDKVersion = VersionTuple()) override {}
-
 private:
   void recordRelocation(MCAssembler &Asm, const MCFragment *Fragment,
                         const MCFixup &Fixup, MCValue Target,

--- a/llvm/lib/MC/MCObjectWriter.cpp
+++ b/llvm/lib/MC/MCObjectWriter.cpp
@@ -25,10 +25,6 @@ void MCObjectWriter::reset() {
   EmitAddrsigSection = false;
   SubsectionsViaSymbols = false;
   CGProfile.clear();
-  LinkerOptions.clear();
-  LOHContainer.reset();
-  DataRegions.clear();
-  IndirectSymbols.clear();
 }
 
 bool MCObjectWriter::isSymbolRefDifferenceFullyResolved(

--- a/llvm/lib/MC/MachOCASWriter.cpp
+++ b/llvm/lib/MC/MachOCASWriter.cpp
@@ -53,9 +53,9 @@ MachOCASWriter::MachOCASWriter(
         SerializeObjectFile,
     std::optional<MCTargetOptions::ResultCallBackTy> ResultCallBack,
     raw_pwrite_stream *CasIDOS)
-    : Target(TT), CAS(CAS), Mode(Mode), ResultCallBack(ResultCallBack), OS(OS),
+    : MachObjectWriter(std::move(MOTW), InternalOS, IsLittleEndian), Target(TT),
+      CAS(CAS), Mode(Mode), ResultCallBack(ResultCallBack), OS(OS),
       CasIDOS(CasIDOS), InternalOS(InternalBuffer),
-      MOW(std::move(MOTW), InternalOS, IsLittleEndian),
       CreateFromMcAssembler(CreateFromMcAssembler),
       SerializeObjectFile(SerializeObjectFile) {
   assert(TT.isLittleEndian() == IsLittleEndian && "Endianess should match");

--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -49,18 +49,21 @@ void MachObjectWriter::reset() {
   Relocations.clear();
   IndirectSymBase.clear();
   IndirectSymbols.clear();
+  DataRegions.clear();
   SectionAddress.clear();
   SectionOrder.clear();
   StringTable.clear();
   LocalSymbolData.clear();
   ExternalSymbolData.clear();
   UndefinedSymbolData.clear();
+  LOHContainer.reset();
   VersionInfo.Major = 0;
   VersionInfo.SDKVersion = VersionTuple();
   TargetVariantVersionInfo.Major = 0;
   TargetVariantVersionInfo.SDKVersion = VersionTuple();
   PtrAuthABIVersion = std::nullopt;
   PtrAuthKernelABIVersion = false;
+  LinkerOptions.clear();
   MCObjectWriter::reset();
 }
 
@@ -1094,11 +1097,10 @@ void MachObjectWriter::writeDataInCodeRegion(MCAssembler &Asm) {
     else
       report_fatal_error("Data region not terminated");
 
-    LLVM_DEBUG(dbgs() << "data in code region-- kind: "
-                      << (MachO::DataRegionType)Data.Kind << "  start: "
-                      << Start << "(" << Data.Start->getName() << ")"
-                      << "  end: " << End << "(" << Data.End->getName() << ")"
-                      << "  size: " << End - Start << "\n");
+    LLVM_DEBUG(dbgs() << "data in code region-- kind: " << Data.Kind
+                      << "  start: " << Start << "(" << Data.Start->getName()
+                      << ")" << "  end: " << End << "(" << Data.End->getName()
+                      << ")" << "  size: " << End - Start << "\n");
     W.write<uint32_t>(Start);
     W.write<uint16_t>(End - Start);
     W.write<uint16_t>(Data.Kind);

--- a/llvm/test/MC/CAS/linker-options.ll
+++ b/llvm/test/MC/CAS/linker-options.ll
@@ -1,0 +1,37 @@
+; RUN: llc -O0 -mtriple=x86_64-apple-darwin -o - %s > %t
+; RUN: FileCheck --check-prefix=CHECK-ASM < %t %s
+
+; CHECK-ASM: .linker_option "-lz"
+; CHECK-ASM-NEXT: .linker_option "-framework", "Cocoa"
+
+; RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj -o - %s | llvm-readobj --macho-linker-options - > %t
+; RUN: FileCheck --check-prefix=CHECK-OBJ < %t %s
+; RUN: mkdir -p %t.dir/cas
+; RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj --cas %t.dir/cas -cas-backend -o - %s | llvm-readobj --macho-linker-options - > %t
+
+; REQUIRES: x86-registered-target
+
+; CHECK-OBJ: Linker Options {
+; CHECK-OBJ:   Size: 16
+; CHECK-OBJ:   Strings [
+; CHECK-OBJ:     Value: -lz
+; CHECK-OBJ:   ]
+; CHECK-OBJ: }
+; CHECK-OBJ: Linker Options {
+; CHECK-OBJ:   Size: 32
+; CHECK-OBJ:   Strings [
+; CHECK-OBJ:     Value: -framework
+; CHECK-OBJ:     Value: Cocoa
+; CHECK-OBJ:   ]
+; CHECK-OBJ: }
+; CHECK-OBJ: Linker Options {
+; CHECK-OBJ:   Size: 24
+; CHECK-OBJ:   Strings [
+; CHECK-OBJ:     Value: -lmath
+; CHECK-OBJ:   ]
+; CHECK-OBJ: }
+
+!0 = !{!"-lz"}
+!1 = !{!"-framework", !"Cocoa"}
+!2 = !{!"-lmath"}
+!llvm.linker.options = !{!0, !1, !2}

--- a/llvm/test/MC/MachO/linker-options.ll
+++ b/llvm/test/MC/MachO/linker-options.ll
@@ -6,8 +6,6 @@
 
 ; RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj -o - %s | llvm-readobj --macho-linker-options - > %t
 ; RUN: FileCheck --check-prefix=CHECK-OBJ < %t %s
-; RUN: mkdir -p %t.dir/cas
-; RUN: llc -O0 -mtriple=x86_64-apple-darwin -filetype=obj --cas %t.dir/cas -cas-backend -o - %s | llvm-readobj --macho-linker-options - > %t
 
 ; CHECK-OBJ: Linker Options {
 ; CHECK-OBJ:   Size: 16


### PR DESCRIPTION
This patch rewrites MachOCASWriter to be a derived class of MachObjectWriter which fixes a lot of the issues we see from the changes made to MCAssembler. This also fixes the issue of the MCMachoStreamer only having calls to the getWriter() function that returns a MachOCASWriter.

It also reverts all the changes made to MCObjectWriter for rdar://133264719 and rdar://133001453

(It is a cherry-pick of PR: https://github.com/swiftlang/llvm-project/pull/9086)