### PR TITLE
Extensible rtti multiple inheritance

### DIFF
--- a/lldb/tools/debugserver/source/libdebugserver.cpp
+++ b/lldb/tools/debugserver/source/libdebugserver.cpp
@@ -311,13 +311,6 @@ RNBRunLoopMode RNBRunLoopInferiorExecuting(RNBRemoteSP &remote) {
   return mode;
 }
 
-void ASLLogCallback(void *baton, uint32_t flags, const char *format,
-                    va_list args) {
-#if 0
-	vprintf(format, args);
-#endif
-}
-
 extern "C" int debug_server_main(int fd) {
 #if 1
   g_isatty = 0;
@@ -327,7 +320,6 @@ extern "C" int debug_server_main(int fd) {
   DNBLogSetDebug(1);
   DNBLogSetVerbose(1);
   DNBLogSetLogMask(-1);
-  DNBLogSetLogCallback(ASLLogCallback, NULL);
 #endif
 
   signal(SIGPIPE, signal_handler);

--- a/llvm/include/llvm/Support/ExtensibleRTTI.h
+++ b/llvm/include/llvm/Support/ExtensibleRTTI.h
@@ -81,10 +81,6 @@ public:
     return ClassID == classID();
   }
 
-  /// Check whether this instance is a subclass of QueryT.
-  template <typename QueryT>
-  bool isA() const { return isA(QueryT::classID()); }
-
 private:
   virtual void anchor();
 
@@ -110,21 +106,37 @@ private:
 ///   static char ID;
 /// };
 ///
-template <typename ThisT, typename ParentT>
-class RTTIExtends : public ParentT {
+template <typename ThisT, typename... ParentTs>
+class RTTIExtends : public ParentTs... {
 public:
   // Inherit constructors from ParentT.
-  using ParentT::ParentT;
+  using ParentTs::ParentTs...;
 
   static const void *classID() { return &ThisT::ID; }
 
   const void *dynamicClassID() const override { return &ThisT::ID; }
 
+  /// Check whether this instance is a subclass of QueryT.
+  template <typename QueryT>
+  bool isA() const { return isA(QueryT::classID()); }
+
   bool isA(const void *const ClassID) const override {
-    return ClassID == classID() || ParentT::isA(ClassID);
+    return ClassID == classID() || parentsAreA<ParentTs...>(ClassID);
   }
 
-  static bool classof(const RTTIRoot *R) { return R->isA<ThisT>(); }
+  template <typename T>
+  static bool classof(const T *R) { return R->template isA<ThisT>(); }
+private:
+
+  template <typename T>
+  bool parentsAreA(const void *const ClassID) const {
+    return T::isA(ClassID);
+  }
+
+  template <typename T, typename T2, typename... Ts>
+  bool parentsAreA(const void *const ClassID) const {
+    return T::isA(ClassID) || parentsAreA<T2, Ts...>(ClassID);
+  }
 };
 
 } // end namespace llvm

--- a/llvm/unittests/Support/ExtensibleRTTITest.cpp
+++ b/llvm/unittests/Support/ExtensibleRTTITest.cpp
@@ -36,15 +36,24 @@ public:
   static char ID;
 };
 
+class MyMultipleInheritanceType
+  : public RTTIExtends<MyMultipleInheritanceType,
+                       MyDerivedType, MyOtherDerivedType> {
+public:
+  static char ID;
+};
+
 char MyBaseType::ID = 0;
 char MyDerivedType::ID = 0;
 char MyOtherDerivedType::ID = 0;
 char MyDeeperDerivedType::ID = 0;
+char MyMultipleInheritanceType::ID = 0;
 
 TEST(ExtensibleRTTI, isa) {
   MyBaseType B;
   MyDerivedType D;
   MyDeeperDerivedType DD;
+  MyMultipleInheritanceType MI;
 
   EXPECT_TRUE(isa<MyBaseType>(B));
   EXPECT_FALSE(isa<MyDerivedType>(B));
@@ -60,26 +69,53 @@ TEST(ExtensibleRTTI, isa) {
   EXPECT_TRUE(isa<MyDerivedType>(DD));
   EXPECT_FALSE(isa<MyOtherDerivedType>(DD));
   EXPECT_TRUE(isa<MyDeeperDerivedType>(DD));
+
+  EXPECT_TRUE(isa<MyBaseType>(MI));
+  EXPECT_TRUE(isa<MyDerivedType>(MI));
+  EXPECT_TRUE(isa<MyOtherDerivedType>(MI));
+  EXPECT_FALSE(isa<MyDeeperDerivedType>(MI));
+  EXPECT_TRUE(isa<MyMultipleInheritanceType>(MI));
 }
 
 TEST(ExtensibleRTTI, cast) {
-  MyDerivedType D;
-  MyBaseType &BD = D;
+  MyMultipleInheritanceType MI;
+  MyDerivedType &D = MI;
+  MyOtherDerivedType &OD = MI;
+  MyBaseType &B = D;
 
-  (void)cast<MyBaseType>(D);
-  (void)cast<MyBaseType>(BD);
-  (void)cast<MyDerivedType>(BD);
+  EXPECT_EQ(&cast<MyBaseType>(D), &B);
+  EXPECT_EQ(&cast<MyDerivedType>(MI), &D);
+  EXPECT_EQ(&cast<MyOtherDerivedType>(MI), &OD);
+  EXPECT_EQ(&cast<MyMultipleInheritanceType>(MI), &MI);
 }
 
 TEST(ExtensibleRTTI, dyn_cast) {
-  MyBaseType B;
-  MyDerivedType D;
+  MyMultipleInheritanceType MI;
+  MyDerivedType &D = MI;
+  MyOtherDerivedType &OD = MI;
   MyBaseType &BD = D;
+  MyBaseType &BOD = OD;
 
-  EXPECT_EQ(dyn_cast<MyDerivedType>(&B), nullptr);
-  EXPECT_EQ(dyn_cast<MyDerivedType>(&D), &D);
   EXPECT_EQ(dyn_cast<MyBaseType>(&BD), &BD);
   EXPECT_EQ(dyn_cast<MyDerivedType>(&BD), &D);
+
+  EXPECT_EQ(dyn_cast<MyBaseType>(&BOD), &BOD);
+  EXPECT_EQ(dyn_cast<MyOtherDerivedType>(&BOD), &OD);
+
+  EXPECT_EQ(dyn_cast<MyBaseType>(&D), &BD);
+  EXPECT_EQ(dyn_cast<MyDerivedType>(&D), &D);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&D), &MI);
+
+  EXPECT_EQ(dyn_cast<MyBaseType>(&OD), &BOD);
+  EXPECT_EQ(dyn_cast<MyOtherDerivedType>(&OD), &OD);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&OD), &MI);
+
+  EXPECT_EQ(dyn_cast<MyDerivedType>(&MI), &D);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&MI), &MI);
+
+  EXPECT_EQ(dyn_cast<MyDerivedType>(&MI), &D);
+  EXPECT_EQ(dyn_cast<MyOtherDerivedType>(&MI), &OD);
+  EXPECT_EQ(dyn_cast<MyMultipleInheritanceType>(&MI), &MI);
 }
 
 } // namespace


### PR DESCRIPTION
Extends the `ExtensibleRTTI` utility to support basic multiple inheritance.
    
Clients can now pass multiple parent classes to RTTIExtends. Each parent class will be inherited from publicly (and non-virtually). The isa, cast, and dyn_cast methods will now work as expected for types with multiple inheritance.