### PR TITLE
[clang] Fix merge conflict resolution from 44aa7a066c

### DIFF
--- a/clang/lib/Frontend/DependencyFile.cpp
+++ b/clang/lib/Frontend/DependencyFile.cpp
@@ -275,8 +275,6 @@ void DependencyFileGenerator::attachToPreprocessor(Preprocessor &PP) {
   PP.addPPCallbacks(std::make_unique<DepCollectorPPCallbacks>(*this, PP));
   PP.getHeaderSearchInfo().getModuleMap().addModuleMapCallbacks(
       std::make_unique<DFGMMCallback>(*this, SkipUnusedModuleMaps));
-
-  DependencyCollector::attachToPreprocessor(PP);  
 }
 
 bool DependencyFileGenerator::sawDependency(StringRef Filename, bool FromModule,


### PR DESCRIPTION
The call to attachToPreprocessor was re-introduced in the merge conflict resolution for a revert. This causes duplicate callbacks. See the FIXME for what's going on.