### PR TITLE
[DebugInfo] Emit alternative module name in debug info

### DIFF
--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -22,6 +22,7 @@
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Target/Statistics.h"
+#include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/XcodeSDK.h"
 #include "lldb/lldb-private.h"
@@ -498,7 +499,7 @@ public:
            Type::EncodingDataType encoding_uid_type, const Declaration &decl,
            const CompilerType &compiler_qual_type,
            Type::ResolveState compiler_type_resolve_state,
-           uint32_t opaque_payload = 0) = 0;
+           uint32_t opaque_payload = 0, ConstString alternative_module_name = ConstString()) = 0;
 
   virtual lldb::TypeSP CopyType(const lldb::TypeSP &other_type) = 0;
 
@@ -604,11 +605,11 @@ public:
                         const Declaration &decl,
                         const CompilerType &compiler_qual_type,
                         Type::ResolveState compiler_type_resolve_state,
-                        uint32_t opaque_payload = 0) override {
+                        uint32_t opaque_payload = 0, ConstString alternative_module_name = ConstString()) override {
      lldb::TypeSP type_sp (new Type(
          uid, this, name, byte_size, context, encoding_uid,
          encoding_uid_type, decl, compiler_qual_type,
-         compiler_type_resolve_state, opaque_payload));
+         compiler_type_resolve_state, opaque_payload, alternative_module_name));
      m_type_list.Insert(type_sp);
      return type_sp;
   }

--- a/lldb/include/lldb/Symbol/SymbolFileOnDemand.h
+++ b/lldb/include/lldb/Symbol/SymbolFileOnDemand.h
@@ -232,7 +232,7 @@ public:
                         const Declaration &decl,
                         const CompilerType &compiler_qual_type,
                         Type::ResolveState compiler_type_resolve_state,
-                        uint32_t opaque_payload = 0) override {
+                        uint32_t opaque_payload = 0, ConstString alternative_module_name = ConstString()) override {
     return m_sym_file_impl->MakeType(
         uid, name, byte_size, context, encoding_uid, encoding_uid_type, decl,
         compiler_qual_type, compiler_type_resolve_state, opaque_payload);

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -555,6 +555,8 @@ public:
   /// Return the language-specific payload.
   void SetPayload(Payload opaque_payload) { m_payload = opaque_payload; }
 
+  ConstString GetAlternativeModuleName() const { return m_alternative_module_name; }
+
 protected:
   ConstString m_name;
   SymbolFile *m_symbol_file = nullptr;
@@ -571,6 +573,8 @@ protected:
   /// Language-specific flags.
   Payload m_payload;
 
+  ConstString m_alternative_module_name;
+
   Type *GetEncodingType();
 
   bool ResolveCompilerType(ResolveState compiler_type_resolve_state);
@@ -585,7 +589,7 @@ private:
        std::optional<uint64_t> byte_size, SymbolContextScope *context,
        lldb::user_id_t encoding_uid, EncodingDataType encoding_uid_type,
        const Declaration &decl, const CompilerType &compiler_qual_type,
-       ResolveState compiler_type_resolve_state, uint32_t opaque_payload = 0);
+       ResolveState compiler_type_resolve_state, uint32_t opaque_payload = 0, ConstString alternative_module_name = ConstString());
 
   // This makes an invalid type.  Used for functions that return a Type when
   // they get an error.

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -82,7 +82,10 @@ FLAGS_ENUM(TypeQueryOptions){
     /// When true, the find types call should stop the query as soon as a single
     /// matching type is found. When false, the type query should find all
     /// matching types.
-    e_find_one = (1u << 2),
+    e_find_one = (1u << 4),
+    // If set, treat TypeQuery::m_name as a mangled name that should be
+    // searched.
+    e_search_by_mangled_name = (1u << 5),
 };
 LLDB_MARK_AS_BITMASK_ENUM(TypeQueryOptions)
 
@@ -278,6 +281,19 @@ public:
       m_options |= e_find_one;
     else
       m_options &= (e_exact_match | e_find_one);
+  }
+
+  /// Returns true if the type query is supposed to treat the name to be
+  /// searched as a mangled name.
+  bool GetSearchByMangledName() const {
+    return (m_options & e_search_by_mangled_name) != 0;
+  }
+
+  void SetSearchByMangledName(bool b) {
+    if (b)
+      m_options |= e_search_by_mangled_name;
+    else
+      m_options &= ~e_search_by_mangled_name;
   }
 
   /// Access the internal compiler context array.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "LLDBMemoryReader.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntime.h"
 #include "SwiftLanguageRuntimeImpl.h"
@@ -21,6 +22,7 @@
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 #include "lldb/Host/SafeMachO.h"
+#include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/Variable.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ProcessStructReader.h"
@@ -31,7 +33,9 @@
 #include "lldb/Utility/Timer.h"
 #include "lldb/ValueObject/ValueObjectMemory.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringRef.h"
 
+#include "lldb/lldb-private-enumerations.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTWalker.h"
@@ -2976,6 +2980,167 @@ SwiftLanguageRuntimeImpl::GetTypeRef(CompilerType type,
   return type_ref;
 }
 
