### PR TITLE
 Add information on swiftmodule load times to statistics dump command

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -21,6 +21,8 @@
 #include "lldb/Core/ThreadSafeDenseSet.h"
 #include "lldb/Expression/DiagnosticManager.h"
 #include "lldb/Utility/Either.h"
+#include "lldb/Target/Statistics.h"
+#include "llvm/Support/JSON.h"
 
 #include "swift/AST/Import.h"
 #include "swift/AST/Module.h"
@@ -553,6 +555,15 @@ public:
 
   const SwiftModuleMap &GetModuleCache() { return m_swift_module_cache; }
 
+
+  typedef llvm::StringMap<StatsDuration> SwiftModuleLoadTimeMap;
+
+  SwiftModuleLoadTimeMap &GetSwiftModuleLoadTimes() {
+    return m_swift_module_load_time_map;
+  }
+
+  std::optional<llvm::json::Value> ReportStatistics() override;
+
   const swift::irgen::TypeInfo *
   GetSwiftTypeInfo(lldb::opaque_compiler_type_t type);
 
@@ -942,6 +953,7 @@ protected:
   std::shared_ptr<TypeSystemClang> m_clangimporter_typesystem;
   std::unique_ptr<swift::DWARFImporterDelegate> m_dwarfimporter_delegate_up;
   SwiftModuleMap m_swift_module_cache;
+  SwiftModuleLoadTimeMap m_swift_module_load_time_map;
   SwiftTypeFromMangledNameMap m_mangled_name_to_type_map;
   SwiftMangledNameFromTypeMap m_type_to_mangled_name_map;
   uint32_t m_pointer_byte_size = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2061,6 +2061,15 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
   return {};
 }
 
+std::optional<llvm::json::Value> TypeSystemSwiftTypeRef::ReportStatistics() {
+  // This SymbolContext is not being used within the function GetSwiftASTContextOrNull
+  SymbolContext sc;
+  if (auto *swift_ast_context = GetSwiftASTContextOrNull(sc)) {
+    return swift_ast_context->ReportStatistics();
+  }
+  return std::nullopt;
+}
+
 void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
                                               const SymbolContext &sc) const {
   // This gets called only from Thread::FrameSelectedCallback(StackFrame).

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -86,6 +86,8 @@ public:
   void ClearModuleDependentCaches() override;
   lldb::TargetWP GetTargetWP() const override { return {}; }
 
+  std::optional<llvm::json::Value> ReportStatistics() override;
+
   /// Return a SwiftASTContext type for type.
   CompilerType ReconstructType(CompilerType type,
                                const ExecutionContext *exe_ctx);


### PR DESCRIPTION
This is based on the PR https://github.com/swiftlang/llvm-project/pull/5540 that was approved but never merged upstream.

At Meta, we make extensive use of the statistics dump command. One thing we want to track is how long each swiftmodule took to load. We've been using a version of these patches internally for a while and have found them to be useful enough to upstream.