### PR TITLE
Reland "[lldb][test] Re-enable bounds safety tests"

### DIFF
--- a/lldb/test/API/lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py
+++ b/lldb/test/API/lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py
@@ -37,12 +37,10 @@ class TestArrayOfBoundsSafetyPointers(TestBase):
         self.expect("expr array_of_bounds_safety_pointers[1]", patterns = [zero_init_pattern])
         self.expect("frame variable array_of_bounds_safety_pointers[1]", patterns = [zero_init_pattern])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_optimized(self):
         build_dict=dict(CFLAGS_EXTRAS="-O2 -Xclang -fbounds-safety")
         self.__run(build_dict)
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_unoptimized(self):
         build_dict=dict(CFLAGS_EXTRAS="-Xclang -fbounds-safety")
         self.__run(build_dict)

--- a/lldb/test/API/lang/BoundsSafety/array_of_ptrs/main.c
+++ b/lldb/test/API/lang/BoundsSafety/array_of_ptrs/main.c
@@ -1,8 +1,10 @@
+#include <ptrcheck.h>
 #include <stdlib.h>
 
 int *__bidi_indexable array_of_bounds_safety_pointers[2];
 
 int main() {
-  array_of_bounds_safety_pointers[0] = (int *)malloc(16); // break here 1
+  array_of_bounds_safety_pointers[0] = __unsafe_forge_bidi_indexable(
+      int *, (int *)malloc(16), 16); // break here 1
   return 0; // break here 2
 }

--- a/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/TestOutOfBoundsPointer.py
+++ b/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/TestOutOfBoundsPointer.py
@@ -80,7 +80,6 @@ class TestOutOfBoundsPointer(TestBase):
     def overflow_oob(self, type_name):
         return self.get_idx_var_regex(oob_kind=OOBKind.Overflow, type_name=type_name)
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_bidi_known_type_size(self):
         self.build()
 
@@ -151,7 +150,6 @@ class TestOutOfBoundsPointer(TestBase):
         lldbutil.continue_to_breakpoint(self.process, bkpt)
         self.expect("frame variable fams2", patterns=[self.bidi_full_oob("FAMS_t *")])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_bidi_unknown_type_size(self):
         self.build()
 
@@ -203,7 +201,6 @@ class TestOutOfBoundsPointer(TestBase):
         lldbutil.continue_to_breakpoint(self.process, bkpt)
         self.expect("frame variable oob_null", patterns=[self.bidi_full_oob("void *")])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_idx_known_type_size(self):
         self.build()
 
@@ -255,7 +252,6 @@ class TestOutOfBoundsPointer(TestBase):
         lldbutil.continue_to_breakpoint(self.process, bkpt)
         self.expect("frame variable fams2", patterns=[self.full_oob("FAMS_t *")])
 
-    @skipIf(bugnumber="rdar://141363609")
     def test_idx_unknown_type_size(self):
         self.build()
 

--- a/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/bidi_check_known_type_size.c
+++ b/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/bidi_check_known_type_size.c
@@ -26,8 +26,9 @@ get_next_fam_struct(FAMS_t *__bidi_indexable current) {
 static FAMS_t *__bidi_indexable alloc_fams_buffer(size_t num_fams,
                                                   size_t num_elts_in_buffer) {
   const size_t buffer_size = sizeof(int) * num_elts_in_buffer;
+  const size_t alloc_size = num_fams * (sizeof(FAMS_t) + buffer_size);
   FAMS_t *__bidi_indexable fams =
-      malloc(num_fams * (sizeof(FAMS_t) + buffer_size));
+      __unsafe_forge_bidi_indexable(FAMS_t *, malloc(alloc_size), alloc_size);
   // Set the counts and zero init buffer
   FAMS_t *__bidi_indexable current = fams;
   for (size_t fam_num = 0; fam_num < num_fams; ++fam_num) {

--- a/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/idx_check_known_type_size.c
+++ b/lldb/test/API/lang/BoundsSafety/out_of_bounds_pointer/idx_check_known_type_size.c
@@ -24,7 +24,9 @@ static FAMS_t *__indexable get_next_fam_struct(FAMS_t *__indexable current) {
 static FAMS_t *__indexable alloc_fams_buffer(size_t num_fams,
                                              size_t num_elts_in_buffer) {
   const size_t buffer_size = sizeof(int) * num_elts_in_buffer;
-  FAMS_t *__indexable fams = malloc(num_fams * (sizeof(FAMS_t) + buffer_size));
+  const size_t alloc_size = num_fams * (sizeof(FAMS_t) + buffer_size);
+  FAMS_t *__indexable fams =
+      __unsafe_forge_bidi_indexable(FAMS_t *, malloc(alloc_size), alloc_size);
   // Set the counts and zero init buffer
   FAMS_t *__indexable current = fams;
   for (size_t fam_num = 0; fam_num < num_fams; ++fam_num) {


### PR DESCRIPTION
Reverts https://github.com/swiftlang/llvm-project/pull/9970

The tests were failing on Linux due to a missing header and missing `__unsafe_forge_` casts.

This patch re-enables the tests and fixes the failures on Linux.

(cherry picked from commit 1c9e40b1f1420bf19b017c26a1135cb183fc6177)