### PR TITLE
[lldb] Implement support for Clang Submodule imports in Swift contexts.

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1464,9 +1464,9 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                     std::vector<llvm::StringRef> name_parts;
                     SplitDottedName(input, name_parts);
 
-                    std::function<void(swift::ModuleDecl *)> lookup_func =
+                    std::function<void(const swift::ModuleDecl *)> lookup_func =
                         [&ast_ctx, input, name_parts,
-                         &results](swift::ModuleDecl *module) -> void {
+                         &results](const swift::ModuleDecl *module) -> void {
                       for (auto imported_module :
                            swift::namelookup::getAllImports(module)) {
                         auto module = imported_module.importedModule;
@@ -1519,7 +1519,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
                     };
 
                     for (; iter != end; iter++)
-                      lookup_func(iter->second);
+                      lookup_func(&iter->second);
                   }
             }
           }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -304,24 +304,22 @@ public:
   /// \return the ExtraArgs of the ClangImporterOptions.
   const std::vector<std::string> &GetClangArguments();
 
-  /// Attempt to create a Swift module, returning \c nullptr and setting
-  /// \p error if unsuccessful.
+  /// Attempt to create a Swift module.
   ///
   /// \param importInfo Information about which modules should be implicitly
   /// imported by each file of the module.
-  swift::ModuleDecl *CreateModule(const SourceModule &module, Status &error,
-                                  swift::ImplicitImportInfo importInfo);
+  llvm::Expected<swift::ModuleDecl &>
+  CreateModule(std::string module_name, swift::ImplicitImportInfo importInfo);
 
   // This function should only be called when all search paths
   // for all items in a swift::ASTContext have been setup to
   // allow for imports to happen correctly. Use with caution,
   // or use the GetModule() call that takes a FileSpec.
-  swift::ModuleDecl *GetModule(const SourceModule &module, Status &error,
-                               bool *cached = nullptr);
+  llvm::Expected<swift::ModuleDecl &> GetModule(const SourceModule &module,
+                                                bool *cached = nullptr);
+  llvm::Expected<swift::ModuleDecl &> GetModule(const FileSpec &module_spec);
 
-  swift::ModuleDecl *GetModule(const FileSpec &module_spec, Status &error);
-
-  void CacheModule(swift::ModuleDecl *module);
+  void CacheModule(std::string module_name, swift::ModuleDecl *module);
 
   /// Call this after the search paths are set up, it will find the module given
   /// by module, load the module into the AST context, and (if import_dylib is
@@ -538,7 +536,7 @@ public:
   // DebuggerClient's that we are sticking into the Swift Modules.
   void AddDebuggerClient(swift::DebuggerClient *debugger_client);
 
-  typedef llvm::StringMap<swift::ModuleDecl *> SwiftModuleMap;
+  typedef llvm::StringMap<const swift::ModuleDecl &> SwiftModuleMap;
 
   const SwiftModuleMap &GetModuleCache() { return m_swift_module_cache; }
 
@@ -881,7 +879,7 @@ protected:
 
   swift::MemoryBufferSerializedModuleLoader *GetMemoryBufferModuleLoader();
 
-  swift::ModuleDecl *GetCachedModule(const SourceModule &module);
+  swift::ModuleDecl *GetCachedModule(std::string module_name);
 
   void CacheDemangledType(ConstString mangled_name,
                           swift::TypeBase *found_type);

--- a/lldb/test/API/lang/swift/clangimporter/submodules/A/A.h
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/A/A.h
@@ -1,0 +1,4 @@
+#ifndef _A_H_
+#define _A_H_
+#include "B.h"
+#endif

--- a/lldb/test/API/lang/swift/clangimporter/submodules/A/B.h
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/A/B.h
@@ -1,0 +1,6 @@
+#ifndef _B_H_
+#define _B_H_
+struct FromB {
+  int i;
+};
+#endif

--- a/lldb/test/API/lang/swift/clangimporter/submodules/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR) -Xcc -I$(SRCDIR)
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
@@ -1,0 +1,14 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftSubmoduleImport(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test imports of Clang submodules"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, 'break here', lldb.SBFileSpec('main.swift'))
+        # Without the import of A.B this getter would be invisible
+        # because it returns a type form that submodule.
+        self.expect("expression -- a.priv", substrs=['23'])

--- a/lldb/test/API/lang/swift/clangimporter/submodules/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/main.swift
@@ -1,0 +1,10 @@
+// This must be an @_implementationOnly import, otherwise importing A
+// implicitly also imports A.B.
+@_implementationOnly import A.B
+
+struct s {
+  fileprivate var priv : FromB { return FromB(i: 23) }
+}
+
+let a = s()
+print("break here")

--- a/lldb/test/API/lang/swift/clangimporter/submodules/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/module.modulemap
@@ -1,0 +1,4 @@
+module A {
+  umbrella "A"
+  explicit module * { export * }
+}


### PR DESCRIPTION
It is legal to import a Clang submodule using Module.Submodule syntax. LLDB was not handling this correctly when doing contextual imports and stripped everything but the base name.

rdar://137003294
(cherry picked from commit 9fb8853712e207a63d5e43183b840b00b7488f70)