### PR TITLE
[clang][ExtractAPI] Handle AttributedType fragments transparently (#107262)

### DIFF
--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -276,6 +276,19 @@ DeclarationFragments DeclarationFragmentsBuilder::getFragmentsForType(
 
   DeclarationFragments Fragments;
 
+  if (const MacroQualifiedType *MQT = dyn_cast<MacroQualifiedType>(T)) {
+    Fragments.append(
+        getFragmentsForType(MQT->getUnderlyingType(), Context, After));
+    return Fragments;
+  }
+
+  if (const AttributedType *AT = dyn_cast<AttributedType>(T)) {
+    // FIXME: Serialize Attributes correctly
+    Fragments.append(
+        getFragmentsForType(AT->getModifiedType(), Context, After));
+    return Fragments;
+  }
+
   // An ElaboratedType is a sugar for types that are referred to using an
   // elaborated keyword, e.g., `struct S`, `enum E`, or (in C++) via a
   // qualified name, e.g., `N::M::type`, or both.

--- a/clang/test/ExtractAPI/attributed-typedef.m
+++ b/clang/test/ExtractAPI/attributed-typedef.m
@@ -1,0 +1,24 @@
+// RUN: rm -rf %t
+// RUN: %clang_cc1 -extract-api --pretty-sgf --emit-sgf-symbol-labels-for-testing \
+// RUN:   -triple arm64-apple-macosx -x objective-c-header %s -o %t/output.symbols.json
+
+_Pragma("clang assume_nonnull begin")
+
+struct Foo { int a; };
+typedef struct Foo *Bar;
+// RUN: FileCheck %s -input-file %t/output.symbols.json --check-prefix FUNC
+void func(Bar b);
+// FUNC-LABEL: "!testLabel": "c:@F@func",
+// CHECK-NOT: Foo
+// CHECK: "pathComponents"
+
+// RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix THING
+#define SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
+extern Bar const thing SWIFT_NAME(swiftThing);
+// THING-LABEL: "!testLabel": "c:@thing"
+// THING-NOT: Foo
+// THING: "pathComponents"
+
+_Pragma("clang assume_nonnull end")
+
+// expected-no-diagnostics


### PR DESCRIPTION
rdar://131958623