### PR TITLE
Properly disable `clang/test/Driver/lld-repro.c`

### DIFF
--- a/clang/test/Driver/lld-repro.c
+++ b/clang/test/Driver/lld-repro.c
@@ -3,7 +3,7 @@
 
 // Swift LLVM fork downstream change start
 // lld from the Swift LLVM fork does not support linking Darwin Mach-O files
-// UNSUPPORTED: *
+// UNSUPPORTED: target={{.*}}
 // Swift LLVM fork downstream change end
 
 // RUN: echo "-nostartfiles -nostdlib -fuse-ld=lld -gen-reproducer=error -fcrash-diagnostics-dir=%t" \


### PR DESCRIPTION
The test was failing as a result of a malformed glob in the UNSUPPORTED directive.

Replace with `UNSUPPORTED target={{.*}}` to disable the test on all platforms, which I assume was the intent.