### PR TITLE
[Swift REPL] Inherit the environment for the Swift REPL

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -188,15 +188,11 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
                                     // breakpoint above, it better
                                     // say it is internal
 
-  lldb_private::ProcessLaunchInfo launch_info;
+  lldb_private::ProcessLaunchInfo launch_info =
+      target_sp->GetProcessLaunchInfo();
+
+  // FIXME: Why is this necessary? Document or change once we know the answer.
   llvm::StringRef target_settings_argv0 = target_sp->GetArg0();
-
-  if (target_sp->GetDisableASLR())
-    launch_info.GetFlags().Set(eLaunchFlagDisableASLR);
-
-  if (target_sp->GetDisableSTDIO())
-    launch_info.GetFlags().Set(eLaunchFlagDisableSTDIO);
-
   if (!target_settings_argv0.empty()) {
     launch_info.GetArguments().AppendArgument(target_settings_argv0);
     launch_info.SetExecutableFile(exe_module_sp->GetPlatformFileSpec(), false);
@@ -204,7 +200,6 @@ lldb::REPLSP SwiftREPL::CreateInstanceFromDebugger(Status &err,
     launch_info.SetExecutableFile(exe_module_sp->GetPlatformFileSpec(), true);
   }
 
-  launch_info.GetEnvironment() = target_sp->GetTargetEnvironment();
   debugger.SetAsyncExecution(false);
   err = target_sp->Launch(launch_info, nullptr);
   debugger.SetAsyncExecution(true);

--- a/lldb/test/Shell/SwiftREPL/EnvVars.test
+++ b/lldb/test/Shell/SwiftREPL/EnvVars.test
@@ -1,0 +1,10 @@
+// Test inheriting environment variables in the REPL.
+// REQUIRES: system-darwin
+// REQUIRES: swift
+
+// RUN: FOO=foo %lldb --repl -O 'settings set target.inherit-env true' < %s 2>&1 \
+// RUN: | FileCheck %s
+
+import Foundation
+ProcessInfo.processInfo.environment["FOO"]
+// CHECK: $R0: String? = "foo"


### PR DESCRIPTION
The Swift REPL was had rolling the ProcessLaunchInfo instead of using the one already setup by the target. While populating the launch info, it used `Target::GetTargetEnvironment()` which only looks at the corresponding setting, and ignoring the `inherit-environment` setting. The alternative of calling `Target::GetInheritedEnvironment` is also wrong, because that has the inverse problem: it only inherits the environment and doesn't merge it with the target's environment variables. The solution is to use `Target::GetProcessLaunchInfo` which populates the launch info correctly.

Propagating the environment correctly is particularly important on Windows where `Path` needs to be passed to the inferior to allow `LoadLibraryW(L"swiftCore.dll")` to succeed. Without this patch, the library is not found and the inferior exits terminating the REPL instance.

- Fixes: llvm/llvm-project#9551
- Will fix swiftlang/swift#76702 and swiftlang/swift#70005 with a corresponding driver change to set `inherit-environment` when invoking the REPL.

rdar://137522456
(cherry picked from commit 79d7505db09d7c6ab508baf7b021c15d02e158a6)