### PR TITLE
[cc1depscan_main] Fix use-after-free when a scan daemon is used and its diagnostic output is used

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -369,7 +369,7 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
 static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
     const char *Exec, ArrayRef<const char *> OldArgs,
     StringRef WorkingDirectory, SmallVectorImpl<const char *> &NewArgs,
-    StringRef &DiagnosticOutput, StringRef Path,
+    std::string &DiagnosticOutput, StringRef Path,
     const DepscanSharing &Sharing,
     llvm::function_ref<const char *(const Twine &)> SaveArg,
     llvm::cas::ObjectStore &CAS) {
@@ -396,9 +396,13 @@ static llvm::Expected<llvm::cas::CASID> scanAndUpdateCC1UsingDaemon(
   CC1DepScanDProtocol::ResultKind Result;
   StringRef FailedReason;
   StringRef RootID;
+  StringRef DiagOut;
   if (auto E = Comms.getScanResult(Saver, Result, FailedReason, RootID,
-                                   RawNewArgs, DiagnosticOutput))
+                                   RawNewArgs, DiagOut)) {
+    DiagnosticOutput = DiagOut;
     return std::move(E);
+  }
+  DiagnosticOutput = DiagOut;
 
   if (Result != CC1DepScanDProtocol::SuccessResult)
     return llvm::createStringError(llvm::inconvertibleErrorCode(),
@@ -503,7 +507,7 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
   if (ProduceIncludeTree)
     Sharing.CASArgs.push_back("-fdepscan-include-tree");
 
-  StringRef DiagnosticOutput;
+  std::string DiagnosticOutput;
   bool DiagnosticErrorOccurred = false;
   auto ScanAndUpdate = [&]() {
     if (std::optional<std::string> DaemonPath =


### PR DESCRIPTION
This was found when building with ASAN enabled, the `CAS/depscan-with-error.c` test fails.

rdar://136931134