### PR TITLE
Cherry-picks slide fix

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -639,9 +639,9 @@ LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
              file_address, object_file->GetFileSpec().GetFilename());
     return {};
   }
-  auto sec = sec_list->GetSectionAtIndex(0);
-  auto sec_file_address = sec->GetFileAddress();
-  auto sec_load_address = sec->GetLoadBaseAddress(&m_process.GetTarget());
+  SectionSP sec = sec_list->GetSectionAtIndex(0);
+  addr_t sec_file_address = sec->GetFileAddress();
+  addr_t sec_load_address = sec->GetLoadBaseAddress(&m_process.GetTarget());
 
   if (sec_load_address < sec_file_address) {
     LLDB_LOG(log,
@@ -651,10 +651,10 @@ LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
     return {};
   }
 
-  auto slide = sec_load_address - sec_file_address;
+  addr_t slide = sec_load_address - sec_file_address;
 
   bool overflow = false;
-  auto virtual_address = llvm::SaturatingAdd(file_address, slide, &overflow);
+  addr_t virtual_address = llvm::SaturatingAdd(file_address, slide, &overflow);
   if (overflow) {
     LLDB_LOG(log, "[MemoryReader] file address {0:x} + slide {1:x} overflows",
              sec_load_address, sec_file_address);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -643,17 +643,17 @@ LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
   auto sec_file_address = sec->GetFileAddress();
   auto sec_load_address = sec->GetLoadBaseAddress(&m_process.GetTarget());
 
-  bool overflow = false;
-  auto slide =
-      llvm::SaturatingAdd(sec_load_address, -sec_file_address, &overflow);
-  if (overflow) {
+  if (sec_load_address < sec_file_address) {
     LLDB_LOG(log,
-             "[MemoryReader] section load address {0:x} - file address {1:x} "
-             "overflows",
+             "[MemoryReader] section load address {0:x} is smaller than "
+             "section file address {1:x}",
              sec_load_address, sec_file_address);
     return {};
   }
 
+  auto slide = sec_load_address - sec_file_address;
+
+  bool overflow = false;
   auto virtual_address = llvm::SaturatingAdd(file_address, slide, &overflow);
   if (overflow) {
     LLDB_LOG(log, "[MemoryReader] file address {0:x} + slide {1:x} overflows",


### PR DESCRIPTION
There were two commits that are missing on stable/20240723, which fix TestSwiftFoundationTypeNotification.py and TestSwiftFoundationTypeNotification.py.