+CompilerType SwiftLanguageRuntimeImpl::AdjustTypeForOriginallyDefinedInModule(
+    CompilerType type) {
+  if (!type)
+    return type;
+
+  auto ts = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  assert(ts);
+  if (!ts)
+    return type;
+
+  auto &tss = ts->GetTypeSystemSwiftTypeRef();
+
+  swift::Demangle::Demangler dem;
+  auto *node = dem.demangleSymbol(type.GetMangledTypeName());
+
+  auto type_node = node->getFirstChild()->getFirstChild();
+  assert(node && node->hasChildren());
+  if (!node || !node->hasChildren()) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[AdjustTypeForOriginallyDefinedInModule] Unexpected node for "
+             "type with mangled name {0}",
+             type.GetMangledTypeName());
+
+    return type;
+  }
+
+  bool did_transform = false;
+  std::function<NodePointer(NodePointer)> transform_all_module_nodes =
+      [&](NodePointer node) -> NodePointer {
+    auto compiler_type = tss.RemangleAsType(dem, node);
+    if (!compiler_type) {
+      LLDB_LOG(GetLog(LLDBLog::Types),
+               "[AdjustTypeForOriginallyDefinedInModule] Unexpected mangling "
+               "error when mangling adjusted node for type with mangled name "
+               "{0}",
+               type.GetMangledTypeName());
+
+        return node;
+      }
+
+      lldb::TypeSP lldb_type =
+          tss.GetCachedType(compiler_type.GetMangledTypeName());
+
+      if (!lldb_type || true) {
+        TypeQuery query(compiler_type.GetMangledTypeName(), e_find_one | e_search_by_mangled_name);
+        TypeResults results;
+        ModuleList &module_list = m_process.GetTarget().GetImages();
+        module_list.FindTypes(tss.GetModule(), query, results);
+        lldb_type = results.GetFirstType();
+
+        if (!lldb_type) {
+          TypeQuery query(compiler_type.GetMangledTypeName(), e_find_one);
+          TypeResults results;
+          ModuleList &module_list = m_process.GetTarget().GetImages();
+          module_list.FindTypes(tss.GetModule(), query, results);
+          lldb_type = results.GetFirstType();
+
+          if (!lldb_type) {
+
+            LLDB_LOGV(
+                GetLog(LLDBLog::Types),
+                "[AdjustTypeForOriginallyDefinedInModule] Could not find lldb "
+                "type for type with mangled name {0}",
+                type.GetMangledTypeName());
+
+            return node;
+          }
+        }
+      }
+
+    StringRef alternative_module_name;
+    if (!lldb_type->GetAlternativeModuleName().IsEmpty()) {
+        alternative_module_name = lldb_type->GetAlternativeModuleName();
+    } else {
+      auto context = lldb_type->GetDeclContext();
+      if (context.size() <= 1)
+          return node;
+
+      for (auto it = context.rbegin() + 1; it != context.rend(); ++it) {
+          if (it->kind != CompilerContextKind::ClassOrStruct)
+            return node;
+
+        TypeQuery query(it->name, e_find_one | e_search_by_mangled_name);
+        TypeResults results;
+        ModuleList &module_list = m_process.GetTarget().GetImages();
+        module_list.FindTypes(tss.GetModule(), query, results);
+        auto parent_type = results.GetFirstType();
+
+        if (!parent_type) {
+          TypeQuery query(it->name, e_find_one);
+          TypeResults results;
+          ModuleList &module_list = m_process.GetTarget().GetImages();
+          module_list.FindTypes(tss.GetModule(), query, results);
+          parent_type = results.GetFirstType();
+
+          if (!parent_type)
+            return node;
+        }
+          if (!parent_type->GetAlternativeModuleName().IsEmpty()) {
+            alternative_module_name = parent_type->GetAlternativeModuleName();
+            break;
+          }
+      }
+    }
+
+    bool did_transform_module = false;
+    auto module_tranformer =
+        [&](NodePointer module_node,
+            llvm::StringRef module_name) -> NodePointer {
+          if (did_transform_module)
+            return module_node;
+      if (module_node->getText() == swift::MANGLING_MODULE_OBJC)
+        return module_node;
+
+      // If the mangled name's module and module context module match then
+      // there's nothing to do.
+      if (module_node->getText() == module_name)
+        return module_node;
+
+      // Otherwise this is a type who is originally defined in a separate
+      // module. Adjust the module name.
+      auto *adjusted_module_node = dem.createNodeWithAllocatedText(
+          Node::Kind::Module, module_name);
+          did_transform_module = true;
+      return adjusted_module_node;
+    };
+
+    // NodePointer transformed = TypeSystemSwiftTypeRef::Transform(dem, node, [&](NodePointer module_node) {
+    //       return module_tranformer(module_node, module_context);
+    //     });
+    NodePointer transformed = TypeSystemSwiftTypeRef::TransformModuleName(
+        node, dem, [&](NodePointer module_node) {
+          return module_tranformer(module_node, alternative_module_name);
+        });
+
+    NodePointer t2 = TypeSystemSwiftTypeRef::TransformBoundGenericTypes(dem,
+        transformed, transform_all_module_nodes);
+    return t2;
+  };
+  // First transform the module of the type.
+
+  type_node = transform_all_module_nodes(type_node);
+  node->getFirstChild()->replaceChild(0, type_node);
+  // if (!did_transform)
+  //   return type;
+
+  auto mangling = mangleNode(node);
+  assert(mangling.isSuccess());
+  if (!mangling.isSuccess()) {
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[AdjustTypeForOriginallyDefinedInModule] Unexpected mangling "
+             "error when mangling adjusted node for type with mangled name {0}",
+             type.GetMangledTypeName());
+
+    return type;
+  }
+
+  auto str = mangling.result();
+  return ts->GetTypeFromMangledTypename(ConstString(str));
+}
+
 const swift::reflection::TypeInfo *
 SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
     CompilerType type, ExecutionContextScope *exe_scope,
@@ -3006,6 +3171,8 @@ SwiftLanguageRuntimeImpl::GetSwiftRuntimeTypeInfo(
       type = BindGenericTypeParameters(*frame, type);
     }
 
+
+  type = AdjustTypeForOriginallyDefinedInModule(type);
   // BindGenericTypeParameters imports the type into the scratch
   // context, but we need to resolve (any DWARF links in) the typeref
   // in the original module.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -358,6 +358,12 @@ protected:
   CompilerType m_box_metadata_type;
 
 private:
+  /// Types with the @_originallyDefinedIn attribute are serialized with with
+   /// the original module name in reflection metadata. At the same time the type
+   /// is serialized with the swiftmodule name in debug info, but with a parent
+   /// module with the original module name. This function adjusts \type to look
+   /// up the type in reflection metadata if necessary.
+   CompilerType AdjustTypeForOriginallyDefinedInModule(CompilerType type);
   /// Don't call these directly.
   /// \{
   /// There is a global variable \p _swift_classIsSwiftMask that is

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -33,6 +33,7 @@
 #include "lldb/Utility/Status.h"
 
 #include "clang/AST/DeclObjC.h"
+#include "llvm/BinaryFormat/Dwarf.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -67,6 +68,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
   Declaration decl;
   ConstString mangled_name;
   ConstString name;
+  ConstString alternative_module_name;
   ConstString preferred_name;
 
   std::optional<uint64_t> dwarf_byte_size;
@@ -108,6 +110,9 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
             // change the underlying Swift type.
             return ParseTypeFromDWARF(sc, die.GetReferencedDIE(attr),
                                       type_is_new_ptr);
+          break;
+        case DW_AT_LLVM_alternative_module_name:
+alternative_module_name.SetCString(form_value.AsCString());
           break;
         default:
           break;
@@ -198,7 +203,7 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         // We don't have an exe_scope here by design, so we need to
         // read the size from DWARF.
         dwarf_byte_size, nullptr, LLDB_INVALID_UID, Type::eEncodingIsUID, &decl,
-        compiler_type, Type::ResolveState::Full);
+        compiler_type, Type::ResolveState::Full, 0, alternative_module_name);
   }
 
   // Cache this type.

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -198,9 +198,9 @@ DWARFDIE::LookupDeepestBlock(lldb::addr_t address) const {
   return result;
 }
 
