### PR TITLE
[BoundsSafety] Fix tests with anonymous decl names

### DIFF
--- a/clang/test/BoundsSafety/AST/SystemHeaders/builtin-function-main.c
+++ b/clang/test/BoundsSafety/AST/SystemHeaders/builtin-function-main.c
@@ -1,4 +1,3 @@
-
 #include <ptrcheck.h>
 #include <builtin-function-sys.h>
 
@@ -23,7 +22,7 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: |     |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: |     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |     | | |   | `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'void *'
 // CHECK: |     | | |   | `-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'void *'
 // CHECK: |     | | |   `-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'unsigned long'
@@ -31,7 +30,7 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |     | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: |     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
 // CHECK: |     | | |   | `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
-// CHECK: |     | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |     | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |     | | |   `-AssumptionExpr
 // CHECK: |     | | |     |-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned long'
 // CHECK: |     | | |     `-BinaryOperator {{.+}} 'int' '>='
@@ -51,17 +50,17 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |     | |     `-DeclRefExpr {{.+}} [[var_size]]
 // CHECK: |     | `-OpaqueValueExpr [[ove]]
 // CHECK: |     |   `-CallExpr
-// CHECK: |     |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()(*)(void *__single __sized_by(), const void *__single __sized_by(), unsigned long)' <BuiltinFnToFnPtr>
+// CHECK: |     |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)(*)(void *__single __sized_by(function-parameter-0-2), const void *__single __sized_by(function-parameter-0-2), unsigned long)' <BuiltinFnToFnPtr>
 // CHECK: |     |     | `-DeclRefExpr {{.+}}
-// CHECK: |     |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()':'void *__single' <BoundsSafetyPointerCast>
+// CHECK: |     |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK: |     |     | `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *'
-// CHECK: |     |     |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by()':'const void *__single' <BoundsSafetyPointerCast>
+// CHECK: |     |     |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by(function-parameter-0-2)':'const void *__single' <BoundsSafetyPointerCast>
 // CHECK: |     |     | `-OpaqueValueExpr [[ove_2]] {{.*}} 'void *'
 // CHECK: |     |     `-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned long'
 // CHECK: |     |-OpaqueValueExpr [[ove_1]] {{.*}} 'void *'
 // CHECK: |     |-OpaqueValueExpr [[ove_2]] {{.*}} 'void *'
 // CHECK: |     |-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned long'
-// CHECK: |     `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |     `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |-FunctionDecl [[func_static_1:0x[^ ]+]] {{.+}} static
 // CHECK: | |-ParmVarDecl [[var_dst_1:0x[^ ]+]]
 // CHECK: | |-ParmVarDecl [[var_src_1:0x[^ ]+]]
@@ -72,7 +71,7 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |       `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: |         |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: |         | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: |         | | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |         | | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |         | | |   | `-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'void *'
 // CHECK: |         | | |   | `-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'void *'
 // CHECK: |         | | |   `-OpaqueValueExpr [[ove_7:0x[^ ]+]] {{.*}} 'unsigned long'
@@ -80,7 +79,7 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |         | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: |         | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
 // CHECK: |         | | |   | `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
-// CHECK: |         | | |   |   `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |         | | |   |   `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |         | | |   `-AssumptionExpr
 // CHECK: |         | | |     |-OpaqueValueExpr [[ove_7]] {{.*}} 'unsigned long'
 // CHECK: |         | | |     `-BinaryOperator {{.+}} 'int' '>='
@@ -100,17 +99,17 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |         | |     `-DeclRefExpr {{.+}} [[var_size_1]]
 // CHECK: |         | `-OpaqueValueExpr [[ove_4]]
 // CHECK: |         |   `-CallExpr
-// CHECK: |         |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()(*)(void *__single __sized_by(), const void *__single __sized_by(), unsigned long)' <BuiltinFnToFnPtr>
+// CHECK: |         |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)(*)(void *__single __sized_by(function-parameter-0-2), const void *__single __sized_by(function-parameter-0-2), unsigned long)' <BuiltinFnToFnPtr>
 // CHECK: |         |     | `-DeclRefExpr {{.+}}
