### PR TITLE
[Cherry-pick into next] Fix bitrotted test

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -82,6 +82,7 @@ public:
   bool GetUseSwiftDWARFImporter() const;
   bool SetUseSwiftDWARFImporter(bool new_value);
   bool GetSwiftValidateTypeSystem() const;
+  bool GetSwiftTypeSystemFallback() const;
   bool GetSwiftLoadConformances() const;
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -777,6 +777,7 @@ class Base(unittest.TestCase):
             ),
             # Enable expensive validations in TypeSystemSwiftTypeRef.
             "settings set symbols.swift-validate-typesystem true",
+            "settings set symbols.swift-typesystem-compiler-fallback true",
             "settings set use-color false",
         ]
 

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -28,6 +28,11 @@ let Definition = "modulelist" in {
   def SwiftValidateTypeSystem: Property<"swift-validate-typesystem", "Boolean">,
     DefaultFalse,
     Desc<"Validate all Swift typesystem queries. Used for testing an asserts-enabled LLDB only.">;
+  def SwiftTypeSystemFallback
+      : Property<"swift-typesystem-compiler-fallback", "Boolean">,
+        DefaultTrue,
+        Desc<"If a query against reflection metadata / debug info fails, retry "
+             "using Swift modules.">;
   def SwiftLoadConformances: Property<"swift-load-conformances", "Boolean">,
     DefaultFalse,
     Desc<"Resolve type alias via the conformance section. Disabled for performance reasons">;

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -200,6 +200,12 @@ bool ModuleListProperties::GetSwiftValidateTypeSystem() const {
       idx, g_modulelist_properties[idx].default_uint_value != 0);
 }
 
+bool ModuleListProperties::GetSwiftTypeSystemFallback() const {
+  const uint32_t idx = ePropertySwiftTypeSystemFallback;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
 bool ModuleListProperties::GetSwiftLoadConformances() const {
   const uint32_t idx = ePropertySwiftLoadConformances;
   return GetPropertyAtIndexAs<bool>(

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -441,6 +441,13 @@ public:
   GetManglingFlavor(ExecutionContext *exe_ctx = nullptr);
 
 protected:
+  /// Determine whether the fallback is enabled via setting.
+  bool UseSwiftASTContextFallback(const char *func_name,
+                                  lldb::opaque_compiler_type_t type);
+  /// Print a warning that a fallback was necessary.
+  bool DiagnoseSwiftASTContextFallback(const char *func_name,
+                                       lldb::opaque_compiler_type_t type);
+
   /// Helper that creates an AST type from \p type.
   ///
   /// FIXME: This API is dangerous, it would be better to return a
@@ -556,6 +563,7 @@ protected:
     unsigned char retry_count = 0;
   };
 
+  std::once_flag m_fallback_warning;
   mutable std::mutex m_swift_ast_context_lock;
   /// The "precise" SwiftASTContexts managed by this scratch context. There
   /// exists one per Swift module. The keys in this map are module names.

--- a/lldb/test/Shell/Swift/cond-breakpoint.test
+++ b/lldb/test/Shell/Swift/cond-breakpoint.test
@@ -1,11 +1,13 @@
 # REQUIRES: swift
 # RUN: rm -rf %t && mkdir %t && cd %t
-# RUN: %target-swiftc -g %S/Inputs/main.swift -o a.out
-# RUN: %lldb a.out -b -s %s 2>&1 | FileCheck %s
+# RUN: %target-swiftc -g %S/Inputs/main.swift -o %t/a.out
+# RUN: %lldb %t/a.out -b -s %s 2>&1 | FileCheck %s
 
 # CHECK-NOT: Stopped due to an error evaluating condition of breakpoint
+# CHECK: stop reason = breakpoint
 
 # The parentheses surrounding the expression matter.
 br s -n main -c '((nil == nil))'
 r
 c
+quit

--- a/lldb/test/Shell/lit-lldb-init.in
+++ b/lldb/test/Shell/lit-lldb-init.in
@@ -9,3 +9,4 @@ settings set target.auto-apply-fixits false
 settings set target.inherit-tcc true
 settings set target.detach-on-error false
 settings set symbols.swift-validate-typesystem true
+settings set symbols.swift-typesystem-compiler-fallback true


### PR DESCRIPTION
```
commit c8167526a54073ee4d22f469197720193a3c7a87
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Feb 13 16:52:05 2025 -0800

    Fix bitrotted test

commit a120b8e5d14749ddfeda427794e45544dc617574
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Feb 13 17:09:50 2025 -0800

    TypeSystemSwiftTypeRef: Make SwiftASTContext fallback switchable
    
    via a new setting symbols.swift-typesystem-fallback
    
    The new setting is currently on by default, prints a warning if the
    fallback was engaged and successful, and is meant to eventually be
    turned off when running the LLDB testsuite.
    
    rdar://142512839
```
