### PR TITLE
[cherry-pick][lldb][swift] Use assembly unwinders to recover async registers

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -37,9 +37,11 @@
 #include "lldb/Interpreter/CommandObject.h"
 #include "lldb/Interpreter/CommandObjectMultiword.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
+#include "lldb/Symbol/FuncUnwinders.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/UnwindLLDB.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/OptionParsing.h"
@@ -2542,6 +2544,8 @@ struct AsyncUnwindRegisterNumbers {
   /// frames below us as they need to react differently. There is no good way to
   /// expose this, so we set another dummy register to communicate this state.
   uint32_t dummy_regnum;
+
+  RegisterKind GetRegisterKind() const { return lldb::eRegisterKindDWARF; }
 };
 } // namespace
 
@@ -2584,37 +2588,148 @@ lldb::addr_t SwiftLanguageRuntime::GetAsyncContext(RegisterContext *regctx) {
   return LLDB_INVALID_ADDRESS;
 }
 
-/// Creates an expression accessing *(fp - 8) or **(fp - 8) if
-/// `with_double_deref` is true. This is only valid for x86_64 or aarch64.
-llvm::ArrayRef<uint8_t>
-GetAsyncRegFromFramePointerDWARFExpr(llvm::Triple::ArchType triple,
-                                     bool with_double_deref) {
-  assert(triple == llvm::Triple::x86_64 || triple == llvm::Triple::aarch64);
+/// Functional wrapper to read a register as an address.
+static llvm::Expected<addr_t> ReadRegisterAsAddress(RegisterContext &regctx,
+                                                    RegisterKind regkind,
+                                                    unsigned regnum) {
+  unsigned lldb_regnum =
+      regctx.ConvertRegisterKindToRegisterNumber(regkind, regnum);
+  auto reg = regctx.ReadRegisterAsUnsigned(lldb_regnum, LLDB_INVALID_ADDRESS);
+  if (reg != LLDB_INVALID_ADDRESS)
+    return reg;
+  return llvm::createStringError(
+      "SwiftLanguageRuntime: failed to read register from regctx");
+}
 
-  // These expressions must have static storage, due to how UnwindPlan::Row
-  // works.
-  static const uint8_t g_cfa_dwarf_expression_x86_64[] = {
-      llvm::dwarf::DW_OP_breg6, // DW_OP_breg6, register 6 == rbp
-      0x78,                     //    sleb128 -8 (ptrsize)
-      llvm::dwarf::DW_OP_deref,
-      llvm::dwarf::DW_OP_deref,
-  };
-  static const uint8_t g_cfa_dwarf_expression_arm64[] = {
-      llvm::dwarf::DW_OP_breg29, // DW_OP_breg29, register 29 == fp
-      0x78,                      //    sleb128 -8 (ptrsize)
-      llvm::dwarf::DW_OP_deref,
-      llvm::dwarf::DW_OP_deref,
-  };
+/// Functional wrapper to read a pointer from process memory at `addr +
+/// offset`.
+static llvm::Expected<addr_t> ReadPtrFromAddr(Process &process, addr_t addr,
+                                              int offset = 0) {
+  Status error;
+  addr_t ptr = process.ReadPointerFromMemory(addr + offset, error);
+  if (ptr != LLDB_INVALID_ADDRESS)
+    return ptr;
+  return llvm::createStringError("SwiftLanguageRuntime: Failed to read ptr "
+                                 "from memory address 0x%8.8" PRIx64
+                                 " Error was %s",
+                                 addr + offset, error.AsCString());
+}
 
-  const uint8_t *expr = triple == llvm::Triple::x86_64
-                            ? g_cfa_dwarf_expression_x86_64
-                            : g_cfa_dwarf_expression_arm64;
-  auto size = triple == llvm::Triple::x86_64
-                  ? sizeof(g_cfa_dwarf_expression_x86_64)
-                  : sizeof(g_cfa_dwarf_expression_arm64);
-  if (with_double_deref)
-    return llvm::ArrayRef<uint8_t>(expr, size);
-  return llvm::ArrayRef<uint8_t>(expr, size - 1);
+/// Computes the Canonical Frame Address (CFA) by converting the abstract
+/// location of UnwindPlan::Row::FAValue into a concrete address. This is a
+/// simplified version of the methods in RegisterContextUnwind, since plumbing
+/// access to those here would be challenging.
+static llvm::Expected<addr_t> GetCFA(Process &process, RegisterContext &regctx,
+                                     RegisterKind regkind,
+                                     UnwindPlan::Row::FAValue cfa_loc) {
+  using ValueType = UnwindPlan::Row::FAValue::ValueType;
+  switch (cfa_loc.GetValueType()) {
+  case ValueType::isRegisterPlusOffset: {
+    unsigned regnum = cfa_loc.GetRegisterNumber();
+    if (llvm::Expected<addr_t> regvalue =
+            ReadRegisterAsAddress(regctx, regkind, regnum))
+      return *regvalue + cfa_loc.GetOffset();
+    else
+      return regvalue;
+  }
+  case ValueType::isConstant:
+  case ValueType::isDWARFExpression:
+  case ValueType::isRaSearch:
+  case ValueType::isRegisterDereferenced:
+  case ValueType::unspecified:
+    break;
+  }
+  return llvm::createStringError(
+      "SwiftLanguageRuntime: Unsupported FA location type = %d",
+      cfa_loc.GetValueType());
+}
+
+/// Attempts to use UnwindPlans that inspect assembly to recover the entry value
+/// of the async context register. This is a simplified version of the methods
+/// in RegisterContextUnwind, since plumbing access to those here would be
+/// challenging.
+static llvm::Expected<addr_t> ReadAsyncContextRegisterFromUnwind(
+    SymbolContext &sc, Process &process, Address pc, Address func_start_addr,
+    RegisterContext &regctx, AsyncUnwindRegisterNumbers regnums) {
+  FuncUnwindersSP unwinders =
+      pc.GetModule()->GetUnwindTable().GetFuncUnwindersContainingAddress(pc,
+                                                                         sc);
+  if (!unwinders)
+    return llvm::createStringError("SwiftLanguageRuntime: Failed to find "
+                                   "function unwinder at address 0x%8.8" PRIx64,
+                                   pc.GetFileAddress());
+
+  Target &target = process.GetTarget();
+  UnwindPlanSP unwind_plan =
+      unwinders->GetUnwindPlanAtNonCallSite(target, regctx.GetThread());
+  if (!unwind_plan)
+    return llvm::createStringError(
+        "SwiftLanguageRuntime: Failed to find non call site unwind plan at "
+        "address 0x%8.8" PRIx64,
+        pc.GetFileAddress());
+
+  const RegisterKind unwind_regkind = unwind_plan->GetRegisterKind();
+  UnwindPlan::RowSP row = unwind_plan->GetRowForFunctionOffset(
+      pc.GetFileAddress() - func_start_addr.GetFileAddress());
+
+  // To request info about a register from the unwind plan, the register must
+  // be in the same domain as the unwind plan's registers.
+  uint32_t async_reg_unwind_regdomain;
+  if (!regctx.ConvertBetweenRegisterKinds(
+          regnums.GetRegisterKind(), regnums.async_ctx_regnum, unwind_regkind,
+          async_reg_unwind_regdomain)) {
+    // This should never happen.
+    // If asserts are disabled, return an error to avoid creating an invalid
+    // unwind plan.
+    auto error_msg = "SwiftLanguageRuntime: Failed to convert register domains";
+    llvm_unreachable(error_msg);
+    return llvm::createStringError(error_msg);
+  }
+
+  // If the plan doesn't have information about the async register, we can use
+  // its current value, as this is a callee saved register.
+  UnwindPlan::Row::AbstractRegisterLocation regloc;
+  if (!row->GetRegisterInfo(async_reg_unwind_regdomain, regloc))
+    return ReadRegisterAsAddress(regctx, regnums.GetRegisterKind(),
+                                 regnums.async_ctx_regnum);
+
+  // Handle the few abstract locations we are likely to encounter.
+  using RestoreType = UnwindPlan::Row::AbstractRegisterLocation::RestoreType;
+  RestoreType loctype = regloc.GetLocationType();
+  switch (loctype) {
+  case RestoreType::same:
+    return ReadRegisterAsAddress(regctx, regnums.GetRegisterKind(),
+                                 regnums.async_ctx_regnum);
+  case RestoreType::inOtherRegister: {
+    unsigned regnum = regloc.GetRegisterNumber();
+    return ReadRegisterAsAddress(regctx, unwind_regkind, regnum);
+  }
+  case RestoreType::atCFAPlusOffset: {
+    llvm::Expected<addr_t> cfa =
+        GetCFA(process, regctx, unwind_regkind, row->GetCFAValue());
+    if (!cfa)
+      return cfa.takeError();
+    return ReadPtrFromAddr(process, *cfa, regloc.GetOffset());
+  }
+  case RestoreType::isCFAPlusOffset: {
+    if (llvm::Expected<addr_t> cfa =
+            GetCFA(process, regctx, unwind_regkind, row->GetCFAValue()))
+      return *cfa + regloc.GetOffset();
+    else
+      return cfa;
+  }
+  case RestoreType::isConstant:
+    return regloc.GetConstant();
+  case RestoreType::unspecified:
+  case RestoreType::undefined:
+  case RestoreType::atAFAPlusOffset:
+  case RestoreType::isAFAPlusOffset:
+  case RestoreType::isDWARFExpression:
+  case RestoreType::atDWARFExpression:
+    break;
+  }
+  return llvm::createStringError(
+      "SwiftLanguageRuntime: Unsupported register location type = %d", loctype);
 }
 
 // Examine the register state and detect the transition from a real
@@ -2625,6 +2740,11 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
                                            RegisterContext *regctx,
                                            bool &behaves_like_zeroth_frame) {
   LLDB_SCOPED_TIMER();
+  auto log_expected = [](llvm::Error error) {
+    Log *log = GetLog(LLDBLog::Unwind);
+    LLDB_LOG_ERROR(log, std::move(error), "{0}");
+    return UnwindPlanSP();
+  };
 
   Target &target(process_sp->GetTarget());
   auto arch = target.GetArchitecture();
@@ -2644,12 +2764,6 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
     return UnwindPlanSP();
   }
 
