### PR TITLE
Cherry-pick https://github.com/swiftlang/llvm-project/pull/9164 to next

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -724,7 +724,7 @@ Error ObjectStoreCachingOutputs::finishComputedResult(
 std::optional<int> ObjectStoreCachingOutputs::replayCachedResult(
     const llvm::cas::CASID &ResultCacheKey, llvm::cas::ObjectRef ResultID,
     bool JustComputedResult) {
-  if (JustComputedResult && !ComputedJobNeedsReplay)
+  if (JustComputedResult && !WriteOutputAsCASID)
     return std::nullopt;
 
   // FIXME: Stop calling report_fatal_error().
@@ -745,10 +745,7 @@ std::optional<int> ObjectStoreCachingOutputs::replayCachedResult(
 Expected<std::optional<int>> ObjectStoreCachingOutputs::replayCachedResult(
     const llvm::cas::CASID &ResultCacheKey,
     clang::cas::CompileJobCacheResult &Result, bool JustComputedResult) {
-  // FIXME: The correct fix for MCCAS replay is that you have an official CASID
-  // file output going all the way down into ObjectWriter, we can remove this
-  // callback and special case.
-  if (JustComputedResult && !ComputedJobNeedsReplay)
+  if (JustComputedResult && !WriteOutputAsCASID)
     return std::nullopt;
 
   llvm::cas::ObjectStore &CAS = Result.getCAS();

--- a/clang/test/CAS/cas-backend.c
+++ b/clang/test/CAS/cas-backend.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: llvm-cas --cas %t/cas --ingest %s > %t/casid
 //
-// RUN: %clang -cc1 -triple x86_64-apple-macos11 -fcas-backend \
+// RUN: %clang -cc1 -fcas-emit-casid-file -triple x86_64-apple-macos11 -fcas-backend \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache %s -emit-obj -o %t/output.o \
 // RUN:   -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb \
@@ -11,7 +11,7 @@
 // RUN: ls %t/output.o && rm %t/output.o
 // RUN: ls %t/deps.d && mv %t/deps.d %t/deps.d.orig
 //
-// RUN: CLANG_CAS_BACKEND_SAVE_CASID_FILE=1 %clang -cc1 \
+// RUN: %clang -cc1 -fcas-emit-casid-file\
 // RUN:   -triple x86_64-apple-macos11 -fcas-backend \
 // RUN:   -fcas-path %t/cas -fcas-fs @%t/casid -fcache-compile-job \
 // RUN:   -Rcompile-job-cache %s -emit-obj -o %t/output.o \

--- a/clang/test/CAS/casid-output-test.cpp
+++ b/clang/test/CAS/casid-output-test.cpp
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// Check if -fcasid-output works on a cache miss with file based caching
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fcasid-output -g -c %s -o %t/test.o
+// RUN: cat %t/test.o | FileCheck %s
+// RUN: rm -rf %t/test.o
+// Check if -fcasid-output works on a cache hit with file based caching
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fcasid-output -g -c %s -o %t/test.o
+// RUN: cat %t/test.o | FileCheck %s
+// RUN: rm -rf %t/test.o
+// RUN: rm -rf %t/cas
+
+// Check if -fcasid-output works on a cache miss with MCCAS
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fcasid-output -g -c %s -o %t/test.o
+// RUN: cat %t/test.o | FileCheck %s
+// RUN: rm -rf %t/test.o
+
+// Check if -fcasid-output works on a cache hit with MCCAS
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fcasid-output -g -c %s -o %t/test.o
+// RUN: cat %t/test.o | FileCheck %s
+
+// CHECK: llvmcas://{{[a-f0-9]+}}
+
+
+void foo() {}


### PR DESCRIPTION
When clang caching and MCCAS are enabled, on a cache miss, the object file is not written to in MachOCASWriter, instead the replay code is rerun and the object file is serialized and written out. However, in swift, the replay code isn't run on a cache miss at all, and it expects the object writer to write to the object file.

This patch makes it so that on a cache miss, the MachOCASWriter always writes to the raw_ostream buffer for the object file and doesn't serialize the object file in the replay code.

(cherry picked from commit ce65bfa22872a8ac11b5b26de8a70a703089ffb0)