### PR TITLE
🍒[cxx-interop] Workaround a template instantiation issue

### DIFF
--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -403,4 +403,33 @@ struct GVNSinkPass : PassInfoMixin<GVNSinkPass> {
 
 } // end namespace llvm
 
+struct llvm::GVNPass::Expression {
+  uint32_t opcode;
+  bool commutative = false;
+  // The type is not necessarily the result type of the expression, it may be
+  // any additional type needed to disambiguate the expression.
+  Type *type = nullptr;
+  SmallVector<uint32_t, 4> varargs;
+  
+  Expression(uint32_t o = ~2U) : opcode(o) {}
+
+  bool operator==(const Expression &other) const {
+    if (opcode != other.opcode)
+      return false;
+    if (opcode == ~0U || opcode == ~1U)
+      return true;
+    if (type != other.type)
+      return false;
+    if (varargs != other.varargs)
+      return false;
+    return true;
+  }
+
+  friend hash_code hash_value(const Expression &Value) {
+    return hash_combine(
+        Value.opcode, Value.type,
+        hash_combine_range(Value.varargs.begin(), Value.varargs.end()));
+  }
+};
+
 #endif // LLVM_TRANSFORMS_SCALAR_GVN_H

--- a/llvm/lib/Transforms/Scalar/GVN.cpp
+++ b/llvm/lib/Transforms/Scalar/GVN.cpp
@@ -135,35 +135,6 @@ static cl::opt<uint32_t> MaxNumInsnsPerBlock(
     cl::desc("Max number of instructions to scan in each basic block in GVN "
              "(default = 100)"));
 
-struct llvm::GVNPass::Expression {
-  uint32_t opcode;
-  bool commutative = false;
-  // The type is not necessarily the result type of the expression, it may be
-  // any additional type needed to disambiguate the expression.
-  Type *type = nullptr;
-  SmallVector<uint32_t, 4> varargs;
-
-  Expression(uint32_t o = ~2U) : opcode(o) {}
-
-  bool operator==(const Expression &other) const {
-    if (opcode != other.opcode)
-      return false;
-    if (opcode == ~0U || opcode == ~1U)
-      return true;
-    if (type != other.type)
-      return false;
-    if (varargs != other.varargs)
-      return false;
-    return true;
-  }
-
-  friend hash_code hash_value(const Expression &Value) {
-    return hash_combine(
-        Value.opcode, Value.type,
-        hash_combine_range(Value.varargs.begin(), Value.varargs.end()));
-  }
-};
-
 namespace llvm {
 
 template <> struct DenseMapInfo<GVNPass::Expression> {


### PR DESCRIPTION
`class GVNPass` has a private member `ValueTable VN`, where `ValueTable` uses a forward-declared type `Expression`, which is declared in a .cpp file. This is currently causing issues since Swift started importing private fields of C++ types.

PR for main: https://github.com/swiftlang/llvm-project/pull/10073

rdar://145070564