-// CHECK: |         |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()':'void *__single' <BoundsSafetyPointerCast>
+// CHECK: |         |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK: |         |     | `-OpaqueValueExpr [[ove_5]] {{.*}} 'void *'
-// CHECK: |         |     |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by()':'const void *__single' <BoundsSafetyPointerCast>
+// CHECK: |         |     |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by(function-parameter-0-2)':'const void *__single' <BoundsSafetyPointerCast>
 // CHECK: |         |     | `-OpaqueValueExpr [[ove_6]] {{.*}} 'void *'
 // CHECK: |         |     `-OpaqueValueExpr [[ove_7]] {{.*}} 'unsigned long'
 // CHECK: |         |-OpaqueValueExpr [[ove_5]] {{.*}} 'void *'
 // CHECK: |         |-OpaqueValueExpr [[ove_6]] {{.*}} 'void *'
 // CHECK: |         |-OpaqueValueExpr [[ove_7]] {{.*}} 'unsigned long'
-// CHECK: |         `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |         `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |-FunctionDecl [[func_static_2:0x[^ ]+]] {{.+}} static
 // CHECK: | |-ParmVarDecl [[var_dst_2:0x[^ ]+]]
 // CHECK: | |-ParmVarDecl [[var_src_2:0x[^ ]+]]
@@ -122,7 +121,7 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |   |     `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: |   |       |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: |   |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: |   |       | | |-OpaqueValueExpr [[ove_8:0x[^ ]+]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |   |       | | |-OpaqueValueExpr [[ove_8:0x[^ ]+]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |   |       | | |   | `-OpaqueValueExpr [[ove_9:0x[^ ]+]] {{.*}} 'void *'
 // CHECK: |   |       | | |   | `-OpaqueValueExpr [[ove_10:0x[^ ]+]] {{.*}} 'void *'
 // CHECK: |   |       | | |   `-OpaqueValueExpr [[ove_11:0x[^ ]+]] {{.*}} 'unsigned long'
@@ -130,7 +129,7 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |   |       | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: |   |       | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
 // CHECK: |   |       | | |   | `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
-// CHECK: |   |       | | |   |   `-OpaqueValueExpr [[ove_8]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |   |       | | |   |   `-OpaqueValueExpr [[ove_8]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |   |       | | |   `-AssumptionExpr
 // CHECK: |   |       | | |     |-OpaqueValueExpr [[ove_11]] {{.*}} 'unsigned long'
 // CHECK: |   |       | | |     `-BinaryOperator {{.+}} 'int' '>='
