### PR TITLE
Remove classic whole-project compiler invocations.

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -80,13 +80,10 @@ public:
   bool GetUseSwiftClangImporter() const;
   bool GetUseSwiftDWARFImporter() const;
   bool SetUseSwiftDWARFImporter(bool new_value);
-  bool GetUseSwiftTypeRefTypeSystem() const;
-  bool SetUseSwiftTypeRefTypeSystem(bool new_value);
   bool GetSwiftValidateTypeSystem() const;
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);
 
-  bool GetUseSwiftPreciseCompilerInvocation() const;
   bool GetEnableSwiftMetadataCache() const;
   uint64_t GetSwiftMetadataCacheMaxByteSize();
   uint64_t GetSwiftMetadataCacheExpirationDays();

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1301,7 +1301,8 @@ public:
 
   std::optional<SwiftScratchContextReader>
   GetSwiftScratchContext(Status &error, ExecutionContextScope &exe_scope,
-                         bool create_on_demand = true);
+                         bool create_on_demand = true,
+                         bool for_playground = false);
 
   /// Return whether this is the Swift REPL.
   bool IsSwiftREPL();

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -25,15 +25,9 @@ let Definition = "modulelist" in {
   def UseSwiftDWARFImporter: Property<"use-swift-dwarfimporter", "Boolean">,
     DefaultTrue,
     Desc<"Reconstruct Clang module dependencies from DWARF when debugging Swift code">;
-  def UseSwiftTypeRefTypeSystem: Property<"use-swift-typeref-typesystem", "Boolean">,
-    DefaultTrue,
-    Desc<"Prefer Swift Remote Mirrors over Remote AST">;
   def SwiftValidateTypeSystem: Property<"swift-validate-typesystem", "Boolean">,
     DefaultFalse,
     Desc<"Validate all Swift typesystem queries. Used for testing an asserts-enabled LLDB only.">;
-  def UseSwiftPreciseCompilerInvocation: Property<"swift-precise-compiler-invocation", "Boolean">,
-    DefaultTrue,
-    Desc<"In the Swift expression evaluator, create many Swift compiler instances with the precise invocation for the current context, instead of a single compiler instance that merges all flags from the entire project.">;
   def SwiftModuleLoadingMode: Property<"swift-module-loading-mode", "Enum">,
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,
     EnumValues<"OptionEnumValues(g_swift_module_loading_mode_enums)">,

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1634,7 +1634,7 @@ bool Module::SetArchitecture(const ArchSpec &new_arch) {
 #ifdef LLDB_ENABLE_SWIFT
     if (auto ts =
             llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get()))
-      ts->SetTriple(new_arch.GetTriple());
+      ts->SetTriple(SymbolContext(shared_from_this()), new_arch.GetTriple());
 #endif // LLDB_ENABLE_SWIFT
     return true;
   }

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -194,27 +194,10 @@ bool ModuleListProperties::SetUseSwiftDWARFImporter(bool new_value) {
   return SetPropertyAtIndex(idx, new_value);
 }
 
