### PR TITLE
Migrate away from PointerUnion::{is,get} (NFC)

### DIFF
--- a/clang/lib/Index/ClangIndexRecordWriter.cpp
+++ b/clang/lib/Index/ClangIndexRecordWriter.cpp
@@ -107,7 +107,7 @@ bool ClangIndexRecordWriter::writeRecord(StringRef Filename,
     for (auto &Rel : Occur.Relations)
       Related.push_back(writer::SymbolRelation{Rel.RelatedSymbol, Rel.Roles});
     if (Occur.MacroName)
-      MacroNames[Occur.DeclOrMacro.get<const MacroInfo *>()] = Occur.MacroName;
+      MacroNames[cast<const MacroInfo *>(Occur.DeclOrMacro)] = Occur.MacroName;
 
     Impl.addOccurrence(Occur.DeclOrMacro.getOpaqueValue(), Occur.Roles, Line,
                        Col, Related);
@@ -130,7 +130,7 @@ bool ClangIndexRecordWriter::writeRecord(StringRef Filename,
       Sym.USR = getUSR(II, MI);
       assert(!Sym.USR.empty() && "Recorded macro without USR!");
     } else {
-      const Decl *D = DeclOrMacro.get<const Decl *>();
+      const Decl *D = cast<const Decl *>(DeclOrMacro);
       Sym.SymInfo = getSymbolInfo(D);
 
       auto *ND = dyn_cast<NamedDecl>(D);

--- a/clang/lib/Index/IndexRecordHasher.cpp
+++ b/clang/lib/Index/IndexRecordHasher.cpp
@@ -156,7 +156,7 @@ std::array<uint8_t, 8> index::hashRecord(const FileIndexRecord &record,
       hasher.hashDecl(D);
     } else {
       hasher.hashMacro(Info.MacroName,
-                       Info.DeclOrMacro.get<const MacroInfo *>());
+                       cast<const MacroInfo *>(Info.DeclOrMacro));
     }
 
     for (auto &Rel : Info.Relations) {

--- a/clang/lib/Tooling/Refactor/Extract.cpp
+++ b/clang/lib/Tooling/Refactor/Extract.cpp
@@ -623,7 +623,7 @@ public:
               return;
             return Handler(captureVariable(VD));
           }
-          return Handler(captureField(Entity.get<const FieldDecl *>()));
+          return Handler(captureField(cast<const FieldDecl *>(Entity)));
         });
   }
 


### PR DESCRIPTION
Note that PointerUnion::{is,get} have been deprecated in PointerUnion.h and the usage of {isa,cast} is recommended.