### PR TITLE
[clang][deps] Disable `FileManager` sharing with `CASFS`

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -480,6 +480,8 @@ public:
     // This will prevent us compiling individual modules asynchronously since
     // FileManager is not thread-safe, but it does improve performance for now.
     ScanInstance.getFrontendOpts().ModulesShareFileManager = true;
+    if (DepCASFS)
+      ScanInstance.getFrontendOpts().ModulesShareFileManager = false;
     ScanInstance.getHeaderSearchOpts().ModuleFormat = "raw";
     ScanInstance.getHeaderSearchOpts().ModulesIncludeVFSUsage =
         any(OptimizeArgs & ScanningOptimizations::VFS);


### PR DESCRIPTION
The CAS-based scanner relies on each module accessing the VFS, which sharing of `FileManager` prevents. This fixes the following tests:

```
  Clang :: ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
  Clang :: ClangScanDeps/modules-cas-fs-prefix-mapping.c
  Clang :: ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
  Clang :: ClangScanDeps/modules-cas-full-by-mod-name.c
  Clang :: ClangScanDeps/modules-cas-trees.c
  Clang :: ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
  Clang :: ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c
```