### PR TITLE
[-Wunsafe-buffer-usage][BoundsSafety] support __null_terminated in the interop mode

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13198,8 +13198,10 @@ def warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by : Warning
           "sending type to parameter of incompatible type}0,1|"
     "%diff{casting $ to incompatible type $|"
           "casting type to incompatible type}0,1|"
-  "}2 is an unsafe operation; use '%select{__unsafe_terminated_by_from_indexable|__unsafe_null_terminated_from_indexable}3()' "
-  "or '%select{__unsafe_forge_terminated_by|__unsafe_forge_null_terminated}3()' to perform this conversion">, InGroup<BoundsSafetyStrictTerminatedByCast>, DefaultError;
+  "}2 is an unsafe operation"
+  "%select{; use '__unsafe_terminated_by_from_indexable()' or '__unsafe_forge_terminated_by()' to perform this conversion|"
+  "; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion|"
+  "}3">, InGroup<BoundsSafetyStrictTerminatedByCast>, DefaultError;
 def err_bounds_safety_incompatible_non_terminated_by_to_terminated_by : Error<warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by.Summary>;
 def err_bounds_safety_incompatible_terminated_by_to_non_terminated_by_mismatch : Error<
   "%select{"
@@ -13603,18 +13605,6 @@ def note_unsafe_count_attributed_pointer_argument : Note<
 def warn_unsafe_single_pointer_argument : Warning<
   "unsafe assignment to function parameter of __single pointer type">,
   InGroup<UnsafeBufferUsage>, DefaultIgnore;
-def warn_unsafe_assign_to_null_terminated_pointer : Warning<
-  "unsafe %select{assignment to a pointer of|"
-                  "assignment to a parameter of|"
-                  "return of|"
-                  "conversion to|"
-                  "initialization of a pointer of|"
-                  "assignment to a pointer of|"
-                  "casting to}2 '__null_terminated' type">,
-  InGroup<UnsafeBufferUsage>, DefaultIgnore;
-def note_unsafe_assign_to_null_terminated_pointer : Note<
-  "the source pointer may not point to null-terminated data; "
-  "only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers">;
 #ifndef NDEBUG
 // Not a user-facing diagnostic. Useful for debugging false negatives in
 // -fsafe-buffer-usage-suggestions (i.e. lack of -Wunsafe-buffer-usage fixits).

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13603,6 +13603,19 @@ def note_unsafe_count_attributed_pointer_argument : Note<
 def warn_unsafe_single_pointer_argument : Warning<
   "unsafe assignment to function parameter of __single pointer type">,
   InGroup<UnsafeBufferUsage>, DefaultIgnore;
+def warn_unsafe_assign_to_null_terminated_pointer : Warning<
+  "unsafe %select{assignment to a pointer of|"
+                  "assignment to a parameter of|"
+                  "return of|"
+                  "conversion to|"
+                  "initialization of a pointer of|"
+                  "assignment to a pointer of|"
+                  "casting to}2 '__null_terminated' type; "
+  "only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers">,
+  InGroup<UnsafeBufferUsage>, DefaultIgnore;
+def warn_unsafe_named_cast_to_null_terminated_pointer : Warning<
+  "C++ named cast to '__null_terminated' type is unsafe">,
+  InGroup<UnsafeBufferUsage>, DefaultIgnore;
 #ifndef NDEBUG
 // Not a user-facing diagnostic. Useful for debugging false negatives in
 // -fsafe-buffer-usage-suggestions (i.e. lack of -Wunsafe-buffer-usage fixits).

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13610,12 +13610,11 @@ def warn_unsafe_assign_to_null_terminated_pointer : Warning<
                   "conversion to|"
                   "initialization of a pointer of|"
                   "assignment to a pointer of|"
-                  "casting to}2 '__null_terminated' type; "
-  "only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers">,
+                  "casting to}2 '__null_terminated' type">,
   InGroup<UnsafeBufferUsage>, DefaultIgnore;
-def warn_unsafe_named_cast_to_null_terminated_pointer : Warning<
-  "C++ named cast to '__null_terminated' type is unsafe">,
-  InGroup<UnsafeBufferUsage>, DefaultIgnore;
+def note_unsafe_assign_to_null_terminated_pointer : Note<
+  "the source pointer may not point to null-terminated data; "
+  "only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers">;
 #ifndef NDEBUG
 // Not a user-facing diagnostic. Useful for debugging false negatives in
 // -fsafe-buffer-usage-suggestions (i.e. lack of -Wunsafe-buffer-usage fixits).

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1562,7 +1562,7 @@ public:
   BoundsSafetyPointerAttributes CurPointerAbi;
 
   /// \returns true iff `-Wunsafe-buffer-usage` is enabled for `Loc`.
-  bool isCXXSafeBuffersEnabledAt(SourceLocation Loc) {
+  bool isCXXSafeBuffersEnabledAt(SourceLocation Loc) const {
     return !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc);
   }
   /* TO_UPSTREAM(BoundsSafety) OFF */

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1561,9 +1561,11 @@ public:
   /// __single in user code and __unsafe_indexable in system headers.
   BoundsSafetyPointerAttributes CurPointerAbi;
 
-  /// \returns true iff `-Wunsafe-buffer-usage` is enabled for `Loc`.
-  bool isCXXSafeBuffersEnabledAt(SourceLocation Loc) const {
-    return !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc);
+  /// \return true iff `-Wunsafe-buffer-usage` is enabled for `Loc` and Bounds
+  /// Safety attribute-only mode is on.
+  bool isCXXSafeBuffersBoundsSafetyInteropEnabledAt(SourceLocation Loc) const {
+    return LangOpts.CPlusPlus && LangOpts.isBoundsSafetyAttributeOnlyMode() &&
+           !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc);
   }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1560,6 +1560,11 @@ public:
   /// be controlled with \#pragma clang abi_ptr_attr set(*ATTR*). Defaults to
   /// __single in user code and __unsafe_indexable in system headers.
   BoundsSafetyPointerAttributes CurPointerAbi;
