### PR TITLE
Cherry pick commits that relanded commit 34a72d1c5a014cbe9f9e270853d39d96c4901444

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -968,8 +968,13 @@ AST_MATCHER(ArraySubscriptExpr, isSafeArraySubscript) {
     return false;
   }
 
-  if (const auto *IdxLit = dyn_cast<IntegerLiteral>(Node.getIdx())) {
-    const APInt ArrIdx = IdxLit->getValue();
+  Expr::EvalResult EVResult;
+  const Expr *IndexExpr = Node.getIdx();
+  if (!IndexExpr->isValueDependent() &&
+      IndexExpr->EvaluateAsInt(EVResult, Finder->getASTContext())) {
+    llvm::APSInt ArrIdx = EVResult.Val.getInt();
+    // FIXME: ArrIdx.isNegative() we could immediately emit an error as that's a
+    // bug
     if (ArrIdx.isNonNegative() && ArrIdx.getLimitedValue() < limit)
       return true;
   }

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -968,11 +968,8 @@ AST_MATCHER(ArraySubscriptExpr, isSafeArraySubscript) {
     return false;
   }
 
-  Expr::EvalResult EVResult;
-  if (Node.getIdx()->EvaluateAsInt(EVResult, Finder->getASTContext())) {
-    llvm::APSInt ArrIdx = EVResult.Val.getInt();
-    // FIXME: ArrIdx.isNegative() we could immediately emit an error as that's a
-    // bug
+  if (const auto *IdxLit = dyn_cast<IntegerLiteral>(Node.getIdx())) {
+    const APInt ArrIdx = IdxLit->getValue();
     if (ArrIdx.isNonNegative() && ArrIdx.getLimitedValue() < limit)
       return true;
   }

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-array.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-array.cpp
@@ -92,35 +92,3 @@ char access_strings() {
   c = array_string[5];
   return c;
 }
-
-struct T {
-  int array[10];
-};
-
-const int index = 1;
-
-constexpr int get_const(int x) {
-  if(x < 3)
-    return ++x;
-  else
-    return x + 5;
-};
-
-void array_indexed_const_expr(unsigned idx) {
-  // expected-note@+2 {{change type of 'arr' to 'std::array' to label it for hardening}}
-  // expected-warning@+1{{'arr' is an unsafe buffer that does not perform bounds checks}}
-  int arr[10];
-  arr[sizeof(int)] = 5;
-
-  int array[sizeof(T)];
-  array[sizeof(int)] = 5;
-  array[sizeof(T) -1 ] = 3;
-
-  int k = arr[6 & 5];
-  k = arr[2 << index];
-  k = arr[8 << index]; // expected-note {{used in buffer access here}}
-  k = arr[16 >> 1];
-  k = arr[get_const(index)];
-  k = arr[get_const(5)]; // expected-note {{used in buffer access here}}
-  k = arr[get_const(4)];
-}

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-array.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-array.cpp
@@ -92,3 +92,35 @@ char access_strings() {
   c = array_string[5];
   return c;
 }
+
+struct T {
+  int array[10];
+};
+
+const int index = 1;
+
+constexpr int get_const(int x) {
+  if(x < 3)
+    return ++x;
+  else
+    return x + 5;
+};
+
+void array_indexed_const_expr(unsigned idx) {
+  // expected-note@+2 {{change type of 'arr' to 'std::array' to label it for hardening}}
+  // expected-warning@+1{{'arr' is an unsafe buffer that does not perform bounds checks}}
+  int arr[10];
+  arr[sizeof(int)] = 5;
+
+  int array[sizeof(T)];
+  array[sizeof(int)] = 5;
+  array[sizeof(T) -1 ] = 3;
+
+  int k = arr[6 & 5];
+  k = arr[2 << index];
+  k = arr[8 << index]; // expected-note {{used in buffer access here}}
+  k = arr[16 >> 1];
+  k = arr[get_const(index)];
+  k = arr[get_const(5)]; // expected-note {{used in buffer access here}}
+  k = arr[get_const(4)];
+}


### PR DESCRIPTION
The commit 34a72d1c5a014cbe9f9e270853d39d96c4901444 led to an assertion violation in one of third party code bases and was reverted upstream. This PR cherry picks that revert and the relanded commit.