### PR TITLE
[lldb] LRUCache for Swift type system mangling/demangling

### DIFF
--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -300,7 +300,7 @@ ConstString Mangled::GetDemangledName(// BEGIN SWIFT
         Log *log = GetLog(LLDBLog::Demangle);
         LLDB_LOGF(log, "demangle swift: %s", mangled_name);
         std::string demangled(SwiftLanguageRuntime::DemangleSymbolAsString(
-            mangled_name, SwiftLanguageRuntime::eTypeName, sc));
+            m_mangled, SwiftLanguageRuntime::eTypeName, sc));
         // Don't cache the demangled name the function isn't available yet.
         if (!sc || !sc->function) {
           LLDB_LOGF(log, "demangle swift: %s -> \"%s\" (not cached)",
@@ -344,7 +344,7 @@ ConstString Mangled::GetDisplayDemangledName(
   if (m_mangled &&
       SwiftLanguageRuntime::IsSwiftMangledName(m_mangled.GetStringRef()))
     return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
-        m_mangled.GetStringRef(), SwiftLanguageRuntime::eSimplified, sc));
+        m_mangled, SwiftLanguageRuntime::eSimplified, sc));
 #endif // LLDB_ENABLE_SWIFT
 // END SWIFT
   if (Language *lang = Language::FindPlugin(GuessLanguage()))

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1665,7 +1665,7 @@ bool SwiftLanguage::GetFunctionDisplayName(
     if (sc->function->GetLanguage() != eLanguageTypeSwift)
       return false;
     std::string display_name = SwiftLanguageRuntime::DemangleSymbolAsString(
-        sc->function->GetMangled().GetMangledName().GetStringRef(),
+        sc->function->GetMangled().GetMangledName(),
         SwiftLanguageRuntime::eSimplified, sc, exe_ctx);
     if (display_name.empty())
       return false;
@@ -1678,7 +1678,7 @@ bool SwiftLanguage::GetFunctionDisplayName(
     if (sc->function->GetLanguage() != eLanguageTypeSwift)
       return false;
     std::string display_name = SwiftLanguageRuntime::DemangleSymbolAsString(
-        sc->function->GetMangled().GetMangledName().GetStringRef(),
+        sc->function->GetMangled().GetMangledName(),
         SwiftLanguageRuntime::eSimplified, sc, exe_ctx);
     if (display_name.empty())
       return false;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -147,7 +147,7 @@ public:
 
   enum DemangleMode { eSimplified, eTypeName, eDisplayTypeName };
   static std::string
-  DemangleSymbolAsString(llvm::StringRef symbol, DemangleMode mode,
+  DemangleSymbolAsString(ConstString symbol, DemangleMode mode,
                          const SymbolContext *sc = nullptr,
                          const ExecutionContext *exe_ctx = nullptr);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -721,7 +721,7 @@ void SwiftLanguageRuntime::GetGenericParameterNamesForFunction(
 }
 
 std::string SwiftLanguageRuntime::DemangleSymbolAsString(
-    StringRef symbol, DemangleMode mode, const SymbolContext *sc,
+    ConstString symbol, DemangleMode mode, const SymbolContext *sc,
     const ExecutionContext *exe_ctx) {
   bool did_init = false;
   llvm::DenseMap<ArchetypePath, StringRef> dict;
@@ -775,7 +775,7 @@ std::string SwiftLanguageRuntime::DemangleSymbolAsString(
       return name;
     };
   }
-  return swift::Demangle::demangleSymbolAsString(symbol, options);
+  return swift_demangle::DemangleSymbolAsString(symbol, options);
 }
 
 swift::Demangle::NodePointer

--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -3,6 +3,7 @@ add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
   TypeSystemSwift.cpp
   TypeSystemSwiftTypeRef.cpp
   SwiftASTContext.cpp
+  SwiftDemangle.cpp
 
   LINK_LIBS
     lldbCore

--- a/lldb/source/Plugins/TypeSystem/Swift/LRUCache.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LRUCache.h
@@ -1,0 +1,136 @@
+//===-- LRUCache.h ----------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_LRUCache_h_
+#define liblldb_LRUCache_h_
+
+#include "lldb/Utility/ConstString.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include <list>
+#include <mutex>
+
+namespace lldb_private {
+namespace swift_demangle {
+
+/// A thread-safe Least Recently Used (LRU) cache implementation.
+///
+/// This class template implements an LRU cache with a fixed capacity, which
+/// supports insertion, retrieval, and a factory-based retrieval mechanism. It
+/// ensures thread safety through the use of a mutex lock. Keys are always
+/// `ConstString`
+template <typename Value>
+class LRUCache {
+public:
+  /// Constructs an instance with the specified capacity.
+  LRUCache(size_t capacity) : m_capacity(capacity) {}
+
+  /// Retrieves a value from the cache for the given key.
+  /// If the key is found in the cache, the corresponding value is returned and
+  /// the element is moved to the front of the LRU list, indicating it was
+  /// recently used. If the key is not found, std::nullopt is returned
+  std::optional<Value> Get(ConstString key) {
+    std::lock_guard lock{m_mutex};
+    auto map_it = m_map.find(key);
+    if (map_it == m_map.end())
+      return std::nullopt;
+    const auto &map_value = map_it->second;
+    MoveListElementToFront(map_value.list_it);
+    return map_value.value;
+  }
+
+  /// Inserts a key-value pair into the cache.
+  /// If the key already exists in the cache, its value is updated and the
+  /// element is moved to the front of the LRU list. If the key does not exist,
+  /// it is inserted into the cache. If the cache is at full capacity, the least
+  /// recently used element is evicted to make space for the new element.
+  void Put(ConstString key, const Value &value) {
+    if (m_capacity == 0)
+      return;
+    std::lock_guard lock{m_mutex};
+    auto map_it = m_map.find(key);
+    if (map_it != m_map.end()) {
+      auto &map_value = map_it->second;
+      map_value.value = value;
+      MoveListElementToFront(map_value.list_it);
+    } else {
+      InsertElement(key, value);
+    }
+  }
+
+  /// Retrieves a value from the cache or creates it if not present.
+  /// If the key is found in the cache, the corresponding value is returned and
+  /// the element is moved to the front of the LRU list. If the key is not
+  /// found, the given factory function is called to create a new value, which
+  /// is then inserted into the cache before being returned.
+  Value GetOrCreate(ConstString key, llvm::function_ref<Value()> factory) {
+    if (m_capacity == 0)
+      return factory();
+
+    {
+      std::lock_guard lock{m_mutex};
+      if (auto map_it = m_map.find(key); map_it != m_map.end()) {
+        const auto &map_value = map_it->second;
+        MoveListElementToFront(map_value.list_it);
+        return map_value.value;
+      }
+    }
+
+    // Call `factory` with `m_mutex` unlocked
+    const auto value = factory();
+
+    {
+      std::lock_guard lock{m_mutex};
+      InsertElement(key, value);
+    }
+
+    return value;
+  }
+
+private:
+  using List = std::list<ConstString>;
+  struct MapValue {
+    List::iterator list_it;
+    Value value;
+  };
+  using Map = llvm::DenseMap<ConstString, MapValue>;
+
+  void InsertElement(ConstString key, const Value &value) {
+    assert(m_capacity > 0);
+
+    if (m_list.size() >= m_capacity) {
+      // Evict the least recent element
+      auto key = m_list.back();
+      m_list.pop_back();
+      m_map.erase(key);
+    }
+
+    m_list.emplace_front(key);
+    std::pair<typename Map::iterator, bool> emplace_result =
+        m_map.try_emplace(key, MapValue{m_list.begin(), value});
+    assert(emplace_result.second && "Element with this key already exists");
+  }
+
+  void MoveListElementToFront(typename List::iterator it) {
+    m_list.splice(m_list.begin(), m_list, it);
+  }
+
+  size_t m_capacity;
+  List m_list;
+  Map m_map;
+  std::mutex m_mutex;
+};
+
+} // namespace swift_demangle
+} // namespace lldb_private
+
+#endif

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.cpp
@@ -1,0 +1,27 @@
+//===-- SwiftDemangle.cpp ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftDemangle.h"
+#include "LRUCache.h"
+
+namespace lldb_private {
+namespace swift_demangle {
+
+SharedDemangledNode GetCachedDemangledSymbol(ConstString name) {
+  static LRUCache<SharedDemangledNode> g_shared_cache{10};
+  return g_shared_cache.GetOrCreate(
+      name, [name] { return SharedDemangledNode::FromMangledSymbol(name); });
+}
+
+
+} // namespace swift_demangle
+} // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -72,6 +72,20 @@ GetDemangledType(swift::Demangle::Demangler &dem, llvm::StringRef name) {
   return GetType(dem.demangleSymbol(name));
 }
 
+/// Creates a copy of `node` using `dem` as a factory. Kind, text and index are
+/// copied but children aren't.
+static inline NodePointer
+CopyNodeWithoutChildren(swift::Demangle::Demangler &dem, const Node *node) {
+  if (!node)
+    return nullptr;
+  const auto kind = node->getKind();
+  if (node->hasText())
+    return dem.createNode(kind, node->getText());
+  if (node->hasIndex())
+    return dem.createNode(kind, node->getIndex());
+  return dem.createNode(kind);
+}
+
 /// Shared ownership wrapper for swift::Demangle::NodePointer
 ///
 /// Can be valid or invalid. A valid instance stores a non-null NodePointer and

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -124,6 +124,10 @@ public:
 
   explicit operator bool() const { return IsValid(); }
 
+  bool operator==(const SharedDemangledNode &other) const {
+    return Node::deepEquals(GetRawNode(), other.GetRawNode());
+  }
+
   /// Gets a raw pointer to the Node.
   swift::Demangle::NodePointer GetRawNode() const & { return m_node; }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -932,7 +932,7 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::Transform(
   }
   if (changed) {
     // Create a new node with the transformed children.
-    node = CopyNodeWithoutChildren(dem, node);
+    node = CopyNodeWithoutChildren(dem, *node);
     for (NodePointer transformed_child : children)
       node->addChild(transformed_child, dem);
   }
@@ -1349,10 +1349,9 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
             if (module->getKind() != Node::Kind::Module)
               break;
 
-            NodePointer canonical = CopyNodeWithoutChildren(dem, node);
-            for (NodePointer child : *node) {
-              canonical->addChild(child, dem);
-            }
+            // `node` may be from the demangling cache, so we can't mutate it.
+            // Create a copy instead.
+            NodePointer canonical = CopyNodeWithChildrenReferences(dem, *node);
             canonical->addChild(module, dem);
             canonical->addChild(identifier, dem);
             return canonical;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -13,7 +13,6 @@
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.h"
-#include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 
 #include "Plugins/ExpressionParser/Clang/ClangExternalASTSourceCallbacks.h"
 #include "Plugins/ExpressionParser/Clang/ClangUtil.h"
@@ -885,7 +884,8 @@ TypeSystemSwiftTypeRef::GetTupleElement(lldb::opaque_compiler_type_t type,
   TupleElement result;
   using namespace swift::Demangle;
   Demangler dem;
-  NodePointer node = TypeSystemSwiftTypeRef::DemangleCanonicalType(dem, type);
+  const auto node_shared = TypeSystemSwiftTypeRef::DemangleCanonicalType(type);
+  NodePointer node = node_shared.GetRawNode();
   if (!node || node->getKind() != Node::Kind::Tuple)
     return {};
   if (node->getNumChildren() < idx)
@@ -1049,6 +1049,14 @@ TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
 
 /// Return the demangle tree representation of this type's canonical
 /// (type aliases resolved) type.
+NodePointerWithDeps<SharedDemangledNode>
+TypeSystemSwiftTypeRef::GetCanonicalDemangleTreeWithCache(
+    swift::Demangle::Demangler &dem, ConstString mangled_name) {
+  const auto node = GetCachedDemangledSymbol(mangled_name);
+  return NodePointerWithDeps<SharedDemangledNode>(
+      GetCanonicalNode(dem, node.GetRawNode()), node);
+}
+
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetCanonicalDemangleTree(
     swift::Demangle::Demangler &dem, StringRef mangled_name) {
   auto *node = dem.demangleSymbol(mangled_name);
@@ -1359,13 +1367,15 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
 
 /// Return the demangle tree representation with all "__C" module
 /// names with their actual Clang module names.
-swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetDemangleTreeForPrinting(
-    swift::Demangle::Demangler &dem, const char *mangled_name,
+NodePointerWithDeps<SharedDemangledNode> TypeSystemSwiftTypeRef::GetDemangleTreeForPrinting(
+    swift::Demangle::Demangler &dem, ConstString mangled_name,
     bool resolve_objc_module) {
   LLDB_SCOPED_TIMER();
 
-  auto *node = dem.demangleSymbol(mangled_name);
-  return GetNodeForPrintingImpl(dem, node, resolve_objc_module);
+  const auto node = GetCachedDemangledSymbol(mangled_name);
+  return NodePointerWithDeps<SharedDemangledNode>(
+      GetNodeForPrintingImpl(dem, node.GetRawNode(), resolve_objc_module),
+      node);
 }
 
 /// Determine wether this demangle tree contains a node of kind \c kind.
@@ -2503,11 +2513,11 @@ TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &dem,
   return GetTypeFromMangledTypename(mangled_element);
 }
 
-swift::Demangle::NodePointer TypeSystemSwiftTypeRef::DemangleCanonicalType(
-    swift::Demangle::Demangler &dem, opaque_compiler_type_t opaque_type) {
-  using namespace swift::Demangle;
+swift_demangle::SharedDemangledNode
+TypeSystemSwiftTypeRef::DemangleCanonicalType(
+    opaque_compiler_type_t opaque_type) {
   CompilerType type = GetCanonicalType(opaque_type);
-  return GetDemangledType(dem, type.GetMangledTypeName().GetStringRef());
+  return GetCachedDemangledType(type.GetMangledTypeName());
 }
 
 CompilerType
@@ -2535,7 +2545,8 @@ bool TypeSystemSwiftTypeRef::IsArrayType(opaque_compiler_type_t type,
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node_shared = DemangleCanonicalType(type);
+    NodePointer node = node_shared.GetRawNode();
     if (!node || node->getNumChildren() != 2 ||
         node->getKind() != Node::Kind::BoundGenericStructure)
       return false;
@@ -2579,8 +2590,7 @@ bool TypeSystemSwiftTypeRef::IsArrayType(opaque_compiler_type_t type,
 bool TypeSystemSwiftTypeRef::IsAggregateType(opaque_compiler_type_t type) {
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
-    Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
 
     if (!node)
       return false;
@@ -2618,7 +2628,7 @@ bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     // Note: There are a number of other candidates, and this list may need
     // updating. Ex: `NoEscapeFunctionType`, `ThinFunctionType`, etc.
     return node && (node->getKind() == Node::Kind::FunctionType ||
@@ -2633,13 +2643,13 @@ size_t TypeSystemSwiftTypeRef::GetNumberOfFunctionArguments(
   auto impl = [&]() -> size_t {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     if (!node || (node->getKind() != Node::Kind::FunctionType &&
                   node->getKind() != Node::Kind::NoEscapeFunctionType &&
                   node->getKind() != Node::Kind::ImplFunctionType))
       return 0;
     unsigned num_args = 0;
-    for (NodePointer child : *node) {
+    for (NodePointer child : *node.GetRawNode()) {
       if (child->getKind() == Node::Kind::ImplParameter)
         ++num_args;
       if (child->getKind() == Node::Kind::ArgumentTuple &&
@@ -2663,13 +2673,13 @@ TypeSystemSwiftTypeRef::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     if (!node || (node->getKind() != Node::Kind::FunctionType &&
                   node->getKind() != Node::Kind::NoEscapeFunctionType &&
                   node->getKind() != Node::Kind::ImplFunctionType))
       return {};
     unsigned num_args = 0;
-    for (NodePointer child : *node) {
+    for (NodePointer child : *node.GetRawNode()) {
       if (child->getKind() == Node::Kind::ImplParameter) {
         if (num_args == index)
           for (NodePointer type : *child)
@@ -2775,8 +2785,8 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
       }
     };
 
-    auto *node = DemangleCanonicalType(dem, type);
-    return is_possible_dynamic(node);
+    const auto node = DemangleCanonicalType(type);
+    return is_possible_dynamic(node.GetRawNode());
   };
   VALIDATE_AND_RETURN(
       impl, IsPossibleDynamicType, type, g_no_exe_ctx,
@@ -2789,7 +2799,7 @@ bool TypeSystemSwiftTypeRef::IsPointerType(opaque_compiler_type_t type,
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     if (!node || node->getKind() != Node::Kind::BuiltinTypeName ||
         !node->hasText())
       return false;
@@ -2805,8 +2815,7 @@ bool TypeSystemSwiftTypeRef::IsPointerType(opaque_compiler_type_t type,
 bool TypeSystemSwiftTypeRef::IsVoidType(opaque_compiler_type_t type) {
   auto impl = [&]() {
     using namespace swift::Demangle;
-    Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     return node && node->getNumChildren() == 0 &&
            node->getKind() == Node::Kind::Tuple;
   };
@@ -2833,10 +2842,11 @@ ConstString TypeSystemSwiftTypeRef::GetTypeName(opaque_compiler_type_t type,
                                                 bool BaseOnly) {
   auto impl = [&]() {
     using namespace swift::Demangle;
+    auto mangled_name = ConstString(AsMangledName(type));
     Demangler dem;
-    NodePointer print_node =
-        GetDemangleTreeForPrinting(dem, AsMangledName(type), true);
-    auto mangling = mangleNode(print_node);
+    auto print_node =
+        GetDemangleTreeForPrinting(dem, mangled_name, true);
+    auto mangling = mangleNode(print_node.GetRawNode());
     std::string remangled;
     if (mangling.isSuccess())
       remangled = mangling.result();
@@ -2847,7 +2857,7 @@ ConstString TypeSystemSwiftTypeRef::GetTypeName(opaque_compiler_type_t type,
       remangled = buf.str();
     }
     return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
-        remangled, SwiftLanguageRuntime::eTypeName));
+        ConstString(remangled), SwiftLanguageRuntime::eTypeName));
   };
   VALIDATE_AND_RETURN(impl, GetTypeName, type, g_no_exe_ctx,
                       (ReconstructType(type), false),
@@ -2859,10 +2869,11 @@ TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
   LLDB_SCOPED_TIMER();
   auto impl = [&]() {
     using namespace swift::Demangle;
+    auto mangled_name = ConstString(AsMangledName(type));
     Demangler dem;
-    NodePointer print_node =
-        GetDemangleTreeForPrinting(dem, AsMangledName(type), false);
-    auto mangling = mangleNode(print_node);
+    auto print_node =
+        GetDemangleTreeForPrinting(dem, mangled_name, false);
+    auto mangling = mangleNode(print_node.GetRawNode());
     std::string remangled;
     if (mangling.isSuccess())
       remangled = mangling.result();
@@ -2873,7 +2884,7 @@ TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
       remangled = buf.str();
     }
     return ConstString(SwiftLanguageRuntime::DemangleSymbolAsString(
-        remangled, SwiftLanguageRuntime::eDisplayTypeName, sc));
+        ConstString(remangled), SwiftLanguageRuntime::eDisplayTypeName, sc));
   };
   VALIDATE_AND_RETURN(impl, GetDisplayTypeName, type, g_no_exe_ctx,
                       (ReconstructType(type), sc), (ReconstructType(type), sc));
@@ -2883,10 +2894,11 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     opaque_compiler_type_t type, CompilerType *pointee_or_element_clang_type) {
   auto impl = [&]() {
     using namespace swift::Demangle;
-    Demangler dem;
-    NodePointer node = dem.demangleSymbol(AsMangledName(type));
+    auto mangled_name = ConstString(AsMangledName(type));
+    const auto node = GetCachedDemangledSymbol(mangled_name);
     bool unresolved_typealias = false;
-    uint32_t flags = CollectTypeInfo(dem, node, unresolved_typealias);
+    Demangler dem;
+    uint32_t flags = CollectTypeInfo(dem, node.GetRawNode(), unresolved_typealias);
     if (unresolved_typealias && GetSwiftASTContext(nullptr)) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
@@ -2950,16 +2962,17 @@ CompilerType
 TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
   auto impl = [&]() {
     using namespace swift::Demangle;
+    auto mangled_name = ConstString(AsMangledName(type));
     Demangler dem;
-    NodePointer canonical = GetCanonicalDemangleTree(dem, AsMangledName(type));
-    if (ContainsUnresolvedTypeAlias(canonical)) {
+    const auto canonical = GetCanonicalDemangleTreeWithCache(dem, mangled_name);
+    if (ContainsUnresolvedTypeAlias(canonical.GetRawNode())) {
       // If this is a typealias defined in the expression evaluator,
       // then we don't have debug info to resolve it from.
       CompilerType ast_type =
         ReconstructType({weak_from_this(), type}, nullptr).GetCanonicalType();
       return GetTypeFromMangledTypename(ast_type.GetMangledTypeName());
     }
-    auto mangling = mangleNode(canonical);
+    auto mangling = mangleNode(canonical.GetRawNode());
     if (!mangling.isSuccess())
       return CompilerType();
     ConstString mangled(mangling.result());
@@ -2986,12 +2999,12 @@ TypeSystemSwiftTypeRef::GetFunctionReturnType(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     if (!node || (node->getKind() != Node::Kind::FunctionType &&
                   node->getKind() != Node::Kind::NoEscapeFunctionType &&
                   node->getKind() != Node::Kind::ImplFunctionType))
       return {};
-    for (NodePointer child : *node) {
+    for (NodePointer child : *node.GetRawNode()) {
       if (child->getKind() == Node::Kind::ImplResult) {
         for (NodePointer type : *child)
           if (type->getKind() == Node::Kind::Type)
@@ -3222,7 +3235,7 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
 
     using namespace swift::Demangle;
     Demangler dem;
-    auto *node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     auto kind = node->getKind();
 
     if (kind == Node::Kind::BuiltinTypeName) {
@@ -3819,8 +3832,7 @@ TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type,
                                                 bool expand_pack) {
   auto impl = [&]() -> size_t {
     using namespace swift::Demangle;
-    Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
 
     if (!node)
       return 0;
@@ -3887,8 +3899,8 @@ bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
-    auto *node = DemangleCanonicalType(dem, type);
-    return ContainsGenericTypeParameter(node) && !IsFunctionType(type);
+    const auto node = DemangleCanonicalType(type);
+    return ContainsGenericTypeParameter(node.GetRawNode()) && !IsFunctionType(type);
   };
   VALIDATE_AND_RETURN(impl, IsMeaninglessWithoutDynamicResolution, type,
                       g_no_exe_ctx, (ReconstructType(type)),
@@ -3925,8 +3937,9 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
   LLDB_SCOPED_TIMER();
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
-    Demangler dem;
-    NodePointer node = GetDemangledType(dem, AsMangledName(type));
+    auto mangled_name = ConstString(AsMangledName(type));
+    const auto demangled_type = GetCachedDemangledType(mangled_name);
+    NodePointer node = demangled_type.GetRawNode();
 
     auto *log = GetLog(LLDBLog::Types);
     // Types with generic parameters have to be resolved before calling
@@ -3935,7 +3948,7 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
       LLDB_LOGF(log,
                 "Checking if type %s which contains a generic parameter is "
                 "an imported type",
-                AsMangledName(type));
+                mangled_name.GetCString());
 
     if (!::IsImportedType(node))
       return false;
@@ -3948,7 +3961,7 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
     if (!IsClangImportedType(node, decl_context))
       return false;
     if (original_type)
-      if (TypeSP clang_type = LookupClangType(AsMangledName(type), decl_context))
+      if (TypeSP clang_type = LookupClangType(mangled_name.GetStringRef(), decl_context))
         *original_type = clang_type->GetForwardCompilerType();
     return true;
   };
@@ -3961,8 +3974,7 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
 bool TypeSystemSwiftTypeRef::IsExistentialType(
     lldb::opaque_compiler_type_t type) {
   using namespace swift::Demangle;
-  Demangler dem;
-  NodePointer node = DemangleCanonicalType(dem, type);
+  const auto node = DemangleCanonicalType(type);
   if (!node || node->getNumChildren() != 1)
     return false;
   switch (node->getKind()) {
@@ -3988,10 +4000,9 @@ CompilerType TypeSystemSwiftTypeRef::GetRawPointerType() {
 bool TypeSystemSwiftTypeRef::IsErrorType(opaque_compiler_type_t type) {
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
-    Demangler dem;
-    NodePointer protocol_list = DemangleCanonicalType(dem, type);
+    const auto protocol_list = DemangleCanonicalType(type);
     if (protocol_list && protocol_list->getKind() == Node::Kind::ProtocolList)
-      for (auto type_list : *protocol_list)
+      for (auto type_list : *protocol_list.GetRawNode())
         if (type_list && type_list->getKind() == Node::Kind::TypeList)
           for (auto type : *type_list)
             if (type && type->getKind() == Node::Kind::Type)
@@ -4100,9 +4111,9 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type,
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
 
-    if (!node || ContainsUnresolvedTypeAlias(node)) {
+    if (!node || ContainsUnresolvedTypeAlias(node.GetRawNode())) {
       // If we couldn't resolve all type aliases, we might be in a REPL session
       // where getting to the debug information necessary for resolving that
       // type alias isn't possible, or the user might have defined the
@@ -4116,7 +4127,7 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type,
     }
 
     if (node->getKind() == Node::Kind::Metatype) {
-      for (NodePointer child : *node)
+      for (NodePointer child : *node.GetRawNode())
         if (child->getKind() == Node::Kind::Type)
           return RemangleAsType(dem, child);
       return {};
@@ -4382,7 +4393,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
 
     using namespace swift::Demangle;
     Demangler dem;    
-    auto *node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     if (!node)
       return false;
     switch (node->getKind()) {
@@ -4453,7 +4464,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     case Node::Kind::Structure: {
       // In some instances, a swift `structure` wraps an objc enum. The enum
       // case needs to be handled, but structs are no-ops.
-      auto resolved = ResolveTypeAlias(dem, node, true);
+      auto resolved = ResolveTypeAlias(dem, node.GetRawNode(), true);
       auto clang_type = std::get<CompilerType>(resolved);
       if (!clang_type)
         return false;
@@ -4522,9 +4533,9 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     // then we don't have debug info to resolve it from.
     using namespace swift::Demangle;
     Demangler dem;
-    auto *node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     bool unresolved_typealias = false;
-    CollectTypeInfo(dem, node, unresolved_typealias);
+    CollectTypeInfo(dem, node.GetRawNode(), unresolved_typealias);
     if (!node || unresolved_typealias) {
       if (auto swift_ast_ctx = GetSwiftASTContextFromExecutionScope(exe_scope))
         return swift_ast_ctx->DumpTypeValue(
@@ -4766,7 +4777,7 @@ bool TypeSystemSwiftTypeRef::IsReferenceType(opaque_compiler_type_t type,
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     if (!node || node->getNumChildren() != 1 ||
         node->getKind() != Node::Kind::InOut)
       return false;
@@ -4794,7 +4805,7 @@ TypeSystemSwiftTypeRef::GetGenericArgumentType(opaque_compiler_type_t type,
                                                size_t idx) {
   auto impl = [&]() -> CompilerType {
     Demangler dem;
-    NodePointer node = DemangleCanonicalType(dem, type);
+    const auto node = DemangleCanonicalType(type);
     if (!node || node->getNumChildren() != 2)
       return {};
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -14,6 +14,7 @@
 #define liblldb_TypeSystemSwiftTypeRef_h_
 
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
+#include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 #include "lldb/Core/SwiftForward.h"
 #include "lldb/Utility/ThreadSafeDenseMap.h"
 
@@ -369,6 +370,11 @@ public:
   swift::Demangle::NodePointer
   GetCanonicalDemangleTree(swift::Demangle::Demangler &dem,
                            llvm::StringRef mangled_name);
+
+  /// Return the canonicalized Demangle tree for a Swift mangled type name.
+  swift_demangle::NodePointerWithDeps<swift_demangle::SharedDemangledNode>
+  GetCanonicalDemangleTreeWithCache(swift::Demangle::Demangler &dem, ConstString mangled_name);
+
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
 
@@ -420,9 +426,8 @@ protected:
   /// drill into the Global(TypeMangling(Type())).
   ///
   /// \return the child of Type or a nullptr.
-  swift::Demangle::NodePointer
-  DemangleCanonicalType(swift::Demangle::Demangler &dem,
-                        lldb::opaque_compiler_type_t type);
+  swift_demangle::SharedDemangledNode
+  DemangleCanonicalType(lldb::opaque_compiler_type_t type);
 
   /// If \p node is a Struct/Class/Typedef in the __C module, return a
   /// Swiftified node by looking up the name in the corresponding APINotes and
@@ -441,9 +446,9 @@ protected:
 
   /// Return the demangle tree representation with all "__C" module
   /// names with their actual Clang module names.
-  swift::Demangle::NodePointer
+  swift_demangle::NodePointerWithDeps<swift_demangle::SharedDemangledNode>
   GetDemangleTreeForPrinting(swift::Demangle::Demangler &dem,
-                             const char *mangled_name,
+                             ConstString mangled_name,
                              bool resolve_objc_module);
 
   /// Return an APINotes manager for the module with module id \id.


### PR DESCRIPTION
This is more like a proof of concept rather than the final solution, but it shows relatively good performance improvement for `ValueObjectPrinter::PrintValueObject`.
Tested using `v x` where `x` is a struct with about 35000+ nested unique types. Measured total time of the `lldb_private::ValueObjectPrinter::PrintValueObject()` call using Instruments (Time Profiler, default resolution)
Before: 24.7 s
After: 17.4 s

There's potential for more performance gains using local `LRUCache`s and the global one (`GetCachedDemangledSymbol`). The next obvious candidate for optimization is `TypeSystemSwiftTypeRef::DemangleCanonicalType`. But it's trickier - it takes `Demangler` as an argument, so I'd have to change the signature and all the references. 