### PR TITLE
[lldb] Disable UnsafeCurrentTask test on linux

### DIFF
--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -29,6 +29,7 @@ class TestCase(TestBase):
         )
 
     @swiftTest
+    @skipIfLinux
     def test_current_task(self):
         """Test Task synthetic child for UnsafeCurrentTask (from an async let)."""
         self.build()


### PR DESCRIPTION
This is failing here https://ci.swift.org/job/oss-swift-pr-test-ubuntu-20_04/7767

```
error: no variable named 'currentTask' found in this frame
```