### PR TITLE
[lldb][SBAPI] Add new SBType::GetTemplateParameterValue API (#126901)

### DIFF
--- a/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
+++ b/lldb/bindings/python/static-binding/LLDBWrapPython.cpp
@@ -81870,6 +81870,57 @@ fail:
 }
 
 
+SWIGINTERN PyObject *_wrap_SBType_GetTemplateArgumentValue(PyObject *self, PyObject *args) {
+  PyObject *resultobj = 0;
+  lldb::SBType *arg1 = (lldb::SBType *) 0 ;
+  lldb::SBTarget arg2 ;
+  uint32_t arg3 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  unsigned int val3 ;
+  int ecode3 = 0 ;
+  PyObject *swig_obj[3] ;
+  lldb::SBValue result;
+  
+  (void)self;
+  if (!SWIG_Python_UnpackTuple(args, "SBType_GetTemplateArgumentValue", 3, 3, swig_obj)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(swig_obj[0], &argp1,SWIGTYPE_p_lldb__SBType, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "SBType_GetTemplateArgumentValue" "', argument " "1"" of type '" "lldb::SBType *""'"); 
+  }
+  arg1 = reinterpret_cast< lldb::SBType * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(swig_obj[1], &argp2, SWIGTYPE_p_lldb__SBTarget,  0  | 0);
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), "in method '" "SBType_GetTemplateArgumentValue" "', argument " "2"" of type '" "lldb::SBTarget""'"); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_NullReferenceError, "invalid null reference " "in method '" "SBType_GetTemplateArgumentValue" "', argument " "2"" of type '" "lldb::SBTarget""'");
+    } else {
+      lldb::SBTarget * temp = reinterpret_cast< lldb::SBTarget * >(argp2);
+      arg2 = *temp;
+      if (SWIG_IsNewObj(res2)) delete temp;
+    }
+  }
+  ecode3 = SWIG_AsVal_unsigned_SS_int(swig_obj[2], &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "SBType_GetTemplateArgumentValue" "', argument " "3"" of type '" "uint32_t""'");
+  } 
+  arg3 = static_cast< uint32_t >(val3);
+  {
+    SWIG_PYTHON_THREAD_BEGIN_ALLOW;
+    result = (arg1)->GetTemplateArgumentValue(SWIG_STD_MOVE(arg2),arg3);
+    SWIG_PYTHON_THREAD_END_ALLOW;
+  }
+  resultobj = SWIG_NewPointerObj((new lldb::SBValue(result)), SWIGTYPE_p_lldb__SBValue, SWIG_POINTER_OWN |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
 SWIGINTERN PyObject *_wrap_SBType_GetTemplateArgumentKind(PyObject *self, PyObject *args) {
   PyObject *resultobj = 0;
   lldb::SBType *arg1 = (lldb::SBType *) 0 ;
@@ -100016,6 +100067,7 @@ static PyMethodDef SwigMethods[] = {
 		"    * Objective-C: Always returns an invalid SBType.\n"
 		"\n"
 		""},
+	 { "SBType_GetTemplateArgumentValue", _wrap_SBType_GetTemplateArgumentValue, METH_VARARGS, "SBType_GetTemplateArgumentValue(SBType self, SBTarget target, uint32_t idx) -> SBValue"},
 	 { "SBType_GetTemplateArgumentKind", _wrap_SBType_GetTemplateArgumentKind, METH_VARARGS, "\n"
 		"SBType_GetTemplateArgumentKind(SBType self, uint32_t idx) -> lldb::TemplateArgumentKind\n"
 		"Returns the kind of the template argument with the given index.\n"

--- a/lldb/bindings/python/static-binding/lldb.py
+++ b/lldb/bindings/python/static-binding/lldb.py
@@ -14028,6 +14028,10 @@ class SBType(object):
         """
         return _lldb.SBType_GetTemplateArgumentType(self, idx)
 
+    def GetTemplateArgumentValue(self, target, idx):
+        r"""GetTemplateArgumentValue(SBType self, SBTarget target, uint32_t idx) -> SBValue"""
+        return _lldb.SBType_GetTemplateArgumentValue(self, target, idx)
+
     def GetTemplateArgumentKind(self, idx):
         r"""
         GetTemplateArgumentKind(SBType self, uint32_t idx) -> lldb::TemplateArgumentKind

--- a/lldb/include/lldb/API/SBTarget.h
+++ b/lldb/include/lldb/API/SBTarget.h
@@ -970,6 +970,7 @@ protected:
   friend class SBSection;
   friend class SBSourceManager;
   friend class SBSymbol;
+  friend class SBType;
   friend class SBTypeStaticField;
   friend class SBValue;
   friend class SBVariablesOptions;

--- a/lldb/include/lldb/API/SBType.h
+++ b/lldb/include/lldb/API/SBType.h
@@ -221,6 +221,13 @@ public:
 
   lldb::SBType GetTemplateArgumentType(uint32_t idx);
 
+  /// Returns the value of the non-type template parameter at index \c idx.
+  /// If \c idx is out-of-bounds or the template parameter doesn't have
+  /// a value, returns an empty SBValue.
+  ///
+  /// This function will expand parameter packs.
+  lldb::SBValue GetTemplateArgumentValue(lldb::SBTarget target, uint32_t idx);
+
   /// Return the TemplateArgumentKind of the template argument at index idx.
   /// Variadic argument packs are automatically expanded.
   lldb::TemplateArgumentKind GetTemplateArgumentKind(uint32_t idx);

--- a/lldb/include/lldb/API/SBValue.h
+++ b/lldb/include/lldb/API/SBValue.h
@@ -444,6 +444,7 @@ protected:
   friend class SBModule;
   friend class SBTarget;
   friend class SBThread;
+  friend class SBType;
   friend class SBTypeStaticField;
   friend class SBTypeSummary;
   friend class SBValueList;

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -704,6 +704,42 @@ lldb::TemplateArgumentKind SBType::GetTemplateArgumentKind(uint32_t idx) {
   return eTemplateArgumentKindNull;
 }
 
+lldb::SBValue SBType::GetTemplateArgumentValue(lldb::SBTarget target,
+                                               uint32_t idx) {
+  LLDB_INSTRUMENT_VA(this, target, idx);
+
+  if (!IsValid())
+    return {};
+
+  std::optional<CompilerType::IntegralTemplateArgument> arg;
+  const bool expand_pack = true;
+  switch (GetTemplateArgumentKind(idx)) {
+  case eTemplateArgumentKindIntegral:
+    arg = m_opaque_sp->GetCompilerType(false).GetIntegralTemplateArgument(
+        idx, expand_pack);
+    break;
+  default:
+    break;
+  }
+
+  if (!arg)
+    return {};
+
+  Scalar value{arg->value};
+  DataExtractor data;
+  value.GetData(data);
+
+  ExecutionContext exe_ctx;
+  auto target_sp = target.GetSP();
+  if (!target_sp)
+    return {};
+
+  target_sp->CalculateExecutionContext(exe_ctx);
+
+  return ValueObject::CreateValueObjectFromData("value", data, exe_ctx,
+                                                arg->type);
+}
+
 SBType SBType::FindDirectNestedType(const char *name) {
   LLDB_INSTRUMENT_VA(this, name);
 

--- a/lldb/test/API/lang/cpp/template-arguments/Makefile
+++ b/lldb/test/API/lang/cpp/template-arguments/Makefile
@@ -1,3 +1,4 @@
 CXX_SOURCES := main.cpp
+CXXFLAGS_EXTRAS := -std=c++20
 
 include Makefile.rules

--- a/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
+++ b/lldb/test/API/lang/cpp/template-arguments/TestCppTemplateArguments.py
@@ -8,7 +8,7 @@ class TestCase(TestBase):
     @no_debug_info_test
     def test(self):
         self.build()
-        self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
+        target = self.dbg.CreateTarget(self.getBuildArtifact("a.out"))
 
         value = self.expect_expr("temp1", result_type="C<int, 2>")
         template_type = value.GetType()
@@ -27,10 +27,42 @@ class TestCase(TestBase):
         self.assertEqual(
             template_type.GetTemplateArgumentType(1).GetName(), "unsigned int"
         )
-        # FIXME: There is no way to get the actual value of the parameter.
+
+        # Template parameter isn't a NTTP.
+        self.assertFalse(template_type.GetTemplateArgumentValue(target, 0))
+
+        # Template parameter index out-of-bounds.
+        self.assertFalse(template_type.GetTemplateArgumentValue(target, 2))
+
+        # Template parameter is a NTTP.
+        param_val = template_type.GetTemplateArgumentValue(target, 1)
+        self.assertEqual(param_val.GetTypeName(), "unsigned int")
+        self.assertEqual(param_val.GetValueAsUnsigned(), 2)
 
         # Try to get an invalid template argument.
         self.assertEqual(
             template_type.GetTemplateArgumentKind(2), lldb.eTemplateArgumentKindNull
         )
         self.assertEqual(template_type.GetTemplateArgumentType(2).GetName(), "")
+
+        value = self.expect_expr("temp2", result_type="Foo<short, -2>")
+
+        # Can't get template parameter value with invalid target.
+        self.assertFalse(value.GetType().GetTemplateArgumentValue(lldb.SBTarget(), 1))
+
+        template_param_value = value.GetType().GetTemplateArgumentValue(target, 1)
+        self.assertTrue(template_param_value)
+        self.assertEqual(template_param_value.GetTypeName(), "short")
+        self.assertEqual(template_param_value.GetValueAsSigned(), -2)
+
+        value = self.expect_expr("temp3", result_type="Foo<char, 'v'>")
+        template_param_value = value.GetType().GetTemplateArgumentValue(target, 1)
+        self.assertTrue(template_param_value)
+        self.assertEqual(template_param_value.GetTypeName(), "char")
+        self.assertEqual(chr(template_param_value.GetValueAsSigned()), "v")
+
+        # FIXME: type should be Foo<float, 2.0f>
+        # FIXME: double/float NTTP parameter values currently not supported.
+        value = self.expect_expr("temp4", result_type="Foo<float, float>")
+        template_param_value = value.GetType().GetTemplateArgumentValue(target, 1)
+        self.assertFalse(template_param_value)

--- a/lldb/test/API/lang/cpp/template-arguments/main.cpp
+++ b/lldb/test/API/lang/cpp/template-arguments/main.cpp
@@ -5,4 +5,9 @@ struct C {
 
 C<int, 2> temp1;
 
+template <typename T, T value> struct Foo {};
+Foo<short, -2> temp2;
+Foo<char, 'v'> temp3;
+Foo<float, 2.0f> temp4;
+
 int main() {}


### PR DESCRIPTION
This patch adds a new API to `SBType` to retrieve the value of a template parameter given an index. We re-use the
`TypeSystemClang::GetIntegralTemplateArgument` for this and thus currently only supports integral non-type template parameters. Types like float/double are not supported yet.

rdar://144395216
(cherry picked from commit 3ad8657ff60b9967235ad65fdb8b767aae0e799d)