### PR TITLE
[BoundsSafety][NFC] Fix warning variable 'FT' set but not used 🍒

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -4191,7 +4191,7 @@ static bool mergeFunctionDeclTerminatedByAttribute(FunctionDecl *New,
       QualType NewFuncTy = Self.Context.getFunctionType(
           MergeRetTy, MergeParamTys, FT->getExtProtoInfo());
       New->setType(NewFuncTy);
-    } else if (auto *FT = New->getType()->getAs<FunctionNoProtoType>()) {
+    } else if (New->getType()->isFunctionNoProtoType()) {
       QualType NewFuncTy = Self.Context.getFunctionNoProtoType(MergeRetTy);
       New->setType(NewFuncTy);
     }


### PR DESCRIPTION
(cherry picked from commit f2c12cb914275430a1d44b93b1a872453058aa9f)