### PR TITLE
[lldb] Adjust module name for types with @_originallyDefinedIn

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -358,6 +358,12 @@ protected:
   CompilerType m_box_metadata_type;
 
 private:
+  /// Types with the @_originallyDefinedIn attribute are serialized with with
+  /// the original module name in reflection metadata. At the same time the type
+  /// is serialized with the swiftmodule name in debug info, but with a parent
+  /// module with the original module name. This function adjusts \type to look
+  /// up the type in reflection metadata if necessary.
+  CompilerType AdjustTypeForOriginallyDefinedInModule(CompilerType type);
   /// Don't call these directly.
   /// \{
   /// There is a global variable \p _swift_classIsSwiftMask that is

--- a/lldb/test/API/lang/swift/originally_defined_in/Makefile
+++ b/lldb/test/API/lang/swift/originally_defined_in/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
+++ b/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
+
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        filespec = lldb.SBFileSpec("main.swift")
+        target, process, thread, breakpoint1 = lldbutil.run_to_source_breakpoint(
+            self, "break here", filespec
+        )
+        self.expect("frame variable a", substrs=["a.A", "a = (i = 10)"])
+        self.expect("frame variable b", substrs=["a.Alias", "b = (i = 20)"])
+        self.expect("frame variable d", substrs=["a.C.D", "d = (i = 30)"])
+        self.expect("frame variable e", substrs=["a.E<a.Prop>", "e = (i = 40)"])

--- a/lldb/test/API/lang/swift/originally_defined_in/main.swift
+++ b/lldb/test/API/lang/swift/originally_defined_in/main.swift
@@ -1,0 +1,47 @@
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct A {
+    let i = 10
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct B {
+    let i = 20
+}
+
+typealias Alias = B
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public enum C {
+    public struct D {
+        let i = 30
+    }
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public enum E<T> {
+    case t(T)
+}
+
+public struct Prop {
+    let i = 40
+}
+
+func f() {
+    let a = A()
+    let b = Alias()
+    let d = C.D()
+    let e = E<Prop>.t(Prop())
+    print("break here")
+}
+
+f()
+
+


### PR DESCRIPTION
The compiler generates types with @_originallyDefinedIn as a child of the original module, but with the ABI module in the mangled name. Before looking up types in reflection metadata, adjust the type's mangled name to use the original module name, since that's what's stored in reflection metadata.

rdar://137146961