### PR TITLE
[lldb] Accept address in task backtrace and select commands

### DIFF
--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -5,13 +5,27 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    def test(self):
+
+    def test_backtrace_task_variable(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
+        self.do_backtrace("task")
+
+    def test_backtrace_task_address(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        task = frame.FindVariable("task")
+        task_addr = task.GetChildMemberWithName("address").unsigned
+        self.do_backtrace(task_addr)
+
+    def do_backtrace(self, arg):
         self.expect(
-            "language swift task backtrace task",
+            f"language swift task backtrace {arg}",
             substrs=[
                 ".sleep(",
                 "`second() at main.swift:6",

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -6,12 +6,25 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    def test_backtrace_selected_task(self):
+    def test_backtrace_selected_task_variable(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
-        self.runCmd("language swift task select task")
+        self.do_backtrace_selected_task("task")
+
+    def test_backtrace_selected_task_address(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        task = frame.FindVariable("task")
+        task_addr = task.GetChildMemberWithName("address").unsigned
+        self.do_backtrace_selected_task(task_addr)
+
+    def do_backtrace_selected_task(self, arg):
+        self.runCmd(f"language swift task select {arg}")
         self.expect(
             "thread backtrace",
             substrs=[
@@ -22,16 +35,28 @@ class TestCase(TestBase):
             ],
         )
 
-    def test_navigate_selected_task_stack(self):
+    def test_navigate_stack_of_selected_task_variable(self):
         self.build()
-        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+        _, process, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
-        self.runCmd("language swift task select task")
+        self.do_test_navigate_selected_task_stack(process, "task")
+        self.assertEqual(thread.id, 0xF00000001)
 
-        thread = process.selected_thread
-        self.assertEqual(thread.id, 2)
-        self.assertEqual(thread.idx, 0xFFFFFFFF)
+    def test_navigate_stack_of_selected_task_address(self):
+        self.build()
+        _, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        task = frame.FindVariable("task")
+        task_addr = task.GetChildMemberWithName("address").unsigned
+        self.do_test_navigate_selected_task_stack(process, task_addr)
+
+    def do_test_navigate_selected_task_stack(self, process, arg):
+        self.runCmd(f"language swift task select {arg}")
+        thread = process.GetSelectedThread()
+
         self.assertIn(
             "libswift_Concurrency.", thread.GetSelectedFrame().module.file.basename
         )

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -41,7 +41,6 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
         self.do_test_navigate_selected_task_stack(process, "task")
-        self.assertEqual(thread.id, 0xF00000001)
 
     def test_navigate_stack_of_selected_task_address(self):
         self.build()


### PR DESCRIPTION
Update the `language swift task {backtrace,select}` commands to take a task address.

This is useful in conjunction with https://github.com/swiftlang/llvm-project/pull/10176 which prints a tasks address. An example use case is printing a `TaskGroup`, and then using the address of one of the group's child tasks with either the `backtrace` or `select` command.