-const char *DWARFDIE::GetMangledName() const {
+const char *DWARFDIE::GetMangledName(bool substitute_name_allowed) const {
   if (IsValid())
-    return m_die->GetMangledName(m_cu);
+    return m_die->GetMangledName(m_cu, substitute_name_allowed);
   else
     return nullptr;
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.h
@@ -28,7 +28,7 @@ public:
   // Accessors
 
   // Accessing information about a DIE
-  const char *GetMangledName() const;
+  const char *GetMangledName(bool substitute_name_allowed = true) const;
 
   bool IsGenericTrampoline() const;
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DebugNamesDWARFIndex.cpp
@@ -14,7 +14,9 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Utility/RegularExpression.h"
 #include "lldb/Utility/Stream.h"
+#include "lldb/Utility/StreamString.h"
 #include "llvm/ADT/Sequence.h"
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
 
 using namespace lldb_private;
@@ -156,11 +158,6 @@ bool DebugNamesDWARFIndex::ProcessEntry(
     llvm::function_ref<bool(DWARFDIE die)> callback) {
   DWARFDIE die = GetDIE(entry);
   if (!die)
-    return true;
-  // Clang used to erroneously emit index entries for declaration DIEs in case
-  // when the definition is in a type unit (llvm.org/pr77696).
-  if (die.IsStructUnionOrClass() &&
-      die.GetAttributeValueAsUnsigned(DW_AT_declaration, 0))
     return true;
   return callback(die);
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2776,6 +2776,20 @@ void SymbolFileDWARF::FindTypes(const TypeQuery &query, TypeResults &results) {
         return true; // Keep iterating over index types, language mismatch.
     }
 
+    // Since mangled names are unique, we only need to check if the names are
+    // the same.
+    if (query.GetSearchByMangledName()) {
+      if (die.GetMangledName(/*substitute_name_allowed=*/false) !=
+          query.GetTypeBasename().GetStringRef())
+        return true; // Keep iterating over index types, mangled name mismatch.
+      if (Type *matching_type = ResolveType(die, true, true)) {
+        results.InsertUnique(matching_type->shared_from_this());
+        return !results.Done(query); // Keep iterating if we aren't done.
+      }
+      return true; // Keep iterating over index types, weren't able to resolve
+                   // this type
+    }
+
     // Check the context matches
     std::vector<lldb_private::CompilerContext> die_context;
     if (query.GetModuleSearch())

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -35,6 +35,7 @@
 
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/../../lib/ClangImporter/ClangAdapter.h"
+#include "swift/Demangling/Demangler.h"
 #include "swift/Frontend/Frontend.h"
 
 #include "clang/APINotes/APINotesManager.h"
@@ -43,6 +44,7 @@
 #include "clang/AST/DeclObjC.h"
 
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallVector.h"
 
 #include <algorithm>
 #include <sstream>
@@ -148,6 +150,69 @@ TypeSystemSwiftTypeRef::CanonicalizeSugar(swift::Demangle::Demangler &dem,
   });
 }
 
+swift::Demangle::ManglingErrorOr<std::string>
+TypeSystemSwiftTypeRef::TransformModuleName(
+    llvm::StringRef mangled_name,
+    const llvm::StringMap<llvm::StringRef> &module_name_map) {
+  swift::Demangle::Demangler dem;
+  auto *node = dem.demangleSymbol(mangled_name);
+  auto *adjusted_node = TypeSystemSwiftTypeRef::Transform(
+      dem, node, [&](swift::Demangle::NodePointer node) {
+        if (node->getKind() == Node::Kind::Module) {
+          auto module_name = node->getText();
+          if (module_name_map.contains(module_name)) {
+            auto real_name = module_name_map.lookup(module_name);
+            auto *adjusted_module_node =
+                dem.createNodeWithAllocatedText(Node::Kind::Module, real_name);
+            return adjusted_module_node;
+          }
+        }
+
+        return node;
+      });
+
+  auto mangling = mangleNode(adjusted_node);
+  return mangling;
+}
+
+static NodePointer CloneNode(Demangler &dem, NodePointer node, bool set_children = true) {
+  NodePointer clone;
+  auto kind = node->getKind();
+  if (node->hasText())
+    clone = dem.createNodeWithAllocatedText(kind, node->getText());
+  else if (node->hasIndex())
+    clone = dem.createNode(kind, node->getIndex());
+  else
+    clone = dem.createNode(kind);
+  if (set_children)
+    for (NodePointer transformed_child : *node)
+      clone->addChild(transformed_child, dem);
+  return clone;
+}
+
+NodePointer TypeSystemSwiftTypeRef::TransformModuleName(NodePointer node, Demangler &dem,
+    std::function<NodePointer(NodePointer)>
+        module_transformer) {
+  assert(node->getKind() == Node::Kind::Type);
+  if (node->getKind() != Node::Kind::Type) {
+    LLDB_LOGF(GetLog(LLDBLog::Types),
+             "[TransformModuleName] Unexpected node kind %hu", static_cast<uint16_t>(node->getKind()));
+    return node;
+  }
+
+  std::function<NodePointer(NodePointer)> a = [&](NodePointer node) -> NodePointer {
+    if (node->hasChildren()) {
+      auto transformed = a(node->getFirstChild());
+      auto clone = CloneNode(dem, node);
+      clone->replaceChild(0, transformed);
+      return clone;
+    }
+    return module_transformer(node);
+  };
+
+  return a(node);
+}
+
 llvm::StringRef
 TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
   if (!node)
@@ -177,6 +242,56 @@ TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
     for (NodePointer child : *node)
       return GetBaseName(child);
     return {};
+  }
+}
+
+NodePointer TypeSystemSwiftTypeRef::TransformBoundGenericTypes(
+  swift::Demangle::Demangler &dem,
+    swift::Demangle::NodePointer node,
+    std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
+        type_transformer) {
+  if (node->getKind() != Node::Kind::Type || !node->hasChildren())
+    return node;
+
+  NodePointer bound_generic_node = node->getFirstChild();
+  if (bound_generic_node->getNumChildren() != 2)
+    return node;
+
+  NodePointer type_list_node = nullptr;
+  switch (bound_generic_node->getKind()) {
+  case Node::Kind::BoundGenericClass:
+  case Node::Kind::BoundGenericEnum:
+  case Node::Kind::BoundGenericStructure:
+  case Node::Kind::BoundGenericProtocol:
+  case Node::Kind::BoundGenericOtherNominalType:
+  case Node::Kind::BoundGenericTypeAlias:
+    type_list_node = bound_generic_node->getChild(1);
+    break;
+  default:
+    return node;
+  }
+  bool node_mutated = false;
+  auto transformed = TypeSystemSwiftTypeRef::Transform(dem, type_list_node, [&](NodePointer node) {
+    for (NodePointer child : *type_list_node) {
+      if (child == node) {
+        return type_transformer(child);
+      }
+    }
+    return node;
+  });
+
+  bound_generic_node = CloneNode(dem, bound_generic_node);
+  bound_generic_node->replaceChild(1, transformed);
+  node = CloneNode(dem, node);
+  node->replaceChild(0, bound_generic_node);
+  return node;
+  for (size_t i = 0; i < type_list_node->getNumChildren(); ++i) {
+    NodePointer bound_type = type_list_node->getChild(i);
+    NodePointer transformed = type_transformer(bound_type);
+    if (transformed != bound_type) {
+      type_list_node->replaceChild(i, transformed);
+      node_mutated = true;
+    }
   }
 }
 
