### PR TITLE
[lldb] Remove functionality to rename module names before reconstruction

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -430,10 +430,6 @@ public:
   /// Import compiler_type into this context and return the swift::CanType.
   swift::CanType GetCanonicalSwiftType(CompilerType compiler_type);
 private:
-  /// Reconstruct a Swift AST type from a mangled name by looking its
-  /// components up in Swift modules.
-  llvm::Expected<swift::TypeBase *>
-  ReconstructTypeImpl(ConstString mangled_typename);
 
 protected:
   swift::Type GetSwiftType(lldb::opaque_compiler_type_t opaque_type);
@@ -905,10 +901,6 @@ protected:
 
   CompilerType GetAsClangType(ConstString mangled_name);
 
-  /// Inserts the mapping from the module's ABI name to it's regular name into
-  /// m_module_abi_to_regular_name if they're different.
-  void RegisterModuleABINameToRealName(swift::ModuleDecl *module);
-
   /// Data members.
   /// @{
   // Always non-null outside of unit tests.
@@ -972,9 +964,6 @@ protected:
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;
 
-  /// Holds the source module name (value) for all modules with a custom ABI
-  /// name (key).
-  llvm::StringMap<llvm::StringRef> m_module_abi_to_regular_name;
   /// Whether this is a scratch or a module AST context.
   bool m_is_scratch_context = false;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -147,31 +147,6 @@ TypeSystemSwiftTypeRef::CanonicalizeSugar(swift::Demangle::Demangler &dem,
   });
 }
 
-swift::Demangle::ManglingErrorOr<std::string>
-TypeSystemSwiftTypeRef::TransformModuleName(
-    llvm::StringRef mangled_name,
-    const llvm::StringMap<llvm::StringRef> &module_name_map) {
-  swift::Demangle::Demangler dem;
-  auto *node = dem.demangleSymbol(mangled_name);
-  auto *adjusted_node = TypeSystemSwiftTypeRef::Transform(
-      dem, node, [&](swift::Demangle::NodePointer node) {
-        if (node->getKind() == Node::Kind::Module) {
-          auto module_name = node->getText();
-          if (module_name_map.contains(module_name)) {
-            auto real_name = module_name_map.lookup(module_name);
-            auto *adjusted_module_node =
-                dem.createNodeWithAllocatedText(Node::Kind::Module, real_name);
-            return adjusted_module_node;
-          }
-        }
-
-        return node;
-      });
-
-  auto mangling = mangleNode(adjusted_node);
-  return mangling;
-}
-
 llvm::StringRef
 TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
   if (!node)

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -365,12 +365,6 @@ public:
   CanonicalizeSugar(swift::Demangle::Demangler &dem,
                     swift::Demangle::NodePointer node);
 
-  /// Transforms the module name in the mangled type name using module_name_map
-  /// as the mapping source.
-  static swift::Demangle::ManglingErrorOr<std::string>
-  TransformModuleName(llvm::StringRef mangled_name,
-                      const llvm::StringMap<llvm::StringRef> &module_name_map);
-
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   swift::Demangle::NodePointer
   GetCanonicalDemangleTree(swift::Demangle::Demangler &dem,

--- a/lldb/test/API/lang/swift/clashing_abi_name/Library.swift
+++ b/lldb/test/API/lang/swift/clashing_abi_name/Library.swift
@@ -1,0 +1,8 @@
+
+public class Generic<T> {
+  let t: T
+  public init(t: T) {
+    self.t = t
+  }
+}
+

--- a/lldb/test/API/lang/swift/clashing_abi_name/Makefile
+++ b/lldb/test/API/lang/swift/clashing_abi_name/Makefile
@@ -1,0 +1,17 @@
+SWIFT_SOURCES := main.swift
+LD_EXTRAS = -lLibrary -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+all: libLibrary.dylib a.out
+
+include Makefile.rules
+
+libLibrary.dylib: Library.swift
+	$(MAKE) MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=Library \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution -emit-library -emit-module -parse-as-library -module-abi-name a" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
+
+clean::
+	$(MAKE) BASENAME=Library VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk clean

--- a/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
+++ b/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
@@ -1,0 +1,36 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftClashingABIName(TestBase):
+    @swiftTest
+    @skipUnlessDarwin
+    def test(self):
+        """Test that expressions with types in modules with clashing abi names works"""
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'), 
+        extra_images=['Library'])
+
+        self.expect('expr --bind-generic-types true -- generic1', 
+                    substrs=['a.Generic<a.One>', 't =', 'j = 98'])
+
+        self.expect('expr --bind-generic-types true -- generic2', 
+                    substrs=['a.Generic2<a.Generic<a.One>>', 't2 =', 't =', 'j = 98'])
+
+        self.expect('expr --bind-generic-types true -- generic3',
+                    substrs=['a.Generic2<a.Generic<a.One>>', 't2 =', 't =', 'j = 98'])
+    @swiftTest
+    @skipUnlessDarwin
+    def test_in_self(self):
+        """Test a library with a private import for which there is no debug info"""
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(
+            self, 'break for self', lldb.SBFileSpec('main.swift'))
+
+        self.expect('expr --bind-generic-types true -- self', 
+                    substrs=['a.Generic<a.One>', 't =', 'j = 98'])
+

--- a/lldb/test/API/lang/swift/clashing_abi_name/dylib.mk
+++ b/lldb/test/API/lang/swift/clashing_abi_name/dylib.mk
@@ -1,0 +1,4 @@
+DYLIB_ONLY := YES
+DYLIB_NAME := $(BASENAME)
+DYLIB_SWIFT_SOURCES := $(DYLIB_NAME).swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clashing_abi_name/main.swift
+++ b/lldb/test/API/lang/swift/clashing_abi_name/main.swift
@@ -1,0 +1,29 @@
+import Library
+
+public class One {
+  let j = 98
+  init() {}
+}
+
+public class Generic2<T> {
+  let t2: T
+  public init(t: T) {
+    self.t2 = t
+  }
+
+  func foo() {
+    print("break for self")
+  }
+}
+
+
+func main() {
+  let two = a.One()
+  let generic1 = Library.Generic<a.One>(t: two)
+  let generic2 = a.Generic2<Library.Generic<a.One>>(t: generic1)
+  let generic3 = Library.Generic<a.Generic2<Library.Generic<a.One>>>(t: generic2)
+  generic2.foo()
+  print("break here")
+}
+
+main()


### PR DESCRIPTION
Remove functionality to rename a type's module name from ABI name to real name before type reconstruction.

With changes in the compiler side, this functionality is not needed anymore. Besides, this functionality was incomplete as it could not deal with multiple modules sharing the same ABI name.

(cherry picked from commit b102270d575ce3574e581afcc83e77b83a2c4ccc)