### PR TITLE
[swift-lldb] Port TypeSystem::DiagnoseWarnings() to precise compiler …

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -558,7 +558,8 @@ public:
   /// have a way to communicate errors. This method can be called by a
   /// process to tell the TypeSystem to send any diagnostics to the
   /// process so they can be surfaced to the user.
-  virtual void DiagnoseWarnings(Process &process, Module &module) const;
+  virtual void DiagnoseWarnings(Process &process,
+                                const SymbolContext &sc) const;
 
   virtual std::optional<llvm::json::Value> ReportStatistics();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1166,13 +1166,14 @@ static void printASTValidationError(
     LLDB_LOG(log, "  -- {0}", ExtraOpt);
 }
 
-void SwiftASTContext::DiagnoseWarnings(Process &process, Module &module) const {
-  if (!HasDiagnostics())
+void SwiftASTContext::DiagnoseWarnings(Process &process,
+                                       const SymbolContext &sc) const {
+  if (!sc.module_sp || !HasDiagnostics())
     return;
   auto debugger_id = process.GetTarget().GetDebugger().GetID();
   std::string msg;
   llvm::raw_string_ostream(msg) << "Cannot load Swift type information for "
-                                << module.GetFileSpec().GetPath();
+                                << sc.module_sp->GetFileSpec().GetPath();
   Debugger::ReportWarning(msg, debugger_id, &m_swift_import_warning);
   StreamAllDiagnostics(debugger_id);
 }
@@ -2111,7 +2112,8 @@ ProcessModule(Module &module, std::string m_description,
               std::vector<swift::PluginSearchOption> &plugin_search_options,
               std::vector<std::string> &module_search_paths,
               std::vector<std::pair<std::string, bool>> &framework_search_paths,
-              std::vector<std::string> &extra_clang_args) {
+              std::vector<std::string> &extra_clang_args,
+              std::string &error) {
   {
     llvm::raw_string_ostream ss(m_description);
     ss << "::ProcessModule(" << '"';
@@ -2215,8 +2217,7 @@ ProcessModule(Module &module, std::string m_description,
     return;
   bool found_swift_modules = false;
   bool got_serialized_options = false;
-  llvm::SmallString<0> error;
-  llvm::raw_svector_ostream errs(error);
+  llvm::raw_string_ostream errs(error);
   swift::CompilerInvocation invocation;
   auto ast_file_datas = module.GetASTData(eLanguageTypeSwift);
   std::string module_name = module.GetSpecificationDescription();
@@ -2365,7 +2366,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     bool got_serialized_options = false;
     llvm::SmallString<0> error;
     llvm::raw_svector_ostream errs(error);
-    // Implicit search paths will be discovered by ValidateSecionModules().
+    // Implicit search paths will be discovered by ValidateSectionModules().
     bool discover_implicit_search_paths = false;
     auto ast_file_datas = module.GetASTData(eLanguageTypeSwift);
     std::string module_name = module.GetSpecificationDescription();
@@ -2436,6 +2437,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   const bool use_all_compiler_flags = false;
   const bool is_target_module = true;
 
+  std::string error;
   StringRef module_filter;
   std::vector<swift::PluginSearchOption> plugin_search_options;
   std::vector<std::string> extra_clang_args = swift_ast_sp->GetClangArguments();
@@ -2444,7 +2446,10 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   ProcessModule(module, m_description, discover_implicit_search_paths,
                 use_all_compiler_flags, is_target_module, module_filter, triple,
                 plugin_search_options, module_search_paths,
-                framework_search_paths, extra_clang_args);
+                framework_search_paths, extra_clang_args, error);
+  if (!error.empty())
+    swift_ast_sp->AddDiagnostic(eSeverityError, error);
+
   // Apply the working directory to all relative paths.
   StringRef overrideOpts = target ? target->GetSwiftClangOverrideOptions() : "";
   swift_ast_sp->AddExtraClangArgs(extra_clang_args, overrideOpts);
@@ -2800,6 +2805,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
 
   for (ModuleSP module_sp : target.GetImages().Modules())
     if (module_sp) {
+      std::string error;
       StringRef module_filter;
       std::vector<std::string> extra_clang_args;
       ProcessModule(*module_sp, m_description, discover_implicit_search_paths,
@@ -2807,7 +2813,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
                     target.GetExecutableModulePointer() == module_sp.get(),
                     module_filter, triple, plugin_search_options,
                     module_search_paths, framework_search_paths,
-                    extra_clang_args);
+                    extra_clang_args, error);
       swift_ast_sp->AddExtraClangArgs(extra_clang_args,
                                       target.GetSwiftClangOverrideOptions());
     }
@@ -3137,14 +3143,17 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
                                       /*is_system*/ false});
   ModuleSP module_sp = sc.module_sp;
   if (module_sp) {
+    std::string error;
     StringRef module_filter = swift_module_name;
     std::vector<std::string> extra_clang_args;
     ProcessModule(*module_sp, m_description, discover_implicit_search_paths,
                   use_all_compiler_flags,
                   target.GetExecutableModulePointer() == module_sp.get(),
                   module_filter, triple, plugin_search_options,
-                  module_search_paths, framework_search_paths,
-                  extra_clang_args);
+                  module_search_paths, framework_search_paths, extra_clang_args,
+                  error);
+    if (!error.empty())
+      swift_ast_sp->AddDiagnostic(eSeverityError, error);
     swift_ast_sp->AddExtraClangArgs(extra_clang_args,
                                     target.GetSwiftClangOverrideOptions());
   }