@@ -933,13 +1048,7 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::Transform(
   }
   if (changed) {
     // Create a new node with the transformed children.
-    auto kind = node->getKind();
-    if (node->hasText())
-      node = dem.createNodeWithAllocatedText(kind, node->getText());
-    else if (node->hasIndex())
-      node = dem.createNode(kind, node->getIndex());
-    else
-      node = dem.createNode(kind);
+    node = CloneNode(dem, node, /*set_children=*/false);
     for (NodePointer transformed_child : children)
       node->addChild(transformed_child, dem);
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -365,6 +365,25 @@ public:
   CanonicalizeSugar(swift::Demangle::Demangler &dem,
                     swift::Demangle::NodePointer node);
 
+  /// Transforms the module name in the mangled type name using module_name_map
+  /// as the mapping source.
+  static swift::Demangle::ManglingErrorOr<std::string>
+  TransformModuleName(llvm::StringRef mangled_name,
+                      const llvm::StringMap<llvm::StringRef> &module_name_map);
+
+  /// Given a node pointer to a type, transforms the module name of the type's
+  /// demangle tree by applying \module_transformer to the module node.
+  static swift::Demangle::NodePointer  TransformModuleName(
+      swift::Demangle::NodePointer node, swift::Demangle::Demangler &dem,
+      std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
+          module_transformer);
+
+  static swift::Demangle::NodePointer TransformBoundGenericTypes(
+    swift::Demangle::Demangler &dem,
+      swift::Demangle::NodePointer node,
+      std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
+          type_transformer);
+
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   swift::Demangle::NodePointer
   GetCanonicalDemangleTree(swift::Demangle::Demangler &dem,

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -10,6 +10,7 @@
 #include <optional>
 
 #include "lldb/Core/Module.h"
+#include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -269,14 +270,14 @@ Type::Type(lldb::user_id_t uid, SymbolFile *symbol_file, ConstString name,
            std::optional<uint64_t> byte_size, SymbolContextScope *context,
            user_id_t encoding_uid, EncodingDataType encoding_uid_type,
            const Declaration &decl, const CompilerType &compiler_type,
-           ResolveState compiler_type_resolve_state, uint32_t opaque_payload)
+           ResolveState compiler_type_resolve_state, uint32_t opaque_payload, ConstString alternative_module_name)
     : std::enable_shared_from_this<Type>(), UserID(uid), m_name(name),
       m_symbol_file(symbol_file), m_context(context),
       m_encoding_uid(encoding_uid), m_encoding_uid_type(encoding_uid_type),
       m_decl(decl), m_compiler_type(compiler_type),
       m_compiler_type_resolve_state(compiler_type ? compiler_type_resolve_state
                                                   : ResolveState::Unresolved),
