### PR TITLE
[lldb] Remove ifdef around upstreamed swift enumerations

### DIFF
--- a/lldb/source/Core/Section.cpp
+++ b/lldb/source/Core/Section.cpp
@@ -462,9 +462,7 @@ bool Section::ContainsOnlyDebugInfo() const {
   case eSectionTypeDWARFGNUDebugAltLink:
   case eSectionTypeCTF:
   case eSectionTypeLLDBTypeSummaries:
-#ifdef LLDB_ENABLE_SWIFT
   case eSectionTypeSwiftModules:
-#endif
     return true;
   }
   return false;

--- a/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CPlusPlusLanguage.cpp
@@ -384,9 +384,7 @@ bool CPlusPlusLanguage::IsCPPMangledName(llvm::StringRef name) {
   case Mangled::eManglingSchemeNone:
   case Mangled::eManglingSchemeRustV0:
   case Mangled::eManglingSchemeD:
-#ifdef LLDB_ENABLE_SWIFT
   case Mangled::eManglingSchemeSwift:
-#endif
     return false;
   }
 }


### PR DESCRIPTION
Otherwise we have functions that don't return a value on all paths and/or compiler warnings.