### PR TITLE
[clang][ExtractAPI] Generate subheading for typedef'd anonymous types (#110689)

### DIFF
--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -1622,6 +1622,9 @@ DeclarationFragmentsBuilder::getSubHeading(const NamedDecl *Decl) {
              cast<CXXMethodDecl>(Decl)->isOverloadedOperator()) {
     Fragments.append(Decl->getNameAsString(),
                      DeclarationFragments::FragmentKind::Identifier);
+  } else if (isa<TagDecl>(Decl) &&
+             cast<TagDecl>(Decl)->getTypedefNameForAnonDecl()) {
+    return getSubHeading(cast<TagDecl>(Decl)->getTypedefNameForAnonDecl());
   } else if (Decl->getIdentifier()) {
     Fragments.append(Decl->getName(),
                      DeclarationFragments::FragmentKind::Identifier);

--- a/clang/test/ExtractAPI/typedef_anonymous_record.c
+++ b/clang/test/ExtractAPI/typedef_anonymous_record.c
@@ -35,7 +35,21 @@ typedef struct { } MyStruct;
 // MYSTRUCT:      "kind": {
 // MYSTRUCT-NEXT:   "displayName": "Structure",
 // MYSTRUCT-NEXT:   "identifier": "c.struct"
-// MYSTRUCT: "title": "MyStruct"
+// MYSTRUCT:           "names": {
+// MYSTRUCT-NEXT:        "navigator": [
+// MYSTRUCT-NEXT:          {
+// MYSTRUCT-NEXT:            "kind": "identifier",
+// MYSTRUCT-NEXT:            "spelling": "MyStruct"
+// MYSTRUCT-NEXT:          }
+// MYSTRUCT-NEXT:        ],
+// MYSTRUCT-NEXT:        "subHeading": [
+// MYSTRUCT-NEXT:          {
+// MYSTRUCT-NEXT:            "kind": "identifier",
+// MYSTRUCT-NEXT:            "spelling": "MyStruct"
+// MYSTRUCT-NEXT:          }
+// MYSTRUCT-NEXT:        ],
+// MYSTRUCT-NEXT:        "title": "MyStruct"
+// MYSTRUCT-NEXT:      },
 // MYSTRUCT:      "pathComponents": [
 // MYSTRUCT-NEXT:    "MyStruct"
 // MYSTRUCT-NEXT:  ]
@@ -111,7 +125,21 @@ typedef enum { Case } MyEnum;
 // MYENUM:     "kind": {
 // MYENUM-NEXT:  "displayName": "Enumeration",
 // MYENUM-NEXT:  "identifier": "c.enum"
-// MYENUM: "title": "MyEnum"
+// MYENUM:           "names": {
+// MYENUM-NEXT:        "navigator": [
+// MYENUM-NEXT:          {
+// MYENUM-NEXT:            "kind": "identifier",
+// MYENUM-NEXT:            "spelling": "MyEnum"
+// MYENUM-NEXT:          }
+// MYENUM-NEXT:        ],
+// MYENUM-NEXT:        "subHeading": [
+// MYENUM-NEXT:          {
+// MYENUM-NEXT:            "kind": "identifier",
+// MYENUM-NEXT:            "spelling": "MyEnum"
+// MYENUM-NEXT:          }
+// MYENUM-NEXT:        ],
+// MYENUM-NEXT:        "title": "MyEnum"
+// MYENUM-NEXT:      },
 
 // CASE-LABEL: "!testLabel": "c:@EA@MyEnum@Case"
 // CASE:      "pathComponents": [


### PR DESCRIPTION
When an anonymous type has a typedef we normally use the typedef's name in places where we expect a named identifier in the symbol graph. This extends this logic to apply to subheadings.

rdar://136690614