### PR TITLE
[lldb] Prevent spurious TypeRef type system validation message (NFC)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2532,13 +2532,12 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
 #else
   // We allow the typeref typesystem to return a type where
   // SwiftASTContext fails.
-  if (!l) {
-    llvm::dbgs() << l.GetMangledTypeName() << " != " << r.GetMangledTypeName()
-                 << "\n";
+  if (!l || !r) {
+    if (l || r)
+      llvm::dbgs() << l.GetMangledTypeName() << " != " << r.GetMangledTypeName()
+                   << "\n";
     return !r;
   }
-  if (!r)
-    return true;
 #endif
 
   // See comments in SwiftASTContext::ReconstructType(). For


### PR DESCRIPTION
This fixes the following log output:

```
 != 
 != 
 != 
```

This was happening when both the TypeRef type system (lhs) and the SwiftASTContext (rhs) produced an empty `CompilerType` for some operation.