### PR TITLE
[lldb] Use TaskPriority as type of Task.enqueuePriority member (#10207)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -810,6 +810,9 @@ public:
     // TypeMangling for "Swift.UInt64"
     CompilerType uint64_type =
         m_ts->GetTypeFromMangledTypename(ConstString("$ss6UInt64VD"));
+    // TypeMangling for "Swift.TaskPriority"
+    CompilerType priority_type =
+        m_ts->GetTypeFromMangledTypename(ConstString("$sScPD"));
 
 #define RETURN_CHILD(FIELD, NAME, TYPE)                                        \
   if (!FIELD) {                                                                \
@@ -842,7 +845,7 @@ public:
     case 2:
       RETURN_CHILD(m_kind_sp, kind, uint32_type);
     case 3:
-      RETURN_CHILD(m_enqueue_priority_sp, enqueuePriority, uint32_type);
+      RETURN_CHILD(m_enqueue_priority_sp, enqueuePriority, priority_type);
     case 4:
       RETURN_CHILD(m_is_child_task_sp, isChildTask, bool_type);
     case 5:

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
                 "address = 0x",
                 "id = 2",
                 "kind = 0",
-                "enqueuePriority = 21",
+                "enqueuePriority = .medium",
                 "isChildTask = false",
                 "isFuture = true",
                 "isGroupChildTask = false",


### PR DESCRIPTION
Changes the type of `enqueuePriority` to `TaskPriority`. This allows Tasks to be displayed using human readable names added in #10205 (`TaskPriority` summary provider).

(cherry-picked from commit 1c65036ec40f6bdf5544bafe1bfcd5fd2ca35e4f)