### PR TITLE
[lldb] Introduce Swift Task synthetic provider

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -12,6 +12,7 @@
 
 #include "SwiftFormatters.h"
 #include "Plugins/Language/Swift/SwiftStringIndex.h"
+#include "Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "lldb/Core/ValueObject.h"
@@ -20,11 +21,14 @@
 #include "lldb/Target/Process.h"
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/DataBufferHeap.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/Timer.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/Types.h"
 #include "swift/Demangling/ManglingMacros.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include <optional>
 
@@ -721,6 +725,7 @@ bool lldb_private::formatters::swift::BuiltinObjC_SummaryProvider(
 namespace lldb_private {
 namespace formatters {
 namespace swift {
+
 class EnumSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
 public:
   EnumSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp);
@@ -735,6 +740,104 @@ private:
   ExecutionContextRef m_exe_ctx_ref;
   ConstString m_element_name;
   size_t m_child_index;
+};
+
+class TaskSyntheticFrontEnd : public SyntheticChildrenFrontEnd {
+public:
+  TaskSyntheticFrontEnd(lldb::ValueObjectSP valobj_sp)
+      : SyntheticChildrenFrontEnd(*valobj_sp.get()) {}
+
+  constexpr static StringLiteral TaskChildren[] = {
+      "isChildTask",    "isFuture",    "isGroupChildTask",
+      "isAsyncLetTask", "isCancelled", "isStatusRecordLocked",
+      "isEscalated",    "isEnqueued",  "isRunning",
+  };
+
+  llvm::Expected<uint32_t> CalculateNumChildren() override {
+    auto count = ArrayRef(TaskChildren).size();
+    return m_task_info.hasIsRunning ? count : count - 1;
+  }
+
+  lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override {
+    auto target_sp = m_backend.GetTargetSP();
+#define RETURN_CHILD(FIELD, NAME)                                              \
+  if (!FIELD)                                                                  \
+    FIELD = ValueObject::CreateValueObjectFromBool(target_sp,                  \
+                                                   m_task_info.NAME, #NAME);   \
+  return FIELD
+
+    switch (idx) {
+    case 0:
+      RETURN_CHILD(m_is_child_task_sp, isChildTask);
+    case 1:
+      RETURN_CHILD(m_is_future_sp, isFuture);
+    case 2:
+      RETURN_CHILD(m_is_group_child_task_sp, isGroupChildTask);
+    case 3:
+      RETURN_CHILD(m_is_async_let_task_sp, isAsyncLetTask);
+    case 4:
+      RETURN_CHILD(m_is_cancelled_sp, isCancelled);
+    case 5:
+      RETURN_CHILD(m_is_status_record_locked_sp, isStatusRecordLocked);
+    case 6:
+      RETURN_CHILD(m_is_escalated_sp, isEscalated);
+    case 7:
+      RETURN_CHILD(m_is_enqueued_sp, isEnqueued);
+    case 8:
+      RETURN_CHILD(m_is_running_sp, isRunning);
+    default:
+      return {};
+    }
+
+#undef RETURN_CHILD
+  }
+
+  lldb::ChildCacheState Update() override {
+    if (auto *runtime = SwiftLanguageRuntime::Get(m_backend.GetProcessSP())) {
+      auto reflection_ctx = runtime->GetReflectionContext();
+      auto task_obj_sp = m_backend.GetChildMemberWithName("_task");
+      auto task_ptr = task_obj_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+      if (task_ptr != LLDB_INVALID_ADDRESS) {
+        auto [error, task_info] = reflection_ctx->asyncTaskInfo(task_ptr);
+        if (error) {
+          LLDB_LOG(GetLog(LLDBLog::Types),
+                   "could not get info for async task {0:x}: {1}", task_ptr,
+                   *error);
+        } else {
+          m_task_info = task_info;
+          for (auto child :
+               {m_is_child_task_sp, m_is_future_sp, m_is_group_child_task_sp,
+                m_is_async_let_task_sp, m_is_cancelled_sp,
+                m_is_status_record_locked_sp, m_is_escalated_sp,
+                m_is_enqueued_sp, m_is_running_sp})
+            child.reset();
+        }
+      }
+    }
+    return ChildCacheState::eRefetch;
+  }
+
+  bool MightHaveChildren() override { return true; }
+
+  size_t GetIndexOfChildWithName(ConstString name) override {
+    ArrayRef children = TaskChildren;
+    auto it = llvm::find(children, name);
+    if (it == children.end())
+      return UINT32_MAX;
+    return std::distance(children.begin(), it);
+  }
+
+private:
+  ReflectionContextInterface::AsyncTaskInfo m_task_info;
+  ValueObjectSP m_is_child_task_sp;
+  ValueObjectSP m_is_future_sp;
+  ValueObjectSP m_is_group_child_task_sp;
+  ValueObjectSP m_is_async_let_task_sp;
+  ValueObjectSP m_is_cancelled_sp;
+  ValueObjectSP m_is_status_record_locked_sp;
+  ValueObjectSP m_is_escalated_sp;
+  ValueObjectSP m_is_enqueued_sp;
+  ValueObjectSP m_is_running_sp;
 };
 }
 }
@@ -792,6 +895,14 @@ lldb_private::formatters::swift::EnumSyntheticFrontEndCreator(
   if (!valobj_sp)
     return NULL;
   return (new EnumSyntheticFrontEnd(valobj_sp));
+}
+
+SyntheticChildrenFrontEnd *
+lldb_private::formatters::swift::TaskSyntheticFrontEndCreator(
+    CXXSyntheticChildren *, lldb::ValueObjectSP valobj_sp) {
+  if (!valobj_sp)
+    return NULL;
+  return new TaskSyntheticFrontEnd(valobj_sp);
 }
 
 bool lldb_private::formatters::swift::ObjC_Selector_SummaryProvider(

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -116,6 +116,9 @@ bool TypePreservingNSNumber_SummaryProvider(ValueObject &valobj, Stream &stream,
 
 SyntheticChildrenFrontEnd *EnumSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
+
+SyntheticChildrenFrontEnd *TaskSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                                        lldb::ValueObjectSP);
 }
 }
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -412,6 +412,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                   lldb_private::formatters::swift::TaskSyntheticFrontEndCreator,
                   "Swift.Task synthetic children",
                   ConstString("^Swift\\.Task<.+,.+>"), synth_flags, true);
