### PR TITLE
[lldb] Replace use of v/var aliases in Swift tests (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/c_type_external_provider/TestSwiftCTypeExternalProvider.py
+++ b/lldb/test/API/lang/swift/c_type_external_provider/TestSwiftCTypeExternalProvider.py
@@ -25,7 +25,7 @@ class TestSwiftCTypeExternalProvider(TestBase):
             self, 'Set breakpoint here', self.main_source_spec)
 
         # Consult the second field to ensure we call GetIndexOfChildMemberWithName.
-        self.expect('v dummy.second', substrs=['2'])
+        self.expect('frame var dummy.second', substrs=['2'])
 
         # Make sure we look up the type with the external type info provider.
         provider_log_found = False

--- a/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
+++ b/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
@@ -17,7 +17,7 @@ class TestSwiftCTypeIvar(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
-        # self.expect('v a', substrs=['asdf'])
+        # self.expect('frame var a', substrs=['asdf'])
         a = self.frame().FindVariable("a")
         lldbutil.check_variable(
             self,

--- a/lldb/test/API/lang/swift/cxx_interop/backward/format-actors/TestSwiftBackwardInteropFormatActors.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/format-actors/TestSwiftBackwardInteropFormatActors.py
@@ -16,4 +16,4 @@ class TestSwiftBackwardInteropFormatActors(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.cpp'))
 
-        self.expect('v actor', substrs=['Actor', 'str = "Hello"'])
+        self.expect('frame var actor', substrs=['Actor', 'str = "Hello"'])

--- a/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/TestSwiftBackwardInteropFormatSwiftStdlibTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-stdlib-types/TestSwiftBackwardInteropFormatSwiftStdlibTypes.py
@@ -18,7 +18,7 @@ class TestSwiftBackwardInteropFormatSwiftStdlibTypes(TestBase):
     @swiftTest
     def test_array(self):
         self.setup('break here for array')
-        self.expect('v array', substrs=['Swift.Array<a.SwiftClass>',
+        self.expect('frame var array', substrs=['Swift.Array<a.SwiftClass>',
             '[0]', 'str = "Hello from the Swift class!"', 
             '[1]', 'str = "Hello from the Swift class!"',])
 
@@ -26,25 +26,25 @@ class TestSwiftBackwardInteropFormatSwiftStdlibTypes(TestBase):
     def test_array_of_ints(self):
         self.setup('break here for array of ints')
 
-        self.expect('v array', substrs=['Swift.Array<Swift.Int32>', '1', '2', '3', '4'])
+        self.expect('frame var array', substrs=['Swift.Array<Swift.Int32>', '1', '2', '3', '4'])
 
     @swiftTest
     def test_optional(self):
         self.setup('break here for optional')
 
-        self.expect('v optional', substrs=['Swift.Optional<a.SwiftClass>', 
+        self.expect('frame var optional', substrs=['Swift.Optional<a.SwiftClass>',
             'str = "Hello from the Swift class!"'])
 
     @swiftTest
     def test_optional_primitive(self):
         self.setup('break here for optional primitive')
 
-        self.expect('v optional', substrs=['Swift.Optional<Swift.Double>', 
+        self.expect('frame var optional', substrs=['Swift.Optional<Swift.Double>',
             '4.2'])
 
     @swiftTest
     def test_string(self):
         self.setup('break here for string')
 
-        self.expect('v string', substrs=['"Hello from Swift!"'])
+        self.expect('frame var string', substrs=['"Hello from Swift!"'])
 

--- a/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-types-in-cxx/TestSwiftBackwardInteropFormatSwiftTypesInCxx.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/format-swift-types-in-cxx/TestSwiftBackwardInteropFormatSwiftTypesInCxx.py
@@ -19,7 +19,7 @@ class TestSwiftBackwardInteropFormatSwiftTypesInCxx(TestBase):
     def test_class(self):
         self.setup('Break here for class')
 
-        self.expect('v swiftClass', substrs=['SwiftClass', 'field = 42', 
+        self.expect('frame var swiftClass', substrs=['SwiftClass', 'field = 42', 
             'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
             '[3] = "strings"'])
         self.expect('expr swiftClass', substrs=['SwiftClass', 'field = 42', 
@@ -30,7 +30,7 @@ class TestSwiftBackwardInteropFormatSwiftTypesInCxx(TestBase):
     def test_subclass(self):
         self.setup('Break here for subclass')
 
-        self.expect('v swiftSublass', substrs=['SwiftSubclass', 'field = 42', 
+        self.expect('frame var swiftSublass', substrs=['SwiftSubclass', 'field = 42', 
             'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
             '[3] = "strings"', 'extraField = "this is an extra subclass field"'])
         self.expect('expr swiftSublass', substrs=['SwiftSubclass', 'field = 42', 
@@ -41,7 +41,7 @@ class TestSwiftBackwardInteropFormatSwiftTypesInCxx(TestBase):
     def test_struct(self):
         self.setup('Break here for struct')
 
-        self.expect('v swiftStruct', substrs=['SwiftStruct', 'str = "Hello this is a big string"', 
+        self.expect('frame var swiftStruct', substrs=['SwiftStruct', 'str = "Hello this is a big string"', 
             'boolean = true'])
         self.expect('expr swiftStruct', substrs=['SwiftStruct', 'str = "Hello this is a big string"', 
             'boolean = true'])
@@ -50,7 +50,7 @@ class TestSwiftBackwardInteropFormatSwiftTypesInCxx(TestBase):
     def test_generic_struct(self):
         self.setup('Break here for generic struct')
 
-        self.expect('v wrapper', substrs=['a.GenericStructPair<a.SwiftClass, a.SwiftStruct>', 
+        self.expect('frame var wrapper', substrs=['a.GenericStructPair<a.SwiftClass, a.SwiftStruct>', 
                 'field = 42', 'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
                 '[3] = "strings"', 'str = "Hello this is a big string"', 'boolean = true'])
         self.expect('expr wrapper', substrs=['a.GenericStructPair<a.SwiftClass, a.SwiftStruct>', 
@@ -62,7 +62,7 @@ class TestSwiftBackwardInteropFormatSwiftTypesInCxx(TestBase):
     def test_generic_enum(self):
         self.setup('Break here for generic enum')
 
-        self.expect('v swiftEnum', substrs=['a.GenericEnum<a.SwiftClass>', 'some',
+        self.expect('frame var swiftEnum', substrs=['a.GenericEnum<a.SwiftClass>', 'some',
                 'field = 42', 'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
                 '[3] = "strings"'])
         self.expect('expr swiftEnum', substrs=['a.GenericEnum<a.SwiftClass>', 'some',
@@ -74,7 +74,7 @@ class TestSwiftBackwardInteropFormatSwiftTypesInCxx(TestBase):
     def test_swift_ivars(self):
         self.setup('Break here for swift ivars')
 
-        self.expect('v type_with_ivars', substrs=['TypeWithSwiftIvars', 'swiftClass',
+        self.expect('frame var type_with_ivars', substrs=['TypeWithSwiftIvars', 'swiftClass',
                 'field = 42', 'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
                 '[3] = "strings"', 'swiftSubclass', 'field = 42', 'arr = 4 values', 
                 '[0] = "An"', '[1] = "array"', '[2] = "of"', '[3] = "strings"', 
@@ -91,7 +91,7 @@ class TestSwiftBackwardInteropFormatSwiftTypesInCxx(TestBase):
     def test_typealias(self):
         self.setup('Break here for swift alias')
 
-        self.expect('v aliased', substrs=['SwiftClass', 'field = 42', 
+        self.expect('frame var aliased', substrs=['SwiftClass', 'field = 42', 
             'arr = 4 values', '[0] = "An"', '[1] = "array"', '[2] = "of"', 
             '[3] = "strings"'])
         self.expect('expr aliased', substrs=['SwiftClass', 'field = 42', 

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
@@ -15,31 +15,31 @@ class TestSwiftForwardInteropClassInNamespace(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v fooClass', substrs=['foo::CxxClass', 'foo_field = 10'])
+        self.expect('frame var fooClass', substrs=['foo::CxxClass', 'foo_field = 10'])
         self.expect('expr fooClass', substrs=['foo::CxxClass', 'foo_field = 10'])
 
-        self.expect('v barClass', substrs=['bar::CxxClass', 'bar_field = 30'])
+        self.expect('frame var barClass', substrs=['bar::CxxClass', 'bar_field = 30'])
         self.expect('expr barClass', substrs=['bar::CxxClass', 'bar_field = 30'])
 
 
-        self.expect('v bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+        self.expect('frame var bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
         self.expect('expr bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
 
-        self.expect('v bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
+        self.expect('frame var bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
         self.expect('expr bazClass', substrs=['baz::CxxClass', 'baz_field = 50'])
 
-        self.expect('v fooInherited', substrs=['foo::InheritedCxxClass', 
+        self.expect('frame var fooInherited', substrs=['foo::InheritedCxxClass', 
             'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
         self.expect('expr fooInherited', substrs=['foo::InheritedCxxClass', 
             'foo::CxxClass = (foo_field = 10)', 'foo_subfield = 20'])
 
-        self.expect('v barInherited', substrs=['bar::InheritedCxxClass', 
+        self.expect('frame var barInherited', substrs=['bar::InheritedCxxClass', 
             'bar::CxxClass = (bar_field = 30)', 'bar_subfield = 40'])
         self.expect('expr barInherited', substrs=['bar::InheritedCxxClass', 
             'bar::CxxClass = (bar_field = 30)', 'bar_subfield = 40'])
 
 
-        self.expect('v bazInherited', substrs=['bar::baz::InheritedCxxClass', 
+        self.expect('frame var bazInherited', substrs=['bar::baz::InheritedCxxClass', 
                 'bar::baz::CxxClass = (baz_field = 50)', 'baz_subfield = 60'])
         self.expect('expr bazInherited', substrs=['bar::baz::InheritedCxxClass', 
                 'bar::baz::CxxClass = (baz_field = 50)', 'baz_subfield = 60'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -15,8 +15,8 @@ class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v x', substrs=['CxxClass', 'a1 = 10', 'a2 = 20', 'a3 = 30'])
+        self.expect('frame var x', substrs=['CxxClass', 'a1 = 10', 'a2 = 20', 'a3 = 30'])
         self.expect('expr x', substrs=['CxxClass', 'a1 = 10', 'a2 = 20', 'a3 = 30'])
 
-        self.expect('v y', substrs=['InheritedCxxClass', 'a1 = 10', 'a2 = 20', 'a3 = 30', 'a4 = 40'])
+        self.expect('frame var y', substrs=['InheritedCxxClass', 'a1 = 10', 'a2 = 20', 'a3 = 30', 'a4 = 40'])
         self.expect('expr y', substrs=['InheritedCxxClass', 'a1 = 10', 'a2 = 20', 'a3 = 30', 'a4 = 40'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
@@ -14,9 +14,9 @@ class TestSwiftForwardInteropCxxClass(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v x', substrs=['CxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
+        self.expect('frame var x', substrs=['CxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('po x', substrs=['CxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
 
-        self.expect('v y', substrs=['InheritedCxxClass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
+        self.expect('frame var y', substrs=['InheritedCxxClass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
         # FIXME: rdar://106216567
         self.expect('po y', substrs=['InheritedCxxClass', 'a4', '40'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
@@ -16,10 +16,10 @@ class TestCxxForwardInteropNestedClasses(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v nested', substrs=['CxxClass::NestedClass', 'b = 20'])
+        self.expect('frame var nested', substrs=['CxxClass::NestedClass', 'b = 20'])
         self.expect('expr nested', substrs=['CxxClass::NestedClass', 'b = 20'])
 
-        self.expect('v nestedSubclass', substrs=['CxxClass::NestedSubclass', 
+        self.expect('frame var nestedSubclass', substrs=['CxxClass::NestedSubclass', 
             'SuperClass = (a = 10)', 'c = 30'])
         self.expect('expr nestedSubclass', substrs=['CxxClass::NestedSubclass', 
             'SuperClass = (a = 10)', 'c = 30'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -21,39 +21,39 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
         # take an execution context, so the validation happens in the
         # wrong SwiftASTContext.
         self.expect('settings set symbols.swift-validate-typesystem false')
-        self.expect('v map', substrs=['CxxMap', 'first = 1, second = 3', 
+        self.expect('frame var map', substrs=['CxxMap', 'first = 1, second = 3', 
             'first = 2, second = 2', 'first = 3, second = 3'])
         self.expect('expr map', substrs=['CxxMap', 'first = 1, second = 3', 
             'first = 2, second = 2', 'first = 3, second = 3'])
 
-        self.expect('v optional', substrs=['CxxOptional', 'optional', 'Has Value=true',
+        self.expect('frame var optional', substrs=['CxxOptional', 'optional', 'Has Value=true',
             'Value = "In optional!"'])
         self.expect('expr optional', substrs=['CxxOptional', 'Has Value=true',
             'Value = "In optional!"'])
 
-        self.expect('v emptyOptional', substrs=['CxxOptional', 'emptyOptional', 
+        self.expect('frame var emptyOptional', substrs=['CxxOptional', 'emptyOptional', 
             'Has Value=false'])
         self.expect('expr emptyOptional', substrs=['CxxOptional', 'Has Value=false'])
 
-        self.expect('v set', substrs=['CxxSet', 'size=3', '3.7', '4.2', '9.19'])
+        self.expect('frame var set', substrs=['CxxSet', 'size=3', '3.7', '4.2', '9.19'])
         self.expect('expr set', substrs=['CxxSet', 'size=3', '3.7', '4.2', '9.19'])
 
-        self.expect('v string', substrs=['string', 'Hello from C++!'])
+        self.expect('frame var string', substrs=['string', 'Hello from C++!'])
         self.expect('expr string', substrs=['Hello from C++!'])
 
-        self.expect('v unorderedMap', substrs=['CxxUnorderedMap', 
+        self.expect('frame var unorderedMap', substrs=['CxxUnorderedMap', 
             '(first = 3, second = "three")', '(first = 2, second = "two")',
             '(first = 1, second = "one")'], ordered=False)
         self.expect('expr unorderedMap', substrs=['CxxUnorderedMap', 
             '(first = 3, second = "three")', '(first = 2, second = "two")',
             '(first = 1, second = "one")'], ordered=False)
 
-        self.expect('v unorderedSet', substrs=['CxxUnorderedSet',
+        self.expect('frame var unorderedSet', substrs=['CxxUnorderedSet',
             'first', 'second', 'third'], ordered=False)
         self.expect('expr unorderedSet', substrs=['CxxUnorderedSet',
             'first', 'second', 'third'], ordered=False)
         
-        self.expect('v vector', substrs=['CxxVector', '[0] = 4.1', '[1] = 3.7',
+        self.expect('frame var vector', substrs=['CxxVector', '[0] = 4.1', '[1] = 3.7',
             '[2] = 9.19'])
         self.expect('expr vector', substrs=['CxxVector', '[0] = 4.1', '[1] = 3.7',
             '[2] = 9.19'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/swift-class-with-cxx-ivars/TestSwiftForwardInteropClassWithCxxIvars.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/swift-class-with-cxx-ivars/TestSwiftForwardInteropClassWithCxxIvars.py
@@ -15,21 +15,21 @@ class TestSwiftForwardInteropClassWithCxxIvars(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v swiftClass', substrs=['SwiftClass', 'cxxClass', 'a1', '10', 'a2', '20', 'a3', '30',
+        self.expect('frame var swiftClass', substrs=['SwiftClass', 'cxxClass', 'a1', '10', 'a2', '20', 'a3', '30',
             'cxxSubclass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
         self.expect('expr swiftClass', substrs=['SwiftClass', 'cxxClass', 'a1', '10', 'a2', '20', 'a3', '30',
             'cxxSubclass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
 
-        self.expect('v swiftStruct', substrs=['SwiftStruct', 'cxxClass', 'a1', '10', 'a2', '20', 'a3', '30',
+        self.expect('frame var swiftStruct', substrs=['SwiftStruct', 'cxxClass', 'a1', '10', 'a2', '20', 'a3', '30',
             'cxxSubclass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
         self.expect('expr swiftStruct', substrs=['SwiftStruct', 'cxxClass', 'a1', '10', 'a2', '20', 'a3', '30',
             'cxxSubclass', 'a1', '10', 'a2', '20', 'a3', '30', 'a4', '40'])
 
 
-        self.expect('v swiftEnum1', substrs=['SwiftEnum', 'first', 'a1', '10', 'a2', '20', 'a3', '30'])
+        self.expect('frame var swiftEnum1', substrs=['SwiftEnum', 'first', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('expr swiftEnum1', substrs=['SwiftEnum', 'first', 'a1', '10', 'a2', '20', 'a3', '30'])
 
-        self.expect('v swiftEnum2', substrs=['SwiftEnum', 'second', 'a1', '10', 'a2', '20', 'a3', '30',
+        self.expect('frame var swiftEnum2', substrs=['SwiftEnum', 'second', 'a1', '10', 'a2', '20', 'a3', '30',
             'a4', '40'])
         self.expect('expr swiftEnum2', substrs=['SwiftEnum', 'second', 'a1', '10', 'a2', '20', 'a3', '30',
             'a4', '40'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/swift-generic-with-cxx-type/TestSwiftForwardInteropGenericWithCxxType.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/swift-generic-with-cxx-type/TestSwiftForwardInteropGenericWithCxxType.py
@@ -15,12 +15,12 @@ class TestSwiftForwardInteropGenericWithCxxType(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v classWrapper', substrs=['Wrapper<CxxClass>', 't', 'a1 = 10',
+        self.expect('frame var classWrapper', substrs=['Wrapper<CxxClass>', 't', 'a1 = 10',
             'a2 = 20', 'a3 = 30'])
         self.expect('expr classWrapper', substrs=['Wrapper<CxxClass>', 't', 'a1 = 10',
             'a2 = 20', 'a3 = 30'])
 
-        self.expect('v subclassWrapper', substrs=['Wrapper<CxxSubclass>', 't', 
+        self.expect('frame var subclassWrapper', substrs=['Wrapper<CxxSubclass>', 't', 
             'CxxClass = (a1 = 10, a2 = 20, a3 = 30)', 'a4 = 40'])
         self.expect('expr subclassWrapper', substrs=['Wrapper<CxxSubclass>', 't', 
             'CxxClass = (a1 = 10, a2 = 20, a3 = 30)', 'a4 = 40'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/template-types/TestSwiftForwardInteropTemplateTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/template-types/TestSwiftForwardInteropTemplateTypes.py
@@ -17,7 +17,7 @@ class TestSwiftForwardInteropTemplateTypes(TestBase):
 
         # rdar://106455215 validating the typeref type system will trigger an assert in Clang
         self.runCmd('settings set symbols.swift-validate-typesystem false') 
-        self.expect('v wrapped', substrs=['Wrapper<CxxClass>', 't', 'a1', '10', 'a2', '20', 'a3', '30'])
+        self.expect('frame var wrapped', substrs=['Wrapper<CxxClass>', 't', 'a1', '10', 'a2', '20', 'a3', '30'])
 
         # FIXME: rdar://106455215
         # self.expect('expr wrapped', substrs=['Wrapper<CxxClass>', 't', 'a1', '10', 'a2', '20', 'a3', '30'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/typedefed-type/TestSwiftForwardInteropTypedefType.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/typedefed-type/TestSwiftForwardInteropTypedefType.py
@@ -15,11 +15,11 @@ class TestSwiftForwardInteropTypedefType(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v typedef', substrs=['TypedefedCxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
+        self.expect('frame var typedef', substrs=['TypedefedCxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('expr typedef', substrs=['TypedefedCxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
 
-        self.expect('v using', substrs=['UsingCxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
+        self.expect('frame var using', substrs=['UsingCxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('expr using', substrs=['UsingCxxClass', 'a1', '10', 'a2', '20', 'a3', '30'])
 
-        self.expect('v typealiased', substrs=['TypeAliased', 'a1', '10', 'a2', '20', 'a3', '30'])
+        self.expect('frame var typealiased', substrs=['TypeAliased', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('expr typealiased', substrs=['TypeAliased', 'a1', '10', 'a2', '20', 'a3', '30'])

--- a/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
@@ -15,11 +15,11 @@ class TestSwiftForwardInteropVariadicTemplateTypes(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v pair', substrs=['Pair', 'Tuple<OtherCxxClass>', '_t', 
+        self.expect('frame var pair', substrs=['Pair', 'Tuple<OtherCxxClass>', '_t', 
             'v = false', '_t', 'a1', '10', 'a2', '20', 'a3', '30'])
         self.expect('expr pair', substrs=['Pair', 'Tuple<OtherCxxClass>', '_t', 
             'v = false', '_t', 'a1', '10', 'a2', '20', 'a3', '30'])
 
         # rdar://106459037 (Swift/C++ interop: Variadic templates aren't displayed correctly)
-        # self.expect('v variadic', substrs=['Tuple<CxxClass, OtherCxxClass>', '_t', 
+        # self.expect('frame var variadic', substrs=['Tuple<CxxClass, OtherCxxClass>', '_t', 
         #    'v = false', 'a1', '10', 'a2', '20', 'a3', '30']) 

--- a/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
@@ -19,7 +19,7 @@ class TestSwiftErrorHandlingMissingTypes(TestBase):
         val = var_object.GetChildAtIndex(1)
         # FIXME: Should be True, for now it's just a string
         self.assertFalse(val.GetError().Fail())
-        self.expect('v object',
+        self.expect('frame var object',
                     substrs=['missing debug info for Clang type', 'FromC'])
-        self.expect('v enm',
+        self.expect('frame var enm',
                     substrs=['missing debug info for Clang type', 'ImportedEnum'])

--- a/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
+++ b/lldb/test/API/lang/swift/external_provider_extra_inhabitants/TestExternalProviderExtraInhabitants.py
@@ -15,6 +15,6 @@ class TestExternalProviderExtraInhabitants(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here.', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v object.size.some.width', substrs=['10'])
-        self.expect('v object.size.some.height', substrs=['20'])
+        self.expect('frame var object.size.some.width', substrs=['10'])
+        self.expect('frame var object.size.some.height', substrs=['20'])
 

--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -63,7 +63,7 @@ class TestSwiftMetadataCache(TestBase):
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
         # Run frame variable for the first time to build the cache.
-        self.expect('v v', substrs=['SomeTypeWeWillLookUp'])
+        self.expect('frame var v', substrs=['SomeTypeWeWillLookUp'])
 
         # Check that we wrote the cache for the main module.
         self.assertTrue(self.check_strings_in_log(types_log, [
@@ -78,7 +78,7 @@ class TestSwiftMetadataCache(TestBase):
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
         # Run frame variable for the second time to check if the cache was queried.
-        self.expect('v v', substrs=['SomeTypeWeWillLookUp'])
+        self.expect('frame var v', substrs=['SomeTypeWeWillLookUp'])
 
         # Check that we have a cache and that we found the type of 'v' in it.
         self.assertTrue(self.check_strings_in_log(types_log, [
@@ -101,7 +101,7 @@ class TestSwiftMetadataCache(TestBase):
 
         # Run frame variable for the third time to check that the cache is invalidated
         # and that we rebuild it.
-        self.expect('v v', substrs=['SomeTypeWeWillLookUp'])
+        self.expect('frame var v', substrs=['SomeTypeWeWillLookUp'])
 
         # Check that we found the type of 'v' in the cache.
         self.assertTrue(self.check_strings_in_log(types_log, [

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -31,9 +31,9 @@ class TestSwiftRegex(TestBase):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', self.main_source_spec)
-        self.expect('v regex',
+        self.expect('frame var regex',
                     substrs=['_StringProcessing.Regex<(Substring, Substring, Substring, Substring)>) regex = {'])
-        self.expect('v dslRegex',
+        self.expect('frame var dslRegex',
                     substrs=['(_StringProcessing.Regex<Substring>) dslRegex = {'])
 
     @swiftTest

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
@@ -14,4 +14,4 @@ class TestCase(TestBase):
             self, "// break here", lldb.SBFileSpec("main.swift")
         )
         self.runCmd("settings set symbols.swift-enable-ast-context false")
-        self.expect("v", substrs=["num = 15"])
+        self.expect("frame var c", substrs=["num = 15"])

--- a/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
+++ b/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
@@ -16,6 +16,6 @@ class TestSwiftActorTypes(TestBase):
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.expect('v actor', substrs=['Actor', 'str = "Hello"'])
+        self.expect('frame var actor', substrs=['Actor', 'str = "Hello"'])
         self.expect('expr actor', substrs=['Actor', 'str = "Hello"'])
 


### PR DESCRIPTION
This change is for two reasons:

> prefer `frame variable` over `v` since `v` is technically an alias, so there is a chance that it will be re-aliased later on to something else.
See https://github.com/swiftlang/llvm-project/pull/9320#discussion_r1777645951

Additionally, using `frame var` makes it easier to grep for than using `v`.