### PR TITLE
[lldb] Re-enable Swift OS plugin and disabled tests

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -32,7 +32,7 @@ let Definition = "target_experimental" in {
     EnumValues<"OptionEnumValues(g_swift_pcm_validation_values)">,
     Desc<"Enable validation when loading Clang PCM files (-fvalidate-pch, -fmodules-check-relocated).">;
   def SwiftUseTasksPlugin: Property<"swift-tasks-plugin-enabled", "Boolean">,
-    DefaultFalse,
+    DefaultTrue,
     Desc<"Enables the swift plugin converting tasks into threads">;
 }
 

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 @skipIfAsan  # rdar://138777205
-@skipIf(bugnumber = "rdar://144868718")
 class TestCase(lldbtest.TestBase):
 
     def check_is_in_line(self, thread, linenum):

--- a/lldb/test/API/lang/swift/async/stepping/step_over_lots_of_tasks/TestSwiftAsyncSteppingManyTasks.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_lots_of_tasks/TestSwiftAsyncSteppingManyTasks.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 @skipIfAsan  # rdar://138777205
-@skipIf(bugnumber = "rdar://144868718")
 class TestCase(lldbtest.TestBase):
 
     def check_is_in_line(self, thread, expected_linenum, expected_tid):


### PR DESCRIPTION
With recent fixes, the failures should be gone.