### PR TITLE
[clang][IncludeTree] Update alternative IncludeTreeFS creation API

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -239,6 +239,13 @@ public:
   static Expected<File> create(ObjectStore &DB, StringRef Filename,
                                ObjectRef Contents);
 
+  static Expected<File> get(ObjectStore &DB, ObjectRef Ref) {
+    auto Node = DB.getProxy(Ref);
+    if (!Node)
+      return Node.takeError();
+    return File(std::move(*Node));
+  }
+
   llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
 
   static bool isValid(const ObjectProxy &Node) {
@@ -304,13 +311,6 @@ private:
 
   size_t getNumFilesCurrentList() const;
   FileSizeTy getFileSize(size_t I) const;
-
-  Expected<File> getFile(ObjectRef Ref) {
-    auto Node = getCAS().getProxy(Ref);
-    if (!Node)
-      return Node.takeError();
-    return File(std::move(*Node));
-  }
 
   llvm::Error
   forEachFileImpl(llvm::DenseSet<ObjectRef> &Seen,
@@ -869,10 +869,11 @@ private:
 Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
 createIncludeTreeFileSystem(IncludeTreeRoot &Root);
 
-/// Create the same IncludeTreeFileSystem but from IncludeTree::FileList.
-Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
-createIncludeTreeFileSystem(llvm::cas::ObjectStore &CAS,
-                            IncludeTree::FileList &List);
+/// Create the same IncludeTreeFileSystem but from
+/// ArrayRef<IncludeTree::FileEntry>.
+Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>> createIncludeTreeFileSystem(
+    llvm::cas::ObjectStore &CAS,
+    llvm::ArrayRef<IncludeTree::FileList::FileEntry> List);
 
 } // namespace cas
 } // namespace clang

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -313,13 +313,9 @@ TEST(IncludeTree, IncludeTreeFileSystemOverlay) {
         llvm::Succeeded());
     Files.push_back({File->getRef(), I});
   }
-  std::optional<IncludeTree::FileList> FileList;
-  ASSERT_THAT_ERROR(
-      IncludeTree::FileList::create(*DB, Files, {}).moveInto(FileList),
-      llvm::Succeeded());
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> IncludeTreeFS;
   ASSERT_THAT_ERROR(
-      createIncludeTreeFileSystem(*DB, *FileList).moveInto(IncludeTreeFS),
+      createIncludeTreeFileSystem(*DB, Files).moveInto(IncludeTreeFS),
       llvm::Succeeded());
 
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();


### PR DESCRIPTION
Update the alternaitive API to create IncludeTreeFileSystem to create directly from a list of `FileEntry`. This skips creating a `FileList` in the CAS, thus save time and CAS usage.