### PR TITLE
[BoundsSafety][APINotes] Add support for bounds attribute on return v…

### DIFF
--- a/clang/include/clang/APINotes/Types.h
+++ b/clang/include/clang/APINotes/Types.h
@@ -623,6 +623,11 @@ public:
   /// Ownership convention for return value
   std::string SwiftReturnOwnership;
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  /// Bounds annotations for the return value
+  std::optional<BoundsSafetyInfo> ReturnBoundsSafety;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+
   /// The function parameters.
   std::vector<ParamInfo> Params;
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1655,6 +1655,9 @@ private:
                                 ParsedAttributes *OutAttrs = nullptr);
   void ParseLexedAttribute(LateParsedAttribute &LA,
                            bool EnterScope, bool OnDefinition);
+  /// Note: it's important the the LateParsedAttribute is removed after parsing
+  /// to prevent being reparsed later in the wrong context. This is handled
+  /// automatically by Parser::ParseLexedCAttributeList.
   void ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
                             ParsedAttributes *OutAttrs = nullptr);
   void ParseLexedMethodDeclarations(ParsingClass &Class);
@@ -3944,10 +3947,11 @@ private:
   /// \param ParentDecl If a function or method is provided, the parameters are
   ///   added to the current parsing context.
   /// \param IncludeLoc The location at which this parse was triggered.
-  ExprResult ParseBoundsAttributeArgFromString(StringRef ExprStr,
-                                               StringRef Context,
-                                               Decl *ParentDecl,
-                                               SourceLocation IncludeLoc);
+  /// \param Payload Info to be passed along to the completion handler before
+  /// leaving the current context
+  void ParseBoundsAttributeArgFromString(
+      StringRef ExprStr, StringRef Context, Decl *ParentDecl,
+      SourceLocation IncludeLoc, Sema::IncompleteBoundsAttributeInfo Payload);
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   //===--------------------------------------------------------------------===//

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1132,8 +1132,19 @@ public:
       ParseTypeFromStringCallback;
 
   /* TO_UPSTREAM(BoundsSafety) ON */
+  // Info for completing the processing of the attribute after parsing its
+  // argument
+  struct IncompleteBoundsAttributeInfo {
+    AttributeCommonInfo::Kind Kind;
+    unsigned Level;
+    Decl *D;
+  };
+  /// Complete the suspended bounds attribute after argument has been parsed
+  void CompleteBoundsAttribute(Expr *ParsedExpr,
+                               IncompleteBoundsAttributeInfo Info);
   /// Callback to the parser to parse a type expressed as a string.
-  std::function<ExprResult(StringRef, StringRef, Decl *, SourceLocation)>
+  std::function<void(StringRef, StringRef, Decl *, SourceLocation,
+                     IncompleteBoundsAttributeInfo Info)>
       ParseBoundsAttributeArgFromStringCallback;
   /* TO_UPSTREAM(BoundsSafety) OFF */
 

