### PR TITLE
[6.1] [cas] Definitions from unimported submodules should not be visible

### DIFF
--- a/clang/lib/Serialization/ASTReaderDecl.cpp
+++ b/clang/lib/Serialization/ASTReaderDecl.cpp
@@ -3192,7 +3192,7 @@ bool ASTReader::isConsumerInterestedIn(Decl *D) {
   // emitted when we import the relevant module.
   if (isPartOfPerModuleInitializer(D)) {
     auto *M = D->getImportedOwningModule();
-    if (M && M->Kind == Module::ModuleMapModule &&
+    if (M && M->isModuleMapModule() &&
         getContext().DeclMustBeEmitted(D))
       return false;
   }

--- a/clang/test/CAS/modules-include-tree-unimported-impl.c
+++ b/clang/test/CAS/modules-include-tree-unimported-impl.c
@@ -1,0 +1,50 @@
+// Check that a definition for a symbol in an unimported submodule is not
+// visible for codegen.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// RUN: %deps-to-rsp %t/deps.json --module Mod > %t/Mod.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/Mod.rsp
+// RUN: %clang @%t/tu.rsp -o - | FileCheck %s
+
+// CHECK-NOT: @record = global
+// CHECK: @record = external global
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "clang -S -emit-llvm DIR/tu.c -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- module.modulemap
+module Mod {
+  module A {
+    header "A.h"
+  }
+  explicit module B {
+    header "B.h"
+  }
+}
+
+//--- A.h
+extern int record;
+
+//--- B.h
+int record = 7;
+
+//--- tu.c
+#include "A.h"
+int tu(void) {
+  return record;
+}


### PR DESCRIPTION
**Explanation**: In 66228ed75 a merge conflict was incorrectly resolved leading to modules built with caching to expose definitions that come from unimported submodules to codegen. This would then cause linking errors if multiple TUs imported any part of that module.
**Scope**: Affects modules built with caching enabled.
**Issues**: rdar://131028078
**Original PR**: https://github.com/swiftlang/llvm-project/pull/9716
**Risk**: Low. This reverts to the previous behaviour. Only caching builds involving modules are affected.
**Testing**: New tests added
**Reviewed by**: @cachemeifyoucan 