### PR TITLE
Support dynamic value object pointing to host address

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1114,13 +1114,14 @@ SwiftLanguage::GetHardcodedSynthetics() {
       TypeAndOrName type_or_name;
       Address address;
       Value::ValueType value_type;
+      llvm::ArrayRef<uint8_t> local_buffer;
       // Try to find the dynamic type of the Swift type.
       // TODO: find a way to get the dyamic value type from the
       // command.
       if (swift_runtime->GetDynamicTypeAndAddress(
               *casted_to_swift.get(),
               lldb::DynamicValueType::eDynamicCanRunTarget, type_or_name,
-              address, value_type)) {
+              address, value_type, local_buffer)) {
         if (type_or_name.HasCompilerType()) {
           swift_type = type_or_name.GetCompilerType();
           // Cast it to the more specific type.
@@ -1268,8 +1269,9 @@ SwiftLanguage::GetPossibleFormattersMatches(
   TypeAndOrName type_and_or_name;
   Address address;
   Value::ValueType value_type;
+  llvm::ArrayRef<uint8_t> local_buffer;
   if (!runtime->GetDynamicTypeAndAddress(valobj, use_dynamic, type_and_or_name,
-                                         address, value_type))
+                                         address, value_type, local_buffer))
     return result;
   if (ConstString name = type_and_or_name.GetName())
     result.push_back(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -242,8 +242,8 @@ public:
   bool GetDynamicTypeAndAddress(ValueObject &in_value,
                                 lldb::DynamicValueType use_dynamic,
                                 TypeAndOrName &class_type_or_name,
-                                Address &address,
-                                Value::ValueType &value_type) override;
+                                Address &address, Value::ValueType &value_type,
+                                llvm::ArrayRef<uint8_t> &local_buffer) override;
 
   CompilerType BindGenericTypeParameters(
       CompilerType unbound_type,
@@ -569,7 +569,8 @@ private:
                                       lldb::DynamicValueType use_dynamic,
                                       TypeAndOrName &class_type_or_name,
                                       Address &address,
-                                      Value::ValueType &value_type);
+                                      Value::ValueType &value_type,
+                                      llvm::ArrayRef<uint8_t> &local_buffer);
 #ifndef NDEBUG
   ConstString GetDynamicTypeName_ClassRemoteAST(ValueObject &in_value,
                                                 lldb::addr_t instance_ptr);
@@ -596,18 +597,18 @@ private:
                                       lldb::DynamicValueType use_dynamic,
                                       TypeAndOrName &class_type_or_name,
                                       Address &address,
-                                      Value::ValueType &value_type);
+                                      Value::ValueType &value_type,
+                                      llvm::ArrayRef<uint8_t> &local_buffer);
 
   bool GetDynamicTypeAndAddress_IndirectEnumCase(
       ValueObject &in_value, lldb::DynamicValueType use_dynamic,
       TypeAndOrName &class_type_or_name, Address &address,
-      Value::ValueType &value_type);
+      Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer);
 
-  bool GetDynamicTypeAndAddress_ClangType(ValueObject &in_value,
-                                          lldb::DynamicValueType use_dynamic,
-                                          TypeAndOrName &class_type_or_name,
-                                          Address &address,
-                                          Value::ValueType &value_type);
+  bool GetDynamicTypeAndAddress_ClangType(
+      ValueObject &in_value, lldb::DynamicValueType use_dynamic,
+      TypeAndOrName &class_type_or_name, Address &address,
+      Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer);
 
   /// Dynamic type resolution tends to want to generate scalar data -
   /// but there are caveats Per original comment here "Our address is
