### PR TITLE
[BoundsSaftey] Fix test failure for annotation remarks

### DIFF
--- a/llvm/test/Transforms/Util/auto-init-annotation-remarks.ll
+++ b/llvm/test/Transforms/Util/auto-init-annotation-remarks.ll
@@ -20,7 +20,7 @@ attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !llvm.module.flags = !{!4}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C, file: !1, producer: "debugify", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug)
-!1 = !DIFile(filename: "/Users/zainjaffal/Repos/internal/llvm-project2/llvm/test/Transforms/Util/bounds-safety-annotation-remarks.ll", directory: "/")
+!1 = !DIFile(filename: "/llvm-project/llvm/test/Transforms/Util/bounds-safety-annotation-remarks.ll", directory: "/")
 !2 = !{i32 4}
 !3 = !{i32 1}
 !4 = !{i32 2, !"Debug Info Version", i32 3}
@@ -54,7 +54,7 @@ attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memo
 ; CHECK-NEXT: Pass:            annotation-remarks
 ; CHECK-NEXT: Name:            AutoInitStore
 ; CHECK-NEXT: DebugLoc:        { File: 
-; CHECK-NEXT:                    Line: 3, Column: 1 }
+; CHECK-NEXT:                    Line: 2, Column: 1 }
 ; CHECK-NEXT: Function:        test1
 ; CHECK-NEXT: Args:
 ; CHECK-NEXT:   - String:          Store inserted by -ftrivial-auto-var-init.
@@ -78,7 +78,7 @@ attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memo
 ; CHECK-NEXT: Pass:            annotation-remarks
 ; CHECK-NEXT: Name:            AutoInitStore
 ; CHECK-NEXT: DebugLoc:        { File: 
-; CHECK-NEXT:                    Line: 2, Column: 1 }
+; CHECK-NEXT:                    Line: 3, Column: 1 }
 ; CHECK-NEXT: Function:        test1
 ; CHECK-NEXT: Args:
 ; CHECK-NEXT:   - String:          Store inserted by -ftrivial-auto-var-init.


### PR DESCRIPTION
Fix test that was missed in #9771

(cherry picked from commit 1af225e77d4e80279f137ce7373ff0f4287a7171)