### PR TITLE
[lldb] Disable conformance loading by default 

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -82,6 +82,7 @@ public:
   bool GetUseSwiftDWARFImporter() const;
   bool SetUseSwiftDWARFImporter(bool new_value);
   bool GetSwiftValidateTypeSystem() const;
+  bool GetSwiftLoadConformances() const;
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);
 

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -28,6 +28,9 @@ let Definition = "modulelist" in {
   def SwiftValidateTypeSystem: Property<"swift-validate-typesystem", "Boolean">,
     DefaultFalse,
     Desc<"Validate all Swift typesystem queries. Used for testing an asserts-enabled LLDB only.">;
+  def SwiftLoadConformances: Property<"swift-load-conformances", "Boolean">,
+    DefaultFalse,
+    Desc<"Resolve type alias via the conformance section. Disabled for performance reasons">;
   def SwiftModuleLoadingMode: Property<"swift-module-loading-mode", "Enum">,
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,
     EnumValues<"OptionEnumValues(g_swift_module_loading_mode_enums)">,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -200,6 +200,12 @@ bool ModuleListProperties::GetSwiftValidateTypeSystem() const {
       idx, g_modulelist_properties[idx].default_uint_value != 0);
 }
 
+bool ModuleListProperties::GetSwiftLoadConformances() const {
+  const uint32_t idx = ePropertySwiftLoadConformances;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
 SwiftModuleLoadingMode ModuleListProperties::GetSwiftModuleLoadingMode() const {
   const uint32_t idx = ePropertySwiftModuleLoadingMode;
   return GetPropertyAtIndexAs<SwiftModuleLoadingMode>(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3102,13 +3102,11 @@ SwiftLanguageRuntime::ResolveTypeAlias(CompilerType alias) {
     return llvm::createStringError("no reflection context");
 
   // FIXME: The current implementation that loads all conformances
-  // up-front creates too much small memory traffic. As a stop-gap,
-  // disable the feature on remote devices.
-  auto &triple = GetProcess().GetTarget().GetArchitecture().GetTriple();
-  if (triple.isOSDarwin() && !triple.isTargetMachineMac())
-    return llvm::createStringError("conformance loading disabled on remote "
-                                   "devices for performance reasons");
-  
+  // up-front creates too much small memory traffic during the
+  // LookupTypeWitness step.
+  if (!ModuleList::GetGlobalModuleListProperties().GetSwiftLoadConformances())
+    return llvm::createStringError("conformance loading disabled in settings");
+
   for (const std::string &protocol : GetConformances(in_type)) {
     auto *type_ref =
         reflection_ctx->LookupTypeWitness(in_type, member, protocol);

--- a/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
+++ b/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
@@ -11,6 +11,7 @@ class TestSwiftTypeAliasOtherModule(TestBase):
         """Test that type aliases can be imported from reflection metadata"""
         arch = self.getArchitecture()
         self.build()
+        self.expect('settings set symbols.swift-load-conformances true')
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb expr types -f "%s"' % log)
         lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
This feature is not yet ready. Even locally loading the witnesses takes too long.

rdar://143847977