### PR TITLE
[cherry-pick][lldb] Add OS plugin property for reporting all threads (#123145)

### DIFF
--- a/lldb/include/lldb/Interpreter/Interfaces/OperatingSystemInterface.h
+++ b/lldb/include/lldb/Interpreter/Interfaces/OperatingSystemInterface.h
@@ -27,6 +27,8 @@ public:
   virtual std::optional<std::string> GetRegisterContextForTID(lldb::tid_t tid) {
     return std::nullopt;
   }
+
+  virtual std::optional<bool> DoesPluginReportAllThreads() { return {}; }
 };
 } // namespace lldb_private
 

--- a/lldb/include/lldb/Target/OperatingSystem.h
+++ b/lldb/include/lldb/Target/OperatingSystem.h
@@ -61,6 +61,8 @@ public:
 
   virtual bool IsOperatingSystemPluginThread(const lldb::ThreadSP &thread_sp);
 
+  virtual bool DoesPluginReportAllThreads() = 0;
+
 protected:
   // Member variables.
   Process

--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -386,4 +386,12 @@ lldb::ThreadSP OperatingSystemPython::CreateThread(lldb::tid_t tid,
   return ThreadSP();
 }
 
+bool OperatingSystemPython::DoesPluginReportAllThreads() {
+  // If the python plugin has a "DoesPluginReportAllThreads" method, use it.
+  if (std::optional<bool> plugin_answer =
+          m_operating_system_interface_sp->DoesPluginReportAllThreads())
+    return *plugin_answer;
+  return m_process->GetOSPluginReportsAllThreads();
+}
+
 #endif // #if LLDB_ENABLE_PYTHON

--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.h
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.h
@@ -60,6 +60,8 @@ public:
   // Method for lazy creation of threads on demand
   lldb::ThreadSP CreateThread(lldb::tid_t tid, lldb::addr_t context) override;
 
+  bool DoesPluginReportAllThreads() override;
+
 protected:
   bool IsValid() const {
     return m_script_object_sp && m_script_object_sp->IsValid();

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.cpp
@@ -82,6 +82,16 @@ OperatingSystemPythonInterface::GetRegisterContextForTID(lldb::tid_t tid) {
   return obj->GetAsString()->GetValue().str();
 }
 
+std::optional<bool> OperatingSystemPythonInterface::DoesPluginReportAllThreads() {
+  Status error;
+  StructuredData::ObjectSP obj = Dispatch("does_plugin_report_all_threads", error);
+  if (!ScriptedInterface::CheckStructuredDataObject(LLVM_PRETTY_FUNCTION, obj,
+                                                    error))
+    return {};
+
+  return obj->GetAsBoolean()->GetValue();
+}
+
 void OperatingSystemPythonInterface::Initialize() {
   const std::vector<llvm::StringRef> ci_usages = {
       "settings set target.process.python-os-plugin-path <script-path>",

--- a/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.h
+++ b/lldb/source/Plugins/ScriptInterpreter/Python/Interfaces/OperatingSystemPythonInterface.h
@@ -44,6 +44,8 @@ public:
 
   std::optional<std::string> GetRegisterContextForTID(lldb::tid_t tid) override;
 
+  std::optional<bool> DoesPluginReportAllThreads() override;
+
   static void Initialize();
 
   static void Terminate();

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -1319,7 +1319,7 @@ void Process::UpdateThreadListIfNeeded() {
           // See if the OS plugin reports all threads.  If it does, then
           // it is safe to clear unseen thread's plans here.  Otherwise we
           // should preserve them in case they show up again:
-          clear_unused_threads = GetOSPluginReportsAllThreads();
+          clear_unused_threads = os->DoesPluginReportAllThreads();
 
           // Turn off dynamic types to ensure we don't run any expressions.
           // Objective-C can run an expression to determine if a SBValue is a

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -258,7 +258,7 @@ let Definition = "process_experimental" in {
   def OSPluginReportsAllThreads: Property<"os-plugin-reports-all-threads", "Boolean">,
     Global,
     DefaultTrue,
-    Desc<"Set to False if your OS Plugins doesn't report all threads on each stop.">;
+    Desc<"Set to False if your Python OS Plugin doesn't report all threads on each stop.">;
 }
 
 let Definition = "process" in {

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/TestOSPluginStepping.py
@@ -40,11 +40,6 @@ class TestOSPluginStepping(TestBase):
     def run_python_os_step_missing_thread(self, do_prune):
         """Test that the Python operating system plugin works correctly"""
 
-        # Our OS plugin does NOT report all threads:
-        result = self.dbg.HandleCommand(
-            "settings set process.experimental.os-plugin-reports-all-threads false"
-        )
-
         python_os_plugin_path = os.path.join(self.getSourceDir(), "operating_system.py")
         (target, self.process, thread, thread_bkpt) = lldbutil.run_to_source_breakpoint(
             self, "first stop in thread - do a step out", self.main_file

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/stepping_plugin_threads/operating_system.py
@@ -34,6 +34,9 @@ class OperatingSystemPlugIn(object):
             if not self.g_value.IsValid():
                 print("Could not find g_value")
 
+    def does_plugin_report_all_threads(self):
+        return False
+
     def create_thread(self, tid, context):
         print("Called create thread with tid: ", tid)
         return None


### PR DESCRIPTION
Currently, an LLDB target option controls whether plugins report all threads. However, it seems natural for this knowledge could come from the plugin itself. To support this, this commits adds a virtual method to the plugin base class, making the Python OS query the target option to preserve existing behavior.

(cherry picked from commit cb82771c96d7055d89ca67f383e6fb3c9aced178)