@@ -618,7 +619,8 @@ private:
   Value::ValueType GetValueType(ValueObject &in_value,
                                 CompilerType dynamic_type,
                                 Value::ValueType static_value_type,
-                                bool is_indirect_enum_case);
+                                bool is_indirect_enum_case,
+                                llvm::ArrayRef<uint8_t> &local_buffer);
 
   lldb::UnwindPlanSP
   GetRuntimeUnwindPlan(lldb::ProcessSP process_sp,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2457,20 +2457,19 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
   // If we couldn't find a load address, but the value object has a local
   // buffer, use that.
   if (val_address == LLDB_INVALID_ADDRESS && address_type == eAddressTypeHost) {
-    // Get the start and size of the local buffer.
-    auto start = in_value.GetValue().GetScalar().ULongLong();
-    auto local_buffer_size = in_value.GetLocalBufferSize();
+    // Check if the dynamic type fits in the value object's buffer.
+    auto in_value_buffer = in_value.GetLocalBuffer();
 
-    // If we can't find the size of the local buffer we can't safely know if the
+    // If we can't find the local buffer we can't safely know if the
     // dynamic type fits in it.
-    if (local_buffer_size == LLDB_INVALID_ADDRESS)
+    if (in_value_buffer.empty())
       return false;
     // If the dynamic type doesn't in the buffer we can't use it either.
-    if (local_buffer_size < bound_type.GetByteSize(exe_scope))
+    if (in_value_buffer.size() < bound_type.GetByteSize(exe_scope))
       return false;
 
     value_type = Value::GetValueTypeFromAddressType(address_type);
-    local_buffer = {(uint8_t *)start, local_buffer_size};
+    local_buffer = in_value_buffer;
     return true;
   }
   if (*size && (!val_address || val_address == LLDB_INVALID_ADDRESS))

--- a/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
+++ b/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
@@ -172,7 +172,7 @@ bool ValueObjectDynamicValue::UpdateValue() {
       if (runtime)
         found_dynamic_type = runtime->GetDynamicTypeAndAddress(
             *m_parent, m_use_dynamic, class_type_or_name, dynamic_address,
-            value_type);
+            value_type, local_buffer);
     }
 #endif // LLDB_ENABLE_SWIFT
   if (!found_dynamic_type &&

--- a/lldb/test/API/lang/swift/enable_testing/Makefile
+++ b/lldb/test/API/lang/swift/enable_testing/Makefile
@@ -1,0 +1,18 @@
+SWIFT_SOURCES := main.swift
+
+all:  libPublic.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lPublic -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libPublic.dylib: Public.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=Public \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution -enable-testing" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=Public \
+		DYLIB_SWIFT_SOURCES:=Public.swift \
+		-f $(MAKEFILE_RULES)
+

--- a/lldb/test/API/lang/swift/enable_testing/Public.swift
+++ b/lldb/test/API/lang/swift/enable_testing/Public.swift
@@ -1,0 +1,15 @@
+class SomeClass {
+    let value = 42
+}
+
+class ClassWithProperty {
+    private var v = SomeClass()
+
+    func f() {
+        print("break here")
+    }
+}
+
+public func entry() {
+    ClassWithProperty().f()
+}

--- a/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
+++ b/lldb/test/API/lang/swift/enable_testing/TestSwiftEnableTesting.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEnableTesting(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test that expression evaluation generates a direct member access to a private property in a module compiled with -enable-library-evolution and -enable-testing"""
+
+        self.build()
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("Public.swift"), extra_images=["Public"]
+        )
+
+        self.expect("expression v", substrs=["Public.SomeClass", "value = 42"])

--- a/lldb/test/API/lang/swift/enable_testing/main.swift
+++ b/lldb/test/API/lang/swift/enable_testing/main.swift
@@ -1,0 +1,3 @@
+import Public
+
+entry()

--- a/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
+++ b/lldb/test/API/lang/swift/private_discriminator/TestSwiftPrivateDiscriminator.py
@@ -27,7 +27,7 @@ class TestSwiftPrivateDiscriminator(lldbtest.TestBase):
         self.expect("expr --bind-generic-types true -- self", error=True, substrs=["Hint"])
         # This should work because expression evaluation automatically falls back
         # to not binding generic parameters.
-        self.expect("expression self", substrs=['Generic', '<T>', 'n', '23'])
+        self.expect("expression self", substrs=['Generic', '<Builder.Private>', 'n', '23'])
 
         process.Continue()
         # This should work.

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -30,15 +30,19 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         # Test that not binding works.
         self.expect("expr --bind-generic-types false -- self", 
-                    substrs=["Public.StructWrapper<T>", 
+                    substrs=["Public.StructWrapper<Private.InvisibleStruct>", 
                              'name = "The invisible struct."'])
         # Test that the "auto" behavior also works.
         self.expect("expr --bind-generic-types auto -- self", 
-                    substrs=["Public.StructWrapper<T>", 
+                    substrs=["Public.StructWrapper<Private.InvisibleStruct>", 
                              'name = "The invisible struct."'])
         # Test that the default (should be the auto option) also works.
-        self.expect("expr -- self", substrs=["Public.StructWrapper<T>", 
+        self.expect("expr -- self", substrs=["Public.StructWrapper<Private.InvisibleStruct>", 
                                           'name = "The invisible struct."'])
+        # Test that accessing the field works.
+        self.expect("expr --bind-generic-types false -- t", 
+                    substrs=["Private.InvisibleStruct", 
+                             'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for class', lldb.SBFileSpec('Public.swift'), None)
@@ -54,6 +58,9 @@ class TestSwiftPrivateGenericType(TestBase):
                              'name = "The invisible struct."'])
         self.expect("expr -- self", 
                     substrs=["Public.ClassWrapper<Private.InvisibleStruct>", 
+                             'name = "The invisible struct."'])
+        self.expect("expr --bind-generic-types false -- t", 
+                    substrs=["Private.InvisibleStruct", 
                              'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
@@ -77,6 +84,13 @@ class TestSwiftPrivateGenericType(TestBase):
                              "<Private.InvisibleClass, Private.InvisibleStruct>", 
                              'name = "The invisible class."',
                              "someNumber = 42"])
+        self.expect("expr --bind-generic-types false -- t", 
+                    substrs=["Private.InvisibleClass", 
+                             'name = "The invisible class."', 
+                             "someNumber = 42"])
+        self.expect("expr --bind-generic-types false -- u", 
+                    substrs=["Private.InvisibleStruct", 
+                             'name = "The invisible struct."'])
 
         breakpoint = target.BreakpointCreateBySourceRegex(
             'break here for three generic parameters', lldb.SBFileSpec('Public.swift'), None)
@@ -86,21 +100,21 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.ThreeGenericParameters",
-                             "<T, U, V>", 
+                             "<Private.InvisibleClass, Private.InvisibleStruct, Bool>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
                              "v = true"])
         self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.ThreeGenericParameters",
-                             "<T, U, V>", 
+                             "<Private.InvisibleClass, Private.InvisibleStruct, Bool>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
                              "v = true"])
         self.expect("expr -- self", 
                     substrs=["Public.ThreeGenericParameters",
-                             "<T, U, V>", 
+                             "<Private.InvisibleClass, Private.InvisibleStruct, Bool>", 
                              'name = "The invisible class."',
                              "someNumber = 42",
                              'name = "The invisible struct."',
@@ -114,7 +128,7 @@ class TestSwiftPrivateGenericType(TestBase):
                     error=True)
         self.expect("expr --bind-generic-types false -- self", 
                     substrs=["Public.FourGenericParameters",
-                             "<T, U, V, W>", 
+                             "<Private.InvisibleStruct, Private.InvisibleClass, [String], Int>", 
                              'name = "The invisible struct."',
                              'name = "The invisible class."',
                              "someNumber = 42",
@@ -122,7 +136,7 @@ class TestSwiftPrivateGenericType(TestBase):
                              "w = 482"])
         self.expect("expr --bind-generic-types auto -- self", 
                     substrs=["Public.FourGenericParameters",
-                             "<T, U, V, W>", 
+                             "<Private.InvisibleStruct, Private.InvisibleClass, [String], Int>", 
                              'name = "The invisible struct."',
                              'name = "The invisible class."',
                              "someNumber = 42",
@@ -130,7 +144,7 @@ class TestSwiftPrivateGenericType(TestBase):
                              "w = 482"])
         self.expect("expr -- self", 
                     substrs=["Public.FourGenericParameters",
-                             "<T, U, V, W>", 
+                             "<Private.InvisibleStruct, Private.InvisibleClass, [String], Int>", 
                              'name = "The invisible struct."',
                              'name = "The invisible class."',
                              "someNumber = 42",

--- a/lldb/test/API/lang/swift/resilience_other_module/Makefile
+++ b/lldb/test/API/lang/swift/resilience_other_module/Makefile
@@ -1,0 +1,27 @@
+SWIFT_SOURCES := main.swift
+
+all: libWithDebInfo.dylib libWithoutDebInfo.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lWithDebInfo -lWithoutDebInfo -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libWithDebInfo.dylib: WithDebInfo.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=WithDebInfo \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=WithDebInfo \
+		DYLIB_SWIFT_SOURCES:=WithDebInfo.swift \
+		-f $(MAKEFILE_RULES)
+
+libWithoutDebInfo.dylib: WithoutDebInfo.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=WithoutDebInfo \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=WithoutDebInfo \
+		DYLIB_SWIFT_SOURCES:=WithoutDebInfo.swift \
+		-f $(MAKEFILE_RULES)

--- a/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
+++ b/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceOtherModule(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_with_debug_info(self):
+        self.impl('break here with debug info')
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_without_debug_info(self):
+        self.impl('break here without debug info')
+
+    def impl(self, break_str):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, break_str, lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression s.a", substrs=["Int", "100"])
+        self.expect("expression s.b", substrs=["Int", "200"])

--- a/lldb/test/API/lang/swift/resilience_other_module/WithDebInfo.swift
+++ b/lldb/test/API/lang/swift/resilience_other_module/WithDebInfo.swift
@@ -1,0 +1,5 @@
+public struct S {
+    public var a = 100
+    private var b = 200
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/resilience_other_module/WithoutDebInfo.swift
+++ b/lldb/test/API/lang/swift/resilience_other_module/WithoutDebInfo.swift
@@ -1,0 +1,5 @@
+public struct S {
+    public var a = 100
+    private var b = 200
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/resilience_other_module/main.swift
+++ b/lldb/test/API/lang/swift/resilience_other_module/main.swift
@@ -1,0 +1,15 @@
+import WithDebInfo
+import WithoutDebInfo
+
+func withDebugInfo() {
+    var s = WithDebInfo.S()
+    print("break here with debug info")
+}
+
+func withoutDebugInfo() {
+    var s = WithoutDebInfo.S()
+    print("break here without debug info")
+}
+
+withDebugInfo()
+withoutDebugInfo()

--- a/lldb/test/API/lang/swift/resilience_superclass/Makefile
+++ b/lldb/test/API/lang/swift/resilience_superclass/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -enable-library-evolution
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
+++ b/lldb/test/API/lang/swift/resilience_superclass/TestSwiftResilienceSuperclass.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceSuperclass(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression c.v", substrs=["Int", "42"])

--- a/lldb/test/API/lang/swift/resilience_superclass/main.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass/main.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public class SuperClass<T>: NSObject {
+    var someVar: T
+    init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+}
+
+
+open class OpenSuperClass<T>: NSObject {
+    var someVar: T
+    init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class InheritingOpenClass<T>: OpenSuperClass<T> {
+    var v = 100
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+}
+
+func main() {
+    let c = Class(true)
+    let c2 = InheritingOpenClass(true)
+    print("break here")
+}
+
+main()

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/Makefile
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -enable-library-evolution
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/ModWithClass.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/ModWithClass.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+open class SuperClass<T>: NSObject {
+    var someVar: T
+    public init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+
+    func f() -> Int {
+        let abc = v
+        return v
+    }
+}
+
+public func entry() {
+    let c = Class(true)
+    print("break here")
+}
+

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/TestSwiftResilienceSuperclassMod.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceSuperclassMod(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression c.v", substrs=["Int", "42"])

--- a/lldb/test/API/lang/swift/resilience_superclass_mod/main.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_mod/main.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public class SuperClass<T>: NSObject {
+    var someVar: T
+    init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+}
+
+func main() {
+    let c = Class(true)
+    print("break here")
+}
+
+main()

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/Makefile
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/Makefile
@@ -1,0 +1,28 @@
+SWIFT_SOURCES := main.swift
+
+all: libModWithClass.dylib libModWithSuper.dylib a.out
+
+include Makefile.rules
+LD_EXTRAS = -lModWithClass -L$(BUILDDIR)
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+libModWithClass.dylib: ModWithClass.swift libModWithSuper.dylib
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=ModWithClass \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		LD_EXTRAS="-lModWithSuper -L$(BUILDDIR)" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=ModWithClass \
+		DYLIB_SWIFT_SOURCES:=ModWithClass.swift \
+		-f $(MAKEFILE_RULES)
+
+libModWithSuper.dylib: ModWithSuper.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		BASENAME=ModWithSuper \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=ModWithSuper \
+		DYLIB_SWIFT_SOURCES:=ModWithSuper.swift \
+		-f $(MAKEFILE_RULES)

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithClass.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithClass.swift
@@ -1,0 +1,20 @@
+import ModWithSuper
+
+class Class<T>: SuperClass<T> {
+    var v = 42
+
+    override init(_ t: T) {
+        super.init(t)
+    }
+
+    func f() -> Int {
+        let abc = v
+        return v
+    }
+}
+
+public func entry() {
+    let c = Class(true)
+    print("break here")
+}
+

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithSuper.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/ModWithSuper.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+open class SuperClass<T>: NSObject {
+    var someVar: T
+    public init(_ someVar: T) {
+        self.someVar = someVar
+        super.init()
+    }
+}

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceSuperclassOtherMod(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('ModWithClass.swift'))
+
+        self.expect("expression c.v", substrs=["Int", "42"])

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/main.swift
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/main.swift
@@ -1,0 +1,3 @@
+import ModWithClass
+
+entry()


### PR DESCRIPTION
commit 93d7ce0ec3850a50cbddcb4a3d1ba6f114590939 (HEAD -> cp-02-10, a/cp-02-10)
Author: Augusto Noronha <anoronha@apple.com>
Date:   Fri Feb 7 10:29:13 2025 -0800

    [lldb][NFC] Replace usage of GetLocalBufferSize with GetLocalBuffer

    (cherry picked from commit dd87dffd7e63bfd09506bcea6fea3a0f1cb3ea31)

commit 7351df511029964d75df64bad9640bf190bc550c
Author: Augusto Noronha <anoronha@apple.com>
Date:   Thu Feb 6 19:10:57 2025 -0800

    [lldb] Make GetDynamicTypeAndAddress() use host address if available

    If GetDynamicTypeAndAddress_Value cannot get back to the inferior address,
    but does have a host address and buffer that fits the dynamic type,
    return that.

    (cherry picked from commit 829f2bc38dcca5d560b18c48a32b4df83fa2ef37)

commit 5067ac6caa3d4255e5c162c40c25dd54b93aa104
Author: Augusto Noronha <anoronha@apple.com>
Date:   Fri Jan 17 16:33:11 2025 -0800

    [lldb] Add more expression evaluation resilience tests

    Add more resilience tests with a public superclass that is generic and
    inherits from an objc type and a non-public subclass with a property we
    access on the test. The tests vary in which modules the types exist (one
    resilient executable, one resilient library and non resilient
    executable, 2 resilient libraries and one resilient executable).

    (cherry picked from commit e94df2667b92c9098334d12f63bce88265a42f8e)

commit e71cb6d15fe9d323f7d8604840f51f0b0a5b8259
Author: Augusto Noronha <anoronha@apple.com>
Date:   Tue Jan 7 17:17:51 2025 -0800

    [lldb] Add an expression evaluation test for modules built with
    -enable-testing and -enable-library-evolution

    -enable-testing affects the visibility of types, which together with
    -enable-library-evolution may cause the compiler embedded in LLDB to
    generate incorrect code on expression evaluation.

    (cherry picked from commit 10d72fa9b9040bd4fe17ac3afbf538fc5f5f6321)