### PR TITLE
[clang] Permit lifetimebound in all language modes

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1837,7 +1837,6 @@ def LifetimeBound : DeclOrTypeAttr {
   let Spellings = [Clang<"lifetimebound", 0>];
   let Subjects = SubjectList<[ParmVar, ImplicitObjectParameter], ErrorDiag>;
   let Documentation = [LifetimeBoundDocs];
-  let LangOpts = [CPlusPlus];
   let SimpleHandler = 1;
 }
 

--- a/clang/test/Sema/attr-lifetimebound.c
+++ b/clang/test/Sema/attr-lifetimebound.c
@@ -1,0 +1,8 @@
+// RUN: %clang_cc1 -std=c99 -verify %s
+
+int *f(int* p __attribute__((lifetimebound)));
+
+int *g() {
+  int i;
+  return f(&i); // expected-warning {{address of stack memory associated with local variable 'i' returned}}
+}


### PR DESCRIPTION
Lifetimebound annotations can help diagnose common cases of dangling including escaping the address of a stack variable from a function. This is useful in all C family languages, restricting these diagnostics to C++ is an artificial limitation.

Cherry-picked from 7ac78f13421c6e5dee4655211fc35225bb8812bc