### PR TITLE
[lldb][swift][nfc] Add new overload for AreFuncletsOfSameAsyncFunction

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -165,6 +165,11 @@ public:
   static FuncletComparisonResult
   AreFuncletsOfSameAsyncFunction(llvm::StringRef name1, llvm::StringRef name2);
 
+  /// See AreFuncletsOfSameAsyncFunction(StringRef, StringRef).
+  static FuncletComparisonResult
+  AreFuncletsOfSameAsyncFunction(swift::Demangle::NodePointer node1,
+                                 swift::Demangle::NodePointer node2);
+
   /// Return true if name is a Swift async function symbol.
   static bool IsSwiftAsyncFunctionSymbol(llvm::StringRef name);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -143,7 +143,12 @@ SwiftLanguageRuntime::AreFuncletsOfSameAsyncFunction(llvm::StringRef name1,
   Context ctx;
   NodePointer node1 = DemangleSymbolAsNode(name1, ctx);
   NodePointer node2 = DemangleSymbolAsNode(name2, ctx);
+  return AreFuncletsOfSameAsyncFunction(node1, node2);
+}
 
+SwiftLanguageRuntime::FuncletComparisonResult
+SwiftLanguageRuntime::AreFuncletsOfSameAsyncFunction(
+    swift::Demangle::NodePointer node1, swift::Demangle::NodePointer node2) {
   if (!IsAnySwiftAsyncFunctionSymbol(node1) ||
       !IsAnySwiftAsyncFunctionSymbol(node2))
     return FuncletComparisonResult::NotBothFunclets;

--- a/lldb/unittests/Symbol/TestSwiftDemangler.cpp
+++ b/lldb/unittests/Symbol/TestSwiftDemangler.cpp
@@ -10,10 +10,13 @@ static constexpr auto IsSwiftMangledName =
 static constexpr auto IsAnySwiftAsyncFunctionSymbol = [](StringRef name) {
   return SwiftLanguageRuntime::IsAnySwiftAsyncFunctionSymbol(name);
 };
+static constexpr auto AreFuncletsOfSameAsyncFunction = [](StringRef name1,
+                                                          StringRef name2) {
+  return SwiftLanguageRuntime::AreFuncletsOfSameAsyncFunction(name1, name2);
+};
+
 
 using FuncletComparisonResult = SwiftLanguageRuntime::FuncletComparisonResult;
-static constexpr auto AreFuncletsOfSameAsyncFunction =
-    SwiftLanguageRuntime::AreFuncletsOfSameAsyncFunction;
 
 /// Checks that all names in \c funclets belong to the same function.
 static void CheckGroupOfFuncletsFromSameFunction(ArrayRef<StringRef> funclets) {


### PR DESCRIPTION
This takes demangling Nodes instead of strings, to allow libraries to more efficiently re-use demangling nodes.