### PR TITLE
[lldb] Fix clang importer for swift caching debugging (attempt #2)

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -27,5 +27,7 @@ class TestSwiftClangImporterCaching(TestBase):
         self.filecheck('platform shell cat "%s"' % log, __file__)
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -triple
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'ClangA'
 #       CHECK-NOT: -cc1
 #       CHECK-NOT: -fmodule-file-cache-key
+#       CHECK-NOT: Clang error:

--- a/lldb/test/Shell/Swift/caching.test
+++ b/lldb/test/Shell/Swift/caching.test
@@ -1,0 +1,30 @@
+# REQUIRES: swift
+# REQUIRES: system-darwin
+
+# RUN: rm -rf %t && mkdir %t
+# RUN: split-file %s %t
+# RUN: %target-swiftc -g -Onone -save-temps \
+# RUN:          -module-cache-path %t/cache %t/main.swift \
+# RUN:          -cache-compile-job -cas-path %t/cas -explicit-module-build \
+# RUN:          -module-name main -o %t/main
+
+# RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s
+# CHECK:         LogConfiguration() --   Extra clang arguments
+# CHECK-COUNT-1: LogConfiguration() --     -triple
+# CHECK:         (Int) ${{.*}} = 1
+
+//--- main.swift
+func test() {
+  print("break here")
+}
+test()
+
+//--- lldb.script
+# Force loading from interface to simulate no binary module available.
+settings set symbols.swift-module-loading-mode prefer-interface
+log enable lldb types
+b test
+run
+# Create a SwiftASTContext
+expr 1
+quit


### PR DESCRIPTION
Further improve how lldb constructing clang importer to utilize explicit modules:
* Add logics to initialize the swift ASTContext from direct cc1 arguments embedded in the swiftmodule
* Make sure the direct cc1 arguments are not repeated constructed. It should only be constructed as a fresh invocation
* Make sure the lldb doesn't overwrite the explicit module build settings when filter arguments. This ensures the already built explicit modules are used.
* Use the newly added clang option that ignore CAS info when loading PCMs. This allows lldb to load CAS enabled PCM directly from disk.

rdar://135611011
(cherry picked from commit d3b9f2cc2d33358bbc87765542cc5940dc869b35)