### PR TITLE
[lldb] Upgrade CompilerType::GetBitSize to return llvm::Expected 

### DIFF
--- a/lldb/include/lldb/Expression/ExpressionVariable.h
+++ b/lldb/include/lldb/Expression/ExpressionVariable.h
@@ -33,7 +33,7 @@ public:
 
   virtual ~ExpressionVariable() = default;
 
-  std::optional<uint64_t> GetByteSize() { return m_frozen_sp->GetByteSize(); }
+  llvm::Expected<uint64_t> GetByteSize() { return m_frozen_sp->GetByteSize(); }
 
   ConstString GetName() { return m_frozen_sp->GetName(); }
 

--- a/lldb/include/lldb/Symbol/CompilerType.h
+++ b/lldb/include/lldb/Symbol/CompilerType.h
@@ -418,9 +418,10 @@ public:
   struct IntegralTemplateArgument;
 
   /// Return the size of the type in bytes.
-  std::optional<uint64_t> GetByteSize(ExecutionContextScope *exe_scope) const;
+  llvm::Expected<uint64_t> GetByteSize(ExecutionContextScope *exe_scope) const;
   /// Return the size of the type in bits.
-  std::optional<uint64_t> GetBitSize(ExecutionContextScope *exe_scope) const;
+  llvm::Expected<uint64_t> GetBitSize(ExecutionContextScope *exe_scope) const;
+
   /// Return the stride of the type in bits.
   std::optional<uint64_t>
   GetByteStride(ExecutionContextScope *exe_scope) const;

--- a/lldb/include/lldb/Symbol/Type.h
+++ b/lldb/include/lldb/Symbol/Type.h
@@ -460,7 +460,7 @@ public:
 
   ConstString GetBaseName();
 
-  std::optional<uint64_t> GetByteSize(ExecutionContextScope *exe_scope);
+  llvm::Expected<uint64_t> GetByteSize(ExecutionContextScope *exe_scope);
 
   llvm::Expected<uint32_t> GetNumChildren(bool omit_empty_base_classes);
 

--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -341,7 +341,7 @@ public:
 
   virtual const llvm::fltSemantics &GetFloatTypeSemantics(size_t byte_size) = 0;
 
-  virtual std::optional<uint64_t>
+  virtual llvm::Expected<uint64_t>
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) = 0;
 

--- a/lldb/include/lldb/Target/StackFrameRecognizer.h
+++ b/lldb/include/lldb/Target/StackFrameRecognizer.h
@@ -177,7 +177,7 @@ class ValueObjectRecognizerSynthesizedValue : public ValueObject {
     SetName(parent.GetName());
   }
 
