### PR TITLE
[clang][tests] Fix CAS tests after upstream #108539

### DIFF
--- a/clang/test/ClangScanDeps/cas-trees.c
+++ b/clang/test/ClangScanDeps/cas-trees.c
@@ -83,13 +83,13 @@
 // COMBINED:      remark: compile job cache miss for '[[T1_CACHE_KEY]]'
 // COMBINED-NEXT: remark: compile job cache miss for '[[T2_CACHE_KEY]]'
 
-// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -emit-cas-compdb | FileCheck %s -DPREFIX=%/t -check-prefix=COMPDB
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -emit-cas-compdb | FileCheck %s -DPREFIX=%/t -DCLANG=%clang -check-prefix=COMPDB
 // COMPDB: [
 // COMPDB:   {
 // COMPDB:     "file": "[[PREFIX]]/t1.c",
 // COMPDB:     "directory": "[[PREFIX]]",
 // COMPDB:     "arguments": [
-// COMPDB:       "clang",
+// COMPDB:       "[[CLANG]]",
 // COMPDB:       "-cc1",
 // COMPDB:       "-fcas-path",
 // COMPDB:       "[[PREFIX]]/cas",

--- a/clang/test/ClangScanDeps/include-tree-with-pch.c
+++ b/clang/test/ClangScanDeps/include-tree-with-pch.c
@@ -27,7 +27,7 @@
 // RUN: echo "FULL DEPS START" >> %t/full.txt
 // RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
 
-// RUN: FileCheck %s -DPREFIX=%/t -check-prefix=FULL -input-file %t/full.txt
+// RUN: FileCheck %s -DPREFIX=%/t -DCLANG=%clang -check-prefix=FULL -input-file %t/full.txt
 
 // Capture the tree id from experimental-include-tree ; ensure that it matches
 // the result from experimental-full.
@@ -57,7 +57,7 @@
 // FULL-NEXT:             "t.c"
 // FULL-NOT:              "t.c"
 // FULL:                ]
-// FULL:                "executable": "clang"
+// FULL:                "executable": "[[CLANG]]"
 // FULL:                "file-deps": [
 // FULL-NEXT:             "[[PREFIX]]/t.c"
 // FULL-NEXT:             "[[PREFIX]]/t.h"

--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -36,7 +36,7 @@
 // RUN: echo "FULL DEPS START" >> %t/full.txt
 // RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
 
-// RUN: FileCheck %s -DPREFIX=%/t -check-prefix=FULL -input-file %t/full.txt
+// RUN: FileCheck %s -DPREFIX=%/t -DCLANG=%clang -check-prefix=FULL -input-file %t/full.txt
 
 // Capture the tree id from experimental-include-tree ; ensure that it matches
 // the result from experimental-full.
@@ -67,7 +67,7 @@
 // FULL-NEXT:             "t.c"
 // FULL-NOT:              "t.c"
 // FULL:                ]
-// FULL:                "executable": "clang"
+// FULL:                "executable": "[[CLANG]]"
 // FULL:                "file-deps": [
 // FULL-NEXT:             "[[PREFIX]]/t.c"
 // FULL-NEXT:             "[[PREFIX]]/top.h"


### PR DESCRIPTION
Fix clang path output in clang-scan-deps output after upstream change makes the tool to return full path to clang.

(cherry picked from commit 4b9ce22c8bab20e6ddfc3d0a8b048974c2732311)