### PR TITLE
[Cherry-pick into next] Clean up test decorators (NFC)

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -572,7 +572,8 @@ public:
   /// have a way to communicate errors. This method can be called by a
   /// process to tell the TypeSystem to send any diagnostics to the
   /// process so they can be surfaced to the user.
-  virtual void DiagnoseWarnings(Process &process, Module &module) const;
+  virtual void DiagnoseWarnings(Process &process,
+                                const SymbolContext &sc) const;
 
   virtual std::optional<llvm::json::Value> ReportStatistics();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -490,8 +490,9 @@ public:
   /// Return only fatal errors.
   Status GetFatalErrors() const;
   /// Notify the Process about any Swift or ClangImporter errors.
-  void DiagnoseWarnings(Process &process, Module &module) const override;
-  
+  void DiagnoseWarnings(Process &process,
+                        const SymbolContext &sc) const override;
+
   bool SetColorizeDiagnostics(bool b);
 
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2059,11 +2059,10 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
 }
 
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
-                                              Module &module) const {
-  // This gets called only from Thread::FrameSelectedCallback(StackFrame)
-  // and is of limited usefuleness.
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull(nullptr))
-    swift_ast_context->DiagnoseWarnings(process, module);
+                                              const SymbolContext &sc) const {
+  // This gets called only from Thread::FrameSelectedCallback(StackFrame).
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull(&sc))
+    swift_ast_context->DiagnoseWarnings(process, sc);
 }
 
 plugin::dwarf::DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -108,7 +108,8 @@ public:
   bool SupportsLanguage(lldb::LanguageType language) override;
   Status IsCompatible() override;
 
-  void DiagnoseWarnings(Process &process, Module &module) const override;
+  void DiagnoseWarnings(Process &process,
+                        const SymbolContext &sc) const override;
   plugin::dwarf::DWARFASTParser *GetDWARFParser() override;
   // CompilerDecl functions
   ConstString DeclGetName(void *opaque_decl) override {

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -166,7 +166,8 @@ bool TypeSystem::IsMeaninglessWithoutDynamicResolution(void *type) {
   return false;
 }
 
-void TypeSystem::DiagnoseWarnings(Process &process, Module &module) const {}
+void TypeSystem::DiagnoseWarnings(Process &process,
+                                  const SymbolContext &sc) const {}
 
 Status TypeSystem::IsCompatible() {
   // Assume a language is compatible. Override this virtual function

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -53,6 +53,10 @@
 #include "lldb/Utility/StreamString.h"
 #include "lldb/lldb-enumerations.h"
 
+#ifdef LLDB_ENABLE_SWIFT
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#endif
+
 #include <memory>
 #include <optional>
 
@@ -350,13 +354,20 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
     GetProcess()->PrintWarningToolchainMismatch(sc);
 #endif
   }
-  SymbolContext msc = frame->GetSymbolContext(eSymbolContextModule);
-  if (msc.module_sp)
-    msc.module_sp->ForEachTypeSystem([&](lldb::TypeSystemSP ts) {
-      if (ts)
-        ts->DiagnoseWarnings(*GetProcess(), *msc.module_sp);
-      return true;
-    });
+#ifdef LLDB_ENABLE_SWIFT
+  {
+    SymbolContext msc =
+        frame->GetSymbolContext(eSymbolContextFunction | eSymbolContextModule);
+    Status error;
+    ExecutionContext exe_ctx;
+    frame->CalculateExecutionContext(exe_ctx);
+    if (auto *exe_scope = exe_ctx.GetBestExecutionContextScope())
+      if (auto target = frame->CalculateTarget())
+        if (auto swift_ast_ctx =
+                target->GetSwiftScratchContext(error, *exe_scope, false))
+          swift_ast_ctx->get()->DiagnoseWarnings(*GetProcess(), msc);
+  }
+#endif
 }
 
 lldb::StopInfoSP Thread::GetStopInfo() {

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -37,11 +37,7 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
         else:
             prefix = 'NEGATIVE'
         self.filecheck('platform shell cat "%s"' % types_log, __file__,
-                       '--check-prefix=CHECK_MOD_'+prefix)
-        self.filecheck('platform shell cat "%s"' % types_log, __file__,
                        '--check-prefix=CHECK_EXP_'+prefix)
-# CHECK_MOD_POSITIVE: SwiftASTContextForModule("a.out")::LogConfiguration(){{.*hidden$}}
-# CHECK_MOD_NEGATIVE: SwiftASTContextForModule("a.out")::LogConfiguration(){{.*hidden$}}
-# CHECK_EXP_POSITIVE: SwiftASTContextForExpressions::LogConfiguration(){{.*hidden$}}
-# CHECK_EXP_NEGATIVE-NOT: SwiftASTContextForExpressions::LogConfiguration(){{.*hidden$}}
-# CHECK_EXP_NEGATIVE: SwiftASTContextForExpressions::LogConfiguration(){{.*}}Extra clang arguments
+# CHECK_EXP_POSITIVE: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*hidden$}}
+# CHECK_EXP_NEGATIVE-NOT: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*hidden$}}
+# CHECK_EXP_NEGATIVE: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}}Extra clang arguments

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -39,10 +39,6 @@ class TestSwiftREPLExceptions(TestBase):
         self.build()
         self.do_repl_test()
 
-    def setUp(self):
-        # Call super's setUp().
-        TestBase.setUp(self)
-
     @skipIfRemote
     def do_repl_test(self):
         sdk_root = ""

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -25,9 +25,8 @@ class TestSwiftREPLExceptions(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    def test_set_repl_mode_exceptions(self):
+    def DISABLED_test_set_repl_mode_exceptions(self):
         """ Test that SetREPLMode turns off trapping exceptions."""
-        return
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.swift")
         self.do_repl_mode_test()
@@ -45,6 +44,8 @@ class TestSwiftREPLExceptions(TestBase):
         with open(self.getBuildArtifact("sdkroot.txt"), 'r') as f:
             sdk_root = f.readlines()[0]
         self.assertGreater(len(sdk_root), 0)
+        if sdk_root[-1] == '\n':
+            sdk_root = sdk_root[:-1]
         build_dir = self.getBuildDir()
         repl_args = [lldbtest_config.lldbExec, "-x", "--repl=-enable-objc-interop -sdk %s -L%s -I%s"%(sdk_root, build_dir, build_dir)]
         repl_proc = subprocess.Popen(repl_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=build_dir)
@@ -67,7 +68,7 @@ class TestSwiftREPLExceptions(TestBase):
                 lldb.SBFileSpec(os.path.join(wd, filename)))
             self.assertFalse(err.Fail(), 'Failed to copy ' + filename)
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(self,
-                                   "Set a breakpoint here", self.main_source_file) 
+                                   "Set a breakpoint here", self.main_source_file)
 
         frame = thread.GetFrameAtIndex(0)
         options = lldb.SBExpressionOptions()

