### PR TITLE
[lldb] Introduce precise Fallback SwiftASTContexts. 

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -203,8 +203,11 @@ SwiftUnsafeRawBufferPointer::SwiftUnsafeRawBufferPointer(ValueObject &valobj)
 }
 
 lldb::ChildCacheState SwiftUnsafeRawBufferPointer::Update() {
-  if (!m_valobj.GetNumChildren())
+  auto num_or_error = m_valobj.GetNumChildren();
+  if (!num_or_error) {
+    llvm::consumeError(num_or_error.takeError());
     return ChildCacheState::eRefetch;
+  }
 
   // Here is the layout of Swift's UnsafeRaw[Mutable]BufferPointer.
   // It's a view of the raw bytes of the pointee object. Each byte is viewed as

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -207,7 +207,7 @@ public:
   /// context.
   static lldb::TypeSystemSP
   CreateInstance(const SymbolContext &sc,
-                 TypeSystemSwiftTypeRefForExpressions &typeref_typesystem,
+                 TypeSystemSwiftTypeRef &typeref_typesystem,
                  const char *extra_options = nullptr);
 
   static void EnumerateSupportedLanguages(

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1839,8 +1839,7 @@ TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext &sc) const {
 
   // Create a new SwiftASTContextForExpressions.
   TypeSystemSP ts = SwiftASTContext::CreateInstance(
-      LanguageType::eLanguageTypeSwift, *m_module,
-      *const_cast<TypeSystemSwiftTypeRef *>(this));
+      sc, *const_cast<TypeSystemSwiftTypeRef *>(this));
   m_swift_ast_context_map.insert({key, ts});
 
   auto *swift_ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(ts.get());

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -49,7 +49,7 @@ class TestSwiftDedupMacros(TestBase):
 #       CHECK: SwiftASTContextForExpressions{{.*}}-DSPACE
 #       CHECK-NOT: {{ SPACE}}
 #       CHECK: SwiftASTContextForExpressions{{.*}}-UNDEBUG
-#       CHECK: SwiftASTContextForModule("libDylib{{.*}}-DDEBUG=1
-#       CHECK: SwiftASTContextForModule("libDylib{{.*}}-DSPACE
+#       CHECK: SwiftASTContext(module: "Dylib{{.*}}-DDEBUG=1
+#       CHECK: SwiftASTContext(module: "Dylib{{.*}}-DSPACE
 #       CHECK-NOT: {{ SPACE}}
-#       CHECK: SwiftASTContextForModule("libDylib{{.*}}-UNDEBUG
+#       CHECK: SwiftASTContext(module: "Dylib{{.*}}-UNDEBUG

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -91,5 +91,5 @@ class TestSwiftDeploymentTarget(TestBase):
         self.filecheck(
             f'platform shell cat "{log}"', __file__, "-check-prefix=CHECK-PRECISE"
         )
-#       CHECK-PRECISE: SwiftASTContextForExpressions(module: "NewerTarget", cu: "NewerTarget.swift")::CreateInstance() -- Fully specified target triple {{.*}}-apple-macosx11.1.0
+#       CHECK-PRECISE: SwiftASTContextForExpressions(module: "NewerTarget", cu: "NewerTarget.swift")::CreateInstance() -- Fully specified triple {{.*}}-apple-macosx11.1.0
 #       CHECK-PRECISE: SwiftASTContextForExpressions(module: "NewerTarget", cu: "NewerTarget.swift")::SetTriple("{{.*}}-apple-macosx11.1.0")

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -26,5 +26,6 @@ class TestSwiftTripleDetection(TestBase):
         process = target.LaunchSimple(None, None, self.get_process_working_directory())
         self.expect("expression 1")
         self.filecheck('platform shell cat "%s"' % types_log, __file__)
-        # CHECK: {{SwiftASTContextForExpressions.*Preferring module triple .*-apple-macos.[0-9.]+ over target triple .*-apple-macos-unknown.}}
+        # CHECK: {{SwiftASTContextForExpressions.*Module triple: ".*-apple-macos.[0-9.]+"}}
+        # CHECK: {{SwiftASTContextForExpressions.*Target triple: ".*-apple-macos-unknown"}}
         # CHECK: {{SwiftASTContextForExpressions.*setting to ".*-apple-macos.[0-9.]+"}}


### PR DESCRIPTION
When we switched to precise compiler invocations, we still kept the per-module fallback SwiftASTContext. This can be a problem when also using explicit modules, because explicit module imports only work with precise compiler invocations. This patch changes
TypeSystemSwiftTyperef to pass its SymbolContext when creating its fallback SwiftASTContext. This basically turns on precise compiler invocationsfor fallback contexts. The price is more compiler instances, but this is only way to make them work reliably with explicit modules.

rdar://137087616