### PR TITLE
[Passes] Run ConstraintElimination after loop optimizations.

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-missed-binop-overflow.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-missed-binop-overflow.c
@@ -60,7 +60,7 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT: Function:        test_shl
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Annotated '
-// OPT-REM-NEXT:   - count:           '2'
+// OPT-REM-NEXT:   - count:           '3'
 // OPT-REM-NEXT:   - String:          ' instructions with '
 // OPT-REM-NEXT:   - type:            bounds-safety-missed-optimization-nuw
 // OPT-REM-NEXT: ...
@@ -231,23 +231,26 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT: Function:        test_shl
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Inserted '
-// OPT-REM-NEXT:   - count:           '4'
+// OPT-REM-NEXT:   - count:           '5'
 // OPT-REM-NEXT:   - String:          ' LLVM IR instruction'
 // OPT-REM-NEXT:   - String:          s
 // OPT-REM-NEXT:   - String:          "\n"
 // OPT-REM-NEXT:   - String:          "used for:\n"
-// OPT-REM-NEXT:   - String:          bounds-safety-check-ptr-lt-upper-bound, bounds-safety-check-ptr-ge-lower-bound
+// OPT-REM-NEXT:   - String:          bounds-safety-missed-optimization-nuw, bounds-safety-check-ptr-lt-upper-bound, bounds-safety-check-ptr-ge-lower-bound
 // OPT-REM-NEXT:   - String:           |
 // OPT-REM-NEXT: {{^[ 	]+$}}
 // OPT-REM-NEXT: {{^[ 	]+$}}
 // OPT-REM-NEXT:       instructions:
 // OPT-REM-EMPTY: 
 // OPT-REM-NEXT:   - String:           |
+// OPT-REM-NEXT:       other (LLVM IR 'shl')
 // OPT-REM-NEXT:       cmp ult (LLVM IR 'icmp')
 // OPT-REM-NEXT:       cmp uge (LLVM IR 'icmp')
 // OPT-REM-NEXT:       and (LLVM IR 'and')
 // OPT-REM-NEXT:       cond branch (LLVM IR 'br')
 // OPT-REM-EMPTY: 
+// OPT-REM-NEXT:    - String:          "Missed Optimization Info\n"
+// OPT-REM-NEXT:    - String:          Check can not be removed because the arithmetic operation might wrap in the unsigned sense. Optimize the check by adding conditions to check for overflow before doing the operation
 // OPT-REM-NEXT: ...
 
 // OPT-REM-NEXT: --- !Analysis
@@ -271,7 +274,7 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT: Function:        test_mul
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Annotated '
-// OPT-REM-NEXT:   - count:           '2'
+// OPT-REM-NEXT:   - count:           '3'
 // OPT-REM-NEXT:   - String:          ' instructions with '
 // OPT-REM-NEXT:   - type:            bounds-safety-missed-optimization-nuw
 // OPT-REM-NEXT: ...
@@ -442,24 +445,25 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT: Function:        test_mul
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Inserted '
-// OPT-REM-NEXT:   - count:           '4'
+// OPT-REM-NEXT:   - count:           '5'
 // OPT-REM-NEXT:   - String:          ' LLVM IR instruction'
 // OPT-REM-NEXT:   - String:          s
 // OPT-REM-NEXT:   - String:          "\n"
 // OPT-REM-NEXT:   - String:          "used for:\n"
-// OPT-REM-NEXT:   - String:          bounds-safety-check-ptr-lt-upper-bound, bounds-safety-check-ptr-ge-lower-bound
+// OPT-REM-NEXT:   - String:          bounds-safety-missed-optimization-nuw, bounds-safety-check-ptr-lt-upper-bound, bounds-safety-check-ptr-ge-lower-bound
 // OPT-REM-NEXT:   - String:           |
 // OPT-REM-NEXT: {{^[ 	]+$}}
 // OPT-REM-NEXT: {{^[ 	]+$}}
 // OPT-REM-NEXT:       instructions:
 // OPT-REM-EMPTY: 
 // OPT-REM-NEXT:   - String:           |