--- a/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
+++ b/lldb/test/API/repl/cpp_exceptions/TestSwiftCPPExceptionsInREPL.py
@@ -13,7 +13,7 @@ import lldb
 import swift
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
-from lldbsuite.test import decorators
+from lldbsuite.test.decorators import *
 
 
 class TestSwiftREPLExceptions(TestBase):
@@ -23,8 +23,8 @@ class TestSwiftREPLExceptions(TestBase):
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
 
-    @decorators.skipUnlessDarwin
-    @decorators.swiftTest
+    @skipUnlessDarwin
+    @swiftTest
     def test_set_repl_mode_exceptions(self):
         """ Test that SetREPLMode turns off trapping exceptions."""
         return
@@ -32,8 +32,8 @@ class TestSwiftREPLExceptions(TestBase):
         self.main_source_file = lldb.SBFileSpec("main.swift")
         self.do_repl_mode_test()
 
-    @decorators.skipUnlessDarwin
-    @decorators.swiftTest
+    @skipUnlessDarwin
+    @swiftTest
     def test_repl_exceptions(self):
         """ Test the lldb --repl turns off trapping exceptions."""
         self.build()
@@ -43,7 +43,7 @@ class TestSwiftREPLExceptions(TestBase):
         # Call super's setUp().
         TestBase.setUp(self)
 
-    @decorators.skipIfRemote
+    @skipIfRemote
     def do_repl_test(self):
         sdk_root = ""
         with open(self.getBuildArtifact("sdkroot.txt"), 'r') as f:


### PR DESCRIPTION
```
commit 6e0815dcb851f6fa2e96d2cbbb96115122c39c35
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Sep 9 12:38:49 2024 -0700

    Clean up test decorators (NFC)

commit 377ba4728a7b74fbc80585360a3087b3823db616
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Sep 9 12:40:27 2024 -0700

    Remove unnecessary function (NFC)

commit a33c59e85c6b9e6e53237742480b20a3d1b74096
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Sep 9 13:47:02 2024 -0700

    More test cleanups (NFC)

commit 48cc29d1ca91f04241c0a3c59a6bb8c686c09c54
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Sep 6 18:16:14 2024 -0700

    [swift-lldb] Port TypeSystem::DiagnoseWarnings() to precise compiler invocations.
    
    Due to the validation assertions triggering additional
    SwiftASTContexts to be created, this missing feature only breaks a
    shell test when running the tests with assertion disabled!
```
