### PR TITLE
[lldb] Remove unfiltered stop reason propagation from StopInfoMachException

### DIFF
--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -780,13 +780,8 @@ StopInfoSP StopInfoMachException::CreateStopReasonWithMachException(
         // but if it is for another thread, we can just report no reason.  We
         // don't need to worry about stepping over the breakpoint here, that
         // will be taken care of when the thread resumes and notices that
-        // there's a breakpoint under the pc. If we have an operating system
-        // plug-in, we might have set a thread specific breakpoint using the
-        // operating system thread ID, so we can't make any assumptions about
-        // the thread ID so we must always report the breakpoint regardless
-        // of the thread.
-        if (bp_site_sp->ValidForThisThread(thread) ||
-            thread.GetProcess()->GetOperatingSystem() != nullptr)
+        // there's a breakpoint under the pc.
+        if (bp_site_sp->ValidForThisThread(thread))
           return StopInfo::CreateStopReasonWithBreakpointSiteID(
               thread, bp_site_sp->GetID());
         else if (is_trace_if_actual_breakpoint_missing)

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -219,3 +219,16 @@ class PluginPythonOSPlugin(TestBase):
             6,
             "Make sure we stepped from line 5 to line 6 in main.c",
         )
+
+        thread_bp_number = lldbutil.run_break_set_by_source_regexp(
+            self, "Set tid-specific breakpoint here", num_expected_locations=1
+        )
+        breakpoint = target.FindBreakpointByID(thread_bp_number)
+        # This breakpoint should not be hit.
+        breakpoint.SetThreadID(123)
+        process.Continue()
+
+        frame = thread.GetFrameAtIndex(0)
+        self.assertFalse(
+            frame.IsValid(), "Should not stop, the breakpoint was not for this thread."
+        )

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/main.c
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/main.c
@@ -3,5 +3,7 @@
 int main (int argc, char const *argv[], char const *envp[])
 {
     puts("stop here"); // Set breakpoint here
+    puts("hello");
+    puts("don't stop here on tid-specific breakpoint"); // Set tid-specific breakpoint here
     return 0;
 }


### PR DESCRIPTION
In the presence of OS plugins, StopInfoMachException currently propagates breakpoint stop reasons even if those breakpoints were not intended for a specific thread, effectively removing our ability to set thread-specific breakpoints.

This was originally added in [1], but the motivation provided in the comment does not seem strong enough to remove the ability to set thread-specific breakpoints. The only way to break thread specific breakpoints would be if a user set such a breakpoint and _then_ loaded an OS plugin, a scenario which we would likely not want to support.

[1]: https://github.com/swiftlang/llvm-project/commit/ab745c2ad865c07f3905482fd071ef36c024713a#diff-8ec6e41b1dffa7ac4b5841aae24d66442ef7ebc62c8618f89354d84594f91050R501