### PR TITLE
[c-index-test] Fix JSON string quoting

### DIFF
--- a/clang/test/Index/Store/Inputs/json.c.json
+++ b/clang/test/Index/Store/Inputs/json.c.json
@@ -39,6 +39,14 @@
       "name": "Sub",
       "roles": "Def",
       "rel-roles": "RelBase,RelCont"
+    },
+    {
+      "kind": "function",
+      "lang": "C",
+      "usr": "c:@F@operator\"\"_c#*1C#l#",
+      "name": "operator\"\"_c",
+      "codegen": "__Zli2_cPKcm",
+      "roles": "Def"
     }
   ],
   "records": [
@@ -104,6 +112,12 @@
             }
           ]
 
+        },
+        {
+          "symbol": 4,
+          "line": 4,
+          "col": 7,
+          "roles": "Def"
         }
       ]
     }

--- a/clang/test/Index/Store/Inputs/test3.cpp
+++ b/clang/test/Index/Store/Inputs/test3.cpp
@@ -1,2 +1,4 @@
 class Base {};
 class Sub : public Base {};
+
+char *operator""_c(const char *c, unsigned long) { return const_cast<char *>(c); }

--- a/clang/tools/c-index-test/JSONAggregation.cpp
+++ b/clang/tools/c-index-test/JSONAggregation.cpp
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/BuryPointer.h"
+#include "llvm/Support/JSON.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -270,12 +271,17 @@ void Aggregator::dumpJSON(raw_ostream &OS) {
   for (unsigned i = 0, e = Symbols.size(); i != e; ++i) {
     OS.indent(4) << "{\n";
     SymbolInfo &symInfo = Symbols[i];
-    OS.indent(6) << "\"kind\": \"" << getSymbolKindString(symInfo.Kind) << "\",\n";
-    OS.indent(6) << "\"lang\": \"" << getSymbolLanguageString(symInfo.Lang) << "\",\n";
-    OS.indent(6) << "\"usr\": \"" << symInfo.USR << "\",\n";
-    OS.indent(6) << "\"name\": \"" << symInfo.Name << "\",\n";
+
+    OS.indent(6) << "\"kind\": "
+                 << json::Value(getSymbolKindString(symInfo.Kind)) << ",\n";
+    OS.indent(6) << "\"lang\": "
+                 << json::Value(getSymbolLanguageString(symInfo.Lang))
+                 << ",\n";
+    OS.indent(6) << "\"usr\": " << json::Value(symInfo.USR) << ",\n";
+    OS.indent(6) << "\"name\": " << json::Value(symInfo.Name) << ",\n";
     if (!symInfo.CodegenName.empty())
-      OS.indent(6) << "\"codegen\": \"" << symInfo.CodegenName << "\",\n";
+      OS.indent(6) << "\"codegen\": " << json::Value(symInfo.CodegenName)
+                   << ",\n";
     OS.indent(6) << "\"roles\": \"";
     printSymbolRoles(symInfo.Roles, OS);
     OS << '\"';
@@ -344,7 +350,7 @@ void Aggregator::dumpJSON(raw_ostream &OS) {
   for (unsigned i = 0, e = Units.size(); i != e; ++i) {
     OS.indent(4) << "{\n";
     UnitInfo &unit = *Units[i];
-    OS.indent(6) << "\"triple\": \"" << unit.Triple << "\",\n";
+    OS.indent(6) << "\"triple\": " << json::Value(unit.Triple) << ",\n";
     OS.indent(6) << "\"out-file\": " << unit.OutFile << ",\n";
     if (!unit.UnitDepends.empty()) {
       OS.indent(6) << "\"unit-dependencies\": [";


### PR DESCRIPTION
Previously, c-index-test assumed that all it could write strings to the JSON output directly. This breaks if any strings contain double-quotes or backslashes, which can occur for C++ string literals.

Ensure that strings are properly quoted for JSON, and add a test for string literals.