### PR TITLE
[Cherry-pick into swift/release/6.1] [lldb] Expose structured errors in SBError (#120784)

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -30287,6 +30287,34 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SBError_GetErrorData(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBError *arg1 = (lldb::SBError *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  lldb::SBStructuredData result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_lldb__SBError, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBError_GetErrorData" "', argument " "1"" of type '" "lldb::SBError const *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBError * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = ((lldb::SBError const *)arg1)->GetErrorData();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new lldb::SBStructuredData(result)), SWIGTYPE_p_lldb__SBStructuredData, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SBError_GetType(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBError *arg1 = (lldb::SBError *) 0 ;
@@ -37422,34 +37450,6 @@ fail:
 }
 
 
-SWIGINTERN PyObject *_wrap_SBFrame_GetLanguageSpecificData(PyObject *self, PyObject *args) {
-  PyObject *resultobj = 0;
-  lldb::SBFrame *arg1 = (lldb::SBFrame *) 0 ;
-  void *argp1 = 0 ;
-  int res1 = 0 ;
-  PyObject *swig_obj[1] ;
-  lldb::SBStructuredData result;
-  
-  (void)self;
-  if (!args) SWIG_fail;
-  swig_obj[0] = args;
-  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_lldb__SBFrame, 0 |  0 );
-  if (!SWIG_IsOK(res1)) {
-    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBFrame_GetLanguageSpecificData" "', argument " "1"" of type '" "lldb::SBFrame const *""'"); 
-  }
-  arg1 = reinterpret_cast< lldb::SBFrame * >(argp1);
-  {
-    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
-    result = ((lldb::SBFrame const *)arg1)->GetLanguageSpecificData();
-    SWIG_PYTHON_THREAD_END_ALLOW;
-  }
-  resultobj = SWIG_NewPointerObj((new lldb::SBStructuredData(result)), SWIGTYPE_p_lldb__SBStructuredData, SWIG_POINTER_OWN |  0 );
-  return resultobj;
-fail:
-  return NULL;
-}
-
-
 SWIGINTERN PyObject *_wrap_SBFrame_IsInlined__SWIG_0(PyObject *self, Py_ssize_t nobjs, PyObject **swig_obj) {
   PyObject *resultobj = 0;
   lldb::SBFrame *arg1 = (lldb::SBFrame *) 0 ;
@@ -37928,6 +37928,34 @@ fail:
     "    lldb::SBFrame::EvaluateExpression(char const *,lldb::DynamicValueType,bool)\n"
     "    lldb::SBFrame::EvaluateExpression(char const *,lldb::SBExpressionOptions const &)\n");
   return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_SBFrame_GetLanguageSpecificData(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBFrame *arg1 = (lldb::SBFrame *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject *swig_obj[1] ;
+  lldb::SBStructuredData result;
+  
+  (void)self;
+  if (!args) SWIG_fail;
+  swig_obj[0] = args;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_lldb__SBFrame, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBFrame_GetLanguageSpecificData" "', argument " "1"" of type '" "lldb::SBFrame const *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBFrame * >(argp1);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = ((lldb::SBFrame const *)arg1)->GetLanguageSpecificData();
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new lldb::SBStructuredData(result)), SWIGTYPE_p_lldb__SBStructuredData, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
 }
 
 
@@ -96340,6 +96368,7 @@ static PyMethodDef SwigMethods[] = {
 	 { "SBError_Fail", _wrap_SBError_Fail, METH_O, "SBError_Fail(SBError self) -> bool"},
 	 { "SBError_Success", _wrap_SBError_Success, METH_O, "SBError_Success(SBError self) -> bool"},
 	 { "SBError_GetError", _wrap_SBError_GetError, METH_O, "SBError_GetError(SBError self) -> uint32_t"},
+	 { "SBError_GetErrorData", _wrap_SBError_GetErrorData, METH_O, "SBError_GetErrorData(SBError self) -> SBStructuredData"},
 	 { "SBError_GetType", _wrap_SBError_GetType, METH_O, "SBError_GetType(SBError self) -> lldb::ErrorType"},
 	 { "SBError_SetError", _wrap_SBError_SetError, METH_VARARGS, "SBError_SetError(SBError self, uint32_t err, lldb::ErrorType type)"},
 	 { "SBError_SetErrorToErrno", _wrap_SBError_SetErrorToErrno, METH_O, "SBError_SetErrorToErrno(SBError self)"},
@@ -96654,7 +96683,6 @@ static PyMethodDef SwigMethods[] = {
 		"    .\n"
 		""},
 	 { "SBFrame_IsSwiftThunk", _wrap_SBFrame_IsSwiftThunk, METH_O, "SBFrame_IsSwiftThunk(SBFrame self) -> bool"},
-	 { "SBFrame_GetLanguageSpecificData", _wrap_SBFrame_GetLanguageSpecificData, METH_O, "SBFrame_GetLanguageSpecificData(SBFrame self) -> SBStructuredData"},
 	 { "SBFrame_IsInlined", _wrap_SBFrame_IsInlined, METH_VARARGS, "\n"
 		"SBFrame_IsInlined(SBFrame self) -> bool\n"
 		"SBFrame_IsInlined(SBFrame self) -> bool\n"
@@ -96681,6 +96709,7 @@ static PyMethodDef SwigMethods[] = {
 		"    The version that doesn't supply a 'use_dynamic' value will use the\n"
 		"    target's default.\n"
 		""},
+	 { "SBFrame_GetLanguageSpecificData", _wrap_SBFrame_GetLanguageSpecificData, METH_O, "SBFrame_GetLanguageSpecificData(SBFrame self) -> SBStructuredData"},
 	 { "SBFrame_GetFrameBlock", _wrap_SBFrame_GetFrameBlock, METH_O, "\n"
 		"SBFrame_GetFrameBlock(SBFrame self) -> SBBlock\n"
 		"\n"
@@ -102332,6 +102361,8 @@ SWIG_init(void) {
   SWIG_Python_SetConstant(d, "eArgTypeRemotePath",SWIG_From_int(static_cast< int >(lldb::eArgTypeRemotePath)));
   SWIG_Python_SetConstant(d, "eArgTypeRemoteFilename",SWIG_From_int(static_cast< int >(lldb::eArgTypeRemoteFilename)));
   SWIG_Python_SetConstant(d, "eArgTypeModule",SWIG_From_int(static_cast< int >(lldb::eArgTypeModule)));
+  SWIG_Python_SetConstant(d, "eArgTypeCPUName",SWIG_From_int(static_cast< int >(lldb::eArgTypeCPUName)));
+  SWIG_Python_SetConstant(d, "eArgTypeCPUFeatures",SWIG_From_int(static_cast< int >(lldb::eArgTypeCPUFeatures)));
   SWIG_Python_SetConstant(d, "eArgTypeLastArg",SWIG_From_int(static_cast< int >(lldb::eArgTypeLastArg)));
   SWIG_Python_SetConstant(d, "eSymbolTypeAny",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeAny)));
   SWIG_Python_SetConstant(d, "eSymbolTypeInvalid",SWIG_From_int(static_cast< int >(lldb::eSymbolTypeInvalid)));

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -1017,6 +1017,10 @@ eArgTypeRemoteFilename = _lldb.eArgTypeRemoteFilename
 
 eArgTypeModule = _lldb.eArgTypeModule
 
+eArgTypeCPUName = _lldb.eArgTypeCPUName
+
+eArgTypeCPUFeatures = _lldb.eArgTypeCPUFeatures
+
 eArgTypeLastArg = _lldb.eArgTypeLastArg
 
 eSymbolTypeAny = _lldb.eSymbolTypeAny
@@ -5425,6 +5429,10 @@ class SBError(object):
         r"""GetError(SBError self) -> uint32_t"""
         return _lldb.SBError_GetError(self)
 
+    def GetErrorData(self):
+        r"""GetErrorData(SBError self) -> SBStructuredData"""
+        return _lldb.SBError_GetErrorData(self)
+
     def GetType(self):
         r"""GetType(SBError self) -> lldb::ErrorType"""
         return _lldb.SBError_GetType(self)
@@ -6435,10 +6443,6 @@ class SBFrame(object):
         r"""IsSwiftThunk(SBFrame self) -> bool"""
         return _lldb.SBFrame_IsSwiftThunk(self)
 
-    def GetLanguageSpecificData(self):
-        r"""GetLanguageSpecificData(SBFrame self) -> SBStructuredData"""
-        return _lldb.SBFrame_GetLanguageSpecificData(self)
-
     def IsInlined(self, *args):
         r"""
         IsInlined(SBFrame self) -> bool
@@ -6476,6 +6480,10 @@ class SBFrame(object):
             target's default.
         """
         return _lldb.SBFrame_EvaluateExpression(self, *args)
+
+    def GetLanguageSpecificData(self):
+        r"""GetLanguageSpecificData(SBFrame self) -> SBStructuredData"""
+        return _lldb.SBFrame_GetLanguageSpecificData(self)
 
     def GetFrameBlock(self):
         r"""

--- a/lldb/include/lldb/API/SBError.h
+++ b/lldb/include/lldb/API/SBError.h
@@ -44,7 +44,12 @@ public:
 
   bool Success() const;
 
+  /// Get the error code.
   uint32_t GetError() const;
+
+  /// Get the error in machine-readable form. Particularly useful for
+  /// compiler diagnostics.
+  SBStructuredData GetErrorData() const;
 
   lldb::ErrorType GetType() const;
 

--- a/lldb/include/lldb/API/SBStructuredData.h
+++ b/lldb/include/lldb/API/SBStructuredData.h
@@ -115,6 +115,7 @@ protected:
   friend class SBLaunchInfo;
   friend class SBDebugger;
   friend class SBFrame;
+  friend class SBError;
   friend class SBTarget;
   friend class SBProcess;
   friend class SBThread;

--- a/lldb/include/lldb/Utility/DiagnosticsRendering.h
+++ b/lldb/include/lldb/Utility/DiagnosticsRendering.h
@@ -57,6 +57,13 @@ struct DiagnosticDetail {
   std::string rendered;
 };
 
+StructuredData::ObjectSP Serialize(llvm::ArrayRef<DiagnosticDetail> details);
+
+void RenderDiagnosticDetails(Stream &stream,
+                             std::optional<uint16_t> offset_in_command,
+                             bool show_inline,
+                             llvm::ArrayRef<DiagnosticDetail> details);
+
 class DiagnosticError
     : public llvm::ErrorInfo<DiagnosticError, CloneableECError> {
 public:
@@ -64,12 +71,11 @@ public:
   DiagnosticError(std::error_code ec) : ErrorInfo(ec) {}
   lldb::ErrorType GetErrorType() const override;
   virtual llvm::ArrayRef<DiagnosticDetail> GetDetails() const = 0;
+  StructuredData::ObjectSP GetAsStructuredData() const override {
+    return Serialize(GetDetails());
+  }
   static char ID;
 };
 
-void RenderDiagnosticDetails(Stream &stream,
-                             std::optional<uint16_t> offset_in_command,
-                             bool show_inline,
-                             llvm::ArrayRef<DiagnosticDetail> details);
 } // namespace lldb_private
 #endif

--- a/lldb/include/lldb/Utility/Status.h
+++ b/lldb/include/lldb/Utility/Status.h
@@ -10,6 +10,7 @@
 #define LLDB_UTILITY_STATUS_H
 
 #include "lldb/Utility/FileSpec.h"
+#include "lldb/Utility/StructuredData.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/StringRef.h"
@@ -38,6 +39,7 @@ public:
   CloneableError() : ErrorInfo() {}
   virtual std::unique_ptr<CloneableError> Clone() const = 0;
   virtual lldb::ErrorType GetErrorType() const = 0;
+  virtual StructuredData::ObjectSP GetAsStructuredData() const = 0;
   static char ID;
 };
 
@@ -49,6 +51,7 @@ public:
   std::error_code convertToErrorCode() const override { return EC; }
   void log(llvm::raw_ostream &OS) const override { OS << EC.message(); }
   lldb::ErrorType GetErrorType() const override;
+  virtual StructuredData::ObjectSP GetAsStructuredData() const override;
   static char ID;
 
 protected:
@@ -182,6 +185,9 @@ public:
   ///     is valid and is able to be converted to a string value,
   ///     NULL otherwise.
   const char *AsCString(const char *default_error_str = "unknown error") const;
+
+  /// Get the error in machine-readable form.
+  StructuredData::ObjectSP GetAsStructuredData() const;
 
   /// Clear the object state.
   ///

--- a/lldb/source/API/SBError.cpp
+++ b/lldb/source/API/SBError.cpp
@@ -9,6 +9,8 @@
 #include "lldb/API/SBError.h"
 #include "Utils.h"
 #include "lldb/API/SBStream.h"
+#include "lldb/API/SBStructuredData.h"
+#include "lldb/Core/StructuredDataImpl.h"
 #include "lldb/Utility/Instrumentation.h"
 #include "lldb/Utility/Status.h"
 #include "lldb/Utility/VASPrintf.h"
@@ -95,6 +97,18 @@ uint32_t SBError::GetError() const {
 
 
   return err;
+}
+
+SBStructuredData SBError::GetErrorData() const {
+  LLDB_INSTRUMENT_VA(this);
+
+  SBStructuredData sb_data;
+  if (!m_opaque_up)
+    return sb_data;
+
+  StructuredData::ObjectSP data(m_opaque_up->GetAsStructuredData());
+  sb_data.m_impl_up->SetObjectSP(data);
+  return sb_data;
 }
 
 ErrorType SBError::GetType() const {

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -145,57 +145,7 @@ std::string CommandReturnObject::GetErrorString(bool with_diagnostics) {
 }
 
 StructuredData::ObjectSP CommandReturnObject::GetErrorData() {
-  auto make_array = []() { return std::make_unique<StructuredData::Array>(); };
-  auto make_bool = [](bool b) {
-    return std::make_unique<StructuredData::Boolean>(b);
-  };
-  auto make_dict = []() {
-    return std::make_unique<StructuredData::Dictionary>();
-  };
-  auto make_int = [](unsigned i) {
-    return std::make_unique<StructuredData::UnsignedInteger>(i);
-  };
-  auto make_string = [](llvm::StringRef s) {
-    return std::make_unique<StructuredData::String>(s);
-  };
-  auto dict_up = make_dict();
-  dict_up->AddItem("version", make_int(1));
-  auto array_up = make_array();
-  for (const DiagnosticDetail &diag : m_diagnostics) {
-    auto detail_up = make_dict();
-    if (auto &sloc = diag.source_location) {
-      auto sloc_up = make_dict();
-      sloc_up->AddItem("file", make_string(sloc->file.GetPath()));
-      sloc_up->AddItem("line", make_int(sloc->line));
-      sloc_up->AddItem("length", make_int(sloc->length));
-      sloc_up->AddItem("hidden", make_bool(sloc->hidden));
-      sloc_up->AddItem("in_user_input", make_bool(sloc->in_user_input));
-      detail_up->AddItem("source_location", std::move(sloc_up));
-    }
-    llvm::StringRef severity = "unknown";
-    switch (diag.severity) {
-    case lldb::eSeverityError:
-      severity = "error";
-      break;
-    case lldb::eSeverityWarning:
-      severity = "warning";
-      break;
-    case lldb::eSeverityInfo:
-      severity = "note";
-      break;
-    }
-    detail_up->AddItem("severity", make_string(severity));
-    detail_up->AddItem("message", make_string(diag.message));
-    detail_up->AddItem("rendered", make_string(diag.rendered));
-    array_up->AddItem(std::move(detail_up));
-  }
-  dict_up->AddItem("details", std::move(array_up));
-  if (auto stream_sp = m_err_stream.GetStreamAtIndex(eStreamStringIndex)) {
-    auto text = std::static_pointer_cast<StreamString>(stream_sp)->GetString();
-    if (!text.empty())
-      dict_up->AddItem("text", make_string(text));
-  }
-  return dict_up;
+  return Serialize(m_diagnostics);
 }
 
 // Similar to AppendError, but do not prepend 'Status: ' to message, and don't

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -207,37 +207,56 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
         (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "// Break here", self.main_source_spec
         )
+
+        def check_error(diags):
+            # Version.
+            version = diags.GetValueForKey("version")
+            self.assertEqual(version.GetIntegerValue(), 1)
+
+            details = diags.GetValueForKey("details")
+
+            # Detail 1/2: undeclared 'a'
+            diag = details.GetItemAtIndex(0)
+
+            severity = diag.GetValueForKey("severity")
+            message = diag.GetValueForKey("message")
+            rendered = diag.GetValueForKey("rendered")
+            sloc = diag.GetValueForKey("source_location")
+            filename = sloc.GetValueForKey("file")
+            hidden = sloc.GetValueForKey("hidden")
+            in_user_input = sloc.GetValueForKey("in_user_input")
+
+            self.assertEqual(str(severity), "error")
+            self.assertIn("undeclared identifier 'a'", str(message))
+            # The rendered string should contain the source file.
+            self.assertIn("user expression", str(rendered))
+            self.assertIn("user expression", str(filename))
+            self.assertFalse(hidden.GetBooleanValue())
+            self.assertTrue(in_user_input.GetBooleanValue())
+
+            # Detail 1/2: undeclared 'b'
+            diag = details.GetItemAtIndex(1)
+            message = diag.GetValueForKey("message")
+            self.assertIn("undeclared identifier 'b'", str(message))
+
+        # Test diagnostics in CommandReturnObject
         interp = self.dbg.GetCommandInterpreter()
         cro = lldb.SBCommandReturnObject()
         interp.HandleCommand("expression -- a+b", cro)
 
         diags = cro.GetErrorData()
-        # Version.
-        version = diags.GetValueForKey("version")
+        check_error(diags)
+
+        # Test diagnostics in SBError
+        frame = thread.GetSelectedFrame()
+        value = frame.EvaluateExpression("a+b")
+        error = value.GetError()
+        self.assertTrue(error.Fail())
+        self.assertEquals(error.GetType(), lldb.eErrorTypeExpression)
+        data = error.GetErrorData()
+        version = data.GetValueForKey("version")
         self.assertEqual(version.GetIntegerValue(), 1)
-
-        details = diags.GetValueForKey("details")
-
-        # Detail 1/2: undeclared 'a'
-        diag = details.GetItemAtIndex(0)
-
-        severity = diag.GetValueForKey("severity")
-        message = diag.GetValueForKey("message")
-        rendered = diag.GetValueForKey("rendered")
-        sloc = diag.GetValueForKey("source_location")
-        filename = sloc.GetValueForKey("file")
-        hidden = sloc.GetValueForKey("hidden")
-        in_user_input = sloc.GetValueForKey("in_user_input")
-
-        self.assertEqual(str(severity), "error")
-        self.assertIn("undeclared identifier 'a'", str(message))
-        # The rendered string should contain the source file.
-        self.assertIn("user expression", str(rendered))
-        self.assertIn("user expression", str(filename))
-        self.assertFalse(hidden.GetBooleanValue())
-        self.assertTrue(in_user_input.GetBooleanValue())
-
-        # Detail 1/2: undeclared 'b'
-        diag = details.GetItemAtIndex(1)
-        message = diag.GetValueForKey("message")
-        self.assertIn("undeclared identifier 'b'", str(message))
+        err_ty = data.GetValueForKey("type")
+        self.assertEqual(err_ty.GetIntegerValue(), lldb.eErrorTypeExpression)
+        diags = data.GetValueForKey("errors").GetItemAtIndex(0)
+        check_error(diags)

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -113,12 +113,23 @@ class TestFrameVar(TestBase):
         frame = thread.GetFrameAtIndex(0)
         var_list = frame.GetVariables(True, True, False, True)
         self.assertEqual(var_list.GetSize(), 0)
-        api_error = var_list.GetError().GetCString()
+        api_error = var_list.GetError()
+        api_error_str = api_error.GetCString()
 
         for s in error_strings:
             self.assertIn(s, command_error)
         for s in error_strings:
-            self.assertIn(s, api_error)
+            self.assertIn(s, api_error_str)
+
+        # Check the structured error data.
+        data = api_error.GetErrorData()
+        version = data.GetValueForKey("version")
+        self.assertEqual(version.GetIntegerValue(), 1)
+        err_ty = data.GetValueForKey("type")
+        self.assertEqual(err_ty.GetIntegerValue(), lldb.eErrorTypeGeneric)
+        message = str(data.GetValueForKey("errors").GetItemAtIndex(0))
+        for s in error_strings:
+            self.assertIn(s, message)
 
     @skipIfRemote
     @skipUnlessDarwin


### PR DESCRIPTION
```
commit d9cc37fea7b02954079ca59e8f7f28cffacc7e9e
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Dec 20 13:02:54 2024 -0800

    [lldb] Expose structured errors in SBError (#120784)
    
    Building on top of previous work that exposed expression diagnostics via
    SBCommandReturnObject, this patch generalizes the support to expose any
    SBError as machine-readable structured data. One use-case of this is to
    allow IDEs to better visualize expression diagnostics.
    
    rdar://139997604
```
