### PR TITLE
[CAS] Fix working-directory canonicalization when using clang cc1depscan

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5181,7 +5181,16 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
     // file here.
     if (Output.isFilename()) {
       CmdArgs.push_back("-o");
-      CmdArgs.push_back(Output.getFilename());
+      // Fix up the output file if it is a relative path to
+      // `-working-directory`.
+      SmallString<128> OutPath(
+          Args.getLastArgValue(options::OPT_working_directory));
+      StringRef Out = Output.getFilename();
+      if (llvm::sys::path::is_relative(Out) && !OutPath.empty()) {
+        llvm::sys::path::append(OutPath, Output.getFilename());
+        Out = OutPath.str();
+      }
+      CmdArgs.push_back(Args.MakeArgString(Out));
     }
     // FIXME: Clean up this code and factor out the common logic (see the end of
     // the function)

--- a/clang/test/CAS/path-independent-cas-outputs.c
+++ b/clang/test/CAS/path-independent-cas-outputs.c
@@ -19,6 +19,11 @@
 // RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-HIT
 // RUN: diff %t/a/t1_working_dir.o %t/b/t2_working_dir.o
 
+/// Check using a different working directory should cache hit as long as the compilation-dirs are setup correctly and inputs are the same.
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \
+// RUN:   %clang -target x86_64-apple-macos11 -c %s -working-directory %t/b -o t3_working_dir.o -DNEW_FLAG -Rcompile-job-cache -fdebug-compilation-dir=%t -fcoverage-compilation-dir=%t \
+// RUN:   2>&1 | FileCheck %s --check-prefix=CACHE-HIT
+
 // Check that output path is correctly detected with - (stdout)
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache \


### PR DESCRIPTION
This is a followup to bb91b1ce3bb2a662890efb67395125b0f1aac21c to fix the removal of working-directory when clang cc1depscan is used. Since the scanner will removes the working-directory, clang-driver needs to make sure the output is correct if that is a relative path to the `-working-directory` option.

rdar://136203252