### PR TITLE
[ORC] Compile UnwindInfoManager out entirely on non-Apple platforms.

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h
+++ b/llvm/include/llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h
@@ -14,6 +14,8 @@
 #ifndef LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_UNWINDINFOMANAGER_H
 #define LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_UNWINDINFOMANAGER_H
 
+#ifdef __APPLE__
+
 #include "llvm/ExecutionEngine/Orc/Shared/ExecutorAddress.h"
 #include "llvm/Support/Error.h"
 #include <map>
@@ -70,5 +72,7 @@ private:
 };
 
 } // namespace llvm::orc
+
+#endif // __APPLE__
 
 #endif // LLVM_EXECUTIONENGINE_ORC_TARGETPROCESS_UNWINDINFOMANAGER_H

--- a/llvm/lib/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.cpp
+++ b/llvm/lib/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.cpp
@@ -6,13 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifdef __APPLE__
+
 #include "llvm/ExecutionEngine/Orc/TargetProcess/UnwindInfoManager.h"
 #include "llvm/ExecutionEngine/Orc/Shared/OrcRTBridge.h"
 #include "llvm/ExecutionEngine/Orc/Shared/WrapperFunctionUtils.h"
 
-#ifdef __APPLE__
 #include <dlfcn.h>
-#endif // __APPLE__
 
 #define DEBUG_TYPE "orc"
 
@@ -161,3 +161,5 @@ Error UnwindInfoManager::deregisterSectionsImpl(
 }
 
 } // namespace llvm::orc
+
+#endif // __APPLE__


### PR DESCRIPTION
This code is only useable on Apple platforms.