### PR TITLE
[🍒 swift/release/6.1] [lldb] Cleanup dyld_process_t after constructing SharedCacheInfo (#106157)

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -636,12 +636,15 @@ bool SharedCacheInfo::CreateSharedCacheInfoWithInstrospectionSPIs() {
   if (!dyld_process)
     return false;
 
+  auto cleanup_process_on_exit =
+      llvm::make_scope_exit([&]() { dyld_process_dispose(dyld_process); });
+
   dyld_process_snapshot_t snapshot =
       dyld_process_snapshot_create_for_process(dyld_process, nullptr);
   if (!snapshot)
     return false;
 
-  auto on_exit =
+  auto cleanup_snapshot_on_exit =
       llvm::make_scope_exit([&]() { dyld_process_snapshot_dispose(snapshot); });
 
   dyld_shared_cache_t shared_cache =


### PR DESCRIPTION
…6157)

Without calling `dyld_process_dispose`, LLDB will leak the memory associated with the `dyld_process_t`.

rdar://134738265
(cherry picked from commit 384d69fcbbd07941e7eb1899435e4d56d0469637)