### PR TITLE
Revert "[lldb][test] Renable tests on asan builds"

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfAsan # rdar://138777205
 class TestCase(lldbtest.TestBase):
     @swiftTest
     @skipIf(oslist=["windows", "linux"])

--- a/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_out/TestSteppingOutAsync.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import re
 
 
+@skipIfAsan # rdar://138777205
 class TestCase(lldbtest.TestBase):
 
     def check_and_get_frame_names(self, process):

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfAsan  # rdar://138777205
 class TestCase(lldbtest.TestBase):
 
     def check_is_in_line(self, thread, linenum):

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfAsan  # rdar://138777205
 class TestCase(lldbtest.TestBase):
 
     def check_is_in_line(self, thread, linenum):

--- a/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
+++ b/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
 
+@skipIfAsan # rdar://138777205
 class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
     @swiftTest
     @skipIfWindows


### PR DESCRIPTION
This reverts commit 099c989dd8041807e4611defe685143d4749e296.

While the underlying issue was fixed, it requires a debugserver that contains the fix. Tests don't use the just-built debugserver. Sadly there is no way to specify a conjunction for the annotations (`skipif system version < x & skipifasan`), which would be a more targeted skip.