### PR TITLE
[cherry-pick]  [lldb] Thread mangling flavor together with node pointer and [lldb] Adapt lldb to new ASTMangler constructor

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -12,6 +12,7 @@
 
 #include "SwiftExpressionParser.h"
 
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "SwiftASTManipulator.h"
 #include "SwiftDiagnostic.h"
 #include "SwiftExpressionSourceCode.h"
@@ -1181,8 +1182,9 @@ AddArchetypeTypeAliases(std::unique_ptr<SwiftASTManipulator> &code_manipulator,
     llvm::StringRef &type_name = pair.getFirst();
     MetadataPointerInfo &info = pair.getSecond();
 
-    auto dependent_type =
-        typeref_typesystem->CreateGenericTypeParamType(info.depth, info.index);
+    auto flavor = SwiftLanguageRuntime::GetManglingFlavor(type_name);
+    auto dependent_type = typeref_typesystem->CreateGenericTypeParamType(
+        info.depth, info.index, flavor);
     auto bound_type =
         runtime->BindGenericTypeParameters(stack_frame, dependent_type);
     if (!bound_type) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1501,10 +1501,13 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
 
   ConstString mangled_name;
 
-  {
-    swift::Mangle::ASTMangler mangler(true);
+  if (ThreadSafeASTContext ast_ctx = swift_ast_ctx->GetASTContext()) {
+    swift::Mangle::ASTMangler mangler(**ast_ctx, true);
     mangled_name = ConstString(mangler.mangleGlobalVariableFull(var_decl));
   }
+
+  if (mangled_name.IsEmpty())
+    return;
 
   lldb::addr_t symbol_addr;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -20,6 +20,7 @@
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/lldb-private.h"
+#include "swift/Demangling/ManglingFlavor.h"
 
 #include <optional>
 #include "llvm/ADT/StringSet.h"
@@ -132,6 +133,12 @@ public:
   /// since some day we may want to support more than one swift variant.
   static bool IsSwiftMangledName(llvm::StringRef name);
 
+  static swift::Mangle::ManglingFlavor
+  GetManglingFlavor(llvm::StringRef mangledName) {
+    if (mangledName.starts_with("$e") || mangledName.starts_with("_$e"))
+      return swift::Mangle::ManglingFlavor::Embedded;
+    return swift::Mangle::ManglingFlavor::Default;
+  }
   enum class FuncletComparisonResult {
     NotBothFunclets,
     DifferentAsyncFunctions,
@@ -271,6 +278,7 @@ public:
   /// context.
   static void GetGenericParameterNamesForFunction(
       const SymbolContext &sc, const ExecutionContext *exe_ctx,
+      swift::Mangle::ManglingFlavor flavor,
       llvm::DenseMap<ArchetypePath, llvm::StringRef> &dict);
 
   /// Invoke callback for each DependentGenericParamType.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -297,9 +297,12 @@ CompilerType SwiftLanguageRuntimeImpl::BindGenericTypeParametersRemoteAST(
     if (target_swift_type->hasArchetype())
       target_swift_type = target_swift_type->mapTypeOutOfContext().getPointer();
 
-    // Replace opaque types with their underlying types when possible.
-    swift::Mangle::ASTMangler mangler(true);
+    ThreadSafeASTContext ast_ctx = swift_ast_ctx->GetASTContext();
+    if (!ast_ctx)
+      return base_type;
 
+    // Replace opaque types with their underlying types when possible.
+    swift::Mangle::ASTMangler mangler(**ast_ctx, true);
     // Rewrite all dynamic self types to their static self types.
     target_swift_type =
         target_swift_type.transformRec([](swift::TypeBase *type)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
 #include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntimeImpl.h"
 #include "lldb/Symbol/VariableList.h"

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -21,6 +21,7 @@
 #include "DWARFDIE.h"
 
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "swift/Demangling/ManglingFlavor.h"
 #include "swift/RemoteInspection/TypeLowering.h"
 
 #include "lldb/Utility/LLDBLog.h"
@@ -63,7 +64,9 @@ getTypeAndDie(TypeSystemSwiftTypeRef &ts,
               const swift::reflection::TypeRef *TR) {
   swift::Demangle::Demangler dem;
   swift::Demangle::NodePointer node = TR->getDemangling(dem);
-  auto type = ts.RemangleAsType(dem, node);
+  // TODO: mangling flavor should come from the TypeRef.
+  auto type =
+      ts.RemangleAsType(dem, node, swift::Mangle::ManglingFlavor::Embedded);
   if (!type) {
     if (auto log = GetLog(LLDBLog::Types)) {
       std::stringstream ss;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -46,6 +46,7 @@
 #include "swift/Basic/PrimarySpecificPaths.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/ManglingFlavor.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/ModuleInterfaceLoader.h"
@@ -5298,10 +5299,12 @@ SwiftASTContext::GetNonTriviallyManagedReferenceKind(
   return {};
 }
 
-CompilerType
-SwiftASTContext::CreateGenericTypeParamType(unsigned int depth,
-                                                 unsigned int index) {
+CompilerType SwiftASTContext::CreateGenericTypeParamType(
+    unsigned int depth, unsigned int index,
+    swift::Mangle::ManglingFlavor flavor) {
   ThreadSafeASTContext ast_ctx = GetASTContext();
+  auto ast_flavor = GetManglingFlavor();
+  assert(flavor == ast_flavor && "Requested flavor and ast flavor diverge!");
   return ToCompilerType(
       swift::GenericTypeParamType::getType(depth, index, **ast_ctx));
 }
@@ -5969,7 +5972,8 @@ ConstString SwiftASTContext::GetTypeName(opaque_compiler_type_t type,
 /// Build a dictionary of Archetype names that appear in \p type.
 static llvm::DenseMap<swift::CanType, swift::Identifier>
 GetArchetypeNames(swift::Type swift_type, swift::ASTContext &ast_ctx,
-                  const SymbolContext *sc) {
+                  const SymbolContext *sc,
+                  swift::Mangle::ManglingFlavor flavor) {
   LLDB_SCOPED_TIMER();
   llvm::DenseMap<swift::CanType, swift::Identifier> dict;
 
@@ -5979,7 +5983,7 @@ GetArchetypeNames(swift::Type swift_type, swift::ASTContext &ast_ctx,
 
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, StringRef> names;
   SwiftLanguageRuntime::GetGenericParameterNamesForFunction(*sc, nullptr,
-                                                            names);
+                                                            flavor, names);
   swift_type.visit([&](swift::Type type) {
     if (!type->isTypeParameter() || dict.count(type->getCanonicalType()))
       return;
@@ -6008,7 +6012,8 @@ ConstString SwiftASTContext::GetDisplayTypeName(opaque_compiler_type_t type,
     print_options.SynthesizeSugarOnTypes = true;
     print_options.FullyQualifiedTypesIfAmbiguous = true;
     ThreadSafeASTContext ast_ctx = GetASTContext();
-    auto dict = GetArchetypeNames(swift_type, **ast_ctx, sc);
+    auto dict =
+        GetArchetypeNames(swift_type, **ast_ctx, sc, GetManglingFlavor());
     print_options.AlternativeTypeNames = &dict;
     type_name = swift_type.getString(print_options);
   }
@@ -9273,4 +9278,10 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
       modules->emplace_back(swift::ImportedModule(loaded_module));
   }
   return true;
+}
+
+swift::Mangle::ManglingFlavor SwiftASTContext::GetManglingFlavor() {
+  return GetASTContext()->LangOpts.hasFeature(swift::Feature::Embedded)
+             ? swift::Mangle::ManglingFlavor::Embedded
+             : swift::Mangle::ManglingFlavor::Default;
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4579,7 +4579,11 @@ ConstString SwiftASTContext::GetMangledTypeName(swift::TypeBase *type_base) {
 
   assert(!swift_type->hasArchetype() &&
          "type has not been mapped out of context");
-  swift::Mangle::ASTMangler mangler(true);
+  ThreadSafeASTContext ast_ctx = GetASTContext();
+  if (!ast_ctx)
+    return {};
+
+  swift::Mangle::ASTMangler mangler(**ast_ctx, true);
   std::string s = mangler.mangleTypeForDebugger(swift_type, nullptr);
   if (s.empty())
     return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -24,6 +24,7 @@
 
 #include "swift/AST/Import.h"
 #include "swift/AST/Module.h"
+#include "swift/Demangling/ManglingFlavor.h"
 #include "swift/Parse/ParseVersion.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
@@ -467,8 +468,9 @@ public:
       lldb::opaque_compiler_type_t type) override;
 
   /// Creates a GenericTypeParamType with the desired depth and index.
-  CompilerType CreateGenericTypeParamType(unsigned int depth,
-                                               unsigned int index) override;
+  CompilerType
+  CreateGenericTypeParamType(unsigned int depth, unsigned int index,
+                             swift::Mangle::ManglingFlavor flavor) override;
 
   CompilerType GetErrorType() override;
 
@@ -859,6 +861,9 @@ public:
   /// Perform all the implicit imports for the current frame.
   void PerformCompileUnitImports(const SymbolContext &sc, lldb::ProcessSP process_sp,
                                  Status &error);
+
+  /// Returns the mangling flavor associated with this ASTContext.
+  swift::Mangle::ManglingFlavor GetManglingFlavor();
 
 protected:
   bool GetCompileUnitImportsImpl(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -15,6 +15,7 @@
 
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/Demangling/ManglingFlavor.h"
 #include "llvm/ADT/ArrayRef.h"
 
 namespace lldb_private {
@@ -94,9 +95,9 @@ mangleType(swift::Demangle::Demangler &dem,
 }
 
 /// Produce a type mangling for a class.
-inline ManglingErrorOr<std::string> mangleClass(swift::Demangle::Demangler &dem,
-                                                llvm::StringRef moduleName,
-                                                llvm::StringRef className) {
+inline ManglingErrorOr<std::string>
+mangleClass(swift::Demangle::Demangler &dem, llvm::StringRef moduleName,
+            llvm::StringRef className, swift::Mangle::ManglingFlavor flavor) {
   auto *classNode = dem.createNode(Node::Kind::Class);
   auto *module =
       dem.createNodeWithAllocatedText(Node::Kind::Module, moduleName);
@@ -104,7 +105,7 @@ inline ManglingErrorOr<std::string> mangleClass(swift::Demangle::Demangler &dem,
       dem.createNodeWithAllocatedText(Node::Kind::Identifier, className);
   classNode->addChild(module, dem);
   classNode->addChild(identifier, dem);
-  return mangleNode(mangleType(dem, classNode));
+  return mangleNode(mangleType(dem, classNode), flavor);
 }
 
 } // namespace swift_demangle

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -21,6 +21,7 @@
 #include "lldb/Utility/Flags.h"
 #include "lldb/lldb-enumerations.h"
 #include "lldb/lldb-private.h"
+#include "swift/Demangling/ManglingFlavor.h"
 
 namespace clang {
 class Decl;
@@ -169,9 +170,10 @@ public:
   GetNonTriviallyManagedReferenceKind(lldb::opaque_compiler_type_t type) = 0;
 
   /// Creates a GenericTypeParamType with the desired depth and index.
-  virtual CompilerType CreateGenericTypeParamType(unsigned int depth,
-                                                       unsigned int index) = 0;
-                                                       
+  virtual CompilerType
+  CreateGenericTypeParamType(unsigned int depth, unsigned int index,
+                             swift::Mangle::ManglingFlavor flavor) = 0;
+
   using TypeSystem::DumpTypeDescription;
   virtual void DumpTypeDescription(
       lldb::opaque_compiler_type_t type, bool print_help_if_available,


### PR DESCRIPTION
    [lldb] Thread mangling flavor together with node pointer

    LLDB performs many analysis as transformations by converting a mangled
    name into a demangle tree and later on back to a mangled name.
    Unfortunately there's no cheap way for a demangle tree to carry its
    mangled name's mangling flavor. This patch threads the mangling flavor
    along with the demangle tree so when converting a demangle tree back to
    a mangled name we reconstruct it with the same mangling flavor as the
    original type.

    (cherry picked from commit 2cb73cd17109833d6f9e09b10c8fcf1c876e0592)

-------------------------------------------------------------

    [lldb] Adapt lldb to new ASTMangler constructor

    ASTMangler needs an ast context due to the new embedded Swift mangling
    change. This patch simply keeps LLDB building by using the new
    contructor.

    (cherry picked from commit 4b4aaeaa61d879f2eee45b14d49133abc069bf25)