### PR TITLE
[lldb] Add Swift syntax highlighting using SwiftSyntax

### DIFF
--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(LLVM_NO_RTTI 1)
 
+add_subdirectory(SwiftHighlighter)
+
 add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   FoundationValueTypes.cpp
   LogChannelSwift.cpp
@@ -9,6 +11,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   SwiftDictionary.cpp
   SwiftFormatters.cpp
   SwiftHashedContainer.cpp
+  SwiftHighlighterBridge.cpp
   SwiftLanguage.cpp
   SwiftMetatype.cpp
   SwiftOptionSet.cpp
@@ -28,6 +31,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
     swiftAST
     swiftClangImporter
     clangAST
+    swiftHighlighter
 
   LINK_COMPONENTS
     Support

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighter/.swift-format
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighter/.swift-format
@@ -1,0 +1,17 @@
+{
+    "version": 1,
+    "lineLength": 120,
+    "indentation": {
+        "spaces": 2
+    },
+    "lineBreakBeforeEachArgument": true,
+    "indentConditionalCompilationBlocks": false,
+    "rules": {
+        "AlwaysUseLowerCamelCase": false,
+        "AmbiguousTrailingClosureOverload": false,
+        "NoBlockComments": false,
+        "OrderedImports": true,
+        "UseLetInEveryBoundCaseVariable": false,
+        "UseSynthesizedInitializer": false
+    }
+}

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighter/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighter/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(SwiftHighlighter LANGUAGES Swift)
+
+# Verify that we have a new enough compiler
+if("${CMAKE_Swift_COMPILER_VERSION}" VERSION_LESS 5.9)
+  message(FATAL_ERROR "Bidirectional C++ Interop requires Swift 5.9 or greater. Have ${CMAKE_Swift_COMPILER_VERSION}")
+endif()
+
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+   NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  message(FATAL_ERROR "Project requires building with Clang.
+  Have ${CMAKE_CXX_COMPILER_ID}")
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
+# Set up swiftrt.o and runtime library search paths
+include(InitializeSwift)
+# Include the _swift_generate_cxx_header function
+include(GenerateCxxHeader)
+
+
+add_library(swiftHighlighter STATIC swiftHighlighter.swift)
+target_link_libraries(swiftHighlighter SwiftSyntax)
+target_link_libraries(swiftHighlighter SwiftParser)
+
+target_compile_options(swiftHighlighter PUBLIC
+  "$<$<COMPILE_LANGUAGE:Swift>:-cxx-interoperability-mode=default>")
+
+
+set(SWIFT_HIGHLIGHTER_INCLUDE_DIR "${LLDB_SWIFT_LIBS}/host/"
+  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+_swift_generate_cxx_header(swiftHighlighter
+  swiftHighlighter/swiftHighlighter-swift.h
+  SEARCH_PATHS "${SWIFT_HIGHLIGHTER_INCLUDE_DIR}")

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighter/SwiftHighlighter.swift
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighter/SwiftHighlighter.swift
@@ -1,0 +1,352 @@
+import CxxStdlib
+import SwiftHighlighterSupport
+import SwiftParser
+import SwiftSyntax
+
+private extension String {
+  /// Helper function to extract ranges expressed in UTF8 offsets from a string.
+  subscript(_ range: Range<AbsolutePosition>) -> Substring.UTF8View {
+    let start = index(startIndex, offsetBy: range.lowerBound.utf8Offset)
+    let end = index(startIndex, offsetBy: range.upperBound.utf8Offset)
+    return self.utf8[start..<end]
+  }
+}
+
+private extension TriviaPiece {
+  var isComment: Bool {
+    return switch self {
+    case .lineComment, .blockComment, .docLineComment, .docBlockComment:
+      true
+    default:
+      false
+    }
+  }
+}
+
+enum AnsiColor {
+  enum Bright {
+    static let red = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.bright.red}"), true))
+    static let green = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.bright.green}"), true))
+    static let yellow = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.bright.yellow}"), true))
+    static let blue = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.bright.blue}"), true))
+    static let purple = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.bright.purple}"), true))
+    static let cyan = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.bright.cyan}"), true))
+  }
+  static let red = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.red}"), true))
+  static let green = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.green}"), true))
+  static let yellow = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.yellow}"), true))
+  static let blue = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.blue}"), true))
+  static let purple = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.purple}"), true))
+  static let cyan = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.fg.cyan}"), true))
+  static let normal = String(ansi.FormatAnsiTerminalCodes(std.string("${ansi.normal}"), true))
+}
+
+/// The different syntactic elements that can be highlighted.
+enum HighlightStyle {
+  case comment
+  case stringLiteral
+  case numberLiteral
+  case keyword
+  case attribute
+  case typeDeclaration
+  case otherDeclaration
+  case typeIdentifier
+  case function
+  case functionLabel
+
+  func getColor() -> String {
+    return switch self {
+    case .comment: AnsiColor.purple
+    case .stringLiteral: AnsiColor.green
+    case .numberLiteral: AnsiColor.yellow
+    case .keyword: AnsiColor.Bright.red
+    case .attribute: AnsiColor.red
+    case .typeDeclaration: AnsiColor.Bright.green
+    case .otherDeclaration: AnsiColor.normal
+    case .typeIdentifier: AnsiColor.green
+    case .function: AnsiColor.cyan
+    case .functionLabel: AnsiColor.cyan
+    }
+  }
+}
+
+struct HighlightMarker: Comparable {
+  enum Priority: Comparable {
+    case low
+    case medium
+    case high
+  }
+
+  // The range inside the source code that should be highlighted.
+  let range: Range<AbsolutePosition>
+  // The style that this highlight should adopt.
+  let style: HighlightStyle
+  // The priority of this marker. Multiple highlight markers can be parsed for the same
+  // range, the priority is used to pick which highlight to keep.
+  let priority: Priority
+
+  init(range: Range<AbsolutePosition>, style: HighlightStyle, priority: Priority) {
+    self.range = range
+    self.style = style
+    self.priority = priority
+  }
+
+  func produceHighlight(using string: String) -> String {
+    return "\(style.getColor())\(String(string[range])!)\(AnsiColor.normal)"
+  }
+
+  static func < (lhs: HighlightMarker, rhs: HighlightMarker) -> Bool {
+    assert(!lhs.range.overlaps(rhs.range), "Ranges overlap!")
+    return lhs.range.lowerBound < rhs.range.upperBound
+  }
+}
+
+class SwiftSyntaxHighlighter: SyntaxVisitor {
+  private let source: String
+
+  /// The set of markers parsed from the source.
+  private(set) var highlightMarkers = [HighlightMarker]()
+
+  /// The range that should be highlighted. The source might have more text than what will be highlighted,
+  /// but be included to provide better context for the SyntaxVisitor. With the range, SwiftSyntaxHighlighter
+  /// can avoid adding highlight markers to text that won't be displayed, as well as skipping over SyntaxNodes
+  /// that are outside of the range of what will be highlighted.
+  private let highlightRange: Range<AbsolutePosition>
+
+  private init(sourceString: String, highlightRange: Range<AbsolutePosition>) {
+    self.source = sourceString
+    let sourceFile: SourceFileSyntax = Parser.parse(source: sourceString)
+    self.highlightRange = highlightRange
+    super.init(viewMode: .all)
+    walk(sourceFile)
+  }
+
+  private func mark(range: Range<AbsolutePosition>, style: HighlightStyle, priority: HighlightMarker.Priority = .medium)
+  {
+    let newMarker = HighlightMarker(range: range, style: style, priority: priority)
+
+    // Find if there is a marker in the same range of the one we're trying to add.
+    let storedMarkerIndex = highlightMarkers.firstIndex { storedMarker in
+      newMarker.range == storedMarker.range
+    }
+
+    // If there is, keep the one with higher priority.
+    if let storedMarkerIndex {
+      let storedMarker = highlightMarkers[storedMarkerIndex]
+      assert(storedMarker.priority != newMarker.priority, "Markers with same range have same priority")
+      if storedMarker.priority < newMarker.priority {
+        self.highlightMarkers.remove(at: storedMarkerIndex)
+      } else {
+        return
+      }
+    }
+
+    let overlapped = highlightMarkers.first(where: { $0.range.overlaps(newMarker.range) })
+    assert(overlapped == nil, "Ranges overlap!")
+
+    self.highlightMarkers.append(newMarker)
+  }
+
+  private func extractPositionWithoutTrivia(from syntax: SyntaxProtocol) -> Range<AbsolutePosition> {
+    return syntax.positionAfterSkippingLeadingTrivia..<syntax.endPositionBeforeTrailingTrivia
+  }
+
+  private func addHighlightIfVisible(
+    to node: SyntaxProtocol,
+    withStyle style: HighlightStyle,
+    andPriority priority: HighlightMarker.Priority = .medium
+  ) {
+    // If this node's range doesn't overlap with what needs to be highlighted there's nothing to do.
+    guard node.range.overlaps(highlightRange) else {
+      return
+    }
+    mark(range: extractPositionWithoutTrivia(from: node), style: style, priority: priority)
+  }
+
+  private func addHighlightIfVisible(
+    toRange range: Range<AbsolutePosition>,
+    with style: HighlightStyle,
+    and priority: HighlightMarker.Priority = .medium
+  ) {
+    // If this node's range doesn't overlap with what needs to be highlighted there's nothing to do.
+    guard range.overlaps(highlightRange) else {
+      return
+    }
+    mark(range: range, style: style, priority: priority)
+  }
+
+  // Parse all the trivia pieces attached to the trivia. For highlight purposes these are comments.
+  private func parse(trivia: Trivia, startingFrom startPosition: AbsolutePosition) {
+    var startPosition = startPosition
+    for triviaPiece in trivia.pieces {
+      let endPosition = startPosition + triviaPiece.sourceLength
+      if triviaPiece.isComment {
+        addHighlightIfVisible(toRange: startPosition..<endPosition, with: .comment)
+      }
+      startPosition = endPosition
+    }
+  }
+
+  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    guard token.range.overlaps(highlightRange) else { return .skipChildren }
+
+    switch token.tokenKind {
+    case .keyword:
+      // Keywords might already be processed as identifiers ("self", "super"),
+      // add them with a high priority as we want the "keyword" colorization
+      // to win over the identifier one.
+      addHighlightIfVisible(to: token, withStyle: .keyword, andPriority: .high)
+    case .stringQuote, .stringSegment:
+      addHighlightIfVisible(to: token, withStyle: .stringLiteral)
+    case .integerLiteral, .floatLiteral:
+      addHighlightIfVisible(to: token, withStyle: .numberLiteral)
+    default:
+      break
+    }
+    parse(trivia: token.leadingTrivia, startingFrom: token.position)
+    parse(trivia: token.trailingTrivia, startingFrom: token.endPositionBeforeTrailingTrivia)
+
+    return .visitChildren
+  }
+
+  override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .typeDeclaration)
+    return .visitChildren
+  }
+
+  override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .typeDeclaration)
+    return .visitChildren
+  }
+
+  override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .typeDeclaration)
+    return .visitChildren
+  }
+
+  override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .typeDeclaration)
+    return .visitChildren
+  }
+
+  override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .typeDeclaration)
+    return .visitChildren
+  }
+
+  override func visit(_ node: EnumCaseElementSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .otherDeclaration)
+    return .visitChildren
+  }
+
+  override func visit(_ node: AttributeSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.atSign, withStyle: .attribute, andPriority: .high)
+    addHighlightIfVisible(to: node.attributeName, withStyle: .attribute, andPriority: .high)
+    return .visitChildren
+  }
+
+  override func visit(_ node: IdentifierPatternSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.identifier, withStyle: .otherDeclaration)
+    return .visitChildren
+  }
+
+  override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .function)
+    return .visitChildren
+  }
+
+  override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.firstName, withStyle: .functionLabel)
+    return .visitChildren
+  }
+
+  override func visit(_ node: IdentifierTypeSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .typeIdentifier)
+    return .visitChildren
+  }
+
+  override func visit(_ node: MemberTypeSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    addHighlightIfVisible(to: node.name, withStyle: .typeIdentifier)
+    return .visitChildren
+  }
+
+  override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    if let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self) {
+      addHighlightIfVisible(to: memberAccess.declName, withStyle: .function)
+    } else if let declReference = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+      addHighlightIfVisible(to: declReference, withStyle: .function)
+    }
+    return .visitChildren
+  }
+
+  override func visit(_ node: LabeledExprSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    if let label = node.label {
+      addHighlightIfVisible(to: label, withStyle: .functionLabel)
+    }
+    return .visitChildren
+  }
+
+  override func visit(_ node: DeclReferenceExprSyntax) -> SyntaxVisitorContinueKind {
+    guard node.range.overlaps(highlightRange) else { return .skipChildren }
+
+    // DeclReferences are a very broad category, so add highlights to them with low
+    // priority, in case there are more accurate categories that can highlight them.
+    addHighlightIfVisible(to: node, withStyle: .otherDeclaration, andPriority: .low)
+    return .visitChildren
+  }
+
+  static func highlight(source: String, highlightRange: Range<AbsolutePosition>) -> String {
+    let highlighter = SwiftSyntaxHighlighter(sourceString: source, highlightRange: highlightRange)
+    let sorted = highlighter.highlightMarkers.sorted()
+    var highlighted = ""
+    // Because we're only highlighting whats in highlightRange, start with its lower bound.
+    var lastParsedIndex = highlightRange.lowerBound
+    for marker in sorted {
+      if marker.range.lowerBound.utf8Offset > 0 {
+        // Append any unhighlighted text before the marker.
+        highlighted += String(source[lastParsedIndex..<marker.range.lowerBound])!
+      }
+      // Add the highlighted marker's text.
+      highlighted += marker.produceHighlight(using: source)
+      lastParsedIndex = marker.range.upperBound
+    }
+    // Add anything left after the last maerker.
+    highlighted += String(source[lastParsedIndex..<highlightRange.upperBound])!
+    return highlighted
+  }
+}
+
+public func highlight(previousSource: String, source: String) -> String {
+  let entireSource = previousSource + source
+  let start = AbsolutePosition(utf8Offset: previousSource.utf8.count)
+  let end = start.advanced(by: source.utf8.count)
+  return SwiftSyntaxHighlighter.highlight(source: entireSource, highlightRange: start..<end)
+}

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighter/cmake/modules/GenerateCxxHeader.cmake
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighter/cmake/modules/GenerateCxxHeader.cmake
@@ -1,0 +1,66 @@
+# Generate the bridging header from Swift to C++
+#
+# target: the name of the target to generate headers for.
+#         This target must build swift source files.
+# header: the name of the header file to generate.
+#
+# NOTE: This logic will eventually be unstreamed into CMake.
+function(_swift_generate_cxx_header target header)
+  if(NOT TARGET ${target})
+    message(FATAL_ERROR "Target ${target} not defined.")
+  endif()
+
+  if(NOT DEFINED CMAKE_Swift_COMPILER)
+    message(WARNING "Swift not enabled in project. Cannot generate headers for Swift files.")
+    return()
+  endif()
+
+  cmake_parse_arguments(ARG "" "" "SEARCH_PATHS;MODULE_NAME" ${ARGN})
+
+  if(NOT ARG_MODULE_NAME)
+    set(target_module_name $<TARGET_PROPERTY:${target},Swift_MODULE_NAME>)
+    set(ARG_MODULE_NAME $<IF:$<BOOL:${target_module_name}>,${target_module_name},${target}>)
+  endif()
+
+  if(ARG_SEARCH_PATHS)
+    list(TRANSFORM ARG_SEARCH_PATHS PREPEND "-I")
+  endif()
+
+  if(APPLE)
+    set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
+  elseif(WIN32)
+    set(SDK_FLAGS "-sdk" "$ENV{SDKROOT}")
+  elseif(DEFINED ${CMAKE_SYSROOT})
+    set(SDK_FLAGS "-sdk" "${CMAKE_SYSROOT}")
+  endif()
+
+  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR include
+    OUTPUT_VARIABLE base_path)
+
+  cmake_path(APPEND base_path ${header}
+    OUTPUT_VARIABLE header_path)
+
+  set(_AllSources $<TARGET_PROPERTY:${target},SOURCES>)
+  set(_SwiftSources $<FILTER:${_AllSources},INCLUDE,\\.swift$>)
+  add_custom_command(OUTPUT ${header_path}
+    DEPENDS ${_SwiftSources}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND
+      ${CMAKE_Swift_COMPILER} -frontend -typecheck
+      ${ARG_SEARCH_PATHS}
+      ${_SwiftSources}
+      ${SDK_FLAGS}
+      -module-name "${ARG_MODULE_NAME}"
+      -cxx-interoperability-mode=default
+      -emit-clang-header-path ${header_path}
+      -Xcc -std=c++17
+    COMMENT
+      "Generating '${header_path}'"
+    COMMAND_EXPAND_LISTS)
+
+  # Added to public interface for dependees to find.
+  target_include_directories(${target} PUBLIC ${base_path})
+  # Added to the target to ensure target rebuilds if header changes and is used
+  # by sources in the target.
+  target_sources(${target} PRIVATE ${header_path})
+endfunction()

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighter/cmake/modules/InitializeSwift.cmake
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighter/cmake/modules/InitializeSwift.cmake
@@ -1,0 +1,83 @@
+# Compute the name of the architecture directory on Windows from the CMake
+# system processor name.
+function(_swift_windows_arch_name output_variable_name target_arch)
+  if(NOT WIN32)
+    return()
+  endif()
+
+  if("${target_arch}" STREQUAL "AMD64")
+    set("${output_variable_name}" "x86_64" PARENT_SCOPE)
+  elseif("${target_arch}" STREQUAL "ARM64")
+    set("${output_variable_name}" "aarch64" PARENT_SCOPE)
+  else()
+    message(FATAL_ERROR "Unknown windows architecture: ${target_arch}")
+  endif()
+endfunction()
+
+# Compute flags and search paths
+# NOTE: This logic will eventually move to CMake
+function(_setup_swift_paths)
+  # If we haven't set the swift library search paths, do that now
+  if(NOT SWIFT_LIBRARY_SEARCH_PATHS)
+    if(APPLE)
+      set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
+    endif()
+
+    # Note: This does not handle cross-compiling correctly.
+    #       To handle it correctly, we would need to pass the target triple and
+    #       flags to this compiler invocation.
+    execute_process(
+      COMMAND ${CMAKE_Swift_COMPILER} ${SDK_FLAGS} -print-target-info
+      OUTPUT_VARIABLE SWIFT_TARGET_INFO
+    )
+
+    # extract search paths from swift driver response
+    string(JSON SWIFT_TARGET_PATHS GET ${SWIFT_TARGET_INFO} "paths")
+
+    string(JSON SWIFT_TARGET_LIBRARY_PATHS GET ${SWIFT_TARGET_PATHS} "runtimeLibraryPaths")
+    string(JSON SWIFT_TARGET_LIBRARY_PATHS_LENGTH LENGTH ${SWIFT_TARGET_LIBRARY_PATHS})
+    math(EXPR SWIFT_TARGET_LIBRARY_PATHS_LENGTH "${SWIFT_TARGET_LIBRARY_PATHS_LENGTH} - 1 ")
+
+    string(JSON SWIFT_TARGET_LIBRARY_IMPORT_PATHS GET ${SWIFT_TARGET_PATHS} "runtimeLibraryImportPaths")
+    string(JSON SWIFT_TARGET_LIBRARY_IMPORT_PATHS_LENGTH LENGTH ${SWIFT_TARGET_LIBRARY_IMPORT_PATHS})
+    math(EXPR SWIFT_TARGET_LIBRARY_IMPORT_PATHS_LENGTH "${SWIFT_TARGET_LIBRARY_IMPORT_PATHS_LENGTH} - 1 ")
+
+    string(JSON SWIFT_SDK_IMPORT_PATH ERROR_VARIABLE errno GET ${SWIFT_TARGET_PATHS} "sdkPath")
+
+    foreach(JSON_ARG_IDX RANGE ${SWIFT_TARGET_LIBRARY_PATHS_LENGTH})
+      string(JSON SWIFT_LIB GET ${SWIFT_TARGET_LIBRARY_PATHS} ${JSON_ARG_IDX})
+      list(APPEND SWIFT_SEARCH_PATHS ${SWIFT_LIB})
+    endforeach()
+
+    foreach(JSON_ARG_IDX RANGE ${SWIFT_TARGET_LIBRARY_IMPORT_PATHS_LENGTH})
+      string(JSON SWIFT_LIB GET ${SWIFT_TARGET_LIBRARY_IMPORT_PATHS} ${JSON_ARG_IDX})
+      list(APPEND SWIFT_SEARCH_PATHS ${SWIFT_LIB})
+    endforeach()
+
+    if(SWIFT_SDK_IMPORT_PATH)
+      list(APPEND SWIFT_SEARCH_PATHS ${SWIFT_SDK_IMPORT_PATH})
+    endif()
+
+    # Save the swift library search paths
+    set(SWIFT_LIBRARY_SEARCH_PATHS ${SWIFT_SEARCH_PATHS} CACHE FILEPATH "Swift driver search paths")
+  endif()
+
+  link_directories(${SWIFT_LIBRARY_SEARCH_PATHS})
+
+  if(WIN32)
+    _swift_windows_arch_name(SWIFT_WIN_ARCH_DIR "${CMAKE_SYSTEM_PROCESSOR}")
+    set(SWIFT_SWIFTRT_FILE "$ENV{SDKROOT}/usr/lib/swift/windows/${SWIFT_WIN_ARCH_DIR}/swiftrt.obj")
+    add_link_options("$<$<LINK_LANGUAGE:Swift>:${SWIFT_SWIFTRT_FILE}>")
+  elseif(NOT APPLE)
+    find_file(SWIFT_SWIFTRT_FILE
+              swiftrt.o
+              PATHS ${SWIFT_LIBRARY_SEARCH_PATHS}
+              NO_CACHE
+              REQUIRED
+              NO_DEFAULT_PATH)
+    add_link_options("$<$<LINK_LANGUAGE:Swift>:${SWIFT_SWIFTRT_FILE}>")
+  endif()
+endfunction()
+
+
+_setup_swift_paths()

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighter/include/SwiftHighlighterSupport.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighter/include/SwiftHighlighterSupport.h
@@ -1,0 +1,182 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: this is copied from include/lldb/Utility/AnsiTerminal.h, with
+// some modifications to remove references to llvm types (for example,
+// replacing llvm::StringRef with std::string), because at the moment
+// Swift/C++ interop is not able to import the LLDB (or LLVM) umbrella. This
+// should be removed when that's possible.
+
+#ifndef SWIFTHIGHLIGHTERSUPPORT_H
+#define SWIFTHIGHLIGHTERSUPPORT_H
+
+#define ANSI_FG_COLOR_BLACK 30
+#define ANSI_FG_COLOR_RED 31
+#define ANSI_FG_COLOR_GREEN 32
+#define ANSI_FG_COLOR_YELLOW 33
+#define ANSI_FG_COLOR_BLUE 34
+#define ANSI_FG_COLOR_PURPLE 35
+#define ANSI_FG_COLOR_CYAN 36
+#define ANSI_FG_COLOR_WHITE 37
+
+#define ANSI_FG_COLOR_BRIGHT_BLACK 90
+#define ANSI_FG_COLOR_BRIGHT_RED 91
+#define ANSI_FG_COLOR_BRIGHT_GREEN 92
+#define ANSI_FG_COLOR_BRIGHT_YELLOW 93
+#define ANSI_FG_COLOR_BRIGHT_BLUE 94
+#define ANSI_FG_COLOR_BRIGHT_PURPLE 95
+#define ANSI_FG_COLOR_BRIGHT_CYAN 96
+#define ANSI_FG_COLOR_BRIGHT_WHITE 97
+
+#define ANSI_BG_COLOR_BLACK 40
+#define ANSI_BG_COLOR_RED 41
+#define ANSI_BG_COLOR_GREEN 42
+#define ANSI_BG_COLOR_YELLOW 43
+#define ANSI_BG_COLOR_BLUE 44
+#define ANSI_BG_COLOR_PURPLE 45
+#define ANSI_BG_COLOR_CYAN 46
+#define ANSI_BG_COLOR_WHITE 47
+
+#define ANSI_BG_COLOR_BRIGHT_BLACK 100
+#define ANSI_BG_COLOR_BRIGHT_RED 101
+#define ANSI_BG_COLOR_BRIGHT_GREEN 102
+#define ANSI_BG_COLOR_BRIGHT_YELLOW 103
+#define ANSI_BG_COLOR_BRIGHT_BLUE 104
+#define ANSI_BG_COLOR_BRIGHT_PURPLE 105
+#define ANSI_BG_COLOR_BRIGHT_CYAN 106
+#define ANSI_BG_COLOR_BRIGHT_WHITE 107
+
+#define ANSI_SPECIAL_FRAMED 51
+#define ANSI_SPECIAL_ENCIRCLED 52
+
+#define ANSI_CTRL_NORMAL 0
+#define ANSI_CTRL_BOLD 1
+#define ANSI_CTRL_FAINT 2
+#define ANSI_CTRL_ITALIC 3
+#define ANSI_CTRL_UNDERLINE 4
+#define ANSI_CTRL_SLOW_BLINK 5
+#define ANSI_CTRL_FAST_BLINK 6
+#define ANSI_CTRL_IMAGE_NEGATIVE 7
+#define ANSI_CTRL_CONCEAL 8
+#define ANSI_CTRL_CROSSED_OUT 9
+
+#define ANSI_ESC_START "\033["
+#define ANSI_ESC_END "m"
+
+#define ANSI_STR(s) #s
+#define ANSI_DEF_STR(s) ANSI_STR(s)
+
+#define ANSI_ESCAPE1(s) ANSI_ESC_START ANSI_DEF_STR(s) ANSI_ESC_END
+
+#define ANSI_1_CTRL(ctrl1) "\033["##ctrl1 ANSI_ESC_END
+#define ANSI_2_CTRL(ctrl1, ctrl2) "\033["##ctrl1 ";"##ctrl2 ANSI_ESC_END
+
+#include <string>
+
+namespace ansi {
+
+inline std::string FormatAnsiTerminalCodes(std::string format,
+                                           bool do_color = true) {
+  // Convert "${ansi.XXX}" tokens to ansi values or clear them if do_color is
+  // false.
+  // clang-format off
+  static const struct {
+    const char *name;
+    const char *value;
+  } g_color_tokens[] = {
+#define _TO_STR2(_val) #_val
+#define _TO_STR(_val) _TO_STR2(_val)
+      {"fg.black}",         ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BLACK) ANSI_ESC_END},
+      {"fg.red}",           ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_RED) ANSI_ESC_END},
+      {"fg.green}",         ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_GREEN) ANSI_ESC_END},
+      {"fg.yellow}",        ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_YELLOW) ANSI_ESC_END},
+      {"fg.blue}",          ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BLUE) ANSI_ESC_END},
+      {"fg.purple}",        ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_PURPLE) ANSI_ESC_END},
+      {"fg.cyan}",          ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_CYAN) ANSI_ESC_END},
+      {"fg.white}",         ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_WHITE) ANSI_ESC_END},
+      {"fg.bright.black}",  ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_BLACK) ANSI_ESC_END},
+      {"fg.bright.red}",    ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_RED) ANSI_ESC_END},
+      {"fg.bright.green}",  ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_GREEN) ANSI_ESC_END},
+      {"fg.bright.yellow}", ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_YELLOW) ANSI_ESC_END},
+      {"fg.bright.blue}",   ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_BLUE) ANSI_ESC_END},
+      {"fg.bright.purple}", ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_PURPLE) ANSI_ESC_END},
+      {"fg.bright.cyan}",   ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_CYAN) ANSI_ESC_END},
+      {"fg.bright.white}",  ANSI_ESC_START _TO_STR(ANSI_FG_COLOR_BRIGHT_WHITE) ANSI_ESC_END},
+      {"bg.black}",         ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BLACK) ANSI_ESC_END},
+      {"bg.red}",           ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_RED) ANSI_ESC_END},
+      {"bg.green}",         ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_GREEN) ANSI_ESC_END},
+      {"bg.yellow}",        ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_YELLOW) ANSI_ESC_END},
+      {"bg.blue}",          ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BLUE) ANSI_ESC_END},
+      {"bg.purple}",        ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_PURPLE) ANSI_ESC_END},
+      {"bg.cyan}",          ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_CYAN) ANSI_ESC_END},
+      {"bg.white}",         ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_WHITE) ANSI_ESC_END},
+      {"bg.bright.black}",  ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_BLACK) ANSI_ESC_END},
+      {"bg.bright.red}",    ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_RED) ANSI_ESC_END},
+      {"bg.bright.green}",  ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_GREEN) ANSI_ESC_END},
+      {"bg.bright.yellow}", ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_YELLOW) ANSI_ESC_END},
+      {"bg.bright.blue}",   ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_BLUE) ANSI_ESC_END},
+      {"bg.bright.purple}", ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_PURPLE) ANSI_ESC_END},
+      {"bg.bright.cyan}",   ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_CYAN) ANSI_ESC_END},
+      {"bg.bright.white}",  ANSI_ESC_START _TO_STR(ANSI_BG_COLOR_BRIGHT_WHITE) ANSI_ESC_END},
+      {"normal}",           ANSI_ESC_START _TO_STR(ANSI_CTRL_NORMAL) ANSI_ESC_END},
+      {"bold}",             ANSI_ESC_START _TO_STR(ANSI_CTRL_BOLD) ANSI_ESC_END},
+      {"faint}",            ANSI_ESC_START _TO_STR(ANSI_CTRL_FAINT) ANSI_ESC_END},
+      {"italic}",           ANSI_ESC_START _TO_STR(ANSI_CTRL_ITALIC) ANSI_ESC_END},
+      {"underline}",        ANSI_ESC_START _TO_STR(ANSI_CTRL_UNDERLINE) ANSI_ESC_END},
+      {"slow-blink}",       ANSI_ESC_START _TO_STR(ANSI_CTRL_SLOW_BLINK) ANSI_ESC_END},
+      {"fast-blink}",       ANSI_ESC_START _TO_STR(ANSI_CTRL_FAST_BLINK) ANSI_ESC_END},
+      {"negative}",         ANSI_ESC_START _TO_STR(ANSI_CTRL_IMAGE_NEGATIVE) ANSI_ESC_END},
+      {"conceal}",          ANSI_ESC_START _TO_STR(ANSI_CTRL_CONCEAL) ANSI_ESC_END},
+      {"crossed-out}",      ANSI_ESC_START _TO_STR(ANSI_CTRL_CROSSED_OUT) ANSI_ESC_END},
+#undef _TO_STR
+#undef _TO_STR2
+  };
+  // clang-format on
+
+  static std::string tok_hdr = "${ansi.";
+
+  std::string fmt;
+  while (!format.empty()) {
+    std::string left = format.substr(0, format.find(tok_hdr));
+    std::string right =
+        format.substr(format.find(tok_hdr) + tok_hdr.size(), format.size());
+
+    fmt += left;
+
+    if (left == format && right.empty()) {
+      // The header was not found.  Just exit.
+      break;
+    }
+
+    bool found_code = false;
+    for (int i = 0; i < 42; ++i) {
+      auto code = g_color_tokens[i];
+      if (right.rfind(code.name) != 0) {
+        continue;
+      }
+      right = right.substr(strlen(code.name));
+
+      if (do_color)
+        fmt.append(code.value);
+      found_code = true;
+      break;
+    }
+    format = right;
+    // If we haven't found a valid replacement value, we just copy the string
+    // to the result without any modifications.
+    if (!found_code)
+      fmt.append(tok_hdr);
+  }
+  return fmt;
+}
+} // namespace ansi
+
+#endif // SWIFTHIGHLIGHTERSUPPORT_H

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighter/include/module.modulemap
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighter/include/module.modulemap
@@ -1,0 +1,3 @@
+module SwiftHighlighterSupport {
+  header "SwiftHighlighterSupport.h"
+}

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighterBridge.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighterBridge.cpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#include "SwiftHighlighterBridge.h"
+#include "swiftHighlighter/swiftHighlighter-swift.h"
+#include <string>
+
+using namespace lldb_private;
+using namespace swiftHighlighter;
+
+void SwiftHighlighterBridge::Highlight(const HighlightStyle &options,
+                                 llvm::StringRef line,
+                                 std::optional<size_t> cursor_pos,
+                                 llvm::StringRef previous_lines,
+                                 Stream &s) const {
+  std::string highlighted = highlight(previous_lines.str(), line.str());
+  s << highlighted;
+}

