### PR TITLE
[lldb][Mach-O] Initialize cputype/cpusubtype in test corefiles (#120518)

### DIFF
--- a/lldb/test/API/macosx/lc-note/firmware-corefile/create-empty-corefile.cpp
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/create-empty-corefile.cpp
@@ -189,6 +189,14 @@ void add_lc_segment(std::vector<std::vector<uint8_t>> &loadcmds,
 
 std::string get_uuid_from_binary(const char *fn, cpu_type_t &cputype,
                                  cpu_subtype_t &cpusubtype) {
+// We may be given a file, set reasonable values.
+#if defined(__x86_64__)
+  cputype = CPU_TYPE_X86;
+  cpusubtype = CPU_SUBTYPE_X86_ALL;
+#else
+  cputype = CPU_TYPE_ARM64;
+  cpusubtype = CPU_SUBTYPE_ARM64_ALL;
+#endif
   if (strlen(fn) == 0)
     return {};
 


### PR DESCRIPTION
TestFirmwareCorefiles.py has a helper utility,
create-empty-corefile.cpp, which creates corefiles with different metadata to specify the binary that should be loaded. It normally uses an actual binary's UUID for the metadata, and it uses the binary's cputype/cpusubtype for the corefile's mach header.

There is one test where it creates a corefile with metadata for a UUID that cannot be found -- it is given no binary -- and in that case, the cputype/cpusubtype it sets in the core file mach header was uninitialized data. Through luck, on Darwin systems, the uninitialized data typically matched a CPU_TYPE from machine.h and the test would work. But when the value doens't match one of thoes defines, lldb would reject the corefile entirely, and the test would fail. This has been an infrequent failure on the CI bots for a while and I couldn't ever repo it. There's a recent configuration where it was happening every time and I was able to track it down.

rdar://141727563
(cherry picked from commit 527595f92789f9701a4b91ab32b792034352f78d)