### PR TITLE
[CAS] Improve when MappedFileRegionBumpPtr is out of space

### DIFF
--- a/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
@@ -63,11 +63,14 @@ public:
   }
 
   /// Allocate at least \p AllocSize. Rounds up to \a getAlign().
-  char *allocate(uint64_t AllocSize) {
-    return data() + allocateOffset(AllocSize);
+  Expected<char *> allocate(uint64_t AllocSize) {
+    auto Offset = allocateOffset(AllocSize);
+    if (LLVM_UNLIKELY(!Offset))
+      return Offset.takeError();
+    return data() + *Offset;
   }
   /// Allocate, returning the offset from \a data() instead of a pointer.
-  int64_t allocateOffset(uint64_t AllocSize);
+  Expected<int64_t> allocateOffset(uint64_t AllocSize);
 
   char *data() const { return Region.data(); }
   uint64_t size() const { return *BumpPtr; }

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -271,7 +271,7 @@ public:
 
   /// Form a reference for the provided hash. The reference can be used as part
   /// of a CAS object even if it's not associated with an object yet.
-  ObjectID getReference(ArrayRef<uint8_t> Hash);
+  Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
 
   /// Get an existing reference to the object \p Digest.
   ///
@@ -362,7 +362,7 @@ private:
   Error importFullTree(ObjectID PrimaryID, ObjectHandle UpstreamNode);
   Error importSingleNode(ObjectID PrimaryID, ObjectHandle UpstreamNode);
 
-  IndexProxy indexHash(ArrayRef<uint8_t> Hash);
+  Expected<IndexProxy> indexHash(ArrayRef<uint8_t> Hash);
 
   Error createStandaloneLeaf(IndexProxy &I, ArrayRef<char> Data);
 

--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -9,6 +9,7 @@
 #include "llvm/CAS/BuiltinObjectHasher.h"
 #include "llvm/CAS/OnDiskGraphDB.h"
 #include "llvm/Support/BLAKE3.h"
+#include "llvm/Testing/Support/Error.h"
 
 namespace llvm::unittest::cas {
 
@@ -30,7 +31,9 @@ inline ObjectID digest(OnDiskGraphDB &DB, StringRef Data,
   for (ObjectID Ref : Refs)
     RefHashes.push_back(DB.getDigest(Ref));
   HashType Digest = digest(Data, RefHashes);
-  return DB.getReference(Digest);
+  std::optional<ObjectID> ID;
+  EXPECT_THAT_ERROR(DB.getReference(Digest).moveInto(ID), Succeeded());
+  return *ID;
 }
 
 inline HashType digest(StringRef Data) {


### PR DESCRIPTION
Fix a corner case for how MappedFileRegionBumpPtr returns the allocator into a valid state after it runs out of space. It makes sure the allocation that bump the allocator out of range needs to reset the pointer into its original state.

Also propagate the failed allocation errors to make sure those errors are properly handled without throwing fatal errors to crash the system.