### PR TITLE
[lldb] Avoid unnecessary regex check in dwim-print

### DIFF
--- a/lldb/include/lldb/Interpreter/CommandReturnObject.h
+++ b/lldb/include/lldb/Interpreter/CommandReturnObject.h
@@ -117,6 +117,11 @@ public:
   void AppendMessageWithFormat(const char *format, ...)
       __attribute__((format(printf, 2, 3)));
 
+  void AppendNote(llvm::StringRef in_string);
+
+  void AppendNoteWithFormat(const char *format, ...)
+      __attribute__((format(printf, 2, 3)));
+
   void AppendWarning(llvm::StringRef in_string);
 
   void AppendWarningWithFormat(const char *format, ...)
@@ -132,6 +137,11 @@ public:
   template <typename... Args>
   void AppendMessageWithFormatv(const char *format, Args &&...args) {
     AppendMessage(llvm::formatv(format, std::forward<Args>(args)...).str());
+  }
+
+  template <typename... Args>
+  void AppendNoteWithFormatv(const char *format, Args &&...args) {
+    AppendNote(llvm::formatv(format, std::forward<Args>(args)...).str());
   }
 
   template <typename... Args>

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -123,10 +123,10 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
       if (note_shown)
         return;
 
-      result.GetOutputStream()
-          << "note: object description requested, but type doesn't implement "
-             "a custom object description. Consider using \"p\" instead of "
-             "\"po\" (this note will only be shown once per debug session).\n";
+      result.AppendNote(
+          "object description requested, but type doesn't implement "
+          "a custom object description. Consider using \"p\" instead of "
+          "\"po\" (this note will only be shown once per debug session).\n");
       note_shown = true;
     }
   };
@@ -180,8 +180,8 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
         StringRef flags;
         if (args.HasArgs())
           flags = args.GetArgString();
-        result.AppendMessageWithFormatv("note: ran `frame variable {0}{1}`",
-                                        flags, expr);
+        result.AppendNoteWithFormatv("ran `frame variable {0}{1}`", flags,
+                                     expr);
       }
 
       dump_val_object(*valobj_sp);
@@ -280,8 +280,7 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
       StringRef flags;
       if (args.HasArgs())
         flags = args.GetArgStringWithDelimiter();
-      result.AppendMessageWithFormatv("note: ran `expression {0}{1}`", flags,
-                                      expr);
+      result.AppendNoteWithFormatv("ran `expression {0}{1}`", flags, expr);
     }
 
     if (valobj_sp->GetError().GetError() != UserExpression::kNoResult)

--- a/lldb/source/Commands/CommandObjectDWIMPrint.cpp
+++ b/lldb/source/Commands/CommandObjectDWIMPrint.cpp
@@ -103,6 +103,10 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
   // Add a hint if object description was requested, but no description
   // function was implemented.
   auto maybe_add_hint = [&](llvm::StringRef output) {
+    static bool note_shown = false;
+    if (note_shown)
+      return;
+
     // Identify the default output of object description for Swift and
     // Objective-C
     // "<Name: 0x...>. The regex is:
@@ -112,16 +116,13 @@ void CommandObjectDWIMPrint::DoExecute(StringRef command,
     // - Followed by 5 or more hex digits.
     // - Followed by ">".
     // - End with zero or more whitespace characters.
-    const std::regex swift_class_regex("^<\\S+: 0x[[:xdigit:]]{5,}>\\s*$");
+    static const std::regex swift_class_regex(
+        "^<\\S+: 0x[[:xdigit:]]{5,}>\\s*$");
 
     if (GetDebugger().GetShowDontUsePoHint() && target_ptr &&
         (language == lldb::eLanguageTypeSwift ||
          language == lldb::eLanguageTypeObjC) &&
         std::regex_match(output.data(), swift_class_regex)) {
-
-      static bool note_shown = false;
-      if (note_shown)
-        return;
 
       result.AppendNote(
           "object description requested, but type doesn't implement "

--- a/lldb/source/Interpreter/CommandReturnObject.cpp
+++ b/lldb/source/Interpreter/CommandReturnObject.cpp
@@ -27,6 +27,12 @@ static llvm::raw_ostream &warning(Stream &strm) {
          << "warning: ";
 }
 
+static llvm::raw_ostream &note(Stream &strm) {
+  return llvm::WithColor(strm.AsRawOstream(), llvm::HighlightColor::Note,
+                         llvm::ColorMode::Enable)
+         << "note: ";
+}
+
 static void DumpStringToStreamWithNewline(Stream &strm, const std::string &s) {
   bool add_newline = false;
   if (!s.empty()) {
@@ -74,6 +80,18 @@ void CommandReturnObject::AppendMessageWithFormat(const char *format, ...) {
   GetOutputStream() << sstrm.GetString();
 }
 
+void CommandReturnObject::AppendNoteWithFormat(const char *format, ...) {
+  if (!format)
+    return;
+  va_list args;
+  va_start(args, format);
+  StreamString sstrm;
+  sstrm.PrintfVarArg(format, args);
+  va_end(args);
+
+  note(GetOutputStream()) << sstrm.GetString();
+}
+
 void CommandReturnObject::AppendWarningWithFormat(const char *format, ...) {
   if (!format)
     return;
@@ -90,6 +108,12 @@ void CommandReturnObject::AppendMessage(llvm::StringRef in_string) {
   if (in_string.empty())
     return;
   GetOutputStream() << in_string.rtrim() << '\n';
+}
+
+void CommandReturnObject::AppendNote(llvm::StringRef in_string) {
+  if (in_string.empty())
+    return;
+  note(GetOutputStream()) << in_string.rtrim() << '\n';
 }
 
 void CommandReturnObject::AppendWarning(llvm::StringRef in_string) {


### PR DESCRIPTION
[lldb] Avoid unnecessary regex check in dwim-print (#114608)

An (unmeasured) improvement to performance of `dwim-print` when used as `po`.

This change lifts the check for `note_shown` to the top of the lambda, to avoid all subsequent work when the hint has already been shown. The main effect is to avoid performing a regex match when the hint is not going to be shown.

This change also constructs the `std::regex` only once, by making it static.