### PR TITLE
Workaround invalid reloc 315 on aarch64 Linux

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
@@ -22,7 +22,6 @@ class AArch64_ELFTargetObjectFile : public TargetLoweringObjectFileELF {
 public:
   AArch64_ELFTargetObjectFile() {
     PLTRelativeVariantKind = MCSymbolRefExpr::VK_PLT;
-    SupportIndirectSymViaGOTPCRel = true;
   }
 
   const MCExpr *getIndirectSymViaGOTPCRel(const GlobalValue *GV,


### PR DESCRIPTION
`gold` fails to link `libswiftDispatch.so` on aarch64 Linux due to:
```
/usr/bin/ld.gold: error: Invalid/unrecognized reloc reloc 315.
/usr/bin/ld.gold: internal error in global, at ../../gold/aarch64.cc:6398
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

Attempt to workaround this via disabling
`SupportIndirectSymViaGOTPCRel`.

rdar://135050296