### PR TITLE
[clang][ExtractAPI] Fix quirks in interaction with submodules (#105868)

### DIFF
--- a/clang/include/clang/ExtractAPI/DeclarationFragments.h
+++ b/clang/include/clang/ExtractAPI/DeclarationFragments.h
@@ -411,9 +411,9 @@ public:
   /// Build DeclarationFragments for a macro.
   ///
   /// \param Name name of the macro.
-  /// \param MD the associated MacroDirective.
+  /// \param MI the associated MacroInfo.
   static DeclarationFragments getFragmentsForMacro(StringRef Name,
-                                                   const MacroDirective *MD);
+                                                   const MacroInfo *MI);
 
   /// Build DeclarationFragments for a typedef \p TypedefNameDecl.
   static DeclarationFragments

--- a/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
+++ b/clang/include/clang/ExtractAPI/ExtractAPIVisitor.h
@@ -213,7 +213,7 @@ protected:
 
   StringRef getOwningModuleName(const Decl &D) {
     if (auto *OwningModule = D.getImportedOwningModule())
-      return OwningModule->Name;
+      return OwningModule->getTopLevelModule()->Name;
 
     return {};
   }

--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -1327,13 +1327,11 @@ DeclarationFragmentsBuilder::getFragmentsForFunctionTemplateSpecialization(
 
 DeclarationFragments
 DeclarationFragmentsBuilder::getFragmentsForMacro(StringRef Name,
-                                                  const MacroDirective *MD) {
+                                                  const MacroInfo *MI) {
   DeclarationFragments Fragments;
   Fragments.append("#define", DeclarationFragments::FragmentKind::Keyword)
       .appendSpace();
   Fragments.append(Name, DeclarationFragments::FragmentKind::Identifier);
-
-  auto *MI = MD->getMacroInfo();
 
   if (MI->isFunctionLike()) {
     Fragments.append("(", DeclarationFragments::FragmentKind::Text);

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -928,8 +928,8 @@ bool SymbolGraphSerializer::traverseObjCCategoryRecord(
     return true;
 
   auto *CurrentModule = ModuleForCurrentSymbol;
-  if (Record->isExtendingExternalModule())
-    ModuleForCurrentSymbol = &ExtendedModules[Record->Interface.Source];
+  if (auto ModuleExtendedByRecord = Record->getExtendedExternalModule())
+    ModuleForCurrentSymbol = &ExtendedModules[*ModuleExtendedByRecord];
 
   if (!walkUpFromObjCCategoryRecord(Record))
     return false;

--- a/clang/test/ExtractAPI/bool.c
+++ b/clang/test/ExtractAPI/bool.c
@@ -2,8 +2,8 @@
 // RUN: split-file %s %t
 // RUN: sed -e "s@INPUT_DIR@%{/t:regex_replacement}@g" \
 // RUN: %t/reference.output.json.in >> %t/reference.output.json
-// RUN: %clang -extract-api --pretty-sgf -target arm64-apple-macosx \
-// RUN: %t/input.h -o %t/output.json
+// RUN: %clang_cc1 -extract-api --product-name=BoolTest --pretty-sgf -triple arm64-apple-macosx \
+// RUN:   %t/input.h -o %t/output.json
 
 // Generator version is not consistent across test runs, normalize it.
 // RUN: sed -e "s@\"generator\": \".*\"@\"generator\": \"?\"@g" \
@@ -15,7 +15,7 @@
 bool Foo;
 
 bool IsFoo(bool Bar);
-/// expected-no-diagnostics
+// expected-no-diagnostics
 
 //--- reference.output.json.in
 {
@@ -28,7 +28,7 @@ bool IsFoo(bool Bar);
     "generator": "?"
   },
   "module": {
-    "name": "",
+    "name": "BoolTest",
     "platform": {
       "architecture": "arm64",
       "operatingSystem": {

--- a/clang/test/ExtractAPI/emit-symbol-graph/multi_file.c
+++ b/clang/test/ExtractAPI/emit-symbol-graph/multi_file.c
@@ -27,9 +27,6 @@
 #ifndef TEST_H
 #define TEST_H
 
-#define testmarcro1 32
-#define testmacro2 42
-
 int testfunc (int param1, int param2);
 void testfunc2 ();
 #endif /* TEST_H */
@@ -185,7 +182,7 @@ int main ()
       "location": {
         "position": {
           "character": 4,
-          "line": 6
+          "line": 3
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -249,7 +246,7 @@ int main ()
       "location": {
         "position": {
           "character": 5,
-          "line": 7
+          "line": 4
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -334,106 +331,6 @@ int main ()
       },
       "pathComponents": [
         "main"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "testmarcro1"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "c",
-        "precise": "c:test.h@39@macro@testmarcro1"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 3
-        },
-        "uri": "file://INPUT_DIR/test.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "testmarcro1"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "testmarcro1"
-          }
-        ],
-        "title": "testmarcro1"
-      },
-      "pathComponents": [
-        "testmarcro1"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "testmacro2"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "c",
-        "precise": "c:test.h@62@macro@testmacro2"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 4
-        },
-        "uri": "file://INPUT_DIR/test.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "testmacro2"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "testmacro2"
-          }
-        ],
-        "title": "testmacro2"
-      },
-      "pathComponents": [
-        "testmacro2"
       ]
     }
   ]
@@ -573,7 +470,7 @@ int main ()
       "location": {
         "position": {
           "character": 4,
-          "line": 6
+          "line": 3
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -637,7 +534,7 @@ int main ()
       "location": {
         "position": {
           "character": 5,
-          "line": 7
+          "line": 4
         },
         "uri": "file://INPUT_DIR/test.h"
       },
@@ -658,106 +555,6 @@ int main ()
       },
       "pathComponents": [
         "testfunc2"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "testmarcro1"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "c",
-        "precise": "c:test.h@39@macro@testmarcro1"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 3
-        },
-        "uri": "file://INPUT_DIR/test.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "testmarcro1"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "testmarcro1"
-          }
-        ],
-        "title": "testmarcro1"
-      },
-      "pathComponents": [
-        "testmarcro1"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "testmacro2"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "c",
-        "precise": "c:test.h@62@macro@testmacro2"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 4
-        },
-        "uri": "file://INPUT_DIR/test.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "testmacro2"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "testmacro2"
-          }
-        ],
-        "title": "testmacro2"
-      },
-      "pathComponents": [
-        "testmacro2"
       ]
     }
   ]

