### PR TITLE
Partially revert "[llvm][lld] Support R_AARCH64_GOTPCREL32 (#72584)"

### DIFF
--- a/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
+++ b/llvm/lib/Target/AArch64/MCTargetDesc/AArch64ELFObjectWriter.cpp
@@ -206,10 +206,7 @@ unsigned AArch64ELFObjectWriter::getRelocType(MCContext &Ctx,
     case FK_Data_2:
       return R_CLS(ABS16);
     case FK_Data_4:
-      return (!IsILP32 &&
-              Target.getAccessVariant() == MCSymbolRefExpr::VK_GOTPCREL)
-                 ? ELF::R_AARCH64_GOTPCREL32
-                 : R_CLS(ABS32);
+      return R_CLS(ABS32);
     case FK_Data_8: {
       bool IsAuth = (RefKind == AArch64MCExpr::VK_AUTH ||
                      RefKind == AArch64MCExpr::VK_AUTHADDR);

--- a/llvm/test/MC/AArch64/elf-reloc-gotpcrel32.s
+++ b/llvm/test/MC/AArch64/elf-reloc-gotpcrel32.s
@@ -1,3 +1,5 @@
+// XFAIL: !rdar135050296
+
 // RUN: llvm-mc -triple=aarch64 -filetype=obj %s -o - | \
 // RUN:   llvm-readobj -r - | FileCheck %s
 


### PR DESCRIPTION
This reverts the MC changes from commit
04a906ec980e7bf49ffda0808766f51d08e8ae76, which cause failures when linking with gold on arm64.