### PR TITLE
[lldb] Introduce command to select task "threads"

### DIFF
--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -34,7 +34,7 @@ class TestCase(TestBase):
             "thread list",
             substrs=[
                 "* thread #4294967295: tid = ",
-                "libswift_Concurrency.dylib",
+                "libswift_Concurrency.",
                 "._sleep(",
             ],
         )

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -1,0 +1,75 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import TestBase
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+
+    def test_backtrace_selected_task(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("language swift task select task")
+        self.expect(
+            "thread backtrace",
+            substrs=[
+                ".sleep(",
+                "`second() at main.swift:6:",
+                "`first() at main.swift:2:",
+                "`closure #1 in static Main.main() at main.swift:12:",
+            ],
+        )
+
+    def test_navigate_selected_task_stack(self):
+        self.build()
+        # target, process, thread, bkpt
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("language swift task select task")
+
+        self.expect(
+            "thread list",
+            substrs=[
+                "* thread #4294967295: tid = 0x0002,",
+                "libswift_Concurrency.dylib",
+                "._sleep(",
+            ],
+        )
+
+        frame_index = 0
+        for frame in process.selected_thread:
+            if "`second()" in str(frame):
+                frame_index = frame.idx
+        self.assertNotEqual(frame_index, -1)
+
+        self.expect(
+            f"frame select {frame_index}",
+            substrs=[
+                f"frame #{frame_index}:",
+                "`second() at main.swift:6:",
+                "   5   \tfunc second() async {",
+                "-> 6   \t    try? await Task.sleep(for: .seconds(10))",
+            ],
+        )
+
+        self.expect(
+            "up",
+            substrs=[
+                f"frame #{frame_index + 1}:",
+                "`first() at main.swift:2:",
+                "   1   \tfunc first() async {",
+                "-> 2   \t    await second()",
+            ],
+        )
+
+        self.expect(
+            "up",
+            substrs=[
+                f"frame #{frame_index + 2}:",
+                "`closure #1 in static Main.main() at main.swift:12:",
+                "-> 12  \t            await first()",
+            ],
+        )

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -39,7 +39,7 @@ class TestCase(TestBase):
             ],
         )
 
-        frame_index = 0
+        frame_index = -1
         for frame in process.selected_thread:
             if "`second()" in str(frame):
                 frame_index = frame.idx

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -24,7 +24,6 @@ class TestCase(TestBase):
 
     def test_navigate_selected_task_stack(self):
         self.build()
-        # target, process, thread, bkpt
         _, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -33,7 +33,7 @@ class TestCase(TestBase):
         self.expect(
             "thread list",
             substrs=[
-                "* thread #4294967295: tid = 0x0002,",
+                "* thread #4294967295: tid = ",
                 "libswift_Concurrency.dylib",
                 "._sleep(",
             ],


### PR DESCRIPTION
Introduce `language swift task select <task>`. This uses much of the work done for `task backtrace`, including the artificial thread class `ThreadTask`.

This change allows users to select a task, as though it is a thread. From there, they can run other thread commands, such as `backtrace`. Users can also then run frame navigation commands, such as `up`/`down`/`frame select`.