### PR TITLE
[lldb] Fix building with latest libc++

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationServerLLGS.cpp
@@ -631,7 +631,7 @@ static void WriteRegisterValueInHexFixedWidth(
   } else {
     // Zero-out any unreadable values.
     if (reg_info.byte_size > 0) {
-      std::basic_string<uint8_t> zeros(reg_info.byte_size, '\0');
+      std::vector<uint8_t> zeros(reg_info.byte_size, '\0');
       AppendHexValue(response, zeros.data(), zeros.size(), false);
     }
   }


### PR DESCRIPTION
Since https://reviews.llvm.org/D157058 in libc++,
the base template for char_traits has been removed - it is only provided for char, wchar_t, char8_t, char16_t and char32_t. (Thus, to use basic_string with a type other than those, we'd need to supply suitable traits ourselves.)

For this particular use, a vector works just as well as basic_string.

Differential Revision: https://reviews.llvm.org/D157589

(cherry picked from commit 68744ffbdd7daac41da274eef9ac0d191e11c16d)