### PR TITLE
[lldb] Support plain ObjC names in LLDBTypeInfoProvider

### DIFF
--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/Makefile
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/TestSwiftObjCDescendantClassWithoutASTContext.py
@@ -1,0 +1,17 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        """Print an ObjC derived object without using the AST context."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        self.expect("v", substrs=["num = 15"])

--- a/lldb/test/API/lang/swift/typerefs/objc-descendent/main.swift
+++ b/lldb/test/API/lang/swift/typerefs/objc-descendent/main.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+class C: NSObject {
+  var num: Int = 15
+}
+
+func main() {
+  let c = C()
+  // break here
+  print(c)
+}
+
+main()


### PR DESCRIPTION
Extend `LLDBTypeInfoProvider` to support ObjC class names (such as "NSObject", "NSView") in addition to mangled Swift names.

This is to support `ObjCClassTypeRefs`, which contain the class name, but not the mangled name. Note that `ObjCClassTypeRefs` are typerefs for classes in the ObjC (`__C`) module.

Depends on https://github.com/swiftlang/swift/pull/76678

(cherry picked from commit 4a1abae5581c76dd1d0bab82269aafa185d387b1)