-bool ModuleListProperties::GetUseSwiftTypeRefTypeSystem() const {
-  const uint32_t idx = ePropertyUseSwiftTypeRefTypeSystem;
-  return GetPropertyAtIndexAs<bool>(
-      idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
 bool ModuleListProperties::GetSwiftValidateTypeSystem() const {
   const uint32_t idx = ePropertySwiftValidateTypeSystem;
   return GetPropertyAtIndexAs<bool>(
       idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
-bool ModuleListProperties::GetUseSwiftPreciseCompilerInvocation() const {
-  const uint32_t idx = ePropertyUseSwiftPreciseCompilerInvocation;
-  return GetPropertyAtIndexAs<bool>(
-      idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
-bool ModuleListProperties::SetUseSwiftTypeRefTypeSystem(bool new_value) {
-  const uint32_t idx = ePropertyUseSwiftTypeRefTypeSystem;
-  return SetPropertyAtIndex(idx, new_value);
 }
 
 SwiftModuleLoadingMode ModuleListProperties::GetSwiftModuleLoadingMode() const {

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -845,7 +845,7 @@ IRExecutionUnit::FindInSymbols(const std::vector<ConstString> &names,
       // BEGIN SWIFT
       if (m_in_populate_symtab)
         if (lldb::ModuleSP module_sp = m_jit_module_wp.lock())
-        images.Remove(module_sp);
+          images.Remove(module_sp);
       // END SWIFT
 
       SymbolContextList sc_list;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -897,7 +897,7 @@ llvm::Expected<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
   // When injecting a value pack or pack count into the outer
   // lldb_expr function, treat it as an opaque raw pointer.
   if (m_bind_generic_types == lldb::eDontBind && variable.IsUnboundPack()) {
-    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(&m_sc);
+    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(m_sc);
     if (!swift_ast_ctx)
       return llvm::createStringError("no typesystem for variable " +
                                      variable.GetName().str());

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -569,7 +569,8 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
             type_system_or_err->get());
     auto *target_swift_ast =
         llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-            swift_ts->GetSwiftASTContext(nullptr));
+            swift_ts->GetSwiftASTContext(SymbolContext(
+                m_target.shared_from_this(), m_target.GetExecutableModule())));
     m_swift_ast = target_swift_ast;
   }
   SwiftASTContextForExpressions *swift_ast = m_swift_ast;

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -103,7 +103,9 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
   const SymbolContext *sc = nullptr;
   if (swiftFrame)
     sc = &swiftFrame->GetSymbolContext(eSymbolContextFunction);
-  auto *ctx = ts->GetSwiftASTContext(sc);
+  if (!sc)
+    return "";
+  auto *ctx = ts->GetSwiftASTContext(*sc);
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
@@ -122,7 +122,7 @@ public:
       }
       auto &sc = most_relevant_frame_sp->GetSymbolContext(
           lldb::eSymbolContextFunction);
-      ConstString module_name = TypeSystemSwiftTypeRef::GetSwiftModuleFor(&sc);
+      ConstString module_name = TypeSystemSwiftTypeRef::GetSwiftModuleFor(sc);
       if (!module_name)
         continue;
       if (module_name == swift::STDLIB_NAME)

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1350,22 +1350,23 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
               std::optional<SwiftScratchContextReader> maybe_scratch_ctx =
                   target->GetSwiftScratchContext(error, *exe_scope,
                                                  create_on_demand);
-              const SymbolContext *sc = nullptr;
-              if (auto frame_sp = exe_scope->CalculateStackFrame())
-                sc = &frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
-              if (maybe_scratch_ctx)
-                if (auto scratch_ctx = maybe_scratch_ctx->get())
-                  if (SwiftASTContext *ast_ctx =
-                          scratch_ctx->GetSwiftASTContext(sc)) {
-                    ConstString cs_input{input};
-                    Mangled mangled(cs_input);
-                    if (mangled.GuessLanguage() == eLanguageTypeSwift) {
-                      auto candidate =
-                          ast_ctx->GetTypeFromMangledTypename(cs_input);
-                      if (candidate.IsValid())
-                        results.insert(candidate);
+              if (auto frame_sp = exe_scope->CalculateStackFrame()) {
+                auto &sc =
+                    frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
+                if (maybe_scratch_ctx)
+                  if (auto scratch_ctx = maybe_scratch_ctx->get())
+                    if (SwiftASTContext *ast_ctx =
+                            scratch_ctx->GetSwiftASTContext(sc)) {
+                      ConstString cs_input{input};
+                      Mangled mangled(cs_input);
+                      if (mangled.GuessLanguage() == eLanguageTypeSwift) {
+                        auto candidate =
+                            ast_ctx->GetTypeFromMangledTypename(cs_input);
+                        if (candidate.IsValid())
+                          results.insert(candidate);
+                      }
                     }
-                  }
+              }
             }
           }
 
@@ -1423,76 +1424,77 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
             std::optional<SwiftScratchContextReader> maybe_scratch_ctx =
                 target->GetSwiftScratchContext(error, *exe_scope,
                                                create_on_demand);
-            const SymbolContext *sc = nullptr;
-            if (auto frame_sp = exe_scope->CalculateStackFrame())
-              sc = &frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
+            if (auto frame_sp = exe_scope->CalculateStackFrame()) {
+              const SymbolContext &sc =
+                  frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
+              if (maybe_scratch_ctx)
+                if (auto scratch_ctx = maybe_scratch_ctx->get())
+                  if (SwiftASTContext *ast_ctx =
+                          scratch_ctx->GetSwiftASTContext(sc)) {
+                    auto iter = ast_ctx->GetModuleCache().begin(),
+                         end = ast_ctx->GetModuleCache().end();
 
-            if (maybe_scratch_ctx)
-              if (auto scratch_ctx = maybe_scratch_ctx->get())
-                if (SwiftASTContext *ast_ctx =
-                        scratch_ctx->GetSwiftASTContext(sc)) {
-                  auto iter = ast_ctx->GetModuleCache().begin(),
-                       end = ast_ctx->GetModuleCache().end();
+                    std::vector<llvm::StringRef> name_parts;
+                    SplitDottedName(input, name_parts);
 
-                  std::vector<llvm::StringRef> name_parts;
-                  SplitDottedName(input, name_parts);
-
-                  std::function<void(swift::ModuleDecl *)> lookup_func =
-                      [&ast_ctx, input, name_parts,
-                       &results](swift::ModuleDecl *module) -> void {
-                    for (auto imported_module :
-                         swift::namelookup::getAllImports(module)) {
-                      auto module = imported_module.importedModule;
-                      TypesOrDecls local_results;
-                      ast_ctx->FindTypesOrDecls(input, module, local_results,
-                                                false);
-                      std::optional<TypeOrDecl> candidate;
-                      if (local_results.empty() && name_parts.size() > 1) {
-                        size_t idx_of_deeper = 1;
-                        // if you're looking for Swift.Int in module Swift,
-                        // try looking for Int
-                        if (name_parts.front() == module->getName().str()) {
-                          candidate = ast_ctx->FindTypeOrDecl(
-                              name_parts[1].str().c_str(), module);
-                          idx_of_deeper = 2;
-                        }
-                        // this is probably the top-level name of a nested
-                        // type String.UTF8View
-                        else {
-                          candidate = ast_ctx->FindTypeOrDecl(
-                              name_parts[0].str().c_str(), module);
-                        }
-                        if (candidate.has_value()) {
-                          TypesOrDecls candidates{candidate.value()};
-                          for (; idx_of_deeper < name_parts.size();
-                               idx_of_deeper++) {
-                            TypesOrDecls new_candidates;
-                            for (auto candidate : candidates) {
-                              ast_ctx->FindContainedTypeOrDecl(
-                                  name_parts[idx_of_deeper], candidate,
-                                  new_candidates);
+                    std::function<void(swift::ModuleDecl *)> lookup_func =
+                        [&ast_ctx, input, name_parts,
+                         &results](swift::ModuleDecl *module) -> void {
+                      for (auto imported_module :
+                           swift::namelookup::getAllImports(module)) {
+                        auto module = imported_module.importedModule;
+                        TypesOrDecls local_results;
+                        ast_ctx->FindTypesOrDecls(input, module, local_results,
+                                                  false);
+                        std::optional<TypeOrDecl> candidate;
+                        if (local_results.empty() && name_parts.size() > 1) {
+                          size_t idx_of_deeper = 1;
+                          // if you're looking for Swift.Int in module Swift,
+                          // try looking for Int
+                          if (name_parts.front() == module->getName().str()) {
+                            candidate = ast_ctx->FindTypeOrDecl(
+                                name_parts[1].str().c_str(), module);
+                            idx_of_deeper = 2;
+                          }
+                          // this is probably the top-level name of a nested
+                          // type String.UTF8View
+                          else {
+                            candidate = ast_ctx->FindTypeOrDecl(
+                                name_parts[0].str().c_str(), module);
+                          }
+                          if (candidate.has_value()) {
+                            TypesOrDecls candidates{candidate.value()};
+                            for (; idx_of_deeper < name_parts.size();
+                                 idx_of_deeper++) {
+                              TypesOrDecls new_candidates;
+                              for (auto candidate : candidates) {
+                                ast_ctx->FindContainedTypeOrDecl(
+                                    name_parts[idx_of_deeper], candidate,
+                                    new_candidates);
+                              }
+                              candidates = new_candidates;
                             }
-                            candidates = new_candidates;
+                            for (auto candidate : candidates) {
+                              if (candidate)
+                                results.insert(candidate);
+                            }
                           }
-                          for (auto candidate : candidates) {
-                            if (candidate)
-                              results.insert(candidate);
-                          }
-                        }
-                      } else if (local_results.size() > 0) {
-                        for (const auto &result : local_results)
-                          results.insert(result);
-                      } else if (local_results.empty() && module &&
-                                 name_parts.size() == 1 &&
-                                 name_parts.front() == module->getName().str())
-                        results.insert(
-                            ToCompilerType(swift::ModuleType::get(module)));
-                    }
-                  };
+                        } else if (local_results.size() > 0) {
+                          for (const auto &result : local_results)
+                            results.insert(result);
+                        } else if (local_results.empty() && module &&
+                                   name_parts.size() == 1 &&
+                                   name_parts.front() ==
+                                       module->getName().str())
+                          results.insert(
+                              ToCompilerType(swift::ModuleType::get(module)));
+                      }
+                    };
 
-                  for (; iter != end; iter++)
-                    lookup_func(iter->second);
-                }
+                    for (; iter != end; iter++)
+                      lookup_func(iter->second);
+                  }
+            }
           }
 
           return (results.size() - before);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1231,7 +1231,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
           target.GetSwiftScratchContext(error, frame);
       auto scratch_ctx = maybe_swift_ast->get();
       if (scratch_ctx) {
-        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext(&sc)) {
+        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext(sc)) {
         CompilerType function_type = swift_ast->GetTypeFromMangledTypename(
             mangled_name.GetMangledName());
         if (error.Success()) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3063,7 +3063,7 @@ SwiftLanguageRuntimeImpl::GetConcreteType(ExecutionContextScope *exe_scope,
   if (!promise_sp)
     return CompilerType();
 
-  const SymbolContext *sc = &frame->GetSymbolContext(eSymbolContextFunction);
+  const SymbolContext &sc = frame->GetSymbolContext(eSymbolContextFunction);
   return promise_sp->FulfillTypePromise(sc);
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -300,12 +300,12 @@ protected:
     std::optional<CompilerType> m_compiler_type;
 
   public:
-    CompilerType FulfillTypePromise(const SymbolContext *sc,
+    CompilerType FulfillTypePromise(const SymbolContext &sc,
                                     Status *error = nullptr);
   };
   typedef std::shared_ptr<MetadataPromise> MetadataPromiseSP;
 
-  MetadataPromiseSP GetMetadataPromise(const SymbolContext *sc,
+  MetadataPromiseSP GetMetadataPromise(const SymbolContext &sc,
                                        lldb::addr_t addr,
                                        ValueObject &for_object);
   MetadataPromiseSP

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -203,18 +203,12 @@ public:
   CreateInstance(lldb::LanguageType language, Module &module,
                  TypeSystemSwiftTypeRef &typeref_typesystem,
                  bool fallback = false);
-  /// Create a SwiftASTContext from a Target.  This context is global
-  /// and used for the expression evaluator.
-  static lldb::TypeSystemSP
-  CreateInstance(lldb::LanguageType language,
-                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem,
-                 const char *extra_options);
-
   /// Create a SwiftASTContextForExpressions taylored to a specific symbol
   /// context.
   static lldb::TypeSystemSP
   CreateInstance(const SymbolContext &sc,
-                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem);
+                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem,
+                 const char *extra_options = nullptr);
 
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,
@@ -225,7 +219,7 @@ public:
   
   bool SupportsLanguage(lldb::LanguageType language) override;
 
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override {
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override {
     return GetTypeSystemSwiftTypeRef().GetSwiftASTContext(sc);
   }
 
@@ -419,9 +413,7 @@ public:
   llvm::Triple GetTriple() const;
 
   bool SetTriple(const llvm::Triple triple, lldb_private::Module *module);
-  void SetTriple(const llvm::Triple triple) override {
-    SetTriple(triple, nullptr);
-  }
+  void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
 
   /// Condition a triple to be safe for use with Swift.  Swift is
   /// really peculiar about what CPU types it thinks it has standard

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -115,10 +115,12 @@ public:
 
   const std::string &GetDescription() const { return m_description; }
   static LanguageSet GetSupportedLanguagesForTypes();
-  virtual SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const = 0;
+  virtual SwiftASTContext *
+  GetSwiftASTContext(const SymbolContext &sc) const = 0;
   virtual TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() = 0;
   virtual const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const = 0;
-  virtual void SetTriple(const llvm::Triple triple) = 0;
+  virtual void SetTriple(const SymbolContext &sc,
+                         const llvm::Triple triple) = 0;
   virtual void ClearModuleDependentCaches() = 0;
   virtual lldb::TargetWP GetTargetWP() const = 0;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1705,13 +1705,18 @@ TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions(
   LLDB_LOGF(GetLog(LLDBLog::Types),
             "%s::TypeSystemSwiftTypeRefForExpressions()",
             m_description.c_str());
-  // Is this a REPL?
-  if (extra_options)
+  // Is this a REPL or Playground?
+  if (extra_options) {
+    SymbolContext global_sc(target.shared_from_this(),
+                            target.GetExecutableModule());
+    ConstString module = GetSwiftModuleFor(global_sc);
+    const char *key = module.GetCString();
     m_swift_ast_context_map.insert(
-        {nullptr, SwiftASTContext::CreateInstance(
-                      LanguageType::eLanguageTypeSwift,
-                      *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this),
-                      extra_options)});
+        {key, SwiftASTContext::CreateInstance(
+                  global_sc,
+                  *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this),
+                  extra_options)});
+  }
 }
 
 void TypeSystemSwiftTypeRef::NotifyAllTypeSystems(
@@ -1745,12 +1750,8 @@ Status TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
   lldb::ProcessSP process_sp;
   if (auto target_sp = sc.target_sp)
     process_sp = target_sp->GetProcessSP();
-  if (!ModuleList::GetGlobalModuleListProperties()
-           .GetUseSwiftPreciseCompilerInvocation())
-    if (!GetSwiftASTContextOrNull(nullptr))
-      m_initial_symbol_context_up = std::make_unique<SymbolContext>(sc);
 
-  if (auto *swift_ast_ctx = GetSwiftASTContextOrNull(&sc))
+  if (auto *swift_ast_ctx = GetSwiftASTContextOrNull(sc))
     swift_ast_ctx->PerformCompileUnitImports(sc, process_sp, status);
   return status;
 }
@@ -1779,12 +1780,10 @@ TypeSystemSwiftTypeRefForExpressions::GetPersistentExpressionState() {
   return m_persistent_state_up.get();
 }
 
-ConstString TypeSystemSwiftTypeRef::GetSwiftModuleFor(const SymbolContext *sc) {
-  if (!sc)
+ConstString TypeSystemSwiftTypeRef::GetSwiftModuleFor(const SymbolContext &sc) {
+  if (!sc.function)
     return {};
-  if (!sc->function)
-    return {};
-  std::vector<CompilerContext> decl_ctx = sc->function->GetCompilerContext();
+  std::vector<CompilerContext> decl_ctx = sc.function->GetCompilerContext();
   for (auto &ctx : decl_ctx)
     if (ctx.kind == CompilerContextKind::Module)
       return ctx.name;
@@ -1793,32 +1792,38 @@ ConstString TypeSystemSwiftTypeRef::GetSwiftModuleFor(const SymbolContext *sc) {
 
 SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextFromExecutionScope(
     ExecutionContextScope *exe_scope) const {
-  const SymbolContext *sc = nullptr;
   if (exe_scope) {
-    // The SymbolContext is a Function, which outlives the stack
-    // frame, so not holding on to the shared pointer is safe here.
-    auto stack_frame_sp = exe_scope->CalculateStackFrame();
-    if (stack_frame_sp)
-      sc = &stack_frame_sp->GetSymbolContext(eSymbolContextFunction);
+    ExecutionContext exe_ctx;
+    exe_scope->CalculateExecutionContext(exe_ctx);
+    return GetSwiftASTContextFromExecutionContext(&exe_ctx);
   }
-  return GetSwiftASTContext(sc);
+  return GetSwiftASTContextFromExecutionContext(nullptr);
 }
 
 SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextFromExecutionContext(
     const ExecutionContext *exe_ctx) const {
-  const SymbolContext *sc = nullptr;
+  SymbolContext sc;
   if (exe_ctx) {
     // The SymbolContext is a Function, which outlives the stack
     // frame, so not holding on to the shared pointer is safe here.
     auto stack_frame = exe_ctx->GetFramePtr();
     if (stack_frame)
-      sc = &stack_frame->GetSymbolContext(eSymbolContextFunction);
+      sc = stack_frame->GetSymbolContext(eSymbolContextFunction);
+  }
+  if (!sc.module_sp)
+    if (auto target_sp = GetTargetWP().lock())
+      sc = SymbolContext(target_sp, target_sp->GetExecutableModule());
+
+  if (!sc.module_sp) {
+    LLDB_LOGF(GetLog(LLDBLog::Types),
+              "Cannot create a SwiftASTContext without an execution context");
+    return nullptr;
   }
   return GetSwiftASTContext(sc);
 }
 
 SwiftASTContext *
-TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext *sc) const {
+TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext &sc) const {
   std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
   // There is only one per-module context.
   const char *key = nullptr;
@@ -1843,16 +1848,11 @@ TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext *sc) const {
 }
 
 SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
-    const SymbolContext *sc) const {
-  bool precise = false;
+    const SymbolContext &sc) const {
   // Compute the cache key.
   const char *key = nullptr;
-  if (sc && ModuleList::GetGlobalModuleListProperties()
-                .GetUseSwiftPreciseCompilerInvocation()) {
-    ConstString module = GetSwiftModuleFor(sc);
-    key = module.GetCString();
-    precise = true;
-  }
+  ConstString module = GetSwiftModuleFor(sc);
+  key = module.GetCString();
 
   // Look up the SwiftASTContext in the cache.
   TypeSystemSP ts;
@@ -1876,14 +1876,8 @@ SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
     }
 
     // Create a new SwiftASTContextForExpressions.
-    ts = precise
-             ? SwiftASTContext::CreateInstance(
-                   *sc,
-                   *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this))
-             : SwiftASTContext::CreateInstance(
-                   LanguageType::eLanguageTypeSwift,
-                   *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this),
-                   nullptr);
+    ts = SwiftASTContext::CreateInstance(
+        sc, *const_cast<TypeSystemSwiftTypeRefForExpressions *>(this));
     m_swift_ast_context_map.insert({key, ts});
   }
 
@@ -1907,19 +1901,12 @@ SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
             error.AsCString());
   };
 