+  AddCXXSynthetic(swift_category_sp,
+                  lldb_private::formatters::swift::TaskSyntheticFrontEndCreator,
+                  "Swift.UnsafeCurrentTask synthetic children",
+                  ConstString("Swift.UnsafeCurrentTask"), synth_flags);
 
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Bool_SummaryProvider,

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -408,7 +408,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   SetConfig::Get().RegisterSyntheticChildrenCreators(swift_category_sp,
                                                      synth_flags);
 
-  synth_flags.SetSkipPointers(true);
+  AddCXXSynthetic(swift_category_sp,
+                  lldb_private::formatters::swift::TaskSyntheticFrontEndCreator,
+                  "Swift.Task synthetic children",
+                  ConstString("^Swift\\.Task<.+,.+>"), synth_flags, true);
 
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Bool_SummaryProvider,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/RemoteInspection/ReflectionContext.h"
 #include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntimeImpl.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -366,6 +367,28 @@ public:
   swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) override {
     return m_reflection_ctx.stripSignedPointer(pointer);
+  }
+
+  std::pair<std::optional<std::string>, AsyncTaskInfo>
+  asyncTaskInfo(lldb::addr_t AsyncTaskPtr, unsigned ChildTaskLimit,
+                unsigned AsyncBacktraceLimit) override {
+    auto [error, task_info] = m_reflection_ctx.asyncTaskInfo(
+        AsyncTaskPtr, ChildTaskLimit, AsyncBacktraceLimit);
+    if (error)
+      return {error, {}};
+
+    AsyncTaskInfo result;
+    result.isChildTask = task_info.IsChildTask;
+    result.isFuture = task_info.IsFuture;
+    result.isGroupChildTask = task_info.IsGroupChildTask;
+    result.isAsyncLetTask = task_info.IsAsyncLetTask;
+    result.isCancelled = task_info.IsCancelled;
+    result.isStatusRecordLocked = task_info.IsStatusRecordLocked;
+    result.isEscalated = task_info.IsEscalated;
+    result.hasIsRunning = task_info.HasIsRunning;
+    result.isRunning = task_info.IsRunning;
+    result.isEnqueued = task_info.IsEnqueued;
+    return {{}, result};
   }
 
 private:

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -369,13 +369,13 @@ public:
     return m_reflection_ctx.stripSignedPointer(pointer);
   }
 
-  std::pair<std::optional<std::string>, AsyncTaskInfo>
+  llvm::Expected<AsyncTaskInfo>
   asyncTaskInfo(lldb::addr_t AsyncTaskPtr, unsigned ChildTaskLimit,
                 unsigned AsyncBacktraceLimit) override {
     auto [error, task_info] = m_reflection_ctx.asyncTaskInfo(
         AsyncTaskPtr, ChildTaskLimit, AsyncBacktraceLimit);
     if (error)
-      return {error, {}};
+      return llvm::createStringError(*error);
 
     AsyncTaskInfo result;
     result.isChildTask = task_info.IsChildTask;
@@ -388,7 +388,7 @@ public:
     result.hasIsRunning = task_info.HasIsRunning;
     result.isRunning = task_info.IsRunning;
     result.isEnqueued = task_info.IsEnqueued;
-    return {{}, result};
+    return result;
   }
 
 private:

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -147,20 +147,20 @@ public:
   virtual swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
   struct AsyncTaskInfo {
-    bool isChildTask;
-    bool isFuture;
-    bool isGroupChildTask;
-    bool isAsyncLetTask;
-    bool isCancelled;
-    bool isStatusRecordLocked;
-    bool isEscalated;
-    // If false, the IsRunning flag is not valid.
-    bool hasIsRunning;
-    bool isRunning;
-    bool isEnqueued;
+    bool isChildTask = false;
+    bool isFuture = false;
+    bool isGroupChildTask = false;
+    bool isAsyncLetTask = false;
+    bool isCancelled = false;
+    bool isStatusRecordLocked = false;
+    bool isEscalated = false;
+    /// If false, the IsRunning flag is not valid.
+    bool hasIsRunning = false;
+    bool isRunning = false;
+    bool isEnqueued = false;
   };
   // The default limits are copied from swift-inspect.
