### PR TITLE
[lldb] Enable formatter for ThrowingTaskGroup (#10242)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -432,7 +432,7 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::TaskGroupSyntheticFrontEndCreator,
       "Swift.TaskGroup synthetic children",
-      ConstString("^Swift\\.TaskGroup<.+>"), synth_flags, true);
+      ConstString("^Swift\\.(Throwing)?TaskGroup<.+>"), synth_flags, true);
 
   AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Bool_SummaryProvider,

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -7,12 +7,24 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    def test_value_printing(self):
+    def test_print_task_group(self):
         """Print a TaskGroup and verify its children."""
         self.build()
         lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift")
+            self, "break here TaskGroup", lldb.SBFileSpec("main.swift")
         )
+        self.do_test_print()
+
+    @swiftTest
+    def test_print_throwing_task_group(self):
+        """Print a ThrowingTaskGroup and verify its children."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here ThrowingTaskGroup", lldb.SBFileSpec("main.swift")
+        )
+        self.do_test_print()
+
+    def do_test_print(self):
         self.expect(
             "v group",
             substrs=[
@@ -32,12 +44,24 @@ class TestCase(TestBase):
         )
 
     @swiftTest
-    def test_value_api(self):
+    def test_api_task_group(self):
         """Verify a TaskGroup contains its expected children."""
         self.build()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift")
+            self, "break here TaskGroup", lldb.SBFileSpec("main.swift")
         )
+        self.do_test_api(process)
+
+    @swiftTest
+    def test_api_task_group(self):
+        """Verify a ThrowingTaskGroup contains its expected children."""
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here ThrowingTaskGroup", lldb.SBFileSpec("main.swift")
+        )
+        self.do_test_api(process)
+
+    def do_test_api(self, process):
         thread = process.GetSelectedThread()
         frame = thread.GetSelectedFrame()
         group = frame.FindVariable("group")

--- a/lldb/test/API/lang/swift/async/taskgroups/main.swift
+++ b/lldb/test/API/lang/swift/async/taskgroups/main.swift
@@ -3,12 +3,23 @@
         await withTaskGroup { group in
             for _ in 0..<3 {
                 group.addTask {
-                    try? await Task.sleep(for: .seconds(300))
+                    try? await Task.sleep(for: .seconds(1))
                 }
             }
 
-            print("break here")
+            print("break here TaskGroup")
             for await _ in group {}
+        }
+
+        try? await withThrowingTaskGroup { group in
+            for _ in 0..<3 {
+                group.addTask {
+                    try await Task.sleep(for: .seconds(1))
+                }
+            }
+
+            print("break here ThrowingTaskGroup")
+            for try await _ in group {}
         }
     }
 }


### PR DESCRIPTION
Update the type name regex to support `ThrowingTaskGroup`. Adds equivalent tests.
(cherry-picked from commit 8181ec46fb752480bba9aa3fdede2ebf69c25827)