### PR TITLE
Fix build with -DLLVM_ENABLE_MODULES=1

### DIFF
--- a/clang/include/clang/Serialization/ObjectFilePCHContainerReader.h
+++ b/clang/include/clang/Serialization/ObjectFilePCHContainerReader.h
@@ -9,7 +9,7 @@
 #ifndef LLVM_CLANG_SERIALIZATION_OBJECTFILEPCHCONTAINERREADER_H
 #define LLVM_CLANG_SERIALIZATION_OBJECTFILEPCHCONTAINERREADER_H
 
-#include "clang/Frontend/PCHContainerOperations.h"
+#include "clang/Serialization/PCHContainerOperations.h"
 
 namespace clang {
 /// A PCHContainerReader implementation that uses LLVM to

--- a/clang/include/clang/Tooling/Inclusions/StandardLibrary.h
+++ b/clang/include/clang/Tooling/Inclusions/StandardLibrary.h
@@ -21,6 +21,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace clang {
 class Decl;

--- a/llvm/include/llvm/Analysis/SyntheticCountsUtils.h
+++ b/llvm/include/llvm/Analysis/SyntheticCountsUtils.h
@@ -16,6 +16,7 @@
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Support/ScaledNumber.h"
+#include <vector>
 
 namespace llvm {
 

--- a/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
+++ b/llvm/include/llvm/Transforms/InstCombine/InstCombiner.h
@@ -18,6 +18,7 @@
 #ifndef LLVM_TRANSFORMS_INSTCOMBINE_INSTCOMBINER_H
 #define LLVM_TRANSFORMS_INSTCOMBINE_INSTCOMBINER_H
 
+#include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/Analysis/DomConditionCache.h"
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/Analysis/TargetFolder.h"


### PR DESCRIPTION
* **Explanation**: Fixes compile errors seen when building with -DLLVM_ENABLE_MODULES=1. The specific changes are just adding some missing includes and replacing the include of the wrapper header Frontend/PCHContainerOperations.h with an include of the underlying Serialization/PCHContainerOperations.h header.
* **Scope**: This is an NFC change and only affects the build.
* **Risk**: Low. The previous include (Frontend/PCHContainerOperations.h) just wrapped this file (Serialization/PCHContainerOperations.h) anyway, so this just eliminates an unnecessary indirection.  The other changes are just adding missing includes.
* **Tests**: Existing tests pass.
* **Issues**: rdar://146677307
* **Original PRs**: https://github.com/llvm/llvm-project/pull/102348 and https://github.com/llvm/llvm-project/pull/107654/files
* **Reviewers**: @jansvoboda11 reviewed both upstream PRs