### PR TITLE
[Support] Include `intrin.h` for MSVC intrinsics in `xxhash.cpp`

### DIFF
--- a/llvm/lib/Support/xxhash.cpp
+++ b/llvm/lib/Support/xxhash.cpp
@@ -60,6 +60,10 @@
 #include <arm_neon.h>
 #endif
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 using namespace llvm;
 using namespace support;
 


### PR DESCRIPTION
`__umulh` added in https://github.com/llvm/llvm-project/pull/95863 requires `intrin.h`, make sure to include it.