@@ -150,17 +149,17 @@ char * __counted_by(len) func(char * __counted_by(len) src_str, int len) {
 // CHECK: |   |       | |     `-DeclRefExpr {{.+}} [[var_size_2]]
 // CHECK: |   |       | `-OpaqueValueExpr [[ove_8]]
 // CHECK: |   |       |   `-CallExpr
-// CHECK: |   |       |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()(*)(void *__single __sized_by(), const void *__single __sized_by(), unsigned long)' <BuiltinFnToFnPtr>
+// CHECK: |   |       |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)(*)(void *__single __sized_by(function-parameter-0-2), const void *__single __sized_by(function-parameter-0-2), unsigned long)' <BuiltinFnToFnPtr>
 // CHECK: |   |       |     | `-DeclRefExpr {{.+}}
-// CHECK: |   |       |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()':'void *__single' <BoundsSafetyPointerCast>
+// CHECK: |   |       |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK: |   |       |     | `-OpaqueValueExpr [[ove_9]] {{.*}} 'void *'
-// CHECK: |   |       |     |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by()':'const void *__single' <BoundsSafetyPointerCast>
+// CHECK: |   |       |     |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by(function-parameter-0-2)':'const void *__single' <BoundsSafetyPointerCast>
 // CHECK: |   |       |     | `-OpaqueValueExpr [[ove_10]] {{.*}} 'void *'
 // CHECK: |   |       |     `-OpaqueValueExpr [[ove_11]] {{.*}} 'unsigned long'
 // CHECK: |   |       |-OpaqueValueExpr [[ove_9]] {{.*}} 'void *'
 // CHECK: |   |       |-OpaqueValueExpr [[ove_10]] {{.*}} 'void *'
 // CHECK: |   |       |-OpaqueValueExpr [[ove_11]] {{.*}} 'unsigned long'
-// CHECK: |   |       `-OpaqueValueExpr [[ove_8]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: |   |       `-OpaqueValueExpr [[ove_8]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: |   `-ReturnStmt
 // CHECK: |     `-ImplicitCastExpr {{.+}} 'void *' <LValueToRValue>
 // CHECK: |       `-DeclRefExpr {{.+}} [[var_tmp]]

--- a/clang/test/BoundsSafety/AST/builtin-memcpy-count-annotation.c
+++ b/clang/test/BoundsSafety/AST/builtin-memcpy-count-annotation.c
@@ -1,8 +1,8 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s -Wcast-qual 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental %s -Wcast-qual 2>&1 | FileCheck %s
+
 #include <ptrcheck.h>
+
 void foo(void) {
     char *dst, *src;
     __builtin_memcpy(dst, src, 10);
@@ -16,7 +16,7 @@ void foo(void) {
 // CHECK: {{^}}|   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}|     |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}|     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: {{^}}|     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: {{^}}|     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: {{^}}|     | | |   | | | `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'void *__bidi_indexable'
 // CHECK: {{^}}|     | | |   | | | `-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'const void *__bidi_indexable'
 // CHECK: {{^}}|     | | |   | | `-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'unsigned long'
@@ -24,7 +24,7 @@ void foo(void) {
 // CHECK: {{^}}|     | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}|     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
 // CHECK: {{^}}|     | | |   | `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
-// CHECK: {{^}}|     | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: {{^}}|     | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: {{^}}|     | | |   `-AssumptionExpr
 // CHECK: {{^}}|     | | |     |-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned long'
 // CHECK: {{^}}|     | | |     `-BinaryOperator {{.+}} 'int' '>='
@@ -47,11 +47,11 @@ void foo(void) {
 // CHECK: {{^}}|     |   `-BoundsCheckExpr
 // CHECK: {{^}}|     |     |-BoundsCheckExpr
 // CHECK: {{^}}|     |     | |-CallExpr
-// CHECK: {{^}}|     |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()(*)(void *__single __sized_by(), const void *__single __sized_by(), unsigned long)' <BuiltinFnToFnPtr>
+// CHECK: {{^}}|     |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)(*)(void *__single __sized_by(function-parameter-0-2), const void *__single __sized_by(function-parameter-0-2), unsigned long)' <BuiltinFnToFnPtr>
 // CHECK: {{^}}|     |     | | | `-DeclRefExpr {{.+}}
-// CHECK: {{^}}|     |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()':'void *__single' <BoundsSafetyPointerCast>
+// CHECK: {{^}}|     |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK: {{^}}|     |     | | | `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
-// CHECK: {{^}}|     |     | | |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by()':'const void *__single' <BoundsSafetyPointerCast>
+// CHECK: {{^}}|     |     | | |-ImplicitCastExpr {{.+}} 'const void *__single __sized_by(function-parameter-0-2)':'const void *__single' <BoundsSafetyPointerCast>
 // CHECK: {{^}}|     |     | | | `-OpaqueValueExpr [[ove_2]] {{.*}} 'const void *__bidi_indexable'
 // CHECK: {{^}}|     |     | | `-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned long'
 // CHECK: {{^}}|     |     | `-BinaryOperator {{.+}} 'int' '&&'
@@ -107,4 +107,4 @@ void foo(void) {
 // CHECK: {{^}}|     |-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
 // CHECK: {{^}}|     |-OpaqueValueExpr [[ove_2]] {{.*}} 'const void *__bidi_indexable'
 // CHECK: {{^}}|     |-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned long'
-// CHECK: {{^}}|     `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: {{^}}|     `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'

--- a/clang/test/BoundsSafety/AST/flexible-array-member-promotion-call-builtin.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-promotion-call-builtin.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental %s 2>&1 | FileCheck %s
 
@@ -22,7 +20,7 @@ typedef struct {
 // CHECK:   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK:     |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK:     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK:     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK:     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK:     | | |   | | `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'void *__bidi_indexable'
 // CHECK:     | | |   | |       | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'flex_t *__single'
 // CHECK:     | | |   | |-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'int'
@@ -31,7 +29,7 @@ typedef struct {
 // CHECK:     | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK:     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
 // CHECK:     | | |   | `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
-// CHECK:     | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK:     | | |   |   `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK:     | | |   `-AssumptionExpr
 // CHECK:     | | |     |-OpaqueValueExpr [[ove_4]] {{.*}} 'unsigned long'
 // CHECK:     | | |     `-BinaryOperator {{.+}} 'int' '>='
@@ -65,9 +63,9 @@ typedef struct {
 // CHECK:     | `-OpaqueValueExpr [[ove]]
 // CHECK:     |   `-BoundsCheckExpr {{.+}} 'flex <= __builtin_get_pointer_upper_bound(flex) && __builtin_get_pointer_lower_bound(flex) <= flex && size <= (char *)__builtin_get_pointer_upper_bound(flex) - (char *)flex'
 // CHECK:     |     |-CallExpr
-// CHECK:     |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()(*)(void *__single __sized_by(), int, unsigned long)' <BuiltinFnToFnPtr>
+// CHECK:     |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)(*)(void *__single __sized_by(function-parameter-0-2), int, unsigned long)' <BuiltinFnToFnPtr>
 // CHECK:     |     | | `-DeclRefExpr {{.+}}
-// CHECK:     |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()':'void *__single' <BoundsSafetyPointerCast>
+// CHECK:     |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK:     |     | | `-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
 // CHECK:     |     | |-OpaqueValueExpr [[ove_3]] {{.*}} 'int'
 // CHECK:     |     | `-OpaqueValueExpr [[ove_4]] {{.*}} 'unsigned long'
@@ -99,7 +97,7 @@ typedef struct {
 // CHECK:     |-OpaqueValueExpr [[ove_1]] {{.*}} 'void *__bidi_indexable'
 // CHECK:     |-OpaqueValueExpr [[ove_3]] {{.*}} 'int'
 // CHECK:     |-OpaqueValueExpr [[ove_4]] {{.*}} 'unsigned long'
-// CHECK:     `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK:     `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 void foo(flex_t *flex, unsigned size) {
   __builtin_memset(flex, 0, size);
 }

--- a/clang/test/BoundsSafety/AST/implicit-thin-decls.c
+++ b/clang/test/BoundsSafety/AST/implicit-thin-decls.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental %s 2>&1 | FileCheck %s
 
@@ -33,4 +31,4 @@ typedef struct {
 // CHECK: `-TypedefDecl {{.+}} T 'struct T':'T'
 // CHECK:   `-ElaboratedType {{.+}} 'struct T' sugar
 // CHECK:     `-RecordType {{.+}} 'T'
-// CHECK:       `-Record [[ADDR]] ''
+// CHECK:       `-Record [[ADDR]] {{.+}}

--- a/clang/test/BoundsSafety/AST/system-merge-dynamic-bound-attr.c
+++ b/clang/test/BoundsSafety/AST/system-merge-dynamic-bound-attr.c
@@ -1,7 +1,6 @@
-
-
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -isystem %S/Inputs/system-merge-dynamic-bound-attr %s 2>&1 | FileCheck %s
 // RUN: %clang_cc1 -ast-dump -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -isystem %S/Inputs/system-merge-dynamic-bound-attr %s 2>&1 | FileCheck %s
+
 #include <header-with-attr.h>
 #include <header-no-attr.h>
 
@@ -73,7 +72,7 @@ void Test(unsigned siz) {
 // CHECK: {{^}}    `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}      |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}      | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: {{^}}      | | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: {{^}}      | | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: {{^}}      | | |   | | | `-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'void *__bidi_indexable'
 // CHECK: {{^}}      | | |   | | | `-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'void *__bidi_indexable'
 // CHECK: {{^}}      | | |   | | `-OpaqueValueExpr [[ove_7:0x[^ ]+]] {{.*}} 'unsigned long long'
@@ -81,7 +80,7 @@ void Test(unsigned siz) {
 // CHECK: {{^}}      | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}      | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
 // CHECK: {{^}}      | | |   | `-ImplicitCastExpr {{.+}} 'void *' <BoundsSafetyPointerCast>
-// CHECK: {{^}}      | | |   |   `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: {{^}}      | | |   |   `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 // CHECK: {{^}}      | | |   `-AssumptionExpr
 // CHECK: {{^}}      | | |     |-OpaqueValueExpr [[ove_7]] {{.*}} 'unsigned long long'
 // CHECK: {{^}}      | | |     `-BinaryOperator {{.+}} 'int' '>='
@@ -103,11 +102,11 @@ void Test(unsigned siz) {
 // CHECK: {{^}}      |   `-BoundsCheckExpr
 // CHECK: {{^}}      |     |-BoundsCheckExpr
 // CHECK: {{^}}      |     | |-CallExpr
-// CHECK: {{^}}      |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()(*__single)(void *__single __sized_by(), void *__single __sized_by(), unsigned long long)' <FunctionToPointerDecay>
+// CHECK: {{^}}      |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)(*__single)(void *__single __sized_by(function-parameter-0-2), void *__single __sized_by(function-parameter-0-2), unsigned long long)' <FunctionToPointerDecay>
 // CHECK: {{^}}      |     | | | `-DeclRefExpr {{.+}}
-// CHECK: {{^}}      |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()':'void *__single' <BoundsSafetyPointerCast>
+// CHECK: {{^}}      |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK: {{^}}      |     | | | `-OpaqueValueExpr [[ove_5]] {{.*}} 'void *__bidi_indexable'
-// CHECK: {{^}}      |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by()':'void *__single' <BoundsSafetyPointerCast>
+// CHECK: {{^}}      |     | | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single' <BoundsSafetyPointerCast>
 // CHECK: {{^}}      |     | | | `-OpaqueValueExpr [[ove_6]] {{.*}} 'void *__bidi_indexable'
 // CHECK: {{^}}      |     | | `-OpaqueValueExpr [[ove_7]] {{.*}} 'unsigned long long'
 // CHECK: {{^}}      |     | `-BinaryOperator {{.+}} 'int' '&&'
@@ -163,5 +162,5 @@ void Test(unsigned siz) {
 // CHECK: {{^}}      |-OpaqueValueExpr [[ove_5]] {{.*}} 'void *__bidi_indexable'
 // CHECK: {{^}}      |-OpaqueValueExpr [[ove_6]] {{.*}} 'void *__bidi_indexable'
 // CHECK: {{^}}      |-OpaqueValueExpr [[ove_7]] {{.*}} 'unsigned long long'
-// CHECK: {{^}}      `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by()':'void *__single'
+// CHECK: {{^}}      `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by(function-parameter-0-2)':'void *__single'
 }

--- a/clang/test/BoundsSafety/Sema/builtin-memcpy-count-annotation.c
+++ b/clang/test/BoundsSafety/Sema/builtin-memcpy-count-annotation.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -verify %s
 
@@ -7,6 +5,6 @@
 
 // expected-note@+1{{consider adding '__sized_by(10)' to 'dst'}}
 void foo(char *dst, char *src) {
-    // expected-error@+1{{passing 'char *__single' with pointee of size 1 to parameter of type 'void *__single __sized_by()' (aka 'void *__single') with size value of 10 always fails}}
+    // expected-error@+1{{passing 'char *__single' with pointee of size 1 to parameter of type 'void *__single __sized_by(function-parameter-0-2)' (aka 'void *__single') with size value of 10 always fails}}
     __builtin_memcpy(dst, src, 10);
 }


### PR DESCRIPTION
8c2574832ed2064996389e4259eaf0bea0fa7951 improves print / dump of anonymous declarations. This prints anonymous function parameters in form 'function-parameter-DEPTH-INDEX', which breaks our tests.

rdar://143759769