### PR TITLE
[InstrRef] Preserve debug instr num in aarch64-expand-pseudo LOADgot expansion

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1382,6 +1382,11 @@ bool AArch64ExpandPseudo::expandMI(MachineBasicBlock &MBB,
                                       AArch64II::MO_NC);
       }
 
+      // If the LOADgot instruction has a debug-instr-number, annotate the
+      // LDRWui instruction that it is expanded to with the same
+      // debug-instr-number to preserve debug information.
+      if (MI.peekDebugInstrNum() != 0)
+        MIB2->setDebugInstrNum(MI.peekDebugInstrNum());
       transferImpOps(MI, MIB1, MIB2);
     }
     MI.eraseFromParent();

--- a/llvm/test/CodeGen/AArch64/expand-load-got-pseudo.mir
+++ b/llvm/test/CodeGen/AArch64/expand-load-got-pseudo.mir
@@ -1,0 +1,283 @@
+# RUN: llc -run-pass=aarch64-expand-pseudo -mtriple=aarch64-unknown-linux-gnu -o - %s | FileCheck %s
+
+# This testcase was obtained by looking at FileCheck.cpp and reducing it down via llvm-reduce 
+
+# Check that the LDRXui preserves the debug info by retaining the debug-instr-number 1 in _ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_
+# CHECK: $x8 = ADRP target-flags(aarch64-page, aarch64-got) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev
+# CHECK-NEXT: renamable $x8 = LDRXui killed $x8, target-flags(aarch64-pageoff, aarch64-got, aarch64-nc) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev, debug-instr-number 1
+# CHECK-NEXT: DBG_INSTR_REF !9, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0), debug-location
+
+--- |
+  ; ModuleID = '/Users/shubhamrastogi/Development/test105791650/FileCheck-extract-reduced.ll'
+  source_filename = "/Users/shubhamrastogi/Development/test105791650/FileCheck-extract-reduced.ll"
+  target datalayout = "e-m:o-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-n32:64-S128-Fn32"
+  target triple = "arm64-apple-macosx15.0.0"
+  
+  declare i64 @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev()
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
+  define i1 @_ZNSt3__1neB8nn180100IPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEEEbRKNS_11__wrap_iterIT_EESC_(ptr readnone captures(address) %__x, ptr readonly captures(none) %__y) local_unnamed_addr #0 {
+    %1 = load ptr, ptr %__y, align 8
+    %cmp = icmp eq ptr %__x, %1
+    ret i1 %cmp
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
+  define ptr @_ZNKSt3__111__wrap_iterIPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEE4baseB8nn180100Ev(ptr readonly captures(none) %this) local_unnamed_addr #0 {
+  entry:
+    %0 = load ptr, ptr %this, align 8
+    ret ptr %0
+  }
+  
+  ; Function Attrs: mustprogress nofree norecurse nounwind willreturn
+  define void @_ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_(ptr readnone captures(address) %call6) local_unnamed_addr #1 !dbg !4 {
+    %call8 = load volatile i64, ptr null, align 4294967296, !dbg !24
+      #dbg_value(ptr @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev, !9, !DIExpression(), !25)
+    %cmp.i = icmp eq ptr %call6, @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev
+    br i1 %cmp.i, label %for.body, label %common.ret
+  
+  common.ret:                                       ; preds = %0
+    ret void
+  
+  for.body:                                         ; preds = %0
+    tail call void @llvm.lifetime.start.p0(i64 0, ptr null)
+    ret void
+  }
+  
+  ; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+  declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #2
+  
+  attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read) }
+  attributes #1 = { mustprogress nofree norecurse nounwind willreturn }
+  attributes #2 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+  
+  !llvm.module.flags = !{!0}
+  !llvm.dbg.cu = !{!1}
+  
+  !0 = !{i32 2, !"Debug Info Version", i32 3}
+  !1 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !2, producer: "clang version 21.0.0git (\0A\0A\0A\0Agit@github.com:llvm/llvm-project.git 6deee0d5b36c8b4b83209759df8d4933e4922bc8\0A\0A\0A\0A)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !3, retainedTypes: !3, globals: !3, imports: !3, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk", sdk: "MacOSX15.3.sdk")
+  !2 = !DIFile(filename: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/llvm/lib/FileCheck/FileCheck.cpp", directory: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/build-instr-ref-stage2", checksumkind: CSK_MD5, checksum: "e718c2a5b2d3baab240a5e370113901e")
+  !3 = !{}
+  !4 = distinct !DISubprogram(name: "handleErrors<(\0A\0A\0A\0Alambda at /Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/llvm/include/llvm/Support/Error.h:1070:35\0A\0A\0A\0A)>", linkageName: "_ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_", scope: !6, file: !5, line: 954, type: !7, scopeLine: 954, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !1, templateParams: !3, retainedNodes: !8)
+  !5 = !DIFile(filename: "llvm/include/llvm/Support/Error.h", directory: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project", checksumkind: CSK_MD5, checksum: "0a75676311531ba2140b3f0d994b3c33")
+  !6 = !DINamespace(name: "llvm", scope: null)
+  !7 = distinct !DISubroutineType(types: !3)
+  !8 = !{!9}
+  !9 = !DILocalVariable(name: "__end3", scope: !10, type: !13, flags: DIFlagArtificial)
+  !10 = distinct !DILexicalBlock(scope: !11, file: !5, line: 963, column: 5)
+  !11 = distinct !DILexicalBlock(scope: !12, file: !5, line: 960, column: 34)
+  !12 = distinct !DILexicalBlock(scope: !4, file: !5, line: 960, column: 7)
+  !13 = !DIDerivedType(tag: DW_TAG_typedef, name: "iterator", scope: !15, file: !14, line: 403, baseType: !18, flags: DIFlagPublic)
+  !14 = !DIFile(filename: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk/usr/include/c++/v1/vector", directory: "")
+  !15 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "vector<std::__1::unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> >,\0A\0A\0A\0Astd::__1::allocator<std::__1::unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> > > >", scope: !16, file: !14, line: 387, size: 192, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !3, templateParams: !3, identifier: "_ZTSNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEEE")
+  !16 = !DINamespace(name: "__1", scope: !17, exportSymbols: true)
+  !17 = !DINamespace(name: "std", scope: null)
+  !18 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "__wrap_iter<std::__1::unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> > *>", scope: !16, file: !19, line: 41, baseType: !20, size: 64)
+  !19 = !DIFile(filename: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk/usr/include/c++/v1/__iterator/wrap_iter.h", directory: "")
+  !20 = !DIDerivedType(tag: DW_TAG_typedef, name: "iterator_type", scope: !18, file: !19, line: 30, baseType: !21, flags: DIFlagPublic)
+  !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+  !22 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> >", scope: !16, file: !23, line: 124, size: 64, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !3, templateParams: !3, identifier: "_ZTSNSt3__110unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS2_EEEE")
+  !23 = !DIFile(filename: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk/usr/include/c++/v1/__memory/unique_ptr.h", directory: "")
+  !24 = !DILocation(line: 963, column: 18, scope: !10)
+  !25 = !DILocation(line: 0, scope: !10)
+
+...
+---
+name:            _ZNSt3__1neB8nn180100IPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEEEbRKNS_11__wrap_iterIT_EESC_
+alignment:       4
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+noPhis:          true
+isSSA:           false
+noVRegs:         true
+hasFakeUses:     false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: true
+registers:       []
+liveins:
+  - { reg: '$x0', virtual-reg: '' }
+  - { reg: '$x1', virtual-reg: '' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 0
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: true
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  hasRedZone:      false
+body:             |
+  bb.0 (%ir-block.0):
+    liveins: $x0, $x1
+  
+    renamable $x8 = LDRXui killed renamable $x1, 0 :: (load (s64) from %ir.__y)
+    dead $xzr = SUBSXrr killed renamable $x0, killed renamable $x8, implicit-def $nzcv
+    renamable $w0 = CSINCWr $wzr, $wzr, 1, implicit killed $nzcv
+    RET_ReallyLR implicit $w0
+
+...
+---
+name:            _ZNKSt3__111__wrap_iterIPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEE4baseB8nn180100Ev
+alignment:       4
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+noPhis:          true
+isSSA:           false
+noVRegs:         true
+hasFakeUses:     false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: true
+registers:       []
+liveins:
+  - { reg: '$x0', virtual-reg: '' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 0
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: true
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  hasRedZone:      false
+body:             |
+  bb.0.entry:
+    liveins: $x0
+  
+    renamable $x0 = LDRXui killed renamable $x0, 0 :: (load (s64) from %ir.this)
+    RET_ReallyLR implicit $x0
+
+...
+---
+name:            _ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_
+alignment:       4
+exposesReturnsTwice: false
+legalized:       false
+regBankSelected: false
+selected:        false
+failedISel:      false
+tracksRegLiveness: true
+hasWinCFI:       false
+noPhis:          true
+isSSA:           false
+noVRegs:         true
+hasFakeUses:     false
+callsEHReturn:   false
+callsUnwindInit: false
+hasEHCatchret:   false
+hasEHScopes:     false
+hasEHFunclets:   false
+isOutlined:      false
+debugInstrRef:   true
+failsVerification: false
+tracksDebugUserValues: true
+registers:       []
+liveins:
+  - { reg: '$x0', virtual-reg: '' }
+frameInfo:
+  isFrameAddressTaken: false
+  isReturnAddressTaken: false
+  hasStackMap:     false
+  hasPatchPoint:   false
+  stackSize:       0
+  offsetAdjustment: 0
+  maxAlignment:    1
+  adjustsStack:    false
+  hasCalls:        false
+  stackProtector:  ''
+  functionContext: ''
+  maxCallFrameSize: 0
+  cvBytesOfCalleeSavedRegisters: 0
+  hasOpaqueSPAdjustment: false
+  hasVAStart:      false
+  hasMustTailInVarArgFunc: false
+  hasTailCall:     false
+  isCalleeSavedInfoValid: true
+  localFrameSize:  0
+  savePoint:       ''
+  restorePoint:    ''
+fixedStack:      []
+stack:           []
+entry_values:    []
+callSites:       []
+debugValueSubstitutions: []
+constants:       []
+machineFunctionInfo:
+  hasRedZone:      false
+body:             |
+  bb.0 (%ir-block.0):
+    liveins: $x0
+  
+    $x8 = MOVZXi 0, 0
+    dead $xzr = LDRXui killed renamable $x8, 0, debug-location !24 :: (volatile load (s64) from `ptr null`, align 4294967296)
+    renamable $x8 = LOADgot target-flags(aarch64-got) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev, debug-instr-number 1
+    DBG_INSTR_REF !9, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0), debug-location !25
+    dead $xzr = SUBSXrr killed renamable $x0, killed renamable $x8, implicit-def $nzcv
+    RET_ReallyLR
+
+...


### PR DESCRIPTION
The aarch64-expand-pseudo pass expands the LOADgot instruction to an ADRP instruction and a LDRXui instruction. If the LOADgot had a debug-instr-number, the pass doesn't preserve this to the new expansion.

This patch fixes the issue by making sure the debug-instr-number is correctly applied to the LDRXui instruction generated.