### PR TITLE
[lldb] Wire up preliminary support for BuiltinFixedArray

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5960,15 +5960,18 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
     swift_flags |= eTypeHasDynamicSelf;
   switch (type_kind) {
   case swift::TypeKind::BuiltinDefaultActorStorage:
-  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
   case swift::TypeKind::BuiltinJob:
-  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinRawUnsafeContinuation:
-  case swift::TypeKind::Error:
-  case swift::TypeKind::InOut:
-  case swift::TypeKind::Module:
+  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::ElementArchetype:
+  case swift::TypeKind::Error:
+  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::InOut:
+  case swift::TypeKind::Integer:
+  case swift::TypeKind::Module:
   case swift::TypeKind::OpenedArchetype:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
@@ -5979,7 +5982,6 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILToken:
   case swift::TypeKind::TypeVariable:
-  case swift::TypeKind::ErrorUnion:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
     LOG_PRINTF(GetLog(LLDBLog::Types), "Unexpected type: %s",
@@ -6019,6 +6021,8 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
     swift_flags |=
         eTypeIsBuiltIn | eTypeIsPointer | eTypeIsScalar | eTypeHasValue;
     break;
+  case swift::TypeKind::BuiltinFixedArray:
+    return eTypeIsBuiltIn | eTypeHasChildren;
   case swift::TypeKind::BuiltinVector:
     // TODO: OR in eTypeIsFloat or eTypeIsInteger as needed
     return eTypeIsBuiltIn | eTypeHasChildren | eTypeIsVector;
@@ -6120,6 +6124,8 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinPackIndex:    
   case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::Integer:
   case swift::TypeKind::Pack:
   case swift::TypeKind::PackElement:
   case swift::TypeKind::PackExpansion:
@@ -6146,6 +6152,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
     return lldb::eTypeClassBuiltin;
   case swift::TypeKind::BuiltinVector:
     return lldb::eTypeClassVector;
+  case swift::TypeKind::BuiltinFixedArray:
   case swift::TypeKind::Tuple:
     return lldb::eTypeClassArray;
   case swift::TypeKind::UnmanagedStorage:
@@ -6653,10 +6660,12 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
   case swift::TypeKind::BoundGenericClass:
   case swift::TypeKind::GenericTypeParam:
   case swift::TypeKind::DependentMember:
+  case swift::TypeKind::Integer:
     return lldb::eEncodingUint;
 
+  case swift::TypeKind::BuiltinFixedArray:
+  case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::BuiltinVector:
-    break;
   case swift::TypeKind::Tuple:
     break;
   case swift::TypeKind::UnmanagedStorage:
@@ -6712,53 +6721,59 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
 
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
+  case swift::TypeKind::BuiltinBridgeObject:
   case swift::TypeKind::BuiltinDefaultActorStorage:
-  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
-  case swift::TypeKind::BuiltinJob:
-  case swift::TypeKind::BuiltinTuple:
-  case swift::TypeKind::BuiltinRawUnsafeContinuation:
-  case swift::TypeKind::Error:
-  case swift::TypeKind::InOut:
-  case swift::TypeKind::Module:
-  case swift::TypeKind::BuiltinPackIndex:
-  case swift::TypeKind::Pack:
-  case swift::TypeKind::PackElement:
-  case swift::TypeKind::PackExpansion:
-  case swift::TypeKind::SILPack:
-  case swift::TypeKind::ParameterizedProtocol:
-  case swift::TypeKind::Placeholder:
-  case swift::TypeKind::SILBlockStorage:
-  case swift::TypeKind::SILBox:
-  case swift::TypeKind::SILMoveOnlyWrapped:
-  case swift::TypeKind::SILFunction:
-  case swift::TypeKind::SILToken:
-  case swift::TypeKind::PackArchetype:
-  case swift::TypeKind::TypeVariable:
-  case swift::TypeKind::ErrorUnion:
-  case swift::TypeKind::Unresolved:
-  case swift::TypeKind::VariadicSequence:
-    break;
+  case swift::TypeKind::BuiltinFloat:
   case swift::TypeKind::BuiltinInteger:
   case swift::TypeKind::BuiltinIntegerLiteral:
-  case swift::TypeKind::BuiltinFloat:
-  case swift::TypeKind::BuiltinRawPointer:
+  case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinNativeObject:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
+  case swift::TypeKind::BuiltinPackIndex:
+  case swift::TypeKind::BuiltinRawPointer:
+  case swift::TypeKind::BuiltinRawUnsafeContinuation:
+  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::BuiltinUnsafeValueBuffer:
-  case swift::TypeKind::BuiltinBridgeObject:
   case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::DependentMember:
+  case swift::TypeKind::DynamicSelf:
+  case swift::TypeKind::ElementArchetype:
+  case swift::TypeKind::Error:
+  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::ExistentialMetatype:
   case swift::TypeKind::Function:
   case swift::TypeKind::GenericFunction:
-  case swift::TypeKind::DynamicSelf:
+  case swift::TypeKind::GenericTypeParam:
+  case swift::TypeKind::InOut:
+  case swift::TypeKind::Integer:
+  case swift::TypeKind::Metatype:
+  case swift::TypeKind::Module:
+  case swift::TypeKind::OpaqueTypeArchetype:
+  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::Pack:
+  case swift::TypeKind::PackArchetype:
+  case swift::TypeKind::PackElement:
+  case swift::TypeKind::PackExpansion:
+  case swift::TypeKind::ParameterizedProtocol:
+  case swift::TypeKind::Placeholder:
+  case swift::TypeKind::PrimaryArchetype:
+  case swift::TypeKind::SILBlockStorage:
+  case swift::TypeKind::SILBox:
+  case swift::TypeKind::SILFunction:
+  case swift::TypeKind::SILMoveOnlyWrapped:
+  case swift::TypeKind::SILPack:
+  case swift::TypeKind::SILToken:
+  case swift::TypeKind::TypeVariable:
+  case swift::TypeKind::Unresolved:
+  case swift::TypeKind::VariadicSequence:
     break;
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
     return ToCompilerType(swift_can_type->getReferenceStorageReferent())
         .GetNumChildren(omit_empty_base_classes, exe_ctx);
-  case swift::TypeKind::GenericTypeParam:
-  case swift::TypeKind::DependentMember:
-    break;
 
   case swift::TypeKind::Enum:
   case swift::TypeKind::BoundGenericEnum: {
@@ -6767,9 +6782,10 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
       return cached_enum_info->GetNumElementsWithPayload();
   } break;
 
-  case swift::TypeKind::Tuple:
-  case swift::TypeKind::Struct:
   case swift::TypeKind::BoundGenericStruct:
+  case swift::TypeKind::BuiltinFixedArray:
+  case swift::TypeKind::Struct:
+  case swift::TypeKind::Tuple:
     return GetNumFields(type);
 
   case swift::TypeKind::Class:
@@ -6787,15 +6803,6 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
 
     return protocol_info.m_num_storage_words;
   }
-
-  case swift::TypeKind::ExistentialMetatype:
-  case swift::TypeKind::Metatype:
-  case swift::TypeKind::PrimaryArchetype:
-  case swift::TypeKind::ElementArchetype:
-  case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
-
-    return 0;
 
   case swift::TypeKind::LValue: {
     swift::LValueType *lvalue_type =
@@ -6855,41 +6862,42 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
 
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
+  case swift::TypeKind::BuiltinBridgeObject:
   case swift::TypeKind::BuiltinDefaultActorStorage:
-  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
+  case swift::TypeKind::BuiltinFloat:
+  case swift::TypeKind::BuiltinInteger:
+  case swift::TypeKind::BuiltinIntegerLiteral:
   case swift::TypeKind::BuiltinJob:
-  case swift::TypeKind::BuiltinTuple:
-  case swift::TypeKind::BuiltinRawUnsafeContinuation:
-  case swift::TypeKind::Error:
-  case swift::TypeKind::InOut:
-  case swift::TypeKind::Module:
+  case swift::TypeKind::BuiltinNativeObject:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinPackIndex:
+  case swift::TypeKind::BuiltinRawPointer:
+  case swift::TypeKind::BuiltinRawUnsafeContinuation:
+  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::BuiltinUnsafeValueBuffer:
+  case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::Error:
+  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::InOut:
+  case swift::TypeKind::Integer:
+  case swift::TypeKind::Module:
   case swift::TypeKind::Pack:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
   case swift::TypeKind::PackExpansion:
-  case swift::TypeKind::SILPack:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
   case swift::TypeKind::SILBlockStorage:
   case swift::TypeKind::SILBox:
-  case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
+  case swift::TypeKind::SILMoveOnlyWrapped:
+  case swift::TypeKind::SILPack:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
-  case swift::TypeKind::ErrorUnion:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
-    break;
-  case swift::TypeKind::BuiltinInteger:
-  case swift::TypeKind::BuiltinIntegerLiteral:
-  case swift::TypeKind::BuiltinFloat:
-  case swift::TypeKind::BuiltinRawPointer:
-  case swift::TypeKind::BuiltinNativeObject:
-  case swift::TypeKind::BuiltinUnsafeValueBuffer:
-  case swift::TypeKind::BuiltinBridgeObject:
-  case swift::TypeKind::BuiltinVector:
     break;
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
@@ -6909,6 +6917,10 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
 
   case swift::TypeKind::Tuple:
     return swift::cast<swift::TupleType>(swift_can_type)->getNumElements();
+  case swift::TypeKind::BuiltinFixedArray:
+    return swift::cast<swift::BuiltinFixedArrayType>(swift_can_type)
+        ->getFixedInhabitedSize()
+        .value_or(0);
 
   case swift::TypeKind::Struct:
   case swift::TypeKind::Class:
@@ -7081,41 +7093,42 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
 
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
+  case swift::TypeKind::BuiltinBridgeObject:
   case swift::TypeKind::BuiltinDefaultActorStorage:
-  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
+  case swift::TypeKind::BuiltinFloat:
+  case swift::TypeKind::BuiltinInteger:
+  case swift::TypeKind::BuiltinIntegerLiteral:
   case swift::TypeKind::BuiltinJob:
-  case swift::TypeKind::BuiltinTuple:
-  case swift::TypeKind::BuiltinRawUnsafeContinuation:
-  case swift::TypeKind::Error:
-  case swift::TypeKind::InOut:
-  case swift::TypeKind::Module:
+  case swift::TypeKind::BuiltinNativeObject:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinPackIndex:
+  case swift::TypeKind::BuiltinRawPointer:
+  case swift::TypeKind::BuiltinRawUnsafeContinuation:
+  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::BuiltinUnsafeValueBuffer:
+  case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::Error:
+  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::InOut:
+  case swift::TypeKind::Integer:
+  case swift::TypeKind::Module:
   case swift::TypeKind::Pack:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
   case swift::TypeKind::PackExpansion:
-  case swift::TypeKind::SILPack:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
   case swift::TypeKind::SILBlockStorage:
   case swift::TypeKind::SILBox:
-  case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
+  case swift::TypeKind::SILMoveOnlyWrapped:
+  case swift::TypeKind::SILPack:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
-  case swift::TypeKind::ErrorUnion:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
-    break;
-  case swift::TypeKind::BuiltinInteger:
-  case swift::TypeKind::BuiltinIntegerLiteral:
-  case swift::TypeKind::BuiltinFloat:
-  case swift::TypeKind::BuiltinRawPointer:
-  case swift::TypeKind::BuiltinNativeObject:
-  case swift::TypeKind::BuiltinUnsafeValueBuffer:
-  case swift::TypeKind::BuiltinBridgeObject:
-  case swift::TypeKind::BuiltinVector:
     break;
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
@@ -7149,6 +7162,12 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
 
     const auto &child = tuple_type->getElement(idx);
     return ToCompilerType(child.getType().getPointer());
+  }
+
+  case swift::TypeKind::BuiltinFixedArray: {
+    auto fixed_array =
+        swift::cast<swift::BuiltinFixedArrayType>(swift_can_type);
+    return ToCompilerType(fixed_array->getElementType());
   }
 
   case swift::TypeKind::Class:
@@ -7275,30 +7294,55 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
 
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
+  case swift::TypeKind::BoundGenericClass:
+  case swift::TypeKind::BoundGenericEnum:
+  case swift::TypeKind::BoundGenericStruct:
   case swift::TypeKind::BuiltinDefaultActorStorage:
-  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
+  case swift::TypeKind::BuiltinFixedArray:
   case swift::TypeKind::BuiltinJob:
-  case swift::TypeKind::BuiltinTuple:
-  case swift::TypeKind::BuiltinRawUnsafeContinuation:
-  case swift::TypeKind::Error:
-  case swift::TypeKind::InOut:
-  case swift::TypeKind::Module:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinPackIndex:
+  case swift::TypeKind::BuiltinRawUnsafeContinuation:
+  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::Class:
+  case swift::TypeKind::DependentMember:
+  case swift::TypeKind::DynamicSelf:
+  case swift::TypeKind::ElementArchetype:
+  case swift::TypeKind::Enum:
+  case swift::TypeKind::Error:
+  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::Existential:
+  case swift::TypeKind::ExistentialMetatype:
+  case swift::TypeKind::Function:
+  case swift::TypeKind::GenericFunction:
+  case swift::TypeKind::GenericTypeParam:
+  case swift::TypeKind::InOut:
+  case swift::TypeKind::Integer:
+  case swift::TypeKind::Metatype:
+  case swift::TypeKind::Module:
+  case swift::TypeKind::OpaqueTypeArchetype:
+  case swift::TypeKind::OpenedArchetype:
   case swift::TypeKind::Pack:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
   case swift::TypeKind::PackExpansion:
-  case swift::TypeKind::SILPack:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
+  case swift::TypeKind::PrimaryArchetype:
+  case swift::TypeKind::Protocol:
+  case swift::TypeKind::ProtocolComposition:
   case swift::TypeKind::SILBlockStorage:
   case swift::TypeKind::SILBox:
-  case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
+  case swift::TypeKind::SILMoveOnlyWrapped:
+  case swift::TypeKind::SILPack:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::PackArchetype:
+  case swift::TypeKind::Struct:
+  case swift::TypeKind::Tuple:
   case swift::TypeKind::TypeVariable:
-  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
     return 0;
@@ -7317,32 +7361,8 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   case swift::TypeKind::WeakStorage:
     return GetNumPointeeChildren(
         swift::cast<swift::ReferenceStorageType>(swift_can_type).getPointer());
-  case swift::TypeKind::Tuple:
-  case swift::TypeKind::GenericTypeParam:
-  case swift::TypeKind::DependentMember:
-  case swift::TypeKind::Enum:
-  case swift::TypeKind::Struct:
-  case swift::TypeKind::Class:
-  case swift::TypeKind::Protocol:
-  case swift::TypeKind::Metatype:
-  case swift::TypeKind::ElementArchetype:
-  case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
-  case swift::TypeKind::PrimaryArchetype:
-  case swift::TypeKind::Function:
-  case swift::TypeKind::GenericFunction:
-  case swift::TypeKind::ProtocolComposition:
-  case swift::TypeKind::Existential:
-    return 0;
   case swift::TypeKind::LValue:
     return 1;
-  case swift::TypeKind::UnboundGeneric:
-  case swift::TypeKind::BoundGenericClass:
-  case swift::TypeKind::BoundGenericEnum:
-  case swift::TypeKind::BoundGenericStruct:
-  case swift::TypeKind::ExistentialMetatype:
-  case swift::TypeKind::DynamicSelf:
-    return 0;
 
   case swift::TypeKind::Optional:
   case swift::TypeKind::TypeAlias:
@@ -7433,42 +7453,56 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
 
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
+  case swift::TypeKind::BuiltinBridgeObject:
   case swift::TypeKind::BuiltinDefaultActorStorage:
-  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
+  case swift::TypeKind::BuiltinFloat:
+  case swift::TypeKind::BuiltinInteger:
+  case swift::TypeKind::BuiltinIntegerLiteral:
   case swift::TypeKind::BuiltinJob:
-  case swift::TypeKind::BuiltinTuple:
-  case swift::TypeKind::BuiltinRawUnsafeContinuation:
-  case swift::TypeKind::Error:
-  case swift::TypeKind::InOut:
-  case swift::TypeKind::Module:
+  case swift::TypeKind::BuiltinNativeObject:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinPackIndex:
+  case swift::TypeKind::BuiltinRawPointer:
+  case swift::TypeKind::BuiltinRawUnsafeContinuation:
+  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::BuiltinUnsafeValueBuffer:
+  case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::DependentMember:
+  case swift::TypeKind::DynamicSelf:
+  case swift::TypeKind::ElementArchetype:
+  case swift::TypeKind::Error:
+  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::ExistentialMetatype:
+  case swift::TypeKind::Function:
+  case swift::TypeKind::GenericFunction:
+  case swift::TypeKind::GenericTypeParam:
+  case swift::TypeKind::InOut:
+  case swift::TypeKind::Integer:
+  case swift::TypeKind::Metatype:
+  case swift::TypeKind::Module:
+  case swift::TypeKind::OpaqueTypeArchetype:
+  case swift::TypeKind::OpenedArchetype:
   case swift::TypeKind::Pack:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
   case swift::TypeKind::PackExpansion:
-  case swift::TypeKind::SILPack:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
+  case swift::TypeKind::PrimaryArchetype:
   case swift::TypeKind::SILBlockStorage:
   case swift::TypeKind::SILBox:
-  case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
+  case swift::TypeKind::SILMoveOnlyWrapped:
+  case swift::TypeKind::SILPack:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::TypeVariable:
-  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
     break;
-  case swift::TypeKind::BuiltinInteger:
-  case swift::TypeKind::BuiltinIntegerLiteral:
-  case swift::TypeKind::BuiltinFloat:
-  case swift::TypeKind::BuiltinRawPointer:
-  case swift::TypeKind::BuiltinNativeObject:
-  case swift::TypeKind::BuiltinUnsafeValueBuffer:
-  case swift::TypeKind::BuiltinBridgeObject:
-  case swift::TypeKind::BuiltinVector:
-    break;
+
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
   case swift::TypeKind::WeakStorage:
@@ -7479,9 +7513,6 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
             child_bitfield_bit_size, child_bitfield_bit_offset,
             child_is_base_class, child_is_deref_of_parent, valobj,
             language_flags);
