### PR TITLE
[Cherry-pick into swift/release/6.1] [lldb] Fix a regression in Status::GetErrorType()  (#117095)

### DIFF
--- a/lldb/source/Utility/Status.cpp
+++ b/lldb/source/Utility/Status.cpp
@@ -258,7 +258,11 @@ ErrorType Status::GetType() const {
     // Return the first only.
     if (result != eErrorTypeInvalid)
       return;
-    result = ErrorCodeToErrorType(error.convertToErrorCode());
+    if (error.isA<CloneableError>())
+      result = static_cast<const CloneableError &>(error).GetErrorType();
+    else
+      result = ErrorCodeToErrorType(error.convertToErrorCode());
+
   });
   return result;
 }

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -184,6 +184,18 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
         # the first argument are probably stable enough that this test can check for them.
         self.assertIn("void NSLog(NSString *format", value.GetError().GetCString())
 
+    def test_error_type(self):
+        """Test the error reporting in the API"""
+        self.build()
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "// Break here", self.main_source_spec
+        )
+        frame = thread.GetFrameAtIndex(0)
+        value = frame.EvaluateExpression('#error("I am error.")')
+        error = value.GetError()
+        self.assertEqual(error.GetType(), lldb.eErrorTypeExpression)
+
     def test_command_expr_sbdata(self):
         """Test the structured diagnostics data"""
         self.build()


### PR DESCRIPTION
```
commit a3e2f0acdf5ee452c8eb177b56f476b432539e08
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Nov 21 11:11:25 2024 -0800

    [lldb] Fix a regression in Status::GetErrorType()  (#117095)
    
    The refactored code did not correctly determine the type of expression
    errors.
    
    rdar://139699028
```
