### PR TITLE
[lldb] Fix using self in expression evaluation when self is weakly ca…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1563,7 +1563,8 @@ bool SwiftLanguageRuntime::IsSelf(Variable &variable) {
     return false;
   node_ptr = node_ptr->getFirstChild();
   return node_ptr->getKind() == swift::Demangle::Node::Kind::Constructor ||
-         node_ptr->getKind() == swift::Demangle::Node::Kind::Allocator;
+         node_ptr->getKind() == swift::Demangle::Node::Kind::Allocator ||
+         node_ptr->getKind() == swift::Demangle::Node::Kind::ExplicitClosure;
 }
 
 static swift::Demangle::NodePointer

--- a/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
@@ -9,7 +9,39 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ------------------------------------------------------------------------------
-import lldbsuite.test.lldbinline as lldbinline
-from lldbsuite.test.decorators import *
+#
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *	
+import lldbsuite.test.lldbutil as lldbutil
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+
+
+class TestSwiftGenericExtension(TestBase):
+     @swiftTest
+     def test(self):
+        self.build()
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+             self, "break here for if let success", lldb.SBFileSpec("main.swift")
+         )
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+        self.expect("expr a", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["5"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for guard let success', lldb.SBFileSpec('main.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+        self.expect("expr a", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["5"])
+
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for if let else', lldb.SBFileSpec('main.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for guard let else', lldb.SBFileSpec('main.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])

--- a/lldb/test/API/lang/swift/expression/weak_self/main.swift
+++ b/lldb/test/API/lang/swift/expression/weak_self/main.swift
@@ -19,11 +19,10 @@ class ClosureMaker {
 
   func getClosure() -> (() -> Int) {
     return { [weak self] () -> Int in
-             if let _self = self {
-               return _self.a //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker?)", "5"])
-                              //% self.expect("expr self!", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+             if let self = self {
+               return self.a // break here for if let success
              } else {
-               return 0 //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])
+               return 0 // break here for if let else
             }
           }
   }
@@ -31,10 +30,9 @@ class ClosureMaker {
   func getGuardClosure() -> (() -> Int) {
     return { [weak self] () -> Int in
              guard let self = self else {
-               return 0  //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])
+               return 0 // break here for guard let else
              }
-             return self.a //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker?)", "5"])
-                          //% self.expect("expr self!", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+             return self.a // break here for guard let success
           }
   }
 }


### PR DESCRIPTION
…ptured

This both fixes printing self when multiple self variables are present (for example, "guard let self = self"), as well as referencing self properties without spelling out self ("self.a" vs "a") when self is captured weakly in closures.

rdar://122956043