### PR TITLE
[Test] Update clang/test/Modules/crash-vfs-include-pch.m (#102080)

### DIFF
--- a/clang/test/Modules/crash-vfs-include-pch.m
+++ b/clang/test/Modules/crash-vfs-include-pch.m
@@ -10,7 +10,7 @@
 
 // RUN: env FORCE_CLANG_DIAGNOSTICS_CRASH= TMPDIR=%t TEMP=%t TMP=%t \
 // RUN: not %clang %s -E -include-pch %t/out/pch-used.h.pch -fmodules -nostdlibinc \
-// RUN:     -fimplicit-module-maps -fbuiltin-headers-in-system-modules \
+// RUN:     -fimplicit-module-maps -Xclang -fbuiltin-headers-in-system-modules \
 // RUN:     -fmodules-cache-path=%t/cache -O0 -Xclang -fno-validate-pch \
 // RUN:     -isystem %S/Inputs/System/usr/include -o %t/output.E 2>&1 | FileCheck %s
 


### PR DESCRIPTION
Avoid the driver error for mis-using a clang cc1 flag as driver flag in the crash test.

(cherry picked from commit c826c074813a668de87d4aa8bfc95f9f8adf1e5f)