### PR TITLE
[clang][ObjectiveC] Fix Parsing the `::` Optional Scope Specifier (#119908)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -780,6 +780,9 @@ Improvements to Clang's diagnostics
 - Clang now diagnoses dangling references to fields of temporary objects. Fixes #GH81589.
 
 
+- Fixed a bug where Clang hung on an unsupported optional scope specifier ``::`` when parsing
+  Objective-C. Clang now emits a diagnostic message instead of hanging.
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -2231,8 +2231,15 @@ bool Parser::TryAnnotateTypeOrScopeTokenAfterScopeSpec(
     }
   }
 
-  if (SS.isEmpty())
+  if (SS.isEmpty()) {
+    if (getLangOpts().ObjC && !getLangOpts().CPlusPlus &&
+        Tok.is(tok::coloncolon)) {
+      // ObjectiveC does not allow :: as as a scope token.
+      Diag(ConsumeToken(), diag::err_expected_type);
+      return true;
+    }
     return false;
+  }
 
   // A C++ scope specifier that isn't followed by a typename.
   AnnotateScopeToken(SS, IsNewScope);

--- a/clang/test/Parser/objc-coloncolon.m
+++ b/clang/test/Parser/objc-coloncolon.m
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -x objective-c -fsyntax-only -Wno-objc-root-class -verify %s
+
+int GV = 42;
+
+@interface A
++ (int) getGV;
+- (instancetype)init:(::A *) foo; // expected-error {{expected a type}}
+@end
+
+@implementation A
+- (void)performSelector:(SEL)selector {}
+- (void)double:(int)firstArg :(int)secondArg colon:(int)thirdArg {}
+- (void)test {
+  // The `::` below should not trigger an error.
+  [self performSelector:@selector(double::colon:)];
+}
++ (int) getGV { return ::GV; } // expected-error {{expected a type}}
+- (instancetype)init:(::A *) foo { return self; } // expected-error {{expected a type}}
+@end

--- a/clang/test/Parser/objcxx-coloncolon.mm
+++ b/clang/test/Parser/objcxx-coloncolon.mm
@@ -1,0 +1,9 @@
+// Test to make sure the parser does not get stuck on the optional
+// scope specifier on the type B.
+// RUN: %clang_cc1 -fsyntax-only %s
+
+class B;
+
+@interface A
+- (void) init:(::B *) foo;
+@end


### PR DESCRIPTION
The parser hangs when processing types/variables prefixed by `::` as an optional scope specifier. For example,
```
- (instancetype)init:(::A *) foo;
```

The parser should not hang, and it should emit an error. This PR implements the error check.

rdar://140885078
(cherry picked from commit 14180185026b8ed793cc7dfd037620e5150ccc35)