-  // If we're in the prologue of a function, don't provide a Swift async
-  // unwind plan.  We can be tricked by unmodified caller-registers that
-  // make this look like an async frame when this is a standard ABI function
-  // call, and the parent is the async frame.
-  // This assumes that the frame pointer register will be modified in the
-  // prologue.
   Address pc;
   pc.SetLoadAddress(regctx->GetPC(), &target);
   SymbolContext sc;
@@ -2659,111 +2773,58 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
       return UnwindPlanSP();
 
   Address func_start_addr;
-  uint32_t prologue_size;
   ConstString mangled_name;
   if (sc.function) {
     func_start_addr = sc.function->GetAddressRange().GetBaseAddress();
-    prologue_size = sc.function->GetPrologueByteSize();
     mangled_name = sc.function->GetMangled().GetMangledName();
   } else if (sc.symbol) {
     func_start_addr = sc.symbol->GetAddress();
-    prologue_size = sc.symbol->GetPrologueByteSize();
     mangled_name = sc.symbol->GetMangled().GetMangledName();
   } else {
     return UnwindPlanSP();
   }
 
-  AddressRange prologue_range(func_start_addr, prologue_size);
-  bool in_prologue = (func_start_addr == pc ||
-                      prologue_range.ContainsLoadAddress(pc, &target));
+  if (!IsAnySwiftAsyncFunctionSymbol(mangled_name.GetStringRef()))
+    return UnwindPlanSP();
 
