### PR TITLE
[ThinLTO][Cache] When remote caching is enabled, use the passed-in thin-LTO cache as temp directory

### DIFF
--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -235,6 +235,12 @@ public:
   /// the processing.
   void setSaveTempsDir(std::string Path) { SaveTempsDir = std::move(Path); }
 
+  /// Set the path to a directory where to save temporaries from the remote
+  /// service.
+  void setRemoteServiceTempsDir(std::string Path) {
+    RemoteServiceTempsDir = std::move(Path);
+  }
+
   /// Set the path to a directory where to save generated object files. This
   /// path can be used by a linker to request on-disk files instead of in-memory
   /// buffers. When set, results are available through getProducedBinaryFiles()
@@ -375,6 +381,9 @@ private:
 
   /// Path to a directory to save the temporary bitcode files.
   std::string SaveTempsDir;
+
+  /// Path to a directory to save the temporary remote service files.
+  std::string RemoteServiceTempsDir;
 
   /// Path to a directory to save the generated object files.
   std::string SavedObjectsDirectoryPath;

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -1588,6 +1588,8 @@ void ThinLTOCodeGenerator::run() {
   // First, we need to remember whether the caller requests buffer API or file
   // API based on if the SavedObjectsDirectoryPath was set or not.
   bool UseBufferAPI = SavedObjectsDirectoryPath.empty();
+  if (SavedObjectsDirectoryPath.empty())
+    SavedObjectsDirectoryPath = RemoteServiceTempsDir;
   std::string TempDirectory;
   if (CacheOptions.Type == CachingOptions::CacheType::RemoteService &&
       SavedObjectsDirectoryPath.empty()) {

--- a/llvm/tools/lto/lto.cpp
+++ b/llvm/tools/lto/lto.cpp
@@ -619,6 +619,10 @@ void thinlto_codegen_set_cpu(thinlto_code_gen_t cg, const char *cpu) {
 
 void thinlto_codegen_set_cache_dir(thinlto_code_gen_t cg,
                                    const char *cache_dir) {
+  if (sys::Process::GetEnv("LLVM_THINLTO_USE_REMOTE_CACHE")) {
+    unwrap(cg)->setRemoteServiceTempsDir(cache_dir);
+    return;
+  }
   // FIXME: need to return error somehow.
   Error Err = unwrap(cg)->setCacheDir(cache_dir);
   if (Err)


### PR DESCRIPTION
This ensures that we can move cached artifacts from the remote service to the temp directory because they should be on the same disk volume.

rdar://126211886
(cherry picked from commit d6e056296eb6a6b278c394794ddff94eb2c8fda8)