### PR TITLE
Add information on swiftmodule load times to statistics dump command

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1165,6 +1165,25 @@ static void printASTValidationError(
     LLDB_LOG(log, "  -- {0}", ExtraOpt);
 }
 
+std::optional<llvm::json::Value> SwiftASTContext::ReportStatistics() {
+  const auto &load_times = GetSwiftModuleLoadTimes();
+  llvm::json::Array swift_module_load_times;
+  StatsDuration swift_module_total_load_time;
+  for (const auto &entry : load_times) {
+    llvm::json::Object obj;
+    obj.try_emplace("name", entry.first().str());
+    obj.try_emplace("loadTime", entry.second.get().count());
+    swift_module_total_load_time += entry.second;
+    swift_module_load_times.emplace_back(std::move(obj));
+  }
+
+  llvm::json::Object obj;
+  obj.try_emplace("swiftmodules", std::move(swift_module_load_times));
+  obj.try_emplace("totalLoadTime", swift_module_total_load_time.get().count());
+  llvm::json::Value ret = std::move(obj);
+  return ret;
+}
+
 void SwiftASTContext::DiagnoseWarnings(Process &process,
                                        const SymbolContext &sc) const {
   if (!sc.module_sp || !HasDiagnostics())
@@ -4025,6 +4044,10 @@ swift::ModuleDecl *SwiftASTContext::GetModule(const SourceModule &module,
       *cached = true;
     return module_decl;
   }
+
+  auto &load_time_map = GetSwiftModuleLoadTimes();
+  StatsDuration &load_time = load_time_map[module.path.front().GetStringRef()];
+  ElapsedTime elapsed(load_time);
 
   LLDB_SCOPED_TIMER();
   ThreadSafeASTContext ast = GetASTContext();

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -21,6 +21,8 @@
 #include "lldb/Core/ThreadSafeDenseSet.h"
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Utility/Either.h"
+#include "lldb/Target/Statistics.h"
+#include "llvm/Support/JSON.h"
 
 #include "swift/AST/Import.h"
 #include "swift/AST/Module.h"
@@ -546,6 +548,15 @@ public:
 
   const SwiftModuleMap &GetModuleCache() { return m_swift_module_cache; }
 
+
+  typedef llvm::StringMap<StatsDuration> SwiftModuleLoadTimeMap;
+
+  SwiftModuleLoadTimeMap &GetSwiftModuleLoadTimes() {
+    return m_swift_module_load_time_map;
+  }
+
+  std::optional<llvm::json::Value> ReportStatistics() override;
+
   const swift::irgen::TypeInfo *
   GetSwiftTypeInfo(lldb::opaque_compiler_type_t type);
 
@@ -935,6 +946,7 @@ protected:
   std::shared_ptr<TypeSystemClang> m_clangimporter_typesystem;
   std::unique_ptr<swift::DWARFImporterDelegate> m_dwarfimporter_delegate_up;
   SwiftModuleMap m_swift_module_cache;
+  SwiftModuleLoadTimeMap m_swift_module_load_time_map;
   SwiftTypeFromMangledNameMap m_mangled_name_to_type_map;
   SwiftMangledNameFromTypeMap m_type_to_mangled_name_map;
   uint32_t m_pointer_byte_size = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2033,6 +2033,13 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
   return {};
 }
 
+std::optional<llvm::json::Value> TypeSystemSwiftTypeRef::ReportStatistics() {
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull()) {
+    return swift_ast_context->ReportStatistics();
+  }
+  return llvm::None;
+}
+
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               const SymbolContext &sc) const {
   // This gets called only from Thread::FrameSelectedCallback(StackFrame).

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -88,6 +88,8 @@ public:
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
 
+  std::optional<llvm::json::Value> ReportStatistics() override;
+
   /// Return a SwiftASTContext type for type.
   CompilerType ReconstructType(CompilerType type,
                                const ExecutionContext *exe_ctx);

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -198,6 +198,10 @@ TypeSystem::DeclGetCompilerContext(void *opaque_decl) {
   return {};
 }
 
+std::optional<llvm::json::Value> TypeSystem::ReportStatistics() {
+  return std::nullopt;
+}
+
 std::vector<lldb_private::CompilerContext>
 TypeSystem::DeclContextGetCompilerContext(void *opaque_decl_ctx) {
   return {};


### PR DESCRIPTION
This is based on the PR https://github.com/swiftlang/llvm-project/pull/5540 that was approved but never merged upstream.

At Meta, we make extensive use of the statistics dump command. One thing we want to track is how long each swiftmodule took to load. We've been using a version of these patches internally for a while and have found them to be useful enough to upstream.