### PR TITLE
[lldb] Recursively resolve type aliases when canonicalizing types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -502,9 +502,23 @@ protected:
   CompilerType LookupClangForwardType(llvm::StringRef name, 
                   llvm::ArrayRef<CompilerContext> decl_context);
 
-  std::pair<swift::Demangle::NodePointer, CompilerType> ResolveTypeAlias(
-      swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
-      swift::Mangle::ManglingFlavor flavor, bool prefer_clang_types = false);
+  /// Recursively resolves all type aliases.
+  swift::Demangle::NodePointer
+  ResolveAllTypeAliases(swift::Demangle::Demangler &dem,
+                        swift::Demangle::NodePointer node);
+
+  /// Resolve a type alias node and return a demangle tree for the
+  /// resolved type. If the type alias resolves to a Clang type, return
+  /// a Clang CompilerType.
+  ///
+  /// \param prefer_clang_types if this is true, type aliases in the
+  ///                           __C module are resolved as Clang types.
+  ///
+  std::pair<swift::Demangle::NodePointer, CompilerType>
+  ResolveTypeAlias(swift::Demangle::Demangler &dem,
+                   swift::Demangle::NodePointer node,
+                   swift::Mangle::ManglingFlavor flavor,
+                   bool prefer_clang_types = false);
 
   swift::Demangle::NodePointer
   GetCanonicalNode(swift::Demangle::Demangler &dem,

--- a/lldb/test/API/lang/swift/typealias_recursive/Makefile
+++ b/lldb/test/API/lang/swift/typealias_recursive/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES = main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
+++ b/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
@@ -1,0 +1,14 @@
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftTypeAliasRecurtsive(TestBase):
+    @swiftTest
+    def test(self):
+        """Test that type aliases of type aliases can be resolved"""
+        self.build()
+        self.runCmd("settings set symbols.swift-validate-typesystem false")
+        self.expect("log enable lldb types")
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"))
+        self.expect("frame variable cls", substrs=["ClassAlias?", "0x"])

--- a/lldb/test/API/lang/swift/typealias_recursive/main.swift
+++ b/lldb/test/API/lang/swift/typealias_recursive/main.swift
@@ -1,0 +1,12 @@
+open class MyClass<A, B> {}
+public typealias LocalAlias = Bool
+let anchor : LocalAlias = true
+public typealias ClassAlias = MyClass<LocalAlias, Bool>
+class Repro {
+  let field: ClassAlias?
+  init(cls: ClassAlias?) {
+    self.field = cls // break here
+  }
+}
+
+Repro(cls: ClassAlias())


### PR DESCRIPTION
A type alias that resolved to a type containing more type aliase can now also be handled. To safeguard against broken debug info with cyclic aliases a limit to this is also enforced.

rdar://143156979
(cherry picked from commit ef057640fb4129ffbf9bdff42d186bdf2d8849e2)

 Conflicts:
	lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
	lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h