### PR TITLE
[lldb] Unify WaitForSetEvents and WaitForEventsToReset (#99997)

### DIFF
--- a/lldb/tools/debugserver/source/PThreadEvent.h
+++ b/lldb/tools/debugserver/source/PThreadEvent.h
@@ -16,6 +16,7 @@
 #include "PThreadMutex.h"
 #include <cstdint>
 #include <ctime>
+#include <functional>
 
 class PThreadEvent {
 public:
@@ -52,6 +53,12 @@ protected:
   uint32_t m_bits;
   uint32_t m_validBits;
   uint32_t m_reset_ack_mask;
+
+  uint32_t GetBitsMasked(uint32_t mask) const { return mask & m_bits; }
+
+  uint32_t WaitForEventsImpl(const uint32_t mask,
+                             const struct timespec *timeout_abstime,
+                             std::function<bool()> predicate) const;
 
 private:
   PThreadEvent(const PThreadEvent &) = delete;


### PR DESCRIPTION
Unify the implementations of WaitForSetEvents and WaitForEventsToReset. The former deals with the possibility of a race between the timeout and the predicate while the latter does not. The functions were also inconsistent in when they would recompute the mask. This patch unifies the two implementations and make them behave exactly the same modulo the predicate.

rdar://130562344
(cherry picked from commit 87f2c25f3dad65890fc8e9abbe9765e44979ed9d)