### PR TITLE
[lldb] Implement dynamic type resolution for embedded Swift classes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -363,6 +363,12 @@ public:
     return llvm::createStringError("could not read type from metadata");
   }
 
+  std::optional<swift::remote::RemoteAbsolutePointer>
+  ReadPointer(lldb::addr_t instance_address) override {
+    auto ptr = m_reflection_ctx.readPointer(instance_address);
+    return ptr;
+  }
+
   std::optional<bool> IsValueInlinedInExistentialContainer(
       swift::remote::RemoteAddress existential_address) override {
     return m_reflection_ctx.isValueInlinedInExistentialContainer(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -146,6 +146,8 @@ public:
   ReadTypeFromInstance(lldb::addr_t instance_address,
                        swift::reflection::DescriptorFinder *descriptor_finder,
                        bool skip_artificial_subclasses = false) = 0;
+  virtual std::optional<swift::remote::RemoteAbsolutePointer>
+  ReadPointer(lldb::addr_t instance_address) = 0;
   virtual std::optional<bool> IsValueInlinedInExistentialContainer(
       swift::remote::RemoteAddress existential_address) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &> ApplySubstitutions(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -624,6 +624,10 @@ protected:
       TypeAndOrName &class_type_or_name, Address &address,
       Value::ValueType &value_type, llvm::ArrayRef<uint8_t> &local_buffer);
 
+  /// Resolves the dynamic type of an embedded Swift class type.
+  CompilerType GetDynamicTypeAndAddress_EmbeddedClass(uint64_t instance_ptr,
+                                                      CompilerType class_type);
+
   /// Dynamic type resolution tends to want to generate scalar data -
   /// but there are caveats Per original comment here "Our address is
   /// the location of the dynamic type stored in memory.  It isn't a

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1962,6 +1962,41 @@ static bool IsPrivateNSClass(NodePointer node) {
   return false;
 }
 
+CompilerType SwiftLanguageRuntime::GetDynamicTypeAndAddress_EmbeddedClass(
+    uint64_t instance_ptr, CompilerType class_type) {
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return {};
+  /// If this is an embedded Swift type, there is no metadata, and the
+  /// pointer points to the type's vtable. We can still resolve the type by
+  /// reading the vtable's symbol name.
+  auto pointer = reflection_ctx->ReadPointer(instance_ptr);
+  if (!pointer)
+    return {};
+  llvm::StringRef symbol_name;
+  if (pointer->isResolved()) {
+    // Find the symbol name at this address.
+    Address address;
+    address.SetLoadAddress(pointer->getOffset(), &GetProcess().GetTarget());
+    Symbol *symbol = address.CalculateSymbolContextSymbol();
+    if (!symbol)
+      return {};
+    Mangled mangled = symbol->GetMangled();
+    if (!mangled)
+      return {};
+    symbol_name = symbol->GetMangled().GetMangledName().GetStringRef();
+  } else {
+    symbol_name = pointer->getSymbol();
+  }
+  TypeSystemSwiftTypeRefSP ts = class_type.GetTypeSystem()
+                                    .dyn_cast_or_null<TypeSystemSwift>()
+                                    ->GetTypeSystemSwiftTypeRef();
+  // The symbol name will be something like "type metadata for Class", extract
+  // "Class" from that name.
+  auto dynamic_type = ts->GetTypeFromTypeMetadataNode(symbol_name);
+  return dynamic_type;
+}
+
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     ValueObject &in_value, CompilerType class_type,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
@@ -2023,42 +2058,46 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     if (!reflection_ctx)
       return false;
 
-    const swift::reflection::TypeRef *typeref = nullptr;
-    {
-      auto typeref_or_err = reflection_ctx->ReadTypeFromInstance(
-          instance_ptr, ts->GetDescriptorFinder(), true);
-      if (typeref_or_err)
-        typeref = &*typeref_or_err;
-      else
-        LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), typeref_or_err.takeError(),
-                        "{0}");
+    CompilerType dynamic_type;
+    if (SwiftLanguageRuntime::GetManglingFlavor(
+            class_type.GetMangledTypeName()) ==
+        swift::Mangle::ManglingFlavor::Default) {
+
+      const swift::reflection::TypeRef *typeref = nullptr;
+      {
+        auto typeref_or_err = reflection_ctx->ReadTypeFromInstance(
+            instance_ptr, ts->GetDescriptorFinder(), true);
+        if (typeref_or_err)
+          typeref = &*typeref_or_err;
+        else
+          LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), typeref_or_err.takeError(),
+                          "{0}");
+      }
+
+      if (!typeref) {
+        HEALTH_LOG(
+            "could not read typeref for type: {0} (instance_ptr = {1:x})",
+            class_type.GetMangledTypeName(), instance_ptr);
+        return false;
+      }
+
+      auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+          class_type.GetMangledTypeName());
+
+      swift::Demangle::Demangler dem;
+      swift::Demangle::NodePointer node = typeref->getDemangling(dem);
+      dynamic_type = ts->RemangleAsType(dem, node, flavor);
+    } else {
+      dynamic_type =
+          GetDynamicTypeAndAddress_EmbeddedClass(instance_ptr, class_type);
+      if (!dynamic_type) {
+        HEALTH_LOG("could not resolve dynamic type of embedded swift class: "
+                   "{0} (instance_ptr = {1:x})",
+                   class_type.GetMangledTypeName(), instance_ptr);
+        return false;
+      }
     }
 
