### PR TITLE
Revert "[lldb] Allow fetching of RA register when above fault handler(#98566)"

### DIFF
--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -1402,7 +1402,7 @@ RegisterContextUnwind::SavedLocationForRegister(
       // it's still live in the actual register. Handle this specially.
 
       if (!have_unwindplan_regloc && return_address_reg.IsValid() &&
-          BehavesLikeZerothFrame()) {
+          IsFrameZero()) {
         if (return_address_reg.GetAsKind(eRegisterKindLLDB) !=
             LLDB_INVALID_REGNUM) {
           lldb_private::UnwindLLDB::ConcreteRegisterLocation new_regloc;


### PR DESCRIPTION

This reverts commit fd424179dcb3417fc0675f77d2bf06c750dd1c33.

This patch has two problems.  First, it is unnecessary, Pavel landed a fix a week or so before mine which solves this problem in bbd54e08b08f5ccd38c4665178e65c58f7b14459 .  Second, the fix is incorrect; for a function above a trap handler, where all registers are available, this patch would have lldb fetch the return address register from frame 0.  This might be 10 frames up in the stack; the frame 0 return address register is incorrect.  The change would have been correct a short bit later than this, but Pavel's fix is executed earlier in the function and none of this is needed.

(cherry picked from commit d29a50f358e71a695b23e456d66ed2924617deb9)