-  case swift::TypeKind::GenericTypeParam:
-  case swift::TypeKind::DependentMember:
-    break;
 
   case swift::TypeKind::Enum:
   case swift::TypeKind::BoundGenericEnum: {
@@ -7534,6 +7565,37 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
                                      child_name);
 
     child_byte_offset = *offset;
+    child_bitfield_bit_size = 0;
+    child_bitfield_bit_offset = 0;
+
+    return child_type;
+  }
+
+  case swift::TypeKind::BuiltinFixedArray: {
+    auto fixed_array =
+        swift::cast<swift::BuiltinFixedArrayType>(swift_can_type);
+    auto num_elts = fixed_array->getFixedInhabitedSize();
+    if (!num_elts)
+      break;
+    if (idx >= *num_elts)
+      break;
+
+    CompilerType child_type = ToCompilerType(fixed_array->getElementType());
+    llvm::raw_string_ostream(child_name) << idx;
+
+    if (!get_type_size(child_byte_size, child_type))
+      return llvm::createStringError(
+          "could not get size of fixed array element " + child_name);
+    child_is_base_class = false;
+    child_is_deref_of_parent = false;
+
+    CompilerType compiler_type = ToCompilerType(GetSwiftType(type));
+    // FIXME: This is *not* generally correct, but there is no
+    // reflection metadata yet.
+    uint64_t offset = idx * child_byte_size;
+
+    // FIXME: Are there sub-byte strides?
+    child_byte_offset = offset;
     child_bitfield_bit_size = 0;
     child_bitfield_bit_offset = 0;
 
@@ -7664,18 +7726,6 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
     return child_type;
   }
 
