### PR TITLE
[stable/20240723] Suppress warnings for Swift C++ interop by hiding operator declarations.

### DIFF
--- a/clang/include/clang/AST/DependentDiagnostic.h
+++ b/clang/include/clang/AST/DependentDiagnostic.h
@@ -149,9 +149,11 @@ public:
     return tmp;
   }
 
+#ifndef __swift__
   bool operator==(ddiag_iterator Other) const {
     return Ptr == Other.Ptr;
   }
+#endif
 
   bool operator!=(ddiag_iterator Other) const {
     return Ptr != Other.Ptr;

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -5822,7 +5822,9 @@ struct AAPointerInfo : public AbstractAttribute {
 
     unsigned size() const { return Ranges.size(); }
 
+#ifndef __swift__
     bool operator==(const RangeList &OI) const { return Ranges == OI.Ranges; }
+#endif
 
     /// Merge the ranges in \p RHS into the current ranges.
     /// - Merging a list of  unknown ranges makes the current list unknown.
@@ -5956,11 +5958,13 @@ struct AAPointerInfo : public AbstractAttribute {
     Access(const Access &Other) = default;
 
     Access &operator=(const Access &Other) = default;
+#ifndef __swift__
     bool operator==(const Access &R) const {
       return LocalI == R.LocalI && RemoteI == R.RemoteI && Ranges == R.Ranges &&
              Content == R.Content && Kind == R.Kind;
     }
     bool operator!=(const Access &R) const { return !(*this == R); }
+#endif
 
     Access &operator&=(const Access &R) {
       assert(RemoteI == R.RemoteI && "Expected same instruction!");

--- a/llvm/include/llvm/Transforms/IPO/SampleContextTracker.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleContextTracker.h
@@ -162,6 +162,7 @@ public:
       return *this;
     }
 
+#ifndef __swift__
     bool operator==(const Iterator &Other) const {
       if (NodeQueue.empty() && Other.NodeQueue.empty())
         return true;
@@ -169,6 +170,7 @@ public:
         return false;
       return NodeQueue.front() == Other.NodeQueue.front();
     }
+#endif
 
     ContextTrieNode *operator*() const {
       assert(!NodeQueue.empty() && "Invalid access to end iterator");


### PR DESCRIPTION
Without this change, the Swift compiler build is fully of spammy warnings like this:

```
.../DependentDiagnostic.h:152:8: warning: cycle detected while resolving 'ddiag_iterator' in swift_name attribute for 'operator=='
  bool operator==(ddiag_iterator Other) const {
       ^
.../DependentDiagnostic.h:127:20: note: while resolving 'DeclContext' in swift_name attribute for 'ddiag_iterator'
class DeclContext::ddiag_iterator {
                   ^
.../DependentDiagnostic.h:152:8: note: please report this issue to the owners of 'Clang_AST.DeclBase'
  bool operator==(ddiag_iterator Other) const {
       ^
```

Cherry-pick of https://github.com/swiftlang/llvm-project/pull/9521