### PR TITLE
[cmake] Switch index store flag to opt-in

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -910,9 +910,9 @@ if (LLVM_COMPILER_IS_GCC_COMPATIBLE AND NOT LLVM_ENABLE_WARNINGS)
   append("-w" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 endif()
 
-# Enable '-index-store-path' on a Debug build, if the compiler supports it and for non-IDE generators.
-option(LLVM_DISABLE_INDEX_STORE "Disable '-index-store-path' flag" Off)
-if (NOT LLVM_DISABLE_INDEX_STORE AND NOT XCODE AND NOT MSVC_IDE AND uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+# Allow enabling '-index-store-path' for non-IDE generators if the compiler supports it.
+option(LLVM_ENABLE_INDEX_STORE "Enable '-index-store-path' flag" Off)
+if (LLVM_ENABLE_INDEX_STORE AND NOT XCODE AND NOT MSVC_IDE)
   set(INDEX_DATA_STORE_PATH "${PROJECT_BINARY_DIR}/IndexStore" CACHE STRING "Index store path")
 
   check_c_compiler_flag("-Werror -index-store-path \"${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/IndexStore\"" "C_SUPPORTS_INDEX_STORE")


### PR DESCRIPTION
Enabling by default for debug builds is problematic for those using sccache since it prevents caching. Switch to being opt-in for those that need it.