### PR TITLE
[lldb] Remove unnecessary StaticString_SummaryProvider override (NFC)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -505,16 +505,8 @@ bool lldb_private::formatters::swift::StringIndex_SummaryProvider(
 }
 
 bool lldb_private::formatters::swift::StaticString_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  return StaticString_SummaryProvider(
-      valobj, stream, options,
-      StringPrinter::ReadStringAndDumpToStreamOptions());
-}
-
-bool lldb_private::formatters::swift::StaticString_SummaryProvider(
     ValueObject &valobj, Stream &stream,
-    const TypeSummaryOptions &summary_options,
-    StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
+    const TypeSummaryOptions &summary_options) {
   LLDB_SCOPED_TIMER();
 
   static ConstString g__startPtrOrData("_startPtrOrData");
@@ -552,6 +544,7 @@ bool lldb_private::formatters::swift::StaticString_SummaryProvider(
     return true;
   }
 
+  StringPrinter::ReadStringAndDumpToStreamOptions read_options;
   read_options.SetTargetSP(valobj.GetTargetSP());
   read_options.SetLocation(start_ptr);
   read_options.SetSourceSize(size);

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -63,10 +63,6 @@ bool StringIndex_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool StaticString_SummaryProvider(ValueObject &valobj, Stream &stream,
                                   const TypeSummaryOptions &options);
 
-bool StaticString_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &,
-    StringPrinter::ReadStringAndDumpToStreamOptions);
-
 bool SwiftSharedString_SummaryProvider(ValueObject &valobj, Stream &stream,
                                        const TypeSummaryOptions &options);
 bool SwiftSharedString_SummaryProvider_2(

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -468,9 +468,6 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 lldb_private::formatters::swift::StringIndex_SummaryProvider,
                 "Swift String.Index summary provider",
                 ConstString("Swift.String.Index"), summary_flags);
-  bool (*staticstring_summary_provider)(ValueObject &, Stream &,
-                                        const TypeSummaryOptions &) =
-      lldb_private::formatters::swift::StaticString_SummaryProvider;
   {
     TypeSummaryImpl::Flags substring_summary_flags = summary_flags;
     substring_summary_flags.SetDontShowChildren(false);
@@ -479,7 +476,8 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                   "Swift.Substring summary provider",
                   ConstString("Swift.Substring"), substring_summary_flags);
   }
-  AddCXXSummary(swift_category_sp, staticstring_summary_provider,
+  AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::swift::StaticString_SummaryProvider,
                 "Swift.StaticString summary provider",
                 ConstString("Swift.StaticString"), summary_flags);
   AddCXXSummary(swift_category_sp,


### PR DESCRIPTION
These are not independently called, the call sequence always goes from one to the other.
Combine these two overloads into a single function.
