### PR TITLE
[cherry-pick][stable/20240723] [lldb][ClangExpressionParser] Implement ExternalSemaSource::ReadUndefinedButUsed

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ASTUtils.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ASTUtils.cpp
@@ -18,7 +18,10 @@ lldb_private::ASTConsumerForwarder::~ASTConsumerForwarder() = default;
 
 void lldb_private::ASTConsumerForwarder::PrintStats() { m_c->PrintStats(); }
 
-lldb_private::SemaSourceWithPriorities::~SemaSourceWithPriorities() = default;
+lldb_private::SemaSourceWithPriorities::~SemaSourceWithPriorities() {
+  for (auto *Source : Sources)
+    Source->Release();
+}
 
 void lldb_private::SemaSourceWithPriorities::PrintStats() {
   for (size_t i = 0; i < Sources.size(); ++i)

--- a/lldb/source/Plugins/ExpressionParser/Clang/ASTUtils.h
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ASTUtils.h
@@ -16,6 +16,7 @@
 #include "clang/Sema/Sema.h"
 #include "clang/Sema/SemaConsumer.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Casting.h"
 #include <optional>
 
 namespace clang {
@@ -138,6 +139,24 @@ public:
           &VirtualBaseOffsets) override {
     return m_Source->layoutRecordType(Record, Size, Alignment, FieldOffsets,
                                       BaseOffsets, VirtualBaseOffsets);
+  }
+
+  /// This gets called when Sema is reconciling undefined but used decls.
+  /// For LLDB's use-case, we never provide Clang with function definitions,
+  /// instead we rely on linkage names and symbol resolution to call the
+  /// correct funcitons during JITting. So this implementation clears
+  /// any "undefined" FunctionDecls that Clang found while parsing.
+  ///
+  /// \param[in,out] Undefined A set of used decls for which Clang has not
+  ///                          been provided a definition with.
+  ///
+  void ReadUndefinedButUsed(
+      llvm::MapVector<clang::NamedDecl *, clang::SourceLocation> &Undefined)
+      override {
+    Undefined.remove_if([](auto const &decl_loc_pair) {
+      const clang::NamedDecl *ND = decl_loc_pair.first;
+      return llvm::isa_and_present<clang::FunctionDecl>(ND);
+    });
   }
 };
 

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1122,15 +1122,15 @@ ClangExpressionParser::ParseInternal(DiagnosticManager &diagnostic_manager,
     clang::ExternalASTSource *ast_source = decl_map->CreateProxy();
 
     if (ast_context.getExternalSource()) {
-      auto module_wrapper =
+      auto *module_wrapper =
           new ExternalASTSourceWrapper(ast_context.getExternalSource());
 
-      auto ast_source_wrapper = new ExternalASTSourceWrapper(ast_source);
+      auto *ast_source_wrapper = new ExternalASTSourceWrapper(ast_source);
 
-      auto multiplexer =
-          new SemaSourceWithPriorities(*module_wrapper, *ast_source_wrapper);
-      IntrusiveRefCntPtr<ExternalASTSource> Source(multiplexer);
-      ast_context.setExternalSource(Source);
+      auto *multiplexer =
+          new SemaSourceWithPriorities(module_wrapper, ast_source_wrapper);
+
+      ast_context.setExternalSource(multiplexer);
     } else {
       ast_context.setExternalSource(ast_source);
     }

--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -1121,6 +1121,8 @@ ClangExpressionParser::ParseInternal(DiagnosticManager &diagnostic_manager,
 
     clang::ExternalASTSource *ast_source = decl_map->CreateProxy();
 
+    auto *ast_source_wrapper = new ExternalASTSourceWrapper(ast_source);
+
     if (ast_context.getExternalSource()) {
       auto *module_wrapper =
           new ExternalASTSourceWrapper(ast_context.getExternalSource());
@@ -1134,6 +1136,7 @@ ClangExpressionParser::ParseInternal(DiagnosticManager &diagnostic_manager,
     } else {
       ast_context.setExternalSource(ast_source);
     }
+    m_compiler->getSema().addExternalSource(ast_source_wrapper);
     decl_map->InstallASTContext(*m_ast_context);
   }
 

--- a/lldb/test/Shell/Expr/TestAnonNamespaceParamFunc.cpp
+++ b/lldb/test/Shell/Expr/TestAnonNamespaceParamFunc.cpp
@@ -3,6 +3,8 @@
 // linkage. In this case, a function whose argument
 // is not legally usable outside this TU.
 
+// XFAIL: system-windows
+
 // RUN: %build %s -o %t
 // RUN: %lldb %t -o run -o "expression func(a)" -o exit | FileCheck %s
 

--- a/lldb/test/Shell/Expr/TestAnonNamespaceParamFunc.cpp
+++ b/lldb/test/Shell/Expr/TestAnonNamespaceParamFunc.cpp
@@ -1,0 +1,22 @@
+// Tests that we can evaluate functions that Clang
+// classifies as having clang::Linkage::UniqueExternal
+// linkage. In this case, a function whose argument
+// is not legally usable outside this TU.
+
+// RUN: %build %s -o %t
+// RUN: %lldb %t -o run -o "expression func(a)" -o exit | FileCheck %s
+
+// CHECK: expression func(a)
+// CHECK: (int) $0 = 15
+
+namespace {
+struct InAnon {};
+} // namespace
+
+int func(InAnon a) { return 15; }
+
+int main() {
+  InAnon a;
+  __builtin_debugtrap();
+  return func(a);
+}


### PR DESCRIPTION
Cherry-picks for cleaning up the `ExternalASTSource` allocations and fixing an expression parser bug.

Addresses rdar://69379373