### PR TITLE
[lldb] Check if C++ interop and embedded Swift are enabled on CU instead of whole module

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1205,9 +1205,6 @@ SwiftLanguage::GetHardcodedSynthetics() {
 
       Log *log(GetLog(LLDBLog::DataFormatters));
 
-      if (!valobj.GetTargetSP()->IsSwiftCxxInteropEnabled())
-        return nullptr;
-
       CompilerType type(valobj.GetCompilerType());
       auto swift_type_system =
           type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
@@ -1234,6 +1231,29 @@ SwiftLanguage::GetHardcodedSynthetics() {
       if (!casted) {
         LLDB_LOGV(log, "[Matching Clang imported type] - "
                        "Could not cast value object to clang type");
+        return nullptr;
+      }
+
+      // Find the compile unit and module using the frame, because the value
+      // object may not have a module in the case of an expression that
+      // evaluates to a type.
+      if (!valobj.GetFrameSP())
+        return nullptr;
+
+      auto sc = valobj.GetFrameSP()->GetSymbolContext(
+          lldb::SymbolContextItem::eSymbolContextCompUnit |
+          lldb::SymbolContextItem::eSymbolContextModule);
+
+      // If there is a compile unit, use that to check if C++ interop should be
+      // enabled. If there is no compiler unit, use the module. If neither
+      // exist, assume that C++ interop is disabled.
+      if (auto *cu = sc.comp_unit) {
+        if (!SwiftASTContext::ShouldEnableCXXInterop(cu))
+          return nullptr;
+      } else if (sc.module_sp) {
+        if (!sc.module_sp->IsSwiftCxxInteropEnabled())
+          return nullptr;
+      } else {
         return nullptr;
       }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2628,8 +2628,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   return swift_ast_sp;
 }
 
-/// Determine whether this CU was compiled with C++ interop enabled.
-bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
+bool SwiftASTContext::CheckFlagInCU(CompileUnit *cu, const char *flag) {
   AutoBool interop_enabled =
     ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
   switch (interop_enabled) {
@@ -2643,8 +2642,6 @@ bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
     lldb::ModuleSP module = cu->CalculateSymbolContextModule();
     if (!module)
       return false;
-    // Look for the "-enable-experimental-cxx-interop" compile flag in the
-    // args of the compile units this module is composed of.
     auto *sym_file = module->GetSymbolFile();
     if (!sym_file)
       return false;
@@ -2653,7 +2650,7 @@ bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
       if (unit.get() == cu) {
         if (cu->GetLanguage() == eLanguageTypeSwift)
           for (const char *arg : args.GetArgumentArrayRef())
-            if (strcmp(arg, "-enable-experimental-cxx-interop") == 0)
+            if (strcmp(arg, flag) == 0)
               return true;
         return false;
       }
@@ -2661,6 +2658,15 @@ bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
   }
   }
   return false;
+}
+
+/// Determine whether this CU was compiled with C++ interop enabled.
+bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
+  return CheckFlagInCU(cu, "-enable-experimental-cxx-interop");
+}
+
+bool SwiftASTContext::ShouldEnableEmbeddedSwift(CompileUnit *cu) {
+  return CheckFlagInCU(cu, "-enable-embedded-swift");
 }
 
 static bool IsUnitTestExecutable(lldb_private::Module &module) {
@@ -2776,7 +2782,7 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
     swift_ast_sp->m_is_scratch_context = true;
     auto &lang_opts = swift_ast_sp->GetLanguageOptions();
     lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
-    if (target_sp->IsEmbeddedSwift())
+    if (ShouldEnableEmbeddedSwift(cu))
       lang_opts.enableFeature(swift::Feature::Embedded);
   } else {
     // Typesystem fallback context.
@@ -2793,7 +2799,7 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
     auto &lang_opts = swift_ast_sp->GetLanguageOptions();
     lang_opts.EnableAccessControl = false;
     lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
-    if (module_sp->IsEmbeddedSwift())
+    if (ShouldEnableEmbeddedSwift(cu))
       lang_opts.enableFeature(swift::Feature::Embedded);
   }
   auto defer_log = llvm::make_scope_exit(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2792,7 +2792,7 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
     swift_ast_sp->m_module = module_sp.get();
     auto &lang_opts = swift_ast_sp->GetLanguageOptions();
     lang_opts.EnableAccessControl = false;
-    lang_opts.EnableCXXInterop = module_sp->IsSwiftCxxInteropEnabled();
+    lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
     if (module_sp->IsEmbeddedSwift())
       lang_opts.enableFeature(swift::Feature::Embedded);
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2629,7 +2629,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 }
 
 /// Determine whether this CU was compiled with C++ interop enabled.
-static bool ShouldEnableCXXInterop(CompileUnit *cu) {
+bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
   AutoBool interop_enabled =
     ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
   switch (interop_enabled) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -210,8 +210,12 @@ public:
                  TypeSystemSwiftTypeRef &typeref_typesystem,
                  const char *extra_options = nullptr);
 
-  /// Returns true if Swift C++ interop is enabled for the given compiler unit.
+  /// Returns true if the given flag is present in the given compile unit.
+  static bool CheckFlagInCU(CompileUnit *cu, const char *flag);
+
   static bool ShouldEnableCXXInterop(CompileUnit *cu);
+
+  static bool ShouldEnableEmbeddedSwift(CompileUnit *cu);
 
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -210,6 +210,9 @@ public:
                  TypeSystemSwiftTypeRef &typeref_typesystem,
                  const char *extra_options = nullptr);
 
+  /// Returns true if Swift C++ interop is enabled for the given compiler unit.
+  static bool ShouldEnableCXXInterop(CompileUnit *cu);
+
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,
       std::set<lldb::LanguageType> &languages_for_expressions);


### PR DESCRIPTION
Checking if C++ interop is enabled can be extremely slow if the project is big enough. We have changed this to checking only the compile unit instead, but one usage of the old API slipped by.

rdar://147009063