### PR TITLE
[dsymutil] Add missing newlines in error messages. (#115191)

### DIFF
--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -721,7 +721,7 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
     Expected<OutputLocation> OutputLocationOrErr =
         getOutputFileName(InputFile, Options);
     if (!OutputLocationOrErr) {
-      WithColor::error() << toString(OutputLocationOrErr.takeError());
+      WithColor::error() << toString(OutputLocationOrErr.takeError()) << "\n";
       return EXIT_FAILURE;
     }
     Options.LinkOpts.ResourceDir = OutputLocationOrErr->getResourceDir();
@@ -799,7 +799,7 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
               Options.LinkOpts.NoOutput ? "-" : OutputFile, EC,
               sys::fs::OF_None);
           if (EC) {
-            WithColor::error() << OutputFile << ": " << EC.message();
+            WithColor::error() << OutputFile << ": " << EC.message() << "\n";
             AllOK.fetch_and(false);
             return;
           }


### PR DESCRIPTION
Errors like "cannot create bundle: Not a directory" or "error:
a.out.dSYM: Is a directory" were being emitted without a newline.

(cherry picked from commit bbc3af0577a05bf5c06f5c39d51b7d48bd63d65f)