### PR TITLE
[llvm][cas] Introduce On-disk CAS Log

### DIFF
--- a/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
@@ -16,6 +16,10 @@
 
 namespace llvm::cas {
 
+namespace ondisk {
+class OnDiskCASLogger;
+}
+
 /// Allocator for an owned mapped file region that supports thread-safe and
 /// process-safe bump pointer allocation.
 ///
@@ -48,6 +52,7 @@ public:
   /// access to the file. Must call \c initializeBumpPtr.
   static Expected<MappedFileRegionBumpPtr>
   create(const Twine &Path, uint64_t Capacity, int64_t BumpPtrOffset,
+         std::shared_ptr<ondisk::OnDiskCASLogger> Logger,
          function_ref<Error(MappedFileRegionBumpPtr &)> NewFileConstructor);
 
   /// Finish initializing the bump pointer. Must be called by
@@ -99,6 +104,7 @@ private:
     std::swap(Path, RHS.Path);
     std::swap(FD, RHS.FD);
     std::swap(SharedLockFD, RHS.SharedLockFD);
+    std::swap(Logger, RHS.Logger);
   }
 
 private:
@@ -107,6 +113,7 @@ private:
   std::string Path;
   std::optional<int> FD;
   std::optional<int> SharedLockFD;
+  std::shared_ptr<ondisk::OnDiskCASLogger> Logger = nullptr;
 };
 
 } // namespace llvm::cas

--- a/llvm/include/llvm/CAS/OnDiskCASLogger.h
+++ b/llvm/include/llvm/CAS/OnDiskCASLogger.h
@@ -1,0 +1,78 @@
+//===- OnDiskCASLogger.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_ONDISKLOGGER_H
+#define LLVM_CAS_ONDISKLOGGER_H
+
+#include "llvm/Support/Error.h"
+#include <memory>
+
+namespace llvm {
+class raw_fd_ostream;
+class Twine;
+} // namespace llvm
+
+namespace llvm::cas::ondisk {
+
+/// Interface for logging low-level on-disk cas operations.
+///
+/// This log is intended to mirror the low-level details of the CAS in order to
+/// aid with debugging corruption or other issues with the on-disk format.
+class OnDiskCASLogger {
+public:
+  /// Create or append to a log file inside the given CAS directory \p Path.
+  ///
+  /// \param Path The parent directory of the log file.
+  /// \param LogAllocations Whether to log all low-level allocations. This is
+  ///                       on the order of twice as expensive to log.
+  static Expected<std::unique_ptr<OnDiskCASLogger>> open(const Twine &Path,
+                                                         bool LogAllocations);
+
+  /// Create or append to a log file inside the given CAS directory \p Path if
+  /// logging is enabled by the environment variable \c LLVM_CAS_LOG. If
+  /// LLVM_CAS_LOG is set >= 2 then also log allocations.
+  static Expected<std::unique_ptr<OnDiskCASLogger>>
+  openIfEnabled(const Twine &Path);
+
+  ~OnDiskCASLogger();
+
+  /// An offset into an \c OnDiskHashMappedTrie.
+  using TrieOffset = int64_t;
+
+  void log_compare_exchange_strong(void *Region, TrieOffset Trie, size_t SlotI,
+                                   TrieOffset Expected, TrieOffset New,
+                                   TrieOffset Previous);
+  void log_SubtrieHandle_create(void *Region, TrieOffset Trie,
+                                uint32_t StartBit, uint32_t NumBits);
+  void log_HashMappedTrieHandle_createRecord(void *Region,
+                                             TrieOffset TrieOffset,
+                                             ArrayRef<uint8_t> Hash);
+  void log_MappedFileRegionBumpPtr_resizeFile(StringRef Path, size_t Before,
+                                              size_t After);
+  void log_MappedFileRegionBumpPtr_create(StringRef Path, int FD, void *Region,
+                                          size_t Capacity, size_t Size);
+  void log_MappedFileRegionBumpPtr_oom(StringRef Path, size_t Capacity,
+                                       size_t Size, size_t AllocSize);
+  void log_MappedFileRegionBumpPtr_close(StringRef Path);
+  void log_MappedFileRegionBumpPtr_allocate(void *Region, TrieOffset Off,
+                                            size_t Size);
+  void log_UnifiedOnDiskCache_collectGarbage(StringRef Path);
+  void log_TempFile_create(StringRef Name);
+  void log_TempFile_keep(StringRef TmpName, StringRef Name, std::error_code EC);
+  void log_TempFile_remove(StringRef TmpName, std::error_code EC);
+
+private:
+  OnDiskCASLogger(raw_fd_ostream &OS, bool LogAllocations);
+
+  raw_fd_ostream &OS;
+  bool LogAllocations;
+};
+
+} // namespace llvm::cas::ondisk
+
+#endif // LLVM_CAS_ONDISKLOGGER_H

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -338,6 +338,7 @@ public:
   static Expected<std::unique_ptr<OnDiskGraphDB>>
   open(StringRef Path, StringRef HashName, unsigned HashByteSize,
        std::unique_ptr<OnDiskGraphDB> UpstreamDB = nullptr,
+       std::shared_ptr<OnDiskCASLogger> Logger = nullptr,
        FaultInPolicy Policy = FaultInPolicy::FullTree);
 
   ~OnDiskGraphDB();
@@ -411,8 +412,8 @@ private:
 
   OnDiskGraphDB(StringRef RootPath, OnDiskHashMappedTrie Index,
                 OnDiskDataAllocator DataPool,
-                std::unique_ptr<OnDiskGraphDB> UpstreamDB,
-                FaultInPolicy Policy);
+                std::unique_ptr<OnDiskGraphDB> UpstreamDB, FaultInPolicy Policy,
+                std::shared_ptr<OnDiskCASLogger> Logger);
 
   /// Mapping from hash to object reference.
   ///
@@ -431,6 +432,8 @@ private:
   /// Optional on-disk store to be used for faulting-in nodes.
   std::unique_ptr<OnDiskGraphDB> UpstreamDB;
   FaultInPolicy FIPolicy;
