### PR TITLE
[lldb] Remove ambiguous e commands from tests

### DIFF
--- a/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
+++ b/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
@@ -14,11 +14,11 @@ class TestArchetypeInExpression(TestBase):
         # Check that you can refer to all types and function's archetypes.
         _, process, _, breakpoint = lldbutil.run_to_source_breakpoint(self, 
                 "break here", lldb.SBFileSpec("main.swift"))
-        self.expect("e First.self", substrs=["Int.Type"])
-        self.expect("e Second.self", substrs=["Double.Type"])
-        self.expect("e Third.self", substrs=["Bool.Type"])
-        self.expect("e T.self", substrs=["String.Type"])
-        self.expect("e U.self", substrs=["[Int].Type"])
+        self.expect("expr First.self", substrs=["Int.Type"])
+        self.expect("expr Second.self", substrs=["Double.Type"])
+        self.expect("expr Third.self", substrs=["Bool.Type"])
+        self.expect("expr T.self", substrs=["String.Type"])
+        self.expect("expr U.self", substrs=["[Int].Type"])
         # Assert that frame variable doesn't work
         self.expect("v First.self", 
                 substrs=["no variable or instance variable named 'First' found in this frame"],
@@ -29,7 +29,7 @@ class TestArchetypeInExpression(TestBase):
 
         # Check that referring to a shadowed archetype works correctly.
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e T.self", substrs=["String.Type"])
+        self.expect("expr T.self", substrs=["String.Type"])
         # Assert that frame variable doesn't work
         self.expect("v T.self", 
                 substrs=["no variable or instance variable named 'T' found in this frame"],
@@ -37,12 +37,12 @@ class TestArchetypeInExpression(TestBase):
 
         # Check that you refer to archetypes in nested generic functions.
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e T.self", substrs=["Bool.Type"])
-        self.expect("e U.self", substrs=["Double.Type"])
+        self.expect("expr T.self", substrs=["Bool.Type"])
+        self.expect("expr U.self", substrs=["Double.Type"])
 
         # Check that you refer to archetypes in nested generic functions with shadowed archetypes.
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e T.self", substrs=["String.Type"])
+        self.expect("expr T.self", substrs=["String.Type"])
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e T.self", substrs=["Int.Type"])
+        self.expect("expr T.self", substrs=["Int.Type"])
         

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -14,4 +14,4 @@ class TestSwiftProtocolExtensionSelf(TestBase):
                                           lldb.SBFileSpec('main.swift'))
         # This should work without dynamic types. For discussion, see:
         # https://github.com/apple/llvm-project/pull/2382
-        self.expect("e -d no-run -- f", substrs=[' = 12345'])
+        self.expect("expr -d no-run -- f", substrs=[' = 12345'])

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -65,9 +65,9 @@ class TestLibraryIndirect(TestBase):
             "(SomeLibrary.ContainsTwoInts) container = {\n  wrapped = 0x",
             "\n    value = (first = 2, second = 3)\n  }\n  other = 10\n}",
             "(Int) simple = 1"])
