### PR TITLE
[SUA] Set debug location when creating a call to frame allocator in `emitAlloc`

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -2544,7 +2544,8 @@ static Instruction *lowerNonLocalAlloca(CoroAllocaAllocInst *AI,
                                         coro::Shape &Shape,
                                    SmallVectorImpl<Instruction*> &DeadInsts) {
   IRBuilder<> Builder(AI);
-  auto Alloc = Shape.emitAlloc(Builder, AI->getSize(), nullptr);
+  auto Alloc = Shape.emitAlloc(Builder, AI->getSize(), nullptr,
+                               AI->getDebugLoc());
 
   for (User *U : AI->users()) {
     if (isa<CoroAllocaGetInst>(U)) {

--- a/llvm/lib/Transforms/Coroutines/CoroInternal.h
+++ b/llvm/lib/Transforms/Coroutines/CoroInternal.h
@@ -274,7 +274,8 @@ struct LLVM_LIBRARY_VISIBILITY Shape {
   /// Allocate memory according to the rules of the active lowering.
   ///
   /// \param CG - if non-null, will be updated for the new call
-  Value *emitAlloc(IRBuilder<> &Builder, Value *Size, CallGraph *CG) const;
+  Value *emitAlloc(IRBuilder<> &Builder, Value *Size, CallGraph *CG,
+                   const DebugLoc DbgLoc=nullptr) const;
 
   /// Deallocate memory according to the rules of the active lowering.
   ///

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -1886,7 +1886,8 @@ static void splitRetconCoroutine(Function &F, coro::Shape &Shape,
     // Allocate.  We don't need to update the call graph node because we're
     // going to recompute it from scratch after splitting.
     // FIXME: pass the required alignment
-    RawFramePtr = Shape.emitAlloc(Builder, Builder.getInt64(Size), nullptr);
+    RawFramePtr = Shape.emitAlloc(Builder, Builder.getInt64(Size), nullptr,
+                                  Id->getDebugLoc());
     RawFramePtr =
         Builder.CreateBitCast(RawFramePtr, Shape.CoroBegin->getType());
 

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -481,7 +481,7 @@ static void addCallToCallGraph(CallGraph *CG, CallInst *Call, Function *Callee){
 }
 
 Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
-                              CallGraph *CG) const {
+                              CallGraph *CG, const DebugLoc DbgLoc) const {
   unsigned sizeParamIndex = UINT_MAX;
   switch (ABI) {
   case coro::ABI::Switch:
@@ -512,6 +512,7 @@ Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
       Args.push_back(TypeId);
   }
   auto *Call = Builder.CreateCall(Alloc, Args);
+  Call->setDebugLoc(DbgLoc);
   propagateCallAttrsFromCallee(Call, Alloc);
   addCallToCallGraph(CG, Call, Alloc);
   return Call;


### PR DESCRIPTION
When calling the newly introduced stub for frame allocation swift_coroFrameAllocStub, it could sometimes be inlined requiring it to have information about its debug location. This commit sets the debug location for the call to the frame allocator during coroutine split.

rdar://145239850