### PR TITLE
[lldb][test] Only set ASAN options in ASAN-builds

### DIFF
--- a/lldb/test/Unit/lit.cfg.py
+++ b/lldb/test/Unit/lit.cfg.py
@@ -40,18 +40,18 @@ if config.llvm_use_sanitizer:
     config.environment["TSAN_OPTIONS"] = "halt_on_error=1"
     config.environment["MallocNanoZone"] = "0"
 
-# Begin Swift mod.
-# Swift's libReflection builds without ASAN, which causes a known
-# false positive in std::vector. We also want to support testing a sanitized
-# lldb using unsanitized llvm, clang, and swift libraries.
-config.environment['ASAN_OPTIONS'] += ':' + 'detect_container_overflow=0'
+    # Begin Swift mod.
+    # Swift's libReflection builds without ASAN, which causes a known
+    # false positive in std::vector. We also want to support testing a sanitized
+    # lldb using unsanitized llvm, clang, and swift libraries.
+    config.environment['ASAN_OPTIONS'] += ':' + 'detect_container_overflow=0'
 
-# FIXME: This is the wrong place to disable this. This is working
-# around the fact that the ci.swift.org scripts build only LLDB with
-# asan and this creates an ODR violation in Allocator.h that breaks
-# poisoning.
-config.environment['ASAN_OPTIONS'] += ':' + 'allow_user_poisoning=0'
-# End Swift mod.
+    # FIXME: This is the wrong place to disable this. This is working
+    # around the fact that the ci.swift.org scripts build only LLDB with
+    # asan and this creates an ODR violation in Allocator.h that breaks
+    # poisoning.
+    config.environment['ASAN_OPTIONS'] += ':' + 'allow_user_poisoning=0'
+    # End Swift mod.
 
 
 # testFormat: The test format to use to interpret tests.


### PR DESCRIPTION
Without this the unit-tests currently fail with:
```
llvm-lit: /Volumes/SSD/Apple-internal/llvm-project/llvm/utils/lit/lit/TestingConfig.py:156: fatal: unable to parse config file '/Volumes/SSD/Apple-internal/llvm-project/lldb/test/Unit/lit.cfg.py', traceback: Traceback (most recent call last):
  File "/Volumes/SSD/Apple-internal/llvm-project/llvm/utils/lit/lit/TestingConfig.py", line 144, in load_from_path
    exec(compile(data, path, "exec"), cfg_globals, None)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/SSD/Apple-internal/llvm-project/lldb/test/Unit/lit.cfg.py", line 47, in <module>
    config.environment['ASAN_OPTIONS'] += ':' + 'detect_container_overflow=0'
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'ASAN_OPTIONS'
```

I suspect this was an unfortunate consequence of https://github.com/llvm/llvm-project/commit/4d4024e1edf354113e8d0d11661d466ae5b0bee7 where the auto-merger kept the Swift-only block outside of the newly added if-block without conflict.

This change only exists on the `next` branches at the moment, which is probably why we didn't notice.