### PR TITLE
[Cherry-pick into next] [lldb] Elimintate SwiftASTContext from enum handling

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -997,7 +997,7 @@ llvm::Expected<std::string> SwiftLanguageRuntime::GetEnumCaseName(
     return eti->getCases()[case_index].Name;
 
   // TODO: uncomment this after fixing projection for every type: rdar://138424904
-  // LogUnimplementedTypeKind(__FUNCTION__, type);
+  LogUnimplementedTypeKind(__FUNCTION__, type);
   return llvm::createStringError("unimplemented enum kind");
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8469,15 +8469,9 @@ bool SwiftASTContext::DumpTypeValue(
     SwiftEnumDescriptor *cached_enum_info = GetCachedEnumInfo(type);
     if (cached_enum_info) {
       auto enum_elem_info = cached_enum_info->GetElementFromData(data, true);
-      if (enum_elem_info)
-        s.Printf("%s", enum_elem_info->name.GetCString());
-      else {
-        lldb::offset_t ptr = 0;
-        if (data.GetByteSize())
-          s.Printf("<invalid> (0x%" PRIx8 ")", data.GetU8(&ptr));
-        else
-          s.Printf("<empty>");
-      }
+      if (!enum_elem_info)
+        return false;
+      s.Printf("%s", enum_elem_info->name.GetCString());
       return true;
     } else
       s.Printf("<unknown type>");

--- a/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
+++ b/lldb/test/API/lang/swift/optionset/TestSwiftOptionSetType.py
@@ -13,7 +13,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin,
-        expectedFailureAll(bugnumber="rdar://60396797",
-                           setting=('symbols.use-swift-clangimporter', 'false'))
-])
+                          decorators=[swiftTest,skipUnlessDarwin])


### PR DESCRIPTION
```
commit e5b0f3170cc6ce66fce74c6de71881928c26af6d
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Jan 17 16:45:48 2025 -0800

    [lldb] Elimintate SwiftASTContext from enum handling
    
    rdar://115078610
```
