### PR TITLE
[lldb] Fix path of make command in dotest configuration

### DIFF
--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -10,6 +10,7 @@ executable = '@LLDB_TEST_EXECUTABLE_CONFIGURED@'
 compiler = '@LLDB_TEST_COMPILER_CONFIGURED@'
 swift_compiler = '@LLDB_SWIFTC@'
 dsymutil = '@LLDB_TEST_DSYMUTIL_CONFIGURED@'
+make_path = '@LLDB_TEST_MAKE@'
 lldb_build_dir = '@LLDB_TEST_BUILD_DIRECTORY_CONFIGURED@'
 lldb_build_intel_pt = "@LLDB_BUILD_INTEL_PT@"
 lldb_framework_dir = "@LLDB_FRAMEWORK_DIR_CONFIGURED@"
@@ -37,6 +38,7 @@ if __name__ == '__main__':
     cmd.extend(['--executable', executable])
     cmd.extend(['--compiler', compiler])
     cmd.extend(['--dsymutil', dsymutil])
+    cmd.extend(['--make', make_path])
     cmd.extend(['--lldb-libs-dir', lldb_libs_dir])
     cmd.extend(['--llvm-tools-dir', llvm_tools_dir])
     if swift_compiler:


### PR DESCRIPTION
Fixes a breakage in `lldb-dotest`. The issue is the `configuration.make_path` was not being set. This updates lldb-dotest.in to plumb through the path of the make command.

See llvm/llvm-project#93883 and llvm/llvm-project#111531.