### PR TITLE
[lldb] Add missing int fields to Task synthetic

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -402,6 +402,8 @@ public:
     result.isRunning = task_info.IsRunning;
     result.isEnqueued = task_info.IsEnqueued;
     result.id = task_info.Id;
+    result.kind = task_info.Kind;
+    result.enqueuePriority = task_info.EnqueuePriority;
     result.resumeAsyncContext = task_info.ResumeAsyncContext;
     return result;
   }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -165,6 +165,8 @@ public:
     bool isRunning = false;
     bool isEnqueued = false;
     uint64_t id = 0;
+    uint32_t kind = 0;
+    uint32_t enqueuePriority = 0;
     lldb::addr_t resumeAsyncContext = LLDB_INVALID_ADDRESS;
   };
   // The default limits are copied from swift-inspect.

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -19,6 +19,9 @@ class TestCase(TestBase):
             "frame var task",
             substrs=[
                 "(Task<(), Error>) task = {",
+                "id = 2",
+                "kind = 0",
+                "enqueuePriority = 21",
                 "isChildTask = false",
                 "isFuture = true",
                 "isGroupChildTask = false",


### PR DESCRIPTION
Add `id`, `kind`, and `enqueuePriority` to `Task` data formatter.

Additionally, change the bool fields to a Swift `Bool` type instead of using a C `bool` type.