### PR TITLE
[Cherry-pick into next] [lldb] Avoid crashing when trying reconstruct types with errors

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -441,6 +441,9 @@ public:
   swift::Mangle::ManglingFlavor
   GetManglingFlavor(ExecutionContext *exe_ctx = nullptr);
 
+  /// Returns true if this type contains an error node anywhere.
+  bool ContainsError(lldb::opaque_compiler_type_t type);
+
 protected:
   /// Determine whether the fallback is enabled via setting.
   bool UseSwiftASTContextFallback(const char *func_name,

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -1013,3 +1013,15 @@ TEST_F(TestTypeSystemSwiftTypeRef, GenericSignature) {
     ASSERT_FALSE(maybe_signature.has_value());
   }
 }
+
+TEST_F(TestTypeSystemSwiftTypeRef, Error) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodeBuilder b(dem);
+  {
+    NodePointer n = b.GlobalType(b.Node(Node::Kind::ErrorType, "Fatal Error"));
+    CompilerType t = GetCompilerType(b.Mangle(n));
+    lldb::opaque_compiler_type_t opaque = t.GetOpaqueQualType();
+    ASSERT_TRUE(m_swift_ts->ContainsError(opaque));
+  }
+}


### PR DESCRIPTION
```
commit ea373e66a8550966dd2c9eccd0bd50a9e90e716a
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 25 16:25:35 2025 -0800

    [lldb] Avoid crashing when trying reconstruct types with errors
    
    We have crash reports that can be traced back to performing type
    reconstruction on a mangled name with an error in it. This patch
    avoids this situation by not reconstructing them. Ther is nothing that
    would come of it anyway.
    
    rdar://145225544
```