--- a/clang/test/ExtractAPI/emit-symbol-graph/single_file.c
+++ b/clang/test/ExtractAPI/emit-symbol-graph/single_file.c
@@ -15,9 +15,6 @@
 // CHECK-NOT: warning:
 
 //--- main.c
-#define TESTMACRO1 2
-#define TESTMARCRO2 5
-
 int main ()
 {
   return 0;
@@ -87,7 +84,7 @@ int main ()
       "location": {
         "position": {
           "character": 4,
-          "line": 3
+          "line": 0
         },
         "uri": "file://INPUT_DIR/main.c"
       },
@@ -108,106 +105,6 @@ int main ()
       },
       "pathComponents": [
         "main"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "TESTMACRO1"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "c",
-        "precise": "c:main.c@8@macro@TESTMACRO1"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 0
-        },
-        "uri": "file://INPUT_DIR/main.c"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "TESTMACRO1"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "TESTMACRO1"
-          }
-        ],
-        "title": "TESTMACRO1"
-      },
-      "pathComponents": [
-        "TESTMACRO1"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "TESTMARCRO2"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "c",
-        "precise": "c:main.c@29@macro@TESTMARCRO2"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 1
-        },
-        "uri": "file://INPUT_DIR/main.c"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "TESTMARCRO2"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "TESTMARCRO2"
-          }
-        ],
-        "title": "TESTMARCRO2"
-      },
-      "pathComponents": [
-        "TESTMARCRO2"
       ]
     }
   ]

