### PR TITLE
Disable reading conformances on remote devices.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3096,6 +3096,15 @@ SwiftLanguageRuntime::ResolveTypeAlias(CompilerType alias) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
+
+  // FIXME: The current implementation that loads all conformances
+  // up-front creates too much small memory traffic. As a stop-gap,
+  // disable the feature on remote devices.
+  auto &triple = GetProcess().GetTarget().GetArchitecture().GetTriple();
+  if (triple.isOSDarwin() && !triple.isTargetMachineMac())
+    return llvm::createStringError("conformance loading disabled on remote "
+                                   "devices for performance reasons");
+  
   for (const std::string &protocol : GetConformances(in_type)) {
     auto *type_ref =
         reflection_ctx->LookupTypeWitness(in_type, member, protocol);


### PR DESCRIPTION
This is a stop-gap to prevent a very expensive operation on remote devices. This degrades the experience to what it was on the 6.0 branch, while preserving the functionality when debugging locally and on a simulator.

rdar://143580031