### PR TITLE
[Extra PR for CI][lldb] Adjust to swift::SearchPathOptions enhancing the ImportSearchPaths type

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1312,9 +1312,10 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
     known_##NAME.insert(path KEY);                                             \
   }
 
-  INIT_SEARCH_PATH_SET(std::string, getImportSearchPaths(),
-                       import_search_paths, );
-  INIT_SEARCH_PATH_SET(swift::SearchPathOptions::FrameworkSearchPath,
+  INIT_SEARCH_PATH_SET(swift::SearchPathOptions::SearchPath,
+                       getImportSearchPaths(), import_search_paths,
+                       .Path);
+  INIT_SEARCH_PATH_SET(swift::SearchPathOptions::SearchPath,
                        getFrameworkSearchPaths(), framework_search_paths,
                        .Path);
 
@@ -1398,10 +1399,12 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
           for (auto &searchPath : searchPaths) {
             std::string path = remap(searchPath.Path);
             if (!searchPath.IsFramework) {
+              swift::SearchPathOptions::SearchPath
+                  import_search_path(path, searchPath.IsSystem);
               if (known_import_search_paths.insert(path).second)
-                import_search_paths.push_back(path);
+                import_search_paths.push_back(import_search_path);
             } else {
-              swift::SearchPathOptions::FrameworkSearchPath
+              swift::SearchPathOptions::SearchPath
                   framework_search_path(path, searchPath.IsSystem);
               if (known_framework_search_paths.insert(path).second)
                 framework_search_paths.push_back(framework_search_path);
@@ -1801,7 +1804,7 @@ static void applyOverrideOptions(std::vector<std::string> &args,
 
 void SwiftASTContext::AddExtraClangArgs(
     const std::vector<std::string> &ExtraArgs,
-    const std::vector<std::string> &module_search_paths,
+    const std::vector<std::pair<std::string, bool>> module_search_paths,
     const std::vector<std::pair<std::string, bool>> framework_search_paths,
     StringRef overrideOpts) {
   swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
@@ -1850,7 +1853,7 @@ void SwiftASTContext::AddExtraClangArgs(
 
 void SwiftASTContext::AddExtraClangCC1Args(
     const std::vector<std::string> &source,
-    const std::vector<std::string> &module_search_paths,
+    const std::vector<std::pair<std::string, bool>> module_search_paths,
     const std::vector<std::pair<std::string, bool>> framework_search_paths,
     std::vector<std::string> &dest) {
   clang::CompilerInvocation invocation;
@@ -1871,7 +1874,7 @@ void SwiftASTContext::AddExtraClangCC1Args(
   // additional clang modules when doing type reconstruction.
   for (auto &path : module_search_paths) {
     clangArgs.push_back("-I");
-    clangArgs.push_back(path.c_str());
+    clangArgs.push_back(path.first.c_str());
   }
   for (auto &path : default_paths) {
     llvm::SmallString<128> search_path(GetPlatformSDKPath());
@@ -2204,7 +2207,7 @@ ProcessModule(Module &module, std::string m_description,
               bool is_main_executable, StringRef module_filter,
               llvm::Triple triple,
               std::vector<swift::PluginSearchOption> &plugin_search_options,
-              std::vector<std::string> &module_search_paths,
+              std::vector<std::pair<std::string, bool>> &module_search_paths,
               std::vector<std::pair<std::string, bool>> &framework_search_paths,
               std::vector<std::string> &extra_clang_args,
               std::string &error) {
@@ -2301,7 +2304,7 @@ ProcessModule(Module &module, std::string m_description,
     bool exists = false;
     llvm::sys::fs::is_directory(path, exists);
     if (exists)
-      module_search_paths.push_back(std::string(path));
+      module_search_paths.push_back({std::string(path), /*system*/ false});
   }
 
   // Create a one-off CompilerInvocation as a place to load the
@@ -2334,9 +2337,8 @@ ProcessModule(Module &module, std::string m_description,
   plugin_search_options.insert(plugin_search_options.end(),
                                opts.PluginSearchOpts.begin(),
                                opts.PluginSearchOpts.end());
-  module_search_paths.insert(module_search_paths.end(),
-                             opts.getImportSearchPaths().begin(),
-                             opts.getImportSearchPaths().end());
+  for (auto path : opts.getImportSearchPaths())
+    module_search_paths.push_back({path.Path, path.IsSystem});
   for (auto path : opts.getFrameworkSearchPaths())
     framework_search_paths.push_back({path.Path, path.IsSystem});
   auto &clang_opts = invocation.getClangImporterOptions().ExtraArgs;
@@ -2373,7 +2375,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
     ss << '"' << ')';
   }
   LLDB_SCOPED_TIMERF("%s::CreateInstance", m_description.c_str());
-  std::vector<std::string> module_search_paths;
+  std::vector<std::pair<std::string, bool>> module_search_paths;
   std::vector<std::pair<std::string, bool>> framework_search_paths;
 
   LOG_PRINTF(GetLog(LLDBLog::Types), "(Module)");
@@ -3025,7 +3027,7 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
   ConfigureModuleCachePath(*swift_ast_sp);
 
   std::vector<swift::PluginSearchOption> plugin_search_options;
-  std::vector<std::string> module_search_paths;
+  std::vector<std::pair<std::string, bool>> module_search_paths;
   std::vector<std::pair<std::string, bool>> framework_search_paths;
   std::vector<std::string> extra_clang_args;
 
@@ -3037,10 +3039,11 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
     use_all_compiler_flags =
         !got_serialized_options || target_sp->GetUseAllCompilerFlags();
 
-    for (const FileSpec &path : target_sp->GetSwiftModuleSearchPaths())
-      module_search_paths.push_back(path.GetPath());
-
     const bool is_system = false;
+
+    for (const FileSpec &path : target_sp->GetSwiftModuleSearchPaths())
+      module_search_paths.push_back({path.GetPath(), is_system});
+
     for (const FileSpec &path : target_sp->GetSwiftFrameworkSearchPaths())
       framework_search_paths.push_back({path.GetPath(), is_system});
   }
@@ -3528,7 +3531,7 @@ swift::SearchPathOptions &SwiftASTContext::GetSearchPathOptions() {
 }
 
 void SwiftASTContext::InitializeSearchPathOptions(
-    llvm::ArrayRef<std::string> extra_module_search_paths,
+    llvm::ArrayRef<std::pair<std::string, bool>> extra_module_search_paths,
     llvm::ArrayRef<std::pair<std::string, bool>> extra_framework_search_paths) {
   LLDB_SCOPED_TIMER();
   swift::CompilerInvocation &invocation = GetCompilerInvocation();
@@ -3607,24 +3610,24 @@ void SwiftASTContext::InitializeSearchPathOptions(
   }
 
   llvm::StringMap<bool> processed;
-  std::vector<std::string> invocation_import_paths(
+  std::vector<swift::SearchPathOptions::SearchPath> invocation_import_paths(
       invocation.getSearchPathOptions().getImportSearchPaths());
   // Add all deserialized paths to the map.
   for (const auto &path : invocation_import_paths)
-    processed.insert({path, false});
+    processed.insert({path.Path, path.IsSystem});
 
   // Add/unique all extra paths.
   for (const auto &path : extra_module_search_paths) {
-    auto it_notseen = processed.insert({path, false});
+    auto it_notseen = processed.insert(path);
     if (it_notseen.second)
-      invocation_import_paths.push_back(path);
+      invocation_import_paths.push_back({path.first, path.second});
   }
   invocation.getSearchPathOptions().setImportSearchPaths(
       invocation_import_paths);
 
   // This preserves the IsSystem bit, but deduplicates entries ignoring it.
   processed.clear();
-  std::vector<swift::SearchPathOptions::FrameworkSearchPath>
+  std::vector<swift::SearchPathOptions::SearchPath>
       invocation_framework_paths(
           invocation.getSearchPathOptions().getFrameworkSearchPaths());
   // Add all deserialized paths to the map.
@@ -4049,7 +4052,7 @@ SwiftASTContext::GetModule(const FileSpec &module_spec) {
   std::string module_directory(module_spec.GetDirectory().GetCString());
   bool add_search_path = true;
   for (auto path : ast->SearchPathOpts.getImportSearchPaths()) {
-    if (path == module_directory) {
+    if (path.Path == module_directory) {
       add_search_path = false;
       break;
     }
@@ -5462,7 +5465,7 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
   unsigned num_images = module_list.GetSize();
   for (size_t mi = 0; mi != num_images; ++mi) {
     std::vector<swift::PluginSearchOption> plugin_search_options;
-    std::vector<std::string> module_search_paths;
+    std::vector<std::pair<std::string, bool>> module_search_paths;
     std::vector<std::pair<std::string, bool>> framework_search_paths;
     std::vector<std::string> extra_clang_args;
     lldb::ModuleSP module_sp = module_list.GetModuleAtIndex(mi);
@@ -5556,9 +5559,9 @@ void SwiftASTContext::LogConfiguration(bool is_repl) {
                     (unsigned long long)m_ast_context_ap->SearchPathOpts
                         .getImportSearchPaths()
                         .size());
-  for (const std::string &import_search_path :
+  for (const auto &import_search_path :
        m_ast_context_ap->SearchPathOpts.getImportSearchPaths())
-    HEALTH_LOG_PRINTF("    %s", import_search_path.c_str());
+    HEALTH_LOG_PRINTF("    %s", import_search_path.Path.c_str());
 
   swift::ClangImporterOptions &clang_importer_options =
       GetClangImporterOptions();

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -253,7 +253,7 @@ public:
   swift::SerializationOptions &GetSerializationOptions();
 
   void InitializeSearchPathOptions(
-      llvm::ArrayRef<std::string> module_search_paths,
+      llvm::ArrayRef<std::pair<std::string, bool>> module_search_paths,
       llvm::ArrayRef<std::pair<std::string, bool>> framework_search_paths);
 
   swift::ClangImporterOptions &GetClangImporterOptions();
@@ -277,13 +277,13 @@ public:
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(
       const std::vector<std::string> &ExtraArgs,
-      const std::vector<std::string> &module_search_paths,
+      const std::vector<std::pair<std::string, bool>> module_search_paths,
       const std::vector<std::pair<std::string, bool>> framework_search_paths,
       llvm::StringRef overrideOpts = "");
 
   void AddExtraClangCC1Args(
       const std::vector<std::string> &source,
-      const std::vector<std::string> &module_search_paths,
+      const std::vector<std::pair<std::string, bool>> module_search_paths,
       const std::vector<std::pair<std::string, bool>> framework_search_paths,
       std::vector<std::string> &dest);
   static void AddExtraClangArgs(const std::vector<std::string>& source,


### PR DESCRIPTION


swift::SearchPathOptions renamed FrameworkSearchPath to SearchPath and uses it for both ImportSearchPaths and FrameworkSearchPaths.