-  case swift::TypeKind::ExistentialMetatype:
-  case swift::TypeKind::Metatype:
-    break;
-
-  case swift::TypeKind::ElementArchetype:
-  case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
-  case swift::TypeKind::PrimaryArchetype:
-  case swift::TypeKind::Function:
-  case swift::TypeKind::GenericFunction:
-    break;
-
   case swift::TypeKind::LValue:
     if (idx < llvm::expectedToStdOptional(
                   GetNumChildren(type, omit_empty_base_classes, exe_ctx))
@@ -7696,9 +7746,6 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
         return pointee_clang_type;
       }
     }
-    break;
-  case swift::TypeKind::UnboundGeneric:
-  case swift::TypeKind::DynamicSelf:
     break;
 
   case swift::TypeKind::Optional:
@@ -7758,41 +7805,52 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
 
     const swift::TypeKind type_kind = swift_can_type->getKind();
     switch (type_kind) {
+    case swift::TypeKind::BuiltinBridgeObject:
     case swift::TypeKind::BuiltinDefaultActorStorage:
-    case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
     case swift::TypeKind::BuiltinExecutor:
-    case swift::TypeKind::BuiltinJob:
-    case swift::TypeKind::BuiltinTuple:
-    case swift::TypeKind::BuiltinRawUnsafeContinuation:
-    case swift::TypeKind::Error:
-    case swift::TypeKind::InOut:
-    case swift::TypeKind::Module:
-    case swift::TypeKind::BuiltinPackIndex:
-    case swift::TypeKind::Pack:
-    case swift::TypeKind::PackElement:
-    case swift::TypeKind::PackExpansion:
-    case swift::TypeKind::SILPack:
-    case swift::TypeKind::ParameterizedProtocol:
-    case swift::TypeKind::Placeholder:
-    case swift::TypeKind::SILBlockStorage:
-    case swift::TypeKind::SILBox:
-    case swift::TypeKind::SILMoveOnlyWrapped:
-    case swift::TypeKind::SILFunction:
-    case swift::TypeKind::SILToken:
-    case swift::TypeKind::PackArchetype:
-    case swift::TypeKind::TypeVariable:
-    case swift::TypeKind::ErrorUnion:
-    case swift::TypeKind::Unresolved:
-    case swift::TypeKind::VariadicSequence:
-      break;
+    case swift::TypeKind::BuiltinFloat:
     case swift::TypeKind::BuiltinInteger:
     case swift::TypeKind::BuiltinIntegerLiteral:
-    case swift::TypeKind::BuiltinFloat:
-    case swift::TypeKind::BuiltinRawPointer:
+    case swift::TypeKind::BuiltinJob:
     case swift::TypeKind::BuiltinNativeObject:
+    case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
+    case swift::TypeKind::BuiltinPackIndex:
+    case swift::TypeKind::BuiltinRawPointer:
+    case swift::TypeKind::BuiltinRawUnsafeContinuation:
+    case swift::TypeKind::BuiltinTuple:
+    case swift::TypeKind::BuiltinUnboundGeneric:
     case swift::TypeKind::BuiltinUnsafeValueBuffer:
-    case swift::TypeKind::BuiltinBridgeObject:
     case swift::TypeKind::BuiltinVector:
+    case swift::TypeKind::DynamicSelf:
+    case swift::TypeKind::ElementArchetype:
+    case swift::TypeKind::Error:
+    case swift::TypeKind::ErrorUnion:
+    case swift::TypeKind::ExistentialMetatype:
+    case swift::TypeKind::Function:
+    case swift::TypeKind::GenericFunction:
+    case swift::TypeKind::InOut:
+    case swift::TypeKind::Integer:
+    case swift::TypeKind::Metatype:
+    case swift::TypeKind::Module:
+    case swift::TypeKind::OpaqueTypeArchetype:
+    case swift::TypeKind::OpenedArchetype:
+    case swift::TypeKind::Pack:
+    case swift::TypeKind::PackArchetype:
+    case swift::TypeKind::PackElement:
+    case swift::TypeKind::PackExpansion:
+    case swift::TypeKind::ParameterizedProtocol:
+    case swift::TypeKind::Placeholder:
+    case swift::TypeKind::PrimaryArchetype:
+    case swift::TypeKind::SILBlockStorage:
+    case swift::TypeKind::SILBox:
+    case swift::TypeKind::SILFunction:
+    case swift::TypeKind::SILMoveOnlyWrapped:
+    case swift::TypeKind::SILPack:
+    case swift::TypeKind::SILToken:
+    case swift::TypeKind::TypeVariable:
+    case swift::TypeKind::UnboundGeneric:
+    case swift::TypeKind::Unresolved:
+    case swift::TypeKind::VariadicSequence:
       break;
 
     case swift::TypeKind::UnmanagedStorage:
@@ -7832,8 +7890,8 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
         if (tuple_idx < tuple_type->getNumElements()) {
           child_indexes.push_back(tuple_idx);
           return child_indexes.size();
-        } else
-          return 0;
+        }
+        return 0;
       }
 
       // Otherwise, perform lookup by name.
