### PR TITLE
 Revert "[CompilerRT] Remove sanitizer support for i386 watchsim (#11…

### DIFF
--- a/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
+++ b/compiler-rt/cmake/Modules/CompilerRTDarwinUtils.cmake
@@ -136,13 +136,14 @@ function(darwin_test_archs os valid_archs)
 
   # The simple program will build for x86_64h on the simulator because it is
   # compatible with x86_64 libraries (mostly), but since x86_64h isn't actually
-  # a valid or useful architecture for the simulators. We should drop it.
+  # a valid or useful architecture for the iOS simulator we should drop it.
   if(${os} MATCHES "^(iossim|tvossim|watchossim)$")
     list(REMOVE_ITEM archs "x86_64h")
-    if ("i386" IN_LIST archs)
-      list(REMOVE_ITEM archs "i386")
-      message(STATUS "Disabling i386 slice for simulator")
-    endif()
+  endif()
+
+  if(${os} MATCHES "iossim")
+    message(STATUS "Disabling i386 slice for iossim")
+    list(REMOVE_ITEM archs "i386")
   endif()
 
   if(${os} MATCHES "^ios$")


### PR DESCRIPTION
…7013)"

This reverts commit 762dc7db163954f3e77e5b14b06c7e2749cced42.

This broke the swift build.