### PR TITLE
🍒[clang][PCH] Don't try to create standalone debug-info for types marked nodebug (#123253)

### DIFF
--- a/clang/lib/CodeGen/ObjectFilePCHContainerWriter.cpp
+++ b/clang/lib/CodeGen/ObjectFilePCHContainerWriter.cpp
@@ -84,6 +84,9 @@ class PCHContainerGenerator : public ASTConsumer {
         if (!TD->isCompleteDefinition())
           return true;
 
+      if (D->hasAttr<NoDebugAttr>())
+        return true;
+
       QualType QualTy = Ctx.getTypeDeclType(D);
       if (!QualTy.isNull() && CanRepresent(QualTy.getTypePtr()))
         DI.getOrCreateStandaloneType(QualTy, D->getLocation());

--- a/clang/test/Modules/gmodules-nodebug.cpp
+++ b/clang/test/Modules/gmodules-nodebug.cpp
@@ -1,0 +1,14 @@
+// REQUIRES: asserts
+
+// RUN: %clang_cc1 -std=c++23 -x c++-header -emit-pch -fmodule-format=obj \
+// RUN:   -o %t.pch %s \
+// RUN:   -mllvm -debug-only=pchcontainer &>%t-pch.ll
+// RUN: cat %t-pch.ll | FileCheck %s
+
+template<class...>                     
+using __void_t [[gnu::nodebug]] = void;
+                                       
+__void_t<> func() {}                   
+
+// CHECK: !DICompileUnit
+// CHECK-NOT: __void_t


### PR DESCRIPTION
Fixes one of the crashes uncovered by
https://github.com/llvm/llvm-project/pull/118710

`getOrCreateStandaloneType` asserts that a `DIType` was created for the requested type. If the `Decl` was marked `nodebug`, however, we can't generate debug-info for it, so we would previously trigger the assert. For now keep the assertion around and check the `nodebug` at the callsite.

(cherry picked from commit 30e276d06d3176f145151cea96ab01af0c3e842a)