### PR TITLE
[C++ Modules] Fix `clangd` C++ module PrerequisiteModulesTests

### DIFF
--- a/clang-tools-extra/clangd/unittests/PrerequisiteModulesTest.cpp
+++ b/clang-tools-extra/clangd/unittests/PrerequisiteModulesTest.cpp
@@ -34,6 +34,8 @@ public:
         TFS(TFS) {
     this->ExtraClangFlags.push_back("-std=c++20");
     this->ExtraClangFlags.push_back("-c");
+    this->ExtraClangFlags.push_back("-fmodules");
+    this->ExtraClangFlags.push_back("-fcxx-modules");
   }
 
   void addFile(llvm::StringRef Path, llvm::StringRef Contents);

--- a/clang-tools-extra/clangd/unittests/PrerequisiteModulesTest.cpp
+++ b/clang-tools-extra/clangd/unittests/PrerequisiteModulesTest.cpp
@@ -34,8 +34,6 @@ public:
         TFS(TFS) {
     this->ExtraClangFlags.push_back("-std=c++20");
     this->ExtraClangFlags.push_back("-c");
-    this->ExtraClangFlags.push_back("-fmodules");
-    this->ExtraClangFlags.push_back("-fcxx-modules");
   }
 
   void addFile(llvm::StringRef Path, llvm::StringRef Contents);

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -5271,7 +5271,7 @@ ASTReader::ASTReadResult ASTReader::readUnhashedControlBlockImpl(
     }
     case FILE_SYSTEM_OPTIONS: {
       bool Complain = (ClientLoadCapabilities & ARR_ConfigurationMismatch) == 0;
-      if (!AllowCompatibleConfigurationMismatch &&
+      if (Listener && !AllowCompatibleConfigurationMismatch &&
           ParseFileSystemOptions(Record, Complain, *Listener))
         Result = ConfigurationMismatch;
       break;


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/fe6c24000f2d7316899d4ec4c12273892326ed47 added a few C++ module tests to  `clangd`'s unit test suite. The swift fork handles module parsing differently and requires `-fmodules -fcxx-modules` to process C++20 modules. 

Additionally, these tests tripped a code path not seemingly covered before where the `ASTReader` can dereference a null pointer. 

This PR fixes the tests and checks for the null pointer. 

rdar://133960719