### PR TITLE
[lldb][swift] Fix StackID comparisons to enable stepping out of async functions

### DIFF
--- a/lldb/source/Target/StackID.cpp
+++ b/lldb/source/Target/StackID.cpp
@@ -19,12 +19,13 @@ using namespace lldb_private;
 
 bool StackID::IsCFAOnStack(Process &process) const {
   if (m_cfa_on_stack == eLazyBoolCalculate) {
-    m_cfa_on_stack = eLazyBoolNo;
+    // Conservatively assume stack memory
+    m_cfa_on_stack = eLazyBoolYes;
     if (m_cfa != LLDB_INVALID_ADDRESS) {
       MemoryRegionInfo mem_info;
       if (process.GetMemoryRegionInfo(m_cfa, mem_info).Success())
-        if (mem_info.IsStackMemory() == MemoryRegionInfo::eYes)
-          m_cfa_on_stack = eLazyBoolYes;
+        if (mem_info.IsStackMemory() == MemoryRegionInfo::eNo)
+          m_cfa_on_stack = eLazyBoolNo;
     }
   }
   return m_cfa_on_stack == eLazyBoolYes;

--- a/lldb/source/Target/StackID.cpp
+++ b/lldb/source/Target/StackID.cpp
@@ -86,13 +86,14 @@ IsYoungerHeapCFAs(const StackID &lhs, const StackID &rhs, Process &process) {
     return HeapCFAComparisonResult::NoOpinion;
 
   // FIXME: rdar://76119439
-  // At the boundary between an async parent frame calling a regular child
-  // frame, the CFA of the parent async function is a heap addresses, and the
-  // CFA of concrete child function is a stack address. Therefore, if lhs is
-  // on stack, and rhs is not, lhs is considered less than rhs, independent of
-  // address values.
+  // If one of the frames has a CFA on the stack and the other doesn't, we are
+  // at the boundary between an asynchronous and a synchronous function.
+  // Synchronous functions cannot call asynchronous functions, therefore the
+  // synchronous frame is always younger.
   if (lhs_cfa_on_stack && !rhs_cfa_on_stack)
     return HeapCFAComparisonResult::Younger;
+  if (!lhs_cfa_on_stack && rhs_cfa_on_stack)
+    return HeapCFAComparisonResult::Older;
   return HeapCFAComparisonResult::NoOpinion;
 }
 // END SWIFT

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -30,7 +30,6 @@ class TestCase(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
-    @skipIf("rdar://133849022")
     def test(self):
         """Test `frame variable` in async functions"""
         self.build()

--- a/lldb/unittests/StackID/StackIDTest.cpp
+++ b/lldb/unittests/StackID/StackIDTest.cpp
@@ -86,8 +86,5 @@ TEST_F(StackIDTest, StackHeapCFAComparison) {
   MockStackID cfa_on_heap(/*cfa*/ 10, OnStack::No);
 
   EXPECT_TRUE(StackID::IsYounger(cfa_on_stack, cfa_on_heap, process));
-
-  // FIXME: if the above returned true, swapping the arguments **must** return
-  // false. And yet it doesn't.
-  // EXPECT_FALSE(StackID::IsYounger(cfa_on_heap, cfa_on_stack, process));
+  EXPECT_FALSE(StackID::IsYounger(cfa_on_heap, cfa_on_stack, process));
 }


### PR DESCRIPTION
This should be the final two fixes we need in order to enable stepping out of async functions.

The first commit makes the stack comparison operation symmetric, so that if `IsYounger(A, B)` returns true, then `IsYounger(B, A)` returns false.

The second commit implements StackID comparisons in the case where both CFAs are on the heap.

Pasted the commit messages below for ease of reading.

-----

    [lldb] Make StackID comparison symmetric

    Currently, if we're comparing a StackID on the stack with one StackID on the
    heap, we perform a special kind of IsYounger comparison. However, if
    `IsYounger(A, b)` returns true, it must be the case that `IsYounger(B, A)`
    returns false. But this is not necessarily the case today because, before this
    patch, we would fallback to the traditional "stack" comparison, which is wrong
    if one of the StackIDs is on the heap.

-----

    [lldb] Make StackID comparison search parent heap CFAs

    For two StackIDs whose CFAs are on the heap, i.e., they are both async frames,
    we can decide which one is younger by finding one async context in the
    continuation chain of the other.

    A lot of stepping algorithms rely on frame comparisons. In particular, this
    patch fixes stepping out of async functions, and makes strides towards fixing
    other stepping algorithms.

    The explanation below is not needed to understand this patch, but it sheds some
    light into why the most common kind of step out fails.

    Consider the case where a breakpoint was set inside some async function, the
    program hit that breakpoint, and then a "step out" operation is performed. This
    is a very common use case.

    The thread plan looks like this:

    0. Single step past breakpoint.
    1. Step out

    LLDB performs a single step, and thread plan 0 says "continue running, I'm
    done". Before continuing program execution, LLDB asks all thread plans, in this
    case there's only the step out plan, if it should stop.

    To answer the "should stop" question, the step out plan compares the current
    frame (which is the same as when step out was pushed, since LLDB has only
    performed a single step so far) with its target frame (which is just one frame
    above). In this scenario, the current frame is async, and so the parent frame
    must also be async. The StepOut plan is going to compare two async StackIDs.

    Using the incorrect comparison, StepOut concludes the current frame is _older_
    than the target frame. In other words, the program reached an older frame
    without ever stopping on the target frame. Something weird must have happened,
    and the plan concludes it is done.
