### PR TITLE
[lldb] Check runtime dependencies of SwiftREPL tests in local lit config

### DIFF
--- a/lldb/test/Shell/SwiftREPL/lit.local.cfg
+++ b/lldb/test/Shell/SwiftREPL/lit.local.cfg
@@ -2,3 +2,14 @@ config.suffixes = ['.test']
 
 if 'lldb-repro' in config.available_features:
   config.unsupported = True
+
+def check_exists(path):
+  import os
+  if not os.path.isfile(path):
+    lit_config.warning(f"Runtime dependency not found: {path}")
+
+# Check runtime dependencies for SwiftREPL tests on Windows
+if sys.platform == "win32":
+  host_arch = config.host_triple.split("-")[0]
+  check_exists(f"{config.swift_libs_dir}/windows/{host_arch}/swiftrt.obj")
+  check_exists(f"{config.llvm_shlib_dir}/swiftCore.dll")

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -17,6 +17,7 @@ config.cmake_sysroot = lit_config.substitute("@CMAKE_SYSROOT@")
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.swiftc = "@LLDB_SWIFTC@"
+config.swift_libs_dir = '@LLDB_SWIFT_LIBS@'
 config.lldb_enable_swift = @LLDB_ENABLE_SWIFT_SUPPORT@
 config.have_zlib = @LLVM_ENABLE_ZLIB@
 config.objc_gnustep_dir = "@LLDB_TEST_OBJC_GNUSTEP_DIR@"


### PR DESCRIPTION
The SwiftREPL tests run `repl_swift.exe`, which manually loads a few external dependencies at runtime. In particular [swiftCore.dll](https://github.com/swiftlang/llvm-project/blob/swift/release/6.0/lldb/tools/repl/swift/main.c#L66) and [swiftrt.obj](https://github.com/swiftlang/swift/blob/release/6.0/lib/Driver/WindowsToolChains.cpp#L163).

These binaries need to be in fixed locations and they only exists if the Swift runtime was built correctly. We cannot check them at configuration time, because they might not exist yet. It seems worth checking whether they exist and printing a warning otherwise, because the resulting test failures aren't very obvious.