### PR TITLE
ExpressionParser: inherit the environment for the REPL

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -201,7 +201,7 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
     launch_info.SetExecutableFile(exe_module_sp->GetPlatformFileSpec(), true);
   }
 
-  launch_info.GetEnvironment() = target_sp->GetTargetEnvironment();
+  launch_info.GetEnvironment() = target_sp->GetInheritedEnvironment();
   debugger.SetAsyncExecution(false);
   err = target_sp->Launch(launch_info, nullptr);
   debugger.SetAsyncExecution(true);


### PR DESCRIPTION
This is particularly important on Windows where `Path` needs to be propagated to the inferior to allow `LoadLibraryW(L"swiftCore.dll")` to succeed. The library is looked up via the `Path` environment variable and the default target environment is empty. As a result, the library is not found and the inferior exits terminating the REPL instance.

Fixes: swiftlang/swift#76702
Fixes: swiftlang/swift#70005