### PR TITLE
[lldb][swift] Check runtime dependencies of SwiftREPL tests in local …

### DIFF
--- a/lldb/test/Shell/SwiftREPL/lit.local.cfg
+++ b/lldb/test/Shell/SwiftREPL/lit.local.cfg
@@ -2,3 +2,14 @@ config.suffixes = ['.test']
 
 if 'lldb-repro' in config.available_features:
   config.unsupported = True
+
+def check_exists(path):
+  import os
+  if not os.path.isfile(path):
+    lit_config.warning(f"Runtime dependency not found: {path}")
+
+# Check runtime dependencies for SwiftREPL tests on Windows
+if sys.platform == "win32":
+  host_arch = config.host_triple.split("-")[0]
+  check_exists(f"{config.swift_libs_dir}/windows/{host_arch}/swiftrt.obj")
+  check_exists(f"{config.llvm_shlib_dir}/swiftCore.dll")

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -22,6 +22,7 @@ config.libcxx_libs_dir = "@LIBCXX_LIBRARY_DIR@"
 config.target_triple = "@LLVM_TARGET_TRIPLE@"
 config.python_executable = "@Python3_EXECUTABLE@"
 config.swiftc = "@LLDB_SWIFTC@"
+config.swift_libs_dir = '@LLDB_SWIFT_LIBS@'
 config.lldb_enable_swift = @LLDB_ENABLE_SWIFT_SUPPORT@
 config.have_zlib = @LLVM_ENABLE_ZLIB@
 config.objc_gnustep_dir = "@LLDB_TEST_OBJC_GNUSTEP_DIR@"


### PR DESCRIPTION
…lit config

These binaries only exists if the Swift runtime was built correctly. We cannot check them at configuration time, because they might not exist yet.

(cherry picked from commit 6c8125369520279dcd0670f4c6822c7b2826bc07)