### PR TITLE
[CAS] Fix a regression in HashMapTrie visitor for not visiting root

### DIFF
--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -1262,6 +1262,9 @@ Error TrieVisitor::visit() {
   if (auto Err = validateSubTrie(Root, /*IsRoot=*/true))
     return Err;
 
+  if (auto Err = visitSubTrie("", Root))
+    return Err;
+
   SmallVector<SubtrieHandle> Subs;
   SmallVector<std::string> Prefixes;
   const size_t NumSlots = Root.getNumSlots();

--- a/llvm/test/tools/llvm-cas/dump.test
+++ b/llvm/test/tools/llvm-cas/dump.test
@@ -1,0 +1,27 @@
+RUN: rm -rf %t
+RUN: mkdir %t
+
+RUN: llvm-cas --cas %t/cas --make-blob \
+RUN:   --data - </dev/null
+
+RUN: llvm-cas --cas %t/cas --make-blob \
+RUN:   --data %s
+
+RUN: llvm-cas --cas %t/cas --dump | FileCheck %s
+
+// check the dump format.
+CHECK:      index:
+CHECK-NEXT: hash-num-bits=
+CHECK-NEXT: root addr=
+// it should has at least one index
+CHECK-NEXT: - index=
+
+// two records
+CHECK:      record
+CHECK-NEXT: - addr=
+CHECK-NEXT: - addr=
+
+// both should be small enough to be in data pool
+CHECK:      pool:
+CHECK-NEXT: - addr=
+CHECK-NEXT: - addr=


### PR DESCRIPTION
Fix a regression that a `visitSubTrie` is not called on root node. Add a test to verify the TriePrinter actually prints all the node correctly.