### PR TITLE
[lldb] Recursively resolve type aliases when canonicalizing types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -936,13 +936,6 @@ IsClangImportedType(NodePointer node,
   }
 }
 
-/// Resolve a type alias node and return a demangle tree for the
-/// resolved type. If the type alias resolves to a Clang type, return
-/// a Clang CompilerType.
-///
-/// \param prefer_clang_types if this is true, type aliases in the
-///                           __C module are resolved as Clang types.
-///
 std::pair<swift::Demangle::NodePointer, CompilerType>
 TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
                                          swift::Demangle::NodePointer node,
@@ -1191,7 +1184,7 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
                    Node::Kind::Structure, "Array");
   }
   case Node::Kind::SugaredDictionary:
-    // FIXME: This isnt covered by any test.
+    // FIXME: This isn't covered by any test.
     assert(node->getNumChildren() == 2);
     if (node->getNumChildren() != 2)
       return node;
@@ -1205,15 +1198,27 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
 
   case Node::Kind::BoundGenericTypeAlias:
   case Node::Kind::TypeAlias: {
-    auto node_clangtype = ResolveTypeAlias(dem, node);
-    if (CompilerType clang_type = node_clangtype.second) {
-      if (auto result = GetClangTypeNode(clang_type, dem))
-        return result;
-      else
+    // Safeguard against cyclic aliases.
+    for (unsigned alias_depth = 0; alias_depth < 64; ++alias_depth) {
+      auto node_clangtype = ResolveTypeAlias(dem, node);
+      if (CompilerType clang_type = node_clangtype.second) {
+        if (auto result = GetClangTypeNode(clang_type, dem))
+          return result;
+        // Failed to convert that clang type into a demangle node.
         return node;
+      }
+      if (!node_clangtype.first)
+        return node;
+      if (node_clangtype.first == node)
+        return node;
+      node = node_clangtype.first;
+      if (node->getKind() != Node::Kind::BoundGenericTypeAlias &&
+          node->getKind() != Node::Kind::TypeAlias)
+        // Resolve any type aliases in the resolved type.
+        return GetCanonicalNode(dem, node);
+      // This type alias resolved to another type alias.
     }
-    if (node_clangtype.first)
-      return node_clangtype.first;
+    // Hit the safeguard limit.
     return node;
   }
   default:

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -490,6 +490,18 @@ protected:
   CompilerType LookupClangForwardType(llvm::StringRef name, 
                   llvm::ArrayRef<CompilerContext> decl_context);
 
+  /// Recursively resolves all type aliases.
+  swift::Demangle::NodePointer
+  ResolveAllTypeAliases(swift::Demangle::Demangler &dem,
+                        swift::Demangle::NodePointer node);
+
+  /// Resolve a type alias node and return a demangle tree for the
+  /// resolved type. If the type alias resolves to a Clang type, return
+  /// a Clang CompilerType.
+  ///
+  /// \param prefer_clang_types if this is true, type aliases in the
+  ///                           __C module are resolved as Clang types.
+  ///
   std::pair<swift::Demangle::NodePointer, CompilerType>
   ResolveTypeAlias(swift::Demangle::Demangler &dem,
                    swift::Demangle::NodePointer node,

--- a/lldb/test/API/lang/swift/typealias_recursive/Makefile
+++ b/lldb/test/API/lang/swift/typealias_recursive/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES = main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
+++ b/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
@@ -1,0 +1,14 @@
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftTypeAliasRecurtsive(TestBase):
+    @swiftTest
+    def test(self):
+        """Test that type aliases of type aliases can be resolved"""
+        self.build()
+        self.runCmd("settings set symbols.swift-validate-typesystem false")
+        self.expect("log enable lldb types")
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+        self.expect("frame variable cls", substrs=["ClassAlias?", "0x"])

--- a/lldb/test/API/lang/swift/typealias_recursive/main.swift
+++ b/lldb/test/API/lang/swift/typealias_recursive/main.swift
@@ -1,0 +1,12 @@
+open class MyClass<A, B> {}
+public typealias LocalAlias = Bool
+let anchor : LocalAlias = true
+public typealias ClassAlias = MyClass<LocalAlias, Bool>
+class Repro {
+  let field: ClassAlias?
+  init(cls: ClassAlias?) {
+    self.field = cls // break here
+  }
+}
+
+Repro(cls: ClassAlias())


### PR DESCRIPTION
A type alias that resolved to a type containing more type aliase can now also be handled. To safeguard against broken debug info with cyclic aliases a limit to this is also enforced.

rdar://143156979