@@ -7843,6 +7901,22 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
           return child_indexes.size();
         }
       }
+
+      return 0;
+    }
+    case swift::TypeKind::BuiltinFixedArray: {
+      auto fixed_array =
+          swift::cast<swift::BuiltinFixedArrayType>(swift_can_type);
+      auto num_elts = fixed_array->getFixedInhabitedSize();
+      if (!num_elts)
+        return 0;
+
+      uint32_t array_idx = 0;
+      if (llvm::to_integer(name, array_idx))
+        if (array_idx < *num_elts) {
+          child_indexes.push_back(array_idx);
+          return child_indexes.size();
+        }
 
       return 0;
     }
@@ -7914,17 +7988,6 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
       }
     } break;
 
-    case swift::TypeKind::ExistentialMetatype:
-    case swift::TypeKind::Metatype:
-      break;
-
-    case swift::TypeKind::ElementArchetype:
-    case swift::TypeKind::OpaqueTypeArchetype:
-    case swift::TypeKind::OpenedArchetype:
-    case swift::TypeKind::PrimaryArchetype:
-    case swift::TypeKind::Function:
-    case swift::TypeKind::GenericFunction:
-      break;
     case swift::TypeKind::LValue: {
       CompilerType pointee_clang_type(GetNonReferenceType(type));
 
@@ -7933,9 +7996,6 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
             name, exe_ctx, omit_empty_base_classes, child_indexes);
       }
     } break;
