### PR TITLE
[-Wunsafe-buffer-usage][BoundsSafety] support __null_terminated in the interop mode (#10060)

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13029,8 +13029,10 @@ def warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by : Warning
           "sending type to parameter of incompatible type}0,1|"
     "%diff{casting $ to incompatible type $|"
           "casting type to incompatible type}0,1|"
-  "}2 is an unsafe operation; use '%select{__unsafe_terminated_by_from_indexable|__unsafe_null_terminated_from_indexable}3()' "
-  "or '%select{__unsafe_forge_terminated_by|__unsafe_forge_null_terminated}3()' to perform this conversion">, InGroup<BoundsSafetyStrictTerminatedByCast>, DefaultError;
+  "}2 is an unsafe operation"
+  "%select{; use '__unsafe_terminated_by_from_indexable()' or '__unsafe_forge_terminated_by()' to perform this conversion|"
+  "; use '__unsafe_null_terminated_from_indexable()' or '__unsafe_forge_null_terminated()' to perform this conversion|"
+  "}3">, InGroup<BoundsSafetyStrictTerminatedByCast>, DefaultError;
 def err_bounds_safety_incompatible_non_terminated_by_to_terminated_by : Error<warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by.Summary>;
 def err_bounds_safety_incompatible_terminated_by_to_non_terminated_by_mismatch : Error<
   "%select{"

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1563,6 +1563,13 @@ public:
   /// be controlled with \#pragma clang abi_ptr_attr set(*ATTR*). Defaults to
   /// __single in user code and __unsafe_indexable in system headers.
   BoundsSafetyPointerAttributes CurPointerAbi;
+
+  /// \return true iff `-Wunsafe-buffer-usage` is enabled for `Loc` and Bounds
+  /// Safety attribute-only mode is on.
+  bool isCXXSafeBuffersBoundsSafetyInteropEnabledAt(SourceLocation Loc) const {
+    return LangOpts.CPlusPlus && LangOpts.isBoundsSafetyAttributeOnlyMode() &&
+           !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc);
+  }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// pragma clang section kind

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -12090,12 +12090,38 @@ Sema::CheckValueTerminatedAssignmentConstraints(QualType LHSType,
              Context.hasSameUnqualifiedType(
                  Context.getCorrespondingSignedType(LPointee),
                  Context.getCorrespondingSignedType(RPointee)));
-        if (CompatiblePointees &&
+        if (CompatiblePointees && RHSExpr->isPRValue() &&
             RHSExpr->tryEvaluateTerminatorElement(Evald, Context) &&
             Evald.Val.isInt() &&
             llvm::APSInt::isSameValue(LVTT->getTerminatorValue(Context),
                                       Evald.Val.getInt())) {
           return Sema::Compatible;
+        }
+        // If in C++ Safe Buffers/Bounds Safety interoperation mode, the RHS can
+        // be 'std::string::c_str/data':
+        bool isNullTerm = LVTT->getTerminatorValue(Context).isZero();
+
+        if (isNullTerm && isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+                              RHSExpr->getBeginLoc())) {
+          if (const auto *MCE =
+                  dyn_cast<CXXMemberCallExpr>(RHSExpr->IgnoreParenImpCasts())) {
+            IdentifierInfo *MethodDeclII = nullptr, *ObjTypeII = nullptr;
+
+            if (MCE->getMethodDecl())
+              MethodDeclII = MCE->getMethodDecl()->getIdentifier();
+            if (const auto *RecordDecl =
+                    MCE->getObjectType()->getAsRecordDecl();
+                RecordDecl && RecordDecl->isInStdNamespace())
+              // If not in std namespace, let `ObjTypeII` be null so that the
+              // match fails:
+              ObjTypeII = RecordDecl->getIdentifier();
+            if (MethodDeclII && ObjTypeII &&
+                (MethodDeclII->getName() == "c_str" ||
+                 // std::string::data is also null-terminated since C++11:
+                 MethodDeclII->getName() == "data") &&
+                ObjTypeII->getName() == "basic_string")
+              return Sema::Compatible;
+          }
         }
       }
       return Nested
