### PR TITLE
[clang] Place `features.json` in `LLVM_BINARY_DIR` instead of `CMAKE_BINARY_DIR`

### DIFF
--- a/clang/tools/driver/CMakeLists.txt
+++ b/clang/tools/driver/CMakeLists.txt
@@ -144,7 +144,7 @@ endif()
 
 # Add features.json file into usr/share/clang
 set(features_file_src "${CMAKE_CURRENT_SOURCE_DIR}/features.json")
-set(features_file_dest "${CMAKE_BINARY_DIR}/share/clang/features.json")
+set(features_file_dest "${LLVM_BINARY_DIR}/share/clang/features.json")
 
 configure_file(${features_file_src} ${features_file_dest} @ONLY)
 


### PR DESCRIPTION
Even with unified build, llvm is not always the top-level project but it can be a part of a larger build. In such cases, `CMAKE_BINARY_DIR` is not the same as `LLVM_BINARY_DIR` but swift side expects `features.json` is in `LLVM_BINARY_DIR`[^1].

[^1]: https://github.com/swiftlang/swift/blob/swift-DEVELOPMENT-SNAPSHOT-2025-02-14-a/lib/Option/CMakeLists.txt#L11