### PR TITLE
[🍒][C++ Safe Buffers][BoundsSafety] Fix that some interop diagnostics cannot be suppressed by __unsafe_buffer_usage_begin/end

### DIFF
--- a/clang/include/clang/Lex/Preprocessor.h
+++ b/clang/include/clang/Lex/Preprocessor.h
@@ -3018,6 +3018,11 @@ private:
   } LoadedSafeBufferOptOutMap;
 
 public:
+  // FIXME: The result of saving Safe Buffers opt-out regions in PP is that
+  // clang needs to check two places---PP and DiagnosticsEngine, in order to
+  // confirm if C++ Safe Buffers is enabled at a location.   This might not be
+  // ideal as developers can forget to check one of the places.
+  //
   /// \return true iff the given `Loc` is in a "-Wunsafe-buffer-usage" opt-out
   /// region.  This `Loc` must be a source location that has been pre-processed.
   bool isSafeBufferOptOut(const SourceManager&SourceMgr, const SourceLocation &Loc) const;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1566,10 +1566,7 @@ public:
 
   /// \return true iff `-Wunsafe-buffer-usage` is enabled for `Loc` and Bounds
   /// Safety attribute-only mode is on.
-  bool isCXXSafeBuffersBoundsSafetyInteropEnabledAt(SourceLocation Loc) const {
-    return LangOpts.CPlusPlus && LangOpts.isBoundsSafetyAttributeOnlyMode() &&
-           !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc);
-  }
+  bool isCXXSafeBuffersBoundsSafetyInteropEnabledAt(SourceLocation Loc) const;
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// pragma clang section kind

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -80,6 +80,20 @@
 using namespace clang;
 using namespace sema;
 
+/* TO_UPSTREAM(BoundsSafety) ON */
+bool Sema::isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
+    SourceLocation Loc) const {
+  // Informations of '#pragma clang unsafe_buffer_usage begin/end' are stored
+  // Preprocessor.  So we need also check
+  // `getPreprocessor().isSafeBufferOptOut`.
+  bool NotSupressedByPragmas =
+      Loc.isInvalid() || !getPreprocessor().isSafeBufferOptOut(SourceMgr, Loc);
+  return LangOpts.CPlusPlus && LangOpts.isBoundsSafetyAttributeOnlyMode() &&
+         NotSupressedByPragmas &&
+         !Diags.isIgnored(diag::warn_unsafe_buffer_operation, Loc);
+}
+/* TO_UPSTREAM(BoundsSafety) OFF */
+
 SourceLocation Sema::getLocForEndOfToken(SourceLocation Loc, unsigned Offset) {
   return Lexer::getLocForEndOfToken(Loc, Offset, SourceMgr, LangOpts);
 }


### PR DESCRIPTION
The interop diagnostics emitted in Sema cannot be suppressed by `#pragma clang unsafe_buffer_usage begin/end`.  This is because the opt-out regions marked by those pragmas are stored in Preprocessor not DiagnosticsEngine.  We need query both the Preprocessor and DiagnosticsEngine to confirm if C++ Safe Buffers is enabled at a location.  This commit fixes this problem.

(rdar://146438364)
(cherry picked from commit 87da2d5058ffb9cc706c5cef5831c0aef1900dab)