### PR TITLE
[lldb] Fix duplicated args for swift caching debugging

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1770,7 +1770,8 @@ void SwiftASTContext::AddExtraClangArgs(
   // If using direct cc1 flags, compute the arguments and return.
   // Since this is cc1 flags, no driver overwrite can be applied.
   if (importer_options.DirectClangCC1ModuleBuild) {
-    AddExtraClangCC1Args(ExtraArgs, importer_options.ExtraArgs);
+    if (fresh_invocation)
+      AddExtraClangCC1Args(ExtraArgs, importer_options.ExtraArgs);
     return;
   }
 

--- a/lldb/test/Shell/Swift/caching.test
+++ b/lldb/test/Shell/Swift/caching.test
@@ -1,0 +1,26 @@
+# REQUIRES: swift
+# REQUIRES: system-darwin
+
+# RUN: rm -rf %t && mkdir %t
+# RUN: split-file %s %t
+# RUN: %target-swiftc -g -Onone -save-temps \
+# RUN:          -module-cache-path %t/cache %t/main.swift \
+# RUN:          -cache-compile-job -cas-path %t/cas -explicit-module-build \
+# RUN:          -module-name main -o %t/main
+
+# RUN: %lldb %t/main -s %t/lldb.script
+
+//--- main.swift
+func test() {
+  print("break here")
+}
+test()
+
+//--- lldb.script
+# Force loading from interface to simulate no binary module available.
+settings set symbols.swift-module-loading-mode prefer-interface
+b test
+run
+# Create a SwiftASTContext
+expr 1
+quit


### PR DESCRIPTION
Only add clang cc1 args for fresh invocation since appending is not supported. Also add a test case for testing swift caching debugging by creating SwiftASTContext from interface file.

rdar://135611011