--- a/clang/test/ExtractAPI/macros.c
+++ b/clang/test/ExtractAPI/macros.c
@@ -1,416 +1,358 @@
 // RUN: rm -rf %t
-// RUN: split-file %s %t
-// RUN: sed -e "s@INPUT_DIR@%{/t:regex_replacement}@g" \
-// RUN: %t/reference.output.json.in >> %t/reference.output.json
-// RUN: %clang -extract-api --pretty-sgf --product-name=Macros -target arm64-apple-macosx \
-// RUN: -x objective-c-header %t/input.h -o %t/output.json | FileCheck -allow-empty %s
+// RUN: %clang_cc1 -extract-api --pretty-sgf --emit-sgf-symbol-labels-for-testing --product-name=Macros -triple arm64-apple-macosx \
+// RUN:   -isystem %S -x objective-c-header %s -o %t/output.symbols.json
 
-// Generator version is not consistent across test runs, normalize it.
-// RUN: sed -e "s@\"generator\": \".*\"@\"generator\": \"?\"@g" \
-// RUN: %t/output.json >> %t/output-normalized.json
-// RUN: diff %t/reference.output.json %t/output-normalized.json
-
-// CHECK-NOT: error:
-// CHECK-NOT: warning:
-
-//--- input.h
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix HELLO
 #define HELLO 1
-#define WORLD 2
-#define MACRO_FUN(x) x x
-#define FUN(x, y, z) x + y + z
-#define FUNC99(x, ...)
-#define FUNGNU(x...)
+// HELLO-LABEL: "!testLabel": "c:@macro@HELLO"
+// HELLO:      "accessLevel": "public",
+// HELLO-NEXT: "declarationFragments": [
+// HELLO-NEXT:   {
+// HELLO-NEXT:     "kind": "keyword",
+// HELLO-NEXT:     "spelling": "#define"
+// HELLO-NEXT:   },
+// HELLO-NEXT:   {
+// HELLO-NEXT:     "kind": "text",
+// HELLO-NEXT:     "spelling": " "
+// HELLO-NEXT:   },
+// HELLO-NEXT:   {
+// HELLO-NEXT:     "kind": "identifier",
+// HELLO-NEXT:     "spelling": "HELLO"
+// HELLO-NEXT:   }
+// HELLO-NEXT: ],
+// HELLO:      "kind": {
+// HELLO-NEXT:   "displayName": "Macro",
+// HELLO-NEXT:   "identifier": "objective-c.macro"
+// HELLO-NEXT: },
+// HELLO-NEXT: "location": {
+// HELLO-NEXT:   "position": {
+// HELLO-NEXT:     "character": 8,
+// HELLO-NEXT:     "line": [[# @LINE - 25]]
+// HELLO-NEXT:   },
+// HELLO-NEXT:   "uri": "file://{{.*}}/macros.c"
+// HELLO-NEXT: },
+// HELLO-NEXT: "names": {
+// HELLO-NEXT:   "navigator": [
+// HELLO-NEXT:     {
+// HELLO-NEXT:       "kind": "identifier",
+// HELLO-NEXT:       "spelling": "HELLO"
+// HELLO-NEXT:     }
+// HELLO-NEXT:   ],
+// HELLO-NEXT:   "subHeading": [
+// HELLO-NEXT:     {
+// HELLO-NEXT:       "kind": "identifier",
+// HELLO-NEXT:       "spelling": "HELLO"
+// HELLO-NEXT:     }
+// HELLO-NEXT:   ],
+// HELLO-NEXT:   "title": "HELLO"
+// HELLO-NEXT: },
+// HELLO-NEXT: "pathComponents": [
+// HELLO-NEXT:   "HELLO"
+// HELLO-NEXT: ]
 
