### PR TITLE
[lldb][swift] Fix thread plan to step through swift_task_switch 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2522,20 +2522,7 @@ void SwiftLanguageRuntime::DidFinishExecutingUserExpression(
 
 bool SwiftLanguageRuntime::IsABIStable() { FORWARD(IsABIStable); }
 
-namespace {
-/// The target specific register numbers used for async unwinding.
-///
-/// For UnwindPlans, these use eh_frame / dwarf register numbering.
-struct AsyncUnwindRegisterNumbers {
-  uint32_t async_ctx_regnum;
-  uint32_t fp_regnum;
-  uint32_t pc_regnum;
-
-  RegisterKind GetRegisterKind() const { return lldb::eRegisterKindDWARF; }
-};
-} // namespace
-
-static std::optional<AsyncUnwindRegisterNumbers>
+std::optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple) {
   switch (triple) {
   case llvm::Triple::x86_64: {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -517,6 +517,21 @@ private:
                              unsigned num_indirections = 0);
 };
 
+/// The target specific register numbers used for async unwinding.
+///
+/// For UnwindPlans, these use eh_frame / dwarf register numbering.
+struct AsyncUnwindRegisterNumbers {
+  uint32_t async_ctx_regnum;
+  uint32_t fp_regnum;
+  uint32_t pc_regnum;
+
+  /// All register numbers in this struct are given in the eRegisterKindDWARF
+  /// domain.
+  lldb::RegisterKind GetRegisterKind() const { return lldb::eRegisterKindDWARF; }
+};
+
+std::optional<AsyncUnwindRegisterNumbers>
+GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 } // namespace lldb_private
 
 #endif // liblldb_SwiftLanguageRuntime_h_

--- a/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+@skipIfAsan  # rdar://138777205
+class TestCase(lldbtest.TestBase):
+
+    def check_is_in_line(self, thread, linenum):
+        frame = thread.frames[0]
+        line_entry = frame.GetLineEntry()
+        self.assertEqual(linenum, line_entry.GetLine())
+
+    @swiftTest
+    @skipIf(oslist=["windows", "linux"])
+    def test(self):
+        """Test conditions for async step-over."""
+        self.build()
+
+        source_file = lldb.SBFileSpec("main.swift")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "BREAK HERE", source_file
+        )
+
+        expected_line_nums = [4]  # print(x)
+        expected_line_nums += [5, 6, 7, 5, 6, 7, 5]  # two runs over the loop
+        expected_line_nums += [8, 9]  # if line + if block
+        # FIXME: IRGen is producing incorrected line numbers. rdar://139826231
+        expected_line_nums[-1] = 11
+        for expected_line_num in expected_line_nums:
+            thread.StepOver()
+            stop_reason = thread.GetStopReason()
+            self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
+            self.check_is_in_line(thread, expected_line_num)

--- a/lldb/test/API/lang/swift/async/stepping/step_over/main.swift
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/main.swift
@@ -1,0 +1,16 @@
+@main enum entry {
+  static func main() async {
+    let x = await f() // BREAK HERE
+    print(x)
+    for i in 1...2 {
+      await f()
+    }
+    if (await f() == 30) {
+      print("here!")
+    }
+  }
+}
+
+func f() async -> Int {
+  return 30
+}


### PR DESCRIPTION
This PR removes `ThreadPlanStepInAsync` and replaces it with `ThreadPlanRunToAddressOnAsyncCtx`, a thread plan that runs to a specific address on a specific async context.

Please review each commit individually.

This is another attempt at: https://github.com/swiftlang/llvm-project/pull/9452