### PR TITLE
[lldb] Change the type alias resolution algorithm

### DIFF
--- a/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
+++ b/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
@@ -7,11 +7,14 @@ class TestSwiftTypeAlias(TestBase):
     def test(self):
         """Test type aliases are only searched in the debug info once"""
         self.build()
-        log = self.getBuildArtifact("dwarf.log")
-        self.expect("log enable dwarf lookups -f " + log)
+        if self.TraceOn():
+            log = self.getBuildArtifact("dwarf.log")
+            self.expect("log enable dwarf lookups -f " + log)
 
         target, process, _, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift"), extra_images=['Dylib'])
         self.expect("target variable foo", substrs=["(Dylib.MyAlias)", "23"])
         self.expect("target variable bar",
                     substrs=["(Dylib.MyGenericAlias<Dylib.MyAlias>)", "42"])
+        self.expect("target variable baz",
+                    substrs=["(Dylib.MyGenericAlias<a.LocalAlias>)", "42"])

--- a/lldb/test/API/lang/swift/typealias/main.swift
+++ b/lldb/test/API/lang/swift/typealias/main.swift
@@ -3,4 +3,5 @@ typealias LocalAlias = Foo
 let local = LocalAlias()
 let foo = MyAlias()
 let bar = MyGenericAlias<MyAlias>()
-print("\(local), \(foo), \(bar)") // break here
+let baz = MyGenericAlias<LocalAlias>()
+print("\(local), \(foo), \(bar), \(baz)") // break here


### PR DESCRIPTION
from a post-oder to a pre-order traversal.  This is necessary to resolve generic type aliases that bind other type aliases in one go, instead of first resolving the bound type aliases.  Debug Info will have a record for `SomeAlias<SomeOtherAlias>` but not `SomeAlias<WhatSomeOtherAliasResolvesTo>` because it tries to preserve all sugar.

rdar://144884987
(cherry picked from commit b16a454ffc90fddec88f096107d7ff6da155bc2e)