### PR TITLE
[lldb] Introduce backtracing of Swift Tasks (#9845)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/CMakeLists.txt
@@ -6,6 +6,7 @@ add_lldb_library(lldbPluginSwiftLanguageRuntime PLUGIN
   SwiftLanguageRuntimeNames.cpp
   SwiftLanguageRuntimeRemoteAST.cpp
   SwiftMetadataCache.cpp
+  SwiftTask.cpp
 
   LINK_LIBS
     swiftAST

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -401,6 +401,8 @@ public:
     result.hasIsRunning = task_info.HasIsRunning;
     result.isRunning = task_info.IsRunning;
     result.isEnqueued = task_info.IsEnqueued;
+    result.id = task_info.Id;
+    result.resumeAsyncContext = task_info.ResumeAsyncContext;
     return result;
   }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -15,6 +15,7 @@
 
 #include <mutex>
 
+#include "lldb/lldb-defines.h"
 #include "lldb/lldb-types.h"
 #include "swift/ABI/ObjectFile.h"
 #include "swift/Remote/RemoteAddress.h"
@@ -163,6 +164,8 @@ public:
     bool hasIsRunning = false;
     bool isRunning = false;
     bool isEnqueued = false;
+    uint64_t id = 0;
+    lldb::addr_t resumeAsyncContext = LLDB_INVALID_ADDRESS;
   };
   // The default limits are copied from swift-inspect.
   virtual llvm::Expected<AsyncTaskInfo>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.cpp
