### PR TITLE
[lldb] Use TaskPriority as type of Task.enqueuePriority member

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1605,6 +1605,38 @@ bool lldb_private::formatters::swift::TypePreservingNSNumber_SummaryProvider(
   return false;
 }
 
+bool lldb_private::formatters::swift::TaskPriority_SummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  uint64_t raw_value = UINT8_MAX;
+  if (auto child_sp = valobj.GetChildMemberWithName("rawValue"))
+    if (auto synthetic_sp = child_sp->GetSyntheticValue())
+      raw_value = synthetic_sp->GetValueAsUnsigned(UINT8_MAX);
+  if (raw_value >= UINT8_MAX)
+    return false;
+
+  switch (raw_value) {
+  case 0x19:
+    // Also .userInitiated
+    stream.PutCString(".high");
+    break;
+  case 0x15:
+    // Also .default (deprecated)
+    stream.PutCString(".medium");
+    break;
+  case 0x11:
+    // Also .utilitiy
+    stream.PutCString(".low");
+    break;
+  case 0x09:
+    stream.PutCString(".background");
+    break;
+  default:
+    stream.Format("{0}", raw_value);
+    break;
+  }
+  return true;
+}
+
 namespace {
 
 /// Enumerate the kinds of SIMD elements.

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -810,6 +810,9 @@ public:
     // TypeMangling for "Swift.UInt64"
     CompilerType uint64_type =
         m_ts->GetTypeFromMangledTypename(ConstString("$ss6UInt64VD"));
+    // TypeMangling for "Swift.TaskPriority"
+    CompilerType priority_type =
+        m_ts->GetTypeFromMangledTypename(ConstString("$sScPD"));
 
 #define RETURN_CHILD(FIELD, NAME, TYPE)                                        \
   if (!FIELD) {                                                                \
@@ -842,7 +845,7 @@ public:
     case 2:
       RETURN_CHILD(m_kind_sp, kind, uint32_type);
     case 3:
-      RETURN_CHILD(m_enqueue_priority_sp, enqueuePriority, uint32_type);
+      RETURN_CHILD(m_enqueue_priority_sp, enqueuePriority, priority_type);
     case 4:
       RETURN_CHILD(m_is_child_task_sp, isChildTask, bool_type);
     case 5:

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -114,6 +114,9 @@ bool ObjC_Selector_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool TypePreservingNSNumber_SummaryProvider(ValueObject &valobj, Stream &stream,
                                             const TypeSummaryOptions &options);
 
+bool TaskPriority_SummaryProvider(ValueObject &valobj, Stream &stream,
+                                  const TypeSummaryOptions &options);
+
 SyntheticChildrenFrontEnd *EnumSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -482,6 +482,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
   AddCXXSummary(swift_category_sp, staticstring_summary_provider,
                 "Swift.StaticString summary provider",
                 ConstString("Swift.StaticString"), summary_flags);
+  AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::swift::TaskPriority_SummaryProvider,
+                "Swift TaskPriority summary provider", "Swift.TaskPriority",
+                summary_flags);
   summary_flags.SetSkipPointers(false);
   // this is an ObjC dynamic type - as such it comes in pointer form
   // NSContiguousString* - do not skip pointers here

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
                 "address = 0x",
                 "id = 2",
                 "kind = 0",
-                "enqueuePriority = 21",
+                "enqueuePriority = .medium",
                 "isChildTask = false",
                 "isFuture = true",
                 "isGroupChildTask = false",

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test(self):
+        """Test summary formatter for TaskPriority."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame var",
+            substrs=[
+                "high = .high",
+                "medium = .medium",
+                "low = .low",
+                "background = .background",
+                "custom = 15",
+            ],
+        )

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/main.swift
@@ -1,0 +1,10 @@
+@main struct Entry {
+  static func main() {
+    let high = TaskPriority.high
+    let medium = TaskPriority.medium
+    let low = TaskPriority.low
+    let background = TaskPriority.background
+    let custom = TaskPriority(rawValue: 15)
+    print("break here")
+  }
+}


### PR DESCRIPTION
Changes the type of `enqueuePriority` to `TaskPriority`. This allows Tasks to be displayed using human readable names added in #10205 (`TaskPriority` summary provider).