### PR TITLE
[lldb][lldb-dap][test] Skip launch test on Windows again

### DIFF
--- a/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
+++ b/lldb/test/API/tools/lldb-dap/launch/TestDAP_launch.py
@@ -224,6 +224,7 @@ class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
                 'arg[%i] "%s" not in "%s"' % (i + 1, quoted_arg, lines[i]),
             )
 
+    @skipIfWindows
     def test_environment_with_object(self):
         """
         Tests launch of a simple program with environment variables


### PR DESCRIPTION
https://github.com/swiftlang/llvm-project/pull/9770 enabled a bunch of lldb-dap tests on Windows. Apparently, `TestDAP_launch.test_environment_with_object` is still flaky. Let's disable it in order to avoid sporadic failures of pre-merge tests.