-    // If we couldn't find the typeref from the instance, the best we can do is
-    // use the static type. This is a valid use case when the binary doesn't
-    // contain any metadata (for example, embedded Swift).
-    if (!typeref) {
-      auto typeref_or_err = reflection_ctx->GetTypeRef(
-          class_type.GetMangledTypeName(), ts->GetDescriptorFinder());
-      if (typeref_or_err)
-        typeref = &*typeref_or_err;
-      else
-        LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), typeref_or_err.takeError(),
-                        "{0}");
-    }
-
-    if (!typeref) {
-      HEALTH_LOG("could not read typeref for type: {0} (instance_ptr = {0:x})",
-                 class_type.GetMangledTypeName(), instance_ptr);
-      return false;
-    }
-
-    auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
-        class_type.GetMangledTypeName());
-
-    swift::Demangle::Demangler dem;
-    swift::Demangle::NodePointer node = typeref->getDemangling(dem);
-    CompilerType dynamic_type = ts->RemangleAsType(dem, node, flavor);
     LLDB_LOG(log, "dynamic type of instance_ptr {0:x} is {1}", instance_ptr,
              class_type.GetMangledTypeName());
     class_type_or_name.SetCompilerType(dynamic_type);
@@ -2207,39 +2246,77 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
   auto tr_ts = tss->GetTypeSystemSwiftTypeRef();
   if (!tr_ts)
     return false;
-  auto pair = reflection_ctx->ProjectExistentialAndUnwrapClass(
-      remote_existential, *existential_typeref,
-      tr_ts->GetDescriptorFinder());
+
+  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+      existential_type.GetMangledTypeName());
+  CompilerType dynamic_type;
+  uint64_t dynamic_address = 0;
+  if (flavor == swift::Mangle::ManglingFlavor::Default) {
+    auto pair = reflection_ctx->ProjectExistentialAndUnwrapClass(
+        remote_existential, *existential_typeref, tr_ts->GetDescriptorFinder());
+
+    if (!pair) {
+      if (log)
+        log->Printf("Runtime failed to get dynamic type of existential");
+      return false;
+    }
+
+    const swift::reflection::TypeRef *typeref;
+    swift::remote::RemoteAddress out_address(nullptr);
+    std::tie(typeref, out_address) = *pair;
+
+    auto ts = tss->GetTypeSystemSwiftTypeRef();
+    if (!ts)
+      return false;
+    swift::Demangle::Demangler dem;
+    swift::Demangle::NodePointer node = typeref->getDemangling(dem);
+    dynamic_type = ts->RemangleAsType(dem, node, flavor);
+    dynamic_address = out_address.getAddressData();
+  } else {
+    // In the embedded Swift case, the existential container just points to the
+    // instance.
+    auto reflection_ctx = GetReflectionContext();
+    if (!reflection_ctx)
+      return false;
+    auto maybe_addr_or_symbol =
+        reflection_ctx->ReadPointer(existential_address);
+    if (!maybe_addr_or_symbol)
+      return false;
+
+    uint64_t address = 0;
+    if (maybe_addr_or_symbol->isResolved()) {
+      address = maybe_addr_or_symbol->getOffset();
+    } else {
+      SymbolContextList sc_list;
+      auto &module_list = GetProcess().GetTarget().GetImages();
+      module_list.FindSymbolsWithNameAndType(
+          ConstString(maybe_addr_or_symbol->getSymbol()), eSymbolTypeAny,
+          sc_list);
+      if (sc_list.GetSize() != 1)
+        return false;
+
+      SymbolContext sc = sc_list[0];
+      Symbol *symbol = sc.symbol;
+      address = symbol->GetLoadAddress(&GetProcess().GetTarget());
+    }
+
+    dynamic_type =
+        GetDynamicTypeAndAddress_EmbeddedClass(address, existential_type);
+    if (!dynamic_type)
+      return false;
+    dynamic_address = maybe_addr_or_symbol->getOffset();
+  }
   if (use_local_buffer)
     PopLocalBuffer();
 