+// OPT-REM-NEXT:       other (LLVM IR 'shl')
 // OPT-REM-NEXT:       cmp ult (LLVM IR 'icmp')
 // OPT-REM-NEXT:       cmp uge (LLVM IR 'icmp')
 // OPT-REM-NEXT:       and (LLVM IR 'and')
 // OPT-REM-NEXT:       cond branch (LLVM IR 'br')
 // OPT-REM-EMPTY: 
-// OPT-REM-NEXT: ...
+// OPT-REM: ...
 
 // OPT-REM-NEXT: --- !Analysis
 // OPT-REM-NEXT: Pass:            annotation-remarks
@@ -495,7 +499,7 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT: Function:        test_add
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Annotated '
-// OPT-REM-NEXT:   - count:           '4'
+// OPT-REM-NEXT:   - count:           '2'
 // OPT-REM-NEXT:   - String:          ' instructions with '
 // OPT-REM-NEXT:   - type:            bounds-safety-check-ptr-lt-upper-bound
 // OPT-REM-NEXT: ...
@@ -508,7 +512,7 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT: Function:        test_add
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Annotated '
-// OPT-REM-NEXT:   - count:           '4'
+// OPT-REM-NEXT:   - count:           '2'
 // OPT-REM-NEXT:   - String:          ' instructions with '
 // OPT-REM-NEXT:   - type:            bounds-safety-check-ptr-ge-lower-bound
 // OPT-REM-NEXT: ...
@@ -521,7 +525,7 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT: Function:        test_add
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Annotated '
-// OPT-REM-NEXT:   - count:           '13'
+// OPT-REM-NEXT:   - count:           '9'
 // OPT-REM-NEXT:   - String:          ' instructions with '
 // OPT-REM-NEXT:   - type:            bounds-safety-total-summary
 // OPT-REM-NEXT: ...
