### PR TITLE
[lldb] NFC: Update for `getArgumentInterfaceType` rename

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -611,7 +611,7 @@ public:
 
       swift::EnumElementDecl *case_decl = enum_case.decl;
       assert(case_decl);
-      auto arg_type = case_decl->getArgumentInterfaceType();
+      auto arg_type = case_decl->getPayloadInterfaceType();
       CompilerType case_type;
       if (arg_type) {
         case_type = ToCompilerType(


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift/pull/76771