### PR TITLE
[lldb] Create "task" alias for "language swift task"

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -470,7 +470,8 @@ void CommandInterpreter::Initialize() {
 
 #ifdef LLDB_ENABLE_SWIFT
   cmd_obj_sp = GetCommandSPExact("language swift task");
-  AddAlias("task", cmd_obj_sp);
+  if (cmd_obj_sp)
+    AddAlias("task", cmd_obj_sp);
 #endif
 
   cmd_obj_sp = GetCommandSPExact("platform shell");

--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -468,6 +468,11 @@ void CommandInterpreter::Initialize() {
 #endif
   }
 
+#ifdef LLDB_ENABLE_SWIFT
+  cmd_obj_sp = GetCommandSPExact("language swift task");
+  AddAlias("task", cmd_obj_sp);
+#endif
+
   cmd_obj_sp = GetCommandSPExact("platform shell");
   if (cmd_obj_sp) {
     CommandAlias *shell_alias = AddAlias("shell", cmd_obj_sp, " --host --");

--- a/lldb/test/API/functionalities/abbreviation/TestCommonShortSpellings.py
+++ b/lldb/test/API/functionalities/abbreviation/TestCommonShortSpellings.py
@@ -22,10 +22,10 @@ class CommonShortSpellingsTestCase(TestBase):
             ("disp", "_regexp-display"),  # a.k.a., 'display'
             ("di", "disassemble"),
             ("dis", "disassemble"),
-            ("ta st a", "target stop-hook add"),
+            ("tar st a", "target stop-hook add"),
             ("fr v", "frame variable"),
             ("f 1", "frame select 1"),
-            ("ta st li", "target stop-hook list"),
+            ("tar st li", "target stop-hook list"),
         ]
 
         for short_val, long_val in abbrevs:

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -25,7 +25,7 @@ class TestCase(TestBase):
 
     def do_backtrace(self, arg):
         self.expect(
-            f"language swift task backtrace {arg}",
+            f"task backtrace {arg}",
             substrs=[
                 ".sleep(",
                 "`second() at main.swift:6",

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -24,7 +24,7 @@ class TestCase(TestBase):
         self.do_backtrace_selected_task(task_addr)
 
     def do_backtrace_selected_task(self, arg):
-        self.runCmd(f"language swift task select {arg}")
+        self.runCmd(f"task select {arg}")
         self.expect(
             "thread backtrace",
             substrs=[
@@ -53,7 +53,7 @@ class TestCase(TestBase):
         self.do_test_navigate_selected_task_stack(process, task_addr)
 
     def do_test_navigate_selected_task_stack(self, process, arg):
-        self.runCmd(f"language swift task select {arg}")
+        self.runCmd(f"task select {arg}")
         thread = process.GetSelectedThread()
 
         self.assertIn(

--- a/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
+++ b/lldb/test/API/lang/swift/async/tasks/info/TestSwiftTaskInfo.py
@@ -23,7 +23,7 @@ class TestCase(TestBase):
         )
         self.runCmd("frame variable task")
         frame_variable_output = self.res.GetOutput()
-        self.runCmd("language swift task info")
+        self.runCmd("task info")
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))
 
@@ -41,6 +41,6 @@ class TestCase(TestBase):
 
         self.runCmd("frame variable task")
         frame_variable_output = self.res.GetOutput()
-        self.runCmd(f"language swift task info {task_addr}")
+        self.runCmd(f"task info {task_addr}")
         task_info_output = self.res.GetOutput()
         self.assertEqual(_tail(task_info_output), _tail(frame_variable_output))

--- a/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
@@ -53,12 +53,15 @@ class TestSwiftDWARFImporterBridgingHeader(lldbtest.TestBase):
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("point"),
                                 typename='bridging-header.h.Point', num_children=2)
-        self.expect("ta v -d no-dyn point", substrs=["x = 1", "y = 2"])
-        self.expect("ta v -d no-dyn swiftStructCMember",
-                    substrs=[
-                        # FIXME: This doesn't even work with the original bridging header!
-                        #"point", "x = 3", "y = 4",
-                        "swift struct c member"])
+        self.expect("target v -d no-dyn point", substrs=["x = 1", "y = 2"])
+        self.expect(
+            "target v -d no-dyn swiftStructCMember",
+            substrs=[
+                # FIXME: This doesn't even work with the original bridging header!
+                # "point", "x = 3", "y = 4",
+                "swift struct c member"
+            ],
+        )
         process.Clear()
         target.Clear()
         lldb.SBDebugger.MemoryPressureDetected()

--- a/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/BridgingPCH/TestSwiftDWARFImporterBridgingPCH.py
@@ -53,9 +53,9 @@ class TestSwiftDWARFImporterBridgingHeader(lldbtest.TestBase):
         lldbutil.check_variable(self,
                                 target.FindFirstGlobalVariable("point"),
                                 typename='bridging-header.h.Point', num_children=2)
-        self.expect("target v -d no-dyn point", substrs=["x = 1", "y = 2"])
+        self.expect("tar v -d no-dyn point", substrs=["x = 1", "y = 2"])
         self.expect(
-            "target v -d no-dyn swiftStructCMember",
+            "tar v -d no-dyn swiftStructCMember",
             substrs=[
                 # FIXME: This doesn't even work with the original bridging header!
                 # "point", "x = 3", "y = 4",

--- a/lldb/test/API/macosx/builtin-debugtrap/TestBuiltinDebugTrap.py
+++ b/lldb/test/API/macosx/builtin-debugtrap/TestBuiltinDebugTrap.py
@@ -28,7 +28,7 @@ class BuiltinDebugTrapTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("f")
             self.runCmd("bt")
-            self.runCmd("target v global")
+            self.runCmd("tar v global")
 
         self.assertEqual(
             process.GetSelectedThread().GetStopReason(), lldb.eStopReasonException
@@ -46,7 +46,7 @@ class BuiltinDebugTrapTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("f")
             self.runCmd("bt")
-            self.runCmd("target v global")
+            self.runCmd("tar v global")
 
         self.assertEqual(
             process.GetSelectedThread().GetStopReason(), lldb.eStopReasonException
@@ -61,7 +61,7 @@ class BuiltinDebugTrapTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("f")
             self.runCmd("bt")
-            self.runCmd("target v global")
+            self.runCmd("tar v global")
 
         self.assertEqual(
             process.GetSelectedThread().GetStopReason(), lldb.eStopReasonException

--- a/lldb/test/API/macosx/builtin-debugtrap/TestBuiltinDebugTrap.py
+++ b/lldb/test/API/macosx/builtin-debugtrap/TestBuiltinDebugTrap.py
@@ -28,7 +28,7 @@ class BuiltinDebugTrapTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("f")
             self.runCmd("bt")
-            self.runCmd("ta v global")
+            self.runCmd("target v global")
 
         self.assertEqual(
             process.GetSelectedThread().GetStopReason(), lldb.eStopReasonException
@@ -46,7 +46,7 @@ class BuiltinDebugTrapTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("f")
             self.runCmd("bt")
-            self.runCmd("ta v global")
+            self.runCmd("target v global")
 
         self.assertEqual(
             process.GetSelectedThread().GetStopReason(), lldb.eStopReasonException
@@ -61,7 +61,7 @@ class BuiltinDebugTrapTestCase(TestBase):
         if self.TraceOn():
             self.runCmd("f")
             self.runCmd("bt")
-            self.runCmd("ta v global")
+            self.runCmd("target v global")
 
         self.assertEqual(
             process.GetSelectedThread().GetStopReason(), lldb.eStopReasonException


### PR DESCRIPTION
Make the `task` subcommands to be convenient by adding an alias for `language swift task`.