### PR TITLE
builtins: adjust code to build for ARM64 on MSVC

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/fp_mode.c
+++ b/compiler-rt/lib/builtins/aarch64/fp_mode.c
@@ -23,8 +23,13 @@
 #ifndef __ARM_FP
 // For soft float targets, allow changing rounding mode by overriding the weak
 // __aarch64_fe_default_rmode symbol.
+#if defined(_MSC_VER)
+CRT_FE_ROUND_MODE __default_rmode = CRT_FE_TONEAREST;
+#pragma comment(linker, "/alternatename:__aarch64_fe_default_rmode=__default_rmode")
+#else
 CRT_FE_ROUND_MODE __attribute__((weak)) __aarch64_fe_default_rmode =
     CRT_FE_TONEAREST;
+#endif
 #endif
 
 CRT_FE_ROUND_MODE __fe_getround(void) {


### PR DESCRIPTION
Avoid the use of `__attribute__` syntax on MSVC as that is not portable. For the weak symbol definition, use the MSVC extension of creating a weak alias through `/alternatename`.