### PR TITLE
[cherry-pick][lldb] Fix check in swift test

### DIFF
--- a/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
+++ b/lldb/test/API/lang/swift/async/unwind/sayhello/TestSwiftAsyncUnwind.py
@@ -3,6 +3,10 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
+def get_num_registers(frame):
+    general_purpose_regs = frame.GetRegisters()[0]
+    num_regs = sum(reg.GetError().Success() for reg in general_purpose_regs)
+    return num_regs
 
 class TestSwiftAsyncUnwind(lldbtest.TestBase):
 
@@ -29,8 +33,8 @@ class TestSwiftAsyncUnwind(lldbtest.TestBase):
         # Check that we can only get a limited number of registers for
         # frames that unwound with an AsyncContext, as a sanity check
         # to see that this is really the async unwinder.
-        self.assertIn(thread.GetFrameAtIndex(1).GetRegisters().GetSize(), [2,3,4])
-        self.assertIn(thread.GetFrameAtIndex(2).GetRegisters().GetSize(), [2,3,4])
+        self.assertIn(get_num_registers(thread.GetFrameAtIndex(1)), [2,3,4])
+        self.assertIn(get_num_registers(thread.GetFrameAtIndex(2)), [2,3,4])
 
         # Delete the old breakpoint, otherwise it would be reached again.
         target.BreakpointDelete(bkpt.GetID())


### PR DESCRIPTION
This test was _attempting_ to check that the number of registers available was 2, 3, or 4.
However, what it was _actually_ checking was the number of register _sets_. This commit fixes that.

(cherry picked from commit c53229d87590fbac32e5f35560b63ccafcc316d4)