--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -384,6 +384,14 @@ void ReadFunctionInfo(const uint8_t *&Data, FunctionInfo &Info) {
   Payload >>= 3;
   Info.NullabilityAudited = Payload & 0x1;
   Payload >>= 1;
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (Payload & 0x01) {
+    BoundsSafetyInfo BSI;
+    ReadBoundsSafetyInfo(Data, BSI);
+    Info.ReturnBoundsSafety = BSI;
+  }
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+  Payload >>= 1;
   assert(Payload == 0 && "Bad API notes");
 
   Info.NumAdjustedNullable =

--- a/clang/lib/APINotes/APINotesTypes.cpp
+++ b/clang/lib/APINotes/APINotesTypes.cpp
@@ -61,6 +61,7 @@ LLVM_DUMP_METHOD void ObjCPropertyInfo::dump(llvm::raw_ostream &OS) const {
   OS << '\n';
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 LLVM_DUMP_METHOD void BoundsSafetyInfo::dump(llvm::raw_ostream &OS) const {
   if (KindAudited) {
     assert((BoundsSafetyKind)Kind >= BoundsSafetyKind::CountedBy);
@@ -88,6 +89,7 @@ LLVM_DUMP_METHOD void BoundsSafetyInfo::dump(llvm::raw_ostream &OS) const {
   OS << "ExternalBounds: "
      << (ExternalBounds.empty() ? "<missing>" : ExternalBounds) << '\n';
 }
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
   static_cast<const VariableInfo &>(*this).dump(OS);
@@ -97,8 +99,10 @@ LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
     OS << (Lifetimebound ? "[Lifetimebound] " : "");
   OS << "RawRetainCountConvention: " << RawRetainCountConvention << ' ';
   OS << '\n';
+  /* TO_UPSTREAM(BoundsSafety) ON */
   if (BoundsSafety)
     BoundsSafety->dump(OS);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 LLVM_DUMP_METHOD void FunctionInfo::dump(llvm::raw_ostream &OS) const {
@@ -109,6 +113,12 @@ LLVM_DUMP_METHOD void FunctionInfo::dump(llvm::raw_ostream &OS) const {
     OS << "Result Type: " << ResultType << ' ';
   if (!SwiftReturnOwnership.empty())
     OS << "SwiftReturnOwnership: " << SwiftReturnOwnership << ' ';
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (ReturnBoundsSafety) {
+    OS << "Result bounds: ";
+    ReturnBoundsSafety->dump(OS);
+  }
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   if (!Params.empty())
     OS << '\n';
   for (auto &PI : Params)

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -1148,6 +1148,10 @@ unsigned getFunctionInfoSize(const FunctionInfo &FI) {
     size += getParamInfoSize(P);
   size += sizeof(uint16_t) + FI.ResultType.size();
   size += sizeof(uint16_t) + FI.SwiftReturnOwnership.size();
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (auto BSI = FI.ReturnBoundsSafety)
+    size += getBoundsSafetyInfoSize(*BSI);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   return size;
 }
 
@@ -1156,6 +1160,11 @@ void emitFunctionInfo(raw_ostream &OS, const FunctionInfo &FI) {
   emitCommonEntityInfo(OS, FI);
 
   uint8_t flags = 0;
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (FI.ReturnBoundsSafety)
+    flags |= 0x01;
+  flags <<= 0x01;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   flags |= FI.NullabilityAudited;
   flags <<= 3;
   if (auto RCC = FI.getRetainCountConvention())
@@ -1164,6 +1173,10 @@ void emitFunctionInfo(raw_ostream &OS, const FunctionInfo &FI) {
   llvm::support::endian::Writer writer(OS, llvm::endianness::little);
 
   writer.write<uint8_t>(flags);
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (auto BSI = FI.ReturnBoundsSafety)
+    emitBoundsSafetyInfo(OS, *FI.ReturnBoundsSafety);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   writer.write<uint8_t>(FI.NumAdjustedNullable);
   writer.write<uint64_t>(FI.NullabilityPayload);
 

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -319,6 +319,9 @@ struct Method {
   bool Required = false;
   StringRef ResultType;
   StringRef SwiftReturnOwnership;
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  std::optional<BoundsSafetyNotes> ReturnBoundsSafety;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 };
 
 typedef std::vector<Method> MethodsSeq;
@@ -355,6 +358,9 @@ template <> struct MappingTraits<Method> {
     IO.mapOptional("ResultType", M.ResultType, StringRef(""));
     IO.mapOptional("SwiftReturnOwnership", M.SwiftReturnOwnership,
                    StringRef(""));
+    /* TO_UPSTREAM(BoundsSafety) ON */
+    IO.mapOptional("BoundsSafety", M.ReturnBoundsSafety);
+    /* TO_UPSTREAM(BoundsSafety) OFF */
   }
 };
 } // namespace yaml
@@ -451,6 +457,9 @@ struct Function {
   StringRef Type;
   StringRef ResultType;
   StringRef SwiftReturnOwnership;
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  std::optional<BoundsSafetyNotes> ReturnBoundsSafety;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 };
 
 typedef std::vector<Function> FunctionsSeq;
@@ -475,6 +484,9 @@ template <> struct MappingTraits<Function> {
     IO.mapOptional("ResultType", F.ResultType, StringRef(""));
     IO.mapOptional("SwiftReturnOwnership", F.SwiftReturnOwnership,
                    StringRef(""));
+    /* TO_UPSTREAM(BoundsSafety) ON */
+    IO.mapOptional("BoundsSafety", F.ReturnBoundsSafety);
+    /* TO_UPSTREAM(BoundsSafety) OFF */
   }
 };
 } // namespace yaml
@@ -905,14 +917,14 @@ public:
       PI.setLifetimebound(P.Lifetimebound);
       PI.setType(std::string(P.Type));
       PI.setRetainCountConvention(P.RetainCountConvention);
-      BoundsSafetyInfo BSI;
       /* TO_UPSTREAM(BoundsSafety) ON */
       if (P.BoundsSafety) {
+        BoundsSafetyInfo BSI;
         BSI.setKindAudited(P.BoundsSafety->Kind);
         BSI.setLevelAudited(P.BoundsSafety->Level);
         BSI.ExternalBounds = P.BoundsSafety->BoundsExpr.str();
+        PI.BoundsSafety = BSI;
       }
-      PI.BoundsSafety = BSI;
       /* TO_UPSTREAM(BoundsSafety) OFF */
       if (static_cast<int>(OutInfo.Params.size()) <= P.Position)
         OutInfo.Params.resize(P.Position + 1);
@@ -1112,6 +1124,15 @@ public:
     convertAvailability(Function.Availability, FI, Function.Name);
     FI.setSwiftPrivate(Function.SwiftPrivate);
     FI.SwiftName = std::string(Function.SwiftName);
+    /* TO_UPSTREAM(BoundsSafety) ON */
+    if (Function.ReturnBoundsSafety) {
+      BoundsSafetyInfo BSI;
+      BSI.setKindAudited(Function.ReturnBoundsSafety->Kind);
+      BSI.setLevelAudited(Function.ReturnBoundsSafety->Level);
+      BSI.ExternalBounds = Function.ReturnBoundsSafety->BoundsExpr.str();
+      FI.ReturnBoundsSafety = BSI;
+    }
+    /* TO_UPSTREAM(BoundsSafety) OFF */
     std::optional<ParamInfo> This;
     convertParams(Function.Params, FI, This);
     if constexpr (std::is_same_v<FuncOrMethodInfo, CXXMethodInfo>)

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -7893,7 +7893,7 @@ void Parser::ParseFunctionDeclarator(Declarator &D,
   StartLoc = LParenLoc;
 
   /* TO_UPSTREAM(BoundsSafety) ON */
-  LateParsedAttrList LateParamAttrs(/*PSoon=*/false,
+  LateParsedAttrList LateParamAttrs(/*PSoon=*/true,
                                     /*LateAttrParseExperimentalExtOnly=*/true);
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
@@ -8018,9 +8018,7 @@ void Parser::ParseFunctionDeclarator(Declarator &D,
   }
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
-  for (auto LateParamAttr : LateParamAttrs) {
-    ParseLexedCAttribute(*LateParamAttr, true);
-  }
+  ParseLexedCAttributeList(LateParamAttrs, true, nullptr);
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
   // Collect non-parameter declarations from the prototype if this is a function
@@ -8996,10 +8994,9 @@ TypeResult Parser::ParseTypeFromString(StringRef TypeStr, StringRef Context,
 }
 
 /* TO_UPSTREAM(BoundsSafety) ON */
-ExprResult
-Parser::ParseBoundsAttributeArgFromString(StringRef ExprStr, StringRef Context,
-                                          Decl *ParentDecl,
-                                          SourceLocation IncludeLoc) {
+void Parser::ParseBoundsAttributeArgFromString(
+    StringRef ExprStr, StringRef Context, Decl *ParentDecl,
+    SourceLocation IncludeLoc, Sema::IncompleteBoundsAttributeInfo Payload) {
   // Consume (unexpanded) tokens up to the end-of-directive.
   SmallVector<Token, 4> Tokens;
   {
@@ -9073,9 +9070,11 @@ Parser::ParseBoundsAttributeArgFromString(StringRef ExprStr, StringRef Context,
   // Consume the end token.
   if (Tok.is(tok::eof) && Tok.getEofData() == ExprStr.data())
     ConsumeAnyToken();
+  // Need to create the type before leaving function context
+  if (Result.isUsable())
+    Actions.CompleteBoundsAttribute(Result.get(), Payload);
   if (EnterScope)
     Actions.ActOnExitFunctionContext();
-  return Result;
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -79,9 +79,10 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
   /* TO_UPSTREAM(BoundsSafety) ON */
   Actions.ParseBoundsAttributeArgFromStringCallback =
       [this](StringRef ExprStr, StringRef Context, Decl *Parent,
-             SourceLocation IncludeLoc) {
+             SourceLocation IncludeLoc,
+             Sema::IncompleteBoundsAttributeInfo Payload) {
         return this->ParseBoundsAttributeArgFromString(ExprStr, Context, Parent,
-                                                       IncludeLoc);
+                                                       IncludeLoc, Payload);
       };
   /* TO_UPSTREAM(BoundsSafety) OFF */
 }

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -410,6 +410,34 @@ static void ProcessAPINotes(Sema &S, Decl *D,
 }
 
 /* TO_UPSTREAM(BoundsSafety) ON */
+void Sema::CompleteBoundsAttribute(Expr *ParsedExpr,
+                                   IncompleteBoundsAttributeInfo Info) {
+  assert(ParsedExpr);
+  std::string AttrName;
+  switch (Info.Kind) {
+  case AttributeCommonInfo::AT_CountedBy:
+    AttrName = "__counted_by";
+    break;
+  case AttributeCommonInfo::AT_CountedByOrNull:
+    AttrName = "__counted_by_or_null";
+    break;
+  case AttributeCommonInfo::AT_SizedBy:
+    AttrName = "__sized_by";
+    break;
+  case AttributeCommonInfo::AT_SizedByOrNull:
+    AttrName = "__sized_by_or_null";
+    break;
+  case AttributeCommonInfo::AT_PtrEndedBy:
+    AttrName = "__ended_by";
+    break;
+  default:
+    llvm_unreachable("invalid bounds attribute kind in API notes");
+  }
+  applyPtrCountedByEndedByAttr(Info.D, Info.Level, Info.Kind, ParsedExpr,
+                               Info.D->getLocation(), Info.D->getSourceRange(),
+                               AttrName,
+                               /* originates in API notes */ true);
+}
 static void applyBoundsSafety(Sema &S, ValueDecl *D,
                               const api_notes::BoundsSafetyInfo &Info,
                               VersionedInfoMetadata Metadata) {
@@ -420,41 +448,29 @@ static void applyBoundsSafety(Sema &S, ValueDecl *D,
     if (auto ParmDecl = dyn_cast<ParmVarDecl>(ScopeDecl)) {
       ScopeDecl = dyn_cast<FunctionDecl>(ParmDecl->getDeclContext());
     }
-    auto ParsedExpr = S.ParseBoundsAttributeArgFromStringCallback(
-        Info.ExternalBounds, "<API Notes>", ScopeDecl, D->getLocation());
-    if (ParsedExpr.isInvalid())
-      return;
-
-    std::string AttrName;
-    AttributeCommonInfo::Kind Kind;
     assert(*Info.getKind() >= BoundsSafetyKind::CountedBy);
     assert(*Info.getKind() <= BoundsSafetyKind::EndedBy);
+    AttributeCommonInfo::Kind Kind;
     switch (*Info.getKind()) {
     case BoundsSafetyKind::CountedBy:
-      AttrName = "__counted_by";
       Kind = AttributeCommonInfo::AT_CountedBy;
       break;
     case BoundsSafetyKind::CountedByOrNull:
-      AttrName = "__counted_by_or_null";
       Kind = AttributeCommonInfo::AT_CountedByOrNull;
       break;
     case BoundsSafetyKind::SizedBy:
-      AttrName = "__sized_by";
       Kind = AttributeCommonInfo::AT_SizedBy;
       break;
     case BoundsSafetyKind::SizedByOrNull:
-      AttrName = "__sized_by_or_null";
       Kind = AttributeCommonInfo::AT_SizedByOrNull;
       break;
     case BoundsSafetyKind::EndedBy:
-      AttrName = "__ended_by";
       Kind = AttributeCommonInfo::AT_PtrEndedBy;
       break;
     }
-
-    S.applyPtrCountedByEndedByAttr(
-        D, *Info.getLevel(), Kind, ParsedExpr.get(), D->getLocation(),
-        D->getSourceRange(), AttrName, /* originates in API notes */ true);
+    S.ParseBoundsAttributeArgFromStringCallback(
+        Info.ExternalBounds, "<API Notes>", ScopeDecl, D->getLocation(),
+        {Kind, *Info.getLevel(), D});
   }
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */
@@ -596,6 +612,14 @@ static void ProcessAPINotes(Sema &S, FunctionOrMethod AnyFunc,
       }
     }
   }
+
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  // FIXME(hnrklssn): apply to ObjC methods when support has landed
+  if (FD && Info.ReturnBoundsSafety.has_value())
+    // applyPtrCountedByEndedByAttr rebuilds FunctionType,
+    // no need to set AnyTypeChanged
+    applyBoundsSafety(S, FD, *Info.ReturnBoundsSafety, Metadata);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 
   // If the result type or any of the parameter types changed for a function
   // declaration, we have to rebuild the type.

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
@@ -133,3 +133,79 @@ Functions:
     Parameters:
       - Position:      0
         Type: "int * __attribute__((__terminated_by__(0)))"
+
+  - Name:              asdf_return_counted
+    BoundsSafety:
+        Kind: counted_by
+        Level: 0
+        BoundedBy: len
+  - Name:              asdf_return_sized
+    BoundsSafety:
+        Kind: sized_by
+        Level: 0
+        BoundedBy: size
+  - Name:              asdf_return_counted_n
+    BoundsSafety:
+        Kind: counted_by_or_null
+        Level: 0
+        BoundedBy: len
+  - Name:              asdf_return_sized_n
+    BoundsSafety:
+        Kind: sized_by_or_null
+        Level: 0
+        BoundedBy: size
+  - Name:              asdf_return_ended
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: end
+  - Name:              asdf_return_sized_mul
+    BoundsSafety:
+        Kind: sized_by
+        Level: 0
+        BoundedBy: "size * count"
+  - Name:              asdf_return_counted_out
+    BoundsSafety:
+        Kind: counted_by
+        BoundedBy: "*len"
+  - Name:              asdf_return_counted_const
+    BoundsSafety:
+        Kind: counted_by
+        Level: 0
+        BoundedBy: 7
+  - Name:             asdf_return_counted_nullable
+    BoundsSafety:
+        Kind: counted_by
+        Level: 0
+        BoundedBy: len
+  - Name:              asdf_return_counted_default_level
+    BoundsSafety:
+        Kind: counted_by
+        BoundedBy: len
+  - Name:              asdf_return_counted_redundant
+    BoundsSafety:
+        Kind: counted_by
+        BoundedBy: len
+  - Name:              asdf_return_ended_chained
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: mid
+  - Name:              asdf_return_ended_chained_reverse
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: end
+  - Name:              asdf_return_ended_redundant
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: end
+  - Name:              asdf_return_nterm
+    ResultType: "char * __attribute__((__terminated_by__(0)))"

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
@@ -19,3 +19,22 @@ void asdf_ended_already_ended(int * buf, int * mid __attribute__((__ended_by__(e
 void asdf_ended_redundant(int * __attribute__((__ended_by__(end))) buf, int * end);
 
 void asdf_nterm(char * buf);
+
+int * asdf_return_counted(int len);
+int * asdf_return_sized(int size);
+int * asdf_return_counted_n(int len);
+int * asdf_return_sized_n(int size);
+int * asdf_return_ended(int * end);
+
+int * asdf_return_sized_mul(int size, int count);
+int * asdf_return_counted_out(int * len);
+int * asdf_return_counted_const(int * buf);
+int * _Nullable asdf_return_counted_nullable(int len);
+int * asdf_return_counted_default_level(int len);
+int * __attribute__((__counted_by__(len))) asdf_return_counted_redundant(int len);
+
+int * asdf_return_ended_chained(int * mid, int * end);
+int * asdf_return_ended_chained_reverse(int * mid, int * end);
+int * __attribute__((__ended_by__(end))) asdf_return_ended_redundant(int * end);
+
+char * asdf_return_nterm();

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.apinotes
@@ -1,0 +1,213 @@
+---
+Name: BoundsUnsafeCxx
+Tags:
+  - Name: Foo
+    Methods:
+      - Name:              asdf_counted
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_sized
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: size
+      - Name:              asdf_counted_n
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by_or_null
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_sized_n
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by_or_null
+                Level: 0
+                BoundedBy: size
+      - Name:              asdf_ended
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_sized_mul
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: "size * count"
+      - Name:              asdf_counted_out
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 1
+                BoundedBy: "*len"
+      - Name:              asdf_counted_const
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: 7
+      - Name:             asdf_counted_nullable
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_counted_noescape
+        Parameters:
+          - Position:      0
+            NoEscape:      true
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_counted_default_level
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                BoundedBy: len
+      - Name:              asdf_counted_redundant
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                BoundedBy: len
+      - Name:              asdf_ended_chained
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: mid
+          - Position:      1
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_ended_chained_reverse
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: mid
+      - Name:              asdf_ended_already_started
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_ended_already_ended
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: mid
+      - Name:              asdf_ended_redundant
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_nterm
+        Parameters:
+          - Position:      0
+            Type: "int * __attribute__((__terminated_by__(0)))"
+    
+      - Name:              asdf_return_counted
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+      - Name:              asdf_return_sized
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: size
+      - Name:              asdf_return_counted_n
+        BoundsSafety:
+            Kind: counted_by_or_null
+            Level: 0
+            BoundedBy: len
+      - Name:              asdf_return_sized_n
+        BoundsSafety:
+            Kind: sized_by_or_null
+            Level: 0
+            BoundedBy: size
+      - Name:              asdf_return_ended
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Name:              asdf_return_sized_mul
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: "size * count"
+      - Name:              asdf_return_counted_out
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: "*len"
+      - Name:              asdf_return_counted_const
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: 7
+      - Name:             asdf_return_counted_nullable
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+      - Name:              asdf_return_counted_default_level
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
+      - Name:              asdf_return_counted_redundant
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
+      - Name:              asdf_return_ended_chained
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+      - Name:              asdf_return_ended_chained_reverse
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Name:              asdf_return_ended_redundant
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Name:              asdf_return_nterm
+        ResultType: "char * __attribute__((__terminated_by__(0)))"

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.hpp
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.hpp
@@ -1,0 +1,44 @@
+class Foo {
+    void asdf_counted(int * buf, int len);
+    void asdf_sized(int * buf, int size);
+    void asdf_counted_n(int * buf, int len);
+    void asdf_sized_n(int * buf, int size);
+    void asdf_ended(int * buf, int * end);
+
+    void asdf_sized_mul(int * buf, int size, int count);
+    void asdf_counted_out(int ** buf, int * len);
+    void asdf_counted_const(int * buf);
+    void asdf_counted_nullable(int len, int * _Nullable buf);
+    void asdf_counted_noescape(int * buf, int len);
+    void asdf_counted_default_level(int * buf, int len);
+    void asdf_counted_redundant(int * __attribute__((__counted_by__(len))) buf, int len);
+    
+    void asdf_ended_chained(int * buf, int * mid, int * end);
+    void asdf_ended_chained_reverse(int * buf, int * mid, int * end);
+    void asdf_ended_already_started(int * __attribute__((__ended_by__(mid))) buf, int * mid, int * end);
+    void asdf_ended_already_ended(int * buf, int * mid __attribute__((__ended_by__(end))), int * end);
+    void asdf_ended_redundant(int * __attribute__((__ended_by__(end))) buf, int * end);
+    
+    void asdf_nterm(char * buf);
+
+
+    int * asdf_return_counted(int len);
+    int * asdf_return_sized(int size);
+    int * asdf_return_counted_n(int len);
+    int * asdf_return_sized_n(int size);
+    int * asdf_return_ended(int * end);
+    
+    int * asdf_return_sized_mul(int size, int count);
+    int * asdf_return_counted_out(int * len);
+    int * asdf_return_counted_const(int * buf);
+    int * _Nullable asdf_return_counted_nullable(int len);
+    int * asdf_return_counted_noescape(int len);
+    int * asdf_return_counted_default_level(int len);
+    int * __attribute__((__counted_by__(len))) asdf_return_counted_redundant(int len);
+    
+    int * asdf_return_ended_chained(int * mid, int * end);
+    int * asdf_return_ended_chained_reverse(int * mid, int * end);
+    int * __attribute__((__ended_by__(end))) asdf_return_ended_redundant(int * end);
+    
+    char * asdf_return_nterm();
+};

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
@@ -1,5 +1,5 @@
 ---
-Name: BoundsUnsafe
+Name: BoundsUnsafeObjC
 Classes:
   - Name: Foo
     Methods:

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -2,6 +2,10 @@ module BoundsUnsafe {
   header "BoundsUnsafe.h"
 }
 
+module BoundsUnsafeCxx {
+  header "BoundsUnsafeCxx.hpp"
+}
+
 module BoundsUnsafeErrors {
   header "BoundsUnsafeErrors.h"
 }


### PR DESCRIPTION
…alue

Previously you could only attach bounds attributes to function parameters. Now return values are also supported, although not yet for ObjectiveC methods. Adds test case for bounds safety API notes in C++, and fixes bug where late parsed bounds attributes on C++ method parameters are parsed twice, due to not being removed from the late attributes list after parsing.

rdar://146332875