### PR TITLE
[lldb][swift] Add function to extract funclet numbers

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -181,6 +181,14 @@ public:
   /// function, or suspend resume partial function symbol.
   static bool IsAnySwiftAsyncFunctionSymbol(swift::Demangle::NodePointer node);
 
+  /// If node is a Swift async funclet, return its funclet number.
+  static std::optional<uint64_t>
+  GetFuncletNumber(swift::Demangle::NodePointer node);
+
+  /// If name is a Swift async funclet, return its funclet number.
+  static std::optional<uint64_t>
+  GetFuncletNumber(llvm::StringRef name);
+
   /// Return the async context address using the target's specific register.
   static lldb::addr_t GetAsyncContext(RegisterContext *regctx);
 


### PR DESCRIPTION
Async functions are broken into many pieces, and each piece is identified by an integer number in the mangling scheme. This establishes an ordering between funclets which we can exploit, in a subsequent commit, to filter out multiple breakpoints locations attributed to the same line.

An exception: entry funclets don't have such a number. This commit assigns 0 to them, to better reflect the intent of ordering funclets.