-  virtual std::pair<std::optional<std::string>, AsyncTaskInfo>
+  virtual llvm::Expected<AsyncTaskInfo>
   asyncTaskInfo(lldb::addr_t AsyncTaskPtr, unsigned ChildTaskLimit = 1000000,
                 unsigned AsyncBacktraceLimit = 1000) = 0;
 };

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -18,6 +18,7 @@
 #include "lldb/lldb-types.h"
 #include "swift/ABI/ObjectFile.h"
 #include "swift/Remote/RemoteAddress.h"
+#include "swift/RemoteInspection/ReflectionContext.h"
 #include "swift/RemoteInspection/TypeRef.h"
 #include <optional>
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -145,6 +146,23 @@ public:
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
+  struct AsyncTaskInfo {
+    bool isChildTask;
+    bool isFuture;
+    bool isGroupChildTask;
+    bool isAsyncLetTask;
+    bool isCancelled;
+    bool isStatusRecordLocked;
+    bool isEscalated;
+    // If false, the IsRunning flag is not valid.
+    bool hasIsRunning;
+    bool isRunning;
+    bool isEnqueued;
+  };
+  // The default limits are copied from swift-inspect.
+  virtual std::pair<std::optional<std::string>, AsyncTaskInfo>
+  asyncTaskInfo(lldb::addr_t AsyncTaskPtr, unsigned ChildTaskLimit = 1000000,
+                unsigned AsyncBacktraceLimit = 1000) = 0;
 };
 
 using ThreadSafeReflectionContext = LockGuarded<ReflectionContextInterface>;

--- a/lldb/test/API/lang/swift/async/formatters/task/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/Makefile
@@ -1,2 +1,3 @@
 SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
 include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        """Test Task synthetic child provider."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        # Note: The value of isEnqueued is timing dependent. For that reason,
+        # the test checks only that it has a value, not what the value is.
+        self.expect(
+            "frame var task",
+            substrs=[
+                "(Task<(), Error>) task = {",
+                "isChildTask = false",
+                "isFuture = true",
+                "isGroupChildTask = false",
+                "isAsyncLetTask = false",
+                "isCancelled = false",
+                "isEnqueued = ",
+            ],
+        )

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -5,11 +5,12 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
-    def test(self):
-        """Test Task synthetic child provider."""
+
+    def test_top_level_task(self):
+        """Test Task synthetic child provider for top-level Task."""
         self.build()
         lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift")
+            self, "break for top-level task", lldb.SBFileSpec("main.swift")
         )
         # Note: The value of isEnqueued is timing dependent. For that reason,
         # the test checks only that it has a value, not what the value is.
@@ -23,5 +24,24 @@ class TestCase(TestBase):
                 "isAsyncLetTask = false",
                 "isCancelled = false",
                 "isEnqueued = ",
+            ],
+        )
+
+    def test_current_task(self):
+        """Test Task synthetic child for UnsafeCurrentTask (from an async let)."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break for current task", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame var currentTask",
+            substrs=[
+                "(UnsafeCurrentTask) currentTask = {",
+                "isChildTask = true",
+                "isFuture = true",
+                "isGroupChildTask = false",
+                "isAsyncLetTask = true",
+                "isCancelled = false",
+                "isEnqueued = false",
             ],
         )

--- a/lldb/test/API/lang/swift/async/formatters/task/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/main.swift
@@ -1,10 +1,22 @@
-func f() {
-    let task = Task {
-        // Extend the task's lifetime, hopefully long enough for the breakpoint to hit.
-        await try Task.sleep(for: .seconds(0.5))
-        print("inside")
+func f() async -> Int {
+    withUnsafeCurrentTask { currentTask in
+        if let currentTask {
+            print("break for current task")
+        }
     }
-    print("break here")
+    return 30
 }
 
-f()
+@main struct Main {
+    static func main() async {
+        let task = Task {
+            // Extend the task's lifetime, hopefully long enough for the breakpoint to hit.
+            try await Task.sleep(for: .seconds(0.5))
+            print("inside")
+        }
+        print("break for top-level task")
+
+        async let number = f()
+        print(await number)
+    }
+}

--- a/lldb/test/API/lang/swift/async/formatters/task/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/main.swift
@@ -1,0 +1,10 @@
+func f() {
+    let task = Task {
+        // Extend the task's lifetime, hopefully long enough for the breakpoint to hit.
+        await try Task.sleep(for: .seconds(0.5))
+        print("inside")
+    }
+    print("break here")
+}
+
+f()


### PR DESCRIPTION
Add a synthetic provider for Swift's `Task` and `UnsafeCurrentTask` types.

This uses `ReflectionContext::asyncTaskInfo`. In this initial version, only the bool flags are plugged through. Follow up changes will add more metadata (ex task ID, priority), child tasks, and backtraces.