### PR TITLE
🍒 [clang][cache] Work around crash in diagnostics syntax highlighting

### DIFF
--- a/clang/lib/Frontend/CachedDiagnostics.cpp
+++ b/clang/lib/Frontend/CachedDiagnostics.cpp
@@ -669,6 +669,8 @@ struct CachingDiagnosticsProcessor::DiagnosticsConsumer
       // de-canonicalized filenames during compilation (the original diagnostic
       // uses canonical paths).
       assert(Serializer.DiagEngine.getClient() == OrigConsumer);
+      // FIXME: This is not sound: giving the original consumer diagnostics with
+      // different SourceManager may break them.
       Serializer.DiagEngine.Report(NewDiag);
     } else {
       OrigConsumer->HandleDiagnostic(Level, Info);

--- a/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/clang/lib/Frontend/TextDiagnostic.cpp
@@ -1138,7 +1138,7 @@ highlightLines(StringRef FileData, unsigned StartLineNumber,
       std::make_unique<SmallVector<TextDiagnostic::StyleRange>[]>(
           EndLineNumber - StartLineNumber + 1);
 
-  if (!PP || !ShowColors)
+  if (!PP || &PP->getSourceManager() != &SM || !ShowColors)
     return SnippetRanges;
 
   // Might cause emission of another diagnostic.


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/66514 Clang relies on the FileIDs and buffer pointers stored within Preprocessor to perform syntax highlighting in diagnostics. With compilation caching, we round-trip diagnostics through serialization that uses a separate copy of SourceManager. This assigns different FileIDs and allocates buffers anew, breaking invariants of the consumer.

This fix is not easy to test, since we'd rely on the order FileIDs get created, where in memory the buffers get allocated and the checkpoint interval.

rdar://134198448
(cherry picked from commit 3613d180d936467caca7c4bf90fa711270973ecb)