### PR TITLE
[lldb][swift] Mark async unwinding plans as SourcedFromCompiler

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2426,7 +2426,9 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
   UnwindPlanSP plan = std::make_shared<UnwindPlan>(lldb::eRegisterKindDWARF);
   plan->AppendRow(row);
   plan->SetSourceName("Swift Transition-to-AsyncContext-Chain");
-  plan->SetSourcedFromCompiler(eLazyBoolNo);
+  // Make this plan more authoritative, so that the unwinding fallback
+  // mechanisms don't kick in and produce a physical backtrace instead.
+  plan->SetSourcedFromCompiler(eLazyBoolYes);
   plan->SetUnwindPlanValidAtAllInstructions(eLazyBoolYes);
   plan->SetUnwindPlanForSignalTrap(eLazyBoolYes);
   return plan;
@@ -2466,7 +2468,9 @@ UnwindPlanSP SwiftLanguageRuntime::GetFollowAsyncContextUnwindPlan(
   UnwindPlanSP plan = std::make_shared<UnwindPlan>(lldb::eRegisterKindDWARF);
   plan->AppendRow(row);
   plan->SetSourceName("Swift Following-AsyncContext-Chain");
-  plan->SetSourcedFromCompiler(eLazyBoolNo);
+  // Make this plan more authoritative, so that the unwinding fallback
+  // mechanisms don't kick in and produce a physical backtrace instead.
+  plan->SetSourcedFromCompiler(eLazyBoolYes);
   plan->SetUnwindPlanValidAtAllInstructions(eLazyBoolYes);
   plan->SetUnwindPlanForSignalTrap(eLazyBoolYes);
   behaves_like_zeroth_frame = true;

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/TestSwiftShortAsyncUnwind.py
@@ -1,0 +1,26 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftAsyncUnwind(lldbtest.TestBase):
+
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    @skipIf(oslist=["windows", "linux"])
+    def test(self):
+        """Test async unwinding with short backtraces work properly"""
+        self.build()
+        src = lldb.SBFileSpec("main.swift")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "BREAK HERE", src
+        )
+
+        self.assertEqual(2, thread.GetNumFrames())
+        self.assertIn("work", thread.GetFrameAtIndex(0).GetFunctionName())
+        self.assertIn(
+            "await resume partial function for implicit closure",
+            thread.GetFrameAtIndex(1).GetFunctionName(),
+        )

--- a/lldb/test/API/lang/swift/async/unwind/short_unwind/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/short_unwind/main.swift
@@ -1,0 +1,15 @@
+func work() async -> Int {
+  try? await Task.sleep(for: .seconds(3))  // BREAK HERE
+  return 10
+}
+func foo_should_step_over() async -> Int {
+  async let an_array = [work(), work(), work()]
+  await an_array
+  return 10
+}
+
+@main struct Main {
+  static func main() async {
+    await foo_should_step_over()
+  }
+}


### PR DESCRIPTION
LLDB always attempts to check other unwinding plans when an unwind plan produces a CFA == 0. It does so because it doesn't distinguish the case where the plan truly produced the end of the stack versus the case where the plan was faulty.

We need a mechanism to disable this for swift async plans: if the language runtime constructs such a plan, then that plan will correctly identify the bottom of the stack. Checking other plans is harmless in non-async settings (they would just produce the same backtrace), but it is harmful for async virtual backtraces, as a "regular" unwind plan would produce a real backtrace if it were asked to start from the top of the stack (which would happen in short backtraces).

Until such mechanism exists, we can work around the issue by claiming swift async plans are "sourced from compiler", which seem to disable the fallback mechanism because plans sourced from the compiler are considered the most reliable plans.

rdar://142683622