### PR TITLE
[BoundsSafety] Update Tests with More Capture Info

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/bounds-attributed-return-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/bounds-attributed-return-O2.c
@@ -66,7 +66,7 @@ int *__counted_by(count) cb_in_from_indexable(int count, int *__indexable p) {
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cb_in_from_single(
-// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[SPEC_SELECT:%.*]] = icmp ult i32 [[COUNT]], 2
 // CHECK-NEXT:    br i1 [[SPEC_SELECT]], label %[[CONT:.*]], label %[[TRAP:.*]], !annotation [[META2]]
@@ -81,7 +81,7 @@ int *__counted_by(count) cb_in_from_single(int count, int *__single p) {
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cb_in_from_cb(
-// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp slt i32 [[COUNT]], 0, !annotation [[META2]]
 // CHECK-NEXT:    br i1 [[CMP_NOT]], label %[[TRAP:.*]], label %[[CONT:.*]], !annotation [[META2]]
@@ -96,7 +96,7 @@ int *__counted_by(count) cb_in_from_cb(int count, int *__counted_by(count) p) {
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cb_in_from_cb2(
-// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]], i32 noundef [[LEN:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]], i32 noundef [[LEN:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[LEN]] to i64
 // CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp slt i32 [[LEN]], 0, !annotation [[META2]]
@@ -172,7 +172,7 @@ int *__counted_by(count) cb_in_from_cbn2(int count, int *__counted_by_or_null(le
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cb_out_from_single(
-// CHECK-SAME: ptr noundef readonly captures(none) [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readonly captures(none) [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[COUNT]], align 4, !tbaa [[TBAA11:![0-9]+]]
 // CHECK-NEXT:    [[OR_COND:%.*]] = icmp ult i32 [[TMP0]], 2, !annotation [[META2]]
@@ -188,7 +188,7 @@ int *__counted_by(*count) cb_out_from_single(int *__single count, int *__single 
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cbn_in_from_single(
-// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned captures(address_is_null, ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp eq ptr [[P]], null, !annotation [[META2]]
 // CHECK-NEXT:    [[SPEC_SELECT:%.*]] = icmp ult i32 [[COUNT]], 2
@@ -237,7 +237,7 @@ void *__sized_by(size) sb_in_from_bidi(int size, void *__bidi_indexable p) {
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @sb_in_from_single(
-// CHECK-SAME: i32 noundef [[SIZE:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[SIZE:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[SPEC_SELECT:%.*]] = icmp ult i32 [[SIZE]], 5
 // CHECK-NEXT:    br i1 [[SPEC_SELECT]], label %[[CONT:.*]], label %[[TRAP:.*]], !annotation [[META2]]
@@ -252,7 +252,7 @@ void *__sized_by(size) sb_in_from_single(int size, int *__single p) {
 }
 
 // CHECK-LABEL: define dso_local ptr @eb_in_from_bidi(
-// CHECK-SAME: ptr noundef readnone [[END:%.*]], ptr noundef readonly captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readnone captures(address) [[END:%.*]], ptr noundef readonly captures(none) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_P_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 8
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP_SROA_1_0_P_SROA_IDX]], align 8
@@ -278,7 +278,7 @@ void *__ended_by(end) eb_in_from_bidi(void *__single end, void *__bidi_indexable
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @eb_in_from_single(
-// CHECK-SAME: ptr noundef readnone [[END:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readnone captures(address) [[END:%.*]], ptr noundef readnone returned captures(address, ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 4, !annotation [[META2]]
 // CHECK-NEXT:    [[CMP:%.*]] = icmp ule ptr [[END]], [[UPPER]], !annotation [[META2]]

--- a/clang/test/BoundsSafety/CodeGen/bounds-attributed-return-disabled-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/bounds-attributed-return-disabled-O2.c
@@ -17,7 +17,7 @@ int *__counted_by(count) cb_in_from_bidi(int count, int *__bidi_indexable p) {
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cb_in_from_single(
-// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {
+// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret ptr [[P]]
 //
@@ -26,7 +26,7 @@ int *__counted_by(count) cb_in_from_single(int count, int *__single p) {
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cb_out_from_single(
-// CHECK-SAME: ptr noundef readnone captures(none) [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {
+// CHECK-SAME: ptr noundef readnone captures(none) [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret ptr [[P]]
 //
@@ -35,7 +35,7 @@ int *__counted_by(*count) cb_out_from_single(int *count, int *__single p) {
 }
 
 // CHECK-LABEL: define dso_local noundef ptr @cbn_in_from_single(
-// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {
+// CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    ret ptr [[P]]
 //

--- a/clang/test/BoundsSafety/CodeGen/compound-literal-counted_by_or_null-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/compound-literal-counted_by_or_null-O2.c
@@ -772,7 +772,7 @@ void assign_via_ptr_from_cbon(struct cbon* ptr, int new_count,
 }
 
 // CHECK-LABEL: define dso_local void @assign_operator_from_cbon(
-// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone captures(address_is_null) [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ne ptr [[NEW_PTR]], null, !annotation [[META22]]
 // CHECK-NEXT:    [[CMP_NOT48:%.*]] = icmp slt i32 [[NEW_COUNT]], 0
@@ -795,7 +795,7 @@ void assign_operator_from_cbon(int new_count,
 
 
 // CHECK-LABEL: define dso_local void @local_var_init_from_cbon(
-// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone captures(address_is_null) [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ne ptr [[NEW_PTR]], null, !annotation [[META22]]
 // CHECK-NEXT:    [[CMP_NOT46:%.*]] = icmp slt i32 [[NEW_COUNT]], 0
@@ -867,7 +867,7 @@ struct cbon return_cbon_from_cbon(int new_count,
 }
 
 // CHECK-LABEL: define dso_local void @construct_not_used_from_cbon(
-// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone captures(address_is_null) [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ne ptr [[NEW_PTR]], null, !annotation [[META22]]
 // CHECK-NEXT:    [[CMP_NOT46:%.*]] = icmp slt i32 [[NEW_COUNT]], 0

--- a/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O2.c
@@ -91,7 +91,7 @@ void assign_via_ptr(struct eb* ptr,
 }
 
 // CHECK-LABEL: define dso_local void @assign_operator(
-// CHECK-SAME: ptr noundef readonly captures(none) [[NEW_START:%.*]], ptr noundef readnone [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readonly captures(none) [[NEW_START:%.*]], ptr noundef readnone captures(address) [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_NEW_START_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[NEW_START]], i64 8
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP_SROA_1_0_NEW_START_SROA_IDX]], align 8
@@ -122,7 +122,7 @@ void assign_operator(char* __bidi_indexable new_start, char* new_end) {
 
 
 // CHECK-LABEL: define dso_local void @local_var_init(
-// CHECK-SAME: ptr noundef readonly captures(none) [[NEW_START:%.*]], ptr noundef readnone [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readonly captures(none) [[NEW_START:%.*]], ptr noundef readnone captures(address) [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_NEW_START_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[NEW_START]], i64 8
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP_SROA_1_0_NEW_START_SROA_IDX]], align 8
@@ -218,7 +218,7 @@ struct eb return_eb(char* __bidi_indexable new_start, char* new_end) {
 }
 
 // CHECK-LABEL: define dso_local void @construct_not_used(
-// CHECK-SAME: ptr noundef readonly captures(none) [[NEW_START:%.*]], ptr noundef readnone [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readonly captures(none) [[NEW_START:%.*]], ptr noundef readnone captures(address) [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_NEW_START_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[NEW_START]], i64 8
 // CHECK-NEXT:    [[AGG_TEMP_SROA_1_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP_SROA_1_0_NEW_START_SROA_IDX]], align 8
@@ -614,7 +614,7 @@ void assign_via_ptr_from_eb(struct eb* ptr,
 }
 
 // CHECK-LABEL: define dso_local void @assign_operator_from_eb(
-// CHECK-SAME: ptr noundef readnone [[NEW_START:%.*]], ptr noundef readnone [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readnone captures(address) [[NEW_START:%.*]], ptr noundef readnone captures(address) [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[CMP19_NOT:%.*]] = icmp ugt ptr [[NEW_START]], [[NEW_END]], !annotation [[META2]]
 // CHECK-NEXT:    br i1 [[CMP19_NOT]], label %[[TRAP:.*]], label %[[CONT:.*]], !annotation [[META2]]
@@ -634,7 +634,7 @@ void assign_operator_from_eb(char* __ended_by(new_end) new_start, char* new_end)
 
 
 // CHECK-LABEL: define dso_local void @local_var_init_from_eb(
-// CHECK-SAME: ptr noundef readnone [[NEW_START:%.*]], ptr noundef readnone [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readnone captures(address) [[NEW_START:%.*]], ptr noundef readnone captures(address) [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[CMP19_NOT:%.*]] = icmp ugt ptr [[NEW_START]], [[NEW_END]], !annotation [[META2]]
 // CHECK-NEXT:    br i1 [[CMP19_NOT]], label %[[TRAP:.*]], label %[[CONT:.*]], !annotation [[META2]]
@@ -697,7 +697,7 @@ struct eb return_eb_from_eb(char* __ended_by(new_end) new_start, char* new_end) 
 }
 
 // CHECK-LABEL: define dso_local void @construct_not_used_from_eb(
-// CHECK-SAME: ptr noundef readnone [[NEW_START:%.*]], ptr noundef readnone [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef readnone captures(address) [[NEW_START:%.*]], ptr noundef readnone captures(address) [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[CMP19_NOT:%.*]] = icmp ugt ptr [[NEW_START]], [[NEW_END]], !annotation [[META2]]
 // CHECK-NEXT:    br i1 [[CMP19_NOT]], label %[[TRAP:.*]], label %[[CONT:.*]], !annotation [[META2]]

--- a/clang/test/BoundsSafety/CodeGen/compound-literal-sized_by_or_null-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/compound-literal-sized_by_or_null-O2.c
@@ -772,7 +772,7 @@ void assign_via_ptr_from_sbon(struct sbon* ptr, int new_count,
 }
 
 // CHECK-LABEL: define dso_local void @assign_operator_from_sbon(
-// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone captures(address_is_null) [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ne ptr [[NEW_PTR]], null, !annotation [[META22]]
 // CHECK-NEXT:    [[CMP_NOT48:%.*]] = icmp slt i32 [[NEW_COUNT]], 0
@@ -795,7 +795,7 @@ void assign_operator_from_sbon(int new_count,
 
 
 // CHECK-LABEL: define dso_local void @local_var_init_from_sbon(
-// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone captures(address_is_null) [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ne ptr [[NEW_PTR]], null, !annotation [[META22]]
 // CHECK-NEXT:    [[CMP_NOT46:%.*]] = icmp slt i32 [[NEW_COUNT]], 0
@@ -867,7 +867,7 @@ struct sbon return_sbon_from_sbon(int new_count,
 }
 
 // CHECK-LABEL: define dso_local void @construct_not_used_from_sbon(
-// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: i32 noundef [[NEW_COUNT:%.*]], ptr noundef readnone captures(address_is_null) [[NEW_PTR:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ne ptr [[NEW_PTR]], null, !annotation [[META22]]
 // CHECK-NEXT:    [[CMP_NOT46:%.*]] = icmp slt i32 [[NEW_COUNT]], 0

--- a/clang/test/BoundsSafety/CodeGen/counted-by-nested-assignments-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/counted-by-nested-assignments-O2.c
@@ -12,7 +12,7 @@
 // WITHOUT-NEXT:    store i32 0, ptr [[X]], align 4, !tbaa [[TBAA2:![0-9]+]]
 // WITHOUT-NEXT:    ret void
 // CHECK-LABEL: define dso_local void @foo(
-// CHECK-SAME: ptr noundef writeonly [[X:%.*]], i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ptr noundef writeonly captures(address) [[X:%.*]], i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[COUNT]] to i64
 // CHECK-NEXT:    [[ADD_PTR_IDX:%.*]] = shl nuw nsw i64 [[IDX_EXT]], 2, !annotation [[META2:![0-9]+]]
@@ -54,7 +54,7 @@ void foo(int *__counted_by(count) x, unsigned count) {
 // WITHOUT-NEXT:    store i32 0, ptr [[BOUND_PTR_ARITH]], align 4, !tbaa [[TBAA2]]
 // WITHOUT-NEXT:    ret void
 // CHECK-LABEL: define dso_local void @bar(
-// CHECK-SAME: ptr noundef writeonly [[X:%.*]], i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef writeonly captures(address) [[X:%.*]], i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[IDX_EXT:%.*]] = sext i32 [[COUNT]] to i64
 // CHECK-NEXT:    [[ADD_PTR_IDX:%.*]] = shl nsw i64 [[IDX_EXT]], 2, !annotation [[META5]]

--- a/clang/test/BoundsSafety/CodeGen/counted-by-or-null-negative-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/counted-by-or-null-negative-O2.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 
 // CHECK-LABEL: define dso_local void @to_bidi(
-// CHECK-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"__bounds_safety::wide_ptr.bidi_indexable") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readnone [[ARG:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"__bounds_safety::wide_ptr.bidi_indexable") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readnone captures(address_is_null) [[ARG:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp eq ptr [[ARG]], null, !annotation [[META2:![0-9]+]]
 // CHECK-NEXT:    br i1 [[TOBOOL_NOT]], label [[BOUNDSCHECK_NULL:%.*]], label [[TRAP:%.*]], !annotation [[META2]]
@@ -25,7 +25,7 @@ int *__bidi_indexable to_bidi(int * arg) {
 }
 
 // CHECK-LABEL: define dso_local void @to_bidi_literal_count(
-// CHECK-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"__bounds_safety::wide_ptr.bidi_indexable") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readnone [[ARG:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"__bounds_safety::wide_ptr.bidi_indexable") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readnone captures(address_is_null) [[ARG:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp eq ptr [[ARG]], null, !annotation [[META2]]
 // CHECK-NEXT:    br i1 [[TOBOOL_NOT]], label [[BOUNDSCHECK_NULL:%.*]], label [[TRAP_CRITEDGE:%.*]], !annotation [[META2]]
@@ -42,7 +42,7 @@ int *__bidi_indexable to_bidi_literal_count(int * arg) {
 }
 
 // CHECK-LABEL: define dso_local void @to_bidi_const_count(
-// CHECK-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"__bounds_safety::wide_ptr.bidi_indexable") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readnone [[ARG:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr dead_on_unwind noalias writable writeonly sret(%"__bounds_safety::wide_ptr.bidi_indexable") align 8 captures(none) [[AGG_RESULT:%.*]], ptr noundef readnone captures(address_is_null) [[ARG:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TOBOOL_NOT:%.*]] = icmp eq ptr [[ARG]], null, !annotation [[META2]]
 // CHECK-NEXT:    br i1 [[TOBOOL_NOT]], label [[BOUNDSCHECK_NULL:%.*]], label [[TRAP_CRITEDGE:%.*]], !annotation [[META2]]

--- a/clang/test/BoundsSafety/CodeGen/ended-by-nested-assignments-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/ended-by-nested-assignments-O2.c
@@ -13,7 +13,7 @@
 // WITHOUT-NEXT:    store i32 0, ptr [[START]], align 4, !tbaa [[TBAA2]]
 // WITHOUT-NEXT:    ret void
 // CHECK-LABEL: define dso_local void @foo(
-// CHECK-SAME: ptr noundef writeonly [[START:%.*]], ptr noundef writeonly [[END:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ptr noundef writeonly captures(address) [[START:%.*]], ptr noundef writeonly captures(address) [[END:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[END]], i64 -4
 // CHECK-NEXT:    [[BOUND_PTR_ARITH3:%.*]] = getelementptr i8, ptr [[START]], i64 4
@@ -46,7 +46,7 @@ void foo(int *__ended_by(end) start, int * end) {
 // WITHOUT-NEXT:    store i32 0, ptr [[BOUND_PTR_ARITH3]], align 4, !tbaa [[TBAA2]]
 // WITHOUT-NEXT:    ret void
 // CHECK-LABEL: define dso_local void @bar(
-// CHECK-SAME: ptr noundef writeonly [[START:%.*]], ptr noundef writeonly [[END:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-SAME: ptr noundef writeonly captures(address) [[START:%.*]], ptr noundef writeonly captures(address) [[END:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[START]], i64 4
 // CHECK-NEXT:    [[BOUND_PTR_ARITH3:%.*]] = getelementptr i8, ptr [[END]], i64 -4

--- a/clang/test/BoundsSafety/CodeGen/nested-struct-member-count-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/nested-struct-member-count-O2.c
@@ -16,7 +16,7 @@ struct Outer {
 };
 
 // CHECK-LABEL: define dso_local i8 @access(
-// CHECK-SAME: ptr noundef readonly [[BAR:%.*]], i32 noundef [[INDEX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// CHECK-SAME: ptr noundef readonly captures(address) [[BAR:%.*]], i32 noundef [[INDEX:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[FAM:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 8
 // CHECK-NEXT:    [[LEN:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 4

--- a/clang/test/BoundsSafety/CodeGen/trap-function-returns-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/trap-function-returns-O2.c
@@ -5,7 +5,7 @@
 #include <ptrcheck.h>
 
 // X86_64-LABEL: define dso_local i32 @foo(
-// X86_64-SAME: ptr noundef readonly [[BAR:%.*]], i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
+// X86_64-SAME: ptr noundef readonly captures(address) [[BAR:%.*]], i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // X86_64-NEXT:  entry:
 // X86_64-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[COUNT]] to i64
 // X86_64-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw i32, ptr [[BAR]], i64 [[IDX_EXT]]


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/7e3735d1a1b85cea48feb45cb7c2b5d8eaa216ae#diff-9a37ee3638cac6b7801f64bceefcc3a1e21ca7a9ced3b977bc280c55f7ba8820 landed upstream and it seems to be here to stay. The upstream change led to more capture info computed. This PR updates the `next`-only tests to reflect the added capture info. 

Fixes rdar://144878274