### PR TITLE
[lldb] Add builtin e alias for expression (#115359)

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -442,6 +442,8 @@ void CommandInterpreter::Initialize() {
 
   cmd_obj_sp = GetCommandSPExact("expression");
   if (cmd_obj_sp) {
+    // Ensure `e` runs `expression`.
+    AddAlias("e", cmd_obj_sp);
     AddAlias("call", cmd_obj_sp, "--")->SetHelpLong("");
     CommandAlias *parray_alias =
         AddAlias("parray", cmd_obj_sp, "--element-count %1 --");

--- a/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
+++ b/lldb/test/API/functionalities/abbreviation/TestAbbreviations.py
@@ -20,6 +20,10 @@ class AbbreviationsTestCase(TestBase):
         self.assertTrue(result.Succeeded())
         self.assertEqual("apropos script", result.GetOutput())
 
+        command_interpreter.ResolveCommand("e", result)
+        self.assertTrue(result.Succeeded())
+        self.assertEqual("expression", result.GetOutput())
+
         command_interpreter.ResolveCommand("h", result)
         self.assertTrue(result.Succeeded())
         self.assertEqual("help", result.GetOutput())


### PR DESCRIPTION
The changes in 461f859a72 (llvm/llvm-project#65974) resulted in a change in behavior not just for completion, but also for selection of inexact commands.

Since many use `e` to mean `expression`, this change adds an alias for `e`. Note that the referenced change similarly aliases `h` to `help`.

(cherry picked from commit 60e3a81c4299baf80e7b80db9cb8368223ee9546)
