### PR TITLE
[lldb] Introduce an ImportedDeclaration and [lldb] Handle @_originallyDefinedIn 

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -12,6 +12,7 @@
 #include "lldb/Core/Address.h"
 #include "lldb/Core/ModuleList.h"
 #include "lldb/Core/ModuleSpec.h"
+#include "lldb/Symbol/ImportedDeclaration.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolContextScope.h"
 #include "lldb/Symbol/TypeSystem.h"
@@ -436,6 +437,21 @@ public:
   ///     Any matching types will be populated into the \a results object using
   ///     TypeMap::InsertUnique(...).
   void FindTypes(const TypeQuery &query, TypeResults &results);
+
+  /// Finds imported declarations whose name match \p name.
+  ///
+  /// \param[in] name
+  ///     The name to search the imported declaration by.
+  ///
+  /// \param[in] results
+  ///     Any matching types will be populated into the \a results object.
+  ///
+  /// \param[in] find_one
+  ///     If set to true, the search will stop after the first imported
+  ///     declaration is found.
+  void FindImportedDeclarations(ConstString name,
+                                std::vector<ImportedDeclaration> &results,
+                                bool find_one);
 
   /// Get const accessor for the module architecture.
   ///

--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -12,6 +12,7 @@
 #include "lldb/Core/Address.h"
 #include "lldb/Core/ModuleSpec.h"
 #include "lldb/Core/UserSettingsController.h"
+#include "lldb/Symbol/ImportedDeclaration.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/Iterable.h"
 #include "lldb/Utility/Status.h"
@@ -396,6 +397,25 @@ public:
   ///     TypeMap::InsertUnique(...).
   void FindTypes(Module *search_first, const TypeQuery &query,
                  lldb_private::TypeResults &results) const;
+
+  /// Finds imported declarations whose name match \p name.
+  ///
+  /// \param[in] search_first
+  ///     If non-null, this module will be searched before any other
+  ///     modules.
+  ///
+  /// \param[in] name
+  ///     The name to search the imported declaration by.
+  ///
+  /// \param[in] results
+  ///     Any matching types will be populated into the \a results object.
+  ///
+  /// \param[in] find_one
+  ///     If set to true, the search will stop after the first imported
+  ///     declaration is found.
+  void FindImportedDeclarations(Module *search_first, ConstString name,
+                                std::vector<ImportedDeclaration> &results,
+                                bool find_one) const;
 
   bool FindSourceFile(const FileSpec &orig_spec, FileSpec &new_spec) const;
 

--- a/lldb/include/lldb/Symbol/ImportedDeclaration.h
+++ b/lldb/include/lldb/Symbol/ImportedDeclaration.h
@@ -1,0 +1,34 @@
+//===-- ImportedDeclaration.h -----------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SYMBOL_IMPORTED_DECLARATION_H
+#define LLDB_SYMBOL_IMPORTED_DECLARATION_H
+
+#include "lldb/Utility/ConstString.h"
+#include "lldb/Utility/UserID.h"
+
+namespace lldb_private {
+
+struct ImportedDeclaration : public UserID {
+
+  ImportedDeclaration(lldb::user_id_t uid, ConstString name,
+                      SymbolFile *symbol_file)
+      : UserID(uid), m_name(name), m_symbol_file(symbol_file) {}
+
+  ConstString GetName() const { return m_name; }
+
+  std::vector<lldb_private::CompilerContext> GetDeclContext() const;
+
+private:
+  ConstString m_name;
+  SymbolFile *m_symbol_file = nullptr;
+};
+
+} // namespace lldb_private
+
+#endif // LLDB_SYMBOL_IMPORTED_DECLARATION_H

--- a/lldb/include/lldb/Symbol/SymbolFile.h
+++ b/lldb/include/lldb/Symbol/SymbolFile.h
@@ -18,6 +18,8 @@
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/SourceModule.h"
+#include "lldb/Symbol/Symbol.h"
+#include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/Type.h"
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/TypeSystem.h"
@@ -305,6 +307,21 @@ public:
                              bool include_inlines, SymbolContextList &sc_list);
   virtual void FindFunctions(const RegularExpression &regex,
                              bool include_inlines, SymbolContextList &sc_list);
