### PR TITLE
[lldb/crashlog] Fix typo in error message when creating a target (#122514)

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -1512,7 +1512,7 @@ def load_crashlog_in_scripted_process(debugger, crashlog_path, options, result):
         arch = crashlog.process_arch
         if not arch:
             raise InteractiveCrashLogException(
-                "couldn't create find the architecture to create the target"
+                "couldn't find the architecture to create the target"
             )
         target = debugger.CreateTargetWithFileAndArch(None, arch)
     # 4. Fail


### PR DESCRIPTION
This fixes a typo when creating a target from the crashlog script and that we were not able to find a valid architecture from the crash report.

rdar://137344016

Signed-off-by: Med Ismail Bennani <ismail@bennani.ma>
(cherry picked from commit 833a17489dd96f35df3a17ad231ada82acf38ef9)