### PR TITLE
[Swift] Update for removal of Type::transform()

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -941,14 +941,14 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
                                        "actual_swift_type is a nullptr");
 
       auto transformed_type =
-          actual_swift_type->transform([](swift::Type t) -> swift::Type {
-            if (auto *aliasTy =
-                    swift::dyn_cast<swift::TypeAliasType>(t.getPointer())) {
-              if (aliasTy && aliasTy->getDecl()->isDebuggerAlias()) {
+          actual_swift_type->transformRec([](swift::TypeBase *t)
+              -> std::optional<swift::Type> {
+            if (auto *aliasTy = swift::dyn_cast<swift::TypeAliasType>(t)) {
+              if (aliasTy->getDecl()->isDebuggerAlias()) {
                 return aliasTy->getSinglyDesugaredType();
               }
             }
-            return t;
+            return std::nullopt;
           });
 
       if (!transformed_type)

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4690,14 +4690,15 @@ void SwiftASTContext::CacheDemangledTypeFailure(ConstString name) {
 /// requires some more plumbing on the Swift side to properly handle generic
 /// specializations.
 static swift::Type ConvertSILFunctionTypesToASTFunctionTypes(swift::Type t) {
-  return t.transform([](swift::Type t) -> swift::Type {
-    if (auto *silFn = t->getAs<swift::SILFunctionType>()) {
+  return t.transformRec([](swift::TypeBase *t) -> std::optional<swift::Type> {
+    if (auto *silFn = swift::dyn_cast<swift::SILFunctionType>(t)) {
       // FIXME: Verify ExtInfo state is correct, not working by accident.
       swift::FunctionType::ExtInfo info;
-      return swift::FunctionType::get({}, t->getASTContext().TheEmptyTupleType,
-                                      info);
+      return swift::Type(
+          swift::FunctionType::get({}, t->getASTContext().TheEmptyTupleType,
+                                   info));
     }
-    return t;
+    return std::nullopt;
   });
 }
 


### PR DESCRIPTION
(cherry picked from commit 3d22ac7f4bbbba57618b3b6e077cc0627c65f47e)