-//--- reference.output.json.in
-{
-  "metadata": {
-    "formatVersion": {
-      "major": 0,
-      "minor": 5,
-      "patch": 3
-    },
-    "generator": "?"
-  },
-  "module": {
-    "name": "Macros",
-    "platform": {
-      "architecture": "arm64",
-      "operatingSystem": {
-        "minimumVersion": {
-          "major": 11,
-          "minor": 0,
-          "patch": 0
-        },
-        "name": "macosx"
-      },
-      "vendor": "apple"
-    }
-  },
-  "relationships": [],
-  "symbols": [
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "HELLO"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:input.h@8@macro@HELLO"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "objective-c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 0
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "HELLO"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "HELLO"
-          }
-        ],
-        "title": "HELLO"
-      },
-      "pathComponents": [
-        "HELLO"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "WORLD"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:input.h@24@macro@WORLD"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "objective-c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 1
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "WORLD"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "WORLD"
-          }
-        ],
-        "title": "WORLD"
-      },
-      "pathComponents": [
-        "WORLD"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "MACRO_FUN"
-        },
-        {
-          "kind": "text",
-          "spelling": "("
-        },
-        {
-          "kind": "internalParam",
-          "spelling": "x"
-        },
-        {
-          "kind": "text",
-          "spelling": ")"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:input.h@40@macro@MACRO_FUN"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "objective-c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 2
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "MACRO_FUN"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "MACRO_FUN"
-          }
-        ],
-        "title": "MACRO_FUN"
-      },
-      "pathComponents": [
-        "MACRO_FUN"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "FUN"
-        },
-        {
-          "kind": "text",
-          "spelling": "("
-        },
-        {
-          "kind": "internalParam",
-          "spelling": "x"
-        },
-        {
-          "kind": "text",
-          "spelling": ", "
-        },
-        {
-          "kind": "internalParam",
-          "spelling": "y"
-        },
-        {
-          "kind": "text",
-          "spelling": ", "
-        },
-        {
-          "kind": "internalParam",
-          "spelling": "z"
-        },
-        {
-          "kind": "text",
-          "spelling": ")"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:input.h@65@macro@FUN"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "objective-c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 3
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "FUN"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "FUN"
-          }
-        ],
-        "title": "FUN"
-      },
-      "pathComponents": [
-        "FUN"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "FUNC99"
-        },
-        {
-          "kind": "text",
-          "spelling": "("
-        },
-        {
-          "kind": "internalParam",
-          "spelling": "x"
-        },
-        {
-          "kind": "text",
-          "spelling": ", ...)"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:input.h@96@macro@FUNC99"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "objective-c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 4
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "FUNC99"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "FUNC99"
-          }
-        ],
-        "title": "FUNC99"
-      },
-      "pathComponents": [
-        "FUNC99"
-      ]
-    },
-    {
-      "accessLevel": "public",
-      "declarationFragments": [
-        {
-          "kind": "keyword",
-          "spelling": "#define"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "identifier",
-          "spelling": "FUNGNU"
-        },
-        {
-          "kind": "text",
-          "spelling": "("
-        },
-        {
-          "kind": "internalParam",
-          "spelling": "x"
-        },
-        {
-          "kind": "text",
-          "spelling": "...)"
-        }
-      ],
-      "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:input.h@119@macro@FUNGNU"
-      },
-      "kind": {
-        "displayName": "Macro",
-        "identifier": "objective-c.macro"
-      },
-      "location": {
-        "position": {
-          "character": 8,
-          "line": 5
-        },
-        "uri": "file://INPUT_DIR/input.h"
-      },
-      "names": {
-        "navigator": [
-          {
-            "kind": "identifier",
-            "spelling": "FUNGNU"
-          }
-        ],
-        "subHeading": [
-          {
-            "kind": "identifier",
-            "spelling": "FUNGNU"
-          }
-        ],
-        "title": "FUNGNU"
-      },
-      "pathComponents": [
-        "FUNGNU"
-      ]
-    }
-  ]
-}
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix WORLD
+#define WORLD 2
+// WORLD-LABEL: "!testLabel": "c:@macro@WORLD"
+// WORLD:      "accessLevel": "public",
+// WORLD-NEXT: "declarationFragments": [
+// WORLD-NEXT:   {
+// WORLD-NEXT:     "kind": "keyword",
+// WORLD-NEXT:     "spelling": "#define"
+// WORLD-NEXT:   },
+// WORLD-NEXT:   {
+// WORLD-NEXT:     "kind": "text",
+// WORLD-NEXT:     "spelling": " "
+// WORLD-NEXT:   },
+// WORLD-NEXT:   {
+// WORLD-NEXT:     "kind": "identifier",
+// WORLD-NEXT:     "spelling": "WORLD"
+// WORLD-NEXT:   }
+// WORLD-NEXT: ],
+// WORLD:      "kind": {
+// WORLD-NEXT:   "displayName": "Macro",
+// WORLD-NEXT:   "identifier": "objective-c.macro"
+// WORLD-NEXT: },
+// WORLD-NEXT: "location": {
+// WORLD-NEXT:   "position": {
+// WORLD-NEXT:     "character": 8,
+// WORLD-NEXT:     "line": [[# @LINE - 25]]
+// WORLD-NEXT:   },
+// WORLD-NEXT:   "uri": "file://{{.*}}/macros.c"
+// WORLD-NEXT: },
+// WORLD-NEXT: "names": {
+// WORLD-NEXT:   "navigator": [
+// WORLD-NEXT:     {
+// WORLD-NEXT:       "kind": "identifier",
+// WORLD-NEXT:       "spelling": "WORLD"
+// WORLD-NEXT:     }
+// WORLD-NEXT:   ],
+// WORLD-NEXT:   "subHeading": [
+// WORLD-NEXT:     {
+// WORLD-NEXT:       "kind": "identifier",
+// WORLD-NEXT:       "spelling": "WORLD"
+// WORLD-NEXT:     }
+// WORLD-NEXT:   ],
+// WORLD-NEXT:   "title": "WORLD"
+// WORLD-NEXT: },
+// WORLD-NEXT: "pathComponents": [
+// WORLD-NEXT:   "WORLD"
+// WORLD-NEXT: ]
+
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix MACRO_FUN
+#define MACRO_FUN(x) x x
+// MACRO_FUN-LABEL: "!testLabel": "c:@macro@MACRO_FUN"
+// MACRO_FUN-NEXT: "accessLevel": "public",
+// MACRO_FUN-NEXT: "declarationFragments": [
+// MACRO_FUN-NEXT:   {
+// MACRO_FUN-NEXT:     "kind": "keyword",
+// MACRO_FUN-NEXT:     "spelling": "#define"
+// MACRO_FUN-NEXT:   },
+// MACRO_FUN-NEXT:   {
+// MACRO_FUN-NEXT:     "kind": "text",
+// MACRO_FUN-NEXT:     "spelling": " "
+// MACRO_FUN-NEXT:   },
+// MACRO_FUN-NEXT:   {
+// MACRO_FUN-NEXT:     "kind": "identifier",
+// MACRO_FUN-NEXT:     "spelling": "MACRO_FUN"
+// MACRO_FUN-NEXT:   },
+// MACRO_FUN-NEXT:   {
+// MACRO_FUN-NEXT:     "kind": "text",
+// MACRO_FUN-NEXT:     "spelling": "("
+// MACRO_FUN-NEXT:   },
+// MACRO_FUN-NEXT:   {
+// MACRO_FUN-NEXT:     "kind": "internalParam",
+// MACRO_FUN-NEXT:     "spelling": "x"
+// MACRO_FUN-NEXT:   },
+// MACRO_FUN-NEXT:   {
+// MACRO_FUN-NEXT:     "kind": "text",
+// MACRO_FUN-NEXT:     "spelling": ")"
+// MACRO_FUN-NEXT:   }
+// MACRO_FUN-NEXT: ],
+// MACRO_FUN:      "kind": {
+// MACRO_FUN-NEXT:   "displayName": "Macro",
+// MACRO_FUN-NEXT:   "identifier": "objective-c.macro"
+// MACRO_FUN-NEXT: },
+// MACRO_FUN-NEXT: "location": {
+// MACRO_FUN-NEXT:   "position": {
+// MACRO_FUN-NEXT:     "character": 8,
+// MACRO_FUN-NEXT:     "line": [[# @LINE - 37]]
+// MACRO_FUN-NEXT:   },
+// MACRO_FUN-NEXT:   "uri": "file://{{.*}}/macros.c"
+// MACRO_FUN-NEXT: },
+// MACRO_FUN-NEXT: "names": {
+// MACRO_FUN-NEXT:   "navigator": [
+// MACRO_FUN-NEXT:     {
+// MACRO_FUN-NEXT:       "kind": "identifier",
+// MACRO_FUN-NEXT:       "spelling": "MACRO_FUN"
+// MACRO_FUN-NEXT:     }
+// MACRO_FUN-NEXT:   ],
+// MACRO_FUN-NEXT:   "subHeading": [
+// MACRO_FUN-NEXT:     {
+// MACRO_FUN-NEXT:       "kind": "identifier",
+// MACRO_FUN-NEXT:       "spelling": "MACRO_FUN"
+// MACRO_FUN-NEXT:     }
+// MACRO_FUN-NEXT:   ],
+// MACRO_FUN-NEXT:   "title": "MACRO_FUN"
+// MACRO_FUN-NEXT: },
+// MACRO_FUN-NEXT: "pathComponents": [
+// MACRO_FUN-NEXT:   "MACRO_FUN"
+// MACRO_FUN-NEXT: ]
+
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix FUN
+#define FUN(x, y, z) x + y + z
+// FUN-LABEL: "!testLabel": "c:@macro@FUN"
+// FUN-NEXT: "accessLevel": "public",
+// FUN-NEXT: "declarationFragments": [
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "keyword",
+// FUN-NEXT:     "spelling": "#define"
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "text",
+// FUN-NEXT:     "spelling": " "
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "identifier",
+// FUN-NEXT:     "spelling": "FUN"
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "text",
+// FUN-NEXT:     "spelling": "("
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "internalParam",
+// FUN-NEXT:     "spelling": "x"
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "text",
+// FUN-NEXT:     "spelling": ", "
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "internalParam",
+// FUN-NEXT:     "spelling": "y"
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "text",
+// FUN-NEXT:     "spelling": ", "
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "internalParam",
+// FUN-NEXT:     "spelling": "z"
+// FUN-NEXT:   },
+// FUN-NEXT:   {
+// FUN-NEXT:     "kind": "text",
+// FUN-NEXT:     "spelling": ")"
+// FUN-NEXT:   }
+// FUN-NEXT: ],
+// FUN:      "kind": {
+// FUN-NEXT:   "displayName": "Macro",
+// FUN-NEXT:   "identifier": "objective-c.macro"
+// FUN-NEXT: },
+// FUN-NEXT: "location": {
+// FUN-NEXT:   "position": {
+// FUN-NEXT:     "character": 8,
+// FUN-NEXT:     "line": [[# @LINE - 53]]
+// FUN-NEXT:   },
+// FUN-NEXT:   "uri": "file://{{.*}}/macros.c"
+// FUN-NEXT: },
+// FUN-NEXT: "names": {
+// FUN-NEXT:   "navigator": [
+// FUN-NEXT:     {
+// FUN-NEXT:       "kind": "identifier",
+// FUN-NEXT:       "spelling": "FUN"
+// FUN-NEXT:     }
+// FUN-NEXT:   ],
+// FUN-NEXT:   "subHeading": [
+// FUN-NEXT:     {
+// FUN-NEXT:       "kind": "identifier",
+// FUN-NEXT:       "spelling": "FUN"
+// FUN-NEXT:     }
+// FUN-NEXT:   ],
+// FUN-NEXT:   "title": "FUN"
+// FUN-NEXT: },
+// FUN-NEXT: "pathComponents": [
+// FUN-NEXT:   "FUN"
+// FUN-NEXT: ]
+
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix FUNC99
+#define FUNC99(x, ...)
+// FUNC99-LABEL: "!testLabel": "c:@macro@FUNC99"
+// FUNC99-NEXT: "accessLevel": "public",
+// FUNC99-NEXT: "declarationFragments": [
+// FUNC99-NEXT:   {
+// FUNC99-NEXT:     "kind": "keyword",
+// FUNC99-NEXT:     "spelling": "#define"
+// FUNC99-NEXT:   },
+// FUNC99-NEXT:   {
+// FUNC99-NEXT:     "kind": "text",
+// FUNC99-NEXT:     "spelling": " "
+// FUNC99-NEXT:   },
+// FUNC99-NEXT:   {
+// FUNC99-NEXT:     "kind": "identifier",
+// FUNC99-NEXT:     "spelling": "FUNC99"
+// FUNC99-NEXT:   },
+// FUNC99-NEXT:   {
+// FUNC99-NEXT:     "kind": "text",
+// FUNC99-NEXT:     "spelling": "("
+// FUNC99-NEXT:   },
+// FUNC99-NEXT:   {
+// FUNC99-NEXT:     "kind": "internalParam",
+// FUNC99-NEXT:     "spelling": "x"
+// FUNC99-NEXT:   },
+// FUNC99-NEXT:   {
+// FUNC99-NEXT:     "kind": "text",
+// FUNC99-NEXT:     "spelling": ", ...)"
+// FUNC99-NEXT:   }
+// FUNC99-NEXT: ],
+// FUNC99:      "kind": {
+// FUNC99-NEXT:   "displayName": "Macro",
+// FUNC99-NEXT:   "identifier": "objective-c.macro"
+// FUNC99-NEXT: },
+// FUNC99-NEXT: "location": {
+// FUNC99-NEXT:   "position": {
+// FUNC99-NEXT:     "character": 8,
+// FUNC99-NEXT:     "line": [[# @LINE - 37]]
+// FUNC99-NEXT:   },
+// FUNC99-NEXT:   "uri": "file://{{.*}}/macros.c"
+// FUNC99-NEXT: },
+// FUNC99-NEXT: "names": {
+// FUNC99-NEXT:   "navigator": [
+// FUNC99-NEXT:     {
+// FUNC99-NEXT:       "kind": "identifier",
+// FUNC99-NEXT:       "spelling": "FUNC99"
+// FUNC99-NEXT:     }
+// FUNC99-NEXT:   ],
+// FUNC99-NEXT:   "subHeading": [
+// FUNC99-NEXT:     {
+// FUNC99-NEXT:       "kind": "identifier",
+// FUNC99-NEXT:       "spelling": "FUNC99"
+// FUNC99-NEXT:     }
+// FUNC99-NEXT:   ],
+// FUNC99-NEXT:   "title": "FUNC99"
+// FUNC99-NEXT: },
+// FUNC99-NEXT: "pathComponents": [
+// FUNC99-NEXT:   "FUNC99"
+// FUNC99-NEXT: ]
+
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix FUNGNU
+#define FUNGNU(x...)
+// FUNGNU-LABEL: "!testLabel": "c:@macro@FUNGNU"
+// FUNGNU-NEXT: "accessLevel": "public",
+// FUNGNU-NEXT: "declarationFragments": [
+// FUNGNU-NEXT:   {
+// FUNGNU-NEXT:     "kind": "keyword",
+// FUNGNU-NEXT:     "spelling": "#define"
+// FUNGNU-NEXT:   },
+// FUNGNU-NEXT:   {
+// FUNGNU-NEXT:     "kind": "text",
+// FUNGNU-NEXT:     "spelling": " "
+// FUNGNU-NEXT:   },
+// FUNGNU-NEXT:   {
+// FUNGNU-NEXT:     "kind": "identifier",
+// FUNGNU-NEXT:     "spelling": "FUNGNU"
+// FUNGNU-NEXT:   },
+// FUNGNU-NEXT:   {
+// FUNGNU-NEXT:     "kind": "text",
+// FUNGNU-NEXT:     "spelling": "("
+// FUNGNU-NEXT:   },
+// FUNGNU-NEXT:   {
+// FUNGNU-NEXT:     "kind": "internalParam",
+// FUNGNU-NEXT:     "spelling": "x"
+// FUNGNU-NEXT:   },
+// FUNGNU-NEXT:   {
+// FUNGNU-NEXT:     "kind": "text",
+// FUNGNU-NEXT:     "spelling": "...)"
+// FUNGNU-NEXT:   }
+// FUNGNU-NEXT: ],
+// FUNGNU:      "kind": {
+// FUNGNU-NEXT:   "displayName": "Macro",
+// FUNGNU-NEXT:   "identifier": "objective-c.macro"
+// FUNGNU-NEXT: },
+// FUNGNU-NEXT: "location": {
+// FUNGNU-NEXT:   "position": {
+// FUNGNU-NEXT:     "character": 8,
+// FUNGNU-NEXT:     "line": [[# @LINE - 37]]
+// FUNGNU-NEXT:   },
+// FUNGNU-NEXT:   "uri": "file://{{.*}}/macros.c"
+// FUNGNU-NEXT: },
+// FUNGNU-NEXT: "names": {
+// FUNGNU-NEXT:   "navigator": [
+// FUNGNU-NEXT:     {
+// FUNGNU-NEXT:       "kind": "identifier",
+// FUNGNU-NEXT:       "spelling": "FUNGNU"
+// FUNGNU-NEXT:     }
+// FUNGNU-NEXT:   ],
+// FUNGNU-NEXT:   "subHeading": [
+// FUNGNU-NEXT:     {
+// FUNGNU-NEXT:       "kind": "identifier",
+// FUNGNU-NEXT:       "spelling": "FUNGNU"
+// FUNGNU-NEXT:     }
+// FUNGNU-NEXT:   ],
+// FUNGNU-NEXT:   "title": "FUNGNU"
+// FUNGNU-NEXT: },
+// FUNGNU-NEXT: "pathComponents": [
+// FUNGNU-NEXT:   "FUNGNU"
+// FUNGNU-NEXT: ]
+
+// expected-no-diagnostics
+

