### PR TITLE
[lldb][swift] Fix unwinding of Q funclets by comparing PC to continuation ptr

### DIFF
--- a/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_in_all_instructions/TestSwiftAsyncUnwindAllInstructions.py
@@ -62,26 +62,7 @@ class TestCase(lldbtest.TestBase):
                 breakpoints.add(bp.GetID())
         return breakpoints
 
-    # FIXME: there are challenges when unwinding Q funclets ("await resume"),
-    # see rdar://137048317. For now, we only know how to unwind during and
-    # shortly after the prologue. This function returns "should skip" if we're
-    # at a PC that is too far from the prologue (~16 bytes). This is a
-    # rough approximation that seems to work for both x86 and arm.
-    def should_skip_Q_funclet(self, thread):
-        current_frame = thread.frames[0]
-        function = current_frame.GetFunction()
-        if "await resume" not in function.GetName():
-            return False
-
-        max_prologue_offset = 16
-        prologue_end = function.GetStartAddress()
-        prologue_end.OffsetAddress(function.GetPrologueByteSize() + max_prologue_offset)
-        current_pc = current_frame.GetPCAddress()
-        return current_pc.GetFileAddress() >= prologue_end.GetFileAddress()
-
     def check_unwind_ok(self, thread, bpid):
-        if self.should_skip_Q_funclet(thread):
-            return
         # Check that we see the virtual backtrace:
         expected_funcnames = [
             "ASYNC___1___",


### PR DESCRIPTION
Unwinding these funclets is tricky because they change, halfway through the function, the meaning of the async register. In particular, the meaning changes from:
a) "the async context to be freed" [of the async function that just finished executing]
To:
b) "the async context of the current async function" [which has just been resumed].

LLDB has no way of identifying the instruction in which this transition happened.

This patch improves the situation slightly by employing a heuristic: if the async register has a continuation pointer that is equal to the currently executing funclet, then the stop is _before_ the transition point. This heuristic fails on some recursive async functions.

An alternative approach involves assuming we will never stop between the end of the prologue and the transition point, so that LLDB may always unwind assuming it is past the transition point if the stop is outside the prologue. This has the benefit that it should "always work", including in recursive funclets.

However, it is difficult to reason about where a debugger may stop; in fact, very often the transition point is the second instruction after the prologue, which will trigger the fail point in a common scenario. Breakpoints are often placed in the _first_ instruction after the prologue, and any kind of step operation will first "instruction step" over the breakpoint location, placing the debugger exactly in the "incorrect unwinding" zone.

A correct implementation will likely require more guarantees from the compiler. See rdar://139676623