### PR TITLE
next 🍒 [Support/VirtualFileSystem] Fix C++ interop error w/ undefined `ObjectRef`

### DIFF
--- a/llvm/include/llvm/Support/VirtualFileSystem.h
+++ b/llvm/include/llvm/Support/VirtualFileSystem.h
@@ -18,6 +18,9 @@
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+// FIXME: Bringing in "CASReference.h" because Swift/C++ interop complains about
+// `ObjectRef` being undefined.
+#include "llvm/CAS/CASReference.h"
 #include "llvm/Support/Chrono.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/Error.h"


### PR DESCRIPTION
Cherry-pick of f93fb9e6953e12cd8f5eda6be9cd3dcd61de261f that fixes https://github.com/swiftlang/swift-llvm-bindings on the `rebranch` scheme.