### PR TITLE
[lldb][test] Propagate SDKROOT env var in Shell tests on Windows

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -219,7 +219,16 @@ def use_support_substitutions(config):
             sdk_path = lit.util.to_string(out)
             llvm_config.lit_config.note("using SDKROOT: %r" % sdk_path)
             host_flags += ["-isysroot", sdk_path]
-    elif sys.platform != "win32":
+    elif sys.platform == "win32":
+        # Required in SwiftREPL tests
+        sdk_path = os.environ.get("SDKROOT")
+        if sdk_path:
+            llvm_config.lit_config.note(f"using SDKROOT: {sdk_path}")
+            llvm_config.with_environment("SDKROOT", sdk_path)
+        else:
+            llvm_config.lit_config.warning(
+                "mandatory environment variable not found: SDKROOT")
+    else:
         host_flags += ["-pthread"]
 
     config.target_shared_library_suffix = (


### PR DESCRIPTION
We need the manual lookup in lldb/source/Host/windows/HostInfoWindowsSwift.cpp to succeed. Otherwise SwiftASTContext::CreateInstance() fails with: Cannot create Swift scratch context (couldn't load the Swift stdlib)

(cherry picked from commit 7302c510d6154bcdf0c5b4b8111920226f801c49)