### PR TITLE
[🍒 swift/release/6.1] [llvm][AArch64] Fix a crash in performPostLD1Combine

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ISelLowering.cpp
@@ -22450,10 +22450,15 @@ static SDValue performPostLD1Combine(SDNode *N,
   if (!VT.is128BitVector() && !VT.is64BitVector())
     return SDValue();
 
-  unsigned LoadIdx = IsLaneOp ? 1 : 0;
-  SDNode *LD = N->getOperand(LoadIdx).getNode();
   // If it is not LOAD, can not do such combine.
-  if (LD->getOpcode() != ISD::LOAD)
+  unsigned LoadIdx = IsLaneOp ? 1 : 0;
+  LoadSDNode *LD = dyn_cast<LoadSDNode>(N->getOperand(LoadIdx).getNode());
+  if (!LD)
+    return SDValue();
+
+  // If the Generic combiner already helped form a pre- or post-indexed load,
+  // skip forming one here.
+  if (LD->isIndexed())
     return SDValue();
 
   // The vector lane must be a constant in the LD1LANE opcode.


### PR DESCRIPTION
Cherry-pick of https://github.com/llvm/llvm-project/pull/118538
------------------------------------

The combine was attempting to replace a load that already had index writeback, resulting in an incorrect CombineTo, which would have changed the number of SDValue results of the instruction. The fix is to skip forming the LD1 combine when the load is already an indexed one.

**• Risk:** Low, this change turns an assertion failure / crash into a skipped optimization.
**• Testing:** Updated regression tests
**• Reviewed by:** @aemerson 
**• Original PR:** https://github.com/llvm/llvm-project/pull/118538
**• Radar:** rdar://138004275