### PR TITLE
[cas] Automatically use smaller CAS files on macOS tmpfs

### DIFF
--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -57,6 +57,10 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 
+#if __has_include(<sys/mount.h>)
+#include <sys/mount.h> // statfs
+#endif
+
 #define DEBUG_TYPE "on-disk-cas"
 
 using namespace llvm;
@@ -1332,6 +1336,22 @@ size_t OnDiskGraphDB::getStorageSize() const {
   return Index.size() + DataPool.size() + getStandaloneStorageSize();
 }
 
+static bool useSmallMappedFiles(const Twine &P) {
+  // macOS tmpfs does not support sparse tails.
+#if defined(__APPLE__) && __has_include(<sys/mount.h>)
+  SmallString<128> PathStorage;
+  StringRef Path = P.toNullTerminatedStringRef(PathStorage);
+  struct statfs StatFS;
+  if (statfs(Path.data(), &StatFS) != 0)
+    return false;
+
+  if (strcmp(StatFS.f_fstypename, "tmpfs") == 0)
+    return true;
+#endif
+
+  return false;
+}
+
 Expected<std::unique_ptr<OnDiskGraphDB>> OnDiskGraphDB::open(
     StringRef AbsPath, StringRef HashName, unsigned HashByteSize,
     std::unique_ptr<OnDiskGraphDB> UpstreamDB, FaultInPolicy Policy) {
@@ -1344,6 +1364,11 @@ Expected<std::unique_ptr<OnDiskGraphDB>> OnDiskGraphDB::open(
 
   uint64_t MaxIndexSize = 8 * GB;
   uint64_t MaxDataPoolSize = 16 * GB;
+
+  if (useSmallMappedFiles(AbsPath)) {
+    MaxIndexSize = 1 * GB;
+    MaxDataPoolSize = 2 * GB;
+  }
 
   auto CustomSize = getOverriddenMaxMappingSize();
   if (!CustomSize)


### PR DESCRIPTION
macOS tmpfs does not support sparse file tails, leading to out-of-space issues when using our default large maximum mapped file sizes in the CAS.

When using tmpfs switch to 1 GB index/cache and 2 GB data pool.

rdar://113036612