### PR TITLE
[CMake] Fold export_executable_symbols_* into function args

### DIFF
--- a/clang/unittests/Interpreter/CMakeLists.txt
+++ b/clang/unittests/Interpreter/CMakeLists.txt
@@ -13,6 +13,8 @@ add_clang_unittest(ClangReplInterpreterTests
   InterpreterTest.cpp
   InterpreterExtensionsTest.cpp
   CodeCompletionTest.cpp
+
+  EXPORT_SYMBOLS
   )
 target_link_libraries(ClangReplInterpreterTests PUBLIC
   clangAST
@@ -27,8 +29,6 @@ target_link_libraries(ClangReplInterpreterTests PUBLIC
 if(NOT WIN32)
   add_subdirectory(ExceptionTests)
 endif()
-
-export_executable_symbols(ClangReplInterpreterTests)
 
 if(MSVC)
   set_target_properties(ClangReplInterpreterTests PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)

--- a/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
+++ b/clang/unittests/Interpreter/ExceptionTests/CMakeLists.txt
@@ -12,6 +12,8 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_unittest(ClangReplInterpreterExceptionTests
   InterpreterExceptionTest.cpp
+
+  EXPORT_SYMBOLS
   )
 
 llvm_update_compile_flags(ClangReplInterpreterExceptionTests)
@@ -22,5 +24,3 @@ target_link_libraries(ClangReplInterpreterExceptionTests PUBLIC
   clangFrontend
   )
 add_dependencies(ClangReplInterpreterExceptionTests clang-resource-headers)
-
-export_executable_symbols(ClangReplInterpreterExceptionTests)

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -1212,7 +1212,7 @@ if( ${CMAKE_SYSTEM_NAME} MATCHES SunOS )
 endif( ${CMAKE_SYSTEM_NAME} MATCHES SunOS )
 
 # Make sure we don't get -rdynamic in every binary. For those that need it,
-# use export_executable_symbols(target).
+# use EXPORT_SYMBOLS argument.
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
 include(AddLLVM)
@@ -1253,7 +1253,7 @@ if( LLVM_INCLUDE_UTILS )
   if( LLVM_INCLUDE_TESTS )
     set(LLVM_SUBPROJECT_TITLE "Third-Party/Google Test")
     add_subdirectory(${LLVM_THIRD_PARTY_DIR}/unittest ${CMAKE_CURRENT_BINARY_DIR}/third-party/unittest)
-    set(LLVM_SUBPROJECT_TITLE) 
+    set(LLVM_SUBPROJECT_TITLE)
   endif()
 else()
   if ( LLVM_INCLUDE_TESTS )

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -1016,7 +1016,7 @@ endmacro()
 
 macro(add_llvm_executable name)
   cmake_parse_arguments(ARG
-    "DISABLE_LLVM_LINK_LLVM_DYLIB;IGNORE_EXTERNALIZE_DEBUGINFO;NO_INSTALL_RPATH;SUPPORT_PLUGINS"
+    "DISABLE_LLVM_LINK_LLVM_DYLIB;IGNORE_EXTERNALIZE_DEBUGINFO;NO_INSTALL_RPATH;SUPPORT_PLUGINS;EXPORT_SYMBOLS"
     "ENTITLEMENTS;BUNDLE_PATH"
     ""
     ${ARGN})
@@ -1076,7 +1076,8 @@ macro(add_llvm_executable name)
   endif(LLVM_EXPORTED_SYMBOL_FILE)
 
   if (DEFINED LLVM_ENABLE_EXPORTED_SYMBOLS_IN_EXECUTABLES AND
-      NOT LLVM_ENABLE_EXPORTED_SYMBOLS_IN_EXECUTABLES)
+      NOT LLVM_ENABLE_EXPORTED_SYMBOLS_IN_EXECUTABLES AND
+      NOT ARG_EXPORT_SYMBOLS)
     if(LLVM_LINKER_SUPPORTS_NO_EXPORTED_SYMBOLS)
       set_property(TARGET ${name} APPEND_STRING PROPERTY
         LINK_FLAGS " -Wl,-no_exported_symbols")
@@ -1117,6 +1118,10 @@ macro(add_llvm_executable name)
   endif()
 
   llvm_codesign(${name} ENTITLEMENTS ${ARG_ENTITLEMENTS} BUNDLE_PATH ${ARG_BUNDLE_PATH})
+
+  if (ARG_EXPORT_SYMBOLS)
+    export_executable_symbols(${name})
+  endif()
 endmacro(add_llvm_executable name)
 
 # add_llvm_pass_plugin(name [NO_MODULE] ...)
@@ -1469,7 +1474,7 @@ macro(add_llvm_example name)
   if( NOT LLVM_BUILD_EXAMPLES )
     set(EXCLUDE_FROM_ALL ON)
   endif()
-  add_llvm_executable(${name} ${ARGN})
+  add_llvm_executable(${name} EXPORT_SYMBOLS ${ARGN})
   if( LLVM_BUILD_EXAMPLES )
     install(TARGETS ${name} RUNTIME DESTINATION "${LLVM_EXAMPLES_INSTALL_DIR}")
   endif()

--- a/llvm/examples/ExceptionDemo/CMakeLists.txt
+++ b/llvm/examples/ExceptionDemo/CMakeLists.txt
@@ -16,6 +16,6 @@ endif()
 
 add_llvm_example(ExceptionDemo
   ExceptionDemo.cpp
-  )
 
-export_executable_symbols(ExceptionDemo)
+  EXPORT_SYMBOLS
+  )