-  if (in_prologue) {
-    if (!IsAnySwiftAsyncFunctionSymbol(mangled_name.GetStringRef()))
-      return UnwindPlanSP();
-  } else {
-    addr_t saved_fp = LLDB_INVALID_ADDRESS;
-    Status error;
-    if (!process_sp->ReadMemory(fp, &saved_fp, 8, error))
-      return UnwindPlanSP();
-
-    // Get the high nibble of the dreferenced fp; if the 60th bit is set,
-    // this is the transition to a swift async AsyncContext chain.
-    if ((saved_fp & (0xfULL << 60)) >> 60 != 1)
-      return UnwindPlanSP();
-  }
-
-  // The coroutine funclets split from an async function have 2 different ABIs:
-  //  - Async suspend partial functions and the first funclet get their async
-  //    context directly in the async register.
-  //  - Async await resume partial functions take their context indirectly, it
-  //    needs to be dereferenced to get the actual function's context.
-  // The debug info for locals reflects this difference, so our unwinding of the
-  // context register needs to reflect it too.
+  // The async register contains, at the start of the funclet:
+  // 1. The async context of the async function that just finished executing,
+  // for await resume ("Q") funclets ("indirect context").
+  // 2. The async context for the currently executing async function, for all
+  // other funclets ("Y" and "Yx" funclets, where "x" is a number).
   bool indirect_context =
       IsSwiftAsyncAwaitResumePartialFunctionSymbol(mangled_name.GetStringRef());
