### PR TITLE
[lldb] Drop additional '.' in file suffix in SaveExpressionTextToTempFile

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -1317,11 +1317,11 @@ bool SwiftASTManipulator::SaveExpressionTextToTempFile(
   llvm::StringRef suffix;
   switch (options.GetLanguage()) {
   default:
-    suffix = ".cpp";
+    suffix = "cpp";
     break;
 
   case lldb::eLanguageTypeSwift:
-    suffix = ".swift";
+    suffix = "swift";
     break;
   }
 


### PR DESCRIPTION
llvm::sys::fs::createTemporaryFile already appends a '.' when specifying a suffix.

Files were being created as repl..swift 