### PR TITLE
[lldb][swift] Use assembly unwinders to recover async registers

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2677,9 +2677,14 @@ static llvm::Expected<addr_t> ReadAsyncContextRegisterFromUnwind(
   uint32_t async_reg_unwind_regdomain;
   if (!regctx.ConvertBetweenRegisterKinds(
           regnums.GetRegisterKind(), regnums.async_ctx_regnum, unwind_regkind,
-          async_reg_unwind_regdomain))
-    return llvm::createStringError(
-        "SwiftLanguageRuntime: Failed to convert register domains");
+          async_reg_unwind_regdomain)) {
+    // This should never happen.
+    // If asserts are disabled, return an error to avoid creating an invalid
+    // unwind plan.
+    auto error_msg = "SwiftLanguageRuntime: Failed to convert register domains";
+    llvm_unreachable(error_msg);
+    return llvm::createStringError(error_msg);
+  }
 
   // If the plan doesn't have information about the async register, we can use
   // its current value, as this is a callee saved register.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -496,7 +496,7 @@ private:
   /// address of the first non-prologue instruction.
   std::optional<lldb::addr_t>
   TrySkipVirtualParentProlog(lldb::addr_t async_reg_val, Process &process,
-                             unsigned num_indirections);
+                             unsigned num_indirections = 0);
 };
 
 } // namespace lldb_private

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(lldbtest.TestBase):
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
-    @skipIf(bugnumber="rdar://136083188")
     def test(self):
         """Test conditions for async step-in."""
         self.build()
@@ -28,7 +27,7 @@ class TestCase(lldbtest.TestBase):
         # Using the line table, build a set of the non-zero line numbers for
         # this this function - and verify that there is exactly one line.
         lines = {inst.addr.line_entry.line for inst in instructions}
-        lines.remove(0)
+        lines.discard(0)
         self.assertEqual(lines, {3})
 
         # Required for builds that have debug info.

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -25,6 +25,7 @@ import lldbsuite.test.lldbutil as lldbutil
 # path as the previous one. However, it is the first time an unwind plan
 # created from that path is used to create another unwind plan.
 
