### PR TITLE
Fix tests mccas-replay.c and libclang-replay-job.c

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -616,7 +616,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
   Clang.setInvocation(std::move(Invok));
   llvm::raw_svector_ostream DiagOS(DiagText);
   Clang.createDiagnostics(
-      Clang.getVirtualFileSystem(),
+      *llvm::vfs::getRealFileSystem(),
       new TextDiagnosticPrinter(DiagOS, &Clang.getDiagnosticOpts()));
   Clang.setVerboseOutputStream(DiagOS);
 


### PR DESCRIPTION
5f9554f94a5c1b60834ab8271965102e78db7ee7 changed the code in `CompileJobCache::replayCachedResult` to fix a build error with rdar://140434303 due to the API for `CompilerInstance::createDiagnostics` changing and needing a `llvm::vfs::FileSystem &VFS` object as well.

The fix removed the compiler error but causes a crash in mccas-replay.c and libclang-replay-job.c due to no `FileManager` object being set in the `CompilerInstance`

This patch fixes the test crashes

Fixes rdar://142330498 ([BlueDragon] apple-clang-stage1-RA-next: Clang.CAS.mccas-replay.c test failure)