### PR TITLE
[BoundsSafety] Rebuild bound attributed types when declaring a function with typeof/typedef

### DIFF
--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
@@ -570,8 +570,7 @@ public:
     }
 
     assert(!Ty->getCountExpr()->HasSideEffects(Ctx));
-    ExprResult CountR =
-        DeclReplacer.TransformBoundsAttrExpr(Ty->getCountExpr());
+    ExprResult CountR = DeclReplacer.TransformExpr(Ty->getCountExpr());
     if (CountR.isInvalid())
       return ExprError();
     Expr *Count = CountR.get();
@@ -781,7 +780,7 @@ public:
     // '__ended_by'. We may revisit this if we decide to expose '__started_by'
     // to users.
     if (auto *End = Ty->getEndPointer()) {
-      if (!PushValidOrErr(DeclReplacer.TransformBoundsAttrExpr(End)))
+      if (!PushValidOrErr(DeclReplacer.TransformExpr(End)))
         return ExprError();
     }
 
@@ -969,7 +968,7 @@ public:
       Counts.push_back(Zero.get());
     }
 
-    ExprResult NewCount = DeclReplacer.TransformBoundsAttrExpr(Count);
+    ExprResult NewCount = DeclReplacer.TransformExpr(Count);
     NewCount = SemaRef.DefaultLvalueConversion(NewCount.get());
     if (NewCount.isInvalid())
       return;
@@ -1025,7 +1024,7 @@ public:
 
       assert(!RangePtr->HasSideEffects(SemaRef.Context));
       // Since we materialize self assignments, we can reuse the materialized value.
-      ExprResult NewRangePtr = DeclReplacer.TransformBoundsAttrExpr(RangePtr);
+      ExprResult NewRangePtr = DeclReplacer.TransformExpr(RangePtr);
       assert(!NewRangePtr.isInvalid());
       // This is assuming the range has not been changed.
       NewRangePtr = SemaRef.DefaultFunctionArrayLvalueConversion(NewRangePtr.get());