-    case swift::TypeKind::UnboundGeneric:
-    case swift::TypeKind::DynamicSelf:
-      break;
 
     case swift::TypeKind::Optional:
     case swift::TypeKind::TypeAlias:
@@ -8149,30 +8209,40 @@ bool SwiftASTContext::DumpTypeValue(
 
   const swift::TypeKind type_kind = swift_can_type->getKind();
   switch (type_kind) {
+  case swift::TypeKind::BoundGenericStruct:
   case swift::TypeKind::BuiltinDefaultActorStorage:
-  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinExecutor:
+  case swift::TypeKind::BuiltinFixedArray:
   case swift::TypeKind::BuiltinJob:
-  case swift::TypeKind::BuiltinTuple:
-  case swift::TypeKind::BuiltinRawUnsafeContinuation:
-  case swift::TypeKind::Error:
-  case swift::TypeKind::InOut:
-  case swift::TypeKind::Module:
+  case swift::TypeKind::BuiltinNonDefaultDistributedActorStorage:
   case swift::TypeKind::BuiltinPackIndex:
+  case swift::TypeKind::BuiltinRawUnsafeContinuation:
+  case swift::TypeKind::BuiltinTuple:
+  case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::DynamicSelf:
+  case swift::TypeKind::Error:
+  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::Existential:
+  case swift::TypeKind::InOut:
+  case swift::TypeKind::Integer:
+  case swift::TypeKind::Module:
   case swift::TypeKind::Pack:
+  case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
   case swift::TypeKind::PackExpansion:
-  case swift::TypeKind::SILPack:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
+  case swift::TypeKind::ProtocolComposition:
   case swift::TypeKind::SILBlockStorage:
   case swift::TypeKind::SILBox:
-  case swift::TypeKind::SILMoveOnlyWrapped:
   case swift::TypeKind::SILFunction:
+  case swift::TypeKind::SILMoveOnlyWrapped:
+  case swift::TypeKind::SILPack:
   case swift::TypeKind::SILToken:
-  case swift::TypeKind::PackArchetype:
+  case swift::TypeKind::Tuple:
   case swift::TypeKind::TypeVariable:
-  case swift::TypeKind::ErrorUnion:
+  case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::Unresolved:
   case swift::TypeKind::VariadicSequence:
     break;
@@ -8264,11 +8334,6 @@ bool SwiftASTContext::DumpTypeValue(
                              item_count, UINT32_MAX, LLDB_INVALID_ADDRESS,
                              bitfield_bit_size, bitfield_bit_offset, exe_scope);
   } break;
-  case swift::TypeKind::BuiltinVector:
-    break;
-
-  case swift::TypeKind::Tuple:
-    break;
 
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
@@ -8307,13 +8372,6 @@ bool SwiftASTContext::DumpTypeValue(
                              UINT32_MAX, LLDB_INVALID_ADDRESS,
                              bitfield_bit_size, bitfield_bit_offset, exe_scope);
   } break;
