### PR TITLE
🍒[CMake] Enable CMP0156 if available

### DIFF
--- a/cmake/Modules/CMakePolicy.cmake
+++ b/cmake/Modules/CMakePolicy.cmake
@@ -29,3 +29,11 @@ endif()
 if(POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW)
 endif()
+
+# CMP0156: De-duplicate libraries on link lines based on linker capabilities.
+# New in CMake 3.29: https://cmake.org/cmake/help/latest/policy/CMP0156.html
+# Avoids the deluge of 'ld: warning: ignoring duplicate libraries' warnings when
+# building with the Apple linker.
+if(POLICY CMP0156)
+  cmake_policy(SET CMP0156 NEW)
+endif()


### PR DESCRIPTION
CMP0156 removes duplicate library links based on linker capabilities. The new Apple linker emits warnings when libraries are repeated on the link line because they do not have an effect.
Enabling this policy will remove the duplicate libraries, fixing these warnings.

Cherry-Picking back from https://github.com/llvm/llvm-project/pull/115046.