### PR TITLE
[lldb] Change the type alias resolution algorithm

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1264,22 +1264,69 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
     // Hit the safeguard limit.
     return node;
   }
-  default:
-    break;
+  default: {
+    llvm::SmallVector<NodePointer, 2> children;
+    bool changed = false;
+    for (NodePointer child : *node) {
+      NodePointer transformed = GetCanonicalNode(dem, child, flavor);
+      changed |= (child != transformed);
+      children.push_back(transformed);
+    }
+    if (changed) {
+      // Create a new node with the transformed children.
+      auto kind = node->getKind();
+      if (node->hasText())
+        node = dem.createNodeWithAllocatedText(kind, node->getText());
+      else if (node->hasIndex())
+        node = dem.createNode(kind, node->getIndex());
+      else
+        node = dem.createNode(kind);
+      for (NodePointer transformed_child : children)
+        node->addChild(transformed_child, dem);
+    }
+    return node;
+  }
   }
   return node;
 }
 
-/// Iteratively resolve all type aliases in \p node by looking up their
-/// desugared types in the debug info of module \p M.
 swift::Demangle::NodePointer
 TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
                                          swift::Demangle::NodePointer node,
                                          swift::Mangle::ManglingFlavor flavor) {
+  if (!node)
+    return nullptr;
+  // This is a pre-order traversal, which is necessary to resolve
+  // generic type aliases that bind other type aliases in one go,
+  // instead of first resolving the bound type aliases.  Debug Info
+  // will have a record for SomeAlias<SomeOtherAlias> but not
+  // SomeAlias<WhatSomeOtherAliasResolvesTo> because it tries to
+  // preserve all sugar.
   using namespace swift::Demangle;
-  return TypeSystemSwiftTypeRef::Transform(dem, node, [&](NodePointer node) {
-    return Canonicalize(dem, node, flavor);
-  });
+  NodePointer transformed = Canonicalize(dem, node, flavor);
+  if (node != transformed)
+    return transformed;
+
+  llvm::SmallVector<NodePointer, 2> children;
+  bool changed = false;
+  for (NodePointer child : *node) {
+    NodePointer transformed_child = GetCanonicalNode(dem, child, flavor);
+    changed |= (child != transformed_child);
+    children.push_back(transformed_child);
+  }
+  if (changed) {
+    // Create a new node with the transformed children.
+    auto kind = node->getKind();
+    if (node->hasText())
+      node = dem.createNodeWithAllocatedText(kind, node->getText());
+    else if (node->hasIndex())
+      node = dem.createNode(kind, node->getIndex());
+    else
+      node = dem.createNode(kind);
+    for (NodePointer transformed_child : children)
+      node->addChild(transformed_child, dem);
+  }
+  return node;
 }
 
 /// Return the demangle tree representation of this type's canonical

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -394,6 +394,7 @@ public:
   AdjustTypeForOriginallyDefinedInModule(llvm::StringRef mangled_typename);
 
   /// Return the canonicalized Demangle tree for a Swift mangled type name.
+  /// It resolves all type aliases and removes sugar.
   swift::Demangle::NodePointer
   GetCanonicalDemangleTree(swift::Demangle::Demangler &dem,
                            llvm::StringRef mangled_name);
@@ -460,13 +461,6 @@ protected:
   /// Cast \p opaque_type as a mangled name.
   static const char *AsMangledName(lldb::opaque_compiler_type_t type);
 
-  /// Helper function that canonicalizes node, but doesn't look at its
-  /// children.
-  swift::Demangle::NodePointer
-  Canonicalize(swift::Demangle::Demangler &dem,
-               swift::Demangle::NodePointer node,
-               swift::Mangle::ManglingFlavor flavor);
-
   /// Demangle the mangled name of the canonical type of \p type and
   /// drill into the Global(TypeMangling(Type())).
   ///
