### PR TITLE
[MachOWriter] Initialize the values for PtrAuth fields

### DIFF
--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -171,8 +171,8 @@ private:
   VersionInfoType VersionInfo{};
   VersionInfoType TargetVariantVersionInfo{};
 
-  std::optional<unsigned> PtrAuthABIVersion;
-  bool PtrAuthKernelABIVersion;
+  std::optional<unsigned> PtrAuthABIVersion = std::nullopt;
+  bool PtrAuthKernelABIVersion = false;
 
   // The list of linker options for LC_LINKER_OPTION.
   std::vector<std::vector<std::string>> LinkerOptions;


### PR DESCRIPTION
Initialize some fields in MachOObjectWriter that was moved from ObjectWriter. Fix the UBSAN tests failed for uninitialized variables.