### PR TITLE
[lldb] Loosen test of concrete type of DSL Regex (NFC)

### DIFF
--- a/lldb/test/Shell/SwiftREPL/Regex.test
+++ b/lldb/test/Shell/SwiftREPL/Regex.test
@@ -14,7 +14,7 @@ let regex2 = /Order from <(.*)>, type: (.*), count in dozen: ([0-9]+)/
 
 import RegexBuilder
 let dslRegex = Regex { .digit }
-// CHECK: _StringProcessing.Regex<Substring> =
+// CHECK: _StringProcessing.Regex<{{.+}}> =
 
 // We should only see this output once, regardless of availability.
 // CHECK-NOT: _StringProcessing


### PR DESCRIPTION
(cherry-picked from commit d8ece74bc1ccd8366ab2ad18a52449602ab1e748)