### PR TITLE
[lldb] Run generic expression evaluator first

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandOptionArgumentTable.h
+++ b/lldb/include/lldb/Interpreter/CommandOptionArgumentTable.h
@@ -160,8 +160,9 @@ static constexpr OptionEnumValueElement g_bind_gen_type_params[] = {
     {
         lldb::eBindAuto,
         "auto",
-        "Attempt to run the expression with bound generic parameters first, "
-        "fallback to unbound generic parameters if binding the type parameters "
+        "Attempt to run the expression with unbound generic parameters first, "
+        "fallback to binding the generic parameters if the expression with "
+        "unbound generic type parameters "
         "fails",
     },
     {lldb::eBind, "true", "Bind generic type parameters."},

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -878,7 +878,7 @@ swift::FuncDecl *SwiftASTManipulator::GetFunctionToInjectVariableInto(
   // When not binding generic type parameters, we want to inject the metadata
   // pointers in the wrapper, so we can pass them as opaque pointers in the
   // trampoline function later on.
-  if (m_bind_generic_types == lldb::eDontBind &&
+  if (!ShouldBindGenericTypes(m_bind_generic_types) &&
       (variable.IsMetadataPointer() || variable.IsPackCount() ||
        variable.IsUnboundPack()))
     return m_entrypoint_decl;
@@ -896,7 +896,8 @@ llvm::Expected<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
 
   // When injecting a value pack or pack count into the outer
   // lldb_expr function, treat it as an opaque raw pointer.
-  if (m_bind_generic_types == lldb::eDontBind && variable.IsUnboundPack()) {
+  if (!ShouldBindGenericTypes(m_bind_generic_types) &&
+      variable.IsUnboundPack()) {
     auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(m_sc);
     if (!swift_ast_ctx)
       return llvm::createStringError("no typesystem for variable " +

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -284,6 +284,12 @@ public:
                                const EvaluateExpressionOptions &options,
                                std::string &expr_source_path);
 
+  // By default expression evaluation should not try to bind the generic types.
+  static bool
+  ShouldBindGenericTypes(lldb::BindGenericTypes bind_generic_types) {
+    return bind_generic_types == lldb::eBind;
+  }
+
   swift::FuncDecl *GetEntrypointDecl() const {
     return m_entrypoint_decl;
   }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -51,7 +51,10 @@ public:
   enum class ParseResult {
     success,
     retry_fresh_context,
-    retry_no_bind_generic_params,
+    retry_bind_generic_params,
+    // Retry by binding the generic parameters because the generic expression
+    // evaluator does not support running this expression.
+    retry_bind_generic_params_not_supported,
     unrecoverable_error
   };
   //------------------------------------------------------------------

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -408,7 +408,8 @@ do {
         weak_self ? "Swift.Optional where Wrapped == " : "";
 
     // The expression text is inserted into the body of $__lldb_user_expr_%u.
-    if (options.GetBindGenericTypes() == lldb::eDontBind) {
+    if (!SwiftASTManipulator::ShouldBindGenericTypes(
+            options.GetBindGenericTypes())) {
       // A Swift program can't have types with non-bound generic type parameters
       // inside a non generic function. For example, the following program would
       // not compile as T is not part of foo's signature.
@@ -511,7 +512,8 @@ func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
                             wrapped_expr_text.GetData(), availability.c_str(),
                             current_counter);
     }
-  } else if (options.GetBindGenericTypes() == lldb::eDontBind) {
+  } else if (!SwiftASTManipulator::ShouldBindGenericTypes(
+                 options.GetBindGenericTypes())) {
     auto c = MakeGenericSignaturesAndCalls(local_variables, generic_sig,
                                            needs_object_ptr);
     if (!c) {


### PR DESCRIPTION
The generic expression evaluator can be significantly faster than the regular one since it only needs to import information about the module the debugger is stopped at to evaluate the expression. This patch swaps the order of the expression evaluators so that the generic expression evaluator is tried first.

rdar://139239935