### PR TITLE
Handle stepping through language thunks that call other functions than the target

### DIFF
--- a/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
+++ b/lldb/include/lldb/Target/ThreadPlanShouldStopHere.h
@@ -59,7 +59,8 @@ public:
     eNone = 0,
     eAvoidInlines = (1 << 0),
     eStepInAvoidNoDebug = (1 << 1),
-    eStepOutAvoidNoDebug = (1 << 2)
+    eStepOutAvoidNoDebug = (1 << 2),
+    eStepOutPastThunks = (1 << 3)
   };
 
   // Constructors and Destructors

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -525,9 +525,12 @@ static lldb::ThreadPlanSP GetStepThroughTrampolinePlan(Thread &thread,
                   GetThunkKindName(thunk_kind));
     AddressRange sym_addr_range(sc.symbol->GetAddress(),
                                 sc.symbol->GetByteSize());
-    return std::make_shared<ThreadPlanStepInRange>(thread, sym_addr_range, sc,
+    ThreadPlanSP new_plan_sp = std::make_shared<ThreadPlanStepInRange>(thread, sym_addr_range, sc,
                                                    nullptr, eOnlyDuringStepping,
                                                    eLazyBoolNo, eLazyBoolNo);
+    static_cast<ThreadPlanStepInRange *>(new_plan_sp.get())
+        ->GetFlags().Clear(ThreadPlanShouldStopHere::eStepOutPastThunks);
+    return new_plan_sp;     
   }
   }
 

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -9,6 +9,7 @@
 #include "lldb/Target/ThreadPlanShouldStopHere.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/Symbol.h"
+#include "lldb/Target/Language.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
@@ -86,7 +87,12 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
     if (symbol) {
       ProcessSP process_sp(current_plan->GetThread().GetProcess());
       for (auto *runtime : process_sp->GetLanguageRuntimes()) {
-        if (runtime->IsSymbolARuntimeThunk(*symbol))
+        if (runtime->IsSymbolARuntimeThunk(*symbol) &&
+            flags.Test(ThreadPlanShouldStopHere::eStepOutPastThunks)) {
+          LLDB_LOGF(
+              log, "Stepping out past a language thunk %s for: %s",
+              frame->GetFunctionName(),
+              Language::GetNameForLanguageType(runtime->GetLanguageType()));
           should_stop_here = false;
       }
     }
@@ -139,11 +145,14 @@ ThreadPlanSP ThreadPlanShouldStopHere::DefaultStepFromHereCallback(
     if (sc.symbol) {
       ProcessSP process_sp(current_plan->GetThread().GetProcess());
       for (auto *runtime : process_sp->GetLanguageRuntimes()) {
-        if (runtime->IsSymbolARuntimeThunk(*sc.symbol)) {
-          if (log)
-            log->Printf("In runtime thunk %s - stepping out.",
-                        sc.symbol->GetName().GetCString());
+        if (runtime->IsSymbolARuntimeThunk(*sc.symbol) &&
+            flags.Test(ThreadPlanShouldStopHere::eStepOutPastThunks)) {
+          LLDB_LOGF(
+              log, "Stepping out past a language thunk %s for: %s",
+              frame->GetFunctionName(),
+              Language::GetNameForLanguageType(runtime->GetLanguageType()));
           just_step_out = true;
+          break;
         }
       }
       // If the whole function is marked line 0 just step out, that's easier &

--- a/lldb/source/Target/ThreadPlanShouldStopHere.cpp
+++ b/lldb/source/Target/ThreadPlanShouldStopHere.cpp
@@ -94,6 +94,7 @@ bool ThreadPlanShouldStopHere::DefaultShouldStopHereCallback(
               frame->GetFunctionName(),
               Language::GetNameForLanguageType(runtime->GetLanguageType()));
           should_stop_here = false;
+        }
       }
     }
   }

--- a/lldb/source/Target/ThreadPlanStepInRange.cpp
+++ b/lldb/source/Target/ThreadPlanStepInRange.cpp
@@ -29,7 +29,8 @@ using namespace lldb;
 using namespace lldb_private;
 
 uint32_t ThreadPlanStepInRange::s_default_flag_values =
-    ThreadPlanShouldStopHere::eStepInAvoidNoDebug;
+    ThreadPlanShouldStopHere::eStepInAvoidNoDebug |
+    ThreadPlanShouldStopHere::eStepOutPastThunks;
 
 // ThreadPlanStepInRange: Step through a stack range, either stepping over or
 // into based on the value of \a type.