--- a/lldb/source/Plugins/Language/Swift/SwiftHighlighterBridge.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftHighlighterBridge.h
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_SwiftHighlighterBridge_h_
+#define liblldb_SwiftHighlighterBridge_h_
+
+#include "lldb/Core/Highlighter.h"
+#include "lldb/Utility/Stream.h"
+
+namespace lldb_private {
+
+/// A "bridge" that calls into the Swift code that does Syntax highlighting.
+/// This class's purpose is to mplement the Highlighter interface, as Swift/C++
+/// interop doesn't allow for a Swift class to inherit from a C++ one, and
+/// forward the calls of "Highlight" to Swift.
+class SwiftHighlighterBridge : public Highlighter {
+
+public:
+  SwiftHighlighterBridge() = default;
+
+  llvm::StringRef GetName() const override { return "swift"; }
+
+  void Highlight(const HighlightStyle &options, llvm::StringRef line,
+                 std::optional<size_t> cursor_pos,
+                 llvm::StringRef previous_lines, Stream &s) const override;
+};
+} // namespace lldb_private
+
+#endif // liblldb_SwiftHighlighterBridge_h_

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SwiftLanguage.h"
-
+#include "SwiftHighlighterBridge.h"
 #include "SwiftUnsafeTypes.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/PluginManager.h"