--- a/llvm/examples/HowToUseLLJIT/CMakeLists.txt
+++ b/llvm/examples/HowToUseLLJIT/CMakeLists.txt
@@ -7,6 +7,6 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_example(HowToUseLLJIT
   HowToUseLLJIT.cpp
-  )
 
-export_executable_symbols(HowToUseLLJIT)
+  EXPORT_SYMBOLS
+  )

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter1/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter1/CMakeLists.txt
@@ -14,5 +14,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(BuildingAJIT-Ch1
   toy.cpp
   )
-
-export_executable_symbols(BuildingAJIT-Ch1)

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter2/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter2/CMakeLists.txt
@@ -14,5 +14,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(BuildingAJIT-Ch2
   toy.cpp
   )
-
-export_executable_symbols(BuildingAJIT-Ch2)

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter3/CMakeLists.txt
@@ -15,5 +15,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(BuildingAJIT-Ch3
   toy.cpp
   )
-
-export_executable_symbols(BuildingAJIT-Ch3)

--- a/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/BuildingAJIT/Chapter4/CMakeLists.txt
@@ -15,5 +15,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(BuildingAJIT-Ch4
   toy.cpp
   )
-
-export_executable_symbols(BuildingAJIT-Ch4)

--- a/llvm/examples/Kaleidoscope/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/CMakeLists.txt
@@ -3,7 +3,7 @@ set_target_properties(Kaleidoscope PROPERTIES FOLDER "LLVM/Examples")
 
 macro(add_kaleidoscope_chapter name)
   add_dependencies(Kaleidoscope ${name})
-  add_llvm_example(${name} ${ARGN})
+  add_llvm_example(${name} EXPORT_SYMBOLS ${ARGN})
 endmacro(add_kaleidoscope_chapter name)
 
 add_subdirectory(BuildingAJIT)

--- a/llvm/examples/Kaleidoscope/Chapter4/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter4/CMakeLists.txt
@@ -15,5 +15,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(Kaleidoscope-Ch4
   toy.cpp
   )
-
-export_executable_symbols(Kaleidoscope-Ch4)

--- a/llvm/examples/Kaleidoscope/Chapter5/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter5/CMakeLists.txt
@@ -15,5 +15,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(Kaleidoscope-Ch5
   toy.cpp
   )
