### PR TITLE
[🍒 swift/release/6.1] [lldb] Make sure completions don't end with newlines (#117054)

### DIFF
--- a/lldb/include/lldb/Utility/CompletionRequest.h
+++ b/lldb/include/lldb/Utility/CompletionRequest.h
@@ -52,8 +52,8 @@ public:
   public:
     Completion(llvm::StringRef completion, llvm::StringRef description,
                CompletionMode mode)
-        : m_completion(completion.str()), m_descripton(description.str()),
-          m_mode(mode) {}
+        : m_completion(completion.rtrim().str()),
+          m_descripton(description.rtrim().str()), m_mode(mode) {}
     const std::string &GetCompletion() const { return m_completion; }
     const std::string &GetDescription() const { return m_descripton; }
     CompletionMode GetMode() const { return m_mode; }


### PR DESCRIPTION
The logic that prints completions and their descriptions assumes neither the completion itself nor the description ends with a newline. I considered making this an assert, but decided against it as completions can indirectly come from user input (e.g. oddly crafted names). Instead, avoid the potential for mistakes by defensively stripping them.

(cherry picked from commit 4b5a8d6835897477873242ef1ee529d00dedd9a1)