### PR TITLE
[lldb] Mark forward C++ interop test XFAIL

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/TestSwiftForwardInteropVerboseTrap.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/verbose_trap/TestSwiftForwardInteropVerboseTrap.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropVerboseTrap(TestBase):
 
     @swiftTest
+    @expectedFailureAll(bugnumber="rdar://139429226")
     def test(self):
         self.build()
         target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))


### PR DESCRIPTION
After Swift PR #77323, we import C++ source locations for imported code. This improves some diagnostics but also breaks some of the heuristics LLDB have to select the right frame on traps. This PR marks the test XFAIL until we figure out a better heuristic to stop at the right frame. This is not a trivial question as we cannot just mark all C++ imported source locations artifical, some of that code is user written, some is not (coming from frameworks, STL). Moreover, some users might prefer to stop in the C++ code and some users might prefer to stop in Swift code.

(cherry picked from commit 1c0bdf9682ad559a1926d2d2feb5a0f7db55d14e)