### PR TITLE
swift lldb: rename OpenedArchetype -> ExistentialArchetype

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6097,7 +6097,7 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   case swift::TypeKind::Integer:
   case swift::TypeKind::Locatable:
   case swift::TypeKind::Module:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::ParameterizedProtocol:
   case swift::TypeKind::Placeholder:
   case swift::TypeKind::PrimaryArchetype:
@@ -6312,7 +6312,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   case swift::TypeKind::PrimaryArchetype:
   case swift::TypeKind::ElementArchetype:
   case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::ErrorUnion:
@@ -6791,7 +6791,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
     return lldb::eEncodingIEEE754; // TODO: detect if an integer is unsigned
 
   case swift::TypeKind::PrimaryArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::ElementArchetype:
   case swift::TypeKind::OpaqueTypeArchetype:
   case swift::TypeKind::BuiltinRawPointer:
@@ -6894,7 +6894,7 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
   case swift::TypeKind::Metatype:
   case swift::TypeKind::Module:
   case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::Pack:
   case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
@@ -7098,7 +7098,7 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
 
   case swift::TypeKind::ElementArchetype:
   case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::PrimaryArchetype:
   case swift::TypeKind::Function:
   case swift::TypeKind::GenericFunction:
@@ -7407,7 +7407,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
 
   case swift::TypeKind::ElementArchetype:
   case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::PrimaryArchetype:
   case swift::TypeKind::Function:
   case swift::TypeKind::GenericFunction:
@@ -7470,7 +7470,7 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   case swift::TypeKind::Metatype:
   case swift::TypeKind::Module:
   case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::Pack:
   case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
@@ -7627,7 +7627,7 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
   case swift::TypeKind::Metatype:
   case swift::TypeKind::Module:
   case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::Pack:
   case swift::TypeKind::PackArchetype:
   case swift::TypeKind::PackElement:
@@ -8009,7 +8009,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     case swift::TypeKind::Metatype:
     case swift::TypeKind::Module:
     case swift::TypeKind::OpaqueTypeArchetype:
-    case swift::TypeKind::OpenedArchetype:
+    case swift::TypeKind::ExistentialArchetype:
     case swift::TypeKind::Pack:
     case swift::TypeKind::PackArchetype:
     case swift::TypeKind::PackElement:
@@ -8437,7 +8437,7 @@ bool SwiftASTContext::DumpTypeValue(
   case swift::TypeKind::BuiltinBridgeObject:
   case swift::TypeKind::ElementArchetype:
   case swift::TypeKind::OpaqueTypeArchetype:
-  case swift::TypeKind::OpenedArchetype:
+  case swift::TypeKind::ExistentialArchetype:
   case swift::TypeKind::PrimaryArchetype:
   case swift::TypeKind::Function:
   case swift::TypeKind::GenericFunction:


### PR DESCRIPTION
As done in the swift repo

Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10237