-  if (precise && sc) {
-    perform_initial_import(*sc);
-  } else {
-    if (m_initial_symbol_context_up) {
-      perform_initial_import(*m_initial_symbol_context_up);
-      m_initial_symbol_context_up.reset();
-    }
-  }
+  perform_initial_import(sc);
   return swift_ast_context;
 }
 
 SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull(
-    const SymbolContext *sc) const {
+    const SymbolContext &sc) const {
   std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
 
   const char *key = nullptr;
@@ -1930,15 +1917,12 @@ SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull(
 }
 
 SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContextOrNull(
-    const SymbolContext *sc) const {
+    const SymbolContext &sc) const {
   std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
 
   const char *key = nullptr;
-  if (sc && ModuleList::GetGlobalModuleListProperties()
-                .GetUseSwiftPreciseCompilerInvocation()) {
-    ConstString module = GetSwiftModuleFor(sc);
-    key = module.GetCString();
-  }
+  ConstString module = GetSwiftModuleFor(sc);
+  key = module.GetCString();
 
   auto it = m_swift_ast_context_map.find(key);
   if (it != m_swift_ast_context_map.end())
@@ -1976,10 +1960,12 @@ llvm::Triple TypeSystemSwiftTypeRef::GetTriple() const {
   return {};
 }
 
-void TypeSystemSwiftTypeRef::SetTriple(const llvm::Triple triple) {
-  // This function appears to be only called via Module::SetArchitecture(ArchSpec).
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull(nullptr))
-    swift_ast_context->SetTriple(triple);
+void TypeSystemSwiftTypeRef::SetTriple(const SymbolContext &sc,
+                                       const llvm::Triple triple) {
+  // This function appears to be only called via
+  // Module::SetArchitecture(ArchSpec).
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull(sc))
+    swift_ast_context->SetTriple(sc, triple);
 }
 
 void TypeSystemSwiftTypeRef::ClearModuleDependentCaches() {
@@ -2053,7 +2039,8 @@ bool TypeSystemSwiftTypeRef::SupportsLanguage(lldb::LanguageType language) {
 
 Status TypeSystemSwiftTypeRef::IsCompatible() {
   // This is called only from SBModule.
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
+  // Currently basically a noop, since the module isn't being passed in.
+  if (auto *swift_ast_context = GetSwiftASTContext(SymbolContext()))
     return swift_ast_context->IsCompatible();
   return {};
 }
@@ -2061,7 +2048,7 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               const SymbolContext &sc) const {
   // This gets called only from Thread::FrameSelectedCallback(StackFrame).
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull(&sc))
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull(sc))
     swift_ast_context->DiagnoseWarnings(process, sc);
 }
 
