### PR TITLE
[lldb] Remove unused field from AsyncUnwindRegisterNumbers (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2298,14 +2298,12 @@ GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple) {
   case llvm::Triple::x86_64: {
     AsyncUnwindRegisterNumbers regnums;
     regnums.async_ctx_regnum = dwarf_r14_x86_64;
-    regnums.fp_regnum = dwarf_rbp_x86_64;
     regnums.pc_regnum = dwarf_rip_x86_64;
     return regnums;
   }
   case llvm::Triple::aarch64: {
     AsyncUnwindRegisterNumbers regnums;
     regnums.async_ctx_regnum = arm64_dwarf::x22;
-    regnums.fp_regnum = arm64_dwarf::fp;
     regnums.pc_regnum = arm64_dwarf::pc;
     return regnums;
   }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -839,7 +839,6 @@ private:
 /// For UnwindPlans, these use eh_frame / dwarf register numbering.
 struct AsyncUnwindRegisterNumbers {
   uint32_t async_ctx_regnum;
-  uint32_t fp_regnum;
   uint32_t pc_regnum;
 
   /// All register numbers in this struct are given in the eRegisterKindDWARF


### PR DESCRIPTION
(cherry-picked from commit a5ea48e1c09da51686af448665821c903d5d2af5)