### PR TITLE
[CAS] Improve the cc1 flag round trip speed when CAS is used. NFCI

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -768,6 +768,8 @@ def err_drv_inputs_and_include_tree : Error<
   "passing input files is incompatible with '-fcas-include-tree'">;
 def err_drv_incompatible_option_include_tree : Error<
   "passing incompatible option '%0' with '-fcas-include-tree'">;
+def err_drv_include_tree_miss_input_kind : Error<
+  "missing '-x' input kind when using '-fcas-include-tree'">;
 
 def err_drv_invalid_directx_shader_module : Error<
   "invalid profile : %0">;

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -866,6 +866,9 @@ private:
                        bool RemoveFileOnSignal, bool UseTemporary,
                        bool CreateMissingDirectories);
 
+  /// Initialize inputs from CAS.
+  void initializeDelayedInputFileFromCAS();
+
 public:
   std::unique_ptr<raw_pwrite_stream> createNullOutputFile();
 

--- a/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-api-notes.c
@@ -51,6 +51,7 @@
 // RUN:   -fcas-path %t/cas -fsyntax-only 2>&1 | \
 // RUN:   FileCheck %s -check-prefix=INCOMPATIBLE
 
+// INCOMPATIBLE: error: missing '-x' input kind when using '-fcas-include-tree'
 // INCOMPATIBLE: error: passing incompatible option '-fapinotes' with '-fcas-include-tree'
 
 //--- cdb.json.template


### PR DESCRIPTION
Delay initialize the inputs from CAS to after ParseArgs to speed up the performance of round tripping arguments. This will save the CAS initialization/destruction costs when round tripping cc1 arguments, which is often used to modify/update cc1 arguments.

rdar://134363755