+
+  llvm::Expected<addr_t> async_reg = ReadAsyncContextRegisterFromUnwind(
+      sc, *process_sp, pc, func_start_addr, *regctx, *regnums);
+  if (!async_reg)
+    return log_expected(async_reg.takeError());
+  llvm::Expected<addr_t> async_ctx =
+      indirect_context ? ReadPtrFromAddr(*m_process, *async_reg) : *async_reg;
+  if (!async_ctx)
+    return log_expected(async_ctx.takeError());
 
   UnwindPlan::RowSP row(new UnwindPlan::Row);
   const int32_t ptr_size = 8;
   row->SetOffset(0);
 
-  if (in_prologue) {
-    if (indirect_context)
-      row->GetCFAValue().SetIsRegisterDereferenced(regnums->async_ctx_regnum);
-    else
-      row->GetCFAValue().SetIsRegisterPlusOffset(regnums->async_ctx_regnum, 0);
-  } else {
-    // In indirect funclets, dereferencing (fp-8) once produces the CFA of the
-    // frame above. Dereferencing twice will produce the current frame's CFA.
-    bool with_double_deref = indirect_context;
-    llvm::ArrayRef<uint8_t> expr = GetAsyncRegFromFramePointerDWARFExpr(
-        arch.GetMachine(), with_double_deref);
-    row->GetCFAValue().SetIsDWARFExpression(expr.data(), expr.size());
-  }
+  // The CFA of a funclet is its own async context.
+  row->GetCFAValue().SetIsConstant(*async_ctx);
 
