### PR TITLE
[CAS] Handle DataPool overflow in OnDiskGraphDB

### DIFF
--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -302,6 +302,11 @@ public:
   /// large object if the process crashed right at the point of inserting it.
   size_t getStorageSize() const;
 
+  /// \returns The precentage of space utilization of hard space limits.
+  ///
+  /// Return value is an integer between 0 and 100 for percentage.
+  unsigned getHardStorageLimitUtilization() const;
+
   void print(raw_ostream &OS) const;
 
   /// How to fault-in nodes if an upstream database is used.

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -275,6 +275,7 @@ public:
   }
 
   size_t size() const;
+  size_t capacity() const;
 
   /// Gets or creates a file at \p Path with a hash-mapped trie named \p
   /// TrieName. The hash size is \p NumHashBits (in bits) and the records store
@@ -366,6 +367,7 @@ public:
   MutableArrayRef<uint8_t> getUserHeader();
 
   size_t size() const;
+  size_t capacity() const;
 
   static Expected<OnDiskDataAllocator>
   create(const Twine &Path, const Twine &TableName, uint64_t MaxFileSize,

--- a/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
+++ b/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
@@ -39,6 +39,13 @@ public:
     return Cache.size();
   }
 
+  /// \returns The precentage of space utilization of hard space limits.
+  ///
+  /// Return value is an integer between 0 and 100 for percentage.
+  unsigned getHardStorageLimitUtilization() const {
+    return Cache.size() * 100ULL / Cache.capacity();
+  }
+
   /// Open the on-disk store from a directory.
   ///
   /// \param Path directory for the on-disk store. The directory will be created

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -1397,8 +1397,8 @@ Expected<std::unique_ptr<OnDiskGraphDB>> OnDiskGraphDB::open(
   constexpr uint64_t MB = 1024ull * 1024ull;
   constexpr uint64_t GB = 1024ull * 1024ull * 1024ull;
 
-  uint64_t MaxIndexSize = 8 * GB;
-  uint64_t MaxDataPoolSize = 16 * GB;
+  uint64_t MaxIndexSize = 12 * GB;
+  uint64_t MaxDataPoolSize = 24 * GB;
 
   if (useSmallMappedFiles(AbsPath)) {
     MaxIndexSize = 1 * GB;

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -980,6 +980,9 @@ static Error checkTable(StringRef Label, size_t Expected, size_t Observed,
 }
 
 size_t OnDiskHashMappedTrie::size() const { return Impl->File.size(); }
+size_t OnDiskHashMappedTrie::capacity() const {
+  return Impl->File.getRegion().size();
+}
 
 Expected<OnDiskHashMappedTrie>
 OnDiskHashMappedTrie::create(const Twine &PathTwine, const Twine &TrieNameTwine,
@@ -1415,6 +1418,9 @@ MutableArrayRef<uint8_t> OnDiskDataAllocator::getUserHeader() {
 }
 
 size_t OnDiskDataAllocator::size() const { return Impl->File.size(); }
+size_t OnDiskDataAllocator::capacity() const {
+  return Impl->File.getRegion().size();
+}
 
 OnDiskDataAllocator::OnDiskDataAllocator(std::unique_ptr<ImplType> Impl)
     : Impl(std::move(Impl)) {}
@@ -1456,6 +1462,14 @@ void OnDiskHashMappedTrie::print(
 }
 
 size_t OnDiskHashMappedTrie::size() const {
+  report_fatal_error("not supported");
+}
+
+size_t OnDiskHashMappedTrie::capacity() const {
+  report_fatal_error("not supported");
+}
+
+size_t OnDiskDataAllocator::capacity() const {
   report_fatal_error("not supported");
 }
 

--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -271,6 +271,14 @@ bool UnifiedOnDiskCache::hasExceededSizeLimit() const {
   uint64_t CurSizeLimit = SizeLimit;
   if (!CurSizeLimit)
     return false;
+
+  // If the hard limit is beyond 85%, declare above limit and request clean up.
+  unsigned CurrentPrecent =
+      std::max(PrimaryGraphDB->getHardStorageLimitUtilization(),
+               PrimaryKVDB->getHardStorageLimitUtilization());
+  if (CurrentPrecent > 85)
+    return true;
+
   // We allow each of the directories in the chain to reach up to half the
   // intended size limit. Check whether the primary directory has exceeded half
   // the limit or not, in order to decide whether we need to start a new chain.


### PR DESCRIPTION
Handle DataPool overflow in GraphDB:
* When the data pool can't hold more items, allocate the new entries
  on disk standalone (degraded performance and more disk space consumption)
* Teach UnifiedCAS to more aggressively chaining and reclaiming space if
  data pool is relatively full (currently hard code to 85%) but the CAS
  is not at the space limit for overall size.

rdar://139242950