### PR TITLE
[X86] Also test swifttailcc in shrink-wrapping disablement. NFC.

### DIFF
--- a/llvm/test/CodeGen/X86/x86-tailcc-shrink-wrapping.ll
+++ b/llvm/test/CodeGen/X86/x86-tailcc-shrink-wrapping.ll
@@ -48,7 +48,7 @@ b:
 declare tailcc void @f2()
 declare tailcc void @f1(ptr, i64, ptr, i8, ptr, ptr, ptr, ptr, ptr, ptr)
 
-define tailcc void @test_shrink_wrap_swifttailcc(i64 %0) {
+define swifttailcc void @test_shrink_wrap_swifttailcc(i64 %0) {
 ; CHECK-LABEL: test_shrink_wrap_swifttailcc:
 ; CHECK:       ## %bb.0:
 ; CHECK-NEXT:    subq $32, %rsp
@@ -74,12 +74,12 @@ define tailcc void @test_shrink_wrap_swifttailcc(i64 %0) {
   %cond = icmp ugt i64 %0, 0
   br i1 %cond, label %a, label %b
 a:
-  musttail call tailcc void @sf1(ptr null, i64 16, ptr null, i8 1, ptr null, ptr null, ptr null, ptr null, ptr null, ptr null)
+  musttail call swifttailcc void @sf1(ptr null, i64 16, ptr null, i8 1, ptr null, ptr null, ptr null, ptr null, ptr null, ptr null)
   ret void
 b:
-  musttail call tailcc void @sf2()
+  musttail call swifttailcc void @sf2()
   ret void
 }
 
-declare tailcc void @sf2()
-declare tailcc void @sf1(ptr, i64, ptr, i8, ptr, ptr, ptr, ptr, ptr, ptr)
+declare swifttailcc void @sf2()
+declare swifttailcc void @sf1(ptr, i64, ptr, i8, ptr, ptr, ptr, ptr, ptr, ptr)


### PR DESCRIPTION
14065737a74e disabled shrink-wrapping for tailcc/swifttailcc functions. But I copy-pasta'd the test into only testing tailcc. Also test swifttailcc.

rdar://141673907