### PR TITLE
builtins: adjust code for ARM64 on MSVC harder

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/fp_mode.c
+++ b/compiler-rt/lib/builtins/aarch64/fp_mode.c
@@ -24,6 +24,7 @@
 // For soft float targets, allow changing rounding mode by overriding the weak
 // __aarch64_fe_default_rmode symbol.
 #if defined(_MSC_VER)
+extern CRT_FE_ROUND_MODE __default_rmode;
 CRT_FE_ROUND_MODE __default_rmode = CRT_FE_TONEAREST;
 #pragma comment(linker, "/alternatename:__aarch64_fe_default_rmode=__default_rmode")
 #else

--- a/compiler-rt/lib/builtins/aarch64/lse.S
+++ b/compiler-rt/lib/builtins/aarch64/lse.S
@@ -28,11 +28,7 @@
 .arch armv8-a
 #endif
 
-#if !defined(__APPLE__)
-HIDDEN(__aarch64_have_lse_atomics)
-#else
-HIDDEN(___aarch64_have_lse_atomics)
-#endif
+HIDDEN(SYMBOL_NAME(__aarch64_have_lse_atomics))
 
 // Generate mnemonics for
 // L_cas:                                 SIZE: 1,2,4,8,16 MODEL: 1,2,3,4,5
@@ -131,13 +127,8 @@ HIDDEN(___aarch64_have_lse_atomics)
 
 // Macro for branch to label if no LSE available
 .macro JUMP_IF_NOT_LSE label
-#if !defined(__APPLE__)
-        adrp    x(tmp0), __aarch64_have_lse_atomics
-        ldrb    w(tmp0), [x(tmp0), :lo12:__aarch64_have_lse_atomics]
-#else
-        adrp    x(tmp0), ___aarch64_have_lse_atomics@page
-        ldrb    w(tmp0), [x(tmp0), ___aarch64_have_lse_atomics@pageoff]
-#endif
+        adrp    x(tmp0), SYMBOL_NAME(__aarch64_have_lse_atomics)
+        ldrb    w(tmp0), [x(tmp0), :lo12:SYMBOL_NAME(__aarch64_have_lse_atomics)]
         cbz     w(tmp0), \label
 .endm
 

--- a/compiler-rt/lib/builtins/cpu_model/aarch64.c
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64.c
@@ -30,8 +30,12 @@ typedef struct __ifunc_arg_t {
 
 // LSE support detection for out-of-line atomics
 // using HWCAP and Auxiliary vector
-_Bool __aarch64_have_lse_atomics
-    __attribute__((visibility("hidden"), nocommon)) = false;
+#if defined(_MSC_VER)
+__declspec(allocate(".data"))
+#else
+__attribute__((__visibility__("hidden"), __nocommon__))
+#endif
+_Bool __aarch64_have_lse_atomics = false;
 
 #if defined(__FreeBSD__)
 // clang-format off: should not reorder sys/auxv.h alphabetically
@@ -54,12 +58,18 @@ _Bool __aarch64_have_lse_atomics
 
 #if !defined(DISABLE_AARCH64_FMV)
 
-// Architecture features used
-// in Function Multi Versioning
+// Architecture features used in function multi-versioning
+#if defined(_MSC_VER)
+__declspec(allocate(".data"))
+#endif
 struct {
   unsigned long long features;
   // As features grows new fields could be added
-} __aarch64_cpu_features __attribute__((visibility("hidden"), nocommon));
+} __aarch64_cpu_features
+#if !defined(_MSC_VER)
+__attribute__((__visibility__("hidden"), __nocommon__))
+#endif
+;
 
 // The formatter wants to re-order these includes, but doing so is incorrect:
 // clang-format off


### PR DESCRIPTION
This addresses additional compilation issues that were highlighted by trying to build the builtins for Windows ARM64 on the Swift rebranch.