### PR TITLE
Fix step over bug rdar://140159600

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -24,11 +24,7 @@ class TestCase(lldbtest.TestBase):
         )
 
         # Step over should reach every line in the interval [10, 20]
-        expected_line_nums = [10, 11, 12, 13, 14, 15]
-        # FIXME: for some reason we loop back to the start of the do block after the last statement.
-        # rdar://140159600
-        expected_line_nums += [8]
-        expected_line_nums += [17, 18, 19, 20]
+        expected_line_nums = range(10, 21)
         for expected_line_num in expected_line_nums:
             thread.StepOver()
             stop_reason = thread.GetStopReason()


### PR DESCRIPTION
rdar://140159600 ([swift][DebugInfo] Line Table at the end of "do-block" jumps back to the start of the block) describes a bug where in async code, we jump back to the top of a do block after we step over the last line of the do block in async code. The test, lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py had to be modified to account for that, this bug has been fixed with https://github.com/swiftlang/swift/pull/79833 and therefore the test has to also be modified.