### PR TITLE
🍒[cxx-interop][LLDB] Update test for variadic templates

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
@@ -17,9 +17,9 @@ class TestSwiftForwardInteropVariadicTemplateTypes(TestBase):
 
         self.expect('frame var pair', substrs=['Pair', 'Tuple<OtherCxxClass>', '_t', 
             'v = false', '_t', 'a1', '10', 'a2', '20', 'a3', '30'])
-        self.expect('expr pair', substrs=['Pair', 'Tuple<OtherCxxClass>', '_t', 
-            'v = false', '_t', 'a1', '10', 'a2', '20', 'a3', '30'])
-
         # rdar://106459037 (Swift/C++ interop: Variadic templates aren't displayed correctly)
-        # self.expect('frame var variadic', substrs=['Tuple<CxxClass, OtherCxxClass>', '_t', 
-        #    'v = false', 'a1', '10', 'a2', '20', 'a3', '30']) 
+        # self.expect('expr pair', substrs=['Pair', 'Tuple<OtherCxxClass>', '_t',
+        #                                   'v = false', '_t', 'a1', '10', 'a2', '20', 'a3', '30'])
+
+        self.expect('frame var variadic', substrs=['Tuple<OtherCxxClass, CxxClass>', '_t', 
+           'a1', '10', 'a2', '20', 'a3', '30', 'v = false']) 


### PR DESCRIPTION
C++ class template instantiations previously did not get a valid generated Swift type name if they used variadic generics.

See https://github.com/swiftlang/swift/pull/77450.

rdar://139435937
rdar://106459037