### PR TITLE
[lldb] Improve performance of TypeSystemSwiftTypeRef via lazy canonic…

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -448,6 +448,13 @@ protected:
   /// Cast \p opaque_type as a mangled name.
   static const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
+  /// Helper function that canonicalizes node, but doesn't look at its
+  /// children.
+  swift::Demangle::NodePointer
+  Canonicalize(swift::Demangle::Demangler &dem,
+               swift::Demangle::NodePointer node,
+               swift::Mangle::ManglingFlavor flavor);
+
   /// Demangle the mangled name of the canonical type of \p type and
   /// drill into the Global(TypeMangling(Type())).
   ///
@@ -455,6 +462,15 @@ protected:
   swift::Demangle::NodePointer
   DemangleCanonicalType(swift::Demangle::Demangler &dem,
                         lldb::opaque_compiler_type_t type);
+
+  /// Demangle the mangled name of \p type after canonicalizing its
+  /// outermost type node and drill into the
+  /// Global(TypeMangling(Type())).
+  ///
+  /// \return the child of Type or a nullptr.
+  swift::Demangle::NodePointer
+  DemangleCanonicalOutermostType(swift::Demangle::Demangler &dem,
+                                 lldb::opaque_compiler_type_t type);
 
   /// If \p node is a Struct/Class/Typedef in the __C module, return a
   /// Swiftified node by looking up the name in the corresponding APINotes and


### PR DESCRIPTION
…alization

Most of the queries in TypeSystemSwiftTypeRef request a full canonicalized type, which involves resolving all nested type aliases (which kicks off expensive DWARF lookups), but they only look at the outermost node. This patch introduces DemangleCanonicalOutermostType() to avoid this redundant work.

(cherry picked from commit be1476406dc6b492ec85c8277896744d5453cd03)

 Conflicts:
	lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
	lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h