@@ -20535,9 +20561,11 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
     const auto *DstPointerType = DstType->getAs<ValueTerminatedType>();
     IsDstNullTerm =
         DstPointerType->getTerminatorValue(getASTContext()).isZero();
-    if (getLangOpts().BoundsSafetyRelaxedSystemHeaders) {
-      DiagKind =
-          diag::warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
+
+    if (getLangOpts().BoundsSafetyRelaxedSystemHeaders ||
+        isCXXSafeBuffersBoundsSafetyInteropEnabledAt(Loc)) {
+      DiagKind = diag::
+          warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by;
       isInvalid = false;
     } else {
       DiagKind =
@@ -20813,8 +20841,11 @@ bool Sema::DiagnoseAssignmentResult(AssignConvertType ConvTy,
           diag::
               warn_bounds_safety_incompatible_non_terminated_by_to_terminated_by) {
     FDiag << FirstType << SecondType << ActionForDiag
-          << SrcExpr->getSourceRange() << 
-          (IsDstNullTerm ? /*null_terminated*/ 1 : /*terminated_by*/ 0);
+          << SrcExpr->getSourceRange()
+          << (!isCXXSafeBuffersBoundsSafetyInteropEnabledAt(Loc)
+                  ? (IsDstNullTerm ? /*null_terminated*/ 1
+                                   : /*terminated_by*/ 0)
+                  : 2 /* cut message irrelevant to that mode*/);
   } else {
     FDiag << FirstType << SecondType << ActionForDiag
           << SrcExpr->getSourceRange();

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -4200,6 +4200,15 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
                                 const ImplicitConversionSequence &ICS,
                                 AssignmentAction Action,
                                 CheckedConversionKind CCK) {
+  if (ToType->isPointerType() &&
+      isCXXSafeBuffersBoundsSafetyInteropEnabledAt(From->getBeginLoc())) {
+    // In C++ Safe Buffers/Bounds Safety interop mode, warn about implicit
+    // conversions from non-`__null_terminated` to `__null_terminated`:
+    AssignConvertType ConvTy =
+        CheckValueTerminatedAssignmentConstraints(ToType, From);
+    DiagnoseAssignmentResult(ConvTy, From->getExprLoc(), ToType,
+                             From->getType(), From, Action);
+  }
   // C++ [over.match.oper]p7: [...] operands of class type are converted [...]
   if (CCK == CheckedConversionKind::ForBuiltinOverloadedOp &&
       !From->getType()->isRecordType())

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -8865,7 +8865,8 @@ ExprResult InitializationSequence::Perform(Sema &S,
                           Entity.getKind() == InitializedEntity::EK_Result);
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
-  if (S.LangOpts.BoundsSafety) {
+  if (S.LangOpts.BoundsSafety || S.isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+                                     CurInit.get()->getBeginLoc())) {
     auto *Init = CurInit.get();
     const auto K = Entity.getKind();
     if (Init && Entity.getParent() == nullptr &&

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
@@ -1,0 +1,205 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wno-all -Wunsafe-buffer-usage -fsafe-buffer-usage-suggestions -fexperimental-bounds-safety-attributes -verify %s
+
+#include <ptrcheck.h>
+
+typedef unsigned size_t;
+namespace std {
+  template <typename CharT>
+  struct basic_string {
+    const CharT *data() const noexcept;
+    CharT *data() noexcept;
+    const CharT *c_str() const noexcept;
+    size_t size() const noexcept;
+    size_t length() const noexcept;
+  };
+
+  typedef basic_string<char> string;
+
+  template <typename CharT>
+  struct basic_string_view {
+    basic_string_view(basic_string<CharT> str);
+    const CharT *data() const noexcept;
+    size_t size() const noexcept;
+    size_t length() const noexcept;
+  };
+
+  typedef basic_string_view<char> string_view;
+} // namespace std
+
+void nt_parm(const char * __null_terminated);
+const char * __null_terminated get_nt(const char *, size_t);
+
+void basics(const char * cstr, size_t cstr_len, std::string cxxstr) {
+  const char * __null_terminated p = "hello";   // safe init
+
+  nt_parm(p);
+  nt_parm(get_nt(cstr, cstr_len));
+
+  const char * __null_terminated p2 = cxxstr.c_str(); // safe init
+  const char * __null_terminated p3;
+
+  p3 = cxxstr.c_str();         // safe assignment
+  p3 = "hello";                // safe assignment
+  p3 = p;                      // safe assignment
+  p3 = get_nt(cstr, cstr_len); // safe assignment
+
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'const char *' is an unsafe operation}}
+  const char * __null_terminated p4 = cstr;  // warn
+
+  // expected-error@+1 {{passing 'const char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  nt_parm(cstr);                             // warn
+  // expected-error@+1 {{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'const char *' is an unsafe operation}}
+  p4 = cstr;                                 // warn
+
+  std::string_view view{cxxstr};
+
+  // expected-error@+1 {{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'const char *' is an unsafe operation}}
+  p4 = view.data();                          // warn
+  // expected-error@+1 {{passing 'const char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  nt_parm(view.data());                      // warn
+
+  const char * __null_terminated p5 = 0;                 // nullptr is ok
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'const char *' is an unsafe operation}}
+  const char * __null_terminated p6 = (const char *)1;   // other integer literal is unsafe
+
+  // (non-0)-terminated pointer is NOT compatible with 'std::string::c_str':
+  // expected-error@+1 {{initializing 'const char * __terminated_by(42)' (aka 'const char *') with an expression of incompatible type 'const char *' is an unsafe operation}}
+  const char * __terminated_by(42) p7 = cxxstr.c_str();
+}
+
+void test_explicit_cast(char * p, const char * q) {
+  // expected-error@+1 {{casting 'char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  const char * __null_terminated nt = (const char * __null_terminated) p;
+  const char * __null_terminated nt2 = reinterpret_cast<const char * __null_terminated> (p); // FP for now
+
+    // expected-error@+1 {{casting 'char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  nt = (const char * __null_terminated) p;
+  nt2 = reinterpret_cast<const char * __null_terminated> (p); // FP for now
+  // expected-error@+1 {{casting 'char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  nt2 = static_cast<const char * __null_terminated> (p);      // FP for now
+
+  // expected-error@+1 {{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  const char * __null_terminated nt3 = (const char * __null_terminated) q;
+  const char * __null_terminated nt4 = reinterpret_cast<const char * __null_terminated> (q); // FP for now
+
+  // expected-error@+1 {{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  nt3 = (const char * __null_terminated) q;
+  nt4 = reinterpret_cast<const char * __null_terminated> (q); // FP for now
+  // expected-error@+1 {{casting 'const char *' to incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  nt4 = static_cast<const char * __null_terminated> (q);
+
+  // OK cases for C-style casts
+  char * __null_terminated nt_p;
+  const char * __null_terminated nt_p2;
+  int * __null_terminated nt_p3;
+  const int * __null_terminated nt_p4;
+
+  const char * __null_terminated nt5 = (const char * __null_terminated) nt_p;
+  const char * __null_terminated nt6 = (const char * __null_terminated) nt_p2;
+  const char * __null_terminated nt7 = (const char * __null_terminated) nt_p3;
+  const char * __null_terminated nt8 = (const char * __null_terminated) nt_p4;
+
+  nt5 = (const char * __null_terminated) nt_p;
+  nt6 = (const char * __null_terminated) nt_p2;
+  nt7 = (const char * __null_terminated) nt_p3;
+  nt8 = (const char * __null_terminated) nt_p4;
+
+
+  char * __null_terminated nt9 = (char * __null_terminated) nt_p;
+  char * __null_terminated nt10 = (char * __null_terminated) nt_p2;
+  char * __null_terminated nt11 = (char * __null_terminated) nt_p3;
+  char * __null_terminated nt12 = (char * __null_terminated) nt_p4;
+
+  nt9 = (char * __null_terminated) nt_p;
+  nt10 = (char * __null_terminated) nt_p2;
+  nt11 = (char * __null_terminated) nt_p3;
+  nt12 = (char * __null_terminated) nt_p4;
+}
+
+const char * __null_terminated test_return(const char * p, char * q, std::string &str) {
+  if (p)
+    return p; // expected-error {{returning 'const char *' from a function with incompatible result type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  if (q)
+    return q; // expected-error {{returning 'char *' from a function with incompatible result type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  return str.c_str();
+}
+
+void test_array(char * cstr) {
+  const char arr[__null_terminated 3] = {'h', 'i', '\0'};
+  // expected-error@+1 {{array 'arr2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'i')}}
+  const char arr2[__null_terminated 2] = {'h', 'i'};
+  const char * __null_terminated arr3[] = {"hello", "world"};
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  const char * __null_terminated arr4[] = {"hello", "world", cstr};
+
+  // expected-error@+1 {{assigning to 'const char * __terminated_by(0)' (aka 'const char *') from incompatible type 'char *' is an unsafe operation}}
+  arr3[0] = cstr;
+}
+
+struct T {
+  int a;
+  const char * __null_terminated p;
+  struct TT {
+    int a;
+    const char * __null_terminated p;
+  } tt;
+};
+void test_compound(char * cstr) {
+  std::string str;
+  T t = {42, "hello"};
+  T t2 = {.a = 42};
+  T t3 = {.p = str.c_str()};
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  T t4 = {42, "hello", {.p = cstr}};
+
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  t4 = (struct T){42, "hello", {.p = cstr}};
+}
+
+  // expected-error@+3 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+class C {
+  const char * __null_terminated p;
+  const char * __null_terminated q = (char *) 1; // warn
+  struct T t;
+public:
+  // expected-error@+1 2{{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  C(char * p): p(p), t({0, p}) {};
+  C(const char * __null_terminated p, struct T t);
+};
+
+void f(const C &c);
+C test_class(char * cstr) {
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  C c{cstr, {0, cstr}};
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  C c1(cstr, {0, cstr});
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  C *c2 = new C(cstr, {0, cstr});
+  // expected-error@+2 {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}
+  f(C{cstr, {0, cstr}});
+
+  C("hello", {0, "hello"});
+  if (1-1)
+    return {cstr, {}}; // expected-error {{passing 'char *' to parameter of incompatible type 'const char * __terminated_by(0)' (aka 'const char *') is an unsafe operation}}
+  return {"hello", {}};
+}
+
+
+// Test input/output __null_terminated parameter.
+// expected-note@+1 {{candidate function not viable:}}
+void g(const char * __null_terminated *p);
+void test_output(const char * __null_terminated p) {
+  const char * __null_terminated local_nt = p;
+  const char * const_local;
+  char * local;
+
+  g(&local_nt); // safe
+  // expected-error@+1 {{passing 'const char **' to parameter of incompatible type 'const char * __terminated_by(0)*' (aka 'const char **') that adds '__terminated_by' attribute is not allowed}}
+  g(&const_local);
+  // expected-error@+1 {{no matching function for call to 'g'}}
+  g(&local);
+}


### PR DESCRIPTION
For a __null_terminated pointer 'p', only a __null_terminated pointer, a string literal or a call to `std::string::c_str/data` can be assigned to (/passed to/used to initialize, etc.) 'p'.  Otherwise, an error will be emitted. The implementation reuses Bounds Safety's diagnostics.

(rdar://138798346)