### PR TITLE
[lldb] Add summary formatter for Swift Task (#10265)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -117,6 +117,9 @@ bool TypePreservingNSNumber_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool TaskPriority_SummaryProvider(ValueObject &valobj, Stream &stream,
                                   const TypeSummaryOptions &options);
 
+bool Task_SummaryProvider(ValueObject &valobj, Stream &stream,
+                          const TypeSummaryOptions &options);
+
 SyntheticChildrenFrontEnd *EnumSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -491,6 +491,19 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 lldb_private::formatters::swift::TaskPriority_SummaryProvider,
                 "Swift TaskPriority summary provider", "Swift.TaskPriority",
                 summary_flags);
+  {
+    auto task_summary_flags = summary_flags;
+    task_summary_flags.SetDontShowChildren(false);
+    AddCXXSummary(swift_category_sp,
+                  lldb_private::formatters::swift::Task_SummaryProvider,
+                  "Swift Task summary provider", "^Swift\\.Task<.+,.+>",
+                  task_summary_flags, true);
+    AddCXXSummary(swift_category_sp,
+                  lldb_private::formatters::swift::Task_SummaryProvider,
+                  "Swift UnsafeCurrentTask summary provider",
+                  "Swift.UnsafeCurrentTask", task_summary_flags);
+  }
+
   summary_flags.SetSkipPointers(false);
   // this is an ObjC dynamic type - as such it comes in pointer form
   // NSContiguousString* - do not skip pointers here

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -15,12 +16,19 @@ class TestCase(TestBase):
         )
         self.expect(
             "v cont",
-            substrs=[
-                "(UnsafeContinuation<Void, Never>) cont = {",
-                "task = {",
-                "address = 0x",
-                "id = ",
-                "isFuture = true",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(UnsafeContinuation<Void, Never>\) cont = \{
+                      task = id:(\d+) flags:(?:running\|)?future \{
+                        address = 0x[0-9a-f]+
+                        id = \1
+                        enqueuePriority = 0
+                        children = \{\}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )
 
@@ -33,11 +41,18 @@ class TestCase(TestBase):
         )
         self.expect(
             "v cont",
-            substrs=[
-                "(CheckedContinuation<Int, Never>) cont = {",
-                "task = {",
-                "address = 0x",
-                "id = ",
-                "isFuture = true",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(CheckedContinuation<Int, Never>\) cont = \{
+                      task = id:(\d+) flags:(?:running\|)?future \{
+                        address = 0x[0-9a-f]+
+                        id = \1
+                        enqueuePriority = 0
+                        children = \{\}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -17,19 +18,17 @@ class TestCase(TestBase):
         # the test checks only that it has a value, not what the value is.
         self.expect(
             "frame var task",
-            substrs=[
-                "(Task<(), Error>) task = {",
-                "address = 0x",
-                "id = 2",
-                "kind = 0",
-                "enqueuePriority = .medium",
-                "isChildTask = false",
-                "isFuture = true",
-                "isGroupChildTask = false",
-                "isAsyncLetTask = false",
-                "isCancelled = false",
-                "isEnqueued = ",
-                "children = {}",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(Task<\(\), Error>\) task = id:(\d+) flags:(?:running\|)?enqueued\|future \{
+                      address = 0x[0-9a-f]+
+                      id = \1
+                      enqueuePriority = \.medium
+                      children = \{\}
+                    }
+                    """
+                ).strip()
             ],
         )
 
@@ -43,16 +42,16 @@ class TestCase(TestBase):
         )
         self.expect(
             "frame var currentTask",
-            substrs=[
-                "(UnsafeCurrentTask) currentTask = {",
-                "address = 0x",
-                "id = ",
-                "isChildTask = true",
-                "isFuture = true",
-                "isGroupChildTask = false",
-                "isAsyncLetTask = true",
-                "isCancelled = false",
-                "isEnqueued = false",
-                "children = {}",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(UnsafeCurrentTask\) currentTask = id:(\d+) flags:(?:running\|)?asyncLetTask|childTask|future \{
+                      address = 0x[0-9a-f]+
+                      id = \1
+                      enqueuePriority = \.medium
+                      children = \{\}
+                    \}
+                    """
+                ).strip()
             ],
         )

--- a/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -16,18 +17,23 @@ class TestCase(TestBase):
         )
         self.expect(
             "language swift task info",
-            substrs=[
-                "(UnsafeCurrentTask) current_task = {",
-                "address = 0x",
-                "id = 1",
-                "isChildTask = false",
-                "isAsyncLetTask = false",
-                "children = {",
-                "0 = {",
-                "address = 0x",
-                "id = 2",
-                "isChildTask = true",
-                "isAsyncLetTask = true",
-                "children = {}",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \(UnsafeCurrentTask\) current_task = id:1 flags:(?:running\|)?future \{
+                      address = 0x[0-9a-f]+
+                      id = 1
+                      enqueuePriority = 0
+                      children = \{
+                        0 = id:2 flags:(?:running\|)?asyncLetTask\|childTask\|future {
+                          address = 0x[0-9a-f]+
+                          id = 2
+                          enqueuePriority = \.medium
+                          children = \{\}
+                        \}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -1,3 +1,4 @@
+import textwrap
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -27,19 +28,31 @@ class TestCase(TestBase):
     def do_test_print(self):
         self.expect(
             "v group",
-            substrs=[
-                "[0] = {",
-                "address = 0x",
-                "id = ",
-                "isGroupChildTask = true",
-                "[1] = {",
-                "address = 0x",
-                "id = ",
-                "isGroupChildTask = true",
-                "[2] = {",
-                "address = 0x",
-                "id = ",
-                "isGroupChildTask = true",
+            patterns=[
+                textwrap.dedent(
+                    r"""
+                    \((?:Throwing)?TaskGroup<\(\)\??(?:, Error)?>\) group = \{
+                      \[0\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                        address = 0x[0-9a-f]+
+                        id = \1
+                        enqueuePriority = \.medium
+                        children = \{\}
+                      \}
+                      \[1\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                        address = 0x[0-9a-f]+
+                        id = \2
+                        enqueuePriority = \.medium
+                        children = \{\}
+                      \}
+                      \[2\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                        address = 0x[0-9a-f]+
+                        id = \3
+                        enqueuePriority = \.medium
+                        children = \{\}
+                      \}
+                    \}
+                    """
+                ).strip()
             ],
         )
 
@@ -53,7 +66,7 @@ class TestCase(TestBase):
         self.do_test_api(process)
 
     @swiftTest
-    def test_api_task_group(self):
+    def test_api_throwing_task_group(self):
         """Verify a ThrowingTaskGroup contains its expected children."""
         self.build()
         _, process, _, _ = lldbutil.run_to_source_breakpoint(


### PR DESCRIPTION
This change vertically condenses how a `Task` is displayed, by hiding the boolean
members (ex `isRunning`) and placing those flags in the summary string.

The synthetic formatter continues to expose these (and only these) 4 children:
  * `address`
  * `id`
  * `enqueuePriority`
  * `children`

The flags are pipe (`|`) delimited, matching the format used by `swift-inspect`.

Here's an example of output when printing a `Task`:

```
(Task<(), Error>) task = id:2 flags:enqueued|future {
  address = 0x14b604490
  id = 2
  enqueuePriority = .medium
  children = {}
}
```

This change also removes the `Task`'s `kind` field, which currently relevant only in
special cases. See `JobKind` in `MetadataValues.h`.


(cherry-picked from commit a7714ed0a84a9cfab345dc3174508563a85be025)