### PR TITLE
[clang] Fix Dependency Scanning Test Failures Caused by `deed6e90081889e851be7b6cfcdc6a04bbd142e5`

### DIFF
--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -278,7 +278,6 @@ void DependencyFileGenerator::attachToPreprocessor(Preprocessor &PP) {
   PP.getHeaderSearchInfo().getModuleMap().addModuleMapCallbacks(
       std::make_unique<DFGMMCallback>(*this, SkipUnusedModuleMaps));
 
-  DependencyCollector::attachToPreprocessor(PP);
   FS = PP.getFileManager().getVirtualFileSystemPtr();
 }
 


### PR DESCRIPTION
It seems that deed6e90081889e851be7b6cfcdc6a04bbd142e5 accidentally added `DepCollectorPPCallbacks` twice, which led to the following 5 test case failures.

```
Clang :: Frontend/dependency-gen-phony.c
Clang :: Modules/dependency-skip-unused-modulemaps.m
Clang-Unit :: Tooling/./ToolingTests/DependencyScanner/ScanDepsReuseFilemanager
Clang-Unit :: Tooling/./ToolingTests/DependencyScanner/ScanDepsReuseFilemanagerHasInclude
Clang-Unit :: Tooling/./ToolingTests/DependencyScanner/ScanDepsReuseFilemanagerSkippedFile
```

This PR removes the duplicate and fixes the failing tests.

rdar://142333288