### PR TITLE
Change ObjC message tracing output format

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -9452,7 +9452,7 @@ selectMethodOwnerKey(const clang::NamedDecl *clangD) {
 
 void clang::serializeObjCMethodReferencesAsJson(
     const clang::ObjCMethodReferenceInfo &Info, llvm::raw_ostream &OS) {
-  llvm::json::OStream Out(OS, /*IndentSize=*/4);
+  llvm::json::OStream Out(OS);
   Out.object([&] {
     Out.attribute(Info.ToolName, Info.ToolVersion);
     Out.attribute("format-version", Info.FormatVersion);
@@ -9484,7 +9484,9 @@ void clang::serializeObjCMethodReferencesAsJson(
             Mangler->mangleObjCMethodName(clangD, Out2,
                                           /*includePrefixByte=*/false, true);
             Out.attribute(selectMethodKey(clangD), MangledMethodName);
-            Out.attribute("declared_at", Loc.printToString(SM));
+            if (Loc.isMacroID())
+              Out.attribute("declared_by_macro", SM.getFilename(SM.getSpellingLoc(Loc)));
+            Out.attribute("declared_at", SM.getFilename(SM.getExpansionLoc(Loc)));
             Out.attribute("referenced_at_file_id", FileID);
           });
         }

--- a/clang/test/AST/Inputs/objc-method-tracing.h
+++ b/clang/test/AST/Inputs/objc-method-tracing.h
@@ -17,3 +17,8 @@ CDef
 @protocol P0
 -(void)m5;
 @end
+
+#define CDef2 \
+@interface D \
+-(void)m9; \
+@end

--- a/clang/test/AST/objc-method-tracing.mm
+++ b/clang/test/AST/objc-method-tracing.mm
@@ -1,5 +1,6 @@
+// RUN: rm -fr %t.txt
 // RUN: env CLANG_COMPILER_OBJC_MESSAGE_TRACE_PATH=%t.txt %clang_cc1 -fsyntax-only -triple arm64-apple-macosx15.0.0 -I %S/Inputs %s
-// RUN: cat %t.txt | FileCheck %s
+// RUN: cat %t.txt | %python -c 'import json, sys; json.dump(json.loads(sys.stdin.read()), sys.stdout, sort_keys=True, indent=2)' | FileCheck %s
 
 #include "objc-method-tracing.h"
 
@@ -57,73 +58,87 @@ void test8(B *b) {
   [b m8];
 }
 
+CDef2
+
+void test9(D *d) {
+  [d m9];
+}
+
 // CHECK: {
 // CHECK-NEXT:    "clang-compiler-version": "{{.*}}clang version
-// CHECK-NEXT:    "format-version": 1,
-// CHECK-NEXT:    "target": "arm64-apple-macosx15.0.0",
-// CHECK-NEXT:    "references": [
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "interface_type": "A",
-// CHECK-NEXT:            "instance_method": "-[A m0]",
-// CHECK-NEXT:            "declared_at": "[[HEADER_FILE:.*]]:2:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "interface_type": "B",
-// CHECK-NEXT:            "instance_method": "-[B m0]",
-// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:6:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "interface_type": "B",
-// CHECK-NEXT:            "class_method": "+[B m1]",
-// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:7:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "interface_type": "B",
-// CHECK-NEXT:            "category_type": "Cat1",
-// CHECK-NEXT:            "instance_method": "-[B(Cat1) m2]",
-// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE:.*]]:7:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "interface_type": "C",
-// CHECK-NEXT:            "instance_method": "-[C m4]",
-// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:15:1 <Spelling=[[HEADER_FILE]]:11:14>",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "protocol_type": "P0",
-// CHECK-NEXT:            "instance_method": "-[P0 m5]",
-// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]:18:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "interface_type": "B",
-// CHECK-NEXT:            "category_type": "",
-// CHECK-NEXT:            "instance_method": "-[B() m6]",
-// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:11:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "implementation_type": "B",
-// CHECK-NEXT:            "instance_method": "-[B m7:arg1:]",
-// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:15:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:            "interface_type": "B",
-// CHECK-NEXT:            "category_implementation_type": "Cat1",
-// CHECK-NEXT:            "instance_method": "-[B(Cat1) m8]",
-// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]:20:1",
-// CHECK-NEXT:            "referenced_at_file_id": 1
-// CHECK-NEXT:        }
-// CHECK-NEXT:    ],
 // CHECK-NEXT:    "fileMap": [
 // CHECK-NEXT:        {
 // CHECK-NEXT:            "file_id": 1,
-// CHECK-NEXT:            "file_path": "[[SOURCE_FILE]]"
+// CHECK-NEXT:            "file_path": "[[SOURCE_FILE:.*]]"
 // CHECK-NEXT:        }
-// CHECK-NEXT:    ]
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "format-version": 1,
+// CHECK-NEXT:    "references": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE:.*]]",
+// CHECK-NEXT:            "instance_method": "-[A m0]",
+// CHECK-NEXT:            "interface_type": "A",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]",
+// CHECK-NEXT:            "instance_method": "-[B m0]",
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "class_method": "+[B m1]",
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]",
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "category_type": "Cat1",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]",
+// CHECK-NEXT:            "instance_method": "-[B(Cat1) m2]",
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]",
+// CHECK-NEXT:            "declared_by_macro": "[[HEADER_FILE]]",
+// CHECK-NEXT:            "instance_method": "-[C m4]",
+// CHECK-NEXT:            "interface_type": "C",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "declared_at": "[[HEADER_FILE]]",
+// CHECK-NEXT:            "instance_method": "-[P0 m5]",
+// CHECK-NEXT:            "protocol_type": "P0",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "category_type": "",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]",
+// CHECK-NEXT:            "instance_method": "-[B() m6]",
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]",
+// CHECK-NEXT:            "implementation_type": "B",
+// CHECK-NEXT:            "instance_method": "-[B m7:arg1:]",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "category_implementation_type": "Cat1",
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]",
+// CHECK-NEXT:            "instance_method": "-[B(Cat1) m8]",
+// CHECK-NEXT:            "interface_type": "B",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:            "declared_at": "[[SOURCE_FILE]]",
+// CHECK-NEXT:            "declared_by_macro": "[[HEADER_FILE]]",
+// CHECK-NEXT:            "instance_method": "-[D m9]",
+// CHECK-NEXT:            "interface_type": "D",
+// CHECK-NEXT:            "referenced_at_file_id": 1
+// CHECK-NEXT:        }
+// CHECK-NEXT:    ],
+// CHECK-NEXT:    "target": "arm64-apple-macosx15.0.0"
 // CHECK-NEXT: }


### PR DESCRIPTION
Make the following changes to the output:

- Stop pretty-printing the output and just emit one JSON object per line.
- Stop emitting column/line numbers of declarations.
- Emit `declared_by_macro` for macro locations.