### PR TITLE
[lldb] Support plain ObjC names in LLDBTypeInfoProvider

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -12,12 +12,10 @@
 
 #include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntimeImpl.h"
-#include "lldb/Symbol/CompilerType.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/RemoteInspection/DescriptorFinder.h"
-#include <_types/_uint64_t.h>
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -12,10 +12,12 @@
 
 #include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntimeImpl.h"
+#include "lldb/Symbol/CompilerType.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/RemoteInspection/DescriptorFinder.h"
+#include <_types/_uint64_t.h>
 
 using namespace lldb;
 using namespace lldb_private;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -336,7 +336,7 @@ public:
     } else {
 #ifndef NDEBUG
       // Check that our hardcoded mangling wrapper is still up-to-date.
-      assert(node && node->getKind() == swift::Demangle::Node::Kind::Global);
+      assert(node->getKind() == swift::Demangle::Node::Kind::Global);
       assert(node->getNumChildren() == 1);
       node = node->getChild(0);
       assert(node->getKind() == swift::Demangle::Node::Kind::TypeMangling);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -70,7 +70,34 @@ static swift::Demangle::NodePointer
 GetDemangledType(swift::Demangle::Demangler &dem, llvm::StringRef name) {
   return GetType(dem.demangleSymbol(name));
 }
-  
+
+/// Wrap node in Global/TypeMangling/Type.
+static swift::Demangle::NodePointer
+mangleType(swift::Demangle::Demangler &dem,
+           swift::Demangle::NodePointer typeNode) {
+  auto *global = dem.createNode(Node::Kind::Global);
+  auto *typeMangling = dem.createNode(Node::Kind::TypeMangling);
+  global->addChild(typeMangling, dem);
+  auto *type = dem.createNode(Node::Kind::Type);
+  typeMangling->addChild(type, dem);
+  type->addChild(typeNode, dem);
+  return global;
+}
+
+/// Produce a type mangling for a class.
+inline ManglingErrorOr<std::string> mangleClass(swift::Demangle::Demangler &dem,
+                                                llvm::StringRef moduleName,
+                                                llvm::StringRef className) {
+  auto *classNode = dem.createNode(Node::Kind::Class);
+  auto *module =
+      dem.createNodeWithAllocatedText(Node::Kind::Module, moduleName);
+  auto *identifier =
+      dem.createNodeWithAllocatedText(Node::Kind::Identifier, className);
+  classNode->addChild(module, dem);
+  classNode->addChild(identifier, dem);
+  return mangleNode(mangleType(dem, classNode));
+}
+
 } // namespace swift_demangle
 } // namespace lldb_private
 

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/Makefile
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
@@ -1,0 +1,17 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        """Print an ObjC derived object without using the AST context."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        self.expect("v", substrs=["num = 15"])

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/main.swift
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/main.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+class C: NSObject {
+  var num: Int = 15
+}
+
+func main() {
+  let c = C()
+  // break here
+  print(c)
+}
+
+main()


### PR DESCRIPTION
Extend `LLDBTypeInfoProvider` to support ObjC class names (such as "NSObject", "NSView") in addition to mangled Swift names.

This is to support `ObjCClassTypeRefs`, which contain the class name, but not the mangled name. Note that `ObjCClassTypeRefs` are typerefs for classes in the ObjC (`__C`) module.

Depends on https://github.com/swiftlang/swift/pull/76678