### PR TITLE
[Cherry-pick into next] [lldb] Add a hint for potential missing module imports in the expression evaluator

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -253,9 +253,11 @@ ifneq "$(FRAMEWORK)" ""
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Headers
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Resources
+ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
 ifneq "$(MODULENAME)" ""
 	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule
 	cp -r $(MODULENAME).swiftmodule $(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule/$(ARCH).swiftmodule
+endif
 endif
 	(cd $(FRAMEWORK).framework/Versions; ln -sf A Current)
 	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Headers Headers)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -298,14 +298,14 @@ public:
   llvm::Expected<uint32_t> GetNumChildren(CompilerType type,
                                           ExecutionContextScope *exe_scopej) {
     STUB_LOG();
-    return 0;
+    return llvm::createStringError("runtime not loaded");
   }
 
-  std::optional<std::string> GetEnumCaseName(CompilerType type,
+  llvm::Expected<std::string> GetEnumCaseName(CompilerType type,
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx) {
     STUB_LOG();
-    return {};
+    return llvm::createStringError("runtime not loaded");
   }
 
   std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>
@@ -2417,7 +2417,7 @@ SwiftLanguageRuntime::GetNumChildren(CompilerType type,
   FORWARD(GetNumChildren, type, exe_scope);
 }
 
-std::optional<std::string> SwiftLanguageRuntime::GetEnumCaseName(
+llvm::Expected<std::string> SwiftLanguageRuntime::GetEnumCaseName(
     CompilerType type, const DataExtractor &data, ExecutionContext *exe_ctx) {
   FORWARD(GetEnumCaseName, type, data, exe_ctx);
 }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -344,7 +344,7 @@ public:
 
   /// Determine the enum case name for the \p data value of the enum \p type.
   /// This is performed using Swift reflection.
-  std::optional<std::string> GetEnumCaseName(CompilerType type,
+  llvm::Expected<std::string> GetEnumCaseName(CompilerType type,
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeImpl.h
@@ -134,7 +134,7 @@ public:
   std::optional<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);
 
-  std::optional<std::string> GetEnumCaseName(CompilerType type,
+  llvm::Expected<std::string> GetEnumCaseName(CompilerType type,
                                               const DataExtractor &data,
                                               ExecutionContext *exe_ctx);
 

--- a/lldb/test/API/lang/swift/expression/error_missing_type/Library.swift
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/Library.swift
@@ -1,0 +1,10 @@
+private enum E {
+case WithString(String)
+case OtherCase
+}
+
+public struct S {
+  private var e : E { get { return .WithString("hidden") } }
+}
+
+public func getS() -> S { return S() }

--- a/lldb/test/API/lang/swift/expression/error_missing_type/Makefile
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/Makefile
@@ -1,0 +1,14 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -I.
+LD_EXTRAS = -lLibrary -L$(BUILDDIR)
+all: libLibrary.dylib a.out
+
+lib%.dylib: %.swift
+	$(MAKE) MAKE_DSYM=NO DYLIB_ONLY=YES \
+		DYLIB_HIDE_SWIFTMODULE=YES \
+		DYLIB_NAME=$(shell basename $< .swift) \
+		DYLIB_SWIFT_SOURCES=$(shell basename $<) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(MAKEFILE_RULES) all
+	rm -f Library.private.swiftinterface
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftExpressionErrorMissingType(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    def test(self):
+        """Test an extra hint inserted by LLDB for missing module imports"""
+        self.build()
+        os.remove(self.getBuildArtifact("Library.swiftmodule"))
+        lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'),
+                                          extra_images=['Library'])
+
+        self.expect('expression s.e', error=True,
+                    substrs=['spelled', 'correctly', 'module', 'import'])

--- a/lldb/test/API/lang/swift/expression/error_missing_type/main.swift
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/main.swift
@@ -1,0 +1,3 @@
+import Library
+let s = getS()
+print("break here")

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -3,7 +3,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-class TestSwiftExpressionErrorReportingy(TestBase):
+class TestSwiftExpressionErrorReporting(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest


### PR DESCRIPTION
```
commit e13165e32abd06607cc41518d0b643913aa8bd77
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Nov 8 12:32:13 2024 -0800

    [lldb] Add a hint for potential missing module imports in the expression evaluator
```
