### PR TITLE
[lldb] Make GetDynamicTypeAndAddress() use host address if available

### DIFF
--- a/lldb/include/lldb/Target/LanguageRuntime.h
+++ b/lldb/include/lldb/Target/LanguageRuntime.h
@@ -106,12 +106,16 @@ public:
         "language doesn't support getting vtable information");
   }
 
-  // this call should return true if it could set the name and/or the type
-  virtual bool GetDynamicTypeAndAddress(ValueObject &in_value,
-                                        lldb::DynamicValueType use_dynamic,
-                                        TypeAndOrName &class_type_or_name,
-                                        Address &address,
-                                        Value::ValueType &value_type) = 0;
+  /// This call should return true if it could set the name and/or the type
+  /// Sets address to the address of the dynamic type if value_type is set to
+  /// a file or load address. Sets local_buffer to a buffer containing the data
+  /// of the dynamic type if value_type is set to a host address. Callers should
+  /// copy local_buffer over into their own buffer if they want to keep the data
+  /// alive.
+  virtual bool GetDynamicTypeAndAddress(
+      ValueObject &in_value, lldb::DynamicValueType use_dynamic,
+      TypeAndOrName &class_type_or_name, Address &address,
+      Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) = 0;
 
   // This call should return a CompilerType given a generic type name and an
   // ExecutionContextScope in which one can actually fetch any specialization

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -869,17 +869,18 @@ public:
 
   virtual void SetLanguageFlags(uint64_t flags) { m_language_flags = flags; }
 
-  /// Returns the size of the local buffer if it's available.
+  /// Returns the local buffer that this ValueObject points to if it's
+  /// available.
   /// \return
-  ///     The size of the local buffer if this value object's value points to a
-  ///     host address, and if that size can be determined. Otherwise, returns
-  ///     LLDB_INVALID_ADDRESS.
+  ///     The local buffer if this value object's value points to a
+  ///     host address, and if that buffer can be determined. Otherwise, returns
+  ///     an empty ArrayRef.
   ///
   /// TODO: Because a ValueObject's Value can point to any arbitrary memory
-  /// location, it is possible that the size of the local buffer can't be
-  /// determined at all. See the comment in Value::m_value for a more thorough
-  /// explanation of why that is.
-  uint64_t GetLocalBufferSize();
+  /// location, it is possible that we can't find what what buffer we're
+  /// pointing to, and thus also can't know its size. See the comment in
+  /// Value::m_value for a more thorough explanation of why that is.
+  llvm::ArrayRef<uint8_t> GetLocalBuffer() const;
 
 protected:
   typedef ClusterManager<ValueObject> ValueObjectManager;

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -869,6 +869,18 @@ public:
 
   virtual void SetLanguageFlags(uint64_t flags) { m_language_flags = flags; }
 
+  /// Returns the size of the local buffer if it's available.
+  /// \return
+  ///     The size of the local buffer if this value object's value points to a
+  ///     host address, and if that size can be determined. Otherwise, returns
+  ///     LLDB_INVALID_ADDRESS.
+  ///
+  /// TODO: Because a ValueObject's Value can point to any arbitrary memory
+  /// location, it is possible that the size of the local buffer can't be
+  /// determined at all. See the comment in Value::m_value for a more thorough
+  /// explanation of why that is.
+  uint64_t GetLocalBufferSize();
+
 protected:
   typedef ClusterManager<ValueObject> ValueObjectManager;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1114,13 +1114,14 @@ SwiftLanguage::GetHardcodedSynthetics() {
       TypeAndOrName type_or_name;
       Address address;
       Value::ValueType value_type;
+      llvm::ArrayRef<uint8_t> local_buffer;
       // Try to find the dynamic type of the Swift type.
       // TODO: find a way to get the dyamic value type from the
       // command.
       if (swift_runtime->GetDynamicTypeAndAddress(
               *casted_to_swift.get(),
               lldb::DynamicValueType::eDynamicCanRunTarget, type_or_name,
-              address, value_type)) {
+              address, value_type, local_buffer)) {
         if (type_or_name.HasCompilerType()) {
           swift_type = type_or_name.GetCompilerType();
           // Cast it to the more specific type.
@@ -1248,8 +1249,9 @@ SwiftLanguage::GetPossibleFormattersMatches(
   TypeAndOrName type_and_or_name;
   Address address;
   Value::ValueType value_type;
+  llvm::ArrayRef<uint8_t> local_buffer;
   if (!runtime->GetDynamicTypeAndAddress(valobj, use_dynamic, type_and_or_name,
-                                         address, value_type))
+                                         address, value_type, local_buffer))
     return result;
   if (ConstString name = type_and_or_name.GetName())
     result.push_back(

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.cpp
@@ -288,7 +288,7 @@ llvm::Expected<LanguageRuntime::VTableInfo>
 bool ItaniumABILanguageRuntime::GetDynamicTypeAndAddress(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &dynamic_address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   // For Itanium, if the type has a vtable pointer in the object, it will be at
   // offset 0 in the object.  That will point to the "address point" within the
   // vtable (not the beginning of the vtable.)  We can then look up the symbol

--- a/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/CPlusPlus/ItaniumABI/ItaniumABILanguageRuntime.h
@@ -54,8 +54,8 @@ public:
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
-                                Address &address,
-                                Value::ValueType &value_type) override;
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
 
   TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
                                  ValueObject &static_value) override;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.cpp
@@ -276,7 +276,7 @@ bool AppleObjCRuntime::CouldHaveDynamicValue(ValueObject &in_value) {
 bool AppleObjCRuntime::GetDynamicTypeAndAddress(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   return false;
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntime.h
@@ -54,8 +54,8 @@ public:
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
-                                Address &address,
-                                Value::ValueType &value_type) override;
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
 
   TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
                                  ValueObject &static_value) override;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.cpp
@@ -48,7 +48,7 @@ AppleObjCRuntimeV1::AppleObjCRuntimeV1(Process *process)
 bool AppleObjCRuntimeV1::GetDynamicTypeAndAddress(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   class_type_or_name.Clear();
   value_type = Value::ValueType::Scalar;
   if (CouldHaveDynamicValue(in_value)) {

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV1.h
@@ -100,8 +100,8 @@ public:
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
-                                Address &address,
-                                Value::ValueType &value_type) override;
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
 
   llvm::Expected<std::unique_ptr<UtilityFunction>>
   CreateObjectChecker(std::string, ExecutionContext &exe_ctx) override;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -775,7 +775,7 @@ AppleObjCRuntimeV2::GetPreferredLanguageRuntime(ValueObject &in_value) {
 bool AppleObjCRuntimeV2::GetDynamicTypeAndAddress(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   // We should never get here with a null process...
   assert(m_process != nullptr);
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.h
@@ -53,8 +53,8 @@ public:
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
-                                Address &address,
-                                Value::ValueType &value_type) override;
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
 
   llvm::Expected<std::unique_ptr<UtilityFunction>>
   CreateObjectChecker(std::string name, ExecutionContext &exe_ctx) override;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.cpp
@@ -127,7 +127,7 @@ bool GNUstepObjCRuntime::CouldHaveDynamicValue(ValueObject &in_value) {
 bool GNUstepObjCRuntime::GetDynamicTypeAndAddress(
     ValueObject &in_value, DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   return false;
 }
 

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/GNUstepObjCRuntime/GNUstepObjCRuntime.h
@@ -67,8 +67,8 @@ public:
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
-                                Address &address,
-                                Value::ValueType &value_type) override;
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
 
   TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
                                  ValueObject &static_value) override;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -242,8 +242,8 @@ public:
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
-                                Address &address,
-                                Value::ValueType &value_type) override;
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
 
   CompilerType BindGenericTypeParameters(
       CompilerType unbound_type,
@@ -569,7 +569,8 @@ private:
                                       lldb::DynamicValueType use_dynamic,
                                       TypeAndOrName &class_type_or_name,
                                       Address &address,
-                                      Value::ValueType &value_type);
+                                      Value::ValueType &value_type,
+                                      llvm::ArrayRef<uint8_t> &local_buffer);
 #ifndef NDEBUG
   ConstString GetDynamicTypeName_ClassRemoteAST(ValueObject &in_value,
                                                 lldb::addr_t instance_ptr);
