### PR TITLE
[lldb] Pass language options to `ide::isSourceInputComplete`

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
@@ -70,6 +70,10 @@ protected:
                         lldb::ValueObjectSP &valobj_sp,
                         ExpressionVariable *var = nullptr) override;
 
+  /// Retrieve the SwiftASTContext to use for completion and line parsing
+  /// checks.
+  SwiftASTContextForExpressions *getSwiftASTContext();
+
   void CompleteCode(const std::string &current_code,
                     CompletionRequest &request) override;
 


### PR DESCRIPTION
Ensure we account for any language options set in the REPL when determining whether a line is considered complete.

I would add a test case but it doesn't seem like there are currently any existing tests for REPL line completeness/indentation, and it doesn't seem like it would be entirely trivial to setup. I have tested locally this resolves the issue.

Resolves #9430