### PR TITLE
Fix a nullptr deref in ObjectFileMachO.cpp

### DIFF
--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -5226,10 +5226,10 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
       for (auto &rpath : rpath_paths) {
         if (llvm::StringRef(rpath).startswith(loader_path)) {
           rpath.erase(0, loader_path.size());
-          rpath.insert(0, this_file_spec.GetDirectory().GetCString());
+          rpath.insert(0, this_file_spec.GetDirectory().AsCString(""));
         } else if (llvm::StringRef(rpath).startswith(executable_path)) {
           rpath.erase(0, executable_path.size());
-          rpath.insert(0, this_file_spec.GetDirectory().GetCString());
+          rpath.insert(0, this_file_spec.GetDirectory().AsCString(""));
         }
       }
 


### PR DESCRIPTION
This code does not longer exist upstream, this is a surgical fix to eliminate a nullptrderef that we received a crash report for.

rdar://133647826