@@ -2386,47 +2373,40 @@ template <typename T> bool Equivalent(std::optional<T> l, T r) {
 constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
 #endif
 
-// This can be removed once the transition is complete.
-#define FALLBACK(REFERENCE, ARGS, DEFAULT)                                     \
-  do {                                                                         \
-    if (!ModuleList::GetGlobalModuleListProperties()                           \
-             .GetUseSwiftTypeRefTypeSystem()) {                                \
-      if (auto *swift_ast_context = GetSwiftASTContext(nullptr))               \
-        return swift_ast_context->REFERENCE ARGS;                              \
-      return DEFAULT;                                                          \
-    }                                                                          \
-  } while (0)
-
 #ifndef NDEBUG
+// Due to the lack of a symbol context, this only does the validation
+// on TypeSystemSwiftTypeRefForExpressions.
 #define VALIDATE_AND_RETURN_STATIC(IMPL, REFERENCE)                            \
   do {                                                                         \
-    FALLBACK(REFERENCE, (), {});                                               \
     auto result = IMPL();                                                      \
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
-    if (!GetSwiftASTContext(nullptr))                                          \
+    auto target_sp = GetTargetWP().lock();                                     \
+    if (!target_sp)                                                            \
       return result;                                                           \
-    assert(Equivalent(result, GetSwiftASTContext(nullptr)->REFERENCE()) &&     \
+    auto *swift_ast_ctx = GetSwiftASTContext(                                  \
+        SymbolContext(target_sp, target_sp->GetExecutableModule()));           \
+    if (!swift_ast_ctx)                                                        \
+      return result;                                                           \
+    assert(Equivalent(result, swift_ast_ctx->REFERENCE()) &&                   \
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");            \
     return result;                                                             \
   } while (0)
 
-#define VALIDATE_AND_RETURN(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS,              \
-                            FALLBACK_ARGS)                                     \
+#define VALIDATE_AND_RETURN(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS)              \
   do {                                                                         \
-    FALLBACK(REFERENCE, FALLBACK_ARGS, {});                                    \
     auto result = IMPL();                                                      \
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
-    if (!GetSwiftASTContext(nullptr))                                          \
+    ExecutionContext _exe_ctx(EXE_CTX);                                        \
+    if (!GetSwiftASTContextFromExecutionContext(&_exe_ctx))                    \
       return result;                                                           \
     if (ShouldSkipValidation(TYPE))                                            \
       return result;                                                           \
     if ((TYPE) && !ReconstructType(TYPE))                                      \
       return result;                                                           \
-    ExecutionContext _exe_ctx(EXE_CTX);                                        \
     /* When in the error backstop the sc will point into the stdlib. */        \
     if (auto *frame = _exe_ctx.GetFramePtr())                                  \
       if (frame->GetSymbolContext(eSymbolContextFunction).GetFunctionName() == \
@@ -2445,23 +2425,19 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
     return result;                                                             \
   } while (0)
 
-#define VALIDATE_AND_RETURN_EXPECTED(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS,     \
-                                     FALLBACK_ARGS)                            \
+#define VALIDATE_AND_RETURN_EXPECTED(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS)     \
   do {                                                                         \
-    FALLBACK(REFERENCE, FALLBACK_ARGS,                                         \
-             llvm::createStringError(llvm::inconvertibleErrorCode(),           \
-                                     "incomplete AST type information"));      \
     auto result = IMPL();                                                      \
     if (!ModuleList::GetGlobalModuleListProperties()                           \
              .GetSwiftValidateTypeSystem())                                    \
       return result;                                                           \
-    if (!GetSwiftASTContext(nullptr))                                          \
+    ExecutionContext _exe_ctx(EXE_CTX);                                        \
+    if (!GetSwiftASTContextFromExecutionContext(&_exe_ctx))                    \
       return result;                                                           \
     if (ShouldSkipValidation(TYPE))                                            \
       return result;                                                           \
     if ((TYPE) && !ReconstructType(TYPE))                                      \
       return result;                                                           \
-    ExecutionContext _exe_ctx(EXE_CTX);                                        \
     /* When in the error backstop the sc will point into the stdlib. */        \
     if (auto *frame = _exe_ctx.GetFramePtr())                                  \
       if (frame->GetSymbolContext(eSymbolContextFunction).GetFunctionName() == \
@@ -2489,17 +2465,20 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
 
 #else
 #define VALIDATE_AND_RETURN_STATIC(IMPL, REFERENCE)                            \
-  FALLBACK(REFERENCE, (), {});                                                 \
   return IMPL()
-#define VALIDATE_AND_RETURN(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS,              \
-                            FALLBACK_ARGS)                                     \
-  FALLBACK(REFERENCE, FALLBACK_ARGS, {});                                      \
-  return IMPL();
-#define VALIDATE_AND_RETURN_EXPECTED(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS,     \
-                                     FALLBACK_ARGS, DEFAULT)                   \
-  FALLBACK(REFERENCE, FALLBACK_ARGS, DEFAULT);                                 \
+#define VALIDATE_AND_RETURN(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS) return IMPL();
+#define VALIDATE_AND_RETURN_EXPECTED(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS)     \
   return IMPL();
 #endif
+
+#define FORWARD_TO_EXPRAST_ONLY(FUNC, ARGS, DEFAULT_RETVAL)                    \
+  do {                                                                         \
+    auto target_sp = GetTargetWP().lock();                                     \
+    if (auto *swift_ast_ctx = GetSwiftASTContext(                              \
+            SymbolContext(target_sp, target_sp->GetExecutableModule())))       \
+      return swift_ast_ctx->FUNC ARGS;                                         \
+    return DEFAULT_RETVAL;                                                     \
+  } while (0)
 
 CompilerType
 TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &dem,
@@ -2593,10 +2572,8 @@ bool TypeSystemSwiftTypeRef::IsArrayType(opaque_compiler_type_t type,
 
     return true;
   };
-  VALIDATE_AND_RETURN(
-      impl, IsArrayType, type, g_no_exe_ctx,
-      (ReconstructType(type), nullptr, nullptr, nullptr),
-      (ReconstructType(type), element_type, size, is_incomplete));
+  VALIDATE_AND_RETURN(impl, IsArrayType, type, g_no_exe_ctx,
+                      (ReconstructType(type), nullptr, nullptr, nullptr));
 }
 
 bool TypeSystemSwiftTypeRef::IsAggregateType(opaque_compiler_type_t type) {
@@ -2628,13 +2605,13 @@ bool TypeSystemSwiftTypeRef::IsAggregateType(opaque_compiler_type_t type) {
     }
   };
   VALIDATE_AND_RETURN(impl, IsAggregateType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 bool TypeSystemSwiftTypeRef::IsDefined(opaque_compiler_type_t type) {
   auto impl = [&]() -> bool { return type; };
   VALIDATE_AND_RETURN(impl, IsDefined, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
@@ -2649,7 +2626,7 @@ bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
                     node->getKind() == Node::Kind::ImplFunctionType);
   };
   VALIDATE_AND_RETURN(impl, IsFunctionType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 size_t TypeSystemSwiftTypeRef::GetNumberOfFunctionArguments(
     opaque_compiler_type_t type) {
@@ -2678,7 +2655,7 @@ size_t TypeSystemSwiftTypeRef::GetNumberOfFunctionArguments(
     return num_args;
   };
   VALIDATE_AND_RETURN(impl, GetNumberOfFunctionArguments, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 CompilerType
 TypeSystemSwiftTypeRef::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
@@ -2721,14 +2698,13 @@ TypeSystemSwiftTypeRef::GetFunctionArgumentAtIndex(opaque_compiler_type_t type,
     return {};
   };
   VALIDATE_AND_RETURN(impl, GetFunctionArgumentAtIndex, type, g_no_exe_ctx,
-                      (ReconstructType(type), index),
                       (ReconstructType(type), index));
 }
 bool TypeSystemSwiftTypeRef::IsFunctionPointerType(
     opaque_compiler_type_t type) {
   auto impl = [&]() -> bool { return IsFunctionType(type); };
   VALIDATE_AND_RETURN(impl, IsFunctionPointerType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
@@ -2805,8 +2781,7 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
   };
   VALIDATE_AND_RETURN(
       impl, IsPossibleDynamicType, type, g_no_exe_ctx,
-      (ReconstructType(type), nullptr, check_cplusplus, check_objc),
-      (ReconstructType(type), target_type, check_cplusplus, check_objc));
+      (ReconstructType(type), nullptr, check_cplusplus, check_objc));
 }
 
 bool TypeSystemSwiftTypeRef::IsPointerType(opaque_compiler_type_t type,
@@ -2824,8 +2799,7 @@ bool TypeSystemSwiftTypeRef::IsPointerType(opaque_compiler_type_t type,
             (node->getText() == swift::BUILTIN_TYPE_NAME_BRIDGEOBJECT));
   };
   VALIDATE_AND_RETURN(impl, IsPointerType, type, g_no_exe_ctx,
-                      (ReconstructType(type), nullptr),
-                      (ReconstructType(type), pointee_type));
+                      (ReconstructType(type), nullptr));
 }
 bool TypeSystemSwiftTypeRef::IsVoidType(opaque_compiler_type_t type) {
   auto impl = [&]() {
@@ -2836,7 +2810,7 @@ bool TypeSystemSwiftTypeRef::IsVoidType(opaque_compiler_type_t type) {
            node->getKind() == Node::Kind::Tuple;
   };
   VALIDATE_AND_RETURN(impl, IsVoidType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 // AST related queries
 uint32_t TypeSystemSwiftTypeRef::GetPointerByteSize() {
@@ -2875,7 +2849,6 @@ ConstString TypeSystemSwiftTypeRef::GetTypeName(opaque_compiler_type_t type,
         remangled, SwiftLanguageRuntime::eTypeName));
   };
   VALIDATE_AND_RETURN(impl, GetTypeName, type, g_no_exe_ctx,
-                      (ReconstructType(type), false),
                       (ReconstructType(type), false));
 }
 ConstString
@@ -2901,7 +2874,7 @@ TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
         remangled, SwiftLanguageRuntime::eDisplayTypeName, sc));
   };
   VALIDATE_AND_RETURN(impl, GetDisplayTypeName, type, g_no_exe_ctx,
-                      (ReconstructType(type), sc), (ReconstructType(type), sc));
+                      (ReconstructType(type), sc));
 }
 
 uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
