### PR TITLE
[lldb] Add Bool synthetic provider

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -623,7 +623,8 @@ bool lldb_private::formatters::swift::SwiftStringStorage_SummaryProvider(
 bool lldb_private::formatters::swift::Bool_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
   static ConstString g_value("_value");
-  ValueObjectSP value_child(valobj.GetChildMemberWithName(g_value, true));
+  ValueObjectSP value_child(
+      valobj.GetNonSyntheticValue()->GetChildMemberWithName(g_value, true));
   if (!value_child)
     return false;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -434,9 +434,14 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "Swift.TaskGroup synthetic children",
       ConstString("^Swift\\.(Throwing)?TaskGroup<.+>"), synth_flags, true);
 
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
+      "Swift.Bool", ConstString("Swift.Bool"), basic_synth_flags);
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Bool_SummaryProvider,
       "Swift.Bool summary provider", ConstString("Swift.Bool"), summary_flags);
+
   AddCXXSummary(
       swift_category_sp,
       lldb_private::formatters::swift::TypePreservingNSNumber_SummaryProvider,

--- a/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
+++ b/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
@@ -29,17 +29,21 @@ class TestSwiftBool(TestBase):
 
         self.assertGreater(thread.GetNumFrames(), 0)
         frame = thread.GetSelectedFrame()
-        
+
         true_vars = ["reg_true", "odd_true", "odd_true_works", "odd_false_works"]
         for name in true_vars:
             var = frame.FindVariable(name)
             summary = var.GetSummary()
-            self.assertTrue(summary == "true", "%s should be true, was: %s"%(name, summary))
+            self.assertEqual(
+                summary, "true", "%s should be true, was: %s" % (name, summary)
+            )
+            self.assertEqual(var.unsigned & 1, 1)
 
         false_vars = ["reg_false", "odd_false"]
         for name in false_vars:
             var = frame.FindVariable(name)
             summary = var.GetSummary()
-            self.assertTrue(summary == "false", "%s should be false, was: %s"%(name, summary))
-
-
+            self.assertEqual(
+                summary, "false", "%s should be false, was: %s" % (name, summary)
+            )
+            self.assertEqual(var.unsigned & 1, 0)

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -106,7 +106,7 @@ class TestSwiftOptionalType(TestBase):
             self,
             optTrue,
             use_dynamic=False,
-            num_children=1,
+            num_children=0,
             summary='true')
 
         optFalse = self.frame().FindVariable("optFalse")
@@ -114,7 +114,7 @@ class TestSwiftOptionalType(TestBase):
             self,
             optFalse,
             use_dynamic=False,
-            num_children=1,
+            num_children=0,
             summary='false')
 
         optNil = self.frame().FindVariable("optNil")


### PR DESCRIPTION
Add a synthetic provider for `Swift.Bool` for these improvements:

  1. Allows value objects to produce an integer value of 0 or 1
  2. Eliminates the child member from `Bool` value objects

Producing an integer value is useful for working with `Bool` values without having to
compare to the strings `"true"` or `"false"`.

Removing the child member improves how `Bool` variables are exposed in UI. A value
object with child members can be expanded in UI, however `Bool` variables should be
represented as a single scalar value, not a structure.