@@ -643,33 +647,6 @@ void test_sub(int* __indexable A, int N) {
 // OPT-REM-NEXT:       instructions:
 // OPT-REM-EMPTY: 
 // OPT-REM-NEXT:   - String:          "trap (LLVM IR 'call')\nother (LLVM IR 'unreachable')"
-// OPT-REM-NEXT: ...
-
-// OPT-REM-NEXT: --- !Analysis
-// OPT-REM-NEXT: Pass:            annotation-remarks
-// OPT-REM-NEXT: Name:            BoundsSafetyCheck
-// OPT-REM-NEXT: DebugLoc:        { File: '{{.*}}bounds-safety-missed-binop-overflow.c', 
-// OPT-REM-NEXT:                    Line: 29, Column: 11 }
-// OPT-REM-NEXT: Function:        test_add
-// OPT-REM-NEXT: Args:
-// OPT-REM-NEXT:   - String:          'Inserted '
-// OPT-REM-NEXT:   - count:           '4'
-// OPT-REM-NEXT:   - String:          ' LLVM IR instruction'
-// OPT-REM-NEXT:   - String:          s
-// OPT-REM-NEXT:   - String:          "\n"
-// OPT-REM-NEXT:   - String:          "used for:\n"
-// OPT-REM-NEXT:   - String:          bounds-safety-check-ptr-lt-upper-bound, bounds-safety-check-ptr-ge-lower-bound
-// OPT-REM-NEXT:   - String:           |
-// OPT-REM-NEXT: {{^[ 	]+$}}
-// OPT-REM-NEXT: {{^[ 	]+$}}
-// OPT-REM-NEXT:       instructions:
-// OPT-REM-EMPTY: 
-// OPT-REM-NEXT:   - String:           |
-// OPT-REM-NEXT:       cmp ult (LLVM IR 'icmp')
-// OPT-REM-NEXT:       cmp uge (LLVM IR 'icmp')
-// OPT-REM-NEXT:       and (LLVM IR 'and')
-// OPT-REM-NEXT:       cond branch (LLVM IR 'br')
-// OPT-REM-EMPTY: 
 // OPT-REM-NEXT: ...
 
 // OPT-REM-NEXT: --- !Analysis

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-no-bringup-missing-checks.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-no-bringup-missing-checks.c
@@ -124,8 +124,8 @@ void loop_all_accesses_in_bounds_variable_start_2_add(int* __counted_by(n) dst,
 // CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ [[TMP2]], [[ENTRY:%.*]] ], [ [[INDVARS_IV_NEXT:%.*]], [[FOR_BODY]] ]
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr i32, ptr [[DST:%.*]], i64 [[INDVARS_IV]]
 // CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw i64 [[INDVARS_IV]], 1
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult i64 [[INDVARS_IV_NEXT]], [[TMP0]]
+// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
+// CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i64 [[INDVARS_IV_NEXT]], [[TMP0]]
 // CHECK-NEXT:    br i1 [[CMP]], label [[FOR_BODY]], label [[FOR_COND_CLEANUP:%.*]], {{!llvm.loop ![0-9]+}}
 //
 void loop_all_accesses_in_bounds_variable_start_3_modulo(int* __counted_by(n) dst,

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations-structs-with-arrays.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations-structs-with-arrays.c
@@ -10,84 +10,27 @@ struct buf {
   int arr[10];
 };
 
-// rdar://128576231
 // CHECK-LABEL: @array_member_access_can_remove(
-// CHECK-NEXT:  cont2:
-// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[BP:%.*]], i64 44
+// CHECK-NEXT:  cont2.9:
+// CHECK-NEXT:    [[ARR:%.*]] = getelementptr inbounds nuw i8, ptr [[BP:%.*]], i64 4
 // CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[BP]], i64 8
-// CHECK-NEXT:    [[ARR:%.*]] = getelementptr inbounds nuw i8, ptr [[BP]], i64 4
 // CHECK-NEXT:    store i32 0, ptr [[ARR]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr [[BP]], i64 12, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP2:%.*]] = icmp ule ptr [[TMP1]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP3:%.*]] = icmp ule ptr [[TMP0]], [[TMP1]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_1:%.*]] = and i1 [[TMP2]], [[TMP3]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_1]], label [[CONT2_1:%.*]], label [[TRAP:%.*]], {{!annotation ![0-9]+}}
-// CHECK:       trap:
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       cont2.1:
 // CHECK-NEXT:    store i32 1, ptr [[TMP0]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_2:%.*]] = getelementptr i8, ptr [[BP]], i64 12
-// CHECK-NEXT:    [[TMP4:%.*]] = getelementptr i8, ptr [[BP]], i64 16, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP5:%.*]] = icmp ule ptr [[TMP4]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP6:%.*]] = icmp ule ptr [[ARRAYIDX_2]], [[TMP4]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_2:%.*]] = and i1 [[TMP5]], [[TMP6]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_2]], label [[CONT2_2:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.2:
 // CHECK-NEXT:    store i32 2, ptr [[ARRAYIDX_2]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_3:%.*]] = getelementptr i8, ptr [[BP]], i64 16
-// CHECK-NEXT:    [[TMP7:%.*]] = getelementptr i8, ptr [[BP]], i64 20, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP8:%.*]] = icmp ule ptr [[TMP7]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[ARRAYIDX_3]], [[TMP7]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_3:%.*]] = and i1 [[TMP8]], [[TMP9]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_3]], label [[CONT2_3:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.3:
 // CHECK-NEXT:    store i32 3, ptr [[ARRAYIDX_3]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_4:%.*]] = getelementptr i8, ptr [[BP]], i64 20
-// CHECK-NEXT:    [[TMP10:%.*]] = getelementptr i8, ptr [[BP]], i64 24, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP11:%.*]] = icmp ule ptr [[TMP10]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP12:%.*]] = icmp ule ptr [[ARRAYIDX_4]], [[TMP10]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_4:%.*]] = and i1 [[TMP11]], [[TMP12]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_4]], label [[CONT2_4:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.4:
 // CHECK-NEXT:    store i32 4, ptr [[ARRAYIDX_4]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_5:%.*]] = getelementptr i8, ptr [[BP]], i64 24
-// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[BP]], i64 28, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX_5]], [[TMP13]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_5:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_5]], label [[CONT2_5:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.5:
 // CHECK-NEXT:    store i32 5, ptr [[ARRAYIDX_5]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_6:%.*]] = getelementptr i8, ptr [[BP]], i64 28
-// CHECK-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[BP]], i64 32, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP17:%.*]] = icmp ule ptr [[TMP16]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[ARRAYIDX_6]], [[TMP16]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_6:%.*]] = and i1 [[TMP17]], [[TMP18]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_6]], label [[CONT2_6:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.6:
 // CHECK-NEXT:    store i32 6, ptr [[ARRAYIDX_6]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_7:%.*]] = getelementptr i8, ptr [[BP]], i64 32
-// CHECK-NEXT:    [[TMP19:%.*]] = getelementptr i8, ptr [[BP]], i64 36, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP20:%.*]] = icmp ule ptr [[TMP19]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP21:%.*]] = icmp ule ptr [[ARRAYIDX_7]], [[TMP19]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_7:%.*]] = and i1 [[TMP20]], [[TMP21]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_7]], label [[CONT2_7:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.7:
 // CHECK-NEXT:    store i32 7, ptr [[ARRAYIDX_7]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_8:%.*]] = getelementptr i8, ptr [[BP]], i64 36
-// CHECK-NEXT:    [[TMP22:%.*]] = getelementptr i8, ptr [[BP]], i64 40, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP23:%.*]] = icmp ule ptr [[TMP22]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP24:%.*]] = icmp ule ptr [[ARRAYIDX_8]], [[TMP22]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_8:%.*]] = and i1 [[TMP23]], [[TMP24]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_8]], label [[CONT2_8:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.8:
 // CHECK-NEXT:    store i32 8, ptr [[ARRAYIDX_8]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    [[ARRAYIDX_9:%.*]] = getelementptr i8, ptr [[BP]], i64 40
-// CHECK-NEXT:    [[TMP25:%.*]] = getelementptr i8, ptr [[BP]], i64 44, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[ARRAYIDX_9]], [[TMP25]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP]], label [[CONT2_9:%.*]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.9:
 // CHECK-NEXT:    store i32 9, ptr [[ARRAYIDX_9]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    ret void
 //
@@ -96,91 +39,38 @@ void array_member_access_can_remove(struct buf *bp) {
      bp->arr[i] = i;
 }
 
-// rdar://128576231
 // CHECK-LABEL: @array_member_access_trap_on_last_iter(
-// CHECK-NEXT:  cont2:
-// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[BP:%.*]], i64 44
+// CHECK-NEXT:  cont2.9:
+// CHECK-NEXT:    [[ARR:%.*]] = getelementptr inbounds nuw i8, ptr [[BP:%.*]], i64 4
+// CHECK-NEXT:    [[UPPER:%.*]] = getelementptr inbounds nuw i8, ptr [[BP]], i64 44
 // CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[BP]], i64 8
-// CHECK-NEXT:    [[ARR:%.*]] = getelementptr inbounds nuw i8, ptr [[BP]], i64 4
 // CHECK-NEXT:    store i32 0, ptr [[ARR]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr [[BP]], i64 12, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    store i32 1, ptr [[TMP0]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_2:%.*]] = getelementptr i8, ptr [[BP]], i64 12
+// CHECK-NEXT:    store i32 2, ptr [[ARRAYIDX_2]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_3:%.*]] = getelementptr i8, ptr [[BP]], i64 16
+// CHECK-NEXT:    store i32 3, ptr [[ARRAYIDX_3]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_4:%.*]] = getelementptr i8, ptr [[BP]], i64 20
+// CHECK-NEXT:    store i32 4, ptr [[ARRAYIDX_4]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_5:%.*]] = getelementptr i8, ptr [[BP]], i64 24
+// CHECK-NEXT:    store i32 5, ptr [[ARRAYIDX_5]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_6:%.*]] = getelementptr i8, ptr [[BP]], i64 28
+// CHECK-NEXT:    store i32 6, ptr [[ARRAYIDX_6]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_7:%.*]] = getelementptr i8, ptr [[BP]], i64 32
+// CHECK-NEXT:    store i32 7, ptr [[ARRAYIDX_7]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_8:%.*]] = getelementptr i8, ptr [[BP]], i64 36
+// CHECK-NEXT:    store i32 8, ptr [[ARRAYIDX_8]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_9:%.*]] = getelementptr i8, ptr [[BP]], i64 40
+// CHECK-NEXT:    store i32 9, ptr [[ARRAYIDX_9]], align 4, {{!tbaa ![0-9]+}}
+// CHECK-NEXT:    [[ARRAYIDX_10:%.*]] = getelementptr i8, ptr [[BP]], i64 44
+// CHECK-NEXT:    [[TMP1:%.*]] = getelementptr i8, ptr [[BP]], i64 48, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    [[TMP2:%.*]] = icmp ule ptr [[TMP1]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP3:%.*]] = icmp ule ptr [[TMP0]], [[TMP1]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_1:%.*]] = and i1 [[TMP2]], [[TMP3]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_1]], label [[CONT2_1:%.*]], label [[TRAP:%.*]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP3:%.*]] = icmp ule ptr [[ARRAYIDX_10]], [[TMP1]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[OR_COND_10:%.*]] = and i1 [[TMP2]], [[TMP3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[OR_COND_10]], label [[CONT2_10:%.*]], label [[TRAP:%.*]], {{!annotation ![0-9]+}}
 // CHECK:       trap:
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) {{#[0-9]+}}, {{!annotation ![0-9]+}}
 // CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
-// CHECK:       cont2.1:
-// CHECK-NEXT:    store i32 1, ptr [[TMP0]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_2:%.*]] = getelementptr i8, ptr [[BP]], i64 12
-// CHECK-NEXT:    [[TMP4:%.*]] = getelementptr i8, ptr [[BP]], i64 16, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP5:%.*]] = icmp ule ptr [[TMP4]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP6:%.*]] = icmp ule ptr [[ARRAYIDX_2]], [[TMP4]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_2:%.*]] = and i1 [[TMP5]], [[TMP6]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_2]], label [[CONT2_2:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.2:
-// CHECK-NEXT:    store i32 2, ptr [[ARRAYIDX_2]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_3:%.*]] = getelementptr i8, ptr [[BP]], i64 16
-// CHECK-NEXT:    [[TMP7:%.*]] = getelementptr i8, ptr [[BP]], i64 20, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP8:%.*]] = icmp ule ptr [[TMP7]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP9:%.*]] = icmp ule ptr [[ARRAYIDX_3]], [[TMP7]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_3:%.*]] = and i1 [[TMP8]], [[TMP9]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_3]], label [[CONT2_3:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.3:
-// CHECK-NEXT:    store i32 3, ptr [[ARRAYIDX_3]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_4:%.*]] = getelementptr i8, ptr [[BP]], i64 20
-// CHECK-NEXT:    [[TMP10:%.*]] = getelementptr i8, ptr [[BP]], i64 24, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP11:%.*]] = icmp ule ptr [[TMP10]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP12:%.*]] = icmp ule ptr [[ARRAYIDX_4]], [[TMP10]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_4:%.*]] = and i1 [[TMP11]], [[TMP12]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_4]], label [[CONT2_4:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.4:
-// CHECK-NEXT:    store i32 4, ptr [[ARRAYIDX_4]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_5:%.*]] = getelementptr i8, ptr [[BP]], i64 24
-// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr i8, ptr [[BP]], i64 28, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP14:%.*]] = icmp ule ptr [[TMP13]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP15:%.*]] = icmp ule ptr [[ARRAYIDX_5]], [[TMP13]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_5:%.*]] = and i1 [[TMP14]], [[TMP15]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_5]], label [[CONT2_5:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.5:
-// CHECK-NEXT:    store i32 5, ptr [[ARRAYIDX_5]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_6:%.*]] = getelementptr i8, ptr [[BP]], i64 28
-// CHECK-NEXT:    [[TMP16:%.*]] = getelementptr i8, ptr [[BP]], i64 32, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP17:%.*]] = icmp ule ptr [[TMP16]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP18:%.*]] = icmp ule ptr [[ARRAYIDX_6]], [[TMP16]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_6:%.*]] = and i1 [[TMP17]], [[TMP18]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_6]], label [[CONT2_6:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.6:
-// CHECK-NEXT:    store i32 6, ptr [[ARRAYIDX_6]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_7:%.*]] = getelementptr i8, ptr [[BP]], i64 32
-// CHECK-NEXT:    [[TMP19:%.*]] = getelementptr i8, ptr [[BP]], i64 36, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP20:%.*]] = icmp ule ptr [[TMP19]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP21:%.*]] = icmp ule ptr [[ARRAYIDX_7]], [[TMP19]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_7:%.*]] = and i1 [[TMP20]], [[TMP21]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_7]], label [[CONT2_7:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.7:
-// CHECK-NEXT:    store i32 7, ptr [[ARRAYIDX_7]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_8:%.*]] = getelementptr i8, ptr [[BP]], i64 36
-// CHECK-NEXT:    [[TMP22:%.*]] = getelementptr i8, ptr [[BP]], i64 40, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP23:%.*]] = icmp ule ptr [[TMP22]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP24:%.*]] = icmp ule ptr [[ARRAYIDX_8]], [[TMP22]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_8:%.*]] = and i1 [[TMP23]], [[TMP24]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_8]], label [[CONT2_8:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.8:
-// CHECK-NEXT:    store i32 8, ptr [[ARRAYIDX_8]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_9:%.*]] = getelementptr i8, ptr [[BP]], i64 40
-// CHECK-NEXT:    [[TMP25:%.*]] = getelementptr i8, ptr [[BP]], i64 44, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[ARRAYIDX_9]], [[TMP25]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP]], label [[CONT2_9:%.*]], {{!annotation ![0-9]+}}
-// CHECK:       cont2.9:
-// CHECK-NEXT:    store i32 9, ptr [[ARRAYIDX_9]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[ARRAYIDX_10:%.*]] = getelementptr i8, ptr [[BP]], i64 44
-// CHECK-NEXT:    [[TMP26:%.*]] = getelementptr i8, ptr [[BP]], i64 48, {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP27:%.*]] = icmp ule ptr [[TMP26]], [[UPPER]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[TMP28:%.*]] = icmp ule ptr [[ARRAYIDX_10]], [[TMP26]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    [[OR_COND_10:%.*]] = and i1 [[TMP27]], [[TMP28]], {{!annotation ![0-9]+}}
-// CHECK-NEXT:    br i1 [[OR_COND_10]], label [[CONT2_10:%.*]], label [[TRAP]], {{!annotation ![0-9]+}}
 // CHECK:       cont2.10:
 // CHECK-NEXT:    store i32 10, ptr [[ARRAYIDX_10]], align 4, {{!tbaa ![0-9]+}}
 // CHECK-NEXT:    ret void

--- a/clang/test/BoundsSafety/CodeGen/range-check-optimizations.c
+++ b/clang/test/BoundsSafety/CodeGen/range-check-optimizations.c
@@ -126,8 +126,8 @@ void loop_all_accesses_in_bounds_variable_start_2_add(int* __counted_by(n) dst,
 // CHECK-NEXT:    [[INDVARS_IV:%.*]] = phi i64 [ [[TMP2]], [[ENTRY:%.*]] ], [ [[INDVARS_IV_NEXT:%.*]], [[FOR_BODY]] ]
 // CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr i32, ptr [[DST:%.*]], i64 [[INDVARS_IV]]
 // CHECK-NEXT:    store i32 0, ptr [[ARRAYIDX]], align 4, {{!tbaa ![0-9]+}}
-// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw i64 [[INDVARS_IV]], 1
-// CHECK-NEXT:    [[CMP:%.*]] = icmp ult i64 [[INDVARS_IV_NEXT]], [[TMP0]]
+// CHECK-NEXT:    [[INDVARS_IV_NEXT]] = add nuw nsw i64 [[INDVARS_IV]], 1
+// CHECK-NEXT:    [[CMP:%.*]] = icmp samesign ult i64 [[INDVARS_IV_NEXT]], [[TMP0]]
 // CHECK-NEXT:    br i1 [[CMP]], label [[FOR_BODY]], label [[FOR_COND_CLEANUP:%.*]], {{!llvm.loop ![0-9]+}}
 //
 void loop_all_accesses_in_bounds_variable_start_3_modulo(int* __counted_by(n) dst,

--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -746,8 +746,6 @@ PassBuilder::buildFunctionSimplificationPipeline(OptimizationLevel Level,
   // FIXME: It isn't clear why we do this *after* loop passes rather than
   // before...
   FPM.addPass(SCCPPass());
-  if (EnableConstraintElimination)
-    FPM.addPass(ConstraintEliminationPass());
 
   // Delete dead bit computations (instcombine runs after to fold away the dead
   // computations, and then ADCE will run later to exploit any new DCE
@@ -758,6 +756,9 @@ PassBuilder::buildFunctionSimplificationPipeline(OptimizationLevel Level,
   // opportunities opened up by them.
   FPM.addPass(InstCombinePass());
   invokePeepholeEPCallbacks(FPM, Level);
+
+  if (EnableConstraintElimination)
+    FPM.addPass(ConstraintEliminationPass());
 
   // Re-consider control flow based optimizations after redundancy elimination,
   // redo DCE, etc.

--- a/llvm/test/Other/new-pm-defaults.ll
+++ b/llvm/test/Other/new-pm-defaults.ll
@@ -205,11 +205,11 @@
 ; CHECK-O1-NEXT: Running pass: MemCpyOptPass
 ; CHECK-O1-NEXT: Running analysis: PostDominatorTreeAnalysis
 ; CHECK-O-NEXT: Running pass: SCCPPass
-; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O-NEXT: Running pass: BDCEPass
 ; CHECK-O-NEXT: Running analysis: DemandedBitsAnalysis
 ; CHECK-O-NEXT: Running pass: InstCombinePass
 ; CHECK-EP-PEEPHOLE-NEXT: Running pass: NoOpFunctionPass
+; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass
 ; CHECK-O23SZ-NEXT: Running analysis: LazyValueAnalysis
 ; CHECK-O23SZ-NEXT: Running pass: CorrelatedValuePropagationPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-defaults.ll
@@ -131,10 +131,10 @@
 ; CHECK-O1-NEXT: Running pass: MemCpyOptPass
 ; CHECK-O1-NEXT: Running analysis: PostDominatorTreeAnalysis
 ; CHECK-O-NEXT: Running pass: SCCPPass
-; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O-NEXT: Running pass: BDCEPass
 ; CHECK-O-NEXT: Running analysis: DemandedBitsAnalysis
 ; CHECK-O-NEXT: Running pass: InstCombinePass
+; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass
 ; CHECK-O23SZ-NEXT: Running analysis: LazyValueAnalysis
 ; CHECK-O23SZ-NEXT: Running pass: CorrelatedValuePropagationPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-pgo-defaults.ll
@@ -116,10 +116,10 @@
 ; CHECK-O23SZ-NEXT: Running analysis: MemoryDependenceAnalysis
 ; CHECK-O1-NEXT: Running pass: MemCpyOptPass
 ; CHECK-O-NEXT: Running pass: SCCPPass
-; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O-NEXT: Running pass: BDCEPass
 ; CHECK-O-NEXT: Running analysis: DemandedBitsAnalysis
 ; CHECK-O-NEXT: Running pass: InstCombinePass
+; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass
 ; CHECK-O23SZ-NEXT: Running analysis: LazyValueAnalysis
 ; CHECK-O23SZ-NEXT: Running pass: CorrelatedValuePropagationPass

--- a/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-postlink-samplepgo-defaults.ll
@@ -125,10 +125,10 @@
 ; CHECK-O23SZ-NEXT: Running analysis: MemoryDependenceAnalysis
 ; CHECK-O1-NEXT: Running pass: MemCpyOptPass
 ; CHECK-O-NEXT: Running pass: SCCPPass
-; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O-NEXT: Running pass: BDCEPass
 ; CHECK-O-NEXT: Running analysis: DemandedBitsAnalysis
 ; CHECK-O-NEXT: Running pass: InstCombinePass
+; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass
 ; CHECK-O23SZ-NEXT: Running analysis: LazyValueAnalysis
 ; CHECK-O23SZ-NEXT: Running pass: CorrelatedValuePropagationPass

--- a/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-defaults.ll
@@ -163,10 +163,10 @@
 ; CHECK-O1-NEXT: Running pass: MemCpyOptPass
 ; CHECK-O1-NEXT: Running analysis: PostDominatorTreeAnalysis
 ; CHECK-O-NEXT: Running pass: SCCPPass
-; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O-NEXT: Running pass: BDCEPass
 ; CHECK-O-NEXT: Running analysis: DemandedBitsAnalysis
 ; CHECK-O-NEXT: Running pass: InstCombinePass
+; CHECK-O23SZ-NEXT: Running pass: ConstraintElimination
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass
 ; CHECK-O23SZ-NEXT: Running analysis: LazyValueAnalysis
 ; CHECK-O23SZ-NEXT: Running pass: CorrelatedValuePropagationPass

--- a/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-pgo-defaults.ll
@@ -165,10 +165,10 @@
 ; CHECK-O23SZ-NEXT: Running analysis: MemoryDependenceAnalysis
 ; CHECK-O1-NEXT: Running pass: MemCpyOptPass
 ; CHECK-O-NEXT: Running pass: SCCPPass
-; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O-NEXT: Running pass: BDCEPass
 ; CHECK-O-NEXT: Running analysis: DemandedBitsAnalysis
 ; CHECK-O-NEXT: Running pass: InstCombinePass
+; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass
 ; CHECK-O23SZ-NEXT: Running analysis: LazyValueAnalysis
 ; CHECK-O23SZ-NEXT: Running pass: CorrelatedValuePropagationPass

--- a/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
+++ b/llvm/test/Other/new-pm-thinlto-prelink-samplepgo-defaults.ll
@@ -129,10 +129,10 @@
 ; CHECK-O23SZ-NEXT: Running analysis: MemoryDependenceAnalysis
 ; CHECK-O1-NEXT: Running pass: MemCpyOptPass
 ; CHECK-O-NEXT: Running pass: SCCPPass
-; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O-NEXT: Running pass: BDCEPass
 ; CHECK-O-NEXT: Running analysis: DemandedBitsAnalysis
 ; CHECK-O-NEXT: Running pass: InstCombinePass
+; CHECK-O23SZ-NEXT: Running pass: ConstraintEliminationPass
 ; CHECK-O23SZ-NEXT: Running pass: JumpThreadingPass
 ; CHECK-O23SZ-NEXT: Running analysis: LazyValueAnalysis
 ; CHECK-O23SZ-NEXT: Running pass: CorrelatedValuePropagationPass


### PR DESCRIPTION
Adjusting the position of the second run on ConstraintElimination to run after InstCombine can help us remove more range checks, due to InstCombine canonicalizing the IR after loop optimizations.

rdar://128576231