### PR TITLE
[6.0.1] Temporarily skip tests that fail on noasserts bots

### DIFF
--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -9,10 +9,12 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
+    @skipIf(bugnumber='rdar://135553659')
     @swiftTest
     def test_positive(self):
         self.do_test('true')
 
+    @skipIf(bugnumber='rdar://135553659')
     @swiftTest
     def test_negative(self):
         self.do_test('false')

--- a/lldb/test/Shell/Swift/MissingVFSOverlay.test
+++ b/lldb/test/Shell/Swift/MissingVFSOverlay.test
@@ -1,5 +1,6 @@
 # Test that error messages from constructing ClangImporter
 # are surfaced to the user.
+# REQUIRES: 135553659
 # REQUIRES: swift
 
 # RUN: rm -rf %t && mkdir %t && cd %t


### PR DESCRIPTION
(cherry picked from commit 55d4c5ec31aabb1e6fdf42d79dcd40e890e5367a)