### PR TITLE
[Clang][AST] Don't use canonical type when checking dependence in Type::isOverloadable

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -1123,6 +1123,7 @@ Bug Fixes to C++ Support
 - Fixed assertion failure by skipping the analysis of an invalid field declaration. (#GH99868)
 - Fix an issue with dependent source location expressions (#GH106428), (#GH81155), (#GH80210), (#GH85373)
 - Fix handling of ``_`` as the name of a lambda's init capture variable. (#GH107024)
+- Fixed a crash when an expression with a dependent ``__typeof__`` type is used as the operand of a unary operator. (#GH97646)
 
 
 Bug Fixes to AST Handling

--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -8452,7 +8452,7 @@ inline bool Type::isUndeducedType() const {
 /// Determines whether this is a type for which one can define
 /// an overloaded operator.
 inline bool Type::isOverloadableType() const {
-  if (!CanonicalType->isDependentType())
+  if (!isDependentType())
     return isRecordType() || isEnumeralType();
   return !isArrayType() && !isFunctionType() && !isAnyPointerType() &&
          !isMemberPointerType();

--- a/clang/test/SemaCXX/decltype.cpp
+++ b/clang/test/SemaCXX/decltype.cpp
@@ -164,6 +164,14 @@ static_assert(A<int>().f<int>() != 0, ""); // expected-error {{static assertion 
                                            // expected-note@-1 {{expression evaluates to '0 != 0'}}
 }
 
+namespace GH97646 {
+  template<bool B>
+  void f() {
+    decltype(B) x = false;
+    !x;
+  }
+}
+
 template<typename>
 class conditional {
 };

--- a/clang/test/SemaCXX/typeof.cpp
+++ b/clang/test/SemaCXX/typeof.cpp
@@ -3,3 +3,11 @@
 typeof_unqual(int) u = 12; // expected-error {{expected function body after function declarator}}
 __typeof_unqual(int) _u = 12;
 __typeof_unqual__(int) __u = 12;
+
+namespace GH97646 {
+  template<bool B>
+  void f() {
+    __typeof__(B) x = false;
+    !x;
+  }
+}


### PR DESCRIPTION
Fixes #97646.

Conflicts:
	clang/docs/ReleaseNotes.rst
	clang/test/SemaCXX/decltype.cpp