### PR TITLE
[lldb] Add SBTypeStaticField to SBDefines (#111560)

### DIFF
--- a/lldb/include/lldb/API/SBDefines.h
+++ b/lldb/include/lldb/API/SBDefines.h
@@ -124,6 +124,7 @@ class LLDB_API SBTypeFormat;
 class LLDB_API SBTypeMember;
 class LLDB_API SBTypeMemberFunction;
 class LLDB_API SBTypeNameSpecifier;
+class LLDB_API SBTypeStaticField;
 class LLDB_API SBTypeSummary;
 class LLDB_API SBTypeSummaryOptions;
 class LLDB_API SBTypeSynthetic;


### PR DESCRIPTION
SBTypeStaticField was missing from SBDefines, this commit adds the class there.

(cherry picked from commit ababa483b2ff31357f8c504b1110e255a56ff762)