### PR TITLE
[lldb][TypeSystemClang][NFC] Log failure to InitBuiltinTypes

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -747,6 +747,10 @@ void TypeSystemClang::CreateASTContext() {
   TargetInfo *target_info = getTargetInfo();
   if (target_info)
     m_ast_up->InitBuiltinTypes(*target_info);
+  else if (auto *log = GetLog(LLDBLog::Expressions))
+    LLDB_LOG(log,
+             "Failed to initialize builtin ASTContext types for target '{0}'",
+             m_target_triple);
 
   GetASTMap().Insert(m_ast_up.get(), this);
 


### PR DESCRIPTION
If we fail to initialize the ASTContext builtins, LLDB may crash in non-obvious ways down-the-line, e.g., when it tries to call `ASTContext::getTypeSize` on a builtin like `ast.UnsignedCharTy`, which would derefernce a `null` `QualType`.

The initialization can fail if we either didn't set the `TypeSystemClang` target triple, or if the embedded clang isn't enabled for a certain target.

This patch attempts to help pin-point the failure case post-mortem by adding a log message here that prints the triple.

rdar://134260837
(cherry picked from commit 2847020dbd9b8f932ee564651ec72ce15fa37d07)