### PR TITLE
[lldb] Introduce Swift Task synthetic provider (#9404)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -116,6 +116,9 @@ bool TypePreservingNSNumber_SummaryProvider(ValueObject &valobj, Stream &stream,
 
 SyntheticChildrenFrontEnd *EnumSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
+
+SyntheticChildrenFrontEnd *TaskSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                                        lldb::ValueObjectSP);
 }
 }
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -408,7 +408,14 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   SetConfig::Get().RegisterSyntheticChildrenCreators(swift_category_sp,
                                                      synth_flags);
 
-  synth_flags.SetSkipPointers(true);
+  AddCXXSynthetic(swift_category_sp,
+                  lldb_private::formatters::swift::TaskSyntheticFrontEndCreator,
+                  "Swift.Task synthetic children",
+                  ConstString("^Swift\\.Task<.+,.+>"), synth_flags, true);
+  AddCXXSynthetic(swift_category_sp,
+                  lldb_private::formatters::swift::TaskSyntheticFrontEndCreator,
+                  "Swift.UnsafeCurrentTask synthetic children",
+                  ConstString("Swift.UnsafeCurrentTask"), synth_flags);
 
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Bool_SummaryProvider,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -18,6 +18,7 @@
 #include "lldb/lldb-types.h"
 #include "swift/ABI/ObjectFile.h"
 #include "swift/Remote/RemoteAddress.h"
+#include "swift/RemoteInspection/ReflectionContext.h"
 #include "swift/RemoteInspection/TypeRef.h"
 #include <optional>
 #include "llvm/ADT/STLFunctionalExtras.h"
@@ -145,6 +146,23 @@ public:
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
+  struct AsyncTaskInfo {
+    bool isChildTask = false;
+    bool isFuture = false;
+    bool isGroupChildTask = false;
+    bool isAsyncLetTask = false;
+    bool isCancelled = false;
+    bool isStatusRecordLocked = false;
+    bool isEscalated = false;
+    /// If false, the IsRunning flag is not valid.
+    bool hasIsRunning = false;
+    bool isRunning = false;
+    bool isEnqueued = false;
+  };
+  // The default limits are copied from swift-inspect.
+  virtual llvm::Expected<AsyncTaskInfo>
+  asyncTaskInfo(lldb::addr_t AsyncTaskPtr, unsigned ChildTaskLimit = 1000000,
+                unsigned AsyncBacktraceLimit = 1000) = 0;
 };
 
 using ThreadSafeReflectionContext = LockGuarded<ReflectionContextInterface>;

--- a/lldb/test/API/lang/swift/async/formatters/task/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -1,0 +1,47 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    def test_top_level_task(self):
+        """Test Task synthetic child provider for top-level Task."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break for top-level task", lldb.SBFileSpec("main.swift")
+        )
+        # Note: The value of isEnqueued is timing dependent. For that reason,
+        # the test checks only that it has a value, not what the value is.
+        self.expect(
+            "frame var task",
+            substrs=[
+                "(Task<(), Error>) task = {",
+                "isChildTask = false",
+                "isFuture = true",
+                "isGroupChildTask = false",
+                "isAsyncLetTask = false",
+                "isCancelled = false",
+                "isEnqueued = ",
+            ],
+        )
+
+    def test_current_task(self):
+        """Test Task synthetic child for UnsafeCurrentTask (from an async let)."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break for current task", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame var currentTask",
+            substrs=[
+                "(UnsafeCurrentTask) currentTask = {",
+                "isChildTask = true",
+                "isFuture = true",
+                "isGroupChildTask = false",
+                "isAsyncLetTask = true",
+                "isCancelled = false",
+                "isEnqueued = false",
+            ],
+        )

--- a/lldb/test/API/lang/swift/async/formatters/task/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/main.swift
@@ -1,0 +1,22 @@
+func f() async -> Int {
+    withUnsafeCurrentTask { currentTask in
+        if let currentTask {
+            print("break for current task")
+        }
+    }
+    return 30
+}
+
+@main struct Main {
+    static func main() async {
+        let task = Task {
+            // Extend the task's lifetime, hopefully long enough for the breakpoint to hit.
+            try await Task.sleep(for: .seconds(0.5))
+            print("inside")
+        }
+        print("break for top-level task")
+
+        async let number = f()
+        print(await number)
+    }
+}


### PR DESCRIPTION
Add a synthetic provider for Swift's `Task` and `UnsafeCurrentTask` types.

This uses `ReflectionContext::asyncTaskInfo`. In this initial version, only the bool 
flags are plugged through. Follow up changes will add more metadata (ex task ID, 
priority), child tasks, and backtraces.

(cherry-picked from commit 1d3fd3582d5bd4fc49854f40e6d6acf9cbe38d9c)