### PR TITLE
[🍒 stable/20240723] [lldb] Fix synchronization in AlarmTest (NFC)

### DIFF
--- a/lldb/unittests/Host/AlarmTest.cpp
+++ b/lldb/unittests/Host/AlarmTest.cpp
@@ -56,6 +56,9 @@ TEST(AlarmTest, Create) {
   // Leave plenty of time for all the alarms to fire.
   std::this_thread::sleep_for(TEST_TIMEOUT);
 
+  // Acquire the lock to check the callbacks.
+  std::lock_guard<std::mutex> guard(m);
+
   // Make sure all the alarms fired around the expected time.
   for (size_t i = 0; i < 5; ++i)
     EXPECT_GE(callbacks_actual[i], callbacks_expected[i]);
@@ -82,6 +85,9 @@ TEST(AlarmTest, Exit) {
 
     // Let the alarm go out of scope before any alarm had a chance to fire.
   }
+
+  // Acquire the lock to check the callbacks.
+  std::lock_guard<std::mutex> guard(m);
 
   // Make sure none of the alarms fired.
   for (bool callback : callbacks)
@@ -112,6 +118,9 @@ TEST(AlarmTest, Cancel) {
 
   // Leave plenty of time for all the alarms to fire.
   std::this_thread::sleep_for(TEST_TIMEOUT);
+
+  // Acquire the lock to check the callbacks.
+  std::lock_guard<std::mutex> guard(m);
 
   // Make sure none of the first 4 alarms fired.
   for (size_t i = 0; i < 4; ++i)
@@ -146,12 +155,16 @@ TEST(AlarmTest, Restart) {
 
   // Update the last 2 alarms.
   for (size_t i = 3; i < 5; ++i) {
+    std::lock_guard<std::mutex> guard(m);
     callbacks_expected[i] = std::chrono::system_clock::now() + ALARM_TIMEOUT;
     EXPECT_TRUE(alarm.Restart(handles[i]));
   }
 
   // Leave plenty of time for all the alarms to fire.
   std::this_thread::sleep_for(TEST_TIMEOUT);
+
+  // Acquire the lock to check the callbacks.
+  std::lock_guard<std::mutex> guard(m);
 
   // Make sure all the alarms around the expected time.
   for (size_t i = 0; i < 5; ++i)


### PR DESCRIPTION
ThreadSanitizer detected a data race as if synchronized via sleep.

(cherry picked from commit 7c20bdf373d6cd7f35dee5c71cf94f0eb1be3200)