### PR TITLE
[lldb] Fix dynamic type resolution for ObjC protocol existentials

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2865,10 +2865,15 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
   else if (type_info.AllSet(eTypeIsMetatype | eTypeIsProtocol))
     success = GetDynamicTypeAndAddress_ExistentialMetatype(
         in_value, val_type, use_dynamic, class_type_or_name, address);
-  else if (type_info.AnySet(eTypeIsProtocol))
-    success = GetDynamicTypeAndAddress_Existential(in_value, val_type, use_dynamic,
-                                                class_type_or_name, address);
-  else {
+  else if (type_info.AnySet(eTypeIsProtocol)) {
+    if (type_info.AnySet(eTypeIsObjC))
+      success = GetDynamicTypeAndAddress_Class(in_value, val_type, use_dynamic,
+                                               class_type_or_name, address,
+                                               static_value_type, local_buffer);
+    else
+      success = GetDynamicTypeAndAddress_Existential(
+          in_value, val_type, use_dynamic, class_type_or_name, address);
+  } else {
     CompilerType bound_type;
     if (type_info.AnySet(eTypeHasUnboundGeneric | eTypeHasDynamicSelf)) {
       // Perform generic type resolution.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6188,11 +6188,18 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
                    eTypeInstanceIsPointer;
     break;
 
-  case swift::TypeKind::Protocol:
+  case swift::TypeKind::Protocol: {
+    auto *protocol =
+        llvm::cast<swift::ProtocolType>(swift_can_type.getPointer());
+    swift::ProtocolDecl *decl = protocol->getDecl();
+    if (decl->isObjC())
+      swift_flags |= eTypeIsObjC | eTypeHasValue;
+    LLVM_FALLTHROUGH;
+  }
   case swift::TypeKind::ProtocolComposition:
-  case swift::TypeKind::Existential:
+  case swift::TypeKind::Existential: {
     swift_flags |= eTypeHasChildren | eTypeIsStructUnion | eTypeIsProtocol;
-    break;
+  } break;
   case swift::TypeKind::ExistentialMetatype:
     swift_flags |= eTypeIsProtocol;
     LLVM_FALLTHROUGH;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1575,20 +1575,45 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetDemangleTreeForPrinting(
   return GetNodeForPrintingImpl(dem, node, flavor, resolve_objc_module);
 }
 
-/// Determine wether this demangle tree contains a node of kind \c kind.
+/// Determine wether this demangle tree contains a node of kind \c kind and with
+/// text \c text (if provided).
 static bool Contains(swift::Demangle::NodePointer node,
-                     swift::Demangle::Node::Kind kind) {
+                     swift::Demangle::Node::Kind kind,
+                     llvm::StringRef text = "") {
   if (!node)
     return false;
 
-  if (node->getKind() == kind)
-    return true;
+  if (node->getKind() == kind) {
+    if (text.empty())
+      return true;
+    if (!node->hasText())
+      return false;
+    return node->getText() == text;
+  }
 
   for (swift::Demangle::NodePointer child : *node)
-    if (Contains(child, kind))
+    if (Contains(child, kind, text))
       return true;
 
   return false;
+}
+
+static bool ProtocolCompositionContainsSingleObjcProtocol(
+    swift::Demangle::NodePointer node) {
+  // Kind=ProtocolList
+  // Kind=TypeList
+  //   Kind=Type
+  //     Kind=Protocol
+  //       Kind=Module, text="__C"
+  //       Kind=Identifier, text="SomeIdentifier"
+  if (node->getKind() != Node::Kind::ProtocolList)
+    return false;
+  NodePointer type_list = node->getFirstChild();
+  if (type_list->getKind() != Node::Kind::TypeList ||
+      type_list->getNumChildren() != 1)
+    return false;
+  NodePointer type = type_list->getFirstChild();
+  return Contains(type, Node::Kind::Module, swift::MANGLING_MODULE_OBJC);
 }
 
 /// Determine wether this demangle tree contains a generic type parameter.
@@ -1777,6 +1802,8 @@ uint32_t TypeSystemSwiftTypeRef::CollectTypeInfo(
       swift_flags |= eTypeIsProtocol;
       // Bug-for-bug-compatibility.
       swift_flags |= eTypeHasChildren | eTypeIsStructUnion;
+      if (ProtocolCompositionContainsSingleObjcProtocol(node))
+        swift_flags |= eTypeIsObjC | eTypeHasValue;
       break;
 
     case Node::Kind::ExistentialMetatype:

--- a/lldb/test/API/lang/swift/objc_protocol/Makefile
+++ b/lldb/test/API/lang/swift/objc_protocol/Makefile
@@ -1,0 +1,6 @@
+SWIFT_SOURCES := main.swift
+SWIFT_BRIDGING_HEADER := bridging-header.h
+OBJC_SOURCES := objc.m
+SWIFT_OBJC_INTEROP := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
+++ b/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftObjcProtocol(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Tests that dynamic type resolution works for an Objective-C protocol existential"""
+        self.build()
+        (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        self.expect("frame variable v", substrs=["SwiftClass", "a = 42", "b = 938"])
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect(
+            "frame variable v",
+            substrs=["ObjcClass", "_someString", '"The objc string"'],
+        )

--- a/lldb/test/API/lang/swift/objc_protocol/bridging-header.h
+++ b/lldb/test/API/lang/swift/objc_protocol/bridging-header.h
@@ -1,0 +1,11 @@
+
+#include <Foundation/Foundation.h>
+
+@protocol ObjcProtocol <NSObject>
+@end
+
+@interface ObjcClass : NSObject <ObjcProtocol>
+@property NSString *someString;
+- (instancetype)init;
++ (id<ObjcProtocol>)getP;
+@end

--- a/lldb/test/API/lang/swift/objc_protocol/main.swift
+++ b/lldb/test/API/lang/swift/objc_protocol/main.swift
@@ -1,0 +1,17 @@
+class SwiftClass: NSObject, ObjcProtocol {
+    let a = 42
+    let b = 938
+} 
+
+func foo(v: (any ObjcProtocol)) {
+    print(v) // break here
+}
+
+func f() {
+    let swiftClass = SwiftClass()
+    foo(v: swiftClass)
+    let objcClass = ObjcClass()!
+    foo(v: objcClass)
+}
+f()
+

--- a/lldb/test/API/lang/swift/objc_protocol/objc.m
+++ b/lldb/test/API/lang/swift/objc_protocol/objc.m
@@ -1,0 +1,16 @@
+#include "bridging-header.h"
+
+@implementation ObjcClass
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    self.someString = @"The objc string";
+  }
+  return self;
+}
+
++ (id<ObjcProtocol>)getP {
+  return [ObjcClass new];
+}
+@end


### PR DESCRIPTION
An existential whose protocol type is an Objective-C protocol is not passed in an existential container, but as a plain old instance pointer. This patch dynamic type resolution failing for those types.

rdar://144028358