@@ -1,0 +1,74 @@
+#include "SwiftTask.h"
+#include "SwiftLanguageRuntime.h"
+#include "lldb/Target/Process.h"
+#include "lldb/lldb-enumerations.h"
+#include "llvm/Support/Error.h"
+
+using namespace llvm;
+using namespace lldb;
+
+namespace lldb_private {
+
+ThreadTask::ThreadTask(tid_t tid, addr_t async_ctx, addr_t resume_fn,
+                       ExecutionContext &exe_ctx)
+    : Thread(exe_ctx.GetProcessRef(), tid, true),
+      m_reg_info_sp(exe_ctx.GetFrameSP()->GetRegisterContext()),
+      m_async_ctx(async_ctx), m_resume_fn(resume_fn) {}
+
+RegisterContextSP lldb_private::ThreadTask::GetRegisterContext() {
+  if (!m_async_reg_ctx_sp)
+    m_async_reg_ctx_sp = std::make_shared<RegisterContextTask>(
+        *this, m_reg_info_sp, m_resume_fn, m_async_ctx);
+  return m_async_reg_ctx_sp;
+}
+
+llvm::Expected<std::shared_ptr<ThreadTask>>
+ThreadTask::Create(tid_t tid, addr_t async_ctx, ExecutionContext &exe_ctx) {
+  auto &process = exe_ctx.GetProcessRef();
+  auto &target = exe_ctx.GetTargetRef();
+
+  // A simplified description of AsyncContext. See swift/Task/ABI.h
+  // struct AsyncContext {
+  //   AsyncContext *Parent;                    // offset 0
+  //   TaskContinuationFunction *ResumeParent;  // offset 8
+  // };
+  // The resume function is stored at `offsetof(AsyncContext, ResumeParent)`,
+  // which is the async context's base address plus the size of a pointer.
+  uint32_t ptr_size = target.GetArchitecture().GetAddressByteSize();
+  addr_t resume_ptr = async_ctx + ptr_size;
+  Status status;
+  addr_t resume_fn = process.ReadPointerFromMemory(resume_ptr, status);
+  if (status.Fail() || resume_fn == LLDB_INVALID_ADDRESS)
+    return createStringError("failed to read task's resume function");
+
+  return std::make_shared<ThreadTask>(tid, async_ctx, resume_fn, exe_ctx);
+}
+
+RegisterContextTask::RegisterContextTask(Thread &thread,
+                                         RegisterContextSP reg_info_sp,
+                                         addr_t resume_fn, addr_t async_ctx)
+    : RegisterContext(thread, 0), m_reg_info_sp(reg_info_sp),
+      m_async_ctx(async_ctx), m_resume_fn(resume_fn) {
+  auto &target = thread.GetProcess()->GetTarget();
+  auto triple = target.GetArchitecture().GetTriple();
+  if (auto regnums = GetAsyncUnwindRegisterNumbers(triple.getArch()))
+    m_async_ctx_regnum = regnums->async_ctx_regnum;
+}
+
+bool RegisterContextTask::ReadRegister(const RegisterInfo *reg_info,
+                                       RegisterValue &reg_value) {
+  if (!reg_info)
+    return false;
+
+  if (reg_info->kinds[eRegisterKindGeneric] == LLDB_REGNUM_GENERIC_PC) {
+    reg_value = m_resume_fn;
+    return true;
+  }
+  if (reg_info->kinds[eRegisterKindLLDB] == m_async_ctx_regnum) {
+    reg_value = m_async_ctx;
+    return true;
+  }
+  return false;
+}
+
+} // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.h
@@ -1,0 +1,97 @@
+
+#include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/Thread.h"
+#include "lldb/Utility/RegisterValue.h"
+#include "lldb/lldb-forward.h"
+
+namespace lldb_private {
+
+using namespace lldb;
+
+/// Provides a subset of Thread operations for Swift Tasks.
+///
+/// Currently, this supports backtraces of Tasks, and selecting frames in the
+/// backtrace. Async frames make available the variables that are stored in the
+/// Task's "async context" (instead of the stack).
+///
+/// See `Task<Success, Failure>` and `UnsafeCurrentTask`
+class ThreadTask final : public Thread {
+public:
+  ThreadTask(tid_t tid, addr_t async_ctx, addr_t resume_fn,
+             ExecutionContext &exe_ctx);
+
+  static llvm::Expected<std::shared_ptr<ThreadTask>>
+  Create(tid_t tid, addr_t async_ctx, ExecutionContext &exe_ctx);
+
+  /// Returns a Task specific register context (RegisterContextTask).
+  RegisterContextSP GetRegisterContext() override;
+
+  ~ThreadTask() override { DestroyThread(); }
+
+  // No-op overrides.
+  void RefreshStateAfterStop() override {}
+  lldb::RegisterContextSP
+  CreateRegisterContextForFrame(StackFrame *frame) override {
+    return {};
+  }
+  bool CalculateStopInfo() override { return false; }
+
+private:
+  /// A register context that is the source of `RegisterInfo` data.
+  RegisterContextSP m_reg_info_sp;
+  /// Lazily initialized `RegisterContextTask`.
+  RegisterContextSP m_async_reg_ctx_sp;
+  /// The Task's async context.
+  addr_t m_async_ctx = LLDB_INVALID_ADDRESS;
+  /// The address of the async context's resume function.
+  addr_t m_resume_fn = LLDB_INVALID_ADDRESS;
+};
+
+/// A Swift Task specific register context. Supporting class for `ThreadTask`,
+/// see its documentation for details.
+class RegisterContextTask final : public RegisterContext {
+public:
+  RegisterContextTask(Thread &thread, RegisterContextSP reg_info_sp,
+                      addr_t resume_fn, addr_t async_ctx);
+
+  /// RegisterContextTask supports readonly from only two (necessary)
+  /// registers. Namely, the pc and the async context registers.
+  bool ReadRegister(const RegisterInfo *reg_info,
+                    RegisterValue &reg_value) override;
+
+  // Pass through overrides.
+  size_t GetRegisterCount() override {
+    return m_reg_info_sp->GetRegisterCount();
+  }
+  const RegisterInfo *GetRegisterInfoAtIndex(size_t idx) override {
+    return m_reg_info_sp->GetRegisterInfoAtIndex(idx);
+  }
+  size_t GetRegisterSetCount() override {
+    return m_reg_info_sp->GetRegisterSetCount();
+  }
+  const RegisterSet *GetRegisterSet(size_t reg_set) override {
+    return m_reg_info_sp->GetRegisterSet(reg_set);
+  }
+  lldb::ByteOrder GetByteOrder() override {
+    return m_reg_info_sp->GetByteOrder();
+  }
+
+  // No-op overrides.
+  void InvalidateAllRegisters() override {}
+  bool WriteRegister(const RegisterInfo *reg_info,
+                     const RegisterValue &reg_value) override {
+    return false;
+  }
+
+private:
+  /// A register context that is the source of `RegisterInfo` data.
+  RegisterContextSP m_reg_info_sp;
+  /// The architecture specific regnum (LLDB) which holds the async context.
+  uint32_t m_async_ctx_regnum = LLDB_INVALID_REGNUM;
+  /// The Task's async context.
+  RegisterValue m_async_ctx;
+  /// The address of the async context's resume function.
+  RegisterValue m_resume_fn;
+};
+
+} // namespace lldb_private

--- a/lldb/test/API/lang/swift/async/tasks/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import TestBase
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "language swift task backtrace task",
+            substrs=[
+                ".sleep(",
+                "`second() at main.swift:6",
+                "`first() at main.swift:2",
+                "`closure #1 in static Main.main() at main.swift:12",
+            ],
+        )

--- a/lldb/test/API/lang/swift/async/tasks/main.swift
+++ b/lldb/test/API/lang/swift/async/tasks/main.swift
@@ -1,0 +1,17 @@
+func first() async {
+    await second()
+}
+
+func second() async {
+    try? await Task.sleep(for: .seconds(10))
+}
+
+@main struct Main {
+    static func main() async {
+        let task = Task {
+            await first()
+        }
+        try? await Task.sleep(for: .seconds(0.01))
+        print("break here")
+    }
+}


### PR DESCRIPTION
Introduces the first of a new group of commands for working with Swift Task instances.

The new command group is `language swift task`, and the first command is `backtrace`. This `backtrace` command takes the name of a task variable and prints the task's backtrace. The variable can be either `Task<Success, Failure>` or `UnsafeCurrentTask`. The output is similar to the builtin `thread backtrace` (`bt`) command.

See the original PR: https://github.com/swiftlang/llvm-project/pull/9787

(cherry picked from commit 2c3335dafa328a1c9b4fc5652aeee72727ec9465)
