### PR TITLE
Headers: use `corecrt_malloc.h` instead of `malloc.h`

### DIFF
--- a/clang/lib/Headers/mm_malloc.h
+++ b/clang/lib/Headers/mm_malloc.h
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
-#include <malloc.h>
+#include <corecrt_malloc.h>
 #else
 #ifndef __cplusplus
 extern int posix_memalign(void **__memptr, size_t __alignment, size_t __size);


### PR DESCRIPTION
Rather than adding a dependency on `ucrt`, shuffle down a layer to `corecrt`. This may help restore the ability to modularise the Windows SDK.