### PR TITLE
[Cherry-pick into next] [lldb] Delete unreachable(ish) code (NFCish)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3767,17 +3767,6 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
           if (llvm::StringRef(AsMangledName(type))
                   .ends_with("sSo18NSNotificationNameaD"))
             return GetTypeFromMangledTypename(ConstString("$sSo8NSStringCD"));
-          if (result->GetMangledTypeName().GetStringRef().count('$') > 1 &&
-              get_ast_num_children() ==
-                  llvm::expectedToStdOptional(runtime->GetNumChildren(
-                      {weak_from_this(), type}, exe_scope)))
-            // If available, prefer the AST for private types. Private
-            // identifiers are not ABI; the runtime returns anonymous private
-            // identifiers (using a '$' prefix) which cannot match identifiers
-            // in the AST. Because these private types can't be used in an AST
-            // context, prefer the AST type if available.
-            if (auto ast_type = fallback())
-              return ast_type;
           return result;
         }
         if (!result)

--- a/lldb/test/API/lang/swift/private_member/Makefile
+++ b/lldb/test/API/lang/swift/private_member/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
+++ b/lldb/test/API/lang/swift/private_member/TestSwiftPrivateMember.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftPrivateMember(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target,  process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('main.swift'))
+        frame = thread.frames[0]
+        x = frame.FindVariable("x")
+        member = x.GetChildAtIndex(0)
+        self.assertIn("23", str(member))

--- a/lldb/test/API/lang/swift/private_member/main.swift
+++ b/lldb/test/API/lang/swift/private_member/main.swift
@@ -1,0 +1,14 @@
+fileprivate struct U {
+  let i = 23
+}
+
+fileprivate struct V {
+  let member = U()
+}
+
+func main() {
+  let x = V()
+  print(x) // break here
+}
+
+main()

--- a/lldb/test/API/lang/swift/value_generics/TestSwiftValueGenerics.py
+++ b/lldb/test/API/lang/swift/value_generics/TestSwiftValueGenerics.py
@@ -10,12 +10,14 @@ class TestSwiftVariadicGenerics(TestBase):
     def test(self):
         self.build()
 
-        target,  process, _, _ = lldbutil.run_to_source_breakpoint(
+        target,  process, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec('main.swift'))
-        self.expect('log enable lldb types')
-        self.expect("frame variable v",
+        self.expect("frame variable ints",
                     substrs=["a.Vector<4, Int>", "storage",
-                             "0", "0",
-                             "1", "1",
-                             "2", "2",
-                             "3", "3"])
+                             "0", "1", "2", "3"])
+        self.expect("frame variable bools",
+                    substrs=["a.Vector<2, Bool>", "storage",
+                             "false", "true"])
+        self.expect("frame variable structs",
+                    substrs=["a.Vector<2, S>", "storage",
+                             "i", "1", "j", "2", "i", "3", "j", "4"])

--- a/lldb/test/API/lang/swift/value_generics/main.swift
+++ b/lldb/test/API/lang/swift/value_generics/main.swift
@@ -37,12 +37,20 @@ extension Vector: Copyable where Element: Copyable {
 extension Vector: BitwiseCopyable where Element: BitwiseCopyable {}
 
 func main() {
-    var v = Vector<4, Int>(repeating: 0)
-    v[0] = 0
-    v[1] = 1
-    v[2] = 2
-    v[3] = 3
+    var ints = Vector<4, Int>(repeating: 0)
+    ints[0] = 0
+    ints[1] = 1
+    ints[2] = 2
+    ints[3] = 3
+    var bools = Vector<2, Bool>(repeating: false)
+    bools[0] = false
+    bools[1] = true
 
-    print(v)  // break here
+    struct S { let i : Int; let j : Int };
+    var structs = Vector<2, S>(repeating: S(i: 1, j: 2))
+    structs[0] = S(i: 1, j: 2)
+    structs[1] = S(i: 3, j: 4)
+    
+    print("\(ints), \(bools), \(structs)")  // break here
 }
 main()


### PR DESCRIPTION
```
commit 2472c96b8a5b1177d406a902d86393376894bdec
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jan 30 12:34:31 2025 -0800

    [lldb] Delete unreachable(ish) code (NFCish)
    
    No test in the testsuite triggeres this code path, except for the new
    ValueGeneric tes, which triggers it for entirely the wrong reason. I
    added a new test that exercises the case that is mentioned in the
    comment to make sure that this is indeed obsolete.

commit 0baa1accb9118432cedbef8549f38427217789b4
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jan 30 15:38:56 2025 -0800

    [lldb] Wire up reflection support for Builtin.FixedArray
```
