### PR TITLE
[rebranch] [lldb] Pass language options to `ide::isSourceInputComplete`

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
@@ -70,6 +70,10 @@ protected:
                         lldb::ValueObjectSP &valobj_sp,
                         ExpressionVariable *var = nullptr) override;
 
+  /// Retrieve the SwiftASTContext to use for completion and line parsing
+  /// checks.
+  SwiftASTContextForExpressions *getSwiftASTContext();
+
   void CompleteCode(const std::string &current_code,
                     CompletionRequest &request) override;
 


### PR DESCRIPTION
*rebranch cherry-pick of #9439*