### PR TITLE
[lldb] Remove ambiguous e commands from tests

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
@@ -30,7 +30,7 @@ class TestSwiftForwardInteropClassInNamespace(TestBase):
 
         self.expect('v fooInherited', substrs=['foo::InheritedCxxClass', 
             'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
-        self.expect('e fooInherited', substrs=['foo::InheritedCxxClass', 
+        self.expect('expr fooInherited', substrs=['foo::InheritedCxxClass', 
             'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
 
         self.expect('v barInherited', substrs=['bar::InheritedCxxClass', 


### PR DESCRIPTION
(cherry picked from commit c1a4f08735b7ebb2d2aabd80fc42cc25f50c3e6f)