### PR TITLE
[lldb] Prevent a bunch of potential use-after-free with SwiftASTContext

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -567,7 +567,7 @@ SwiftASTContextForExpressions *SwiftREPL::getSwiftASTContext() {
   // our own copy of the AST and using this separate AST for completion.
   //----------------------------------------------------------------------
   if (m_swift_ast)
-    return m_swift_ast;
+    return m_swift_ast.get();
 
   auto type_system_or_err =
       m_target.GetScratchTypeSystemForLanguage(eLanguageTypeSwift, false);
@@ -585,11 +585,9 @@ SwiftASTContextForExpressions *SwiftREPL::getSwiftASTContext() {
   if (!sc_list.GetSize())
     return nullptr;
 
-  auto *target_swift_ast =
-      llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
-          swift_ts->GetSwiftASTContext(sc_list[0]));
-  m_swift_ast = target_swift_ast;
-  return m_swift_ast;
+  m_swift_ast = std::static_pointer_cast<SwiftASTContextForExpressions>(
+      swift_ts->GetSwiftASTContext(sc_list[0]));
+  return m_swift_ast.get();
 }
 
 void SwiftREPL::CompleteCode(const std::string &current_code,

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
@@ -24,6 +24,8 @@ namespace lldb_private {
 
 class IRExecutionUnit;
 class SwiftASTContextForExpressions;
+typedef std::shared_ptr<SwiftASTContextForExpressions>
+    SwiftASTContextForExpressionsSP;
 
 //----------------------------------------------------------------------
 /// @class SwiftREPL SwiftREPL.h "lldb/Expression/SwiftREPL.h"
@@ -78,7 +80,7 @@ protected:
                     CompletionRequest &request) override;
 
 private:
-  SwiftASTContextForExpressions *m_swift_ast = nullptr;
+  SwiftASTContextForExpressionsSP m_swift_ast;
   bool m_completion_module_initialized = false;
 };
 }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -742,9 +742,11 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                        target->GetExecutableModule());
   else
     sc = frame->GetSymbolContext(lldb::eSymbolContextFunction);
-  auto *swift_ast_ctx = m_swift_scratch_ctx->GetSwiftASTContext(sc);
-  m_swift_ast_ctx =
-      llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(swift_ast_ctx);
+  auto swift_ast_ctx = m_swift_scratch_ctx->GetSwiftASTContext(sc);
+  if (llvm::dyn_cast_or_null<SwiftASTContextForExpressions>(
+          swift_ast_ctx.get()))
+    m_swift_ast_ctx =
+        std::static_pointer_cast<SwiftASTContextForExpressions>(swift_ast_ctx);
 
   if (!m_swift_ast_ctx)
     return error("could not create a Swift AST context");

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.h
@@ -190,7 +190,7 @@ private:
   };
 
   TypeSystemSwiftTypeRefForExpressionsSP m_swift_scratch_ctx;
-  SwiftASTContextForExpressions *m_swift_ast_ctx;
+  SwiftASTContextForExpressionsSP m_swift_ast_ctx;
   PersistentVariableDelegate m_persistent_variable_delegate;
   std::unique_ptr<SwiftExpressionParser> m_parser;
   std::optional<SwiftLanguageRuntime::GenericSignature> m_generic_signature;

