### PR TITLE
[CAS] Improve when MappedFileRegionBumpPtr is out of space

### DIFF
--- a/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
@@ -63,11 +63,14 @@ public:
   }
 
   /// Allocate at least \p AllocSize. Rounds up to \a getAlign().
-  char *allocate(uint64_t AllocSize) {
-    return data() + allocateOffset(AllocSize);
+  Expected<char *> allocate(uint64_t AllocSize) {
+    auto Offset = allocateOffset(AllocSize);
+    if (LLVM_UNLIKELY(!Offset))
+      return Offset.takeError();
+    return data() + *Offset;
   }
   /// Allocate, returning the offset from \a data() instead of a pointer.
-  int64_t allocateOffset(uint64_t AllocSize);
+  Expected<int64_t> allocateOffset(uint64_t AllocSize);
 
   char *data() const { return Region.data(); }
   uint64_t size() const { return *BumpPtr; }

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -271,7 +271,7 @@ public:
 
   /// Form a reference for the provided hash. The reference can be used as part
   /// of a CAS object even if it's not associated with an object yet.
-  ObjectID getReference(ArrayRef<uint8_t> Hash);
+  Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
 
   /// Get an existing reference to the object \p Digest.
   ///
@@ -362,7 +362,7 @@ private:
   Error importFullTree(ObjectID PrimaryID, ObjectHandle UpstreamNode);
   Error importSingleNode(ObjectID PrimaryID, ObjectHandle UpstreamNode);
 
-  IndexProxy indexHash(ArrayRef<uint8_t> Hash);
+  Expected<IndexProxy> indexHash(ArrayRef<uint8_t> Hash);
 
   Error createStandaloneLeaf(IndexProxy &I, ArrayRef<char> Data);
 

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -52,10 +52,13 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
+#include <optional>
 
 #define DEBUG_TYPE "on-disk-cas"
 
@@ -915,8 +918,9 @@ void OnDiskGraphDB::print(raw_ostream &OS) const {
   }
 }
 
