### PR TITLE
Fix test failure in fake-use-suppress-load.ll

### DIFF
--- a/llvm/test/CodeGen/X86/fake-use-suppress-load.ll
+++ b/llvm/test/CodeGen/X86/fake-use-suppress-load.ll
@@ -1,5 +1,5 @@
 ; Suppress redundant loads feeding into fake uses.
-; RUN: llc -filetype=asm -o - %s --mtriple=x86_64-unknown-unknown | FileCheck %s
+; RUN: llc -filetype=asm -experimental-debug-variable-locations=true -o - %s --mtriple=x86_64-unknown-unknown | FileCheck %s
 ; Windows ABI works differently, there's no offset.
 ;
 ; Look for the spill


### PR DESCRIPTION
Because Intruction Referencing based Live Debug Values doesn't handle entry values correctly, it was disabled in X86 with ccc06fa64481aea70b77d0e88afb08cc005bc50c

We need to enable Instruction Referencing based Live Debug Values for fake-use-suppress-load.ll to pass, the work for fixing entry value handling is substantial, so a quick fix for now is to just enable Instruction Referencing based LDV with an -mllvm option in the test.