### PR TITLE
[MachOWriter] Initialize the values for PtrAuth fields

### DIFF
--- a/llvm/include/llvm/MC/MCMachObjectWriter.h
+++ b/llvm/include/llvm/MC/MCMachObjectWriter.h
@@ -154,8 +154,8 @@ private:
   VersionInfoType VersionInfo{};
   VersionInfoType TargetVariantVersionInfo{};
 
-  std::optional<unsigned> PtrAuthABIVersion;
-  bool PtrAuthKernelABIVersion;
+  std::optional<unsigned> PtrAuthABIVersion = std::nullopt;
+  bool PtrAuthKernelABIVersion = false;
 
   MachSymbolData *findSymbolData(const MCSymbol &Sym);
 


### PR DESCRIPTION
Initialize some fields in MachOObjectWriter that was moved from ObjectWriter. Fix the UBSAN tests failed for uninitialized variables.

(cherry picked from commit 76bb8e24d8ae859cd89c81648112400b67b1747d)