### PR TITLE
[lldb] Adjust to swift::SearchPathOptions enhancing the ImportSearchPaths type

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -253,7 +253,7 @@ public:
   swift::SearchPathOptions &GetSearchPathOptions();
 
   void InitializeSearchPathOptions(
-      llvm::ArrayRef<std::string> module_search_paths,
+      llvm::ArrayRef<std::pair<std::string, bool>> module_search_paths,
       llvm::ArrayRef<std::pair<std::string, bool>> framework_search_paths);
 
   swift::ClangImporterOptions &GetClangImporterOptions();
@@ -277,13 +277,13 @@ public:
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(
       const std::vector<std::string> &ExtraArgs,
-      const std::vector<std::string> &module_search_paths,
+      const std::vector<std::pair<std::string, bool>> module_search_paths,
       const std::vector<std::pair<std::string, bool>> framework_search_paths,
       llvm::StringRef overrideOpts = "");
 
   void AddExtraClangCC1Args(
       const std::vector<std::string> &source,
-      const std::vector<std::string> &module_search_paths,
+      const std::vector<std::pair<std::string, bool>> module_search_paths,
       const std::vector<std::pair<std::string, bool>> framework_search_paths,
       std::vector<std::string> &dest);
   static void AddExtraClangArgs(const std::vector<std::string>& source,


### PR DESCRIPTION
swift::SearchPathOptions renamed FrameworkSearchPath to SearchPath and uses it for both ImportSearchPaths and FrameworkSearchPaths.

rdar://141967997