### PR TITLE
Fix an MSVC build issue.

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -598,27 +598,29 @@ else()
   set(COMPILER_RT_LINK_OR_COPY copy)
 endif()
 
-foreach(pat cas swp ldadd ldclr ldeor ldset)
-  foreach(size 1 2 4 8 16)
-    foreach(model 1 2 3 4 5)
-      if(pat STREQUAL "cas" OR NOT size STREQUAL "16")
-        set(source_asm "${CMAKE_CURRENT_SOURCE_DIR}/aarch64/lse.S")
-        set(helper_asm "${OA_HELPERS_DIR}/outline_atomic_${pat}${size}_${model}.S")
-        add_custom_command(
-          OUTPUT "${helper_asm}"
-          COMMAND ${CMAKE_COMMAND} -E ${COMPILER_RT_LINK_OR_COPY} "${source_asm}" "${helper_asm}"
-          DEPENDS "${source_asm}"
-        )
-        set_source_files_properties("${helper_asm}"
-          PROPERTIES
-          COMPILE_DEFINITIONS "L_${pat};SIZE=${size};MODEL=${model}"
-          INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
-        )
-        list(APPEND aarch64_SOURCES "${helper_asm}")
-      endif()
-    endforeach(model)
-  endforeach(size)
-endforeach(pat)
+if(COMPILER_RT_HAS_ASM_LSE)
+  foreach(pat cas swp ldadd ldclr ldeor ldset)
+    foreach(size 1 2 4 8 16)
+      foreach(model 1 2 3 4 5)
+        if(pat STREQUAL "cas" OR NOT size STREQUAL "16")
+          set(source_asm "${CMAKE_CURRENT_SOURCE_DIR}/aarch64/lse.S")
+          set(helper_asm "${OA_HELPERS_DIR}/outline_atomic_${pat}${size}_${model}.S")
+          add_custom_command(
+            OUTPUT "${helper_asm}"
+            COMMAND ${CMAKE_COMMAND} -E ${COMPILER_RT_LINK_OR_COPY} "${source_asm}" "${helper_asm}"
+            DEPENDS "${source_asm}"
+          )
+          set_source_files_properties("${helper_asm}"
+            PROPERTIES
+            COMPILE_DEFINITIONS "L_${pat};SIZE=${size};MODEL=${model}"
+            INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+          )
+          list(APPEND aarch64_SOURCES "${helper_asm}")
+        endif()
+      endforeach(model)
+    endforeach(size)
+  endforeach(pat)
+endif()
 
 if (MINGW)
   set(aarch64_SOURCES


### PR DESCRIPTION
Disable the LSE files if COMPILER_RT_HAS_ASM_LSE failed as MSVC cannot seem to handle .S input files.

```
[258/401] Building ASM object CMakeFiles\clang_rt.builtins-aarch64.dir\outline_atomic_helpers.dir\outline_atomic_cas1_3.S.obj
Microsoft (R) C/C++ Optimizing Compiler Version 19.38.33135 for ARM64
Copyright (C) Microsoft Corporation.  All rights reserved.

cl : Command line warning D9035 : option 'o' has been deprecated and will be removed in a future release
cl : Command line warning D9024 : unrecognized source file type 'S:\b\5\runtimes\builtins-aarch64-unknown-windows-msvc-bins\outline_atomic_helpers.dir\outline_atomic_cas1_3.S', object file assumed
cl : Command line warning D9027 : source file 'S:\b\5\runtimes\builtins-aarch64-unknown-windows-msvc-bins\outline_atomic_helpers.dir\outline_atomic_cas1_3.S' ignored
cl : Command line warning D9021 : no action performed
```