### PR TITLE
[lldb] Fix an incorrect trigger of a per-module scratch context

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -3,7 +3,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-@skipIf(bugnumber = "rdar://135575668")
 class TestSwiftExprImport(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))

--- a/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
@@ -21,7 +21,6 @@ import sys
 
 
 class TestSwiftSimpleExpressions(TestBase):
-    @skipIf(bugnumber = "rdar://135575668")
     @swiftTest
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""


### PR DESCRIPTION
which indirectly caused several ModuleSP shared pointers to live longer than two tests expected them to.

The problem is that swift::performImportResolution() now apparently also reports syntax errors in function bodies, so I had to add a (terrible) heuristic to filter out actual module import errors.

rdar://135575668