-  if (indirect_context) {
-    if (in_prologue) {
-      row->SetRegisterLocationToSame(regnums->async_ctx_regnum, false);
-    } else {
-      llvm::ArrayRef<uint8_t> expr = GetAsyncRegFromFramePointerDWARFExpr(
-          arch.GetMachine(), false /*with_double_deref*/);
-      row->SetRegisterLocationToIsDWARFExpression(
-          regnums->async_ctx_regnum, expr.data(), expr.size(), false);
-    }
-  } else {
-    // In the first part of a split async function, the context is passed
-    // directly, so we can use the CFA value directly.
-    row->SetRegisterLocationToIsCFAPlusOffset(regnums->async_ctx_regnum, 0,
-                                              false);
-    // The fact that we are in this case needs to be communicated to the frames
-    // below us as they need to react differently. There is no good way to
-    // expose this, so we set another dummy register to communicate this state.
-    static const uint8_t g_dummy_dwarf_expression[] = {
-        llvm::dwarf::DW_OP_const1u, 0
-    };
-    row->SetRegisterLocationToIsDWARFExpression(
-        regnums->dummy_regnum, g_dummy_dwarf_expression,
-        sizeof(g_dummy_dwarf_expression), false);
-  }
+  // The value of the async register in the parent frame is the entry value of
+  // the async register in the current frame. This mimics a function call, as
+  // if the parent funclet had called the current funclet.
+  row->SetRegisterLocationToIsConstant(regnums->async_ctx_regnum, *async_reg,
+                                       /*can_replace=*/false);
 
-  std::optional<addr_t> pc_after_prologue = [&]() -> std::optional<addr_t> {
-    // In the prologue, use the async_reg as is, it has not been clobbered.
-    if (in_prologue)
-      return TrySkipVirtualParentProlog(GetAsyncContext(regctx), *process_sp,
-                                        indirect_context);
+  // The parent frame needs to know how to interpret the value it is given for
+  // its own async register. A dummy register is used to communicate that.
+  if (!indirect_context)
+    row->SetRegisterLocationToIsConstant(regnums->dummy_regnum, 0,
+                                         /*can_replace=*/false);
 
-    // Both ABIs (x86_64 and aarch64) guarantee the async reg is saved at:
-    // *(fp - 8).
-    Status error;
-    addr_t async_reg_entry_value = LLDB_INVALID_ADDRESS;
-    process_sp->ReadMemory(fp - ptr_size, &async_reg_entry_value, ptr_size,
-                           error);
-    if (error.Fail())
-      return {};
-    return TrySkipVirtualParentProlog(async_reg_entry_value, *process_sp,
-                                      indirect_context);
-  }();
-
-  if (pc_after_prologue)
+  if (std::optional<addr_t> pc_after_prologue =
+          TrySkipVirtualParentProlog(*async_ctx, *process_sp))
     row->SetRegisterLocationToIsConstant(regnums->pc_regnum, *pc_after_prologue,
                                          false);
   else

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -496,7 +496,7 @@ private:
   /// address of the first non-prologue instruction.
   std::optional<lldb::addr_t>
   TrySkipVirtualParentProlog(lldb::addr_t async_reg_val, Process &process,
-                             unsigned num_indirections);
+                             unsigned num_indirections = 0);
 };
 
 } // namespace lldb_private

--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -27,7 +27,7 @@ class TestCase(lldbtest.TestBase):
         # Using the line table, build a set of the non-zero line numbers for
         # this this function - and verify that there is exactly one line.
         lines = {inst.addr.line_entry.line for inst in instructions}