@@ -483,6 +477,20 @@ protected:
   swift::Demangle::NodePointer
   DemangleCanonicalOutermostType(swift::Demangle::Demangler &dem,
                                  lldb::opaque_compiler_type_t type);
+
+  /// Desugar to this node and if it is a type alias resolve it by
+  /// looking up its type in the debug info.
+  swift::Demangle::NodePointer
+  Canonicalize(swift::Demangle::Demangler &dem,
+               swift::Demangle::NodePointer node,
+               swift::Mangle::ManglingFlavor flavor);
+
+  /// Iteratively desugar and resolve all type aliases in \p node by
+  /// looking up their types in the debug info.
+  swift::Demangle::NodePointer
+  GetCanonicalNode(swift::Demangle::Demangler &dem,
+                   swift::Demangle::NodePointer node,
+                   swift::Mangle::ManglingFlavor flavor);
 
   /// If \p node is a Struct/Class/Typedef in the __C module, return a
   /// Swiftified node by looking up the name in the corresponding APINotes and
@@ -514,12 +522,6 @@ protected:
   CompilerType LookupClangForwardType(llvm::StringRef name, 
                   llvm::ArrayRef<CompilerContext> decl_context);
 
-  /// Recursively resolves all type aliases.
-  swift::Demangle::NodePointer
-  ResolveAllTypeAliases(swift::Demangle::Demangler &dem,
-                        swift::Demangle::NodePointer node,
-                        swift::Mangle::ManglingFlavor flavor);
-
   /// Resolve a type alias node and return a demangle tree for the
   /// resolved type. If the type alias resolves to a Clang type, return
   /// a Clang CompilerType.
@@ -530,11 +532,6 @@ protected:
   std::pair<swift::Demangle::NodePointer, CompilerType> ResolveTypeAlias(
       swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
       swift::Mangle::ManglingFlavor flavor, bool prefer_clang_types = false);
-
-  swift::Demangle::NodePointer
-  GetCanonicalNode(swift::Demangle::Demangler &dem,
-                   swift::Demangle::NodePointer node,
-                   swift::Mangle::ManglingFlavor flavor);
 
   uint32_t CollectTypeInfo(swift::Demangle::Demangler &dem,
                            swift::Demangle::NodePointer node,

--- a/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
+++ b/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
@@ -7,11 +7,14 @@ class TestSwiftTypeAlias(TestBase):
     def test(self):
         """Test type aliases are only searched in the debug info once"""
         self.build()
-        log = self.getBuildArtifact("dwarf.log")
-        self.expect("log enable dwarf lookups -f " + log)
+        if self.TraceOn():
+            log = self.getBuildArtifact("dwarf.log")
+            self.expect("log enable dwarf lookups -f " + log)
 
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift"), extra_images=['Dylib'])
         self.expect("target variable foo", substrs=["(Dylib.MyAlias)", "23"])
         self.expect("target variable bar",
                     substrs=["(Dylib.MyGenericAlias<Dylib.MyAlias>)", "42"])
+        self.expect("target variable baz",
+                    substrs=["(Dylib.MyGenericAlias<a.LocalAlias>)", "42"])

--- a/lldb/test/API/lang/swift/typealias/main.swift
+++ b/lldb/test/API/lang/swift/typealias/main.swift
@@ -3,4 +3,5 @@ typealias LocalAlias = Foo
 let local = LocalAlias()
 let foo = MyAlias()
 let bar = MyGenericAlias<MyAlias>()
-print("\(local), \(foo), \(bar)") // break here
+let baz = MyGenericAlias<LocalAlias>()
+print("\(local), \(foo), \(bar), \(baz)") // break here


### PR DESCRIPTION
from a post-oder to a pre-order traversal.  This is necessary to resolve generic type aliases that bind other type aliases in one go, instead of first resolving the bound type aliases.  Debug Info will have a record for `SomeAlias<SomeOtherAlias>` but not `SomeAlias<WhatSomeOtherAliasResolvesTo>` because it tries to preserve all sugar.

rdar://144884987