### PR TITLE
[clang][CAS] Fix assertion failures from libclang replay APIs

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -616,7 +616,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
   Clang.setInvocation(std::move(Invok));
   llvm::raw_svector_ostream DiagOS(DiagText);
   Clang.createDiagnostics(
-      Clang.getVirtualFileSystem(),
+      *llvm::vfs::getRealFileSystem(),
       new TextDiagnosticPrinter(DiagOS, &Clang.getDiagnosticOpts()));
   Clang.setVerboseOutputStream(DiagOS);
 


### PR DESCRIPTION
Fix the libclang cache replay function after
bdd10d9d249bd1c2a45e3de56a5accd97e953458. This restore the old behavior while fixing the assertion failure when accessing the file manager before it being initialized.