### PR TITLE
[lldb] Fix a regression in SBValue::GetObjectDescription()  (#117242)

### DIFF
--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -380,8 +380,10 @@ const char *SBValue::GetObjectDescription() {
     return nullptr;
 
   llvm::Expected<std::string> str = value_sp->GetObjectDescription();
-  if (!str)
-    return ConstString("error: " + toString(str.takeError())).AsCString();
+  if (!str) {
+    llvm::consumeError(str.takeError());
+    return nullptr;
+  }
   return ConstString(*str).AsCString();
 }
 

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -195,6 +195,10 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
         value = frame.EvaluateExpression('#error("I am error.")')
         error = value.GetError()
         self.assertEqual(error.GetType(), lldb.eErrorTypeExpression)
+        value = frame.FindVariable("f")
+        self.assertTrue(value.IsValid())
+        desc = value.GetObjectDescription()
+        self.assertEqual(desc, None)
 
     def test_command_expr_sbdata(self):
         """Test the structured diagnostics data"""

--- a/lldb/test/API/lang/swift/po/uninitialized/main.swift
+++ b/lldb/test/API/lang/swift/po/uninitialized/main.swift
@@ -15,7 +15,7 @@ class POClass {
 
 func main() {
   var object: POClass
-  object = POClass() //% self.assertTrue(self.frame().FindVariable('object').GetObjectDescription() == 'error: <uninitialized>', 'po correctly detects uninitialized instances')
+  object = POClass() //% self.assertEqual(self.frame().FindVariable('object').GetObjectDescription(), None, 'po correctly detects uninitialized instances'); self.expect("po object", substrs=["<uninitialized>"])
   print("yay I am done") //% self.assertTrue('POClass:' in self.frame().FindVariable('object').GetObjectDescription())
 }
 


### PR DESCRIPTION
The old behavior was to return a null string in the error case,when refactoring the error handling I thought it would be a good idea to print the error in the description, but that breaks clients that try to print a description first and then do something else in the error case. The API is not great but it's clear that in-band errors are also not a good idea.

rdar://133956263
(cherry picked from commit 7553fb127485d034e2ffdbb5461fef2b6f04b989)

 Conflicts:
	lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py