### PR TITLE
[Cherry-pick into swift/release/6.1] [lldb] Fix off by one in array index check in Objective C runtime plugin (#118995)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -3291,7 +3291,7 @@ bool AppleObjCRuntimeV2::NonPointerISACache::EvaluateNonPointerISA(
       }
 
       // If the index is still out of range then this isn't a pointer.
-      if (index > m_indexed_isa_cache.size())
+      if (index >= m_indexed_isa_cache.size())
         return false;
 
       LLDB_LOGF(log, "AOCRT::NPI Evaluate(ret_isa = 0x%" PRIx64 ")",


### PR DESCRIPTION
```
commit a46ee733d244333785c0896ce399341fe30240b0
Author: David Spickett <david.spickett@linaro.org>
Date:   Fri Dec 6 16:40:57 2024 +0000

    [lldb] Fix off by one in array index check in Objective C runtime plugin (#118995)
    
    Reported in #116944 / https://pvs-studio.com/en/blog/posts/cpp/1188/.
```
