### PR TITLE
[apple-ci] Capture clang crash reproducers

### DIFF
--- a/apple-ci/clang/am/build.sh
+++ b/apple-ci/clang/am/build.sh
@@ -19,6 +19,8 @@ echo
 
 NINJA=$(xcrun -f ninja)
 
+export CLANG_CRASH_DIAGNOSTICS_DIR=${WORKSPACE}/.CLANG_CRASH_DIAGNOSTICS_DIR
+
 HOST_COMPILER_PATH=$(dirname $(xcrun -f clang))
 
 mkdir -p $BUILD_DIR && cd $_


### PR DESCRIPTION
... when building with the am build script.