### PR TITLE
Enable fdefine-target-os-macros in Darwin driver

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3316,6 +3316,10 @@ void Darwin::addClangTargetOptions(
     if (!RequiresSubdirectorySearch)
       CC1Args.push_back("-fno-modulemap-allow-subdirectory-search");
   }
+
+  if (!DriverArgs.hasArgNoClaim(options::OPT_fdefine_target_os_macros,
+                                options::OPT_fno_define_target_os_macros))
+    CC1Args.push_back("-fdefine-target-os-macros");
 }
 
 void Darwin::addClangCC1ASTargetOptions(

--- a/clang/test/Driver/fdefine-target-os-macros.c
+++ b/clang/test/Driver/fdefine-target-os-macros.c
@@ -1,5 +1,5 @@
 // RUN: %clang -### --target=arm64-apple-darwin %s 2>&1 | FileCheck %s --check-prefix=DARWIN-DEFAULT
-// DARWIN-DEFAULT-NOT: "-fdefine-target-os-macros"
+// DARWIN-DEFAULT: "-fdefine-target-os-macros"
 
 // RUN: %clang -### --target=arm-none-linux-gnu %s 2>&1 | FileCheck %s --check-prefix=NON-DARWIN-DEFAULT
 // RUN: %clang -### --target=x86_64-pc-win32 %s 2>&1 | FileCheck %s --check-prefix=NON-DARWIN-DEFAULT


### PR DESCRIPTION
To keep consistency with upstream llvm-project and internal qualifications, enable the `-fdefine-target-os-macros` extension in the Darwin driver.