### PR TITLE
🍒 [lldb][HostInfoMacOSX] Try to use DW_AT_LLVM_sysroot instead of xcrun when looking up SDK

### DIFF
--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -54,6 +54,9 @@ public:
 #endif
 
   /// Query xcrun to find an Xcode SDK directory.
+  ///
+  /// Note, this is an expensive operation if the SDK we're querying
+  /// does not exist in an Xcode installation path on the host.
   static llvm::Expected<llvm::StringRef> GetSDKRoot(SDKOptions options);
   static llvm::Expected<llvm::StringRef> FindSDKTool(XcodeSDK sdk,
                                                      llvm::StringRef tool);

--- a/lldb/include/lldb/Utility/XcodeSDK.h
+++ b/lldb/include/lldb/Utility/XcodeSDK.h
@@ -9,6 +9,7 @@
 #ifndef LLDB_UTILITY_SDK_H
 #define LLDB_UTILITY_SDK_H
 
+#include "lldb/Utility/FileSpec.h"
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/VersionTuple.h"
@@ -23,6 +24,7 @@ namespace lldb_private {
 /// An abstraction for Xcode-style SDKs that works like \ref ArchSpec.
 class XcodeSDK {
   std::string m_name;
+  FileSpec m_sysroot;
 
 public:
   /// Different types of Xcode SDKs.
@@ -62,6 +64,8 @@ public:
   /// directory component of a path one would pass to clang's -isysroot
   /// parameter. For example, "MacOSX.10.14.sdk".
   XcodeSDK(std::string &&name) : m_name(std::move(name)) {}
+  XcodeSDK(std::string name, FileSpec sysroot)
+      : m_name(std::move(name)), m_sysroot(std::move(sysroot)) {}
   static XcodeSDK GetAnyMacOS() { return XcodeSDK("MacOSX.sdk"); }
 
   /// The merge function follows a strict order to maintain monotonicity:
@@ -79,6 +83,7 @@ public:
   llvm::VersionTuple GetVersion() const;
   Type GetType() const;
   llvm::StringRef GetString() const;
+  const FileSpec &GetSysroot() const;
   /// Whether this Xcode SDK supports Swift.
   bool SupportsSwift() const;
 

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwin.cpp
@@ -1420,6 +1420,9 @@ PlatformDarwin::ResolveSDKPathFromDebugInfo(Module &module) {
 
   auto [sdk, _] = std::move(*sdk_or_err);
 
+  if (FileSystem::Instance().Exists(sdk.GetSysroot()))
+    return sdk.GetSysroot().GetPath();
+
   auto path_or_err = HostInfo::GetSDKRoot(HostInfo::SDKOptions{sdk});
   if (!path_or_err)
     return llvm::createStringError(

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1024,21 +1024,26 @@ XcodeSDK SymbolFileDWARF::ParseXcodeSDK(CompileUnit &comp_unit) {
   const char *sdk = cu_die.GetAttributeValueAsString(DW_AT_APPLE_sdk, nullptr);
   if (!sdk)
     return {};
-  const char *sysroot =
+  std::string sysroot =
       cu_die.GetAttributeValueAsString(DW_AT_LLVM_sysroot, "");
-  // Register the sysroot path remapping with the module belonging to
-  // the CU as well as the one belonging to the symbol file. The two
-  // would be different if this is an OSO object and module is the
-  // corresponding debug map, in which case both should be updated.
-  ModuleSP module_sp = comp_unit.GetModule();
-  if (module_sp)
-    module_sp->RegisterXcodeSDK(sdk, sysroot);
 
-  ModuleSP local_module_sp = m_objfile_sp->GetModule();
-  if (local_module_sp && local_module_sp != module_sp)
-    local_module_sp->RegisterXcodeSDK(sdk, sysroot);
+  // RegisterXcodeSDK calls into xcrun which is not aware of CLT, which is
+  // expensive.
+  if (sysroot.find("/Library/Developer/CommandLineTools/SDKs") != 0) {
+    // Register the sysroot path remapping with the module belonging to
+    // the CU as well as the one belonging to the symbol file. The two
+    // would be different if this is an OSO object and module is the
+    // corresponding debug map, in which case both should be updated.
+    ModuleSP module_sp = comp_unit.GetModule();
+    if (module_sp)
+      module_sp->RegisterXcodeSDK(sdk, sysroot);
 
-  return {sdk};
+    ModuleSP local_module_sp = m_objfile_sp->GetModule();
+    if (local_module_sp && local_module_sp != module_sp)
+      local_module_sp->RegisterXcodeSDK(sdk, sysroot);
+  }
+
+  return {sdk, FileSpec{std::move(sysroot)}};
 }
 
 size_t SymbolFileDWARF::ParseFunctions(CompileUnit &comp_unit) {

--- a/lldb/source/Utility/XcodeSDK.cpp
+++ b/lldb/source/Utility/XcodeSDK.cpp
@@ -142,6 +142,8 @@ XcodeSDK::Type XcodeSDK::GetType() const {
 
 llvm::StringRef XcodeSDK::GetString() const { return m_name; }
 
+const FileSpec &XcodeSDK::GetSysroot() const { return m_sysroot; }
+
 bool XcodeSDK::Info::operator<(const Info &other) const {
   return std::tie(type, version, internal) <
          std::tie(other.type, other.version, other.internal);
@@ -153,6 +155,10 @@ bool XcodeSDK::Info::operator==(const Info &other) const {
 }
 
 void XcodeSDK::Merge(const XcodeSDK &other) {
+  auto add_internal_sdk_suffix = [](llvm::StringRef sdk) {
+    return (sdk.substr(0, sdk.size() - 3) + "Internal.sdk").str();
+  };
+
   // The "bigger" SDK always wins.
   auto l = Parse();
   auto r = other.Parse();
@@ -160,10 +166,13 @@ void XcodeSDK::Merge(const XcodeSDK &other) {
     *this = other;
   else {
     // The Internal flag always wins.
-    if (llvm::StringRef(m_name).ends_with(".sdk"))
-      if (!l.internal && r.internal)
-        m_name =
-            m_name.substr(0, m_name.size() - 3) + std::string("Internal.sdk");
+    if (!l.internal && r.internal) {
+      if (llvm::StringRef(m_name).ends_with(".sdk"))
+        m_name = add_internal_sdk_suffix(m_name);
+
+      if (m_sysroot.GetFileNameExtension() == ".sdk")
+        m_sysroot.SetFilename(add_internal_sdk_suffix(m_sysroot.GetFilename()));
+    }
   }
 }
 

--- a/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
@@ -307,13 +307,28 @@ SDKPathParsingTestData sdkPathParsingTestCases[] = {
      .expect_internal_sdk = true,
      .expect_sdk_path_pattern = "Internal.sdk"},
 
-    /// Two CUs with an internal SDK each
-    {.input_sdk_paths =
-         {"/Library/Developer/CommandLineTools/SDKs/iPhoneOS14.1.sdk",
-          "/Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk"},
+    /// Two CUs with a public (non-CommandLineTools) SDK each
+    {.input_sdk_paths = {"/Path/To/SDKs/iPhoneOS14.1.sdk",
+                         "/Path/To/SDKs/MacOSX11.3.sdk"},
      .expect_mismatch = false,
      .expect_internal_sdk = false,
      .expect_sdk_path_pattern = "iPhoneOS14.1.sdk"},
+
+    /// One CU with CommandLineTools and the other a public SDK
+    {.input_sdk_paths =
+         {"/Library/Developer/CommandLineTools/SDKs/iPhoneOS14.1.sdk",
+          "/Path/To/SDKs/MacOSX11.3.sdk"},
+     .expect_mismatch = false,
+     .expect_internal_sdk = false,
+     .expect_sdk_path_pattern = "iPhoneOS14.1.sdk"},
+
+    /// One CU with CommandLineTools and the other an internal SDK
+    {.input_sdk_paths =
+         {"/Library/Developer/CommandLineTools/SDKs/iPhoneOS14.1.sdk",
+          "/Path/To/SDKs/MacOSX11.3.Internal.sdk"},
+     .expect_mismatch = true,
+     .expect_internal_sdk = true,
+     .expect_sdk_path_pattern = "iPhoneOS14.1.Internal.sdk"},
 };
 
 INSTANTIATE_TEST_CASE_P(SDKPathParsingTests, SDKPathParsingMultiparamTests,

--- a/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
+++ b/lldb/unittests/SymbolFile/DWARF/XcodeSDKModuleTests.cpp
@@ -116,11 +116,8 @@ DWARF:
   SymbolFileDWARF &sym_file = dwarf_cu->GetSymbolFileDWARF();
   CompUnitSP comp_unit = sym_file.GetCompileUnitAtIndex(0);
   ASSERT_TRUE(static_cast<bool>(comp_unit.get()));
-  ModuleSP module = t.GetModule();
-  ASSERT_EQ(module->GetSourceMappingList().GetSize(), 0u);
   XcodeSDK sdk = sym_file.ParseXcodeSDK(*comp_unit);
   ASSERT_EQ(sdk.GetType(), XcodeSDK::Type::MacOSX);
-  ASSERT_EQ(module->GetSourceMappingList().GetSize(), 1u);
 }
 
 TEST_F(XcodeSDKModuleTests, TestSDKPathFromDebugInfo_InvalidSDKPath) {

--- a/lldb/unittests/Utility/XcodeSDKTest.cpp
+++ b/lldb/unittests/Utility/XcodeSDKTest.cpp
@@ -34,12 +34,17 @@ TEST(XcodeSDKTest, ParseTest) {
   EXPECT_EQ(XcodeSDK("MacOSX10.9.sdk").GetVersion(), llvm::VersionTuple(10, 9));
   EXPECT_EQ(XcodeSDK("MacOSX10.15.4.sdk").GetVersion(), llvm::VersionTuple(10, 15));
   EXPECT_EQ(XcodeSDK("MacOSX.sdk").IsAppleInternalSDK(), false);
+  EXPECT_EQ(
+      XcodeSDK("MacOSX.sdk", FileSpec{"/Path/To/MacOSX.sdk"}).GetSysroot(),
+      FileSpec("/Path/To/MacOSX.sdk"));
   EXPECT_EQ(XcodeSDK("MacOSX10.15.Internal.sdk").GetType(), XcodeSDK::MacOSX);
   EXPECT_EQ(XcodeSDK("MacOSX10.15.Internal.sdk").GetVersion(),
             llvm::VersionTuple(10, 15));
   EXPECT_EQ(XcodeSDK("MacOSX10.15.Internal.sdk").IsAppleInternalSDK(), true);
+  EXPECT_FALSE(XcodeSDK("MacOSX10.15.Internal.sdk").GetSysroot());
   EXPECT_EQ(XcodeSDK().GetType(), XcodeSDK::unknown);
   EXPECT_EQ(XcodeSDK().GetVersion(), llvm::VersionTuple());
+  EXPECT_FALSE(XcodeSDK().GetSysroot());
 }
 
 TEST(XcodeSDKTest, MergeTest) {
@@ -60,6 +65,14 @@ TEST(XcodeSDKTest, MergeTest) {
   XcodeSDK empty;
   empty.Merge(XcodeSDK("MacOSX10.14.Internal.sdk"));
   EXPECT_EQ(empty.GetString(), llvm::StringRef("MacOSX10.14.Internal.sdk"));
+  EXPECT_FALSE(empty.GetSysroot());
+  empty.Merge(XcodeSDK("MacOSX9.5.Internal.sdk", FileSpec{"/Path/To/9.5.sdk"}));
+  EXPECT_FALSE(empty.GetSysroot());
+  empty.Merge(XcodeSDK("MacOSX12.5.sdk", FileSpec{"/Path/To/12.5.sdk"}));
+  EXPECT_EQ(empty.GetSysroot(), FileSpec{"/Path/To/12.5.sdk"});
+  empty.Merge(XcodeSDK("MacOSX11.5.Internal.sdk",
+                       FileSpec{"/Path/To/12.5.Internal.sdk"}));
+  EXPECT_EQ(empty.GetSysroot(), FileSpec{"/Path/To/12.5.Internal.sdk"});
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
`GetSDKRoot` uses `xcrun` to find an SDK root path for a given SDK version string. But if the SDK doesn't exist in the Xcode installations, but instead lives in the `CommandLineTools`, `xcrun` will fail to find it. Negative searches for an SDK path cost a lot (a few seconds) each time `xcrun` is invoked. We do cache negative results in `find_cached_path` inside LLDB, but we would still pay the price on every new debug session the first time we evaluate an expression. This doesn't only cause a noticable delay in running the expression, but also generates following error:
```
error: Error while searching for Xcode SDK: timed out waiting for shell command to complete
(int) $0 = 42
```

In this patch we avoid these possibly expensive calls to `xcrun` by checking the `DW_AT_LLVM_sysroot`, and if it exists, using that as the SDK path. We need an explicit check for the `CommandLineTools` path before we call `RegisterXcodeSDK`, because that will try to call `xcrun`. This won't prevent other uses of `GetSDKRoot` popping up that cause us to make expensive `xcrun` calls, but for now this addresses the regression in the expression evaluator. We also had to adjust the `XcodeSDK::Merge` logic to update the sysroot. There is one case for which this wouldn't make sense: if a CU was compiled with `CommandLineTools` and a different one with an older internal SDK, in that case we would update the `CommandLineTools` sysroot with a `.Internal.sdk` prefix, which won't possibly exist for `CommandLineTools`. I added a unit-test for this. Not sure if we want to explicitly detect and disallow this, given it's quite a niche scenario.

rdar://113619904
rdar://113619723

(cherry picked from commit https://github.com/swiftlang/llvm-project/commit/77a8770d4976e086f36004a6b8bf09e76d981451)