### PR TITLE
builtins: repair the Darwin build for ARM64

### DIFF
--- a/compiler-rt/lib/builtins/aarch64/lse.S
+++ b/compiler-rt/lib/builtins/aarch64/lse.S
@@ -127,8 +127,13 @@ HIDDEN(SYMBOL_NAME(__aarch64_have_lse_atomics))
 
 // Macro for branch to label if no LSE available
 .macro JUMP_IF_NOT_LSE label
+#if defined(__APPLE__)
+        adrp    x(tmp0), SYMBOL_NAME(__aarch64_have_lse_atomics)@page
+        ldrb    w(tmp0), [x(tmp0), SYMBOL_NAME(__aarch64_have_lse_atomics)@pageoff]
+#else
         adrp    x(tmp0), SYMBOL_NAME(__aarch64_have_lse_atomics)
         ldrb    w(tmp0), [x(tmp0), :lo12:SYMBOL_NAME(__aarch64_have_lse_atomics)]
+#endif
         cbz     w(tmp0), \label
 .endm
 


### PR DESCRIPTION
The addressing mode for the ADR/ADRP is different on Darwin than on other platforms. Restore the Darwin specific path to allow building on this platform.