### PR TITLE
[ObjC] Fix Objc Type Info Struct after 1d6302eb3b23d33f273169c1354e9927eb4b1345

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -7720,8 +7720,6 @@ CGObjCNonFragileABIMac::GetInterfaceEHType(const ObjCInterfaceDecl *ID,
     values.add(VTablePtr);
   }
 
-  values.add(llvm::ConstantExpr::getInBoundsGetElementPtr(
-      VTableGV->getValueType(), VTableGV, VTableIdx));
   values.add(GetClassName(ClassName));
   values.add(GetClassGlobal(ID, /*metaclass*/ false, NotForDefinition));
 


### PR DESCRIPTION
1d6302eb3b23d33f273169c1354e9927eb4b1345 merged formatting changes from 53c618c07154, but accidentally added the `vtable` pointer twice to `struct objc_typeinfo`. 

This PR fixes rdar://144803388