### PR TITLE
[lldb] Update Swift String summary formatter for new bridged case

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -257,6 +257,8 @@ static bool makeStringGutsSummary(
   │ Immortal, Small     ║  1  │ASCII│  1  │  0  │
   ├─────────────────────╫─────┼─────┼─────┼─────┤
   │ Immortal, Large     ║  1  │  0  │  0  │  0  │
+  ├─────────────────────╫─────┼─────┼─────┼─────┤
+  │ Immortal, Bridged   ║  1  │  1  │  0  │  0  │
   ╞═════════════════════╬═════╪═════╪═════╪═════╡
   │ Native              ║  0  │  0  │  0  │  0  │
   ├─────────────────────╫─────┼─────┼─────┼─────┤
@@ -373,7 +375,7 @@ static bool makeStringGutsSummary(
   if ((discriminator & 0b0111'0000) == 0)
     return error("unexpected discriminator");
 
-  if ((discriminator & 0b1110'0000) == 0b0100'0000) { // 010xxxxx: Bridged
+  if ((discriminator & 0b0110'0000) == 0b0100'0000) { // x10xxxxx: Bridged
     TypeSystemClangSP clang_ts_sp =
         ScratchTypeSystemClang::GetForTarget(process->GetTarget());
     if (!clang_ts_sp)

--- a/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/bridged_string/TestSwiftBridgedStringVariables.py
@@ -37,6 +37,7 @@ class TestSwiftBridgedStringVariables(TestBase):
         s4 = self.frame().FindVariable("s4")
         s5 = self.frame().FindVariable("s5")
         s6 = self.frame().FindVariable("s6")
+        s7 = self.frame().FindVariable("s7")
 
         lldbutil.check_variable(self, s1, summary='"Hello world"')
         lldbutil.check_variable(self, s2, summary='"ΞΕΛΛΘ"')
@@ -44,4 +45,5 @@ class TestSwiftBridgedStringVariables(TestBase):
         lldbutil.check_variable(self, s4, summary='"ΞΕΛΛΘ"')
         lldbutil.check_variable(self, s5, use_dynamic=True, summary='"abc"')
         lldbutil.check_variable(self, s6, summary='"abc"')
+        lldbutil.check_variable(self, s7, summary='"kCFRunLoopDefaultMode"')
 

--- a/lldb/test/API/lang/swift/variables/bridged_string/main.swift
+++ b/lldb/test/API/lang/swift/variables/bridged_string/main.swift
@@ -19,6 +19,7 @@ func main()
 	let s4 = s2 as NSString
 	let s5 = "abc" as NSString
 	let s6 = String(s5)
+	let s7 = CFRunLoopMode.defaultMode!.rawValue as String
 	print(s1) // Set breakpoint here
         withExtendedLifetime((s2, s3, s4, s5, s6)) {}
 }


### PR DESCRIPTION
Supports a new discriminator case: "immortal, bridged". Added in swiftlang/swift#74881.

There are now three **bridged** cases: immortal, shared, foreign. The top 4 bits of the discriminator of these cases are:

| Case | Bits |
| - | - |
| immortal | 1100 |
| shared | 0100 |
| foreign | 0101 |

This change updates the mask used to recognize immortal bridged strings. Previously the mask was `0b1110`, which checked the top bit (for zero). Now the mask is `0b0110`, which ignores the top bit. When the middle two bits are `10`, then it's treated as a bridged string.

rdar://141019389