### PR TITLE
[Index] Convert to hashing to `HashBuilder` with BLAKE3

### DIFF
--- a/clang/include/clang/Index/IndexRecordWriter.h
+++ b/clang/include/clang/Index/IndexRecordWriter.h
@@ -75,7 +75,7 @@ public:
   /// \returns Success if we should continue writing this record, AlreadyExists
   /// if the record file has already been written, or Failure if there was an
   /// error, in which case \p Error will be set.
-  Result beginRecord(StringRef Filename, llvm::hash_code RecordHash,
+  Result beginRecord(StringRef Filename, uint64_t RecordHash,
                      std::string &Error, std::string *RecordFile = nullptr);
 
   /// Finish writing the record file.

--- a/clang/lib/Index/ClangIndexRecordWriter.cpp
+++ b/clang/lib/Index/ClangIndexRecordWriter.cpp
@@ -63,8 +63,7 @@ StringRef ClangIndexRecordWriter::getUSRNonCached(const IdentifierInfo *Name,
 
 ClangIndexRecordWriter::ClangIndexRecordWriter(ASTContext &Ctx,
                                                RecordingOptions Opts)
-    : Impl(Opts.DataDirPath), Ctx(Ctx), RecordOpts(std::move(Opts)),
-      Hasher(Ctx) {
+    : Impl(Opts.DataDirPath), Ctx(Ctx), RecordOpts(std::move(Opts)) {
   if (Opts.RecordSymbolCodeGenName)
     ASTNameGen.reset(new ASTNameGenerator(Ctx));
 }
@@ -76,7 +75,9 @@ bool ClangIndexRecordWriter::writeRecord(StringRef Filename,
                                          std::string &Error,
                                          std::string *OutRecordFile) {
 
-  auto RecordHash = Hasher.hashRecord(IdxRecord);
+  std::array<uint8_t, 8> RecordHashArr = index::hashRecord(IdxRecord, Ctx);
+  uint64_t RecordHash = 0;
+  std::memcpy(&RecordHash, RecordHashArr.data(), RecordHashArr.size());
 
   switch (Impl.beginRecord(Filename, RecordHash, Error, OutRecordFile)) {
   case IndexRecordWriter::Result::Success:

--- a/clang/lib/Index/ClangIndexRecordWriter.h
+++ b/clang/lib/Index/ClangIndexRecordWriter.h
@@ -33,7 +33,6 @@ class ClangIndexRecordWriter {
   std::unique_ptr<ASTNameGenerator> ASTNameGen;
   llvm::BumpPtrAllocator Allocator;
   llvm::DenseMap<const void *, StringRef> USRByDecl;
-  IndexRecordHasher Hasher;
 
 public:
   ClangIndexRecordWriter(ASTContext &Ctx, RecordingOptions Opts);

--- a/clang/lib/Index/IndexRecordHasher.h
+++ b/clang/lib/Index/IndexRecordHasher.h
@@ -9,57 +9,16 @@
 #ifndef LLVM_CLANG_LIB_INDEX_INDEXRECORDHASHER_H
 #define LLVM_CLANG_LIB_INDEX_INDEXRECORDHASHER_H
 
-#include "clang/Basic/LLVM.h"
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/Hashing.h"
+#include <array>
 
 namespace clang {
-  class ASTContext;
-  class Decl;
-  class DeclarationName;
-  class IdentifierInfo;
-  class MacroInfo;
-  class NestedNameSpecifier;
-  class QualType;
-  class Type;
-  template <typename> class CanQual;
-  typedef CanQual<Type> CanQualType;
+class ASTContext;
 
 namespace index {
   class FileIndexRecord;
 
-class IndexRecordHasher {
-  ASTContext &Ctx;
-  llvm::DenseMap<const void *, llvm::hash_code> HashByPtr;
-
-public:
-  explicit IndexRecordHasher(ASTContext &Ctx) : Ctx(Ctx) {}
-  ASTContext &getASTContext() { return Ctx; }
-
-  llvm::hash_code hashRecord(const FileIndexRecord &Record);
-  llvm::hash_code hash(const Decl *D);
-  llvm::hash_code hash(const IdentifierInfo *Name, const MacroInfo *M);
-  llvm::hash_code hash(QualType Ty);
-  llvm::hash_code hash(CanQualType Ty);
-  llvm::hash_code hash(DeclarationName Name);
-  llvm::hash_code hash(const NestedNameSpecifier *NNS);
-
-private:
-  template <typename T>
-  llvm::hash_code tryCache(const void *Ptr, T Obj);
-
-  struct MacroDef {
-    const IdentifierInfo *Name;
-    const MacroInfo *MI;
-  };
-
-  llvm::hash_code hashImpl(const Decl *D);
-  llvm::hash_code hashImpl(MacroDef MD);
-  llvm::hash_code hashImpl(CanQualType Ty);
-  llvm::hash_code hashImpl(DeclarationName Name);
-  llvm::hash_code hashImpl(const NestedNameSpecifier *NNS);
-};
-
+  std::array<uint8_t, 8> hashRecord(const FileIndexRecord &record,
+                                    ASTContext &context);
 } // end namespace index
 } // end namespace clang
 

--- a/clang/lib/Index/IndexRecordWriter.cpp
+++ b/clang/lib/Index/IndexRecordWriter.cpp
@@ -240,7 +240,7 @@ IndexRecordWriter::IndexRecordWriter(StringRef IndexPath)
 }
 
 IndexRecordWriter::Result
-IndexRecordWriter::beginRecord(StringRef Filename, hash_code RecordHash,
+IndexRecordWriter::beginRecord(StringRef Filename, uint64_t RecordHash,
                                std::string &Error, std::string *OutRecordFile) {
   using namespace llvm::sys;
   assert(!Record && "called beginRecord before calling endRecord on previous");

--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -136,8 +136,12 @@ IndexUnitWriter::IndexUnitWriter(FileManager &FileMgr,
   this->ProviderIdentifier = std::string(ProviderIdentifier);
   this->ProviderVersion = std::string(ProviderVersion);
   SmallString<256> AbsOutputFile(OutputFile);
-  if (OutputFile != "-")  // Can't make stdout absolute, should stay as "-".
+  if (OutputFile != "-")  {
+    // Can't make stdout absolute, should stay as "-".
     FileMgr.makeAbsolutePath(AbsOutputFile);
+    llvm::sys::path::native(AbsOutputFile);
+  }
+
   this->OutputFile = std::string(AbsOutputFile.str());
   this->ModuleName = std::string(ModuleName);
   this->MainFile = MainFile;
@@ -227,13 +231,14 @@ void IndexUnitWriter::getUnitNameForOutputFile(StringRef FilePath,
                                                SmallVectorImpl<char> &Str) {
   SmallString<256> AbsPath(FilePath);
   FileMgr.makeAbsolutePath(AbsPath);
+  llvm::sys::path::native(AbsPath);
   return getUnitNameForAbsoluteOutputFile(AbsPath, Str, Remapper);
 }
 
 void IndexUnitWriter::getUnitPathForOutputFile(StringRef FilePath,
                                                SmallVectorImpl<char> &Str) {
   Str.append(UnitsPath.begin(), UnitsPath.end());
-  Str.push_back('/');
+  Str.push_back(llvm::sys::path::get_separator().front());
   return getUnitNameForOutputFile(FilePath, Str);
 }
 

--- a/clang/test/Index/Store/print-unit-remapped-hash.c
+++ b/clang/test/Index/Store/print-unit-remapped-hash.c
@@ -8,11 +8,15 @@ void foo(int i);
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: cd %t && %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -fdebug-prefix-map=%S/Inputs=INPUT_ROOT -fdebug-prefix-map=%S=SRC_ROOT -fdebug-prefix-map=%t=BUILD_ROOT -index-store-path %t/idx %S/print-unit-remapped.c -triple x86_64-apple-macosx10.8
-// RUN: c-index-test core -print-unit %t/idx | FileCheck %s
+// RUN: c-index-test core -print-unit %t/idx > %t/units.out
 
 // Relative paths should work as well - the unit name, main-path, and out-file should not change.
-// RUN: rm -rf %t
+// RUN: rm -rf %t/idx
 // RUN: cd %S && %clang_cc1 -I %S/Inputs -isystem %S/Inputs/sys -fdebug-prefix-map=%S=SRC_ROOT -index-store-path %t/idx print-unit-remapped.c -o print-unit-remapped.c.o -triple x86_64-apple-macosx10.8
-// RUN: c-index-test core -print-unit %t/idx | FileCheck %s
+// RUN: c-index-test core -print-unit %t/idx >> %t/units.out
 
-// CHECK: print-unit-remapped.c.o-20EK9G967JO97
+// RUN: FileCheck %s -input-file %t/units.out
+
+// CHECK: print-unit-remapped.c.o-[[OUT_HASH:.*$]]
+// CHECK: print-unit-remapped.c.o-[[OUT_HASH]]
+// CHECK-NOT: print-unit-remapped.c.o-


### PR DESCRIPTION
`Hashing.h` is non-deterministic between runs. Update the index hashing to use xxhash for the unit hash and BLAKE3 for the record hash. Ideally we'd use xxhash for the record hash as well, but there's no easy `HashBuilder` option for it today.

This also removes the hash caching logic from the record hasher, as it turns out to be slower than just hashing everything for BLAKE3 and greatly simplifies the implementation with its removal.

Numbers for indexing `Foundation` and `Cocoa` textual includes on an M2 Pro over 10 runs with 3 warmup are as follows.

Build with full re-index (ie. index removed between each run) -
```
      Current: 688ms +- 8ms
       BLAKE3: 691ms +- 4ms
BLAKE3 cached: 711ms +- 8ms
   No-op hash: 620ms +- 4ms
```

Same but with an existing index (which would hash but then not write any output) -
```
      Current: 396ms +- 4ms
       BLAKE3: 394ms +- 4ms
BLAKE3 cached: 419ms +- 3ms
   No-op hash: 382ms +- 5ms
```

The no-op hash is a little misleading in the full re-index since it will be writing out fewer records. But the existing index case is interesting, showing that hashing is only a small part of the entire build and index.

Also worth noting that there was some fairly significant run-to-run variance of around 30ms, but the above was a generally typical pattern (ie. current about the same as BLAKE3, which is faster than BLAKE3 cached, and no-op is the fastest). The main take away is that this isn't a noticable performance regression.