### PR TITLE
[clang] Fix lifetimebound APINotes tests

### DIFF
--- a/clang/test/APINotes/lifetimebound.cpp
+++ b/clang/test/APINotes/lifetimebound.cpp
@@ -11,6 +11,8 @@
 
 // CHECK-METHOD: CXXMethodDecl {{.+}} methodToAnnotate 
 // CHECK-METHOD-NEXT: ParmVarDecl {{.+}} p
+// CHECK-METHOD-NEXT: SwiftVersionedAdditionAttr
+// CHECK-METHOD-NEXT: LifetimeBoundAttr
 // CHECK-METHOD-NEXT: LifetimeBoundAttr
 
 // CHECK-METHOD-THIS: CXXMethodDecl {{.+}} annotateThis 'int *() {{\[\[}}clang::lifetimebound{{\]\]}}'


### PR DESCRIPTION
The APINotes implementation upstream and downstream are not exactly the same, this PR makes sure the lifetimebound type attribute for 'this' object is deduplicated, and updates the test to respect versioned attributes.

rdar://140295698