### PR TITLE
[lldb] Test po of multiline string (#8815)

### DIFF
--- a/lldb/test/API/lang/swift/po/sys_types/main.swift
+++ b/lldb/test/API/lang/swift/po/sys_types/main.swift
@@ -33,8 +33,9 @@ func main() {
   //% self.expect("script lldb.frame.FindVariable('nsobject').GetObjectDescription()", substrs = ['<NSObject: 0x']) # may change depending on OS/platform
   var anyobject: AnyObject = 1234 as NSNumber //% self.expect("po any", substrs = ['1234'])
   var notification = Notification(name: Notification.Name(rawValue: "JustANotification"), object: nil)
-  print("yay I am done!") //% self.expect("po notification", substrs=['JustANotification'])
-   //% self.expect("po notification", matching=False, substrs=['super'])
+  var lines = "one\ndue" //% self.expect("po notification", substrs=['JustANotification'])
+  //% self.expect("po notification", matching=False, substrs=['super'])
+  print("yay I am done!") //% self.expect("po lines", startstr='one\ndue')
 }
 
 main()


### PR DESCRIPTION
Test `po` of a multiline string and verify that newlines are not escaped.

See https://github.com/apple/swift/pull/73550

(cherry-picked from commit e02c6a87f4b9cc6d7e6c536590f55f373d290baa)