### PR TITLE
[lldb] Propagate SDKROOT env var in Shell tests on Windows

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -149,7 +149,16 @@ def use_support_substitutions(config):
             sdk_path = lit.util.to_string(out)
             llvm_config.lit_config.note("using SDKROOT: %r" % sdk_path)
             host_flags += ["-isysroot", sdk_path]
-    elif sys.platform != "win32":
+    elif sys.platform == "win32":
+        # Required in SwiftREPL tests
+        sdk_path = os.environ.get("SDKROOT")
+        if sdk_path:
+            llvm_config.lit_config.note(f"using SDKROOT: {sdk_path}")
+            llvm_config.with_environment("SDKROOT", sdk_path)
+        else:
+            llvm_config.lit_config.warning(
+                "mandatory environment variable not found: SDKROOT")
+    else:
         host_flags += ["-pthread"]
 
     config.target_shared_library_suffix = (


### PR DESCRIPTION
The manual lookup in [lldb/source/Host/windows/HostInfoWindowsSwift.cpp](https://github.com/swiftlang/llvm-project/blob/8d289cd1419f024c26e2bd29217b6e95678544f3/lldb/source/Host/windows/HostInfoWindowsSwift.cpp#L59) must be successful so that [SwiftASTContext::CreateInstance()](https://github.com/swiftlang/llvm-project/blob/bf61e12eb50349bcd7e01b673a7bfc5990b6120c/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp#L2519) doesn't fail with: `Cannot create Swift scratch context (couldn't load the Swift stdlib)`