-        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
-        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "value = (first = 2, second = 3)"])
-        self.expect("e container.wrapped.value", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
+        self.expect("expr container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
+        self.expect("expr container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "0x", "value = (first = 2, second = 3)"])
+        self.expect("expr container.wrapped.value", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
     @swiftTest
     def test_implementation_only_import_library_no_library_module(self):
@@ -102,6 +102,6 @@ class TestLibraryIndirect(TestBase):
             "wrapped = 0x",
             "other = 10",
             "(Int) simple = 1"])
-        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "wrapped = 0x", "other = 10"])
-        self.expect("e container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "value = (first = 2, second = 3)"])
-        self.expect("e container.wrapped.value", error=True, substrs=["value of type 'BoxedTwoInts' has no member 'value'"])
+        self.expect("expr container", substrs=["(SomeLibrary.ContainsTwoInts)", "wrapped = 0x", "other = 10"])
+        self.expect("expr container.wrapped", substrs=["(SomeLibrary.BoxedTwoInts)", "value = (first = 2, second = 3)"])
+        self.expect("expr container.wrapped.value", error=True, substrs=["value of type 'BoxedTwoInts' has no member 'value'"])

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -53,8 +53,8 @@ class TestLibraryResilient(TestBase):
         self.expect("fr var", substrs=[
             "(SomeLibrary.ContainsTwoInts) container = {\n  wrapped = (first = 2, second = 3)\n  other = 10\n}",
             "(Int) simple = 1"])
-        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
-        self.expect("e container.wrapped", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
+        self.expect("expr container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
+        self.expect("expr container.wrapped", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
     @swiftTest
     @expectedFailureAll(oslist=["windows"]) # Requires Remote Mirrors support
@@ -74,5 +74,5 @@ class TestLibraryResilient(TestBase):
         self.expect("fr var", substrs=[
             "(SomeLibrary.ContainsTwoInts) container = {", "other = 10",
             "(Int) simple = 1"])
-        self.expect("e container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
-        self.expect("e container.wrapped", error=True, substrs=["value of type 'ContainsTwoInts' has no member 'wrapped'"])
+        self.expect("expr container", substrs=["(SomeLibrary.ContainsTwoInts)", "other = 10"])
+        self.expect("expr container.wrapped", error=True, substrs=["value of type 'ContainsTwoInts' has no member 'wrapped'"])

--- a/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -46,9 +46,9 @@ class TestSwiftModuleSearchPaths(TestBase):
                     self.getBuildDir())
         
         # import the module
-        self.runCmd("e import Module")
+        self.runCmd("expr import Module")
         
         # Check that we know about the function declared in the module
         self.match(
-            "e plusTen(10)", "error: Couldn't lookup symbols:", error=True)
+            "expr plusTen(10)", "error: Couldn't lookup symbols:", error=True)
 

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -24,7 +24,7 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
         self.expect("frame var -d run -- self",
                     substrs=['Builder.Private', 'n', '23'])
 
-        self.expect("e --bind-generic-types true -- self", error=True, substrs=["Hint"])
+        self.expect("expr --bind-generic-types true -- self", error=True, substrs=["Hint"])
         # This should work because expression evaluation automatically falls back
         # to not binding generic parameters.
         self.expect("expression self", substrs=['Generic', '<T>', 'n', '23'])

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -25,54 +25,54 @@ class TestSwiftPrivateGenericType(TestBase):
                 'break here for struct', lldb.SBFileSpec('Public.swift'),
                 extra_images=['Public'])
         # Make sure this fails without generic expression evaluation.
-        self.expect("e --bind-generic-types true -- self", 
+        self.expect("expr --bind-generic-types true -- self", 
                     substrs=["Couldn't realize Swift AST type of self."], 
                     error=True)
         # Test that not binding works.
-        self.expect("e --bind-generic-types false -- self", 
+        self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.StructWrapper<T>", 
                              'name = "The invisible struct."'])
         # Test that the "auto" behavior also works.
-        self.expect("e --bind-generic-types auto -- self", 
+        self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.StructWrapper<T>", 
                              'name = "The invisible struct."'])
         # Test that the default (should be the auto option) also works.
-        self.expect("e -- self", substrs=["Public.StructWrapper<T>", 
+        self.expect("expr -- self", substrs=["Public.StructWrapper<T>", 
                                           'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for class', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types true -- self", 
+        self.expect("expr --bind-generic-types true -- self", 
                     substrs=["Couldn't realize Swift AST type of self."], 
                     error=True)
-        self.expect("e --bind-generic-types false -- self", 
+        self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
                              'name = "The invisible struct."'])
-        self.expect("e --bind-generic-types auto -- self", 
+        self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
                              'name = "The invisible struct."'])
-        self.expect("e -- self", 
+        self.expect("expr -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
                              'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for two generic parameters', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types true -- self", 
+        self.expect("expr --bind-generic-types true -- self", 
                     substrs=["Couldn't realize Swift AST type of self."], 
                     error=True)
-        self.expect("e --bind-generic-types false -- self", 
+        self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.TwoGenericParameters",
                              "<Private.InvisibleClass, Private.InvisibleStruct>", 
                              'name = "The invisible class."',
                              "someNumber = 42"])
-        self.expect("e --bind-generic-types auto -- self", 
+        self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.TwoGenericParameters",
                              "<Private.InvisibleClass, Private.InvisibleStruct>", 
                              'name = "The invisible class."',
                              "someNumber = 42"])
-        self.expect("e -- self", 
+        self.expect("expr -- self", 
                     substrs=["Public.TwoGenericParameters",
                              "<Private.InvisibleClass, Private.InvisibleStruct>", 
                              'name = "The invisible class."',
@@ -81,24 +81,24 @@ class TestSwiftPrivateGenericType(TestBase):
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for three generic parameters', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types true -- self", 
+        self.expect("expr --bind-generic-types true -- self", 
                     substrs=["Couldn't realize Swift AST type of self."], 
                     error=True)
-        self.expect("e --bind-generic-types false -- self", 
+        self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.ThreeGenericParameters",
                              "<T, U, V>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
                              "v = true"])
-        self.expect("e --bind-generic-types auto -- self", 
+        self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.ThreeGenericParameters",
                              "<T, U, V>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
                              "v = true"])
-        self.expect("e -- self", 
+        self.expect("expr -- self", 
                     substrs=["Public.ThreeGenericParameters",
                              "<T, U, V>", 
                              'name = "The invisible class."',
@@ -109,10 +109,10 @@ class TestSwiftPrivateGenericType(TestBase):
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for four generic parameters', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types true -- self", 
+        self.expect("expr --bind-generic-types true -- self", 
                     substrs=["Couldn't realize Swift AST type of self."], 
                     error=True)
-        self.expect("e --bind-generic-types false -- self", 
+        self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.FourGenericParameters",
                              "<T, U, V, W>", 
                              'name = "The invisible struct."',
@@ -120,7 +120,7 @@ class TestSwiftPrivateGenericType(TestBase):
                              "someNumber = 42",
                              "v = 3 values", "One", "two", "three",
                              "w = 482"])
-        self.expect("e --bind-generic-types auto -- self", 
+        self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.FourGenericParameters",
                              "<T, U, V, W>", 
                              'name = "The invisible struct."',
@@ -128,7 +128,7 @@ class TestSwiftPrivateGenericType(TestBase):
                              "someNumber = 42",
                              "v = 3 values", "One", "two", "three",
                              "w = 482"])
-        self.expect("e -- self", 
+        self.expect("expr -- self", 
                     substrs=["Public.FourGenericParameters",
                              "<T, U, V, W>", 
                              'name = "The invisible struct."',
@@ -140,19 +140,19 @@ class TestSwiftPrivateGenericType(TestBase):
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for non-generic', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types false -- self", 
+        self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Could not evaluate the expression without binding generic types."], 
                     error=True)
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for nested generic parameters', lldb.SBFileSpec('Public.swift'), None)
         lldbutil.continue_to_breakpoint(process, breakpoint)
-        self.expect("e --bind-generic-types false -- self", 
+        self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Could not evaluate the expression without binding generic types."], 
                     error=True)
 
         # Check that if both binding and not binding the generic type parameters fail, we report 
         # the "bind generic params" error message, as that's the default case that runs first.
-        self.expect("e --bind-generic-types auto -- self", 
+        self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Couldn't realize Swift AST type of self."], 
                     error=True)

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
@@ -15,4 +15,4 @@ class TestDefaultProtocolExtensionNoSelfReference(TestBase):
         self.build()
 
         lldbutil.run_to_source_breakpoint(self, 'break here', lldb.SBFileSpec('main.swift'))
-        self.expect('e -d no-run-target -- self', substrs=["(a.C) $R0 = 0x"])
+        self.expect('expr -d no-run-target -- self', substrs=["(a.C) $R0 = 0x"])

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -81,10 +81,10 @@ class TestSwiftRegex(TestBase):
             self, 'Set breakpoint here', self.main_source_spec)
 
         # Make sure we can use the extended syntax without enabling anything.
-        self.expect('e -- #/Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/#',
+        self.expect('expr -- #/Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/#',
                     substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>'])
 
         self.runCmd(
             "settings set target.experimental.swift-enable-bare-slash-regex true")
-        self.expect('e -- /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/',
+        self.expect('expr -- /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/',
                     substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>'])


### PR DESCRIPTION
(cherry picked from commit 0d67ef1abd42cfbccf5919762808ecf994370187)