### PR TITLE
[clang][ExtractAPI] Remove erroneous module name check in MacroCallbacks (#107059)

### DIFF
--- a/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
+++ b/clang/lib/ExtractAPI/ExtractAPIConsumer.cpp
@@ -350,7 +350,7 @@ public:
   bool shouldMacroBeIncluded(const SourceLocation &MacroLoc,
                              StringRef ModuleName) override {
     // Do not include macros from external files
-    return LCF(MacroLoc) || API.ProductName == ModuleName;
+    return LCF(MacroLoc);
   }
 
 private:


### PR DESCRIPTION
rdar://135044923