### PR TITLE
[Cherry-pick into next] Update non-asserts variant of macro

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2497,8 +2497,10 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
   FALLBACK(REFERENCE, FALLBACK_ARGS, {});                                      \
   return IMPL();
 #define VALIDATE_AND_RETURN_EXPECTED(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS,     \
-                                     FALLBACK_ARGS, DEFAULT)                   \
-  FALLBACK(REFERENCE, FALLBACK_ARGS, DEFAULT);                                 \
+                                     FALLBACK_ARGS)                            \
+  FALLBACK(REFERENCE, FALLBACK_ARGS,                                           \
+           llvm::createStringError(llvm::inconvertibleErrorCode(),             \
+                                   "incomplete AST type information"));        \
   return IMPL();
 #endif
 


### PR DESCRIPTION
```
commit b922d0670ebf97f10ce3fd417b1a8cda49287587
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Jun 3 13:29:04 2024 -0700

    Update non-asserts variant of macro
```
