### PR TITLE
[lldb][test] TestLocationListLookup.py: XFAIL on x86

### DIFF
--- a/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
+++ b/lldb/test/API/functionalities/location-list-lookup/TestLocationListLookup.py
@@ -46,6 +46,7 @@ class LocationListLookupTestCase(TestBase):
     @skipIf(dwarf_version=["<", "3"])
     @skipIf(compiler="clang", compiler_version=["<", "12.0"])
     @skipUnlessDarwin
+    @expectedFailureAll(archs=["x86_64"])
     def test_loclist_expr(self):
         self.build()
         self.check_local_vars(self.launch(), check_expr=True)


### PR DESCRIPTION
The location lists produced for the `this` parameter by Clang when using the old LiveDebugVariables pass (`-experimental-debug-variable-locations=false`) on x86 cause this test to fail.

rdar://135577167