### PR TITLE
[lldb] Don't report Xcode sdk error for non-Darwin platforms

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2840,14 +2840,17 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
   std::optional<XcodeSDK> sdk;
   if (cu)
     if (auto platform_sp = Platform::GetHostPlatform()) {
-      auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
-      if (!sdk_or_err)
-        Debugger::ReportError("Error while parsing SDK path from debug info: " +
-                              toString(sdk_or_err.takeError()));
-      else {
-        sdk = *sdk_or_err;
-        LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
-                   sdk->GetString().str().c_str());
+      if (platform_sp->GetName() != PlatformDarwin::GetPluginNameStatic()) {
+        auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
+        if (!sdk_or_err)
+          Debugger::ReportError(
+              "Error while parsing SDK path from debug info: " +
+              toString(sdk_or_err.takeError()));
+        else {
+          sdk = *sdk_or_err;
+          LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
+                     sdk->GetString().str().c_str());
+        }
       }
     }
 


### PR DESCRIPTION
On linux I noticed the following error. This change prevents this error from being reported for non-Darwin platforms.

```
error: Error while parsing SDK path from debug info: virtual llvm::Expected<XcodeSDK> lldb_private::Platform::GetSDKPathFromDebugInfo(CompileUnit &) not implemented for 'host' platform.
```