### PR TITLE
Fix TypeCoupledDeclRefInfo (de-)serialization bug

### DIFF
--- a/clang/include/clang/Serialization/ASTRecordWriter.h
+++ b/clang/include/clang/Serialization/ASTRecordWriter.h
@@ -149,6 +149,7 @@ public:
   void writeTypeCoupledDeclRefInfo(TypeCoupledDeclRefInfo Info) {
     writeDeclRef(Info.getDecl());
     writeBool(Info.isDeref());
+    writeBool(Info.isMember());
   }
 
   /// Emit a source range.

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -9276,7 +9276,10 @@ DeclarationNameInfo ASTRecordReader::readDeclarationNameInfo() {
 }
 
 TypeCoupledDeclRefInfo ASTRecordReader::readTypeCoupledDeclRefInfo() {
-  return TypeCoupledDeclRefInfo(readDeclAs<ValueDecl>(), readBool());
+  ValueDecl *D = readDeclAs<ValueDecl>();
+  bool IsDeref = readBool();
+  bool IsMember = readBool();
+  return TypeCoupledDeclRefInfo(D, IsDeref, IsMember);
 }
 
 void ASTRecordReader::readQualifierInfo(QualifierInfo &Info) {

--- a/clang/test/APINotes/boundssafety-errors.c
+++ b/clang/test/APINotes/boundssafety-errors.c
@@ -1,6 +1,3 @@
-// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t/Headers
 // RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/SemaErrors.c 2>&1 | FileCheck %s

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -1,6 +1,3 @@
-// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
 

--- a/clang/test/APINotes/boundssafety.m
+++ b/clang/test/APINotes/boundssafety.m
@@ -1,6 +1,3 @@
-// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t && mkdir -p %t
 
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s

--- a/clang/test/BoundsSafety/Modules/count-assign.c
+++ b/clang/test/BoundsSafety/Modules/count-assign.c
@@ -1,4 +1,3 @@
-// REQUIRES: system-darwin
 // RUN: rm -rf %t
 // RUN: %clang_cc1 -fbounds-safety -fmodules -fno-implicit-modules -x c -I%S/Inputs/count-assign -emit-module %S/Inputs/count-assign/module.modulemap -fmodule-name=ca -o %t/count-assign.pcm
 // RUN: %clang_cc1 -fbounds-safety  -fmodules -fno-implicit-modules -x c -I%S/Inputs/count-assign -ast-dump-all -o - %s -fmodule-file=%t/count-assign.pcm | FileCheck %s

--- a/clang/test/BoundsSafety/PCH/count-assign-with-pch.c
+++ b/clang/test/BoundsSafety/PCH/count-assign-with-pch.c
@@ -1,4 +1,3 @@
-// REQUIRES: system-darwin
 // Test without pch.
 // RUN: %clang_cc1 -fbounds-safety -include %s -fsyntax-only -verify %s
 

--- a/clang/test/BoundsSafety/PCH/nested-struct-member-count.c
+++ b/clang/test/BoundsSafety/PCH/nested-struct-member-count.c
@@ -1,0 +1,59 @@
+// Test without pch.
+// RUN: %clang_cc1 -fbounds-safety -include %s %s -ast-dump 2>&1 | FileCheck %s
+
+// Test with pch.
+// RUN: %clang_cc1 -fbounds-safety -emit-pch -o %t %s
+// RUN: %clang_cc1 -fbounds-safety -include-pch %t %s -ast-dump 2>&1 | FileCheck %s
+
+#ifndef HEADER
+#define HEADER
+#include <ptrcheck.h>
+
+struct Inner {
+    int dummy;
+    int len;
+};
+
+struct Outer {
+    struct Inner hdr;
+    char fam[__counted_by(hdr.len)];
+};
+
+#else
+
+char access(struct Outer *bar, int index) {
+    return bar->fam[index];
+}
+
+// CHECK:  -FunctionDecl [[func_access:0x[^ ]+]] {{.+}} access
+// CHECK:   |-ParmVarDecl [[var_bar:0x[^ ]+]]
+// CHECK:   |-ParmVarDecl [[var_index:0x[^ ]+]]
+// CHECK:   `-CompoundStmt
+// CHECK:     `-ReturnStmt
+// CHECK:       `-ImplicitCastExpr {{.+}} 'char' <LValueToRValue>
+// CHECK:         `-ArraySubscriptExpr
+// CHECK:           |-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK:           | |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK:           | | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK:           | | | |-ImplicitCastExpr {{.+}} 'char *' <ArrayToPointerDecay>
+// CHECK:           | | | | `-MemberExpr {{.+}} ->fam
+// CHECK:           | | | |   `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | | |-GetBoundExpr {{.+}} upper
+// CHECK:           | | | | `-BoundsSafetyPointerPromotionExpr {{.+}} 'struct Outer *__bidi_indexable'
+// CHECK:           | | | |   |-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | | |   |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK:           | | | |   | |-ImplicitCastExpr {{.+}} 'char *' <ArrayToPointerDecay>
+// CHECK:           | | | |   | | `-MemberExpr {{.+}} ->fam
+// CHECK:           | | | |   | |   `-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | | |   | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK:           | | | |   |   `-MemberExpr {{.+}} .len
+// CHECK:           | | | |   |     `-MemberExpr {{.+}} ->hdr
+// CHECK:           | | | |   |       `-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | `-OpaqueValueExpr [[ove]]
+// CHECK:           | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK:           | |     `-DeclRefExpr {{.+}} [[var_bar]]
+// CHECK:           | `-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK:             `-DeclRefExpr {{.+}} [[var_index]]
+
+#endif


### PR DESCRIPTION
The deserialization logic for `TypeCoupledDeclRefInfo ` had two issues.
    1) Deserialization relied on a specific argument evaluation order, which is unspecified.
    2) IsMember was not (de-)serialized.