### PR TITLE
[BoundsSafety] Rebuild bound attributed types when declaring a function with typeof/typedef 🍒

### DIFF
--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
@@ -570,8 +570,7 @@ public:
     }
 
     assert(!Ty->getCountExpr()->HasSideEffects(Ctx));
-    ExprResult CountR =
-        DeclReplacer.TransformBoundsAttrExpr(Ty->getCountExpr());
+    ExprResult CountR = DeclReplacer.TransformExpr(Ty->getCountExpr());
     if (CountR.isInvalid())
       return ExprError();
     Expr *Count = CountR.get();
@@ -781,7 +780,7 @@ public:
     // '__ended_by'. We may revisit this if we decide to expose '__started_by'
     // to users.
     if (auto *End = Ty->getEndPointer()) {
-      if (!PushValidOrErr(DeclReplacer.TransformBoundsAttrExpr(End)))
+      if (!PushValidOrErr(DeclReplacer.TransformExpr(End)))
         return ExprError();
     }
 
@@ -969,7 +968,7 @@ public:
       Counts.push_back(Zero.get());
     }
 
-    ExprResult NewCount = DeclReplacer.TransformBoundsAttrExpr(Count);
+    ExprResult NewCount = DeclReplacer.TransformExpr(Count);
     NewCount = SemaRef.DefaultLvalueConversion(NewCount.get());
     if (NewCount.isInvalid())
       return;
@@ -1025,7 +1024,7 @@ public:
 
       assert(!RangePtr->HasSideEffects(SemaRef.Context));
       // Since we materialize self assignments, we can reuse the materialized value.
-      ExprResult NewRangePtr = DeclReplacer.TransformBoundsAttrExpr(RangePtr);
+      ExprResult NewRangePtr = DeclReplacer.TransformExpr(RangePtr);
       assert(!NewRangePtr.isInvalid());
       // This is assuming the range has not been changed.
       NewRangePtr = SemaRef.DefaultFunctionArrayLvalueConversion(NewRangePtr.get());

--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.h
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.h
@@ -267,15 +267,6 @@ struct ReplaceDeclRefWithRHS : public TreeTransform<ReplaceDeclRefWithRHS> {
 
   bool AlwaysRebuild() { return true; }
 
-  ExprResult TransformBoundsAttrExpr(Expr *E) {
-    using ExpressionKind =
-        Sema::ExpressionEvaluationContextRecord::ExpressionKind;
-    EnterExpressionEvaluationContext EC(
-        SemaRef, Sema::ExpressionEvaluationContext::PotentiallyEvaluated,
-        nullptr, ExpressionKind::EK_AttrArgument);
-    return TransformExpr(E);
-  }
-
   ExprResult TransformOpaqueValueExpr(OpaqueValueExpr *E) { return Owned(E); }
 
   /// If we are replacing the value pointed to by DeclRef, we unwrap dereference

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -10466,6 +10466,77 @@ static bool isStdBuiltin(ASTContext &Ctx, FunctionDecl *FD,
   }
 }
 
+static void rebuildBoundAttributedTypes(Sema &S, FunctionDecl *FD) {
+  struct ReplaceParams : public TreeTransform<ReplaceParams> {
+    using BaseTransform = TreeTransform<ReplaceParams>;
+    FunctionDecl *FD;
+
+    explicit ReplaceParams(Sema &SemaRef, FunctionDecl *FD)
+        : BaseTransform(SemaRef), FD(FD) {}
+
+    bool AlwaysRebuild() { return true; }
+
+    ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
+      const auto *OldParam = dyn_cast<ParmVarDecl>(E->getDecl());
+      if (!OldParam)
+        return BaseTransform::TransformDeclRefExpr(E);
+      auto *NewParam = FD->getParamDecl(OldParam->getFunctionScopeIndex());
+      return SemaRef.BuildDeclRefExpr(NewParam, E->getType(), E->getValueKind(),
+                                      E->getNameInfo());
+    }
+  } Transform(S, FD);
+
+  auto RebuildBoundAttributeType = [&](QualType Ty) {
+    if (Ty->isBoundsAttributedType() ||
+        (Ty->isPointerType() &&
+         Ty->getPointeeType()->isBoundsAttributedType())) {
+      return Transform.TransformType(Ty);
+    }
+    return Ty;
+  };
+
+  QualType OldRetTy = FD->getReturnType();
+  QualType NewRetTy = RebuildBoundAttributeType(OldRetTy);
+  bool Updated = NewRetTy != OldRetTy;
+
+  llvm::SmallVector<QualType, 4> NewParamTys;
+  NewParamTys.reserve(FD->getNumParams());
+  for (unsigned I = 0; I < FD->getNumParams(); ++I) {
+    ParmVarDecl *Param = FD->getParamDecl(I);
+    QualType OldTy = Param->getType();
+    QualType NewTy = RebuildBoundAttributeType(OldTy);
+
+    NewParamTys.push_back(NewTy);
+
+    if (NewTy == OldTy)
+      continue;
+
+    Param->setType(NewTy);
+    Updated = true;
+
+    // If this param is a count attributed type or a pointer to it (Deref is
+    // true), we need to recreate DependerDeclsAttr for its dependent
+    // parameters.
+    bool Deref = false;
+    const auto *CATy = NewTy->getAs<CountAttributedType>();
+    if (!CATy && NewTy->isPointerType()) {
+      Deref = true;
+      CATy = NewTy->getPointeeType()->getAs<CountAttributedType>();
+    }
+    if (CATy)
+      S.AttachDependerDeclsAttr(Param, CATy, Deref);
+  }
+
+  if (!Updated)
+    return;
+
+  // TODO: We could keep the typeof/typedef sugars.
+  const auto *OldFPT = FD->getType()->castAs<FunctionProtoType>();
+  QualType NewFPT = S.Context.getFunctionType(NewRetTy, NewParamTys,
+                                              OldFPT->getExtProtoInfo());
+  FD->setType(NewFPT);
+}
+
 NamedDecl*
 Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
                               TypeSourceInfo *TInfo, LookupResult &Previous,