@@ -596,18 +597,18 @@ private:
                                       lldb::DynamicValueType use_dynamic,
                                       TypeAndOrName &class_type_or_name,
                                       Address &address,
-                                      Value::ValueType &value_type);
+                                      Value::ValueType &value_type,
+                                      llvm::ArrayRef<uint8_t> &local_buffer);
 
   bool GetDynamicTypeAndAddress_IndirectEnumCase(
       ValueObject &in_value, lldb::DynamicValueType use_dynamic,
       TypeAndOrName &class_type_or_name, Address &address,
-      Value::ValueType &value_type);
+      Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer);
 
-  bool GetDynamicTypeAndAddress_ClangType(ValueObject &in_value,
-                                          lldb::DynamicValueType use_dynamic,
-                                          TypeAndOrName &class_type_or_name,
-                                          Address &address,
-                                          Value::ValueType &value_type);
+  bool GetDynamicTypeAndAddress_ClangType(
+      ValueObject &in_value, lldb::DynamicValueType use_dynamic,
+      TypeAndOrName &class_type_or_name, Address &address,
+      Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer);
 
   /// Dynamic type resolution tends to want to generate scalar data -
   /// but there are caveats Per original comment here "Our address is
@@ -618,7 +619,8 @@ private:
   Value::ValueType GetValueType(ValueObject &in_value,
                                 CompilerType dynamic_type,
                                 Value::ValueType static_value_type,
-                                bool is_indirect_enum_case);
+                                bool is_indirect_enum_case,
+                                llvm::ArrayRef<uint8_t> &local_buffer);
 
   lldb::UnwindPlanSP
   GetRuntimeUnwindPlan(lldb::ProcessSP process_sp,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2451,20 +2451,19 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
   // If we couldn't find a load address, but the value object has a local
   // buffer, use that.
   if (val_address == LLDB_INVALID_ADDRESS && address_type == eAddressTypeHost) {
-    // Get the start and size of the local buffer.
-    auto start = in_value.GetValue().GetScalar().ULongLong();
-    auto local_buffer_size = in_value.GetLocalBufferSize();
+    // Check if the dynamic type fits in the value object's buffer.
+    auto in_value_buffer = in_value.GetLocalBuffer();
 
-    // If we can't find the size of the local buffer we can't safely know if the
+    // If we can't find the local buffer we can't safely know if the
     // dynamic type fits in it.
-    if (local_buffer_size == LLDB_INVALID_ADDRESS)
+    if (in_value_buffer.empty())
       return false;
     // If the dynamic type doesn't in the buffer we can't use it either.
-    if (local_buffer_size < bound_type.GetByteSize(exe_scope))
+    if (in_value_buffer.size() < bound_type.GetByteSize(exe_scope))
       return false;
 
     value_type = Value::GetValueTypeFromAddressType(address_type);
-    local_buffer = {(uint8_t *)start, local_buffer_size};
+    local_buffer = in_value_buffer;
     return true;
   }
   if (*size && (!val_address || val_address == LLDB_INVALID_ADDRESS))

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1847,7 +1847,8 @@ static bool IsPrivateNSClass(NodePointer node) {
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     ValueObject &in_value, CompilerType class_type,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
-    Address &address, Value::ValueType &value_type) {
+    Address &address, Value::ValueType &value_type,
+    llvm::ArrayRef<uint8_t> &local_buffer) {
   AddressType address_type;
   lldb::addr_t instance_ptr = in_value.GetPointerValue(&address_type);
   value_type = Value::GetValueTypeFromAddressType(address_type);
@@ -1873,8 +1874,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     if (auto *objc_runtime =
             SwiftLanguageRuntime::GetObjCRuntime(GetProcess())) {
       Value::ValueType value_type;
-      if (objc_runtime->GetDynamicTypeAndAddress(
-              in_value, use_dynamic, class_type_or_name, address, value_type)) {
+      if (objc_runtime->GetDynamicTypeAndAddress(in_value, use_dynamic,
+                                                 class_type_or_name, address,
+                                                 value_type, local_buffer)) {
         bool found = false;
         // Return the most specific class which we can get the typeref.
         ForEachSuperClassType(in_value, [&](SuperClassType sc) -> bool {
@@ -2430,17 +2432,41 @@ bool SwiftLanguageRuntime::GetAbstractTypeName(StreamString &name,
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
     ValueObject &in_value, CompilerType &bound_type,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
-    Address &address, Value::ValueType &value_type) {
+    Address &address, Value::ValueType &value_type,
+    llvm::ArrayRef<uint8_t> &local_buffer) {
+  auto static_type = in_value.GetCompilerType();
   value_type = Value::ValueType::Invalid;
   class_type_or_name.SetCompilerType(bound_type);
 
   ExecutionContext exe_ctx = in_value.GetExecutionContextRef().Lock(true);
+  ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
+  if (!exe_scope)
+    return false;
   std::optional<uint64_t> size =
       bound_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
   if (!size)
     return false;
   AddressType address_type;
   lldb::addr_t val_address = in_value.GetAddressOf(true, &address_type);
+  // If we couldn't find a load address, but the value object has a local
+  // buffer, use that.
+  if (val_address == LLDB_INVALID_ADDRESS && address_type == eAddressTypeHost) {
+    // Get the start and size of the local buffer.
+    auto start = in_value.GetValue().GetScalar().ULongLong();
+    auto local_buffer_size = in_value.GetLocalBufferSize();
+
+    // If we can't find the size of the local buffer we can't safely know if the
+    // dynamic type fits in it.
+    if (local_buffer_size == LLDB_INVALID_ADDRESS)
+      return false;
+    // If the dynamic type doesn't in the buffer we can't use it either.
+    if (local_buffer_size < bound_type.GetByteSize(exe_scope))
+      return false;
+
+    value_type = Value::GetValueTypeFromAddressType(address_type);
+    local_buffer = {(uint8_t *)start, local_buffer_size};
+    return true;
+  }
   if (*size && (!val_address || val_address == LLDB_INVALID_ADDRESS))
     return false;
 
@@ -2452,7 +2478,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_IndirectEnumCase(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   Status error;
   CompilerType child_type = in_value.GetCompilerType();
   class_type_or_name.SetCompilerType(child_type);
@@ -2484,7 +2510,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_IndirectEnumCase(
       return false;
 
     return GetDynamicTypeAndAddress(*valobj_sp, use_dynamic, class_type_or_name,
-                                    address, value_type);
+                                    address, value_type, local_buffer);
   } else {
     // This is most likely a statically known type.
     address.SetLoadAddress(box_value, &GetProcess().GetTarget());
@@ -2510,7 +2536,8 @@ void SwiftLanguageRuntime::DumpTyperef(CompilerType type,
 
 Value::ValueType SwiftLanguageRuntime::GetValueType(
     ValueObject &in_value, CompilerType dynamic_type,
-    Value::ValueType static_value_type, bool is_indirect_enum_case) {
+    Value::ValueType static_value_type, bool is_indirect_enum_case,
+    llvm::ArrayRef<uint8_t> &local_buffer) {
   CompilerType static_type = in_value.GetCompilerType();
   Flags static_type_flags(static_type.GetTypeInfo());
   Flags dynamic_type_flags(dynamic_type.GetTypeInfo());
@@ -2564,6 +2591,12 @@ Value::ValueType SwiftLanguageRuntime::GetValueType(
       // If the data is not inlined, we have a pointer.
       return Value::ValueType::LoadAddress;
     }
+    // If we found a host address and the dynamic type fits in there, and
+    // this is not a pointer from an existential container, then this points to
+    // the local buffer.
+    if (static_value_type == Value::ValueType::HostAddress &&
+        !local_buffer.empty())
+      return static_value_type;
 
     if (static_type_flags.AllSet(eTypeIsSwift | eTypeIsGenericTypeParam)) {
       // if I am handling a non-pointer Swift type obtained from an archetype,
@@ -2671,7 +2704,7 @@ std::optional<SwiftNominalType> GetSwiftClass(ValueObject &valobj,
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_ClangType(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   AppleObjCRuntime *objc_runtime =
       SwiftLanguageRuntime::GetObjCRuntime(GetProcess());
   if (!objc_runtime)
@@ -2684,8 +2717,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_ClangType(
   // resolution first, and then map the dynamic Objective-C type back
   // into Swift.
   TypeAndOrName dyn_class_type_or_name = class_type_or_name;
-  if (!objc_runtime->GetDynamicTypeAndAddress(
-          in_value, use_dynamic, dyn_class_type_or_name, address, value_type))
+  if (!objc_runtime->GetDynamicTypeAndAddress(in_value, use_dynamic,
+                                              dyn_class_type_or_name, address,
+                                              value_type, local_buffer))
     return false;
 
   StringRef dyn_name = dyn_class_type_or_name.GetName().GetStringRef();
@@ -2791,7 +2825,7 @@ static bool CouldHaveDynamicValue(ValueObject &in_value) {
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
     ValueObject &in_value, lldb::DynamicValueType use_dynamic,
     TypeAndOrName &class_type_or_name, Address &address,
-    Value::ValueType &value_type) {
+    Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer) {
   class_type_or_name.Clear();
   if (use_dynamic == lldb::eNoDynamicValues)
     return false;
@@ -2800,8 +2834,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
 
   // Try to import a Clang type into Swift.
   if (in_value.GetObjectRuntimeLanguage() == eLanguageTypeObjC)
-    return GetDynamicTypeAndAddress_ClangType(
-        in_value, use_dynamic, class_type_or_name, address, value_type);
+    return GetDynamicTypeAndAddress_ClangType(in_value, use_dynamic,
+                                              class_type_or_name, address,
+                                              value_type, local_buffer);
 
   if (!CouldHaveDynamicValue(in_value))
     return false;
@@ -2817,7 +2852,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
   // Type kinds with instance metadata don't need generic type resolution.
   if (is_indirect_enum_case)
     success = GetDynamicTypeAndAddress_IndirectEnumCase(
-        in_value, use_dynamic, class_type_or_name, address, static_value_type);
+        in_value, use_dynamic, class_type_or_name, address, static_value_type,
+        local_buffer);
   else if (type_info.AnySet(eTypeIsPack))
     success = GetDynamicTypeAndAddress_Pack(in_value, val_type, use_dynamic,
                                             class_type_or_name, address,
@@ -2826,7 +2862,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
            type_info.AllSet(eTypeIsBuiltIn | eTypeIsPointer | eTypeHasValue))
     success = GetDynamicTypeAndAddress_Class(in_value, val_type, use_dynamic,
                                              class_type_or_name, address,
-                                             static_value_type);
+                                             static_value_type, local_buffer);
   else if (type_info.AllSet(eTypeIsMetatype | eTypeIsProtocol))
     success = GetDynamicTypeAndAddress_ExistentialMetatype(
         in_value, val_type, use_dynamic, class_type_or_name, address);
@@ -2850,16 +2886,16 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
 
     Flags subst_type_info(bound_type.GetTypeInfo());
     if (subst_type_info.AnySet(eTypeIsClass)) {
-      success = GetDynamicTypeAndAddress_Class(in_value, bound_type,
-                                               use_dynamic, class_type_or_name,
-                                               address, static_value_type);
+      success = GetDynamicTypeAndAddress_Class(
+          in_value, bound_type, use_dynamic, class_type_or_name, address,
+          static_value_type, local_buffer);
     } else if (subst_type_info.AnySet(eTypeIsProtocol)) {
       success = GetDynamicTypeAndAddress_Existential(
           in_value, bound_type, use_dynamic, class_type_or_name, address);
     } else {
-      success = GetDynamicTypeAndAddress_Value(in_value, bound_type,
-                                               use_dynamic, class_type_or_name,
-                                               address, static_value_type);
+      success = GetDynamicTypeAndAddress_Value(
+          in_value, bound_type, use_dynamic, class_type_or_name, address,
+          static_value_type, local_buffer);
     }
   }
 
@@ -2869,8 +2905,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
     if (static_value_type == Value::ValueType::Invalid)
       static_value_type = in_value.GetValue().GetValueType();
 
-    value_type = GetValueType(in_value, class_type_or_name.GetCompilerType(),
-                              static_value_type, is_indirect_enum_case);
+    value_type =
+        GetValueType(in_value, class_type_or_name.GetCompilerType(),
+                     static_value_type, is_indirect_enum_case, local_buffer);
   }
   return success;
 }

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -917,6 +917,22 @@ bool ValueObject::SetData(DataExtractor &data, Status &error) {
   return true;
 }
 
+uint64_t ValueObject::GetLocalBufferSize() {
+  if (m_value.GetValueType() != Value::ValueType::HostAddress)
+    return LLDB_INVALID_ADDRESS;
+  auto start = m_value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
+  if (start == LLDB_INVALID_ADDRESS)
+    return LLDB_INVALID_ADDRESS;
+  // Does our pointer point to this value object's m_data buffer?
+  if ((uint64_t)m_data.GetDataStart() == start)
+    return m_data.GetByteSize();
+  // Does our pointer point to the value's buffer?
+  if ((uint64_t)m_value.GetBuffer().GetBytes() == start)
+    return m_value.GetBuffer().GetByteSize();
+  // Our pointer points to something else. We can't know what the size is.
+  return LLDB_INVALID_ADDRESS;
+}
+
 static bool CopyStringDataToBufferSP(const StreamString &source,
                                      lldb::WritableDataBufferSP &destination) {
   llvm::StringRef src = source.GetString();

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -917,20 +917,20 @@ bool ValueObject::SetData(DataExtractor &data, Status &error) {
   return true;
 }
 
-uint64_t ValueObject::GetLocalBufferSize() {
+llvm::ArrayRef<uint8_t> ValueObject::GetLocalBuffer() const {
   if (m_value.GetValueType() != Value::ValueType::HostAddress)
-    return LLDB_INVALID_ADDRESS;
+    return {};
   auto start = m_value.GetScalar().ULongLong(LLDB_INVALID_ADDRESS);
   if (start == LLDB_INVALID_ADDRESS)
-    return LLDB_INVALID_ADDRESS;
+    return {};
   // Does our pointer point to this value object's m_data buffer?
   if ((uint64_t)m_data.GetDataStart() == start)
-    return m_data.GetByteSize();
+    return m_data.GetData();
   // Does our pointer point to the value's buffer?
   if ((uint64_t)m_value.GetBuffer().GetBytes() == start)
-    return m_value.GetBuffer().GetByteSize();
+    return m_value.GetBuffer().GetData();
   // Our pointer points to something else. We can't know what the size is.
-  return LLDB_INVALID_ADDRESS;
+  return {};
 }
 
 static bool CopyStringDataToBufferSP(const StreamString &source,

--- a/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
+++ b/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
@@ -279,7 +279,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
       SetValueDidChange(true);
 
     // If we found a host address, and the dynamic type fits in the local buffer
-    // that was found, point to thar buffer. Later on this function will copy
+    // that was found, point to that buffer. Later on this function will copy
     // the buffer over.
     if (value_type == Value::ValueType::HostAddress && !local_buffer.empty()) {
       auto *exe_scope = exe_ctx.GetBestExecutionContextScope();

--- a/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
+++ b/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
@@ -172,7 +172,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
       if (runtime)
         found_dynamic_type = runtime->GetDynamicTypeAndAddress(
             *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
-            value_type);
+            value_type, local_buffer);
     }
 #endif // LLDB_ENABLE_SWIFT
   if (!found_dynamic_type &&
@@ -193,7 +193,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
       // Fallback to the runtime for `known_type`.
       found_dynamic_type = runtime->GetDynamicTypeAndAddress(
           *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
-          value_type);
+          value_type, local_buffer);
   } else if (!found_dynamic_type) {
     runtime = process->GetLanguageRuntime(lldb::eLanguageTypeC_plus_plus);
     if (runtime)

--- a/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
+++ b/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
@@ -157,6 +157,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
   Address dynamic_address;
   bool found_dynamic_type = false;
   Value::ValueType value_type;
+  llvm::ArrayRef<uint8_t> local_buffer;
 
   LanguageRuntime *runtime = nullptr;
   lldb::LanguageType known_type = m_parent->GetObjectRuntimeLanguage();
@@ -183,7 +184,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
       // Try the preferred runtime first.
       found_dynamic_type = preferred_runtime->GetDynamicTypeAndAddress(
           *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
-          value_type);
+          value_type, local_buffer);
       if (found_dynamic_type)
         // Set the operative `runtime` for later use in this function.
         runtime = preferred_runtime;
@@ -198,14 +199,14 @@ bool ValueObjectDynamicValue::UpdateValue() {
     if (runtime)
       found_dynamic_type = runtime->GetDynamicTypeAndAddress(
           *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
-          value_type);
+          value_type, local_buffer);
 
     if (!found_dynamic_type) {
       runtime = process->GetLanguageRuntime(lldb::eLanguageTypeObjC);
       if (runtime)
         found_dynamic_type = runtime->GetDynamicTypeAndAddress(
             *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
-            value_type);
+            value_type, local_buffer);
     }
   }
 
@@ -277,11 +278,29 @@ bool ValueObjectDynamicValue::UpdateValue() {
     if (m_address.IsValid())
       SetValueDidChange(true);
 
-    // We've moved, so we should be fine...
-    m_address = dynamic_address;
-    lldb::TargetSP target_sp(GetTargetSP());
-    lldb::addr_t load_address = m_address.GetLoadAddress(target_sp.get());
-    m_value.GetScalar() = load_address;
+    // If we found a host address, and the dynamic type fits in the local buffer
+    // that was found, point to thar buffer. Later on this function will copy
+    // the buffer over.
+    if (value_type == Value::ValueType::HostAddress && !local_buffer.empty()) {
+      auto *exe_scope = exe_ctx.GetBestExecutionContextScope();
+      // If we found a host address but it doesn't fit in the buffer, there's
+      // nothing we can do.
+      if (local_buffer.size() <
+          m_dynamic_type_info.GetCompilerType().GetByteSize(exe_scope)) {
+        SetValueIsValid(false);
+        return false;
+      }
+
+      m_value.GetScalar() = (uint64_t)local_buffer.data();
+      m_address = LLDB_INVALID_ADDRESS;
+    } else {
+      // Otherwise we have a legitimate address on the target. Point to the load
+      // address.
+      m_address = dynamic_address;
+      lldb::TargetSP target_sp(GetTargetSP());
+      lldb::addr_t load_address = m_address.GetLoadAddress(target_sp.get());
+      m_value.GetScalar() = load_address;
+    }
   }
 
   if (runtime)
@@ -296,7 +315,11 @@ bool ValueObjectDynamicValue::UpdateValue() {
     LLDB_LOGF(log, "[%s %p] has a new dynamic type %s", GetName().GetCString(),
               static_cast<void *>(this), GetTypeName().GetCString());
 
-  if (m_address.IsValid() && m_dynamic_type_info) {
+  // m_address could be invalid but we could still have a local buffer
+  // containing the dynamic value.
+  if ((m_address.IsValid() ||
+       m_value.GetValueType() == Value::ValueType::HostAddress) &&
+      m_dynamic_type_info) {
     // The variable value is in the Scalar value inside the m_value. We can
     // point our m_data right to it.
     m_error = m_value.GetValueAsData(&exe_ctx, m_data, GetModule().get());

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -27,7 +27,7 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
         self.expect("expr --bind-generic-types true -- self", error=True, substrs=["Hint"])
         # This should work because expression evaluation automatically falls back
         # to not binding generic parameters.
-        self.expect("expression self", substrs=['Generic', '<T>', 'n', '23'])
+        self.expect("expression self", substrs=['Generic', '<Builder.Private>', 'n', '23'])
 
         process.Continue()
         # This should work.

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -30,15 +30,19 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         # Test that not binding works.
         self.expect("expr --bind-generic-types false -- self", 
-                    substrs=["Public.StructWrapper<T>", 
+                    substrs=["Public.StructWrapper<Private.InvisibleStruct>", 
                              'name = "The invisible struct."'])
         # Test that the "auto" behavior also works.
         self.expect("expr --bind-generic-types auto -- self", 
-                    substrs=["Public.StructWrapper<T>", 
+                    substrs=["Public.StructWrapper<Private.InvisibleStruct>", 
                              'name = "The invisible struct."'])
         # Test that the default (should be the auto option) also works.
-        self.expect("expr -- self", substrs=["Public.StructWrapper<T>", 
+        self.expect("expr -- self", substrs=["Public.StructWrapper<Private.InvisibleStruct>", 
                                           'name = "The invisible struct."'])
+        # Test that accessing the field works.
+        self.expect("expr --bind-generic-types false -- t", 
+                    substrs=["Private.InvisibleStruct", 
+                             'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for class', lldb.SBFileSpec('Public.swift'), None)
@@ -54,6 +58,9 @@ class TestSwiftPrivateGenericType(TestBase):
                              'name = "The invisible struct."'])
         self.expect("expr -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
+                             'name = "The invisible struct."'])
+        self.expect("expr --bind-generic-types false -- t", 
+                    substrs=["Private.InvisibleStruct", 
                              'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
@@ -77,6 +84,13 @@ class TestSwiftPrivateGenericType(TestBase):
                              "<Private.InvisibleClass, Private.InvisibleStruct>", 
                              'name = "The invisible class."',
                              "someNumber = 42"])
+        self.expect("expr --bind-generic-types false -- t", 
+                    substrs=["Private.InvisibleClass", 
+                             'name = "The invisible class."', 
+                             "someNumber = 42"])
+        self.expect("expr --bind-generic-types false -- u", 
+                    substrs=["Private.InvisibleStruct", 
+                             'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for three generic parameters', lldb.SBFileSpec('Public.swift'), None)
@@ -86,21 +100,21 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.ThreeGenericParameters",
-                             "<T, U, V>", 
+                             "<Private.InvisibleClass, Private.InvisibleStruct, Bool>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
                              "v = true"])
         self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.ThreeGenericParameters",
-                             "<T, U, V>", 
+                             "<Private.InvisibleClass, Private.InvisibleStruct, Bool>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
                              "v = true"])
         self.expect("expr -- self", 
                     substrs=["Public.ThreeGenericParameters",
-                             "<T, U, V>", 
+                             "<Private.InvisibleClass, Private.InvisibleStruct, Bool>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
@@ -114,7 +128,7 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.FourGenericParameters",
-                             "<T, U, V, W>", 
+                             "<Private.InvisibleStruct, Private.InvisibleClass, [String], Int>", 
                              'name = "The invisible struct."',
                              'name = "The invisible class."',
                              "someNumber = 42",
@@ -122,7 +136,7 @@ class TestSwiftPrivateGenericType(TestBase):
                              "w = 482"])
         self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.FourGenericParameters",
-                             "<T, U, V, W>", 
+                             "<Private.InvisibleStruct, Private.InvisibleClass, [String], Int>", 
                              'name = "The invisible struct."',
                              'name = "The invisible class."',
                              "someNumber = 42",
@@ -130,7 +144,7 @@ class TestSwiftPrivateGenericType(TestBase):
                              "w = 482"])
         self.expect("expr -- self", 
                     substrs=["Public.FourGenericParameters",
-                             "<T, U, V, W>", 
+                             "<Private.InvisibleStruct, Private.InvisibleClass, [String], Int>", 
                              'name = "The invisible struct."',
                              'name = "The invisible class."',
                              "someNumber = 42",

--- a/lldb/unittests/TestingSupport/Symbol/ClangTestUtils.h
+++ b/lldb/unittests/TestingSupport/Symbol/ClangTestUtils.h
@@ -21,20 +21,21 @@ inline clang::DeclarationName getDeclarationName(TypeSystemClang &ast,
   return ast.getASTContext().DeclarationNames.getIdentifier(&II);
 }
 
-inline CompilerType createRecord(TypeSystemClang &ast, llvm::StringRef name) {
+inline CompilerType
+createRecord(TypeSystemClang &ast, llvm::StringRef name,
+             lldb::LanguageType lang = lldb::LanguageType::eLanguageTypeC) {
   return ast.CreateRecordType(ast.getASTContext().getTranslationUnitDecl(),
                               OptionalClangModuleID(),
-                              lldb::AccessType::eAccessPublic, name, 0,
-                              lldb::LanguageType::eLanguageTypeC);
+                              lldb::AccessType::eAccessPublic, name, 0, lang);
 }
 
 /// Create a record with the given name and a field with the given type
 /// and name.
-inline CompilerType createRecordWithField(TypeSystemClang &ast,
-                                          llvm::StringRef record_name,
-                                          CompilerType field_type,
-                                          llvm::StringRef field_name) {
-  CompilerType t = createRecord(ast, record_name);
+inline CompilerType createRecordWithField(
+    TypeSystemClang &ast, llvm::StringRef record_name, CompilerType field_type,
+    llvm::StringRef field_name,
+    lldb::LanguageType lang = lldb::LanguageType::eLanguageTypeC) {
+  CompilerType t = createRecord(ast, record_name, lang);
 
   TypeSystemClang::StartTagDeclarationDefinition(t);
   ast.AddFieldToRecordType(t, field_name, field_type,
@@ -63,12 +64,13 @@ struct SourceASTWithRecord {
   CompilerType record_type;
   clang::RecordDecl *record_decl = nullptr;
   clang::FieldDecl *field_decl = nullptr;
-  SourceASTWithRecord() {
+  SourceASTWithRecord(
+      lldb::LanguageType lang = lldb::LanguageType::eLanguageTypeC) {
     holder = std::make_unique<TypeSystemClangHolder>("test ASTContext");
     ast = holder->GetAST();
     record_type = createRecordWithField(
         *ast, "Source", ast->GetBasicType(lldb::BasicType::eBasicTypeChar),
-        "a_field");
+        "a_field", lang);
     record_decl =
         llvm::cast<clang::RecordDecl>(ClangUtil::GetAsTagDecl(record_type));
     field_decl = *record_decl->fields().begin();

--- a/lldb/unittests/ValueObject/CMakeLists.txt
+++ b/lldb/unittests/ValueObject/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_unittest(LLDBValueObjectTests
   DumpValueObjectOptionsTests.cpp
+  DynamicValueObjectLocalBuffer.cpp
 
   LINK_LIBS
     lldbValueObject

--- a/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
+++ b/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
@@ -1,0 +1,243 @@
+//===---DynamicValueObjectLocalBuffer.cpp-----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Plugins/Platform/Linux/PlatformLinux.h"
+#include "Plugins/ScriptInterpreter/None/ScriptInterpreterNone.h"
+#include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
+#include "TestingSupport/SubsystemRAII.h"
+#include "TestingSupport/Symbol/ClangTestUtils.h"
+#include "lldb/Core/Debugger.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Target/Language.h"
+#include "lldb/Target/LanguageRuntime.h"
+#include "lldb/ValueObject/ValueObject.h"
+#include "lldb/ValueObject/ValueObjectConstResult.h"
+
+#include "gtest/gtest.h"
+
+using namespace lldb;
+using namespace lldb_private;
+using namespace lldb_private::clang_utils;
+
+// This entire class is boilerplate.
+struct MockLanguage : public Language {
+
+  llvm::StringRef GetPluginName() override { return "MockLanguage"; }
+  lldb::LanguageType GetLanguageType() const override {
+    return lldb::eLanguageTypeC_plus_plus;
+  };
+
+  static Language *CreateInstance(lldb::LanguageType language) {
+    return new MockLanguage();
+  }
+  static void Initialize() {
+    PluginManager::RegisterPlugin("MockLanguage", "Mock Language",
+                                  CreateInstance);
+  };
+
+  static void Terminate() { PluginManager::UnregisterPlugin(CreateInstance); }
+  bool IsSourceFile(llvm::StringRef file_path) const override { return true; }
+};
+LLDB_PLUGIN_DEFINE(MockLanguage)
+
+struct MockLanguageRuntime : public LanguageRuntime {
+  // This is the only method in this class that matters for this test.
+  // This will unconditionally succeed and return a type with size 4,
+  // a value_type of HostAddress, and a local buffer that points to the parent's
+  // local buffer.
+  // The tests will set that buffer to be either be larger or smaller than the
+  // type we're returning.
+  bool
+  GetDynamicTypeAndAddress(ValueObject &in_value,
+                           lldb::DynamicValueType use_dynamic,
+                           TypeAndOrName &class_type_or_name, Address &address,
+                           Value::ValueType &value_type,
+                           llvm::ArrayRef<uint8_t> &local_buffer) override {
+    auto ast = in_value.GetCompilerType()
+                   .GetTypeSystem()
+                   .dyn_cast_or_null<TypeSystemClang>();
+
+    auto int_type = createRecordWithField(
+        *ast, "TypeWitInt", ast->GetBasicType(lldb::BasicType::eBasicTypeInt),
+        "theIntField", LanguageType::eLanguageTypeC_plus_plus);
+    class_type_or_name.SetCompilerType(int_type);
+    local_buffer = {(uint8_t *)in_value.GetValue().GetScalar().ULongLong(
+                        LLDB_INVALID_ADDRESS),
+                    in_value.GetLocalBufferSize()};
+    value_type = Value::ValueType::HostAddress;
+
+    return true;
+  }
+
+  // All of this is boilerplate.
+  MockLanguageRuntime(Process *process) : LanguageRuntime(process) {}
+  llvm::StringRef GetPluginName() override { return "MockLanguageRuntime"; }
+  lldb::LanguageType GetLanguageType() const override {
+    return lldb::eLanguageTypeC_plus_plus;
+  }
+
+  llvm::Error GetObjectDescription(Stream &str, ValueObject &object) override {
+    return llvm::Error::success();
+  }
+
+  llvm::Error GetObjectDescription(Stream &str, Value &value,
+                                   ExecutionContextScope *exe_scope) override {
+    return llvm::Error::success();
+  }
+
+  bool CouldHaveDynamicValue(ValueObject &in_value) override { return true; }
+
+  TypeAndOrName FixUpDynamicType(const TypeAndOrName &type_and_or_name,
+                                 ValueObject &static_value) override {
+    return type_and_or_name;
+  }
+
+  lldb::BreakpointResolverSP
+  CreateExceptionResolver(const lldb::BreakpointSP &bkpt, bool catch_bp,
+                          bool throw_bp) override {
+    return lldb::BreakpointResolverSP();
+  }
+
+  lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
+                                                  bool stop_others) override {
+    return {};
+  }
+
+  static LanguageRuntime *CreateInstance(Process *process,
+                                         LanguageType language) {
+    return new MockLanguageRuntime(process);
+  }
+
+  static void Initialize() {
+    PluginManager::RegisterPlugin(
+        "MockLanguageRuntime", "MockLanguageRuntime", CreateInstance,
+        [](CommandInterpreter &interpreter) -> lldb::CommandObjectSP {
+          return {};
+        },
+        [](lldb::LanguageType language,
+           bool throw_bp) -> BreakpointPreconditionSP { return {}; });
+  }
+
+  static void Terminate() { PluginManager::UnregisterPlugin(CreateInstance); }
+};
+LLDB_PLUGIN_DEFINE(MockLanguageRuntime)
+
+// This entire class is boilerplate.
+struct MockProcess : Process {
+  MockProcess(lldb::TargetSP target_sp, lldb::ListenerSP listener_sp)
+      : Process(target_sp, listener_sp) {}
+
+  llvm::StringRef GetPluginName() override { return "mock process"; }
+
+  bool CanDebug(lldb::TargetSP target, bool plugin_specified_by_name) override {
+    return false;
+  };
+
+  Status DoDestroy() override { return {}; }
+
+  void RefreshStateAfterStop() override {}
+
+  bool DoUpdateThreadList(ThreadList &old_thread_list,
+                          ThreadList &new_thread_list) override {
+    return false;
+  };
+
+  size_t DoReadMemory(lldb::addr_t vm_addr, void *buf, size_t size,
+                      Status &error) override {
+    // No need to read memory in these tests.
+    return size;
+  }
+};
+
+class DynamicValueObjectLocalBufferTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    ArchSpec arch("i386-pc-linux");
+    Platform::SetHostPlatform(
+        platform_linux::PlatformLinux::CreateInstance(true, &arch));
+    // std::call_once(TestUtilities::g_debugger_initialize_flag,
+    //                []() { Debugger::Initialize(nullptr); });
+    m_debugger_sp = Debugger::CreateInstance();
+    ASSERT_TRUE(m_debugger_sp);
+    m_debugger_sp->GetTargetList().CreateTarget(*m_debugger_sp, "", arch,
+                                                eLoadDependentsNo,
+                                                m_platform_sp, m_target_sp);
+    ASSERT_TRUE(m_target_sp);
+    ASSERT_TRUE(m_target_sp->GetArchitecture().IsValid());
+    ASSERT_TRUE(m_platform_sp);
+    m_listener_sp = Listener::MakeListener("dummy");
+    m_process_sp = std::make_shared<MockProcess>(m_target_sp, m_listener_sp);
+    ASSERT_TRUE(m_process_sp);
+    m_exe_ctx = ExecutionContext(m_process_sp);
+
+    m_holder = std::make_unique<clang_utils::TypeSystemClangHolder>("test");
+    m_type_system = m_holder->GetAST();
+    LLDB_PLUGIN_INITIALIZE(MockLanguage);
+    LLDB_PLUGIN_INITIALIZE(MockLanguageRuntime);
+  }
+  void TearDown() override {
+    LLDB_PLUGIN_TERMINATE(MockLanguage);
+    LLDB_PLUGIN_TERMINATE(MockLanguageRuntime);
+  }
+
+  void TestValueObjectWithLocalBuffer(DataExtractor &data_extractor,
+                                      bool should_succeed) {
+    std::unique_ptr<TypeSystemClangHolder> holder =
+        std::make_unique<TypeSystemClangHolder>("test ASTContext");
+    TypeSystemClang *ast = holder->GetAST();
+    auto char_type = createRecordWithField(
+        *ast, "TypeWithChar",
+        ast->GetBasicType(lldb::BasicType::eBasicTypeChar), "theField");
+
+    ExecutionContextScope *exe_scope = m_exe_ctx.GetBestExecutionContextScope();
+    ConstString var_name("test_var");
+    auto valobj_sp = ValueObjectConstResult::Create(exe_scope, char_type,
+                                                    var_name, data_extractor);
+    auto dyn_valobj = valobj_sp->GetDynamicValue(lldb::eDynamicCanRunTarget);
+    ASSERT_TRUE(dyn_valobj->GetValueIsValid() == should_succeed);
+  }
+
+  SubsystemRAII<FileSystem, HostInfo, platform_linux::PlatformLinux,
+                ScriptInterpreterNone>
+      m_subsystems;
+  std::unique_ptr<clang_utils::TypeSystemClangHolder> m_holder;
+  lldb::DebuggerSP m_debugger_sp;
+  lldb::TargetSP m_target_sp;
+  lldb::PlatformSP m_platform_sp;
+  lldb::ListenerSP m_listener_sp;
+  lldb::ProcessSP m_process_sp;
+  ExecutionContext m_exe_ctx;
+  TypeSystemClang *m_type_system;
+};
+
+TEST_F(DynamicValueObjectLocalBufferTest, BufferTooSmall) {
+  /// Test that a value object with a buffer to small to fit the
+  /// "dynamic" type will return an invalid dynamic value object.
+  u_int8_t value = 1;
+  ByteOrder endian = endian::InlHostByteOrder();
+  DataExtractor data_extractor{&value, sizeof(value), endian, 4};
+  TestValueObjectWithLocalBuffer(data_extractor, false);
+}
+
+TEST_F(DynamicValueObjectLocalBufferTest, BufferTooBig) {
+  /// Test that a value object with a buffer big enough fit the
+  /// "dynamic" type will return a valid dynamic value object.
+  uint64_t value = 1;
+  ByteOrder endian = endian::InlHostByteOrder();
+  DataExtractor data_extractor{&value, sizeof(value), endian, 4};
+  TestValueObjectWithLocalBuffer(data_extractor, true);
+}
+
+TEST_F(DynamicValueObjectLocalBufferTest, BufferExactlyRight) {
+  /// Test that a value object with a buffer exactly the size of the
+  /// "dynamic" type will return a valid dynamic value object.
+  uint32_t value = 1;
+  ByteOrder endian = endian::InlHostByteOrder();
+  DataExtractor data_extractor{&value, sizeof(value), endian, 4};
+  TestValueObjectWithLocalBuffer(data_extractor, true);
+}

--- a/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
+++ b/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
@@ -66,11 +66,8 @@ struct MockLanguageRuntime : public LanguageRuntime {
         *ast, "TypeWitInt", ast->GetBasicType(lldb::BasicType::eBasicTypeInt),
         "theIntField", LanguageType::eLanguageTypeC_plus_plus);
     class_type_or_name.SetCompilerType(int_type);
-    local_buffer = {(uint8_t *)in_value.GetValue().GetScalar().ULongLong(
-                        LLDB_INVALID_ADDRESS),
-                    static_cast<size_t>(in_value.GetLocalBufferSize())};
+    local_buffer = in_value.GetLocalBuffer();
     value_type = Value::ValueType::HostAddress;
-
     return true;
   }
 

--- a/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
+++ b/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
@@ -218,7 +218,7 @@ public:
 TEST_F(DynamicValueObjectLocalBufferTest, BufferTooSmall) {
   /// Test that a value object with a buffer to small to fit the
   /// "dynamic" type will return an invalid dynamic value object.
-  u_int8_t value = 1;
+  uint8_t value = 1;
   ByteOrder endian = endian::InlHostByteOrder();
   DataExtractor data_extractor{&value, sizeof(value), endian, 4};
   TestValueObjectWithLocalBuffer(data_extractor, false);

--- a/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
+++ b/lldb/unittests/ValueObject/DynamicValueObjectLocalBuffer.cpp
@@ -68,7 +68,7 @@ struct MockLanguageRuntime : public LanguageRuntime {
     class_type_or_name.SetCompilerType(int_type);
     local_buffer = {(uint8_t *)in_value.GetValue().GetScalar().ULongLong(
                         LLDB_INVALID_ADDRESS),
-                    in_value.GetLocalBufferSize()};
+                    static_cast<size_t>(in_value.GetLocalBufferSize())};
     value_type = Value::ValueType::HostAddress;
 
     return true;


### PR DESCRIPTION

    [lldb] Make GetDynamicTypeAndAddress() use host address if available

    If GetDynamicTypeAndAddress_Value cannot get back to the inferior address,
    but does have a host address and buffer that fits the dynamic type,
    return that.


    [lldb] Make ValueObjectDynamicValue::UpdateValue() point to  a host b… (#125143)

    …uffer

    ValueObjectDynamicValue::UpdateValue() assumes that the dynamic type
    found by GetDynamicTypeAndAddress() would return an address in the
    inferior. This commit makes it so it can deal with being passed a host
    address instead.

    This is needed downstream by the Swift fork.

    rdar://143357274
    (cherry picked from commit 0cbc4983adcdbbd85ccb38b2dfbfe5985367b1b2)