### PR TITLE
builtins: simplify storage section

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/aarch64.c
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64.c
@@ -30,9 +30,7 @@ typedef struct __ifunc_arg_t {
 
 // LSE support detection for out-of-line atomics
 // using HWCAP and Auxiliary vector
-#if defined(_MSC_VER)
-__declspec(allocate(".data"))
-#else
+#if !defined(_MSC_VER)
 __attribute__((__visibility__("hidden"), __nocommon__))
 #endif
 _Bool __aarch64_have_lse_atomics = false;


### PR DESCRIPTION
The default storage section for initialised data is `.data`. There is no need to explicitly mark the data segment as `.data` to mirror the semantics of `__nocommon__`. This reduces the clutter and maintains compatibility.