-      m_payload(opaque_payload) {
+      m_payload(opaque_payload), m_alternative_module_name(alternative_module_name) {
   if (byte_size) {
     m_byte_size = *byte_size;
     m_byte_size_has_value = true;

--- a/lldb/test/API/lang/swift/originally_defined_in/Makefile
+++ b/lldb/test/API/lang/swift/originally_defined_in/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+ include Makefile.rules

--- a/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
+++ b/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
+
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        filespec = lldb.SBFileSpec("main.swift")
+        target, process, thread, breakpoint1 = lldbutil.run_to_source_breakpoint(
+            self, "break here", filespec
+        )
+        # self.expect("frame variable a", substrs=["a.A", "a = (i = 10)"])
+        # self.expect("frame variable b", substrs=["a.Alias", "b = (i = 20)"])
+        #self.expect("frame variable d", substrs=["a.C.D", "d = (i = 30)"])
+        # self.expect("frame variable e", substrs=["a.E<a.Prop>", "e = (i = 40)"])
+        # self.expect("frame variable e3", substrs=["a.E<a.Prop>", "e = (i = 40)"])
+        self.expect("frame variable con", substrs=["a.EEEEE<a.Prop2>", "e2 = (i = 50)"])

--- a/lldb/test/API/lang/swift/originally_defined_in/main.swift
+++ b/lldb/test/API/lang/swift/originally_defined_in/main.swift
@@ -1,0 +1,63 @@
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct A {
+    let i = 10
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct B {
+    let i = 20
+}
+
+typealias Alias = B
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public enum C {
+    public struct D {
+        let i = 30
+    }
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public enum EEEEE<T> {
+    case t(T)
+}
+
+public struct Prop {
+    let i = 40
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct Prop2 {
+    let i = 50
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct Pair<T, U> {
+    let t: T
+    let u: U
+}
+
+func f() {
+    let a = A()
+    let b = Alias()
+    let d = C.D()
+    let e = EEEEE<Prop>.t(Prop())
+    let e2 = EEEEE<Prop2>.t(Prop2())
+    // Other.Pair<Other.EEEEE<Other.Pair<Other.Prop2, Other.C.D>, Other.EEEEE<a.Prop>>
+    let con = Pair(t: EEEEE.t(Pair(t: Prop2(), u: C.D())), u: EEEEE.t(Prop()))
+    print("break here")
+}
+
+f()

--- a/lldb/test/Shell/SymbolFile/DWARF/debug-types-mangled-name.ll
+++ b/lldb/test/Shell/SymbolFile/DWARF/debug-types-mangled-name.ll
@@ -1,0 +1,63 @@
+; Test finding types by CompilerContext.
+; REQUIRES: aarch64
+; RUN: llc %s -filetype=obj -o %t.o
+; RUN: lldb-test symbols %t.o -find=type --mangled-name=UniqueDifferentName | FileCheck %s 
+;
+; NORESULTS: Found 0 types
+; CHECK: Found 1 types:
+; CHECK: struct DifferentName {
+; CHECK-NEXT:     int i;
+; CHECK-NEXT: }
+
+source_filename = "t.c"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+target triple = "arm64-unknown-linux-gnu"
+
+%struct.SameName = type { i32 }
+%struct.DifferentName = type { i32 }
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 !dbg !10 {
+entry:
+  %retval = alloca i32, align 4
+  %s = alloca %struct.SameName, align 4
+  %d = alloca %struct.DifferentName, align 4
+  store i32 0, ptr %retval, align 4
+    #dbg_declare(ptr %s, !16, !DIExpression(), !20)
+    #dbg_declare(ptr %d, !21, !DIExpression(), !25)
+  ret i32 0, !dbg !26
+}
+
+attributes #0 = { noinline  optnone  }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !4, !5, !6, !7, !8}
+!llvm.ident = !{!9}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "t.c", directory: "/")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{i32 8, !"PIC Level", i32 2}
+!6 = !{i32 7, !"PIE Level", i32 2}
+!7 = !{i32 7, !"uwtable", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 1}
+!9 = !{!""}
+!10 = distinct !DISubprogram(name: "main", scope: !11, file: !11, line: 9, type: !12, scopeLine: 9, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !15)
+!11 = !DIFile(filename: "t.c", directory: "")
+!12 = !DISubroutineType(types: !13)
+!13 = !{!14}
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{}
+!16 = !DILocalVariable(name: "s", scope: !10, file: !11, line: 10, type: !17)
+!17 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "SameName", file: !11, line: 1, size: 32, elements: !18, runtimeLang: DW_LANG_Swift, identifier: "SameName")
+!18 = !{!19}
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !17, file: !11, line: 2, baseType: !14, size: 32)
+!20 = !DILocation(line: 10, column: 19, scope: !10)
+!21 = !DILocalVariable(name: "d", scope: !10, file: !11, line: 11, type: !22)
+!22 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "DifferentName", file: !11, line: 5, size: 32, elements: !23, runtimeLang: DW_LANG_Swift, identifier: "UniqueDifferentName")
+!23 = !{!24}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !22, file: !11, line: 6, baseType: !14, size: 32)
+!25 = !DILocation(line: 11, column: 24, scope: !10)
+!26 = !DILocation(line: 12, column: 3, scope: !10)

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -13,6 +13,7 @@
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "lldb/Breakpoint/BreakpointLocation.h"
 #include "lldb/Core/Debugger.h"
+#include "lldb/Core/Mangled.h"
 #include "lldb/Core/Module.h"
 #include "lldb/Core/Section.h"
 #include "lldb/Expression/IRMemoryMap.h"
@@ -23,6 +24,7 @@
 #include "lldb/Symbol/LineTable.h"
 #include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/Symtab.h"
+#include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/TypeMap.h"
 #include "lldb/Symbol/VariableList.h"
@@ -179,6 +181,10 @@ static cl::opt<FindType> Find(
 
 static cl::opt<std::string> Name("name", cl::desc("Name to find."),
                                  cl::sub(SymbolsSubcommand));
+static cl::opt<std::string> MangledName(
+    "mangled-name",
+    cl::desc("Mangled name to find. Only compatible when searching types"),
+    cl::sub(SymbolsSubcommand));
 static cl::opt<bool>
     Regex("regex",
           cl::desc("Search using regular expressions (available for variables "
@@ -463,6 +469,9 @@ static lldb::DescriptionLevel GetDescriptionLevel() {
 }
 
 Error opts::symbols::findFunctions(lldb_private::Module &Module) {
+  if (!MangledName.empty())
+    return make_string_error("Cannot search functions by mangled name.");
+
   SymbolFile &Symfile = *Module.GetSymbolFile();
   SymbolContextList List;
   auto compiler_context = parseCompilerContext();
@@ -524,6 +533,8 @@ Error opts::symbols::findBlocks(lldb_private::Module &Module) {
   assert(!Regex);
   assert(!File.empty());
   assert(Line != 0);
+  if (!MangledName.empty())
+    return make_string_error("Cannot search blocks by mangled name.");
 
   SymbolContextList List;
 
@@ -558,6 +569,9 @@ Error opts::symbols::findBlocks(lldb_private::Module &Module) {
 }
 
 Error opts::symbols::findNamespaces(lldb_private::Module &Module) {
+  if (!MangledName.empty())
+    return make_string_error("Cannot search namespaces by mangled name.");
+
   SymbolFile &Symfile = *Module.GetSymbolFile();
   Expected<CompilerDeclContext> ContextOr = getDeclContext(Symfile);
   if (!ContextOr)
@@ -580,8 +594,12 @@ Error opts::symbols::findTypes(lldb_private::Module &Module) {
   Expected<CompilerDeclContext> ContextOr = getDeclContext(Symfile);
   if (!ContextOr)
     return ContextOr.takeError();
+  ;
 
   TypeResults results;
+  if (!Name.empty() && !MangledName.empty())
+    return make_string_error("Cannot search by both name and mangled name.");
+
   if (!Name.empty()) {
     if (ContextOr->IsValid()) {
       TypeQuery query(*ContextOr, ConstString(Name),
@@ -595,6 +613,20 @@ Error opts::symbols::findTypes(lldb_private::Module &Module) {
         query.AddLanguage(Language::GetLanguageTypeFromString(Language));
       Symfile.FindTypes(query, results);
     }
+  } else if (!MangledName.empty()) {
+    Opts = TypeQueryOptions::e_search_by_mangled_name;
+    if (ContextOr->IsValid()) {
+      TypeQuery query(*ContextOr, ConstString(MangledName), Opts);
+      if (!Language.empty())
+        query.AddLanguage(Language::GetLanguageTypeFromString(Language));
+      Symfile.FindTypes(query, results);
+    } else {
+      TypeQuery query(MangledName, Opts);
+      if (!Language.empty())
+        query.AddLanguage(Language::GetLanguageTypeFromString(Language));
+      Symfile.FindTypes(query, results);
+    }
+
   } else {
     TypeQuery query(parseCompilerContext(), TypeQueryOptions::e_module_search);
     if (!Language.empty())
@@ -612,6 +644,9 @@ Error opts::symbols::findTypes(lldb_private::Module &Module) {
 }
 
 Error opts::symbols::findVariables(lldb_private::Module &Module) {
+  if (!MangledName.empty())
+    return make_string_error("Cannot search variables by mangled name.");
+
   SymbolFile &Symfile = *Module.GetSymbolFile();
   VariableList List;
   if (Regex) {

--- a/lldb/tools/lldb-test/lldb-test.cpp
+++ b/lldb/tools/lldb-test/lldb-test.cpp
@@ -614,7 +614,7 @@ Error opts::symbols::findTypes(lldb_private::Module &Module) {
       Symfile.FindTypes(query, results);
     }
   } else if (!MangledName.empty()) {
-    Opts = TypeQueryOptions::e_search_by_mangled_name;
+    auto Opts = TypeQueryOptions::e_search_by_mangled_name;
     if (ContextOr->IsValid()) {
       TypeQuery query(*ContextOr, ConstString(MangledName), Opts);
       if (!Language.empty())

--- a/llvm/include/llvm/BinaryFormat/Dwarf.def
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.def
@@ -618,6 +618,7 @@ HANDLE_DW_AT(0x3e08, LLVM_ptrauth_isa_pointer, 0, LLVM)
 HANDLE_DW_AT(0x3e09, LLVM_ptrauth_authenticates_null_values, 0, LLVM)
 HANDLE_DW_AT(0x3e0a, LLVM_ptrauth_authentication_mode, 0, LLVM)
 HANDLE_DW_AT(0x3e0b, LLVM_num_extra_inhabitants, 0, LLVM)
+HANDLE_DW_AT(0x3ff1, LLVM_alternative_module_name, 0, APPLE)
 
 // Apple extensions.
 HANDLE_DW_AT(0x3fe1, APPLE_optimized, 0, APPLE)

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -494,12 +494,16 @@ namespace llvm {
     /// \param NumExtraInhabitants The number of extra inhabitants of the type.
     /// An extra inhabitant is a bit pattern that does not represent a valid
     /// value for instances of a given type.
+    /// \param AlternativeModuleName An alternative module name associated with
+    /// this type. This is used by Swift to encode the module's ABI name for
+    /// types defined with @_originallyDefinedIn.
     DICompositeType *createStructType(
         DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
         uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
         DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang = 0,
         DIType *VTableHolder = nullptr, StringRef UniqueIdentifier = "",
-        DIType *SpecificationOf = nullptr, uint32_t NumExtraInhabitants = 0);
+        DIType *SpecificationOf = nullptr, uint32_t NumExtraInhabitants = 0,
+        StringRef AlternativeModuleName = "");
 
     /// Create debugging information entry for an union.
     /// \param Scope        Scope in which this union is defined.

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -676,14 +676,14 @@ namespace llvm {
                                        unsigned RuntimeLang = 0,
                                        uint64_t SizeInBits = 0,
                                        uint32_t AlignInBits = 0,
-                                       StringRef UniqueIdentifier = "");
+                                       StringRef UniqueIdentifier = "", StringRef AlternativeModuleName = "");
 
     /// Create a temporary forward-declared type.
     DICompositeType *createReplaceableCompositeType(
         unsigned Tag, StringRef Name, DIScope *Scope, DIFile *F, unsigned Line,
         unsigned RuntimeLang = 0, uint64_t SizeInBits = 0,
         uint32_t AlignInBits = 0, DINode::DIFlags Flags = DINode::FlagFwdDecl,
-        StringRef UniqueIdentifier = "", DINodeArray Annotations = nullptr);
+        StringRef UniqueIdentifier = "", DINodeArray Annotations = nullptr, StringRef AlternativeModuleName = "");
 
     /// Retain DIScope* in a module even if it is not referenced
     /// through debug info anchors.

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -5433,7 +5433,8 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
   OPTIONAL(rank, MDSignedOrMDField, );                                         \
   OPTIONAL(annotations, MDField, );                                            \
   OPTIONAL(num_extra_inhabitants, MDUnsignedField, (0, UINT32_MAX));           \
-  OPTIONAL(specification_of, MDField, ); 
+  OPTIONAL(specification_of, MDField, );                                       \
+  OPTIONAL(alternative_module_name, MDStringField, );
   PARSE_MD_FIELDS();
 #undef VISIT_MD_FIELDS
 
@@ -5449,8 +5450,9 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
     if (auto *CT = DICompositeType::buildODRType(
             Context, *identifier.Val, tag.Val, name.Val, file.Val, line.Val,
             scope.Val, baseType.Val, size.Val, align.Val, offset.Val,
-            specification_of.Val, num_extra_inhabitants.Val, flags.Val,
-            elements.Val, runtimeLang.Val, vtableHolder.Val, templateParams.Val,
+            specification_of.Val, num_extra_inhabitants.Val,
+            alternative_module_name.Val, flags.Val, elements.Val,
+            runtimeLang.Val, vtableHolder.Val, templateParams.Val,
             discriminator.Val, dataLocation.Val, associated.Val, allocated.Val,
             Rank, annotations.Val)) {
       Result = CT;
@@ -5465,7 +5467,8 @@ bool LLParser::parseDICompositeType(MDNode *&Result, bool IsDistinct) {
        size.Val, align.Val, offset.Val, flags.Val, elements.Val,
        runtimeLang.Val, vtableHolder.Val, templateParams.Val, identifier.Val,
        discriminator.Val, dataLocation.Val, associated.Val, allocated.Val, Rank,
-       annotations.Val, specification_of.Val, num_extra_inhabitants.Val));
+       annotations.Val, specification_of.Val, num_extra_inhabitants.Val,
+       alternative_module_name.Val));
   return false;
 }
 

--- a/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/llvm/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1929,6 +1929,7 @@ void ModuleBitcodeWriter::writeDICompositeType(
   Record.push_back(VE.getMetadataOrNullID(N->getAnnotations().get()));
   Record.push_back(N->getNumExtraInhabitants());
   Record.push_back(VE.getMetadataOrNullID(N->getRawSpecificationOf()));
+  Record.push_back(VE.getMetadataOrNullID(N->getRawAlternativeModuleName()));
 
   Stream.EmitRecord(bitc::METADATA_COMPOSITE_TYPE, Record, Abbrev);
   Record.clear();

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -27,6 +27,7 @@
 #include "llvm/MC/MCSection.h"
 #include "llvm/MC/MCStreamer.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Target/TargetLoweringObjectFile.h"
 #include <cassert>
 #include <cstdint>
@@ -642,7 +643,7 @@ void DwarfUnit::updateAcceleratorTables(const DIScope *Context,
   if (Ty->getName().empty())
     return;
   if (Ty->isForwardDecl())
-    return;
+    llvm::errs() << "Here";
 
   // add temporary record for this type to be added later
 

--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -1049,6 +1049,11 @@ void DwarfUnit::constructTypeDIE(DIE &Buffer, const DICompositeType *CTy) {
       addDIEEntry(Buffer, dwarf::DW_AT_specification,
                   *getOrCreateContextDIE(SpecifiedFrom));
 
+    auto AlternativeModuleName = CTy->getAlternativeModuleName();
+    if (!AlternativeModuleName.empty())
+      addString(Buffer, dwarf::DW_AT_LLVM_alternative_module_name,
+                AlternativeModuleName);
+
     break;
   }
   default:

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -1831,7 +1831,7 @@ DIE *DWARFLinker::DIECloner::cloneDIE(const DWARFDie &InputDIE,
     Unit.addNamespaceAccelerator(Die, AttrInfo.Name);
   } else if (Tag == dwarf::DW_TAG_imported_declaration && AttrInfo.Name) {
     Unit.addNamespaceAccelerator(Die, AttrInfo.Name);
-  } else if (isTypeTag(Tag) && !AttrInfo.IsDeclaration) {
+  } else if (isTypeTag(Tag)) {
     bool Success = getDIENames(InputDIE, AttrInfo, DebugStrPool);
     uint64_t RuntimeLang =
         dwarf::toUnsigned(InputDIE.find(dwarf::DW_AT_APPLE_runtime_class))

--- a/llvm/lib/IR/AsmWriter.cpp
+++ b/llvm/lib/IR/AsmWriter.cpp
@@ -2221,6 +2221,7 @@ static void writeDICompositeType(raw_ostream &Out, const DICompositeType *N,
   Printer.printMetadata("annotations", N->getRawAnnotations());
   if (auto *SpecificationOf = N->getRawSpecificationOf())
     Printer.printMetadata("specification_of", SpecificationOf);
+  Printer.printString("alternative_module_name", N->getAlternativeModuleName());
   Out << ")";
 }
 

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -523,13 +523,13 @@ DICompositeType *DIBuilder::createStructType(
     uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
     DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang,
     DIType *VTableHolder, StringRef UniqueIdentifier, DIType *SpecificationOf,
-    uint32_t NumExtraInhabitants) {
+    uint32_t NumExtraInhabitants, StringRef AlternativeModuleName) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_structure_type, Name, File, LineNumber,
       getNonCompileUnitScope(Context), DerivedFrom, SizeInBits, AlignInBits, 0,
       Flags, Elements, RunTimeLang, VTableHolder, nullptr, UniqueIdentifier,
       nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, SpecificationOf,
-      NumExtraInhabitants);
+      NumExtraInhabitants, AlternativeModuleName);
   trackIfUnresolved(R);
   return R;
 }

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -14,6 +14,7 @@
 #include "LLVMContextImpl.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/APSInt.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfo.h"
@@ -668,13 +669,13 @@ DICompositeType *
 DIBuilder::createForwardDecl(unsigned Tag, StringRef Name, DIScope *Scope,
                              DIFile *F, unsigned Line, unsigned RuntimeLang,
                              uint64_t SizeInBits, uint32_t AlignInBits,
-                             StringRef UniqueIdentifier) {
+                             StringRef UniqueIdentifier, StringRef AlternativeModuleName) {
   // FIXME: Define in terms of createReplaceableForwardDecl() by calling
   // replaceWithUniqued().
   auto *RetTy = DICompositeType::get(
       VMContext, Tag, Name, F, Line, getNonCompileUnitScope(Scope), nullptr,
       SizeInBits, AlignInBits, 0, DINode::FlagFwdDecl, nullptr, RuntimeLang,
-      nullptr, nullptr, UniqueIdentifier);
+      nullptr, nullptr, UniqueIdentifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, AlternativeModuleName);
   trackIfUnresolved(RetTy);
   return RetTy;
 }
@@ -683,13 +684,13 @@ DICompositeType *DIBuilder::createReplaceableCompositeType(
     unsigned Tag, StringRef Name, DIScope *Scope, DIFile *F, unsigned Line,
     unsigned RuntimeLang, uint64_t SizeInBits, uint32_t AlignInBits,
     DINode::DIFlags Flags, StringRef UniqueIdentifier,
-    DINodeArray Annotations) {
+    DINodeArray Annotations, StringRef AlternativeModuleName) {
   auto *RetTy =
       DICompositeType::getTemporary(
           VMContext, Tag, Name, F, Line, getNonCompileUnitScope(Scope), nullptr,
           SizeInBits, AlignInBits, 0, Flags, nullptr, RuntimeLang, nullptr,
           nullptr, UniqueIdentifier, nullptr, nullptr, nullptr, nullptr,
-          nullptr, Annotations)
+          nullptr, Annotations, nullptr, 0, AlternativeModuleName)
           .release();
   trackIfUnresolved(RetTy);
   return RetTy;

--- a/llvm/lib/IR/LLVMContextImpl.h
+++ b/llvm/lib/IR/LLVMContextImpl.h
@@ -657,6 +657,7 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
   Metadata *Annotations;
   Metadata *SpecificationOf;
   uint32_t NumExtraInhabitants;
+  MDString *AlternativeModuleName;
 
   MDNodeKeyImpl(unsigned Tag, MDString *Name, Metadata *File, unsigned Line,
                 Metadata *Scope, Metadata *BaseType, uint64_t SizeInBits,
@@ -666,7 +667,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
                 MDString *Identifier, Metadata *Discriminator,
                 Metadata *DataLocation, Metadata *Associated,
                 Metadata *Allocated, Metadata *Rank, Metadata *Annotations,
-                Metadata *SpecificationOf, uint32_t NumExtraInhabitants) 
+                Metadata *SpecificationOf, uint32_t NumExtraInhabitants,
+                MDString *AlternativeModuleName)
       : Tag(Tag), Name(Name), File(File), Line(Line), Scope(Scope),
         BaseType(BaseType), SizeInBits(SizeInBits), OffsetInBits(OffsetInBits),
         AlignInBits(AlignInBits), Flags(Flags), Elements(Elements),
@@ -675,8 +677,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
         Discriminator(Discriminator), DataLocation(DataLocation),
         Associated(Associated), Allocated(Allocated), Rank(Rank),
         Annotations(Annotations), SpecificationOf(SpecificationOf),
-        NumExtraInhabitants(NumExtraInhabitants) {
-  }
+        NumExtraInhabitants(NumExtraInhabitants),
+        AlternativeModuleName(AlternativeModuleName) {}
   MDNodeKeyImpl(const DICompositeType *N)
       : Tag(N->getTag()), Name(N->getRawName()), File(N->getRawFile()),
         Line(N->getLine()), Scope(N->getRawScope()),
@@ -691,7 +693,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
         Associated(N->getRawAssociated()), Allocated(N->getRawAllocated()),
         Rank(N->getRawRank()), Annotations(N->getRawAnnotations()),
         SpecificationOf(N->getSpecificationOf()),
-        NumExtraInhabitants(N->getNumExtraInhabitants()) {}
+        NumExtraInhabitants(N->getNumExtraInhabitants()),
+        AlternativeModuleName(N->getRawAlternativeModuleName()) {}
 
   bool isKeyOf(const DICompositeType *RHS) const {
     return Tag == RHS->getTag() && Name == RHS->getRawName() &&
@@ -711,7 +714,8 @@ template <> struct MDNodeKeyImpl<DICompositeType> {
            Allocated == RHS->getRawAllocated() && Rank == RHS->getRawRank() &&
            Annotations == RHS->getRawAnnotations() &&
            SpecificationOf == RHS->getSpecificationOf() &&
-           NumExtraInhabitants == RHS->getNumExtraInhabitants();
+           NumExtraInhabitants == RHS->getNumExtraInhabitants() &&
+           AlternativeModuleName == RHS->getRawAlternativeModuleName();
   }
 
   unsigned getHashValue() const {

--- a/llvm/test/Assembler/debug-info.ll
+++ b/llvm/test/Assembler/debug-info.ll
@@ -1,8 +1,8 @@
 ; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s
 ; RUN: verify-uselistorder %s
 
-; CHECK: !named = !{!0, !0, !1, !2, !3, !4, !5, !6, !7, !8, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45}
-!named = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48}
+; CHECK: !named = !{!0, !0, !1, !2, !3, !4, !5, !6, !7, !8, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46}
+!named = !{!0, !1, !2, !3, !4, !5, !6, !7, !8, !9, !10, !11, !12, !13, !14, !15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29, !30, !31, !32, !33, !34, !35, !36, !37, !38, !39, !40, !41, !42, !43, !44, !45, !46, !47, !48, !49}
 
 ; CHECK:      !0 = !DISubrange(count: 3, lowerBound: 0)
 ; CHECK-NEXT: !1 = !DISubrange(count: 3, lowerBound: 4)
@@ -117,3 +117,6 @@
 
 ;CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "ExtraInhabitantCompositeType", file: !10, size: 64, num_extra_inhabitants: 66, identifier: "MangledExtraInhabitantCompositeType")
 !48 = !DICompositeType(tag: DW_TAG_structure_type, name: "ExtraInhabitantCompositeType", file: !12, size: 64, num_extra_inhabitants: 66, identifier: "MangledExtraInhabitantCompositeType")
+
+;CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "TypeWithAlternativeModule", file: !10, size: 32, alternative_module_name: "AlternativeName")
+!49 = !DICompositeType(tag: DW_TAG_structure_type, name: "TypeWithAlternativeModule", file: !12, size: 32, alternative_module_name: "AlternativeName")

--- a/llvm/test/DebugInfo/AArch64/alternative_module_name.ll
+++ b/llvm/test/DebugInfo/AArch64/alternative_module_name.ll
@@ -1,0 +1,24 @@
+; RUN: llc %s -filetype=obj -mtriple arm64e-apple-darwin -o - \
+; RUN:   | llvm-dwarfdump - | FileCheck %s
+
+; CHECK: DW_TAG_structure_type
+; CHECK: DW_AT_LLVM_alternative_module_name ("AlternativeName")
+
+target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
+
+@p = common global i8* null, align 8, !dbg !100
+
+!llvm.dbg.cu = !{!2}
+!llvm.module.flags = !{!6, !7}
+
+!2 = distinct !DICompileUnit(language: DW_LANG_C99, file: !3, emissionKind: FullDebug, globals: !5)
+!3 = !DIFile(filename: "/tmp/p.c", directory: "/")
+!4 = !{}
+!5 = !{!100}
+!6 = !{i32 2, !"Dwarf Version", i32 4}
+!7 = !{i32 2, !"Debug Info Version", i32 3}
+
+!10 = !DICompositeType(tag: DW_TAG_structure_type, name: "TypeWithAlternativeModule", file: !3, size: 32, alternative_module_name: "AlternativeName")
+
+!100 = !DIGlobalVariableExpression(var: !101, expr: !DIExpression())
+!101 = distinct !DIGlobalVariable(name: "p", scope: !2, file: !3, line: 1, type: !10, isLocal: false, isDefinition: true)

--- a/llvm/unittests/IR/DebugTypeODRUniquingTest.cpp
+++ b/llvm/unittests/IR/DebugTypeODRUniquingTest.cpp
@@ -30,8 +30,8 @@ TEST(DebugTypeODRUniquingTest, getODRType) {
   // Without a type map, this should return null.
   EXPECT_FALSE(DICompositeType::getODRType(
       Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, nullptr, 0, DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
-      nullptr, nullptr, nullptr, nullptr, nullptr));
+      nullptr, 0, 0, 0, nullptr, 0, nullptr, DINode::FlagZero, nullptr, 0,
+      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
 
   // Enable the mapping.  There still shouldn't be a type.
   Context.enableDebugTypeODRUniquing();
@@ -40,24 +40,23 @@ TEST(DebugTypeODRUniquingTest, getODRType) {
   // Create some ODR-uniqued type.
   auto &CT = *DICompositeType::getODRType(
       Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, nullptr, 0, DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
-      nullptr, nullptr, nullptr, nullptr, nullptr);
+      nullptr, 0, 0, 0, nullptr, 0, nullptr, DINode::FlagZero, nullptr, 0,
+      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   EXPECT_EQ(UUID.getString(), CT.getIdentifier());
 
   // Check that we get it back, even if we change a field.
   EXPECT_EQ(&CT, DICompositeType::getODRTypeIfExists(Context, UUID));
-  EXPECT_EQ(&CT,
-            DICompositeType::getODRType(
-                Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0,
-                nullptr, nullptr, 0, 0, 0, nullptr, 0, DINode::FlagZero, nullptr, 0,
-                nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                nullptr));
+  EXPECT_EQ(&CT, DICompositeType::getODRType(
+                     Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
+                     0, nullptr, nullptr, 0, 0, 0, nullptr, 0, nullptr,
+                     DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
+                     nullptr, nullptr, nullptr, nullptr, nullptr));
   EXPECT_EQ(&CT, DICompositeType::getODRType(
                      Context, UUID, dwarf::DW_TAG_class_type,
                      MDString::get(Context, "name"), nullptr, 0, nullptr,
-                     nullptr, 0, 0, 0, nullptr, 0, DINode::FlagZero, nullptr, 0, nullptr,
-                     nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                     nullptr));
+                     nullptr, 0, 0, 0, nullptr, 0, nullptr, DINode::FlagZero,
+                     nullptr, 0, nullptr, nullptr, nullptr, nullptr, nullptr,
+                     nullptr, nullptr, nullptr));
 
   // Check that it's discarded with the type map.
   Context.disableDebugTypeODRUniquing();
@@ -76,43 +75,43 @@ TEST(DebugTypeODRUniquingTest, buildODRType) {
   MDString &UUID = *MDString::get(Context, "Type");
   auto &CT = *DICompositeType::buildODRType(
       Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, nullptr, 0,  DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr,
-      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+      nullptr, 0, 0, 0, nullptr, 0, nullptr, DINode::FlagFwdDecl, nullptr, 0,
+      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
   EXPECT_EQ(&CT, DICompositeType::getODRTypeIfExists(Context, UUID));
   EXPECT_EQ(dwarf::DW_TAG_class_type, CT.getTag());
 
   // Update with another forward decl.  This should be a no-op.
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     0, nullptr, nullptr, 0, 0, 0, nullptr, 0, DINode::FlagFwdDecl, nullptr,
-                     0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                     nullptr, nullptr));
+                     0, nullptr, nullptr, 0, 0, 0, nullptr, 0, nullptr,
+                     DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr, nullptr,
+                     nullptr, nullptr, nullptr, nullptr, nullptr));
 
   EXPECT_FALSE(DICompositeType::buildODRType(
       Context, UUID, dwarf::DW_TAG_structure_type, nullptr, nullptr, 0, nullptr,
-      nullptr, 0, 0, 0, nullptr, 0, DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr,
-      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
+      nullptr, 0, 0, 0, nullptr, 0, nullptr, DINode::FlagFwdDecl, nullptr, 0,
+      nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
 
   // Update with a definition.  This time we should see a change.
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     0, nullptr, nullptr, 0, 0, 0, nullptr, 0, DINode::FlagZero, nullptr, 0,
-                     nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                     nullptr, nullptr));
+                     0, nullptr, nullptr, 0, 0, 0, nullptr, 0, nullptr,
+                     DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
+                     nullptr, nullptr, nullptr, nullptr, nullptr));
   EXPECT_FALSE(CT.isForwardDecl());
 
   // Further updates should be ignored.
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     0, nullptr, nullptr, 0, 0, 0, nullptr, 0, DINode::FlagFwdDecl, nullptr,
-                     0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                     nullptr, nullptr));
+                     0, nullptr, nullptr, 0, 0, 0, nullptr, 0, nullptr,
+                     DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr, nullptr,
+                     nullptr, nullptr, nullptr, nullptr, nullptr));
   EXPECT_FALSE(CT.isForwardDecl());
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, dwarf::DW_TAG_class_type, nullptr, nullptr,
-                     111u, nullptr, nullptr, 0, 0, 0, nullptr, 0, DINode::FlagZero, nullptr,
-                     0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-                     nullptr, nullptr));
+                     111u, nullptr, nullptr, 0, 0, 0, nullptr, 0, nullptr,
+                     DINode::FlagZero, nullptr, 0, nullptr, nullptr, nullptr,
+                     nullptr, nullptr, nullptr, nullptr, nullptr));
   EXPECT_NE(111u, CT.getLine());
 }
 
