### PR TITLE
[clang][IncludeTree] Do not preserve working directory from scanning

### DIFF
--- a/clang/test/ClangScanDeps/include-tree-working-directory.c
+++ b/clang/test/ClangScanDeps/include-tree-working-directory.c
@@ -11,6 +11,8 @@
 // RUN: %clang @%t/tu.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
 // RUN: %clang @%t/tu.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
 // RUN: ls %t/t.o
+// RUN: ls %t/t.d
+// RUN: ls %t/t.dia
 
 // CACHE-MISS: remark: compile job cache miss
 // CACHE-HIT: remark: compile job cache hit
@@ -25,10 +27,26 @@
 // CHECK: [[PREFIX]]/t.c llvmcas://
 // CHECK: [[PREFIX]]/relative/h1.h llvmcas://
 
+/// Using a different working directory should cache hit as well.
+/// FIXME: Working directory affects some codegen options added by clang driver, preserve them to make sure the cache hit.
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb2.json.template > %t/cdb2.json
+// RUN: clang-scan-deps -compilation-database %t/cdb2.json -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   > %t/deps2.json
+// RUN: %deps-to-rsp %t/deps2.json --tu-index 0 > %t/tu2.rsp
+// RUN: %clang @%t/tu2.rsp -Rcompile-job-cache 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+
 //--- cdb.json.template
 [{
   "directory": "DIR/other",
-  "command": "clang -c t.c -I relative -working-directory DIR -o t.o",
+  "command": "clang -c t.c -I relative -working-directory DIR -o t.o -MD -serialize-diagnostics t.dia",
+  "file": "DIR/t.c"
+}]
+
+//--- cdb2.json.template
+[{
+  "directory": "DIR/other",
+  "command": "clang -c DIR/t.c -I DIR/relative -working-directory DIR/other -o DIR/t2.o -MD -serialize-diagnostics DIR/t2.dia -fdebug-compilation-dir=DIR -fcoverage-compilation-dir=DIR",
   "file": "DIR/t.c"
 }]
 


### PR DESCRIPTION
clang incldue-tree has been consistently using absolute path to encode all the inputs so there is no need to preserve `-working-directory` option from the scanner.

This does affect output paths so make sure the output paths are updated as well to absolute path.

(cherry picked from commit bb91b1ce3bb2a662890efb67395125b0f1aac21c)