@@ -2912,18 +2885,21 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     NodePointer node = dem.demangleSymbol(AsMangledName(type));
     bool unresolved_typealias = false;
     uint32_t flags = CollectTypeInfo(dem, node, unresolved_typealias);
-    if (unresolved_typealias && GetSwiftASTContext(nullptr)) {
-      // If this is a typealias defined in the expression evaluator,
-      // then we don't have debug info to resolve it from.
-      return GetSwiftASTContext(nullptr)->GetTypeInfo(
-          ReconstructType(type), pointee_or_element_clang_type);
+    if (unresolved_typealias) {
+      auto target_sp = GetTargetWP().lock();
+      if (auto *swift_ast_ctx = GetSwiftASTContext(
+              SymbolContext(target_sp, target_sp->GetExecutableModule()))) {
+        // If this is a typealias defined in the expression evaluator,
+        // then we don't have debug info to resolve it from.
+        return swift_ast_ctx->GetTypeInfo(ReconstructType(type),
+                                          pointee_or_element_clang_type);
+      }
     }
     return flags;
   };
 
   VALIDATE_AND_RETURN(impl, GetTypeInfo, type, g_no_exe_ctx,
-                      (ReconstructType(type), nullptr),
-                      (ReconstructType(type), pointee_or_element_clang_type));
+                      (ReconstructType(type), nullptr));
 }
 lldb::TypeClass
 TypeSystemSwiftTypeRef::GetTypeClass(opaque_compiler_type_t type) {
@@ -2954,7 +2930,7 @@ TypeSystemSwiftTypeRef::GetTypeClass(opaque_compiler_type_t type) {
     return eTypeClassOther;
   };
   VALIDATE_AND_RETURN(impl, GetTypeClass, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 // Creating related types
@@ -2967,7 +2943,6 @@ TypeSystemSwiftTypeRef::GetArrayElementType(opaque_compiler_type_t type,
     return element_type;
   };
   VALIDATE_AND_RETURN(impl, GetArrayElementType, type, exe_scope,
-                      (ReconstructType(type, exe_scope), exe_scope),
                       (ReconstructType(type, exe_scope), exe_scope));
 }
 
@@ -2991,19 +2966,18 @@ TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
     return GetTypeFromMangledTypename(mangled);
   };
   VALIDATE_AND_RETURN(impl, GetCanonicalType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 int TypeSystemSwiftTypeRef::GetFunctionArgumentCount(
     opaque_compiler_type_t type) {
   auto impl = [&]() -> int { return GetNumberOfFunctionArguments(type); };
   VALIDATE_AND_RETURN(impl, GetFunctionArgumentCount, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 CompilerType TypeSystemSwiftTypeRef::GetFunctionArgumentTypeAtIndex(
     opaque_compiler_type_t type, size_t idx) {
   auto impl = [&] { return GetFunctionArgumentAtIndex(type, idx); };
   VALIDATE_AND_RETURN(impl, GetFunctionArgumentTypeAtIndex, type, g_no_exe_ctx,
-                      (ReconstructType(type), idx),
                       (ReconstructType(type), idx));
 }
 CompilerType
@@ -3036,18 +3010,18 @@ TypeSystemSwiftTypeRef::GetFunctionReturnType(opaque_compiler_type_t type) {
     return RemangleAsType(dem, type);
   };
   VALIDATE_AND_RETURN(impl, GetFunctionReturnType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
+
 size_t
 TypeSystemSwiftTypeRef::GetNumMemberFunctions(opaque_compiler_type_t type) {
   // We forward the call to SwiftASTContext because an implementation of
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
-    return swift_ast_context->GetNumMemberFunctions(ReconstructType(type));
-  return {};
+  FORWARD_TO_EXPRAST_ONLY(GetNumMemberFunctions, (ReconstructType(type)), {});
 }
+
 TypeMemberFunctionImpl
 TypeSystemSwiftTypeRef::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
                                                  size_t idx) {
@@ -3055,17 +3029,15 @@ TypeSystemSwiftTypeRef::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
-    return swift_ast_context->GetMemberFunctionAtIndex(ReconstructType(type),
-                                                       idx);
-  return {};
+  FORWARD_TO_EXPRAST_ONLY(GetMemberFunctionAtIndex, (ReconstructType(type),
+                                                     idx), {});
 }
 
 CompilerType
 TypeSystemSwiftTypeRef::GetPointeeType(opaque_compiler_type_t type) {
   auto impl = []() { return CompilerType(); };
   VALIDATE_AND_RETURN(impl, GetPointeeType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 CompilerType
@@ -3087,7 +3059,7 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
     return RemangleAsType(dem, pointer_type);
   };
   VALIDATE_AND_RETURN(impl, GetPointerType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
@@ -3203,10 +3175,8 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
               AsMangledName(type));
     return {};
   };
-  FALLBACK(GetBitSize, (ReconstructType(type), exe_scope), {});
   if (exe_scope && exe_scope->CalculateProcess()) {
     VALIDATE_AND_RETURN(impl, GetBitSize, type, exe_scope,
-                        (ReconstructType(type, exe_scope), exe_scope),
                         (ReconstructType(type, exe_scope), exe_scope));
   } else
     return impl();
@@ -3232,7 +3202,6 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
     return {};
   };
   VALIDATE_AND_RETURN(impl, GetByteStride, type, exe_scope,
-                      (ReconstructType(type, exe_scope), exe_scope),
                       (ReconstructType(type, exe_scope), exe_scope));
 }
 
@@ -3308,8 +3277,7 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
   uint64_t validation_count = 0;
 #endif
   VALIDATE_AND_RETURN(impl, GetEncoding, type, g_no_exe_ctx,
-                      (ReconstructType(type), validation_count),
-                      (ReconstructType(type), count));
+                      (ReconstructType(type), validation_count));
 }
 
 llvm::Expected<uint32_t>
@@ -3341,7 +3309,6 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
       exe_ctx_obj = *exe_ctx;
     VALIDATE_AND_RETURN_EXPECTED(
         impl, GetNumChildren, type, exe_ctx_obj,
-        (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx),
         (ReconstructType(type, exe_ctx), omit_empty_base_classes, exe_ctx));
   }
   LLDB_LOGF(GetLog(LLDBLog::Types),
@@ -3365,8 +3332,6 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
 uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
                                               ExecutionContext *exe_ctx) {
   LLDB_SCOPED_TIMER();
-  FALLBACK(GetNumFields, (ReconstructType(type), exe_ctx), {});
-
   auto impl = [&]() -> std::optional<uint32_t> {
     if (exe_ctx)
       if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP()))
@@ -3403,7 +3368,6 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
       if (exe_ctx)
         exe_ctx_obj = *exe_ctx;
       VALIDATE_AND_RETURN(impl, GetNumFields, type, exe_ctx_obj,
-                          (ReconstructType(type, exe_ctx), exe_ctx),
                           (ReconstructType(type, exe_ctx), exe_ctx));
     }()
                         .value_or(0);
@@ -3427,11 +3391,10 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
   LLDB_SCOPED_TIMER();
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
-    return swift_ast_context->GetFieldAtIndex(
-        ReconstructType(type), idx, name, bit_offset_ptr, bitfield_bit_size_ptr,
-        is_bitfield_ptr);
-  return {};
+  FORWARD_TO_EXPRAST_ONLY(GetFieldAtIndex,
+                          (ReconstructType(type), idx, name, bit_offset_ptr,
+                           bitfield_bit_size_ptr, is_bitfield_ptr),
+                          {});
 }
 
 swift::reflection::DescriptorFinder *
