### PR TITLE
[lldb] Tweak sleep timing in TestSwiftTaskSelect

### DIFF
--- a/lldb/test/API/lang/swift/async/tasks/main.swift
+++ b/lldb/test/API/lang/swift/async/tasks/main.swift
@@ -11,7 +11,7 @@ func second() async {
         let task = Task {
             await first()
         }
-        try? await Task.sleep(for: .seconds(0.01))
+        try? await Task.sleep(for: .seconds(0.1))
         print("break here")
     }
 }


### PR DESCRIPTION
Increase the sleep time from 0.01s to 0.1s, to give more time to the task instance to progress to its `sleep`.

rdar://144493695