-
-  case swift::TypeKind::ProtocolComposition:
-  case swift::TypeKind::Existential:
-  case swift::TypeKind::UnboundGeneric:
-  case swift::TypeKind::BoundGenericStruct:
-  case swift::TypeKind::DynamicSelf:
-    break;
 
   case swift::TypeKind::Optional:
   case swift::TypeKind::TypeAlias:

--- a/lldb/test/API/lang/swift/value_generics/Makefile
+++ b/lldb/test/API/lang/swift/value_generics/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xfrontend -enable-builtin-module -Xfrontend -enable-experimental-feature -Xfrontend ValueGenerics -Xfrontend -disable-experimental-parser-round-trip -Xfrontend -disable-availability-checking
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/value_generics/TestSwiftValueGenerics.py
+++ b/lldb/test/API/lang/swift/value_generics/TestSwiftValueGenerics.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftVariadicGenerics(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target,  process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('main.swift'))
+        self.expect('log enable lldb types')
+        self.expect("frame variable v",
+                    substrs=["a.Vector<4, Int>", "storage",
+                             "0", "0",
+                             "1", "1",
+                             "2", "2",
+                             "3", "3"])

--- a/lldb/test/API/lang/swift/value_generics/main.swift
+++ b/lldb/test/API/lang/swift/value_generics/main.swift
@@ -1,0 +1,50 @@
+import Builtin
+
+@frozen
+public struct Vector<let Count: Int, Element: ~Copyable>: ~Copyable {
+    private var storage: Builtin.FixedArray<Count, Element>
+
+    public init(_ valueForIndex: (Int) -> Element) {
+        storage = Builtin.emplace { rawPointer in
+            let base = UnsafeMutablePointer<Element>(rawPointer)
+            for i in 0..<Count {
+                (base + i).initialize(to: valueForIndex(i))
+            }
+        }
+    }
+
+    public subscript(i: Int) -> Element {
+        _read {
+            assert(i >= 0 && i < Count)
+            let rawPointer = Builtin.addressOfBorrow(self)
+            let base = UnsafePointer<Element>(rawPointer)
+            yield ((base + i).pointee)
+        }
+
+        _modify {
+            assert(i >= 0 && i < Count)
+            let rawPointer = Builtin.addressof(&self)
+            let base = UnsafeMutablePointer<Element>(rawPointer)
+            yield (&(base + i).pointee)
+        }
+    }
+}
+extension Vector: Copyable where Element: Copyable {
+    public init(repeating value: Element) {
+        self.init { _ in value }
+    }
+}
+extension Vector: BitwiseCopyable where Element: BitwiseCopyable {}
+
+func main() {
+    var v = Vector<4, Int>(repeating: 0)
+    v[0] = 0
+    v[1] = 1
+    v[2] = 2
+    v[3] = 3
+
+  // break here
+    print(v)
+
+}
+main()


### PR DESCRIPTION
This is both partially incorrect due to missing stride computation and only works in SwiftASTContext right now due to missing Reflection support on the compiler side.

But it eliminates the nasty warnings in SwiftASTContext.cpp and works for byte-aligned arrays.