@@ -5602,13 +5611,16 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
     lldb::ModuleSP module_sp = module_list.GetModuleAtIndex(mi);
     if (!module_sp)
       continue;
+    std::string error;
     StringRef module_filter;
     ProcessModule(*module_sp, m_description, discover_implicit_search_paths,
                   use_all_compiler_flags,
                   target_sp->GetExecutableModulePointer() == module_sp.get(),
                   module_filter, GetTriple(), plugin_search_options,
-                  module_search_paths, framework_search_paths,
-                  extra_clang_args);
+                  module_search_paths, framework_search_paths, extra_clang_args,
+                  error);
+    if (!error.empty())
+      AddDiagnostic(eSeverityError, error);
     // If the use-all-compiler-flags setting is enabled, the
     // expression context is supposed to merge all search paths
     // from all dylibs.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -485,8 +485,9 @@ public:
   /// Return only fatal errors.
   Status GetFatalErrors() const;
   /// Notify the Process about any Swift or ClangImporter errors.
-  void DiagnoseWarnings(Process &process, Module &module) const override;
-  
+  void DiagnoseWarnings(Process &process,
+                        const SymbolContext &sc) const override;
+
   bool SetColorizeDiagnostics(bool b);
 
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2059,11 +2059,10 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
 }
 
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
-                                              Module &module) const {
-  // This gets called only from Thread::FrameSelectedCallback(StackFrame)
-  // and is of limited usefuleness.
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull(nullptr))
-    swift_ast_context->DiagnoseWarnings(process, module);
+                                              const SymbolContext &sc) const {
+  // This gets called only from Thread::FrameSelectedCallback(StackFrame).
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull(&sc))
+    swift_ast_context->DiagnoseWarnings(process, sc);
 }
 
 plugin::dwarf::DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -108,7 +108,8 @@ public:
   bool SupportsLanguage(lldb::LanguageType language) override;
   Status IsCompatible() override;
 
