### PR TITLE
[lldb][NFC] Rename functions from Protocol to Existential

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -251,14 +251,14 @@ protected:
   ConstString GetDynamicTypeName_ClassRemoteAST(ValueObject &in_value,
                                                 lldb::addr_t instance_ptr);
 #endif
-  bool GetDynamicTypeAndAddress_Protocol(ValueObject &in_value,
+  bool GetDynamicTypeAndAddress_Existential(ValueObject &in_value,
                                          CompilerType protocol_type,
                                          lldb::DynamicValueType use_dynamic,
                                          TypeAndOrName &class_type_or_name,
                                          Address &address);
 #ifndef NDEBUG
   std::optional<std::pair<CompilerType, Address>>
-  GetDynamicTypeAndAddress_ProtocolRemoteAST(ValueObject &in_value,
+  GetDynamicTypeAndAddress_ExistentialRemoteAST(ValueObject &in_value,
                                              CompilerType protocol_type,
                                              bool use_local_buffer,
                                              lldb::addr_t existential_address);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -220,8 +220,8 @@ ConstString SwiftLanguageRuntimeImpl::GetDynamicTypeName_ClassRemoteAST(
 }
 
 std::optional<std::pair<CompilerType, Address>>
-SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ProtocolRemoteAST(
-    ValueObject &in_value, CompilerType protocol_type, bool use_local_buffer,
+SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ExistentialRemoteAST(
+    ValueObject &in_value, CompilerType existential_type, bool use_local_buffer,
     lldb::addr_t existential_address) {
   // Dynamic type resolution in RemoteAST might pull in other Swift
   // modules, so use the scratch context where such operations are
@@ -245,7 +245,7 @@ SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ProtocolRemoteAST(
   swift::remote::RemoteAddress remote_existential(existential_address);
   auto &remote_ast = GetRemoteASTContext(*swift_ast_ctx);
   auto swift_type =
-      llvm::expectedToStdOptional(swift_ast_ctx->GetSwiftType(protocol_type))
+      llvm::expectedToStdOptional(swift_ast_ctx->GetSwiftType(existential_type))
           .value_or(swift::Type());
   if (!swift_type)
     return {};


### PR DESCRIPTION
SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_Protocol and the RemoteAST counterpart actually find the dynamic type of existentials, not "protocol" types. Rename these two functions and references inside them from protocol to existential to more accurately express what they do.