@@ -3499,14 +3462,6 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
                                    "no SwiftASTContext");
   };
-  FALLBACK(GetChildCompilerTypeAtIndex,
-           (ReconstructType(type), exe_ctx, idx, transparent_pointers,
-            omit_empty_base_classes, ignore_array_bounds, child_name,
-            child_byte_size, child_byte_offset, child_bitfield_bit_size,
-            child_bitfield_bit_offset, child_is_base_class,
-            child_is_deref_of_parent, valobj, language_flags),
-           llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "no SwiftASTContext"));
   std::optional<unsigned> ast_num_children;
   auto get_ast_num_children = [&]() {
     if (ast_num_children)
@@ -3751,22 +3706,13 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
        omit_empty_base_classes, ignore_array_bounds, ast_child_name,
        ast_child_byte_size, ast_child_byte_offset, ast_child_bitfield_bit_size,
        ast_child_bitfield_bit_offset, ast_child_is_base_class,
-       ast_child_is_deref_of_parent, valobj, ast_language_flags),
-      (ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
-       omit_empty_base_classes, ignore_array_bounds, child_name,
-       child_byte_size, child_byte_offset, child_bitfield_bit_size,
-       child_bitfield_bit_offset, child_is_base_class, child_is_deref_of_parent,
-       valobj, language_flags));
+       ast_child_is_deref_of_parent, valobj, ast_language_flags));
 }
 
 size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
     opaque_compiler_type_t type, StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   LLDB_SCOPED_TIMER();
-  FALLBACK(GetIndexOfChildMemberWithName,
-           (ReconstructType(type), name, exe_ctx,
-            omit_empty_base_classes, child_indexes),
-           {});
   if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
@@ -3870,7 +3816,6 @@ TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type,
     return 0;
   };
   VALIDATE_AND_RETURN(impl, GetNumTemplateArguments, type, g_no_exe_ctx,
-                      (ReconstructType(type), expand_pack),
                       (ReconstructType(type), expand_pack));
 }
 
@@ -3878,7 +3823,7 @@ CompilerType
 TypeSystemSwiftTypeRef::GetTypeForFormatters(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType { return {weak_from_this(), type}; };
   VALIDATE_AND_RETURN(impl, GetTypeForFormatters, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 LazyBool
@@ -3902,7 +3847,6 @@ TypeSystemSwiftTypeRef::ShouldPrintAsOneLiner(opaque_compiler_type_t type,
     return eLazyBoolCalculate;
   };
   VALIDATE_AND_RETURN(impl, ShouldPrintAsOneLiner, type, g_no_exe_ctx,
-                      (ReconstructType(type), valobj),
                       (ReconstructType(type), valobj));
 }
 
@@ -3916,8 +3860,7 @@ bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
     return ContainsGenericTypeParameter(node) && !IsFunctionType(type);
   };
   VALIDATE_AND_RETURN(impl, IsMeaninglessWithoutDynamicResolution, type,
-                      g_no_exe_ctx, (ReconstructType(type)),
-                      (ReconstructType(type)));
+                      g_no_exe_ctx, (ReconstructType(type)));
 }
 
 CompilerType
@@ -3977,7 +3920,6 @@ bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
         *original_type = clang_type->GetForwardCompilerType();
     return true;
   };
-  FALLBACK(IsImportedType, (ReconstructType(type), original_type), {});
   // We can't validate the result because ReconstructType may call this
   // function, causing an infinite loop.
   return impl();
@@ -4034,7 +3976,7 @@ bool TypeSystemSwiftTypeRef::IsErrorType(opaque_compiler_type_t type) {
     return false;
   };
   VALIDATE_AND_RETURN(impl, IsErrorType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
@@ -4084,7 +4026,7 @@ TypeSystemSwiftTypeRef::GetReferentType(opaque_compiler_type_t type) {
     return RemangleAsType(dem, node);
   };
   VALIDATE_AND_RETURN(impl, GetReferentType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 swift::Demangle::NodePointer
@@ -4116,7 +4058,7 @@ TypeSystemSwiftTypeRef::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
     return RemangleAsType(dem, type_node);
   };
   VALIDATE_AND_RETURN(impl, GetStaticSelfType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 CompilerType
@@ -4149,7 +4091,6 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type,
     return {weak_from_this(), type};
   };
   VALIDATE_AND_RETURN(impl, GetInstanceType, type, exe_scope,
-                      (ReconstructType(type, exe_scope), exe_scope),
                       (ReconstructType(type, exe_scope), exe_scope));
 }
 
@@ -4259,12 +4200,15 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
 
   // The signature of VALIDATE_AND_RETURN doesn't support this function, below
   // is an inlined function-specific variation.
-  FALLBACK(CreateTupleType, (elements), {});
 #ifndef NDEBUG
   if (ModuleList::GetGlobalModuleListProperties()
           .GetSwiftValidateTypeSystem()) {
     auto result = impl();
-    SwiftASTContext *swift_ast_ctx = GetSwiftASTContext(nullptr);
+    auto target_sp = GetTargetWP().lock();
+    if (!target_sp)
+      return result;
+    auto *swift_ast_ctx = GetSwiftASTContext(
+        SymbolContext(target_sp, target_sp->GetExecutableModule()));
     if (!swift_ast_ctx)
       return result;
     std::vector<TupleElement> ast_elements;
@@ -4299,7 +4243,7 @@ bool TypeSystemSwiftTypeRef::IsTupleType(lldb::opaque_compiler_type_t type) {
     return node && node->getKind() == Node::Kind::Tuple;
   };
   VALIDATE_AND_RETURN(impl, IsTupleType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 std::optional<TypeSystemSwift::NonTriviallyManagedReferenceKind>
@@ -4324,8 +4268,7 @@ TypeSystemSwiftTypeRef::GetNonTriviallyManagedReferenceKind(
     }
   };
   VALIDATE_AND_RETURN(impl, GetNonTriviallyManagedReferenceKind, type,
-                      g_no_exe_ctx, (ReconstructType(type)),
-                      (ReconstructType(type)));
+                      g_no_exe_ctx, (ReconstructType(type)));
 }
 
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
@@ -4561,11 +4504,6 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
   }
 
 #ifndef NDEBUG