-        lines.remove(0)
+        lines.discard(0)
         self.assertEqual(lines, {3})
 
         # Required for builds that have debug info.

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -1,0 +1,135 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+# This test creates 5 async frames:
+# * ASYNC___1___, which is called by
+# * ASYNC___2___, which is called by
+# * ...
+# * ASYNC___5___, which is called by
+#
+# The number of frames is important to exercise all possible unwind plans:
+# * The top frame (ASYNC___1___) is created by just inspecting the registers as
+# they are.
+# * The plan for ASYNC___1___ -> ASYNC___2___ is created through
+# `GetRuntimeUnwindPlan`, which is responsible for the transition from a real
+# frame to a virtual frame.
+# * The plan for ASYNC___2___ -> ASYNC___3___ is created through
+# GetFollowAsyncContextUnwindPlan, which is responsible to create a virtual
+# frame from another virtual frame.
+# * The plan for ASYNC___3___ -> ASYNC___4___ is created through
+# GetFollowAsyncContextUnwindPlan, but this time it follow the code path where
+# `is_indirect = true` (see its implementation).
+# * The plan for ASYNC___4___ -> ASYNC___5___ is created through the same code
+# path as the previous one. However, it is the first time an unwind plan
+# created from that path is used to create another unwind plan.
+
+
+class TestCase(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    def set_breakpoints_all_funclets(self, target):
+        funclet_names = [
+            "$s1a12ASYNC___1___4condS2i_tYaF",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY0_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTQ1_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY2_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTQ3_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY4_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTQ5_",
+            "$s1a12ASYNC___1___4condS2i_tYaFTY6_",
+        ]
+
+        breakpoints = set()
+        for funclet_name in funclet_names:
+            sym_ctx_list = target.FindFunctions(funclet_name)
+            self.assertEqual(
+                sym_ctx_list.GetSize(),
+                1,
+                f"failed to get symbol context for {funclet_name}",
+            )
+            function = sym_ctx_list[0].function
+
+            instructions = list(function.GetInstructions(target))
+            self.assertGreater(len(instructions), 0)
+            for instruction in instructions:
+                bp = target.BreakpointCreateBySBAddress(instruction.GetAddress())
+                self.assertTrue(
+                    bp.IsValid(), f"failed to set bp inside funclet {funclet_name}"
+                )
+                breakpoints.add(bp.GetID())
+        return breakpoints
+
+    # FIXME: there are challenges when unwinding Q funclets ("await resume"),
+    # see rdar://137048317. For now, we only know how to unwind during and
+    # shortly after the prologue. This function returns "should skip" if we're
+    # at a PC that is too far from the prologue (~16 bytes). This is a
+    # rough approximation that seems to work for both x86 and arm.
+    def should_skip_Q_funclet(self, thread):
+        current_frame = thread.frames[0]
+        function = current_frame.GetFunction()
+        if "await resume" not in function.GetName():
+            return False
+
+        max_prologue_offset = 16
+        prologue_end = function.GetStartAddress()
+        prologue_end.OffsetAddress(function.GetPrologueByteSize() + max_prologue_offset)
+        current_pc = current_frame.GetPCAddress()
+        return current_pc.GetFileAddress() >= prologue_end.GetFileAddress()
+
+    def check_unwind_ok(self, thread, bpid):
+        if self.should_skip_Q_funclet(thread):
+            return
+        # Check that we see the virtual backtrace:
+        expected_funcnames = [
+            "ASYNC___1___",
+            "ASYNC___2___",
+            "ASYNC___3___",
+            "ASYNC___4___",
+            "ASYNC___5___",
+        ]
+        frames = thread.frames
+        self.assertGreater(
+            len(frames), len(expected_funcnames), f"Invalid backtrace for {frames}"
+        )
+        actual_funcnames = [
+            frame.GetFunctionName() for frame in frames[: len(expected_funcnames)]
+        ]
+        for expected_name, actual_name in zip(expected_funcnames, actual_funcnames):
+            self.assertIn(expected_name, actual_name, f"Unexpected backtrace: {frames}")
+
+    @swiftTest
+    @skipIf(oslist=["windows", "linux"])
+    def test(self):
+        """Test that the debugger can unwind at all instructions of all funclets"""
+        self.build()
+
+        source_file = lldb.SBFileSpec("main.swift")
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "BREAK HERE", source_file
+        )
+
+        breakpoints = self.set_breakpoints_all_funclets(target)
+        num_breakpoints = len(breakpoints)
+
+        # Reach most breakpoints and ensure we can unwind in that position.
+        while True:
+            process.Continue()
+            if process.GetState() == lldb.eStateExited:
+                break
+            thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
+            self.assertTrue(thread.IsValid())
+            bpid = thread.GetStopReasonDataAtIndex(0)
+            breakpoints.remove(bpid)
+            target.FindBreakpointByID(bpid).SetEnabled(False)
+
+            self.check_unwind_ok(thread, bpid)
+
+        # We will never hit all breakpoints we set, because of things like
+        # overflow handling or other unreachable traps. However, it's good to
+        # have some sanity check that we have hit at least a decent chunk of
+        # them.
+        breakpoints_not_hit = len(breakpoints)
+        self.assertLess(breakpoints_not_hit / num_breakpoints, 0.10)