-  if (!pair) {
-    if (log)
-      log->Printf("Runtime failed to get dynamic type of existential");
-    return false;
-  }
-
-  const swift::reflection::TypeRef *typeref;
-  swift::remote::RemoteAddress out_address(nullptr);
-  std::tie(typeref, out_address) = *pair;
-  auto ts = tss->GetTypeSystemSwiftTypeRef();
-  if (!ts)
-    return false;
-  swift::Demangle::Demangler dem;
-  swift::Demangle::NodePointer node = typeref->getDemangling(dem);
-  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
-      existential_type.GetMangledTypeName());
-
-  class_type_or_name.SetCompilerType(ts->RemangleAsType(dem, node, flavor));
-  address.SetRawAddress(out_address.getAddressData());
+  class_type_or_name.SetCompilerType(dynamic_type);
+  address.SetRawAddress(dynamic_address);
 
 #ifndef NDEBUG
   if (ModuleList::GetGlobalModuleListProperties()
           .GetSwiftValidateTypeSystem()) {
     auto reference_pair = GetDynamicTypeAndAddress_ExistentialRemoteAST(
         in_value, existential_type, use_local_buffer, existential_address);
-    assert(pair.has_value() >= reference_pair.has_value() &&
-           "RemoteAST and runtime diverge");
 
     if (reference_pair) {
       CompilerType ref_type = std::get<CompilerType>(*reference_pair);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -375,6 +375,18 @@ TypeSystemSwiftTypeRef::GetBaseName(swift::Demangle::NodePointer node) {
   }
 }
 
+CompilerType TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
+    llvm::StringRef mangled_name) {
+  Demangler dem;
+  NodePointer node = dem.demangleSymbol(mangled_name);
+  NodePointer type = swift_demangle::NodeAtPath(
+      node, {Node::Kind::Global, Node::Kind::TypeMetadata, Node::Kind::Type});
+  if (!type)
+    return {};
+  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
+  return RemangleAsType(dem, type, flavor);
+}
+
 TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name_ref) {
   llvm::SmallVector<CompilerContext, 2> decl_context;
   // Make up a decl context for non-nested types.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -401,6 +401,10 @@ public:
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
 
+  /// Given a mangled name that mangles a "type metadata for Type", return a
+  /// CompilerType with that Type.
+  CompilerType GetTypeFromTypeMetadataNode(llvm::StringRef mangled_name);
+
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;

--- a/lldb/test/API/lang/swift/embedded/class_type_resolution/Makefile
+++ b/lldb/test/API/lang/swift/embedded/class_type_resolution/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/class_type_resolution/TestSwiftEmbeddedClassTypeResolution.py
+++ b/lldb/test/API/lang/swift/embedded/class_type_resolution/TestSwiftEmbeddedClassTypeResolution.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedClassTypeResolution(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect('frame variable s', substrs=['a.Sub', 'a.Super', 'superField = 42', 'subField = 100'])
+        self.expect('frame variable p', substrs=['a.Sub', 'a.Super', 'superField = 42', 'subField = 100'])

--- a/lldb/test/API/lang/swift/embedded/class_type_resolution/main.swift
+++ b/lldb/test/API/lang/swift/embedded/class_type_resolution/main.swift
@@ -1,0 +1,19 @@
+protocol P: AnyObject {
+
+}
+
+class Super: P {
+    let superField = 42
+}
+
+class Sub: Super {
+    let subField = 100
+}
+
+func f() {
+    let s: Super = Sub()
+    let p: P = Sub()
+    print("break here")
+}
+
+f()


### PR DESCRIPTION
Although embedded Swift doesn't have any metadata, we can leverage the vtable to find out what the dynamic type of  a class is. Similarly, embedded Swift only allows class existentials, so we can use the same mechanism to find out the dynamic type of those too.

rdar://136615921