### PR TITLE
Suppress warnings for Swift C++ interop by hiding operator declarations

### DIFF
--- a/llvm/include/llvm/Support/SuffixTree.h
+++ b/llvm/include/llvm/Support/SuffixTree.h
@@ -197,12 +197,14 @@ public:
       return It;
     }
 
+#ifndef __swift__
     bool operator==(const RepeatedSubstringIterator &Other) const {
       return N == Other.N;
     }
     bool operator!=(const RepeatedSubstringIterator &Other) const {
       return !(*this == Other);
     }
+#endif
 
     RepeatedSubstringIterator(
         SuffixTreeInternalNode *N,


### PR DESCRIPTION
Solves this warning during the Swift compiler build:

```
.../SuffixTree.h:200:10: warning: cycle detected while resolving 'RepeatedSubstringIterator' in swift_name attribute for 'operator=='
```