### PR TITLE
[Cherry-pick into next] [lldb] Fix dynamic type resolution for ObjC protocol existentials

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2880,10 +2880,15 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
   else if (type_info.AllSet(eTypeIsMetatype | eTypeIsProtocol))
     success = GetDynamicTypeAndAddress_ExistentialMetatype(
         in_value, val_type, use_dynamic, class_type_or_name, address);
-  else if (type_info.AnySet(eTypeIsProtocol))
-    success = GetDynamicTypeAndAddress_Existential(in_value, val_type, use_dynamic,
-                                                class_type_or_name, address);
-  else {
+  else if (type_info.AnySet(eTypeIsProtocol)) {
+    if (type_info.AnySet(eTypeIsObjC))
+      success = GetDynamicTypeAndAddress_Class(in_value, val_type, use_dynamic,
+                                               class_type_or_name, address,
+                                               static_value_type, local_buffer);
+    else
+      success = GetDynamicTypeAndAddress_Existential(
+          in_value, val_type, use_dynamic, class_type_or_name, address);
+  } else {
     CompilerType bound_type;
     if (type_info.AnySet(eTypeHasUnboundGeneric | eTypeHasDynamicSelf)) {
       // Perform generic type resolution.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6189,11 +6189,18 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
                    eTypeInstanceIsPointer;
     break;
 
-  case swift::TypeKind::Protocol:
+  case swift::TypeKind::Protocol: {
+    auto *protocol =
+        llvm::cast<swift::ProtocolType>(swift_can_type.getPointer());
+    swift::ProtocolDecl *decl = protocol->getDecl();
+    if (decl->isObjC())
+      swift_flags |= eTypeIsObjC | eTypeHasValue;
+    LLVM_FALLTHROUGH;
+  }
   case swift::TypeKind::ProtocolComposition:
-  case swift::TypeKind::Existential:
+  case swift::TypeKind::Existential: {
     swift_flags |= eTypeHasChildren | eTypeIsStructUnion | eTypeIsProtocol;
-    break;
+  } break;
   case swift::TypeKind::ExistentialMetatype:
     swift_flags |= eTypeIsProtocol;
     LLVM_FALLTHROUGH;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -60,6 +60,25 @@ NodeAtPath(swift::Demangle::NodePointer root,
   return ChildAtPath(root, kind_path.drop_front());
 }
 
+/// Find the first child node of root that satisfies cond.
+inline swift::Demangle::NodePointer
+FindIf(swift::Demangle::NodePointer root,
+       std::function<bool(swift::Demangle::NodePointer)> cond) {
+  if (!root)
+    return nullptr;
+
+  auto *node = root;
+  if (cond(node))
+    return node;
+  for (auto *child : *node) {
+    assert(child && "swift::Demangle::Node has null child");
+    if (auto *found = FindIf(child, cond))
+      return found;
+  }
+
+  return nullptr;
+}
+
 /// \return the child of the TypeMangling node.
 static swift::Demangle::NodePointer
 GetTypeMangling(swift::Demangle::NodePointer n) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -446,7 +446,7 @@ protected:
   bool UseSwiftASTContextFallback(const char *func_name,
                                   lldb::opaque_compiler_type_t type);
   /// Print a warning that a fallback was necessary.
-  bool DiagnoseSwiftASTContextFallback(const char *func_name,
+  void DiagnoseSwiftASTContextFallback(const char *func_name,
                                        lldb::opaque_compiler_type_t type);
 
   /// Helper that creates an AST type from \p type.
@@ -546,6 +546,11 @@ protected:
   swift::Demangle::NodePointer
   GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
                        CompilerType clang_type);
+
+  /// Determine if this type contains a type from a module that looks
+  /// like it was JIT-compiled by LLDB.
+  bool IsExpressionEvaluatorDefined(lldb::opaque_compiler_type_t type);
+
 #ifndef NDEBUG
   /// Check whether the type being dealt with is tricky to validate due to
   /// discrepancies between TypeSystemSwiftTypeRef and SwiftASTContext.

--- a/lldb/test/API/lang/swift/expression/self/Makefile
+++ b/lldb/test/API/lang/swift/expression/self/Makefile
@@ -1,6 +1,3 @@
 SWIFT_SOURCES := main.swift
 include Makefile.rules
 
-cleanup:
-	rm -f Makefile *.d
-

--- a/lldb/test/API/lang/swift/objc_protocol/Makefile
+++ b/lldb/test/API/lang/swift/objc_protocol/Makefile
@@ -1,0 +1,6 @@
+SWIFT_SOURCES := main.swift
+SWIFT_BRIDGING_HEADER := bridging-header.h
+OBJC_SOURCES := objc.m
+SWIFT_OBJC_INTEROP := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
+++ b/lldb/test/API/lang/swift/objc_protocol/TestSwiftObjcProtocol.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftObjcProtocol(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Tests that dynamic type resolution works for an Objective-C protocol existential"""
+        self.build()
+        (target, process, thread, breakpoint) = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        self.expect("frame variable v", substrs=["SwiftClass", "a = 42", "b = 938"])
+        lldbutil.continue_to_breakpoint(process, breakpoint)
+        self.expect(
+            "frame variable v",
+            substrs=["ObjcClass", "_someString", '"The objc string"'],
+        )

--- a/lldb/test/API/lang/swift/objc_protocol/bridging-header.h
+++ b/lldb/test/API/lang/swift/objc_protocol/bridging-header.h
@@ -1,0 +1,11 @@
+
+#include <Foundation/Foundation.h>
+
+@protocol ObjcProtocol <NSObject>
+@end
+
+@interface ObjcClass : NSObject <ObjcProtocol>
+@property NSString *someString;
+- (instancetype)init;
++ (id<ObjcProtocol>)getP;
+@end

--- a/lldb/test/API/lang/swift/objc_protocol/main.swift
+++ b/lldb/test/API/lang/swift/objc_protocol/main.swift
@@ -1,0 +1,17 @@
+class SwiftClass: NSObject, ObjcProtocol {
+    let a = 42
+    let b = 938
+} 
+
+func foo(v: (any ObjcProtocol)) {
+    print(v) // break here
+}
+
+func f() {
+    let swiftClass = SwiftClass()
+    foo(v: swiftClass)
+    let objcClass = ObjcClass()!
+    foo(v: objcClass)
+}
+f()
+

--- a/lldb/test/API/lang/swift/objc_protocol/objc.m
+++ b/lldb/test/API/lang/swift/objc_protocol/objc.m
@@ -1,0 +1,16 @@
+#include "bridging-header.h"
+
+@implementation ObjcClass
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    self.someString = @"The objc string";
+  }
+  return self;
+}
+
++ (id<ObjcProtocol>)getP {
+  return [ObjcClass new];
+}
+@end


### PR DESCRIPTION
```
commit 419a0bbe6dc2a22afa1f4bd632e4b12526cec419
Author: Augusto Noronha <anoronha@apple.com>
Date:   Fri Feb 14 13:33:16 2025 -0800

    [lldb] Fix dynamic type resolution for ObjC protocol existentials
    
    An existential whose protocol type is an Objective-C protocol is not
    passed in an existential container, but as a plain old instance pointer.
    This patch dynamic type resolution failing for those types.
    
    rdar://144028358

commit ce4b4eeb47abac632da901f259c7767251dcb00b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 18 17:08:07 2025 -0800

    [lldb] Allow SwiftASTContext fallbacks for types from expressions
    
    Generally, it would be feasible to rely on DWARF and reflectio
    metadata for JIT-compiled images, but in practice, not everything that
    an expression returns may be anchored by a variable, which makes
    having debug info for expression-defined types hit and miss. If an
    expression type is involved, LLDB will have done the costly
    SwiftASTContext initialization already, so there isn't much saved by
    avoiding the fallback in this case.
```
