### PR TITLE
[lldb][formatter] Add children of Swift Tasks (#10057)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -407,6 +407,8 @@ public:
     result.kind = task_info.Kind;
     result.enqueuePriority = task_info.EnqueuePriority;
     result.resumeAsyncContext = task_info.ResumeAsyncContext;
+    for (auto child : task_info.ChildTasks)
+      result.childTasks.push_back(child);
     return result;
   }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -170,6 +170,7 @@ public:
     uint32_t kind = 0;
     uint32_t enqueuePriority = 0;
     lldb::addr_t resumeAsyncContext = LLDB_INVALID_ADDRESS;
+    std::vector<lldb::addr_t> childTasks;
   };
   // The default limits are copied from swift-inspect.
   virtual llvm::Expected<AsyncTaskInfo>

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -28,6 +28,7 @@ class TestCase(TestBase):
                 "isAsyncLetTask = false",
                 "isCancelled = false",
                 "isEnqueued = ",
+                "children = {}",
             ],
         )
 
@@ -49,5 +50,6 @@ class TestCase(TestBase):
                 "isAsyncLetTask = true",
                 "isCancelled = false",
                 "isEnqueued = false",
+                "children = {}",
             ],
         )

--- a/lldb/test/API/lang/swift/async/formatters/task/children/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
@@ -1,0 +1,31 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "language swift task info",
+            substrs=[
+                "(UnsafeCurrentTask) current_task = {",
+                "id = 1",
+                "isChildTask = false",
+                "isAsyncLetTask = false",
+                "children = {",
+                "0 = {",
+                "id = 2",
+                "isChildTask = true",
+                "isAsyncLetTask = true",
+                "children = {}",
+            ],
+        )

--- a/lldb/test/API/lang/swift/async/formatters/task/children/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/main.swift
@@ -1,0 +1,11 @@
+func f() async -> Int {
+    try? await Task.sleep(for: .seconds(300))
+    return 30
+}
+
+@main struct Main {
+    static func main() async {
+        async let number = f()
+        await print("break here \(number)")
+    }
+}


### PR DESCRIPTION
When displaying a Swift `Task`, include its child tasks.

This adds a `children` child to the `Task` synthetic provider. The type of `children` is a dynamically constructed tuple of N `UnsafeCurrentTask`, where N is the number of child tasks.

This allows users to see structured concurrency child tasks, in particular `async let` child tasks, and `TaskGroup` child tasks.
(cherry-picked from commit 0e7ec032c7faad426788ee0a97b2c4da6931baa9)