### PR TITLE
Remove classic whole-project compiler invocations.

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -80,13 +80,10 @@ public:
   bool GetUseSwiftClangImporter() const;
   bool GetUseSwiftDWARFImporter() const;
   bool SetUseSwiftDWARFImporter(bool new_value);
-  bool GetUseSwiftTypeRefTypeSystem() const;
-  bool SetUseSwiftTypeRefTypeSystem(bool new_value);
   bool GetSwiftValidateTypeSystem() const;
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);
 
-  bool GetUseSwiftPreciseCompilerInvocation() const;
   bool GetEnableSwiftMetadataCache() const;
   uint64_t GetSwiftMetadataCacheMaxByteSize();
   uint64_t GetSwiftMetadataCacheExpirationDays();

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1306,7 +1306,8 @@ public:
 
   std::optional<SwiftScratchContextReader>
   GetSwiftScratchContext(Status &error, ExecutionContextScope &exe_scope,
-                         bool create_on_demand = true);
+                         bool create_on_demand = true,
+                         bool for_playground = false);
 
   /// Return whether this is the Swift REPL.
   bool IsSwiftREPL();

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -25,15 +25,9 @@ let Definition = "modulelist" in {
   def UseSwiftDWARFImporter: Property<"use-swift-dwarfimporter", "Boolean">,
     DefaultTrue,
     Desc<"Reconstruct Clang module dependencies from DWARF when debugging Swift code">;
-  def UseSwiftTypeRefTypeSystem: Property<"use-swift-typeref-typesystem", "Boolean">,
-    DefaultTrue,
-    Desc<"Prefer Swift Remote Mirrors over Remote AST">;
   def SwiftValidateTypeSystem: Property<"swift-validate-typesystem", "Boolean">,
     DefaultFalse,
     Desc<"Validate all Swift typesystem queries. Used for testing an asserts-enabled LLDB only.">;
-  def UseSwiftPreciseCompilerInvocation: Property<"swift-precise-compiler-invocation", "Boolean">,
-    DefaultTrue,
-    Desc<"In the Swift expression evaluator, create many Swift compiler instances with the precise invocation for the current context, instead of a single compiler instance that merges all flags from the entire project.">;
   def SwiftModuleLoadingMode: Property<"swift-module-loading-mode", "Enum">,
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,
     EnumValues<"OptionEnumValues(g_swift_module_loading_mode_enums)">,

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1635,7 +1635,7 @@ bool Module::SetArchitecture(const ArchSpec &new_arch) {
 #ifdef LLDB_ENABLE_SWIFT
     if (auto ts =
             llvm::dyn_cast_or_null<TypeSystemSwift>(type_system_or_err->get()))
-      ts->SetTriple(new_arch.GetTriple());
+      ts->SetTriple(SymbolContext(shared_from_this()), new_arch.GetTriple());
 #endif // LLDB_ENABLE_SWIFT
     return true;
   }

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -194,27 +194,10 @@ bool ModuleListProperties::SetUseSwiftDWARFImporter(bool new_value) {
   return SetPropertyAtIndex(idx, new_value);
 }
 
-bool ModuleListProperties::GetUseSwiftTypeRefTypeSystem() const {
-  const uint32_t idx = ePropertyUseSwiftTypeRefTypeSystem;
-  return GetPropertyAtIndexAs<bool>(
-      idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
 bool ModuleListProperties::GetSwiftValidateTypeSystem() const {
   const uint32_t idx = ePropertySwiftValidateTypeSystem;
   return GetPropertyAtIndexAs<bool>(
       idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
-bool ModuleListProperties::GetUseSwiftPreciseCompilerInvocation() const {
-  const uint32_t idx = ePropertyUseSwiftPreciseCompilerInvocation;
-  return GetPropertyAtIndexAs<bool>(
-      idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
-bool ModuleListProperties::SetUseSwiftTypeRefTypeSystem(bool new_value) {
-  const uint32_t idx = ePropertyUseSwiftTypeRefTypeSystem;
-  return SetPropertyAtIndex(idx, new_value);
 }
 
 SwiftModuleLoadingMode ModuleListProperties::GetSwiftModuleLoadingMode() const {

--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -834,7 +834,7 @@ IRExecutionUnit::FindInSymbols(const std::vector<ConstString> &names,
       // BEGIN SWIFT
       if (m_in_populate_symtab)
         if (lldb::ModuleSP module_sp = m_jit_module_wp.lock())
-        images.Remove(module_sp);
+          images.Remove(module_sp);
       // END SWIFT
 
       SymbolContextList sc_list;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -897,7 +897,7 @@ llvm::Expected<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
   // When injecting a value pack or pack count into the outer
   // lldb_expr function, treat it as an opaque raw pointer.
   if (m_bind_generic_types == lldb::eDontBind && variable.IsUnboundPack()) {
-    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(&m_sc);
+    auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(m_sc);
     if (!swift_ast_ctx)
       return llvm::createStringError("no typesystem for variable " +
                                      variable.GetName().str());

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -569,7 +569,8 @@ void SwiftREPL::CompleteCode(const std::string &current_code,
             type_system_or_err->get());
     auto *target_swift_ast =
         llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-            swift_ts->GetSwiftASTContext(nullptr));
+            swift_ts->GetSwiftASTContext(SymbolContext(
+                m_target.shared_from_this(), m_target.GetExecutableModule())));
     m_swift_ast = target_swift_ast;
   }
   SwiftASTContextForExpressions *swift_ast = m_swift_ast;

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -103,7 +103,9 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
   const SymbolContext *sc = nullptr;
   if (swiftFrame)
     sc = &swiftFrame->GetSymbolContext(eSymbolContextFunction);
-  auto *ctx = ts->GetSwiftASTContext(sc);
+  if (!sc)
+    return "";
+  auto *ctx = ts->GetSwiftASTContext(*sc);
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
@@ -122,7 +122,7 @@ public:
       }
       auto &sc = most_relevant_frame_sp->GetSymbolContext(
           lldb::eSymbolContextFunction);
-      ConstString module_name = TypeSystemSwiftTypeRef::GetSwiftModuleFor(&sc);
+      ConstString module_name = TypeSystemSwiftTypeRef::GetSwiftModuleFor(sc);
       if (!module_name)
         continue;
       if (module_name == swift::STDLIB_NAME)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1231,7 +1231,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
           target.GetSwiftScratchContext(error, frame);
       auto scratch_ctx = maybe_swift_ast->get();
       if (scratch_ctx) {
-        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext(&sc)) {
+        if (SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext(sc)) {
         CompilerType function_type = swift_ast->GetTypeFromMangledTypename(
             mangled_name.GetMangledName());
         if (error.Success()) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3063,7 +3063,7 @@ SwiftLanguageRuntimeImpl::GetConcreteType(ExecutionContextScope *exe_scope,
   if (!promise_sp)
     return CompilerType();
 
-  const SymbolContext *sc = &frame->GetSymbolContext(eSymbolContextFunction);
+  const SymbolContext &sc = frame->GetSymbolContext(eSymbolContextFunction);
   return promise_sp->FulfillTypePromise(sc);
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -300,12 +300,12 @@ protected:
     std::optional<CompilerType> m_compiler_type;
 
   public:
-    CompilerType FulfillTypePromise(const SymbolContext *sc,
+    CompilerType FulfillTypePromise(const SymbolContext &sc,
                                     Status *error = nullptr);
   };
   typedef std::shared_ptr<MetadataPromise> MetadataPromiseSP;
 
-  MetadataPromiseSP GetMetadataPromise(const SymbolContext *sc,
+  MetadataPromiseSP GetMetadataPromise(const SymbolContext &sc,
                                        lldb::addr_t addr,
                                        ValueObject &for_object);
   MetadataPromiseSP

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -203,18 +203,12 @@ public:
   CreateInstance(lldb::LanguageType language, Module &module,
                  TypeSystemSwiftTypeRef &typeref_typesystem,
                  bool fallback = false);
-  /// Create a SwiftASTContext from a Target.  This context is global
-  /// and used for the expression evaluator.
-  static lldb::TypeSystemSP
-  CreateInstance(lldb::LanguageType language,
-                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem,
-                 const char *extra_options);
-
   /// Create a SwiftASTContextForExpressions taylored to a specific symbol
   /// context.
   static lldb::TypeSystemSP
   CreateInstance(const SymbolContext &sc,
-                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem);
+                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem,
+                 const char *extra_options = nullptr);
 
   /// Returns true if Swift C++ interop is enabled for the given compiler unit.
   static bool ShouldEnableCXXInterop(CompileUnit *cu);
@@ -228,7 +222,7 @@ public:
   
   bool SupportsLanguage(lldb::LanguageType language) override;
 
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override {
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override {
     return GetTypeSystemSwiftTypeRef().GetSwiftASTContext(sc);
   }
 
@@ -422,9 +416,7 @@ public:
   llvm::Triple GetTriple() const;
 
   bool SetTriple(const llvm::Triple triple, lldb_private::Module *module);
-  void SetTriple(const llvm::Triple triple) override {
-    SetTriple(triple, nullptr);
-  }
+  void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
 
   /// Condition a triple to be safe for use with Swift.  Swift is
   /// really peculiar about what CPU types it thinks it has standard

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -115,10 +115,12 @@ public:
 
   const std::string &GetDescription() const { return m_description; }
   static LanguageSet GetSupportedLanguagesForTypes();
-  virtual SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const = 0;
+  virtual SwiftASTContext *
+  GetSwiftASTContext(const SymbolContext &sc) const = 0;
   virtual TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() = 0;
   virtual const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const = 0;
-  virtual void SetTriple(const llvm::Triple triple) = 0;
+  virtual void SetTriple(const SymbolContext &sc,
+                         const llvm::Triple triple) = 0;
   virtual void ClearModuleDependentCaches() = 0;
   virtual lldb::TargetWP GetTargetWP() const = 0;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -68,7 +68,7 @@ public:
   ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   /// Get the corresponding SwiftASTContext, and create one if necessary.
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override;
   /// Convenience helpers.
   SwiftASTContext *
   GetSwiftASTContextFromExecutionScope(ExecutionContextScope *exe_scope) const;
@@ -76,7 +76,7 @@ public:
   GetSwiftASTContextFromExecutionContext(const ExecutionContext *exe_ctx) const;
   /// Return SwiftASTContext, iff one has already been created.
   virtual SwiftASTContext *
-  GetSwiftASTContextOrNull(const SymbolContext *sc) const;
+  GetSwiftASTContextOrNull(const SymbolContext &sc) const;
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override { return *this; }
   const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const override {
     return *this;
@@ -84,7 +84,7 @@ public:
   SwiftDWARFImporterForClangTypes &GetSwiftDWARFImporterForClangTypes();
   ClangNameImporter *GetNameImporter() const;
   llvm::Triple GetTriple() const;
-  void SetTriple(const llvm::Triple triple) override;
+  void SetTriple(const SymbolContext &sc, const llvm::Triple triple) override;
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
 
@@ -133,7 +133,7 @@ public:
   Module *GetModule() const { return m_module; }
 
   /// Return the owning Swift module for a function.
-  static ConstString GetSwiftModuleFor(const SymbolContext *sc);
+  static ConstString GetSwiftModuleFor(const SymbolContext &sc);
 
   // Tests
 #ifndef NDEBUG
@@ -530,9 +530,9 @@ public:
   TypeSystemSwiftTypeRefForExpressions(lldb::LanguageType language,
                                        Target &target, Module &module);
 
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext *sc) const override;
+  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override;
   SwiftASTContext *
-  GetSwiftASTContextOrNull(const SymbolContext *sc) const override;
+  GetSwiftASTContextOrNull(const SymbolContext &sc) const override;
   lldb::TargetWP GetTargetWP() const override { return m_target_wp; }
 
   void ModulesDidLoad(ModuleList &module_list);

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -19,4 +19,4 @@ class TestSwiftRewriteClangPaths(TestBase):
 
         # Scan through the types log.
         self.filecheck('platform shell cat "%s"' % log, __file__)
-#       CHECK:  SwiftASTContextForExpressions::RemapClangImporterOptions() -- remapped{{.*}}/LocalSDK/
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RemapClangImporterOptions() -- remapped{{.*}}/LocalSDK/

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -63,8 +63,8 @@ class TestSwiftDeploymentTarget(TestBase):
         )
         self.expect("expression f", substrs=["i = 23"])
         self.filecheck('platform shell cat ""%s"' % log, __file__)
-#       CHECK: SwiftASTContextForExpressions::SetTriple({{.*}}apple-macosx11.0.0
-#       CHECK-NOT: SwiftASTContextForExpressions::RegisterSectionModules("a.out"){{.*}} AST Data blobs
+#       CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::SetTriple({{.*}}apple-macosx11.0.0
+#       CHECK-NOT: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RegisterSectionModules("a.out"){{.*}} AST Data blobs
 
     @skipUnlessDarwin  # This test uses macOS triples explicitly.
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -26,7 +26,6 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
     @skipUnlessDarwin
     @swiftTest
     def test(self):
-        self.runCmd("settings set symbols.use-swift-dwarfimporter true")
         self.build()
         dylib = self.getBuildArtifact('libLibrary.dylib')
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -37,19 +36,3 @@ class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
         self.runCmd('log enable lldb types -f "%s"' % log)
 
         self.expect("target var -d run myobj", substrs=["(ObjCClass)"])
-
-        found = 0
-        response = 0
-        import io
-        logfile = io.open(log, "r", encoding='utf-8')
-        for line in logfile:
-            if 'SwiftDWARFImporterDelegate::lookupValue("ObjCClass")' in line:
-                found += 1
-            elif found == 1 and response == 0 and 'SwiftDWARFImporterDelegate' in line:
-                self.assertTrue('from debug info' in line, line)
-                response += 1
-            elif found == 2 and response == 1 and 'SwiftDWARFImporterDelegate' in line:
-                self.assertTrue('types collected' in line, line)
-                response += 1
-        self.assertEqual(found, 1)
-        self.assertEqual(response, 1)

--- a/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
+++ b/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
@@ -21,23 +21,4 @@ class TestSwiftFrameworkPaths(lldbtest.TestBase):
         self.expect("expression -- 0")
         self.filecheck('platform shell cat "%s"' % log, __file__,
                        '--check-prefix=CHECK_SYS')
-        # CHECK_SYS: SwiftASTContextForExpressions::LogConfiguration(){{.*}}/secret_path
-
-    @swiftTest
-    # Don't run ClangImporter tests if Clangimporter is disabled.
-    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=no_match(["macosx"]))
-    def test_module_context_framework_path(self):
-        """Test the discovery of framework search paths from framework dependencies."""
-        self.build()
-        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('main.swift'))
-
-        self.expect('settings set symbols.swift-validate-typesystem false')
-        self.expect('settings set symbols.use-swift-typeref-typesystem false')
-        log = self.getBuildArtifact("types.log")
-        self.expect('log enable lldb types -f "%s"' % log)
-        self.expect("expression -- d", substrs=["member"])
-        self.filecheck('platform shell cat "%s"' % log, __file__,
-                       '--check-prefix=CHECK_MOD')
-        # CHECK_MOD: SwiftASTContextForModule("a.out")::LogConfiguration(){{.*}}other_secret_path
+        # CHECK_SYS: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}/secret_path

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -21,9 +21,9 @@ class TestSwiftLateDylib(TestBase):
         self.expect("expr -- import Dylib")
         # Scan through the types log.
         self.filecheck('platform shell cat "%s"' % log, __file__)
-# CHECK: SwiftASTContextForExpressions::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
+# CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
 # CHECK-NOT: __PATH_FROM_DYLIB__
 #       Verify that the deployment target didn't change:
-# CHECK: SwiftASTContextForExpressions::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
+# CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
 #       But LLDB has picked up extra paths:
-# CHECK: SwiftASTContextForExpressions::LogConfiguration(){{.*}}__PATH_FROM_DYLIB__
+# CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}__PATH_FROM_DYLIB__

--- a/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
+++ b/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
@@ -25,15 +25,5 @@ class TestSwiftRuntimeLibraryPath(lldbtest.TestBase):
             self, 'main')
 
         self.expect("expression 1")
-        import io
-        logfile = io.open(log, "r", encoding='utf-8')
-        in_expr_log = 0
-        found = 0
-        for line in logfile:
-            if line.startswith(" SwiftASTContextForExpressions::LogConfiguration(SwiftASTContext"):
-                in_expr_log += 1
-            if in_expr_log and "Runtime library paths" in line and \
-               "2 items" in line:
-                found += 1
-        self.assertEqual(in_expr_log, 1)
-        self.assertEqual(found, 1)
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+        # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Runtime library paths{{.*}}2 items

--- a/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -18,9 +18,7 @@ class TestSwiftSystemFramework(lldbtest.TestBase):
 
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb types -f "%s"' % log)
-        self.expect("settings set target.use-all-compiler-flags true")
         self.expect("expression -- 0")
         self.filecheck('platform shell cat "%s"' % log, __file__)
-#       CHECK: SwiftASTContextForExpressions{{.*}}-- rejecting framework path
 #       CHECK: SwiftASTContextForExpressions{{.*}}LogConfiguration()
 #       CHECK-NOT: LogConfiguration(){{.*}}/System/Library/Frameworks

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -25,18 +25,6 @@ class TestSwiftTripleDetection(TestBase):
         bkpt = target.BreakpointCreateByName("main")
         process = target.LaunchSimple(None, None, self.get_process_working_directory())
         self.expect("expression 1")
-        import io
-        types_logfile = io.open(types_log, "r", encoding='utf-8')
-
-        import re
-        availability_re = re.compile(r'@available\(macCatalyst 1.*, \*\)')
-        found = 0
-        for line in types_logfile:
-            print(line)
-            if re.search('SwiftASTContextForExpressions.*Underspecified target triple .*-apple-macos-unknown', line):
-                found += 1
-                continue
-            if found == 1 and re.search('SwiftASTContextForExpressions.*setting to ".*-apple-macos.[0-9.]+"', line):
-               found += 1
-               break
-        self.assertEqual(found, 2)
+        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        # CHECK: {{SwiftASTContextForExpressions.*Preferring module triple .*-apple-macos.[0-9.]+ over target triple .*-apple-macos-unknown.}}
+        # CHECK: {{SwiftASTContextForExpressions.*setting to ".*-apple-macos.[0-9.]+"}}

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -16,11 +16,9 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
         in_expr_log = 0
         found = 0
         for line in logfile:
-            if line.startswith(" SwiftASTContextForExpressions::LogConfiguration(SwiftASTContext"):
-                in_expr_log += 1
-            if in_expr_log and "SDK path" in line and expected_path in line:
+            if (line.startswith(' SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration()') and
+                "SDK path" in line and expected_path in line):
                 found += 1
-        self.assertEqual(in_expr_log, 1)
         self.assertEqual(found, 1)
 
     @swiftTest


### PR DESCRIPTION
This feature was off-by default in Swift 6.0
This patch completes the transition to precise compiler invocations by removing the backwards-compatibility.

The many test updates are for tests that were checking for the old behavior (which was still present in the tests due to the typeref-typesystem validation creating an classic-mode scratch context).

(cherry picked from commit ad57a42aebb28b05a668d44d72e16f2ae30b134d)