### PR TITLE
[Sanitizers][lldb] TestAsanSwift fix

### DIFF
--- a/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
+++ b/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
@@ -134,8 +134,10 @@ class AsanSwiftTestCase(lldbtest.TestBase):
             thread.GetStopReason(),
             lldb.eStopReasonInstrumentation)
 
+        self.runCmd("expr long $ar = (long)__asan_get_report_address()")
+
         self.expect(
-            "memory history `__asan_get_report_address()`",
+            "memory history $ar",
             substrs=[
                 'Memory allocated by Thread 1',
                 'main.swift'])


### PR DESCRIPTION
Apparently lldb doesn't tolerate backtick notation with function calls included. But it only happens when invoked from the test (script) - if I invoke "memory history `__asan_get_report_address()'" from lldb command line, it works fine. Maybe it's some escaping issue - in any case, I changed it to use temporary variable and verified that the automated test passes.

rdar://139744655