### PR TITLE
[lldb][FrameRecognizer] Make VerboseTrapFrameRecognizer aware of Swift-C++ interop frames

### DIFF
--- a/lldb/source/Target/VerboseTrapFrameRecognizer.cpp
+++ b/lldb/source/Target/VerboseTrapFrameRecognizer.cpp
@@ -9,6 +9,7 @@
 
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/RegularExpression.h"
 
 #include "clang/CodeGen/ModuleBuilder.h"
 
@@ -36,10 +37,15 @@ static StackFrameSP FindMostRelevantFrame(Thread &selected_thread) {
     if (!frame_name)
       return nullptr;
 
-    // Found a frame outside of the `std` namespace. That's the
+    // Find a frame outside of the `std` namespace. That's the
     // first frame in user-code that ended up triggering the
     // verbose_trap. Hence that's the one we want to display.
-    if (!frame_name.GetStringRef().starts_with("std::"))
+    //
+    // IsHidden will get us to the first non-implementation detail
+    // frame. But that could still be in the `std` namespace, so
+    // check the namespace prefix too.
+    if (!frame_name.GetStringRef().starts_with("std::") &&
+        !most_relevant_frame_sp->IsHidden())
       return most_relevant_frame_sp;
 
     ++stack_idx;

--- a/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/Makefile
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_CXX_INTEROP := 1
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR) 
+include Makefile.rules

--- a/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/TestSwiftForwardInteropVerboseTrap.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/TestSwiftForwardInteropVerboseTrap.py
@@ -1,0 +1,22 @@
+
+"""
+Test that verbose_trap works on forward interop mode.
+"""
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSwiftForwardInteropVerboseTrap(TestBase):
+
+    @swiftTest
+    def test(self):
+        self.build()
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        self.assertTrue(target, VALID_TARGET)
+
+        target.BreakpointCreateByName("Break here", "a.out")
+        process = target.LaunchSimple(None, None, self.get_process_working_directory())
+        self.assertTrue(process, PROCESS_IS_VALID)
+
+        # Make sure we stopped in the first user-level frame.
+        self.assertTrue(self.frame().name.startswith("a.takes<"))

--- a/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/aborts.h
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/aborts.h
@@ -1,0 +1,30 @@
+#include <iterator>
+
+namespace std {
+void function_that_aborts() { __builtin_verbose_trap("Error", "from C++"); }
+
+struct ConstIterator {
+private:
+  int value;
+
+public:
+  // Make sure this auto-conforms to UnsafeCxxInputIterator
+
+  using iterator_category = std::input_iterator_tag;
+  using value_type = int;
+  using pointer = int *;
+  using reference = const int &;
+  using difference_type = int;
+
+  ConstIterator(int value) : value(value) {}
+
+  void operator*() const { std::function_that_aborts(); }
+
+  ConstIterator &operator++() { return *this; }
+  ConstIterator operator++(int) { return ConstIterator(value); }
+
+  bool operator==(const ConstIterator &other) const { return false; }
+  bool operator!=(const ConstIterator &other) const { return true; }
+};
+
+} // namespace std

--- a/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/main.swift
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/main.swift
@@ -1,0 +1,14 @@
+import Aborts
+
+func takes(_ t: some UnsafeCxxInputIterator) {
+    t.pointee
+}
+
+func main() {
+  var x = std.ConstIterator(137);
+  takes(x);
+  print("Break here");
+}
+
+main()
+

--- a/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/module.modulemap
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/module.modulemap
@@ -1,0 +1,5 @@
+module Aborts {
+  header "aborts.h"
+  requires cplusplus
+}
+


### PR DESCRIPTION
This patch ensures that if `libc++` is called from Swift (via Swift interop for example), and triggers a `__builtin_verbose_trap`, we don't stop in the Swift-C++ compiler-generated shims.

E.g., in the example test-case, the stacktrace looks like:
```
frame #0: 0x0000000102998c00 a.out`std::function_that_aborts() [inlined] __clang_trap_msg$Error$from C++ at aborts.h:0
frame #1: 0x0000000102998c00 a.out`std::function_that_aborts() at aborts.h:4:31
frame #2: 0x0000000102998c1c a.out`std::ConstIterator::operator*(this=0x0000600003954420) const at aborts.h:21:28
frame #3: 0x0000000102998ab0 a.out`std.ConstIterator.pointee.read() at <compiler-generated>:0
frame #4: 0x0000000102998a14 a.out`protocol witness for UnsafeCxxInputIterator.pointee.read in conformance std.ConstIterator at <compiler-generated>:0
frame #5: 0x0000000102998760 a.out`takes<ConstIterator>(t=Aborts.ConstIterator @ 0x000000016d46aeb8) at main.swift:4:7
frame #6: 0x00000001029985e0 a.out`main() at main.swift:9:3
frame #7: 0x0000000102998584 a.out`main at main.swift:13:1
frame #8: 0x000000019053df20 dyld`start + 1988
```

We want to stop in frame 5, which is where the call into `std` started.

rdar://136357737