-  std::optional<uint64_t> GetByteSize() override {
+  llvm::Expected<uint64_t> GetByteSize() override {
     return m_parent->GetByteSize();
   }
   lldb::ValueType GetValueType() const override { return m_type; }

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -357,7 +357,7 @@ public:
   virtual bool CanProvideValue();
 
   // Subclasses must implement the functions below.
-  virtual std::optional<uint64_t> GetByteSize() = 0;
+  virtual llvm::Expected<uint64_t> GetByteSize() = 0;
 
   virtual lldb::ValueType GetValueType() const = 0;
 

--- a/lldb/include/lldb/ValueObject/ValueObjectCast.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectCast.h
@@ -30,7 +30,7 @@ public:
   static lldb::ValueObjectSP Create(ValueObject &parent, ConstString name,
                                     const CompilerType &cast_type);
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   llvm::Expected<uint32_t> CalculateNumChildren(uint32_t max) override;
 

--- a/lldb/include/lldb/ValueObject/ValueObjectChild.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectChild.h
@@ -29,7 +29,7 @@ class ValueObjectChild : public ValueObject {
 public:
   ~ValueObjectChild() override;
 
-  std::optional<uint64_t> GetByteSize() override { return m_byte_size; }
+  llvm::Expected<uint64_t> GetByteSize() override { return m_byte_size; }
 
   lldb::offset_t GetByteOffset() override { return m_byte_offset; }
 

--- a/lldb/include/lldb/ValueObject/ValueObjectConstResult.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectConstResult.h
@@ -64,7 +64,7 @@ public:
   static lldb::ValueObjectSP Create(ExecutionContextScope *exe_scope,
                                     Status &&error);
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   lldb::ValueType GetValueType() const override;
 

--- a/lldb/include/lldb/ValueObject/ValueObjectDynamicValue.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectDynamicValue.h
@@ -35,7 +35,7 @@ class ValueObjectDynamicValue : public ValueObject {
 public:
   ~ValueObjectDynamicValue() override = default;
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   ConstString GetTypeName() override;
 

--- a/lldb/include/lldb/ValueObject/ValueObjectMemory.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectMemory.h
@@ -41,7 +41,7 @@ public:
                                     const Address &address,
                                     const CompilerType &ast_type);
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   ConstString GetTypeName() override;
 

--- a/lldb/include/lldb/ValueObject/ValueObjectRegister.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectRegister.h
@@ -37,7 +37,7 @@ public:
                                     lldb::RegisterContextSP &reg_ctx_sp,
                                     uint32_t set_idx);
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   lldb::ValueType GetValueType() const override {
     return lldb::eValueTypeRegisterSet;
@@ -89,7 +89,7 @@ public:
                                     lldb::RegisterContextSP &reg_ctx_sp,
                                     const RegisterInfo *reg_info);
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm ::Expected<uint64_t> GetByteSize() override;
 
   lldb::ValueType GetValueType() const override {
     return lldb::eValueTypeRegister;

--- a/lldb/include/lldb/ValueObject/ValueObjectSyntheticFilter.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectSyntheticFilter.h
@@ -37,7 +37,7 @@ class ValueObjectSynthetic : public ValueObject {
 public:
   ~ValueObjectSynthetic() override;
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   ConstString GetTypeName() override;
 

--- a/lldb/include/lldb/ValueObject/ValueObjectVTable.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectVTable.h
@@ -62,7 +62,7 @@ public:
 
   static lldb::ValueObjectSP Create(ValueObject &parent);
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   llvm::Expected<uint32_t> CalculateNumChildren(uint32_t max) override;
 

--- a/lldb/include/lldb/ValueObject/ValueObjectVariable.h
+++ b/lldb/include/lldb/ValueObject/ValueObjectVariable.h
@@ -38,7 +38,7 @@ public:
   static lldb::ValueObjectSP Create(ExecutionContextScope *exe_scope,
                                     const lldb::VariableSP &var_sp);
 
-  std::optional<uint64_t> GetByteSize() override;
+  llvm::Expected<uint64_t> GetByteSize() override;
 
   ConstString GetTypeName() override;
 

--- a/lldb/source/API/SBType.cpp
+++ b/lldb/source/API/SBType.cpp
@@ -127,8 +127,8 @@ uint64_t SBType::GetByteSize() {
   LLDB_INSTRUMENT_VA(this);
 
   if (IsValid())
-    if (std::optional<uint64_t> size =
-            m_opaque_sp->GetCompilerType(false).GetByteSize(nullptr))
+    if (std::optional<uint64_t> size = llvm::expectedToOptional(
+            m_opaque_sp->GetCompilerType(false).GetByteSize(nullptr)))
       return *size;
   return 0;
 }

--- a/lldb/source/API/SBValue.cpp
+++ b/lldb/source/API/SBValue.cpp
@@ -329,7 +329,7 @@ size_t SBValue::GetByteSize() {
   ValueLocker locker;
   lldb::ValueObjectSP value_sp(GetSP(locker));
   if (value_sp) {
-    result = value_sp->GetByteSize().value_or(0);
+    result = llvm::expectedToOptional(value_sp->GetByteSize()).value_or(0);
   }
 
   return result;

--- a/lldb/source/Commands/CommandObjectWatchpoint.cpp
+++ b/lldb/source/Commands/CommandObjectWatchpoint.cpp
@@ -867,9 +867,10 @@ protected:
       if (addr_type == eAddressTypeLoad) {
         // We're in business.
         // Find out the size of this variable.
-        size = m_option_watchpoint.watch_size.GetCurrentValue() == 0
-                   ? valobj_sp->GetByteSize().value_or(0)
-                   : m_option_watchpoint.watch_size.GetCurrentValue();
+        size =
+            m_option_watchpoint.watch_size.GetCurrentValue() == 0
+                ? llvm::expectedToOptional(valobj_sp->GetByteSize()).value_or(0)
+                : m_option_watchpoint.watch_size.GetCurrentValue();
       }
       compiler_type = valobj_sp->GetCompilerType();
     } else {
@@ -1080,7 +1081,8 @@ protected:
     /// of the expression, so convert to that if we found a valid type.
     CompilerType compiler_type(valobj_sp->GetCompilerType());
 
-    std::optional<uint64_t> valobj_size = valobj_sp->GetByteSize();
+    std::optional<uint64_t> valobj_size =
+        llvm::expectedToOptional(valobj_sp->GetByteSize());
     // Set the type as a uint8_t array if the size being watched is
     // larger than the ValueObject's size (which is probably the size
     // of a pointer).

--- a/lldb/source/DataFormatters/FormattersHelpers.cpp
+++ b/lldb/source/DataFormatters/FormattersHelpers.cpp
@@ -285,7 +285,9 @@ bool lldb_private::formatters::FormatBoundsSafetyPointer(
   uint64_t pointee_byte_size = 0;
   if (compiler_type.IsPointerType(&pointee_type)) {
     pointee_byte_size =
-        pointee_type.GetByteSize(valobj.GetTargetSP().get()).value_or(0);
+        llvm::expectedToOptional(
+            pointee_type.GetByteSize(valobj.GetTargetSP().get()))
+            .value_or(0);
   }
 
   if (auto maybe_oob_info = GetOOBInfo(ptr, /*upper_bound=*/upper_bound,

--- a/lldb/source/DataFormatters/TypeFormat.cpp
+++ b/lldb/source/DataFormatters/TypeFormat.cpp
@@ -99,13 +99,20 @@ bool TypeFormatImpl_Format::FormatObject(ValueObject *valobj,
             return false;
         }
 
+        auto size_or_err = compiler_type.GetByteSize(exe_scope);
+        if (!size_or_err) {
+          LLDB_LOG_ERRORV(
+              GetLog(LLDBLog::Types), size_or_err.takeError(),
+              "Cannot get size of type while formatting object: {0}");
+          return false;
+        }
         StreamString sstr;
         compiler_type.DumpTypeValue(
             &sstr,                          // The stream to use for display
             GetFormat(),                    // Format to display this type with
             data,                           // Data to extract from
             0,                              // Byte offset into "m_data"
-            *size,                          // Byte size of item in "m_data"
+            *size_or_err,                   // Byte size of item in "m_data"
             valobj->GetBitfieldBitSize(),   // Bitfield bit size
             valobj->GetBitfieldBitOffset(), // Bitfield bit offset
             exe_scope,

--- a/lldb/source/DataFormatters/VectorType.cpp
+++ b/lldb/source/DataFormatters/VectorType.cpp
@@ -197,15 +197,15 @@ static lldb::Format GetItemFormatForFormat(lldb::Format format,
 static std::optional<size_t>
 CalculateNumChildren(CompilerType container_elem_type, uint64_t num_elements,
                      CompilerType element_type) {
-  std::optional<uint64_t> container_elem_size =
-      container_elem_type.GetByteSize(/* exe_scope */ nullptr);
+  std::optional<uint64_t> container_elem_size = llvm::expectedToOptional(
+      container_elem_type.GetByteSize(/* exe_scope */ nullptr));
   if (!container_elem_size)
     return {};
 
   auto container_size = *container_elem_size * num_elements;
 
-  std::optional<uint64_t> element_size =
-      element_type.GetByteSize(/* exe_scope */ nullptr);
+  std::optional<uint64_t> element_size = llvm::expectedToOptional(
+      element_type.GetByteSize(/* exe_scope */ nullptr));
   if (!element_size || !*element_size)
     return {};
 
@@ -236,10 +236,11 @@ public:
           nullptr, Status::FromError(num_children_or_err.takeError()));
     if (idx >= *num_children_or_err)
       return {};
-    std::optional<uint64_t> size = m_child_type.GetByteSize(nullptr);
-    if (!size)
-      return {};
-    auto offset = idx * *size;
+    auto size_or_err = m_child_type.GetByteSize(nullptr);
+    if (!size_or_err)
+      return ValueObjectConstResult::Create(
+          nullptr, Status::FromError(size_or_err.takeError()));
+    auto offset = idx * *size_or_err;
     StreamString idx_name;
     idx_name.Printf("[%" PRIu64 "]", (uint64_t)idx);
     ValueObjectSP child_sp(m_backend.GetSyntheticChildAtOffset(

--- a/lldb/source/Expression/ExpressionVariable.cpp
+++ b/lldb/source/Expression/ExpressionVariable.cpp
@@ -20,7 +20,8 @@ char ExpressionVariable::ID;
 ExpressionVariable::ExpressionVariable() : m_flags(0) {}
 
 uint8_t *ExpressionVariable::GetValueBytes() {
-  std::optional<uint64_t> byte_size = m_frozen_sp->GetByteSize();
+  std::optional<uint64_t> byte_size =
+      llvm::expectedToOptional(m_frozen_sp->GetByteSize());
   if (byte_size && *byte_size) {
     if (m_frozen_sp->GetDataExtractor().GetByteSize() < *byte_size) {
       m_frozen_sp->GetValue().ResizeData(*byte_size);

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -545,9 +545,12 @@ public:
         valobj_sp->GetData(data, extract_error);
         if (!extract_error.Success()) {
           if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
-            std::optional<uint64_t> size =
-                valobj_type.GetByteSize(frame_sp.get());
-            if (size && *size == 0) {
+            auto size_or_err = valobj_type.GetByteSize(frame_sp.get());
+            if (!size_or_err) {
+              err = Status::FromError(size_or_err.takeError());
+              return;
+            }
+            if (*size_or_err == 0) {
               // We don't need to materialize empty structs in Swift.
               return;
             }
@@ -676,14 +679,19 @@ public:
 
       Status extract_error;
 
-      map.GetMemoryData(data, m_temporary_allocation,
-                        valobj_sp->GetByteSize().value_or(0), extract_error);
+      map.GetMemoryData(
+          data, m_temporary_allocation,
+          llvm::expectedToOptional(valobj_sp->GetByteSize()).value_or(0),
+          extract_error);
 
       if (!extract_error.Success()) {
         if (valobj_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
-          std::optional<uint64_t> size =
-              valobj_type.GetByteSize(frame_sp.get());
-          if (size && *size == 0)
+          auto size_or_err = valobj_type.GetByteSize(frame_sp.get());
+          if (!size_or_err) {
+            err = Status::FromError(size_or_err.takeError());
+            return;
+          }
+          if (*size_or_err == 0)
             // We don't need to dematerialize empty structs in Swift.
             return;
         }

--- a/lldb/source/Expression/Materializer.cpp
+++ b/lldb/source/Expression/Materializer.cpp
@@ -79,8 +79,9 @@ public:
     const bool zero_memory = false;
 
     lldb::addr_t mem = map.Malloc(
-        m_persistent_variable_sp->GetByteSize().value_or(0), 8,
-        lldb::ePermissionsReadable | lldb::ePermissionsWritable,
+        llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
+            .value_or(0),
+        8, lldb::ePermissionsReadable | lldb::ePermissionsWritable,
         IRMemoryMap::eAllocationPolicyMirror, zero_memory, allocate_error);
 
     if (!allocate_error.Success()) {
@@ -117,9 +118,11 @@ public:
 
     Status write_error;
 
-    map.WriteMemory(mem, m_persistent_variable_sp->GetValueBytes(),
-                    m_persistent_variable_sp->GetByteSize().value_or(0),
-                    write_error);
+    map.WriteMemory(
+        mem, m_persistent_variable_sp->GetValueBytes(),
+        llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
+            .value_or(0),
+        write_error);
 
     if (!write_error.Success()) {
       err = Status::FromErrorStringWithFormat(
@@ -247,7 +250,8 @@ public:
             map.GetBestExecutionContextScope(),
             m_persistent_variable_sp.get()->GetCompilerType(),
             m_persistent_variable_sp->GetName(), location, eAddressTypeLoad,
-            m_persistent_variable_sp->GetByteSize().value_or(0));
+            llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
+                .value_or(0));
 
         if (frame_top != LLDB_INVALID_ADDRESS &&
             frame_bottom != LLDB_INVALID_ADDRESS && location >= frame_bottom &&
@@ -292,7 +296,8 @@ public:
         LLDB_LOGF(log, "Dematerializing %s from 0x%" PRIx64 " (size = %llu)",
                   m_persistent_variable_sp->GetName().GetCString(),
                   (uint64_t)mem,
-                  (unsigned long long)m_persistent_variable_sp->GetByteSize()
+                  (unsigned long long)llvm::expectedToOptional(
+                      m_persistent_variable_sp->GetByteSize())
                       .value_or(0));
 
         // Read the contents of the spare memory area
@@ -301,9 +306,11 @@ public:
 
         Status read_error;
 
-        map.ReadMemory(m_persistent_variable_sp->GetValueBytes(), mem,
-                       m_persistent_variable_sp->GetByteSize().value_or(0),
-                       read_error);
+        map.ReadMemory(
+            m_persistent_variable_sp->GetValueBytes(), mem,
+            llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
+                .value_or(0),
+            read_error);
 
         if (!read_error.Success()) {
           err = Status::FromErrorStringWithFormat(
@@ -384,12 +391,16 @@ public:
       if (!err.Success()) {
         dump_stream.Printf("  <could not be read>\n");
       } else {
-        DataBufferHeap data(m_persistent_variable_sp->GetByteSize().value_or(0),
-                            0);
+        DataBufferHeap data(
+            llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
+                .value_or(0),
+            0);
 
-        map.ReadMemory(data.GetBytes(), target_address,
-                       m_persistent_variable_sp->GetByteSize().value_or(0),
-                       err);
+        map.ReadMemory(
+            data.GetBytes(), target_address,
+            llvm::expectedToOptional(m_persistent_variable_sp->GetByteSize())
+                .value_or(0),
+            err);
 
         if (!err.Success()) {
           dump_stream.Printf("  <could not be read>\n");
@@ -554,7 +565,8 @@ public:
           return;
         }
 
-        if (data.GetByteSize() < GetByteSize(scope)) {
+        if (data.GetByteSize() <
+            llvm::expectedToOptional(GetByteSize(scope)).value_or(0)) {
           if (data.GetByteSize() == 0 && !LocationExpressionIsValid()) {
             err = Status::FromErrorStringWithFormat(
                 "the variable '%s' has no location, "
@@ -564,7 +576,8 @@ public:
             err = Status::FromErrorStringWithFormat(
                 "size of variable %s (%" PRIu64
                 ") is larger than the ValueObject's size (%" PRIu64 ")",
-                GetName().AsCString(), GetByteSize(scope).value_or(0),
+                GetName().AsCString(),
+                llvm::expectedToOptional(GetByteSize(scope)).value_or(0),
                 data.GetByteSize());
           }
           return;
@@ -815,7 +828,7 @@ private:
   ///
   /// \returns On success, returns byte size of the type associated
   ///          with this variable. Returns std::nullopt otherwise.
-  virtual std::optional<uint64_t>
+  virtual llvm::Expected<uint64_t>
   GetByteSize(ExecutionContextScope *scope) const = 0;
 
   /// Returns 'true' if the location expression associated with this variable
@@ -856,7 +869,7 @@ public:
     return ValueObjectVariable::Create(scope, m_variable_sp);
   }
 
-  std::optional<uint64_t>
+  llvm::Expected<uint64_t>
   GetByteSize(ExecutionContextScope *scope) const override {
     return m_variable_sp->GetType()->GetByteSize(scope);
   }
@@ -899,12 +912,12 @@ public:
     return m_valobj_sp;
   }
 
-  std::optional<uint64_t>
+  llvm::Expected<uint64_t>
   GetByteSize(ExecutionContextScope *scope) const override {
     if (m_valobj_sp)
       return m_valobj_sp->GetCompilerType().GetByteSize(scope);
 
-    return {};
+    return llvm::createStringError("no value object");
   }
 
   bool LocationExpressionIsValid() const override {
@@ -976,12 +989,12 @@ public:
       if (!exe_scope)
         exe_scope = map.GetBestExecutionContextScope();
 
-      std::optional<uint64_t> byte_size = m_type.GetByteSize(exe_scope);
-      if (!byte_size) {
-        err = Status::FromErrorStringWithFormat(
-            "can't get size of type \"%s\"", m_type.GetTypeName().AsCString());
+      auto byte_size_or_err = m_type.GetByteSize(exe_scope);
+      if (!byte_size_or_err) {
+        err = Status::FromError(byte_size_or_err.takeError());
         return;
       }
+      auto byte_size = *byte_size_or_err;
 
       std::optional<size_t> opt_bit_align = m_type.GetTypeBitAlign(exe_scope);
       if (!opt_bit_align) {
@@ -997,10 +1010,10 @@ public:
       const bool zero_memory = true;
 
       m_temporary_allocation = map.Malloc(
-          *byte_size, byte_align,
+          byte_size, byte_align,
           lldb::ePermissionsReadable | lldb::ePermissionsWritable,
           IRMemoryMap::eAllocationPolicyMirror, zero_memory, alloc_error);
-      m_temporary_allocation_size = *byte_size;
+      m_temporary_allocation_size = byte_size;
 
       if (!alloc_error.Success()) {
         err = Status::FromErrorStringWithFormat(
@@ -1131,7 +1144,8 @@ public:
 
     ret->ValueUpdated();
 
-    const size_t pvar_byte_size = ret->GetByteSize().value_or(0);
+    const size_t pvar_byte_size =
+        llvm::expectedToOptional(ret->GetByteSize()).value_or(0);
     uint8_t *pvar_data = ret->GetValueBytes();
 
     map.ReadMemory(pvar_data, address, pvar_byte_size, read_error);

--- a/lldb/source/Host/macosx/objcxx/Host.mm
+++ b/lldb/source/Host/macosx/objcxx/Host.mm
@@ -1467,7 +1467,7 @@ Status Host::ShellExpandArguments(ProcessLaunchInfo &launch_info) {
       char *wd = getcwd(nullptr, 0);
       if (wd == nullptr) {
         error = Status::FromErrorStringWithFormat(
-            "cwd does not exist; cannot launch with shell argument expansion");
+            "cwd does not exist: Cannot launch with shell argument expansion");
         return error;
       } else {
         FileSpec working_dir(wd);

--- a/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABIMacOSX_arm64.cpp
@@ -142,7 +142,8 @@ bool ABIMacOSX_arm64::GetArgumentValues(Thread &thread,
       return false;
 
     CompilerType value_type = value->GetCompilerType();
-    std::optional<uint64_t> bit_size = value_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_size =
+        llvm::expectedToOptional(value_type.GetBitSize(&thread));
     if (!bit_size)
       return false;
 
@@ -490,8 +491,8 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     uint32_t &NGRN,       // NGRN (see ABI documentation)
     uint32_t &NSRN,       // NSRN (see ABI documentation)
     DataExtractor &data) {
-  std::optional<uint64_t> byte_size =
-      value_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> byte_size = llvm::expectedToOptional(
+      value_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
   if (!byte_size || *byte_size == 0)
     return false;
 
@@ -508,8 +509,8 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     if (NSRN < 8 && (8 - NSRN) >= homogeneous_count) {
       if (!base_type)
         return false;
-      std::optional<uint64_t> base_byte_size =
-          base_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+      std::optional<uint64_t> base_byte_size = llvm::expectedToOptional(
+          base_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
       if (!base_byte_size)
         return false;
       uint32_t data_offset = 0;
@@ -643,7 +644,8 @@ ValueObjectSP ABIMacOSX_arm64::GetReturnValueObjectImpl(
   if (!reg_ctx)
     return return_valobj_sp;
 
-  std::optional<uint64_t> byte_size = return_compiler_type.GetByteSize(&thread);
+  std::optional<uint64_t> byte_size =
+      llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
   if (!byte_size)
     return return_valobj_sp;
 

--- a/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
+++ b/lldb/source/Plugins/ABI/AArch64/ABISysV_arm64.cpp
@@ -147,7 +147,8 @@ bool ABISysV_arm64::GetArgumentValues(Thread &thread, ValueList &values) const {
     if (value_type) {
       bool is_signed = false;
       size_t bit_width = 0;
-      std::optional<uint64_t> bit_size = value_type.GetBitSize(&thread);
+      std::optional<uint64_t> bit_size =
+          llvm::expectedToOptional(value_type.GetBitSize(&thread));
       if (!bit_size)
         return false;
       if (value_type.IsIntegerOrEnumerationType(is_signed)) {
@@ -464,8 +465,8 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     uint32_t &NGRN,       // NGRN (see ABI documentation)
     uint32_t &NSRN,       // NSRN (see ABI documentation)
     DataExtractor &data) {
-  std::optional<uint64_t> byte_size =
-      value_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> byte_size = llvm::expectedToOptional(
+      value_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
 
   if (byte_size || *byte_size == 0)
     return false;
@@ -483,8 +484,8 @@ static bool LoadValueFromConsecutiveGPRRegisters(
     if (NSRN < 8 && (8 - NSRN) >= homogeneous_count) {
       if (!base_type)
         return false;
-      std::optional<uint64_t> base_byte_size =
-          base_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+      std::optional<uint64_t> base_byte_size = llvm::expectedToOptional(
+          base_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
       if (!base_byte_size)
         return false;
       uint32_t data_offset = 0;
@@ -613,7 +614,8 @@ ValueObjectSP ABISysV_arm64::GetReturnValueObjectImpl(
   if (!reg_ctx)
     return return_valobj_sp;
 
-  std::optional<uint64_t> byte_size = return_compiler_type.GetByteSize(&thread);
+  std::optional<uint64_t> byte_size =
+      llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
   if (!byte_size)
     return return_valobj_sp;
 

--- a/lldb/source/Plugins/ABI/ARC/ABISysV_arc.cpp
+++ b/lldb/source/Plugins/ABI/ARC/ABISysV_arc.cpp
@@ -459,7 +459,9 @@ ABISysV_arc::GetReturnValueObjectSimple(Thread &thread,
   const uint32_t type_flags = compiler_type.GetTypeInfo();
   // Integer return type.
   if (type_flags & eTypeIsInteger) {
-    const size_t byte_size = compiler_type.GetByteSize(&thread).value_or(0);
+    const size_t byte_size =
+        llvm::expectedToOptional(compiler_type.GetByteSize(&thread))
+            .value_or(0);
     auto raw_value = ReadRawValue(reg_ctx, byte_size);
 
     const bool is_signed = (type_flags & eTypeIsSigned) != 0;
@@ -483,7 +485,9 @@ ABISysV_arc::GetReturnValueObjectSimple(Thread &thread,
 
     if (compiler_type.IsFloatingPointType(float_count, is_complex) &&
         1 == float_count && !is_complex) {
-      const size_t byte_size = compiler_type.GetByteSize(&thread).value_or(0);
+      const size_t byte_size =
+          llvm::expectedToOptional(compiler_type.GetByteSize(&thread))
+              .value_or(0);
       auto raw_value = ReadRawValue(reg_ctx, byte_size);
 
       if (!SetSizedFloat(value.GetScalar(), raw_value, byte_size))

--- a/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABIMacOSX_arm.cpp
@@ -1453,7 +1453,8 @@ bool ABIMacOSX_arm::GetArgumentValues(Thread &thread, ValueList &values) const {
     if (compiler_type) {
       bool is_signed = false;
       size_t bit_width = 0;
-      std::optional<uint64_t> bit_size = compiler_type.GetBitSize(&thread);
+      std::optional<uint64_t> bit_size =
+          llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
       if (!bit_size)
         return false;
       if (compiler_type.IsIntegerOrEnumerationType(is_signed))
@@ -1559,7 +1560,8 @@ ValueObjectSP ABIMacOSX_arm::GetReturnValueObjectImpl(
 
   const RegisterInfo *r0_reg_info = reg_ctx->GetRegisterInfoByName("r0", 0);
   if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-    std::optional<uint64_t> bit_width = compiler_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_width =
+        llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
     if (!bit_width)
       return return_valobj_sp;
 
@@ -1580,7 +1582,7 @@ ValueObjectSP ABIMacOSX_arm::GetReturnValueObjectImpl(
               reg_ctx->GetRegisterInfoByName("r3", 0);
           if (r1_reg_info && r2_reg_info && r3_reg_info) {
             std::optional<uint64_t> byte_size =
-                compiler_type.GetByteSize(&thread);
+                llvm::expectedToOptional(compiler_type.GetByteSize(&thread));
             if (!byte_size)
               return return_valobj_sp;
             ProcessSP process_sp(thread.GetProcess());

--- a/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
+++ b/lldb/source/Plugins/ABI/ARM/ABISysV_arm.cpp
@@ -1459,7 +1459,8 @@ bool ABISysV_arm::GetArgumentValues(Thread &thread, ValueList &values) const {
       size_t bit_width = 0;
       if (compiler_type.IsIntegerOrEnumerationType(is_signed) ||
           compiler_type.IsPointerOrReferenceType()) {
-        if (std::optional<uint64_t> size = compiler_type.GetBitSize(&thread))
+        if (std::optional<uint64_t> size =
+                llvm::expectedToOptional(compiler_type.GetBitSize(&thread)))
           bit_width = *size;
       } else {
         // We only handle integer, pointer and reference types currently...
@@ -1566,8 +1567,10 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
 
   const RegisterInfo *r0_reg_info =
       reg_ctx->GetRegisterInfo(eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1);
-  std::optional<uint64_t> bit_width = compiler_type.GetBitSize(&thread);
-  std::optional<uint64_t> byte_size = compiler_type.GetByteSize(&thread);
+  std::optional<uint64_t> bit_width =
+      llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
+  std::optional<uint64_t> byte_size =
+      llvm::expectedToOptional(compiler_type.GetByteSize(&thread));
   if (!bit_width || !byte_size)
     return return_valobj_sp;
 
@@ -1703,7 +1706,8 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
           compiler_type.IsHomogeneousAggregate(&base_type);
 
       if (homogeneous_count > 0 && homogeneous_count <= 4) {
-        std::optional<uint64_t> base_byte_size = base_type.GetByteSize(&thread);
+        std::optional<uint64_t> base_byte_size =
+            llvm::expectedToOptional(base_type.GetByteSize(&thread));
         if (base_type.IsVectorType()) {
           if (base_byte_size &&
               (*base_byte_size == 8 || *base_byte_size == 16)) {
@@ -1732,7 +1736,7 @@ ValueObjectSP ABISysV_arm::GetReturnValueObjectImpl(
 
             if (base_type.IsFloatingPointType(float_count, is_complex)) {
               std::optional<uint64_t> base_byte_size =
-                  base_type.GetByteSize(&thread);
+                  llvm::expectedToOptional(base_type.GetByteSize(&thread));
               if (float_count == 2 && is_complex) {
                 if (index != 0 && base_byte_size &&
                     vfp_byte_size != *base_byte_size)

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips.cpp
@@ -807,7 +807,8 @@ ValueObjectSP ABISysV_mips::GetReturnValueObjectImpl(
 
   // In MIPS register "r2" (v0) holds the integer function return values
   const RegisterInfo *r2_reg_info = reg_ctx->GetRegisterInfoByName("r2", 0);
-  std::optional<uint64_t> bit_width = return_compiler_type.GetBitSize(&thread);
+  std::optional<uint64_t> bit_width =
+      llvm::expectedToOptional(return_compiler_type.GetBitSize(&thread));
   if (!bit_width)
     return return_valobj_sp;
   if (return_compiler_type.IsIntegerOrEnumerationType(is_signed)) {

--- a/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
+++ b/lldb/source/Plugins/ABI/Mips/ABISysV_mips64.cpp
@@ -756,7 +756,8 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
   Target *target = exe_ctx.GetTargetPtr();
   const ArchSpec target_arch = target->GetArchitecture();
   ByteOrder target_byte_order = target_arch.GetByteOrder();
-  std::optional<uint64_t> byte_size = return_compiler_type.GetByteSize(&thread);
+  std::optional<uint64_t> byte_size =
+      llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
   if (!byte_size)
     return return_valobj_sp;
   const uint32_t type_flags = return_compiler_type.GetTypeInfo(nullptr);
@@ -965,8 +966,8 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
             CompilerType field_compiler_type =
                 return_compiler_type.GetFieldAtIndex(
                     idx, name, &field_bit_offset, nullptr, nullptr);
-            std::optional<uint64_t> field_byte_width =
-                field_compiler_type.GetByteSize(&thread);
+            std::optional<uint64_t> field_byte_width = llvm::expectedToOptional(
+                field_compiler_type.GetByteSize(&thread));
             if (!field_byte_width)
               return return_valobj_sp;
 
@@ -1038,7 +1039,7 @@ ValueObjectSP ABISysV_mips64::GetReturnValueObjectImpl(
         CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
             idx, name, &field_bit_offset, nullptr, nullptr);
         std::optional<uint64_t> field_byte_width =
-            field_compiler_type.GetByteSize(&thread);
+            llvm::expectedToOptional(field_compiler_type.GetByteSize(&thread));
 
         // if we don't know the size of the field (e.g. invalid type), just
         // bail out

--- a/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
+++ b/lldb/source/Plugins/ABI/PowerPC/ABISysV_ppc.cpp
@@ -395,7 +395,8 @@ bool ABISysV_ppc::GetArgumentValues(Thread &thread, ValueList &values) const {
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type = value->GetCompilerType();
-    std::optional<uint64_t> bit_size = compiler_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_size =
+        llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
     if (!bit_size)
       return false;
     bool is_signed;
@@ -459,7 +460,7 @@ Status ABISysV_ppc::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
-          compiler_type.GetBitSize(frame_sp.get());
+          llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
       if (!bit_width) {
         error = Status::FromErrorString("can't get type size");
         return error;
@@ -524,7 +525,7 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectSimple(
       // Extract the register context so we can read arguments from registers
 
       std::optional<uint64_t> byte_size =
-          return_compiler_type.GetByteSize(&thread);
+          llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
       if (!byte_size)
         return return_valobj_sp;
       uint64_t raw_value = thread.GetRegisterContext()->ReadRegisterAsUnsigned(
@@ -571,7 +572,7 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectSimple(
         // Don't handle complex yet.
       } else {
         std::optional<uint64_t> byte_size =
-            return_compiler_type.GetByteSize(&thread);
+            llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
         if (byte_size && *byte_size <= sizeof(long double)) {
           const RegisterInfo *f1_info = reg_ctx->GetRegisterInfoByName("f1", 0);
           RegisterValue f1_value;
@@ -605,7 +606,7 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectSimple(
         thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
   } else if (type_flags & eTypeIsVector) {
     std::optional<uint64_t> byte_size =
-        return_compiler_type.GetByteSize(&thread);
+        llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
     if (byte_size && *byte_size > 0) {
       const RegisterInfo *altivec_reg = reg_ctx->GetRegisterInfoByName("v2", 0);
       if (altivec_reg) {
@@ -655,7 +656,8 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectImpl(
   if (!reg_ctx_sp)
     return return_valobj_sp;
 
-  std::optional<uint64_t> bit_width = return_compiler_type.GetBitSize(&thread);
+  std::optional<uint64_t> bit_width =
+      llvm::expectedToOptional(return_compiler_type.GetBitSize(&thread));
   if (!bit_width)
     return return_valobj_sp;
   if (return_compiler_type.IsAggregateType()) {
@@ -698,7 +700,7 @@ ValueObjectSP ABISysV_ppc::GetReturnValueObjectImpl(
         CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
             idx, name, &field_bit_offset, nullptr, nullptr);
         std::optional<uint64_t> field_bit_width =
-            field_compiler_type.GetBitSize(&thread);
+            llvm::expectedToOptional(field_compiler_type.GetBitSize(&thread));
         if (!field_bit_width)
           return return_valobj_sp;
 

--- a/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
+++ b/lldb/source/Plugins/ABI/RISCV/ABISysV_riscv.cpp
@@ -544,7 +544,8 @@ ABISysV_riscv::GetReturnValueObjectSimple(Thread &thread,
   value.SetCompilerType(compiler_type);
 
   const uint32_t type_flags = compiler_type.GetTypeInfo();
-  const size_t byte_size = compiler_type.GetByteSize(&thread).value_or(0);
+  const size_t byte_size =
+      llvm::expectedToOptional(compiler_type.GetByteSize(&thread)).value_or(0);
   const ArchSpec arch = thread.GetProcess()->GetTarget().GetArchitecture();
   const llvm::Triple::ArchType machine = arch.GetMachine();
 

--- a/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
+++ b/lldb/source/Plugins/ABI/SystemZ/ABISysV_s390x.cpp
@@ -356,7 +356,8 @@ bool ABISysV_s390x::GetArgumentValues(Thread &thread, ValueList &values) const {
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type = value->GetCompilerType();
-    std::optional<uint64_t> bit_size = compiler_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_size =
+        llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
     if (!bit_size)
       return false;
     bool is_signed;
@@ -428,7 +429,7 @@ Status ABISysV_s390x::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
-          compiler_type.GetBitSize(frame_sp.get());
+          llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
       if (!bit_width) {
         error = Status::FromErrorString("can't get type size");
         return error;
@@ -496,7 +497,7 @@ ValueObjectSP ABISysV_s390x::GetReturnValueObjectSimple(
     if (type_flags & eTypeIsInteger) {
       // Extract the register context so we can read arguments from registers.
       std::optional<uint64_t> byte_size =
-          return_compiler_type.GetByteSize(&thread);
+          llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
       if (!byte_size)
         return return_valobj_sp;
       uint64_t raw_value = thread.GetRegisterContext()->ReadRegisterAsUnsigned(
@@ -543,7 +544,7 @@ ValueObjectSP ABISysV_s390x::GetReturnValueObjectSimple(
         // Don't handle complex yet.
       } else {
         std::optional<uint64_t> byte_size =
-            return_compiler_type.GetByteSize(&thread);
+            llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
         if (byte_size && *byte_size <= sizeof(long double)) {
           const RegisterInfo *f0_info = reg_ctx->GetRegisterInfoByName("f0", 0);
           RegisterValue f0_value;

--- a/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIMacOSX_i386.cpp
@@ -165,7 +165,8 @@ bool ABIMacOSX_i386::GetArgumentValues(Thread &thread,
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type(value->GetCompilerType());
-    std::optional<uint64_t> bit_size = compiler_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_size =
+        llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
     if (bit_size) {
       bool is_signed;
       if (compiler_type.IsIntegerOrEnumerationType(is_signed))
@@ -275,7 +276,8 @@ ABIMacOSX_i386::GetReturnValueObjectImpl(Thread &thread,
   bool is_signed;
 
   if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
-    std::optional<uint64_t> bit_width = compiler_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_width =
+        llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
     if (!bit_width)
       return return_valobj_sp;
     unsigned eax_id =

--- a/lldb/source/Plugins/ABI/X86/ABISysV_i386.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_i386.cpp
@@ -182,7 +182,8 @@ bool ABISysV_i386::GetArgumentValues(Thread &thread, ValueList &values) const {
 
     // Currently: Support for extracting values with Clang QualTypes only.
     CompilerType compiler_type(value->GetCompilerType());
-    std::optional<uint64_t> bit_size = compiler_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_size =
+        llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
     if (bit_size) {
       bool is_signed;
       if (compiler_type.IsIntegerOrEnumerationType(is_signed)) {
@@ -392,7 +393,7 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
   {
     value.SetValueType(Value::ValueType::Scalar);
     std::optional<uint64_t> byte_size =
-        return_compiler_type.GetByteSize(&thread);
+        llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
     if (!byte_size)
       return return_valobj_sp;
     bool success = false;
@@ -517,7 +518,7 @@ ValueObjectSP ABISysV_i386::GetReturnValueObjectSimple(
   } else if (type_flags & eTypeIsVector) // 'Packed'
   {
     std::optional<uint64_t> byte_size =
-        return_compiler_type.GetByteSize(&thread);
+        llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
     if (byte_size && *byte_size > 0) {
       const RegisterInfo *vec_reg = reg_ctx->GetRegisterInfoByName("xmm0", 0);
       if (vec_reg == nullptr)

--- a/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABISysV_x86_64.cpp
@@ -268,7 +268,8 @@ bool ABISysV_x86_64::GetArgumentValues(Thread &thread,
     // We currently only support extracting values with Clang QualTypes. Do we
     // care about others?
     CompilerType compiler_type = value->GetCompilerType();
-    std::optional<uint64_t> bit_size = compiler_type.GetBitSize(&thread);
+    std::optional<uint64_t> bit_size =
+        llvm::expectedToOptional(compiler_type.GetBitSize(&thread));
     if (!bit_size)
       return false;
     bool is_signed;
@@ -340,7 +341,7 @@ Status ABISysV_x86_64::SetReturnValueObject(lldb::StackFrameSP &frame_sp,
           "We don't support returning complex values at present");
     else {
       std::optional<uint64_t> bit_width =
-          compiler_type.GetBitSize(frame_sp.get());
+          llvm::expectedToOptional(compiler_type.GetBitSize(frame_sp.get()));
       if (!bit_width) {
         error = Status::FromErrorString("can't get type size");
         return error;
@@ -410,7 +411,7 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
       // Extract the register context so we can read arguments from registers
 
       std::optional<uint64_t> byte_size =
-          return_compiler_type.GetByteSize(&thread);
+          llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
       if (!byte_size)
         return return_valobj_sp;
       uint64_t raw_value = thread.GetRegisterContext()->ReadRegisterAsUnsigned(
@@ -457,7 +458,7 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
         // Don't handle complex yet.
       } else {
         std::optional<uint64_t> byte_size =
-            return_compiler_type.GetByteSize(&thread);
+            llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
         if (byte_size && *byte_size <= sizeof(long double)) {
           const RegisterInfo *xmm0_info =
               reg_ctx->GetRegisterInfoByName("xmm0", 0);
@@ -497,7 +498,7 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectSimple(
         thread.GetStackFrameAtIndex(0).get(), value, ConstString(""));
   } else if (type_flags & eTypeIsVector) {
     std::optional<uint64_t> byte_size =
-        return_compiler_type.GetByteSize(&thread);
+        llvm::expectedToOptional(return_compiler_type.GetByteSize(&thread));
     if (byte_size && *byte_size > 0) {
       const RegisterInfo *altivec_reg =
           reg_ctx->GetRegisterInfoByName("xmm0", 0);
@@ -835,7 +836,7 @@ static bool FlattenAggregateType(
     CompilerType field_compiler_type = return_compiler_type.GetFieldAtIndex(
         idx, name, &field_bit_offset, nullptr, nullptr);
     std::optional<uint64_t> field_bit_width =
-        field_compiler_type.GetBitSize(&thread);
+        llvm::expectedToOptional(field_compiler_type.GetBitSize(&thread));
 
     // if we don't know the size of the field (e.g. invalid type), exit
     if (!field_bit_width || *field_bit_width == 0) {
@@ -877,7 +878,8 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
   if (!reg_ctx_sp)
     return return_valobj_sp;
 
-  std::optional<uint64_t> bit_width = return_compiler_type.GetBitSize(&thread);
+  std::optional<uint64_t> bit_width =
+      llvm::expectedToOptional(return_compiler_type.GetBitSize(&thread));
   if (!bit_width)
     return return_valobj_sp;
   if (return_compiler_type.IsAggregateType()) {
@@ -975,7 +977,10 @@ ValueObjectSP ABISysV_x86_64::GetReturnValueObjectImpl(
         bool is_complex;
 
         CompilerType field_compiler_type = aggregate_compiler_types[idx];
-        uint32_t field_byte_width = (uint32_t) (*field_compiler_type.GetByteSize(&thread));
+        uint32_t field_byte_width =
+            (uint32_t)(llvm::expectedToOptional(
+                           field_compiler_type.GetByteSize(&thread))
+                           .value_or(0));
         uint32_t field_byte_offset = aggregate_field_offsets[idx];
 
         uint32_t field_bit_width = field_byte_width * 8;

--- a/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
+++ b/lldb/source/Plugins/ABI/X86/ABIWindows_x86_64.cpp
@@ -675,7 +675,10 @@ ValueObjectSP ABIWindows_x86_64::GetReturnValueObjectImpl(
       uint32_t count;
 
       CompilerType field_compiler_type = aggregate_compiler_types[idx];
-      uint32_t field_byte_width = (uint32_t) (*field_compiler_type.GetByteSize(&thread));
+      uint32_t field_byte_width =
+          (uint32_t)(llvm::expectedToOptional(
+                         field_compiler_type.GetByteSize(&thread))
+                         .value_or(0));
       uint32_t field_byte_offset = aggregate_field_offsets[idx];
 
       // this is unlikely w/o the overall size being greater than 8 bytes

--- a/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/IRForTarget.cpp
@@ -301,16 +301,17 @@ bool IRForTarget::CreateResultVariable(llvm::Function &llvm_function) {
   }
 
   lldb::TargetSP target_sp(m_execution_unit.GetTarget());
-  std::optional<uint64_t> bit_size = m_result_type.GetBitSize(target_sp.get());
-  if (!bit_size) {
+  auto bit_size_or_err = m_result_type.GetBitSize(target_sp.get());
+  if (!bit_size_or_err) {
     lldb_private::StreamString type_desc_stream;
     m_result_type.DumpTypeDescription(&type_desc_stream);
 
     LLDB_LOG(log, "Result type has unknown size");
 
     m_error_stream.Printf("Error [IRForTarget]: Size of result type '%s' "
-                          "couldn't be determined\n",
-                          type_desc_stream.GetData());
+                          "couldn't be determined\n%s",
+                          type_desc_stream.GetData(),
+                          llvm::toString(bit_size_or_err.takeError()).c_str());
     return false;
   }
 
@@ -325,7 +326,8 @@ bool IRForTarget::CreateResultVariable(llvm::Function &llvm_function) {
 
   LLDB_LOG(log, "Creating a new result global: \"{0}\" with size {1}",
            m_result_name,
-           m_result_type.GetByteSize(target_sp.get()).value_or(0));
+           llvm::expectedToOptional(m_result_type.GetByteSize(target_sp.get()))
+               .value_or(0));
 
   // Construct a new result global and set up its metadata
 
@@ -1038,7 +1040,8 @@ bool IRForTarget::MaybeHandleVariable(Value *llvm_value_ptr) {
     }
 
     auto *target = m_execution_unit.GetTarget().get();
-    std::optional<uint64_t> value_size = compiler_type.GetByteSize(target);
+    std::optional<uint64_t> value_size =
+        llvm::expectedToOptional(compiler_type.GetByteSize(target));
     if (!value_size)
       return false;
     std::optional<size_t> opt_alignment = compiler_type.GetTypeBitAlign(target);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1048,9 +1048,12 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
     // this check scattered in several places in the codebase, we should at
     // some point centralize it.
     lldb::StackFrameSP stack_frame_sp = stack_frame_wp.lock();
-    std::optional<uint64_t> size =
+    auto size_or_err =
         variable.GetType().GetByteSize(stack_frame_sp.get());
-    if (repl && size && *size == 0) {
+    if (!size_or_err)
+      return size_or_err.takeError();
+    uint64_t size = *size_or_err;
+    if (repl && size == 0) {
       auto &repl_mat = *llvm::cast<SwiftREPLMaterializer>(&materializer);
       offset = repl_mat.AddREPLResultVariable(
           variable.GetType(), variable.GetDecl(),

--- a/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/CxxStringTypes.cpp
@@ -123,7 +123,8 @@ bool lldb_private::formatters::WCharStringSummaryProvider(
     return false;
 
   // Safe to pass nullptr for exe_scope here.
-  std::optional<uint64_t> size = wchar_compiler_type.GetBitSize(nullptr);
+  std::optional<uint64_t> size =
+      llvm::expectedToOptional(wchar_compiler_type.GetBitSize(nullptr));
   if (!size)
     return false;
   const uint32_t wchar_size = *size;
@@ -183,7 +184,8 @@ bool lldb_private::formatters::WCharSummaryProvider(
     return false;
 
     // Safe to pass nullptr for exe_scope here.
-  std::optional<uint64_t> size = wchar_compiler_type.GetBitSize(nullptr);
+  std::optional<uint64_t> size =
+      llvm::expectedToOptional(wchar_compiler_type.GetBitSize(nullptr));
   if (!size)
     return false;
   const uint32_t wchar_size = *size;

--- a/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/GenericBitset.cpp
@@ -111,8 +111,8 @@ ValueObjectSP GenericBitsetFrontEnd::GetChildAtIndex(uint32_t idx) {
   ValueObjectSP chunk;
   // For small bitsets __first_ is not an array, but a plain size_t.
   if (m_first->GetCompilerType().IsArrayType(&type)) {
-    std::optional<uint64_t> bit_size =
-        type.GetBitSize(ctx.GetBestExecutionContextScope());
+    std::optional<uint64_t> bit_size = llvm::expectedToOptional(
+        type.GetBitSize(ctx.GetBestExecutionContextScope()));
     if (!bit_size || *bit_size == 0)
       return {};
     chunk = m_first->GetChildAtIndex(idx / *bit_size);
@@ -123,8 +123,8 @@ ValueObjectSP GenericBitsetFrontEnd::GetChildAtIndex(uint32_t idx) {
   if (!type || !chunk)
     return {};
 
-  std::optional<uint64_t> bit_size =
-      type.GetBitSize(ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> bit_size = llvm::expectedToOptional(
+      type.GetBitSize(ctx.GetBestExecutionContextScope()));
   if (!bit_size || *bit_size == 0)
     return {};
   size_t chunk_idx = idx % *bit_size;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxx.cpp
@@ -476,8 +476,8 @@ ExtractLibcxxStringInfo(ValueObject &valobj) {
     // likely that the string isn't initialized and we're reading garbage.
     ExecutionContext exe_ctx(location_sp->GetExecutionContextRef());
     const std::optional<uint64_t> max_bytes =
-        location_sp->GetCompilerType().GetByteSize(
-            exe_ctx.GetBestExecutionContextScope());
+        llvm::expectedToOptional(location_sp->GetCompilerType().GetByteSize(
+            exe_ctx.GetBestExecutionContextScope()));
     if (!max_bytes || size > *max_bytes)
       return {};
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxInitializerList.cpp
@@ -90,8 +90,11 @@ lldb_private::formatters::LibcxxInitializerListSyntheticFrontEnd::Update() {
   if (!m_element_type.IsValid())
     return lldb::ChildCacheState::eRefetch;
 
-  if (std::optional<uint64_t> size = m_element_type.GetByteSize(nullptr)) {
-    m_element_size = *size;
+  llvm::Expected<uint64_t> size_or_err = m_element_type.GetByteSize(nullptr);
+  if (!size_or_err)
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), size_or_err.takeError(), "{0}");
+  else {
+    m_element_size = *size_or_err;
     // Store raw pointers or end up with a circular dependency.
     m_start = m_backend.GetChildMemberWithName("__begin_").get();
   }

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxProxyArray.cpp
@@ -139,7 +139,8 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::Update() {
     return ChildCacheState::eRefetch;
 
   m_element_type = type.GetTypeTemplateArgument(0);
-  if (std::optional<uint64_t> size = m_element_type.GetByteSize(nullptr))
+  if (std::optional<uint64_t> size =
+          llvm::expectedToOptional(m_element_type.GetByteSize(nullptr)))
     m_element_size = *size;
 
   if (m_element_size == 0)
@@ -154,7 +155,8 @@ lldb_private::formatters::LibcxxStdProxyArraySyntheticFrontEnd::Update() {
     return ChildCacheState::eRefetch;
 
   m_element_type_size_t = type.GetTypeTemplateArgument(0);
-  if (std::optional<uint64_t> size = m_element_type_size_t.GetByteSize(nullptr))
+  if (std::optional<uint64_t> size =
+          llvm::expectedToOptional(m_element_type_size_t.GetByteSize(nullptr)))
     m_element_size_size_t = *size;
 
   if (m_element_size_size_t == 0)

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSliceArray.cpp
@@ -125,7 +125,8 @@ lldb_private::formatters::LibcxxStdSliceArraySyntheticFrontEnd::Update() {
     return ChildCacheState::eRefetch;
 
   m_element_type = type.GetTypeTemplateArgument(0);
-  if (std::optional<uint64_t> size = m_element_type.GetByteSize(nullptr))
+  if (std::optional<uint64_t> size =
+          llvm::expectedToOptional(m_element_type.GetByteSize(nullptr)))
     m_element_size = *size;
 
   if (m_element_size == 0)

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxSpan.cpp
@@ -104,8 +104,11 @@ lldb_private::formatters::LibcxxStdSpanSyntheticFrontEnd::Update() {
   m_element_type = data_type_finder_sp->GetCompilerType().GetPointeeType();
 
   // Get element size.
-  if (std::optional<uint64_t> size = m_element_type.GetByteSize(nullptr)) {
-    m_element_size = *size;
+  llvm::Expected<uint64_t> size_or_err = m_element_type.GetByteSize(nullptr);
+  if (!size_or_err)
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), size_or_err.takeError(), "{0}");
+  else {
+    m_element_size = *size_or_err;
 
     // Get data.
     if (m_element_size > 0) {

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxValarray.cpp
@@ -106,7 +106,8 @@ lldb_private::formatters::LibcxxStdValarraySyntheticFrontEnd::Update() {
     return ChildCacheState::eRefetch;
 
   m_element_type = type.GetTypeTemplateArgument(0);
-  if (std::optional<uint64_t> size = m_element_type.GetByteSize(nullptr))
+  if (std::optional<uint64_t> size =
+          llvm::expectedToOptional(m_element_type.GetByteSize(nullptr)))
     m_element_size = *size;
 
   if (m_element_size == 0)

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVariant.cpp
@@ -97,10 +97,13 @@ LibcxxVariantGetIndexValidity(ValueObjectSP &impl_sp) {
   // the byte size.
   CompilerType index_type = index_sp->GetCompilerType();
 
-  std::optional<uint64_t> index_type_bytes = index_type.GetByteSize(nullptr);
-  if (!index_type_bytes)
-    return LibcxxVariantIndexValidity::Invalid;
-
+  llvm::Expected<uint64_t> index_type_bytes = index_type.GetByteSize(nullptr);
+  if (!index_type_bytes) {
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), index_type_bytes.takeError(),
+                    "{0}");
+    if (!index_type_bytes)
+      return LibcxxVariantIndexValidity::Invalid;
+  }
   uint64_t npos_value = VariantNposValue(*index_type_bytes);
   uint64_t index_value = index_sp->GetValueAsUnsigned(0);
 

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -132,8 +132,11 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::Update() {
     return lldb::ChildCacheState::eRefetch;
 
   m_element_type = data_type_finder_sp->GetCompilerType().GetPointeeType();
-  if (std::optional<uint64_t> size = m_element_type.GetByteSize(nullptr)) {
-    m_element_size = *size;
+  llvm::Expected<uint64_t> size_or_err = m_element_type.GetByteSize(nullptr);
+  if (!size_or_err)
+    LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), size_or_err.takeError(), "{0}");
+  else {
+    m_element_size = *size_or_err;
 
     if (m_element_size > 0) {
       // store raw pointers or end up with a circular dependency
@@ -198,7 +201,8 @@ lldb_private::formatters::LibcxxVectorBoolSyntheticFrontEnd::GetChildAtIndex(
     return {};
   mask = 1 << bit_index;
   bool bit_set = ((byte & mask) != 0);
-  std::optional<uint64_t> size = m_bool_type.GetByteSize(nullptr);
+  std::optional<uint64_t> size =
+      llvm::expectedToOptional(m_bool_type.GetByteSize(nullptr));
   if (!size)
     return {};
   WritableDataBufferSP buffer_sp(new DataBufferHeap(*size, 0));

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcpp.cpp
@@ -317,7 +317,8 @@ bool lldb_private::formatters::LibStdcppWStringSummaryProvider(
         return false;
 
       // Safe to pass nullptr for exe_scope here.
-      std::optional<uint64_t> size = wchar_compiler_type.GetBitSize(nullptr);
+      std::optional<uint64_t> size =
+          llvm::expectedToOptional(wchar_compiler_type.GetBitSize(nullptr));
       if (!size)
         return false;
       const uint32_t wchar_size = *size;

--- a/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibStdcppUniquePointer.cpp
@@ -103,7 +103,8 @@ lldb::ChildCacheState LibStdcppUniquePtrSyntheticFrontEnd::Update() {
   // storage due to no_unique_address, so infer the actual size from the total
   // size of the unique_ptr class. If sizeof(unique_ptr) == sizeof(void*) then
   // the deleter is empty and should be hidden.
-  if (tuple_sp->GetByteSize() > ptr_obj->GetByteSize()) {
+  if (llvm::expectedToOptional(tuple_sp->GetByteSize()).value_or(0) >
+      llvm::expectedToOptional(ptr_obj->GetByteSize()).value_or(0)) {
     ValueObjectSP del_obj = tuple_frontend->GetChildAtIndex(1);
     if (del_obj)
       m_del_obj = del_obj->Clone(ConstString("deleter")).get();

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1778,8 +1778,8 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
     return false;
 
   ExecutionContext exe_ctx = valobj.GetExecutionContextRef().Lock(true);
-  std::optional<uint64_t> opt_type_size =
-    simd_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> opt_type_size = llvm::expectedToOptional(
+      simd_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
   if (!opt_type_size)
     return false;
   uint64_t type_size = *opt_type_size;
@@ -1793,8 +1793,8 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
   if (!arg_type)
     return false;
 
-  std::optional<uint64_t> opt_arg_size =
-      arg_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> opt_arg_size = llvm::expectedToOptional(
+      arg_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
   if (!opt_arg_size)
     return false;
   uint64_t arg_size = *opt_arg_size;

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCClassDescriptorV2.cpp
@@ -722,7 +722,7 @@ void ClassDescriptorV2::iVarsStorage::fill(AppleObjCRuntimeV2 &runtime,
                 "name = {0}, encoding = {1}, offset_ptr = {2:x}, size = "
                 "{3}, type_size = {4}",
                 name, type, offset_ptr, size,
-                ivar_type.GetByteSize(nullptr).value_or(0));
+                expectedToOptional(ivar_type.GetByteSize(nullptr)).value_or(0));
       Scalar offset_scalar;
       Status error;
       const int offset_ptr_size = 4;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1761,8 +1761,8 @@ void SwiftLanguageRuntime::WillStartExecutingUserExpression(
     return;
   }
   ConstString BoolName("bool");
-  std::optional<uint64_t> bool_size =
-      ts->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
+  std::optional<uint64_t> bool_size = llvm::expectedToOptional(
+      ts->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr));
   if (!bool_size)
     return;
 
@@ -1836,8 +1836,8 @@ void SwiftLanguageRuntime::DidFinishExecutingUserExpression(
     return;
   }
   ConstString BoolName("bool");
-  std::optional<uint64_t> bool_size =
-      ts->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr);
+  std::optional<uint64_t> bool_size = llvm::expectedToOptional(
+      ts->GetBuiltinTypeByName(BoolName).GetByteSize(nullptr));
   if (!bool_size)
     return;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -418,7 +418,7 @@ public:
                                         ExecutionContext *exe_ctx);
 
   /// Ask Remote Mirrors for the size of a Swift type.
-  std::optional<uint64_t> GetBitSize(CompilerType type,
+  llvm::Expected<uint64_t> GetBitSize(CompilerType type,
                                       ExecutionContextScope *exe_scope);
 
   /// Ask Remote mirrors for the stride of a Swift type.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -381,7 +381,8 @@ public:
       return nullptr;
     TypeSystemSwiftTypeRef &typesystem = *m_ts;
     // Build a TypeInfo for the Clang type.
-    auto size = clang_type.GetByteSize(exe_scope);
+    std::optional<uint64_t> size =
+        llvm::expectedToOptional(clang_type.GetByteSize(exe_scope));
     auto bit_align = clang_type.GetTypeBitAlign(exe_scope);
     std::vector<swift::reflection::FieldInfo> fields;
     if (clang_type.IsAggregateType()) {
@@ -1214,9 +1215,11 @@ llvm::Expected<CompilerType> SwiftLanguageRuntime::GetChildCompilerTypeAtIndex(
   if (auto pack_element_type = ts->GetSILPackElementAtIndex(type, idx)) {
     llvm::raw_string_ostream os(child_name);
     os << '.' << idx;
-    child_byte_size =
-        GetBitSize(pack_element_type, exe_ctx.GetBestExecutionContextScope())
-            .value_or(0);
+    auto size_or_err =
+        GetBitSize(pack_element_type, exe_ctx.GetBestExecutionContextScope());
+    if (!size_or_err)
+      return size_or_err.takeError();
+    child_byte_size = *size_or_err;
     int stack_dir = -1;
     child_byte_offset = ts->GetPointerByteSize() * idx * stack_dir;
     child_bitfield_bit_size = 0;
@@ -2236,7 +2239,9 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
 
 
   if (use_local_buffer)
-    PushLocalBuffer(existential_address, in_value.GetByteSize().value_or(0));
+    PushLocalBuffer(
+        existential_address,
+        llvm::expectedToOptional(in_value.GetByteSize()).value_or(0));
 
   swift::remote::RemoteAddress remote_existential(existential_address);
 
@@ -2522,7 +2527,7 @@ CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
       LLDB_LOG_ERROR(
           GetLog(LLDBLog::Expressions | LLDBLog::Types),
           type_ref_or_err.takeError(),
-          "Couldn't get rype ref when binding generic type parameters: {0}");
+          "Couldn't get type ref when binding generic type parameters: {0}");
       failure = true;
       return;
     }
@@ -2687,8 +2692,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
   ExecutionContextScope *exe_scope = exe_ctx.GetBestExecutionContextScope();
   if (!exe_scope)
     return false;
-  std::optional<uint64_t> size =
-      bound_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> size = llvm::expectedToOptional(
+      bound_type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
   if (!size)
     return false;
   AddressType address_type;
@@ -2704,7 +2709,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Value(
     if (in_value_buffer.empty())
       return false;
     // If the dynamic type doesn't in the buffer we can't use it either.
-    if (in_value_buffer.size() < bound_type.GetByteSize(exe_scope))
+    if (in_value_buffer.size() <
+        llvm::expectedToOptional(bound_type.GetByteSize(exe_scope)).value_or(0))
       return false;
 
     value_type = Value::GetValueTypeFromAddressType(address_type);
@@ -2810,8 +2816,9 @@ Value::ValueType SwiftLanguageRuntime::GetValueType(
       }
 
       if (use_local_buffer)
-        PushLocalBuffer(existential_address,
-                        in_value.GetByteSize().value_or(0));
+        PushLocalBuffer(
+            existential_address,
+            llvm::expectedToOptional(in_value.GetByteSize()).value_or(0));
 
       // Read the value witness table and check if the data is inlined in
       // the existential container or not.
@@ -3331,7 +3338,10 @@ SwiftLanguageRuntime::GetTypeRef(CompilerType type,
   auto type_ref_or_err = reflection_ctx->GetTypeRef(
       dem, node, module_holder->GetDescriptorFinder());
   if (!type_ref_or_err)
-    return type_ref_or_err.takeError();
+    return llvm::joinErrors(
+        llvm::createStringError("cannot get typeref for type %s",
+                                type.GetMangledTypeName().GetCString()),
+        type_ref_or_err.takeError());
 
   if (log && log->GetVerbose()) {
     std::stringstream ss;
@@ -3537,14 +3547,12 @@ SwiftLanguageRuntime::ResolveTypeAlias(CompilerType alias) {
   return llvm::createStringError("cannot resolve type alias via reflection");
 }
 
-std::optional<uint64_t>
+llvm::Expected<uint64_t>
 SwiftLanguageRuntime::GetBitSize(CompilerType type,
                                  ExecutionContextScope *exe_scope) {
   auto type_info_or_err = GetSwiftRuntimeTypeInfo(type, exe_scope);
-  if (!type_info_or_err) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), type_info_or_err.takeError(), "{0}");
-    return {};
-  }
+  if (!type_info_or_err)
+    return type_info_or_err.takeError();
 
   return type_info_or_err->getSize() * 8;
 }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -245,7 +245,9 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialRemoteAST(
   if (!swift_type)
     return {};
   if (use_local_buffer)
-    PushLocalBuffer(existential_address, in_value.GetByteSize().value_or(0));
+    PushLocalBuffer(
+        existential_address,
+        llvm::expectedToOptional(in_value.GetByteSize()).value_or(0));
 
   auto result = remote_ast.getDynamicTypeAndAddressForExistential(
       remote_existential, swift_type);

--- a/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
+++ b/lldb/source/Plugins/RegisterTypeBuilder/RegisterTypeBuilderClang.cpp
@@ -116,7 +116,8 @@ CompilerType RegisterTypeBuilderClang::GetRegisterType(
     type_system->SetIsPacked(fields_type);
 
     // This should be true if RegisterFlags padded correctly.
-    assert(*fields_type.GetByteSize(nullptr) == flags.GetSize());
+    assert(llvm::expectedToOptional(fields_type.GetByteSize(nullptr))
+               .value_or(0) == flags.GetSize());
   }
 
   return fields_type;

--- a/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
+++ b/lldb/source/Plugins/SymbolFile/CTF/SymbolFileCTF.cpp
@@ -436,14 +436,11 @@ SymbolFileCTF::CreateArray(const CTFArray &ctf_array) {
         llvm::formatv("Could not find array element type: {0}", ctf_array.type),
         llvm::inconvertibleErrorCode());
 
-  std::optional<uint64_t> element_size = element_type->GetByteSize(nullptr);
-  if (!element_size)
-    return llvm::make_error<llvm::StringError>(
-        llvm::formatv("could not get element size of type: {0}",
-                      ctf_array.type),
-        llvm::inconvertibleErrorCode());
+  auto element_size_or_err = element_type->GetByteSize(nullptr);
+  if (!element_size_or_err)
+    return element_size_or_err.takeError();
 
-  uint64_t size = ctf_array.nelems * *element_size;
+  uint64_t size = ctf_array.nelems * *element_size_or_err;
 
   CompilerType compiler_type = m_ast->CreateArrayType(
       element_type->GetFullCompilerType(), ctf_array.nelems,
@@ -543,7 +540,8 @@ bool SymbolFileCTF::CompleteType(CompilerType &compiler_type) {
   for (const CTFRecord::Field &field : ctf_record->fields) {
     Type *field_type = ResolveTypeUID(field.type);
     assert(field_type && "field must be complete");
-    const uint32_t field_size = field_type->GetByteSize(nullptr).value_or(0);
+    const uint32_t field_size =
+        llvm::expectedToOptional(field_type->GetByteSize(nullptr)).value_or(0);
     TypeSystemClang::AddFieldToRecordType(compiler_type, field.name,
                                           field_type->GetFullCompilerType(),
                                           eAccessPublic, field_size);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2166,8 +2166,9 @@ SymbolFileDWARF::GlobalVariableMap &SymbolFileDWARF::GetGlobalAranges() {
                         location_result->GetScalar().ULongLong();
                     lldb::addr_t byte_size = 1;
                     if (var_sp->GetType())
-                      byte_size =
-                          var_sp->GetType()->GetByteSize(nullptr).value_or(0);
+                      byte_size = llvm::expectedToOptional(
+                                      var_sp->GetType()->GetByteSize(nullptr))
+                                      .value_or(0);
                     m_global_aranges_up->Append(GlobalVariableMap::Entry(
                         file_addr, byte_size, var_sp.get()));
                   }
@@ -3830,9 +3831,11 @@ VariableSP SymbolFileDWARF::ParseVariableDIE(const SymbolContext &sc,
       DWARFFormValue::IsDataForm(const_value_form.Form());
   if (use_type_size_for_value && type_sp->GetType()) {
     DWARFExpression *location = location_list.GetMutableExpressionAtAddress();
-    location->UpdateValue(const_value_form.Unsigned(),
-                          type_sp->GetType()->GetByteSize(nullptr).value_or(0),
-                          die.GetCU()->GetAddressByteSize());
+    location->UpdateValue(
+        const_value_form.Unsigned(),
+        llvm::expectedToOptional(type_sp->GetType()->GetByteSize(nullptr))
+            .value_or(0),
+        die.GetCU()->GetAddressByteSize());
   }
 
   // Swift let-bindings are marked by a DW_TAG_const_type.

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -556,8 +556,8 @@ lldb::TypeSP SymbolFileNativePDB::CreateModifierType(PdbTypeSymId type_id,
   lldb::TypeSP modified_type = GetOrCreateType(mr.ModifiedType);
 
   return MakeType(toOpaqueUid(type_id), ConstString(name),
-                  modified_type->GetByteSize(nullptr), nullptr,
-                  LLDB_INVALID_UID, Type::eEncodingIsUID, decl, ct,
+                  llvm::expectedToOptional(modified_type->GetByteSize(nullptr)),
+                  nullptr, LLDB_INVALID_UID, Type::eEncodingIsUID, decl, ct,
                   Type::ResolveState::Full);
 }
 
@@ -674,10 +674,11 @@ lldb::TypeSP SymbolFileNativePDB::CreateTagType(PdbTypeSymId type_id,
   Declaration decl;
   TypeSP underlying_type = GetOrCreateType(er.UnderlyingType);
 
-  return MakeType(toOpaqueUid(type_id), ConstString(uname),
-                  underlying_type->GetByteSize(nullptr), nullptr,
-                  LLDB_INVALID_UID, lldb_private::Type::eEncodingIsUID, decl,
-                  ct, lldb_private::Type::ResolveState::Forward);
+  return MakeType(
+      toOpaqueUid(type_id), ConstString(uname),
+      llvm::expectedToOptional(underlying_type->GetByteSize(nullptr)), nullptr,
+      LLDB_INVALID_UID, lldb_private::Type::eEncodingIsUID, decl, ct,
+      lldb_private::Type::ResolveState::Forward);
 }
 
 TypeSP SymbolFileNativePDB::CreateArrayType(PdbTypeSymId type_id,
@@ -1902,11 +1903,12 @@ TypeSP SymbolFileNativePDB::CreateTypedef(PdbGlobalSymId id) {
   ts->GetNativePDBParser()->GetOrCreateTypedefDecl(id);
 
   Declaration decl;
-  return MakeType(
-      toOpaqueUid(id), ConstString(udt.Name), target_type->GetByteSize(nullptr),
-      nullptr, target_type->GetID(), lldb_private::Type::eEncodingIsTypedefUID,
-      decl, target_type->GetForwardCompilerType(),
-      lldb_private::Type::ResolveState::Forward);
+  return MakeType(toOpaqueUid(id), ConstString(udt.Name),
+                  llvm::expectedToOptional(target_type->GetByteSize(nullptr)),
+                  nullptr, target_type->GetID(),
+                  lldb_private::Type::eEncodingIsTypedefUID, decl,
+                  target_type->GetForwardCompilerType(),
+                  lldb_private::Type::ResolveState::Forward);
 }
 
 TypeSP SymbolFileNativePDB::GetOrCreateTypedef(PdbGlobalSymId id) {

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -4915,9 +4915,47 @@ TypeSystemClang::GetFloatTypeSemantics(size_t byte_size) {
   return llvm::APFloatBase::Bogus();
 }
 
-std::optional<uint64_t>
+llvm::Expected<uint64_t>
+TypeSystemClang::GetObjCBitSize(QualType qual_type,
+                                ExecutionContextScope *exe_scope) {
+  assert(qual_type->isObjCObjectOrInterfaceType());
+  ExecutionContext exe_ctx(exe_scope);
+  if (Process *process = exe_ctx.GetProcessPtr()) {
+    if (ObjCLanguageRuntime *objc_runtime =
+            ObjCLanguageRuntime::Get(*process)) {
+      if (std::optional<uint64_t> bit_size =
+              objc_runtime->GetTypeBitSize(GetType(qual_type)))
+        return *bit_size;
+    }
+  } else {
+    static bool g_printed = false;
+    if (!g_printed) {
+      StreamString s;
+      DumpTypeDescription(qual_type.getAsOpaquePtr(), s);
+
+      llvm::outs() << "warning: trying to determine the size of type ";
+      llvm::outs() << s.GetString() << "\n";
+      llvm::outs() << "without a valid ExecutionContext. this is not "
+                      "reliable. please file a bug against LLDB.\n";
+      llvm::outs() << "backtrace:\n";
+      llvm::sys::PrintStackTrace(llvm::outs());
+      llvm::outs() << "\n";
+      g_printed = true;
+    }
+  }
+
+  return getASTContext().getTypeSize(qual_type) +
+         getASTContext().getTypeSize(getASTContext().ObjCBuiltinClassTy);
+}
+
+llvm::Expected<uint64_t>
 TypeSystemClang::GetBitSize(lldb::opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {
+  const bool base_name_only = true;
+  if (!GetCompleteType(type))
+    return llvm::createStringError(
+        "could not complete type %s",
+        GetTypeName(type, base_name_only).AsCString(""));
   if (GetCompleteType(type)) {
     clang::QualType qual_type(GetCanonicalQualType(type));
     const clang::Type::TypeClass type_class = qual_type->getTypeClass();
@@ -4926,7 +4964,9 @@ TypeSystemClang::GetBitSize(lldb::opaque_compiler_type_t type,
       if (GetCompleteType(type))
         return getASTContext().getTypeSize(qual_type);
       else
-        return std::nullopt;
+        return llvm::createStringError(
+            "could not complete type %s",
+            GetTypeName(type, base_name_only).AsCString(""));
       break;
 
     case clang::Type::ObjCInterface:
@@ -4976,7 +5016,9 @@ TypeSystemClang::GetBitSize(lldb::opaque_compiler_type_t type,
         return bit_size;
     }
   }
-  return std::nullopt;
+  return llvm::createStringError(
+      "could not get size of type %s",
+      GetTypeName(type, base_name_only).AsCString(""));
 }
 
 std::optional<size_t>
@@ -6496,12 +6538,14 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
             child_byte_offset = bit_offset / 8;
             CompilerType base_class_clang_type = GetType(base_class->getType());
             child_name = base_class_clang_type.GetTypeName().AsCString("");
-            std::optional<uint64_t> size =
+            auto size_or_err =
                 base_class_clang_type.GetBitSize(get_exe_scope());
-            if (!size)
-              return llvm::createStringError("no size info for base class");
+            if (!size_or_err)
+              return llvm::joinErrors(
+                  llvm::createStringError("no size info for base class"),
+                  size_or_err.takeError());
 
-            uint64_t base_class_clang_type_bit_size = *size;
+            uint64_t base_class_clang_type_bit_size = *size_or_err;
 
             // Base classes bit sizes should be a multiple of 8 bits in size
             assert(base_class_clang_type_bit_size % 8 == 0);
@@ -6529,12 +6573,13 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
           // alignment (field_type_info.second) from the AST context.
           CompilerType field_clang_type = GetType(field->getType());
           assert(field_idx < record_layout.getFieldCount());
-          std::optional<uint64_t> size =
-              field_clang_type.GetByteSize(get_exe_scope());
-          if (!size)
-            return llvm::createStringError("no size info for field");
+          auto size_or_err = field_clang_type.GetByteSize(get_exe_scope());
+          if (!size_or_err)
+            return llvm::joinErrors(
+                llvm::createStringError("no size info for field"),
+                size_or_err.takeError());
 
-          child_byte_size = *size;
+          child_byte_size = *size_or_err;
           const uint32_t child_bit_size = child_byte_size * 8;
 
           // Figure out the field offset within the current struct/union/class
@@ -6704,12 +6749,12 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
 
         // We have a pointer to an simple type
         if (idx == 0 && pointee_clang_type.GetCompleteType()) {
-          if (std::optional<uint64_t> size =
-                  pointee_clang_type.GetByteSize(get_exe_scope())) {
-            child_byte_size = *size;
-            child_byte_offset = 0;
-            return pointee_clang_type;
-          }
+          auto size_or_err = pointee_clang_type.GetByteSize(get_exe_scope());
+          if (!size_or_err)
+            return size_or_err.takeError();
+          child_byte_size = *size_or_err;
+          child_byte_offset = 0;
+          return pointee_clang_type;
         }
       }
     }
@@ -6727,12 +6772,12 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
           ::snprintf(element_name, sizeof(element_name), "[%" PRIu64 "]",
                      static_cast<uint64_t>(idx));
           child_name.assign(element_name);
-          if (std::optional<uint64_t> size =
-                  element_type.GetByteSize(get_exe_scope())) {
-            child_byte_size = *size;
-            child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
-            return element_type;
-          }
+          auto size_or_err = element_type.GetByteSize(get_exe_scope());
+          if (!size_or_err)
+            return size_or_err.takeError();
+          child_byte_size = *size_or_err;
+          child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
+          return element_type;
         }
       }
     }
@@ -6746,12 +6791,12 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
         CompilerType element_type = GetType(array->getElementType());
         if (element_type.GetCompleteType()) {
           child_name = std::string(llvm::formatv("[{0}]", idx));
-          if (std::optional<uint64_t> size =
-                  element_type.GetByteSize(get_exe_scope())) {
-            child_byte_size = *size;
-            child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
-            return element_type;
-          }
+          auto size_or_err = element_type.GetByteSize(get_exe_scope());
+          if (!size_or_err)
+            return size_or_err.takeError();
+          child_byte_size = *size_or_err;
+          child_byte_offset = (int32_t)idx * (int32_t)child_byte_size;
+          return element_type;
         }
       }
     }
@@ -6785,12 +6830,12 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
 
       // We have a pointer to an simple type
       if (idx == 0) {
-        if (std::optional<uint64_t> size =
-                pointee_clang_type.GetByteSize(get_exe_scope())) {
-          child_byte_size = *size;
-          child_byte_offset = 0;
-          return pointee_clang_type;
-        }
+        auto size_or_err = pointee_clang_type.GetByteSize(get_exe_scope());
+        if (!size_or_err)
+          return size_or_err.takeError();
+        child_byte_size = *size_or_err;
+        child_byte_offset = 0;
+        return pointee_clang_type;
       }
     }
     break;
@@ -6823,12 +6868,12 @@ llvm::Expected<CompilerType> TypeSystemClang::GetChildCompilerTypeAtIndex(
 
         // We have a pointer to an simple type
         if (idx == 0) {
-          if (std::optional<uint64_t> size =
-                  pointee_clang_type.GetByteSize(get_exe_scope())) {
-            child_byte_size = *size;
-            child_byte_offset = 0;
-            return pointee_clang_type;
-          }
+          auto size_or_err = pointee_clang_type.GetByteSize(get_exe_scope());
+          if (!size_or_err)
+            return size_or_err.takeError();
+          child_byte_size = *size_or_err;
+          child_byte_offset = 0;
+          return pointee_clang_type;
         }
       }
     }

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.h
@@ -898,15 +898,17 @@ public:
 
   const llvm::fltSemantics &GetFloatTypeSemantics(size_t byte_size) override;
 
-  std::optional<uint64_t> GetByteSize(lldb::opaque_compiler_type_t type,
-                                      ExecutionContextScope *exe_scope) {
-    if (std::optional<uint64_t> bit_size = GetBitSize(type, exe_scope))
-      return (*bit_size + 7) / 8;
-    return std::nullopt;
+  llvm::Expected<uint64_t> GetByteSize(lldb::opaque_compiler_type_t type,
+                                       ExecutionContextScope *exe_scope) {
+    auto bit_size_or_err = GetBitSize(type, exe_scope);
+    if (!bit_size_or_err)
+      return bit_size_or_err.takeError();
+    return (*bit_size_or_err + 7) / 8;
   }
 
-  std::optional<uint64_t> GetBitSize(lldb::opaque_compiler_type_t type,
-                                     ExecutionContextScope *exe_scope) override;
+  llvm::Expected<uint64_t>
+  GetBitSize(lldb::opaque_compiler_type_t type,
+             ExecutionContextScope *exe_scope) override;
 
   std::optional<uint64_t>
   GetByteStride(lldb::opaque_compiler_type_t type,
@@ -1252,6 +1254,9 @@ private:
   /// Helper method that is used in \ref TypeSystemClang::TypeSystemClang
   /// on creation of a new instance.
   void LogCreation() const;
+
+  llvm::Expected<uint64_t> GetObjCBitSize(clang::QualType qual_type,
+                                          ExecutionContextScope *exe_scope);
 
   // Classes that inherit from TypeSystemClang can see and modify these
   std::string m_target_triple;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6603,17 +6603,18 @@ bool SwiftASTContext::IsFixedSize(CompilerType compiler_type) {
   return false;
 }
 
-std::optional<uint64_t>
+llvm::Expected<uint64_t>
 SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {
-  VALID_OR_RETURN_CHECK_TYPE(type, std::nullopt);
+  VALID_OR_RETURN_CHECK_TYPE(type, llvm::createStringError("invalid context"));
   LLDB_SCOPED_TIMER();
 
   // If the type has type parameters, bind them first.
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
   if (swift_can_type->hasTypeParameter()) {
     if (!exe_scope)
-      return {};
+      return llvm::createStringError(
+          "Cannot resolve generic type without a running process");
     ExecutionContext exe_ctx;
     exe_scope->CalculateExecutionContext(exe_ctx);
     CompilerType bound_type =
@@ -6622,14 +6623,19 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
     // Check that the type has been bound successfully -- and if not,
     // log the event and bail out to avoid an infinite loop.
     swift::CanType swift_bound_type(GetCanonicalSwiftType(bound_type));
-    if (swift_bound_type && swift_bound_type->hasTypeParameter()) {
-      LOG_PRINTF(GetLog(LLDBLog::Types), "Can't bind type: %s",
-                 bound_type.GetTypeName().AsCString());
-      return {};
-    }
+    if (swift_bound_type && swift_bound_type->hasTypeParameter())
+      return llvm::createStringError("Cannot bind type: %s",
+                                     bound_type.GetTypeName().AsCString(""));
 
-    // Note thay the bound type may be in a different AST context.
-    return bound_type.GetBitSize(exe_scope);
+    // Note that the bound type may be in a different AST context.
+    auto size_or_err = bound_type.GetBitSize(exe_scope);
+    if (!size_or_err && swift_bound_type->hasAnyPack()) {
+      // FIXME: We miss reflection support for pack types.
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Types), size_or_err.takeError(),
+                     "Could not get size of pack type. Ignoring: {0}");
+      return GetPointerByteSize() * 3 * 8;
+    }
+    return size_or_err;
   }
 
   // LLDB's ValueObject subsystem expects functions to be a single
@@ -6647,10 +6653,12 @@ SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
 
   // Ask the dynamic type system.
   if (!exe_scope)
-    return {};
+    return llvm::createStringError(
+        "Cannot determine size of type without a running process");
+
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_scope->CalculateProcess()))
     return runtime->GetBitSize({weak_from_this(), type}, exe_scope);
-  return {};
+  return llvm::createStringError("Cannot determine size of type");
 }
 
 std::optional<uint64_t>
@@ -7378,7 +7386,8 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
     std::tie(child_type, name) = GetExistentialTypeChild(
         *this, **ast_ctx, compiler_type, protocol_info, idx);
 
-    std::optional<uint64_t> child_size = child_type.GetByteSize(nullptr);
+    std::optional<uint64_t> child_size =
+        llvm::expectedToOptional(child_type.GetByteSize(nullptr));
     if (!child_size)
       return {};
     if (bit_offset_ptr)
@@ -7573,14 +7582,10 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
   LLDB_SCOPED_TIMER();
 
-  auto get_type_size = [&exe_ctx](uint32_t &result, CompilerType type) {
+  auto get_type_size = [&exe_ctx](CompilerType type) {
     auto *exe_scope =
         exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr;
-    std::optional<uint64_t> size = type.GetByteSize(exe_scope);
-    if (!size)
-      return false;
-    result = *size;
-    return true;
+    return type.GetByteSize(exe_scope);
   };
 
   language_flags = 0;
@@ -7660,9 +7665,13 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
       const SwiftEnumDescriptor::ElementInfo *element_info =
           cached_enum_info->GetElementWithPayloadAtIndex(idx);
       child_name.assign(element_info->name.GetCString());
-      if (!get_type_size(child_byte_size, element_info->payload_type))
-        return llvm::createStringError("could not get size for enum element " +
-                                       llvm::Twine(idx));
+      auto size_or_err = get_type_size(element_info->payload_type);
+      if (!size_or_err)
+        return llvm::joinErrors(
+            llvm::createStringError("could not get size for enum element " +
+                                    llvm::Twine(idx)),
+            size_or_err.takeError());
+      child_byte_size = *size_or_err;
       child_byte_offset = 0;
       child_bitfield_bit_size = 0;
       child_bitfield_bit_offset = 0;
@@ -7689,9 +7698,13 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
     child_name = GetTupleElementName(tuple_type, idx, printed_idx);
 
     CompilerType child_type = ToCompilerType(child.getType().getPointer());
-    if (!get_type_size(child_byte_size, child_type))
-      return llvm::createStringError("could not get size of tuple element " +
-                                     child_name);
+    auto size_or_err = get_type_size(child_type);
+    if (!size_or_err)
+      return llvm::joinErrors(
+          llvm::createStringError("could not get size for tuple element " +
+                                  child_name),
+          size_or_err.takeError());
+    child_byte_size = *size_or_err;
     child_is_base_class = false;
     child_is_deref_of_parent = false;
 
@@ -7721,9 +7734,13 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
     CompilerType child_type = ToCompilerType(fixed_array->getElementType());
     llvm::raw_string_ostream(child_name) << idx;
 
-    if (!get_type_size(child_byte_size, child_type))
-      return llvm::createStringError(
-          "could not get size of fixed array element " + child_name);
+    auto size_or_err = get_type_size(child_type);
+    if (!size_or_err)
+      return llvm::joinErrors(
+          llvm::createStringError("could not get size of fixes array element " +
+                                  child_name),
+          size_or_err.takeError());
+    child_byte_size = *size_or_err;
     child_is_base_class = false;
     child_is_deref_of_parent = false;
 
@@ -7751,8 +7768,12 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
             ToCompilerType(superclass_swift_type.getPointer());
 
         child_name = GetSuperclassName(superclass_type);
-        if (!get_type_size(child_byte_size, superclass_type))
-          return llvm::createStringError("could not get size of super class");
+        auto size_or_err = get_type_size(superclass_type);
+        if (!size_or_err)
+          return llvm::joinErrors(
+              llvm::createStringError("could not get size of super class"),
+              size_or_err.takeError());
+        child_byte_size = *size_or_err;
         child_is_base_class = true;
         child_is_deref_of_parent = false;
 
@@ -7791,10 +7812,13 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
             CompilerType child_type =
                 ToCompilerType(VD->getTypeInContext().getPointer());
             child_name = VD->getNameStr().str();
-            if (!get_type_size(child_byte_size, child_type))
-              return llvm::createStringError("could not get size of field " +
-                                             child_name);
-
+            auto size_or_err = get_type_size(child_type);
+            if (!size_or_err)
+              return llvm::joinErrors(
+                  llvm::createStringError("could not get size of field " +
+                                          child_name),
+                  size_or_err.takeError());
+            child_byte_size = *size_or_err;
             child_is_base_class = false;
             child_is_deref_of_parent = false;
             child_byte_offset = 0;
@@ -7817,9 +7841,13 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
 
     CompilerType child_type = ToCompilerType(child_swift_type.getPointer());
     child_name = property->getBaseName().userFacingName().str();
-    if (!get_type_size(child_byte_size, child_type))
-      return llvm::createStringError("could not get size of field " +
-                                     child_name);
+    auto size_or_err = get_type_size(child_type);
+    if (!size_or_err)
+      return llvm::joinErrors(
+          llvm::createStringError("could not get size of field " +
+                                  child_name),
+          size_or_err.takeError());
+    child_byte_size = *size_or_err;
     child_is_base_class = false;
     child_is_deref_of_parent = false;
 
@@ -7852,9 +7880,13 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
 
     std::tie(child_type, child_name) = GetExistentialTypeChild(
         *this, **ast_ctx, compiler_type, protocol_info, idx);
-    if (!get_type_size(child_byte_size, child_type))
-      return llvm::createStringError("could not get size of field " +
-                                     llvm::Twine(idx));
+    auto size_or_err = get_type_size(child_type);
+    if (!size_or_err)
+      return llvm::joinErrors(
+          llvm::createStringError("could not get size of field " +
+                                  llvm::Twine(idx)),
+          size_or_err.takeError());
+    child_byte_size = *size_or_err;
     child_byte_offset = idx * child_byte_size;
     child_bitfield_bit_size = 0;
     child_bitfield_bit_offset = 0;
@@ -7878,8 +7910,12 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
 
       // We have a pointer to a simple type
       if (idx == 0) {
-        if (!get_type_size(child_byte_size, pointee_clang_type))
-          return llvm::createStringError("could not get size of lvalue");
+        auto size_or_err = get_type_size(pointee_clang_type);
+        if (!size_or_err)
+          return llvm::joinErrors(
+              llvm::createStringError("could not get size of lvalue"),
+              size_or_err.takeError());
+        child_byte_size = *size_or_err;
         child_byte_offset = 0;
         return pointee_clang_type;
       }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -705,7 +705,7 @@ public:
 
   // Exploring the type
 
-  std::optional<uint64_t>
+  llvm::Expected<uint64_t>
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3537,11 +3537,11 @@ CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
 }
 
 // Exploring the type
-std::optional<uint64_t>
+llvm::Expected<uint64_t>
 TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                                    ExecutionContextScope *exe_scope) {
   LLDB_SCOPED_TIMER();
-  auto impl = [&]() -> std::optional<uint64_t> {
+  auto impl = [&]() -> llvm::Expected<uint64_t> {
     auto get_static_size = [&](bool cached_only) -> std::optional<uint64_t> {
       if (IsMeaninglessWithoutDynamicResolution(type))
         return {};
@@ -3582,21 +3582,25 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
       // pointer instead of the underlying object.
       if (Flags(clang_type.GetTypeInfo()).AllSet(eTypeIsObjC | eTypeIsClass))
         return GetPointerByteSize() * 8;
-      if (auto clang_size = clang_type.GetBitSize(exe_scope))
-        return clang_size;
+      auto clang_size = clang_type.GetBitSize(exe_scope);
+      return clang_size;
     }
-    if (!exe_scope) {
-      LLDB_LOGF(GetLog(LLDBLog::Types),
-                "Couldn't compute size of type %s without an execution "
-                "context.",
-                AsMangledName(type));
-      return {};
-    }
+    if (!exe_scope)
+      return llvm::createStringError(
+          "Cannot compute size of type %s without an execution context.",
+          AsMangledName(type));
     // The hot code path is to ask the Swift runtime for the size.
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
-      if (auto result = runtime->GetBitSize({weak_from_this(), type}, exe_scope))
-        return result;
+      auto result_or_err =
+          runtime->GetBitSize({weak_from_this(), type}, exe_scope);
+      if (result_or_err)
+        return *result_or_err;
+      LLDB_LOG_ERROR(
+          GetLog(LLDBLog::Types), result_or_err.takeError(),
+          "Couldn't compute size of type {1} using Swift language runtime: {0}",
+          AsMangledName(type));
+
       // Runtime failed, fallback to SwiftASTContext.
       if (UseSwiftASTContextFallback(__FUNCTION__, type)) {
         if (auto swift_ast_context =
@@ -3618,21 +3622,20 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
     // If we have already parsed this as an lldb::Type from DWARF,
     // return its static size.
     if (auto cached_type_static_size = get_static_size(true))
-      return cached_type_static_size;
+      return *cached_type_static_size;
 
     // If we are here, we probably are in a target with no process and
     // inspect a gloabl variable.  Do an (expensive) search for the
     // static type in the debug info.
     if (auto static_size = get_static_size(false))
-      return static_size;
-    LLDB_LOGF(GetLog(LLDBLog::Types),
-              "Couldn't compute size of type %s using static debug info.",
-              AsMangledName(type));
-    return {};
+      return *static_size;
+    return llvm::createStringError(
+        "Cannot compute size of type %s using static debug info.",
+        AsMangledName(type));
   };
   if (exe_scope && exe_scope->CalculateProcess()) {
-    VALIDATE_AND_RETURN(impl, GetBitSize, type, exe_scope,
-                        (ReconstructType(type, exe_scope), exe_scope));
+    VALIDATE_AND_RETURN_EXPECTED(impl, GetBitSize, type, exe_scope,
+                                 (ReconstructType(type, exe_scope), exe_scope));
   } else
     return impl();
 }
@@ -3928,8 +3931,7 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
           child_byte_size, child_byte_offset, child_bitfield_bit_size,
           child_bitfield_bit_offset, child_is_base_class,
           child_is_deref_of_parent, valobj, language_flags);
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "no SwiftASTContext");
+    return llvm::createStringError("no SwiftASTContext");
   };
   std::optional<unsigned> ast_num_children;
   auto get_ast_num_children = [&]() {
@@ -3982,7 +3984,9 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
               child_name = "rawValue";
               auto bit_size = raw_value.GetBitSize(
                   exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr);
-              child_byte_size = bit_size.value_or(0) / 8;
+              if (!bit_size)
+                return bit_size.takeError();
+              child_byte_size = *bit_size / 8;
               child_byte_offset = 0;
               child_bitfield_bit_size = 0;
               child_bitfield_bit_offset = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -196,7 +196,7 @@ public:
   CompilerType GetVoidFunctionType();
 
   // Exploring the type
-  std::optional<uint64_t>
+  llvm::Expected<uint64_t>
   GetBitSize(lldb::opaque_compiler_type_t type,
              ExecutionContextScope *exe_scope) override;
   std::optional<uint64_t>

--- a/lldb/source/Symbol/CompilerType.cpp
+++ b/lldb/source/Symbol/CompilerType.cpp
@@ -15,6 +15,8 @@
 #include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/DataBufferHeap.h"
 #include "lldb/Utility/DataExtractor.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/Scalar.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StreamString.h"
@@ -809,19 +811,20 @@ CompilerType::GetBasicTypeFromAST(lldb::BasicType basic_type) const {
 }
 // Exploring the type
 
-std::optional<uint64_t>
+llvm::Expected<uint64_t>
 CompilerType::GetBitSize(ExecutionContextScope *exe_scope) const {
   if (IsValid())
     if (auto type_system_sp = GetTypeSystem())
       return type_system_sp->GetBitSize(m_type, exe_scope);
-  return {};
+  return llvm::createStringError("Invalid type: Cannot determine size");
 }
 
-std::optional<uint64_t>
+llvm::Expected<uint64_t>
 CompilerType::GetByteSize(ExecutionContextScope *exe_scope) const {
-  if (std::optional<uint64_t> bit_size = GetBitSize(exe_scope))
-    return (*bit_size + 7) / 8;
-  return {};
+  auto bit_size_or_err = GetBitSize(exe_scope);
+  if (!bit_size_or_err)
+    return bit_size_or_err.takeError();
+  return (*bit_size_or_err + 7) / 8;
 }
 
 std::optional<uint64_t>
@@ -1157,10 +1160,18 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
     if (encoding == lldb::eEncodingInvalid || count != 1)
       return false;
 
-    std::optional<uint64_t> byte_size = GetByteSize(exe_scope);
+    auto byte_size_or_err = GetByteSize(exe_scope);
+    if (!byte_size_or_err) {
+      LLDB_LOG_ERRORV(
+          GetLog(LLDBLog::Types), byte_size_or_err.takeError(),
+          "Cannot get value as scalar: Cannot determine type size: {0}");
+      return false;
+    }
+    uint64_t byte_size = *byte_size_or_err;
+
     // A bit or byte size of 0 is not a bug, but it doesn't make sense to read a
     // scalar of zero size.
-    if (!byte_size || *byte_size == 0)
+    if (byte_size == 0)
       return false;
 
     lldb::offset_t offset = data_byte_offset;
@@ -1170,15 +1181,15 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
     case lldb::eEncodingVector:
       break;
     case lldb::eEncodingUint:
-      if (*byte_size <= sizeof(unsigned long long)) {
-        uint64_t uval64 = data.GetMaxU64(&offset, *byte_size);
-        if (*byte_size <= sizeof(unsigned int)) {
+      if (byte_size <= sizeof(unsigned long long)) {
+        uint64_t uval64 = data.GetMaxU64(&offset, byte_size);
+        if (byte_size <= sizeof(unsigned int)) {
           value = (unsigned int)uval64;
           return true;
-        } else if (*byte_size <= sizeof(unsigned long)) {
+        } else if (byte_size <= sizeof(unsigned long)) {
           value = (unsigned long)uval64;
           return true;
-        } else if (*byte_size <= sizeof(unsigned long long)) {
+        } else if (byte_size <= sizeof(unsigned long long)) {
           value = (unsigned long long)uval64;
           return true;
         } else
@@ -1187,15 +1198,15 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
       break;
 
     case lldb::eEncodingSint:
-      if (*byte_size <= sizeof(long long)) {
-        int64_t sval64 = data.GetMaxS64(&offset, *byte_size);
-        if (*byte_size <= sizeof(int)) {
+      if (byte_size <= sizeof(long long)) {
+        int64_t sval64 = data.GetMaxS64(&offset, byte_size);
+        if (byte_size <= sizeof(int)) {
           value = (int)sval64;
           return true;
-        } else if (*byte_size <= sizeof(long)) {
+        } else if (byte_size <= sizeof(long)) {
           value = (long)sval64;
           return true;
-        } else if (*byte_size <= sizeof(long long)) {
+        } else if (byte_size <= sizeof(long long)) {
           value = (long long)sval64;
           return true;
         } else
@@ -1204,10 +1215,10 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
       break;
 
     case lldb::eEncodingIEEE754:
-      if (*byte_size <= sizeof(long double)) {
+      if (byte_size <= sizeof(long double)) {
         uint32_t u32;
         uint64_t u64;
-        if (*byte_size == sizeof(float)) {
+        if (byte_size == sizeof(float)) {
           if (sizeof(float) == sizeof(uint32_t)) {
             u32 = data.GetU32(&offset);
             value = *((float *)&u32);
@@ -1217,7 +1228,7 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
             value = *((float *)&u64);
             return true;
           }
-        } else if (*byte_size == sizeof(double)) {
+        } else if (byte_size == sizeof(double)) {
           if (sizeof(double) == sizeof(uint32_t)) {
             u32 = data.GetU32(&offset);
             value = *((double *)&u32);
@@ -1227,7 +1238,7 @@ bool CompilerType::GetValueAsScalar(const lldb_private::DataExtractor &data,
             value = *((double *)&u64);
             return true;
           }
-        } else if (*byte_size == sizeof(long double)) {
+        } else if (byte_size == sizeof(long double)) {
           if (sizeof(long double) == sizeof(uint32_t)) {
             u32 = data.GetU32(&offset);
             value = *((long double *)&u32);

--- a/lldb/source/Symbol/Type.cpp
+++ b/lldb/source/Symbol/Type.cpp
@@ -448,14 +448,18 @@ Type *Type::GetEncodingType() {
   return m_encoding_type;
 }
 
-std::optional<uint64_t> Type::GetByteSize(ExecutionContextScope *exe_scope) {
+llvm::Expected<uint64_t> Type::GetByteSize(ExecutionContextScope *exe_scope) {
   if (m_byte_size_has_value)
     return static_cast<uint64_t>(m_byte_size);
 
   switch (m_encoding_uid_type) {
   case eEncodingInvalid:
+    return llvm::createStringError("could not get type size: invalid encoding");
+
   case eEncodingIsSyntheticUID:
-    break;
+    return llvm::createStringError(
+        "could not get type size: synthetic encoding");
+
   case eEncodingIsUID:
   case eEncodingIsConstUID:
   case eEncodingIsRestrictUID:
@@ -465,18 +469,18 @@ std::optional<uint64_t> Type::GetByteSize(ExecutionContextScope *exe_scope) {
     Type *encoding_type = GetEncodingType();
     if (encoding_type)
       if (std::optional<uint64_t> size =
-              encoding_type->GetByteSize(exe_scope)) {
+              llvm::expectedToOptional(encoding_type->GetByteSize(exe_scope))) {
         m_byte_size = *size;
         m_byte_size_has_value = true;
         return static_cast<uint64_t>(m_byte_size);
       }
 
-    if (std::optional<uint64_t> size =
-            GetLayoutCompilerType().GetByteSize(exe_scope)) {
-      m_byte_size = *size;
-      m_byte_size_has_value = true;
-      return static_cast<uint64_t>(m_byte_size);
-    }
+    auto size_or_err = GetLayoutCompilerType().GetByteSize(exe_scope);
+    if (!size_or_err)
+      return size_or_err.takeError();
+    m_byte_size = *size_or_err;
+    m_byte_size_has_value = true;
+    return static_cast<uint64_t>(m_byte_size);
   } break;
 
     // If we are a pointer or reference, then this is just a pointer size;
@@ -491,7 +495,8 @@ std::optional<uint64_t> Type::GetByteSize(ExecutionContextScope *exe_scope) {
       }
     } break;
   }
-  return {};
+  return llvm::createStringError(
+      "could not get type size: unexpected encoding");
 }
 
 llvm::Expected<uint32_t> Type::GetNumChildren(bool omit_empty_base_classes) {
@@ -532,7 +537,9 @@ bool Type::ReadFromMemory(ExecutionContext *exe_ctx, lldb::addr_t addr,
   }
 
   const uint64_t byte_size =
-      GetByteSize(exe_ctx ? exe_ctx->GetBestExecutionContextScope() : nullptr)
+      llvm::expectedToOptional(
+          GetByteSize(exe_ctx ? exe_ctx->GetBestExecutionContextScope()
+                              : nullptr))
           .value_or(0);
   if (data.GetByteSize() < byte_size) {
     lldb::DataBufferSP data_sp(new DataBufferHeap(byte_size, '\0'));

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -1488,7 +1488,9 @@ lldb::ValueObjectSP StackFrame::GuessValueForAddress(lldb::addr_t addr) {
 namespace {
 ValueObjectSP GetValueForOffset(StackFrame &frame, ValueObjectSP &parent,
                                 int64_t offset) {
-  if (offset < 0 || uint64_t(offset) >= parent->GetByteSize()) {
+  if (offset < 0 ||
+      uint64_t(offset) >=
+          llvm::expectedToOptional(parent->GetByteSize()).value_or(0)) {
     return ValueObjectSP();
   }
 
@@ -1505,7 +1507,8 @@ ValueObjectSP GetValueForOffset(StackFrame &frame, ValueObjectSP &parent,
     }
 
     int64_t child_offset = child_sp->GetByteOffset();
-    int64_t child_size = child_sp->GetByteSize().value_or(0);
+    int64_t child_size =
+        llvm::expectedToOptional(child_sp->GetByteSize()).value_or(0);
 
     if (offset >= child_offset && offset < (child_offset + child_size)) {
       return GetValueForOffset(frame, child_sp, offset - child_offset);
@@ -1537,9 +1540,13 @@ ValueObjectSP GetValueForDereferincingOffset(StackFrame &frame,
     return ValueObjectSP();
   }
 
-  if (offset >= 0 && uint64_t(offset) >= pointee->GetByteSize()) {
-    int64_t index = offset / pointee->GetByteSize().value_or(1);
-    offset = offset % pointee->GetByteSize().value_or(1);
+  if (offset >= 0 &&
+      uint64_t(offset) >=
+          llvm::expectedToOptional(pointee->GetByteSize()).value_or(0)) {
+    uint64_t size =
+        llvm::expectedToOptional(pointee->GetByteSize()).value_or(1);
+    int64_t index = offset / size;
+    offset = offset % size;
     const bool can_create = true;
     pointee = base->GetSyntheticArrayMember(index, can_create);
   }

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -2138,10 +2138,13 @@ lldb::ValueObjectSP Thread::GetSiginfoValue() {
     return ValueObjectConstResult::Create(
         &target, Status::FromErrorString("no siginfo_t for the platform"));
 
-  std::optional<uint64_t> type_size = type.GetByteSize(nullptr);
-  assert(type_size);
+  auto type_size_or_err = type.GetByteSize(nullptr);
+  if (!type_size_or_err)
+    return ValueObjectConstResult::Create(
+        &target, Status::FromError(type_size_or_err.takeError()));
+
   llvm::Expected<std::unique_ptr<llvm::MemoryBuffer>> data =
-      GetSiginfo(*type_size);
+      GetSiginfo(*type_size_or_err);
   if (!data)
     return ValueObjectConstResult::Create(&target,
                                           Status::FromError(data.takeError()));

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -745,8 +745,8 @@ size_t ValueObject::GetPointeeData(DataExtractor &data, uint32_t item_idx,
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
   std::optional<uint64_t> item_type_size =
-      pointee_or_element_compiler_type.GetByteSize(
-          exe_ctx.GetBestExecutionContextScope());
+      llvm::expectedToOptional(pointee_or_element_compiler_type.GetByteSize(
+          exe_ctx.GetBestExecutionContextScope()));
   if (!item_type_size)
     return 0;
   const uint64_t bytes = item_count * *item_type_size;
@@ -862,7 +862,7 @@ bool ValueObject::SetData(DataExtractor &data, Status &error) {
   uint64_t count = 0;
   const Encoding encoding = GetCompilerType().GetEncoding(count);
 
-  const size_t byte_size = GetByteSize().value_or(0);
+  const size_t byte_size = llvm::expectedToOptional(GetByteSize()).value_or(0);
 
   Value::ValueType value_type = m_value.GetValueType();
 
@@ -1292,7 +1292,8 @@ void ValueObject::SetValueFromInteger(const llvm::APInt &value, Status &error) {
   // Verify the proposed new value is the right size.
   lldb::TargetSP target = GetTargetSP();
   uint64_t byte_size = 0;
-  if (auto temp = GetCompilerType().GetByteSize(target.get()))
+  if (auto temp =
+          llvm::expectedToOptional(GetCompilerType().GetByteSize(target.get())))
     byte_size = temp.value();
   if (value.getBitWidth() != byte_size * CHAR_BIT) {
     error = Status::FromErrorString(
@@ -1355,7 +1356,8 @@ void ValueObject::SetValueFromInteger(lldb::ValueObjectSP new_val_sp,
     if (success) {
       lldb::TargetSP target = GetTargetSP();
       uint64_t num_bits = 0;
-      if (auto temp = new_val_sp->GetCompilerType().GetBitSize(target.get()))
+      if (auto temp = llvm::expectedToOptional(
+              new_val_sp->GetCompilerType().GetBitSize(target.get())))
         num_bits = temp.value();
       SetValueFromInteger(llvm::APInt(num_bits, int_val), error);
     } else
@@ -1747,7 +1749,7 @@ bool ValueObject::SetValueFromCString(const char *value_str, Status &error) {
   uint64_t count = 0;
   const Encoding encoding = GetCompilerType().GetEncoding(count);
 
-  const size_t byte_size = GetByteSize().value_or(0);
+  const size_t byte_size = llvm::expectedToOptional(GetByteSize()).value_or(0);
 
   Value::ValueType value_type = m_value.GetValueType();
 
@@ -1931,13 +1933,15 @@ ValueObjectSP ValueObject::GetSyntheticBitFieldChild(uint32_t from, uint32_t to,
       uint32_t bit_field_offset = from;
       if (GetDataExtractor().GetByteOrder() == eByteOrderBig)
         bit_field_offset =
-            GetByteSize().value_or(0) * 8 - bit_field_size - bit_field_offset;
+            llvm::expectedToOptional(GetByteSize()).value_or(0) * 8 -
+            bit_field_size - bit_field_offset;
       // We haven't made a synthetic array member for INDEX yet, so lets make
       // one and cache it for any future reference.
       ValueObjectChild *synthetic_child = new ValueObjectChild(
-          *this, GetCompilerType(), index_const_str, GetByteSize().value_or(0),
-          0, bit_field_size, bit_field_offset, false, false,
-          eAddressTypeInvalid, 0);
+          *this, GetCompilerType(), index_const_str,
+          llvm::expectedToOptional(GetByteSize()).value_or(0), 0,
+          bit_field_size, bit_field_offset, false, false, eAddressTypeInvalid,
+          0);
 
       // Cache the value if we got one back...
       if (synthetic_child) {
@@ -1972,8 +1976,8 @@ ValueObjectSP ValueObject::GetSyntheticChildAtOffset(
     return {};
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
-  std::optional<uint64_t> size =
-      type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> size = llvm::expectedToOptional(
+      type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
   if (!size)
     return {};
   ValueObjectChild *synthetic_child =
@@ -2014,8 +2018,8 @@ ValueObjectSP ValueObject::GetSyntheticBase(uint32_t offset,
   const bool is_base_class = true;
 
   ExecutionContext exe_ctx(GetExecutionContextRef());
-  std::optional<uint64_t> size =
-      type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  std::optional<uint64_t> size = llvm::expectedToOptional(
+      type.GetByteSize(exe_ctx.GetBestExecutionContextScope()));
   if (!size)
     return {};
   ValueObjectChild *synthetic_child =
@@ -3067,8 +3071,10 @@ ValueObjectSP ValueObject::Cast(const CompilerType &compiler_type) {
 
   ExecutionContextScope *exe_scope =
       ExecutionContext(GetExecutionContextRef()).GetBestExecutionContextScope();
-  if (compiler_type.GetByteSize(exe_scope) <=
-          GetCompilerType().GetByteSize(exe_scope) ||
+  if (llvm::expectedToOptional(compiler_type.GetByteSize(exe_scope))
+              .value_or(0) <=
+          llvm::expectedToOptional(GetCompilerType().GetByteSize(exe_scope))
+              .value_or(0) ||
       m_value.GetValueType() == Value::ValueType::LoadAddress)
     return DoCast(compiler_type);
 
@@ -3293,9 +3299,10 @@ lldb::ValueObjectSP ValueObject::CastToBasicType(CompilerType type) {
   lldb::TargetSP target = GetTargetSP();
   uint64_t type_byte_size = 0;
   uint64_t val_byte_size = 0;
-  if (auto temp = type.GetByteSize(target.get()))
+  if (auto temp = llvm::expectedToOptional(type.GetByteSize(target.get())))
     type_byte_size = temp.value();
-  if (auto temp = GetCompilerType().GetByteSize(target.get()))
+  if (auto temp =
+          llvm::expectedToOptional(GetCompilerType().GetByteSize(target.get())))
     val_byte_size = temp.value();
 
   if (is_pointer) {
@@ -3442,7 +3449,7 @@ lldb::ValueObjectSP ValueObject::CastToEnumType(CompilerType type) {
 
   lldb::TargetSP target = GetTargetSP();
   uint64_t byte_size = 0;
-  if (auto temp = type.GetByteSize(target.get()))
+  if (auto temp = llvm::expectedToOptional(type.GetByteSize(target.get())))
     byte_size = temp.value();
 
   if (is_float) {
@@ -3717,7 +3724,7 @@ ValueObject::CreateValueObjectFromAPInt(lldb::TargetSP target,
                                         llvm::StringRef name) {
   ExecutionContext exe_ctx(target.get(), false);
   uint64_t byte_size = 0;
-  if (auto temp = type.GetByteSize(target.get()))
+  if (auto temp = llvm::expectedToOptional(type.GetByteSize(target.get())))
     byte_size = temp.value();
   lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
       reinterpret_cast<const void *>(v.getRawData()), byte_size,
@@ -3745,7 +3752,8 @@ ValueObject::CreateValueObjectFromBool(lldb::TargetSP target, bool value,
   }
   ExecutionContext exe_ctx(target.get(), false);
   uint64_t byte_size = 0;
-  if (auto temp = target_type.GetByteSize(target.get()))
+  if (auto temp =
+          llvm::expectedToOptional(target_type.GetByteSize(target.get())))
     byte_size = temp.value();
   lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
       reinterpret_cast<const void *>(&value), byte_size, exe_ctx.GetByteOrder(),
@@ -3763,7 +3771,7 @@ lldb::ValueObjectSP ValueObject::CreateValueObjectFromNullptr(
   uintptr_t zero = 0;
   ExecutionContext exe_ctx(target.get(), false);
   uint64_t byte_size = 0;
-  if (auto temp = type.GetByteSize(target.get()))
+  if (auto temp = llvm::expectedToOptional(type.GetByteSize(target.get())))
     byte_size = temp.value();
   lldb::DataExtractorSP data_sp = std::make_shared<DataExtractor>(
       reinterpret_cast<const void *>(zero), byte_size, exe_ctx.GetByteOrder(),

--- a/lldb/source/ValueObject/ValueObjectCast.cpp
+++ b/lldb/source/ValueObject/ValueObjectCast.cpp
@@ -49,7 +49,7 @@ llvm::Expected<uint32_t> ValueObjectCast::CalculateNumChildren(uint32_t max) {
   return *children_count <= max ? *children_count : max;
 }
 
-std::optional<uint64_t> ValueObjectCast::GetByteSize() {
+llvm::Expected<uint64_t> ValueObjectCast::GetByteSize() {
   ExecutionContext exe_ctx(GetExecutionContextRef());
   return m_value.GetValueByteSize(nullptr, &exe_ctx);
 }

--- a/lldb/source/ValueObject/ValueObjectChild.cpp
+++ b/lldb/source/ValueObject/ValueObjectChild.cpp
@@ -201,8 +201,9 @@ bool ValueObjectChild::UpdateValue() {
             const bool thread_and_frame_only_if_stopped = true;
             ExecutionContext exe_ctx(GetExecutionContextRef().Lock(
                 thread_and_frame_only_if_stopped));
-            if (auto type_bit_size = GetCompilerType().GetBitSize(
-                    exe_ctx.GetBestExecutionContextScope())) {
+            if (auto type_bit_size =
+                    llvm::expectedToOptional(GetCompilerType().GetBitSize(
+                        exe_ctx.GetBestExecutionContextScope()))) {
               uint64_t bitfield_end =
                   m_bitfield_bit_size + m_bitfield_bit_offset;
               if (bitfield_end > *type_bit_size) {

--- a/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
+++ b/lldb/source/ValueObject/ValueObjectDynamicValue.cpp
@@ -108,7 +108,7 @@ ValueObjectDynamicValue::CalculateNumChildren(uint32_t max) {
     return m_parent->GetNumChildren(max);
 }
 
-std::optional<uint64_t> ValueObjectDynamicValue::GetByteSize() {
+llvm::Expected<uint64_t> ValueObjectDynamicValue::GetByteSize() {
   const bool success = UpdateValueIfNeeded(false);
   if (success && m_dynamic_type_info.HasType()) {
     ExecutionContext exe_ctx(GetExecutionContextRef());
@@ -286,7 +286,8 @@ bool ValueObjectDynamicValue::UpdateValue() {
       // If we found a host address but it doesn't fit in the buffer, there's
       // nothing we can do.
       if (local_buffer.size() <
-          m_dynamic_type_info.GetCompilerType().GetByteSize(exe_scope)) {
+          llvm::expectedToOptional(
+              m_dynamic_type_info.GetCompilerType().GetByteSize(exe_scope))) {
         SetValueIsValid(false);
         return false;
       }

--- a/lldb/source/ValueObject/ValueObjectMemory.cpp
+++ b/lldb/source/ValueObject/ValueObjectMemory.cpp
@@ -147,10 +147,14 @@ llvm::Expected<uint32_t> ValueObjectMemory::CalculateNumChildren(uint32_t max) {
   return *child_count <= max ? *child_count : max;
 }
 
-std::optional<uint64_t> ValueObjectMemory::GetByteSize() {
+llvm::Expected<uint64_t> ValueObjectMemory::GetByteSize() {
   ExecutionContext exe_ctx(GetExecutionContextRef());
-  if (m_type_sp)
-    return m_type_sp->GetByteSize(exe_ctx.GetBestExecutionContextScope());
+  if (m_type_sp) {
+    if (auto size =
+            m_type_sp->GetByteSize(exe_ctx.GetBestExecutionContextScope()))
+      return *size;
+    return llvm::createStringError("could not get byte size of memory object");
+  }
   return m_compiler_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
 }
 

--- a/lldb/source/ValueObject/ValueObjectRegister.cpp
+++ b/lldb/source/ValueObject/ValueObjectRegister.cpp
@@ -84,7 +84,7 @@ ValueObjectRegisterSet::CalculateNumChildren(uint32_t max) {
   return 0;
 }
 
-std::optional<uint64_t> ValueObjectRegisterSet::GetByteSize() { return 0; }
+llvm::Expected<uint64_t> ValueObjectRegisterSet::GetByteSize() { return 0; }
 
 bool ValueObjectRegisterSet::UpdateValue() {
   m_error.Clear();
@@ -226,7 +226,7 @@ ValueObjectRegister::CalculateNumChildren(uint32_t max) {
   return *children_count <= max ? *children_count : max;
 }
 
-std::optional<uint64_t> ValueObjectRegister::GetByteSize() {
+llvm::Expected<uint64_t> ValueObjectRegister::GetByteSize() {
   return m_reg_info.byte_size;
 }
 

--- a/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
+++ b/lldb/source/ValueObject/ValueObjectSyntheticFilter.cpp
@@ -133,7 +133,7 @@ bool ValueObjectSynthetic::MightHaveChildren() {
   return (m_might_have_children != eLazyBoolNo);
 }
 
-std::optional<uint64_t> ValueObjectSynthetic::GetByteSize() {
+llvm::Expected<uint64_t> ValueObjectSynthetic::GetByteSize() {
   return m_parent->GetByteSize();
 }
 

--- a/lldb/source/ValueObject/ValueObjectVTable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVTable.cpp
@@ -31,7 +31,7 @@ public:
 
   ~ValueObjectVTableChild() override = default;
 
-  std::optional<uint64_t> GetByteSize() override { return m_addr_size; };
+  llvm::Expected<uint64_t> GetByteSize() override { return m_addr_size; };
 
   llvm::Expected<uint32_t> CalculateNumChildren(uint32_t max) override {
     return 0;
@@ -154,10 +154,10 @@ ValueObjectVTable::ValueObjectVTable(ValueObject &parent)
   SetFormat(eFormatPointer);
 }
 
-std::optional<uint64_t> ValueObjectVTable::GetByteSize() {
+llvm::Expected<uint64_t> ValueObjectVTable::GetByteSize() {
   if (m_vtable_symbol)
     return m_vtable_symbol->GetByteSize();
-  return std::nullopt;
+  return llvm::createStringError("no symbol for vtable");
 }
 
 llvm::Expected<uint32_t> ValueObjectVTable::CalculateNumChildren(uint32_t max) {

--- a/lldb/source/ValueObject/ValueObjectVariable.cpp
+++ b/lldb/source/ValueObject/ValueObjectVariable.cpp
@@ -119,14 +119,10 @@ ValueObjectVariable::CalculateNumChildren(uint32_t max) {
   return *child_count <= max ? *child_count : max;
 }
 
-std::optional<uint64_t> ValueObjectVariable::GetByteSize() {
+llvm::Expected<uint64_t> ValueObjectVariable::GetByteSize() {
   ExecutionContext exe_ctx(GetExecutionContextRef());
 
   CompilerType type(GetCompilerType());
-
-  if (!type.IsValid())
-    return {};
-
   return type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
 }
 
@@ -147,9 +143,13 @@ bool ValueObjectVariable::UpdateValue() {
   CompilerType var_type(GetCompilerTypeImpl());
   if (var_type.IsValid() && var_type.GetMinimumLanguage() == lldb::eLanguageTypeSwift) {
     ExecutionContext exe_ctx(GetExecutionContextRef());
-    std::optional<uint64_t> size =
-      var_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
-    if (size && *size == 0) {
+    auto size_or_err =
+        var_type.GetByteSize(exe_ctx.GetBestExecutionContextScope());
+    if (!size_or_err) {
+      m_error = Status::FromError(size_or_err.takeError());
+      return false;
+    }
+    if (*size_or_err == 0) {
       m_value.SetCompilerType(var_type);
       return m_error.Success();
     }

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/class-type-nullptr-deref.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/class-type-nullptr-deref.s
@@ -4,7 +4,7 @@
 # RUN: llvm-mc --triple x86_64-pc-linux %s --filetype=obj -o %t
 # RUN: %lldb %t -o "target variable x" -o exit 2>&1 | FileCheck %s
 
-# CHECK: Unable to determine byte size.
+# CHECK: Invalid type: Cannot determine size
 
 # This tests a fix for a crash. If things are working we don't get a segfault.
 

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-signature-loop.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-signature-loop.s
@@ -4,7 +4,7 @@
 # RUN: ld.lld %t.o -o %t
 # RUN: %lldb %t -o "target variable e" -b | FileCheck %s
 
-# CHECK: error: Unable to determine byte size.
+# CHECK: error: Invalid type: Cannot determine size
 
         .type   e,@object               # @e
         .section        .rodata,"a",@progbits

--- a/lldb/unittests/Platform/PlatformSiginfoTest.cpp
+++ b/lldb/unittests/Platform/PlatformSiginfoTest.cpp
@@ -68,7 +68,8 @@ public:
     }
 
     EXPECT_EQ(total_offset, offset * 8);
-    EXPECT_EQ(field_type.GetByteSize(nullptr), std::optional<uint64_t>(size));
+    EXPECT_EQ(llvm::expectedToOptional(field_type.GetByteSize(nullptr)),
+              std::optional<uint64_t>(size));
   }
 
   void ExpectFields(const CompilerType &container,

--- a/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
+++ b/lldb/unittests/SymbolFile/PDB/SymbolFilePDBTests.cpp
@@ -371,7 +371,7 @@ TEST_F(SymbolFilePDBTests, TestSimpleClassTypes) {
   CompilerType compiler_type = udt_type->GetForwardCompilerType();
   EXPECT_TRUE(TypeSystemClang::IsClassType(compiler_type.GetOpaqueQualType()));
   EXPECT_EQ(GetGlobalConstantInteger(session, "sizeof_Class"),
-            udt_type->GetByteSize(nullptr));
+            llvm::expectedToOptional(udt_type->GetByteSize(nullptr)));
 }
 
 TEST_F(SymbolFilePDBTests, TestNestedClassTypes) {
@@ -427,7 +427,7 @@ TEST_F(SymbolFilePDBTests, TestNestedClassTypes) {
   EXPECT_TRUE(TypeSystemClang::IsClassType(compiler_type.GetOpaqueQualType()));
 
   EXPECT_EQ(GetGlobalConstantInteger(session, "sizeof_NestedClass"),
-            udt_type->GetByteSize(nullptr));
+            llvm::expectedToOptional(udt_type->GetByteSize(nullptr)));
 }
 
 TEST_F(SymbolFilePDBTests, TestClassInNamespace) {
@@ -471,7 +471,7 @@ TEST_F(SymbolFilePDBTests, TestClassInNamespace) {
   EXPECT_TRUE(TypeSystemClang::IsClassType(compiler_type.GetOpaqueQualType()));
 
   EXPECT_EQ(GetGlobalConstantInteger(session, "sizeof_NSClass"),
-            udt_type->GetByteSize(nullptr));
+            llvm::expectedToOptional(udt_type->GetByteSize(nullptr)));
 }
 
 TEST_F(SymbolFilePDBTests, TestEnumTypes) {
@@ -501,7 +501,7 @@ TEST_F(SymbolFilePDBTests, TestEnumTypes) {
     std::string sizeof_var = "sizeof_";
     sizeof_var.append(Enum);
     EXPECT_EQ(GetGlobalConstantInteger(session, sizeof_var),
-              enum_type->GetByteSize(nullptr));
+              llvm::expectedToOptional(enum_type->GetByteSize(nullptr)));
   }
 }
 
@@ -547,7 +547,7 @@ TEST_F(SymbolFilePDBTests, TestTypedefs) {
     std::string sizeof_var = "sizeof_";
     sizeof_var.append(Typedef);
     EXPECT_EQ(GetGlobalConstantInteger(session, sizeof_var),
-              typedef_type->GetByteSize(nullptr));
+              llvm::expectedToOptional(typedef_type->GetByteSize(nullptr)));
   }
 }
 


### PR DESCRIPTION
[[lldb] Upgrade CompilerType::GetBitSize to return llvm::Expected (](https://github.com/swiftlang/llvm-project/commit/b8091c180be2176a704a0c4b93059515b53996c7)https://github.com/llvm/llvm-project/pull/129601 
https://github.com/llvm/llvm-project/pull/129601)

This patch pushes the error handling boundary for the GetBitSize()
methods from Runtime into the Type and CompilerType APIs. This makes
it easier to diagnose problems thanks to more meaningful error
messages being available. GetBitSize() is often the first thing LLDB
asks about a type, so this method is particularly important for a
better user experience.

rdar://145667239
(cherry picked from commit https://github.com/swiftlang/llvm-project/commit/878a64f94a264ea4b564d6063614ddb0b5da3f6c)