@@ -11025,11 +11096,64 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
     // @endcode
 
     // Synthesize a parameter for each argument type.
-    for (const auto &AI : FT->param_types()) {
-      ParmVarDecl *Param =
-          BuildParmVarDeclForTypedef(NewFD, D.getIdentifierLoc(), AI);
-      Param->setScopeInfo(0, Params.size());
-      Params.push_back(Param);
+
+    /* TO_UPSTREAM(BoundsSafety) ON */
+    if (getLangOpts().BoundsSafetyAttributes) {
+      // If the parameters are used as dependent variables, we can synthesize
+      // named parameters for use in the declaration. Named dependent variables
+      // let us generate better diagnostics for the user (e.g.,
+      // __counted_by(len) instead of __counted_by()). Otherwise, just
+      // synthesize unnamed parameters.
+      llvm::SmallVector<const ParmVarDecl *, 4> NamedParams(FT->getNumParams(),
+                                                            nullptr);
+      auto AddNamedParamFromDependentType = [&](QualType Ty) {
+        const auto *BAT = Ty->getAs<BoundsAttributedType>();
+        if (!BAT && Ty->isPointerType())
+          BAT = Ty->getPointeeType()->getAs<BoundsAttributedType>();
+        if (!BAT)
+          return;
+        for (const auto &DD : BAT->dependent_decls()) {
+          if (const auto *PVD = dyn_cast<ParmVarDecl>(DD.getDecl()))
+            NamedParams[PVD->getFunctionScopeIndex()] = PVD;
+        }
+      };
+      AddNamedParamFromDependentType(FT->getReturnType());
+      for (QualType ParamTy : FT->param_types())
+        AddNamedParamFromDependentType(ParamTy);
+
+      // Temporarily put parameter variables in the translation unit, not the
+      // enclosing context. This is what Sema::ActOnParamDeclarator() already
+      // does when declaring a function without a typedef/typeof. In
+      // BoundsSafety, we do it to allow creating references to the parameters
+      // when rebuilding the count expression. Otherwise, creating such
+      // references triggers an error.
+      for (unsigned I = 0; I < FT->getNumParams(); ++I) {
+        QualType Ty = FT->getParamType(I);
+        const ParmVarDecl *NamedParam = NamedParams[I];
+        ParmVarDecl *Param;
+        if (!NamedParam) {
+          Param = BuildParmVarDeclForTypedef(Context.getTranslationUnitDecl(),
+                                             D.getIdentifierLoc(), Ty);
+        } else {
+          SourceLocation Loc = D.getIdentifierLoc();
+          Param = ParmVarDecl::Create(Context, Context.getTranslationUnitDecl(),
+                                      Loc, Loc, NamedParam->getIdentifier(), Ty,
+                                      Context.getTrivialTypeSourceInfo(Ty, Loc),
+                                      SC_None, nullptr);
+          Param->setImplicit();
+        }
+        Param->setScopeInfo(0, Params.size());
+        Params.push_back(Param);
+      }
+    }
+    /* TO_UPSTREAM(BoundsSafety) OFF */
+    else {
+      for (const auto &AI : FT->param_types()) {
+        ParmVarDecl *Param =
+            BuildParmVarDeclForTypedef(NewFD, D.getIdentifierLoc(), AI);
+        Param->setScopeInfo(0, Params.size());
+        Params.push_back(Param);
+      }
     }
   } else {
     assert(R->isFunctionNoProtoType() && NewFD->getNumParams() == 0 &&
@@ -11040,6 +11164,20 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
   NewFD->setParams(Params);
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
+  if (getLangOpts().BoundsSafetyAttributes) {
+    if (!D.isFunctionDeclarator() && R->isFunctionProtoType()) {
+      // The function is being declared with a typedef/typeof. We need to
+      // rebuild the bound attributed types, so that their expression refer the
+      // to the new parameters.
+      rebuildBoundAttributedTypes(*this, NewFD);
+
+      for (ParmVarDecl *Param : Params) {
+        assert(Param->getDeclContext() == Context.getTranslationUnitDecl());
+        Param->setDeclContext(NewFD);
+      }
+    }
+  }
+
   if (getLangOpts().BoundsSafety) {
     // This is a good place to make sure that no array parameter has decayed
     // to a __single pointer. Annoyingly, we can't do this when parameters are

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -7469,7 +7469,7 @@ QualType TreeTransform<Derived>::TransformCountAttributedType(
   if (getDerived().AlwaysRebuild() || InnerTy != OldTy->desugar() ||
       OldCount != NewCount) {
     /* TO_UPSTREAM(BoundsSafety) ON */
-    if (SemaRef.getLangOpts().hasBoundsSafety()) {
+    if (SemaRef.getLangOpts().BoundsSafetyAttributes) {
       Result = SemaRef.BuildCountAttributedType(
           InnerTy, NewCount, OldTy->isCountInBytes(), OldTy->isOrNull());
     } else {

--- a/clang/test/BoundsSafety/AST/typedef-function-attrs-late-parsed-ret.c
+++ b/clang/test/BoundsSafety/AST/typedef-function-attrs-late-parsed-ret.c
@@ -92,12 +92,12 @@ void foo(
 // CHECK: |       `-AttributedType {{.+}} 'int *__single' sugar
 // CHECK: |         `-PointerType {{.+}} 'int *__single'
 // CHECK: |           `-BuiltinType {{.+}} 'int'
-// CHECK: |-FunctionDecl {{.+}} g_cb 'cb_t':'int *__single __counted_by(count)(int)'
-// CHECK: | `-ParmVarDecl {{.+}} implicit 'int'
-// CHECK: |-FunctionDecl {{.+}} g_sb 'sb_t':'void *__single __sized_by(size)(int)'
-// CHECK: | `-ParmVarDecl {{.+}} implicit 'int'
-// CHECK: |-FunctionDecl {{.+}} g_eb 'eb_t':'int *__single __ended_by(end)(int *__single)'
-// CHECK: | `-ParmVarDecl {{.+}} implicit 'int *__single'
+// CHECK: |-FunctionDecl {{.+}} g_cb 'int *__single __counted_by(count)(int)'
+// CHECK: | `-ParmVarDecl {{.+}} implicit used count 'int'
+// CHECK: |-FunctionDecl {{.+}} g_sb 'void *__single __sized_by(size)(int)'
+// CHECK: | `-ParmVarDecl {{.+}} implicit used size 'int'
+// CHECK: |-FunctionDecl {{.+}} g_eb 'int *__single __ended_by(end)(int *__single)'
+// CHECK: | `-ParmVarDecl {{.+}} implicit used end 'int *__single'
 // CHECK: |-VarDecl {{.+}} g_cb_ptr 'int *__single __counted_by(count)(*__single)(int)'
 // CHECK: |-VarDecl {{.+}} g_sb_ptr 'void *__single __sized_by(size)(*__single)(int)'
 // CHECK: |-VarDecl {{.+}} g_eb_ptr 'int *__single __ended_by(end)(*__single)(int *__single)'
@@ -116,14 +116,14 @@ void foo(
 // CHECK:   |-ParmVarDecl {{.+}} a_ptr_eb 'eb_t *__single'
 // CHECK:   `-CompoundStmt {{.+}}
 // CHECK:     |-DeclStmt
-// CHECK:     | `-FunctionDecl {{.+}} l_cb 'cb_t':'int *__single __counted_by(count)(int)'
-// CHECK:     |   `-ParmVarDecl {{.+}} implicit 'int'
+// CHECK:     | `-FunctionDecl {{.+}} l_cb 'int *__single __counted_by(count)(int)'
+// CHECK:     |   `-ParmVarDecl {{.+}} implicit used count 'int'
 // CHECK:     |-DeclStmt
-// CHECK:     | `-FunctionDecl {{.+}} l_sb 'sb_t':'void *__single __sized_by(size)(int)'
-// CHECK:     |   `-ParmVarDecl {{.+}} implicit 'int'
+// CHECK:     | `-FunctionDecl {{.+}} l_sb 'void *__single __sized_by(size)(int)'
+// CHECK:     |   `-ParmVarDecl {{.+}} implicit used size 'int'
 // CHECK:     |-DeclStmt
-// CHECK:     | `-FunctionDecl {{.+}} l_eb 'eb_t':'int *__single __ended_by(end)(int *__single)'
-// CHECK:     |   `-ParmVarDecl {{.+}} implicit 'int *__single'
+// CHECK:     | `-FunctionDecl {{.+}} l_eb 'int *__single __ended_by(end)(int *__single)'
+// CHECK:     |   `-ParmVarDecl {{.+}} implicit used end 'int *__single'
 // CHECK:     |-DeclStmt
 // CHECK:     | `-VarDecl {{.+}} l_cb_ptr 'int *__single __counted_by(count)(*__single)(int)'
 // CHECK:     |-DeclStmt

--- a/clang/test/BoundsSafety/AST/typedef-function-bounds-attributed.c
+++ b/clang/test/BoundsSafety/AST/typedef-function-bounds-attributed.c
@@ -1,0 +1,155 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x c -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -ast-dump %s 2>&1 | FileCheck %s
+
+#include <ptrcheck.h>
+
+/* typeof */
+
+// CHECK:      FunctionDecl {{.+}} to_cb_in_in 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_in_in_x 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+void to_cb_in_in(int *__counted_by(len) p, int len);
+__typeof__(to_cb_in_in) to_cb_in_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_in_out 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(*len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_in_out_x 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 0
+void to_cb_in_out(int *__counted_by(*len) p, int *len);
+__typeof__(to_cb_in_out) to_cb_in_out_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_out_in 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 1
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_out_in_x 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 1
+void to_cb_out_in(int *__counted_by(len) * p, int len);
+__typeof__(to_cb_out_in) to_cb_out_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_out_out 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by(*len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 1
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_out_out_x 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 1
+void to_cb_out_out(int *__counted_by(*len) * p, int *len);
+__typeof__(to_cb_out_out) to_cb_out_out_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cb_ret 'int *{{.*}} __counted_by(len)(int)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT: FunctionDecl {{.+}} to_cb_ret_x 'int *{{.*}} __counted_by(len)(int)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+int *__counted_by(len) to_cb_ret(int len);
+__typeof__(to_cb_ret) to_cb_ret_x;
+
+// CHECK:      FunctionDecl {{.+}} to_sb_in_in 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'void *{{.*}} __sized_by(size)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used size 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_sb_in_in_x 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'void *{{.*}} __sized_by(size)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used size 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+void to_sb_in_in(void *__sized_by(size) p, int size);
+__typeof__(to_sb_in_in) to_sb_in_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_cbn_in_in 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} p 'int *{{.*}} __counted_by_or_null(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+// CHECK-NEXT: FunctionDecl {{.+}} to_cbn_in_in_x 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by_or_null(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+void to_cbn_in_in(int *__counted_by_or_null(len) p, int len);
+__typeof__(to_cbn_in_in) to_cbn_in_in_x;
+
+// CHECK:      FunctionDecl {{.+}} to_eb 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} used start 'int *{{.*}} __ended_by(end)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} used end 'int *{{.*}} /* __started_by(start) */ '
+// CHECK-NEXT: FunctionDecl {{.+}} to_eb_x 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit used start 'int *{{.*}} __ended_by(end)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used end 'int *{{.*}} /* __started_by(start) */ '
+void to_eb(int *__ended_by(end) start, int *end);
+__typeof__(to_eb) to_eb_x;
+
+/* typedef */
+
+// CHECK:      TypedefDecl {{.+}} td_cb_in_in 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK:      FunctionDecl {{.+}} tb_cb_in_in_x 'void (int *{{.*}} __counted_by(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+typedef void(td_cb_in_in)(int *__counted_by(len) p, int len);
+td_cb_in_in tb_cb_in_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_in_out 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK:      FunctionDecl {{.+}} td_cb_in_out_x 'void (int *{{.*}} __counted_by(*len), int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 0
+typedef void(td_cb_in_out)(int *__counted_by(*len) p, int *len);
+td_cb_in_out td_cb_in_out_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_out_in 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK:      FunctionDecl {{.+}} td_cb_out_in_x 'void (int *{{.*}} __counted_by(len)*{{.*}}, int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 1
+typedef void(td_cb_out_in)(int *__counted_by(len) * p, int len);
+td_cb_out_in td_cb_out_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_out_out 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK:      FunctionDecl {{.+}} td_cb_out_out_x 'void (int *{{.*}} __counted_by(*len)*{{.*}}, int *{{.*}})'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by(*len)*{{.*}}'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int *{{.*}}'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit IsDeref {{.+}} 1
+typedef void(td_cb_out_out)(int *__counted_by(*len) * p, int *len);
+td_cb_out_out td_cb_out_out_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cb_ret 'int *{{.*}} __counted_by(len)(int)'
+// CHECK:      FunctionDecl {{.+}} td_cb_ret_x 'int *{{.*}} __counted_by(len)(int)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+typedef int *__counted_by(len)(td_cb_ret)(int len);
+td_cb_ret td_cb_ret_x;
+
+// CHECK:      TypedefDecl {{.+}} td_sb_in_in 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK:      FunctionDecl {{.+}} tb_sb_in_in_x 'void (void *{{.*}} __sized_by(size), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'void *{{.*}} __sized_by(size)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used size 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+typedef void(td_sb_in_in)(void *__sized_by(size) p, int size);
+td_sb_in_in tb_sb_in_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_cbn_in_in 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK:      FunctionDecl {{.+}} tb_cbn_in_in_x 'void (int *{{.*}} __counted_by_or_null(len), int)'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit 'int *{{.*}} __counted_by_or_null(len)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used len 'int'
+// CHECK-NEXT:   `-DependerDeclsAttr {{.+}} Implicit {{.+}} 0
+typedef void(td_cbn_in_in)(int *__counted_by_or_null(len) p, int len);
+td_cbn_in_in tb_cbn_in_in_x;
+
+// CHECK:      TypedefDecl {{.+}} td_eb 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK:      FunctionDecl {{.+}} td_eb_x 'void (int *{{.*}} __ended_by(end), int *{{.*}} /* __started_by(start) */ )'
+// CHECK-NEXT: |-ParmVarDecl {{.+}} implicit used start 'int *{{.*}} __ended_by(end)'
+// CHECK-NEXT: `-ParmVarDecl {{.+}} implicit used end 'int *{{.*}} /* __started_by(start) */ '
+typedef void(td_eb)(int *__ended_by(end) start, int *end);
+td_eb td_eb_x;

--- a/clang/test/BoundsSafety/Sema/typeof-func-rebuild-types.c
+++ b/clang/test/BoundsSafety/Sema/typeof-func-rebuild-types.c
@@ -1,0 +1,28 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -verify %s
+
+#include <ptrcheck.h>
+
+// Check if clang rebuilds param/return types of function declared with
+// typeof/typedef.
+// If the types are not rebuilt, the count expr in `bar` and `baz` will refer
+// to `len` in `foo`, and the analysis will fail to catch the following errors.
+
+void foo(int *__counted_by(len), int len);
+
+__typeof__(foo) bar;
+
+typedef void(baz_t)(int *__counted_by(len), int len);
+
+baz_t baz;
+
+void test(void) {
+  // expected-note@+1 3{{'array' declared here}}
+  int array[42];
+  // expected-error@+1{{passing array 'array' (which has 42 elements) to parameter of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 100 always fails}}
+  foo(array, 100);
+  // expected-error@+1{{passing array 'array' (which has 42 elements) to parameter of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 100 always fails}}
+  bar(array, 100);
+  // expected-error@+1{{passing array 'array' (which has 42 elements) to parameter of type 'int *__single __counted_by(len)' (aka 'int *__single') with count value of 100 always fails}}
+  baz(array, 100);
+}


### PR DESCRIPTION
Declaring a function with typedef/typeof, which has bounds attributed types, creates a bounds attribute expression that refers to the parameters of the old function.

```
  void foo(int *__counted_by(len), int len);
  __typeof__(foo) bar;
```

In the above example, the count expression in `bar` refers to `len` in the function `foo`. Instead, it should refer to `len` in `bar`.

Moreover, declaring a function with typedef/typeof loses `DependerDeclsAttr`. In the above example, `len` in `bar` won't have the attribute.

This change rebuilds the function type if the function is declared with typeof/typedef. This will rebuild the bounds attribute expression to refer to the parameters of the function being declared. Moreover, it creates `DependerDeclsAttr` for the dependent parameters.

rdar://131339532
(cherry picked from commit 14fa7253dcd6567f27005eccb4de6fee51047fb0)