### PR TITLE
[BoundsSafety][NFC] Simplify the interface of `BoundsSafetyCheckAssignmentToCountAttrPtrWithIncompletePointeeTy`

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2228,16 +2228,18 @@ public:
   /// \param RHSExpr The expression being assigned from.
   /// \param Action The type assignment being performed
   /// \param Loc The SourceLocation to use for error diagnostics
-  /// \param ComputeAssignee If provided this function will be called before
-  ///        emitting a diagnostic. The function should return the name of
-  ///        entity being assigned to or an empty string if this cannot be
-  ///        determined.
+  /// \param Assignee The ValueDecl being assigned. This is used to compute
+  ///        the name of the assignee. If the assignee isn't known this can
+  ///        be set to nullptr.
+  /// \param ShowFullyQualifiedAssigneeName If set to true when using \p
+  ///        Assignee to compute the name of the assignee use the fully
+  ///        qualified name, otherwise use the unqualified name.
   ///
   /// \returns True iff no diagnostic where emitted, false otherwise.
   bool BoundsSafetyCheckAssignmentToCountAttrPtr(
       QualType LHSTy, Expr *RHSExpr, AssignmentAction Action,
-      SourceLocation Loc,
-      std::function<std::string()> ComputeAssignee = nullptr);
+      SourceLocation Loc, const ValueDecl *Assignee,
+      bool ShowFullyQualifiedAssigneeName);
 
   /// Perform Checks for assigning to a `__counted_by` or
   /// `__counted_by_or_null` pointer type \param LHSTy where the pointee type
@@ -2248,15 +2250,18 @@ public:
   /// \param RHSExpr The expression being assigned from.
   /// \param Action The type assignment being performed
   /// \param Loc The SourceLocation to use for error diagnostics
-  /// \param ComputeAssignee If provided this function will be called before
-  ///        emitting a diagnostic. The function should return the name of
-  ///        entity being assigned to or an empty string if this cannot be
-  ///        determined.
+  /// \param Assignee The ValueDecl being assigned. This is used to compute
+  ///        the name of the assignee. If the assignee isn't known this can
+  ///        be set to nullptr.
+  /// \param ShowFullyQualifiedAssigneeName If set to true when using \p
+  ///        Assignee to compute the name of the assignee use the fully
+  ///        qualified name, otherwise use the unqualified name.
   ///
   /// \returns True iff no diagnostic where emitted, false otherwise.
   bool BoundsSafetyCheckAssignmentToCountAttrPtrWithIncompletePointeeTy(
       QualType LHSTy, Expr *RHSExpr, AssignmentAction Action,
-      SourceLocation Loc, std::function<std::string()> ComputeAssignee);
+      SourceLocation Loc, const ValueDecl *Assignee,
+      bool ShowFullyQualifiedAssigneeName);
 
   /// Perform Bounds Safety Semantic checks for initializing a Bounds Safety
   /// pointer.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -9503,8 +9503,8 @@ Sema::CheckReturnValExpr(Expr *RetValExp, QualType lhsType,
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
   BoundsSafetyCheckAssignmentToCountAttrPtr(
-      lhsType, RetValExp, AssignmentAction::Returning,
-      RetValExp->getBeginLoc());
+      lhsType, RetValExp, AssignmentAction::Returning, RetValExp->getBeginLoc(),
+      /*Assignee=*/nullptr, /*ShowFullQualifiedAssigneeName=*/false);
 
   // For a count-attributed return type, its dependent count variables can be
   // assigned in arbitrary places. Don't try to find the assigned values, just

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -16730,20 +16730,19 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
     // Even if this check fails don't return early to allow the best
     // possible error recovery and to allow any subsequent diagnostics to
     // work.
+    const ValueDecl *Assignee = nullptr;
+    bool ShowFullyQualifiedAssigneeName = false;
+    // In simple cases describe what is being assigned to
+    if (auto *DR = dyn_cast<DeclRefExpr>(LHSExpr->IgnoreParenCasts())) {
+      Assignee = DR->getDecl();
+    } else if (auto *ME = dyn_cast<MemberExpr>(LHSExpr->IgnoreParenCasts())) {
+      Assignee = ME->getMemberDecl();
+      ShowFullyQualifiedAssigneeName = true;
+    }
+
     (void)BoundsSafetyCheckAssignmentToCountAttrPtr(
-        LHSType, RHS.get(), AssignmentAction::Assigning, Loc,
-        [&LHSExpr]() -> std::string {
-          // In simple cases describe what is being assigned to
-          if (auto *DR = dyn_cast<DeclRefExpr>(LHSExpr->IgnoreParenCasts())) {
-            auto *II = DR->getDecl()->getDeclName().getAsIdentifierInfo();
-            if (II)
-              return II->getName().str();
-          } else if (auto *ME =
-                         dyn_cast<MemberExpr>(LHSExpr->IgnoreParenCasts())) {
-            return ME->getMemberDecl()->getQualifiedNameAsString();
-          }
-          return "";
-        });
+        LHSType, RHS.get(), AssignmentAction::Assigning, Loc, Assignee,
+        ShowFullyQualifiedAssigneeName);
   }
 /* TO_UPSTREAM(BoundsSafety) OFF */
 


### PR DESCRIPTION
[BoundsSafety][NFC] Simplify the interface of
`BoundsSafetyCheckAssignmentToCountAttrPtrWithIncompletePointeeTy`

Previously the interface took a std::function<std::string>. The
rationale behind this was to prevent callers from always allocating and
computing a `std::string`.

While trying to upstream this code (rdar://133600117)
(https://github.com/llvm/llvm-project/pull/106321) it was pointed out
that there might be a simpler way to implement this.

This patch instead has callers pass

* a `ValueDecl*` pointer. In the cases where this isn't known (currently
  return values and unnamed parameters) this can be set to nullptr
* a boolean flag stating whether or not the `ValueDecl*` should be fully
  qualified when printed.

This avoids needing to pass a `std::function` and also avoids `std::string`
unnecessary allocation.

rdar://142544708