### PR TITLE
Fix test failure in stats-dump.test on next

### DIFF
--- a/llvm/tools/llvm-cas-dump/StatsCollector.cpp
+++ b/llvm/tools/llvm-cas-dump/StatsCollector.cpp
@@ -150,10 +150,11 @@ void StatsCollector::printToOuts(ArrayRef<ObjectProxy> TopLevels,
   StringLiteral Format =
       ObjectStatsFormat == FormatType::Pretty ? FormatPretty : FormatCSV;
 
-  StatOS << llvm::formatv(HeaderFormat.begin(), "Kind", "Count", "", "Parents",
-                          "", "Children", "", "Data (B)", "", "Cost (B)", "");
+  StatOS << llvm::formatv(false, HeaderFormat.begin(), "Kind", "Count", "",
+                          "Parents", "", "Children", "", "Data (B)", "",
+                          "Cost (B)", "");
   if (ObjectStatsFormat == FormatType::Pretty) {
-    StatOS << llvm::formatv(HeaderFormat.begin(), "====", "=====", "",
+    StatOS << llvm::formatv(false, HeaderFormat.begin(), "====", "=====", "",
                             "=======", "", "========", "", "========", "",
                             "========", "");
   }
@@ -164,10 +165,11 @@ void StatsCollector::printToOuts(ArrayRef<ObjectProxy> TopLevels,
     auto getPercent = [](double N, double D) { return D ? N / D : 0.0; };
     size_t Size = Info.getTotalSize(NumHashBytes);
     StatOS << llvm::formatv(
-        Format.begin(), Kind, Info.Count, getPercent(Info.Count, Totals.Count),
-        Info.NumParents, getPercent(Info.NumParents, Totals.NumParents),
-        Info.NumChildren, getPercent(Info.NumChildren, Totals.NumChildren),
-        Info.DataSize, getPercent(Info.DataSize, Totals.DataSize), Size,
+        false, Format.begin(), Kind, Info.Count,
+        getPercent(Info.Count, Totals.Count), Info.NumParents,
+        getPercent(Info.NumParents, Totals.NumParents), Info.NumChildren,
+        getPercent(Info.NumChildren, Totals.NumChildren), Info.DataSize,
+        getPercent(Info.DataSize, Totals.DataSize), Size,
         getPercent(Size, Totals.getTotalSize(NumHashBytes)));
   };
   for (StringRef Kind : Kinds)


### PR DESCRIPTION
The patch in 9ce4af5cadc24060f3c3674e01902d374afea983 adds code to validate the number of arguments to formatv(), however, the code for stat collection tries to write a different number of arguments based on what format is used. Therefore turn off the validation of argument count.