-OnDiskGraphDB::IndexProxy OnDiskGraphDB::indexHash(ArrayRef<uint8_t> Hash) {
-  OnDiskHashMappedTrie::pointer P = Index.insertLazy(
+Expected<OnDiskGraphDB::IndexProxy>
+OnDiskGraphDB::indexHash(ArrayRef<uint8_t> Hash) {
+  auto P = Index.insertLazy(
       Hash, [](FileOffset TentativeOffset,
                OnDiskHashMappedTrie::ValueProxy TentativeValue) {
         assert(TentativeValue.Data.size() == sizeof(TrieRecord));
@@ -924,8 +928,11 @@ OnDiskGraphDB::IndexProxy OnDiskGraphDB::indexHash(ArrayRef<uint8_t> Hash) {
             isAddrAligned(Align::Of<TrieRecord>(), TentativeValue.Data.data()));
         new (TentativeValue.Data.data()) TrieRecord();
       });
-  assert(P && "Expected insertion");
-  return getIndexProxyFromPointer(P);
+  if (LLVM_UNLIKELY(!P))
+    return P.takeError();
+
+  assert(*P && "Expected insertion");
+  return getIndexProxyFromPointer(*P);
 }
 
 OnDiskGraphDB::IndexProxy OnDiskGraphDB::getIndexProxyFromPointer(
@@ -937,9 +944,11 @@ OnDiskGraphDB::IndexProxy OnDiskGraphDB::getIndexProxyFromPointer(
                         reinterpret_cast<const TrieRecord *>(P->Data.data()))};
 }
 
-ObjectID OnDiskGraphDB::getReference(ArrayRef<uint8_t> Hash) {
-  IndexProxy I = indexHash(Hash);
-  return getExternalReference(I);
+Expected<ObjectID> OnDiskGraphDB::getReference(ArrayRef<uint8_t> Hash) {
+  auto I = indexHash(Hash);
+  if (LLVM_UNLIKELY(!I))
+    return I.takeError();
+  return getExternalReference(*I);
 }
 
 ObjectID OnDiskGraphDB::getExternalReference(const IndexProxy &I) {
@@ -954,10 +963,13 @@ OnDiskGraphDB::getExistingReference(ArrayRef<uint8_t> Digest) {
       return std::nullopt;
     std::optional<ObjectID> UpstreamID =
         UpstreamDB->getExistingReference(Digest);
-    if (!UpstreamID)
+    if (LLVM_UNLIKELY(!UpstreamID))
+      return std::nullopt;
+    auto Ref = expectedToOptional(indexHash(Digest));
+    if (!Ref)
       return std::nullopt;
     if (!I)
-      I.emplace(indexHash(Digest));
+      I.emplace(*Ref);
     return getExternalReference(*I);
   };
 
@@ -1246,14 +1258,16 @@ Error OnDiskGraphDB::store(ObjectID ID, ArrayRef<ObjectID> Refs,
   auto Alloc = [&](size_t Size) -> Expected<char *> {
     if (Size <= TrieRecord::MaxEmbeddedSize) {
       SK = TrieRecord::StorageKind::DataPool;
-      OnDiskDataAllocator::pointer P = DataPool.allocate(Size);
-      PoolOffset = P.getOffset();
+      auto P = DataPool.allocate(Size);
+      if (LLVM_UNLIKELY(!P))
+        return P.takeError();
+      PoolOffset = P->getOffset();
       LLVM_DEBUG({
         dbgs() << "pool-alloc addr=" << (void *)PoolOffset.get()
                << " size=" << Size
                << " end=" << (void *)(PoolOffset.get() + Size) << "\n";
       });
-      return P->data();
+      return (*P)->data();
     }
 
     SK = TrieRecord::StorageKind::Standalone;
@@ -1465,19 +1479,21 @@ Error OnDiskGraphDB::importFullTree(ObjectID PrimaryID,
     }
 
     ObjectID UpstreamID = *(Cur.RefI++);
-    ObjectID PrimaryID = getReference(UpstreamDB->getDigest(UpstreamID));
-    if (containsObject(PrimaryID, /*CheckUpstream=*/false)) {
+    auto PrimaryID = getReference(UpstreamDB->getDigest(UpstreamID));
+    if (LLVM_UNLIKELY(!PrimaryID))
+      return PrimaryID.takeError();
+    if (containsObject(*PrimaryID, /*CheckUpstream=*/false)) {
       // This \p ObjectID already exists in the primary. Either it was imported
       // via \p importFullTree or the client created it, in which case the
       // client takes responsibility for how it was formed.
-      enqueueNode(PrimaryID, std::nullopt);
+      enqueueNode(*PrimaryID, std::nullopt);
       continue;
     }
     Expected<std::optional<ObjectHandle>> UpstreamNode =
         UpstreamDB->load(UpstreamID);
     if (!UpstreamNode)
       return UpstreamNode.takeError();
-    enqueueNode(PrimaryID, *UpstreamNode);
+    enqueueNode(*PrimaryID, *UpstreamNode);
   }
 
   assert(PrimaryNodesStack.size() == 1);
@@ -1497,8 +1513,12 @@ Error OnDiskGraphDB::importSingleNode(ObjectID PrimaryID,
   auto UpstreamRefs = UpstreamDB->getObjectRefs(UpstreamNode);
   SmallVector<ObjectID, 64> Refs;
   Refs.reserve(std::distance(UpstreamRefs.begin(), UpstreamRefs.end()));
-  for (ObjectID UpstreamRef : UpstreamRefs)
-    Refs.push_back(getReference(UpstreamDB->getDigest(UpstreamRef)));
+  for (ObjectID UpstreamRef : UpstreamRefs) {
+    auto Ref = getReference(UpstreamDB->getDigest(UpstreamRef));
+    if (LLVM_UNLIKELY(!Ref))
+      return Ref.takeError();
+    Refs.push_back(*Ref);
+  }
 
   return store(PrimaryID, Refs, Data);
 }
@@ -1507,9 +1527,12 @@ Expected<std::optional<ObjectHandle>>
 OnDiskGraphDB::faultInFromUpstream(ObjectID PrimaryID) {
   assert(UpstreamDB);
 
-  ObjectID UpstreamID = UpstreamDB->getReference(getDigest(PrimaryID));
+  auto UpstreamID = UpstreamDB->getReference(getDigest(PrimaryID));
+  if (LLVM_UNLIKELY(!UpstreamID))
+    return UpstreamID.takeError();
+
   Expected<std::optional<ObjectHandle>> UpstreamNode =
-      UpstreamDB->load(UpstreamID);
+      UpstreamDB->load(*UpstreamID);
   if (!UpstreamNode)
     return UpstreamNode.takeError();
   if (!*UpstreamNode)

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -11,7 +11,9 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/MappedFileRegionBumpPtr.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -160,12 +162,21 @@ private:
 
 } // end anonymous namespace
 
+static Error createTableConfigError(std::errc ErrC, StringRef Path,
+                                    StringRef TableName, const Twine &Msg) {
+  return createStringError(make_error_code(ErrC),
+                           Path + "[" + TableName + "]: " + Msg);
+}
+
 Expected<DatabaseFile>
 DatabaseFile::create(const Twine &Path, uint64_t Capacity,
                      function_ref<Error(DatabaseFile &)> NewDBConstructor) {
   // Constructor for if the file doesn't exist.
   auto NewFileConstructor = [&](MappedFileRegionBumpPtr &Alloc) -> Error {
-    assert(Alloc.capacity() >= sizeof(Header));
+    if (Alloc.capacity() < sizeof(Header))
+      return createTableConfigError(std::errc::argument_out_of_domain,
+                                    Path.str(), "datafile",
+                                    "Allocator too small for header");
     (void)new (Alloc.data()) Header{getMagic(), getVersion(), {0}, {0}};
     Alloc.initializeBumpPtr(offsetof(Header, BumpPtr));
     DatabaseFile DB(Alloc);
@@ -377,9 +388,10 @@ public:
   /// If it's already valid, it should be used instead of allocating a new one.
   ///
   /// Returns the subtrie that now lives at \p I.
-  SubtrieHandle sink(size_t I, SubtrieSlotValue V,
-                     MappedFileRegionBumpPtr &Alloc, size_t NumSubtrieBits,
-                     SubtrieHandle &UnusedSubtrie, size_t NewI);
+  Expected<SubtrieHandle> sink(size_t I, SubtrieSlotValue V,
+                               MappedFileRegionBumpPtr &Alloc,
+                               size_t NumSubtrieBits,
+                               SubtrieHandle &UnusedSubtrie, size_t NewI);
 
   /// Only safe if the subtrie is empty.
   void reinitialize(uint32_t StartBit, uint32_t NumBits);
@@ -398,8 +410,9 @@ public:
   uint32_t getNumBits() const { return H->NumBits; }
   uint32_t getNumUnusedBits() const { return H->NumUnusedBits; }
 
-  static SubtrieHandle create(MappedFileRegionBumpPtr &Alloc, uint32_t StartBit,
-                              uint32_t NumBits, uint32_t NumUnusedBits = 0);
+  static Expected<SubtrieHandle> create(MappedFileRegionBumpPtr &Alloc,
+                                        uint32_t StartBit, uint32_t NumBits,
+                                        uint32_t NumUnusedBits = 0);
 
   static SubtrieHandle getFromFileOffset(MappedFileRegion &Region,
                                          FileOffset Offset) {
@@ -489,13 +502,13 @@ public:
   }
 
   RecordData getRecord(SubtrieSlotValue Offset);
-  RecordData createRecord(MappedFileRegionBumpPtr &Alloc,
-                          ArrayRef<uint8_t> Hash);
+  Expected<RecordData> createRecord(MappedFileRegionBumpPtr &Alloc,
+                                    ArrayRef<uint8_t> Hash);
 
   explicit operator bool() const { return H; }
   const Header &getHeader() const { return *H; }
   SubtrieHandle getRoot() const;
-  SubtrieHandle getOrCreateRoot(MappedFileRegionBumpPtr &Alloc);
+  Expected<SubtrieHandle> getOrCreateRoot(MappedFileRegionBumpPtr &Alloc);
   MappedFileRegion &getRegion() const { return *Region; }
 
   size_t getFlags() const { return H->Flags; }
@@ -514,7 +527,7 @@ public:
     return IndexGenerator{Root.getNumBits(), getNumSubtrieBits(), Hash};
   }
 
-  static HashMappedTrieHandle
+  static Expected<HashMappedTrieHandle>
   create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
          std::optional<uint64_t> NumRootBits, uint64_t NumSubtrieBits,
          uint64_t NumHashBits, uint64_t RecordDataSize);
@@ -543,18 +556,21 @@ struct OnDiskHashMappedTrie::ImplType {
   HashMappedTrieHandle Trie;
 };
 
-SubtrieHandle SubtrieHandle::create(MappedFileRegionBumpPtr &Alloc,
-                                    uint32_t StartBit, uint32_t NumBits,
-                                    uint32_t NumUnusedBits) {
+Expected<SubtrieHandle> SubtrieHandle::create(MappedFileRegionBumpPtr &Alloc,
+                                              uint32_t StartBit,
+                                              uint32_t NumBits,
+                                              uint32_t NumUnusedBits) {
   assert(StartBit <= HashMappedTrieHandle::MaxNumHashBits);
   assert(NumBits <= UINT8_MAX);
   assert(NumUnusedBits <= UINT8_MAX);
   assert(NumBits + NumUnusedBits <= HashMappedTrieHandle::MaxNumRootBits);
 
-  void *Mem = Alloc.allocate(getSize(NumBits + NumUnusedBits));
+  auto Mem = Alloc.allocate(getSize(NumBits + NumUnusedBits));
+  if (LLVM_UNLIKELY(!Mem))
+    return Mem.takeError();
   auto *H =
-      new (Mem) SubtrieHandle::Header{(uint16_t)StartBit, (uint8_t)NumBits,
-                                      (uint8_t)NumUnusedBits, /*ZeroPad4B=*/0};
+      new (*Mem) SubtrieHandle::Header{(uint16_t)StartBit, (uint8_t)NumBits,
+                                       (uint8_t)NumUnusedBits, /*ZeroPad4B=*/0};
   SubtrieHandle S(Alloc.getRegion(), *H);
   for (auto I = S.Slots.begin(), E = S.Slots.end(); I != E; ++I)
     new (I) SlotT(0);
@@ -567,17 +583,20 @@ SubtrieHandle HashMappedTrieHandle::getRoot() const {
   return SubtrieHandle();
 }
 
-SubtrieHandle
+Expected<SubtrieHandle>
 HashMappedTrieHandle::getOrCreateRoot(MappedFileRegionBumpPtr &Alloc) {
   assert(&Alloc.getRegion() == &getRegion());
   if (SubtrieHandle Root = getRoot())
     return Root;
 
   int64_t Race = 0;
-  SubtrieHandle LazyRoot = SubtrieHandle::create(Alloc, 0, H->NumSubtrieBits);
+  auto LazyRoot = SubtrieHandle::create(Alloc, 0, H->NumSubtrieBits);
+  if (LLVM_UNLIKELY(!LazyRoot))
+    return LazyRoot.takeError();
+
   if (H->RootTrieOffset.compare_exchange_strong(
-          Race, LazyRoot.getOffset().asSubtrie()))
-    return LazyRoot;
+          Race, LazyRoot->getOffset().asSubtrie()))
+    return *LazyRoot;
 
   // There was a race. Return the other root.
   //
@@ -585,20 +604,22 @@ HashMappedTrieHandle::getOrCreateRoot(MappedFileRegionBumpPtr &Alloc) {
   return SubtrieHandle(getRegion(), SubtrieSlotValue::getSubtrieOffset(Race));
 }
 
-HashMappedTrieHandle
+Expected<HashMappedTrieHandle>
 HashMappedTrieHandle::create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
                              std::optional<uint64_t> NumRootBits,
                              uint64_t NumSubtrieBits, uint64_t NumHashBits,
                              uint64_t RecordDataSize) {
   // Allocate.
-  intptr_t Offset = Alloc.allocateOffset(sizeof(Header) + Name.size() + 1);
+  auto Offset = Alloc.allocateOffset(sizeof(Header) + Name.size() + 1);
+  if (LLVM_UNLIKELY(!Offset))
+    return Offset.takeError();
 
   // Construct the header and the name.
   assert(Name.size() <= UINT16_MAX && "Expected smaller table name");
   assert(NumSubtrieBits <= UINT8_MAX && "Expected valid subtrie bits");
   assert(NumHashBits <= UINT16_MAX && "Expected valid hash size");
   assert(RecordDataSize <= UINT32_MAX && "Expected smaller table name");
-  auto *H = new (Alloc.getRegion().data() + Offset)
+  auto *H = new (Alloc.getRegion().data() + *Offset)
       Header{{TableHandle::TableKind::HashMappedTrie, (uint16_t)Name.size(),
               (uint32_t)sizeof(Header)},
              (uint8_t)NumSubtrieBits,
@@ -613,9 +634,11 @@ HashMappedTrieHandle::create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
 
   // Construct a root trie, if requested.
   HashMappedTrieHandle Trie(Alloc.getRegion(), *H);
+  auto Sub = SubtrieHandle::create(Alloc, 0, *NumRootBits);
+  if (LLVM_UNLIKELY(!Sub))
+    return Sub.takeError();
   if (NumRootBits)
-    H->RootTrieOffset =
-        SubtrieHandle::create(Alloc, 0, *NumRootBits).getOffset().asSubtrie();
+    H->RootTrieOffset = Sub->getOffset().asSubtrie();
   return Trie;
 }
 
@@ -629,13 +652,16 @@ HashMappedTrieHandle::getRecord(SubtrieSlotValue Offset) {
   return RecordData{Proxy, Offset};
 }
 
-HashMappedTrieHandle::RecordData
+Expected<HashMappedTrieHandle::RecordData>
 HashMappedTrieHandle::createRecord(MappedFileRegionBumpPtr &Alloc,
                                    ArrayRef<uint8_t> Hash) {
   assert(&Alloc.getRegion() == Region);
   assert(Hash.size() == getNumHashBytes());
-  RecordData Record = getRecord(
-      SubtrieSlotValue::getDataOffset(Alloc.allocateOffset(getRecordSize())));
+  auto Offset = Alloc.allocateOffset(getRecordSize());
+  if (LLVM_UNLIKELY(!Offset))
+    return Offset.takeError();
+
+  RecordData Record = getRecord(SubtrieSlotValue::getDataOffset(*Offset));
   llvm::copy(Hash, const_cast<uint8_t *>(Record.Proxy.Hash.begin()));
   return Record;
 }
@@ -723,7 +749,7 @@ void SubtrieHandle::reinitialize(uint32_t StartBit, uint32_t NumBits) {
   H->NumBits = NumBits;
 }
 
-OnDiskHashMappedTrie::pointer
+Expected<OnDiskHashMappedTrie::pointer>
 OnDiskHashMappedTrie::insertLazy(const_pointer Hint, ArrayRef<uint8_t> Hash,
                                  LazyInsertOnConstructCB OnConstruct,
                                  LazyInsertOnLeakCB OnLeak) {
@@ -731,8 +757,12 @@ OnDiskHashMappedTrie::insertLazy(const_pointer Hint, ArrayRef<uint8_t> Hash,
   assert(Hash.size() == Trie.getNumHashBytes() && "Invalid hash");
 
   MappedFileRegionBumpPtr &Alloc = Impl->File.getAlloc();
-  SubtrieHandle S = Trie.getOrCreateRoot(Alloc);
-  IndexGenerator IndexGen = Trie.getIndexGen(S, Hash);
+  std::optional<SubtrieHandle> S;
+  auto Err = Trie.getOrCreateRoot(Alloc).moveInto(S);
+  if (LLVM_UNLIKELY(Err))
+    return std::move(Err);
+
+  IndexGenerator IndexGen = Trie.getIndexGen(*S, Hash);
 
   size_t Index;
   if (std::optional<HintT> H = Hint.getHint(*this)) {
@@ -757,17 +787,19 @@ OnDiskHashMappedTrie::insertLazy(const_pointer Hint, ArrayRef<uint8_t> Hash,
   std::optional<HashMappedTrieHandle::RecordData> NewRecord;
   SubtrieHandle UnusedSubtrie;
   for (;;) {
-    SubtrieSlotValue Existing = S.load(Index);
+    SubtrieSlotValue Existing = S->load(Index);
 
     // Try to set it, if it's empty.
     if (!Existing) {
       if (!NewRecord) {
-        NewRecord = Trie.createRecord(Alloc, Hash);
+        auto Err = Trie.createRecord(Alloc, Hash).moveInto(NewRecord);
+        if (LLVM_UNLIKELY(Err))
+          return std::move(Err);
         if (OnConstruct)
           OnConstruct(NewRecord->Offset.asDataFileOffset(), NewRecord->Proxy);
       }
 
-      if (S.compare_exchange_strong(Index, Existing, NewRecord->Offset))
+      if (S->compare_exchange_strong(Index, Existing, NewRecord->Offset))
         return pointer(NewRecord->Offset.asDataFileOffset(), NewRecord->Proxy);
 
       // Race means that Existing is no longer empty; fall through...
@@ -795,8 +827,11 @@ OnDiskHashMappedTrie::insertLazy(const_pointer Hint, ArrayRef<uint8_t> Hash,
       size_t NewIndexForExistingContent =
           IndexGen.getCollidingBits(ExistingRecord.Proxy.Hash);
 
-      S = S.sink(Index, Existing, Alloc, IndexGen.getNumBits(), UnusedSubtrie,
-                 NewIndexForExistingContent);
+      auto Err = S->sink(Index, Existing, Alloc, IndexGen.getNumBits(),
+                         UnusedSubtrie, NewIndexForExistingContent)
+                     .moveInto(S);
+      if (LLVM_UNLIKELY(Err))
+        return std::move(Err);
       Index = NextIndex;
 
       // Found the difference.
@@ -806,31 +841,36 @@ OnDiskHashMappedTrie::insertLazy(const_pointer Hint, ArrayRef<uint8_t> Hash,
   }
 }
 
-SubtrieHandle SubtrieHandle::sink(size_t I, SubtrieSlotValue V,
-                                  MappedFileRegionBumpPtr &Alloc,
-                                  size_t NumSubtrieBits,
-                                  SubtrieHandle &UnusedSubtrie, size_t NewI) {
-  SubtrieHandle NewS;
+Expected<SubtrieHandle> SubtrieHandle::sink(size_t I, SubtrieSlotValue V,
+                                            MappedFileRegionBumpPtr &Alloc,
+                                            size_t NumSubtrieBits,
+                                            SubtrieHandle &UnusedSubtrie,
+                                            size_t NewI) {
+  std::optional<SubtrieHandle> NewS;
   if (UnusedSubtrie) {
     // Steal UnusedSubtrie and initialize it.
-    std::swap(NewS, UnusedSubtrie);
-    NewS.reinitialize(getStartBit() + getNumBits(), NumSubtrieBits);
+    NewS.emplace();
+    std::swap(*NewS, UnusedSubtrie);
+    NewS->reinitialize(getStartBit() + getNumBits(), NumSubtrieBits);
   } else {
     // Allocate a new, empty subtrie.
-    NewS = SubtrieHandle::create(Alloc, getStartBit() + getNumBits(),
-                                 NumSubtrieBits);
+    auto Err = SubtrieHandle::create(Alloc, getStartBit() + getNumBits(),
+                                     NumSubtrieBits)
+                   .moveInto(NewS);
+    if (LLVM_UNLIKELY(Err))
+      return std::move(Err);
   }
 
-  NewS.store(NewI, V);
-  if (compare_exchange_strong(I, V, NewS.getOffset()))
-    return NewS; // Success!
+  NewS->store(NewI, V);
+  if (compare_exchange_strong(I, V, NewS->getOffset()))
+    return *NewS; // Success!
 
   // Raced.
   assert(V.isSubtrie() && "Expected racing sink() to add a subtrie");
 
   // Wipe out the new slot so NewS can be reused and set the out parameter.
-  NewS.store(NewI, SubtrieSlotValue());
-  UnusedSubtrie = NewS;
+  NewS->store(NewI, SubtrieSlotValue());
+  UnusedSubtrie = *NewS;
 
   // Return the subtrie added by the concurrent sink() call.
   return SubtrieHandle(Alloc.getRegion(), V);
@@ -996,12 +1036,6 @@ void SubtrieHandle::print(raw_ostream &OS, HashMappedTrieHandle Trie,
 
 LLVM_DUMP_METHOD void OnDiskHashMappedTrie::dump() const { print(dbgs()); }
 
-static Error createTableConfigError(std::errc ErrC, StringRef Path,
-                                    StringRef TableName, const Twine &Msg) {
-  return createStringError(make_error_code(ErrC),
-                           Path + "[" + TableName + "]: " + Msg);
-}
-
 static Expected<size_t> checkParameter(StringRef Label, size_t Max,
                                        std::optional<size_t> Value,
                                        std::optional<size_t> Default,
@@ -1075,10 +1109,13 @@ OnDiskHashMappedTrie::create(const Twine &PathTwine, const Twine &TrieNameTwine,
 
   // Constructor for if the file doesn't exist.
   auto NewDBConstructor = [&](DatabaseFile &DB) -> Error {
-    HashMappedTrieHandle Trie =
+    auto Trie =
         HashMappedTrieHandle::create(DB.getAlloc(), TrieName, NumRootBits,
                                      NumSubtrieBits, NumHashBits, DataSize);
-    DB.addTable(Trie);
+    if (LLVM_UNLIKELY(!Trie))
+      return Trie.takeError();
+
+    DB.addTable(*Trie);
     return Error::success();
   };
 
@@ -1150,10 +1187,13 @@ public:
     return TableHandle(*Region, H->GenericHeader);
   }
 
-  MutableArrayRef<char> allocate(MappedFileRegionBumpPtr &Alloc,
-                                 size_t DataSize) {
+  Expected<MutableArrayRef<char>> allocate(MappedFileRegionBumpPtr &Alloc,
+                                           size_t DataSize) {
     assert(&Alloc.getRegion() == Region);
-    return MutableArrayRef(Alloc.allocate(DataSize), DataSize);
+    auto Ptr = Alloc.allocate(DataSize);
+    if (LLVM_UNLIKELY(!Ptr))
+      return Ptr.takeError();
+    return MutableArrayRef(*Ptr, DataSize);
   }
 
   explicit operator bool() const { return H; }
@@ -1165,8 +1205,9 @@ public:
                            H->UserHeaderSize);
   }
 
-  static DataAllocatorHandle create(MappedFileRegionBumpPtr &Alloc,
-                                    StringRef Name, uint32_t UserHeaderSize);
+  static Expected<DataAllocatorHandle> create(MappedFileRegionBumpPtr &Alloc,
+                                              StringRef Name,
+                                              uint32_t UserHeaderSize);
 
   DataAllocatorHandle() = default;
   DataAllocatorHandle(MappedFileRegion &Region, Header &H)
@@ -1188,16 +1229,18 @@ struct OnDiskDataAllocator::ImplType {
   DataAllocatorHandle Store;
 };
 
-DataAllocatorHandle DataAllocatorHandle::create(MappedFileRegionBumpPtr &Alloc,
-                                                StringRef Name,
-                                                uint32_t UserHeaderSize) {
+Expected<DataAllocatorHandle>
+DataAllocatorHandle::create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
+                            uint32_t UserHeaderSize) {
   // Allocate.
-  intptr_t Offset =
+  auto Offset =
       Alloc.allocateOffset(sizeof(Header) + UserHeaderSize + Name.size() + 1);
+  if (LLVM_UNLIKELY(!Offset))
+    return Offset.takeError();
 
   // Construct the header and the name.
   assert(Name.size() <= UINT16_MAX && "Expected smaller table name");
-  auto *H = new (Alloc.getRegion().data() + Offset)
+  auto *H = new (Alloc.getRegion().data() + *Offset)
       Header{{TableHandle::TableKind::DataAllocator, (uint16_t)Name.size(),
               (int32_t)(sizeof(Header) + UserHeaderSize)},
              /*AllocatorOffset=*/{0},
@@ -1221,11 +1264,14 @@ Expected<OnDiskDataAllocator> OnDiskDataAllocator::create(
 
   // Constructor for if the file doesn't exist.
   auto NewDBConstructor = [&](DatabaseFile &DB) -> Error {
-    DataAllocatorHandle Store =
+    auto Store =
         DataAllocatorHandle::create(DB.getAlloc(), TableName, UserHeaderSize);
-    DB.addTable(Store);
+    if (LLVM_UNLIKELY(!Store))
+      return Store.takeError();
+
+    DB.addTable(*Store);
     if (UserHeaderSize)
-      UserHeaderInit(Store.getUserHeader().data());
+      UserHeaderInit(Store->getUserHeader().data());
     return Error::success();
   };
 
@@ -1253,11 +1299,14 @@ Expected<OnDiskDataAllocator> OnDiskDataAllocator::create(
   return OnDiskDataAllocator(std::make_unique<ImplType>(std::move(Impl)));
 }
 
-OnDiskDataAllocator::pointer OnDiskDataAllocator::allocate(size_t Size) {
-  MutableArrayRef<char> Data =
-      Impl->Store.allocate(Impl->File.getAlloc(), Size);
-  return pointer(FileOffset(Data.data() - Impl->Store.getRegion().data()),
-                 Data);
+Expected<OnDiskDataAllocator::pointer>
+OnDiskDataAllocator::allocate(size_t Size) {
+  auto Data = Impl->Store.allocate(Impl->File.getAlloc(), Size);
+  if (LLVM_UNLIKELY(!Data))
+    return Data.takeError();
+
+  return pointer(FileOffset(Data->data() - Impl->Store.getRegion().data()),
+                 *Data);
 }
 
 const char *OnDiskDataAllocator::beginData(FileOffset Offset) const {
@@ -1290,7 +1339,7 @@ OnDiskHashMappedTrie::create(const Twine &PathTwine, const Twine &TrieNameTwine,
   report_fatal_error("not supported");
 }
 
-OnDiskHashMappedTrie::pointer
+Expected<OnDiskHashMappedTrie::pointer>
 OnDiskHashMappedTrie::insertLazy(const_pointer Hint, ArrayRef<uint8_t> Hash,
                                  LazyInsertOnConstructCB OnConstruct,
                                  LazyInsertOnLeakCB OnLeak) {
@@ -1325,7 +1374,8 @@ Expected<OnDiskDataAllocator> OnDiskDataAllocator::create(
   report_fatal_error("not supported");
 }
 
-OnDiskDataAllocator::pointer OnDiskDataAllocator::allocate(size_t Size) {
+Expected<OnDiskDataAllocator::pointer>
+OnDiskDataAllocator::allocate(size_t Size) {
   report_fatal_error("not supported");
 }
 

--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -9,6 +9,7 @@
 #include "llvm/CAS/BuiltinObjectHasher.h"
 #include "llvm/CAS/OnDiskGraphDB.h"
 #include "llvm/Support/BLAKE3.h"
+#include "llvm/Testing/Support/Error.h"
 
 namespace llvm::unittest::cas {
 
@@ -30,7 +31,9 @@ inline ObjectID digest(OnDiskGraphDB &DB, StringRef Data,
   for (ObjectID Ref : Refs)
     RefHashes.push_back(DB.getDigest(Ref));
   HashType Digest = digest(Data, RefHashes);
-  return DB.getReference(Digest);
+  std::optional<ObjectID> ID;
+  EXPECT_THAT_ERROR(DB.getReference(Digest).moveInto(ID), Succeeded());
+  return *ID;
 }
 
 inline HashType digest(StringRef Data) {


### PR DESCRIPTION
Fix a corner case for how MappedFileRegionBumpPtr returns the allocator into a valid state after it runs out of space. It makes sure the allocation that bump the allocator out of range needs to reset the pointer into its original state.

Also propagate the failed allocation errors to make sure those errors are properly handled without throwing fatal errors to crash the system.