### PR TITLE
Skip tests known to fail on 15.0

### DIFF
--- a/lldb/test/API/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/measurement/TestSwiftFoundationTypeMeasurement.py
@@ -15,6 +15,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
+@skipIf(macos_version=["=", "15.0"])
 class TestCase(TestBase):
     @swiftTest
     @skipUnlessDarwin

--- a/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
+++ b/lldb/test/API/lang/swift/nsarray_code_running_formatter/TestSwiftNSArrayCodeRunningFormatter.py
@@ -12,5 +12,8 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin])
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    decorators=[swiftTest, skipUnlessDarwin, skipIf(macos_version=["=", "15.0"])],
+)


### PR DESCRIPTION
These tests are passing on 15.1: rdar://139217313

(cherry picked from commit fe2ec153f3cef0bac99254fcb4bc67602a11c65c)