@@ -38,6 +38,7 @@
 #include "SwiftFormatters.h"
 
 #include <functional>
+#include <memory>
 #include <mutex>
 
 #include "lldb/lldb-enumerations.h"
@@ -61,6 +62,8 @@ using lldb_private::formatters::swift::DictionaryConfig;
 using lldb_private::formatters::swift::SetConfig;
 
 LLDB_PLUGIN_DEFINE(SwiftLanguage)
+
+SwiftLanguage::SwiftLanguage() : m_highlighter((std::make_unique<SwiftHighlighterBridge>()) ) {}
 
 void SwiftLanguage::Initialize() {
   LogChannelSwift::Initialize();

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -27,7 +27,7 @@ class SwiftLanguage : public Language {
 public:
   virtual ~SwiftLanguage() = default;
 
-  SwiftLanguage() = default;
+  SwiftLanguage();
 
   lldb::LanguageType GetLanguageType() const override {
     return lldb::eLanguageTypeSwift;
@@ -75,6 +75,10 @@ public:
   ConstString
   GetDemangledFunctionNameWithoutArguments(Mangled mangled) const override;
 
+  const Highlighter *GetHighlighter() const override {
+    return m_highlighter.get();
+  }
+
   //------------------------------------------------------------------
   // Static Functions
   //------------------------------------------------------------------
@@ -94,6 +98,8 @@ public:
   // PluginInterface protocol
   //------------------------------------------------------------------
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+private: 
+  std::unique_ptr<Highlighter> m_highlighter;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
Use SwiftSyntax to parse source code that will be displayed in command line LLDB and syntax highlight it. This adds a new CMake project under Plugins/Language/Swift/SwiftHighlighter, which has a dependency on the SwiftSyntax shared library which is already used by the compiler.