-
-export_executable_symbols(Kaleidoscope-Ch5)

--- a/llvm/examples/Kaleidoscope/Chapter6/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter6/CMakeLists.txt
@@ -15,5 +15,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(Kaleidoscope-Ch6
   toy.cpp
   )
-
-export_executable_symbols(Kaleidoscope-Ch6)

--- a/llvm/examples/Kaleidoscope/Chapter7/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter7/CMakeLists.txt
@@ -16,5 +16,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(Kaleidoscope-Ch7
   toy.cpp
   )
-
-export_executable_symbols(Kaleidoscope-Ch7)

--- a/llvm/examples/Kaleidoscope/Chapter8/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter8/CMakeLists.txt
@@ -5,5 +5,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(Kaleidoscope-Ch8
   toy.cpp
   )
-
-export_executable_symbols(Kaleidoscope-Ch8)

--- a/llvm/examples/Kaleidoscope/Chapter9/CMakeLists.txt
+++ b/llvm/examples/Kaleidoscope/Chapter9/CMakeLists.txt
@@ -11,5 +11,3 @@ set(LLVM_LINK_COMPONENTS
 add_kaleidoscope_chapter(Kaleidoscope-Ch9
   toy.cpp
   )
-
-export_executable_symbols(Kaleidoscope-Ch9)

--- a/llvm/examples/OrcV2Examples/LLJITDumpObjects/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITDumpObjects/CMakeLists.txt
@@ -11,5 +11,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITDumpObjects
   LLJITDumpObjects.cpp
   )
-
-export_executable_symbols(LLJITDumpObjects)

--- a/llvm/examples/OrcV2Examples/LLJITRemovableCode/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITRemovableCode/CMakeLists.txt
@@ -12,5 +12,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITRemovableCode
   LLJITRemovableCode.cpp
   )
-
-export_executable_symbols(LLJITRemovableCode)

--- a/llvm/examples/OrcV2Examples/LLJITWithCustomObjectLinkingLayer/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithCustomObjectLinkingLayer/CMakeLists.txt
@@ -10,5 +10,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithCustomObjectLinkingLayer
   LLJITWithCustomObjectLinkingLayer.cpp
   )
-
-export_executable_symbols(LLJITWithCustomObjectLinkingLayer)

--- a/llvm/examples/OrcV2Examples/LLJITWithExecutorProcessControl/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithExecutorProcessControl/CMakeLists.txt
@@ -10,5 +10,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithExecutorProcessControl
   LLJITWithExecutorProcessControl.cpp
   )
-
-export_executable_symbols(LLJITWithExecutorProcessControl)

--- a/llvm/examples/OrcV2Examples/LLJITWithGDBRegistrationListener/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithGDBRegistrationListener/CMakeLists.txt
@@ -12,7 +12,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithGDBRegistrationListener
   LLJITWithGDBRegistrationListener.cpp
   )
-
-# We want JIT'd code to be able to link against process symbols like printf
-# for this example, so make sure they're exported.
-export_executable_symbols(LLJITWithGDBRegistrationListener)

--- a/llvm/examples/OrcV2Examples/LLJITWithInitializers/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithInitializers/CMakeLists.txt
@@ -11,5 +11,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithInitializers
   LLJITWithInitializers.cpp
   )
-
-export_executable_symbols(LLJITWithInitializers)

--- a/llvm/examples/OrcV2Examples/LLJITWithLazyReexports/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithLazyReexports/CMakeLists.txt
@@ -10,5 +10,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithLazyReexports
   LLJITWithLazyReexports.cpp
   )
-
-export_executable_symbols(LLJITWithLazyReexports)

--- a/llvm/examples/OrcV2Examples/LLJITWithObjectCache/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithObjectCache/CMakeLists.txt
@@ -10,5 +10,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithObjectCache
   LLJITWithObjectCache.cpp
   )
-
-export_executable_symbols(LLJITWithObjectCache)

