### PR TITLE
🍒 [lldb] Fix crash missing MSInheritanceAttr with DWARF on Windows (#112928)

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -48,6 +48,7 @@
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/Specifiers.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/Casting.h"
@@ -2368,6 +2369,16 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
       m_ast.GetAsCXXRecordDecl(clang_type.GetOpaqueQualType());
   if (record_decl)
     GetClangASTImporter().SetRecordLayout(record_decl, layout_info);
+
+  // DWARF doesn't have the attribute, but we can infer the value the same way
+  // as Clang Sema does. It's required to calculate the size of pointers to
+  // member functions of this type.
+  if (m_ast.getASTContext().getTargetInfo().getCXXABI().isMicrosoft()) {
+    auto IM = record_decl->calculateInheritanceModel();
+    record_decl->addAttr(clang::MSInheritanceAttr::CreateImplicit(
+        m_ast.getASTContext(), true, {},
+        clang::MSInheritanceAttr::Spelling(IM)));
+  }
 
   // Now parse all contained types inside of the class. We make forward
   // declarations to all classes, but we need the CXXRecordDecl to have decls

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2880,6 +2880,9 @@ static bool GetCompleteQualType(clang::ASTContext *ast,
         ast, llvm::cast<clang::AttributedType>(qual_type)->getModifiedType(),
         allow_completion);
 
+  case clang::Type::MemberPointer:
+    return !qual_type.getTypePtr()->isIncompleteType();
+
   default:
     break;
   }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -2881,7 +2881,17 @@ static bool GetCompleteQualType(clang::ASTContext *ast,
         allow_completion);
 
   case clang::Type::MemberPointer:
-    return !qual_type.getTypePtr()->isIncompleteType();
+    // MS C++ ABI requires type of the class to be complete of which the pointee
+    // is a member.
+    if (ast->getTargetInfo().getCXXABI().isMicrosoft()) {
+      auto *MPT = qual_type.getTypePtr()->castAs<clang::MemberPointerType>();
+      if (MPT->getClass()->isRecordType())
+        GetCompleteRecordType(ast, clang::QualType(MPT->getClass(), 0),
+                              allow_completion);
+
+      return !qual_type.getTypePtr()->isIncompleteType();
+    }
+    break;
 
   default:
     break;

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/member-pointers.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/member-pointers.cpp
@@ -2,23 +2,62 @@
 
 // Itanium ABI:
 // RUN: %clang --target=x86_64-pc-linux -gdwarf -c -o %t_linux.o %s
-// RUN: %lldb -f %t_linux.o -b -o "target variable mp" | FileCheck %s
+// RUN: %lldb -f %t_linux.o -b -o "target variable s1 s2 m1 m2 v1 v2 v3 v4" | FileCheck --check-prefix=CHECK-GNU %s
 //
-// CHECK: (char SI::*) mp = 0x0000000000000000
+// CHECK-GNU: (void (Single1::*)()) s1 = 0x00000000000000000000000000000000
+// CHECK-GNU: (void (Single2::*)()) s2 = 0x00000000000000000000000000000000
+// CHECK-GNU: (void (Multiple1::*)()) m1 = 0x00000000000000000000000000000000
+// CHECK-GNU: (void (Multiple2::*)()) m2 = 0x00000000000000000000000000000000
+// CHECK-GNU: (void (Virtual1::*)()) v1 = 0x00000000000000000000000000000000
+// CHECK-GNU: (void (Virtual2::*)()) v2 = 0x00000000000000000000000000000000
+// CHECK-GNU: (void (Virtual3::*)()) v3 = 0x00000000000000000000000000000000
+// CHECK-GNU: (void (Virtual4::*)()) v4 = 0x00000000000000000000000000000000
 
 // Microsoft ABI:
-// RUN: %clang_cl --target=x86_64-windows-msvc -c -gdwarf -o %t_win.obj -- %s
-// RUN: lld-link /out:%t_win.exe %t_win.obj /nodefaultlib /entry:main /debug
-// RUN: %lldb -f %t_win.exe -b -o "target variable mp" | FileCheck --check-prefix=CHECK-MSVC %s
+// RUN: %clang_cl --target=x86_64-windows-msvc -c -gdwarf -o %t_win.obj /GS- -- %s
+// RUN: lld-link /out:%t_win.exe %t_win.obj /entry:main /debug /nodefaultlib
+// RUN: %lldb -f %t_win.exe -b -o "target variable s1 s2 m1 m2 v1 v2 v3 v4" | FileCheck --check-prefix=CHECK-MSVC %s
 //
