### PR TITLE
[lldb] Skip TestSwiftAsyncSteppingManyTasks when clangimporter=false

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step_over_lots_of_tasks/TestSwiftAsyncSteppingManyTasks.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_lots_of_tasks/TestSwiftAsyncSteppingManyTasks.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 @skipIfAsan  # rdar://138777205
+@skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
 class TestCase(lldbtest.TestBase):
 
     def check_is_in_line(self, thread, expected_linenum, expected_tid):


### PR DESCRIPTION
This configuration on the bots causes the OS plugin to not be loaded properly. Disabling the test while we investigate.

```
File "/Users/ec2-user/jenkins/workspace/swift-PR-macos/branch-main/llvm-project/lldb/test/API/lang/swift/async/stepping/step_over_lots_of_tasks/TestSwiftAsyncSteppingManyTasks.py", line 61, in test_step_over_top_level_fibonacci
    self.assertEqual(process.GetSelectedThread(), thread_in_fib)
AssertionError: thread #1: tid = 0x66b91b, queue = 'com.apple.main-thread' != No value
Config=x86_64-/Users/ec2-user/jenkins/workspace/swift-PR-macos/branch-main/build/buildbot_incremental/llvm-macosx-x86_64/bin/clang
```

Note how the TID is not that of a swift task.