--- a/llvm/examples/OrcV2Examples/LLJITWithObjectLinkingLayerPlugin/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithObjectLinkingLayerPlugin/CMakeLists.txt
@@ -10,5 +10,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithObjectLinkingLayerPlugin
   LLJITWithObjectLinkingLayerPlugin.cpp
   )
-
-export_executable_symbols(LLJITWithObjectLinkingLayerPlugin)

--- a/llvm/examples/OrcV2Examples/LLJITWithOptimizingIRTransform/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithOptimizingIRTransform/CMakeLists.txt
@@ -12,5 +12,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithOptimizingIRTransform
   LLJITWithOptimizingIRTransform.cpp
   )
-
-export_executable_symbols(LLJITWithOptimizingIRTransform)

--- a/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithRemoteDebugging/CMakeLists.txt
@@ -20,6 +20,4 @@ if (LLVM_INCLUDE_UTILS)
     DEPENDS
       llvm-jitlink-executor
   )
-
-  export_executable_symbols(LLJITWithRemoteDebugging)
 endif()

--- a/llvm/examples/OrcV2Examples/LLJITWithThinLTOSummaries/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/LLJITWithThinLTOSummaries/CMakeLists.txt
@@ -12,5 +12,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(LLJITWithThinLTOSummaries
   LLJITWithThinLTOSummaries.cpp
   )
-
-export_executable_symbols(LLJITWithThinLTOSummaries)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsAddObjectFile/CMakeLists.txt
@@ -13,5 +13,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(OrcV2CBindingsAddObjectFile
   OrcV2CBindingsAddObjectFile.c
   )
-
-export_executable_symbols(OrcV2CBindingsAddObjectFile)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsBasicUsage/CMakeLists.txt
@@ -13,5 +13,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(OrcV2CBindingsBasicUsage
   OrcV2CBindingsBasicUsage.c
   )
-
-export_executable_symbols(OrcV2CBindingsBasicUsage)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsDumpObjects/CMakeLists.txt
@@ -13,5 +13,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(OrcV2CBindingsDumpObjects
   OrcV2CBindingsDumpObjects.c
   )
-
-export_executable_symbols(OrcV2CBindingsDumpObjects)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsIRTransforms/CMakeLists.txt
@@ -14,5 +14,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(OrcV2CBindingsIRTransforms
   OrcV2CBindingsIRTransforms.c
   )
-
-export_executable_symbols(OrcV2CBindingsIRTransforms)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsLazy/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsLazy/CMakeLists.txt
@@ -13,5 +13,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(OrcV2CBindingsLazy
   OrcV2CBindingsLazy.c
   )
-
-export_executable_symbols(OrcV2CBindingsLazy)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsRemovableCode/CMakeLists.txt
@@ -13,5 +13,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(OrcV2CBindingsRemovableCode
   OrcV2CBindingsRemovableCode.c
   )
-
-export_executable_symbols(OrcV2CBindingsRemovableCode)

--- a/llvm/examples/OrcV2Examples/OrcV2CBindingsVeryLazy/CMakeLists.txt
+++ b/llvm/examples/OrcV2Examples/OrcV2CBindingsVeryLazy/CMakeLists.txt
@@ -13,5 +13,3 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_example(OrcV2CBindingsVeryLazy
   OrcV2CBindingsVeryLazy.c
   )
-
-export_executable_symbols(OrcV2CBindingsVeryLazy)

--- a/llvm/tools/lli/CMakeLists.txt
+++ b/llvm/tools/lli/CMakeLists.txt
@@ -56,6 +56,6 @@ add_llvm_tool(lli
 
   DEPENDS
   intrinsics_gen
-  )
 
-export_executable_symbols(lli)
+  EXPORT_SYMBOLS
+  )

--- a/llvm/tools/lli/ChildTarget/CMakeLists.txt
+++ b/llvm/tools/lli/ChildTarget/CMakeLists.txt
@@ -10,6 +10,6 @@ add_llvm_utility(lli-child-target
 
   DEPENDS
   intrinsics_gen
-)
 
