### PR TITLE
[Cherry-pick into next] [lldb] Remove references to obsolete setting

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -10,7 +10,6 @@ class TestSwiftWerror(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @expectedFailureAll(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -9,7 +9,6 @@ class TestSwiftClangImporterCaching(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))
     @skipIf(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'), bugnumber='rdar://128094135')
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -19,7 +19,6 @@ import os
 class TestSwiftDedupMacros(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     # NOTE: rdar://44201206 - This test may sporadically segfault. It's likely
     # that the underlying memory corruption issue has been addressed, but due
     # to the difficulty of reproducing the crash, we are not sure. If a crash

--- a/lldb/test/API/lang/swift/clangimporter/explicit_cc1/TestSwiftClangImporterExplicitCC1.py
+++ b/lldb/test/API/lang/swift/clangimporter/explicit_cc1/TestSwiftClangImporterExplicitCC1.py
@@ -9,7 +9,6 @@ class TestSwiftClangImporterExplicitCC1(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))
     @skipIf(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'), bugnumber='rdar://128094135')
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExprImport(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @swiftTest
     def test(self):
         """Test error handling if the expression evaluator

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -11,7 +11,6 @@ class TestSwiftHardMacroConflict(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -20,7 +20,6 @@ import shutil
 class TestSwiftHeadermapConflict(TestBase):
     @skipIf(bugnumber="rdar://60396797",
             setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/TestSwiftIncludeConflict.py
@@ -20,7 +20,6 @@ import shutil
 class TestSwiftIncludeConflict(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/TestSwiftMacroConflict.py
@@ -20,7 +20,6 @@ import shutil
 class TestSwiftMacroConflict(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @skipIf(bugnumber="rdar://121539666")
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/TestSwiftObjCMainConflictingDylibsBridgingHeader.py
@@ -39,9 +39,6 @@ class TestSwiftObjCMainConflictingDylibsBridgingHeader(TestBase):
             'break here', lldb.SBFileSpec('Foo.swift'))
         process.Continue()
         self.expect("fr var foo", "expected result", substrs=["23"])
-        precise = self.dbg.GetSetting('symbols.swift-precise-compiler-invocation').GetBooleanValue()
-        if not precise:
-            return
         # FIXME: This should work with precise compiler invocations.
         self.expect("expression foo", "expected result", substrs=["$R3", "23"])
         self.expect("expression $R3", "expected result", substrs=["23"])

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -20,7 +20,6 @@ import shutil
 class TestSwiftRewriteClangPaths(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))
@@ -29,7 +28,6 @@ class TestSwiftRewriteClangPaths(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))
     @skipUnlessDarwin
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
@@ -9,7 +9,6 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropCxxLangOpt(TestBase):
 
     @swiftTest
-    @expectedFailureAll(setting=('symbols.swift-precise-compiler-invocation', 'false'))
     def test_class(self):
         """
         Test that C++ interoperability is enabled on a per-CU basis.

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -69,7 +69,6 @@ class TestSwiftDeploymentTarget(TestBase):
     @skipUnlessDarwin  # This test uses macOS triples explicitly.
     @skipIfDarwinEmbedded
     @skipIf(macos_version=["<", "11.1"])
-    @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))
     @swiftTest
     def test_swift_precise_compiler_invocation_triple(self):
         """

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -7,7 +7,6 @@ class TestSwiftLateDylib(TestBase):
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     @expectedFailureAll(setting=('plugin.typesystem.clang.experimental-redecl-completion', 'true'))
     def test(self):
         """Test that a late loaded Swift dylib is debuggable"""

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -12,7 +12,6 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     def test_system_framework(self):
         """Test that a framework that is registered as autolinked in a Swift
            module used in the target, but not linked against the target is

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -22,17 +22,15 @@ class TestSwiftPrivateImport(TestBase):
             self, 'break here', lldb.SBFileSpec('main.swift'),
             extra_images=['Library', 'Invisible'])
 
-        precise = self.dbg.GetSetting('symbols.swift-precise-compiler-invocation').GetBooleanValue()
-        if precise:
-            # Test that importing the expression context (i.e., the module
-            # "a") pulls in the explicit dependencies, but not their
-            # private imports.  This comes before the other checks,
-            # because type reconstruction will still trigger an import of
-            # the "Invisible" module that we can't prevent later one.
-            self.expect("expression 1+1")
-            self.filecheck('platform shell cat "%s"' % log, __file__)
-#           CHECK:  Module import remark: loaded module 'Library'
-#           CHECK-NOT: Module import remark: loaded module 'Invisible'
+        # Test that importing the expression context (i.e., the module
+        # "a") pulls in the explicit dependencies, but not their
+        # private imports.  This comes before the other checks,
+        # because type reconstruction will still trigger an import of
+        # the "Invisible" module that we can't prevent later one.
+        self.expect("expression 1+1")
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK:  Module import remark: loaded module 'Library'
+#       CHECK-NOT: Module import remark: loaded module 'Invisible'
 
         self.expect("fr var -d run -- x", substrs=["(Invisible.InvisibleStruct)"])
         self.expect("fr var -d run -- y", substrs=["(Library.Conforming)",

--- a/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
+++ b/lldb/test/API/lang/swift/tagged_pointer/TestSwiftTaggedPointer.py
@@ -13,7 +13,6 @@ class TestSwiftTaggedPointer(lldbtest.TestBase):
     @skipUnlessDarwin
     # This test exposes a bug in DWARFImporterForClangTypes, which
     # doesn't do type completion correctly. (rdar://118337109)
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'true'))
     def test(self):
         self.build()
         # On the bots only, Swift typesystem validation fails.

--- a/lldb/test/API/lang/swift/value_generics/main.swift
+++ b/lldb/test/API/lang/swift/value_generics/main.swift
@@ -43,8 +43,6 @@ func main() {
     v[2] = 2
     v[3] = 3
 
-  // break here
-    print(v)
-
+    print(v)  // break here
 }
 main()


### PR DESCRIPTION
```
commit 94c1b7730c582e3fa2885cde9b7ac43591ff64f4
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Jan 29 17:27:28 2025 -0800

    [lldb] Remove references to obsolete setting
```
