### PR TITLE
[BoundsSafety] Fix for opt-remarks

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-missed-binop-overflow.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-missed-binop-overflow.c
@@ -1,4 +1,4 @@
-// XFAIL: *
+
 
 // RUN: %clang_cc1 -fbounds-safety -Os %s -triple arm64-apple-iphoneos -emit-llvm -o %t-Os.s -opt-record-file %t-Os.opt.yaml -opt-record-format yaml
 // RUN: FileCheck --input-file %t-Os.opt.yaml --check-prefixes OPT-REM %s

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-missed-ptr-induction.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-missed-ptr-induction.c
@@ -1,4 +1,4 @@
-// XFAIL: *
+
 
 // RUN: %clang_cc1 -fbounds-safety -Os %s -triple arm64-apple-iphoneos -emit-llvm -o %t-Os.s -opt-record-file %t-Os.opt.yaml -opt-record-format yaml
 // RUN: FileCheck --input-file %t-Os.opt.yaml --check-prefixes OPT-REM %s

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-ptr-conversion-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-ptr-conversion-O0.c
@@ -1,4 +1,4 @@
-// XFAIL: *
+
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos -Wno-bounds-safety-init-list -fbounds-safety -O0 %s -emit-llvm -o %t-O0.s -opt-record-file %t-O0.opt.yaml -opt-record-format yaml
 // RUN: FileCheck --input-file %t-O0.s --check-prefixes IR %s

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-ptr-conversion-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-ptr-conversion-O2.c
@@ -106,28 +106,6 @@ int main(int argc, char **argv) {
 // OPT-REM-NEXT: Pass:            annotation-remarks
 // OPT-REM-NEXT: Name:            BoundsSafetyCheck
 // OPT-REM-NEXT: DebugLoc:        { File: '{{.*}}bounds-safety-ptr-conversion-O2.c',
-// OPT-REM-NEXT:                    Line: 0, Column: 0 }
-// OPT-REM-NEXT: Function:        main
-// OPT-REM-NEXT: Args:
-// OPT-REM-NEXT:   - String:          'Inserted '
-// OPT-REM-NEXT:   - count:           '2'
-// OPT-REM-NEXT:   - String:          ' LLVM IR instruction'
-// OPT-REM-NEXT:   - String:          s
-// OPT-REM-NEXT:   - String:          "\n"
-// OPT-REM-NEXT:   - String:          "used for:\n"
-// OPT-REM-NEXT:   - String:          bounds-safety-generic, bounds-safety-check-ptr-lt-upper-bound, bounds-safety-check-ptr-ge-lower-bound
-// OPT-REM-NEXT:   - String:           |
-// OPT-REM-NEXT: {{^[ 	]+$}}
-// OPT-REM-NEXT: {{^[ 	]+$}}
-// OPT-REM-NEXT:       instructions:
-// OPT-REM-EMPTY:
-// OPT-REM-NEXT:   - String:          "trap (LLVM IR 'call')\nother (LLVM IR 'unreachable')"
-// OPT-REM-NEXT: ...
-
-// OPT-REM-NEXT: --- !Analysis
-// OPT-REM-NEXT: Pass:            annotation-remarks
-// OPT-REM-NEXT: Name:            BoundsSafetyCheck
-// OPT-REM-NEXT: DebugLoc:        { File: '{{.*}}bounds-safety-ptr-conversion-O2.c',
 // OPT-REM-NEXT:                    Line: 12, Column: 25 }
 // OPT-REM-NEXT: Function:        main
 // OPT-REM-NEXT: Args:
@@ -144,6 +122,28 @@ int main(int argc, char **argv) {
 // OPT-REM-NEXT:       instructions:
 // OPT-REM-EMPTY:
 // OPT-REM-NEXT:   - String:          "cmp eq (LLVM IR 'icmp')\ncond branch (LLVM IR 'br')"
+// OPT-REM-NEXT: ...
+
+// OPT-REM-NEXT: --- !Analysis
+// OPT-REM-NEXT: Pass:            annotation-remarks
+// OPT-REM-NEXT: Name:            BoundsSafetyCheck
+// OPT-REM-NEXT: DebugLoc:        { File: '{{.*}}bounds-safety-ptr-conversion-O2.c',
+// OPT-REM-NEXT:                    Line: 0, Column: 0 }
+// OPT-REM-NEXT: Function:        main
+// OPT-REM-NEXT: Args:
+// OPT-REM-NEXT:   - String:          'Inserted '
+// OPT-REM-NEXT:   - count:           '2'
+// OPT-REM-NEXT:   - String:          ' LLVM IR instruction'
+// OPT-REM-NEXT:   - String:          s
+// OPT-REM-NEXT:   - String:          "\n"
+// OPT-REM-NEXT:   - String:          "used for:\n"
+// OPT-REM-NEXT:   - String:          bounds-safety-generic, bounds-safety-check-ptr-lt-upper-bound, bounds-safety-check-ptr-ge-lower-bound
+// OPT-REM-NEXT:   - String:           |
+// OPT-REM-NEXT: {{^[ 	]+$}}
+// OPT-REM-NEXT: {{^[ 	]+$}}
+// OPT-REM-NEXT:       instructions:
+// OPT-REM-EMPTY:
+// OPT-REM-NEXT:   - String:          "trap (LLVM IR 'call')\nother (LLVM IR 'unreachable')"
 // OPT-REM-NEXT: ...
 
 // OPT-REM-NOT: --- !Analysis

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-bounds-argc-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-bounds-argc-O0.c
@@ -1,4 +1,4 @@
-// XFAIL: *
+
 
 // RUN: %clang_cc1 -fbounds-safety -O0 %s -emit-llvm -o %t-O0.s -opt-record-file %t-O0.opt.yaml -opt-record-format yaml
 // RUN: FileCheck --input-file %t-O0.s --check-prefixes IR %s

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-bounds-const-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-bounds-const-O0.c
@@ -1,4 +1,4 @@
-// XFAIL: *
+
 
 // RUN: %clang_cc1 -fbounds-safety -O0 %s -emit-llvm -o %t-O0.s -opt-record-file %t-O0.opt.yaml -opt-record-format yaml
 // RUN: FileCheck --input-file %t-O0.s --check-prefixes IR %s

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-argc-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-argc-O0.c
@@ -1,4 +1,4 @@
-// XFAIL: *
+
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos -fbounds-safety -O0 %s -emit-llvm -o %t-O0.s -opt-record-file %t-O0.opt.yaml -opt-record-format yaml
 // RUN: FileCheck --input-file %t-O0.s --check-prefixes IR %s

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-const-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-const-O0.c
@@ -1,4 +1,4 @@
-// XFAIL: *
+
 
 // RUN: %clang_cc1 -triple x86_64-apple-macos -fbounds-safety -O0 %s -emit-llvm -o %t-O0.s -opt-record-file %t-O0.opt.yaml -opt-record-format yaml
 // RUN: FileCheck --input-file %t-O0.s --check-prefixes IR %s

--- a/llvm/lib/Transforms/Scalar/AnnotationRemarks.cpp
+++ b/llvm/lib/Transforms/Scalar/AnnotationRemarks.cpp
@@ -133,7 +133,7 @@ static void runImpl(Function &F, const TargetLibraryInfo &TLI) {
     return;
 
   // Track all annotated instructions aggregated based on their debug location.
-  DenseMap<MDNode *, SmallVector<Instruction *, 4>> DebugLoc2Annotated;
+  MapVector<MDNode *, SmallVector<Instruction *, 4>> DebugLoc2Annotated;
 
   OptimizationRemarkEmitter ORE(&F);
   // First, generate a summary of the annotated instructions.


### PR DESCRIPTION
The output of opt-remarks is non-deterministic because it checks the output while iterating over a DenseMap. To fix this issue, we can replace DenseMap with MapVector.