### PR TITLE
[lldb] Introduce Swift "task info" command

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -12,6 +12,7 @@
 
 #include "SwiftLanguageRuntime.h"
 #include "Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "ReflectionContextInterface.h"
 #include "SwiftMetadataCache.h"
 
@@ -34,6 +35,7 @@
 #include "lldb/Interpreter/CommandObject.h"
 #include "lldb/Interpreter/CommandObjectMultiword.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
+#include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/FuncUnwinders.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/VariableList.h"
@@ -63,6 +65,8 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/Memory.h"
 
 // FIXME: we should not need this
@@ -2183,6 +2187,61 @@ private:
   }
 };
 
+class CommandObjectLanguageSwiftTaskInfo final : public CommandObjectParsed {
+public:
+  CommandObjectLanguageSwiftTaskInfo(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "info",
+                            "Print the Task being run on the current thread.") {
+  }
+
+private:
+  void DoExecute(Args &command, CommandReturnObject &result) override {
+    if (!m_exe_ctx.GetThreadPtr()) {
+      result.AppendError("must be run from a running process and valid thread");
+      return;
+    }
+
+    auto task_addr_or_err =
+        GetTaskAddrFromThreadLocalStorage(m_exe_ctx.GetThreadRef());
+    if (auto error = task_addr_or_err.takeError()) {
+      result.AppendError(toString(std::move(error)));
+      return;
+    }
+
+    auto ts_or_err = m_exe_ctx.GetTargetRef().GetScratchTypeSystemForLanguage(
+        eLanguageTypeSwift);
+    if (auto error = ts_or_err.takeError()) {
+      result.AppendErrorWithFormatv("could not get Swift type system: {0}",
+                                    llvm::fmt_consume(std::move(error)));
+      return;
+    }
+
+    auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(ts_or_err->get());
+    if (!ts) {
+      result.AppendError("could not get Swift type system");
+      return;
+    }
+
+    addr_t task_addr = task_addr_or_err.get();
+    // TypeMangling for "Swift.UnsafeCurrentTask"
+    CompilerType task_type =
+        ts->GetTypeFromMangledTypename(ConstString("$sSctD"));
+    auto task_sp = ValueObject::CreateValueObjectFromAddress(
+        "current_task", task_addr, m_exe_ctx, task_type, false);
+    if (auto synthetic_sp = task_sp->GetSyntheticValue())
+      task_sp = synthetic_sp;
+
+    auto error = task_sp->Dump(result.GetOutputStream());
+    if (error) {
+      result.AppendErrorWithFormatv("failed to print current task: {0}",
+                                    toString(std::move(error)));
+      return;
+    }
+
+    result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
+  }
+};
+
 class CommandObjectLanguageSwiftTask final : public CommandObjectMultiword {
 public:
   CommandObjectLanguageSwiftTask(CommandInterpreter &interpreter)
@@ -2195,6 +2254,9 @@ public:
     LoadSubCommand(
         "select",
         CommandObjectSP(new CommandObjectLanguageSwiftTaskSelect(interpreter)));
+    LoadSubCommand(
+        "info",
+        CommandObjectSP(new CommandObjectLanguageSwiftTaskInfo(interpreter)));
   }
 };
 
@@ -2643,7 +2705,7 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
 }
 
 llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
-#if SWIFT_THREADING_USE_DIRECT_TSD
+#if !SWIFT_THREADING_USE_RESERVED_TLS_KEYS
   return llvm::createStringError(
       "getting the current task from a thread is not supported");
 #else

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2642,19 +2642,19 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
   return pc_value + prologue_size;
 }
 
-std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
+llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
+#if SWIFT_THREADING_USE_DIRECT_TSD
+  return llvm::createStringError(
+      "getting the current task from a thread is not supported");
+#else
   // Compute the thread local storage address for this thread.
-  StructuredData::ObjectSP info_root_sp = thread.GetExtendedInfo();
-  if (!info_root_sp)
-    return {};
-  StructuredData::ObjectSP node =
-      info_root_sp->GetObjectForDotSeparatedPath("tsd_address");
-  if (!node)
-    return {};
-  StructuredData::UnsignedInteger *raw_tsd_addr = node->GetAsUnsignedInteger();
-  if (!raw_tsd_addr)
-    return {};
-  addr_t tsd_addr = raw_tsd_addr->GetUnsignedIntegerValue();
+  addr_t tsd_addr = LLDB_INVALID_ADDRESS;
+  if (auto info_sp = thread.GetExtendedInfo())
+    if (auto *info_dict = info_sp->GetAsDictionary())
+      info_dict->GetValueForKeyAsInteger("tsd_address", tsd_addr);
+
+  if (tsd_addr == LLDB_INVALID_ADDRESS)
+    return llvm::createStringError("could not read current task from thread");
 
   // Offset of the Task pointer in a Thread's local storage.
   Process &process = *thread.GetProcess();
