### PR TITLE
🍒[lldb][ASAN][Swift] Do not use backticks in tests

### DIFF
--- a/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
+++ b/lldb/test/API/functionalities/asan/swift/TestAsanSwift.py
@@ -74,12 +74,14 @@ class AsanSwiftTestCase(lldbtest.TestBase):
             # interceptors.
             self.runCmd("continue")
 
+        self.runCmd("expr let $targetptr = ptr")
+
         # the stop reason of the thread should be breakpoint.
         self.expect("thread list", lldbtest.STOPPED_DUE_TO_BREAKPOINT,
                     substrs=['stopped', 'stop reason = breakpoint'])
 
         self.expect(
-            "memory history `ptr`",
+            "memory history $targetptr",
             substrs=[
                 'Memory allocated by Thread 1',
                 'main.swift'])
@@ -105,7 +107,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
                 break
 
         self.expect(
-            "memory history `ptr`",
+            "memory history $targetptr",
             substrs=[
                 'Memory allocated by Thread 1',
                 'main.swift'])


### PR DESCRIPTION
Backticks prevents emitting proper diagnostics when expression evaluation fails.

Replacing backticks expressions with use of lldb tremporary variables in ASAN lldb Swift test

https://github.com/swiftlang/llvm-project/issues/10012 

(cherry picked from commit 578efae420a6bee094c9b438081516617c5f1075)