### PR TITLE
[stable/20240723][clang][modules] Fix local submodule visibility of macros from transitive import

### DIFF
--- a/clang/include/clang/Basic/Module.h
+++ b/clang/include/clang/Basic/Module.h
@@ -907,10 +907,11 @@ public:
                          StringRef Message)>;
 
   /// Make a specific module visible.
-  void setVisible(Module *M, SourceLocation Loc,
-                  VisibleCallback Vis = [](Module *) {},
-                  ConflictCallback Cb = [](ArrayRef<Module *>, Module *,
-                                           StringRef) {});
+  void setVisible(
+      Module *M, SourceLocation Loc, bool IncludeExports = true,
+      VisibleCallback Vis = [](Module *) {},
+      ConflictCallback Cb = [](ArrayRef<Module *>, Module *, StringRef) {});
+
 private:
   /// Import locations for each visible module. Indexed by the module's
   /// VisibilityID.

--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -1766,7 +1766,8 @@ public:
   bool LexAfterModuleImport(Token &Result);
   void CollectPpImportSuffix(SmallVectorImpl<Token> &Toks);
 
-  void makeModuleVisible(Module *M, SourceLocation Loc);
+  void makeModuleVisible(Module *M, SourceLocation Loc,
+                         bool IncludeExports = true);
 
   SourceLocation getModuleImportLoc(Module *M) const {
     return CurSubmoduleState->VisibleModules.getImportLoc(M);

--- a/clang/lib/Basic/Module.cpp
+++ b/clang/lib/Basic/Module.cpp
@@ -678,7 +678,8 @@ LLVM_DUMP_METHOD void Module::dump() const {
 }
 
 void VisibleModuleSet::setVisible(Module *M, SourceLocation Loc,
-                                  VisibleCallback Vis, ConflictCallback Cb) {
+                                  bool IncludeExports, VisibleCallback Vis,
+                                  ConflictCallback Cb) {
   // We can't import a global module fragment so the location can be invalid.
   assert((M->isGlobalModule() || Loc.isValid()) &&
          "setVisible expects a valid import location");
@@ -704,12 +705,14 @@ void VisibleModuleSet::setVisible(Module *M, SourceLocation Loc,
     Vis(V.M);
 
     // Make any exported modules visible.
-    SmallVector<Module *, 16> Exports;
-    V.M->getExportedModules(Exports);
-    for (Module *E : Exports) {
-      // Don't import non-importable modules.
-      if (!E->isUnimportable())
-        VisitModule({E, &V});
+    if (IncludeExports) {
+      SmallVector<Module *, 16> Exports;
+      V.M->getExportedModules(Exports);
+      for (Module *E : Exports) {
+        // Don't import non-importable modules.
+        if (!E->isUnimportable())
+          VisitModule({E, &V});
+      }
     }
 
     for (auto &C : V.M->Conflicts) {

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -759,9 +759,10 @@ void Preprocessor::EnterSubmodule(Module *M, SourceLocation ImportLoc,
   // Switch to this submodule as the current submodule.
   CurSubmoduleState = &State;
 
-  // This module is visible to itself.
+  // This module is visible to itself, but exports should not be made visible
+  // until they are imported.
   if (FirstTime)
-    makeModuleVisible(M, ImportLoc);
+    makeModuleVisible(M, ImportLoc, /*IncludeExports=*/false);
 }
 
 bool Preprocessor::needModuleMacros() const {

--- a/clang/lib/Lex/Preprocessor.cpp
+++ b/clang/lib/Lex/Preprocessor.cpp
@@ -1336,9 +1336,10 @@ bool Preprocessor::LexAfterModuleImport(Token &Result) {
   return true;
 }
 
-void Preprocessor::makeModuleVisible(Module *M, SourceLocation Loc) {
+void Preprocessor::makeModuleVisible(Module *M, SourceLocation Loc,
+                                     bool IncludeExports) {
   CurSubmoduleState->VisibleModules.setVisible(
-      M, Loc, [](Module *) {},
+      M, Loc, IncludeExports, [](Module *) {},
       [&](ArrayRef<Module *> Path, Module *Conflict, StringRef Message) {
         // FIXME: Include the path in the diagnostic.
         // FIXME: Include the import location for the conflicting module.

--- a/clang/test/Modules/local-submodule-visibility-transitive-import.c
+++ b/clang/test/Modules/local-submodule-visibility-transitive-import.c
@@ -1,0 +1,62 @@
+// Checks that macros from transitive imports work with local submodule
+// visibility. In the below test, previously a() and d() failed because
+// OTHER_MACRO1 and OTHER_MACRO3 were not visible at the use site.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t \
+// RUN:   -fmodules-local-submodule-visibility -I%t %t/tu.c -verify
+
+//--- Other1.h
+#define OTHER_MACRO1(...)
+
+//--- Other2.h
+#define OTHER_MACRO2(...)
+
+//--- Other3.h
+#define OTHER_MACRO3(...)
+
+//--- module.modulemap
+module Other {
+  module O1 { header "Other1.h" }
+  module O2 { header "Other2.h" }
+  module O3 { header "Other3.h" }
+}
+
+//--- Top/A.h
+#include "Other1.h"
+#define MACRO_A OTHER_MACRO1(x, y)
+
+//--- Top/B.h
+#include "Other2.h"
+#define MACRO_B OTHER_MACRO2(x, y)
+
+//--- Top/C.h
+#include "D.h"
+
+//--- Top/D.h
+#include "Other3.h"
+#define MACRO_D OTHER_MACRO3(x, y)
+
+//--- Top/Top.h
+#include "A.h"
+#include "B.h"
+#include "C.h"
+
+void a() MACRO_A;
+void b() MACRO_B;
+void d() MACRO_D;
+
+//--- Top/module.modulemap
+module Top {
+  umbrella header "Top.h"
+  module A { header "A.h" export * }
+  module D { header "D.h" export * }
+  module * { export * }
+  export *
+  export Other.O3
+}
+
+//--- tu.c
+#include "Top/Top.h"
+// expected-no-diagnostics


### PR DESCRIPTION
* **Explanation**: When using local submodule visibility (on by default for c++, off for c/objc), macros from some transitive imports could fail to be made visible depending on whether the submodule was written in the modulemap file or discovered from an umbrella directory.  When using caching this applies to all submodules.
* **Scope**: Affects modules in C++ modes, or if local submodule visibility is manually enabled in other language modes. Can affect non-caching builds depending on how the modulemap is written, but will primarily impact caching builds in practice.
* **Issue/Radar**: rdar://136524433
* **Original PR**: https://github.com/llvm/llvm-project/pull/122955
* **Risk**: Low. Any submodule we stop marking visible immediately after this change will be made visible when it is actually imported, so this should only fix broken cases not change working ones.
* **Testing**: Added regression test.
* **Reviewer**: @Bigcheese 