### PR TITLE
[lldb] Disable TestPublicAPIHeaders.py under asan

### DIFF
--- a/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
+++ b/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
@@ -8,6 +8,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIfAsan
 @skipIfNoSBHeaders
 @skipIfRemote
 @skipUnlessDarwin


### PR DESCRIPTION
This test builds an executable linked against just-built LLDB libraries. This is making it find the just-built sanitizer libraries, instead of the sdk ones.

(cherry picked from commit daea66a1545f9454216e0bdabf520405a9b3a2a7)