### PR TITLE
Skip one inline stepping test for arm-ubuntu.

### DIFF
--- a/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
+++ b/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
@@ -15,7 +15,7 @@ class TestInlineStepping(TestBase):
         bugnumber="# Not really a bug.  ICC combines two inlined functions.",
     )
 
-    @skipIf(oslist=["ubuntu"], archs=["arm"]) # Fails for 32 bit arm
+    @skipIf(oslist=["linux"], archs=["arm"]) # Fails for 32 bit arm
     def test_with_python_api(self):
         """Test stepping over and into inlined functions."""
         self.build()

--- a/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
+++ b/lldb/test/API/functionalities/inline-stepping/TestInlineStepping.py
@@ -14,6 +14,8 @@ class TestInlineStepping(TestBase):
         compiler="icc",
         bugnumber="# Not really a bug.  ICC combines two inlined functions.",
     )
+
+    @skipIf(oslist=["ubuntu"], archs=["arm"]) # Fails for 32 bit arm
     def test_with_python_api(self):
         """Test stepping over and into inlined functions."""
         self.build()


### PR DESCRIPTION
The test is currently passing everywhere but this 32-bit arm ubuntu bot.  I don't have an easy way to debug this, so I'm skipping the test on that platform till we get a chance to figure this out.