### PR TITLE
[lldb] Disable swift tasks plugin while failure is investigated

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -32,7 +32,7 @@ let Definition = "target_experimental" in {
     EnumValues<"OptionEnumValues(g_swift_pcm_validation_values)">,
     Desc<"Enable validation when loading Clang PCM files (-fvalidate-pch, -fmodules-check-relocated).">;
   def SwiftUseTasksPlugin: Property<"swift-tasks-plugin-enabled", "Boolean">,
-    DefaultTrue,
+    DefaultFalse,
     Desc<"Enables the swift plugin converting tasks into threads">;
 }
 


### PR DESCRIPTION
Some tests are running into an issue where breakpoints are not being hit.