### PR TITLE
[next] Update TestSwiftAvailability.py to use lldbplatformutil.getArchitecture()

### DIFF
--- a/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
@@ -17,7 +17,7 @@ def getOSName(os):
     return os
 
 def getArch(os):
-    if os == 'macosx': return 'x86_64'
+    if os == 'macosx': return lldbplatformutil.getArchitecture()
     if os == 'ios': return 'arm64'
     if os == 'tvos': return 'arm64'
     if os == 'watchos': return 'armv7k'


### PR DESCRIPTION
(cherry picked from commit 7cbb01a4ad2a4d47cd2986a588a32fe3b78d313c)