### PR TITLE
[APINotes] Add support for bounds safety annotations

### DIFF
--- a/clang/include/clang/APINotes/Types.h
+++ b/clang/include/clang/APINotes/Types.h
@@ -300,6 +300,7 @@ inline bool operator!=(const ContextInfo &LHS, const ContextInfo &RHS) {
   return !(LHS == RHS);
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 class BoundsSafetyInfo {
 public:
   enum class BoundsSafetyKind {
@@ -361,6 +362,7 @@ inline bool operator==(const BoundsSafetyInfo &LHS,
          LHS.LevelAudited == RHS.LevelAudited && LHS.Level == RHS.Level &&
          LHS.ExternalBounds == RHS.ExternalBounds;
 }
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 /// API notes for a variable/property.
 class VariableInfo : public CommonEntityInfo {
@@ -501,7 +503,9 @@ class ParamInfo : public VariableInfo {
   unsigned RawRetainCountConvention : 3;
 
 public:
+  /* TO_UPSTREAM(BoundsSafety) ON */
   std::optional<BoundsSafetyInfo> BoundsSafety;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 
   ParamInfo()
       : NoEscapeSpecified(false), NoEscape(false),
@@ -552,8 +556,10 @@ public:
     if (!RawRetainCountConvention)
       RawRetainCountConvention = RHS.RawRetainCountConvention;
 
+    /* TO_UPSTREAM(BoundsSafety) ON */
     if (!BoundsSafety)
       BoundsSafety = RHS.BoundsSafety;
+    /* TO_UPSTREAM(BoundsSafety) OFF */
 
     return *this;
   }
@@ -570,7 +576,9 @@ inline bool operator==(const ParamInfo &LHS, const ParamInfo &RHS) {
          LHS.LifetimeboundSpecified == RHS.LifetimeboundSpecified &&
          LHS.Lifetimebound == RHS.Lifetimebound &&
          LHS.RawRetainCountConvention == RHS.RawRetainCountConvention &&
+         /* TO_UPSTREAM(BoundsSafety) ON */
          LHS.BoundsSafety == RHS.BoundsSafety;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 inline bool operator!=(const ParamInfo &LHS, const ParamInfo &RHS) {

--- a/clang/include/clang/APINotes/Types.h
+++ b/clang/include/clang/APINotes/Types.h
@@ -304,7 +304,7 @@ inline bool operator!=(const ContextInfo &LHS, const ContextInfo &RHS) {
 class BoundsSafetyInfo {
 public:
   enum class BoundsSafetyKind {
-    CountedBy,
+    CountedBy = 0,
     CountedByOrNull,
     SizedBy,
     SizedByOrNull,
@@ -354,6 +354,8 @@ public:
   }
 
   friend bool operator==(const BoundsSafetyInfo &, const BoundsSafetyInfo &);
+
+  LLVM_DUMP_METHOD void dump(llvm::raw_ostream &OS) const;
 };
 
 inline bool operator==(const BoundsSafetyInfo &LHS,

--- a/clang/include/clang/APINotes/Types.h
+++ b/clang/include/clang/APINotes/Types.h
@@ -300,6 +300,68 @@ inline bool operator!=(const ContextInfo &LHS, const ContextInfo &RHS) {
   return !(LHS == RHS);
 }
 
+class BoundsSafetyInfo {
+public:
+  enum class BoundsSafetyKind {
+    CountedBy,
+    CountedByOrNull,
+    SizedBy,
+    SizedByOrNull,
+    EndedBy,
+  };
+
+private:
+  /// Whether this property has been audited for nullability.
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned KindAudited : 1;
+
+  /// The kind of nullability for this property. Only valid if the nullability
+  /// has been audited.
+  LLVM_PREFERRED_TYPE(BoundsSafetyKind)
+  unsigned Kind : 3;
+
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned LevelAudited : 1;
+
+  unsigned Level : 3;
+
+public:
+  std::string ExternalBounds;
+
+  BoundsSafetyInfo()
+      : KindAudited(false), Kind(0), LevelAudited(false), Level(0),
+        ExternalBounds("") {}
+
+  std::optional<BoundsSafetyKind> getKind() const {
+    return KindAudited ? std::optional<BoundsSafetyKind>(
+                             static_cast<BoundsSafetyKind>(Kind))
+                       : std::nullopt;
+  }
+
+  void setKindAudited(BoundsSafetyKind kind) {
+    KindAudited = true;
+    Kind = static_cast<unsigned>(kind);
+  }
+
+  std::optional<unsigned> getLevel() const {
+    return LevelAudited ? std::optional<unsigned>(Level) : std::nullopt;
+  }
+
+  void setLevelAudited(unsigned level) {
+    LevelAudited = true;
+    Level = level;
+  }
+
+  friend bool operator==(const BoundsSafetyInfo &, const BoundsSafetyInfo &);
+};
+
+inline bool operator==(const BoundsSafetyInfo &LHS,
+                       const BoundsSafetyInfo &RHS) {
+  return LHS.KindAudited == RHS.KindAudited && LHS.Kind == RHS.Kind &&
+         LHS.LevelAudited == RHS.LevelAudited && LHS.Level == RHS.Level &&
+         LHS.ExternalBounds == RHS.ExternalBounds;
+}
+
 /// API notes for a variable/property.
 class VariableInfo : public CommonEntityInfo {
   /// Whether this property has been audited for nullability.
@@ -439,10 +501,12 @@ class ParamInfo : public VariableInfo {
   unsigned RawRetainCountConvention : 3;
 
 public:
+  std::optional<BoundsSafetyInfo> BoundsSafety;
+
   ParamInfo()
       : NoEscapeSpecified(false), NoEscape(false),
         LifetimeboundSpecified(false), Lifetimebound(false),
-        RawRetainCountConvention() {}
+        RawRetainCountConvention(), BoundsSafety(std::nullopt) {}
 
   std::optional<bool> isNoEscape() const {
     return NoEscapeSpecified ? std::optional<bool>(NoEscape) : std::nullopt;
@@ -488,6 +552,9 @@ public:
     if (!RawRetainCountConvention)
       RawRetainCountConvention = RHS.RawRetainCountConvention;
 
+    if (!BoundsSafety)
+      BoundsSafety = RHS.BoundsSafety;
+
     return *this;
   }
 
@@ -502,7 +569,8 @@ inline bool operator==(const ParamInfo &LHS, const ParamInfo &RHS) {
          LHS.NoEscape == RHS.NoEscape &&
          LHS.LifetimeboundSpecified == RHS.LifetimeboundSpecified &&
          LHS.Lifetimebound == RHS.Lifetimebound &&
-         LHS.RawRetainCountConvention == RHS.RawRetainCountConvention;
+         LHS.RawRetainCountConvention == RHS.RawRetainCountConvention &&
+         LHS.BoundsSafety == RHS.BoundsSafety;
 }
 
 inline bool operator!=(const ParamInfo &LHS, const ParamInfo &RHS) {

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2021,7 +2021,7 @@ private:
   /// Parse a __builtin_bit_cast(T, E), used to implement C++2a std::bit_cast.
   ExprResult ParseBuiltinBitCast();
 
-  /* TO_UPSTREAM(BoundsSafety) ON*/
+  /* TO_UPSTREAM(BoundsSafety) ON */
   //===--------------------------------------------------------------------===//
   /// BoundsSafety: __builtin_unsafe_forge_bidi_indexable(expr, size)
   ExprResult ParseUnsafeForgeBidiIndexable();
@@ -3924,10 +3924,25 @@ private:
   /// \param IncludeLoc The location at which this parse was triggered.
   TypeResult ParseTypeFromString(StringRef TypeStr, StringRef Context,
                                  SourceLocation IncludeLoc);
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  /// Parse the given string as an expression in the argument position for a
+  /// bounds safety attribute.
+  ///
+  /// This is a dangerous utility function currently employed only by API notes.
+  /// It is not a general entry-point for safely parsing expressions from
+  /// strings.
+  ///
+  /// \param ExprStr The string to be parsed as an expression.
+  /// \param Context The name of the context in which this string is being
+  /// parsed, which will be used in diagnostics.
+  /// \param ParentDecl If a function or method is provided, the parameters are
+  ///   added to the current parsing context.
+  /// \param IncludeLoc The location at which this parse was triggered.
   ExprResult ParseBoundsAttributeArgFromString(StringRef ExprStr,
                                                StringRef Context,
                                                Decl *ParentDecl,
                                                SourceLocation IncludeLoc);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 
   //===--------------------------------------------------------------------===//
   // Modules

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -3924,6 +3924,10 @@ private:
   /// \param IncludeLoc The location at which this parse was triggered.
   TypeResult ParseTypeFromString(StringRef TypeStr, StringRef Context,
                                  SourceLocation IncludeLoc);
+  ExprResult ParseBoundsAttributeArgFromString(StringRef ExprStr,
+                                               StringRef Context,
+                                               Decl *ParentDecl,
+                                               SourceLocation IncludeLoc);
 
   //===--------------------------------------------------------------------===//
   // Modules

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -15514,7 +15514,8 @@ public:
   void applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
                                     AttributeCommonInfo::Kind Kind,
                                     Expr *AttrArg, SourceLocation Loc,
-                                    SourceRange Range, StringRef DiagName);
+                                    SourceRange Range, StringRef DiagName,
+                                    bool OriginatesInAPINotes = false);
 
   /// Perform Bounds Safety Semantic checks for assigning to a `__counted_by` or
   /// `__counted_by_or_null` pointer type \param LHSTy.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1131,9 +1131,11 @@ public:
   std::function<TypeResult(StringRef, StringRef, SourceLocation)>
       ParseTypeFromStringCallback;
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
   /// Callback to the parser to parse a type expressed as a string.
   std::function<ExprResult(StringRef, StringRef, Decl *, SourceLocation)>
       ParseBoundsAttributeArgFromStringCallback;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// VAListTagName - The declaration name corresponding to __va_list_tag.
   /// This is used as part of a hack to omit that class from ADL results.
@@ -15508,12 +15510,12 @@ public:
       llvm::SmallVectorImpl<TypeCoupledDeclRefInfo> &Decls, bool CountInBytes,
       bool OrNull);
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
   void applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
                                     AttributeCommonInfo::Kind Kind,
                                     Expr *AttrArg, SourceLocation Loc,
                                     SourceRange Range, StringRef DiagName);
 
-  /* TO_UPSTREAM(BoundsSafety) ON*/
   /// Perform Bounds Safety Semantic checks for assigning to a `__counted_by` or
   /// `__counted_by_or_null` pointer type \param LHSTy.
   ///

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1131,6 +1131,10 @@ public:
   std::function<TypeResult(StringRef, StringRef, SourceLocation)>
       ParseTypeFromStringCallback;
 
+  /// Callback to the parser to parse a type expressed as a string.
+  std::function<ExprResult(StringRef, StringRef, Decl *, SourceLocation)>
+      ParseBoundsAttributeArgFromStringCallback;
+
   /// VAListTagName - The declaration name corresponding to __va_list_tag.
   /// This is used as part of a hack to omit that class from ADL results.
   DeclarationName VAListTagName;
@@ -15503,6 +15507,11 @@ public:
       FieldDecl *FD, Expr *E,
       llvm::SmallVectorImpl<TypeCoupledDeclRefInfo> &Decls, bool CountInBytes,
       bool OrNull);
+
+  void applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
+                                    AttributeCommonInfo::Kind Kind,
+                                    Expr *AttrArg, SourceLocation Loc,
+                                    SourceRange Range, StringRef DiagName);
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
   /// Perform Bounds Safety Semantic checks for assigning to a `__counted_by` or

--- a/clang/lib/APINotes/APINotesFormat.h
+++ b/clang/lib/APINotes/APINotesFormat.h
@@ -24,7 +24,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 34; // SwiftReturnOwnership
+const uint16_t VERSION_MINOR = 35; // BoundsSafety
 
 const uint8_t kSwiftConforms = 1;
 const uint8_t kSwiftDoesNotConform = 2;

--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -323,23 +323,6 @@ public:
 };
 
 /* TO_UPSTREAM(BoundsSafety) ON */
-BoundsSafetyInfo::BoundsSafetyKind readKindFlag(uint8_t kind) {
-  switch (kind) {
-  case 0x00:
-    return BoundsSafetyInfo::BoundsSafetyKind::CountedBy;
-  case 0x01:
-    return BoundsSafetyInfo::BoundsSafetyKind::CountedByOrNull;
-  case 0x02:
-    return BoundsSafetyInfo::BoundsSafetyKind::SizedBy;
-  case 0x03:
-    return BoundsSafetyInfo::BoundsSafetyKind::SizedByOrNull;
-  case 0x04:
-    return BoundsSafetyInfo::BoundsSafetyKind::EndedBy;
-  default:
-    llvm_unreachable("invalid bounds safety kind");
-  }
-}
-
 /// Read serialized BoundsSafetyInfo.
 void ReadBoundsSafetyInfo(const uint8_t *&Data, BoundsSafetyInfo &Info) {
   uint8_t Payload = endian::readNext<uint8_t, llvm::endianness::little>(Data);
@@ -352,7 +335,9 @@ void ReadBoundsSafetyInfo(const uint8_t *&Data, BoundsSafetyInfo &Info) {
 
   if (Payload & 0x01) {
     uint8_t Kind = (Payload >> 1) & 0x7;
-    Info.setKindAudited(readKindFlag(Kind));
+    assert(Kind >= (uint8_t)BoundsSafetyInfo::BoundsSafetyKind::CountedBy);
+    assert(Kind <= (uint8_t)BoundsSafetyInfo::BoundsSafetyKind::EndedBy);
+    Info.setKindAudited((BoundsSafetyInfo::BoundsSafetyKind)Kind);
   }
 
   uint16_t ExternalBoundsLen =

--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -322,6 +322,7 @@ public:
   }
 };
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 BoundsSafetyInfo::BoundsSafetyKind readKindFlag(uint8_t kind) {
   switch (kind) {
   case 0x00:
@@ -359,6 +360,7 @@ void ReadBoundsSafetyInfo(const uint8_t *&Data, BoundsSafetyInfo &Info) {
   Info.ExternalBounds = std::string(Data, Data + ExternalBoundsLen);
   Data += ExternalBoundsLen;
 }
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 /// Read serialized ParamInfo.
 void ReadParamInfo(const uint8_t *&Data, ParamInfo &Info) {
@@ -376,11 +378,13 @@ void ReadParamInfo(const uint8_t *&Data, ParamInfo &Info) {
   if (Payload & 0x01)
     Info.setNoEscape(Payload & 0x02);
   Payload >>= 2;
+  /* TO_UPSTREAM(BoundsSafety) ON */
   if (Payload & 0x01) {
     BoundsSafetyInfo BSI;
     ReadBoundsSafetyInfo(Data, BSI);
     Info.BoundsSafety = BSI;
   }
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 /// Read serialized FunctionInfo.

--- a/clang/lib/APINotes/APINotesTypes.cpp
+++ b/clang/lib/APINotes/APINotesTypes.cpp
@@ -61,6 +61,34 @@ LLVM_DUMP_METHOD void ObjCPropertyInfo::dump(llvm::raw_ostream &OS) const {
   OS << '\n';
 }
 
+LLVM_DUMP_METHOD void BoundsSafetyInfo::dump(llvm::raw_ostream &OS) const {
+  if (KindAudited) {
+    assert((BoundsSafetyKind)Kind >= BoundsSafetyKind::CountedBy);
+    assert((BoundsSafetyKind)Kind <= BoundsSafetyKind::EndedBy);
+    switch ((BoundsSafetyKind)Kind) {
+    case BoundsSafetyKind::CountedBy:
+      OS << "[counted_by] ";
+      break;
+    case BoundsSafetyKind::CountedByOrNull:
+      OS << "[counted_by_or_null] ";
+      break;
+    case BoundsSafetyKind::SizedBy:
+      OS << "[sized_by] ";
+      break;
+    case BoundsSafetyKind::SizedByOrNull:
+      OS << "[sized_by_or_null] ";
+      break;
+    case BoundsSafetyKind::EndedBy:
+      OS << "[ended_by] ";
+      break;
+    }
+  }
+  if (LevelAudited)
+    OS << "Level: " << Level << " ";
+  OS << "ExternalBounds: "
+     << (ExternalBounds.empty() ? "<missing>" : ExternalBounds) << '\n';
+}
+
 LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
   static_cast<const VariableInfo &>(*this).dump(OS);
   if (NoEscapeSpecified)
@@ -69,6 +97,8 @@ LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
     OS << (Lifetimebound ? "[Lifetimebound] " : "");
   OS << "RawRetainCountConvention: " << RawRetainCountConvention << ' ';
   OS << '\n';
+  if (BoundsSafety)
+    BoundsSafety->dump(OS);
 }
 
 LLVM_DUMP_METHOD void FunctionInfo::dump(llvm::raw_ostream &OS) const {

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -1076,27 +1076,12 @@ void APINotesWriter::Implementation::writeGlobalVariableBlock(
 
 /* TO_UPSTREAM(BoundsSafety) ON */
 namespace {
-uint8_t getKindFlag(BoundsSafetyInfo::BoundsSafetyKind kind) {
-  switch (kind) {
-  case BoundsSafetyInfo::BoundsSafetyKind::CountedBy:
-    return 0x00;
-  case BoundsSafetyInfo::BoundsSafetyKind::CountedByOrNull:
-    return 0x01;
-  case BoundsSafetyInfo::BoundsSafetyKind::SizedBy:
-    return 0x02;
-  case BoundsSafetyInfo::BoundsSafetyKind::SizedByOrNull:
-    return 0x03;
-  case BoundsSafetyInfo::BoundsSafetyKind::EndedBy:
-    return 0x04;
-  }
-}
-
 void emitBoundsSafetyInfo(raw_ostream &OS, const BoundsSafetyInfo &BSI) {
   llvm::support::endian::Writer writer(OS, llvm::endianness::little);
   uint8_t flags = 0;
   if (auto kind = BSI.getKind()) {
     flags |= 0x01;                    // 1 bit
-    flags |= getKindFlag(*kind) << 1; // 3 bits
+    flags |= (uint8_t)*kind << 1;     // 3 bits
   }
   flags <<= 4;
   if (auto level = BSI.getLevel()) {

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -1074,6 +1074,7 @@ void APINotesWriter::Implementation::writeGlobalVariableBlock(
   }
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 namespace {
 uint8_t getKindFlag(BoundsSafetyInfo::BoundsSafetyKind kind) {
   switch (kind) {
@@ -1112,11 +1113,14 @@ void emitBoundsSafetyInfo(raw_ostream &OS, const BoundsSafetyInfo &BSI) {
 unsigned getBoundsSafetyInfoSize(const BoundsSafetyInfo &BSI) {
   return 1 + sizeof(uint16_t) + BSI.ExternalBounds.size();
 }
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 unsigned getParamInfoSize(const ParamInfo &PI) {
   unsigned BSISize = 0;
+  /* TO_UPSTREAM(BoundsSafety) ON */
   if (auto BSI = PI.BoundsSafety)
     BSISize = getBoundsSafetyInfoSize(*BSI);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   return getVariableInfoSize(PI) + 1 + BSISize;
 }
 
@@ -1144,8 +1148,10 @@ void emitParamInfo(raw_ostream &OS, const ParamInfo &PI) {
 
   llvm::support::endian::Writer writer(OS, llvm::endianness::little);
   writer.write<uint8_t>(flags);
+  /* TO_UPSTREAM(BoundsSafety) ON */
   if (auto BSI = PI.BoundsSafety)
     emitBoundsSafetyInfo(OS, *PI.BoundsSafety);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 /// Retrieve the serialized size of the given FunctionInfo, for use in on-disk

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -150,6 +150,7 @@ enum class APIAvailability {
 };
 } // namespace
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 namespace {
 struct BoundsSafety {
   BoundsSafetyInfo::BoundsSafetyKind Kind;
@@ -174,6 +175,7 @@ template <> struct ScalarEnumerationTraits<BoundsSafetyInfo::BoundsSafetyKind> {
 };
 } // namespace yaml
 } // namespace llvm
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 namespace llvm {
 namespace yaml {
@@ -213,7 +215,9 @@ struct Param {
   std::optional<NullabilityKind> Nullability;
   std::optional<RetainCountConventionKind> RetainCountConvention;
   StringRef Type;
+  /* TO_UPSTREAM(BoundsSafety) ON */
   BoundsSafety BoundsSafety;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 };
 
 typedef std::vector<Param> ParamsSeq;
@@ -264,10 +268,13 @@ template <> struct MappingTraits<Param> {
     IO.mapOptional("NoEscape", P.NoEscape);
     IO.mapOptional("Lifetimebound", P.Lifetimebound);
     IO.mapOptional("Type", P.Type, StringRef(""));
+    /* TO_UPSTREAM(BoundsSafety) ON */
     IO.mapOptional("BoundsSafety", P.BoundsSafety);
+    /* TO_UPSTREAM(BoundsSafety) OFF */
   }
 };
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 template <> struct MappingTraits<BoundsSafety> {
   static void mapping(IO &IO, BoundsSafety &BS) {
     IO.mapRequired("Kind", BS.Kind);
@@ -275,6 +282,7 @@ template <> struct MappingTraits<BoundsSafety> {
     IO.mapOptional("Level", BS.Level, 0);
   }
 };
+/* TO_UPSTREAM(BoundsSafety) OFF */
 } // namespace yaml
 } // namespace llvm
 
@@ -898,10 +906,12 @@ public:
       PI.setType(std::string(P.Type));
       PI.setRetainCountConvention(P.RetainCountConvention);
       BoundsSafetyInfo BSI;
+      /* TO_UPSTREAM(BoundsSafety) ON */
       BSI.setKindAudited(P.BoundsSafety.Kind);
       BSI.setLevelAudited(P.BoundsSafety.Level);
       BSI.ExternalBounds = P.BoundsSafety.BoundsExpr.str();
       PI.BoundsSafety = BSI;
+      /* TO_UPSTREAM(BoundsSafety) OFF */
       if (static_cast<int>(OutInfo.Params.size()) <= P.Position)
         OutInfo.Params.resize(P.Position + 1);
       if (P.Position == -1)

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -214,10 +214,10 @@ struct Param {
   std::optional<bool> Lifetimebound = false;
   std::optional<NullabilityKind> Nullability;
   std::optional<RetainCountConventionKind> RetainCountConvention;
-  StringRef Type;
   /* TO_UPSTREAM(BoundsSafety) ON */
-  BoundsSafety BoundsSafety;
+  std::optional<BoundsSafety> BoundsSafety;
   /* TO_UPSTREAM(BoundsSafety) OFF */
+  StringRef Type;
 };
 
 typedef std::vector<Param> ParamsSeq;
@@ -907,9 +907,11 @@ public:
       PI.setRetainCountConvention(P.RetainCountConvention);
       BoundsSafetyInfo BSI;
       /* TO_UPSTREAM(BoundsSafety) ON */
-      BSI.setKindAudited(P.BoundsSafety.Kind);
-      BSI.setLevelAudited(P.BoundsSafety.Level);
-      BSI.ExternalBounds = P.BoundsSafety.BoundsExpr.str();
+      if (P.BoundsSafety) {
+        BSI.setKindAudited(P.BoundsSafety->Kind);
+        BSI.setLevelAudited(P.BoundsSafety->Level);
+        BSI.ExternalBounds = P.BoundsSafety->BoundsExpr.str();
+      }
       PI.BoundsSafety = BSI;
       /* TO_UPSTREAM(BoundsSafety) OFF */
       if (static_cast<int>(OutInfo.Params.size()) <= P.Position)

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -8941,6 +8941,7 @@ TypeResult Parser::ParseTypeFromString(StringRef TypeStr, StringRef Context,
   return Result;
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 ExprResult
 Parser::ParseBoundsAttributeArgFromString(StringRef ExprStr, StringRef Context,
                                           Decl *ParentDecl,
@@ -9022,6 +9023,7 @@ Parser::ParseBoundsAttributeArgFromString(StringRef ExprStr, StringRef Context,
     Actions.ActOnExitFunctionContext();
   return Result;
 }
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 void Parser::DiagnoseBitIntUse(const Token &Tok) {
   // If the token is for _ExtInt, diagnose it as being deprecated. Otherwise,

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -8941,6 +8941,88 @@ TypeResult Parser::ParseTypeFromString(StringRef TypeStr, StringRef Context,
   return Result;
 }
 
+ExprResult
+Parser::ParseBoundsAttributeArgFromString(StringRef ExprStr, StringRef Context,
+                                          Decl *ParentDecl,
+                                          SourceLocation IncludeLoc) {
+  // Consume (unexpanded) tokens up to the end-of-directive.
+  SmallVector<Token, 4> Tokens;
+  {
+    // Create a new buffer from which we will parse the type.
+    auto &SourceMgr = PP.getSourceManager();
+    FileID FID = SourceMgr.createFileID(
+        llvm::MemoryBuffer::getMemBufferCopy(ExprStr, Context), SrcMgr::C_User,
+        0, 0, IncludeLoc);
+
+    // Form a new lexer that references the buffer.
+    Lexer L(FID, SourceMgr.getBufferOrFake(FID), PP);
+    L.setParsingPreprocessorDirective(true);
+    L.setIsPragmaLexer(true);
+
+    // Lex the tokens from that buffer.
+    Token Tok;
+    do {
+      L.Lex(Tok);
+      Tokens.push_back(Tok);
+    } while (Tok.isNot(tok::eod));
+  }
+
+  // Replace the "eod" token with an "eof" token identifying the end of
+  // the provided string.
+  Token &EndToken = Tokens.back();
+  EndToken.startToken();
+  EndToken.setKind(tok::eof);
+  EndToken.setLocation(Tok.getLocation());
+  EndToken.setEofData(ExprStr.data());
+
+  // Add the current token back.
+  Tokens.push_back(Tok);
+
+  // Enter the tokens into the token stream.
+  PP.EnterTokenStream(Tokens, /*DisableMacroExpansion=*/false,
+                      /*IsReinject=*/false);
+
+  // Consume the current token so that we'll start parsing the tokens we
+  // added to the stream.
+  ConsumeAnyToken();
+
+  // Enter a new scope.
+  std::unique_ptr<ParseScope> LocalScope;
+  bool EnterScope = ParentDecl && ParentDecl->isFunctionOrFunctionTemplate();
+  if (EnterScope) {
+    LocalScope.reset(new ParseScope(this, Scope::FnScope | Scope::DeclScope));
+    Actions.ActOnReenterFunctionContext(Actions.CurScope, ParentDecl);
+  }
+
+  // Parse the expr.
+  using ExpressionKind =
+      Sema::ExpressionEvaluationContextRecord::ExpressionKind;
+  EnterExpressionEvaluationContext EC(
+      Actions, Sema::ExpressionEvaluationContext::PotentiallyEvaluated, nullptr,
+      ExpressionKind::EK_AttrArgument);
+
+  ExprResult Result(
+      Actions.CorrectDelayedTyposInExpr(ParseAssignmentExpression()));
+
+  // Check if we parsed the whole thing.
+  if (Result.isUsable() &&
+      (Tok.isNot(tok::eof) || Tok.getEofData() != ExprStr.data())) {
+    Diag(Tok.getLocation(), diag::err_type_unparsed);
+  }
+
+  // There could be leftover tokens (e.g. because of an error).
+  // Skip through until we reach the 'end of directive' token.
+  while (Tok.isNot(tok::eof))
+    ConsumeAnyToken();
+
+  // Consume the end token.
+  if (Tok.is(tok::eof) && Tok.getEofData() == ExprStr.data())
+    ConsumeAnyToken();
+  if (EnterScope)
+    Actions.ActOnExitFunctionContext();
+  return Result;
+}
+
 void Parser::DiagnoseBitIntUse(const Token &Tok) {
   // If the token is for _ExtInt, diagnose it as being deprecated. Otherwise,
   // the token is about _BitInt and gets (potentially) diagnosed as use of an

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -76,12 +76,14 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
       [this](StringRef TypeStr, StringRef Context, SourceLocation IncludeLoc) {
         return this->ParseTypeFromString(TypeStr, Context, IncludeLoc);
       };
+  /* TO_UPSTREAM(BoundsSafety) ON */
   Actions.ParseBoundsAttributeArgFromStringCallback =
       [this](StringRef ExprStr, StringRef Context, Decl *Parent,
              SourceLocation IncludeLoc) {
         return this->ParseBoundsAttributeArgFromString(ExprStr, Context, Parent,
                                                        IncludeLoc);
       };
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 DiagnosticBuilder Parser::Diag(SourceLocation Loc, unsigned DiagID) {

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -76,6 +76,12 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
       [this](StringRef TypeStr, StringRef Context, SourceLocation IncludeLoc) {
         return this->ParseTypeFromString(TypeStr, Context, IncludeLoc);
       };
+  Actions.ParseBoundsAttributeArgFromStringCallback =
+      [this](StringRef ExprStr, StringRef Context, Decl *Parent,
+             SourceLocation IncludeLoc) {
+        return this->ParseBoundsAttributeArgFromString(ExprStr, Context, Parent,
+                                                       IncludeLoc);
+      };
 }
 
 DiagnosticBuilder Parser::Diag(SourceLocation Loc, unsigned DiagID) {
@@ -468,8 +474,9 @@ Parser::ParseScopeFlags::~ParseScopeFlags() {
 //===----------------------------------------------------------------------===//
 
 Parser::~Parser() {
-  // Clear out the parse-type-from-string callback.
+  // Clear out the parse-*-from-string callbacks.
   Actions.ParseTypeFromStringCallback = nullptr;
+  Actions.ParseBoundsAttributeArgFromStringCallback = nullptr;
 
   // If we still have scopes active, delete the scope tree.
   delete getCurScope();

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -427,6 +427,8 @@ static void applyBoundsSafety(Sema &S, ValueDecl *D,
 
     std::string AttrName;
     AttributeCommonInfo::Kind Kind;
+    assert(*Info.getKind() >= BoundsSafetyKind::CountedBy);
+    assert(*Info.getKind() <= BoundsSafetyKind::EndedBy);
     switch (*Info.getKind()) {
     case BoundsSafetyKind::CountedBy:
       AttrName = "__counted_by";

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -409,6 +409,51 @@ static void ProcessAPINotes(Sema &S, Decl *D,
                   Metadata);
 }
 
+static void applyBoundsSafety(Sema &S, ValueDecl *D,
+                              const api_notes::BoundsSafetyInfo &Info,
+                              VersionedInfoMetadata Metadata) {
+  using BoundsSafetyKind = api_notes::BoundsSafetyInfo::BoundsSafetyKind;
+  if (Metadata.IsActive && !Info.ExternalBounds.empty() &&
+      S.ParseBoundsAttributeArgFromStringCallback) {
+    Decl *ScopeDecl = D;
+    if (auto ParmDecl = dyn_cast<ParmVarDecl>(ScopeDecl)) {
+      ScopeDecl = dyn_cast<FunctionDecl>(ParmDecl->getDeclContext());
+    }
+    auto ParsedExpr = S.ParseBoundsAttributeArgFromStringCallback(
+        Info.ExternalBounds, "<API Notes>", ScopeDecl, D->getLocation());
+    if (ParsedExpr.isInvalid())
+      return;
+
+    std::string AttrName;
+    AttributeCommonInfo::Kind Kind;
+    switch (*Info.getKind()) {
+    case BoundsSafetyKind::CountedBy:
+      AttrName = "__counted_by";
+      Kind = AttributeCommonInfo::AT_CountedBy;
+      break;
+    case BoundsSafetyKind::CountedByOrNull:
+      AttrName = "__counted_by_or_null";
+      Kind = AttributeCommonInfo::AT_CountedByOrNull;
+      break;
+    case BoundsSafetyKind::SizedBy:
+      AttrName = "__sized_by";
+      Kind = AttributeCommonInfo::AT_SizedBy;
+      break;
+    case BoundsSafetyKind::SizedByOrNull:
+      AttrName = "__sized_by_or_null";
+      Kind = AttributeCommonInfo::AT_SizedByOrNull;
+      break;
+    case BoundsSafetyKind::EndedBy:
+      AttrName = "__ended_by";
+      Kind = AttributeCommonInfo::AT_PtrEndedBy;
+      break;
+    }
+
+    S.applyPtrCountedByEndedByAttr(D, *Info.getLevel(), Kind, ParsedExpr.get(),
+                                   SourceLocation(), SourceRange(), AttrName);
+  }
+}
+
 /// Process API notes for a parameter.
 static void ProcessAPINotes(Sema &S, ParmVarDecl *D,
                             const api_notes::ParamInfo &Info,
@@ -425,6 +470,9 @@ static void ProcessAPINotes(Sema &S, ParmVarDecl *D,
           return new (S.Context)
               LifetimeBoundAttr(S.Context, getPlaceholderAttrInfo());
         });
+
+  if (Info.BoundsSafety.has_value())
+    applyBoundsSafety(S, D, *Info.BoundsSafety, Metadata);
 
   // Retain count convention
   handleAPINotedRetainCountConvention(S, D, Metadata,

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -409,6 +409,7 @@ static void ProcessAPINotes(Sema &S, Decl *D,
                   Metadata);
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 static void applyBoundsSafety(Sema &S, ValueDecl *D,
                               const api_notes::BoundsSafetyInfo &Info,
                               VersionedInfoMetadata Metadata) {
@@ -453,6 +454,7 @@ static void applyBoundsSafety(Sema &S, ValueDecl *D,
                                    SourceLocation(), SourceRange(), AttrName);
   }
 }
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 /// Process API notes for a parameter.
 static void ProcessAPINotes(Sema &S, ParmVarDecl *D,
@@ -471,8 +473,10 @@ static void ProcessAPINotes(Sema &S, ParmVarDecl *D,
               LifetimeBoundAttr(S.Context, getPlaceholderAttrInfo());
         });
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
   if (Info.BoundsSafety.has_value())
     applyBoundsSafety(S, D, *Info.BoundsSafety, Metadata);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 
   // Retain count convention
   handleAPINotedRetainCountConvention(S, D, Metadata,

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -451,7 +451,8 @@ static void applyBoundsSafety(Sema &S, ValueDecl *D,
     }
 
     S.applyPtrCountedByEndedByAttr(D, *Info.getLevel(), Kind, ParsedExpr.get(),
-                                   SourceLocation(), SourceRange(), AttrName);
+                                   D->getLocation(), D->getSourceRange(),
+                                   AttrName);
   }
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -452,9 +452,9 @@ static void applyBoundsSafety(Sema &S, ValueDecl *D,
       break;
     }
 
-    S.applyPtrCountedByEndedByAttr(D, *Info.getLevel(), Kind, ParsedExpr.get(),
-                                   D->getLocation(), D->getSourceRange(),
-                                   AttrName);
+    S.applyPtrCountedByEndedByAttr(
+        D, *Info.getLevel(), Kind, ParsedExpr.get(), D->getLocation(),
+        D->getSourceRange(), AttrName, /* originates in API notes */ true);
   }
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5589,11 +5589,11 @@ class ConstructCountAttributedType :
 
 public:
   explicit ConstructCountAttributedType(Sema &S, unsigned Level,
-                                        const StringRef DiagName, Expr *ArgExpr,
+                                        const StringRef DiagName, Expr *ArgE,
                                         SourceLocation Loc, bool CountInBytes,
                                         bool OrNull, bool AllowRedecl,
                                         bool ScopeCheck = false)
-      : ConstructDynamicBoundType(S, Level, DiagName, ArgExpr, Loc, ScopeCheck,
+      : ConstructDynamicBoundType(S, Level, DiagName, ArgE, Loc, ScopeCheck,
                                   AllowRedecl),
         CountInBytes(CountInBytes), OrNull(OrNull) {
     if (!ArgExpr->getType()->isIntegralOrEnumerationType()) {

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
@@ -1,0 +1,64 @@
+---
+Name: BoundsUnsafe
+Functions:
+  - Name:              asdf_counted
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              asdf_sized
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: size
+  - Name:              asdf_counted_n
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by_or_null
+            Level: 0
+            BoundedBy: len
+  - Name:              asdf_sized_n
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: sized_by_or_null
+            Level: 0
+            BoundedBy: size
+  - Name:              asdf_ended
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+  - Name:              asdf_sized_mul
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: "size * count"
+  - Name:              asdf_counted_out
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 1
+            BoundedBy: "*len"
+  - Name:              asdf_counted_const
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: 7
+  - Name:              asdf_nterm
+    Parameters:
+      - Position:      0
+        Type: "int * __attribute__((__terminated_by__(0)))"
+

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
@@ -57,6 +57,21 @@ Functions:
             Kind: counted_by
             Level: 0
             BoundedBy: 7
+  - Name:             asdf_counted_nullable
+    Parameters:
+      - Position:      1
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              asdf_counted_noescape
+    Parameters:
+      - Position:      0
+        NoEscape:      true
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
   - Name:              asdf_nterm
     Parameters:
       - Position:      0

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
@@ -78,8 +78,58 @@ Functions:
         BoundsSafety:
             Kind: counted_by
             BoundedBy: len
+  - Name:              asdf_counted_redundant
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
+  - Name:              asdf_ended_chained
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+      - Position:      1
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+  - Name:              asdf_ended_chained_reverse
+    Parameters:
+      - Position:      1
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+  - Name:              asdf_ended_already_started
+    Parameters:
+      - Position:      1
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+  - Name:              asdf_ended_already_ended
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+  - Name:              asdf_ended_redundant
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
   - Name:              asdf_nterm
     Parameters:
       - Position:      0
         Type: "int * __attribute__((__terminated_by__(0)))"
-

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
@@ -72,6 +72,12 @@ Functions:
             Kind: counted_by
             Level: 0
             BoundedBy: len
+  - Name:              asdf_counted_default_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
   - Name:              asdf_nterm
     Parameters:
       - Position:      0

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
@@ -10,5 +10,12 @@ void asdf_counted_const(int * buf);
 void asdf_counted_nullable(int len, int * _Nullable buf);
 void asdf_counted_noescape(int * buf, int len);
 void asdf_counted_default_level(int * buf, int len);
+void asdf_counted_redundant(int * __attribute__((__counted_by__(len))) buf, int len);
+
+void asdf_ended_chained(int * buf, int * mid, int * end);
+void asdf_ended_chained_reverse(int * buf, int * mid, int * end);
+void asdf_ended_already_started(int * __attribute__((__ended_by__(mid))) buf, int * mid, int * end);
+void asdf_ended_already_ended(int * buf, int * mid __attribute__((__ended_by__(end))), int * end);
+void asdf_ended_redundant(int * __attribute__((__ended_by__(end))) buf, int * end);
 
 void asdf_nterm(char * buf);

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
@@ -9,5 +9,6 @@ void asdf_counted_out(int ** buf, int * len);
 void asdf_counted_const(int * buf);
 void asdf_counted_nullable(int len, int * _Nullable buf);
 void asdf_counted_noescape(int * buf, int len);
+void asdf_counted_default_level(int * buf, int len);
 
 void asdf_nterm(char * buf);

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
@@ -7,5 +7,7 @@ void asdf_ended(int * buf, int * end);
 void asdf_sized_mul(int * buf, int size, int count);
 void asdf_counted_out(int ** buf, int * len);
 void asdf_counted_const(int * buf);
+void asdf_counted_nullable(int len, int * _Nullable buf);
+void asdf_counted_noescape(int * buf, int len);
 
 void asdf_nterm(char * buf);

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
@@ -1,0 +1,11 @@
+void asdf_counted(int * buf, int len);
+void asdf_sized(int * buf, int size);
+void asdf_counted_n(int * buf, int len);
+void asdf_sized_n(int * buf, int size);
+void asdf_ended(int * buf, int * end);
+
+void asdf_sized_mul(int * buf, int size, int count);
+void asdf_counted_out(int ** buf, int * len);
+void asdf_counted_const(int * buf);
+
+void asdf_nterm(char * buf);

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
@@ -67,6 +67,23 @@ Classes:
                 Kind: counted_by
                 Level: 0
                 BoundedBy: 7
+      - Selector:             "asdf_counted_nullable:buf:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Selector:              "asdf_counted_noescape:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            NoEscape:      true
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
       - Selector:              "asdf_nterm:"
         MethodKind: Instance
         Parameters:

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
@@ -1,0 +1,75 @@
+---
+Name: BoundsUnsafe
+Classes:
+  - Name: Foo
+    Methods:
+      - Selector:              "asdf_counted:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Selector:              "asdf_sized:size:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: size
+      - Selector:              "asdf_counted_n:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by_or_null
+                Level: 0
+                BoundedBy: len
+      - Selector:              "asdf_sized_n:size:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by_or_null
+                Level: 0
+                BoundedBy: size
+      - Selector:              "asdf_ended:end:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Selector:              "asdf_sized_mul:size:count:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: "size * count"
+      - Selector:              "asdf_counted_out:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 1
+                BoundedBy: "*len"
+      - Selector:              "asdf_counted_const:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: 7
+      - Selector:              "asdf_nterm:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            Type: "int * __attribute__((__terminated_by__(0)))"
+

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.h
@@ -1,0 +1,14 @@
+@interface Foo
+- (void) asdf_counted: (int *)buf len: (int)len;
+- (void) asdf_sized: (int *)buf size: (int)size;
+- (void) asdf_counted_n: (int *)buf len: (int)len;
+- (void) asdf_sized_n: (int *)buf size: (int)size;
+- (void) asdf_ended: (int *)buf end: (int *)end;
+
+- (void) asdf_sized_mul: (int *)buf size:(int)size count:(int)count;
+- (void) asdf_counted_out: (int **)buf len:(int *)len;
+- (void) asdf_counted_const: (int *)buf;
+
+- (void) asdf_nterm: (char *) buf;
+@end
+

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.h
@@ -8,6 +8,8 @@
 - (void) asdf_sized_mul: (int *)buf size:(int)size count:(int)count;
 - (void) asdf_counted_out: (int **)buf len:(int *)len;
 - (void) asdf_counted_const: (int *)buf;
+- (void) asdf_counted_nullable: (int)len buf:(int * _Nullable)buf;
+- (void) asdf_counted_noescape: (int *)buf len: (int)len;
 
 - (void) asdf_nterm: (char *) buf;
 @end

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -1,3 +1,11 @@
+module BoundsUnsafe {
+  header "BoundsUnsafe.h"
+}
+
+module BoundsUnsafeObjC {
+  header "BoundsUnsafeObjC.h"
+}
+
 module ExternCtx {
   header "ExternCtx.h"
 }

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -2,6 +2,10 @@ module BoundsUnsafe {
   header "BoundsUnsafe.h"
 }
 
+module BoundsUnsafeErrors {
+  header "BoundsUnsafeErrors.h"
+}
+
 module BoundsUnsafeObjC {
   header "BoundsUnsafeObjC.h"
 }

--- a/clang/test/APINotes/boundssafety-errors.c
+++ b/clang/test/APINotes/boundssafety-errors.c
@@ -55,6 +55,20 @@ Functions:
             Kind: counted_by
             Level: 0
             BoundedBy: static_len
+  - Name:              mismatching_count
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: apinote_len
+  - Name:              mismatching_end
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: apinote_end
 //--- SemaErrors.h
 // CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
 // CHECK-NEXT: oob_level
@@ -73,6 +87,12 @@ void wrong_name(int * buf, int len2);
 // CHECK-NEXT: wrong_scope
 int static_len = 5;
 void wrong_scope(int * buf);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: pointer cannot have more than one count attribute
+// CHECK-NEXT: mismatching_count
+void mismatching_count(int * __attribute__((__counted_by__(header_len))) buf, int apinote_len, int header_len);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: pointer cannot have more than one end attribute
+// CHECK-NEXT: mismatching_end
+void mismatching_end(int * __attribute__((__ended_by__(header_end))) buf, int * apinote_end, int * header_end);
 // CHECK: SemaErrors.c:{{.*}}:{{.*}}: fatal error: could not build module 'SemaErrors'
 
 

--- a/clang/test/APINotes/boundssafety-errors.c
+++ b/clang/test/APINotes/boundssafety-errors.c
@@ -1,0 +1,115 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: split-file %s %t/Headers
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/SemaErrors.c 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/NegLevel.c 2>&1 | FileCheck %s --check-prefix NEGLEVEL
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/InvalidKind.c 2>&1 | FileCheck %s --check-prefix INVALIDKIND
+
+//--- module.modulemap
+module SemaErrors {
+  header "SemaErrors.h"
+}
+module NegLevel {
+  header "NegLevel.h"
+}
+module InvalidKind {
+  header "InvalidKind.h"
+}
+
+//--- SemaErrors.c
+#include "SemaErrors.h"
+//--- SemaErrors.apinotes
+Name: OOBLevel
+Functions:
+  - Name:              oob_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 42
+            BoundedBy: len
+  - Name:              off_by_1_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 1
+            BoundedBy: len
+  - Name:              nonpointer_param
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              wrong_name
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              wrong_scope
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: static_len
+//--- SemaErrors.h
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK-NEXT: oob_level
+void oob_level(int * buf, int len);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK-NEXT: off_by_1_level
+void off_by_1_level(int * buf, int len);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK-NEXT: nonpointer_param
+void nonpointer_param(int buf, int len);
+// CHECK: <API Notes>:1:1: error: use of undeclared identifier 'len'; did you mean 'len2'?
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: note: 'len2' declared here
+// CHECK-NEXT: wrong_name
+void wrong_name(int * buf, int len2);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: count expression in function declaration may only reference parameters of that function
+// CHECK-NEXT: wrong_scope
+int static_len = 5;
+void wrong_scope(int * buf);
+// CHECK: SemaErrors.c:{{.*}}:{{.*}}: fatal error: could not build module 'SemaErrors'
+
+
+//--- NegLevel.apinotes
+Name: NegLevel
+Functions:
+  - Name:              neg_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: -1
+            BoundedBy: len
+//--- NegLevel.h
+void neg_level(int * buf, int len);
+//--- NegLevel.c
+#include "NegLevel.h"
+// NEGLEVEL: NegLevel.apinotes:{{.*}}:{{.*}}: error: invalid number
+// NEGLEVEL-NEXT: Level: -1
+// NEGLEVEL: NegLevel.c:{{.*}}:{{.*}}: fatal error: could not build module 'NegLevel'
+
+
+//--- InvalidKind.apinotes
+Name: InvalidKind
+Functions:
+  - Name:              invalid_kind
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: __counted_by
+            Level: 0
+            BoundedBy: len
+//--- InvalidKind.h
+void invalid_kind(int * buf, int len);
+//--- InvalidKind.c
+#include "InvalidKind.h"
+// INVALIDKIND: InvalidKind.apinotes:{{.*}}:{{.*}}: error: unknown enumerated scalar
+// INVALIDKIND-NEXT: Kind: __counted_by
+// INVALIDKIND: InvalidKind.c:{{.*}}:{{.*}}: fatal error: could not build module 'InvalidKind'
+

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -35,6 +35,9 @@
 // CHECK: buf 'int * __counted_by(len)':'int *'
 // CHECK-NEXT: NoEscapeAttr
 
+// CHECK: asdf_counted_default_level 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+
 // CHECK: asdf_nterm 'void (int * __terminated_by(0))'
 // CHECK: buf 'int * __terminated_by(0)':'int *'
 

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -28,6 +28,13 @@
 // CHECK: asdf_counted_const 'void (int * __counted_by(7))'
 // CHECK: buf 'int * __counted_by(7)':'int *'
 
+// CHECK: asdf_counted_nullable 'void (int, int * __counted_by(len) _Nullable)'
+// CHECK: buf 'int * __counted_by(len) _Nullable':'int *'
+
+// CHECK: asdf_counted_noescape 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+// CHECK-NEXT: NoEscapeAttr
+
 // CHECK: asdf_nterm 'void (int * __terminated_by(0))'
 // CHECK: buf 'int * __terminated_by(0)':'int *'
 

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -15,7 +15,7 @@
 // CHECK: asdf_sized_n 'void (int * __sized_by_or_null(size), int)'
 // CHECK: buf 'int * __sized_by_or_null(size)':'int *'
 
-// CHECK: asdf_ended  'void (int * __ended_by(end), int * /* __started_by(buf) */ )'
+// CHECK: asdf_ended 'void (int * __ended_by(end), int * /* __started_by(buf) */ )'
 // CHECK: buf 'int * __ended_by(end)':'int *'
 // CHECK: end 'int * /* __started_by(buf) */ ':'int *'
 
@@ -38,6 +38,32 @@
 // CHECK: asdf_counted_default_level 'void (int * __counted_by(len), int)'
 // CHECK: buf 'int * __counted_by(len)':'int *'
 
+// CHECK: asdf_counted_redundant 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+
+// CHECK: asdf_ended_chained 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_chained_reverse 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_already_started 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_already_ended 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_redundant 'void (int * __ended_by(end), int * /* __started_by(buf) */ )'
+// CHECK: buf 'int * __ended_by(end)':'int *'
+// CHECK: end 'int * /* __started_by(buf) */ ':'int *'
+
 // CHECK: asdf_nterm 'void (int * __terminated_by(0))'
 // CHECK: buf 'int * __terminated_by(0)':'int *'
-

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -1,0 +1,33 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
+
+#include "BoundsUnsafe.h"
+
+// CHECK: asdf_counted 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+
+// CHECK: asdf_sized 'void (int * __sized_by(size), int)'
+// CHECK: buf 'int * __sized_by(size)':'int *'
+
+// CHECK: asdf_counted_n 'void (int * __counted_by_or_null(len), int)'
+// CHECK: buf 'int * __counted_by_or_null(len)':'int *'
+
+// CHECK: asdf_sized_n 'void (int * __sized_by_or_null(size), int)'
+// CHECK: buf 'int * __sized_by_or_null(size)':'int *'
+
+// CHECK: asdf_ended  'void (int * __ended_by(end), int * /* __started_by(buf) */ )'
+// CHECK: buf 'int * __ended_by(end)':'int *'
+// CHECK: end 'int * /* __started_by(buf) */ ':'int *'
+
+// CHECK: asdf_sized_mul 'void (int * __sized_by(size * count), int, int)'
+// CHECK: buf 'int * __sized_by(size * count)':'int *'
+
+// CHECK: asdf_counted_out 'void (int * __counted_by(*len)*, int *)'
+// CHECK: buf 'int * __counted_by(*len)*'
+
+// CHECK: asdf_counted_const 'void (int * __counted_by(7))'
+// CHECK: buf 'int * __counted_by(7)':'int *'
+
+// CHECK: asdf_nterm 'void (int * __terminated_by(0))'
+// CHECK: buf 'int * __terminated_by(0)':'int *'
+

--- a/clang/test/APINotes/boundssafety.m
+++ b/clang/test/APINotes/boundssafety.m
@@ -1,0 +1,48 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
+
+#include "BoundsUnsafeObjC.h"
+
+// CHECK-LABEL: asdf_counted
+// CHECK: buf 'int * __counted_by(len)':'int *'
+// CHECK-NEXT: len 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_sized
+// CHECK: buf 'int * __sized_by(size)':'int *'
+// CHECK-NEXT: size 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_counted_n
+// CHECK: buf 'int * __counted_by_or_null(len)':'int *'
+// CHECK-NEXT: len 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_sized_n
+// CHECK: buf 'int * __sized_by_or_null(size)':'int *'
+// CHECK-NEXT: size 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_ended
+// CHECK: buf 'int * __ended_by(end)':'int *'
+// CHECK: end 'int * /* __started_by(buf) */ ':'int *'
+
+// CHECK-LABEL: asdf_sized_mul
+// CHECK: buf 'int * __sized_by(size * count)':'int *'
+// CHECK-NEXT: size 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+// CHECK-NEXT: count 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_counted_out
+// CHECK: buf 'int * __counted_by(*len)*'
+// CHECK-NEXT: len 'int *'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} IsDeref {{.*}} 1
+
+// CHECK-LABEL: asdf_counted_const
+// CHECK: buf 'int * __counted_by(7)':'int *'
+
+// CHECK-LABEL: asdf_nterm
+// CHECK: buf 'int * __terminated_by(0)':'int *'
+

--- a/clang/test/APINotes/boundssafety.m
+++ b/clang/test/APINotes/boundssafety.m
@@ -43,6 +43,13 @@
 // CHECK-LABEL: asdf_counted_const
 // CHECK: buf 'int * __counted_by(7)':'int *'
 
+// CHECK-LABEL: asdf_counted_nullable
+// CHECK: buf 'int * __counted_by(len) _Nullable':'int *'
+
+// CHECK-LABEL: asdf_counted_noescape
+// CHECK: buf 'int * __counted_by(len)':'int *'
+// CHECK-NEXT: NoEscapeAttr
+
 // CHECK-LABEL: asdf_nterm
 // CHECK: buf 'int * __terminated_by(0)':'int *'
 


### PR DESCRIPTION
This adds support for annotating function parameters with __counted_by, __sized_by, __counted_by_or_null, __sized_by_or_null, and __ended_by, using API notes. The main content of handlePtrCountedByEndedByAttr is extracted to applyPtrCountedByEndedByAttr and decoupled from ParsedAttr. The helper function ParseBoundsAttributeArgFromString is added to make it possible to parse count expressions from SemaAPINotes.

The current implementation of __terminated_by/__null_terminated makes it harder to extract from the iterative type processing, but since it doesn't require any extra context to parse the attribute, it can be applied using the normal Type override instead.

rdar://139830881