+
+  std::shared_ptr<OnDiskCASLogger> Logger;
 };
 
 } // namespace llvm::cas::ondisk

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -28,6 +28,10 @@ class raw_ostream;
 
 namespace cas {
 
+namespace ondisk {
+class OnDiskCASLogger;
+}
+
 class FileOffset {
 public:
   int64_t get() const { return Offset; }
@@ -253,6 +257,7 @@ public:
   create(const Twine &Path, const Twine &TrieName, size_t NumHashBits,
          uint64_t DataSize, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
+         std::shared_ptr<ondisk::OnDiskCASLogger> Logger = nullptr,
          std::optional<size_t> NewTableNumRootBits = std::nullopt,
          std::optional<size_t> NewTableNumSubtrieBits = std::nullopt);
 
@@ -328,6 +333,7 @@ public:
   create(const Twine &Path, const Twine &TableName, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
          uint32_t UserHeaderSize = 0,
+         std::shared_ptr<ondisk::OnDiskCASLogger> Logger = nullptr,
          function_ref<void(void *)> UserHeaderInit = nullptr);
 
   OnDiskDataAllocator(OnDiskDataAllocator &&RHS);

--- a/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
+++ b/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
@@ -57,7 +57,8 @@ public:
   /// \param ValueSize Size for the value bytes.
   static Expected<std::unique_ptr<OnDiskKeyValueDB>>
   open(StringRef Path, StringRef HashName, unsigned KeySize,
-       StringRef ValueName, size_t ValueSize);
+       StringRef ValueName, size_t ValueSize,
+       std::shared_ptr<OnDiskCASLogger> Logger = nullptr);
 
 private:
   OnDiskKeyValueDB(size_t ValueSize, OnDiskHashMappedTrie Cache)

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -117,7 +117,8 @@ public:
   ///
   /// It is recommended that garbage-collection is triggered concurrently in the
   /// background, so that it has minimal effect on the workload of the process.
-  static Error collectGarbage(StringRef Path);
+  static Error collectGarbage(StringRef Path,
+                              ondisk::OnDiskCASLogger *Logger = nullptr);
 
   Error collectGarbage();
 
@@ -145,6 +146,8 @@ private:
 
   std::unique_ptr<OnDiskKeyValueDB> UpstreamKVDB;
   std::unique_ptr<OnDiskKeyValueDB> PrimaryKVDB;
+
+  std::shared_ptr<ondisk::OnDiskCASLogger> Logger = nullptr;
 };
 
 } // namespace llvm::cas::ondisk

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -19,6 +19,7 @@ add_llvm_component_library(LLVMCAS
   MappedFileRegionBumpPtr.cpp
   ObjectStore.cpp
   OnDiskCAS.cpp
+  OnDiskCASLogger.cpp
   OnDiskCommon.cpp
   OnDiskGraphDB.cpp
   OnDiskHashMappedTrie.cpp

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -9,9 +9,11 @@
 #include "BuiltinCAS.h"
 #include "llvm/CAS/BuiltinCASContext.h"
 #include "llvm/CAS/BuiltinObjectHasher.h"
+#include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/CAS/OnDiskGraphDB.h"
 #include "llvm/CAS/UnifiedOnDiskCache.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/Path.h"
 
 using namespace llvm;
@@ -168,9 +170,15 @@ Expected<std::optional<uint64_t>> OnDiskCAS::getStorageSize() const {
 Error OnDiskCAS::pruneStorageData() { return UniDB->collectGarbage(); }
 
 Expected<std::unique_ptr<OnDiskCAS>> OnDiskCAS::open(StringRef AbsPath) {
+  std::shared_ptr<ondisk::OnDiskCASLogger> Logger;
+  if (Error E =
+          ondisk::OnDiskCASLogger::openIfEnabled(AbsPath).moveInto(Logger))
+    return std::move(E);
+
   Expected<std::unique_ptr<ondisk::OnDiskGraphDB>> DB =
       ondisk::OnDiskGraphDB::open(AbsPath, BuiltinCASContext::getHashName(),
-                                  sizeof(HashType));
+                                  sizeof(HashType), /*UpstreamDB=*/nullptr,
+                                  std::move(Logger));
   if (!DB)
     return DB.takeError();
   return std::unique_ptr<OnDiskCAS>(new OnDiskCAS(std::move(*DB)));

--- a/llvm/lib/CAS/OnDiskCASLogger.cpp
+++ b/llvm/lib/CAS/OnDiskCASLogger.cpp
@@ -1,0 +1,223 @@
+//===- OnDiskCASLogger.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/OnDiskCASLogger.h"
+
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Config/llvm-config.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+#if LLVM_ON_UNIX
+#include <sys/time.h>
+#include <unistd.h>
+#endif
+
+using namespace llvm;
+using namespace llvm::cas;
+using namespace llvm::cas::ondisk;
+
+// The version number in this log should be bumped if the log format is changed
+// in an incompatible way. It is currently a human-readable text file, so in
+// practice this would be if the log changed to binary or other machine-
+// readable format.
+static constexpr StringLiteral Filename = "/v1.log";
+
+OnDiskCASLogger::OnDiskCASLogger(raw_fd_ostream &OS, bool LogAllocations)
+    : OS(OS), LogAllocations(LogAllocations) {}
+
+OnDiskCASLogger::~OnDiskCASLogger() {
+  OS.flush();
+  delete &OS;
+}
+
+static bool isDisabledEnv(StringRef V) {
+  return StringSwitch<bool>(V)
+      .Case("0", true)
+      .CaseLower("no", true)
+      .CaseLower("false", true)
+      .Default(false);
+}
+
+Expected<std::unique_ptr<OnDiskCASLogger>>
+OnDiskCASLogger::openIfEnabled(const Twine &Path) {
+  const char *V = getenv("LLVM_CAS_LOG");
+  if (V && !isDisabledEnv(V)) {
+    int LogLevel = -1;
+    StringRef(V).getAsInteger(10, LogLevel);
+    return OnDiskCASLogger::open(Path, /*LogAllocations=*/LogLevel > 1 ? true
+                                                                       : false);
+  }
+  return nullptr;
+}
+Expected<std::unique_ptr<OnDiskCASLogger>>
+OnDiskCASLogger::open(const Twine &Path, bool LogAllocations) {
+  std::error_code EC;
+  SmallString<128> FullPath;
+  (Path + Filename).toVector(FullPath);
+
+  auto OS =
+      std::make_unique<raw_fd_ostream>(FullPath, EC, sys::fs::CD_OpenAlways,
+                                       sys::fs::FA_Write, sys::fs::OF_Append);
+  if (EC)
+    return createFileError(FullPath, EC);
+
+  // Buffer is not thread-safe.
+  OS->SetUnbuffered();
+
+  return std::unique_ptr<OnDiskCASLogger>(
+      new OnDiskCASLogger{*OS.release(), LogAllocations});
+}
+
+namespace {
+/// Helper to log a single line that adds the timestamp, pid, and tid. The line
+/// is buffered and written in a single call to write() so that if the
+/// underlying OS syscall is handled atomically so is this log message.
+class TextLogLine : public raw_svector_ostream {
+public:
+  TextLogLine(raw_ostream &LogOS) : raw_svector_ostream(Buffer), LogOS(LogOS) {
+    startLogMsg(*this);
+  }
+
+  ~TextLogLine() {
+    finishLogMsg(*this);
+    LogOS.write(Buffer.data(), Buffer.size());
+  }
+
+  static void startLogMsg(raw_ostream &OS) {
+#if LLVM_ON_UNIX
+    struct timeval T;
+    gettimeofday(&T, nullptr);
+    uint64_t Tid;
+    pthread_threadid_np(NULL, &Tid);
+    OS << format("%d.%0.6d", T.tv_sec, T.tv_usec);
+    OS << ' ' << getpid() << ' ' << Tid << ": ";
+#endif
+  }
+
+  static void finishLogMsg(raw_ostream &OS) { OS << '\n'; }
+
+private:
+  raw_ostream &LogOS;
+  SmallString<128> Buffer;
+};
+} // anonymous namespace
+
+static void formatTrieOffset(raw_ostream &OS, int64_t Off) {
+  if (Off < 0) {
+    OS << '-';
+    Off = -Off;
+  }
+  OS << format_hex(Off, 0);
+}
+
+void OnDiskCASLogger::log_compare_exchange_strong(void *Region, TrieOffset Trie,
+                                                  size_t SlotI,
+                                                  TrieOffset Expected,
+                                                  TrieOffset New,
+                                                  TrieOffset Previous) {
+  TextLogLine Log(OS);
+  Log << "cmpxcgh subtrie region=" << Region << " offset=";
+  formatTrieOffset(Log, Trie);
+  Log << " slot=" << SlotI << " expected=";
+  formatTrieOffset(Log, Expected);
+  Log << " new=";
+  formatTrieOffset(Log, New);
+  Log << " prev=";
+  formatTrieOffset(Log, Previous);
+}
+
+void OnDiskCASLogger::log_SubtrieHandle_create(void *Region, TrieOffset Trie,
+                                               uint32_t StartBit,
+                                               uint32_t NumBits) {
+  TextLogLine Log(OS);
+  Log << "create subtrie region=" << Region << " offset=";
+  formatTrieOffset(Log, Trie);
+  Log << " start-bit=" << StartBit << " num-bits=" << NumBits;
+}
+
+void OnDiskCASLogger::log_HashMappedTrieHandle_createRecord(
+    void *Region, TrieOffset Off, ArrayRef<uint8_t> Hash) {
+  TextLogLine Log(OS);
+  Log << "create record region=" << Region << " offset=";
+  formatTrieOffset(Log, Off);
+  Log << " hash=" << format_bytes(Hash, std::nullopt, 32, 32);
+}
+
+void OnDiskCASLogger::log_MappedFileRegionBumpPtr_resizeFile(StringRef Path,
+                                                             size_t Before,
+                                                             size_t After) {
+  TextLogLine Log(OS);
+  Log << "resize mapped file '" << Path << "' from=" << Before
+      << " to=" << After;
+}
+
+void OnDiskCASLogger::log_MappedFileRegionBumpPtr_create(StringRef Path, int FD,
+                                                         void *Region,
+                                                         size_t Capacity,
+                                                         size_t Size) {
+  sys::fs::file_status Stat;
+  std::error_code EC = status(FD, Stat);
+
+  TextLogLine Log(OS);
+  Log << "mmap '" << Path << "' " << Region;
+  Log << " dev=" << (EC ? ~0ull : Stat.getUniqueID().getDevice());
+  Log << " inode=" << (EC ? ~0ull : Stat.getUniqueID().getFile());
+  ;
+  Log << " size=" << Size << " capacity=" << Capacity;
+}
+
+void OnDiskCASLogger::log_MappedFileRegionBumpPtr_oom(StringRef Path,
+                                                      size_t Capacity,
+                                                      size_t Size,
+                                                      size_t AllocSize) {
+  TextLogLine Log(OS);
+  Log << "oom '" << Path << "' old-size=" << Size << " capacity=" << Capacity
+      << "alloc-size=" << AllocSize;
+}
+void OnDiskCASLogger::log_MappedFileRegionBumpPtr_close(StringRef Path) {
+  TextLogLine Log(OS);
+  Log << "close mmap '" << Path << "'";
+}
+void OnDiskCASLogger::log_MappedFileRegionBumpPtr_allocate(void *Region,
+                                                           TrieOffset Off,
+                                                           size_t Size) {
+  if (!LogAllocations)
+    return;
+  TextLogLine Log(OS);
+  Log << "alloc " << Region << " offset=";
+  formatTrieOffset(Log, Off);
+  Log << " size=" << Size;
+}
+
+void OnDiskCASLogger::log_UnifiedOnDiskCache_collectGarbage(StringRef Path) {
+  TextLogLine Log(OS);
+  Log << "collect garbage '" << Path << "'";
+}
+
+void OnDiskCASLogger::log_TempFile_create(StringRef Name) {
+  TextLogLine Log(OS);
+  Log << "standalone file create '" << Name << "'";
+}
+
+void OnDiskCASLogger::log_TempFile_keep(StringRef TmpName, StringRef Name,
+                                        std::error_code EC) {
+  TextLogLine Log(OS);
+  Log << "standalone file rename '" << TmpName << "' to '" << Name << "'";
+  if (EC)
+    Log << " error: " << EC.message();
+}
+
+void OnDiskCASLogger::log_TempFile_remove(StringRef TmpName,
+                                          std::error_code EC) {
+  TextLogLine Log(OS);
+  Log << "standalone file remove '" << TmpName << "'";
+  if (EC)
+    Log << " error: " << EC.message();
+}

--- a/llvm/lib/CAS/OnDiskCASLogger.cpp
+++ b/llvm/lib/CAS/OnDiskCASLogger.cpp
@@ -10,14 +10,11 @@
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Twine.h"
-#include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Process.h"
+#include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
-#if LLVM_ON_UNIX
-#include <sys/time.h>
-#include <unistd.h>
-#endif
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -75,6 +72,18 @@ OnDiskCASLogger::open(const Twine &Path, bool LogAllocations) {
       new OnDiskCASLogger{*OS.release(), LogAllocations});
 }
 
+static uint64_t getTimestampMillis() {
+  #if __apple__
+    // Using chrono is roughly 50% slower.
+    gettimeofday(&tv, 0);
+    return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+  #else
+    auto Time = std::chrono::system_clock::now();
+    auto Millis = std::chrono::duration_cast<std::chrono::milliseconds>(Time.time_since_epoch());
+    return Millis.count();
+  #endif
+}
+
 namespace {
 /// Helper to log a single line that adds the timestamp, pid, and tid. The line
 /// is buffered and written in a single call to write() so that if the
@@ -91,14 +100,9 @@ public:
   }
 
   static void startLogMsg(raw_ostream &OS) {
-#if LLVM_ON_UNIX
-    struct timeval T;
-    gettimeofday(&T, nullptr);
-    uint64_t Tid;
-    pthread_threadid_np(NULL, &Tid);
-    OS << format("%d.%0.6d", T.tv_sec, T.tv_usec);
-    OS << ' ' << getpid() << ' ' << Tid << ": ";
-#endif
+    auto Millis = getTimestampMillis();
+    OS << format("%lld.%0.6lld", Millis / 1000, Millis % 1000);
+    OS << ' ' << sys::Process::getProcessId() << ' ' << get_threadid() << ": ";
   }
 
   static void finishLogMsg(raw_ostream &OS) { OS << '\n'; }

--- a/llvm/lib/CAS/OnDiskCASLogger.cpp
+++ b/llvm/lib/CAS/OnDiskCASLogger.cpp
@@ -12,6 +12,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
@@ -24,7 +25,7 @@ using namespace llvm::cas::ondisk;
 // in an incompatible way. It is currently a human-readable text file, so in
 // practice this would be if the log changed to binary or other machine-
 // readable format.
-static constexpr StringLiteral Filename = "/v1.log";
+static constexpr StringLiteral Filename = "v1.log";
 
 OnDiskCASLogger::OnDiskCASLogger(raw_fd_ostream &OS, bool LogAllocations)
     : OS(OS), LogAllocations(LogAllocations) {}
@@ -57,7 +58,8 @@ Expected<std::unique_ptr<OnDiskCASLogger>>
 OnDiskCASLogger::open(const Twine &Path, bool LogAllocations) {
   std::error_code EC;
   SmallString<128> FullPath;
-  (Path + Filename).toVector(FullPath);
+  Path.toVector(FullPath);
+  sys::path::append(FullPath, Filename);
 
   auto OS =
       std::make_unique<raw_fd_ostream>(FullPath, EC, sys::fs::CD_OpenAlways,

--- a/llvm/lib/CAS/OnDiskCASLogger.cpp
+++ b/llvm/lib/CAS/OnDiskCASLogger.cpp
@@ -107,7 +107,7 @@ public:
 
   static void startLogMsg(raw_ostream &OS) {
     auto Millis = getTimestampMillis();
-    OS << format("%lld.%0.6lld", Millis / 1000, Millis % 1000);
+    OS << format("%lld.%0.3lld", Millis / 1000, Millis % 1000);
     OS << ' ' << sys::Process::getProcessId() << ' ' << get_threadid() << ": ";
   }
 

--- a/llvm/lib/CAS/OnDiskCASLogger.cpp
+++ b/llvm/lib/CAS/OnDiskCASLogger.cpp
@@ -16,6 +16,9 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/raw_ostream.h"
+#ifdef __APPLE__
+#include <sys/time.h>
+#endif
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -75,10 +78,11 @@ OnDiskCASLogger::open(const Twine &Path, bool LogAllocations) {
 }
 
 static uint64_t getTimestampMillis() {
-  #if __apple__
+  #ifdef __APPLE__
     // Using chrono is roughly 50% slower.
-    gettimeofday(&tv, 0);
-    return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+    struct timeval T;
+    gettimeofday(&T, 0);
+    return T.tv_sec * 1000 + T.tv_usec / 1000;
   #else
     auto Time = std::chrono::system_clock::now();
     auto Millis = std::chrono::duration_cast<std::chrono::milliseconds>(Time.time_since_epoch());

--- a/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
+++ b/llvm/lib/CAS/OnDiskHashMappedTrie.cpp
@@ -12,6 +12,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/MappedFileRegionBumpPtr.h"
+#include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
@@ -25,6 +26,7 @@
 
 using namespace llvm;
 using namespace llvm::cas;
+using ondisk::OnDiskCASLogger;
 
 #if LLVM_ENABLE_ONDISK_CAS
 
@@ -138,6 +140,7 @@ public:
 
   static Expected<DatabaseFile>
   create(const Twine &Path, uint64_t Capacity,
+         std::shared_ptr<OnDiskCASLogger> Logger,
          function_ref<Error(DatabaseFile &)> NewDBConstructor);
 
   size_t size() const { return Alloc.size(); }
@@ -174,6 +177,7 @@ static Error createTableConfigError(std::errc ErrC, StringRef Path,
 
 Expected<DatabaseFile>
 DatabaseFile::create(const Twine &Path, uint64_t Capacity,
+                     std::shared_ptr<OnDiskCASLogger> Logger,
                      function_ref<Error(DatabaseFile &)> NewDBConstructor) {
   // Constructor for if the file doesn't exist.
   auto NewFileConstructor = [&](MappedFileRegionBumpPtr &Alloc) -> Error {
@@ -189,9 +193,9 @@ DatabaseFile::create(const Twine &Path, uint64_t Capacity,
 
   // Get or create the file.
   MappedFileRegionBumpPtr Alloc;
-  if (Error E = MappedFileRegionBumpPtr::create(Path, Capacity,
-                                                offsetof(Header, BumpPtr),
-                                                NewFileConstructor)
+  if (Error E = MappedFileRegionBumpPtr::create(
+                    Path, Capacity, offsetof(Header, BumpPtr),
+                    std::move(Logger), NewFileConstructor)
                     .moveInto(Alloc))
     return std::move(E);
 
@@ -374,7 +378,13 @@ public:
   /// Return None on success, or the existing offset on failure.
   bool compare_exchange_strong(size_t I, SubtrieSlotValue &Expected,
                                SubtrieSlotValue New) {
-    return Slots[I].compare_exchange_strong(Expected.Offset, New.Offset);
+    SubtrieSlotValue SaveExpected(Expected);
+    bool Result = Slots[I].compare_exchange_strong(Expected.Offset, New.Offset);
+    if (Logger)
+      Logger->log_compare_exchange_strong(Region->data(), getOffset().Offset, I,
+                                          SaveExpected.Offset, New.Offset,
+                                          Expected.Offset);
+    return Result;
   }
 
   /// Sink \p V from \p I in this subtrie down to \p NewI in a new subtrie with
@@ -409,24 +419,31 @@ public:
   uint32_t getNumBits() const { return H->NumBits; }
 
   static Expected<SubtrieHandle> create(MappedFileRegionBumpPtr &Alloc,
-                                        uint32_t StartBit, uint32_t NumBits);
+                                        uint32_t StartBit, uint32_t NumBits,
+                                        OnDiskCASLogger *Logger);
 
   static SubtrieHandle getFromFileOffset(MappedFileRegion &Region,
-                                         FileOffset Offset) {
-    return SubtrieHandle(Region, SubtrieSlotValue::getSubtrieOffset(Offset));
+                                         FileOffset Offset,
+                                         OnDiskCASLogger *Logger) {
+    return SubtrieHandle(Region, SubtrieSlotValue::getSubtrieOffset(Offset),
+                         Logger);
   }
 
   SubtrieHandle() = default;
-  SubtrieHandle(MappedFileRegion &Region, Header &H)
-      : Region(&Region), H(&H), Slots(getSlots(H)) {}
-  SubtrieHandle(MappedFileRegion &Region, SubtrieSlotValue Offset)
-      : SubtrieHandle(Region, *reinterpret_cast<Header *>(
-                                  Region.data() + Offset.asSubtrie())) {}
+  SubtrieHandle(MappedFileRegion &Region, Header &H, OnDiskCASLogger *Logger)
+      : Region(&Region), H(&H), Slots(getSlots(H)), Logger(Logger) {}
+  SubtrieHandle(MappedFileRegion &Region, SubtrieSlotValue Offset,
+                OnDiskCASLogger *Logger)
+      : SubtrieHandle(
+            Region,
+            *reinterpret_cast<Header *>(Region.data() + Offset.asSubtrie()),
+            Logger) {}
 
 private:
   MappedFileRegion *Region = nullptr;
   Header *H = nullptr;
   MutableArrayRef<SlotT> Slots;
+  OnDiskCASLogger *Logger = nullptr;
 
   static MutableArrayRef<SlotT> getSlots(Header &H) {
     return MutableArrayRef(reinterpret_cast<SlotT *>(&H + 1), 1u << H.NumBits);
@@ -527,7 +544,8 @@ public:
   static Expected<HashMappedTrieHandle>
   create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
          std::optional<uint64_t> NumRootBits, uint64_t NumSubtrieBits,
-         uint64_t NumHashBits, uint64_t RecordDataSize);
+         uint64_t NumHashBits, uint64_t RecordDataSize,
+         std::shared_ptr<OnDiskCASLogger> Logger);
 
   void
   print(raw_ostream &OS,
@@ -538,16 +556,24 @@ public:
           RecordVerifier) const;
 
   HashMappedTrieHandle() = default;
-  HashMappedTrieHandle(MappedFileRegion &Region, Header &H)
-      : Region(&Region), H(&H) {}
-  HashMappedTrieHandle(MappedFileRegion &Region, intptr_t HeaderOffset)
+  HashMappedTrieHandle(MappedFileRegion &Region, Header &H,
+                       std::shared_ptr<OnDiskCASLogger> Logger = nullptr)
+      : Region(&Region), H(&H), Logger(std::move(Logger)) {}
+  HashMappedTrieHandle(MappedFileRegion &Region, intptr_t HeaderOffset,
+                       std::shared_ptr<OnDiskCASLogger> Logger = nullptr)
       : HashMappedTrieHandle(
-            Region, *reinterpret_cast<Header *>(Region.data() + HeaderOffset)) {
+            Region, *reinterpret_cast<Header *>(Region.data() + HeaderOffset),
+            std::move(Logger)) {}
+
+  OnDiskCASLogger *getLogger() const { return Logger.get(); }
+  void setLogger(std::shared_ptr<OnDiskCASLogger> Logger) {
+    this->Logger = std::move(Logger);
   }
 
 private:
   MappedFileRegion *Region = nullptr;
   Header *H = nullptr;
+  std::shared_ptr<OnDiskCASLogger> Logger;
 };
 
 } // end anonymous namespace
@@ -559,7 +585,8 @@ struct OnDiskHashMappedTrie::ImplType {
 
 Expected<SubtrieHandle> SubtrieHandle::create(MappedFileRegionBumpPtr &Alloc,
                                               uint32_t StartBit,
-                                              uint32_t NumBits) {
+                                              uint32_t NumBits,
+                                              OnDiskCASLogger *Logger) {
   assert(StartBit <= HashMappedTrieHandle::MaxNumHashBits);
   assert(NumBits <= UINT8_MAX);
   assert(NumBits <= HashMappedTrieHandle::MaxNumRootBits);
@@ -570,15 +597,20 @@ Expected<SubtrieHandle> SubtrieHandle::create(MappedFileRegionBumpPtr &Alloc,
   auto *H =
       new (*Mem) SubtrieHandle::Header{(uint16_t)StartBit, (uint8_t)NumBits,
                                        /*ZeroPad1B=*/0, /*ZeroPad4B=*/0};
-  SubtrieHandle S(Alloc.getRegion(), *H);
+  SubtrieHandle S(Alloc.getRegion(), *H, Logger);
   for (auto I = S.Slots.begin(), E = S.Slots.end(); I != E; ++I)
     new (I) SlotT(0);
+
+  if (Logger)
+    Logger->log_SubtrieHandle_create(Alloc.data(), S.getOffset().Offset,
+                                     StartBit, NumBits);
   return S;
 }
 
 SubtrieHandle HashMappedTrieHandle::getRoot() const {
   if (int64_t Root = H->RootTrieOffset)
-    return SubtrieHandle(getRegion(), SubtrieSlotValue::getSubtrieOffset(Root));
+    return SubtrieHandle(getRegion(), SubtrieSlotValue::getSubtrieOffset(Root),
+                         Logger.get());
   return SubtrieHandle();
 }
 
@@ -589,25 +621,29 @@ HashMappedTrieHandle::getOrCreateRoot(MappedFileRegionBumpPtr &Alloc) {
     return Root;
 
   int64_t Race = 0;
-  auto LazyRoot = SubtrieHandle::create(Alloc, 0, H->NumSubtrieBits);
+  auto LazyRoot =
+      SubtrieHandle::create(Alloc, 0, H->NumSubtrieBits, Logger.get());
   if (LLVM_UNLIKELY(!LazyRoot))
     return LazyRoot.takeError();
 
   if (H->RootTrieOffset.compare_exchange_strong(
-          Race, LazyRoot->getOffset().asSubtrie()))
+          Race, LazyRoot->getOffset().asSubtrie()),
+      Logger.get())
     return *LazyRoot;
 
   // There was a race. Return the other root.
   //
   // TODO: Avoid leaking the lazy root by storing it in an allocator.
-  return SubtrieHandle(getRegion(), SubtrieSlotValue::getSubtrieOffset(Race));
+  return SubtrieHandle(getRegion(), SubtrieSlotValue::getSubtrieOffset(Race),
+                       Logger.get());
 }
 
 Expected<HashMappedTrieHandle>
 HashMappedTrieHandle::create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
                              std::optional<uint64_t> NumRootBits,
                              uint64_t NumSubtrieBits, uint64_t NumHashBits,
-                             uint64_t RecordDataSize) {
+                             uint64_t RecordDataSize,
+                             std::shared_ptr<OnDiskCASLogger> Logger) {
   // Allocate.
   auto Offset = Alloc.allocateOffset(sizeof(Header) + Name.size() + 1);
   if (LLVM_UNLIKELY(!Offset))
@@ -632,8 +668,8 @@ HashMappedTrieHandle::create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
   NameStorage[Name.size()] = 0;
 
   // Construct a root trie, if requested.
-  HashMappedTrieHandle Trie(Alloc.getRegion(), *H);
-  auto Sub = SubtrieHandle::create(Alloc, 0, *NumRootBits);
+  HashMappedTrieHandle Trie(Alloc.getRegion(), *H, Logger);
+  auto Sub = SubtrieHandle::create(Alloc, 0, *NumRootBits, Logger.get());
   if (LLVM_UNLIKELY(!Sub))
     return Sub.takeError();
   if (NumRootBits)
@@ -662,6 +698,11 @@ HashMappedTrieHandle::createRecord(MappedFileRegionBumpPtr &Alloc,
 
   RecordData Record = getRecord(SubtrieSlotValue::getDataOffset(*Offset));
   llvm::copy(Hash, const_cast<uint8_t *>(Record.Proxy.Hash.begin()));
+
+  if (Logger)
+    Logger->log_HashMappedTrieHandle_createRecord(
+        Alloc.data(), Record.Offset.getRawOffset(), Hash);
+
   return Record;
 }
 
@@ -731,7 +772,7 @@ OnDiskHashMappedTrie::find(ArrayRef<uint8_t> Hash) const {
     }
 
     Index = IndexGen.next();
-    S = SubtrieHandle(Trie.getRegion(), V);
+    S = SubtrieHandle(Trie.getRegion(), V, Trie.getLogger());
   }
 }
 
@@ -795,7 +836,7 @@ OnDiskHashMappedTrie::insertLazy(ArrayRef<uint8_t> Hash,
     }
 
     if (Existing.isSubtrie()) {
-      S = SubtrieHandle(Trie.getRegion(), Existing);
+      S = SubtrieHandle(Trie.getRegion(), Existing, Trie.getLogger());
       Index = IndexGen.next();
       continue;
     }
@@ -844,7 +885,7 @@ Expected<SubtrieHandle> SubtrieHandle::sink(size_t I, SubtrieSlotValue V,
   } else {
     // Allocate a new, empty subtrie.
     auto Err = SubtrieHandle::create(Alloc, getStartBit() + getNumBits(),
-                                     NumSubtrieBits)
+                                     NumSubtrieBits, Logger)
                    .moveInto(NewS);
     if (LLVM_UNLIKELY(Err))
       return std::move(Err);
@@ -862,7 +903,7 @@ Expected<SubtrieHandle> SubtrieHandle::sink(size_t I, SubtrieSlotValue V,
   UnusedSubtrie = *NewS;
 
   // Return the subtrie added by the concurrent sink() call.
-  return SubtrieHandle(Alloc.getRegion(), V);
+  return SubtrieHandle(Alloc.getRegion(), V, Logger);
 }
 
 void OnDiskHashMappedTrie::print(
@@ -983,6 +1024,7 @@ OnDiskHashMappedTrie::create(const Twine &PathTwine, const Twine &TrieNameTwine,
                              size_t NumHashBits, uint64_t DataSize,
                              uint64_t MaxFileSize,
                              std::optional<uint64_t> NewFileInitialSize,
+                             std::shared_ptr<OnDiskCASLogger> Logger,
                              std::optional<size_t> NewTableNumRootBits,
                              std::optional<size_t> NewTableNumSubtrieBits) {
   SmallString<128> PathStorage;
@@ -1023,9 +1065,9 @@ OnDiskHashMappedTrie::create(const Twine &PathTwine, const Twine &TrieNameTwine,
 
   // Constructor for if the file doesn't exist.
   auto NewDBConstructor = [&](DatabaseFile &DB) -> Error {
-    auto Trie =
-        HashMappedTrieHandle::create(DB.getAlloc(), TrieName, NumRootBits,
-                                     NumSubtrieBits, NumHashBits, DataSize);
+    auto Trie = HashMappedTrieHandle::create(DB.getAlloc(), TrieName,
+                                             NumRootBits, NumSubtrieBits,
+                                             NumHashBits, DataSize, Logger);
     if (LLVM_UNLIKELY(!Trie))
       return Trie.takeError();
 
@@ -1035,7 +1077,7 @@ OnDiskHashMappedTrie::create(const Twine &PathTwine, const Twine &TrieNameTwine,
 
   // Get or create the file.
   Expected<DatabaseFile> File =
-      DatabaseFile::create(Path, MaxFileSize, NewDBConstructor);
+      DatabaseFile::create(Path, MaxFileSize, Logger, NewDBConstructor);
   if (!File)
     return File.takeError();
 
@@ -1050,6 +1092,7 @@ OnDiskHashMappedTrie::create(const Twine &PathTwine, const Twine &TrieNameTwine,
                            (size_t)Table->getHeader().Kind, Path, TrieName))
     return std::move(E);
   auto Trie = Table->cast<HashMappedTrieHandle>();
+  Trie.setLogger(Logger);
   assert(Trie && "Already checked the kind");
 
   // Check the hash and data size.
@@ -1275,7 +1318,7 @@ Error TrieVisitor::visit() {
     std::string SubtriePrefix;
     appendIndexBits(SubtriePrefix, I, NumSlots);
     if (Slot.isSubtrie()) {
-      SubtrieHandle S(Trie.getRegion(), Slot);
+      SubtrieHandle S(Trie.getRegion(), Slot, Trie.getLogger());
       Subs.push_back(S);
       Prefixes.push_back(SubtriePrefix);
     }
@@ -1346,7 +1389,7 @@ Error TrieVisitor::traverseTrieNode(SubtrieHandle Node, StringRef Prefix) {
     std::string SubtriePrefix = Prefix.str();
     appendIndexBits(SubtriePrefix, I, NumSlots);
     if (Slot.isSubtrie()) {
-      SubtrieHandle S(Trie.getRegion(), Slot);
+      SubtrieHandle S(Trie.getRegion(), Slot, Trie.getLogger());
       Subs.push_back(S);
       Prefixes.push_back(SubtriePrefix);
     }
@@ -1489,6 +1532,7 @@ DataAllocatorHandle::create(MappedFileRegionBumpPtr &Alloc, StringRef Name,
 Expected<OnDiskDataAllocator> OnDiskDataAllocator::create(
     const Twine &PathTwine, const Twine &TableNameTwine, uint64_t MaxFileSize,
     std::optional<uint64_t> NewFileInitialSize, uint32_t UserHeaderSize,
+    std::shared_ptr<ondisk::OnDiskCASLogger> Logger,
     function_ref<void(void *)> UserHeaderInit) {
   assert(!UserHeaderSize || UserHeaderInit);
   SmallString<128> PathStorage;
@@ -1511,7 +1555,7 @@ Expected<OnDiskDataAllocator> OnDiskDataAllocator::create(
 
   // Get or create the file.
   Expected<DatabaseFile> File =
-      DatabaseFile::create(Path, MaxFileSize, NewDBConstructor);
+      DatabaseFile::create(Path, MaxFileSize, Logger, NewDBConstructor);
   if (!File)
     return File.takeError();
 

--- a/llvm/lib/CAS/OnDiskKeyValueDB.cpp
+++ b/llvm/lib/CAS/OnDiskKeyValueDB.cpp
@@ -51,7 +51,8 @@ OnDiskKeyValueDB::get(ArrayRef<uint8_t> Key) {
 
 Expected<std::unique_ptr<OnDiskKeyValueDB>>
 OnDiskKeyValueDB::open(StringRef Path, StringRef HashName, unsigned KeySize,
-                       StringRef ValueName, size_t ValueSize) {
+                       StringRef ValueName, size_t ValueSize,
+                       std::shared_ptr<OnDiskCASLogger> Logger) {
   if (std::error_code EC = sys::fs::create_directories(Path))
     return createFileError(Path, EC);
 
@@ -72,7 +73,8 @@ OnDiskKeyValueDB::open(StringRef Path, StringRef HashName, unsigned KeySize,
                     CachePath,
                     "llvm.actioncache[" + HashName + "->" + ValueName + "]",
                     KeySize * 8,
-                    /*DataSize=*/ValueSize, MaxFileSize, /*MinFileSize=*/MB)
+                    /*DataSize=*/ValueSize, MaxFileSize, /*MinFileSize=*/MB,
+                    std::move(Logger))
                     .moveInto(ActionCache))
     return std::move(E);
 

--- a/llvm/test/CAS/logging.test
+++ b/llvm/test/CAS/logging.test
@@ -1,0 +1,27 @@
+RUN: rm -rf %t
+RUN: split-file %s %t
+RUN: env LLVM_CAS_LOG=2 llvm-cas --cas %t/cas --ingest %t/input
+RUN: FileCheck %s --input-file %t/cas/v1.log
+
+// CHECK: resize mapped file '{{.*}}v8.index'
+// CHECK: mmap '{{.*}}v8.index' [[INDEX:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}v8.data'
+// CHECK: mmap '{{.*}}v8.data' [[DATA:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}v3.actions'
+// CHECK: mmap '{{.*}}v3.actions' [[ACTIONS:0x[0-9a-f]+]]
+
+// store input/a contents into the datapool
+// CHECK: create record region=[[INDEX]] offset=[[INPUT_A_OFF:0x[0-9a-f]+]] hash=9b096cd140f119
+// CHECK: cmpxcgh subtrie region=[[INDEX]] offset={{.*}} slot={{.*}} expected=0x0 new=[[INPUT_A_OFF]] prev=0x0
+// CHECK: alloc [[DATA]]
+
+// CHECK: resize mapped file '{{.*}}v3.actions'
+// CHECK: close mmap '{{.*}}v3.actions'
+// CHECK: resize mapped file '{{.*}}v8.data'
+// CHECK: close mmap '{{.*}}v8.data'
+// CHECK: resize mapped file '{{.*}}v8.index'
+// CHECK: close mmap '{{.*}}v8.index'
+
+//--- input/a
+Input 1
+

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -27,6 +27,7 @@ add_llvm_unittest(CASTests
   HierarchicalTreeBuilderTest.cpp
   MockGRPCServer.cpp
   ObjectStoreTest.cpp
+  OnDiskCASLoggerTest.cpp
   OnDiskGraphDBTest.cpp
   OnDiskHashMappedTrieTest.cpp
   OnDiskKeyValueDBTest.cpp

--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -159,7 +159,7 @@ TEST(OnDiskCASLoggerTest, MultiProcess) {
   SmallVector<ProcessInfo> PIs;
   for (int I = 0; I < 10; ++I) {
     bool ExecutionFailed;
-    auto PI = ExecuteNoWait(Executable, Argv, {}, {}, 0, &Error,
+    auto PI = ExecuteNoWait(Executable, Argv, ArrayRef<StringRef>{}, {}, 0, &Error,
                             &ExecutionFailed);
     ASSERT_FALSE(ExecutionFailed) << Error;
     PIs.push_back(std::move(PI));

--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -159,7 +159,7 @@ TEST(OnDiskCASLoggerTest, MultiProcess) {
   SmallVector<ProcessInfo> PIs;
   for (int I = 0; I < 10; ++I) {
     bool ExecutionFailed;
-    auto PI = ExecuteNoWait(Executable, Argv, std::nullopt, {}, 0, &Error,
+    auto PI = ExecuteNoWait(Executable, Argv, {}, {}, 0, &Error,
                             &ExecutionFailed);
     ASSERT_FALSE(ExecutionFailed) << Error;
     PIs.push_back(std::move(PI));

--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -1,0 +1,176 @@
+//===- llvm/unittest/CAS/OnDiskCASLoggerTest.cpp --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/OnDiskCASLogger.h"
+#include "llvm/CAS/OnDiskHashMappedTrie.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/LineIterator.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/ThreadPool.h"
+#include "llvm/Support/Threading.h"
+#include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+using namespace llvm::cas::ondisk;
+using namespace llvm::sys;
+
+static void writeToLog(OnDiskCASLogger *Logger, int NumOpens, int NumEntries) {
+  StringRef Path = "/fake_cas/index";
+  uint8_t Hash[32] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                      11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+                      22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+  void *Region = &Logger;
+
+  for (int J = 0; J < NumOpens; ++J) {
+    Logger->log_MappedFileRegionBumpPtr_create(Path, 0, Region, 100, 7);
+    Logger->log_MappedFileRegionBumpPtr_resizeFile(Path, 7, 100);
+    Logger->log_MappedFileRegionBumpPtr_allocate(Region, 0, 50);
+    Logger->log_MappedFileRegionBumpPtr_oom(Path, 100, 51, 50);
+    for (int K = 0; K < NumEntries; ++K) {
+      Logger->log_MappedFileRegionBumpPtr_allocate(Region, K, 10);
+      Logger->log_HashMappedTrieHandle_createRecord(Region, K, Hash);
+      Logger->log_MappedFileRegionBumpPtr_allocate(Region, K, 20);
+      Logger->log_SubtrieHandle_create(Region, K, 1, 2);
+      Logger->log_compare_exchange_strong(Region, K, J, -3, -1, -2);
+    }
+    Logger->log_TempFile_create(Path);
+    Logger->log_TempFile_keep(Path, Path, std::error_code());
+    Logger->log_TempFile_remove(Path, std::error_code());
+    Logger->log_MappedFileRegionBumpPtr_close(Path);
+    Logger->log_UnifiedOnDiskCache_collectGarbage(Path);
+  }
+}
+
+static Error checkLog(StringRef Dir) {
+  // Read back the log and check formatting.
+  auto LogBuf = llvm::MemoryBuffer::getFile(Twine(Dir) + "/v1.log");
+  if (std::error_code EC = LogBuf.getError())
+    return createStringError(EC, "failed to read log");
+
+  if ((*LogBuf)->getBuffer().empty())
+    return createStringError("empty log file");
+
+  for (line_iterator I(**LogBuf, /*SkipBlanks=*/false, '\0'); !I.is_at_eof();
+       ++I) {
+    auto MakeErr = [&](StringRef Reason) -> Error {
+      return createStringError(Twine("invalid log at line ") +
+                               std::to_string(I.line_number()) + ":\n" + *I);
+    };
+    StringRef Line = *I;
+    StringRef TimeS, TimeMS, Pid, Tid;
+    int Num;
+    std::tie(TimeS, Line) = Line.split('.');
+    if (TimeS.empty())
+      return MakeErr("missing '.' for time");
+    if (TimeS.getAsInteger(10, Num))
+      return MakeErr("invalid time s");
+    std::tie(TimeMS, Line) = Line.split(' ');
+    if (TimeMS.empty())
+      return MakeErr("missing ' ' after time ms");
+    if (TimeMS.getAsInteger(10, Num))
+      return MakeErr("invalid time ms");
+    std::tie(Pid, Line) = Line.split(' ');
+    if (Pid.empty())
+      return MakeErr("missing ' ' after pid");
+    if (Pid.getAsInteger(10, Num))
+      return MakeErr("invalid pid");
+    std::tie(Tid, Line) = Line.split(':');
+    if (Tid.empty())
+      return MakeErr("missing ':' after tid");
+    if (Tid.getAsInteger(10, Num))
+      return MakeErr("invalid tid");
+    if (Line.empty())
+      return MakeErr("nothing after ':'");
+  }
+
+  return Error::success();
+}
+
+TEST(OnDiskCASLoggerTest, MultiThread) {
+  unittest::TempDir Dir("OnDiskCASLoggerTest_MultiThread", /*Unique=*/true);
+  llvm::DefaultThreadPool Pool(llvm::hardware_concurrency());
+
+  std::unique_ptr<OnDiskCASLogger> SharedLogger;
+  ASSERT_THAT_ERROR(OnDiskCASLogger::open(Dir.path(), /*LogAllocations=*/true)
+                        .moveInto(SharedLogger),
+                    Succeeded());
+
+  for (int I = 0; I < 10; ++I) {
+    Pool.async([&] {
+      std::unique_ptr<OnDiskCASLogger> OwnedLogger;
+      OnDiskCASLogger *Logger;
+      // Mix using a shared instance and opening new instances in the same log.
+      if (I % 2 == 0) {
+        Logger = SharedLogger.get();
+      } else {
+        ASSERT_THAT_ERROR(
+            OnDiskCASLogger::open(Dir.path(), /*LogAllocations=*/true)
+                .moveInto(OwnedLogger),
+            Succeeded());
+        Logger = OwnedLogger.get();
+      }
+
+      writeToLog(Logger, /*NumOpens=*/10, /*NumEntries=*/100);
+    });
+  }
+  Pool.wait();
+
+  ASSERT_THAT_ERROR(checkLog(Dir.path()), Succeeded());
+}
+
+static cl::opt<std::string> CASLogDir("cas-log-dir");
+// From TestMain.cpp.
+extern const char *TestMainArgv0;
+
+TEST(OnDiskCASLoggerTest, MultiProcess) {
+  if (!CASLogDir.empty()) {
+    // Child process.
+    std::unique_ptr<OnDiskCASLogger> Logger;
+    ASSERT_THAT_ERROR(OnDiskCASLogger::open(CASLogDir, /*LogAllocations=*/true)
+                          .moveInto(Logger),
+                      Succeeded());
+
+    for (int I = 0; I < 10; ++I) {
+      writeToLog(Logger.get(), /*NumOpens=*/10, /*NumEntries=*/100);
+    }
+    exit(0);
+  }
+
+  // Parent process.
+  unittest::TempDir Dir("OnDiskCASLoggerTest_MultiProcess", /*Unique=*/true);
+
+  std::string Executable =
+      sys::fs::getMainExecutable(TestMainArgv0, &CASLogDir);
+  StringRef Argv[] = {Executable,
+                      "--gtest_filter=OnDiskCASLoggerTest.MultiProcess",
+                      "-cas-log-dir", Dir.path()};
+
+  std::string Error;
+  SmallVector<ProcessInfo> PIs;
+  for (int I = 0; I < 10; ++I) {
+    bool ExecutionFailed;
+    auto PI = ExecuteNoWait(Executable, Argv, std::nullopt, {}, 0, &Error,
+                            &ExecutionFailed);
+    ASSERT_FALSE(ExecutionFailed) << Error;
+    PIs.push_back(std::move(PI));
+  }
+
+  for (auto &PI : PIs) {
+    auto Result = Wait(PI, /*Timeout=*/5, &Error);
+    ASSERT_TRUE(Error.empty()) << Error;
+    ASSERT_EQ(Result.Pid, PI.Pid);
+    ASSERT_EQ(Result.ReturnCode, 0);
+  }
+
+  ASSERT_THAT_ERROR(checkLog(Dir.path()), Succeeded());
+}

--- a/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
@@ -104,7 +104,7 @@ TEST(OnDiskGraphDBTest, FaultInSingleNode) {
   std::unique_ptr<OnDiskGraphDB> DB;
   ASSERT_THAT_ERROR(
       OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
-                          std::move(UpstreamDB),
+                          std::move(UpstreamDB), /*Logger=*/nullptr,
                           OnDiskGraphDB::FaultInPolicy::SingleNode)
           .moveInto(DB),
       Succeeded());
@@ -151,7 +151,7 @@ TEST(OnDiskGraphDBTest, FaultInSingleNode) {
   // the upstream.
   ASSERT_THAT_ERROR(
       OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
-                          /*UpstreamDB=*/nullptr,
+                          /*UpstreamDB=*/nullptr, /*Logger=*/nullptr,
                           OnDiskGraphDB::FaultInPolicy::SingleNode)
           .moveInto(DB),
       Succeeded());
@@ -211,6 +211,7 @@ TEST(OnDiskGraphDBTest, FaultInFullTree) {
   std::unique_ptr<OnDiskGraphDB> DB;
   ASSERT_THAT_ERROR(OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
                                         std::move(UpstreamDB),
+                                        /*Logger=*/nullptr,
                                         OnDiskGraphDB::FaultInPolicy::FullTree)
                         .moveInto(DB),
                     Succeeded());
@@ -230,6 +231,7 @@ TEST(OnDiskGraphDBTest, FaultInFullTree) {
   // the upstream.
   ASSERT_THAT_ERROR(OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
                                         /*UpstreamDB=*/nullptr,
+                                        /*Logger=*/nullptr,
                                         OnDiskGraphDB::FaultInPolicy::FullTree)
                         .moveInto(DB),
                     Succeeded());
@@ -265,17 +267,17 @@ TEST(OnDiskGraphDBTest, FaultInPolicyConflict) {
 
     unittest::TempDir Temp("ondiskcas", /*Unique=*/true);
     std::unique_ptr<OnDiskGraphDB> DB;
-    ASSERT_THAT_ERROR(OnDiskGraphDB::open(Temp.path(), "blake3",
-                                          sizeof(HashType),
-                                          std::move(UpstreamDB), Policy1)
-                          .moveInto(DB),
-                      Succeeded());
+    ASSERT_THAT_ERROR(
+        OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
+                            std::move(UpstreamDB), /*Logger=*/nullptr, Policy1)
+            .moveInto(DB),
+        Succeeded());
     DB.reset();
-    ASSERT_THAT_ERROR(OnDiskGraphDB::open(Temp.path(), "blake3",
-                                          sizeof(HashType),
-                                          std::move(UpstreamDB), Policy2)
-                          .moveInto(DB),
-                      Failed());
+    ASSERT_THAT_ERROR(
+        OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
+                            std::move(UpstreamDB), /*Logger=*/nullptr, Policy2)
+            .moveInto(DB),
+        Failed());
   };
   // Open as 'single', then as 'full'.
   tryFaultInPolicyConflict(OnDiskGraphDB::FaultInPolicy::SingleNode,

--- a/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
+++ b/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
@@ -161,7 +161,7 @@ TEST(OnDiskHashMappedTrieTest, OutOfSpace) {
   ASSERT_THAT_ERROR(OnDiskHashMappedTrie::create(
                         Temp.path("NoSpace2").str(), "index",
                         /*NumHashBits=*/8, /*DataSize=*/8, /*MaxFileSize=*/100,
-                        /*NewInitialFileSize=*/std::nullopt,
+                        /*NewInitialFileSize=*/std::nullopt, /*Logger=*/nullptr,
                         /*NewTableNumRootBits=*/1, /*NewTableNumSubtrieBits=*/1)
                         .moveInto(Trie),
                     Succeeded());


### PR DESCRIPTION
Adds a CAS logging interface to track mutations of the CAS and action cache database files. This is designed to aid in the debugging of data corruption and other issues with the low-level on-disk representation.

To enable logging, set the environment variable LLVM_CAS_LOG to 1 or 2. Level 2 includes logging of all allocations inside the index, action cache, and datapool, which increases the overhead. The log file is placed inside the top-level directory of the unified cache. For now it is a human-readable textual format with one line per entry.

rdar://145675013