### PR TITLE
[target] .swift_ast section is a metadata section

### DIFF
--- a/llvm/lib/Target/TargetLoweringObjectFile.cpp
+++ b/llvm/lib/Target/TargetLoweringObjectFile.cpp
@@ -213,7 +213,8 @@ SectionKind TargetLoweringObjectFile::getKindForGlobal(const GlobalObject *GO,
   // Global variables require more detailed analysis.
   const auto *GVar = cast<GlobalVariable>(GO);
 
-  if (GVar->getSection() == ".swift1_autolink_entries")
+  if (GVar->getSection() == ".swift1_autolink_entries" ||
+      GVar->getSection() == ".swift_ast")
     return SectionKind::getMetadata();
 
   // Handle thread-local data first.

--- a/llvm/test/Object/swift-sectionkind-elf.ll
+++ b/llvm/test/Object/swift-sectionkind-elf.ll
@@ -1,0 +1,9 @@
+; RUN: llc -mtriple x86_64-unknown-linux-gnu -filetype asm -o - %s | FileCheck %s
+; REQUIRES: x86-registered-target
+
+@__Swift_AST = internal constant [8 x i8] c"test.ast", section ".swift_ast", align 4
+@_swift1_autolink_entries = private constant [0 x i8] zeroinitializer, section ".swift1_autolink_entries", no_sanitize_address, align 8
+@llvm.used = appending global [2 x ptr] [ptr @__Swift_AST, ptr @_swift1_autolink_entries], section "llvm.metadata"
+
+; CHECK: .section .swift_ast,"R"
+; CHECK: .section .swift1_autolink_entries,"eR"


### PR DESCRIPTION
This change ensures that this section is not marked as loadable, which makes it possible for it to be stripped. The swift_ast section holds the raw Swift module bytes that are needed by LLDB, but that are not required at runtime.

(cherry picked from commit 555eaef3ab34108b68631411f0ec8464ee45af0a)