### PR TITLE
[6.1] [ExtractAPI] reorder the module names in extension symbol graph file names

### DIFF
--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -1068,9 +1068,8 @@ void SymbolGraphSerializer::serializeWithExtensionGraphs(
 
   for (auto &ExtensionSGF : Serializer.ExtendedModules) {
     if (auto ExtensionOS =
-            CreateOutputStream(ExtensionSGF.getKey() + "@" + API.ProductName))
-      Serializer.serializeGraphToStream(*ExtensionOS, Options,
-                                        ExtensionSGF.getKey(),
+            CreateOutputStream(API.ProductName + "@" + ExtensionSGF.getKey()))
+      Serializer.serializeGraphToStream(*ExtensionOS, Options, API.ProductName,
                                         std::move(ExtensionSGF.getValue()));
   }
 }

--- a/clang/test/ExtractAPI/objc_external_category.m
+++ b/clang/test/ExtractAPI/objc_external_category.m
@@ -46,7 +46,7 @@ module ExternalModule {
 // Symbol graph from the build without extension SGFs should be identical to main symbol graph with extension SGFs
 // RUN: diff %t/symbols/Module.symbols.json %t/ModuleNoExt.symbols.json
 
-// RUN: FileCheck %s --input-file %t/symbols/ExternalModule@Module.symbols.json --check-prefix EXT
+// RUN: FileCheck %s --input-file %t/symbols/Module@ExternalModule.symbols.json --check-prefix EXT
 // EXT-DAG: "!testRelLabel": "memberOf $ c:objc(cs)ExtInterface(py)Property $ c:objc(cs)ExtInterface"
 // EXT-DAG: "!testRelLabel": "memberOf $ c:objc(cs)ExtInterface(im)InstanceMethod $ c:objc(cs)ExtInterface"
 // EXT-DAG: "!testRelLabel": "memberOf $ c:objc(cs)ExtInterface(cm)ClassMethod $ c:objc(cs)ExtInterface"
@@ -55,3 +55,10 @@ module ExternalModule {
 // EXT-DAG: "!testLabel": "c:objc(cs)ExtInterface(cm)ClassMethod"
 // EXT-NOT: "!testLabel": "c:objc(cs)ExtInterface"
 // EXT-NOT: "!testLabel": "c:objc(cs)ModInterface"
+
+// Ensure that the 'module' metadata for the extension symbol graph should still reference the
+// declaring module
+
+// RUN: FileCheck %s --input-file %t/symbols/Module@ExternalModule.symbols.json --check-prefix META
+// META:       "module": {
+// META-NEXT:    "name": "Module",


### PR DESCRIPTION
Cherry-pick of https://github.com/llvm/llvm-project/pull/119925 to `swift/release/6.1`

Resolves rdar://140298287

ExtractAPI's support for printing Objective-C category extensions from other modules emits symbol graphs with an
`ExtendedModule@HostModule.symbols.json`. However, this is backwards from existing symbol graph practices, causing issues when these symbol graphs are consumed alongside symbol graphs generated with other tools like Swift. This PR flips the naming scheme to be in line with existing symbol graph tooling.