### PR TITLE
Provide users a way to record ObjC methods referenced by message sends and emit the information to a file in JSON format

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -490,6 +490,24 @@ class ASTContext : public RefCountedBase<ASTContext> {
 
   ASTContext &this_() { return *this; }
 
+  mutable std::optional<std::string> ObjCMsgSendUsageFile;
+  llvm::SmallVector<const ObjCMethodDecl *, 4> ObjCMsgSendUsage;
+
+public:
+  /// Check whether env variable CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH is set.
+  /// If it is set, assign the value to ObjCMsgSendUsageFile.
+  bool isObjCMsgSendUsageFileSpecified() const;
+
+  /// Return the file name stored in ObjCMsgSendUsageFile if it has a value,
+  /// return an empty string otherwise.
+  std::string getObjCMsgSendUsageFilename() const;
+
+  /// Record an ObjC method.
+  void recordObjCMsgSendUsage(const ObjCMethodDecl *Method);
+
+  /// Write the collected ObjC method tracing information to a file.
+  void writeObjCMsgSendUsages(const std::string &Filename);
+
 public:
   /// A type synonym for the TemplateOrInstantiation mapping.
   using TemplateOrSpecializationInfo =

--- a/clang/include/clang/AST/ObjCMethodReferenceInfo.h
+++ b/clang/include/clang/AST/ObjCMethodReferenceInfo.h
@@ -1,0 +1,42 @@
+//===- ObjcMethodReferenceInfo.h - API for ObjC method tracing --*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines APIs for ObjC method tracing.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_OBJC_METHOD_REFERENCE_INFO_H
+#define LLVM_CLANG_OBJC_METHOD_REFERENCE_INFO_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+#include <map>
+#include <string>
+
+namespace clang {
+
+class ObjCMethodDecl;
+
+struct ObjCMethodReferenceInfo {
+  static constexpr unsigned FormatVersion = 1;
+  std::string Target, TargetVariant;
+
+  /// Paths to the files in which ObjC methods are referenced.
+  llvm::SmallVector<std::string, 4> FilePaths;
+
+  /// A map from the index of a file in FilePaths to the list of ObjC methods.
+  std::map<unsigned, llvm::SmallVector<const ObjCMethodDecl *, 4>> References;
+};
+
+/// This function serializes the ObjC message tracing information in JSON.
+void serializeObjCMethodReferencesAsJson(const ObjCMethodReferenceInfo &Info,
+                                         llvm::raw_ostream &OS);
+
+} // namespace clang
+
+#endif // LLVM_CLANG_OBJC_METHOD_REFERENCE_INFO_H

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -37,6 +37,7 @@
 #include "clang/AST/Mangle.h"
 #include "clang/AST/MangleNumberingContext.h"
 #include "clang/AST/NestedNameSpecifier.h"
+#include "clang/AST/ObjCMethodReferenceInfo.h"
 #include "clang/AST/ParentMapContext.h"
 #include "clang/AST/RawCommentList.h"
 #include "clang/AST/RecordLayout.h"
@@ -85,6 +86,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/MD5.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/SipHash.h"
@@ -9239,6 +9241,133 @@ static TypedefDecl *CreateVoidPtrBuiltinVaListDecl(const ASTContext *Context) {
   // typedef void* __builtin_va_list;
   QualType T = Context->getPointerType(Context->VoidTy);
   return Context->buildImplicitTypedef(T, "__builtin_va_list");
+}
+
+bool ASTContext::isObjCMsgSendUsageFileSpecified() const {
+  if (!ObjCMsgSendUsageFile) {
+    if (const char *Filename =
+            std::getenv("CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH"))
+      ObjCMsgSendUsageFile = Filename;
+    else
+      return false;
+  }
+
+  return true;
+}
+
+std::string ASTContext::getObjCMsgSendUsageFilename() const {
+  if (isObjCMsgSendUsageFileSpecified())
+    return *ObjCMsgSendUsageFile;
+  return "";
+}
+
+void ASTContext::recordObjCMsgSendUsage(const ObjCMethodDecl *Method) {
+  ObjCMsgSendUsage.push_back(Method);
+}
+
+static StringRef selectMethodKey(const clang::ObjCMethodDecl *clangD) {
+  assert(clangD);
+  if (clangD->isInstanceMethod())
+    return "instance_method";
+  assert(clangD->isClassMethod() && "must be a class method");
+  return "class_method";
+}
+
+static std::array<std::pair<StringRef, StringRef>, 2>
+selectMethodOwnerKey(const clang::NamedDecl *clangD) {
+  assert(clangD);
+  if (isa<clang::ObjCInterfaceDecl>(clangD))
+    return {{{"interface_type", clangD->getName()}, {}}};
+  if (isa<clang::ObjCImplementationDecl>(clangD))
+    return {{{"implementation_type", clangD->getName()}, {}}};
+  if (auto *Cat = dyn_cast<clang::ObjCCategoryDecl>(clangD))
+    return {{{"interface_type", Cat->getClassInterface()->getName()},
+             {"category_type", Cat->getName()}}};
+  if (auto *Cat = dyn_cast<clang::ObjCCategoryImplDecl>(clangD))
+    return {{{"interface_type",
+              Cat->getCategoryDecl()->getClassInterface()->getName()},
+             {"category_implementation_type", Cat->getName()}}};
+  if (isa<clang::ObjCProtocolDecl>(clangD))
+    return {{{"protocol_type", clangD->getName()}, {}}};
+  llvm_unreachable("unknown method owner");
+}
+
+void clang::serializeObjCMethodReferencesAsJson(
+    const clang::ObjCMethodReferenceInfo &Info, llvm::raw_ostream &OS) {
+  llvm::json::OStream Out(OS, /*IndentSize=*/4);
+  Out.object([&] {
+    Out.attribute("format-version", Info.FormatVersion);
+    Out.attribute("target", Info.Target);
+    if (!Info.TargetVariant.empty())
+      Out.attribute("target-variant", Info.TargetVariant);
+    Out.attributeArray("references", [&] {
+      for (auto &Ref : Info.References) {
+        unsigned FileID = Ref.first;
+        for (const clang::ObjCMethodDecl *clangD : Ref.second) {
+          auto &SM = clangD->getASTContext().getSourceManager();
+          clang::SourceLocation Loc = clangD->getLocation();
+          if (!Loc.isValid())
+            continue;
+          Out.object([&] {
+            if (auto *parent =
+                    dyn_cast_or_null<clang::NamedDecl>(clangD->getParent())) {
+              std::array<std::pair<StringRef, StringRef>, 2> OwnerInfo =
+                  selectMethodOwnerKey(parent);
+              for (auto I : OwnerInfo)
+                if (I.first.data())
+                  Out.attribute(I.first, I.second);
+            }
+
+            std::string MangledMethodName;
+            llvm::raw_string_ostream Out2(MangledMethodName);
+            std::unique_ptr<MangleContext> Mangler(
+                clangD->getASTContext().createMangleContext());
+            Mangler->mangleObjCMethodName(clangD, Out2,
+                                          /*includePrefixByte=*/false, true);
+            Out.attribute(selectMethodKey(clangD), MangledMethodName);
+            Out.attribute("declared_at", Loc.printToString(SM));
+            Out.attribute("referenced_at_file_id", FileID);
+          });
+        }
+      }
+    });
+
+    Out.attributeArray("fileMap", [&] {
+      for (unsigned I = 0, N = Info.FilePaths.size(); I != N; I++) {
+        Out.object([&] {
+          Out.attribute("file_id", I + 1);
+          Out.attribute("file_path", Info.FilePaths[I]);
+        });
+      }
+    });
+  });
+}
+
+void ASTContext::writeObjCMsgSendUsages(const std::string &Filename) {
+  std::error_code EC;
+  auto FDS = std::make_unique<llvm::raw_fd_ostream>(
+      Filename, EC, llvm::sys::fs::OF_Text | llvm::sys::fs::OF_Append);
+  if (EC) {
+    unsigned ID = getDiagnostics().getCustomDiagID(
+        DiagnosticsEngine::Error,
+        "couldn't open objc message send tracing file %0");
+    getDiagnostics().Report(ID) << Filename;
+    return;
+  }
+
+  if (auto L = FDS->lock()) {
+    clang::ObjCMethodReferenceInfo Info;
+    OptionalFileEntryRef FE =
+        SourceMgr.getFileEntryRefForID(SourceMgr.getMainFileID());
+    SmallString<256> MainFile(FE->getName());
+    SourceMgr.getFileManager().makeAbsolutePath(MainFile);
+    Info.Target = getTargetInfo().getTriple().str();
+    if (auto *VariantTriple = getTargetInfo().getDarwinTargetVariantTriple())
+      Info.TargetVariant = VariantTriple->str();
+    Info.FilePaths.push_back(MainFile.c_str());
+    Info.References[1] = ObjCMsgSendUsage;
+    serializeObjCMethodReferencesAsJson(Info, *FDS);
+  }
 }
 
 static TypedefDecl *

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1202,6 +1202,10 @@ void Sema::ActOnEndOfTranslationUnit() {
     }
   }
 