--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/main.swift
@@ -1,0 +1,49 @@
+func async_work() async {
+  print("async working")
+}
+func work() {
+  print("working")
+}
+
+func ASYNC___1___(cond: Int) async -> Int {
+  work()
+  await async_work()
+  for i in 1...3 {
+    work()
+    await async_work()
+    work()
+    if (cond + i == 3) {
+      await async_work()
+      print("exiting loop here!")
+      break;
+    }
+  }
+  return 0
+}
+
+func ASYNC___2___() async -> Int {
+  let result = await ASYNC___1___(cond: 1)
+  return result
+}
+
+func ASYNC___3___() async -> Int {
+  let result = await ASYNC___2___()
+  return result
+}
+
+func ASYNC___4___() async -> Int {
+  let result = await ASYNC___3___()
+  return result
+}
+
+func ASYNC___5___() async -> Int {
+  let result = await ASYNC___4___()
+  return result
+}
+
+@main struct Main {
+  static func main() async {
+    let result = await ASYNC___5___() // BREAK HERE
+    print(result)
+  }
+}


### PR DESCRIPTION
The SwiftLanguageRuntime unwind plan for async functions relies on the extended frame setup to recover the asynchronous contexts of these functions. This extended frame consists of:

1. Tagging the saved fp register by setting its 60 bit, indicating the existence of the extended frame.
2. An additional stack slot where the asynchronous context is saved.

The current unwind plans recover the asynchronous context by reading the stack slot described in (2). This creates a number of challenges:

* The extended frame is not always created (e.g. leaf funclets).
* The extended frame is not necessarily valid inside the prologue or epilogue.
* The code to handle all possible combinations of funclet x {is_prologue, is_epilogue} is very complex.
* Entry funclets don't have the extended frame.

This patch uses a new approach, exploiting the property that the asynchronous context is passed in a callee-saved register. We use existing unwind plans that inspect assembly and track spill slots, and recover the asynchronous register from those.

Unwind Plans are not setup to query other Unwind Plans, more specifically they are not setup to materialize the abstract location provided by an Unwind Plan into a concrete value. Doing so would require a lot of plumbing. Instead, this patch reimplements a very targeted conversion between the abstract locations and concrete register values. We argue this is worth it, as the new unwind procedure is much simpler, relies on existing plans, and works in many cases where the previous implementation doesn't.

Testing-wise, this commit creates a fairly complex async function, with multiple split points, and sets breakpoints on all instructions of all funclets. It then asserts that unwinding works correctly in all of them. This has revealed an issue with Q funclets, which clobber the async context location prior to freeing the context of the funclet that has just finished executing (see the FIXME in the test). This is not a problem with the new approach, but rather it was discovered because of the extensive testing done here.

(cherry picked from commit 312cf91f610a312b1056587c0cf155f827345876) (cherry picked from commit 130728a9926199d4aba7718b42213c9eb5c8f247) (cherry picked from commit cdbd90fb1f5f0afe3b8e107ff6e7f9a7d8c4961e) (cherry picked from commit c03caaf674d1bd93184071ad95c67138cc3ff473) (cherry picked from commit 8f0546a70f624e9322c64e41916306d8df3b148a) (cherry picked from commit 641b295f011620c85d7cd139a88493ae3b42ac63) (cherry picked from commit 341dad688e5ad435c7d0213813c20b3f03676fba)