-  FALLBACK(DumpTypeValue,
-           (ReconstructType(type), s, format, data, data_offset,
-            data_byte_size, bitfield_bit_size, bitfield_bit_offset, exe_scope,
-            is_base_class),
-           {});
   StreamString ast_s;
   auto defer = llvm::make_scope_exit([&] {
     assert(Equivalent(ConstString(ast_s.GetString()),
@@ -4582,9 +4520,6 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
   VALIDATE_AND_RETURN(impl, DumpTypeValue, type, exe_scope,
                       (ReconstructType(type, exe_scope), ast_s, format, data,
                        data_offset, data_byte_size, bitfield_bit_size,
-                       bitfield_bit_offset, exe_scope, is_base_class),
-                      (ReconstructType(type, exe_scope), s, format, data,
-                       data_offset, data_byte_size, bitfield_bit_size,
                        bitfield_bit_offset, exe_scope, is_base_class));
 }
 
@@ -4595,14 +4530,12 @@ bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
            IsReferenceType(type, pointee_type, nullptr);
   };
   VALIDATE_AND_RETURN(impl, IsPointerOrReferenceType, type, g_no_exe_ctx,
-                      (ReconstructType(type), nullptr),
-                      (ReconstructType(type), pointee_type));
+                      (ReconstructType(type), nullptr));
 }
 std::optional<size_t>
 TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
                                         ExecutionContextScope *exe_scope) {
   LLDB_SCOPED_TIMER();
-  FALLBACK(GetTypeBitAlign, (ReconstructType(type), exe_scope), {});
   // This method doesn't use VALIDATE_AND_RETURN because except for
   // fixed-size types the SwiftASTContext implementation forwards to
   // SwiftLanguageRuntime anyway and for many fixed-size types the
@@ -4726,7 +4659,7 @@ bool TypeSystemSwiftTypeRef::IsTypedefType(opaque_compiler_type_t type) {
 #endif
 
   VALIDATE_AND_RETURN(impl, IsTypedefType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 CompilerType
@@ -4753,7 +4686,7 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
     return RemangleAsType(dem, type_node);
   };
   VALIDATE_AND_RETURN(impl, GetTypedefedType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 
 CompilerType
@@ -4762,7 +4695,7 @@ TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
   auto impl = [&]() -> CompilerType { return {weak_from_this(), type}; };
 
   VALIDATE_AND_RETURN(impl, GetFullyUnqualifiedType, type, g_no_exe_ctx,
-                      (ReconstructType(type)), (ReconstructType(type)));
+                      (ReconstructType(type)));
 }
 uint32_t
 TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {
@@ -4770,9 +4703,7 @@ TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
-    return swift_ast_context->GetNumDirectBaseClasses(ReconstructType(type));
-  return {};
+  FORWARD_TO_EXPRAST_ONLY(GetNumDirectBaseClasses, (ReconstructType(type)), {});
 }
 CompilerType TypeSystemSwiftTypeRef::GetDirectBaseClassAtIndex(
     opaque_compiler_type_t type, size_t idx, uint32_t *bit_offset_ptr) {
@@ -4780,10 +4711,8 @@ CompilerType TypeSystemSwiftTypeRef::GetDirectBaseClassAtIndex(
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  if (auto *swift_ast_context = GetSwiftASTContext(nullptr))
-    return swift_ast_context->GetDirectBaseClassAtIndex(ReconstructType(type),
-                                                        idx, bit_offset_ptr);
-  return {};
+  FORWARD_TO_EXPRAST_ONLY(GetDirectBaseClassAtIndex,
+                          (ReconstructType(type), idx, bit_offset_ptr), {});
 }
 bool TypeSystemSwiftTypeRef::IsReferenceType(opaque_compiler_type_t type,
                                              CompilerType *pointee_type,
@@ -4810,8 +4739,7 @@ bool TypeSystemSwiftTypeRef::IsReferenceType(opaque_compiler_type_t type,
   };
 
   VALIDATE_AND_RETURN(impl, IsReferenceType, type, g_no_exe_ctx,
-                      (ReconstructType(type), nullptr, nullptr),
-                      (ReconstructType(type), pointee_type, is_rvalue));
+                      (ReconstructType(type), nullptr, nullptr));
 }
 
 CompilerType
@@ -4844,7 +4772,6 @@ TypeSystemSwiftTypeRef::GetGenericArgumentType(opaque_compiler_type_t type,
   };
 
   VALIDATE_AND_RETURN(impl, GetGenericArgumentType, type, g_no_exe_ctx,
-                      (ReconstructType(type), idx),
                       (ReconstructType(type), idx));
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -68,7 +68,7 @@ public:
   ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   /// Get the corresponding SwiftASTContext, and create one if necessary.
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override;
   /// Convenience helpers.
   SwiftASTContext *
   GetSwiftASTContextFromExecutionScope(ExecutionContextScope *exe_scope) const;
@@ -76,7 +76,7 @@ public:
   GetSwiftASTContextFromExecutionContext(const ExecutionContext *exe_ctx) const;
   /// Return SwiftASTContext, iff one has already been created.
   virtual SwiftASTContext *
-  GetSwiftASTContextOrNull(const SymbolContext *sc) const;
+  GetSwiftASTContextOrNull(const SymbolContext &sc) const;
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override { return *this; }
   const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const override {
     return *this;
@@ -84,7 +84,7 @@ public:
   SwiftDWARFImporterForClangTypes &GetSwiftDWARFImporterForClangTypes();
   ClangNameImporter *GetNameImporter() const;
   llvm::Triple GetTriple() const;
-  void SetTriple(const llvm::Triple triple) override;
+  void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
 
@@ -133,7 +133,7 @@ public:
   Module *GetModule() const { return m_module; }
 
   /// Return the owning Swift module for a function.
-  static ConstString GetSwiftModuleFor(const SymbolContext *sc);
+  static ConstString GetSwiftModuleFor(const SymbolContext &sc);
 
   // Tests
 #ifndef NDEBUG
@@ -530,9 +530,9 @@ public:
   TypeSystemSwiftTypeRefForExpressions(lldb::LanguageType language,
                                        Target &target, Module &module);
 
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override;
   SwiftASTContext *
-  GetSwiftASTContextOrNull(const SymbolContext *sc) const override;
+  GetSwiftASTContextOrNull(const SymbolContext &sc) const override;
   lldb::TargetWP GetTargetWP() const override { return m_target_wp; }
 
   void ModulesDidLoad(ModuleList &module_list);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -2586,7 +2586,8 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
                 type_system_or_err->get())) {
       auto *swift_ast_ctx =
           llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-              swift_scratch_ctx->GetSwiftASTContextOrNull(nullptr));