+  if (getASTContext().isObjCMsgSendUsageFileSpecified())
+    getASTContext().writeObjCMsgSendUsages(
+        getASTContext().getObjCMsgSendUsageFilename());
+
   DiagnoseUnterminatedPragmaAlignPack();
   DiagnoseUnterminatedPragmaAttribute();
   OpenMP().DiagnoseUnterminatedOpenMPDeclareTarget();

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -2739,6 +2739,10 @@ ExprResult SemaObjC::BuildClassMessage(
     if (!isImplicit)
       checkCocoaAPI(SemaRef, Result);
   }
+
+  if (Method && Context.isObjCMsgSendUsageFileSpecified())
+    Context.recordObjCMsgSendUsage(Method);
+
   if (Method)
     checkFoundationAPI(SemaRef, SelLoc, Method, ArrayRef(Args, NumArgs),
                        ReceiverType, /*IsClassObjectCall=*/true);
@@ -3330,6 +3334,10 @@ ExprResult SemaObjC::BuildInstanceMessage(
     if (!isImplicit)
       checkCocoaAPI(SemaRef, Result);
   }
+
+  if (Method && Context.isObjCMsgSendUsageFileSpecified())
+    Context.recordObjCMsgSendUsage(Method);
+
   if (Method) {
     bool IsClassObjectCall = ClassMessage;
     // 'self' message receivers in class methods should be treated as message

--- a/clang/test/AST/Inputs/objc-method-tracing.h
+++ b/clang/test/AST/Inputs/objc-method-tracing.h
@@ -1,0 +1,19 @@
+@interface A
+-(void)m0;
+@end
+
+@interface B
+-(void)m0;
++(void)m1;
+@end
+
+#define CDef \
+@interface C \
+-(void)m4; \
+@end
+
+CDef
+
+@protocol P0
+-(void)m5;
+@end

--- a/clang/test/AST/objc-method-tracing.mm
+++ b/clang/test/AST/objc-method-tracing.mm
@@ -1,0 +1,128 @@
+// RUN: env CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH=%t.txt %clang_cc1 -fsyntax-only -triple arm64-apple-macosx15.0.0 -I %S/Inputs %s
+// RUN: cat %t.txt | FileCheck %s
+
+// CHECK: {
+// CHECK-NEXT:    "format-version": 1,
+// CHECK-NEXT:    "target": "arm64-apple-macosx15.0.0",
+// CHECK-NEXT:    "references": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "A",
+// CHECK-NEXT:            "instance_method": "-[A m0]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE:.*]]:2:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "instance_method": "-[B m0]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:6:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "class_method": "+[B m1]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:7:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "category_type": "Cat1",
+// CHECK-NEXT:            "instance_method": "-[B(Cat1) m2]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE:.*]]:12:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "C",
+// CHECK-NEXT:            "instance_method": "-[C m4]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:15:1 <Spelling=[[HEADER_FILE]]:11:14>",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "protocol_type": "P0",
+// CHECK-NEXT:            "instance_method": "-[P0 m5]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:18:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "category_type": "",
+// CHECK-NEXT:            "instance_method": "-[B() m6]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:16:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "implementation_type": "B",
+// CHECK-NEXT:            "instance_method": "-[B m7:arg1:]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:20:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "category_implementation_type": "Cat1",
+// CHECK-NEXT:            "instance_method": "-[B(Cat1) m8]",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:25:1",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "fileMap": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "file_id": 1,
+// CHECK-NEXT:            "file_path": "[[SOURCE_FILE]]"
+// CHECK-NEXT:        }
+// CHECK-NEXT:    ]
+// CHECK-NEXT: }
+
+#include "objc-method-tracing.h"
+
+@interface B(Cat1)
+-(void)m2;
+@end
+
+@interface B()
+-(void)m6;
+@end
+
+@implementation B
+-(void)m7:(int)i arg1:(float)f {
+}
+@end
+
+@implementation B(Cat1)
+-(void)m8 {
+}
+@end
+
+void test0(A *a) {
+  [a m0];
+}
+
+void test1(B *b) {
+  [b m0];
+}
+
+void test2(B *b) {
+  [B m1];
+}
+
+void test3(B *b) {
+  [b m2];
+}
+
+void test4(C *c) {
+  [c m4];
+}
+
+void test5(id<P0> p0) {
+  [p0 m5];
+}
+
+void test6(B *b) {
+  [b m6];
+}
+
+void test7(B *b) {
+  [b m7:123 arg1:4.5f];
+}
+
+void test8(B *b) {
+  [b m8];
+}


### PR DESCRIPTION
Environmental variable CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH must be set to enable this.