### PR TITLE
[Cherry-pick into next] [lldb] Acquire the map lock after deriving the lookup key

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1911,7 +1911,6 @@ SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
 SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull(
     const SymbolContext &sc) const {
   std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
-
   const char *key = nullptr;
   auto it = m_swift_ast_context_map.find(key);
   if (it != m_swift_ast_context_map.end())
@@ -1921,9 +1920,9 @@ SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull(
 
 SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContextOrNull(
     const SymbolContext &sc) const {
-  std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
-
   const char *key = DeriveKeyFor(sc);
+
+  std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
   auto it = m_swift_ast_context_map.find(key);
   if (it != m_swift_ast_context_map.end())
     return llvm::cast_or_null<SwiftASTContext>(it->second.typesystem.get());


### PR DESCRIPTION
```
commit a657eef5a38d74d92c2204ebce00cddfe5413b90
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Nov 19 15:50:15 2024 -0800

    [lldb] Acquire the map lock after deriving the lookup key
    
    The computation of the key may itself does DWARF lookups which may
    acquire additional locks through callbacks into TypeSystem.
    
    rdar://139841554
```