-export_executable_symbols(lli-child-target)
+  EXPORT_SYMBOLS
+)

--- a/llvm/tools/llvm-jitlink/CMakeLists.txt
+++ b/llvm/tools/llvm-jitlink/CMakeLists.txt
@@ -26,6 +26,8 @@ add_llvm_tool(llvm-jitlink
   llvm-jitlink-elf.cpp
   llvm-jitlink-macho.cpp
   llvm-jitlink-statistics.cpp
+
+  EXPORT_SYMBOLS
   )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Haiku")
@@ -35,5 +37,3 @@ endif()
 if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
   target_link_libraries(llvm-jitlink PRIVATE socket)
 endif()
-
-export_executable_symbols(llvm-jitlink)

--- a/llvm/tools/llvm-jitlink/llvm-jitlink-executor/CMakeLists.txt
+++ b/llvm/tools/llvm-jitlink/llvm-jitlink-executor/CMakeLists.txt
@@ -9,6 +9,6 @@ add_llvm_utility(llvm-jitlink-executor
 
   DEPENDS
   intrinsics_gen
-)
 
-export_executable_symbols(llvm-jitlink-executor)
+  EXPORT_SYMBOLS
+)

--- a/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
+++ b/llvm/unittests/ExecutionEngine/Orc/CMakeLists.txt
@@ -43,10 +43,10 @@ add_llvm_unittest(OrcJITTests
   TaskDispatchTest.cpp
   ThreadSafeModuleTest.cpp
   WrapperFunctionUtilsTest.cpp
+
+  EXPORT_SYMBOLS
   )
 
 target_link_libraries(OrcJITTests PRIVATE
                         LLVMTestingSupport
                         ${ORC_JIT_TEST_LIBS})
-
-export_executable_symbols(OrcJITTests)

--- a/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
+++ b/llvm/unittests/Support/DynamicLibrary/CMakeLists.txt
@@ -38,7 +38,7 @@ function(dynlib_add_module NAME)
     )
 
   add_dependencies(DynamicLibraryTests ${NAME})
-  
+
   if(LLVM_INTEGRATED_CRT_ALLOC)
     # We need to link in the Support lib for the Memory allocator override,
     # otherwise the DynamicLibrary.Shutdown test will fail, because it would
@@ -48,7 +48,7 @@ function(dynlib_add_module NAME)
     llvm_map_components_to_libnames(llvm_libs Support)
     target_link_libraries(${NAME} ${llvm_libs} "-INCLUDE:malloc")
   endif()
-  
+
 endfunction(dynlib_add_module)
 
 # Revert -Wl,-z,nodelete on this test since it relies on the file

--- a/mlir/tools/mlir-cpu-runner/CMakeLists.txt
+++ b/mlir/tools/mlir-cpu-runner/CMakeLists.txt
@@ -7,6 +7,8 @@ set(LLVM_LINK_COMPONENTS
 
 add_mlir_tool(mlir-cpu-runner
   mlir-cpu-runner.cpp
+
+  EXPORT_SYMBOLS
   )
 llvm_update_compile_flags(mlir-cpu-runner)
 target_link_libraries(mlir-cpu-runner PRIVATE
@@ -22,5 +24,3 @@ target_link_libraries(mlir-cpu-runner PRIVATE
   MLIRTargetLLVMIRExport
   MLIRSupport
   )
-
-export_executable_symbols(mlir-cpu-runner)


### PR DESCRIPTION
Fix the builds with LLVM_TOOL_LLVM_DRIVER_BUILD enabled.

LLVM_ENABLE_EXPORTED_SYMBOLS_IN_EXECUTABLES is not completely compatible with export_executable_symbols as the later will be ignored if the previous is set to NO.

Fix the issue by passing if symbols need to be exported to llvm_add_exectuable so the link flag can be determined directly without calling export_executable_symbols_* later.