### PR TITLE
[lldb][test] Re-enable bounds safety tests

### DIFF
--- a/lldb/test/API/lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py
+++ b/lldb/test/API/lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py
@@ -37,12 +37,10 @@ class TestArrayOfBoundsSafetyPointers(TestBase):
         self.expect("expr array_of_bounds_safety_pointers[1]", patterns = [zero_init_pattern])
         self.expect("frame variable array_of_bounds_safety_pointers[1]", patterns = [zero_init_pattern])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_optimized(self):
         build_dict=dict(CFLAGS_EXTRAS="-O2 -Xclang -fbounds-safety")
         self.__run(build_dict)
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_unoptimized(self):
         build_dict=dict(CFLAGS_EXTRAS="-Xclang -fbounds-safety")
         self.__run(build_dict)

--- a/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/TestOutOfBoundsPointer.py
+++ b/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/TestOutOfBoundsPointer.py
@@ -80,7 +80,6 @@ class TestOutOfBoundsPointer(TestBase):
     def overflow_oob(self, type_name):
         return self.get_idx_var_regex(oob_kind=OOBKind.Overflow, type_name=type_name)
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_bidi_known_type_size(self):
         self.build()
 
@@ -151,7 +150,6 @@ class TestOutOfBoundsPointer(TestBase):
         lldbutil.continue_to_breakpoint(self.process, bkpt)
         self.expect("frame variable fams2", patterns=[self.bidi_full_oob("FAMS_t *")])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_bidi_unknown_type_size(self):
         self.build()
 
@@ -203,7 +201,6 @@ class TestOutOfBoundsPointer(TestBase):
         lldbutil.continue_to_breakpoint(self.process, bkpt)
         self.expect("frame variable oob_null", patterns=[self.bidi_full_oob("void *")])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_idx_known_type_size(self):
         self.build()
 
@@ -255,7 +252,6 @@ class TestOutOfBoundsPointer(TestBase):
         lldbutil.continue_to_breakpoint(self.process, bkpt)
         self.expect("frame variable fams2", patterns=[self.full_oob("FAMS_t *")])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_idx_unknown_type_size(self):
         self.build()
 


### PR DESCRIPTION
These pass ever since we've fixed the frame recognizer in https://github.com/swiftlang/llvm-project/pull/9724.

rdar://141363609