### PR TITLE
[lldb] Delete unreachable(ish) code (NFCish)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3768,17 +3768,6 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
           if (llvm::StringRef(AsMangledName(type))
                   .ends_with("sSo18NSNotificationNameaD"))
             return GetTypeFromMangledTypename(ConstString("$sSo8NSStringCD"));
-          if (result->GetMangledTypeName().GetStringRef().count('$') > 1 &&
-              get_ast_num_children() ==
-                  llvm::expectedToStdOptional(runtime->GetNumChildren(
-                      {weak_from_this(), type}, exe_scope)))
-            // If available, prefer the AST for private types. Private
-            // identifiers are not ABI; the runtime returns anonymous private
-            // identifiers (using a '$' prefix) which cannot match identifiers
-            // in the AST. Because these private types can't be used in an AST
-            // context, prefer the AST type if available.
-            if (auto ast_type = fallback())
-              return ast_type;
           return result;
         }
         if (!result)

--- a/lldb/test/API/lang/swift/private_member/Makefile
+++ b/lldb/test/API/lang/swift/private_member/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
+++ b/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftPrivateMember(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target,  process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('main.swift'))
+        frame = thread.frames[0]
+        x = frame.FindVariable("x")
+        member = x.GetChildAtIndex(0)
+        self.assertIn("23", str(member))

--- a/lldb/test/API/lang/swift/private_member/main.swift
+++ b/lldb/test/API/lang/swift/private_member/main.swift
@@ -1,0 +1,14 @@
+fileprivate struct U {
+  let i = 23
+}
+
+fileprivate struct V {
+  let member = U()
+}
+
+func main() {
+  let x = V()
+  print(x) // break here
+}
+
+main()


### PR DESCRIPTION
No test in the testsuite triggeres this code path, except for the new ValueGeneric tes, which triggers it for entirely the wrong reason. I added a new test that exercises the case that is mentioned in the comment to make sure that this is indeed obsolete.