@@ -2662,10 +2662,12 @@ std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
   uint64_t task_ptr_offset_in_tls =
       swift::tls_get_key(swift::tls_key::concurrency_task) * ptr_size;
   addr_t task_addr_location = tsd_addr + task_ptr_offset_in_tls;
-  Status error;
-  addr_t task_addr = process.ReadPointerFromMemory(task_addr_location, error);
-  if (error.Fail())
-    return {};
+  Status status;
+  addr_t task_addr = process.ReadPointerFromMemory(task_addr_location, status);
+  if (status.Fail())
+    return llvm::createStringError("could not get current task from thread: %s",
+                                   status.AsCString());
   return task_addr;
+#endif
 }
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -43,6 +43,7 @@
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/OptionParsing.h"
+#include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/Timer.h"
 #include "lldb/ValueObject/ValueObject.h"
 #include "lldb/ValueObject/ValueObjectCast.h"
@@ -52,8 +53,9 @@
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/Demangling/Demangle.h"
-#include "swift/RemoteInspection/ReflectionContext.h"
 #include "swift/RemoteAST/RemoteAST.h"
+#include "swift/RemoteInspection/ReflectionContext.h"
+#include "swift/Threading/ThreadLocalStorage.h"
 
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclCXX.h"
@@ -2638,5 +2640,32 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
   auto prologue_size = sc.symbol ? sc.symbol->GetPrologueByteSize()
                                  : sc.function->GetPrologueByteSize();
   return pc_value + prologue_size;
+}
+
+std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
+  // Compute the thread local storage address for this thread.
+  StructuredData::ObjectSP info_root_sp = thread.GetExtendedInfo();
+  if (!info_root_sp)
+    return {};
+  StructuredData::ObjectSP node =
+      info_root_sp->GetObjectForDotSeparatedPath("tsd_address");
+  if (!node)
+    return {};
+  StructuredData::UnsignedInteger *raw_tsd_addr = node->GetAsUnsignedInteger();
+  if (!raw_tsd_addr)
+    return {};
+  addr_t tsd_addr = raw_tsd_addr->GetUnsignedIntegerValue();
+
+  // Offset of the Task pointer in a Thread's local storage.
+  Process &process = *thread.GetProcess();
+  size_t ptr_size = process.GetAddressByteSize();
+  uint64_t task_ptr_offset_in_tls =
+      swift::tls_get_key(swift::tls_key::concurrency_task) * ptr_size;
+  addr_t task_addr_location = tsd_addr + task_ptr_offset_in_tls;
+  Status error;
+  addr_t task_addr = process.ReadPointerFromMemory(task_addr_location, error);
+  if (error.Fail())
+    return {};
+  return task_addr;
 }
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -852,7 +852,7 @@ GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 
 /// Inspects thread local storage to find the address of the currently executing
 /// task.
-std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
+llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
 } // namespace lldb_private
 
 #endif // liblldb_SwiftLanguageRuntime_h_

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -849,6 +849,10 @@ struct AsyncUnwindRegisterNumbers {
 
 std::optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
+
+/// Inspects thread local storage to find the address of the currently executing
+/// task.
+std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
 } // namespace lldb_private
 
 #endif // liblldb_SwiftLanguageRuntime_h_

--- a/lldb/test/API/lang/swift/async/tasks/info/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/info/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import TestBase
+import lldbsuite.test.lldbutil as lldbutil
+
+import re
+
+
+def _tail(output):
+    """Delete the first line of output text."""
+    result, _ = re.subn(r"^.*\n", "", output, count=1)
+    return result
+
+
+class TestCase(TestBase):
+
+    @skipUnlessDarwin
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("frame variable task")
+        frame_variable_output = self.res.GetOutput()
+        self.runCmd("language swift task info")
+        task_info_output = self.res.GetOutput()
+        self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))

--- a/lldb/test/API/lang/swift/async/tasks/info/main.swift
+++ b/lldb/test/API/lang/swift/async/tasks/info/main.swift
@@ -1,0 +1,9 @@
+@main struct Main {
+    static func main() async {
+        withUnsafeCurrentTask { task in
+            if let task {
+                print("break here")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds `language swift task info`, which accesses the thread's current `Task`, and prints the task instance.

This is equivalent to using `withUnsafeCurrentTask`, but works without expression evaluation. This lets users print the current task, even when there's no `Task` variable to reference.