### PR TITLE
[lldb] Adapt lldb to new ASTMangler constructor

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1490,10 +1490,11 @@ bool SwiftExpressionParser::Complete(CompletionRequest &request, unsigned line,
 /// system.
 static bool
 RedirectCallFromSinkToTrampolineFunction(llvm::Module &module,
-                                         SwiftASTManipulator &manipulator) {
+                                         SwiftASTManipulator &manipulator,
+                                         swift::ASTContext &ast_ctx) {
   Log *log = GetLog(LLDBLog::Expressions);
 
-  swift::Mangle::ASTMangler mangler;
+  swift::Mangle::ASTMangler mangler(ast_ctx);
   auto *entrypoint_decl = manipulator.GetEntrypointDecl();
   if (!entrypoint_decl) {
     LLDB_LOG(log, "[RedirectCallFromSinkToTrampolineFunction] Could not set "
@@ -2071,16 +2072,18 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
     LLDB_LOG(log, "Generated IR module:\n{0}", s);
   }
 
-  if (m_options.GetBindGenericTypes() == lldb::eDontBind &&
-      !RedirectCallFromSinkToTrampolineFunction(
-          *m_module.get(), *parsed_expr->code_manipulator.get())) {
-    diagnostic_manager.Printf(
-        eSeverityError,
-        "couldn't setup call to the trampoline function. Please enable the "
-        "expression log by running \"log enable lldb "
-        "expr\", then run the failing expression again, and file a "
-        "bugreport with the log output.");
-    return ParseResult::unrecoverable_error;
+  if (ThreadSafeASTContext ast_ctx = m_swift_ast_ctx.GetASTContext()) {
+    if (m_options.GetBindGenericTypes() == lldb::eDontBind &&
+        !RedirectCallFromSinkToTrampolineFunction(
+            *m_module.get(), *parsed_expr->code_manipulator.get(), **ast_ctx)) {
+      diagnostic_manager.Printf(
+          eSeverityError,
+          "couldn't setup call to the trampoline function. Please enable the "
+          "expression log by running \"log enable lldb "
+          "expr\", then run the failing expression again, and file a "
+          "bugreport with the log output.");
+      return ParseResult::unrecoverable_error;
+    }
   }
 
   if (log) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1501,10 +1501,13 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
 
   ConstString mangled_name;
 
-  {
-    swift::Mangle::ASTMangler mangler(true);
+  if (ThreadSafeASTContext ast_ctx = swift_ast_ctx->GetASTContext()) {
+    swift::Mangle::ASTMangler mangler(**ast_ctx, true);
     mangled_name = ConstString(mangler.mangleGlobalVariableFull(var_decl));
   }
+
+  if (mangled_name.IsEmpty())
+    return;
 
   lldb::addr_t symbol_addr;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -297,9 +297,12 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
     if (target_swift_type->hasArchetype())
       target_swift_type = target_swift_type->mapTypeOutOfContext().getPointer();
 
-    // Replace opaque types with their underlying types when possible.
-    swift::Mangle::ASTMangler mangler(true);
+    ThreadSafeASTContext ast_ctx = swift_ast_ctx->GetASTContext();
+    if (!ast_ctx)
+      return base_type;
 
+    // Replace opaque types with their underlying types when possible.
+    swift::Mangle::ASTMangler mangler(**ast_ctx, true);
     // Rewrite all dynamic self types to their static self types.
     target_swift_type =
         target_swift_type.transformRec([](swift::TypeBase *type)

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4560,7 +4560,11 @@ ConstString SwiftASTContext::GetMangledTypeName(swift::TypeBase *type_base) {
 
   assert(!swift_type->hasArchetype() &&
          "type has not been mapped out of context");
-  swift::Mangle::ASTMangler mangler(true);
+  ThreadSafeASTContext ast_ctx = GetASTContext();
+  if (!ast_ctx)
+    return {};
+
+  swift::Mangle::ASTMangler mangler(**ast_ctx, true);
   std::string s = mangler.mangleTypeForDebugger(swift_type, nullptr);
   if (s.empty())
     return {};


### PR DESCRIPTION
ASTMangler needs an ast context due to the new embedded Swift mangling change. This patch simply keeps LLDB building by using the new contructor.