### PR TITLE
🍒 [WindowsDriver] Always consider `WinSdkVersion` (llvm#130377)

### DIFF
--- a/llvm/lib/WindowsDriver/MSVCPaths.cpp
+++ b/llvm/lib/WindowsDriver/MSVCPaths.cpp
@@ -444,6 +444,13 @@ bool getWindowsSDKDir(vfs::FileSystem &VFS, std::optional<StringRef> WinSdkDir,
     return !WindowsSDKLibVersion.empty();
   }
   if (Major == 10) {
+    if (WinSdkVersion) {
+      // Use the user-provided version as-is.
+      WindowsSDKIncludeVersion = WinSdkVersion->str();
+      WindowsSDKLibVersion = WindowsSDKIncludeVersion;
+      return true;
+    }
+
     if (!getWindows10SDKVersionFromPath(VFS, Path, WindowsSDKIncludeVersion))
       return false;
     WindowsSDKLibVersion = WindowsSDKIncludeVersion;
@@ -474,6 +481,12 @@ bool getUniversalCRTSdkDir(vfs::FileSystem &VFS,
           "SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", "KitsRoot10",
           Path, nullptr))
     return false;
+
+  if (WinSdkVersion) {
+    // Use the user-provided version as-is.
+    UCRTVersion = WinSdkVersion->str();
+    return true;
+  }
 
   return getWindows10SDKVersionFromPath(VFS, Path, UCRTVersion);
 }


### PR DESCRIPTION
Currently, the `-Xmicrosoft-windows-sdk-version` is only used if `-Xmicrosoft-windows-sdk-root` is also provided. This is a surprising behavior since the argument should still be taking effect if LLVM uses the Windows SDK root from the registry.

Tested locally in a simple Hello World program including `Windows.h` and compiled with `-Xmicrosoft-windows-sdk-version 10.0.18362.0` on a system where the SDK 10.0.22621.0 is also installed and verified that the correct header was included.

Co-authored-by: Saleem Abdulrasool <compnerd@compnerd.org>
(cherrry picked from commit [606e9fa](https://github.com/swiftlang/llvm-project/commit/606e9fa444559923a9e03cbdffc1abd9e2582d60))