@@ -123,9 +122,9 @@ TEST(DebugTypeODRUniquingTest, buildODRTypeFields) {
   // Build an ODR type that's a forward decl with no other fields set.
   MDString &UUID = *MDString::get(Context, "UUID");
   auto &CT = *DICompositeType::buildODRType(
-      Context, UUID, 0, nullptr, nullptr, 0, nullptr, nullptr, 0, 0, 0, nullptr, 0,
-      DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr, nullptr, nullptr,
-      nullptr, nullptr, nullptr, nullptr);
+      Context, UUID, 0, nullptr, nullptr, 0, nullptr, nullptr, 0, 0, 0, nullptr,
+      0, nullptr, DINode::FlagFwdDecl, nullptr, 0, nullptr, nullptr, nullptr,
+      nullptr, nullptr, nullptr, nullptr, nullptr);
 
 // Create macros for running through all the fields except Identifier and Flags.
 #define FOR_EACH_MDFIELD()                                                     \
@@ -157,9 +156,9 @@ TEST(DebugTypeODRUniquingTest, buildODRTypeFields) {
   EXPECT_EQ(&CT, DICompositeType::buildODRType(
                      Context, UUID, 0, Name, File, Line, Scope, BaseType,
                      SizeInBits, AlignInBits, OffsetInBits, nullptr,
-                     NumExtraInhabitants, DINode::FlagArtificial, Elements,
-                     RuntimeLang, VTableHolder, TemplateParams, nullptr,
-                     nullptr, nullptr, nullptr, nullptr, nullptr));
+                     NumExtraInhabitants, nullptr, DINode::FlagArtificial,
+                     Elements, RuntimeLang, VTableHolder, TemplateParams,
+                     nullptr, nullptr, nullptr, nullptr, nullptr, nullptr));
 
   // Confirm that all the right fields got updated.
 #define DO_FOR_FIELD(X) EXPECT_EQ(X, CT.getRaw##X());


### PR DESCRIPTION
To support Swift types defined with @_originallyDefinedIn, we need to encode the ABI module name in debug info somehow. This patch adds a new alternative_module_name to LLVM IR and DWARF to encode that information.