### PR TITLE
[lldb] Add asan flags to TestCustomShell

### DIFF
--- a/lldb/test/Shell/Host/TestCustomShell.test
+++ b/lldb/test/Shell/Host/TestCustomShell.test
@@ -7,7 +7,7 @@
 
 # RUN: %clang_host %S/Inputs/simple.c -g -o %t.out
 # RUN: SHELL=bogus not %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s --check-prefix ERROR
-# RUN: env -i ASAN_OPTIONS='detect_container_overflow=0' %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s
+# RUN: env -i ASAN_OPTIONS='detect_container_overflow=0,allow_user_poisoning=0' %lldb %t.out -b -o 'process launch -X 1 --' 2>&1 | FileCheck %s
 
 # ERROR: error: shell expansion failed
 # CHECK-NOT: error: shell expansion failed


### PR DESCRIPTION
As discussed in 978574956849007f54b77fd6cda380d90c8e3215, we need to disable "user poisoning" in swift's fork of llvm. However, this particular test overrides the environment, so we need to propagate the asan flags manually.