### PR TITLE
[lldb] Make Doxygen commits consistent with the rest of LLDB (NFC) (#…

### DIFF
--- a/lldb/include/lldb/API/SBSaveCoreOptions.h
+++ b/lldb/include/lldb/API/SBSaveCoreOptions.h
@@ -28,67 +28,87 @@ public:
   /// Set the plugin name. Supplying null or empty string will reset
   /// the option.
   ///
-  /// \param plugin Name of the object file plugin.
+  /// \param plugin
+  ///   Name of the object file plugin.
   SBError SetPluginName(const char *plugin);
 
   /// Get the Core dump plugin name, if set.
   ///
-  /// \return The name of the plugin, or null if not set.
+  /// \return
+  ///   The name of the plugin, or null if not set.
   const char *GetPluginName() const;
 
   /// Set the Core dump style.
   ///
-  /// \param style The style of the core dump.
+  /// \param style
+  ///   The style of the core dump.
   void SetStyle(lldb::SaveCoreStyle style);
 
   /// Get the Core dump style, if set.
   ///
-  /// \return The core dump style, or undefined if not set.
+  /// \return
+  ///   The core dump style, or undefined if not set.
   lldb::SaveCoreStyle GetStyle() const;
 
   /// Set the output file path
   ///
-  /// \param output_file a
-  /// \class SBFileSpec object that describes the output file.
+  /// \param
+  ///   output_file a \class SBFileSpec object that describes the output file.
   void SetOutputFile(SBFileSpec output_file);
 
   /// Get the output file spec
   ///
-  /// \return The output file spec.
+  /// \return
+  ///   The output file spec.
   SBFileSpec GetOutputFile() const;
 
   /// Set the process to save, or unset if supplied with a default constructed
   /// process.
   ///
-  /// \param process The process to save.
-  /// \return Success if process was set, otherwise an error
-  /// \note This will clear all process specific options if a different process
-  /// is specified than the current set process, either explicitly from this
-  /// api, or implicitly from any function that requires a process.
+  /// \param process
+  ///   The process to save.
+  ///
+  /// \return
+  ///   Success if process was set, otherwise an error
+  ///
+  /// \note
+  ///   This will clear all process specific options if a different process
+  ///   is specified than the current set process, either explicitly from this
+  ///   api, or implicitly from any function that requires a process.
   SBError SetProcess(lldb::SBProcess process);
 
   /// Add a thread to save in the core file.
   ///
-  /// \param thread The thread to save.
-  /// \note This will set the process if it is not already set, or return
-  /// and error if the SBThread is not from the set process.
+  /// \param thread
+  ///   The thread to save.
+  ///
+  /// \note
+  ///   This will set the process if it is not already set, or return
+  ///   and error if the SBThread is not from the set process.
   SBError AddThread(lldb::SBThread thread);
 
   /// Remove a thread from the list of threads to save.
   ///
-  /// \param thread The thread to remove.
-  /// \return True if the thread was removed, false if it was not in the list.
+  /// \param thread
+  ///   The thread to remove.
+  ///
+  /// \return
+  ///   True if the thread was removed, false if it was not in the list.
   bool RemoveThread(lldb::SBThread thread);
 
   /// Add a memory region to save in the core file.
   ///
-  /// \param region The memory region to save.
-  /// \returns An empty SBError upon success, or an error if the region is
-  /// invalid.
-  /// \note Ranges that overlapped will be unioned into a single region, this
-  /// also supercedes stack minification. Specifying full regions and a
-  /// non-custom core style will include the specified regions and union them
-  /// with all style specific regions.
+  /// \param region
+  ///   The memory region to save.
+  ///
+  /// \returns
+  ///   An empty SBError upon success, or an error if the region is invalid.
+  ///
+  /// \note
+  ///   Ranges that overlapped will be unioned into a single region, this also
+  ///   supercedes stack minification. Specifying full regions and a non-custom
+  ///   core style will include the specified regions and union them with all
+  ///   style specific regions.
   SBError AddMemoryRegionToSave(const SBMemoryRegionInfo &region);
 
   /// Reset all options.


### PR DESCRIPTION
…116269)

This fixes a warning that '\class' command should not be used in a comment attached to a non-class declaration. It also makes the Doxygen comments in SBSaveCoreOptions consistent with the rest of LLDB.

rdar://139848370
(cherry picked from commit c923ac08f0e9905a5522e9f78118623583a3f845)