### PR TITLE
[🍒][clang][deps] Remove dependency on llvm targets from lib DependencyScanning

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
+++ b/clang/lib/Tooling/DependencyScanning/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
   Core
   Option
   Support

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningService.cpp
@@ -10,7 +10,6 @@
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Support/TargetSelect.h"
 
 using namespace clang;
 using namespace tooling;
@@ -27,10 +26,4 @@ DependencyScanningService::DependencyScanningService(
       SharedFS(std::move(SharedFS)) {
   if (!this->SharedFS)
     SharedCache.emplace();
-
-  // Initialize targets for object file support.
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
 }


### PR DESCRIPTION
In d64eccf we split the object file reader from the writer and removed the dependency on clangCodeGen from the dependency scanner. However, we were still initializing all the llvm targets, which was needed for writing object file pcms but not reading them. This caused us to link more llvm target code than necessary. Shrinks clangd by nearly 50% for me.

rdar://144790713
(cherry picked from commit f8ba0df8781a9f2d0b54fcd6b06a47a06234a4c4)