### PR TITLE
[cherry-pick][lldb] Update PlatformDarwin list of libraries with thread functions (#127922)

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -646,8 +646,8 @@ BreakpointSP PlatformDarwin::SetThreadCreationBreakpoint(Target &target) {
       "start_wqthread", "_pthread_wqthread", "_pthread_start",
   };
 
-  static const char *g_bp_modules[] = {"libsystem_c.dylib",
-                                       "libSystem.B.dylib"};
+  static const char *g_bp_modules[] = {"libsystem_c.dylib", "libSystem.B.dylib",
+                                       "libsystem_pthread.dylib"};
 
   FileSpecList bp_modules;
   for (size_t i = 0; i < std::size(g_bp_modules); i++) {

--- a/lldb/test/API/macosx/thread_start_bps/Makefile
+++ b/lldb/test/API/macosx/thread_start_bps/Makefile
@@ -1,0 +1,3 @@
+C_SOURCES := main.c
+
+include Makefile.rules

--- a/lldb/test/API/macosx/thread_start_bps/TestBreakpointsThreadInit.py
+++ b/lldb/test/API/macosx/thread_start_bps/TestBreakpointsThreadInit.py
@@ -1,0 +1,37 @@
+"""Test that we get thread names when interrupting a process."""
+
+import time
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestInterruptThreadNames(TestBase):
+    @skipUnlessDarwin
+    def test_internal_bps_resolved(self):
+        self.build()
+
+        source_file = lldb.SBFileSpec("main.c")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "initial hello", source_file
+        )
+
+        thread_start_func_names = [
+            "start_wqthread",
+            "_pthread_wqthread",
+            "_pthread_start",
+        ]
+        known_module_names = [
+            "libsystem_c.dylib",
+            "libSystem.B.dylib",
+            "libsystem_pthread.dylib",
+        ]
+        bps = []
+        for func in thread_start_func_names:
+            for module in known_module_names:
+                bps.append(target.BreakpointCreateByName(func, module))
+        num_resolved = 0
+        for bp in bps:
+            num_resolved += bp.GetNumResolvedLocations()
+        self.assertGreater(num_resolved, 0)

--- a/lldb/test/API/macosx/thread_start_bps/main.c
+++ b/lldb/test/API/macosx/thread_start_bps/main.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main() {
+  puts("initial hello");
+  puts("hello from the other side");
+}


### PR DESCRIPTION
Recent versions of the system changed where these functions live.

(cherry picked from commit 81bc28d0bcaca3e7386ced2138566e4d0a838ad5)