### PR TITLE
[lldb] Accept address in task backtrace and select commands (#10191)

### DIFF
--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -5,13 +5,27 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
-    def test(self):
+
+    def test_backtrace_task_variable(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
+        self.do_backtrace("task")
+
+    def test_backtrace_task_address(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+        task = frame.FindVariable("task")
+        task_addr = task.GetChildMemberWithName("address").unsigned
+        self.do_backtrace(task_addr)
+
+    def do_backtrace(self, arg):
         self.expect(
-            "language swift task backtrace task",
+            f"language swift task backtrace {arg}",
             substrs=[
                 ".sleep(",
                 "`second() at main.swift:6",


### PR DESCRIPTION
Update the `language swift task {backtrace,select}` commands to take a task address.

This is useful in conjunction with https://github.com/swiftlang/llvm-project/pull/10176 which prints a tasks address. An example use case is printing a `TaskGroup`, and then using the address of one of the group's child tasks with either the `backtrace` or `select` command.

(cherry-picked from commit 0a0c9a6126c09dd98e14c456daa34b51c73e43dc)