### PR TITLE
Add -fbuiltin-headers-in-system-modules to clang-scan-deps test

### DIFF
--- a/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-prefix-map.c
@@ -315,7 +315,7 @@
 [{
   "file": "DIR/tu.m",
   "directory": "DIR",
-  "command": "CLANG -target x86_64-apple-darwin10 -fsyntax-only DIR/tu.m -I DIR -isystem DIR/System -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache"
+  "command": "CLANG -target x86_64-apple-darwin10 -fsyntax-only DIR/tu.m -I DIR -isystem DIR/System -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -Rcompile-job-cache -Xclang -fbuiltin-headers-in-system-modules"
 }]
 
 //--- module.modulemap


### PR DESCRIPTION
One of the things this test is checking for is that builtin headers get the correct path in Darwin system modules. Add
-fbuiltin-headers-in-system-modules explicitly so that the test does not depend on the SDK version.

rdar://133239616
(cherry picked from commit 55d362b84a6fa1ddb7ec64ce124caea060d1416b)

---

* **Explanation**: Fixes a test when using SDKs that no longer enable `-fbuiltin-headers-in-system-modules` by default.
* **Scope**: Test-only change.
* **Risk**: Test-only
* **Testing**: Tests passed
* **Issue**: rdar://133239616
* **Reviewer**: Fred