### PR TITLE
🍒[APINotes] Avoid duplicated attributes for class template instantiations

### DIFF
--- a/clang/lib/Sema/SemaTemplate.cpp
+++ b/clang/lib/Sema/SemaTemplate.cpp
@@ -2119,7 +2119,6 @@ DeclResult Sema::CheckClassTemplate(
     NewClass->startDefinition();
 
   ProcessDeclAttributeList(S, NewClass, Attr);
-  ProcessAPINotes(NewClass);
 
   if (PrevClassTemplate)
     mergeDeclAttributes(NewClass, PrevClassTemplate->getTemplatedDecl());

--- a/clang/test/APINotes/Inputs/Headers/Templates.h
+++ b/clang/test/APINotes/Inputs/Headers/Templates.h
@@ -6,4 +6,5 @@ struct Box {
   const T* get_ptr() const { return &value; }
 };
 
+using FloatBox = Box<float>;
 using IntBox = Box<int>;

--- a/clang/test/APINotes/templates.cpp
+++ b/clang/test/APINotes/templates.cpp
@@ -7,3 +7,6 @@
 // CHECK-BOX: Dumping Box:
 // CHECK-BOX-NEXT: ClassTemplateDecl {{.+}} imported in Templates Box
 // CHECK-BOX: SwiftAttrAttr {{.+}} <<invalid sloc>> "import_owned"
+
+// Make sure the attributes aren't duplicated.
+// CHECK-BOX-NOT: SwiftAttrAttr {{.+}} <<invalid sloc>> "import_owned"


### PR DESCRIPTION
If a C++ class template is annotated via API Notes, the instantiations had the attributes repeated twice. This is because Clang was adding the attribute twice while processing the same class template. This change makes sure we don't try to add attributes from API Notes twice.

There is currently no way to annotate specific instantiations using API Notes.

rdar://142539959
(cherry picked from commit feb787244e54fe5abe5a96fefc4c74019f21a0ff)