### PR TITLE
[lldb] Add synthetic formatter for Swift.UnsafeContinuation

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -121,6 +121,10 @@ SyntheticChildrenFrontEnd *TaskSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
 
 SyntheticChildrenFrontEnd *
+UnsafeContinuationSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                           lldb::ValueObjectSP);
+
+SyntheticChildrenFrontEnd *
 TaskGroupSyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
 }
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -416,6 +416,12 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                   lldb_private::formatters::swift::TaskSyntheticFrontEndCreator,
                   "Swift.UnsafeCurrentTask synthetic children",
                   ConstString("Swift.UnsafeCurrentTask"), synth_flags);
+  AddCXXSynthetic(swift_category_sp,
+                  lldb_private::formatters::swift::
+                      UnsafeContinuationSyntheticFrontEndCreator,
+                  "Swift.UnsafeContinuation synthetic children",
+                  ConstString("^Swift\\.UnsafeContinuation<.+,.+>"),
+                  synth_flags, true);
   AddCXXSynthetic(
       swift_category_sp,
       lldb_private::formatters::swift::TaskGroupSyntheticFrontEndCreator,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3671,7 +3671,8 @@ lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
       if (node->getText() == swift::BUILTIN_TYPE_NAME_RAWPOINTER ||
           node->getText() == swift::BUILTIN_TYPE_NAME_NATIVEOBJECT ||
           node->getText() == swift::BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER ||
-          node->getText() == swift::BUILTIN_TYPE_NAME_BRIDGEOBJECT)
+          node->getText() == swift::BUILTIN_TYPE_NAME_BRIDGEOBJECT ||
+          node->getText() == swift::BUILTIN_TYPE_NAME_RAWUNSAFECONTINUATION)
         return lldb::eEncodingUint;
       if (node->getText().starts_with(swift::BUILTIN_TYPE_NAME_VEC)) {
         count = 0;

--- a/lldb/test/API/lang/swift/async/continuations/Makefile
+++ b/lldb/test/API/lang/swift/async/continuations/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test_value_printing(self):
+        """Print an UnsafeContinuation and verify its children."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "v cont",
+            substrs=[
+                "(UnsafeContinuation<Void, Never>) cont = {",
+                "task = {",
+                "isFuture = true",
+            ],
+        )

--- a/lldb/test/API/lang/swift/async/continuations/main.swift
+++ b/lldb/test/API/lang/swift/async/continuations/main.swift
@@ -1,0 +1,8 @@
+@main struct Main {
+  static func main() async {
+    await withUnsafeContinuation { (cont: UnsafeContinuation<Void, Never>) in
+      print("break here")
+      cont.resume()
+    }
+  }
+}


### PR DESCRIPTION
Add a synthetic formatter for `UnsafeContinuation`. The formatter shows the internal Swift `Task`.

rdar://135886597