### PR TITLE
Serialization: silence a warning on MSVC

### DIFF
--- a/clang/lib/Serialization/ASTWriterStmt.cpp
+++ b/clang/lib/Serialization/ASTWriterStmt.cpp
@@ -2320,8 +2320,8 @@ void ASTStmtWriter::VisitBoundsSafetyPointerPromotionExpr(
   VisitExpr(E);
   Record.push_back(E->getNumChildren());
   switch (E->getNumChildren()) {
-  case 3: Record.AddStmt(E->getLowerBound()); [[clang::fallthrough]];
-  case 2: Record.AddStmt(E->getUpperBound()); [[clang::fallthrough]];
+  case 3: Record.AddStmt(E->getLowerBound()); LLVM_FALLTHROUGH;
+  case 2: Record.AddStmt(E->getUpperBound()); LLVM_FALLTHROUGH;
   case 1: Record.AddStmt(E->getPointer()); break;
   default: llvm_unreachable("incorrect number of child nodes");
   }


### PR DESCRIPTION
Use `LLVM_FALLTHROUGH` rather than the unportable
`[[clang::fallthrough]]`. This will expand properly to the standard spelling or the compiler specific spelling and allow building with different compilers.