### PR TITLE
🍒[Clang] Dispatch default overloads of `TemplateArgumentVisitor` to the implementation

### DIFF
--- a/clang/include/clang/AST/TemplateArgumentVisitor.h
+++ b/clang/include/clang/AST/TemplateArgumentVisitor.h
@@ -52,7 +52,8 @@ public:
 #define VISIT_METHOD(CATEGORY)                                                 \
   RetTy Visit##CATEGORY##TemplateArgument(REF(TemplateArgument) TA,            \
                                           ParamTys... P) {                     \
-    return VisitTemplateArgument(TA, std::forward<ParamTys>(P)...);            \
+    return static_cast<ImplClass *>(this)->VisitTemplateArgument(              \
+        TA, std::forward<ParamTys>(P)...);                                     \
   }
 
   VISIT_METHOD(Null);


### PR DESCRIPTION
This fixes an issue where overriding
`clang::ConstTemplateArgumentVisitor::VisitTemplateArgument` in an implementation visitor class did not have the desired effect: the overload was not invoked when one of the visitor methods (e.g. `VisitDeclarationArgument`) is not implemented, instead it dispatched to `clang::ConstTemplateArgumentVisitor::VisitTemplateArgument` itself and always returned a default-initialized result.

This makes `TemplateArgumentVisitor` and `ConstTemplateArgumentVisitor` follow the implicit convention that is followed elsewhere in Clang AST, in `RecursiveASTVisitor` and `TypeVisitor`.

(cherry picked from commit d4525b016f5a1ab2852acb2108742b2f9d0bd3bd)