### PR TITLE
[lldb][TypeSystemClang] Avoid accessing definition if none is available

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -9,6 +9,7 @@
 #include "TypeSystemClang.h"
 
 #include "clang/AST/DeclBase.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/ExprCXX.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/Support/Casting.h"
@@ -3650,6 +3651,15 @@ bool TypeSystemClang::IsPolymorphicClass(lldb::opaque_compiler_type_t type) {
   return false;
 }
 
+/// Returns 'true' if \ref decl has been allocated a definition
+/// *and* the definition was marked as completed. There are currently
+/// situations in which LLDB marks a definition as `isCompleteDefinition`
+/// while no definition was allocated. This function guards against those
+/// situations.
+static bool HasCompleteDefinition(clang::CXXRecordDecl *decl) {
+  return decl && decl->hasDefinition() && decl->isCompleteDefinition();
+}
+
 bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
                                             CompilerType *dynamic_pointee_type,
                                             bool check_cplusplus,
@@ -3732,8 +3742,9 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
         if (check_cplusplus) {
           clang::CXXRecordDecl *cxx_record_decl =
               pointee_qual_type->getAsCXXRecordDecl();
+
           if (cxx_record_decl) {
-            bool is_complete = cxx_record_decl->isCompleteDefinition();
+            bool is_complete = HasCompleteDefinition(cxx_record_decl);
 
             if (is_complete)
               success = cxx_record_decl->isDynamicClass();
@@ -3742,7 +3753,9 @@ bool TypeSystemClang::IsPossibleDynamicType(lldb::opaque_compiler_type_t type,
               if (metadata)
                 success = metadata->GetIsDynamicCXXType();
               else {
-                is_complete = GetType(pointee_qual_type).GetCompleteType();
+                // Make sure completion has actually completed the type.
+                is_complete = GetType(pointee_qual_type).GetCompleteType() &&
+                              HasCompleteDefinition(cxx_record_decl);
                 if (is_complete)
                   success = cxx_record_decl->isDynamicClass();
                 else
@@ -5478,8 +5491,12 @@ TypeSystemClang::GetNumChildren(lldb::opaque_compiler_type_t type,
           llvm::cast<clang::RecordType>(qual_type.getTypePtr());
       const clang::RecordDecl *record_decl = record_type->getDecl();
       assert(record_decl);
+
+      // CXXBaseSpecifiers are stored on the definition. If we don't have
+      // one at this point that means we "completed" the type without actually
+      // having allocated a definition.
       const clang::CXXRecordDecl *cxx_record_decl =
-          llvm::dyn_cast<clang::CXXRecordDecl>(record_decl);
+          llvm::dyn_cast<clang::CXXRecordDecl>(record_decl)->getDefinition();
       if (cxx_record_decl) {
         if (omit_empty_base_classes) {
           // Check each base classes to see if it or any of its base classes


### PR DESCRIPTION
We've been hitting cases where LLDB marks a decl as `isCompleteDefinition` but no definition was allocated for it. Then when we access a an API in which Clang assumes a definition exists, and dereferences a nullptr. In the specific case that happens when we've incorrectly been keeping track of the `ImportedDecls` in `clang::ASTImporter` (which manifests as trying to `MapImported` on two different destination decls from the same source decl for the same ClangASTImporterDelegate).

The more fundmental issue is that we're failing to complete the type properly. But the fix for that is still in-progress. So we're working around the crash by guarding against failed type completion.

rdar://133958782