### PR TITLE
[cherry-pick][lldb] Fix a warning

### DIFF
--- a/lldb/source/Plugins/SystemRuntime/MacOSX/AbortWithPayloadFrameRecognizer.cpp
+++ b/lldb/source/Plugins/SystemRuntime/MacOSX/AbortWithPayloadFrameRecognizer.cpp
@@ -175,8 +175,7 @@ AbortWithPayloadFrameRecognizer::RecognizeFrame(lldb::StackFrameSP frame_sp) {
   // For the reason string, we want the string not the address, so fetch that.
   std::string reason_string;
   Status error;
-  size_t str_len =
-      process->ReadCStringFromMemory(reason_addr, reason_string, error);
+  process->ReadCStringFromMemory(reason_addr, reason_string, error);
   if (error.Fail()) {
     // Even if we couldn't read the string, return the other data.
     LLDB_LOG(log, "Couldn't fetch reason string: {0}.", error);


### PR DESCRIPTION
This patch fixes:

  lldb/source/Plugins/SystemRuntime/MacOSX/AbortWithPayloadFrameRecognizer.cpp:177:10:
  error: unused variable 'str_len' [-Werror,-Wunused-variable]

(cherry picked from commit 1fcddc0dfa1b371bc0b278438d5f47cf8d03b511)