-// DWARF has no representation of MSInheritanceAttr, so we cannot determine the size
-// of member-pointers yet. For the moment, make sure we don't crash on such variables.
-// CHECK-MSVC: error: Unable to determine byte size.
+// CHECK-MSVC: (void (Single1::*)()) s1 = 0x0000000000000000
+// CHECK-MSVC: (void (Single2::*)()) s2 = 0x0000000000000000
+// CHECK-MSVC: (void (Multiple1::*)()) m1 = 0x00000000000000000000000000000000
+// CHECK-MSVC: (void (Multiple2::*)()) m2 = 0x00000000000000000000000000000000
+// CHECK-MSVC: (void (Virtual1::*)()) v1 = 0xffffffff000000000000000000000000
+// CHECK-MSVC: (void (Virtual2::*)()) v2 = 0xffffffff000000000000000000000000
+// CHECK-MSVC: (void (Virtual3::*)()) v3 = 0xffffffff000000000000000000000000
+// CHECK-MSVC: (void (Virtual4::*)()) v4 = 0xffffffff000000000000000000000000
 
-struct SI {
-  char si;
-};
+// clang-format off
+struct Single1 { void s1() {} };
+struct Single2 : Single1 { void s2() {} };
 
-char SI::*mp = &SI::si;
+struct Helper {};
+struct Multiple1 : Single1, Helper { void m1() {} };
+struct Multiple2 : Multiple1 { void m2() {} };
 
-int main() { return 0; }
+struct Virtual1 : virtual Single1 { void v1() {} };
+struct Virtual2 : Virtual1 { void v2() {} };
+struct Virtual3 : virtual Multiple1 { void v3() {} };
+struct Virtual4 : Virtual1, Helper { void v4() {} };
+
+void (Single1::*s1)() = nullptr;
+void (Single2::*s2)() = nullptr;
+void (Multiple1::*m1)() = nullptr;
+void (Multiple2::*m2)() = nullptr;
+void (Virtual1::*v1)() = nullptr;
+void (Virtual2::*v2)() = nullptr;
+void (Virtual3::*v3)() = nullptr;
+void (Virtual4::*v4)() = nullptr;
+
+int main(int argc, char *argv[]) {
+  // We need to force emission of type info to DWARF. That's reasonable, because
+  // Clang doesn't know that we need it to infer member-pointer sizes. We could
+  // probably teach Clang to do so, but in most real-world scenarios this might
+  // be a non-issue.
+  Virtual1 vi1;
+  Virtual2 vi2;
+  Virtual3 vi3;
+  Virtual4 vi4;
+  int sum = sizeof(Single2) + sizeof(Multiple2);
+  return argc < sum ? 0 : 1;
+}

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/member-pointers.cpp
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/member-pointers.cpp
@@ -1,0 +1,24 @@
+// REQUIRES: lld
+
+// Itanium ABI:
+// RUN: %clang --target=x86_64-pc-linux -gdwarf -c -o %t_linux.o %s
+// RUN: %lldb -f %t_linux.o -b -o "target variable mp" | FileCheck %s
+//
+// CHECK: (char SI::*) mp = 0x0000000000000000
+
+// Microsoft ABI:
+// RUN: %clang_cl --target=x86_64-windows-msvc -c -gdwarf -o %t_win.obj -- %s
+// RUN: lld-link /out:%t_win.exe %t_win.obj /nodefaultlib /entry:main /debug
+// RUN: %lldb -f %t_win.exe -b -o "target variable mp" | FileCheck --check-prefix=CHECK-MSVC %s
+//
+// DWARF has no representation of MSInheritanceAttr, so we cannot determine the size
+// of member-pointers yet. For the moment, make sure we don't crash on such variables.
+// CHECK-MSVC: error: Unable to determine byte size.
+
+struct SI {
+  char si;
+};
+
+char SI::*mp = &SI::si;
+
+int main() { return 0; }


### PR DESCRIPTION
Member pointers refer to data or function members of a `CXXRecordDecl`, which require a `MSInheritanceAttr` in order to be complete. Without that we cannot calculate the size of a member pointer in memory. The attempt has been causing a crash further down in the clang AST context. In order to implement the feature, DWARF might need a new attribute to convey the information. For the moment, this patch teaches LLDB to handle to situation and avoid the crash.