+
 class TestCase(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
@@ -116,9 +117,10 @@ class TestCase(lldbtest.TestBase):
         # Reach most breakpoints and ensure we can unwind in that position.
         while True:
             process.Continue()
-            thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
-            if thread is None:
+            if process.GetState() == lldb.eStateExited:
                 break
+            thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
+            self.assertTrue(thread.IsValid())
             bpid = thread.GetStopReasonDataAtIndex(0)
             breakpoints.remove(bpid)
             target.FindBreakpointByID(bpid).SetEnabled(False)

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -20,11 +20,10 @@ import lldbsuite.test.lldbutil as lldbutil
 # frame from another virtual frame.
 # * The plan for ASYNC___3___ -> ASYNC___4___ is created through
 # GetFollowAsyncContextUnwindPlan, but this time it follow the code path where
-# `is_indirect = True` (see its implementation).
+# `is_indirect = true` (see its implementation).
 # * The plan for ASYNC___4___ -> ASYNC___5___ is created through the same code
-# path as the previous one. It is not technically needed, but we keep it here
-# because it is the first time where we should be creating an identical plan as
-# the one from the previous frame.
+# path as the previous one. However, it is the first time an unwind plan
+# created from that path is used to create another unwind plan.
 
 class TestCase(lldbtest.TestBase):
 

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -1,0 +1,134 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+# This test creates 5 async frames:
+# * ASYNC___1___, which is called by
+# * ASYNC___2___, which is called by
+# * ...
+# * ASYNC___5___, which is called by
+#
+# The number of frames is important to exercise all possible unwind plans:
+# * The top frame (ASYNC___1___) is created by just inspecting the registers as
+# they are.
+# * The plan for ASYNC___1___ -> ASYNC___2___ is created through
+# `GetRuntimeUnwindPlan`, which is responsible for the transition from a real
+# frame to a virtual frame.
+# * The plan for ASYNC___2___ -> ASYNC___3___ is created through
+# GetFollowAsyncContextUnwindPlan, which is responsible to create a virtual
+# frame from another virtual frame.
+# * The plan for ASYNC___3___ -> ASYNC___4___ is created through
+# GetFollowAsyncContextUnwindPlan, but this time it follow the code path where
+# `is_indirect = True` (see its implementation).
+# * The plan for ASYNC___4___ -> ASYNC___5___ is created through the same code
+# path as the previous one. It is not technically needed, but we keep it here
+# because it is the first time where we should be creating an identical plan as
+# the one from the previous frame.
+
+class TestCase(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    def set_breakpoints_all_funclets(self, target):
+        funclet_names = [
+            "$s1a12ASYNC___1___4condS2i_tYaF",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY0_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTQ1_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY2_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTQ3_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY4_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTQ5_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY6_",
+        ]
+
+        breakpoints = set()
+        for funclet_name in funclet_names:
+            sym_ctx_list = target.FindFunctions(funclet_name)
+            self.assertEqual(
+                sym_ctx_list.GetSize(),
+                1,
+                f"failed to get symbol context for {funclet_name}",
+            )
+            function = sym_ctx_list[0].function
+
+            instructions = list(function.GetInstructions(target))
+            self.assertGreater(len(instructions), 0)
+            for instruction in instructions:
+                bp = target.BreakpointCreateBySBAddress(instruction.GetAddress())
+                self.assertTrue(
+                    bp.IsValid(), f"failed to set bp inside funclet {funclet_name}"
+                )
+                breakpoints.add(bp.GetID())
+        return breakpoints
+
+    # FIXME: there are challenges when unwinding Q funclets ("await resume"),
+    # see rdar://137048317. For now, we only know how to unwind during and
+    # shortly after the prologue. This function returns "should skip" if we're
+    # at a PC that is too far from the prologue (~16 bytes). This is a
+    # rough approximation that seems to work for both x86 and arm.
+    def should_skip_Q_funclet(self, thread):
+        current_frame = thread.frames[0]
+        function = current_frame.GetFunction()
+        if "await resume" not in function.GetName():
+            return False
+
+        max_prologue_offset = 16
+        prologue_end = function.GetStartAddress()
+        prologue_end.OffsetAddress(function.GetPrologueByteSize() + max_prologue_offset)
+        current_pc = current_frame.GetPCAddress()
+        return current_pc.GetFileAddress() >= prologue_end.GetFileAddress()
+
+    def check_unwind_ok(self, thread, bpid):
+        if self.should_skip_Q_funclet(thread):
+            return
+        # Check that we see the virtual backtrace:
+        expected_funcnames = [
+            "ASYNC___1___",
+            "ASYNC___2___",
+            "ASYNC___3___",
+            "ASYNC___4___",
+            "ASYNC___5___",
+        ]
+        frames = thread.frames
+        self.assertGreater(
+            len(frames), len(expected_funcnames), f"Invalid backtrace for {frames}"
+        )
+        actual_funcnames = [
+            frame.GetFunctionName() for frame in frames[: len(expected_funcnames)]
+        ]
+        for expected_name, actual_name in zip(expected_funcnames, actual_funcnames):
+            self.assertIn(expected_name, actual_name, f"Unexpected backtrace: {frames}")
+
+    @swiftTest
+    @skipIf(oslist=["windows", "linux"])
+    def test(self):
+        """Test that the debugger can unwind at all instructions of all funclets"""
+        self.build()
+
+        source_file = lldb.SBFileSpec("main.swift")
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "BREAK HERE", source_file
+        )
+
+        breakpoints = self.set_breakpoints_all_funclets(target)
+        num_breakpoints = len(breakpoints)
+
+        # Reach most breakpoints and ensure we can unwind in that position.
+        while True:
+            process.Continue()
+            thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
+            if thread is None:
+                break
+            bpid = thread.GetStopReasonDataAtIndex(0)
+            breakpoints.remove(bpid)
+            target.FindBreakpointByID(bpid).SetEnabled(False)
+
+            self.check_unwind_ok(thread, bpid)
+
+        # We will never hit all breakpoints we set, because of things like
+        # overflow handling or other unreachable traps. However, it's good to
+        # have some sanity check that we have hit at least a decent chunk of
+        # them.
+        breakpoints_not_hit = len(breakpoints)
+        self.assertGreater(0.10, breakpoints_not_hit / num_breakpoints)

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -131,4 +131,4 @@ class TestCase(lldbtest.TestBase):
         # have some sanity check that we have hit at least a decent chunk of
         # them.
         breakpoints_not_hit = len(breakpoints)
-        self.assertGreater(0.10, breakpoints_not_hit / num_breakpoints)
+        self.assertLess(breakpoints_not_hit / num_breakpoints, 0.10)

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/main.swift
@@ -1,0 +1,49 @@
+func async_work() async {
+  print("async working")
+}
+func work() {
+  print("working")
+}
+
+func ASYNC___1___(cond: Int) async -> Int {
+  work()
+  await async_work()
+  for i in 1...3 {
+    work()
+    await async_work()
+    work()
+    if (cond + i == 3) {
+      await async_work()
+      print("breaking here!")
+      break;
+    }
+  }
+  return 0
+}
+
+func ASYNC___2___() async -> Int {
+  let result = await ASYNC___1___(cond: 1)
+  return result
+}
+
+func ASYNC___3___() async -> Int {
+  let result = await ASYNC___2___()
+  return result
+}
+
+func ASYNC___4___() async -> Int {
+  let result = await ASYNC___3___()
+  return result
+}
+
+func ASYNC___5___() async -> Int {
+  let result = await ASYNC___4___()
+  return result
+}
+
+@main struct Main {
+  static func main() async {
+    let result = await ASYNC___5___() // BREAK HERE
+    print(result)
+  }
+}

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/main.swift
@@ -14,7 +14,7 @@ func ASYNC___1___(cond: Int) async -> Int {
     work()
     if (cond + i == 3) {
       await async_work()
-      print("breaking here!")
+      print("exiting loop here!")
       break;
     }
   }


### PR DESCRIPTION
The SwiftLanguageRuntime unwind plan for async functions relies on the extended frame setup to recover the asynchronous contexts of these functions. This extended frame consists of:

1. Tagging the saved fp register by setting its 60 bit, indicating the existence of the extended frame.
2. An additional stack slot where the asynchronous context is saved.

The current unwind plans recover the asynchronous context by reading the stack slot described in (2). This creates a number of challenges:

* The extended frame is not always created (e.g. leaf funclets).
* The extended frame is not necessarily valid inside the prologue or epilogue.
* The code to handle all possible combinations of funclet x {is_prologue, is_epilogue} is very complex.
* Entry funclets don't have the extended frame.

This patch uses a new approach, exploiting the property that the asynchronous context is passed in a callee-saved register. We use existing unwind plans that inspect assembly and track spill slots, and recover the asynchronous register from those.

Unwind Plans are not setup to query other Unwind Plans, more specifically they are not setup to materialize the abstract location provided by an Unwind Plan into a concrete value. Doing so would require a lot of plumbing. Instead, this patch reimplements a very targeted conversion between the abstract locations and concrete register values. We argue this is worth it, as the new unwind procedure is much simpler, relies on existing plans, and works in many cases where the previous implementation doesn't.

Testing-wise, this commit creates a fairly complex async function, with multiple split points, and sets breakpoints on all instructions of all funclets. It then asserts that unwinding works correctly in all of them. This has revealed an issue with Q funclets, which clobber the async context location prior to freeing the context of the funclet that has just finished executing (see the FIXME in the test). This is not a problem with the new approach, but rather it was discovered because of the extensive testing done here.