### PR TITLE
[Cherry-pick into next] [lldb] Retire the Swift-specific scratch context accessors

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -612,14 +612,6 @@ public:
   GetTypeSystemForLanguage(lldb::LanguageType language, Target *target,
                            bool can_create);
 
-  // BEGIN SWIFT
-  llvm::Expected<lldb::TypeSystemSP>
-  GetTypeSystemForLanguage(lldb::LanguageType language, Target *target,
-                           bool can_create, const char *compiler_options);
-
-  void RemoveTypeSystemsForLanguage(lldb::LanguageType language);
-  // END SWIFT
-
   /// Check all type systems in the map to see if any have forcefully completed
   /// types;
   bool GetHasForcefullyCompletedTypes() const;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1264,19 +1264,13 @@ public:
 
   llvm::Expected<lldb::TypeSystemSP>
   GetScratchTypeSystemForLanguage(lldb::LanguageType language,
-                                  bool create_on_demand = true,
-                                  const char *compiler_options = nullptr);
+                                  bool create_on_demand = true);
 
   std::vector<lldb::TypeSystemSP>
   GetScratchTypeSystems(bool create_on_demand = true);
 
   PersistentExpressionState *
   GetPersistentExpressionStateForLanguage(lldb::LanguageType language);
-
-#ifdef LLDB_ENABLE_SWIFT
-  SwiftPersistentExpressionState *
-  GetSwiftPersistentExpressionState(ExecutionContextScope &exe_scope);
-#endif // LLDB_ENABLE_SWIFT
 
   const TypeSystemMap &GetTypeSystemMap();
 
@@ -1310,18 +1304,7 @@ public:
   CreateUtilityFunction(std::string expression, std::string name,
                         lldb::LanguageType language, ExecutionContext &exe_ctx);
 
-
 #ifdef LLDB_ENABLE_SWIFT
-  /// Get the lock guarding the scratch typesystem from being re-initialized.
-  std::shared_mutex &GetSwiftScratchContextLock() {
-    return m_scratch_typesystem_lock;
-  }
-
-  TypeSystemSwiftTypeRefForExpressionsSP
-  GetSwiftScratchContext(Status &error, ExecutionContextScope &exe_scope,
-                         bool create_on_demand = true,
-                         bool for_playground = false);
-
   /// Return whether this is the Swift REPL.
   bool IsSwiftREPL();
 
@@ -1738,9 +1721,6 @@ protected:
   llvm::StringMap<DummySignalValues> m_dummy_signals;
 
   bool m_did_display_scratch_fallback_warning = false;
-
-  /// Guards the scratch typesystem from being re-initialized.
-  std::shared_mutex m_scratch_typesystem_lock;
 
   static void ImageSearchPathsChanged(const PathMappingList &path_list,
                                       void *baton);

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -613,10 +613,6 @@ public:
 
   virtual bool HasSyntheticValue();
 
