### PR TITLE
[lldb][debugserver] Check if Rosetta debugserver exists (#110943)

### DIFF
--- a/lldb/tools/debugserver/source/DNB.cpp
+++ b/lldb/tools/debugserver/source/DNB.cpp
@@ -475,9 +475,17 @@ nub_process_t DNBProcessAttach(nub_process_t attach_pid,
         extern int communication_fd;
 
         if (communication_fd == -1) {
-          fprintf(stderr, "Trying to attach to a translated process with the "
-                          "native debugserver, exiting...\n");
-          exit(1);
+          DNBLogError("Trying to attach to a translated process with the "
+                      "native debugserver, exiting...\n");
+          return INVALID_NUB_PROCESS_ARCH;
+        }
+
+        struct stat st;
+        if (::stat(translated_debugserver, &st) != 0) {
+          DNBLogError("Translated inferior process but Rosetta debugserver not "
+                      "found at %s",
+                      translated_debugserver);
+          return INVALID_NUB_PROCESS_ARCH;
         }
 
         snprintf(fdstr, sizeof(fdstr), "--fd=%d", communication_fd);


### PR DESCRIPTION
If lldb tries to attach to a process that is marked 'Translated' with debugserver, it will exec the Rosetta debugserver to handle the debug session without checking if it is present. If there is a configuration that is somehow missing this, it will fail poorly.

rdar://135641680
(cherry picked from commit c20b90ab8557b38efe8e8e993d41d8c08b798267)