--- a/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/MainThreadChecker/InstrumentationRuntimeMainThreadChecker.cpp
@@ -105,7 +105,7 @@ static std::string TranslateObjCNameToSwiftName(std::string className,
     sc = &swiftFrame->GetSymbolContext(eSymbolContextFunction);
   if (!sc)
     return "";
-  auto *ctx = ts->GetSwiftASTContext(*sc);
+  auto ctx = ts->GetSwiftASTContext(*sc);
   if (!ctx)
     return "";
   swift::ClangImporter *imp = ctx->GetClangImporter();

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1355,7 +1355,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
               auto &sc =
                   frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
               if (scratch_ctx)
-                if (SwiftASTContext *ast_ctx =
+                if (SwiftASTContextSP ast_ctx =
                         scratch_ctx->GetSwiftASTContext(sc)) {
                   ConstString cs_input{input};
                   Mangled mangled(cs_input);
@@ -1424,7 +1424,7 @@ std::unique_ptr<Language::TypeScavenger> SwiftLanguage::GetTypeScavenger() {
               const SymbolContext &sc =
                   frame_sp->GetSymbolContext(lldb::eSymbolContextFunction);
               if (scratch_ctx)
-                if (SwiftASTContext *ast_ctx =
+                if (SwiftASTContextSP ast_ctx =
                         scratch_ctx->GetSwiftASTContext(sc)) {
                   auto iter = ast_ctx->GetModuleCache().begin(),
                        end = ast_ctx->GetModuleCache().end();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1200,7 +1200,7 @@ SwiftLanguageRuntime::GetLanguageSpecificData(SymbolContext sc) {
 
   if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
           type_system_or_err->get()))
-    if (auto *swift_ast_ctx = ts->GetSwiftASTContextOrNull(sc))
+    if (auto swift_ast_ctx = ts->GetSwiftASTContextOrNull(sc))
       dict_sp->AddBooleanItem("SwiftExplicitModules",
                               swift_ast_ctx->HasExplicitModules());
 
@@ -1229,7 +1229,7 @@ void SwiftLanguageRuntime::FindFunctionPointersInCall(
   auto scratch_ctx = TypeSystemSwiftTypeRefForExpressions::GetForTarget(target);
   if (!scratch_ctx)
     return;
-  SwiftASTContext *swift_ast = scratch_ctx->GetSwiftASTContext(sc);
+  SwiftASTContextSP swift_ast = scratch_ctx->GetSwiftASTContext(sc);
   if (!swift_ast)
     return;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -193,7 +193,7 @@ ConstString SwiftLanguageRuntimeImpl::GetDynamicTypeName_ClassRemoteAST(
       in_value.GetTargetSP());
   if (!ts)
     return {};
-  SwiftASTContext *swift_ast_ctx = ts->GetSwiftASTContext(sc);
+  SwiftASTContextSP swift_ast_ctx = ts->GetSwiftASTContext(sc);
   if (!swift_ast_ctx)
     return {};
 
@@ -232,7 +232,7 @@ SwiftLanguageRuntimeImpl::GetDynamicTypeAndAddress_ExistentialRemoteAST(
   if (!stack_frame_sp)
     return {};
   auto &sc = stack_frame_sp->GetSymbolContext(eSymbolContextFunction);
-  SwiftASTContext *swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
+  SwiftASTContextSP swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
   if (!swift_ast_ctx)
     return {};
 
@@ -285,7 +285,7 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
   if (!scratch_ctx)
     return base_type;
 
-  SwiftASTContext *swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
+  SwiftASTContextSP swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
   if (!swift_ast_ctx)
     return base_type;
   base_type = swift_ast_ctx->ImportType(base_type, error);
@@ -407,7 +407,7 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
 
     target_swift_type = target_swift_type.subst(
         [this, &stack_frame,
-         &swift_ast_ctx](swift::SubstitutableType *type) -> swift::Type {
+         swift_ast_ctx](swift::SubstitutableType *type) -> swift::Type {
           StreamString type_name;
           if (!SwiftLanguageRuntime::GetAbstractTypeName(type_name, type))
             return type;
@@ -460,7 +460,7 @@ CompilerType SwiftLanguageRuntimeImpl::MetadataPromise::FulfillTypePromise(
       *error = Status::FromErrorString("couldn't get Swift scratch context");
     return CompilerType();
   }
-  SwiftASTContext *swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
+  SwiftASTContextSP swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
   if (!swift_ast_ctx) {
     if (error)
       *error = Status::FromErrorString("couldn't get Swift scratch context");
@@ -497,7 +497,7 @@ SwiftLanguageRuntimeImpl::GetMetadataPromise(const SymbolContext &sc,
       for_object.GetTargetSP());
   if (!scratch_ctx)
     return nullptr;
-  SwiftASTContext *swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
+  SwiftASTContextSP swift_ast_ctx = scratch_ctx->GetSwiftASTContext(sc);
   if (!swift_ast_ctx)
     return nullptr;
   if (swift_ast_ctx->HasFatalErrors())

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -218,7 +218,7 @@ public:
   
   bool SupportsLanguage(lldb::LanguageType language) override;
 
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override {
+  SwiftASTContextSP GetSwiftASTContext(const SymbolContext &sc) const override {
     return GetTypeSystemSwiftTypeRef().GetSwiftASTContext(sc);
   }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -29,8 +29,17 @@ class Decl;
 namespace lldb_private {
 class TypeSystemClang;
 class SwiftASTContext;
+class SwiftASTContextForExpressions;
+class TypeSystemSwift;
 class TypeSystemSwiftTypeRef;
 class TypeSystemSwiftTypeRefForExpressions;
+typedef std::shared_ptr<TypeSystemSwift> TypeSystemSwiftSP;
+typedef std::shared_ptr<TypeSystemSwiftTypeRefForExpressions>
+    TypeSystemSwiftTypeRefForExpressionsSP;
+typedef std::shared_ptr<SwiftASTContext> SwiftASTContextSP;
+typedef std::shared_ptr<SwiftASTContextForExpressions>
+    SwiftASTContextForExpressionsSP;
+
 /// The implementation of lldb::Type's m_payload field for TypeSystemSwift.
 class TypePayloadSwift {
   /// Layout: bit 1 ... IsFixedValueBuffer.
@@ -116,7 +125,7 @@ public:
 
   const std::string &GetDescription() const { return m_description; }
   static LanguageSet GetSupportedLanguagesForTypes();
-  virtual SwiftASTContext *
+  virtual SwiftASTContextSP
   GetSwiftASTContext(const SymbolContext &sc) const = 0;
   virtual TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() = 0;
   virtual const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const = 0;
@@ -327,10 +336,6 @@ protected:
   /// The module this typesystem belongs to if any.
   Module *m_module = nullptr;
 };
-
-typedef std::shared_ptr<TypeSystemSwift> TypeSystemSwiftSP;
-typedef std::shared_ptr<TypeSystemSwiftTypeRefForExpressions>
-    TypeSystemSwiftTypeRefForExpressionsSP;
 
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -22,6 +22,7 @@
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "TypeSystemSwiftTypeRef.h"
 #include "lldb/Core/Debugger.h"
 #include "lldb/Core/DumpDataExtractor.h"
 #include "lldb/Host/StreamFile.h"
@@ -1731,7 +1732,7 @@ Status TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
   if (auto target_sp = sc.target_sp)
     process_sp = target_sp->GetProcessSP();
 
-  if (auto *swift_ast_ctx = GetSwiftASTContextOrNull(sc))
+  if (auto swift_ast_ctx = GetSwiftASTContextOrNull(sc))
     swift_ast_ctx->PerformCompileUnitImports(sc, process_sp, status);
   return status;
 }
@@ -1806,7 +1807,7 @@ SymbolContext TypeSystemSwiftTypeRef::GetSymbolContext(
   return sc;
 }
 
-SwiftASTContext *
+SwiftASTContextSP
 TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext &sc) const {
   if (!sc.module_sp) {
     LLDB_LOGV(GetLog(LLDBLog::Types),
@@ -1824,7 +1825,7 @@ TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext &sc) const {
     // there is no point in trying to initialize when that happens.
     if (!it->second.typesystem)
       return nullptr;
-    return llvm::cast<SwiftASTContext>(it->second.typesystem.get());
+    return std::static_pointer_cast<SwiftASTContext>(it->second.typesystem);
   }
 
   // Create a new SwiftASTContextForExpressions.
@@ -1832,11 +1833,11 @@ TypeSystemSwiftTypeRef::GetSwiftASTContext(const SymbolContext &sc) const {
       sc, *const_cast<TypeSystemSwiftTypeRef *>(this));
   m_swift_ast_context_map.insert({key, {ts, 0}});
 
-  auto *swift_ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(ts.get());
+  auto swift_ast_context = std::static_pointer_cast<SwiftASTContext>(ts);
   return swift_ast_context;
 }
 
-SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
+SwiftASTContextSP TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
     const SymbolContext &sc) const {
   if (!sc.module_sp) {
     LLDB_LOGV(GetLog(LLDBLog::Types),
@@ -1859,8 +1860,8 @@ SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
       // there is no point in trying to initialize when that happens.
       if (!it->second.typesystem)
         return nullptr;
-      auto *swift_ast_ctx =
-          llvm::cast<SwiftASTContext>(it->second.typesystem.get());
+      auto swift_ast_ctx =
+          std::static_pointer_cast<SwiftASTContext>(it->second.typesystem);
       if (!swift_ast_ctx->HasFatalErrors())
         return swift_ast_ctx;
 
@@ -1886,10 +1887,10 @@ SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
   }
 
   // Now perform the initial imports. This step can be very expensive.
-  auto *swift_ast_context = llvm::dyn_cast_or_null<SwiftASTContext>(ts.get());
+  auto swift_ast_context = std::static_pointer_cast<SwiftASTContext>(ts);
   if (!swift_ast_context)
     return nullptr;
-  assert(llvm::isa<SwiftASTContextForExpressions>(swift_ast_context));
+  assert(llvm::isa<SwiftASTContextForExpressions>(swift_ast_context.get()));
 
   auto perform_initial_import = [&](const SymbolContext &sc) {
     Status error;
@@ -1909,25 +1910,25 @@ SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
   return swift_ast_context;
 }
 
-SwiftASTContext *TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull(
+SwiftASTContextSP TypeSystemSwiftTypeRef::GetSwiftASTContextOrNull(
     const SymbolContext &sc) const {
   std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
   const char *key = nullptr;
   auto it = m_swift_ast_context_map.find(key);
   if (it != m_swift_ast_context_map.end())
-    return llvm::cast_or_null<SwiftASTContext>(it->second.typesystem.get());
-  return nullptr;
+    return std::static_pointer_cast<SwiftASTContext>(it->second.typesystem);
+  return {};
 }
 
-SwiftASTContext *TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContextOrNull(
+SwiftASTContextSP TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContextOrNull(
     const SymbolContext &sc) const {
   const char *key = DeriveKeyFor(sc);
 
   std::lock_guard<std::mutex> guard(m_swift_ast_context_lock);
   auto it = m_swift_ast_context_map.find(key);
   if (it != m_swift_ast_context_map.end())
-    return llvm::cast_or_null<SwiftASTContext>(it->second.typesystem.get());
-  return nullptr;
+    return std::static_pointer_cast<SwiftASTContext>(it->second.typesystem);
+  return {};
 }
 
 SwiftDWARFImporterForClangTypes &
@@ -1964,7 +1965,7 @@ void TypeSystemSwiftTypeRef::SetTriple(const SymbolContext &sc,
                                        const llvm::Triple triple) {
   // This function appears to be only called via
   // Module::SetArchitecture(ArchSpec).
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull(sc))
+  if (auto swift_ast_context = GetSwiftASTContextOrNull(sc))
     swift_ast_context->SetTriple(sc, triple);
 }
 
@@ -1997,7 +1998,7 @@ void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
   if (m_dangerous_types.count(key))
     return nullptr;
 
-  auto *swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx));
+  auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx));
   if (!swift_ast_context || swift_ast_context->HasFatalErrors())
     return nullptr;
   void *result = llvm::expectedToStdOptional(swift_ast_context->ReconstructType(
@@ -2022,7 +2023,7 @@ void *TypeSystemSwiftTypeRef::ReconstructType(
 CompilerType
 TypeSystemSwiftTypeRef::ReconstructType(CompilerType type,
                                         const ExecutionContext *exe_ctx) {
-  if (auto *swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+  if (auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
     if (auto ts =
             type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>())
       return {{swift_ast_context->weak_from_this()},
@@ -2056,7 +2057,7 @@ bool TypeSystemSwiftTypeRef::SupportsLanguage(lldb::LanguageType language) {
 Status TypeSystemSwiftTypeRef::IsCompatible() {
   // This is called only from SBModule.
   // Currently basically a noop, since the module isn't being passed in.
-  if (auto *swift_ast_context = GetSwiftASTContext(SymbolContext()))
+  if (auto swift_ast_context = GetSwiftASTContext(SymbolContext()))
     return swift_ast_context->IsCompatible();
   return {};
 }
@@ -2064,7 +2065,7 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               const SymbolContext &sc) const {
   // This gets called only from Thread::FrameSelectedCallback(StackFrame).
-  if (auto *swift_ast_context = GetSwiftASTContextOrNull(sc))
+  if (auto swift_ast_context = GetSwiftASTContextOrNull(sc))
     swift_ast_context->DiagnoseWarnings(process, sc);
 }
 
@@ -2401,7 +2402,7 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
     auto target_sp = GetTargetWP().lock();                                     \
     if (!target_sp)                                                            \
       return result;                                                           \
-    auto *swift_ast_ctx = GetSwiftASTContext(                                  \
+    auto swift_ast_ctx = GetSwiftASTContext(                                   \
         SymbolContext(target_sp, target_sp->GetExecutableModule()));           \
     if (!swift_ast_ctx)                                                        \
       return result;                                                           \
@@ -2487,7 +2488,7 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
 #define FORWARD_TO_EXPRAST_ONLY(FUNC, ARGS, DEFAULT_RETVAL)                    \
   do {                                                                         \
     if (auto target_sp = GetTargetWP().lock())                                 \
-      if (auto *swift_ast_ctx = GetSwiftASTContext(                            \
+      if (auto swift_ast_ctx = GetSwiftASTContext(                            \
               SymbolContext(target_sp, target_sp->GetExecutableModule())))     \
         return swift_ast_ctx->FUNC ARGS;                                       \
     return DEFAULT_RETVAL;                                                     \
@@ -2900,7 +2901,7 @@ uint32_t TypeSystemSwiftTypeRef::GetTypeInfo(
     uint32_t flags = CollectTypeInfo(dem, node, unresolved_typealias);
     if (unresolved_typealias)
       if (auto target_sp = GetTargetWP().lock())
-        if (auto *swift_ast_ctx = GetSwiftASTContext(
+        if (auto swift_ast_ctx = GetSwiftASTContext(
                 SymbolContext(target_sp, target_sp->GetExecutableModule())))
           // If this is a typealias defined in the expression evaluator,
           // then we don't have debug info to resolve it from.
@@ -3160,7 +3161,7 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                 "Couldn't compute size of type %s using SwiftLanguageRuntime.",
                 AsMangledName(type));
 
-      if (auto *swift_ast_context =
+      if (auto swift_ast_context =
               GetSwiftASTContext(GetSymbolContext(exe_scope)))
         return swift_ast_context->GetBitSize(ReconstructType(type, exe_scope),
                                              exe_scope);
@@ -3207,7 +3208,7 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
     LLDB_LOGF(GetLog(LLDBLog::Types),
               "Couldn't compute stride of type %s using SwiftLanguageRuntime.",
               AsMangledName(type));
-    if (auto *swift_ast_context =
+    if (auto swift_ast_context =
             GetSwiftASTContext(GetSymbolContext(exe_scope)))
       return swift_ast_context->GetByteStride(ReconstructType(type), exe_scope);
     return {};
@@ -3329,7 +3330,7 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
             AsMangledName(type));
 
   // Try SwiftASTContext.
-  if (auto *swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+  if (auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
     if (auto n = llvm::expectedToStdOptional(swift_ast_context->GetNumChildren(
             ReconstructType(type, exe_ctx), omit_empty_base_classes,
             exe_ctx))) {
@@ -3390,7 +3391,7 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
             "Using SwiftASTContext::GetNumFields fallback for type %s",
             AsMangledName(type));
 
-  if (auto *swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+  if (auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
     return swift_ast_context->GetNumFields(ReconstructType(type, exe_ctx), exe_ctx);
   return {};
 }
@@ -3464,7 +3465,7 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     LLDB_LOG(GetLog(LLDBLog::Types),
              "Had to engage SwiftASTContext fallback for type {0}, field #{1}.",
              AsMangledName(type), idx);
-    if (auto *swift_ast_context =
+    if (auto swift_ast_context =
             GetSwiftASTContext(GetSymbolContext(exe_ctx)))
       return swift_ast_context->GetChildCompilerTypeAtIndex(
           ReconstructType(type, exe_ctx), exe_ctx, idx, transparent_pointers,
@@ -3479,7 +3480,7 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
   auto get_ast_num_children = [&]() {
     if (ast_num_children)
       return *ast_num_children;
-    if (auto *swift_ast_context =
+    if (auto swift_ast_context =
             GetSwiftASTContext(GetSymbolContext(exe_ctx)))
       ast_num_children = llvm::expectedToStdOptional(
           swift_ast_context->GetNumChildren(ReconstructType(type, exe_ctx),
@@ -3790,7 +3791,7 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
             "type %s",
             AsMangledName(type));
 
-  if (auto *swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
+  if (auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx)))
     return swift_ast_context->GetIndexOfChildMemberWithName(
         ReconstructType(type, exe_ctx), name, exe_ctx, omit_empty_base_classes,
         child_indexes);
@@ -4087,7 +4088,7 @@ TypeSystemSwiftTypeRef::GetInstanceType(opaque_compiler_type_t type,
       // type alias isn't possible, or the user might have defined the
       // type alias in the REPL. In these cases, fallback to asking the AST
       // for the canonical type.
-      if (auto *swift_ast_context =
+      if (auto swift_ast_context =
               GetSwiftASTContext(GetSymbolContext(exe_scope)))
         return swift_ast_context->GetInstanceType(
             ReconstructType(type, exe_scope), exe_scope);
@@ -4219,7 +4220,7 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
     auto target_sp = GetTargetWP().lock();
     if (!target_sp)
       return result;
-    auto *swift_ast_ctx = GetSwiftASTContext(
+    auto swift_ast_ctx = GetSwiftASTContext(
         SymbolContext(target_sp, target_sp->GetExecutableModule()));
     if (!swift_ast_ctx)
       return result;
@@ -4331,7 +4332,7 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
 
   // Also dump the swift ast context info, as this functions should not be in
   // any critical path.
-  if (auto *swift_ast_context =
+  if (auto swift_ast_context =
           GetSwiftASTContext(GetSymbolContext(exe_scope))) {
     s->PutCString("Source code info:\n");
     swift_ast_context->DumpTypeDescription(
@@ -4467,7 +4468,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
 
       // No result available from the runtime, fallback to the AST. This occurs
       // for some Clang imported enums.
-      if (auto *swift_ast_context =
+      if (auto swift_ast_context =
               GetSwiftASTContext(GetSymbolContext(exe_scope))) {
         ExecutionContext exe_ctx;
         exe_scope->CalculateExecutionContext(exe_ctx);
@@ -4486,7 +4487,7 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       // SwiftASTContext couldn't resolve. This happens for ObjC
       // typedefs such as CFString in the REPL. More investigation is
       // needed.
-      if (auto *swift_ast_context =
+      if (auto swift_ast_context =
               GetSwiftASTContext(GetSymbolContext(exe_scope)))
         return swift_ast_context->DumpTypeValue(
             ReconstructType(type, exe_scope), s, format, data, data_offset,
@@ -4589,10 +4590,10 @@ TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
     // If this is an expression context, perhaps the type was
     // defined in the expression. In that case we don't have debug
     // info for it, so defer to SwiftASTContext.
-    if (llvm::isa_and_nonnull<SwiftASTContextForExpressions>(
-            GetSwiftASTContext(GetSymbolContext(exe_scope)))) {
+    if (llvm::isa<TypeSystemSwiftTypeRefForExpressions>(this)) {
       ExecutionContext exe_ctx;
-      if (exe_scope)exe_scope->CalculateExecutionContext(exe_ctx);
+      if (exe_scope)
+        exe_scope->CalculateExecutionContext(exe_ctx);
       return ReconstructType({weak_from_this(), type}, &exe_ctx)
           .GetTypeBitAlign(exe_scope);
     }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -68,12 +68,12 @@ public:
   ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   /// Get the corresponding SwiftASTContext, and create one if necessary.
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override;
+  SwiftASTContextSP GetSwiftASTContext(const SymbolContext &sc) const override;
   /// Convenience helpers.
   SymbolContext GetSymbolContext(ExecutionContextScope *exe_scope) const;
   SymbolContext GetSymbolContext(const ExecutionContext *exe_ctx) const;
   /// Return SwiftASTContext, iff one has already been created.
-  virtual SwiftASTContext *
+  virtual SwiftASTContextSP
   GetSwiftASTContextOrNull(const SymbolContext &sc) const;
   TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() override { return *this; }
   const TypeSystemSwiftTypeRef &GetTypeSystemSwiftTypeRef() const override {
@@ -541,8 +541,8 @@ public:
   static TypeSystemSwiftTypeRefForExpressionsSP
   GetForTarget(lldb::TargetSP target);
 
-  SwiftASTContext *GetSwiftASTContext(const SymbolContext &sc) const override;
-  SwiftASTContext *
+  SwiftASTContextSP GetSwiftASTContext(const SymbolContext &sc) const override;
+  SwiftASTContextSP
   GetSwiftASTContextOrNull(const SymbolContext &sc) const override;
   /// This API needs to be called for a REPL or Playground before the first call
   /// to GetSwiftASTContext is being made.


### PR DESCRIPTION
TypeSystemSwiftTypeRef::GetSwiftASTContext() may destroy and recreate any of the SwiftASTContexts in its map of contexts, so clients need to hold on to a shared pointer to avoid another thread destroying the context while it is in use.

rdar://71278998