### PR TITLE
Fix mismerge with remote cache path error

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -4976,13 +4976,13 @@ bool CompilerInvocation::CreateFromArgsImpl(
                    Res.getCASOpts());
 
   // BEGIN MCCAS
-  if (!Res.getFrontendOpts().CompilationCachingServicePath.empty())
+  if (!Res.getFrontendOpts().CompilationCachingServicePath.empty()) {
     if (Res.getCodeGenOpts().UseCASBackend)
       Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
           << "-fcas-backend";
-  if (Res.getFrontendOpts().WriteOutputAsCASID) {
-    Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
-        << "-fcasid-output";
+    if (Res.getFrontendOpts().WriteOutputAsCASID)
+      Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
+          << "-fcasid-output";
   }
   // END MCCAS
 


### PR DESCRIPTION
When using the -fcasid-output option, even if a remote cache path is not passed we can still see the error:

error: '-fcasid-output' is incompatible with remote caching backend

This patch fixes that bug