-#ifdef LLDB_ENABLE_SWIFT
-  TypeSystemSwiftTypeRefForExpressionsSP GetSwiftScratchContext();
-#endif // LLDB_ENABLE_SWIFT
-
   virtual bool IsSynthetic() { return false; }
 
   lldb::ValueObjectSP

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -143,8 +143,9 @@ LLDBNameLookup::LLDBNameLookup(
 
   if (!m_sc.target_sp)
     return;
-  m_persistent_vars =
-      m_sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
+  m_persistent_vars = llvm::cast<SwiftPersistentExpressionState>(
+      m_sc.target_sp->GetPersistentExpressionStateForLanguage(
+          lldb::eLanguageTypeSwift));
 }
 
 swift::SILValue LLDBNameLookup::emitLValueForVariable(
@@ -711,7 +712,8 @@ static void ResolveSpecialNames(
     return;
 
   auto *persistent_state =
-      sc.target_sp->GetSwiftPersistentExpressionState(exe_scope);
+      sc.target_sp->GetPersistentExpressionStateForLanguage(
+          lldb::eLanguageTypeSwift);
 
   std::set<ConstString> resolved_names;
 
@@ -1836,8 +1838,9 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   // Allow variables to be re-used from previous REPL statements.
   if (m_sc.target_sp && (repl || !playground)) {
     Status error;
-    auto *persistent_state =
-        m_sc.target_sp->GetSwiftPersistentExpressionState(*m_exe_scope);
+    auto *persistent_state = llvm::cast<SwiftPersistentExpressionState>(
+        m_sc.target_sp->GetPersistentExpressionStateForLanguage(
+            lldb::eLanguageTypeSwift));
 
     llvm::SmallVector<size_t, 1> declaration_indexes;
     parsed_expr->code_manipulator->FindVariableDeclarations(declaration_indexes,
@@ -2117,8 +2120,9 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     module_name = module->getName().get();
   m_swift_ast_ctx.CacheModule(module_name, module);
   if (m_sc.target_sp) {
-    auto *persistent_state =
-        m_sc.target_sp->GetSwiftPersistentExpressionState(*m_exe_scope);
+    auto *persistent_state = llvm::cast<SwiftPersistentExpressionState>(
+        m_sc.target_sp->GetPersistentExpressionStateForLanguage(
+            lldb::eLanguageTypeSwift));
     persistent_state->CopyInSwiftPersistentDecls(
         parsed_expr->external_lookup.GetStagedDecls());
   }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -189,7 +189,7 @@ private:
     void DidDematerialize(lldb::ExpressionVariableSP &variable) override;
   };
 
-  TypeSystemSwiftSP m_swift_scratch_ctx;
+  TypeSystemSwiftTypeRefForExpressionsSP m_swift_scratch_ctx;
   SwiftASTContextForExpressions *m_swift_ast_ctx;
   PersistentVariableDelegate m_persistent_variable_delegate;
   std::unique_ptr<SwiftExpressionParser> m_parser;

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -330,7 +330,8 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &static_valobj) {
 
     // Get the type of the array elements.
     CompilerType argument_type;
-    auto ts = valobj.GetSwiftScratchContext();
+    auto ts = TypeSystemSwiftTypeRefForExpressions::GetForTarget(
+        *valobj.GetTargetSP());
     if (!ts)
       return nullptr;
     auto *swift_runtime = SwiftLanguageRuntime::Get(process_sp);

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -291,8 +291,9 @@ HashedCollectionConfig::StorageObjectAtAddress(
   // same address.
   Status error;
   ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
-  auto scratch_ctx =
-      process_sp->GetTarget().GetSwiftScratchContext(error, *exe_scope);
+
+  auto scratch_ctx = TypeSystemSwiftTypeRefForExpressions::GetForTarget(
+      process_sp->GetTarget());
   if (!scratch_ctx)
     return nullptr;
   if (error.Fail())

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1055,7 +1055,8 @@ SwiftLanguage::GetHardcodedSynthetics() {
         LLDB_LOGV(log, "[Matching CxxBridgedSyntheticChildProvider] - "
                        "Could not get the swift runtime.");
 
-      auto ts = valobj.GetSwiftScratchContext();
+      auto ts = TypeSystemSwiftTypeRefForExpressions::GetForTarget(
+          valobj.GetTargetSP());
       if (!ts) {
         LLDB_LOGV(log, "[Matching CxxBridgedSyntheticChildProvider] - "
                        "Could not get the Swift scratch context.");
@@ -1367,28 +1368,24 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
           size_t before = results.size();
 
           if (exe_scope) {
-            Target *target = exe_scope->CalculateTarget().get();
-            if (target) {
-              const bool create_on_demand = false;
-              Status error;
-              auto scratch_ctx = target->GetSwiftScratchContext(
-                  error, *exe_scope, create_on_demand);
-              if (auto frame_sp = exe_scope->CalculateStackFrame()) {
-                auto &sc =
-                    frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
-                if (scratch_ctx)
-                  if (SwiftASTContext *ast_ctx =
-                          scratch_ctx->GetSwiftASTContext(sc)) {
-                    ConstString cs_input{input};
-                    Mangled mangled(cs_input);
-                    if (mangled.GuessLanguage() == eLanguageTypeSwift) {
-                      auto candidate =
-                          ast_ctx->GetTypeFromMangledTypename(cs_input);
-                      if (candidate.IsValid())
-                        results.insert(candidate);
-                    }
+            TargetSP target = exe_scope->CalculateTarget();
+            auto scratch_ctx =
+                TypeSystemSwiftTypeRefForExpressions::GetForTarget(target);
+            if (auto frame_sp = exe_scope->CalculateStackFrame()) {
+              auto &sc =
+                  frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
+              if (scratch_ctx)
+                if (SwiftASTContext *ast_ctx =
+                        scratch_ctx->GetSwiftASTContext(sc)) {
+                  ConstString cs_input{input};
+                  Mangled mangled(cs_input);
+                  if (mangled.GuessLanguage() == eLanguageTypeSwift) {
+                    auto candidate =
+                        ast_ctx->GetTypeFromMangledTypename(cs_input);
+                    if (candidate.IsValid())
+                      results.insert(candidate);
                   }
-              }
+                }
             }
           }
 
@@ -1440,11 +1437,9 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
           size_t before = results.size();
 
           if (exe_scope) {
-            Target *target = exe_scope->CalculateTarget().get();
-            const bool create_on_demand = false;
-            Status error;
-            auto scratch_ctx = target->GetSwiftScratchContext(error, *exe_scope,
-                                                              create_on_demand);
+            TargetSP target = exe_scope->CalculateTarget();
+            auto scratch_ctx =
+                TypeSystemSwiftTypeRefForExpressions::GetForTarget(target);
             if (auto frame_sp = exe_scope->CalculateStackFrame()) {
               const SymbolContext &sc =
                   frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -189,7 +189,8 @@ ConstString SwiftLanguageRuntimeImpl::GetDynamicTypeName_ClassRemoteAST(
   if (!stack_frame_sp)
     return {};
   auto &sc = stack_frame_sp->GetSymbolContext(eSymbolContextFunction);
-  TypeSystemSwiftTypeRefForExpressionsSP ts = in_value.GetSwiftScratchContext();
+  auto ts = TypeSystemSwiftTypeRefForExpressions::GetForTarget(
+      in_value.GetTargetSP());
   if (!ts)
     return {};
   SwiftASTContext *swift_ast_ctx = ts->GetSwiftASTContext(sc);
@@ -222,7 +223,8 @@ SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ExistentialRemoteAST(
   // Dynamic type resolution in RemoteAST might pull in other Swift
   // modules, so use the scratch context where such operations are
   // legal and safe.
-  auto scratch_ctx = in_value.GetSwiftScratchContext();
+  auto scratch_ctx = TypeSystemSwiftTypeRefForExpressions::GetForTarget(
+      in_value.GetTargetSP());
   if (!scratch_ctx)
     return {};
 
@@ -279,7 +281,7 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
   // that module context.  Binding archetypes can trigger an import of
   // another module, so switch to a scratch context where such an
   // operation is safe.
-  auto scratch_ctx = target.GetSwiftScratchContext(error, stack_frame);
+  auto scratch_ctx = TypeSystemSwiftTypeRefForExpressions::GetForTarget(target);
   if (!scratch_ctx)
     return base_type;
 
@@ -451,7 +453,8 @@ CompilerType SwiftLanguageRuntimeImpl::MetadataPromise::FulfillTypePromise(
   if (m_compiler_type.has_value())
     return m_compiler_type.value();
 
-  auto scratch_ctx = m_for_object_sp->GetSwiftScratchContext();
+  auto scratch_ctx = TypeSystemSwiftTypeRefForExpressions::GetForTarget(
+      m_for_object_sp->GetTargetSP());
   if (!scratch_ctx) {
     if (error)
       *error = Status::FromErrorString("couldn't get Swift scratch context");
@@ -490,7 +493,8 @@ SwiftLanguageRuntimeImpl::MetadataPromiseSP
 SwiftLanguageRuntimeImpl::GetMetadataPromise(const SymbolContext &sc,
                                              lldb::addr_t addr,
                                              ValueObject &for_object) {
-  auto scratch_ctx = for_object.GetSwiftScratchContext();
+  auto scratch_ctx = TypeSystemSwiftTypeRefForExpressions::GetForTarget(
+      for_object.GetTargetSP());
   if (!scratch_ctx)
     return nullptr;
   SwiftASTContext *swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -533,7 +533,7 @@ public:
   swift::TBDGenOptions &GetTBDGenOptions();
 
   void ClearModuleDependentCaches() override;
-  void LogConfiguration();
+  void LogConfiguration(bool is_repl = false);
   bool HasTarget();
   bool CheckProcessChanged();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -130,7 +130,10 @@ public:
 
   Module *GetModule() const { return m_module; }
 
-  /// Return the owning Swift module for a function.
+  /// Return a key for the SwiftASTContext map. If there is debug info it's the
+  /// name of the owning Swift module for a function.
+  static const char *DeriveKeyFor(const SymbolContext &sc);
+  /// Return the name of the owning Swift module for a function.
   static ConstString GetSwiftModuleFor(const SymbolContext &sc);
 
   // Tests
@@ -534,9 +537,18 @@ public:
                                        Target &target,
                                        const char *extra_options);
 
+  static TypeSystemSwiftTypeRefForExpressionsSP GetForTarget(Target &target);
+  static TypeSystemSwiftTypeRefForExpressionsSP
+  GetForTarget(lldb::TargetSP target);
+
   SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override;
   SwiftASTContext *
   GetSwiftASTContextOrNull(const SymbolContext &sc) const override;
+  /// This API needs to be called for a REPL or Playground before the first call
+  /// to GetSwiftASTContext is being made.
+  void SetCompilerOptions(const char *compiler_options) {
+    m_compiler_options = compiler_options;
+  }
   lldb::TargetWP GetTargetWP() const override { return m_target_wp; }
 
   void ModulesDidLoad(ModuleList &module_list);
@@ -566,6 +578,7 @@ public:
 protected:
   lldb::TargetWP m_target_wp;
   unsigned m_generation = 0;
+  const char *m_compiler_options = nullptr;
 
   /// This exists to implement the PerformCompileUnitImports
   /// mechanism.

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -360,32 +360,6 @@ TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
   return GetTypeSystemForLanguage(language);
 }
 
-// BEGIN SWIFT
-llvm::Expected<TypeSystemSP>
-TypeSystemMap::GetTypeSystemForLanguage(lldb::LanguageType language,
-                                        Target *target, bool can_create,
-                                        const char *compiler_options) {
-  if (can_create) {
-    return GetTypeSystemForLanguage(
-        language,
-        std::optional<CreateCallback>([language, target, compiler_options]() {
-          return TypeSystem::CreateInstance(language, target, compiler_options);
-        }));
-  }
-  return GetTypeSystemForLanguage(language);
-}
-
-void TypeSystemMap::RemoveTypeSystemsForLanguage(lldb::LanguageType language) {
-  std::lock_guard<std::mutex> guard(m_mutex);
-  collection::iterator pos = m_map.find(language);
-  // If we are clearing the map, we don't need to remove this individual item.
-  // It will go away soon enough.
-  if (!m_clear_in_progress) {
-    if (pos != m_map.end())
-      m_map.erase(pos);
-  }
-}
-// END SWIFT
 bool TypeSystem::SupportsLanguageStatic(lldb::LanguageType language) {
   if (language == eLanguageTypeUnknown || language >= eNumLanguageTypes)
     return false;

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -364,7 +364,7 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
     if (auto *exe_scope = exe_ctx.GetBestExecutionContextScope())
       if (auto target = frame->CalculateTarget())
         if (auto swift_ast_ctx =
-                target->GetSwiftScratchContext(error, *exe_scope, false))
+                TypeSystemSwiftTypeRefForExpressions::GetForTarget(*target))
           swift_ast_ctx->DiagnoseWarnings(*GetProcess(), msc);
   }
 #endif

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1812,19 +1812,6 @@ bool ValueObject::GetDeclaration(Declaration &decl) {
   return false;
 }
 
-#ifdef LLDB_ENABLE_SWIFT
-TypeSystemSwiftTypeRefForExpressionsSP ValueObject::GetSwiftScratchContext() {
-  lldb::TargetSP target_sp(GetTargetSP());
-  if (!target_sp)
-    return {};
-  Status error;
-  // FIXME: Not holding on to the lock isn't great fo determinism.
-  ExecutionContext ctx = GetExecutionContextRef().Lock(false);
-  auto *exe_scope = ctx.GetBestExecutionContextScope();
-  return target_sp->GetSwiftScratchContext(error, *exe_scope);
-}
-#endif // LLDB_ENABLE_SWIFT
-
 void ValueObject::AddSyntheticChild(ConstString key, ValueObject *valobj) {
   m_synthetic_children[key] = valobj;
 }
@@ -3864,17 +3851,8 @@ ValueObjectSP ValueObject::Persist() {
     return nullptr;
 
   PersistentExpressionState *persistent_state;
-#ifdef LLDB_ENABLE_SWIFT
-  if (GetPreferredDisplayLanguage() == eLanguageTypeSwift) {
-    ExecutionContext ctx = GetExecutionContextRef().Lock(false);
-    auto *exe_scope = ctx.GetBestExecutionContextScope();
-    if (!exe_scope)
-      return nullptr;
-    persistent_state = target_sp->GetSwiftPersistentExpressionState(*exe_scope);
-  } else
-#endif // LLDB_ENABLE_SWIFT
-    persistent_state = target_sp->GetPersistentExpressionStateForLanguage(
-        GetPreferredDisplayLanguage());
+  persistent_state = target_sp->GetPersistentExpressionStateForLanguage(
+      GetPreferredDisplayLanguage());
 
   if (!persistent_state)
     return nullptr;


### PR DESCRIPTION
```
commit 927f1291288b4bb70fd059b97edf55a8a5b478c0
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Nov 15 16:33:43 2024 -0800

    [lldb] Retire the Swift-specific scratch context accessors
    
    These used to be necessary because there used to be context-specific
    scratch contexts, however, now there is only one global
    TypeSystemSwiftTypeRefForExpressions, and it manages multiple
    SwiftASTContexts. Therefore it is no longer necessary to have
    Swift-specific hooks in Target and ValueObject.
```
