### PR TITLE
[6.1][clang] Allow CompilerInvocation to change CASOptions

### DIFF
--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -304,6 +304,10 @@ public:
     return PPOpts;
   }
   std::shared_ptr<LangOptions> getLangOptsPtr() { return LangOpts; }
+  std::shared_ptr<CASOptions> getCASOptsPtr() { return CASOpts; }
+  void setCASOption(std::shared_ptr<CASOptions> CASOpts) {
+    this->CASOpts = CASOpts;
+  }
   /// @}
 
   /// Create a compiler invocation from a list of input options.


### PR DESCRIPTION
Add APIs to change CASOptions inside CompilerInvocation. This is needed to make copies of CompilerInvocations but share the underlying CAS storage and avoid making more CAS storages that points to the same location.