### PR TITLE
[Cherry-pick into next] Disable typesystem validation in test (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -45,6 +45,9 @@ class TestSwiftInterfaceDSYM(TestBase):
         self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
                     % swift_mod_cache)
 
+        # This interfers with the counting because it initializes an extra compiler.
+        self.runCmd('settings set symbols.swift-validate-typesystem false')
+
         # Set a breakpoint in and launch the main executable
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift"))


### PR DESCRIPTION
```
commit 5de4d54b945ac4df48b19045d51a90b919780120
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Feb 10 16:53:12 2025 -0800

    Disable typesystem validation in test (NFC)
```
