### PR TITLE
[clang] Restore has_feature(swiftasynccc) while swift moves to has_extension.

### DIFF
--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -126,6 +126,14 @@ EXTENSION(swiftcc,
 EXTENSION(swiftasynccc,
   PP.getTargetInfo().checkCallingConvention(CC_SwiftAsync) ==
   clang::TargetInfo::CCCR_OK)
+
+// We have the extension above.  Keep the feature for older swift stdlib,
+// since it only learned to check the extensions recently.
+// rdar://133628186
+FEATURE(swiftasynccc,
+  PP.getTargetInfo().checkCallingConvention(CC_SwiftAsync) ==
+  clang::TargetInfo::CCCR_OK)
+
 FEATURE(pragma_stdc_cx_limited_range, true)
 // Objective-C features
 FEATURE(objc_arr, LangOpts.ObjCAutoRefCount) // FIXME: REMOVE?

--- a/clang/test/Sema/swift-call-conv.c
+++ b/clang/test/Sema/swift-call-conv.c
@@ -17,3 +17,12 @@ void __attribute__((__swiftcall__)) f(void) {}
 // expected-warning@+2 {{'__swiftasynccall__' calling convention is not supported for this target}}
 #endif
 void __attribute__((__swiftasynccall__)) g(void) {}
+
+// Allow has_feature in addition to has_extension to let swift transition.
+// rdar://133628186
+#if __has_feature(swiftasynccc)
+// expected-no-diagnostics
+#else
+// expected-warning@+2 {{'__swiftasynccall__' calling convention is not supported for this target}}
+#endif
+void __attribute__((__swiftasynccall__)) h(void) {}


### PR DESCRIPTION
ea1fea6a6ff7 added has_extension(swiftcc), but also turned swiftasynccc from a feature to an extension.  This breaks swift versions that predate the transition (swiftlang/swift@1f91d9547fa).

Restore a temporary swiftasynccc feature to keep supporting older versions.

rdar://133628186