### PR TITLE
[lldb] Increase test async sleep to 300s (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/async/tasks/main.swift
+++ b/lldb/test/API/lang/swift/async/tasks/main.swift
@@ -3,7 +3,7 @@ func first() async {
 }
 
 func second() async {
-    try? await Task.sleep(for: .seconds(10))
+    try? await Task.sleep(for: .seconds(300))
 }
 
 @main struct Main {


### PR DESCRIPTION
This sleep is not waited on, it can be arbitrarily large, and needs to be large enough that a slow system doesn't cause the sleep to conclude before the test gets a chance to perform its checks.