--- a/lldb/test/API/lang/swift/step_through_allocating_init/Makefile
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/Makefile
@@ -1,0 +1,6 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules
+
+cleanup:
+	rm -f Makefile *.d
+

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -1,0 +1,74 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import os
+import platform
+
+class TestStepThroughAllocatingInit(lldbtest.TestBase):
+    mydir = lldbtest.TestBase.compute_mydir(__file__)
+
+    @swiftTest
+    def test_swift_stepping_api(self):
+        """Test that step in using the Python API steps through thunk."""
+        self.build()
+        self.do_test(True)
+
+    @swiftTest
+    def test_swift_stepping_cli(self):
+        """Same test with the cli - it goes a slightly different path than
+           the API."""
+        self.build()
+        self.do_test(False)
+
+    def setUp(self):
+        lldbtest.TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+        # If you are running against a debug swift you are going to
+        # end up stepping into the stdlib and that will make stepping
+        # tests impossible to write.  So avoid that.
+
+        if platform.system() == 'Darwin':
+            lib_name = "libswiftCore.dylib"
+        else:
+            lib_name = "libswiftCore.so"
+
+        self.dbg.HandleCommand(
+            "settings set "
+            "target.process.thread.step-avoid-libraries {}".format(lib_name))
+
+    def do_test(self, use_api):
+        """Tests that we can step reliably in swift code."""
+        exe_name = "a.out"
+        exe = self.getBuildArtifact(exe_name)
+
+        target, process, thread, breakpoint = lldbutil.run_to_source_breakpoint(self,
+        'Break here to step into init', self.main_source_spec)
+
+        # Step into the function.
+        if use_api:
+            thread.StepInto()
+        else:
+            self.runCmd("thread step-in")
+        frame_0 = thread.frames[0]
+        self.assertIn('Foo.init()', frame_0.GetFunctionName())
+
+        # Check that our parent frame is indeed allocating_init (otherwise we aren't
+        # testing what we think we're testing...
+        frame_1 = thread.frames[1]
+        self.assertIn("allocating_init", frame_1.GetFunctionName())
+
+        # Step one line so some_string is initialized, make sure we can
+        # get its value:
+        thread.StepOver()
+        frame_0 = thread.frames[0]
+        self.assertIn('Foo.init()', frame_0.GetFunctionName())
+        var = frame_0.FindVariable("some_string")
+        self.assertTrue(var.GetError().Success())
+        self.assertEqual(var.GetSummary(), '"foo"')
+        
+        # Now make sure that stepping out steps past the thunk:
+        thread.StepOut()
+        frame_0 = thread.frames[0]
+        self.assertIn("doSomething", frame_0.GetFunctionName())

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -61,7 +61,11 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
 
         # Step one line so some_string is initialized, make sure we can
         # get its value:
-        thread.StepOver()
+        if use_api:
+            thread.StepOver()
+        else:
+            self.runCmd("thread step-over")
+
         frame_0 = thread.frames[0]
         self.assertIn('Foo.init()', frame_0.GetFunctionName())
         var = frame_0.FindVariable("some_string")
@@ -69,6 +73,10 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
         self.assertEqual(var.GetSummary(), '"foo"')
         
         # Now make sure that stepping out steps past the thunk:
-        thread.StepOut()
+        if use_api:
+            thread.StepOut()
+        else:
+            self.runCmd("thread step-out")
+
         frame_0 = thread.frames[0]
         self.assertIn("doSomething", frame_0.GetFunctionName())

--- a/lldb/test/API/lang/swift/step_through_allocating_init/main.swift
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/main.swift
@@ -1,0 +1,18 @@
+class Foo {
+    init() {
+      let some_string = "foo"
+      print(some_string)
+    }
+}
+
+func bar(_ _: Foo) {
+    print("bar")
+}
+
+func doSomething()
+{
+  let f = Foo() // Break here to step into init
+  bar(f)
+}
+
+doSomething()


### PR DESCRIPTION
We have a general feature of "stepping out past language thunks".  But we also have a strategy for resolving the target of a thunk which involves stepping through it, stepping in one level deep, and if we get somewhere interesting we stop.  If we try to do the latter maneuver, we need to turn off the stepping out past thunks or the first time we step out of something "not interesting" we'll also step past the thunk, defeating the strategy.

The fixes that by adding a way to say "this plan should or should not do the step out past thunk, then setting that for the step through plan.

Also added tests for this.