+              swift_scratch_ctx->GetSwiftASTContextOrNull(
+                  SymbolContext(GetExecutableModule())));
       // Replace the scratch context if it contains fatal errors or
       // needs to be replaced because new lldb::Modules were loaded.
       if (swift_ast_ctx && (swift_ast_ctx->CheckProcessChanged() ||
@@ -2634,8 +2635,8 @@ Target::GetScratchTypeSystemForLanguage(lldb::LanguageType language,
               type_system_or_err = llvm::make_error<llvm::StringError>(
                   message, llvm::inconvertibleErrorCode());
             };
-            auto *new_swift_ast_ctx =
-                new_swift_scratch_ctx->GetSwiftASTContext(nullptr);
+            auto *new_swift_ast_ctx = new_swift_scratch_ctx->GetSwiftASTContext(
+                SymbolContext(GetExecutableModule()));
             if (!new_swift_ast_ctx)
               report_error("Failed to construct SwiftASTContextForExpressions");
             else if (new_swift_ast_ctx->HasFatalErrors()) {
@@ -2765,8 +2766,9 @@ UserExpression *Target::GetUserExpressionForLanguage(
     Expression::ResultType desired_type,
     const EvaluateExpressionOptions &options, ValueObject *ctx_obj,
     Status &error) {
-  auto type_system_or_err =
-      GetScratchTypeSystemForLanguage(language.AsLanguageType());
+  auto type_system_or_err = GetScratchTypeSystemForLanguage(
+      language.AsLanguageType(), true,
+      options.GetPlaygroundTransformEnabled() ? "" : nullptr);
   if (auto err = type_system_or_err.takeError()) {
     error.SetErrorStringWithFormat(
         "Could not find type system for language %s: %s",
@@ -2850,54 +2852,29 @@ Target::CreateUtilityFunction(std::string expression, std::string name,
 }
 
 #ifdef LLDB_ENABLE_SWIFT
-std::optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
-    Status &error, ExecutionContextScope &exe_scope, bool create_on_demand) {
+std::optional<SwiftScratchContextReader>
+Target::GetSwiftScratchContext(Status &error, ExecutionContextScope &exe_scope,
+                               bool create_on_demand, bool for_playground) {
   Log *log = GetLog(LLDBLog::Target | LLDBLog::Types | LLDBLog::Expressions);
   LLDB_SCOPED_TIMER();
 
-  const SymbolContext *sc = nullptr;
+  SymbolContext sc;
   Module *lldb_module = nullptr;
-  if (lldb::StackFrameSP stack_frame = exe_scope.CalculateStackFrame()) {
-    sc = &stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
-    lldb_module = sc->module_sp.get();
-  }
-  
-  // Opt into the per-module scratch context if we find incompatible triples.
-  if (!m_use_scratch_typesystem_per_module &&
-      !ModuleList::GetGlobalModuleListProperties()
-           .GetUseSwiftPreciseCompilerInvocation()) {
-    TargetSP target_sp = exe_scope.CalculateTarget();
-    if (lldb_module) {
-      auto module_arch = lldb_module->GetArchitecture();
-      auto target_arch = target_sp->GetArchitecture();
-      auto module_triple = module_arch.GetTriple();
-      auto target_triple = target_arch.GetTriple();
-      if (!module_arch.IsCompatibleMatch(target_arch) ||
-          (module_triple.isArm64e() != target_triple.isArm64e())) {
-        m_use_scratch_typesystem_per_module = true;
-        std::string module_name = lldb_module->GetSpecificationDescription();
-        const char *msg = "%sModule \"%s\" uses triple \"%s\", which is "
-                          "not compatible with the target triple \"%s\". "
-                          "Enabling per-module Swift scratch context.\n";
-
-        StreamSP errs = GetDebugger().GetAsyncErrorStream();
-        if (errs)
-          errs->Printf(msg, "warning: ", module_name.c_str(),
-                       module_triple.str().c_str(),
-                       target_triple.str().c_str());
-        if (log)
-          log->Printf(msg, "", module_name.c_str(), module_triple.str().c_str(),
-                      target_triple.str().c_str());
-      }
+  if (!for_playground)
+    if (lldb::StackFrameSP stack_frame = exe_scope.CalculateStackFrame()) {
+      sc = stack_frame->GetSymbolContext(lldb::eSymbolContextEverything);
+      lldb_module = sc.module_sp.get();
     }
-  }
+  if (!sc.module_sp)
+    sc = SymbolContext(GetExecutableModule());
 
   auto get_cached_module_ts =
       [&](Module *lldb_module) -> TypeSystemSwiftTypeRefForExpressions * {
     ModuleLanguage key = {lldb_module, lldb::eLanguageTypeSwift};
     auto cached = m_scratch_typesystem_for_module.find(key);
     if (cached != m_scratch_typesystem_for_module.end())
-      return llvm::cast<TypeSystemSwiftTypeRefForExpressions>(cached->second.get());
+      return llvm::cast<TypeSystemSwiftTypeRefForExpressions>(
+          cached->second.get());
     return nullptr;
   };
 
@@ -2995,8 +2972,8 @@ std::optional<SwiftScratchContextReader> Target::GetSwiftScratchContext(
   // module-wide one.
   if (!reader) {
     std::shared_lock<std::shared_mutex> lock(GetSwiftScratchContextLock());
-    auto type_system_or_err =
-        GetScratchTypeSystemForLanguage(eLanguageTypeSwift, create_on_demand);
+    auto type_system_or_err = GetScratchTypeSystemForLanguage(
+        eLanguageTypeSwift, create_on_demand, for_playground ? "" : nullptr);
     if (type_system_or_err) {
       if (auto *ts = llvm::cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
               type_system_or_err->get())) {

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -19,4 +19,4 @@ class TestSwiftRewriteClangPaths(TestBase):
 
         # Scan through the types log.
         self.filecheck('platform shell cat "%s"' % log, __file__)
-#       CHECK:  SwiftASTContextForExpressions::RemapClangImporterOptions() -- remapped{{.*}}/LocalSDK/
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RemapClangImporterOptions() -- remapped{{.*}}/LocalSDK/

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -63,8 +63,8 @@ class TestSwiftDeploymentTarget(TestBase):
         )
         self.expect("expression f", substrs=["i = 23"])
         self.filecheck('platform shell cat ""%s"' % log, __file__)
-#       CHECK: SwiftASTContextForExpressions::SetTriple({{.*}}apple-macosx11.0.0
-#       CHECK-NOT: SwiftASTContextForExpressions::RegisterSectionModules("a.out"){{.*}} AST Data blobs
+#       CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::SetTriple({{.*}}apple-macosx11.0.0
+#       CHECK-NOT: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RegisterSectionModules("a.out"){{.*}} AST Data blobs
 
     @skipUnlessDarwin  # This test uses macOS triples explicitly.
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -26,7 +26,6 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
     @skipUnlessDarwin
     @swiftTest
     def test(self):
-        self.runCmd("settings set symbols.use-swift-dwarfimporter true")
         self.build()
         dylib = self.getBuildArtifact('libLibrary.dylib')
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -37,19 +36,3 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
         self.runCmd('log enable lldb types -f "%s"' % log)
 
         self.expect("target var -d run myobj", substrs=["(ObjCClass)"])
-
-        found = 0
-        response = 0
-        import io
-        logfile = io.open(log, "r", encoding='utf-8')
-        for line in logfile:
-            if 'SwiftDWARFImporterDelegate::lookupValue("ObjCClass")' in line:
-                found += 1
-            elif found == 1 and response == 0 and 'SwiftDWARFImporterDelegate' in line:
-                self.assertTrue('from debug info' in line, line)
-                response += 1
-            elif found == 2 and response == 1 and 'SwiftDWARFImporterDelegate' in line:
-                self.assertTrue('types collected' in line, line)
-                response += 1
-        self.assertEqual(found, 1)
-        self.assertEqual(response, 1)

--- a/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
+++ b/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
@@ -21,23 +21,4 @@ class TestSwiftFrameworkPaths(lldbtest.TestBase):
         self.expect("expression -- 0")
         self.filecheck('platform shell cat "%s"' % log, __file__,
                        '--check-prefix=CHECK_SYS')
-        # CHECK_SYS: SwiftASTContextForExpressions::LogConfiguration(){{.*}}/secret_path
-
-    @swiftTest
-    # Don't run ClangImporter tests if Clangimporter is disabled.
-    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=no_match(["macosx"]))
-    def test_module_context_framework_path(self):
-        """Test the discovery of framework search paths from framework dependencies."""
-        self.build()
-        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('main.swift'))
-
-        self.expect('settings set symbols.swift-validate-typesystem false')
-        self.expect('settings set symbols.use-swift-typeref-typesystem false')
-        log = self.getBuildArtifact("types.log")
-        self.expect('log enable lldb types -f "%s"' % log)
-        self.expect("expression -- d", substrs=["member"])
-        self.filecheck('platform shell cat "%s"' % log, __file__,
-                       '--check-prefix=CHECK_MOD')
-        # CHECK_MOD: SwiftASTContextForModule("a.out")::LogConfiguration(){{.*}}other_secret_path
+        # CHECK_SYS: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}/secret_path

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -21,9 +21,9 @@ class TestSwiftLateDylib(TestBase):
         self.expect("expr -- import Dylib")
         # Scan through the types log.
         self.filecheck('platform shell cat "%s"' % log, __file__)
-# CHECK: SwiftASTContextForExpressions::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
+# CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
 # CHECK-NOT: __PATH_FROM_DYLIB__
 #       Verify that the deployment target didn't change:
-# CHECK: SwiftASTContextForExpressions::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
+# CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
 #       But LLDB has picked up extra paths:
-# CHECK: SwiftASTContextForExpressions::LogConfiguration(){{.*}}__PATH_FROM_DYLIB__
+# CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}__PATH_FROM_DYLIB__

--- a/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
+++ b/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
@@ -25,15 +25,5 @@ class TestSwiftRuntimeLibraryPath(lldbtest.TestBase):
             self, 'main')
 
         self.expect("expression 1")
-        import io
-        logfile = io.open(log, "r", encoding='utf-8')
-        in_expr_log = 0
-        found = 0
-        for line in logfile:
-            if line.startswith(" SwiftASTContextForExpressions::LogConfiguration(SwiftASTContext"):
-                in_expr_log += 1
-            if in_expr_log and "Runtime library paths" in line and \
-               "2 items" in line:
-                found += 1
-        self.assertEqual(in_expr_log, 1)
-        self.assertEqual(found, 1)
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+        # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Runtime library paths{{.*}}2 items

--- a/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -18,9 +18,7 @@ class TestSwiftSystemFramework(lldbtest.TestBase):
 
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb types -f "%s"' % log)
-        self.expect("settings set target.use-all-compiler-flags true")
         self.expect("expression -- 0")
         self.filecheck('platform shell cat "%s"' % log, __file__)
-#       CHECK: SwiftASTContextForExpressions{{.*}}-- rejecting framework path
 #       CHECK: SwiftASTContextForExpressions{{.*}}LogConfiguration()
 #       CHECK-NOT: LogConfiguration(){{.*}}/System/Library/Frameworks

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -25,18 +25,6 @@ class TestSwiftTripleDetection(TestBase):
         bkpt = target.BreakpointCreateByName("main")
         process = target.LaunchSimple(None, None, self.get_process_working_directory())
         self.expect("expression 1")
-        import io
-        types_logfile = io.open(types_log, "r", encoding='utf-8')
-
-        import re
-        availability_re = re.compile(r'@available\(macCatalyst 1.*, \*\)')
-        found = 0
-        for line in types_logfile:
-            print(line)
-            if re.search('SwiftASTContextForExpressions.*Underspecified target triple .*-apple-macos-unknown', line):
-                found += 1
-                continue
-            if found == 1 and re.search('SwiftASTContextForExpressions.*setting to ".*-apple-macos.[0-9.]+"', line):
-               found += 1
-               break
-        self.assertEqual(found, 2)
+        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        # CHECK: {{SwiftASTContextForExpressions.*Preferring module triple .*-apple-macos.[0-9.]+ over target triple .*-apple-macos-unknown.}}
+        # CHECK: {{SwiftASTContextForExpressions.*setting to ".*-apple-macos.[0-9.]+"}}

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -16,11 +16,9 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
         in_expr_log = 0
         found = 0
         for line in logfile:
-            if line.startswith(" SwiftASTContextForExpressions::LogConfiguration(SwiftASTContext"):
-                in_expr_log += 1
-            if in_expr_log and "SDK path" in line and expected_path in line:
+            if (line.startswith(' SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration()') and
+                "SDK path" in line and expected_path in line):
                 found += 1
-        self.assertEqual(in_expr_log, 1)
         self.assertEqual(found, 1)
 
     @swiftTest


### PR DESCRIPTION
This feature was off-by default in Swift 6.0
This patch completes the transition to precise compiler invocations by removing the backwards-compatibility.

The many test updates are for tests that were checking for the old behavior (which was still present in the tests due to the typeref-typesystem validation creating an classic-mode scratch context).