### PR TITLE
🍒[lldb][cxx-interop] Populate C++ stdlib options correctly

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3638,6 +3638,8 @@ void SwiftASTContext::InitializeSearchPathOptions(
   }
   invocation.getSearchPathOptions().setFrameworkSearchPaths(
       invocation_framework_paths);
+
+  invocation.computeCXXStdlibOptions();
 }
 
 ThreadSafeASTContext SwiftASTContext::GetASTContext() {

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -14,6 +14,8 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
     @swiftTest
     def test(self):
         self.build()
+        log = self.getBuildArtifact("types.log")
+        self.runCmd('log enable lldb types -f "%s"' % log)
         
         _, _, _, _= lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
@@ -57,3 +59,7 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
             '[2] = 9.19'])
         self.expect('expr vector', substrs=['CxxVector', '[0] = 4.1', '[1] = 3.7',
             '[2] = 9.19'])
+
+        # Make sure lldb picks the correct C++ stdlib.
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK-NOT: but current compilation uses unknown C++ stdlib


### PR DESCRIPTION
This fixes errors printed by lldb:

```
error: module 'XYZ' was built with libc++, but current compilation uses unknown C++ stdlib
```

Original PR: https://github.com/swiftlang/llvm-project/pull/10084

rdar://144894619