### PR TITLE
[CoroSplit][DebugInfo] Adjust heuristic for moving DIScope of funclets

### DIFF
--- a/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
+++ b/lldb/test/API/lang/swift/async/unwind/backtrace_locals/TestSwiftAsyncBacktraceLocals.py
@@ -128,7 +128,7 @@ class TestSwiftAsyncBacktraceLocals(lldbtest.TestBase):
         last_result = None
         while True:
             thread = lldbutil.continue_to_breakpoint(process, self.compute_bkpt)
-            if len(thread) == 0:
+            if thread is None:
                 self.assertEqual(last_result, 55, "Computed the right final value")
                 break
 

--- a/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
+++ b/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
@@ -18,20 +18,16 @@ class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
         )
         breakpoint2 = target.BreakpointCreateBySourceRegex("Breakpoint2", filespec)
         breakpoint3 = target.BreakpointCreateBySourceRegex("Breakpoint3", filespec)
-        self.assertEquals(breakpoint1.GetNumLocations(), 2)
+        self.assertEquals(breakpoint1.GetNumLocations(), 1)
         self.assertEquals(breakpoint2.GetNumLocations(), 1)
-        self.assertEquals(breakpoint3.GetNumLocations(), 2)
+        self.assertEquals(breakpoint3.GetNumLocations(), 1)
 
         location11 = breakpoint1.GetLocationAtIndex(0)
-        location12 = breakpoint1.GetLocationAtIndex(1)
         self.assertEquals(location11.GetHitCount(), 1)
-        self.assertEquals(location12.GetHitCount(), 0)
 
         self.assertEquals(thread.GetStopDescription(128), "breakpoint 1.1")
         process.Continue()
-        self.assertEquals(thread.GetStopDescription(128), "breakpoint 1.2")
 
-        thread.StepOver()
         self.assertEquals(thread.GetStopDescription(128), "breakpoint 2.1")
         self.expect("expr timestamp1", substrs=["42"])
 
@@ -39,16 +35,8 @@ class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
         self.assertIn("breakpoint 3.1", thread.GetStopDescription(128))
         self.expect("expr timestamp1", substrs=["42"])
 
-        process.Continue()
-        self.assertIn("breakpoint 3.2", thread.GetStopDescription(128))
-        self.expect("expr timestamp1", substrs=["42"])
-
-        thread.StepOver()
-        self.expect("expr timestamp1", substrs=["42"])
-        self.expect("expr timestamp2", substrs=["43"])
-
         self.runCmd("settings set language.enable-filter-for-line-breakpoints false")
         breakpoint1_no_filter = target.BreakpointCreateBySourceRegex(
             "Breakpoint1", filespec
         )
-        self.assertEquals(breakpoint1_no_filter.GetNumLocations(), 3)
+        self.assertEquals(breakpoint1_no_filter.GetNumLocations(), 2)

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -73,12 +73,6 @@ class TestSwiftConsumeOperatorAsyncType(TestBase):
         varK = self.get_var('k')
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
 
-        # Go to breakpoint `1.2. k should still be valid. And we should be on the
-        # other side of the force split.
-        self.continue_to(1)
-        varK = self.get_var('k')
-        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
-
         # Go to breakpoint 2. k should still be valid. We should be at the move
         # on the other side of the forceSplit.
         self.continue_to(2)
@@ -105,12 +99,6 @@ class TestSwiftConsumeOperatorAsyncType(TestBase):
         self.assertEqual(varK.unsigned, 0, "varK initialized too early?!")
 
         # Go to break point 6.1. k should be valid.
-        self.continue_to(6)
-        varK = self.get_var('k')
-        self.assertGreater(varK.unsigned, 0, "varK not initialized?!")
-
-        # Go to breakpoint 6.2. k should still be valid. And we should be on the
-        # other side of the force split.
         self.continue_to(6)
         varK = self.get_var('k')
         self.assertGreater(varK.unsigned, 0, "varK not initialized?!")

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -888,6 +888,45 @@ Value *CoroCloner::deriveNewFramePointer() {
   llvm_unreachable("bad ABI");
 }
 