--- a/clang/test/ExtractAPI/submodule-macro.m
+++ b/clang/test/ExtractAPI/submodule-macro.m
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -extract-api --pretty-sgf --emit-sgf-symbol-labels-for-testing \
+// RUN:   --emit-extension-symbol-graphs --symbol-graph-dir=%t/symbols -isystem %t \
+// RUN:   --product-name=Umbrella -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/modules-cache \
+// RUN:   -triple arm64-apple-macosx -x objective-c-header %t/Umbrella.h %t/Subheader.h
+
+//--- Umbrella.h
+#include "Subheader.h"
+#import <stdbool.h>
+
+//--- Subheader.h
+#define FOO 1
+
+//--- module.modulemap
+module Umbrella {
+    umbrella header "Umbrella.h"
+    export *
+    module * { export * }
+}
+
+// RUN: FileCheck %s --input-file  %t/symbols/Umbrella.symbols.json --check-prefix MOD
+// MOD-NOT: bool
+// MOD: "!testLabel": "c:@macro@FOO"
+


### PR DESCRIPTION
Extension SGFs require the module system to be enabled in order to discover which module defines the extended external type. This patch ensures the following:
- Associate symbols with their top level module name, and that only top level modules are considered as modules for emitting extension SGFs.
- Ensure we don't drop macro definitions that came from a submodule. To this end look at all defined macros in `PPCalbacks::EndOfMainFile` instead of relying on `PPCallbacks::MacroDefined` being called to detect a macro definition.

rdar://123020565