### PR TITLE
[lldb] Add synthetic formatter for Swift.TaskGroup (#10143)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -119,6 +119,9 @@ SyntheticChildrenFrontEnd *EnumSyntheticFrontEndCreator(CXXSyntheticChildren *,
 
 SyntheticChildrenFrontEnd *TaskSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
+
+SyntheticChildrenFrontEnd *
+TaskGroupSyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
 }
 }
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -416,6 +416,11 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                   lldb_private::formatters::swift::TaskSyntheticFrontEndCreator,
                   "Swift.UnsafeCurrentTask synthetic children",
                   ConstString("Swift.UnsafeCurrentTask"), synth_flags);
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::TaskGroupSyntheticFrontEndCreator,
+      "Swift.TaskGroup synthetic children",
+      ConstString("^Swift\\.TaskGroup<.+>"), synth_flags, true);
 
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Bool_SummaryProvider,

--- a/lldb/test/API/lang/swift/async/taskgroups/Makefile
+++ b/lldb/test/API/lang/swift/async/taskgroups/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -1,0 +1,43 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test_value_printing(self):
+        """Print a TaskGroup and verify its children."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "v group",
+            substrs=[
+                "[0] = {",
+                "isGroupChildTask = true",
+                "[1] = {",
+                "isGroupChildTask = true",
+                "[2] = {",
+                "isGroupChildTask = true",
+            ],
+        )
+
+    @swiftTest
+    def test_value_api(self):
+        """Verify a TaskGroup contains its expected children."""
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        thread = process.GetSelectedThread()
+        frame = thread.GetSelectedFrame()
+        group = frame.FindVariable("group")
+        self.assertEqual(group.num_children, 3)
+        for task in group:
+            self.assertEqual(str(task), str(group.GetChildMemberWithName(task.name)))
+            self.assertEqual(
+                task.GetChildMemberWithName("isGroupChildTask").summary, "true"
+            )

--- a/lldb/test/API/lang/swift/async/taskgroups/main.swift
+++ b/lldb/test/API/lang/swift/async/taskgroups/main.swift
@@ -1,0 +1,14 @@
+@main struct Main {
+    static func main() async {
+        await withTaskGroup { group in
+            for _ in 0..<3 {
+                group.addTask {
+                    try? await Task.sleep(for: .seconds(300))
+                }
+            }
+
+            print("break here")
+            for await _ in group {}
+        }
+    }
+}


### PR DESCRIPTION
Add synthetic data formatter for `TaskGroup`. This formatter prints the group's tasks using the previously added formatter for `Task`.

(cherry-picked from commit 065c58ec111cdfa80002e72c90be2e0eb6093032)