### PR TITLE
[CAS] Improve the cc1 flag round trip speed when CAS is used. NFCI

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -716,6 +716,8 @@ def err_drv_inputs_and_include_tree : Error<
   "passing input files is incompatible with '-fcas-include-tree'">;
 def err_drv_incompatible_option_include_tree : Error<
   "passing incompatible option '%0' with '-fcas-include-tree'">;
+def err_drv_include_tree_miss_input_kind : Error<
+  "missing '-x' input kind when using '-fcas-include-tree'">;
 
 def err_drv_invalid_directx_shader_module : Error<
   "invalid profile : %0">;

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -824,6 +824,9 @@ private:
                        bool RemoveFileOnSignal, bool UseTemporary,
                        bool CreateMissingDirectories);
 
+  /// Initialize inputs from CAS.
+  void initializeDelayedInputFileFromCAS();
+
 public:
   std::unique_ptr<raw_pwrite_stream> createNullOutputFile();
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -89,6 +89,10 @@ CompilerInstance::~CompilerInstance() {
 void CompilerInstance::setInvocation(
     std::shared_ptr<CompilerInvocation> Value) {
   Invocation = std::move(Value);
+
+  /// Initialize the input from CAS when setting the invocation to preserve
+  /// the same behavior when perform all kinds of FrontendActions.
+  initializeDelayedInputFileFromCAS();
 }
 
 bool CompilerInstance::shouldBuildGlobalModuleIndex() const {
@@ -1000,6 +1004,57 @@ CompilerInstance::createOutputFile(StringRef OutputPath, bool Binary,
   return nullptr;
 }
 
+void CompilerInstance::initializeDelayedInputFileFromCAS() {
+  auto &Opts = Invocation->getFrontendOpts();
+  // Return if no need to initialize or already initialized.
+  if (Opts.CASIncludeTreeID.empty() || !Opts.Inputs.empty())
+    return;
+
+  // If there is include tree, initialize the inputs from CAS.
+  auto reportError = [&](llvm::Error &&E) {
+    Diagnostics->Report(diag::err_fe_unable_to_load_include_tree)
+        << Opts.CASIncludeTreeID << llvm::toString(std::move(E));
+  };
+  auto CAS = Invocation->getCASOpts().getOrCreateDatabases(*Diagnostics).first;
+  if (!CAS)
+    return;
+  auto ID = CAS->parseID(Opts.CASIncludeTreeID);
+  if (!ID)
+    return reportError(ID.takeError());
+  auto Object = CAS->getReference(*ID);
+  if (!Object)
+    return reportError(llvm::cas::ObjectStore::createUnknownObjectError(*ID));
+  auto Root = cas::IncludeTreeRoot::get(*CAS, *Object);
+  if (!Root)
+    return reportError(Root.takeError());
+  auto MainTree = Root->getMainFileTree();
+  if (!MainTree)
+    return reportError(MainTree.takeError());
+  auto BaseFile = MainTree->getBaseFile();
+  if (!BaseFile)
+    return reportError(BaseFile.takeError());
+  auto FilenameBlob = BaseFile->getFilename();
+  if (!FilenameBlob)
+    return reportError(FilenameBlob.takeError());
+
+  auto InputFilename = FilenameBlob->getData();
+
+  if (InputFilename != Module::getModuleInputBufferName()) {
+    Opts.Inputs.emplace_back(Root->getRef(), InputFilename, Opts.DashX,
+                             /*isSystem=*/false);
+  } else {
+    assert(Opts.ProgramAction == frontend::GenerateModule);
+
+    auto Kind = Opts.DashX.withFormat(InputKind::Source);
+    auto Contents = BaseFile->getContents();
+    if (!Contents)
+      return reportError(Contents.takeError());
+    auto Buffer = llvm::MemoryBufferRef(Contents->getData(), InputFilename);
+    Opts.Inputs.emplace_back(Root->getRef(), Buffer, Kind,
+                             (bool)Opts.IsSystemModule);
+  }
+}
+
 Expected<std::unique_ptr<llvm::raw_pwrite_stream>>
 CompilerInstance::createOutputFileImpl(StringRef OutputPath, bool Binary,
                                        bool RemoveFileOnSignal,
@@ -1126,6 +1181,8 @@ bool CompilerInstance::ExecuteAction(FrontendAction &Act) {
 
   if (getFrontendOpts().ShowStats || !getFrontendOpts().StatsFile.empty())
     llvm::EnableStatistics(false);
+
+  initializeDelayedInputFileFromCAS();
 
   for (const FrontendInputFile &FIF : getFrontendOpts().Inputs) {
     // Reset the ID tables if we are reusing the SourceManager and parsing

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3046,50 +3046,6 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
       Consumer(Input.getFile());
 }
 
-static void determineInputFromIncludeTree(
-    StringRef IncludeTreeID, CASOptions &CASOpts, DiagnosticsEngine &Diags,
-    std::optional<cas::IncludeTreeRoot> &IncludeTree,
-    std::optional<llvm::MemoryBufferRef> &Buffer, StringRef &InputFilename) {
-  assert(!IncludeTreeID.empty());
-  auto reportError = [&](llvm::Error &&E) {
-    Diags.Report(diag::err_fe_unable_to_load_include_tree)
-        << IncludeTreeID << llvm::toString(std::move(E));
-  };
-  auto CAS = CASOpts.getOrCreateDatabases(Diags).first;
-  if (!CAS)
-    return;
-  auto ID = CAS->parseID(IncludeTreeID);
-  if (!ID)
-    return reportError(ID.takeError());
-  auto Object = CAS->getReference(*ID);
-  if (!Object)
-    return reportError(llvm::cas::ObjectStore::createUnknownObjectError(*ID));
-  auto Root = cas::IncludeTreeRoot::get(*CAS, *Object);
-  if (!Root)
-    return reportError(Root.takeError());
-  auto MainTree = Root->getMainFileTree();
-  if (!MainTree)
-    return reportError(MainTree.takeError());
-  auto BaseFile = MainTree->getBaseFile();
-  if (!BaseFile)
-    return reportError(BaseFile.takeError());
-  auto FilenameBlob = BaseFile->getFilename();
-  if (!FilenameBlob)
-    return reportError(FilenameBlob.takeError());
-
-  InputFilename = FilenameBlob->getData();
-  IncludeTree = *Root;
-
-  if (InputFilename != Module::getModuleInputBufferName())
-    return;
-
-  // Handle <module-include> buffer
-  auto Contents = BaseFile->getContents();
-  if (!Contents)
-    return reportError(Contents.takeError());
-  Buffer = llvm::MemoryBufferRef(Contents->getData(), InputFilename);
-}
-
 static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
                               CASOptions &CASOpts, DiagnosticsEngine &Diags,
                               bool &IsHeaderFile) {
@@ -3308,17 +3264,18 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
   std::vector<std::string> Inputs = Args.getAllArgValues(OPT_INPUT);
   Opts.Inputs.clear();
 
-  std::optional<cas::IncludeTreeRoot> Tree;
-  std::optional<llvm::MemoryBufferRef> TreeInputBuffer;
   if (!Opts.CASIncludeTreeID.empty()) {
-    if (!Inputs.empty()) {
+    if (!Inputs.empty())
       Diags.Report(diag::err_drv_inputs_and_include_tree);
+
+    if (DashX.isUnknown()) {
+      Diags.Report(diag::err_drv_include_tree_miss_input_kind);
+      DashX = Language::C; // set to default C to avoid crashing.
     }
-    StringRef InputFilename;
-    determineInputFromIncludeTree(Opts.CASIncludeTreeID, CASOpts, Diags, Tree,
-                                  TreeInputBuffer, InputFilename);
-    if (!InputFilename.empty())
-      Inputs.push_back(InputFilename.str());
+
+    // Quit early as include tree will delay input initialization.
+    Opts.DashX = DashX;
+    return Diags.getNumErrors() == NumErrorsBefore;
   }
 
   if (Inputs.empty())
@@ -3351,20 +3308,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     }
 
     Opts.Inputs.emplace_back(std::move(Inputs[i]), IK, IsSystem);
-  }
-
-  if (Tree) {
-    FrontendInputFile &InputFile = Opts.Inputs.back();
-    if (TreeInputBuffer) {
-      // This is automatically set to modulemap when building a module; revert
-      // to a source file for the module includes buffer.
-      auto Kind = InputFile.getKind().withFormat(InputKind::Source);
-      InputFile = FrontendInputFile(Tree->getRef(), *TreeInputBuffer, Kind,
-                                    InputFile.isSystem());
-    } else {
-      InputFile = FrontendInputFile(Tree->getRef(), InputFile.getFile(),
-                                    InputFile.getKind(), InputFile.isSystem());
-    }
   }
 
   Opts.DashX = DashX;

--- a/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
@@ -51,6 +51,7 @@
 // RUN:   -fcas-path %t/cas -fsyntax-only 2>&1 | \
 // RUN:   FileCheck %s -check-prefix=INCOMPATIBLE
 
+// INCOMPATIBLE: error: missing '-x' input kind when using '-fcas-include-tree'
 // INCOMPATIBLE: error: passing incompatible option '-fapinotes' with '-fcas-include-tree'
 
 //--- cdb.json.template


### PR DESCRIPTION
Delay initialize the inputs from CAS to after ParseArgs to speed up the performance of round tripping arguments. This will save the CAS initialization/destruction costs when round tripping cc1 arguments, which is often used to modify/update cc1 arguments.

rdar://134363755