### PR TITLE
[lldb] Support for -print-diagnostic-groups

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1890,8 +1890,7 @@ void SwiftASTContext::ApplyWorkingDir(
 
 void SwiftASTContext::ApplyDiagnosticOptions() {
   const auto &opts = GetCompilerInvocation().getDiagnosticOptions();
-  if (opts.PrintDiagnosticNames)
-    GetDiagnosticEngine().setPrintDiagnosticNames(true);
+  GetDiagnosticEngine().setPrintDiagnosticNamesMode(opts.PrintDiagnosticNames);
 
   if (!opts.DiagnosticDocumentationPath.empty())
     GetDiagnosticEngine().setDiagnosticDocumentationPath(


### PR DESCRIPTION
This is a complimentary change to the change in compiler options https://github.com/swiftlang/swift/pull/76363