### PR TITLE
[lldb] Update two API tests to fix x86 Darwin failures (#121380)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -1408,7 +1408,17 @@ class GdbRemoteTestCaseBase(Base, metaclass=GdbRemoteTestCaseFactory):
             p_response = context.get("p_response")
             self.assertIsNotNone(p_response)
             self.assertTrue(len(p_response) > 0)
-            self.assertFalse(p_response[0] == "E")
+
+            # on x86 Darwin, 4 GPR registers are often
+            # unavailable, this is expected and correct.
+            if (
+                self.getArchitecture() == "x86_64"
+                and self.platformIsDarwin()
+                and p_response[0] == "E"
+            ):
+                values[reg_index] = 0
+            else:
+                self.assertFalse(p_response[0] == "E")
 
             values[reg_index] = unpack_register_hex_unsigned(endian, p_response)
 

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -58,6 +58,13 @@ class RegisterCommandsTestCase(TestBase):
             # could not be read.  This is expected.
             error_str_matched = True
 
+        if self.getArchitecture() == "x86_64" and self.platformIsDarwin():
+            # debugserver on x86 will provide ds/es/ss/gsbase when the
+            # kernel provides them, but most of the time they will be
+            # unavailable.  So "register read -a" will report that
+            # 4 registers were unavailable, it is expected.
+            error_str_matched = True
+
         self.expect(
             "register read -a",
             MISSING_EXPECTED_REGISTERS,

--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -41,6 +41,11 @@ class RegisterCommandsTestCase(TestBase):
 
     @skipIfiOSSimulator
     @skipIf(archs=no_match(["amd64", "arm", "i386", "x86_64"]))
+    # This test assumes Xcode 16.2 or newer is being used, or
+    # the in-tree debugserver is being used.  Some CI bots
+    # are still using an earlier Xcode, and the test will fail.
+    # Skip this test on Intel systems, on release/6.1 branch only.
+    @skipIf(oslist=["macosx"], archs=["x86_64"])
     @expectedFailureAll(oslist=["freebsd", "netbsd"], bugnumber="llvm.org/pr48371")
     def test_register_commands(self):
         """Test commands related to registers, in particular vector registers."""


### PR DESCRIPTION
The Intel Darwin CI bots had their Xcode updated, which brought in a debugserver with Brendan Shanks' change from September 7281e0cb3bbcce396aab8b3ea0967d7a17cd287a
https://github.com/llvm/llvm-project/pull/108663 where four general purpose registers are sent by debugserver when in certain process states. But most processes (nearly all in the testsuite) do not have these registers available, so we will get register read failures when requesting those four. These two tests would flag those as errors. There would have been an additional problem with the g/G packet (which lldb doesn't use w/ debugserver, but the testsuite tests) if placeholder values were not included in the full register context bytes; I fixed that issue with the SME patch to debugserver recently already.

(cherry picked from commit 5056a4b556077da79afe34f54b5447c19a77d97d)