+/// Adjust the scope line of the funclet to the first line number after the
+/// suspend point. This avoids a jump in the line table from the function
+/// declaration (where prologue instructions are attributed to) to the suspend
+/// point.
+/// Only adjust the scope line when the files are the same.
+/// If no candidate line number is found, fallback to the line of ActiveSuspend.
+static void updateScopeLine(Instruction *ActiveSuspend,
+                            DISubprogram &SPToUpdate) {
+  if (!ActiveSuspend)
+    return;
+
+  auto *Successor = ActiveSuspend->getNextNonDebugInstruction();
+  // Corosplit splits the BB around ActiveSuspend, so the meaningful
+  // instructions are not in the same BB.
+  if (auto *Branch = dyn_cast_or_null<BranchInst>(Successor);
+      Branch && Branch->isUnconditional())
+    Successor = Branch->getSuccessor(0)->getFirstNonPHIOrDbg();
+
+  // Find the first successor of ActiveSuspend with a non-zero line location.
+  // If that matches the file of ActiveSuspend, use it.
+  for (; Successor; Successor = Successor->getNextNonDebugInstruction()) {
+    auto DL = Successor->getDebugLoc();
+    if (!DL || DL.getLine() == 0)
+      continue;
+
+    if (SPToUpdate.getFile() == DL->getFile()) {
+      SPToUpdate.setScopeLine(DL.getLine());
+      return;
+    }
+
+    break;
+  }
+
+  // If the search above failed, fallback to the location of ActiveSuspend.
+  if (auto DL = ActiveSuspend->getDebugLoc())
+    if (SPToUpdate.getFile() == DL->getFile())
+      SPToUpdate.setScopeLine(DL->getLine());
+}
+
 static void addFramePointerAttrs(AttributeList &Attrs, LLVMContext &Context,
                                  unsigned ParamIndex, uint64_t Size,
                                  Align Alignment, bool NoAlias) {
@@ -956,18 +995,10 @@ void CoroCloner::create() {
 
   auto &Context = NewF->getContext();
 
-  // For async functions / continuations, adjust the scope line of the
-  // clone to the line number of the suspend point. However, only
-  // adjust the scope line when the files are the same. This ensures
-  // line number and file name belong together. The scope line is
-  // associated with all pre-prologue instructions. This avoids a jump
-  // in the linetable from the function declaration to the suspend point.
   if (DISubprogram *SP = NewF->getSubprogram()) {
     assert(SP != OrigF.getSubprogram() && SP->isDistinct());
-    if (ActiveSuspend)
-      if (auto DL = ActiveSuspend->getDebugLoc())
-        if (SP->getFile() == DL->getFile())
-          SP->setScopeLine(DL->getLine());
+    updateScopeLine(ActiveSuspend, *SP);
+
     // Update the linkage name to reflect the modified symbol name. It
     // is necessary to update the linkage name in Swift, since the
     // mangling changes for resume functions. It might also be the

--- a/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
+++ b/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
@@ -37,9 +37,9 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
 
   %i7 = call ptr @llvm.coro.async.resume(), !dbg !54
   %i10 = call { ptr } (i32, ptr, ptr, ...) @llvm.coro.suspend.async.sl_p0s(i32 0, ptr %i7, ptr nonnull @__swift_async_resume_get_context, ptr nonnull @coroutineA.1, ptr %i7, i64 0, i64 0, ptr %arg), !dbg !54
-  %i11 = extractvalue { ptr } %i10, 0, !dbg !54
-  %i12 = call ptr @__swift_async_resume_get_context(ptr %i11), !dbg !54
-  call void @dont_optimize(ptr %var_with_dbg_value, ptr %var_with_dbg_declare)
+  %i11 = extractvalue { ptr } %i10, 0, !dbg !55
+  %i12 = call ptr @__swift_async_resume_get_context(ptr %i11), !dbg !55
+  call void @dont_optimize(ptr %var_with_dbg_value, ptr %var_with_dbg_declare), !dbg !100
   call void @llvm.dbg.value(metadata ptr %var_with_dbg_value, metadata !50, metadata !DIExpression(DW_OP_deref)), !dbg !54
   %i17 = load i32, ptr getelementptr inbounds (<{i32, i32}>, ptr @coroutineBTu, i64 0, i32 1), align 8, !dbg !54
   call void @llvm.dbg.value(metadata !DIArgList(ptr %var_with_dbg_value, i32 %i17), metadata !501, metadata !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_plus, DW_OP_deref)), !dbg !54
@@ -47,7 +47,7 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
   %i19 = call swiftcc ptr @swift_task_alloc(i64 %i18), !dbg !54
 ; CHECK-NOT: define
 ; CHECK-LABEL: define {{.*}} @coroutineATY0_(
-; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]])
+; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]]) !dbg ![[ATY0:[0-9]*]]
 ; CHECK:      #dbg_declare(ptr %[[frame_ptr]], {{.*}} !DIExpression(
 ; CHECK-SAME:                   DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24)
 ; CHECK:      #dbg_value(ptr %[[frame_ptr]], {{.*}} !DIExpression(
@@ -87,6 +87,8 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
 ; CHECK:      #dbg_declare(ptr %[[frame_ptr]], {{.*}} !DIExpression(
 ; CHECK-SAME:                   DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24)
 }
+
+; CHECK: ![[ATY0]] = {{.*}}DISubprogram(linkageName: "coroutineATY0_", {{.*}} scopeLine: 42
 
 ; Everything from here on is just support code for the coroutines.
 
@@ -172,5 +174,7 @@ declare { ptr } @llvm.coro.suspend.async.sl_p0s(i32, ptr, ptr, ...)
 !71 = !DILocation(line: 0, scope: !70)
 !73 = !DILocation(line: 0, scope: !72)
 !54 = !DILocation(line: 6, scope: !48)
+!55 = !DILocation(line: 0, scope: !48)
 !42 = !DILocation(line: 3, scope: !37)
 !47 = !DILocation(line: 0, scope: !44)
+!100 = !DILocation(line: 42, scope: !48)


### PR DESCRIPTION
CoroSplit has a heuristic where the scope line for funclets is adjusted to match the line of the suspend intrinsic that caused the split. This is useful as it avoids a jump on the line table from the original function declaration to the line where the split happens.

However, very often using the line of the split is not ideal: if we can avoid it, we should not have a line entry for the split location, as this would cause breakpoints by line to match against two functions: the funclet before and the funclet after the split.

This patch adjusts the heuristics to look for the first instruction with a non-zero line number after the split. In other words, this patch makes breakpoints on `await foo()` lines behave much more like a regular function call.

(cherry picked from commit ddcc601353db0464eb15a3e0258ec6789dd1602c)

A few tests had to be adjusted for this, as they have now lost a breakpoint on "the other side of an await expression".