### PR TITLE
[🍒 6.0.0] Skip test test_swift_consume_operator_async

### DIFF
--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -26,6 +26,7 @@ def stderr_print(line):
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
     @swiftTest
+    @skipIf(bugnumber="rdar://133849022", oslist=['linux'])
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.


### PR DESCRIPTION
This test is blocking progress on building x86_64 toolchains for several Linux distributions. Disabling for now.

Mitigation for: rdar://134297435

Cherry-pick of: https://github.com/swiftlang/llvm-project/pull/9205