### PR TITLE
[BoundsSafety] SaveAndRestore MakeStartedByPointerType::Done in TransformPointerType

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6004,6 +6004,7 @@ public:
 
   QualType TransformPointerType(TypeLocBuilder &TLB, PointerTypeLoc TL) {
     llvm::SaveAndRestore<unsigned> LevelLocal(Level);
+    llvm::SaveAndRestore<bool> DoneLocal(Done);
     if (!Done && Level == 0) {
       Expr *StartPtr = BuildStartPtrExpr();
       if (!StartPtr)


### PR DESCRIPTION
PointerType can be visited multiple times if it's wrapped by AttributedType in order to build ModifiedType and EquivalentType.

This fixes the issue where started_by wasn't attached properly in EquivalentType. That issue only appeared in the stable branch where EquivalentType is rebuilt even if it's equal to ModifiedType. `next` already fixed that issue via "[Clang] Bugfixes and improved support for AttributedTypes in lambdas", so this patch doesn't have a reproducing test. However, we'd still cherry-pick it for robustness.

(cherry picked from commit 8fcde03fc281a0772db46ae26d3be9b90ba8c5d6)