### PR TITLE
[lldb] Read the precise SDK for the current CU first.

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -473,6 +473,32 @@ public:
                       LLVM_PRETTY_FUNCTION, GetName()));
   }
 
+  /// Search CU for the SDK path the CUs was compiled against.
+  ///
+  /// \param[in] unit The CU
+  ///
+  /// \returns If successful, returns a parsed XcodeSDK object.
+  virtual llvm::Expected<XcodeSDK> GetSDKPathFromDebugInfo(CompileUnit &unit) {
+    return llvm::createStringError(
+        llvm::formatv("{0} not implemented for '{1}' platform.",
+                      LLVM_PRETTY_FUNCTION, GetName()));
+  }
+
+  /// Returns the full path of the most appropriate SDK for the
+  /// specified compile unit. This function gets this path by parsing
+  /// debug-info (see \ref `GetSDKPathFromDebugInfo`).
+  ///
+  /// \param[in] unit The CU to scan.
+  ///
+  /// \returns If successful, returns the full path to an
+  ///          Xcode SDK.
+  virtual llvm::Expected<std::string>
+  ResolveSDKPathFromDebugInfo(CompileUnit &unit) {
+    return llvm::createStringError(
+        llvm::formatv("{0} not implemented for '{1}' platform.",
+                      LLVM_PRETTY_FUNCTION, GetName()));
+  }
+
   const std::string &GetRemoteURL() const { return m_remote_url; }
 
   bool IsHost() const {

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -29,6 +29,7 @@
 #include "lldb/Interpreter/OptionValueProperties.h"
 #include "lldb/Interpreter/OptionValueString.h"
 #include "lldb/Interpreter/Options.h"
+#include "lldb/Symbol/CompileUnit.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/SymbolVendor.h"
@@ -1418,6 +1419,42 @@ PlatformDarwin::ResolveSDKPathFromDebugInfo(Module &module) {
                       llvm::toString(sdk_or_err.takeError())));
 
   auto [sdk, _] = std::move(*sdk_or_err);
+
+  auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
+  if (!path_or_err)
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        llvm::formatv("Error while searching for SDK (XcodeSDK '{0}'): {1}",
+                      sdk.GetString(),
+                      llvm::toString(path_or_err.takeError())));
+
+  return path_or_err->str();
+}
+
+llvm::Expected<XcodeSDK>
+PlatformDarwin::GetSDKPathFromDebugInfo(CompileUnit &unit) {
+  ModuleSP module_sp = unit.CalculateSymbolContextModule();
+  if (!module_sp)
+    return llvm::createStringError("compile unit has no module");
+  SymbolFile *sym_file = module_sp->GetSymbolFile();
+  if (!sym_file)
+    return llvm::createStringError(
+        llvm::formatv("No symbol file available for module '{0}'",
+                      module_sp->GetFileSpec().GetFilename()));
+
+  return sym_file->ParseXcodeSDK(unit);
+}
+
+llvm::Expected<std::string>
+PlatformDarwin::ResolveSDKPathFromDebugInfo(CompileUnit &unit) {
+  auto sdk_or_err = GetSDKPathFromDebugInfo(unit);
+  if (!sdk_or_err)
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        llvm::formatv("Failed to parse SDK path from debug-info: {0}",
+                      llvm::toString(sdk_or_err.takeError())));
+
+  auto sdk = std::move(*sdk_or_err);
 
   auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!path_or_err)

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.h
@@ -130,6 +130,11 @@ public:
   llvm::Expected<std::string>
   ResolveSDKPathFromDebugInfo(Module &module) override;
 
+  llvm::Expected<XcodeSDK> GetSDKPathFromDebugInfo(CompileUnit &unit) override;
+
+  llvm::Expected<std::string>
+  ResolveSDKPathFromDebugInfo(CompileUnit &unit) override;
+
 protected:
   static const char *GetCompatibleArch(ArchSpec::Core core, size_t idx);
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2148,7 +2148,7 @@ static std::string GetSDKPathFromDebugInfo(std::string m_description,
     return {};
   auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(module);
   if (!sdk_or_err) {
-    Debugger::ReportError("Error while parsing SDK path from debug-info: " +
+    Debugger::ReportError("Error while parsing SDK path from debug info: " +
                           toString(sdk_or_err.takeError()));
     return {};
   }
@@ -2825,8 +2825,28 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
   FileSpec target_sdk_spec = target_sp ? target_sp->GetSDKPath() : FileSpec();
   if (target_sdk_spec && FileSystem::Instance().Exists(target_sdk_spec)) {
     swift_ast_sp->SetPlatformSDKPath(target_sdk_spec.GetPath());
+    LOG_PRINTF(GetLog(LLDBLog::Types), "Using target SDK override: %s",
+               target_sdk_spec.GetPath().c_str());
     handled_sdk_path = true;
   }
+
+  // Get the precise SDK from the symbol context.
+  if (cu)
+    if (auto platform_sp = Platform::GetHostPlatform()) {
+      auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
+      if (!sdk_or_err)
+        Debugger::ReportError("Error while parsing SDK path from debug info: " +
+                              toString(sdk_or_err.takeError()));
+      else {
+        std::string sdk_path = GetSDKPath(m_description, *sdk_or_err);
+        if (!sdk_path.empty()) {
+          swift_ast_sp->SetPlatformSDKPath(sdk_path);
+          handled_sdk_path = true;
+          LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
+                     sdk_path.c_str());
+        }
+      }
+    }
 
   if (!handled_sdk_path) {
     for (size_t mi = 0; mi != num_images; ++mi) {
@@ -2839,8 +2859,8 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
       if (sdk_path.empty())
         continue;
 
-      handled_sdk_path = true;
       swift_ast_sp->SetPlatformSDKPath(sdk_path);
+      handled_sdk_path = true;
       break;
     }
   }

--- a/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
@@ -268,6 +268,13 @@ DWARF:
   EXPECT_EQ(found_mismatch, expect_mismatch);
   EXPECT_EQ(sdk.IsAppleInternalSDK(), expect_internal_sdk);
   EXPECT_NE(sdk.GetString().find(expect_sdk_path_pattern), std::string::npos);
+
+  {
+    auto sdk_or_err =
+        platform_sp->GetSDKPathFromDebugInfo(*dwarf_cu->GetLLDBCompUnit());
+    ASSERT_TRUE(static_cast<bool>(sdk_or_err));
+    EXPECT_EQ(sdk.IsAppleInternalSDK(), expect_internal_sdk);
+  }
 }
 
 SDKPathParsingTestData sdkPathParsingTestCases[] = {


### PR DESCRIPTION
This fixes an oversight made during the switch to precise compiler
invocations.

rdar://141013288