### PR TITLE
[lldb] Objective-C runtime: Work around a bug in the shared cache bui…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -463,7 +463,14 @@ __lldb_apple_objc_v2_get_shared_cache_class_info (void *objc_opt_ro_ptr,
 
         if (objc_opt->version == 16)
         {
-            const objc_clsopt_v16_t* clsopt = (const objc_clsopt_v16_t*)((uint8_t *)objc_opt + objc_opt_v16->largeSharedCachesClassOffset);
+            int32_t large_offset = objc_opt_v16->largeSharedCachesClassOffset;
+            const objc_clsopt_v16_t* clsopt = (const objc_clsopt_v16_t*)((uint8_t *)objc_opt + large_offset);
+            // Work around a bug in some version shared cache builder where the offset overflows 2GiB (rdar://146432183).
+            uint32_t unsigned_offset = (uint32_t)large_offset;
+            if (unsigned_offset > 0x7fffffff && unsigned_offset < 0x82000000) {
+               clsopt = (const objc_clsopt_v16_t*)((uint8_t *)objc_opt + unsigned_offset);
+               DEBUG_PRINTF("warning: applying largeSharedCachesClassOffset overflow workaround!\n");
+            }
             const size_t max_class_infos = class_infos_byte_size/sizeof(ClassInfo);
 
             DEBUG_PRINTF("max_class_infos = %llu\n", (uint64_t)max_class_infos);


### PR DESCRIPTION
…lder (#130209)

where it can overflow a 2GB offset by just a little bit by applying a heuristic.

rdar://145888306
(cherry picked from commit ca0850f916a75a16264798fe7b7be08fdb892c97)