### PR TITLE
[InstrRef] Preserve debug instr num in aarch64-expand-pseudo LOADgot expansion

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/AArch64/AArch64ExpandPseudoInsts.cpp
@@ -1354,6 +1354,11 @@ bool AArch64ExpandPseudo::expandMI(MachineBasicBlock &MBB,
                                       AArch64II::MO_NC);
       }
 
+      // If the LOADgot instruction has a debug-instr-number, annotate the
+      // LDRWui instruction that it is expanded to with the same
+      // debug-instr-number to preserve debug information.
+      if (MI.peekDebugInstrNum() != 0)
+        MIB2->setDebugInstrNum(MI.peekDebugInstrNum());
       transferImpOps(MI, MIB1, MIB2);
     }
     MI.eraseFromParent();

--- a/llvm/test/CodeGen/AArch64/expand-load-got-pseudo.mir
+++ b/llvm/test/CodeGen/AArch64/expand-load-got-pseudo.mir
@@ -1,0 +1,56 @@
+# RUN: llc -run-pass=aarch64-expand-pseudo -mtriple=aarch64-unknown-linux-gnu -o - %s | FileCheck %s
+
+# This testcase was obtained by looking at FileCheck.cpp and reducing it down via llvm-reduce 
+
+# Check that the LDRXui preserves the debug info by retaining the debug-instr-number 1 in _ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_
+# CHECK: $x8 = ADRP target-flags(aarch64-page, aarch64-got) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev
+# CHECK-NEXT: renamable $x8 = LDRXui killed $x8, target-flags(aarch64-pageoff, aarch64-got, aarch64-nc) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev, debug-instr-number 1
+# CHECK-NEXT: DBG_INSTR_REF !9, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0), debug-location
+
+--- |
+  declare i64 @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev()
+  define i1 @_ZNSt3__1neB8nn180100IPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEEEbRKNS_11__wrap_iterIT_EESC_(ptr readnone %__x, ptr nocapture readonly %__y) local_unnamed_addr #0 {
+    %1 = load ptr, ptr %__y, align 8
+    %cmp = icmp eq ptr %1, %__x
+    ret i1 %cmp
+  }
+  define ptr @_ZNKSt3__111__wrap_iterIPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEE4baseB8nn180100Ev(ptr nocapture readonly %this) local_unnamed_addr #0 {
+  entry:
+    %0 = load ptr, ptr %this, align 8
+    ret ptr %0
+  }
+  define void @_ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_(ptr readnone %call6) local_unnamed_addr #1 !dbg !4 {
+    ret void
+  }
+  !llvm.module.flags = !{!0}
+  !llvm.dbg.cu = !{!1}
+  !0 = !{i32 2, !"Debug Info Version", i32 3}
+  !1 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !2, producer: "clang version 21.0.0git (\0A\0A\0A\0Agit@github.com:llvm/llvm-project.git 6deee0d5b36c8b4b83209759df8d4933e4922bc8\0A\0A\0A\0A)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !3, retainedTypes: !3, globals: !3, imports: !3, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk", sdk: "MacOSX15.3.sdk")
+  !2 = !DIFile(filename: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/llvm/lib/FileCheck/FileCheck.cpp", directory: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/build-instr-ref-stage2", checksumkind: CSK_MD5, checksum: "e718c2a5b2d3baab240a5e370113901e")
+  !3 = !{}
+  !4 = distinct !DISubprogram(name: "handleErrors<(\0A\0A\0A\0Alambda at /Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project/llvm/include/llvm/Support/Error.h:1070:35\0A\0A\0A\0A)>", linkageName: "_ZN4llvm12handleErrorsIJZNS_12consumeErrorENS_5ErrorEEUlRKNS_13ErrorInfoBaseEE_EEES1_S1_DpOT_", scope: !6, file: !5, line: 954, type: !7, scopeLine: 954, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !1, templateParams: !3, retainedNodes: !8)
+  !5 = !DIFile(filename: "llvm/include/llvm/Support/Error.h", directory: "/Users/shubhamrastogi/Development/llvm-project-instr-ref/llvm-project", checksumkind: CSK_MD5, checksum: "0a75676311531ba2140b3f0d994b3c33")
+  !6 = !DINamespace(name: "llvm", scope: null)
+  !7 = distinct !DISubroutineType(types: !3)
+  !8 = !{!9}
+  !9 = !DILocalVariable(name: "__end3", scope: !10, type: !13, flags: DIFlagArtificial)
+  !10 = distinct !DILexicalBlock(scope: !11, file: !5, line: 963, column: 5)
+  !11 = distinct !DILexicalBlock(scope: !12, file: !5, line: 960, column: 34)
+  !12 = distinct !DILexicalBlock(scope: !4, file: !5, line: 960, column: 7)
+  !13 = !DIDerivedType(tag: DW_TAG_typedef, name: "iterator", scope: !15, file: !14, line: 403, baseType: !18, flags: DIFlagPublic)
+  !14 = !DIFile(filename: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk/usr/include/c++/v1/vector", directory: "")
+  !15 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "vector<std::__1::unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> >,\0A\0A\0A\0Astd::__1::allocator<std::__1::unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> > > >", scope: !16, file: !14, line: 387, size: 192, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !3, templateParams: !3, identifier: "_ZTSNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEEE")
+  !16 = !DINamespace(name: "__1", scope: !17, exportSymbols: true)
+  !17 = !DINamespace(name: "std", scope: null)
+  !18 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "__wrap_iter<std::__1::unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> > *>", scope: !16, file: !19, line: 41, baseType: !20, size: 64)
+  !19 = !DIFile(filename: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk/usr/include/c++/v1/__iterator/wrap_iter.h", directory: "")
+  !20 = !DIDerivedType(tag: DW_TAG_typedef, name: "iterator_type", scope: !18, file: !19, line: 30, baseType: !21, flags: DIFlagPublic)
+  !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+  !22 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "unique_ptr<llvm::ErrorInfoBase,\0A\0A\0A\0Astd::__1::default_delete<llvm::ErrorInfoBase> >", scope: !16, file: !23, line: 124, size: 64, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !3, templateParams: !3, identifier: "_ZTSNSt3__110unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS2_EEEE")
+  !23 = !DIFile(filename: "/Library/Developer/CommandLineTools/SDKs/MacOSX15.3.sdk/usr/include/c++/v1/__memory/unique_ptr.h", directory: "")
+  !25 = !DILocation(line: 0, scope: !10)
+name:            _ZNSt3__1neB8nn180100IPNS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEEEEbRKNS_11__wrap_iterIT_EESC_
+body:             |
+  bb.0 (%ir-block.0):
+    renamable $x8 = LOADgot target-flags(aarch64-got) @_ZNSt3__16vectorINS_10unique_ptrIN4llvm13ErrorInfoBaseENS_14default_deleteIS3_EEEENS_9allocatorIS6_EEE3endB8nn180100Ev, debug-instr-number 1
+    DBG_INSTR_REF !9, !DIExpression(DW_OP_LLVM_arg, 0), dbg-instr-ref(1, 0), debug-location !25


### PR DESCRIPTION
The aarch64-expand-pseudo pass expands the LOADgot instruction to an ADRP instruction and a LDRXui instruction. If the LOADgot had a debug-instr-number, the pass doesn't preserve this to the new expansion.

This patch fixes the issue by making sure the debug-instr-number is correctly applied to the LDRXui instruction generated.

(cherry picked from commit b3c51db292f05cf89201911cbcca6cba83caadd6)