### PR TITLE
[Cherry-pick into next] [lldb] Add an embedded Swift test for InlineArray (NFC)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -134,7 +134,7 @@ endif
 # Check if we should compile in Swift embedded mode
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
-	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -Xfrontend -disable-objc-interop -runtime-compatibility-version none
+	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -enable-experimental-feature ValueGenerics -Xfrontend -disable-objc-interop -runtime-compatibility-version none
 	ifeq "$(OS)" "Darwin"
 		SWIFTFLAGS += -target $(ARCH)-apple-macos14
 	endif

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -208,3 +208,10 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         innerFunctionType = frame.FindVariable("innerFunctionType")
         innerFuncField = innerFunctionType.GetChildMemberWithName("innerFuncField")
         lldbutil.check_variable(self, innerFuncField, False, value='8479')
+
+        array = frame.FindVariable("array")
+        arrayStorage = array.GetChildMemberWithName("_storage")
+        lldbutil.check_variable(self, arrayStorage, False, num_children=4)
+        for i in range(4):
+            lldbutil.check_variable(self, arrayStorage.GetChildAtIndex(i),
+                                    False, value=str(i+1))

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -159,6 +159,8 @@ func g() {
     let functionType = FunctionType()
     let innerFunctionType = InnerFunctionType()
 
+    var array: InlineArray<4, Int> = [1, 2, 3, 4]
+
     // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
     let dummy = A() // break here
     let string = StaticString("Hello") 


### PR DESCRIPTION
```
commit 0e9ad45c9ada08e0a6652b3e13268539dea364c6
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Feb 21 15:07:12 2025 -0800

    [lldb] Add an embedded Swift test for InlineArray (NFC)
    
    Turns out this feature already works, because all the information is
    also conrtained in the mangled name.
```
