### PR TITLE
🍒 Skip more LLDB Swift ASAN libsanitizer tests

### DIFF
--- a/lldb/test/API/functionalities/asan/TestMemoryHistory.py
+++ b/lldb/test/API/functionalities/asan/TestMemoryHistory.py
@@ -19,6 +19,7 @@ class AsanTestCase(TestBase):
         self.asan_tests()
 
     @skipIf(oslist=no_match(["macosx"]))
+    @skipIfDarwin #  rdar://142836595
     def test_libsanitizers_asan(self):
         try:
             self.build(make_targets=["libsanitizers"])

--- a/lldb/test/API/functionalities/asan/TestReportData.py
+++ b/lldb/test/API/functionalities/asan/TestReportData.py
@@ -20,6 +20,7 @@ class AsanTestReportDataCase(TestBase):
         self.asan_tests()
 
     @skipIf(oslist=no_match(["macosx"]))
+    @skipIfDarwin #  rdar://142836595
     def test_libsanitizers_asan(self):
         try:
             self.build(make_targets=["libsanitizers"])


### PR DESCRIPTION
Disable TestMemoryHistory.py, TestReportData.py temporarily until blocking problem resolved

Original PR: https://github.com/swiftlang/llvm-project/pull/10097

rdar://142836595
(cherry picked from commit 52007035fa08e6e2434d27bb6d2be2e4eb7d9f36)