### PR TITLE
[lldb][test] Re-enable boundssafetytrap.test

### DIFF
--- a/lldb/test/Shell/BoundsSafety/boundssafetytrap.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafetytrap.test
@@ -1,4 +1,3 @@
-# REQUIRES: rdar141363609
 # UNSUPPORTED: system-windows
 # RUN: %clang_host -Xclang -fbounds-safety -g -O0 %S/Inputs/boundsSafetyTrap.c -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s


### PR DESCRIPTION
This should pass now that we removed the
`BoundsSafetyTrapFrameRecognizer` in favour of the `VerboseTrapFrameRecognizer`

(cherry picked from commit 6cb26cf4c3cc0a9d64225204dc22f8ebbe345210)