### PR TITLE
[SUA] Set debug location when creating a call to frame allocator in `emitAlloc`

### DIFF
--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -255,7 +255,8 @@ struct Shape {
   /// Allocate memory according to the rules of the active lowering.
   ///
   /// \param CG - if non-null, will be updated for the new call
-  Value *emitAlloc(IRBuilder<> &Builder, Value *Size, CallGraph *CG) const;
+  Value *emitAlloc(IRBuilder<> &Builder, Value *Size, CallGraph *CG,
+                   const DebugLoc DbgLoc=nullptr) const;
 
   /// Deallocate memory according to the rules of the active lowering.
   ///

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1847,7 +1847,8 @@ void coro::AnyRetconABI::splitCoroutine(Function &F, coro::Shape &Shape,
     // Allocate.  We don't need to update the call graph node because we're
     // going to recompute it from scratch after splitting.
     // FIXME: pass the required alignment
-    RawFramePtr = Shape.emitAlloc(Builder, Builder.getInt64(Size), nullptr);
+    RawFramePtr = Shape.emitAlloc(Builder, Builder.getInt64(Size), nullptr,
+                                  Id->getDebugLoc());
     RawFramePtr =
         Builder.CreateBitCast(RawFramePtr, Shape.CoroBegin->getType());
 

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -503,7 +503,7 @@ static void addCallToCallGraph(CallGraph *CG, CallInst *Call, Function *Callee){
 }
 
 Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
-                              CallGraph *CG) const {
+                              CallGraph *CG, const DebugLoc DbgLoc) const {
   switch (ABI) {
   case coro::ABI::Switch:
     llvm_unreachable("can't allocate memory in coro switch-lowering");
@@ -520,6 +520,7 @@ Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
       Call = Builder.CreateCall(Alloc, Size);
     else
       Call = Builder.CreateCall(Alloc, {Size, TypeId});
+    Call->setDebugLoc(DbgLoc);
     propagateCallAttrsFromCallee(Call, Alloc);
     addCallToCallGraph(CG, Call, Alloc);
     return Call;

--- a/llvm/lib/Transforms/Coroutines/SpillUtils.cpp
+++ b/llvm/lib/Transforms/Coroutines/SpillUtils.cpp
@@ -75,7 +75,8 @@ static Instruction *
 lowerNonLocalAlloca(CoroAllocaAllocInst *AI, const coro::Shape &Shape,
                     SmallVectorImpl<Instruction *> &DeadInsts) {
   IRBuilder<> Builder(AI);
-  auto Alloc = Shape.emitAlloc(Builder, AI->getSize(), nullptr);
+  auto Alloc = Shape.emitAlloc(Builder, AI->getSize(), nullptr,
+                               AI->getDebugLoc());
 
   for (User *U : AI->users()) {
     if (isa<CoroAllocaGetInst>(U)) {


### PR DESCRIPTION
When calling the newly introduced stub for frame allocation swift_coroFrameAllocStub, it could sometimes be inlined requiring it to have information about its debug location. This commit sets the debug location for the call to the frame allocator during coroutine split.

rdar://145239850