### PR TITLE
[lldb] Comment assert in GetEnumCaseName

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -970,7 +970,8 @@ std::optional<std::string> SwiftLanguageRuntimeImpl::GetEnumCaseName(
   if (eti->projectEnumValue(*GetMemoryReader(), addr, &case_index))
     return eti->getCases()[case_index].Name;
 
-  LogUnimplementedTypeKind(__FUNCTION__, type);
+  // TODO: uncomment this after fixing projection for every type: rdar://138424904
+  // LogUnimplementedTypeKind(__FUNCTION__, type);
   return {};
 }
 


### PR DESCRIPTION
There still seem to be some cases where GetEnumCaseName fails to project the enum case. Comment out the assertion until we fix the cases that are currently failing.