### PR TITLE
Add a pass to collect dropped variable statistics (#102233)

### DIFF
--- a/llvm/include/llvm/Passes/StandardInstrumentations.h
+++ b/llvm/include/llvm/Passes/StandardInstrumentations.h
@@ -21,6 +21,7 @@
 #include "llvm/ADT/StringSet.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/OptBisect.h"
 #include "llvm/IR/PassTimingInfo.h"
 #include "llvm/IR/ValueHandle.h"
@@ -578,6 +579,83 @@ private:
   static void SignalHandler(void *);
 };
 
+/// A class to collect and print dropped debug information variable statistics.
+/// After every LLVM IR pass is run, it will print how many #dbg_values were
+/// dropped due to that pass.
+class DroppedVariableStats {
+public:
+  DroppedVariableStats(bool DroppedVarStatsEnabled) {
+    if (DroppedVarStatsEnabled)
+      llvm::outs()
+          << "Pass Level, Pass Name, Num of Dropped Variables, Func or "
+             "Module Name\n";
+  };
+  // We intend this to be unique per-compilation, thus no copies.
+  DroppedVariableStats(const DroppedVariableStats &) = delete;
+  void operator=(const DroppedVariableStats &) = delete;
+
+  void registerCallbacks(PassInstrumentationCallbacks &PIC);
+  void runBeforePass(StringRef PassID, Any IR);
+  void runAfterPass(StringRef PassID, Any IR, const PreservedAnalyses &PA);
+  void runAfterPassInvalidated(StringRef PassID, const PreservedAnalyses &PA);
+  bool getPassDroppedVariables() { return PassDroppedVariables; }
+
+private:
+  bool PassDroppedVariables = false;
+  /// A unique key that represents a #dbg_value.
+  using VarID =
+      std::tuple<const DIScope *, const DIScope *, const DILocalVariable *>;
+
+  struct DebugVariables {
+    /// DenseSet of VarIDs before an optimization pass has run.
+    DenseSet<VarID> DebugVariablesBefore;
+    /// DenseSet of VarIDs after an optimization pass has run.
+    DenseSet<VarID> DebugVariablesAfter;
+  };
+
+  /// A stack of a DenseMap, that maps DebugVariables for every pass to an
+  /// llvm::Function. A stack is used because an optimization pass can call
+  /// other passes.
+  SmallVector<DenseMap<const Function *, DebugVariables>> DebugVariablesStack;
+
+  /// A DenseSet tracking whether a scope was visited before.
+  DenseSet<const DIScope *> VisitedScope;
+  /// A stack of DenseMaps, which map the name of an llvm::Function to a
+  /// DenseMap of VarIDs and their inlinedAt locations before an optimization
+  /// pass has run.
+  SmallVector<DenseMap<StringRef, DenseMap<VarID, DILocation *>>> InlinedAts;
+
+  /// Iterate over all Functions in a Module and report any dropped debug
+  /// information. Will call calculateDroppedVarStatsOnFunction on every
+  /// Function.
+  void calculateDroppedVarStatsOnModule(const Module *M, StringRef PassID,
+                                        std::string FuncOrModName,
+                                        std::string PassLevel);
+  /// Iterate over all Instructions in a Function and report any dropped debug
+  /// information.
+  void calculateDroppedVarStatsOnFunction(const Function *F, StringRef PassID,
+                                          std::string FuncOrModName,
+                                          std::string PassLevel);
+  /// Populate DebugVariablesBefore, DebugVariablesAfter, InlinedAts before or
+  /// after a pass has run to facilitate dropped variable calculation for an
+  /// llvm::Function.
+  void runOnFunction(const Function *F, bool Before);
+  /// Populate DebugVariablesBefore, DebugVariablesAfter, InlinedAts before or
+  /// after a pass has run to facilitate dropped variable calculation for an
+  /// llvm::Module. Calls runOnFunction on every Function in the Module.
+  void runOnModule(const Module *M, bool Before);
+  /// Remove a dropped #dbg_value VarID from all Sets in the
+  /// DroppedVariablesBefore stack.
+  void removeVarFromAllSets(VarID Var, const Function *F);
+  /// Return true if \p Scope is the same as \p DbgValScope or a child scope of
+  /// \p DbgValScope, return false otherwise.
+  bool isScopeChildOfOrEqualTo(DIScope *Scope, const DIScope *DbgValScope);
+  /// Return true if \p InlinedAt is the same as \p DbgValInlinedAt or part of
+  /// the InlinedAt chain, return false otherwise.
+  bool isInlinedAtChildOfOrEqualTo(const DILocation *InlinedAt,
+                                   const DILocation *DbgValInlinedAt);
+};
+
 /// This class provides an interface to register all the standard pass
 /// instrumentations and manages their state (if any).
 class StandardInstrumentations {
@@ -595,6 +673,7 @@ class StandardInstrumentations {
   PrintCrashIRInstrumentation PrintCrashIR;
   IRChangedTester ChangeTester;
   VerifyInstrumentation Verify;
+  DroppedVariableStats DroppedStats;
 
   bool VerifyEach;
 

--- a/llvm/lib/Passes/StandardInstrumentations.cpp
+++ b/llvm/lib/Passes/StandardInstrumentations.cpp
@@ -25,6 +25,8 @@
 #include "llvm/CodeGen/MachineVerifier.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassInstrumentation.h"
 #include "llvm/IR/PassManager.h"
@@ -137,6 +139,11 @@ static cl::opt<std::string> IRDumpDirectory(
              "-print-[before|after]{-all} options will be dumped into "
              "files in this directory rather than written to stderr"),
     cl::Hidden, cl::value_desc("filename"));
+
+static cl::opt<bool>
+    DroppedVarStats("dropped-variable-stats", cl::Hidden,
+                    cl::desc("Dump dropped debug variables stats"),
+                    cl::init(false));
 
 template <typename IRUnitT> static const IRUnitT *unwrapIR(Any IR) {
   const IRUnitT **IRPtr = llvm::any_cast<const IRUnitT *>(&IR);
@@ -2444,8 +2451,7 @@ void DotCfgChangeReporter::registerCallbacks(
 StandardInstrumentations::StandardInstrumentations(
     LLVMContext &Context, bool DebugLogging, bool VerifyEach,
     PrintPassOptions PrintPassOpts)
-    : PrintPass(DebugLogging, PrintPassOpts),
-      OptNone(DebugLogging),
+    : PrintPass(DebugLogging, PrintPassOpts), OptNone(DebugLogging),
       OptPassGate(Context),
       PrintChangedIR(PrintChanged == ChangePrinter::Verbose),
       PrintChangedDiff(PrintChanged == ChangePrinter::DiffVerbose ||
@@ -2453,7 +2459,8 @@ StandardInstrumentations::StandardInstrumentations(
                        PrintChanged == ChangePrinter::ColourDiffVerbose ||
                            PrintChanged == ChangePrinter::ColourDiffQuiet),
       WebsiteChangeReporter(PrintChanged == ChangePrinter::DotCfgVerbose),
-      Verify(DebugLogging), VerifyEach(VerifyEach) {}
+      Verify(DebugLogging), DroppedStats(DroppedVarStats),
+      VerifyEach(VerifyEach) {}
 
 PrintCrashIRInstrumentation *PrintCrashIRInstrumentation::CrashReporter =
     nullptr;
@@ -2513,6 +2520,182 @@ void PrintCrashIRInstrumentation::registerCallbacks(
       });
 }
 
+void DroppedVariableStats::registerCallbacks(
+    PassInstrumentationCallbacks &PIC) {
+  if (!DroppedVarStats)
+    return;
+
+  PIC.registerBeforeNonSkippedPassCallback(
+      [this](StringRef P, Any IR) { return this->runBeforePass(P, IR); });
+  PIC.registerAfterPassCallback(
+      [this](StringRef P, Any IR, const PreservedAnalyses &PA) {
+        return this->runAfterPass(P, IR, PA);
+      });
+  PIC.registerAfterPassInvalidatedCallback(
+      [this](StringRef P, const PreservedAnalyses &PA) {
+        return this->runAfterPassInvalidated(P, PA);
+      });
+}
+
+void DroppedVariableStats::runBeforePass(StringRef PassID, Any IR) {
+  DebugVariablesStack.push_back({DenseMap<const Function *, DebugVariables>()});
+  InlinedAts.push_back({DenseMap<StringRef, DenseMap<VarID, DILocation *>>()});
+  if (auto *M = unwrapIR<Module>(IR))
+    return this->runOnModule(M, true);
+  if (auto *F = unwrapIR<Function>(IR))
+    return this->runOnFunction(F, true);
+  return;
+}
+
+void DroppedVariableStats::runOnFunction(const Function *F, bool Before) {
+  auto &DebugVariables = DebugVariablesStack.back()[F];
+  auto &VarIDSet = (Before ? DebugVariables.DebugVariablesBefore
+                           : DebugVariables.DebugVariablesAfter);
+  auto &InlinedAtsMap = InlinedAts.back();
+  auto FuncName = F->getName();
+  if (Before)
+    InlinedAtsMap.try_emplace(FuncName, DenseMap<VarID, DILocation *>());
+  VarIDSet = DenseSet<VarID>();
+  for (const auto &I : instructions(F)) {
+    for (DbgRecord &DR : I.getDbgRecordRange()) {
+      if (auto *Dbg = dyn_cast<DbgVariableRecord>(&DR)) {
+        auto *DbgVar = Dbg->getVariable();
+        auto DbgLoc = DR.getDebugLoc();
+        VarID Key{DbgVar->getScope(), DbgLoc->getInlinedAtScope(), DbgVar};
+        VarIDSet.insert(Key);
+        if (Before)
+          InlinedAtsMap[FuncName].try_emplace(Key, DbgLoc.getInlinedAt());
+      }
+    }
+  }
+}
+
+void DroppedVariableStats::runOnModule(const Module *M, bool Before) {
+  for (auto &F : *M)
+    runOnFunction(&F, Before);
+}
+
+void DroppedVariableStats::removeVarFromAllSets(VarID Var, const Function *F) {
+  // Do not remove Var from the last element, it will be popped from the stack.
+  for (auto &DebugVariablesMap : llvm::drop_end(DebugVariablesStack))
+    DebugVariablesMap[F].DebugVariablesBefore.erase(Var);
+}
+
+void DroppedVariableStats::calculateDroppedVarStatsOnModule(
+    const Module *M, StringRef PassID, std::string FuncOrModName,
+    std::string PassLevel) {
+  for (auto &F : *M) {
+    calculateDroppedVarStatsOnFunction(&F, PassID, FuncOrModName, PassLevel);
+  }
+}
+
+void DroppedVariableStats::calculateDroppedVarStatsOnFunction(
+    const Function *F, StringRef PassID, std::string FuncOrModName,
+    std::string PassLevel) {
+  unsigned DroppedCount = 0;
+  StringRef FuncName = F->getName();
+  DebugVariables &DbgVariables = DebugVariablesStack.back()[F];
+  DenseSet<VarID> &DebugVariablesBeforeSet = DbgVariables.DebugVariablesBefore;
+  DenseSet<VarID> &DebugVariablesAfterSet = DbgVariables.DebugVariablesAfter;
+  DenseMap<VarID, DILocation *> &InlinedAtsMap = InlinedAts.back()[FuncName];
+  // Find an Instruction that shares the same scope as the dropped #dbg_value or
+  // has a scope that is the child of the scope of the #dbg_value, and has an
+  // inlinedAt equal to the inlinedAt of the #dbg_value or it's inlinedAt chain
+  // contains the inlinedAt of the #dbg_value, if such an Instruction is found,
+  // debug information is dropped.
+  for (VarID Var : DebugVariablesBeforeSet) {
+    if (DebugVariablesAfterSet.contains(Var))
+      continue;
+    const DIScope *DbgValScope = std::get<0>(Var);
+    for (const auto &I : instructions(F)) {
+      auto *DbgLoc = I.getDebugLoc().get();
+      if (!DbgLoc)
+        continue;
+
+      auto *Scope = DbgLoc->getScope();
+      if (isScopeChildOfOrEqualTo(Scope, DbgValScope)) {
+        if (isInlinedAtChildOfOrEqualTo(DbgLoc->getInlinedAt(),
+                                        InlinedAtsMap[Var])) {
+          // Found another instruction in the variable's scope, so there exists
+          // a break point at which the variable could be observed. Count it as
+          // dropped.
+          DroppedCount++;
+          break;
+        }
+      }
+    }
+    removeVarFromAllSets(Var, F);
+  }
+  if (DroppedCount > 0) {
+    llvm::outs() << PassLevel << ", " << PassID << ", " << DroppedCount << ", "
+                 << FuncOrModName << "\n";
+    PassDroppedVariables = true;
+  } else
+    PassDroppedVariables = false;
+}
+
+void DroppedVariableStats::runAfterPassInvalidated(
+    StringRef PassID, const PreservedAnalyses &PA) {
+  DebugVariablesStack.pop_back();
+  InlinedAts.pop_back();
+}
+
+void DroppedVariableStats::runAfterPass(StringRef PassID, Any IR,
+                                        const PreservedAnalyses &PA) {
+  std::string PassLevel;
+  std::string FuncOrModName;
+  if (auto *M = unwrapIR<Module>(IR)) {
+    this->runOnModule(M, false);
+    PassLevel = "Module";
+    FuncOrModName = M->getName();
+    calculateDroppedVarStatsOnModule(M, PassID, FuncOrModName, PassLevel);
+  } else if (auto *F = unwrapIR<Function>(IR)) {
+    this->runOnFunction(F, false);
+    PassLevel = "Function";
+    FuncOrModName = F->getName();
+    calculateDroppedVarStatsOnFunction(F, PassID, FuncOrModName, PassLevel);
+  }
+
+  DebugVariablesStack.pop_back();
+  InlinedAts.pop_back();
+  return;
+}
+
+bool DroppedVariableStats::isScopeChildOfOrEqualTo(DIScope *Scope,
+                                                   const DIScope *DbgValScope) {
+  while (Scope != nullptr) {
+    if (VisitedScope.find(Scope) == VisitedScope.end()) {
+      VisitedScope.insert(Scope);
+      if (Scope == DbgValScope) {
+        VisitedScope.clear();
+        return true;
+      }
+      Scope = Scope->getScope();
+    } else {
+      VisitedScope.clear();
+      return false;
+    }
+  }
+  return false;
+}
+
+bool DroppedVariableStats::isInlinedAtChildOfOrEqualTo(
+    const DILocation *InlinedAt, const DILocation *DbgValInlinedAt) {
+  if (DbgValInlinedAt == InlinedAt)
+    return true;
+  if (!DbgValInlinedAt)
+    return false;
+  if (!InlinedAt)
+    return false;
+  auto *IA = InlinedAt;
+  while (IA) {
+    if (IA == DbgValInlinedAt)
+      return true;
+    IA = IA->getInlinedAt();
+  }
+  return false;
+}
+
 void StandardInstrumentations::registerCallbacks(
     PassInstrumentationCallbacks &PIC, ModuleAnalysisManager *MAM) {
   PrintIR.registerCallbacks(PIC);
@@ -2528,6 +2711,7 @@ void StandardInstrumentations::registerCallbacks(
   WebsiteChangeReporter.registerCallbacks(PIC);
   ChangeTester.registerCallbacks(PIC);
   PrintCrashIR.registerCallbacks(PIC);
+  DroppedStats.registerCallbacks(PIC);
   if (MAM)
     PreservedCFGChecker.registerCallbacks(PIC, *MAM);
 

--- a/llvm/test/Other/dropped-var-stats.ll
+++ b/llvm/test/Other/dropped-var-stats.ll
@@ -1,0 +1,25 @@
+; RUN: opt -dropped-variable-stats %s -passes='verify' -S | FileCheck %s --check-prefix=NOT-DROPPED
+; NOT-DROPPED: Pass Level, Pass Name, Num of Dropped Variables, Func or Module Name
+; NOT-DROPPED-NOT: Function, ADCEPass, 1, _Z3bari
+
+; ModuleID = '/tmp/dropped.cpp'
+define noundef range(i32 -2147483646, -2147483648) i32 @_Z3bari(i32 noundef %y) local_unnamed_addr #1 !dbg !19 {
+    #dbg_value(i32 %y, !15, !DIExpression(), !23)
+  %add = add nsw i32 %y, 2,!dbg !25
+  ret i32 %add,!dbg !26
+}
+!llvm.module.flags = !{ !3, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 20.0.0git (git@github.com:llvm/llvm-project.git 7fc8398aaad65c4c29f1511c374d07308e667af5)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+!1 = !DIFile(filename: "/tmp/dropped.cpp", directory: "/Users/shubham/Development/llvm-project")
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!7 = !{i32 7, !"frame-pointer", i32 1}
+!9 = distinct !DISubprogram( unit: !0, retainedNodes: !14)
+!13 = !DIBasicType()
+!14 = !{}
+!15 = !DILocalVariable( scope: !9, type: !13)
+!19 = distinct !DISubprogram( unit: !0, retainedNodes: !20)
+!20 = !{}
+!23 = !DILocation( scope: !9, inlinedAt: !24)
+!24 = distinct !DILocation( scope: !19)
+!25 = !DILocation( scope: !19)
+!26 = !DILocation( scope: !19)

--- a/llvm/unittests/IR/CMakeLists.txt
+++ b/llvm/unittests/IR/CMakeLists.txt
@@ -42,6 +42,7 @@ add_llvm_unittest(IRTests
   ShuffleVectorInstTest.cpp
   StructuralHashTest.cpp
   TimePassesTest.cpp
+  DroppedVariableStatsTest.cpp
   TypesTest.cpp
   UseTest.cpp
   UserTest.cpp

--- a/llvm/unittests/IR/DroppedVariableStatsTest.cpp
+++ b/llvm/unittests/IR/DroppedVariableStatsTest.cpp
@@ -1,0 +1,446 @@
+//===- unittests/IR/DroppedVariableStatsTest.cpp - TimePassesHandler tests
+//----------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/AsmParser/Parser.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+#include "llvm/PassRegistry.h"
+#include "llvm/Passes/StandardInstrumentations.h"
+#include "llvm/Support/SourceMgr.h"
+#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <llvm/ADT/SmallString.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/PassInstrumentation.h>
+#include <llvm/IR/PassManager.h>
+#include <llvm/IR/PassTimingInfo.h>
+#include <llvm/Support/raw_ostream.h>
+
+using namespace llvm;
+namespace llvm {
+void initializePassTest1Pass(PassRegistry &);
+
+static std::unique_ptr<Module> parseIR(LLVMContext &C, const char *IR) {
+  SMDiagnostic Err;
+  std::unique_ptr<Module> Mod = parseAssemblyString(IR, Err, C);
+  if (!Mod)
+    Err.print("AbstractCallSiteTests", errs());
+  return Mod;
+}
+} // namespace llvm
+
+namespace {
+
+// This test ensures that if a #dbg_value and an instruction that exists in the
+// same scope as that #dbg_value are both deleted as a result of an optimization
+// pass, debug information is considered not dropped.
+TEST(DroppedVariableStats, BothDeleted) {
+  PassInstrumentationCallbacks PIC;
+  PassInstrumentation PI(&PIC);
+
+  LLVMContext C;
+
+  const char *IR =
+      R"(
+      ; Function Attrs: mustprogress nounwind ssp uwtable(sync)
+      define noundef range(i32 -2147483647, -2147483648) i32 @_Z3fooi(i32 noundef %x) local_unnamed_addr #0 !dbg !9 {
+      entry:
+        #dbg_value(i32 %x, !15, !DIExpression(), !16)
+        %add = add nsw i32 %x, 1, !dbg !17
+        ret i32 0
+      }
+      !llvm.dbg.cu = !{!0}
+      !llvm.module.flags = !{!3}
+      !llvm.ident = !{!8}
+      !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+      !1 = !DIFile(filename: "/tmp/code.cpp", directory: "/")
+      !3 = !{i32 2, !"Debug Info Version", i32 3}
+      !8 = !{!"clang"}
+      !9 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooi", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, unit: !0, retainedNodes: !14)
+      !10 = !DIFile(filename: "/tmp/code.cpp", directory: "")
+      !11 = !DISubroutineType(types: !12)
+      !12 = !{!13, !13}
+      !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+      !14 = !{!15}
+      !15 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+      !16 = !DILocation(line: 0, scope: !9)
+      !17 = !DILocation(line: 2, column: 11, scope: !9))";
+
+  std::unique_ptr<llvm::Module> M = parseIR(C, IR);
+  ASSERT_TRUE(M);
+
+  DroppedVariableStats Stats(true);
+  Stats.runBeforePass("Test",
+                      llvm::Any(const_cast<const llvm::Module *>(M.get())));
+
+  // This loop simulates an IR pass that drops debug information.
+  for (auto &F : *M.get()) {
+    for (auto &I : instructions(&F)) {
+      I.dropDbgRecords();
+      I.eraseFromParent();
+      break;
+    }
+    break;
+  }
+  PreservedAnalyses PA;
+  Stats.runAfterPass("Test",
+                     llvm::Any(const_cast<const llvm::Module *>(M.get())), PA);
+  ASSERT_EQ(Stats.getPassDroppedVariables(), false);
+}
+
+// This test ensures that if a #dbg_value is dropped after an optimization pass,
+// but an instruction that shares the same scope as the #dbg_value still exists,
+// debug information is conisdered dropped.
+TEST(DroppedVariableStats, DbgValLost) {
+  PassInstrumentationCallbacks PIC;
+  PassInstrumentation PI(&PIC);
+
+  LLVMContext C;
+
+  const char *IR =
+      R"(
+      ; Function Attrs: mustprogress nounwind ssp uwtable(sync)
+      define noundef range(i32 -2147483647, -2147483648) i32 @_Z3fooi(i32 noundef %x) local_unnamed_addr #0 !dbg !9 {
+      entry:
+        #dbg_value(i32 %x, !15, !DIExpression(), !16)
+        %add = add nsw i32 %x, 1, !dbg !17
+        ret i32 0
+      }
+      !llvm.dbg.cu = !{!0}
+      !llvm.module.flags = !{!3}
+      !llvm.ident = !{!8}
+      !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+      !1 = !DIFile(filename: "/tmp/code.cpp", directory: "/")
+      !3 = !{i32 2, !"Debug Info Version", i32 3}
+      !8 = !{!"clang"}
+      !9 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooi", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, unit: !0, retainedNodes: !14)
+      !10 = !DIFile(filename: "/tmp/code.cpp", directory: "")
+      !11 = !DISubroutineType(types: !12)
+      !12 = !{!13, !13}
+      !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+      !14 = !{!15}
+      !15 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+      !16 = !DILocation(line: 0, scope: !9)
+      !17 = !DILocation(line: 2, column: 11, scope: !9))";
+
+  std::unique_ptr<llvm::Module> M = parseIR(C, IR);
+  ASSERT_TRUE(M);
+
+  DroppedVariableStats Stats(true);
+  Stats.runBeforePass("Test",
+                      llvm::Any(const_cast<const llvm::Module *>(M.get())));
+
+  // This loop simulates an IR pass that drops debug information.
+  for (auto &F : *M.get()) {
+    for (auto &I : instructions(&F)) {
+      I.dropDbgRecords();
+      break;
+    }
+    break;
+  }
+  PreservedAnalyses PA;
+  Stats.runAfterPass("Test",
+                     llvm::Any(const_cast<const llvm::Module *>(M.get())), PA);
+  ASSERT_EQ(Stats.getPassDroppedVariables(), true);
+}
+
+// This test ensures that if a #dbg_value is dropped after an optimization pass,
+// but an instruction that has an unrelated scope as the #dbg_value still
+// exists, debug information is conisdered not dropped.
+TEST(DroppedVariableStats, UnrelatedScopes) {
+  PassInstrumentationCallbacks PIC;
+  PassInstrumentation PI(&PIC);
+
+  LLVMContext C;
+
+  const char *IR =
+      R"(
+      ; Function Attrs: mustprogress nounwind ssp uwtable(sync)
+      define noundef range(i32 -2147483647, -2147483648) i32 @_Z3fooi(i32 noundef %x) local_unnamed_addr #0 !dbg !9 {
+      entry:
+        #dbg_value(i32 %x, !15, !DIExpression(), !16)
+        %add = add nsw i32 %x, 1, !dbg !17
+        ret i32 0
+      }
+      !llvm.dbg.cu = !{!0}
+      !llvm.module.flags = !{!3}
+      !llvm.ident = !{!8}
+      !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+      !1 = !DIFile(filename: "/tmp/code.cpp", directory: "/")
+      !3 = !{i32 2, !"Debug Info Version", i32 3}
+      !8 = !{!"clang"}
+      !9 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooi", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, unit: !0, retainedNodes: !14)
+      !10 = !DIFile(filename: "/tmp/code.cpp", directory: "")
+      !11 = !DISubroutineType(types: !12)
+      !12 = !{!13, !13}
+      !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+      !14 = !{!15}
+      !15 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+      !16 = !DILocation(line: 0, scope: !9)
+      !17 = !DILocation(line: 2, column: 11, scope: !18)
+      !18 = distinct !DISubprogram(name: "bar", linkageName: "_Z3bari", scope: !10, file: !10, line: 11, type: !11, scopeLine: 1,  unit: !0, retainedNodes: !14))";
+
+  std::unique_ptr<llvm::Module> M = parseIR(C, IR);
+  ASSERT_TRUE(M);
+
+  DroppedVariableStats Stats(true);
+  Stats.runBeforePass("Test",
+                      llvm::Any(const_cast<const llvm::Module *>(M.get())));
+
+  // This loop simulates an IR pass that drops debug information.
+  for (auto &F : *M.get()) {
+    for (auto &I : instructions(&F)) {
+      I.dropDbgRecords();
+      break;
+    }
+    break;
+  }
+  PreservedAnalyses PA;
+  Stats.runAfterPass("Test",
+                     llvm::Any(const_cast<const llvm::Module *>(M.get())), PA);
+  ASSERT_EQ(Stats.getPassDroppedVariables(), false);
+}
+
+// This test ensures that if a #dbg_value is dropped after an optimization pass,
+// but an instruction that has a scope which is a child of the #dbg_value scope
+// still exists, debug information is conisdered dropped.
+TEST(DroppedVariableStats, ChildScopes) {
+  PassInstrumentationCallbacks PIC;
+  PassInstrumentation PI(&PIC);
+
+  LLVMContext C;
+
+  const char *IR =
+      R"(
+      ; Function Attrs: mustprogress nounwind ssp uwtable(sync)
+      define noundef range(i32 -2147483647, -2147483648) i32 @_Z3fooi(i32 noundef %x) local_unnamed_addr #0 !dbg !9 {
+      entry:
+        #dbg_value(i32 %x, !15, !DIExpression(), !16)
+        %add = add nsw i32 %x, 1, !dbg !17
+        ret i32 0
+      }
+      !llvm.dbg.cu = !{!0}
+      !llvm.module.flags = !{!3}
+      !llvm.ident = !{!8}
+      !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+      !1 = !DIFile(filename: "/tmp/code.cpp", directory: "/")
+      !3 = !{i32 2, !"Debug Info Version", i32 3}
+      !8 = !{!"clang"}
+      !9 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooi", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, unit: !0, retainedNodes: !14)
+      !10 = !DIFile(filename: "/tmp/code.cpp", directory: "")
+      !11 = !DISubroutineType(types: !12)
+      !12 = !{!13, !13}
+      !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+      !14 = !{!15}
+      !15 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+      !16 = !DILocation(line: 0, scope: !9)
+      !17 = !DILocation(line: 2, column: 11, scope: !18)
+      !18 = distinct !DILexicalBlock(scope: !9, file: !10, line: 10, column: 28))";
+
+  std::unique_ptr<llvm::Module> M = parseIR(C, IR);
+  ASSERT_TRUE(M);
+
+  DroppedVariableStats Stats(true);
+  Stats.runBeforePass("Test",
+                      llvm::Any(const_cast<const llvm::Module *>(M.get())));
+
+  // This loop simulates an IR pass that drops debug information.
+  for (auto &F : *M.get()) {
+    for (auto &I : instructions(&F)) {
+      I.dropDbgRecords();
+      break;
+    }
+    break;
+  }
+  PreservedAnalyses PA;
+  Stats.runAfterPass("Test",
+                     llvm::Any(const_cast<const llvm::Module *>(M.get())), PA);
+  ASSERT_EQ(Stats.getPassDroppedVariables(), true);
+}
+
+// This test ensures that if a #dbg_value is dropped after an optimization pass,
+// but an instruction that has a scope which is a child of the #dbg_value scope
+// still exists, and the #dbg_value is inlined at another location, debug
+// information is conisdered not dropped.
+TEST(DroppedVariableStats, InlinedAt) {
+  PassInstrumentationCallbacks PIC;
+  PassInstrumentation PI(&PIC);
+
+  LLVMContext C;
+
+  const char *IR =
+      R"(; Function Attrs: mustprogress nounwind ssp uwtable(sync)
+      define noundef range(i32 -2147483647, -2147483648) i32 @_Z3fooi(i32 noundef %x) local_unnamed_addr #0 !dbg !9 {
+      entry:
+        #dbg_value(i32 %x, !15, !DIExpression(), !16)
+        %add = add nsw i32 %x, 1, !dbg !17
+        ret i32 0
+      }
+      !llvm.dbg.cu = !{!0}
+      !llvm.module.flags = !{!3}
+      !llvm.ident = !{!8}
+      !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+      !1 = !DIFile(filename: "/tmp/code.cpp", directory: "/")
+      !3 = !{i32 2, !"Debug Info Version", i32 3}
+      !8 = !{!"clang"}
+      !9 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooi", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, unit: !0, retainedNodes: !14)
+      !10 = !DIFile(filename: "/tmp/code.cpp", directory: "")
+      !11 = !DISubroutineType(types: !12)
+      !12 = !{!13, !13}
+      !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+      !14 = !{!15}
+      !15 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+      !16 = !DILocation(line: 0, scope: !9, inlinedAt: !19)
+      !17 = !DILocation(line: 2, column: 11, scope: !18)
+      !18 = distinct !DILexicalBlock(scope: !9, file: !10, line: 10, column: 28)
+      !19 = !DILocation(line: 3, column: 2, scope: !9))";
+
+  std::unique_ptr<llvm::Module> M = parseIR(C, IR);
+  ASSERT_TRUE(M);
+
+  DroppedVariableStats Stats(true);
+  Stats.runBeforePass("Test",
+                      llvm::Any(const_cast<const llvm::Module *>(M.get())));
+
+  // This loop simulates an IR pass that drops debug information.
+  for (auto &F : *M.get()) {
+    for (auto &I : instructions(&F)) {
+      I.dropDbgRecords();
+      break;
+    }
+    break;
+  }
+  PreservedAnalyses PA;
+  Stats.runAfterPass("Test",
+                     llvm::Any(const_cast<const llvm::Module *>(M.get())), PA);
+  ASSERT_EQ(Stats.getPassDroppedVariables(), false);
+}
+
+// This test ensures that if a #dbg_value is dropped after an optimization pass,
+// but an instruction that has a scope which is a child of the #dbg_value scope
+// still exists, and the #dbg_value and the instruction are inlined at another
+// location, debug information is conisdered dropped.
+TEST(DroppedVariableStats, InlinedAtShared) {
+  PassInstrumentationCallbacks PIC;
+  PassInstrumentation PI(&PIC);
+
+  LLVMContext C;
+
+  const char *IR =
+      R"(; Function Attrs: mustprogress nounwind ssp uwtable(sync)
+      define noundef range(i32 -2147483647, -2147483648) i32 @_Z3fooi(i32 noundef %x) local_unnamed_addr #0 !dbg !9 {
+      entry:
+        #dbg_value(i32 %x, !15, !DIExpression(), !16)
+        %add = add nsw i32 %x, 1, !dbg !17
+        ret i32 0
+      }
+      !llvm.dbg.cu = !{!0}
+      !llvm.module.flags = !{!3}
+      !llvm.ident = !{!8}
+      !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+      !1 = !DIFile(filename: "/tmp/code.cpp", directory: "/")
+      !3 = !{i32 2, !"Debug Info Version", i32 3}
+      !8 = !{!"clang"}
+      !9 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooi", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, unit: !0, retainedNodes: !14)
+      !10 = !DIFile(filename: "/tmp/code.cpp", directory: "")
+      !11 = !DISubroutineType(types: !12)
+      !12 = !{!13, !13}
+      !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+      !14 = !{!15}
+      !15 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+      !16 = !DILocation(line: 0, scope: !9, inlinedAt: !19)
+      !17 = !DILocation(line: 2, column: 11, scope: !18, inlinedAt: !19)
+      !18 = distinct !DILexicalBlock(scope: !9, file: !10, line: 10, column: 28)
+      !19 = !DILocation(line: 3, column: 2, scope: !9))";
+
+  std::unique_ptr<llvm::Module> M = parseIR(C, IR);
+  ASSERT_TRUE(M);
+
+  DroppedVariableStats Stats(true);
+  Stats.runBeforePass("Test",
+                      llvm::Any(const_cast<const llvm::Module *>(M.get())));
+
+  // This loop simulates an IR pass that drops debug information.
+  for (auto &F : *M.get()) {
+    for (auto &I : instructions(&F)) {
+      I.dropDbgRecords();
+      break;
+    }
+    break;
+  }
+  PreservedAnalyses PA;
+  Stats.runAfterPass("Test",
+                     llvm::Any(const_cast<const llvm::Module *>(M.get())), PA);
+  ASSERT_EQ(Stats.getPassDroppedVariables(), true);
+}
+
+// This test ensures that if a #dbg_value is dropped after an optimization pass,
+// but an instruction that has a scope which is a child of the #dbg_value scope
+// still exists, and the instruction is inlined at a location that is the
+// #dbg_value's inlined at location, debug information is conisdered dropped.
+TEST(DroppedVariableStats, InlinedAtChild) {
+  PassInstrumentationCallbacks PIC;
+  PassInstrumentation PI(&PIC);
+
+  LLVMContext C;
+
+  const char *IR =
+      R"(; Function Attrs: mustprogress nounwind ssp uwtable(sync)
+      define noundef range(i32 -2147483647, -2147483648) i32 @_Z3fooi(i32 noundef %x) local_unnamed_addr #0 !dbg !9 {
+      entry:
+        #dbg_value(i32 %x, !15, !DIExpression(), !16)
+        %add = add nsw i32 %x, 1, !dbg !17
+        ret i32 0
+      }
+      !llvm.dbg.cu = !{!0}
+      !llvm.module.flags = !{!3}
+      !llvm.ident = !{!8}
+      !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+      !1 = !DIFile(filename: "/tmp/code.cpp", directory: "/")
+      !3 = !{i32 2, !"Debug Info Version", i32 3}
+      !8 = !{!"clang"}
+      !9 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooi", scope: !10, file: !10, line: 1, type: !11, scopeLine: 1, unit: !0, retainedNodes: !14)
+      !10 = !DIFile(filename: "/tmp/code.cpp", directory: "")
+      !11 = !DISubroutineType(types: !12)
+      !12 = !{!13, !13}
+      !13 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+      !14 = !{!15}
+      !15 = !DILocalVariable(name: "x", arg: 1, scope: !9, file: !10, line: 1, type: !13)
+      !16 = !DILocation(line: 0, scope: !9, inlinedAt: !19)
+      !17 = !DILocation(line: 2, column: 11, scope: !18, inlinedAt: !20)
+      !18 = distinct !DILexicalBlock(scope: !9, file: !10, line: 10, column: 28)
+      !19 = !DILocation(line: 3, column: 2, scope: !9);
+      !20 = !DILocation(line: 4, column: 5, scope: !18, inlinedAt: !19))";
+
+  std::unique_ptr<llvm::Module> M = parseIR(C, IR);
+  ASSERT_TRUE(M);
+
+  DroppedVariableStats Stats(true);
+  Stats.runBeforePass("Test",
+                      llvm::Any(const_cast<const llvm::Module *>(M.get())));
+
+  // This loop simulates an IR pass that drops debug information.
+  for (auto &F : *M.get()) {
+    for (auto &I : instructions(&F)) {
+      I.dropDbgRecords();
+      break;
+    }
+    break;
+  }
+  PreservedAnalyses PA;
+  Stats.runAfterPass("Test",
+                     llvm::Any(const_cast<const llvm::Module *>(M.get())), PA);
+  ASSERT_EQ(Stats.getPassDroppedVariables(), true);
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
This patch is inspired by @Snowy1803 excellent work in swift and the patch: https://github.com/swiftlang/swift/pull/73334/files

Add an instrumentation pass to llvm to collect dropped debug information variable statistics for every Function-level and Module-level IR pass.

This patch creates adds the class DroppedVariableStats which iterates over every DbgRecord in a function or module before and after an optimization pass and counts the number of variables who's debug information has been dropped due to that pass, then prints that output to stdout in a csv format.

I ran this patch on optdriver.cpp can see:

Pass Name, Dropped Variables
'InstCombinePass', 1
'SimplifyCFGPass', 6
'JumpThreadingPass', 25

(cherry picked from commit b8930cd13d484fadc12b810d76156c2c9e884f75)