### PR TITLE
Cp 2025 02 13

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandOptionArgumentTable.h
+++ b/lldb/include/lldb/Interpreter/CommandOptionArgumentTable.h
@@ -160,8 +160,9 @@ static constexpr OptionEnumValueElement g_bind_gen_type_params[] = {
     {
         lldb::eBindAuto,
         "auto",
-        "Attempt to run the expression with bound generic parameters first, "
-        "fallback to unbound generic parameters if binding the type parameters "
+        "Attempt to run the expression with unbound generic parameters first, "
+        "fallback to binding the generic parameters if the expression with "
+        "unbound generic type parameters "
         "fails",
     },
     {lldb::eBind, "true", "Bind generic type parameters."},

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -878,7 +878,7 @@ swift::FuncDecl *SwiftASTManipulator::GetFunctionToInjectVariableInto(
   // When not binding generic type parameters, we want to inject the metadata
   // pointers in the wrapper, so we can pass them as opaque pointers in the
   // trampoline function later on.
-  if (m_bind_generic_types == lldb::eDontBind &&
+  if (!ShouldBindGenericTypes(m_bind_generic_types) &&
       (variable.IsMetadataPointer() || variable.IsPackCount() ||
        variable.IsUnboundPack()))
     return m_entrypoint_decl;
@@ -896,7 +896,8 @@ llvm::Expected<swift::Type> SwiftASTManipulator::GetSwiftTypeForVariable(
 
   // When injecting a value pack or pack count into the outer
   // lldb_expr function, treat it as an opaque raw pointer.
-  if (m_bind_generic_types == lldb::eDontBind && variable.IsUnboundPack()) {
+  if (!ShouldBindGenericTypes(m_bind_generic_types) &&
+      variable.IsUnboundPack()) {
     auto swift_ast_ctx = type_system_swift->GetSwiftASTContext(m_sc);
     if (!swift_ast_ctx)
       return llvm::createStringError("no typesystem for variable " +

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.h
@@ -284,6 +284,12 @@ public:
                                const EvaluateExpressionOptions &options,
                                std::string &expr_source_path);
 
+  // By default expression evaluation should not try to bind the generic types.
+  static bool
+  ShouldBindGenericTypes(lldb::BindGenericTypes bind_generic_types) {
+    return bind_generic_types == lldb::eBind;
+  }
+
   swift::FuncDecl *GetEntrypointDecl() const {
     return m_entrypoint_decl;
   }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.h
@@ -51,7 +51,10 @@ public:
   enum class ParseResult {
     success,
     retry_fresh_context,
-    retry_no_bind_generic_params,
+    retry_bind_generic_params,
+    // Retry by binding the generic parameters because the generic expression
+    // evaluator does not support running this expression.
+    retry_bind_generic_params_not_supported,
     unrecoverable_error
   };
   //------------------------------------------------------------------

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -408,7 +408,8 @@ do {
         weak_self ? "Swift.Optional where Wrapped == " : "";
 
     // The expression text is inserted into the body of $__lldb_user_expr_%u.
-    if (options.GetBindGenericTypes() == lldb::eDontBind) {
+    if (!SwiftASTManipulator::ShouldBindGenericTypes(
+            options.GetBindGenericTypes())) {
       // A Swift program can't have types with non-bound generic type parameters
       // inside a non generic function. For example, the following program would
       // not compile as T is not part of foo's signature.
@@ -511,7 +512,8 @@ func $__lldb_expr(_ $__lldb_arg : UnsafeMutablePointer<Any>) {
                             wrapped_expr_text.GetData(), availability.c_str(),
                             current_counter);
     }
-  } else if (options.GetBindGenericTypes() == lldb::eDontBind) {
+  } else if (!SwiftASTManipulator::ShouldBindGenericTypes(
+                 options.GetBindGenericTypes())) {
     auto c = MakeGenericSignaturesAndCalls(local_variables, generic_sig,
                                            needs_object_ptr);
     if (!c) {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -531,9 +531,9 @@ LLDBMemoryReader::addModuleToAddressMap(ModuleSP module,
       (uint64_t)signedPointerStripper(
           swift::remote::RemoteAbsolutePointer("", module_end_address))
           .getOffset()) {
-    lldbassert(false &&
-               "LLDBMemoryReader module to address map ran into pointer "
-               "authentication mask!");
+    LLDB_LOG(GetLog(LLDBLog::Types),
+             "[MemoryReader] module to address map ran into pointer "
+             "authentication mask!");
     return {};
   }
   // The address for the next image is the next pointer aligned address

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1563,7 +1563,8 @@ bool SwiftLanguageRuntime::IsSelf(Variable &variable) {
     return false;
   node_ptr = node_ptr->getFirstChild();
   return node_ptr->getKind() == swift::Demangle::Node::Kind::Constructor ||
-         node_ptr->getKind() == swift::Demangle::Node::Kind::Allocator;
+         node_ptr->getKind() == swift::Demangle::Node::Kind::Allocator ||
+         node_ptr->getKind() == swift::Demangle::Node::Kind::ExplicitClosure;
 }
 
 static swift::Demangle::NodePointer

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2347,6 +2347,7 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
 
   NodePointer canonical = TypeSystemSwiftTypeRef::GetStaticSelfType(
       dem, dem.demangleSymbol(mangled_name.GetStringRef()));
+  canonical = ts.DesugarNode(dem, canonical);
 
   // Build the list of type substitutions.
   swift::reflection::GenericArgumentMap substitutions;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -374,6 +374,11 @@ public:
   CanonicalizeSugar(swift::Demangle::Demangler &dem,
                     swift::Demangle::NodePointer node);
 
+  /// Recursively desugars sugared types (arrays, dictionaries, optionals, etc.)
+  /// in a demangle tree.
+  swift::Demangle::NodePointer DesugarNode(swift::Demangle::Demangler &dem,
+                                           swift::Demangle::NodePointer node);
+
   /// Finds the nominal type node (struct, class, enum) that contains the
   /// module and identifier nodes for that type. If \p node is not a valid
   /// type node, returns a nullptr.

--- a/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
@@ -9,7 +9,39 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ------------------------------------------------------------------------------
-import lldbsuite.test.lldbinline as lldbinline
-from lldbsuite.test.decorators import *
+#
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *	
+import lldbsuite.test.lldbutil as lldbutil
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+
+
+class TestSwiftGenericExtension(TestBase):
+     @swiftTest
+     def test(self):
+        self.build()
+
+        target, process, _, _ = lldbutil.run_to_source_breakpoint(
+             self, "break here for if let success", lldb.SBFileSpec("main.swift")
+         )
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+        self.expect("expr a", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["5"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for guard let success', lldb.SBFileSpec('main.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+        self.expect("expr a", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["5"])
+
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for if let else', lldb.SBFileSpec('main.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])
+
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            'break here for guard let else', lldb.SBFileSpec('main.swift'), None)
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])

--- a/lldb/test/API/lang/swift/expression/weak_self/main.swift
+++ b/lldb/test/API/lang/swift/expression/weak_self/main.swift
@@ -19,11 +19,10 @@ class ClosureMaker {
 
   func getClosure() -> (() -> Int) {
     return { [weak self] () -> Int in
-             if let _self = self {
-               return _self.a //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker?)", "5"])
-                              //% self.expect("expr self!", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+             if let self = self {
+               return self.a // break here for if let success
              } else {
-               return 0 //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])
+               return 0 // break here for if let else
             }
           }
   }
@@ -31,10 +30,9 @@ class ClosureMaker {
   func getGuardClosure() -> (() -> Int) {
     return { [weak self] () -> Int in
              guard let self = self else {
-               return 0  //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["nil"])
+               return 0 // break here for guard let else
              }
-             return self.a //% self.expect("expr self", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker?)", "5"])
-                          //% self.expect("expr self!", DATA_TYPES_DISPLAYED_CORRECTLY, substrs = ["ClosureMaker)", "5"])
+             return self.a // break here for guard let success
           }
   }
 }

--- a/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
+++ b/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
@@ -9,9 +9,21 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 #
 # ------------------------------------------------------------------------------
-import lldbsuite.test.lldbinline as lldbinline
-from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest
-    ])
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftGenericExtension(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "expr -d run-target --bind-generic-types false -- self",
+            substrs=["[0] = 1", "[1] = 2", "[2] = 3"],
+        )

--- a/lldb/test/API/lang/swift/generic_extension/main.swift
+++ b/lldb/test/API/lang/swift/generic_extension/main.swift
@@ -11,10 +11,8 @@
 // -----------------------------------------------------------------------------
 extension Array {
     func test() {
-        print("PATPAT") //% self.expect("expr -d run-target -- self", substrs=['[0] = 1', '[1] = 2', '[2] = 3'])
-        return //% self.expect("frame variable -d run -- self", substrs=['[0] = 1', '[1] = 2', '[2] = 3'])
+        print("break here")
     }
 }
 var a = [1,2,3]
-
 a.test()


### PR DESCRIPTION
commit 4bfcda867ae30efcf90a0df497775a6bdfebfbd5 (a/cp-2025-02-13, cp-2025-02-13)
Author: Augusto Noronha <anoronha@apple.com>
Date:   Wed Feb 12 13:21:13 2025 -0800

    [lldb] Fix using self in expression evaluation when self is weakly captured

    This both fixes printing self when multiple self variables are present (for
    example, "guard let self = self"), as well as referencing self
    properties without spelling out self ("self.a" vs "a") when self is
    captured weakly in closures.

    rdar://122956043
    (cherry picked from commit 4382c862c9a5266ca854d5464ba2686b7197c56d)

commit b18e31c77ce7ddfbf5b1d8ee0f4bb5081dca34ef
Author: Augusto Noronha <anoronha@apple.com>
Date:   Tue Feb 11 13:51:24 2025 -0800

    [lldb] Run generic expression evaluator first

    The generic expression evaluator can be significantly faster than the
    regular one since it only needs to import information about the module
    the debugger is stopped at to evaluate the expression. This patch
    swaps the order of the expression evaluators so that the generic
    expression evaluator is tried first.

    rdar://139239935
    (cherry picked from commit 7b1bb14e1c5124f8ff58545267f47865f0a6b915)

commit 0db92f6e8bc7e99cb0d86276c8a9ae508de50962
Author: Augusto Noronha <anoronha@apple.com>
Date:   Mon Feb 10 11:46:49 2025 -0800

    [lldb] Desugar the type before binding generic parameters

    Queries to remote mirrors can only be done with desugared types.

    (cherry picked from commit 914c4fc9ad7251f5b63d8b5c85ce76fa0c620c95)

commit 2074ae9a09ece4678801c5f2b5861fdcec4de257
Author: Augusto Noronha <anoronha@apple.com>
Date:   Fri Feb 7 16:45:20 2025 -0800

    [lldb] Replace lldbassert with LLDB_LOG in LLDBMemoryReader

    This can spam user's consoles and hinder their debugging experience even
    if nothing goes wrong in their debug session.

    rdar://131955267
    (cherry picked from commit cbf9559bf7ba15374299e39ae5a37f009cf8f5c1)