### PR TITLE
[BoundsSafety] Do not check for bounds-attr output arguments in dependent contexts (#9733)

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -21,6 +21,7 @@
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/DependenceFlags.h"
 #include "clang/AST/EvaluatedExprVisitor.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/ExprCXX.h"
@@ -8251,7 +8252,7 @@ static bool checkDynamicCountPointerAsParameter(Sema &S, FunctionDecl *FDecl,
     if (!ArgInfo.isCountInParamOrCountPointer() && !ArgInfo.isCountInRet() &&
         !ParmInfo.isCountInParamOrCountPointer() && !ParmInfo.isCountInRet())
       continue;
-    assert(!ActualArgExp->isValueDependent());
+
     // Disable these checks for attribute-only mode because we don't want
     // non-type-incompatibility errors in that mode.
     if (!S.getLangOpts().isBoundsSafetyAttributeOnlyMode() &&
@@ -8822,7 +8823,10 @@ ExprResult Sema::BuildResolvedCallExpr(Expr *Fn, NamedDecl *NDecl,
   if (getLangOpts().BoundsSafetyAttributes && FDecl) {
     // FIXME: We need to support function pointers and blocks that don't have
     // function decl.
-    if (!checkDynamicCountPointerAsParameter(*this, FDecl, TheCall))
+
+    // For C++, we don't want to check for any dependent constructs.
+    if (TheCall->getDependence() == ExprDependence::None &&
+        !checkDynamicCountPointerAsParameter(*this, FDecl, TheCall))
       return ExprError();
     if (getLangOpts().BoundsSafety)
       if (!checkDynamicRangePointerAsParameter(*this, FDecl, TheCall))

--- a/clang/test/BoundsSafety/Sema/unsafe-buffer-usage-interop-crash.cpp
+++ b/clang/test/BoundsSafety/Sema/unsafe-buffer-usage-interop-crash.cpp
@@ -11,12 +11,15 @@ class MyClass {
 namespace value_dependent_assertion_violation {
   // Running attribute-only mode on the C++ code below crashes
   // previously.
-  void g(unsigned);
+  void g(int * __counted_by(n) * p, size_t n);
 
   template<typename T>
   struct S {
     void f(T p) {
-      g(sizeof(p));
+      g(nullptr, sizeof(p));
     }
   };
+
+  // expected-error@-4{{incompatible dynamic count pointer argument to parameter of type 'int * __counted_by(n)*' (aka 'int **')}}
+  template struct S<int>; // expected-note{{in instantiation of member function 'value_dependent_assertion_violation::S<int>::f' requested here}}
 }


### PR DESCRIPTION
Same as #9733 but towards stable/20240723

(rdar://141708643)