### PR TITLE
Define a diagnostic group for missing variadic macro arguments (#116855)

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -291,11 +291,13 @@ def : DiagGroup<"c++1z-compat-mangling", [CXX17CompatMangling]>;
 // Name of this warning in GCC.
 def NoexceptType : DiagGroup<"noexcept-type", [CXX17CompatMangling]>;
 
+def VariadicMacroArgumentsOmitted : DiagGroup<"variadic-macro-arguments-omitted">;
+
 // Warnings for C code which is not compatible with previous C standards.
 def CPre11Compat : DiagGroup<"pre-c11-compat">;
 def CPre11CompatPedantic : DiagGroup<"pre-c11-compat-pedantic",
                                      [CPre11Compat]>;
-def CPre23Compat : DiagGroup<"pre-c23-compat">;
+def CPre23Compat : DiagGroup<"pre-c23-compat", [VariadicMacroArgumentsOmitted]>;
 def CPre23CompatPedantic : DiagGroup<"pre-c23-compat-pedantic",
                                      [CPre23Compat]>;
 def : DiagGroup<"pre-c2x-compat", [CPre23Compat]>;
@@ -900,7 +902,7 @@ def VolatileRegisterVar : DiagGroup<"volatile-register-var">;
 def Visibility : DiagGroup<"visibility">;
 def ZeroLengthArray : DiagGroup<"zero-length-array">;
 def GNUZeroLineDirective : DiagGroup<"gnu-zero-line-directive">;
-def GNUZeroVariadicMacroArguments : DiagGroup<"gnu-zero-variadic-macro-arguments">;
+def GNUZeroVariadicMacroArguments : DiagGroup<"gnu-zero-variadic-macro-arguments", [VariadicMacroArgumentsOmitted]>;
 def MisleadingIndentation : DiagGroup<"misleading-indentation">;
 def PtrAuthNullPointers : DiagGroup<"ptrauth-null-pointers">;
 
@@ -1193,7 +1195,7 @@ def CXX17 : DiagGroup<"c++17-extensions", [CXX17Attrs]>;
 
 // A warning group for warnings about using C++20 features as extensions in
 // earlier C++ versions.
-def CXX20 : DiagGroup<"c++20-extensions", [CXX20Designator, CXX20Attrs]>;
+def CXX20 : DiagGroup<"c++20-extensions", [CXX20Designator, CXX20Attrs, VariadicMacroArgumentsOmitted]>;
 
 // A warning group for warnings about using C++23 features as extensions in
 // earlier C++ versions.
@@ -1220,7 +1222,7 @@ def C11 : DiagGroup<"c11-extensions">;
 def C99 : DiagGroup<"c99-extensions", [C99Designator]>;
 
 // A warning group for warnings about using C23 features as extensions.
-def C23 : DiagGroup<"c23-extensions">;
+def C23 : DiagGroup<"c23-extensions", [VariadicMacroArgumentsOmitted]>;
 
 def : DiagGroup<"c2x-extensions", [C23]>;
 

--- a/clang/include/clang/Basic/DiagnosticLexKinds.td
+++ b/clang/include/clang/Basic/DiagnosticLexKinds.td
@@ -483,14 +483,14 @@ def ext_embedded_directive : Extension<
   InGroup<DiagGroup<"embedded-directive">>;
 def ext_c_missing_varargs_arg : Extension<
   "passing no argument for the '...' parameter of a variadic macro is "
-  "a C23 extension">, InGroup<C23>;
+  "a C23 extension">, InGroup<VariadicMacroArgumentsOmitted>;
 def ext_cxx_missing_varargs_arg : Extension<
   "passing no argument for the '...' parameter of a variadic macro is "
-  "a C++20 extension">, InGroup<CXX20>;
+  "a C++20 extension">, InGroup<VariadicMacroArgumentsOmitted>;
 def warn_c17_compat_missing_varargs_arg : Warning<
   "passing no argument for the '...' parameter of a variadic macro is "
   "incompatible with C standards before C23">,
-  InGroup<CPre23Compat>, DefaultIgnore;
+  InGroup<VariadicMacroArgumentsOmitted>, DefaultIgnore;
 def warn_cxx17_compat_missing_varargs_arg : Warning<
   "passing no argument for the '...' parameter of a variadic macro is "
   "incompatible with C++ standards before C++20">,

--- a/clang/test/Lexer/gnu-flags.c
+++ b/clang/test/Lexer/gnu-flags.c
@@ -17,6 +17,8 @@
 
 
 #if ALL || ZEROARGS
+// expected-warning@+9 {{passing no argument for the '...' parameter of a variadic macro is a C23 extension}}
+// expected-note@+4 {{macro 'efoo' defined here}}
 // expected-warning@+3 {{token pasting of ',' and __VA_ARGS__ is a GNU extension}}
 #endif
 

--- a/clang/test/Preprocessor/macro_fn.c
+++ b/clang/test/Preprocessor/macro_fn.c
@@ -1,11 +1,17 @@
 /* RUN: %clang_cc1 %s -Eonly -std=c89 -pedantic -verify
 */
+// RUN: %clang_cc1 %s -Eonly -std=c89 -pedantic -Wno-gnu-zero-variadic-macro-arguments -verify -DOMIT_VARIADIC_MACRO_ARGS -DVARIADIC_MACRO_ARGS_REMOVE_COMMA
+// RUN: %clang_cc1 %s -Eonly -std=c89 -pedantic -Wno-variadic-macro-arguments-omitted -verify -DOMIT_VARIADIC_MACRO_ARGS
 /* PR3937 */
 #define zero() 0 /* expected-note 2 {{defined here}} */
 #define one(x) 0 /* expected-note 2 {{defined here}} */
 #define two(x, y) 0 /* expected-note 4 {{defined here}} */
 #define zero_dot(...) 0   /* expected-warning {{variadic macros are a C99 feature}} */
-#define one_dot(x, ...) 0 /* expected-warning {{variadic macros are a C99 feature}} expected-note 2{{macro 'one_dot' defined here}} */
+#define one_dot(x, ...) 0 /* expected-warning {{variadic macros are a C99 feature}} */
+
+#ifndef OMIT_VARIADIC_MACRO_ARGS
+/* expected-note@-3 2{{macro 'one_dot' defined here}} */
+#endif
 
 zero()
 zero(1);          /* expected-error {{too many arguments provided to function-like macro invocation}} */
@@ -37,16 +43,24 @@ e(x)
 e()
 
 zero_dot()
-one_dot(x)  /* empty ... argument: expected-warning {{passing no argument for the '...' parameter of a variadic macro is a C23 extension}}  */
-one_dot()   /* empty first argument, elided ...: expected-warning {{passing no argument for the '...' parameter of a variadic macro is a C23 extension}} */
+one_dot(x)  /* empty ... argument */
+one_dot()   /* empty first argument, elided ... */
 
+#ifndef OMIT_VARIADIC_MACRO_ARGS
+/* expected-warning@-4 {{passing no argument for the '...' parameter of a variadic macro is a C23 extension}} */
+/* expected-warning@-4 {{passing no argument for the '...' parameter of a variadic macro is a C23 extension}} */
+#endif
 
 /* Crash with function-like macro test at end of directive. */
 #define E() (i == 0)
 #if E
 #endif
 
-
 #define NSAssert(condition, desc, ...) /* expected-warning {{variadic macros are a C99 feature}} */ \
-    SomeComplicatedStuff((desc), ##__VA_ARGS__) /* expected-warning {{token pasting of ',' and __VA_ARGS__ is a GNU extension}} */
+    SomeComplicatedStuff((desc), ##__VA_ARGS__)
+
+#ifndef VARIADIC_MACRO_ARGS_REMOVE_COMMA
+/* expected-warning@-3 {{token pasting of ',' and __VA_ARGS__ is a GNU extension}} */
+#endif
+
 NSAssert(somecond, somedesc)


### PR DESCRIPTION
Make the new diagnostic group a subgroup of the following diagnostic groups:

-Wpre-c23-compat
-Wgnu-zero-variadic-macro-arguments
-Wc++20-extensions
-Wc23-extensions

This change is needed as 5231005193afb8db01afe9a8a1aa308d25f60ba1 made it impossible to use -Wno-gnu-zero-variadic-macro-argumentsis to silence the warning.

rdar://139234984
(cherry picked from commit c8b7ec2edd8d84729070e455002d1e78bdceddc5)