### PR TITLE
[lldb] Add an expression evaluation test for modules built with ...

### DIFF
--- a/lldb/test/API/lang/swift/enable_testing/Makefile
+++ b/lldb/test/API/lang/swift/enable_testing/Makefile
@@ -1,0 +1,18 @@
+SWIFT_SOURCES := main.swift
+
+all:  libPublic.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lPublic -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libPublic.dylib: Public.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=Public \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution -enable-testing" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=Public \
+		DYLIB_SWIFT_SOURCES:=Public.swift \
+		-f $(MAKEFILE_RULES)
+

--- a/lldb/test/API/lang/swift/enable_testing/Public.swift
+++ b/lldb/test/API/lang/swift/enable_testing/Public.swift
@@ -1,0 +1,15 @@
+class SomeClass {
+    let value = 42
+}
+
+class ClassWithProperty {
+    private var v = SomeClass()
+
+    func f() {
+        print("break here")
+    }
+}
+
+public func entry() {
+    ClassWithProperty().f()
+}

--- a/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
+++ b/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEnableTesting(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test that expression evaluation generates a direct member access to a private property in a module compiled with -enable-library-evolution and -enable-testing"""
+
+        self.build()
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("Public.swift"), extra_images=["Public"]
+        )
+
+        self.expect("expression v", substrs=["Public.SomeClass", "value = 42"])

--- a/lldb/test/API/lang/swift/enable_testing/main.swift
+++ b/lldb/test/API/lang/swift/enable_testing/main.swift
@@ -1,0 +1,3 @@
+import Public
+
+entry()

--- a/lldb/test/API/lang/swift/resilience_other_module/Makefile
+++ b/lldb/test/API/lang/swift/resilience_other_module/Makefile
@@ -1,0 +1,27 @@
+SWIFT_SOURCES := main.swift
+
+all: libWithDebInfo.dylib libWithoutDebInfo.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lWithDebInfo -lWithoutDebInfo -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libWithDebInfo.dylib: WithDebInfo.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=WithDebInfo \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=WithDebInfo \
+		DYLIB_SWIFT_SOURCES:=WithDebInfo.swift \
+		-f $(MAKEFILE_RULES)
+
+libWithoutDebInfo.dylib: WithoutDebInfo.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=WithoutDebInfo \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=WithoutDebInfo \
+		DYLIB_SWIFT_SOURCES:=WithoutDebInfo.swift \
+		-f $(MAKEFILE_RULES)

--- a/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
+++ b/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceOtherModule(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_with_debug_info(self):
+        self.impl('break here with debug info')
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_without_debug_info(self):
+        self.impl('break here without debug info')
+
+    def impl(self, break_str):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, break_str, lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression s.a", substrs=["Int", "100"])
+        self.expect("expression s.b", substrs=["Int", "200"])

--- a/lldb/test/API/lang/swift/resilience_other_module/WithDebInfo.swift
+++ b/lldb/test/API/lang/swift/resilience_other_module/WithDebInfo.swift
@@ -1,0 +1,5 @@
+public struct S {
+    public var a = 100
+    private var b = 200
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/resilience_other_module/WithoutDebInfo.swift
+++ b/lldb/test/API/lang/swift/resilience_other_module/WithoutDebInfo.swift
@@ -1,0 +1,5 @@
+public struct S {
+    public var a = 100
+    private var b = 200
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/resilience_other_module/main.swift
+++ b/lldb/test/API/lang/swift/resilience_other_module/main.swift
@@ -1,0 +1,15 @@
+import WithDebInfo
+import WithoutDebInfo
+
+func withDebugInfo() {
+    var s = WithDebInfo.S()
+    print("break here with debug info")
+}
+
+func withoutDebugInfo() {
+    var s = WithoutDebInfo.S()
+    print("break here without debug info")
+}
+
+withDebugInfo()
+withoutDebugInfo()

--- a/lldb/test/API/lang/swift/resilience_superclass/Makefile
+++ b/lldb/test/API/lang/swift/resilience_superclass/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -enable-library-evolution
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
+++ b/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceSuperclass(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression c.v", substrs=["Int", "42"])

--- a/lldb/test/API/lang/swift/resilience_superclass/main.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass/main.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public class SuperClass<T>: NSObject {
+    var someVar: T
+    init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+}
+
+
+open class OpenSuperClass<T>: NSObject {
+    var someVar: T
+    init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class InheritingOpenClass<T>: OpenSuperClass<T> {
+    var v = 100
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+}
+
+func main() {
+    let c = Class(true)
+    let c2 = InheritingOpenClass(true)
+    print("break here")
+}
+
+main()

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/Makefile
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -enable-library-evolution
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/ModWithClass.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/ModWithClass.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+open class SuperClass<T>: NSObject {
+    var someVar: T
+    public init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+
+    func f() -> Int {
+        let abc = v
+        return v
+    }
+}
+
+public func entry() {
+    let c = Class(true)
+    print("break here")
+}
+

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceSuperclassMod(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression c.v", substrs=["Int", "42"])

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/main.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/main.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public class SuperClass<T>: NSObject {
+    var someVar: T
+    init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+}
+
+func main() {
+    let c = Class(true)
+    print("break here")
+}
+
+main()

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/Makefile
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/Makefile
@@ -1,0 +1,28 @@
+SWIFT_SOURCES := main.swift
+
+all: libModWithClass.dylib libModWithSuper.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lModWithClass -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libModWithClass.dylib: ModWithClass.swift libModWithSuper.dylib
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=ModWithClass \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		LD_EXTRAS="-lModWithSuper -L$(BUILDDIR)" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=ModWithClass \
+		DYLIB_SWIFT_SOURCES:=ModWithClass.swift \
+		-f $(MAKEFILE_RULES)
+
+libModWithSuper.dylib: ModWithSuper.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=ModWithSuper \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=ModWithSuper \
+		DYLIB_SWIFT_SOURCES:=ModWithSuper.swift \
+		-f $(MAKEFILE_RULES)

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithClass.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithClass.swift
@@ -1,0 +1,20 @@
+import ModWithSuper
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+
+    func f() -> Int {
+        let abc = v
+        return v
+    }
+}
+
+public func entry() {
+    let c = Class(true)
+    print("break here")
+}
+

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithSuper.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithSuper.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+open class SuperClass<T>: NSObject {
+    var someVar: T
+    public init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceSuperclassOtherMod(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('ModWithClass.swift'))
+
+        self.expect("expression c.v", substrs=["Int", "42"])

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/main.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/main.swift
@@ -1,0 +1,3 @@
+import ModWithClass
+
+entry()


### PR DESCRIPTION
-enable-testing and -enable-library-evolution

-enable-testing affects the visibility of types, which together with -enable-library-evolution may cause the compiler embedded in LLDB to generate incorrect code on expression evaluation.