### PR TITLE
[🍒][Modules] Fix cyclic module dependencies in clang

### DIFF
--- a/clang/include/clang/Serialization/ObjectFilePCHContainerReader.h
+++ b/clang/include/clang/Serialization/ObjectFilePCHContainerReader.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_CLANG_SERIALIZATION_OBJECTFILEPCHCONTAINERREADER_H
 #define LLVM_CLANG_SERIALIZATION_OBJECTFILEPCHCONTAINERREADER_H
 
-#include "clang/Frontend/PCHContainerOperations.h"
+#include "clang/Serialization/PCHContainerOperations.h"
 
 namespace clang {
 /// A PCHContainerReader implementation that uses LLVM to


### PR DESCRIPTION
Breakup the cyclic dependency in module 'Clang_Frontend': Clang_Frontend -> Clang_Serialization -> Clang_Frontend

(cherry picked from commit 61c0a6d72d53107b683b3c4d636df7b9be0d4d09)

---

* **Explanation**: Fix the build when using `-DLLVM_ENABLE_MODULES=1` after the change in #129774. The build breakage was missed because no public CI runs with modules enabled.
* **Scope**: Change is NFC, should just fix the build.
* **Risk**: Low. The previous include (Frontend/PCHContainerOperations.h) just wrapped this file (Serialization/PCHContainerOperations.h) anyway, so this just eliminates an unnecessary indirection.
* **Tests**: Existing tests pass
* **Issues**: rdar://146677307
* **Original PRs**: https://github.com/llvm/llvm-project/pull/102348
* **Reviewers**: @jansvoboda11 reviewed the upstream PR