-  void DiagnoseWarnings(Process &process, Module &module) const override;
+  void DiagnoseWarnings(Process &process,
+                        const SymbolContext &sc) const override;
   plugin::dwarf::DWARFASTParser *GetDWARFParser() override;
   // CompilerDecl functions
   ConstString DeclGetName(void *opaque_decl) override {

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -161,7 +161,8 @@ bool TypeSystem::IsMeaninglessWithoutDynamicResolution(void *type) {
   return false;
 }
 
-void TypeSystem::DiagnoseWarnings(Process &process, Module &module) const {}
+void TypeSystem::DiagnoseWarnings(Process &process,
+                                  const SymbolContext &sc) const {}
 
 Status TypeSystem::IsCompatible() {
   // Assume a language is compatible. Override this virtual function

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -53,6 +53,10 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/lldb-enumerations.h"
 
+#ifdef LLDB_ENABLE_SWIFT
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#endif
+
 #include <memory>
 #include <optional>
 
@@ -343,13 +347,20 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
     GetProcess()->PrintWarningToolchainMismatch(sc);
 #endif
   }
-  SymbolContext msc = frame->GetSymbolContext(eSymbolContextModule);
-  if (msc.module_sp)
-    msc.module_sp->ForEachTypeSystem([&](lldb::TypeSystemSP ts) {
-      if (ts)
-        ts->DiagnoseWarnings(*GetProcess(), *msc.module_sp);
-      return true;
-    });
+#ifdef LLDB_ENABLE_SWIFT
+  {
+    SymbolContext msc =
+        frame->GetSymbolContext(eSymbolContextFunction | eSymbolContextModule);
+    Status error;
+    ExecutionContext exe_ctx;
+    frame->CalculateExecutionContext(exe_ctx);
+    if (auto *exe_scope = exe_ctx.GetBestExecutionContextScope())
+      if (auto target = frame->CalculateTarget())
+        if (auto swift_ast_ctx =
+                target->GetSwiftScratchContext(error, *exe_scope, false))
+          swift_ast_ctx->get()->DiagnoseWarnings(*GetProcess(), msc);
+  }
+#endif
 }
 
 lldb::StopInfoSP Thread::GetStopInfo() {

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -38,11 +38,7 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
         else:
             prefix = 'NEGATIVE'
         self.filecheck('platform shell cat "%s"' % types_log, __file__,
-                       '--check-prefix=CHECK_MOD_'+prefix)
-        self.filecheck('platform shell cat "%s"' % types_log, __file__,
                        '--check-prefix=CHECK_EXP_'+prefix)
-# CHECK_MOD_POSITIVE: SwiftASTContextForModule("a.out")::LogConfiguration(){{.*hidden$}}
-# CHECK_MOD_NEGATIVE: SwiftASTContextForModule("a.out")::LogConfiguration(){{.*hidden$}}
-# CHECK_EXP_POSITIVE: SwiftASTContextForExpressions::LogConfiguration(){{.*hidden$}}
-# CHECK_EXP_NEGATIVE-NOT: SwiftASTContextForExpressions::LogConfiguration(){{.*hidden$}}
-# CHECK_EXP_NEGATIVE: SwiftASTContextForExpressions::LogConfiguration(){{.*}}Extra clang arguments
+# CHECK_EXP_POSITIVE: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*hidden$}}
+# CHECK_EXP_NEGATIVE-NOT: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*hidden$}}
+# CHECK_EXP_NEGATIVE: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}}Extra clang arguments

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -9,12 +9,10 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
-    @skipIf(bugnumber='rdar://135553659')
     @swiftTest
     def test_positive(self):
         self.do_test('true')
 
-    @skipIf(bugnumber='rdar://135553659')
     @swiftTest
     def test_negative(self):
         self.do_test('false')

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -39,10 +39,6 @@ class TestSwiftREPLExceptions(TestBase):
         self.build()
         self.do_repl_test()
 
-    def setUp(self):
-        # Call super's setUp().
-        TestBase.setUp(self)
-
     @skipIfRemote
     def do_repl_test(self):
         sdk_root = ""

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -25,9 +25,8 @@ class TestSwiftREPLExceptions(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    def test_set_repl_mode_exceptions(self):
+    def DISABLED_test_set_repl_mode_exceptions(self):
         """ Test that SetREPLMode turns off trapping exceptions."""
-        return
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.swift")
         self.do_repl_mode_test()
@@ -45,6 +44,8 @@ class TestSwiftREPLExceptions(TestBase):
         with open(self.getBuildArtifact("sdkroot.txt"), 'r') as f:
             sdk_root = f.readlines()[0]
         self.assertGreater(len(sdk_root), 0)
+        if sdk_root[-1] == '\n':
+            sdk_root = sdk_root[:-1]
         build_dir = self.getBuildDir()
         repl_args = [lldbtest_config.lldbExec, "-x", "--repl=-enable-objc-interop -sdk %s -L%s -I%s"%(sdk_root, build_dir, build_dir)]
         repl_proc = subprocess.Popen(repl_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=build_dir)
@@ -67,7 +68,7 @@ class TestSwiftREPLExceptions(TestBase):
                 lldb.SBFileSpec(os.path.join(wd, filename)))
             self.assertFalse(err.Fail(), 'Failed to copy ' + filename)
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
-                                   "Set a breakpoint here", self.main_source_file) 
+                                   "Set a breakpoint here", self.main_source_file)
 
         frame = thread.GetFrameAtIndex(0)
         options = lldb.SBExpressionOptions()

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -13,7 +13,7 @@ import lldb
 import swift
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import decorators
+from lldbsuite.test.decorators import *
 
 
 class TestSwiftREPLExceptions(TestBase):
@@ -23,8 +23,8 @@ class TestSwiftREPLExceptions(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
-    @decorators.skipUnlessDarwin
-    @decorators.swiftTest
+    @skipUnlessDarwin
+    @swiftTest
     def test_set_repl_mode_exceptions(self):
         """ Test that SetREPLMode turns off trapping exceptions."""
         return
@@ -32,8 +32,8 @@ class TestSwiftREPLExceptions(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.swift")
         self.do_repl_mode_test()
 
-    @decorators.skipUnlessDarwin
-    @decorators.swiftTest
+    @skipUnlessDarwin
+    @swiftTest
     def test_repl_exceptions(self):
         """ Test the lldb --repl turns off trapping exceptions."""
         self.build()
@@ -43,7 +43,7 @@ class TestSwiftREPLExceptions(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
-    @decorators.skipIfRemote
+    @skipIfRemote
     def do_repl_test(self):
         sdk_root = ""
         with open(self.getBuildArtifact("sdkroot.txt"), 'r') as f:

--- a/lldb/test/Shell/Swift/MissingVFSOverlay.test
+++ b/lldb/test/Shell/Swift/MissingVFSOverlay.test
@@ -1,6 +1,5 @@
 # Test that error messages from constructing ClangImporter
 # are surfaced to the user.
-# REQUIRES: 135553659
 # REQUIRES: swift
 
 # RUN: rm -rf %t && mkdir %t && cd %t


### PR DESCRIPTION
…invocations.

Due to the validation assertions triggering additional SwiftASTContexts to be created, this missing feature only breaks a shell test when running the tests with assertion disabled!

We only found this via https://ci.swift.org/view/Swift%206.0.0/job/oss-swift-6.0.0-package-ubuntu-24_04/