### PR TITLE
[BoundsSafety] Do not check for bounds-attributed output arguments in dependent contexts

### DIFF
--- a/clang/test/BoundsSafety/Sema/unsafe-buffer-usage-interop-crash.cpp
+++ b/clang/test/BoundsSafety/Sema/unsafe-buffer-usage-interop-crash.cpp
@@ -11,12 +11,15 @@ class MyClass {
 namespace value_dependent_assertion_violation {
   // Running attribute-only mode on the C++ code below crashes
   // previously.
-  void g(unsigned);
+  void g(int * __counted_by(n) * p, size_t n);
 
   template<typename T>
   struct S {
     void f(T p) {
-      g(sizeof(p));
+      g(nullptr, sizeof(p));
     }
   };
+
+  // expected-error@-4{{incompatible dynamic count pointer argument to parameter of type 'int * __counted_by(n)*' (aka 'int **')}}
+  template struct S<int>; // expected-note{{in instantiation of member function 'value_dependent_assertion_violation::S<int>::f' requested here}}
 }


### PR DESCRIPTION
The bounds-attribute-only mode may be applied to C++ programs, where attributed functions/fields can be used in dependent contexts such as a template.  We DO NOT want the type check at those places.  Their instantiations will still be checked.  

Note: bounds-attributed output arguments are the only ones being type checked in the attribute-only mode. 

(rdar://140895392)
(rdar://141708643) // <- feel like better have a new radar for this issue