### PR TITLE
[lldb] Apply available search paths from swift to clang importer

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1913,29 +1913,26 @@ void SwiftASTContext::AddExtraClangCC1Args(
       GetCompilerInvocation().getClangModuleCachePath().str();
 
   // Remove non-existing modules in a systematic way.
-  bool module_missing = false;
-  auto CheckFileExists = [&](const char *file) {
-    if (!llvm::sys::fs::exists(file)) {
-      std::string warn;
-      llvm::raw_string_ostream(warn)
-          << "Nonexistent explicit module file " << file;
-      AddDiagnostic(eSeverityWarning, warn);
-      module_missing = true;
-    }
+  auto CheckFileExists = [&](const std::string &file) -> bool {
+    if (llvm::sys::fs::exists(file))
+      return true;
+    std::string warn;
+    llvm::raw_string_ostream(warn)
+        << "Nonexistent explicit module file " << file;
+    AddDiagnostic(eSeverityWarning, warn);
+    return false;
   };
-  llvm::for_each(invocation.getHeaderSearchOpts().PrebuiltModuleFiles,
-                 [&](const auto &mod) { CheckFileExists(mod.second.c_str()); });
-  llvm::for_each(invocation.getFrontendOpts().ModuleFiles,
-                 [&](const auto &mod) { CheckFileExists(mod.c_str()); });
-
-  // If missing, clear all the prebuilt module options and switch to implicit
-  // modules build.
-  if (module_missing) {
-    invocation.getHeaderSearchOpts().PrebuiltModuleFiles.clear();
-    invocation.getFrontendOpts().ModuleFiles.clear();
-    invocation.getLangOpts().ImplicitModules = true;
-    invocation.getHeaderSearchOpts().ImplicitModuleMaps = true;
+  for (auto it = invocation.getHeaderSearchOpts().PrebuiltModuleFiles.begin();
+       it != invocation.getHeaderSearchOpts().PrebuiltModuleFiles.end();) {
+    if (!CheckFileExists(it->second))
+      it = invocation.getHeaderSearchOpts().PrebuiltModuleFiles.erase(it);
+    else
+      ++it;
   }
+  invocation.getFrontendOpts().ModuleFiles.erase(
+      llvm::remove_if(invocation.getFrontendOpts().ModuleFiles,
+                      [&](const auto &mod) { return !CheckFileExists(mod); }),
+      invocation.getFrontendOpts().ModuleFiles.end());
 
   invocation.generateCC1CommandLine(
       [&](const llvm::Twine &arg) { dest.push_back(arg.str()); });

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1093,6 +1093,23 @@ static void ConfigureResourceDirs(swift::CompilerInvocation &invocation,
   invocation.setRuntimeResourcePath(resource_dir);
 }
 
+static void ConfigureModuleCachePath(SwiftASTContext &swift_ast_sp) {
+  std::string moduleCachePath =
+      swift_ast_sp.GetCompilerInvocation().getClangModuleCachePath().str();
+  if (!moduleCachePath.empty())
+    return;
+
+  // If the moduleCachePath is not configured, setup a default path location.
+  llvm::SmallString<0> path;
+  std::error_code ec =
+      llvm::sys::fs::createUniqueDirectory("ModuleCache", path);
+  if (!ec)
+    moduleCachePath = std::string(path);
+  else
+    moduleCachePath = "/tmp/lldb-ModuleCache";
+  swift_ast_sp.GetCompilerInvocation().setClangModuleCachePath(moduleCachePath);
+}
+
 static const char *getImportFailureString(swift::serialization::Status status) {
   switch (status) {
   case swift::serialization::Status::Valid:
@@ -1778,7 +1795,10 @@ static void applyOverrideOptions(std::vector<std::string> &args,
 }
 
 void SwiftASTContext::AddExtraClangArgs(
-    const std::vector<std::string> &ExtraArgs, StringRef overrideOpts) {
+    const std::vector<std::string> &ExtraArgs,
+    const std::vector<std::string> &module_search_paths,
+    const std::vector<std::pair<std::string, bool>> framework_search_paths,
+    StringRef overrideOpts) {
   if (ExtraArgs.empty())
     return;
 
@@ -1804,7 +1824,8 @@ void SwiftASTContext::AddExtraClangArgs(
   if (importer_options.DirectClangCC1ModuleBuild) {
     if (!fresh_invocation)
       importer_options.ExtraArgs.clear();
-    AddExtraClangCC1Args(ExtraArgs, importer_options.ExtraArgs);
+    AddExtraClangCC1Args(ExtraArgs, module_search_paths, framework_search_paths,
+                         importer_options.ExtraArgs);
     applyOverrideOptions(importer_options.ExtraArgs, overrideOpts);
     return;
   }
@@ -1822,10 +1843,17 @@ void SwiftASTContext::AddExtraClangArgs(
 }
 
 void SwiftASTContext::AddExtraClangCC1Args(
-    const std::vector<std::string> &source, std::vector<std::string> &dest) {
+    const std::vector<std::string> &source,
+    const std::vector<std::string> &module_search_paths,
+    const std::vector<std::pair<std::string, bool>> framework_search_paths,
+    std::vector<std::string> &dest) {
   clang::CompilerInvocation invocation;
+  std::vector<std::string> default_paths = {"/usr/include",
+                                            "/user/local/include"};
   llvm::SmallVector<const char *> clangArgs;
-  clangArgs.reserve(source.size());
+  clangArgs.reserve(source.size() + module_search_paths.size() * 2 +
+                    framework_search_paths.size() * 2 +
+                    default_paths.size() * 2);
   llvm::for_each(source, [&](const std::string &Arg) {
     // Workaround for the extra driver argument embedded in the swiftmodule by
     // some swift compiler version. It always starts with `--target=` and it is
@@ -1833,6 +1861,25 @@ void SwiftASTContext::AddExtraClangCC1Args(
     if (!StringRef(Arg).starts_with("--target="))
       clangArgs.push_back(Arg.c_str());
   });
+  // Append some search paths from swift invocation so lldb can import
+  // additional clang modules when doing type reconstruction.
+  for (auto &path : module_search_paths) {
+    clangArgs.push_back("-I");
+    clangArgs.push_back(path.c_str());
+  }
+  for (auto &path : default_paths) {
+    llvm::SmallString<128> search_path(GetPlatformSDKPath());
+    llvm::sys::path::append(search_path, path);
+    path = std::string(search_path);
+  }
+  for (auto &path : default_paths) {
+    clangArgs.push_back("-I");
+    clangArgs.push_back(path.c_str());
+  }
+  for (auto &path : framework_search_paths) {
+    clangArgs.push_back("-F");
+    clangArgs.push_back(path.first.c_str());
+  }
 
   std::string diags;
   llvm::raw_string_ostream os(diags);
@@ -1858,6 +1905,12 @@ void SwiftASTContext::AddExtraClangCC1Args(
 
   // Ignore CAS info inside modules when loading.
   invocation.getFrontendOpts().ModuleLoadIgnoreCAS = true;
+
+  // Add options to allow clang importer to do implicit module build.
+  invocation.getLangOpts().ImplicitModules = true;
+  invocation.getHeaderSearchOpts().ImplicitModuleMaps = true;
+  invocation.getHeaderSearchOpts().ModuleCachePath =
+      GetCompilerInvocation().getClangModuleCachePath().str();
 
   // Remove non-existing modules in a systematic way.
   bool module_missing = false;
@@ -1898,7 +1951,7 @@ void SwiftASTContext::AddUserClangArgs(TargetProperties &props) {
   std::vector<std::string> user_clang_flags;
   for (const auto &arg : args.entries())
     user_clang_flags.push_back(arg.ref().str());
-  AddExtraClangArgs(user_clang_flags);
+  AddExtraClangArgs(user_clang_flags, {}, {});
 }
 
 /// Turn relative paths in clang options into absolute paths based on
@@ -2471,6 +2524,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
       HostInfo::GetSwiftResourceDir(triple, swift_ast_sp->GetPlatformSDKPath());
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(), resource_dir,
                         triple);
+  ConfigureModuleCachePath(*swift_ast_sp);
 
   swift_ast_sp->SetCompilerInvocationLLDBOverrides();
 
@@ -2494,7 +2548,8 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 
   // Apply the working directory to all relative paths.
   StringRef overrideOpts = target ? target->GetSwiftClangOverrideOptions() : "";
-  swift_ast_sp->AddExtraClangArgs(extra_clang_args, overrideOpts);
+  swift_ast_sp->AddExtraClangArgs(extra_clang_args, module_search_paths,
+                                  framework_search_paths, overrideOpts);
   if (target)
     swift_ast_sp->AddUserClangArgs(*target);
   else
@@ -2930,6 +2985,7 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
       triple, swift_ast_sp->GetPlatformSDKPath());
   ConfigureResourceDirs(swift_ast_sp->GetCompilerInvocation(), resource_dir,
                         triple);
+  ConfigureModuleCachePath(*swift_ast_sp);
 
   std::vector<swift::PluginSearchOption> plugin_search_options;
   std::vector<std::string> module_search_paths;
@@ -2968,7 +3024,8 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
       swift_ast_sp->AddDiagnostic(eSeverityError, error);
     StringRef override_opts =
         target_sp ? target_sp->GetSwiftClangOverrideOptions() : "";
-    swift_ast_sp->AddExtraClangArgs(extra_clang_args, override_opts);
+    swift_ast_sp->AddExtraClangArgs(extra_clang_args, module_search_paths,
+                                    framework_search_paths, override_opts);
   }
 
   // Now fold any extra options we were passed. This has to be done
@@ -3572,7 +3629,8 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   }
 
   // Create the ClangImporter and determine the Clang module cache path.
-  std::string moduleCachePath = "";
+  std::string moduleCachePath =
+      GetCompilerInvocation().getClangModuleCachePath().str();
   std::unique_ptr<swift::ClangImporter> clang_importer_ap;
   auto &clang_importer_options = GetClangImporterOptions();
   if (!m_ast_context_ap->SearchPathOpts.getSDKPath().empty() ||
@@ -3599,24 +3657,12 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
                             underlying_error.c_str());
         }
       }
-      if (clang_importer_ap)
-        moduleCachePath = swift::getModuleCachePathFromClang(
+      if (clang_importer_ap) {
+        auto clangModuleCache = swift::getModuleCachePathFromClang(
             clang_importer_ap->getClangInstance());
-    }
-  }
-
-  if (moduleCachePath.empty()) {
-    moduleCachePath = GetClangModulesCacheProperty();
-    // Even though it is initialized to the default Clang location at startup a
-    // user could have overwritten it with an empty path.
-    if (moduleCachePath.empty()) {
-      llvm::SmallString<0> path;
-      std::error_code ec =
-          llvm::sys::fs::createUniqueDirectory("ModuleCache", path);
-      if (!ec)
-        moduleCachePath = std::string(path);
-      else
-        moduleCachePath = "/tmp/lldb-ModuleCache";
+        if (!clangModuleCache.empty())
+          moduleCachePath = clangModuleCache;
+      }
     }
   }
   LOG_PRINTF(GetLog(LLDBLog::Types), "Using Clang module cache path: %s",

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1801,11 +1801,11 @@ void SwiftASTContext::AddExtraClangArgs(
   importer_options.DirectClangCC1ModuleBuild = invocation_direct_cc1;
 
   // If using direct cc1 flags, compute the arguments and return.
-  // Since this is cc1 flags, override options are driver flags and don't apply.
   if (importer_options.DirectClangCC1ModuleBuild) {
     if (!fresh_invocation)
       importer_options.ExtraArgs.clear();
     AddExtraClangCC1Args(ExtraArgs, importer_options.ExtraArgs);
+    applyOverrideOptions(importer_options.ExtraArgs, overrideOpts);
     return;
   }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -275,10 +275,17 @@ public:
 
   /// Add a list of Clang arguments to the ClangImporter options and
   /// apply the working directory to any relative paths.
-  void AddExtraClangArgs(const std::vector<std::string> &ExtraArgs,
-                         llvm::StringRef overrideOpts = "");
-  void AddExtraClangCC1Args(const std::vector<std::string>& source,
-                                std::vector<std::string>& dest);
+  void AddExtraClangArgs(
+      const std::vector<std::string> &ExtraArgs,
+      const std::vector<std::string> &module_search_paths,
+      const std::vector<std::pair<std::string, bool>> framework_search_paths,
+      llvm::StringRef overrideOpts = "");
+
+  void AddExtraClangCC1Args(
+      const std::vector<std::string> &source,
+      const std::vector<std::string> &module_search_paths,
+      const std::vector<std::pair<std::string, bool>> framework_search_paths,
+      std::vector<std::string> &dest);
   static void AddExtraClangArgs(const std::vector<std::string>& source,
                                 std::vector<std::string>& dest);
   static std::string GetPluginServer(llvm::StringRef plugin_library_path);

--- a/lldb/test/API/lang/swift/clangimporter/caching/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/caching/Makefile
@@ -1,5 +1,5 @@
 SWIFT_SOURCES := main.swift
 SWIFT_ENABLE_EXPLICIT_MODULES := YES
-SWIFTFLAGS_EXTRAS = -I$(SRCDIR) -cache-compile-job -cas-path $(BUILDDIR)/cas
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR) -I/TEST_DIR -F/FRAMEWORK_DIR -cache-compile-job -cas-path $(BUILDDIR)/cas
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -21,12 +21,14 @@ class TestSwiftClangImporterCaching(TestBase):
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'))
         log = self.getBuildArtifact("types.log")
+        self.runCmd("settings set target.swift-clang-override-options +-DADDED=1")
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["b ="])
         self.filecheck('platform shell cat "%s"' % log, __file__)
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -triple
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DADDED=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'ClangA'
 #       CHECK-NOT: -cc1
 #       CHECK-NOT: -fmodule-file-cache-key

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -28,6 +28,13 @@ class TestSwiftClangImporterCaching(TestBase):
         self.filecheck('platform shell cat "%s"' % log, __file__)
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -triple
+### Check include paths in the module are forwards. The first argument is the source directory.
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -I
+#       CHECK-NEXT:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -I
+#       CHECK-NEXT:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /TEST_DIR
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -F
+#       CHECK-NEXT:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /FRAMEWORK_DIR
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DADDED=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'ClangA'
 #       CHECK-NOT: -cc1


### PR DESCRIPTION
For explicit build that uses direct cc1 options (like swift caching), all
search paths are dropped after dependency scanning. The clang modules
from the explicit build are the only modules available for lldb, which
should not be a problem if the context for expression evaluator in lldb
matches the context for swift compiler. But there are currently, there
are edge cases, like when lldb is constructing a type from generics from
a different module, it might tries to import additional clang modules.

Teach lldb to apply the swift search paths to clang importer, in case
some implicit clang module build is required, to make the debugging
process less disruptive. This cannot recover all the search paths (like
clang specific ones that passes through -Xcc options), but lldb were
already relying on the search paths from current module context can find
the clang modules from a different context. This should make the
behavior closer to implicit build before the lldb context and swift
compiler context can match perfectly.

rdar://138664252