--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.h
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.h
@@ -267,15 +267,6 @@ struct ReplaceDeclRefWithRHS : public TreeTransform<ReplaceDeclRefWithRHS> {
 
   bool AlwaysRebuild() { return true; }
 
-  ExprResult TransformBoundsAttrExpr(Expr *E) {
-    using ExpressionKind =
-        Sema::ExpressionEvaluationContextRecord::ExpressionKind;
-    EnterExpressionEvaluationContext EC(
-        SemaRef, Sema::ExpressionEvaluationContext::PotentiallyEvaluated,
-        nullptr, ExpressionKind::EK_AttrArgument);
-    return TransformExpr(E);
-  }
-
   ExprResult TransformOpaqueValueExpr(OpaqueValueExpr *E) { return Owned(E); }
 
   /// If we are replacing the value pointed to by DeclRef, we unwrap dereference

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -7941,7 +7941,7 @@ bool Sema::CheckDynamicCountSizeForAssignment(
   if (!DependentValues.empty()) {
     if (LHSMemberBase)
       Transform.MemberBase = LHSMemberBase;
-    ExprResult CountExprRes = Transform.TransformBoundsAttrExpr(CountExpr);
+    ExprResult CountExprRes = Transform.TransformExpr(CountExpr);
     if (CountExprRes.isInvalid())
       return false;
     CountExpr = CountExprRes.get();
@@ -22609,14 +22609,6 @@ void diagnoseUncapturableValueReferenceOrBinding(Sema &S, SourceLocation loc,
   if (!S.getLangOpts().CPlusPlus && !S.CurContext->isFunctionOrMethod())
     return;
 
-  /* TO_UPSTREAM(BoundsSafety) ON*/
-  if (S.getLangOpts().BoundsSafety) {
-    // Allow capturing variables/fields in bounds attr expr context.
-    if (S.isAttrContext() && (isa<VarDecl>(var) || isa<FieldDecl>(var)))
-      return;
-  }
-  /* TO_UPSTREAM(BoundsSafety) OFF*/
-
   unsigned ValueKind = isa<BindingDecl>(var) ? 1 : 0;
   unsigned ContextKind = 3; // unknown
   if (isa<CXXMethodDecl>(VarDC) &&
@@ -25456,8 +25448,7 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
       QualType ParamType = ParamTypes[I];
       BoundsCheckBuilder Builder(OVEs);
       if (auto *DCPT = ParamType->getAs<CountAttributedType>()) {
-        ExprResult CountExpr =
-            Transform.TransformBoundsAttrExpr(DCPT->getCountExpr());
+        ExprResult CountExpr = Transform.TransformExpr(DCPT->getCountExpr());
         if (!CountExpr.get())
           return ExprError();
         Builder.setAccessCount(CountExpr.get(), DCPT->isCountInBytes(),
@@ -25467,7 +25458,7 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
         // will not have an end pointer, just a start pointer. The start pointer
         // will generate the entire breadth of required checks.
         if (auto *EndPtr = DRPT->getEndPointer()) {
-          ExprResult Upper = Transform.TransformBoundsAttrExpr(EndPtr);
+          ExprResult Upper = Transform.TransformExpr(EndPtr);
           if (!Upper.get())
             return ExprError();
           Builder.setAccessLowerBound(OVEs[I]);
@@ -25491,8 +25482,7 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
   // for flexible array member pointers.
   QualType ResultTy = ResultExpr->getType();
   if (auto *DCPT = ResultTy->getAs<CountAttributedType>()) {
-    ExprResult ReturnCount =
-        Transform.TransformBoundsAttrExpr(DCPT->getCountExpr());
+    ExprResult ReturnCount = Transform.TransformExpr(DCPT->getCountExpr());
     if (!ReturnCount.get())
       return ExprError();
     ReturnCount = DefaultLvalueConversion(ReturnCount.get());
@@ -25507,7 +25497,7 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
     if (!(ResultExpr = Promoted.get()))
       return ExprError();
   } else if (auto *DRPT = ResultTy->getAs<DynamicRangePointerType>()) {
-    ExprResult Upper = Transform.TransformBoundsAttrExpr(DRPT->getEndPointer());
+    ExprResult Upper = Transform.TransformExpr(DRPT->getEndPointer());
     if (!Upper.get())
       return ExprError();
     auto FA = BoundsSafetyPointerAttributes::bidiIndexable();

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7647,7 +7647,7 @@ QualType TreeTransform<Derived>::TransformCountAttributedType(
   if (getDerived().AlwaysRebuild() || InnerTy != OldTy->desugar() ||
       OldCount != NewCount) {
     /* TO_UPSTREAM(BoundsSafety) ON */
-    if (SemaRef.getLangOpts().hasBoundsSafety()) {
+    if (SemaRef.getLangOpts().BoundsSafetyAttributes) {
       Result = SemaRef.BuildCountAttributedType(
           InnerTy, NewCount, OldTy->isCountInBytes(), OldTy->isOrNull());
     } else {

--- a/clang/test/BoundsSafety/AST/typedef-function-attrs-late-parsed-ret.c
+++ b/clang/test/BoundsSafety/AST/typedef-function-attrs-late-parsed-ret.c
@@ -93,12 +93,12 @@ void foo(
 // CHECK: |       `-AttributedType {{.+}} 'int *__single' sugar
 // CHECK: |         `-PointerType {{.+}} 'int *__single'
 // CHECK: |           `-BuiltinType {{.+}} 'int'
-// CHECK: |-FunctionDecl {{.+}} g_cb 'cb_t':'int *__single __counted_by(count)(int)'
-// CHECK: | `-ParmVarDecl {{.+}} implicit 'int'
-// CHECK: |-FunctionDecl {{.+}} g_sb 'sb_t':'void *__single __sized_by(size)(int)'
-// CHECK: | `-ParmVarDecl {{.+}} implicit 'int'
-// CHECK: |-FunctionDecl {{.+}} g_eb 'eb_t':'int *__single __ended_by(end)(int *__single)'
-// CHECK: | `-ParmVarDecl {{.+}} implicit 'int *__single'
+// CHECK: |-FunctionDecl {{.+}} g_cb 'int *__single __counted_by(count)(int)'
+// CHECK: | `-ParmVarDecl {{.+}} implicit used count 'int'
+// CHECK: |-FunctionDecl {{.+}} g_sb 'void *__single __sized_by(size)(int)'
+// CHECK: | `-ParmVarDecl {{.+}} implicit used size 'int'
+// CHECK: |-FunctionDecl {{.+}} g_eb 'int *__single __ended_by(end)(int *__single)'
+// CHECK: | `-ParmVarDecl {{.+}} implicit used end 'int *__single'
 // CHECK: |-VarDecl {{.+}} g_cb_ptr 'int *__single __counted_by(count)(*__single)(int)'
 // CHECK: |-VarDecl {{.+}} g_sb_ptr 'void *__single __sized_by(size)(*__single)(int)'
 // CHECK: |-VarDecl {{.+}} g_eb_ptr 'int *__single __ended_by(end)(*__single)(int *__single)'
@@ -117,14 +117,14 @@ void foo(
 // CHECK:   |-ParmVarDecl {{.+}} a_ptr_eb 'eb_t *__single'
 // CHECK:   `-CompoundStmt {{.+}}
 // CHECK:     |-DeclStmt
-// CHECK:     | `-FunctionDecl {{.+}} l_cb 'cb_t':'int *__single __counted_by(count)(int)'
-// CHECK:     |   `-ParmVarDecl {{.+}} implicit 'int'
+// CHECK:     | `-FunctionDecl {{.+}} l_cb 'int *__single __counted_by(count)(int)'
+// CHECK:     |   `-ParmVarDecl {{.+}} implicit used count 'int'
 // CHECK:     |-DeclStmt
-// CHECK:     | `-FunctionDecl {{.+}} l_sb 'sb_t':'void *__single __sized_by(size)(int)'
-// CHECK:     |   `-ParmVarDecl {{.+}} implicit 'int'
+// CHECK:     | `-FunctionDecl {{.+}} l_sb 'void *__single __sized_by(size)(int)'
+// CHECK:     |   `-ParmVarDecl {{.+}} implicit used size 'int'
 // CHECK:     |-DeclStmt
-// CHECK:     | `-FunctionDecl {{.+}} l_eb 'eb_t':'int *__single __ended_by(end)(int *__single)'
-// CHECK:     |   `-ParmVarDecl {{.+}} implicit 'int *__single'
+// CHECK:     | `-FunctionDecl {{.+}} l_eb 'int *__single __ended_by(end)(int *__single)'
+// CHECK:     |   `-ParmVarDecl {{.+}} implicit used end 'int *__single'
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl {{.+}} l_cb_ptr 'int *__single __counted_by(count)(*__single)(int)'
 // CHECK:     |-DeclStmt

--- a/clang/test/BoundsSafety/AST/typedef-function-bounds-attributed.c
+++ b/clang/test/BoundsSafety/AST/typedef-function-bounds-attributed.c
@@ -1,0 +1,155 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x c -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -ast-dump %s 2>&1 | FileCheck %s
+
+#include <ptrcheck.h>
+
+/* typeof */
+
+// CHECK:      FunctionDecl {{.+}} to_cb_in_in 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_in_in_x 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+void to_cb_in_in(int *__counted_by(len) p, int len);
+__typeof__(to_cb_in_in) to_cb_in_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_in_out 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(*len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_in_out_x 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 0
+void to_cb_in_out(int *__counted_by(*len) p, int *len);
+__typeof__(to_cb_in_out) to_cb_in_out_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_out_in 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 1
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_out_in_x 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 1
+void to_cb_out_in(int *__counted_by(len) * p, int len);
+__typeof__(to_cb_out_in) to_cb_out_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_out_out 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(*len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 1
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_out_out_x 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 1
+void to_cb_out_out(int *__counted_by(*len) * p, int *len);
+__typeof__(to_cb_out_out) to_cb_out_out_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_ret 'int *{{.*}} __counted_by(len)(int)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_ret_x 'int *{{.*}} __counted_by(len)(int)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+int *__counted_by(len) to_cb_ret(int len);
+__typeof__(to_cb_ret) to_cb_ret_x;
+
+// CHECK:      FunctionDecl {{.+}} to_sb_in_in 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'void *{{.*}} __sized_by(size)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used size 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_sb_in_in_x 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'void *{{.*}} __sized_by(size)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used size 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+void to_sb_in_in(void *__sized_by(size) p, int size);
+__typeof__(to_sb_in_in) to_sb_in_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cbn_in_in 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by_or_null(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_cbn_in_in_x 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by_or_null(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+void to_cbn_in_in(int *__counted_by_or_null(len) p, int len);
+__typeof__(to_cbn_in_in) to_cbn_in_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_eb 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} used start 'int *{{.*}} __ended_by(end)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used end 'int *{{.*}} /* __started_by(start) */ '
+// CHECK-NEXT: FunctionDecl {{.+}} to_eb_x 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit used start 'int *{{.*}} __ended_by(end)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used end 'int *{{.*}} /* __started_by(start) */ '
+void to_eb(int *__ended_by(end) start, int *end);
+__typeof__(to_eb) to_eb_x;
+
+/* typedef */
+
+// CHECK:      TypedefDecl {{.+}} td_cb_in_in 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK:      FunctionDecl {{.+}} tb_cb_in_in_x 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+typedef void(td_cb_in_in)(int *__counted_by(len) p, int len);
+td_cb_in_in tb_cb_in_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_in_out 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK:      FunctionDecl {{.+}} td_cb_in_out_x 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 0
+typedef void(td_cb_in_out)(int *__counted_by(*len) p, int *len);
+td_cb_in_out td_cb_in_out_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_out_in 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK:      FunctionDecl {{.+}} td_cb_out_in_x 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 1
+typedef void(td_cb_out_in)(int *__counted_by(len) * p, int len);
+td_cb_out_in td_cb_out_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_out_out 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK:      FunctionDecl {{.+}} td_cb_out_out_x 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 1
+typedef void(td_cb_out_out)(int *__counted_by(*len) * p, int *len);
+td_cb_out_out td_cb_out_out_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_ret 'int *{{.*}} __counted_by(len)(int)'
+// CHECK:      FunctionDecl {{.+}} td_cb_ret_x 'int *{{.*}} __counted_by(len)(int)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+typedef int *__counted_by(len)(td_cb_ret)(int len);
+td_cb_ret td_cb_ret_x;
+
+// CHECK:      TypedefDecl {{.+}} td_sb_in_in 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK:      FunctionDecl {{.+}} tb_sb_in_in_x 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'void *{{.*}} __sized_by(size)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used size 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+typedef void(td_sb_in_in)(void *__sized_by(size) p, int size);
+td_sb_in_in tb_sb_in_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cbn_in_in 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK:      FunctionDecl {{.+}} tb_cbn_in_in_x 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by_or_null(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+typedef void(td_cbn_in_in)(int *__counted_by_or_null(len) p, int len);
+td_cbn_in_in tb_cbn_in_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_eb 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK:      FunctionDecl {{.+}} td_eb_x 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit used start 'int *{{.*}} __ended_by(end)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used end 'int *{{.*}} /* __started_by(start) */ '
+typedef void(td_eb)(int *__ended_by(end) start, int *end);
+td_eb td_eb_x;

--- a/clang/test/BoundsSafety/Sema/typeof-func-rebuild-types.c
+++ b/clang/test/BoundsSafety/Sema/typeof-func-rebuild-types.c
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -verify %s
+
+#include <ptrcheck.h>
+
+// Check if clang rebuilds param/return types of function declared with
+// typeof/typedef.
+// If the types are not rebuilt, the count expr in `bar` and `baz` will refer
+// to `len` in `foo`, and the analysis will fail to catch the following errors.
+
+void foo(int *__counted_by(len), int len);
+
+__typeof__(foo) bar;
+
+typedef void(baz_t)(int *__counted_by(len), int len);
+
+baz_t baz;
+
+void test(void) {
+  // expected-note@+1 3{{'array' declared here}}
+  int array[42];
+  // expected-error@+1{{passing array 'array' (which has 42 elements) to parameter of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 100 always fails}}
+  foo(array, 100);
+  // expected-error@+1{{passing array 'array' (which has 42 elements) to parameter of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 100 always fails}}
+  bar(array, 100);
+  // expected-error@+1{{passing array 'array' (which has 42 elements) to parameter of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 100 always fails}}
+  baz(array, 100);
+}


### PR DESCRIPTION
Declaring a function with typedef/typeof, which has bounds attributed types, creates a bounds attribute expression that refers to the parameters of the old function.

```
  void foo(int *__counted_by(len), int len);
  __typeof__(foo) bar;
```

In the above example, the count expression in `bar` refers to `len` in the function `foo`. Instead, it should refer to `len` in `bar`.

Moreover, declaring a function with typedef/typeof loses `DependerDeclsAttr`. In the above example, `len` in `bar` won't have the attribute.

This change rebuilds the function type if the function is declared with typeof/typedef. This will rebuild the bounds attribute expression to refer to the parameters of the function being declared. Moreover, it creates `DependerDeclsAttr` for the dependent parameters.

rdar://131339532