### PR TITLE
[test][clang] Workaround failure with module+pch

### DIFF
--- a/clang/test/Modules/skip-func-def-odr-with-pch.cppm
+++ b/clang/test/Modules/skip-func-def-odr-with-pch.cppm
@@ -3,11 +3,11 @@
 // RUN: split-file %s %t
 //
 // Testing the behavior of `-fskip-odr-check-in-gmf`
-// RUN: %clang_cc1 -std=c++20 -DDIFFERENT -fskip-odr-check-in-gmf %t/A.cppm -emit-module-interface -o %t/A.pcm
-// RUN: %clang_cc1 -std=c++20 -fskip-odr-check-in-gmf -x c++-header %t/foo.h -emit-pch -o %t/foo.pch
-// RUN: %clang_cc1 -std=c++20 -fskip-odr-check-in-gmf -include-pch %t/foo.pch %t/B.cppm -emit-module-interface -o %t/B.pcm
+// RUN: %clang_cc1 -std=c++20 -DDIFFERENT -fskip-odr-check-in-gmf %t/A.cppm -emit-module-interface -o %t/A.pcm -fmodule-related-to-pch
+// RUN: %clang_cc1 -std=c++20 -fskip-odr-check-in-gmf -x c++-header %t/foo.h -emit-pch -o %t/foo.pch -fmodule-related-to-pch
+// RUN: %clang_cc1 -std=c++20 -fskip-odr-check-in-gmf -include-pch %t/foo.pch %t/B.cppm -emit-module-interface -o %t/B.pcm -fmodule-related-to-pch
 // RUN: %clang_cc1 -std=c++20 -fskip-odr-check-in-gmf -fprebuilt-module-path=%t  \
-// RUN:    %t/C.cpp -verify -fsyntax-only
+// RUN:    %t/C.cpp -verify -fsyntax-only -fmodule-related-to-pch
 
 //--- foo.h
 #ifndef FOO_H


### PR DESCRIPTION
Add -fmodule-related-to-pch to fix test failing on our branch.