### PR TITLE
[lldb] Avoid crashing when trying reconstruct types with errors 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2292,6 +2292,10 @@ void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
   if (m_dangerous_types.count(key))
     return nullptr;
 
+  // This can crash SwiftASTContext.
+  if (ContainsError(type))
+    return nullptr;
+
   auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx));
   if (!swift_ast_context || swift_ast_context->HasFatalErrors())
     return nullptr;
@@ -2895,11 +2899,25 @@ bool TypeSystemSwiftTypeRef::IsExpressionEvaluatorDefined(
   const auto *mangled_name = AsMangledName(type);
   Demangler dem;
   NodePointer node = GetDemangledType(dem, mangled_name);
-  return swift_demangle::FindIf(node, [](NodePointer node) -> NodePointer {
+  return swift_demangle::FindIf(node, [](NodePointer node) -> bool {
     if (node->getKind() == Node::Kind::Module &&
         node->getText().starts_with("__lldb_expr"))
-      return node;
-    return nullptr;
+      return true;
+    return false;
+  });
+}
+
+bool TypeSystemSwiftTypeRef::ContainsError(
+    lldb::opaque_compiler_type_t type) {
+  using namespace swift::Demangle;
+  const auto *mangled_name = AsMangledName(type);
+  Demangler dem;
+  NodePointer node = GetDemangledType(dem, mangled_name);
+  return swift_demangle::FindIf(node, [](NodePointer node) -> bool {
+    // This node is an in-band error, not a Swift.Error type, which is a protocol.
+    if (node->getKind() == Node::Kind::ErrorType)
+      return true;
+    return false;
   });
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -441,6 +441,9 @@ public:
   swift::Mangle::ManglingFlavor
   GetManglingFlavor(ExecutionContext *exe_ctx = nullptr);
 
+  /// Returns true if this type contains an error node anywhere.
+  bool ContainsError(lldb::opaque_compiler_type_t type);
+
 protected:
   /// Determine whether the fallback is enabled via setting.
   bool UseSwiftASTContextFallback(const char *func_name,

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -1013,3 +1013,15 @@ TEST_F(TestTypeSystemSwiftTypeRef, GenericSignature) {
     ASSERT_FALSE(maybe_signature.has_value());
   }
 }
+
+TEST_F(TestTypeSystemSwiftTypeRef, Error) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer n = b.GlobalType(b.Node(Node::Kind::ErrorType, "Fatal Error"));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    lldb::opaque_compiler_type_t opaque = t.GetOpaqueQualType();
+    ASSERT_TRUE(m_swift_ts->ContainsError(opaque));
+  }
+}


### PR DESCRIPTION
We have crash reports that can be traced back to performing type reconstruction on a mangled name with an error in it. This patch avoids this situation by not reconstructing them. Ther is nothing that would come of it anyway.

rdar://145225544