### PR TITLE
Provide users a way to record ObjC methods referenced by message sends and emit the information to a file in JSON format

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -505,6 +505,24 @@ class ASTContext : public RefCountedBase<ASTContext> {
 
   ASTContext &this_() { return *this; }
 
+  mutable std::optional<std::string> ObjCMsgSendUsageFile;
+  llvm::SmallVector<const ObjCMethodDecl *, 4> ObjCMsgSendUsage;
+
+public:
+  /// Check whether env variable CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH is set.
+  /// If it is set, assign the value to ObjCMsgSendUsageFile.
+  bool isObjCMsgSendUsageFileSpecified() const;
+
+  /// Return the file name stored in ObjCMsgSendUsageFile if it has a value,
+  /// return an empty string otherwise.
+  std::string getObjCMsgSendUsageFilename() const;
+
+  /// Record an ObjC method.
+  void recordObjCMsgSendUsage(const ObjCMethodDecl *Method);
+
+  /// Write the collected ObjC method tracing information to a file.
+  void writeObjCMsgSendUsages(const std::string &Filename);
+
 public:
   /// A type synonym for the TemplateOrInstantiation mapping.
   using TemplateOrSpecializationInfo =

--- a/clang/include/clang/AST/ObjCMethodReferenceInfo.h
+++ b/clang/include/clang/AST/ObjCMethodReferenceInfo.h
@@ -1,0 +1,42 @@
+//===- ObjcMethodReferenceInfo.h - API for ObjC method tracing --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines APIs for ObjC method tracing.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_OBJC_METHOD_REFERENCE_INFO_H
+#define LLVM_CLANG_OBJC_METHOD_REFERENCE_INFO_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <string>
+
+namespace clang {
+
+class ObjCMethodDecl;
+
+struct ObjCMethodReferenceInfo {
+  static constexpr unsigned FormatVersion = 1;
+  std::string Target, TargetVariant;
+
+  /// Paths to the files in which ObjC methods are referenced.
+  llvm::SmallVector<std::string, 4> FilePaths;
+
+  /// A map from the index of a file in FilePaths to the list of ObjC methods.
+  std::map<unsigned, llvm::SmallVector<const ObjCMethodDecl *, 4>> References;
+};
+
+/// This function serializes the ObjC message tracing information in JSON.
+void serializeObjCMethodReferencesAsJson(const ObjCMethodReferenceInfo &Info,
+                                         llvm::raw_ostream &OS);
+
+} // namespace clang
+
+#endif // LLVM_CLANG_OBJC_METHOD_REFERENCE_INFO_H

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1201,6 +1201,10 @@ void Sema::ActOnEndOfTranslationUnit() {
     }
   }
 
+  if (getASTContext().isObjCMsgSendUsageFileSpecified())
+    getASTContext().writeObjCMsgSendUsages(
+        getASTContext().getObjCMsgSendUsageFilename());
+
   DiagnoseUnterminatedPragmaAlignPack();
   DiagnoseUnterminatedPragmaAttribute();
   OpenMP().DiagnoseUnterminatedOpenMPDeclareTarget();

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -2740,6 +2740,10 @@ ExprResult SemaObjC::BuildClassMessage(
     if (!isImplicit)
       checkCocoaAPI(SemaRef, Result);
   }
+
+  if (Method && Context.isObjCMsgSendUsageFileSpecified())
+    Context.recordObjCMsgSendUsage(Method);
+
   if (Method)
     checkFoundationAPI(SemaRef, SelLoc, Method, ArrayRef(Args, NumArgs),
                        ReceiverType, /*IsClassObjectCall=*/true);
@@ -3332,6 +3336,10 @@ ExprResult SemaObjC::BuildInstanceMessage(
     if (!isImplicit)
       checkCocoaAPI(SemaRef, Result);
   }
+
+  if (Method && Context.isObjCMsgSendUsageFileSpecified())
+    Context.recordObjCMsgSendUsage(Method);
+
   if (Method) {
     bool IsClassObjectCall = ClassMessage;
     // 'self' message receivers in class methods should be treated as message

--- a/clang/test/AST/Inputs/objc-method-tracing.h
+++ b/clang/test/AST/Inputs/objc-method-tracing.h
@@ -1,0 +1,19 @@
+@interface A
+-(void)m0;
+@end
+
+@interface B
+-(void)m0;
++(void)m1;
+@end
+
+#define CDef \
+@interface C \
+-(void)m4; \
+@end
+
+CDef
+
+@protocol P0
+-(void)m5;
+@end

--- a/clang/test/AST/objc-method-tracing.mm
+++ b/clang/test/AST/objc-method-tracing.mm
@@ -1,0 +1,128 @@
+// RUN: env CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH=%t.txt %clang_cc1 -fsyntax-only -triple arm64-apple-macosx15.0.0 -I %S/Inputs %s
+// RUN: cat %t.txt | FileCheck %s
+
+// CHECK: {
+// CHECK-NEXT:    "format-version": 1,
+// CHECK-NEXT:    "target": "arm64-apple-macosx15.0.0",
+// CHECK-NEXT:    "references": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "A",
+// CHECK-NEXT:            "instance_method": "-[A m0]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE:.*]]:2:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "instance_method": "-[B m0]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:6:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "class_method": "+[B m1]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:7:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "category_type": "Cat1",
+// CHECK-NEXT:            "instance_method": "-[B(Cat1) m2]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE:.*]]:12:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "C",
+// CHECK-NEXT:            "instance_method": "-[C m4]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:15:1 <Spelling=[[HEADER_FILE]]:11:14>",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "protocol_type": "P0",
+// CHECK-NEXT:            "instance_method": "-[P0 m5]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:18:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "category_type": "",
+// CHECK-NEXT:            "instance_method": "-[B() m6]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:16:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "implementation_type": "B",
+// CHECK-NEXT:            "instance_method": "-[B m7:arg1:]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:20:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "category_implementation_type": "Cat1",
+// CHECK-NEXT:            "instance_method": "-[B(Cat1) m8]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:25:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "fileMap": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "file_id": 1,
+// CHECK-NEXT:            "file_path": "[[SOURCE_FILE]]"
+// CHECK-NEXT:        }
+// CHECK-NEXT:    ]
+// CHECK-NEXT: }
+
+#include "objc-method-tracing.h"
+
+@interface B(Cat1)
+-(void)m2;
+@end
+
+@interface B()
+-(void)m6;
+@end
+
+@implementation B
+-(void)m7:(int)i arg1:(float)f {
+}
+@end
+
+@implementation B(Cat1)
+-(void)m8 {
+}
+@end
+
+void test0(A *a) {
+  [a m0];
+}
+
+void test1(B *b) {
+  [b m0];
+}
+
+void test2(B *b) {
+  [B m1];
+}
+
+void test3(B *b) {
+  [b m2];
+}
+
+void test4(C *c) {
+  [c m4];
+}
+
+void test5(id<P0> p0) {
+  [p0 m5];
+}
+
+void test6(B *b) {
+  [b m6];
+}
+
+void test7(B *b) {
+  [b m7:123 arg1:4.5f];
+}
+
+void test8(B *b) {
+  [b m8];
+}


### PR DESCRIPTION
Environmental variable CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH must be set to enable this.