### PR TITLE
Initialize aarch64-cond-br-tuning pass

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -268,6 +268,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAArch64Target() {
   initializeAArch64StackTaggingPreRAPass(*PR);
   initializeAArch64LowerHomogeneousPrologEpilogPass(*PR);
   initializeAArch64DAGToDAGISelLegacyPass(*PR);
+  initializeAArch64CondBrTuningPass(*PR);
 }
 
 void AArch64TargetMachine::reset() { SubtargetMap.clear(); }


### PR DESCRIPTION
The call to the initializeAArch64CondBrTuningPass function is missing in the AArch64TargetMachine LLVMInitializeAArch64Target function.

This means that the pass is not in the pass registry and options such as -run-pass=aarch64-cond-br-tuning and
-stop-after=aarch64-cond-br-tuning cannot be used. This patch fixes that issue.