### PR TITLE
Revert "Merge pull request #9200 from compnerd/static_assert_false"

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -17146,6 +17146,14 @@ Decl *Sema::BuildStaticAssertDeclaration(SourceLocation StaticAssertLoc,
                        FoldKind).isInvalid())
       Failed = true;
 
+    // If the static_assert passes, only verify that
+    // the message is grammatically valid without evaluating it.
+    if (!Failed && AssertMessage && Cond.getBoolValue()) {
+      std::string Str;
+      EvaluateStaticAssertMessageAsString(AssertMessage, Str, Context,
+                                          /*ErrorOnInvalidMessage=*/false);
+    }
+
     // CWG2518
     // [dcl.pre]/p10  If [...] the expression is evaluated in the context of a
     // template definition, the declaration has no effect.
@@ -17153,7 +17161,6 @@ Decl *Sema::BuildStaticAssertDeclaration(SourceLocation StaticAssertLoc,
         getLangOpts().CPlusPlus && CurContext->isDependentContext();
 
     if (!Failed && !Cond && !InTemplateDefinition) {
-
       SmallString<256> MsgBuffer;
       llvm::raw_svector_ostream Msg(MsgBuffer);
       bool HasMessage = AssertMessage;
@@ -17185,8 +17192,8 @@ Decl *Sema::BuildStaticAssertDeclaration(SourceLocation StaticAssertLoc,
             << InnerCond->getSourceRange();
         DiagnoseStaticAssertDetails(InnerCond);
       } else {
-        Diag(StaticAssertLoc, diag::err_static_assert_failed)
-            << !AssertMessage << Msg.str() << AssertExpr->getSourceRange();
+        Diag(AssertExpr->getBeginLoc(), diag::err_static_assert_failed)
+            << !HasMessage << Msg.str() << AssertExpr->getSourceRange();
         PrintContextStack();
       }
       Failed = true;

--- a/clang/test/CXX/drs/dr25xx.cpp
+++ b/clang/test/CXX/drs/dr25xx.cpp
@@ -81,40 +81,6 @@ using ::dr2521::operator""_div;
 #endif
 } // namespace dr2521
 
-namespace dr2518 { // dr2518: 17 review
-
-template <class T>
-void f(T t) {
-  if constexpr (sizeof(T) != sizeof(int)) {
-    static_assert(false, "must be int-sized"); // expected-error {{must be int-size}}
-  }
-}
-
-void g(char c) {
-  f(0);
-  f(c); // expected-note {{requested here}}
-}
-
-template <typename Ty>
-struct S {
-  static_assert(false); // expected-error {{static assertion failed}}
-};
-
-template <>
-struct S<int> {};
-
-template <>
-struct S<float> {};
-
-int test_specialization() {
-  S<int> s1;
-  S<float> s2;
-  S<double> s3; // expected-note {{in instantiation of template class 'dr2518::S<double>' requested here}}
-}
-
-}
-
-
 namespace dr2565 { // dr2565: 16 open
 #if __cplusplus >= 202002L
   template<typename T>


### PR DESCRIPTION
This reverts commit 4857f75aa24e4f0de4cd7ae39f03bc0f79f3f407, reversing changes made to fe0f467028c23cf2fee253c4a62b48992ba0034c.

This reverts PR #9200.

The cherry-pick that's being tried in that PR is already part of the branch (00e2098), and the commit removes code added after the original commit, and duplicates some testing code, producing errors in several tests.

See the comments of #9200 for more details.