### PR TITLE
[cas] Fix replay via libclang

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -616,7 +616,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
   Clang.setInvocation(std::move(Invok));
   llvm::raw_svector_ostream DiagOS(DiagText);
   Clang.createDiagnostics(
-      Clang.getVirtualFileSystem(),
+      *llvm::vfs::getRealFileSystem(),
       new TextDiagnosticPrinter(DiagOS, &Clang.getDiagnosticOpts()));
   Clang.setVerboseOutputStream(DiagOS);
 


### PR DESCRIPTION
In 75b89afa9f1 we fixed a build error after an upstream change, but introduced a null pointer dereference, because the virtual filesystem is not setup on this clang instance. For diagnostics, we can just use the real filesystem.