### PR TITLE
[AArch64] Restore ptrauth_abi_version directive driving the arm64e subtype.

### DIFF
--- a/llvm/lib/MC/MachObjectWriter.cpp
+++ b/llvm/lib/MC/MachObjectWriter.cpp
@@ -199,13 +199,18 @@ void MachObjectWriter::writeHeader(MachO::HeaderFileType Type,
 
   uint32_t Cpusubtype = TargetObjectWriter->getCPUSubtype();
 
-  // Promote arm64e subtypes to always be ptrauth-ABI-versioned, at version 0.
-  // We never need to emit unversioned binaries.
-  // And we don't support arbitrary ABI versions (or the kernel flag) yet.
-  if (TargetObjectWriter->getCPUType() == MachO::CPU_TYPE_ARM64 &&
-      Cpusubtype == MachO::CPU_SUBTYPE_ARM64E)
+  if (PtrAuthABIVersion) {
+    assert(TargetObjectWriter->getCPUType() == MachO::CPU_TYPE_ARM64 &&
+           Cpusubtype == MachO::CPU_SUBTYPE_ARM64E &&
+           "ptrauth ABI version is only supported on arm64e");
+    // Changes to this format should be reflected in MachO::getCPUSubType to
+    // support LTO.
+    // FIXME: Use MachO::getCPUSubType here. We can't use it for now because at
+    // the time we create TargetObjectWriter, we don't know if the assembler
+    // encountered any directives that affect the result.
     Cpusubtype = MachO::CPU_SUBTYPE_ARM64E_WITH_PTRAUTH_VERSION(
-        /*PtrAuthABIVersion=*/0, /*PtrAuthKernelABIVersion=*/false);
+        *PtrAuthABIVersion, PtrAuthKernelABIVersion);
+  }
 
   W.write<uint32_t>(Cpusubtype);
 

--- a/llvm/test/MC/AArch64/arm64e-subtype.s
+++ b/llvm/test/MC/AArch64/arm64e-subtype.s
@@ -10,3 +10,8 @@
 .globl _foo
 _foo:
   ret
+
+; Upstream doesn't support the version directive and flags yet.  So the
+; upstream version of this test doesn't have the directive.
+; Instead it relies on the v0 default.
+.ptrauth_abi_version 0


### PR DESCRIPTION
Upstream doesn't support the version directive and flags yet. Instead it sets a v0 default implicitly.
Here we do support the flag.

Eventually, once the dust has settled, we should probably also switch this to set a default v0.  We should also consider upstreaming the version flag/directive support;  we're discussing that with ELF folks.

Fixes merge abbc5782cbf6.

rdar://134373897