+
+  /// \returns true iff `-Wunsafe-buffer-usage` is enabled for `Loc`.
+  bool isCXXSafeBuffersEnabledAt(SourceLocation Loc) {
+    return !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc);
+  }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// pragma clang section kind

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -200,17 +200,14 @@ namespace {
       if (!DestPTy || !SrcPTy)
         return;
 
-      bool InCXXBoundsSafetyMode =
-          Self.LangOpts.CPlusPlus &&
-          Self.LangOpts.isBoundsSafetyAttributeOnlyMode() &&
-          Self.isCXXSafeBuffersEnabledAt(OpRange.getBegin());
-
       /// BoundsSafety: Such case should be handled as BoundsSafetyPointerCast.
       /// \code
       /// int *__bidi_indexable p1;
       /// int *__indexable p2 = (int *__indexable)p1;
       /// \endcode
-      if (Self.getLangOpts().BoundsSafetyAttributes) {
+      if (Self.getLangOpts().BoundsSafety ||
+          Self.isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+              SrcExpr.get()->getBeginLoc())) {
         unsigned DiagKind = 0;
         bool isInvalid = false;
         // The type error may be nested, so any pointer can result in VT errors
@@ -243,7 +240,9 @@ namespace {
           const auto *DstPointerType = DestType->getAs<ValueTerminatedType>();
           IsDstNullTerm =
               DstPointerType->getTerminatorValue(Self.Context).isZero();
-          if (Self.getLangOpts().BoundsSafetyRelaxedSystemHeaders || InCXXBoundsSafetyMode) {
+          if (Self.getLangOpts().BoundsSafetyRelaxedSystemHeaders ||
+              Self.isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+                  OpRange.getBegin())) {
             DiagKind = diag::
                 warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
             isInvalid = false;
@@ -288,7 +287,8 @@ namespace {
                       warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by) {
             auto FDiag = Self.Diag(OpRange.getBegin(), DiagKind)
                          << SrcType << DestType << AssignmentAction::Casting
-                         << (!InCXXBoundsSafetyMode
+                         << (!Self.isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+                                 OpRange.getBegin())
                                  ? (IsDstNullTerm ? /*null_terminated*/ 1
                                                   : /*terminated_by*/ 0)
                                  : 2 /* cut message irrelevant to that mode*/);

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -240,13 +240,11 @@ namespace {
               DstPointerType->getTerminatorValue(Self.Context).isZero();
           if (Self.LangOpts.isBoundsSafetyAttributeOnlyMode() &&
               Self.LangOpts.CPlusPlus &&
-              !Self.Diags.isIgnored(
-                  diag::warn_unsafe_assign_to_null_terminated_pointer,
-                  SrcExpr.get()->getExprLoc())) {
+              Self.isCXXSafeBuffersEnabledAt(OpRange.getBegin())) {
             // In C++ Safe Buffers/Bounds Safety interop mode, the compiler
             // reports a warning under -Wunsafe-buffer-usage:
             DiagKind = diag::warn_unsafe_assign_to_null_terminated_pointer;
-            isInvalid = true;
+            isInvalid = false;
             break;
           }
           if (Self.getLangOpts().BoundsSafetyRelaxedSystemHeaders) {
@@ -300,6 +298,9 @@ namespace {
             Self.Diag(OpRange.getBegin(), DiagKind)
                 << SrcType << DestType << AssignmentAction::Casting;
           }
+          if (DiagKind == diag::warn_unsafe_assign_to_null_terminated_pointer)
+            Self.Diag(OpRange.getBegin(),
+                      diag::note_unsafe_assign_to_null_terminated_pointer);
 
           Self.TryFixAssigningNullTerminatedToBidiIndexableExpr(SrcExpr.get(),
                                                                   DestType);
@@ -587,17 +588,6 @@ Sema::BuildCXXNamedCast(SourceLocation OpLoc, tok::TokenKind Kind,
 
   Op.checkQualifiedDestType();
 
-  // In C++ Safe Buffers/Bounds Safety interop mode, forbidding  for now all
-  // named cast to __null_terminated pointer type.
-  if (DestType->isPointerType() && LangOpts.hasBoundsSafetyAttributes() &&
-      !Diags.isIgnored(diag::warn_unsafe_named_cast_to_null_terminated_pointer,
-                       E->getBeginLoc())) {
-    if (DestType->getAs<ValueTerminatedType>()) {
-      Diag(E->getBeginLoc(),
-           diag::warn_unsafe_named_cast_to_null_terminated_pointer);
-      return ExprError();
-    }
-  }
   switch (Kind) {
   default: llvm_unreachable("Unknown C++ cast!");
 

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -200,6 +200,11 @@ namespace {
       if (!DestPTy || !SrcPTy)
         return;
 
+      bool InCXXBoundsSafetyMode =
+          Self.LangOpts.CPlusPlus &&
+          Self.LangOpts.isBoundsSafetyAttributeOnlyMode() &&
+          Self.isCXXSafeBuffersEnabledAt(OpRange.getBegin());
+
       /// BoundsSafety: Such case should be handled as BoundsSafetyPointerCast.
       /// \code
       /// int *__bidi_indexable p1;
@@ -238,16 +243,7 @@ namespace {
           const auto *DstPointerType = DestType->getAs<ValueTerminatedType>();
           IsDstNullTerm =
               DstPointerType->getTerminatorValue(Self.Context).isZero();
-          if (Self.LangOpts.isBoundsSafetyAttributeOnlyMode() &&
-              Self.LangOpts.CPlusPlus &&
-              Self.isCXXSafeBuffersEnabledAt(OpRange.getBegin())) {
-            // In C++ Safe Buffers/Bounds Safety interop mode, the compiler
-            // reports a warning under -Wunsafe-buffer-usage:
-            DiagKind = diag::warn_unsafe_assign_to_null_terminated_pointer;
-            isInvalid = false;
-            break;
-          }
-          if (Self.getLangOpts().BoundsSafetyRelaxedSystemHeaders) {
+          if (Self.getLangOpts().BoundsSafetyRelaxedSystemHeaders || InCXXBoundsSafetyMode) {
             DiagKind = diag::
                 warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
             isInvalid = false;
@@ -292,15 +288,14 @@ namespace {
                       warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by) {
             auto FDiag = Self.Diag(OpRange.getBegin(), DiagKind)
                          << SrcType << DestType << AssignmentAction::Casting
-                         << (IsDstNullTerm ? /*null_terminated*/ 1
-                                           : /*terminated_by*/ 0);
+                         << (!InCXXBoundsSafetyMode
+                                 ? (IsDstNullTerm ? /*null_terminated*/ 1
+                                                  : /*terminated_by*/ 0)
+                                 : 2 /* cut message irrelevant to that mode*/);
           } else {
             Self.Diag(OpRange.getBegin(), DiagKind)
                 << SrcType << DestType << AssignmentAction::Casting;
           }
-          if (DiagKind == diag::warn_unsafe_assign_to_null_terminated_pointer)
-            Self.Diag(OpRange.getBegin(),
-                      diag::note_unsafe_assign_to_null_terminated_pointer);
 
           Self.TryFixAssigningNullTerminatedToBidiIndexableExpr(SrcExpr.get(),
                                                                   DestType);

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -205,7 +205,7 @@ namespace {
       /// int *__bidi_indexable p1;
       /// int *__indexable p2 = (int *__indexable)p1;
       /// \endcode
-      if (Self.getLangOpts().hasBoundsSafetyAttributes()) {
+      if (Self.getLangOpts().BoundsSafetyAttributes) {
         unsigned DiagKind = 0;
         bool isInvalid = false;
         // The type error may be nested, so any pointer can result in VT errors

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -205,7 +205,7 @@ namespace {
       /// int *__bidi_indexable p1;
       /// int *__indexable p2 = (int *__indexable)p1;
       /// \endcode
-      if (Self.getLangOpts().BoundsSafety) {
+      if (Self.getLangOpts().hasBoundsSafetyAttributes()) {
         unsigned DiagKind = 0;
         bool isInvalid = false;
         // The type error may be nested, so any pointer can result in VT errors
@@ -238,6 +238,17 @@ namespace {
           const auto *DstPointerType = DestType->getAs<ValueTerminatedType>();
           IsDstNullTerm =
               DstPointerType->getTerminatorValue(Self.Context).isZero();
+          if (Self.LangOpts.isBoundsSafetyAttributeOnlyMode() &&
+              Self.LangOpts.CPlusPlus &&
+              !Self.Diags.isIgnored(
+                  diag::warn_unsafe_assign_to_null_terminated_pointer,
+                  SrcExpr.get()->getExprLoc())) {
+            // In C++ Safe Buffers/Bounds Safety interop mode, the compiler
+            // reports a warning under -Wunsafe-buffer-usage:
+            DiagKind = diag::warn_unsafe_assign_to_null_terminated_pointer;
+            isInvalid = true;
+            break;
+          }
           if (Self.getLangOpts().BoundsSafetyRelaxedSystemHeaders) {
             DiagKind = diag::
                 warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
@@ -576,6 +587,17 @@ Sema::BuildCXXNamedCast(SourceLocation OpLoc, tok::TokenKind Kind,
 
   Op.checkQualifiedDestType();
 
+  // In C++ Safe Buffers/Bounds Safety interop mode, forbidding  for now all
+  // named cast to __null_terminated pointer type.
+  if (DestType->isPointerType() && LangOpts.hasBoundsSafetyAttributes() &&
+      !Diags.isIgnored(diag::warn_unsafe_named_cast_to_null_terminated_pointer,
+                       E->getBeginLoc())) {
+    if (DestType->getAs<ValueTerminatedType>()) {
+      Diag(E->getBeginLoc(),
+           diag::warn_unsafe_named_cast_to_null_terminated_pointer);
+      return ExprError();
+    }
+  }
   switch (Kind) {
   default: llvm_unreachable("Unknown C++ cast!");
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12186,12 +12186,38 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
              Context.hasSameUnqualifiedType(
                  Context.getCorrespondingSignedType(LPointee),
                  Context.getCorrespondingSignedType(RPointee)));
-        if (CompatiblePointees &&
+        if (CompatiblePointees && RHSExpr->isPRValue() &&
             RHSExpr->tryEvaluateTerminatorElement(Evald, Context) &&
             Evald.Val.isInt() &&
             llvm::APSInt::isSameValue(LVTT->getTerminatorValue(Context),
                                       Evald.Val.getInt())) {
           return Sema::Compatible;
+        }
+        // If in C++ Safe Buffers/Bounds Safety interoperation mode, the RHS can
+        // be 'std::string::c_str':
+        bool SafeBuffersEnabled = !Diags.isIgnored(
+            diag::warn_unsafe_assign_to_null_terminated_pointer,
+            RHSExpr->getBeginLoc());
+
+        if (LangOpts.CPlusPlus && SafeBuffersEnabled) {
+          if (const auto *MCE =
+                  dyn_cast<CXXMemberCallExpr>(RHSExpr->IgnoreParenImpCasts())) {
+            IdentifierInfo *MethodDeclII = nullptr, *ObjTypeII = nullptr;
+
+            if (MCE->getMethodDecl())
+              MethodDeclII = MCE->getMethodDecl()->getIdentifier();
+            if (const auto *RecordDecl =
+                    MCE->getObjectType()->getAsRecordDecl()) {
+              // If not in std namespace, let `ObjTypeII` be null so that the
+              // match fails:
+              if (RecordDecl->isInStdNamespace())
+                ObjTypeII = RecordDecl->getIdentifier();
+            }
+            if (MethodDeclII && ObjTypeII &&
+                MethodDeclII->getName() == "c_str" &&
+                ObjTypeII->getName() == "basic_string")
+              return Sema::Compatible;
+          }
         }
       }
       return Nested
@@ -20783,6 +20809,16 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     const auto *DstPointerType = DstType->getAs<ValueTerminatedType>();
     IsDstNullTerm =
         DstPointerType->getTerminatorValue(getASTContext()).isZero();
+    if (getLangOpts().isBoundsSafetyAttributeOnlyMode() &&
+        getLangOpts().CPlusPlus &&
+        !Diags.isIgnored(diag::warn_unsafe_assign_to_null_terminated_pointer,
+                         Loc)) {
+      // In C++ Safe Buffers/Bounds Safety interop mode, the compiler reports a
+      // warning under -Wunsafe-buffer-usage:
+      DiagKind = diag::warn_unsafe_assign_to_null_terminated_pointer;
+      isInvalid = false;
+      break;
+    }
     if (getLangOpts().BoundsSafetyRelaxedSystemHeaders) {
       DiagKind =
           diag::warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12194,7 +12194,7 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
           return Sema::Compatible;
         }
         // If in C++ Safe Buffers/Bounds Safety interoperation mode, the RHS can
-        // be 'std::string::c_str':
+        // be 'std::string::c_str/data':
         bool isNullTerm = LVTT->getTerminatorValue(Context).isZero();
 
         if (LangOpts.CPlusPlus &&
@@ -12212,7 +12212,9 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
               // match fails:
               ObjTypeII = RecordDecl->getIdentifier();
             if (MethodDeclII && ObjTypeII &&
-                MethodDeclII->getName() == "c_str" &&
+                (MethodDeclII->getName() == "c_str" ||
+                 // std::string::data is also null-terminated since C++11:
+                 MethodDeclII->getName() == "data") &&
                 ObjTypeII->getName() == "basic_string")
               return Sema::Compatible;
           }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12195,11 +12195,8 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
         }
         // If in C++ Safe Buffers/Bounds Safety interoperation mode, the RHS can
         // be 'std::string::c_str':
-        bool SafeBuffersEnabled = !Diags.isIgnored(
-            diag::warn_unsafe_assign_to_null_terminated_pointer,
-            RHSExpr->getBeginLoc());
-
-        if (LangOpts.CPlusPlus && SafeBuffersEnabled) {
+        if (LangOpts.CPlusPlus &&
+            isCXXSafeBuffersEnabledAt(RHSExpr->getBeginLoc())) {
           if (const auto *MCE =
                   dyn_cast<CXXMemberCallExpr>(RHSExpr->IgnoreParenImpCasts())) {
             IdentifierInfo *MethodDeclII = nullptr, *ObjTypeII = nullptr;
@@ -12207,12 +12204,11 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
             if (MCE->getMethodDecl())
               MethodDeclII = MCE->getMethodDecl()->getIdentifier();
             if (const auto *RecordDecl =
-                    MCE->getObjectType()->getAsRecordDecl()) {
+                    MCE->getObjectType()->getAsRecordDecl();
+                RecordDecl && RecordDecl->isInStdNamespace())
               // If not in std namespace, let `ObjTypeII` be null so that the
               // match fails:
-              if (RecordDecl->isInStdNamespace())
-                ObjTypeII = RecordDecl->getIdentifier();
-            }
+              ObjTypeII = RecordDecl->getIdentifier();
             if (MethodDeclII && ObjTypeII &&
                 MethodDeclII->getName() == "c_str" &&
                 ObjTypeII->getName() == "basic_string")
@@ -20810,9 +20806,7 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     IsDstNullTerm =
         DstPointerType->getTerminatorValue(getASTContext()).isZero();
     if (getLangOpts().isBoundsSafetyAttributeOnlyMode() &&
-        getLangOpts().CPlusPlus &&
-        !Diags.isIgnored(diag::warn_unsafe_assign_to_null_terminated_pointer,
-                         Loc)) {
+        getLangOpts().CPlusPlus && isCXXSafeBuffersEnabledAt(Loc)) {
       // In C++ Safe Buffers/Bounds Safety interop mode, the compiler reports a
       // warning under -Wunsafe-buffer-usage:
       DiagKind = diag::warn_unsafe_assign_to_null_terminated_pointer;
@@ -21253,6 +21247,11 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
       }
     }
   }
+
+  /* TO_UPSTREAM(BoundsSafety) ON*/
+  if (DiagKind == diag::warn_unsafe_assign_to_null_terminated_pointer)
+    Diag(Loc, diag::note_unsafe_assign_to_null_terminated_pointer);
+  /* TO_UPSTREAM(BoundsSafety) OFF*/
 
   if (IsSrcNullTerm) {
     TryFixAssigningNullTerminatedToImplicitBidiIndexablePtr(Assignee, SrcExpr,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12197,8 +12197,8 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
         // be 'std::string::c_str/data':
         bool isNullTerm = LVTT->getTerminatorValue(Context).isZero();
 
-        if (LangOpts.CPlusPlus &&
-            isCXXSafeBuffersEnabledAt(RHSExpr->getBeginLoc()) && isNullTerm) {
+        if (isNullTerm && isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+                              RHSExpr->getBeginLoc())) {
           if (const auto *MCE =
                   dyn_cast<CXXMemberCallExpr>(RHSExpr->IgnoreParenImpCasts())) {
             IdentifierInfo *MethodDeclII = nullptr, *ObjTypeII = nullptr;
@@ -20720,9 +20720,6 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
       AssignedVarFixIts;
   VarDecl *BoundsSafetyIncompatNestedPtrLocalVarToFix = nullptr;
   FixItHint BoundsSafetyIncompatNestedPtrFixIt;
-  bool InCXXBoundsSafetyMode = LangOpts.CPlusPlus &&
-                               LangOpts.isBoundsSafetyAttributeOnlyMode() &&
-                               isCXXSafeBuffersEnabledAt(Loc);
   /*TO_UPSTREAM(BoundsSafety) OFF*/
 
 
@@ -20813,9 +20810,10 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     IsDstNullTerm =
         DstPointerType->getTerminatorValue(getASTContext()).isZero();
 
-    if (getLangOpts().BoundsSafetyRelaxedSystemHeaders || InCXXBoundsSafetyMode) {
-      DiagKind =
-          diag::warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
+    if (getLangOpts().BoundsSafetyRelaxedSystemHeaders ||
+        isCXXSafeBuffersBoundsSafetyInteropEnabledAt(Loc)) {
+      DiagKind = diag::
+          warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
       isInvalid = false;
     } else {
       DiagKind =
@@ -21092,7 +21090,7 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
               warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by) {
     FDiag << FirstType << SecondType << ActionForDiag
           << SrcExpr->getSourceRange()
-          << (!InCXXBoundsSafetyMode
+          << (!isCXXSafeBuffersBoundsSafetyInteropEnabledAt(Loc)
                   ? (IsDstNullTerm ? /*null_terminated*/ 1
                                    : /*terminated_by*/ 0)
                   : 2 /* cut message irrelevant to that mode*/);

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -20718,6 +20718,9 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
       AssignedVarFixIts;
   VarDecl *BoundsSafetyIncompatNestedPtrLocalVarToFix = nullptr;
   FixItHint BoundsSafetyIncompatNestedPtrFixIt;
+  bool InCXXBoundsSafetyMode = LangOpts.CPlusPlus &&
+                               LangOpts.isBoundsSafetyAttributeOnlyMode() &&
+                               isCXXSafeBuffersEnabledAt(Loc);
   /*TO_UPSTREAM(BoundsSafety) OFF*/
 
 
@@ -20807,15 +20810,8 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     const auto *DstPointerType = DstType->getAs<ValueTerminatedType>();
     IsDstNullTerm =
         DstPointerType->getTerminatorValue(getASTContext()).isZero();
-    if (getLangOpts().isBoundsSafetyAttributeOnlyMode() &&
-        getLangOpts().CPlusPlus && isCXXSafeBuffersEnabledAt(Loc)) {
-      // In C++ Safe Buffers/Bounds Safety interop mode, the compiler reports a
-      // warning under -Wunsafe-buffer-usage:
-      DiagKind = diag::warn_unsafe_assign_to_null_terminated_pointer;
-      isInvalid = false;
-      break;
-    }
-    if (getLangOpts().BoundsSafetyRelaxedSystemHeaders) {
+
+    if (getLangOpts().BoundsSafetyRelaxedSystemHeaders || InCXXBoundsSafetyMode) {
       DiagKind =
           diag::warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
       isInvalid = false;
@@ -21093,8 +21089,11 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
           diag::
               warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by) {
     FDiag << FirstType << SecondType << ActionForDiag
-          << SrcExpr->getSourceRange() << 
-          (IsDstNullTerm ? /*null_terminated*/ 1 : /*terminated_by*/ 0);
+          << SrcExpr->getSourceRange()
+          << (!InCXXBoundsSafetyMode
+                  ? (IsDstNullTerm ? /*null_terminated*/ 1
+                                   : /*terminated_by*/ 0)
+                  : 2 /* cut message irrelevant to that mode*/);
   } else {
     FDiag << FirstType << SecondType << ActionForDiag
           << SrcExpr->getSourceRange();
@@ -21249,11 +21248,6 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
       }
     }
   }
-
-  /* TO_UPSTREAM(BoundsSafety) ON*/
-  if (DiagKind == diag::warn_unsafe_assign_to_null_terminated_pointer)
-    Diag(Loc, diag::note_unsafe_assign_to_null_terminated_pointer);
-  /* TO_UPSTREAM(BoundsSafety) OFF*/
 
   if (IsSrcNullTerm) {
     TryFixAssigningNullTerminatedToImplicitBidiIndexablePtr(Assignee, SrcExpr,

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12195,8 +12195,10 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
         }
         // If in C++ Safe Buffers/Bounds Safety interoperation mode, the RHS can
         // be 'std::string::c_str':
+        bool isNullTerm = LVTT->getTerminatorValue(Context).isZero();
+
         if (LangOpts.CPlusPlus &&
-            isCXXSafeBuffersEnabledAt(RHSExpr->getBeginLoc())) {
+            isCXXSafeBuffersEnabledAt(RHSExpr->getBeginLoc()) && isNullTerm) {
           if (const auto *MCE =
                   dyn_cast<CXXMemberCallExpr>(RHSExpr->IgnoreParenImpCasts())) {
             IdentifierInfo *MethodDeclII = nullptr, *ObjTypeII = nullptr;

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4225,6 +4225,17 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
                                 const ImplicitConversionSequence &ICS,
                                 AssignmentAction Action,
                                 CheckedConversionKind CCK) {
+  if (ToType->isPointerType() && LangOpts.hasBoundsSafetyAttributes() &&
+      !Diags.isIgnored(diag::warn_unsafe_assign_to_null_terminated_pointer,
+                       From->getBeginLoc())) {
+    // In C++ Safe Buffers/Bounds Safety interop mode, warn about implicit
+    // conversions from non-`__null_terminated` to `__null_terminated`:
+    AssignConvertType ConvTy =
+        CheckValueTerminatedAssignmentConstraints(ToType, From);
+    if (DiagnoseAssignmentResult(ConvTy, From->getExprLoc(), ToType,
+                                 From->getType(), From, Action))
+      return ExprError();
+  }
   // C++ [over.match.oper]p7: [...] operands of class type are converted [...]
   if (CCK == CheckedConversionKind::ForBuiltinOverloadedOp &&
       !From->getType()->isRecordType())

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4225,16 +4225,14 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
                                 const ImplicitConversionSequence &ICS,
                                 AssignmentAction Action,
                                 CheckedConversionKind CCK) {
-  if (ToType->isPointerType() && LangOpts.hasBoundsSafetyAttributes() &&
-      !Diags.isIgnored(diag::warn_unsafe_assign_to_null_terminated_pointer,
-                       From->getBeginLoc())) {
+  if (ToType->isPointerType() && LangOpts.isBoundsSafetyAttributeOnlyMode() &&
+      isCXXSafeBuffersEnabledAt(From->getBeginLoc())) {
     // In C++ Safe Buffers/Bounds Safety interop mode, warn about implicit
     // conversions from non-`__null_terminated` to `__null_terminated`:
     AssignConvertType ConvTy =
         CheckValueTerminatedAssignmentConstraints(ToType, From);
-    if (DiagnoseAssignmentResult(ConvTy, From->getExprLoc(), ToType,
-                                 From->getType(), From, Action))
-      return ExprError();
+    DiagnoseAssignmentResult(ConvTy, From->getExprLoc(), ToType,
+                             From->getType(), From, Action);
   }
   // C++ [over.match.oper]p7: [...] operands of class type are converted [...]
   if (CCK == CheckedConversionKind::ForBuiltinOverloadedOp &&

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4225,8 +4225,8 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
                                 const ImplicitConversionSequence &ICS,
                                 AssignmentAction Action,
                                 CheckedConversionKind CCK) {
-  if (ToType->isPointerType() && LangOpts.isBoundsSafetyAttributeOnlyMode() &&
-      isCXXSafeBuffersEnabledAt(From->getBeginLoc())) {
+  if (ToType->isPointerType() &&
+      isCXXSafeBuffersBoundsSafetyInteropEnabledAt(From->getBeginLoc())) {
     // In C++ Safe Buffers/Bounds Safety interop mode, warn about implicit
     // conversions from non-`__null_terminated` to `__null_terminated`:
     AssignConvertType ConvTy =

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -9046,7 +9046,8 @@ ExprResult InitializationSequence::Perform(Sema &S,
                           Entity.getKind() == InitializedEntity::EK_Result);
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
-  if (S.LangOpts.BoundsSafetyAttributes) {
+  if (S.LangOpts.BoundsSafety || S.isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+                                     CurInit.get()->getBeginLoc())) {
     auto *Init = CurInit.get();
     const auto K = Entity.getKind();
     if (Init && Entity.getParent() == nullptr &&

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -9046,7 +9046,7 @@ ExprResult InitializationSequence::Perform(Sema &S,
                           Entity.getKind() == InitializedEntity::EK_Result);
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
-  if (S.LangOpts.hasBoundsSafetyAttributes()) {
+  if (S.LangOpts.BoundsSafetyAttributes) {
     auto *Init = CurInit.get();
     const auto K = Entity.getKind();
     if (Init && Entity.getParent() == nullptr &&

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -9046,7 +9046,7 @@ ExprResult InitializationSequence::Perform(Sema &S,
                           Entity.getKind() == InitializedEntity::EK_Result);
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
-  if (S.LangOpts.BoundsSafety) {
+  if (S.LangOpts.hasBoundsSafetyAttributes()) {
     auto *Init = CurInit.get();
     const auto K = Entity.getKind();
     if (Init && Entity.getParent() == nullptr &&

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -4,7 +4,10 @@
 // RUN:            -verify %s -x objective-c++
 // RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call \
 // RUN:            -verify %s
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage \
+// RUN:            -verify -fexperimental-bounds-safety-attributes %s -DINTEROP_MODE
 
+#ifndef INTEROP_MODE
 typedef struct {} FILE;
 void memcpy();
 void __asan_memcpy();
@@ -155,3 +158,47 @@ void ff(char * p, char * q, std::span<char> s, std::span<char> s2) {
   wcscpy_s();
 #pragma clang diagnostic pop
 }
+
+#else
+
+#include <ptrcheck.h>
+typedef unsigned size_t;
+
+// expected-note@+2{{consider using a safe container and passing '.data()' to the parameter 'dst' and '.size()' to its dependent parameter 'size' or 'std::span' and passing '.first(...).data()' to the parameter 'dst'}}
+// expected-note@+1{{consider using a safe container and passing '.data()' to the parameter 'src' and '.size()' to its dependent parameter 'size' or 'std::span' and passing '.first(...).data()' to the parameter 'src'}}
+void memcpy(void * __sized_by(size) dst, const void * __sized_by(size) src, unsigned size);
+unsigned strlen( const char* __null_terminated str );
+// expected-note@+1{{consider using a safe container and passing '.data()' to the parameter 'buffer' and '.size()' to its dependent parameter 'buf_size' or 'std::span' and passing '.first(...).data()' to the parameter 'buffer'}}
+int snprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
+int snwprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
+int vsnprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
+int sprintf( char* __counted_by(10) buffer, const char* format, ... );
+
+void test(char * p, char * q, const char * str,
+	  const char * __null_terminated safe_str,
+	  char * __counted_by(n) safe_p,
+	  size_t n,
+	  char * __counted_by(10) safe_ten) {
+  memcpy(p, q, 10);                  // expected-warning2{{unsafe assignment to function parameter of count-attributed type}}
+  snprintf(p, 10, "%s", "hlo");      // expected-warning{{unsafe assignment to function parameter of count-attributed type}}
+
+  // We still warn about unsafe string pointer arguments to printfs:
+
+  snprintf(safe_p, n, "%s", str);  // expected-warning{{function 'snprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
+  snwprintf(safe_p, n, "%s", str); // expected-warning{{function 'snwprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
+
+  memcpy(safe_p, safe_p, n);               // no warn
+  strlen(str);                             // expected-warning{{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  snprintf(safe_p, n, "%s", "hlo");        // no warn
+  snprintf(safe_p, n, "%s", safe_str);     // no warn
+  snwprintf(safe_p, n, "%s", safe_str);    // no warn
+
+  // v-printf functions and sprintf are still warned about because
+  // they cannot be fully safe:
+
+  vsnprintf(safe_p, n, "%s", safe_str); // expected-warning{{function 'vsnprintf' is unsafe}} expected-note{{'va_list' is unsafe}}
+  sprintf(safe_ten, "%s", safe_str);    // expected-warning{{function 'sprintf' is unsafe}} expected-note{{change to 'snprintf' for explicit bounds checking}}
+
+}
+
+#endif //#ifdef INTEROP_MODE

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -4,10 +4,7 @@
 // RUN:            -verify %s -x objective-c++
 // RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call \
 // RUN:            -verify %s
-// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage \
-// RUN:            -verify -fexperimental-bounds-safety-attributes %s -DINTEROP_MODE
 
-#ifndef INTEROP_MODE
 typedef struct {} FILE;
 void memcpy();
 void __asan_memcpy();
@@ -158,47 +155,3 @@ void ff(char * p, char * q, std::span<char> s, std::span<char> s2) {
   wcscpy_s();
 #pragma clang diagnostic pop
 }
-
-#else
-
-#include <ptrcheck.h>
-typedef unsigned size_t;
-
-// expected-note@+2{{consider using a safe container and passing '.data()' to the parameter 'dst' and '.size()' to its dependent parameter 'size' or 'std::span' and passing '.first(...).data()' to the parameter 'dst'}}
-// expected-note@+1{{consider using a safe container and passing '.data()' to the parameter 'src' and '.size()' to its dependent parameter 'size' or 'std::span' and passing '.first(...).data()' to the parameter 'src'}}
-void memcpy(void * __sized_by(size) dst, const void * __sized_by(size) src, unsigned size);
-unsigned strlen( const char* __null_terminated str );
-// expected-note@+1{{consider using a safe container and passing '.data()' to the parameter 'buffer' and '.size()' to its dependent parameter 'buf_size' or 'std::span' and passing '.first(...).data()' to the parameter 'buffer'}}
-int snprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
-int snwprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
-int vsnprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
-int sprintf( char* __counted_by(10) buffer, const char* format, ... );
-
-void test(char * p, char * q, const char * str,
-	  const char * __null_terminated safe_str,
-	  char * __counted_by(n) safe_p,
-	  size_t n,
-	  char * __counted_by(10) safe_ten) {
-  memcpy(p, q, 10);                  // expected-warning2{{unsafe assignment to function parameter of count-attributed type}}
-  snprintf(p, 10, "%s", "hlo");      // expected-warning{{unsafe assignment to function parameter of count-attributed type}}
-
-  // We still warn about unsafe string pointer arguments to printfs:
-
-  snprintf(safe_p, n, "%s", str);  // expected-warning{{function 'snprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
-  snwprintf(safe_p, n, "%s", str); // expected-warning{{function 'snwprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
-
-  memcpy(safe_p, safe_p, n);               // no warn
-  strlen(str);                             // expected-warning{{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  snprintf(safe_p, n, "%s", "hlo");        // no warn
-  snprintf(safe_p, n, "%s", safe_str);     // no warn
-  snwprintf(safe_p, n, "%s", safe_str);    // no warn
-
-  // v-printf functions and sprintf are still warned about because
-  // they cannot be fully safe:
-
-  vsnprintf(safe_p, n, "%s", safe_str); // expected-warning{{function 'vsnprintf' is unsafe}} expected-note{{'va_list' is unsafe}}
-  sprintf(safe_ten, "%s", safe_str);    // expected-warning{{function 'sprintf' is unsafe}} expected-note{{change to 'snprintf' for explicit bounds checking}}
-
-}
-
-#endif //#ifdef INTEROP_MODE

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
@@ -43,23 +43,23 @@ void basics(const char * cstr, size_t cstr_len, std::string cxxstr) {
   p3 = p;                      // safe assignment
   p3 = get_nt(cstr, cstr_len); // safe assignment
 
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   const char * __null_terminated p4 = cstr;  // warn
 
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   nt_parm(cstr);                             // warn
-  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   p4 = cstr;                                 // warn
 
   std::string_view view{cxxstr};
 
-  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   p4 = view.data();                          // warn
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   nt_parm(view.data());                      // warn
 
   const char * __null_terminated p5 = 0;                 // nullptr is ok
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   const char * __null_terminated p6 = (const char *)1;   // other integer literal is unsafe
   // test arrays?
   // what if an NT pointer p gets p[n] = ...?
@@ -68,36 +68,59 @@ void basics(const char * cstr, size_t cstr_len, std::string cxxstr) {
 }
 
 void test_explicit_cast(char * p, const char * q) {
-    // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   const char * __null_terminated nt = (const char * __null_terminated) p;
-  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
-  const char * __null_terminated nt2 = reinterpret_cast<const char * __null_terminated> (p);
+  const char * __null_terminated nt2 = reinterpret_cast<const char * __null_terminated> (p); // FP for now
 
-    // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   nt = (const char * __null_terminated) p;
-  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
-  nt2 = reinterpret_cast<const char * __null_terminated> (p);
-  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
-  nt2 = static_cast<const char * __null_terminated> (p);
+  nt2 = reinterpret_cast<const char * __null_terminated> (p); // FP for now
+  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  nt2 = static_cast<const char * __null_terminated> (p);      // FP for now
 
-  // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   const char * __null_terminated nt3 = (const char * __null_terminated) q;
-  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
-  const char * __null_terminated nt4 = reinterpret_cast<const char * __null_terminated> (q);
+  const char * __null_terminated nt4 = reinterpret_cast<const char * __null_terminated> (q); // FP for now
 
-  // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   nt3 = (const char * __null_terminated) q;
-  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
-  nt4 = reinterpret_cast<const char * __null_terminated> (q);
-  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
+  nt4 = reinterpret_cast<const char * __null_terminated> (q); // FP for now
+  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   nt4 = static_cast<const char * __null_terminated> (q);
+
+  // OK cases for C-style casts
+  char * __null_terminated nt_p;
+  const char * __null_terminated nt_p2;
+  int * __null_terminated nt_p3;
+  const int * __null_terminated nt_p4;
+
+  const char * __null_terminated nt5 = (const char * __null_terminated) nt_p;
+  const char * __null_terminated nt6 = (const char * __null_terminated) nt_p2;
+  const char * __null_terminated nt7 = (const char * __null_terminated) nt_p3;
+  const char * __null_terminated nt8 = (const char * __null_terminated) nt_p4;
+
+  nt5 = (const char * __null_terminated) nt_p;
+  nt6 = (const char * __null_terminated) nt_p2;
+  nt7 = (const char * __null_terminated) nt_p3;
+  nt8 = (const char * __null_terminated) nt_p4;
+
+
+  char * __null_terminated nt9 = (char * __null_terminated) nt_p;
+  char * __null_terminated nt10 = (char * __null_terminated) nt_p2;
+  char * __null_terminated nt11 = (char * __null_terminated) nt_p3;
+  char * __null_terminated nt12 = (char * __null_terminated) nt_p4;
+
+  nt9 = (char * __null_terminated) nt_p;
+  nt10 = (char * __null_terminated) nt_p2;
+  nt11 = (char * __null_terminated) nt_p3;
+  nt12 = (char * __null_terminated) nt_p4;
 }
 
 const char * __null_terminated test_return(const char * p, char * q, std::string &str) {
   if (p)
-    return p; // expected-warning {{unsafe return of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    return p; // expected-warning {{unsafe return of '__null_terminated' type}} expected-note{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   if (q)
-    return q; // expected-warning {{unsafe return of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    return q; // expected-warning {{unsafe return of '__null_terminated' type}} expected-note{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   return str.c_str();
 }
 
@@ -106,10 +129,10 @@ void test_array(char * cstr) {
   // expected-error@+1 {{array 'arr2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'i')}}
   const char arr2[__null_terminated 2] = {'h', 'i'};
   const char * __null_terminated arr3[] = {"hello", "world"};
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   const char * __null_terminated arr4[] = {"hello", "world", cstr};
 
-  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   arr3[0] = cstr;
 }
 
@@ -126,42 +149,42 @@ void test_compound(char * cstr) {
   T t = {42, "hello"};
   T t2 = {.a = 42};
   T t3 = {.p = str.c_str()};
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   T t4 = {42, "hello", {.p = cstr}};
 
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   t4 = (struct T){42, "hello", {.p = cstr}};
 }
 
-  // expected-warning@+3 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+3 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+3{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
 class C {
   const char * __null_terminated p;
   const char * __null_terminated q = (char *) 1; // warn
   struct T t;
 public:
-  // expected-warning@+1 2{{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 2{{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1 2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   C(char * p): p(p), t({0, p}) {};
   C(const char * __null_terminated p, struct T t);
 };
 
 void f(const C &c);
 C test_class(char * cstr) {
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   C c{cstr, {0, cstr}};
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   C c1(cstr, {0, cstr});
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   C *c2 = new C(cstr, {0, cstr});
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   f(C{cstr, {0, cstr}});
 
   C("hello", {0, "hello"});
   if (1-1)
-    return {cstr, {}}; // expected-warning {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    return {cstr, {}}; // expected-warning {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
   return {"hello", {}};
 }
 

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
@@ -1,0 +1,182 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wno-all -Wunsafe-buffer-usage -fsafe-buffer-usage-suggestions -fexperimental-bounds-safety-attributes -verify %s
+
+#include <ptrcheck.h>
+
+typedef unsigned size_t;
+namespace std {
+  template <typename CharT>
+  struct basic_string {
+    const CharT *data() const noexcept;
+    CharT *data() noexcept;
+    const CharT *c_str() const noexcept;
+    size_t size() const noexcept;
+    size_t length() const noexcept;
+  };
+
+  typedef basic_string<char> string;
+
+  template <typename CharT>
+  struct basic_string_view {
+    basic_string_view(basic_string<CharT> str);
+    const CharT *data() const noexcept;
+    size_t size() const noexcept;
+    size_t length() const noexcept;
+  };
+
+  typedef basic_string_view<char> string_view;
+} // namespace std
+
+void nt_parm(const char * __null_terminated);
+const char * __null_terminated get_nt(const char *, size_t);
+
+void basics(const char * cstr, size_t cstr_len, std::string cxxstr) {
+  const char * __null_terminated p = "hello";   // safe init
+
+  nt_parm(p);
+  nt_parm(get_nt(cstr, cstr_len));
+
+  const char * __null_terminated p2 = cxxstr.c_str(); // safe init
+  const char * __null_terminated p3;
+
+  p3 = cxxstr.c_str();         // safe assignment
+  p3 = "hello";                // safe assignment
+  p3 = p;                      // safe assignment
+  p3 = get_nt(cstr, cstr_len); // safe assignment
+
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  const char * __null_terminated p4 = cstr;  // warn
+
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  nt_parm(cstr);                             // warn
+  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  p4 = cstr;                                 // warn
+
+  std::string_view view{cxxstr};
+
+  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  p4 = view.data();                          // warn
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  nt_parm(view.data());                      // warn
+
+  const char * __null_terminated p5 = 0;                 // nullptr is ok
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  const char * __null_terminated p6 = (const char *)1;   // other integer literal is unsafe
+  // test arrays?
+  // what if an NT pointer p gets p[n] = ...?
+  // recognize of std::string::c_str() should be under Wunsafe-buffer-usage
+  // Test compound initializer and constructor initializer
+}
+
+void test_explicit_cast(char * p, const char * q) {
+    // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  const char * __null_terminated nt = (const char * __null_terminated) p;
+  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
+  const char * __null_terminated nt2 = reinterpret_cast<const char * __null_terminated> (p);
+
+    // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  nt = (const char * __null_terminated) p;
+  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
+  nt2 = reinterpret_cast<const char * __null_terminated> (p);
+  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
+  nt2 = static_cast<const char * __null_terminated> (p);
+
+  // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  const char * __null_terminated nt3 = (const char * __null_terminated) q;
+  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
+  const char * __null_terminated nt4 = reinterpret_cast<const char * __null_terminated> (q);
+
+  // expected-warning@+1 {{unsafe casting to '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  nt3 = (const char * __null_terminated) q;
+  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
+  nt4 = reinterpret_cast<const char * __null_terminated> (q);
+  // expected-warning@+1 {{C++ named cast to '__null_terminated' type is unsafe}}
+  nt4 = static_cast<const char * __null_terminated> (q);
+}
+
+const char * __null_terminated test_return(const char * p, char * q, std::string &str) {
+  if (p)
+    return p; // expected-warning {{unsafe return of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  if (q)
+    return q; // expected-warning {{unsafe return of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  return str.c_str();
+}
+
+void test_array(char * cstr) {
+  const char arr[__null_terminated 3] = {'h', 'i', '\0'};
+  // expected-error@+1 {{array 'arr2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'i')}}
+  const char arr2[__null_terminated 2] = {'h', 'i'};
+  const char * __null_terminated arr3[] = {"hello", "world"};
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  const char * __null_terminated arr4[] = {"hello", "world", cstr};
+
+  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  arr3[0] = cstr;
+}
+
+struct T {
+  int a;
+  const char * __null_terminated p;
+  struct TT {
+    int a;
+    const char * __null_terminated p;
+  } tt;
+};
+void test_compound(char * cstr) {
+  std::string str;
+  T t = {42, "hello"};
+  T t2 = {.a = 42};
+  T t3 = {.p = str.c_str()};
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  T t4 = {42, "hello", {.p = cstr}};
+
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  t4 = (struct T){42, "hello", {.p = cstr}};
+}
+
+  // expected-warning@+3 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+class C {
+  const char * __null_terminated p;
+  const char * __null_terminated q = (char *) 1; // warn
+  struct T t;
+public:
+  // expected-warning@+1 2{{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  C(char * p): p(p), t({0, p}) {};
+  C(const char * __null_terminated p, struct T t);
+};
+
+void f(const C &c);
+C test_class(char * cstr) {
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  C c{cstr, {0, cstr}};
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  C c1(cstr, {0, cstr});
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  C *c2 = new C(cstr, {0, cstr});
+  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  f(C{cstr, {0, cstr}});
+
+  C("hello", {0, "hello"});
+  if (1-1)
+    return {cstr, {}}; // expected-warning {{unsafe assignment to a parameter of '__null_terminated' type; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  return {"hello", {}};
+}
+
+
+// Test input/output __null_terminated parameter.
+// expected-note@+1 {{candidate function not viable:}}
+void g(const char * __null_terminated *p);
+void test_output(const char * __null_terminated p) {
+  const char * __null_terminated local_nt = p;
+  const char * const_local;
+  char * local;
+
+  g(&local_nt); // safe
+  // expected-error@+1 {{passing 'const char **' to parameter of incompatible type 'const char * __terminated_by(0)*' (aka 'const char **') that adds '__terminated_by' attribute is not allowed}}
+  g(&const_local);
+  // expected-error@+1 {{no matching function for call to 'g'}}
+  g(&local);
+}

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
@@ -65,6 +65,11 @@ void basics(const char * cstr, size_t cstr_len, std::string cxxstr) {
   // what if an NT pointer p gets p[n] = ...?
   // recognize of std::string::c_str() should be under Wunsafe-buffer-usage
   // Test compound initializer and constructor initializer
+
+
+  // (non-0)-terminated pointer is NOT compatible with 'std::string::c_str':
+  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}  
+  const char * __terminated_by(42) p7 = cxxstr.c_str();
 }
 
 void test_explicit_cast(char * p, const char * q) {

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
@@ -43,54 +43,49 @@ void basics(const char * cstr, size_t cstr_len, std::string cxxstr) {
   p3 = p;                      // safe assignment
   p3 = get_nt(cstr, cstr_len); // safe assignment
 
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'const char *' is an unsafe operation}}
   const char * __null_terminated p4 = cstr;  // warn
 
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{passing 'const char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   nt_parm(cstr);                             // warn
-  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'const char *' is an unsafe operation}}
   p4 = cstr;                                 // warn
 
   std::string_view view{cxxstr};
 
-  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'const char *' is an unsafe operation}}
   p4 = view.data();                          // warn
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{passing 'const char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   nt_parm(view.data());                      // warn
 
   const char * __null_terminated p5 = 0;                 // nullptr is ok
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'const char *' is an unsafe operation}}
   const char * __null_terminated p6 = (const char *)1;   // other integer literal is unsafe
-  // test arrays?
-  // what if an NT pointer p gets p[n] = ...?
-  // recognize of std::string::c_str() should be under Wunsafe-buffer-usage
-  // Test compound initializer and constructor initializer
-
 
   // (non-0)-terminated pointer is NOT compatible with 'std::string::c_str':
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}  
+  // expected-error@+1 {{initializing 'const char * __terminated_by(42)' (aka 'const char *') with an expression of incompatible type 'const char *' is an unsafe operation}}
   const char * __terminated_by(42) p7 = cxxstr.c_str();
 }
 
 void test_explicit_cast(char * p, const char * q) {
-    // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{casting 'char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   const char * __null_terminated nt = (const char * __null_terminated) p;
   const char * __null_terminated nt2 = reinterpret_cast<const char * __null_terminated> (p); // FP for now
 
-    // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    // expected-error@+1 {{casting 'char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   nt = (const char * __null_terminated) p;
   nt2 = reinterpret_cast<const char * __null_terminated> (p); // FP for now
-  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{casting 'char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   nt2 = static_cast<const char * __null_terminated> (p);      // FP for now
 
-  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   const char * __null_terminated nt3 = (const char * __null_terminated) q;
   const char * __null_terminated nt4 = reinterpret_cast<const char * __null_terminated> (q); // FP for now
 
-  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   nt3 = (const char * __null_terminated) q;
   nt4 = reinterpret_cast<const char * __null_terminated> (q); // FP for now
-  // expected-warning@+1 {{unsafe casting to '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   nt4 = static_cast<const char * __null_terminated> (q);
 
   // OK cases for C-style casts
@@ -123,9 +118,9 @@ void test_explicit_cast(char * p, const char * q) {
 
 const char * __null_terminated test_return(const char * p, char * q, std::string &str) {
   if (p)
-    return p; // expected-warning {{unsafe return of '__null_terminated' type}} expected-note{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    return p; // expected-error {{returning 'const char *' from a function with incompatible result type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   if (q)
-    return q; // expected-warning {{unsafe return of '__null_terminated' type}} expected-note{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    return q; // expected-error {{returning 'char *' from a function with incompatible result type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   return str.c_str();
 }
 
@@ -134,10 +129,10 @@ void test_array(char * cstr) {
   // expected-error@+1 {{array 'arr2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'i')}}
   const char arr2[__null_terminated 2] = {'h', 'i'};
   const char * __null_terminated arr3[] = {"hello", "world"};
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   const char * __null_terminated arr4[] = {"hello", "world", cstr};
 
-  // expected-warning@+1 {{unsafe assignment to a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'char *' is an unsafe operation}}
   arr3[0] = cstr;
 }
 
@@ -154,42 +149,42 @@ void test_compound(char * cstr) {
   T t = {42, "hello"};
   T t2 = {.a = 42};
   T t3 = {.p = str.c_str()};
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   T t4 = {42, "hello", {.p = cstr}};
 
-  // expected-warning@+1 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   t4 = (struct T){42, "hello", {.p = cstr}};
 }
 
-  // expected-warning@+3 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+3{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+3 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
 class C {
   const char * __null_terminated p;
   const char * __null_terminated q = (char *) 1; // warn
   struct T t;
 public:
-  // expected-warning@+1 2{{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+1 2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+1 2{{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   C(char * p): p(p), t({0, p}) {};
   C(const char * __null_terminated p, struct T t);
 };
 
 void f(const C &c);
 C test_class(char * cstr) {
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   C c{cstr, {0, cstr}};
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   C c1(cstr, {0, cstr});
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   C *c2 = new C(cstr, {0, cstr});
-  // expected-warning@+2 {{unsafe initialization of a pointer of '__null_terminated' type}} expected-note@+2{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
-  // expected-warning@+1 {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note@+1{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
   f(C{cstr, {0, cstr}});
 
   C("hello", {0, "hello"});
   if (1-1)
-    return {cstr, {}}; // expected-warning {{unsafe assignment to a parameter of '__null_terminated' type}} expected-note{{the source pointer may not point to null-terminated data; only '__null_terminated' pointers, string literals, and 'std::string::c_str' calls are compatible with '__null_terminated' pointers}}
+    return {cstr, {}}; // expected-error {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
   return {"hello", {}};
 }
 


### PR DESCRIPTION
For a __null_terminated pointer 'p', only a __null_terminated pointer, a string literal or a call to `std::string::c_str` can be assigned to (/passed to/used to initialize) 'p'.  Otherwise, in the interop mode, an -Wunsafe-buffer-usage warning will be reported.

Similar to how __counted_by is handled, incompatibility in nested __null_terminated pointers (e.g., input/output pointer type arguments) is reported as Bounds Safety type checking errors.

(rdar://138798346)