### PR TITLE
[rebranch] Temporarily ignore mm3dnow.h deprecation warning

### DIFF
--- a/clang/lib/Headers/mm3dnow.h
+++ b/clang/lib/Headers/mm3dnow.h
@@ -12,9 +12,11 @@
 #ifndef _MM3DNOW_H_INCLUDED
 #define _MM3DNOW_H_INCLUDED
 
-#ifndef _CLANG_DISABLE_CRT_DEPRECATION_WARNINGS
-#warning "The <mm3dnow.h> header is deprecated, and 3dNow! intrinsics are unsupported. For other intrinsics, include <x86intrin.h>, instead."
-#endif
+// FIXME: Should be adding a deprecation warning here, but disabling for now to avoid a warning for
+// anything including the intrinsics module when modules are enabled.
+//#ifndef _CLANG_DISABLE_CRT_DEPRECATION_WARNINGS
+//#warning "The <mm3dnow.h> header is deprecated, and 3dNow! intrinsics are unsupported. For other intrinsics, include <x86intrin.h>, instead."
+//#endif
 
 #include <mmintrin.h>
 #include <prfchwintrin.h>

--- a/clang/test/Headers/mm3dnow.c
+++ b/clang/test/Headers/mm3dnow.c
@@ -1,6 +1,8 @@
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding %s -verify
+// FIXME: Deprecation skipped to avoid a warning for anything including the intrinsics module when
+// modules are enabled.
+// SKIPPED: %clang_cc1 -fsyntax-only -ffreestanding %s -verify
 // RUN: %clang_cc1 -fsyntax-only -D_CLANG_DISABLE_CRT_DEPRECATION_WARNINGS -ffreestanding %s -verify
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding -x c++ %s -verify
+// SKIPPED: %clang_cc1 -fsyntax-only -ffreestanding -x c++ %s -verify
 
 #if defined(i386) || defined(__x86_64__)
 #ifndef _CLANG_DISABLE_CRT_DEPRECATION_WARNINGS


### PR DESCRIPTION
Discussing upstream in https://github.com/llvm/llvm-project/pull/96246. For now just remove the warning.