### PR TITLE
[lldb] Desugar the type before binding generic parameters

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2341,6 +2341,7 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
 
   NodePointer canonical = TypeSystemSwiftTypeRef::GetStaticSelfType(
       dem, dem.demangleSymbol(mangled_name.GetStringRef()));
+  canonical = ts.DesugarNode(dem, canonical);
 
   // Build the list of type substitutions.
   swift::reflection::GenericArgumentMap substitutions;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1174,10 +1174,8 @@ Desugar(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
   return desugared;
 }
 
-swift::Demangle::NodePointer
-TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
-                                     swift::Demangle::NodePointer node,
-                                     swift::Mangle::ManglingFlavor flavor) {
+static swift::Demangle::NodePointer Desugar(swift::Demangle::Demangler &dem,
+                                            swift::Demangle::NodePointer node) {
   assert(node);
   auto kind = node->getKind();
   switch (kind) {
@@ -1207,7 +1205,27 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
     if (node->getNumChildren() != 1)
       return node;
     return node->getFirstChild();
+  default:
+    return node;
+  }
+}
 
+swift::Demangle::NodePointer
+TypeSystemSwiftTypeRef::DesugarNode(swift::Demangle::Demangler &dem,
+                                    swift::Demangle::NodePointer node) {
+  using namespace swift::Demangle;
+  return TypeSystemSwiftTypeRef::Transform(
+      dem, node, [&](NodePointer node) { return Desugar(dem, node); });
+}
+
+swift::Demangle::NodePointer
+TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
+                                     swift::Demangle::NodePointer node,
+                                     swift::Mangle::ManglingFlavor flavor) {
+  assert(node);
+  node = Desugar(dem, node);
+  auto kind = node->getKind();
+  switch (kind) {
   case Node::Kind::BoundGenericTypeAlias:
   case Node::Kind::TypeAlias: {
     // Safeguard against cyclic aliases.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -374,6 +374,11 @@ public:
   CanonicalizeSugar(swift::Demangle::Demangler &dem,
                     swift::Demangle::NodePointer node);
 
+  /// Recursively desugars sugared types (arrays, dictionaries, optionals, etc.)
+  /// in a demangle tree.
+  swift::Demangle::NodePointer DesugarNode(swift::Demangle::Demangler &dem,
+                                           swift::Demangle::NodePointer node);
+
   /// Finds the nominal type node (struct, class, enum) that contains the
   /// module and identifier nodes for that type. If \p node is not a valid
   /// type node, returns a nullptr.

--- a/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
+++ b/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
@@ -9,9 +9,21 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ------------------------------------------------------------------------------
-import lldbsuite.test.lldbinline as lldbinline
-from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest
-    ])
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftGenericExtension(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "expr -d run-target --bind-generic-types false -- self",
+            substrs=["[0] = 1", "[1] = 2", "[2] = 3"],
+        )

--- a/lldb/test/API/lang/swift/generic_extension/main.swift
+++ b/lldb/test/API/lang/swift/generic_extension/main.swift
@@ -11,10 +11,8 @@
 // -----------------------------------------------------------------------------
 extension Array {
     func test() {
-        print("PATPAT") //% self.expect("expr -d run-target -- self", substrs=['[0] = 1', '[1] = 2', '[2] = 3'])
-        return //% self.expect("frame variable -d run -- self", substrs=['[0] = 1', '[1] = 2', '[2] = 3'])
+        print("break here")
     }
 }
 var a = [1,2,3]
-
 a.test()


### PR DESCRIPTION
Queries to remote mirrors can only be done with desugared types.