### PR TITLE
[stable/20240723] Avoid calling initializeDelayedInputFileFromCAS() from CompilerInstance::setInvocation()

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -866,9 +866,6 @@ private:
                        bool RemoveFileOnSignal, bool UseTemporary,
                        bool CreateMissingDirectories);
 
-  /// Initialize inputs from CAS.
-  void initializeDelayedInputFileFromCAS();
-
 public:
   std::unique_ptr<raw_pwrite_stream> createNullOutputFile();
 
@@ -890,6 +887,9 @@ public:
                                       DiagnosticsEngine &Diags,
                                       FileManager &FileMgr,
                                       SourceManager &SourceMgr);
+
+  /// Initialize inputs from CAS.
+  void initializeDelayedInputFileFromCAS();
 
   /// @}
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -89,10 +89,6 @@ CompilerInstance::~CompilerInstance() {
 void CompilerInstance::setInvocation(
     std::shared_ptr<CompilerInvocation> Value) {
   Invocation = std::move(Value);
-
-  /// Initialize the input from CAS when setting the invocation to preserve
-  /// the same behavior when perform all kinds of FrontendActions.
-  initializeDelayedInputFileFromCAS();
 }
 
 bool CompilerInstance::shouldBuildGlobalModuleIndex() const {
@@ -1001,6 +997,8 @@ void CompilerInstance::initializeDelayedInputFileFromCAS() {
   // Return if no need to initialize or already initialized.
   if (Opts.CASIncludeTreeID.empty() || !Opts.Inputs.empty())
     return;
+
+  assert(hasDiagnostics() && "need diagnostics engine for CAS loading");
 
   // If there is include tree, initialize the inputs from CAS.
   auto reportError = [&](llvm::Error &&E) {


### PR DESCRIPTION
`initializeDelayedInputFileFromCAS()` requires a diagnostics engine to be already setup but doing something like
```
CompilerInstance compiler;
compiler.setInvocation(std::move(invocation));
compiler.createDiagnostics();
```
is common. It's going to be problematic for maintenance if `setInvocation()` is doing something more complex than setting the property.

That `initializeDelayedInputFileFromCAS()` call also broke `CompileJobCache::replayCachedResult()`, the breakage appears in tests only when building with UBSan.

rdar://136931089