### PR TITLE
[lldb] Fix lldb-dotest.in to use args determined by CMake (#124811)

### DIFF
--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -4,7 +4,8 @@ import subprocess
 import sys
 
 dotest_path = '@LLDB_SOURCE_DIR_CONFIGURED@/test/API/dotest.py'
-dotest_args_str = '@LLDB_DOTEST_ARGS_CONFIGURED@'
+dotest_common_args_str = '@LLDB_TEST_COMMON_ARGS_CONFIGURED@'
+dotest_user_args_str = '@LLDB_TEST_USER_ARGS_CONFIGURED@'
 arch = '@LLDB_TEST_ARCH@'
 executable = '@LLDB_TEST_EXECUTABLE_CONFIGURED@'
 compiler = '@LLDB_TEST_COMPILER_CONFIGURED@'
@@ -28,8 +29,10 @@ if __name__ == '__main__':
     dotest_args = []
     # split on an empty string will produce [''] and if you
     # add that to the command, it will be treated as a directory...
-    if len(dotest_args_str) > 0:
-        dotest_args = dotest_args_str.split(';')
+    if dotest_common_args_str:
+        dotest_args.extend(dotest_common_args_str.split(';'))
+    if dotest_user_args_str:
+        dotest_args.extend(dotest_user_args_str.split(';'))
     # Build dotest.py command.
     cmd = [sys.executable, dotest_path]
     cmd.extend(['--arch', arch])


### PR DESCRIPTION
This change is required as a result of the changes made in D132642
(bb26ebb4d18c1877cc6fd17aa803609abeb95096).

(cherry picked from commit e89e7c4685aa673173220eace7a0a8b64dbd2391)
