### PR TITLE
[lldb] Semantic fix to usage of AsyncUnwindRegisterNumbers (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2321,7 +2321,7 @@ lldb::addr_t SwiftLanguageRuntime::GetAsyncContext(RegisterContext *regctx) {
   auto arch = regctx->CalculateTarget()->GetArchitecture();
   if (auto regnums = GetAsyncUnwindRegisterNumbers(arch.GetMachine())) {
     auto reg = regctx->ConvertRegisterKindToRegisterNumber(
-        RegisterKind::eRegisterKindDWARF, regnums->async_ctx_regnum);
+        regnums->GetRegisterKind(), regnums->async_ctx_regnum);
     return regctx->ReadRegisterAsUnsigned(reg, LLDB_INVALID_ADDRESS);
   }
 


### PR DESCRIPTION
(cherry-picked from commit 81467b8630ed70b21cc6f6b4d2d3afd4e660aab0)