### PR TITLE
[lldb] Add summary formatter for Swift Task

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -850,12 +850,13 @@ public:
     }
     case 3: {
       if (!m_child_tasks_sp) {
-        const auto &tasks = m_task_info.childTasks;
+        using task_type = decltype(m_task_info.childTasks)::value_type;
+        const std::vector<task_type> &tasks = m_task_info.childTasks;
         std::string mangled_typename =
             mangledTypenameForTasksTuple(tasks.size());
         CompilerType tasks_tuple_type =
             m_ts->GetTypeFromMangledTypename(ConstString(mangled_typename));
-        DataExtractor data{tasks.data(), tasks.size() * sizeof(tasks[0]),
+        DataExtractor data{tasks.data(), tasks.size() * sizeof(task_type),
                            endian::InlHostByteOrder(), sizeof(void *)};
         m_child_tasks_sp = ValueObject::CreateValueObjectFromData(
             "children", data, m_backend.GetExecutionContextRef(),
@@ -1645,7 +1646,7 @@ bool lldb_private::formatters::swift::TaskPriority_SummaryProvider(
   return true;
 }
 
-static const std::pair<const char *, const char *> TASK_FLAGS[] = {
+static const std::pair<StringRef, StringRef> TASK_FLAGS[] = {
     {"isRunning", "running"},
     {"isCancelled", "cancelled"},
     {"isEscalated", "escalated"},
@@ -1668,7 +1669,7 @@ bool lldb_private::formatters::swift::Task_SummaryProvider(
 
   stream.Format("id:{0}", get_member("id"));
 
-  std::vector<const char *> flags;
+  std::vector<StringRef> flags;
   for (auto [member, flag] : TASK_FLAGS)
     if (get_member(member))
       flags.push_back(flag);

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -782,7 +782,7 @@ public:
       // clang-format off
       "address",
       "id",
-      "enqueuPriority",
+      "enqueuePriority",
       "children",
 
       // Children below this point are hidden.
@@ -1659,11 +1659,11 @@ static const std::pair<const char *, const char *> TASK_FLAGS[] = {
 
 bool lldb_private::formatters::swift::Task_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  auto get_member = [&valobj](StringRef name) {
+  auto get_member = [&valobj](StringRef name) -> uint64_t {
     if (auto member_sp = valobj.GetChildMemberWithName(name))
       if (auto synthetic_sp = member_sp->GetSyntheticValue())
         return synthetic_sp->GetValueAsUnsigned(0);
-    return 0ULL;
+    return 0;
   };
 
   stream.Format("id:{0}", get_member("id"));

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -36,6 +36,7 @@
 #include "swift/Demangling/ManglingMacros.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/iterator_range.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/raw_ostream.h"
@@ -778,10 +779,13 @@ public:
   }
 
   constexpr static StringLiteral TaskChildren[] = {
+      // clang-format off
       "address",
       "id",
-      "kind",
       "enqueuPriority",
+      "children",
+
+      // Children below this point are hidden.
       "isChildTask",
       "isFuture",
       "isGroupChildTask",
@@ -790,13 +794,13 @@ public:
       "isStatusRecordLocked",
       "isEscalated",
       "isEnqueued",
-      "children",
       "isRunning",
+      // clang-format on
   };
 
   llvm::Expected<uint32_t> CalculateNumChildren() override {
-    auto count = ArrayRef(TaskChildren).size();
-    return m_task_info.hasIsRunning ? count : count - 1;
+    // Show only the first four children address/id/enqueuePriority/children.
+    return 4;
   }
 
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override {
@@ -805,15 +809,6 @@ public:
     // TypeMangling for "Swift.Bool"
     CompilerType bool_type =
         m_ts->GetTypeFromMangledTypename(ConstString("$sSbD"));
-    // TypeMangling for "Swift.UInt32"
-    CompilerType uint32_type =
-        m_ts->GetTypeFromMangledTypename(ConstString("$ss6UInt32VD"));
-    // TypeMangling for "Swift.UInt64"
-    CompilerType uint64_type =
-        m_ts->GetTypeFromMangledTypename(ConstString("$ss6UInt64VD"));
-    // TypeMangling for "Swift.TaskPriority"
-    CompilerType priority_type =
-        m_ts->GetTypeFromMangledTypename(ConstString("$sScPD"));
 
 #define RETURN_CHILD(FIELD, NAME, TYPE)                                        \
   if (!FIELD) {                                                                \
@@ -841,12 +836,33 @@ public:
             raw_pointer_type);
       }
       return m_address_sp;
-    case 1:
+    case 1: {
+      // TypeMangling for "Swift.UInt64"
+      CompilerType uint64_type =
+          m_ts->GetTypeFromMangledTypename(ConstString("$ss6UInt64VD"));
       RETURN_CHILD(m_id_sp, id, uint64_type);
-    case 2:
-      RETURN_CHILD(m_kind_sp, kind, uint32_type);
-    case 3:
+    }
+    case 2: {
+      // TypeMangling for "Swift.TaskPriority"
+      CompilerType priority_type =
+          m_ts->GetTypeFromMangledTypename(ConstString("$sScPD"));
       RETURN_CHILD(m_enqueue_priority_sp, enqueuePriority, priority_type);
+    }
+    case 3: {
+      if (!m_child_tasks_sp) {
+        const auto &tasks = m_task_info.childTasks;
+        std::string mangled_typename =
+            mangledTypenameForTasksTuple(tasks.size());
+        CompilerType tasks_tuple_type =
+            m_ts->GetTypeFromMangledTypename(ConstString(mangled_typename));
+        DataExtractor data{tasks.data(), tasks.size() * sizeof(tasks[0]),
+                           endian::InlHostByteOrder(), sizeof(void *)};
+        m_child_tasks_sp = ValueObject::CreateValueObjectFromData(
+            "children", data, m_backend.GetExecutionContextRef(),
+            tasks_tuple_type);
+      }
+      return m_child_tasks_sp;
+    }
     case 4:
       RETURN_CHILD(m_is_child_task_sp, isChildTask, bool_type);
     case 5:
@@ -865,22 +881,10 @@ public:
     case 11:
       RETURN_CHILD(m_is_enqueued_sp, isEnqueued, bool_type);
     case 12: {
-      if (!m_child_tasks_sp) {
-        const auto &tasks = m_task_info.childTasks;
-        std::string mangled_typename =
-            mangledTypenameForTasksTuple(tasks.size());
-        CompilerType tasks_tuple_type =
-            m_ts->GetTypeFromMangledTypename(ConstString(mangled_typename));
-        DataExtractor data{tasks.data(), tasks.size() * sizeof(tasks[0]),
-                           endian::InlHostByteOrder(), sizeof(void *)};
-        m_child_tasks_sp = ValueObject::CreateValueObjectFromData(
-            "children", data, m_backend.GetExecutionContextRef(),
-            tasks_tuple_type);
-      }
-      return m_child_tasks_sp;
+      if (m_task_info.hasIsRunning)
+        RETURN_CHILD(m_is_running_sp, isRunning, bool_type);
+      return {};
     }
-    case 13:
-      RETURN_CHILD(m_is_running_sp, isRunning, bool_type);
     default:
       return {};
     }
@@ -1638,6 +1642,42 @@ bool lldb_private::formatters::swift::TaskPriority_SummaryProvider(
     stream.Format("{0}", raw_value);
     break;
   }
+  return true;
+}
+
+static const std::pair<const char *, const char *> TASK_FLAGS[] = {
+    {"isRunning", "running"},
+    {"isCancelled", "cancelled"},
+    {"isEscalated", "escalated"},
+    {"isEnqueued", "enqueued"},
+    {"isGroupChildTask", "groupChildTask"},
+    {"isAsyncLetTask", "asyncLetTask"},
+    {"isChildTask", "childTask"},
+    {"isFuture", "future"},
+    {"isStatusRecordLocked", "statusRecordLocked"},
+};
+
+bool lldb_private::formatters::swift::Task_SummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+  auto get_member = [&valobj](StringRef name) {
+    if (auto member_sp = valobj.GetChildMemberWithName(name))
+      if (auto synthetic_sp = member_sp->GetSyntheticValue())
+        return synthetic_sp->GetValueAsUnsigned(0);
+    return 0ULL;
+  };
+
+  stream.Format("id:{0}", get_member("id"));
+
+  std::vector<const char *> flags;
+  for (auto [member, flag] : TASK_FLAGS)
+    if (get_member(member))
+      flags.push_back(flag);
+
+  if (!flags.empty())
+    // Append the flags in an `|` separated list. This matches the format used
+    // by swift-inspect dump-concurrency.
+    stream.Format(" flags:{0:$[|]}", iterator_range(flags));
+
   return true;
 }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -117,6 +117,9 @@ bool TypePreservingNSNumber_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool TaskPriority_SummaryProvider(ValueObject &valobj, Stream &stream,
                                   const TypeSummaryOptions &options);
 
+bool Task_SummaryProvider(ValueObject &valobj, Stream &stream,
+                          const TypeSummaryOptions &options);
+
 SyntheticChildrenFrontEnd *EnumSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -491,6 +491,19 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 lldb_private::formatters::swift::TaskPriority_SummaryProvider,
                 "Swift TaskPriority summary provider", "Swift.TaskPriority",
                 summary_flags);
+  {
+    auto task_summary_flags = summary_flags;
+    task_summary_flags.SetDontShowChildren(false);
+    AddCXXSummary(swift_category_sp,
+                  lldb_private::formatters::swift::Task_SummaryProvider,
+                  "Swift Task summary provider", "^Swift\\.Task<.+,.+>",
+                  task_summary_flags, true);
+    AddCXXSummary(swift_category_sp,
+                  lldb_private::formatters::swift::Task_SummaryProvider,
+                  "Swift UnsafeCurrentTask summary provider",
+                  "Swift.UnsafeCurrentTask", task_summary_flags);
+  }
+
   summary_flags.SetSkipPointers(false);
   // this is an ObjC dynamic type - as such it comes in pointer form
   // NSContiguousString* - do not skip pointers here

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -15,12 +16,19 @@ class TestCase(TestBase):
         )
         self.expect(
             "v cont",
-            substrs=[
-                "(UnsafeContinuation<Void, Never>) cont = {",
-                "task = {",
-                "address = 0x",
-                "id = ",
-                "isFuture = true",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(UnsafeContinuation<Void, Never>\) cont = \{
+                      task = id:(\d+) flags:(?:running\|)?future \{
+                        address = 0x[0-9a-f]+
+                        id = \1
+                        enqueuePriority = 0
+                        children = \{\}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )
 
@@ -33,11 +41,18 @@ class TestCase(TestBase):
         )
         self.expect(
             "v cont",
-            substrs=[
-                "(CheckedContinuation<Int, Never>) cont = {",
-                "task = {",
-                "address = 0x",
-                "id = ",
-                "isFuture = true",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(CheckedContinuation<Int, Never>\) cont = \{
+                      task = id:(\d+) flags:(?:running\|)?future \{
+                        address = 0x[0-9a-f]+
+                        id = \1
+                        enqueuePriority = 0
+                        children = \{\}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -17,19 +18,17 @@ class TestCase(TestBase):
         # the test checks only that it has a value, not what the value is.
         self.expect(
             "frame var task",
-            substrs=[
-                "(Task<(), Error>) task = {",
-                "address = 0x",
-                "id = 2",
-                "kind = 0",
-                "enqueuePriority = .medium",
-                "isChildTask = false",
-                "isFuture = true",
-                "isGroupChildTask = false",
-                "isAsyncLetTask = false",
-                "isCancelled = false",
-                "isEnqueued = ",
-                "children = {}",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(Task<\(\), Error>\) task = id:(\d+) flags:(?:running\|)?enqueued\|future \{
+                      address = 0x[0-9a-f]+
+                      id = \1
+                      enqueuePriority = \.medium
+                      children = \{\}
+                    }
+                    """
+                ).strip()
             ],
         )
 
@@ -43,16 +42,16 @@ class TestCase(TestBase):
         )
         self.expect(
             "frame var currentTask",
-            substrs=[
-                "(UnsafeCurrentTask) currentTask = {",
-                "address = 0x",
-                "id = ",
-                "isChildTask = true",
-                "isFuture = true",
-                "isGroupChildTask = false",
-                "isAsyncLetTask = true",
-                "isCancelled = false",
-                "isEnqueued = false",
-                "children = {}",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(UnsafeCurrentTask\) currentTask = id:(\d+) flags:(?:running\|)?asyncLetTask|childTask|future \{
+                      address = 0x[0-9a-f]+
+                      id = \1
+                      enqueuePriority = \.medium
+                      children = \{\}
+                    \}
+                    """
+                ).strip()
             ],
         )

--- a/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -16,18 +17,23 @@ class TestCase(TestBase):
         )
         self.expect(
             "language swift task info",
-            substrs=[
-                "(UnsafeCurrentTask) current_task = {",
-                "address = 0x",
-                "id = 1",
-                "isChildTask = false",
-                "isAsyncLetTask = false",
-                "children = {",
-                "0 = {",
-                "address = 0x",
-                "id = 2",
-                "isChildTask = true",
-                "isAsyncLetTask = true",
-                "children = {}",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(UnsafeCurrentTask\) current_task = id:1 flags:(?:running\|)?future \{
+                      address = 0x[0-9a-f]+
+                      id = 1
+                      enqueuePriority = 0
+                      children = \{
+                        0 = id:2 flags:(?:running\|)?asyncLetTask\|childTask\|future {
+                          address = 0x[0-9a-f]+
+                          id = 2
+                          enqueuePriority = \.medium
+                          children = \{\}
+                        \}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -27,19 +28,31 @@ class TestCase(TestBase):
     def do_test_print(self):
         self.expect(
             "v group",
-            substrs=[
-                "[0] = {",
-                "address = 0x",
-                "id = ",
-                "isGroupChildTask = true",
-                "[1] = {",
-                "address = 0x",
-                "id = ",
-                "isGroupChildTask = true",
-                "[2] = {",
-                "address = 0x",
-                "id = ",
-                "isGroupChildTask = true",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \((?:Throwing)?TaskGroup<\(\)\??(?:, Error)?>\) group = \{
+                      \[0\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                        address = 0x[0-9a-f]+
+                        id = \1
+                        enqueuePriority = \.medium
+                        children = \{\}
+                      \}
+                      \[1\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                        address = 0x[0-9a-f]+
+                        id = \2
+                        enqueuePriority = \.medium
+                        children = \{\}
+                      \}
+                      \[2\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                        address = 0x[0-9a-f]+
+                        id = \3
+                        enqueuePriority = \.medium
+                        children = \{\}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )
 
@@ -53,7 +66,7 @@ class TestCase(TestBase):
         self.do_test_api(process)
 
     @swiftTest
-    def test_api_task_group(self):
+    def test_api_throwing_task_group(self):
         """Verify a ThrowingTaskGroup contains its expected children."""
         self.build()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
This change vertically condenses how a `Task` is displayed, by hiding the boolean
members (ex `isRunning`) and placing those flags in the summary string.

The synthetic formatter continues to expose these (and only these) 4 children:
  * `address`
  * `id`
  * `enqueuePriority`
  * `children`

The flags are pipe (`|`) delimited, matching the format used by `swift-inspect`.

Here's an example of output when printing a `Task`:

```
(Task<(), Error>) task = id:2 flags:enqueued|future {
  address = 0x14b604490
  id = 2
  enqueuePriority = .medium
  children = {}
}
```

This change also removes the `Task`'s `kind` field, which currently relevant only in
special cases. See `JobKind` in `MetadataValues.h`.
