### PR TITLE
[BoundsSafety][NFC] Fix CodeGen.attr-counted-by.c failure caused by d…

### DIFF
--- a/clang/test/CodeGen/attr-counted-by.c
+++ b/clang/test/CodeGen/attr-counted-by.c
@@ -2059,30 +2059,13 @@ size_t test32_bdos(struct annotated_with_array *ptr, int index) {
   return __bdos(&ptr->flags[index]);
 }
 
-// SANITIZE-WITH-ATTR-LABEL: define dso_local i64 @test33(
-// SANITIZE-WITH-ATTR-SAME: ptr noundef [[PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
-// SANITIZE-WITH-ATTR-NEXT:  entry:
-// SANITIZE-WITH-ATTR-NEXT:    ret i64 -1
-//
-// NO-SANITIZE-WITH-ATTR-LABEL: define dso_local i64 @test33(
-// NO-SANITIZE-WITH-ATTR-SAME: ptr noundef readnone [[PTR:%.*]]) local_unnamed_addr #[[ATTR3]] {
-// NO-SANITIZE-WITH-ATTR-NEXT:  entry:
-// NO-SANITIZE-WITH-ATTR-NEXT:    ret i64 -1
-//
-// SANITIZE-WITHOUT-ATTR-LABEL: define dso_local i64 @test33(
-// SANITIZE-WITHOUT-ATTR-SAME: ptr noundef [[PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
-// SANITIZE-WITHOUT-ATTR-NEXT:  entry:
-// SANITIZE-WITHOUT-ATTR-NEXT:    ret i64 -1
-//
-// NO-SANITIZE-WITHOUT-ATTR-LABEL: define dso_local i64 @test33(
-// NO-SANITIZE-WITHOUT-ATTR-SAME: ptr noundef readnone [[PTR:%.*]]) local_unnamed_addr #[[ATTR1]] {
-// NO-SANITIZE-WITHOUT-ATTR-NEXT:  entry:
-// NO-SANITIZE-WITHOUT-ATTR-NEXT:    ret i64 -1
-//
+// XXX: Commenting out the test that is ill-formed in downstream.
+#if 0
 size_t test33(struct annotated *ptr) {
   // Don't handle '&ptr->array' like normal.
-  return __bdos(&*&*&*&ptr->array);
+  return __bdos(&*&*&*&ptr->array); // error: cannot take address
 }
+#endif
 
 struct multi_subscripts {
   unsigned long flags[42][42];

--- a/clang/test/Sema/attr-counted-by-vla-addrof.c
+++ b/clang/test/Sema/attr-counted-by-vla-addrof.c
@@ -1,0 +1,24 @@
+/* TO_UPSTREAM(BoundsSafety) ON */
+// RUN: %clang_cc1 -fsyntax-only -verify=expected,immediate %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes %s -verify=expected,late
+
+#define __counted_by(f) __attribute__((counted_by(f)))
+#define __bdos(P) __builtin_dynamic_object_size(P, 0)
+
+typedef long unsigned int size_t;
+
+struct annotated {
+  int count;
+  char array[] __counted_by(count);
+};
+
+size_t test1(struct annotated *ptr) {
+  // expected-note@+1{{remove '&' to get address as 'char *' instead of 'char (*)[] __counted_by(count)' (aka 'char (*)[]')}}
+  return __bdos(&ptr->array); // expected-error{{cannot take address of incomplete __counted_by array}}
+}
+
+size_t test2(struct annotated *ptr) {
+  // expected-note@+1{{remove '&' to get address as 'char *' instead of 'char (*)[] __counted_by(count)' (aka 'char (*)[]')}}
+  return __bdos(&*&*&*&ptr->array); // expected-error{{cannot take address of incomplete __counted_by array}}
+}
+/* TO_UPSTREAM(BoundsSafety) OFF */

--- a/clang/test/Sema/attr-counted-by-vla-addrof.c
+++ b/clang/test/Sema/attr-counted-by-vla-addrof.c
@@ -1,6 +1,6 @@
 /* TO_UPSTREAM(BoundsSafety) ON */
-// RUN: %clang_cc1 -fsyntax-only -verify=expected,immediate %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes %s -verify=expected,late
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-late-parse-attributes %s -verify
 
 #define __counted_by(f) __attribute__((counted_by(f)))
 #define __bdos(P) __builtin_dynamic_object_size(P, 0)


### PR DESCRIPTION
…ivergence in downstream

This also separates out the ill-formed test as a Sema test marking it to be upstreamed.