### PR TITLE
[Cherry-pick into next] [lldb] Improve handling of indirect enums using reflection metadata

### DIFF
--- a/lldb/test/API/lang/swift/enums/indirect/Makefile
+++ b/lldb/test/API/lang/swift/enums/indirect/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
+++ b/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
@@ -1,0 +1,64 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestCase(TestBase):
+    @swiftTest
+    def test(self):
+        """Test indirect enums"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        if self.TraceOn():
+            self.expect('v')
+        frame = thread.frames[0]
+        generic_s = frame.FindVariable("generic_s")
+        s = generic_s.GetChildMemberWithName("s")
+        t = s.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value="123")
+
+        generic_large_s = frame.FindVariable("generic_large_s")
+        s = generic_s.GetChildMemberWithName("s")
+        t = s.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value="123")
+
+        generic_c = frame.FindVariable("generic_c")
+        c = generic_c.GetChildMemberWithName("c")
+        t = c.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value="123")
+
+        multi_s = frame.FindVariable("multi_s")
+        s = multi_s.GetChildMemberWithName("s")
+        t = s.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, t, False, value="123")
+
+        multi_c = frame.FindVariable("multi_c")
+        lldbutil.check_variable(self, multi_c, False, value="c")
+
+        tuple_a = frame.FindVariable("tuple_a")
+        a = tuple_a.GetChildMemberWithName("a")
+        self.assertEqual(a.GetNumChildren(), 2)
+        lldbutil.check_variable(self, a.GetChildAtIndex(0), False, value="23")
+        lldbutil.check_variable(self, a.GetChildAtIndex(1), False, summary='"hello"')
+        tuple_b = frame.FindVariable("tuple_b")
+        b = tuple_b.GetChildMemberWithName("b")
+        self.assertEqual(b.GetNumChildren(), 1)
+        lldbutil.check_variable(self, b.GetChildAtIndex(0), False, value="42")
+        tuple_c = frame.FindVariable("tuple_c")
+        c = tuple_c.GetChildMemberWithName("c")
+        lldbutil.check_variable(self, c, False, value="32")
+        tuple_d = frame.FindVariable("tuple_d")
+        lldbutil.check_variable(self, tuple_d, False, value="d")
+
+        tree = frame.FindVariable("tree")
+        n0 = tree.GetChildMemberWithName("node")
+        n1 = n0.GetChildAtIndex(0)
+        n2 = n1.GetChildAtIndex(0)
+        l0 = n2.GetChildAtIndex(0)
+        lldbutil.check_variable(self, l0.GetChildAtIndex(0), False, value="1")
+        l1 = n2.GetChildAtIndex(1)
+        lldbutil.check_variable(self, l1.GetChildAtIndex(0), False, value="2")
+        l2 = n0.GetChildAtIndex(1)
+        lldbutil.check_variable(self, l2.GetChildAtIndex(0), False, value="3")

--- a/lldb/test/API/lang/swift/enums/indirect/main.swift
+++ b/lldb/test/API/lang/swift/enums/indirect/main.swift
@@ -1,0 +1,61 @@
+struct S<T> {
+  let t: T
+}
+
+enum EGenericS<T> {
+  indirect case s(S<T>)
+}
+
+class C<T> {
+  init(t: T) { self.t = t }
+  let t: T
+}
+
+struct LargeS<T> {
+  let t: T
+  let space = (0, 1, 2, 3, 4, 5, 6, 7)
+}
+
+enum EGenericLargeS<T> {
+  indirect case s(LargeS<T>)
+}
+
+enum EGenericC<T> {
+  indirect case c(C<T>)
+}
+
+enum EGenericMulti<T> {
+  indirect case s(S<T>)
+  indirect case c(C<T>)
+}
+
+enum ETuple {
+  indirect case a(Int, String)
+  indirect case b(Int)
+  case c(Int)
+  case d
+}
+
+enum ETree<T> {
+  indirect case node(ETree<T>, ETree<T>)
+  case leaf(T)
+}
+
+func main() {
+  let generic_s = EGenericS<Int>.s(S(t: 123))
+  let generic_large_s = EGenericLargeS<Int>.s(LargeS(t: 123))
+  let generic_c = EGenericC<Int>.c(C(t: 123))
+  let multi_s = EGenericMulti<Int>.s(S(t: 123))
+  let multi_c = EGenericMulti<Int>.c(C(t: 123))
+  let tuple_a = ETuple.a(23, "hello")
+  let tuple_b = ETuple.b(42)
+  let tuple_c = ETuple.c(32)
+  let tuple_d = ETuple.d
+  let tree = ETree<Int>.node(
+      ETree<Int>.node(ETree<Int>.leaf(1),
+                      ETree<Int>.leaf(2)),
+      ETree<Int>.leaf(3))
+  print("break here")
+}
+
+main()


### PR DESCRIPTION
```
commit 06754a2fe04c30bf3c64dbf47f74a968bafa33ea
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Feb 28 18:15:33 2025 -0800

    [lldb] Improve handling of indirect enums using reflection metadata
    
    This adds tests for several kinds of indirect enums that were
    previously uncovered, such as GADTs and generic single-payload enums
    and implements the proper handling of the ClosureContext box these
    payloads come packaged in.
    
    This fixes a lot of edge cases that previously required a
    SwiftASTContext to resolve properly.
    
    rdar://145301500
```
