### PR TITLE
[Cherry-pick into next] Mark tests that require a SwiftASTContext fallback

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -25,6 +25,11 @@ class TestSwiftExtraClangFlags(TestBase):
         VFS overlay using target.swift-extra-clang-flags.
         """
         self.build()
+
+        # Because the bridging header isn't precompiled or in a module
+        # we don't have DWARF type information for the types it contains.
+        self.expect("settings set symbols.swift-typesystem-compiler-fallback true")
+
         # FIXME: this doesn't work if LLDB's build dir contains a space.
         overlay = self.getBuildArtifact('overlay.yaml')
         self.addTearDownHook(

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -46,6 +46,10 @@ class TestSwiftRewriteClangPaths(TestBase):
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb types -f "%s"' % log)
 
+        # Because the bridging header isn't precompiled or in a module
+        # we don't have DWARF type information for the types it contains.
+        self.expect("settings set symbols.swift-typesystem-compiler-fallback true")
+
         # To ensure the module is rebuilt remove the cache to avoid caching.
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")
         if os.path.isdir(mod_cache):


### PR DESCRIPTION
```
commit 1999c9899a01a3b759278be976633bffd203fc0b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 18 13:34:45 2025 -0800

    Mark tests that require a SwiftASTContext fallback
```
