### PR TITLE
[clang][scan] Report module dependencies in topological order

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -478,6 +478,16 @@ CINDEX_LINKAGE size_t clang_experimental_DepGraph_getNumModules(CXDepGraph);
 CINDEX_LINKAGE CXDepGraphModule
 clang_experimental_DepGraph_getModule(CXDepGraph, size_t Index);
 
+/**
+ * \returns the \c CXDepGraphModule object at the given \p Index in
+ * a topologically sorted list.
+ *
+ * The \c CXDepGraphModule object is only valid to use while \c CXDepGraph is
+ * valid. Must be disposed with \c clang_experimental_DepGraphModule_dispose.
+ */
+CINDEX_LINKAGE CXDepGraphModule
+clang_experimental_DepGraph_getModuleTopological(CXDepGraph, size_t Index);
+
 CINDEX_LINKAGE void clang_experimental_DepGraphModule_dispose(CXDepGraphModule);
 
 /**

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -640,12 +640,11 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
     return {};
 
   // If this module has been handled already, just return its ID.
-  auto ModI = MDC.ModularDeps.insert({M, nullptr});
-  if (!ModI.second)
-    return ModI.first->second->ID;
+  if (auto ModI = MDC.ModularDeps.find(M); ModI != MDC.ModularDeps.end())
+    return ModI->second->ID;
 
-  ModI.first->second = std::make_unique<ModuleDeps>();
-  ModuleDeps &MD = *ModI.first->second;
+  auto OwnedMD = std::make_unique<ModuleDeps>();
+  ModuleDeps &MD = *OwnedMD;
 
   MD.ID.ModuleName = M->getFullModuleName();
   MD.IsSystem = M->IsSystem;
@@ -755,6 +754,8 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
 #endif
 
   MD.BuildInfo = std::move(CI);
+
+  MDC.ModularDeps.insert({M, std::move(OwnedMD)});
 
   return MD.ID;
 }

--- a/clang/test/ClangScanDeps/modules-order-c-api.c
+++ b/clang/test/ClangScanDeps/modules-order-c-api.c
@@ -10,6 +10,13 @@
 // RUN: diff %t/output1 %t/output2
 // RUN: diff %t/output1 %t/output3
 
+// And that module dependencies are in topological order.
+// RUN: FileCheck --input-file %t/output1 %s
+// CHECK:     modules
+// CHECK-DAG:     name: FromMod1
+// CHECK-DAG:     name: FromMod2
+// CHECK:         name: FromMain1
+
 //--- module.modulemap
 module FromMain1 { header "FromMain1.h" }
 module FromMain2 { header "FromMain2.h" }

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -801,7 +801,8 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
     llvm::outs() << "modules:\n";
     for (size_t I = 0, E = clang_experimental_DepGraph_getNumModules(Graph);
          I < E; ++I) {
-      CXDepGraphModule Mod = clang_experimental_DepGraph_getModule(Graph, I);
+      CXDepGraphModule Mod =
+          clang_experimental_DepGraph_getModuleTopological(Graph, I);
       const char *Name = clang_experimental_DepGraphModule_getName(Mod);
       const char *ContextHash =
           clang_experimental_DepGraphModule_getContextHash(Mod);

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -545,6 +545,12 @@ size_t clang_experimental_DepGraph_getNumModules(CXDepGraph Graph) {
 
 CXDepGraphModule clang_experimental_DepGraph_getModule(CXDepGraph Graph,
                                                        size_t Index) {
+  return clang_experimental_DepGraph_getModuleTopological(Graph, Index);
+}
+
+CXDepGraphModule
+clang_experimental_DepGraph_getModuleTopological(CXDepGraph Graph,
+                                                 size_t Index) {
   TranslationUnitDeps &TUDeps = unwrap(Graph)->TUDeps;
   return wrap(new DependencyGraphModule{&TUDeps.ModuleGraph[Index]});
 }

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -519,6 +519,7 @@ LLVM_16 {
     clang_experimental_DepGraph_dispose;
     clang_experimental_DepGraph_getDiagnostics;
     clang_experimental_DepGraph_getModule;
+    clang_experimental_DepGraph_getModuleTopological;
     clang_experimental_DepGraph_getNumModules;
     clang_experimental_DepGraph_getNumTUCommands;
     clang_experimental_DepGraph_getTUCommand;


### PR DESCRIPTION
Clients of the dependency scanner may benefit from being able to process modular dependencies in topological order. The scanner already processes dependencies in this order, so it makes sense to make it easy for clients by providing an API with that guarantee.