### PR TITLE
[MCJIT][ORC] Change test guards to 'UNSUPPORTED: system-darwin'.

### DIFF
--- a/llvm/test/ExecutionEngine/MCJIT/test-global-ctors.ll
+++ b/llvm/test/ExecutionEngine/MCJIT/test-global-ctors.ll
@@ -1,6 +1,6 @@
 ; RUN: %lli -jit-kind=mcjit %s > /dev/null
 ; RUN: %lli %s > /dev/null
-; UNSUPPORTED: target={{.*}}-darwin{{.*}}
+; UNSUPPORTED: system-darwin
 @var = global i32 1, align 4
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @ctor_func, ptr null }]
 @llvm.global_dtors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 65535, ptr @dtor_func, ptr null }]

--- a/llvm/test/ExecutionEngine/Orc/weak-comdat.ll
+++ b/llvm/test/ExecutionEngine/Orc/weak-comdat.ll
@@ -1,5 +1,5 @@
 ; RUN: lli -extra-module %p/Inputs/weak-comdat-def.ll %s
-; UNSUPPORTED: target={{.*}}-darwin{{.*}}
+; UNSUPPORTED: system-darwin
 
 declare i32 @g()
 


### PR DESCRIPTION
These tests were guarded with 'UNSUPPORTED: target={{.*}}-darwin{{.*}}', but that check may unintentionally pass if LLVM is configured with a host triple that specifies a specific Darwin flavor, e.g. macOS with -DLLVM_HOST_TRIPLE:STRING=aarch64-apple-macosx13.0. All darwin flavors should set 'system-darwin', so this is a safer feature to check.

rdar://134942819