### PR TITLE
[cherry-pick][lldb][swift] Update tests to account for more accurate codegen

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -26,8 +26,6 @@ class TestCase(lldbtest.TestBase):
         expected_line_nums = [4]  # print(x)
         expected_line_nums += [5, 6, 7, 5, 6, 7, 5]  # two runs over the loop
         expected_line_nums += [8, 9]  # if line + if block
-        # FIXME: IRGen is producing incorrected line numbers. rdar://139826231
-        expected_line_nums[-1] = 11
         for expected_line_num in expected_line_nums:
             thread.StepOver()
             stop_reason = thread.GetStopReason()

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -220,35 +220,10 @@ class TestSwiftStepping(lldbtest.TestBase):
         self.hit_correct_line(thread, "Second case with a where statement")
 
         thread.StepOver()
-        thread.StepOver()
         self.hit_correct_line(
             thread, "print in second case with where statement.")
 
-        #
-        # For some reason, we don't step from the body of the case to
-        # the end of the switch, but back to the case: statement, and
-        # then directly out of the switch.
-        #
         thread.StepOver()
-        steps_back_to_case = self.hit_correct_line(
-            thread,
-            "Sometimes the line table steps to here "
-            "after the body of the case.", False)
-        if steps_back_to_case:
-            self.fail(
-                "Stepping past a taken body of a case statement should not "
-                "step back to the case statement.")
-
-        if self.hit_correct_line(
-                thread,
-                "This is the end of the switch statement", False):
-            thread.StepOver()
-        elif not self.hit_correct_line(
-                thread, "Make a version of P that conforms directly", False):
-            self.fail(
-                "Stepping past the body of the case didn't stop "
-                "where expected.")
-
         self.hit_correct_line(
             thread, "Make a version of P that conforms directly")
 

--- a/lldb/test/API/lang/swift/stepping/main.swift
+++ b/lldb/test/API/lang/swift/stepping/main.swift
@@ -191,12 +191,12 @@ func main () -> Void
         case (let x, let y) where  
                 return_same(x) == return_same(y): // First case with a where statement.
             print("(\(x), \(y)) is on the line x == y")
-        case (let x, let y) where // Sometimes the line table steps to here after the body of the case. 
+        case (let x, let y) where
                 return_same(x) == -return_same(y): // Second case with a where statement.
             print("(\(x), \(y)) is on the line x == -y") // print in second case with where statement.
         case (let x, let y):
             print("Position is: (\(x), \(y))")
-    }  // This is the end of the switch statement
+    }
 
     var direct : P = ConformsDirectly() // Make a version of P that conforms directly
     direct.protocol_func(10)


### PR DESCRIPTION
With [0], more accurate line numbers are generated; as such, some LLDB tests need to be updated.

[0]: https://github.com/swiftlang/swift/pull/77655

(cherry picked from commit 80df1f081b48da207fe1ffdfec5d2f82330e2c8e)