+  /// Finds imported declarations whose name match \p name.
+  ///
+  /// \param[in] name
+  ///     The name to search the imported declaration by.
+  ///
+  /// \param[in] results
+  ///     Any matching types will be populated into the \a results object.
+  ///
+  /// \param[in] find_one
+  ///     If set to true, the search will stop after the first imported
+  ///     declaration is found.
+  virtual void
+  FindImportedDeclaration(ConstString name,
+                          std::vector<ImportedDeclaration> &declarations,
+                          bool find_one) {}
 
   /// Find types using a type-matching object that contains all search
   /// parameters.

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1011,6 +1011,12 @@ void Module::FindTypes(const TypeQuery &query, TypeResults &results) {
   if (SymbolFile *symbols = GetSymbolFile())
     symbols->FindTypes(query, results);
 }
+void Module::FindImportedDeclarations(ConstString name,
+                                      std::vector<ImportedDeclaration> &results,
+                                      bool find_one) {
+  if (SymbolFile *symbols = GetSymbolFile())
+    symbols->FindImportedDeclaration(name, results, find_one);
+}
 
 static Debugger::DebuggerList
 DebuggersOwningModuleRequestingInterruption(Module &module) {

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -831,6 +831,24 @@ void ModuleList::FindTypes(Module *search_first, const TypeQuery &query,
   }
 }
 
+void ModuleList::FindImportedDeclarations(
+    Module *search_first, ConstString name,
+    std::vector<ImportedDeclaration> &results, bool find_one) const {
+  std::lock_guard<std::recursive_mutex> guard(m_modules_mutex);
+  if (search_first) {
+    search_first->FindImportedDeclarations(name, results, find_one);
+    if (find_one && !results.empty())
+      return;
+  }
+  for (const auto &module_sp : m_modules) {
+    if (search_first != module_sp.get()) {
+      module_sp->FindImportedDeclarations(name, results, find_one);
+    }
+    if (find_one && !results.empty())
+      return;
+  }
+}
+
 bool ModuleList::FindSourceFile(const FileSpec &orig_spec,
                                 FileSpec &new_spec) const {
   std::lock_guard<std::recursive_mutex> guard(m_modules_mutex);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2677,6 +2677,22 @@ void SymbolFileDWARF::FindFunctions(const RegularExpression &regex,
   });
 }
 
+void SymbolFileDWARF::FindImportedDeclaration(
+    ConstString name, std::vector<ImportedDeclaration> &sc_list,
+    bool find_one) {
+  llvm::DenseSet<const DWARFDebugInfoEntry *> resolved_dies;
+  m_index->GetNamespaces(name, [&](DWARFDIE die) {
+    if (die.Tag() != llvm::dwarf::DW_TAG_imported_declaration)
+      return true;
+
+    if (name != die.GetName())
+      return true;
+
+    sc_list.emplace_back(die.GetID(), name, this);
+    return !find_one;
+  });
+}
+
 void SymbolFileDWARF::GetMangledNamesForFunction(
     const std::string &scope_qualified_name,
     std::vector<ConstString> &mangled_names) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.h
@@ -195,6 +195,10 @@ public:
   void FindFunctions(const RegularExpression &regex, bool include_inlines,
                      SymbolContextList &sc_list) override;
 
+  void FindImportedDeclaration(ConstString name,
+                               std::vector<ImportedDeclaration> &sc_list,
+                               bool find_one) override;
+
   void
   GetMangledNamesForFunction(const std::string &scope_qualified_name,
                              std::vector<ConstString> &mangled_names) override;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -1122,6 +1122,17 @@ void SymbolFileDWARFDebugMap::FindFunctions(const RegularExpression &regex,
   });
 }
 
+void SymbolFileDWARFDebugMap::FindImportedDeclaration(
+    ConstString name, std::vector<ImportedDeclaration> &declarations,
+    bool find_one) {
+  ForEachSymbolFile([&](SymbolFileDWARF *oso_dwarf) {
+    oso_dwarf->FindImportedDeclaration(name, declarations, find_one);
+    if (find_one && !declarations.empty())
+      return IterationAction::Stop;
+    return IterationAction::Continue;
+  });
+}
+
 void SymbolFileDWARFDebugMap::GetTypes(SymbolContextScope *sc_scope,
                                        lldb::TypeClass type_mask,
                                        TypeList &type_list) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.h
