### PR TITLE
[Cherry-pick into next] [lldb] Adapt Swift plugin to new alias debug info

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -706,7 +706,7 @@ void LogUnimplementedTypeKind(const char *function, CompilerType type) {
   HEALTH_LOG("{0}: unimplemented type info in {1}", type.GetMangledTypeName(),
              function);
 #ifndef NDEBUG
-  llvm::dbgs() << function << ": unimplemented type info in"
+  llvm::dbgs() << function << ": unimplemented type info in "
                << type.GetMangledTypeName() << "\n";
   if (ModuleList::GetGlobalModuleListProperties().GetSwiftValidateTypeSystem())
     assert(false && "not implemented");

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -173,6 +173,12 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
       preferred_name = name;
       compiler_type = m_swift_typesystem.GetTypeFromMangledTypename(
           ConstString(typedef_name));
+    } else {
+      // Otherwise ignore the typedef name and resolve the pointee.
+      if (TypeSP desugared_type = get_type(die)) {
+        preferred_name = name;
+        compiler_type = desugared_type->GetForwardCompilerType();
+      }
     }
   }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2384,9 +2384,18 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
     return {};
   // DW_AT_linkage_name is not part of the accelerator table, so
   // we need to search by decl context.
+  auto options =
+      TypeQueryOptions::e_find_one | TypeQueryOptions::e_module_search;
 
-  TypeQuery query(*context, TypeQueryOptions::e_find_one |
-                                TypeQueryOptions::e_module_search);
+  // FIXME: It would be nice to not need this.
+  if (context->size() == 2 &&
+      context->front().kind == CompilerContextKind::Module &&
+      context->front().name == "Builtin") {
+    // LLVM cannot nest basic types inside a module.
+    context->erase(context->begin());
+    options = TypeQueryOptions::e_find_one;
+  }
+  TypeQuery query(*context, options);
   query.SetLanguages(TypeSystemSwift::GetSupportedLanguagesForTypes());
 
   TypeResults results;


### PR DESCRIPTION
```
commit b16b706d5ad0ae838cb34a1790d84c93acce5e33
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Mar 11 17:10:07 2025 -0700

    [lldb] Adapt Swift plugin to new alias debug info
```