@@ -123,6 +123,9 @@ public:
                      bool include_inlines, SymbolContextList &sc_list) override;
   void FindFunctions(const RegularExpression &regex, bool include_inlines,
                      SymbolContextList &sc_list) override;
+  void FindImportedDeclaration(ConstString name,
+                               std::vector<ImportedDeclaration> &declarations,
+                               bool find_one) override;
   void FindTypes(const lldb_private::TypeQuery &match,
                  lldb_private::TypeResults &results) override;
   CompilerDeclContext FindNamespace(ConstString name,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4720,6 +4720,16 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
                    .getPointer();
   assert(!found_type || &found_type->getASTContext() == *ast_ctx);
 
+  // This type might have been been found in reflection and annotated with
+  // @_originallyDefinedIn. The compiler emits a typelias for these type
+  // pointing them back to the types with the real module name.
+  if (!found_type) {
+    auto adjusted =
+        GetTypeSystemSwiftTypeRef().AdjustTypeForOriginallyDefinedInModule(
+            mangled_typename);
+    found_type =
+        swift::Demangle::getTypeForMangling(**ast_ctx, adjusted).getPointer();
+  }
   // Objective-C classes sometimes have private subclasses that are invisible
   // to the Swift compiler because they are declared and defined in a .m file.
   // If we can't reconstruct an ObjC type, walk up the type hierarchy until we

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -59,8 +59,9 @@ NodeAtPath(swift::Demangle::NodePointer root,
   return ChildAtPath(root, kind_path.drop_front());
 }
 
-/// \return the child of the \p Type node.
-static swift::Demangle::NodePointer GetType(swift::Demangle::NodePointer n) {
+/// \return the child of the TypeMangling node.
+static swift::Demangle::NodePointer
+GetTypeMangling(swift::Demangle::NodePointer n) {
   using namespace swift::Demangle;
   if (!n || n->getKind() != Node::Kind::Global)
     return nullptr;
@@ -68,6 +69,13 @@ static swift::Demangle::NodePointer GetType(swift::Demangle::NodePointer n) {
   if (!n || n->getKind() != Node::Kind::TypeMangling || !n->hasChildren())
     return nullptr;
   n = n->getFirstChild();
+  return n;
+}
+
+/// \return the child of the \p Type node.
+static swift::Demangle::NodePointer GetType(swift::Demangle::NodePointer n) {
+  using namespace swift::Demangle;
+  n = GetTypeMangling(n);
   if (!n || n->getKind() != Node::Kind::Type || !n->hasChildren())
     return nullptr;
   n = n->getFirstChild();
@@ -78,6 +86,14 @@ static swift::Demangle::NodePointer GetType(swift::Demangle::NodePointer n) {
 inline swift::Demangle::NodePointer
 GetDemangledType(swift::Demangle::Demangler &dem, llvm::StringRef name) {
   return GetType(dem.demangleSymbol(name));
+}
+
+/// Demangle a mangled type name and return the child of the \p TypeMangling
+/// node.
+inline swift::Demangle::NodePointer
+GetDemangledTypeMangling(swift::Demangle::Demangler &dem,
+                         llvm::StringRef name) {
+  return GetTypeMangling(dem.demangleSymbol(name));
 }
 
 /// Wrap node in Global/TypeMangling/Type.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -366,6 +366,34 @@ public:
   CanonicalizeSugar(swift::Demangle::Demangler &dem,
                     swift::Demangle::NodePointer node);
 
+  /// Transforms the module name in the mangled type name using module_name_map
+  /// as the mapping source.
+  static swift::Demangle::ManglingErrorOr<std::string>
+  TransformModuleName(llvm::StringRef mangled_name,
+                      const llvm::StringMap<llvm::StringRef> &module_name_map);
+
+  /// Given a node pointer to a type, transforms the module name of the type's
+  /// demangle tree by applying \module_transformer to the module node.
+  static swift::Demangle::NodePointer TransformModuleName(
+      swift::Demangle::NodePointer node, swift::Demangle::Demangler &dem,
+      std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
+          module_transformer);
+
+  /// Transforms the bound generic types of \node by applying \type_transformer
+  /// to them.
+  static swift::Demangle::NodePointer TransformBoundGenericTypes(
+      swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+      std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
+          type_transformer);
+
+  /// Types with the @_originallyDefinedIn attribute are serialized with with
+  /// the original module name in reflection metadata. At the same time the type
+  /// is serialized with the swiftmodule name in debug info, but with a parent
+  /// module with the original module name. This function adjusts \type to look
+  /// up the type in reflection metadata if necessary.
+  std::string
+  AdjustTypeForOriginallyDefinedInModule(llvm::StringRef mangled_typename);
+
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
   swift::Demangle::NodePointer
   GetCanonicalDemangleTree(swift::Demangle::Demangler &dem,

--- a/lldb/source/Symbol/CMakeLists.txt
+++ b/lldb/source/Symbol/CMakeLists.txt
@@ -32,6 +32,7 @@ add_lldb_library(lldbSymbol ${PLUGIN_DEPENDENCY_ARG}
   DeclVendor.cpp
   FuncUnwinders.cpp
   Function.cpp
+  ImportedDeclaration.cpp
   LineEntry.cpp
   LineTable.cpp
   ObjectContainer.cpp

--- a/lldb/source/Symbol/ImportedDeclaration.cpp
+++ b/lldb/source/Symbol/ImportedDeclaration.cpp
@@ -1,0 +1,18 @@
+//===-- Symbol.cpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Symbol/ImportedDeclaration.h"
+#include "lldb/Symbol/SymbolFile.h"
+
+using namespace lldb;
+using namespace lldb_private;
+
+std::vector<lldb_private::CompilerContext>
+ImportedDeclaration::GetDeclContext() const {
+  return m_symbol_file->GetCompilerContextForUID(GetID());
+}

--- a/lldb/test/API/lang/swift/originally_defined_in/Makefile
+++ b/lldb/test/API/lang/swift/originally_defined_in/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+ include Makefile.rules

--- a/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
+++ b/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
@@ -1,0 +1,99 @@
+import os
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
+    
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+        filespec = lldb.SBFileSpec("main.swift")
+        target, process, thread, breakpoint1 = lldbutil.run_to_source_breakpoint(
+            self, "break here", filespec
+        )
+        self.expect("frame variable a", substrs=["a = (i = 10)"])
+        self.expect("frame variable b", substrs=["b = (i = 20)"])
+        self.expect("frame variable d", substrs=["d = (i = 30)"])
+        self.expect("frame variable e", substrs=["i = 50"])
+        self.expect("frame variable f", substrs=["i = 40"])
+        self.expect("frame variable g", substrs=["i = 60"])
+        self.expect("frame variable h", substrs=["t = (i = 50)", "u = (i = 70)"])
+        self.expect(
+            "frame variable complex",
+            substrs=[
+                "t = t {",
+                "t = {",
+                "t = (i = 70)",
+                "u = (i = 30)",
+                "u = t {",
+                "t = (i = 50)",
+            ],
+        )
+    
+    @swiftTest
+    def test_expr(self):
+        """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
+    
+        self.build()
+        filespec = lldb.SBFileSpec("main.swift")
+        target, process, thread, breakpoint1 = lldbutil.run_to_source_breakpoint(
+            self, "break here", filespec
+        )
+        self.expect("expr a", substrs=["(i = 10)"])
+        self.expect("expr b", substrs=["(i = 20)"])
+        self.expect("expr d", substrs=["(i = 30)"])
+        self.expect("expr e", substrs=["(i = 50)"])
+        self.expect("expr f", substrs=["i = 40"])
+        self.expect("expr g", substrs=["i = 60"])
+        self.expect("expr h", substrs=["t = (i = 50)", "u = (i = 70)"])
+        self.expect(
+            "expr complex",
+            substrs=[
+                "t = t {",
+                "t = {",
+                "t = (i = 70)",
+                "u = (i = 30)",
+                "u = t {",
+                "t = (i = 50)",
+            ],
+        )
+    
+    @swiftTest
+    def test_expr_from_generic(self):
+         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
+
+         self.build()
+         filespec = lldb.SBFileSpec("main.swift")
+         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+             self, "break for generic", filespec
+         )
+         self.expect("expr t", substrs=["(i = 10)"])
+         lldbutil.continue_to_breakpoint(process, bkpt)
+         self.expect("expr t", substrs=["(i = 20)"])
+         lldbutil.continue_to_breakpoint(process, bkpt)
+         self.expect("expr t", substrs=["(i = 30)"])
+         lldbutil.continue_to_breakpoint(process, bkpt)
+         self.expect("expr t", substrs=["(i = 50)"])
+         lldbutil.continue_to_breakpoint(process, bkpt)
+         self.expect("expr t", substrs=["(i = 40)"])
+         lldbutil.continue_to_breakpoint(process, bkpt)
+         self.expect("expr t", substrs=["(i = 60)"])
+         lldbutil.continue_to_breakpoint(process, bkpt)
+         self.expect("expr t", substrs=["t = (i = 50)", "u = (i = 70)"])
+         lldbutil.continue_to_breakpoint(process, bkpt)
+         self.expect(
+             "expr t",
+             substrs=[
+                "t = t {",
+                "t = {",
+                "t = (i = 70)",
+                "u = (i = 30)",
+                "u = t {",
+                "t = (i = 50)",
+             ],
+         )

--- a/lldb/test/API/lang/swift/originally_defined_in/main.swift
+++ b/lldb/test/API/lang/swift/originally_defined_in/main.swift
@@ -1,0 +1,109 @@
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct A {
+    let i = 10
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct B {
+    let i = 20
+}
+
+typealias Alias = B
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public enum C {
+    public struct D {
+        let i = 30
+    }
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public enum E<T> {
+    case t(T)
+    case empty
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public class F {
+    let i = 40
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public enum G {
+    case i(Int)
+    case empty
+}
+
+public struct Prop {
+    let i = 50
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct Prop2 {
+    let i = 70
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public struct Pair<T, U> {
+    let t: T
+    let u: U
+}
+
+@_originallyDefinedIn(
+     module: "Other", iOS 2.0, macOS 2.0, tvOS 2.0, watchOS 2.0)
+@available(iOS 1.0, macOS 1.0, tvOS 1.0, watchOS 1.0, *)
+public class ClassPair<T, U> {
+    let t: T
+    let u: U
+    init(t: T, u: U) {
+        self.t = t
+        self.u = u
+    }
+}
+
+func generic<T>(_ t: T) {
+    print("break for generic") 
+}
+
+func f() {
+    let a = A()
+    let b = Alias()
+    let d = C.D()
+    let e = E<Prop>.t(Prop())
+    let f = F()
+    let g = G.i(60)
+    let h = ClassPair(t: Prop(), u: Prop2())
+    let complex = Pair(t: E.t(Pair(t: Prop2(), u: C.D())), u: E.t(Prop()))
+    print("break here")
+}
+
+func g() {
+    generic(A())
+    generic(Alias())
+    generic(C.D())
+    generic(E<Prop>.t(Prop()))
+    generic(F())
+    generic(G.i(60))
+    generic(ClassPair(t: Prop(), u: Prop2()))
+    generic(Pair(t: E.t(Pair(t: Prop2(), u: C.D())), u: E.t(Prop())))
+
+}
+
+f()
+g()


### PR DESCRIPTION
This PR contains two commits:

[lldb] Introduce an ImportedDeclaration

Introduce a debug info independent type, ImportedDeclaration, which is
analogous to DWARF's DW_AT_imported_declaration, as well as a way to
search them by name.

--------------------------------------------------------------------------

[lldb] Handle @_originallyDefinedIn

Types annotated with @_originallyDefinedIn don't live in the module
listed in their mangled name. To account for this, the compiler emits a
DW_TAG_imported_declaration for those types under the name of the
swiftmodule these types can be found at. This patch implements the logic
required to produce the mangled name that can be used in type
reconstruction to successfully find these types.

rdar://137146961