### PR TITLE
[cherry-pick][lldb] Check if C++ interop and embedded Swift are enabled on CU instead of whole module

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1165,9 +1165,6 @@ SwiftLanguage::GetHardcodedSynthetics() {
 
       Log *log(GetLog(LLDBLog::DataFormatters));
 
-      if (!valobj.GetTargetSP()->IsSwiftCxxInteropEnabled())
-        return nullptr;
-
       CompilerType type(valobj.GetCompilerType());
       auto swift_type_system =
           type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
@@ -1194,6 +1191,29 @@ SwiftLanguage::GetHardcodedSynthetics() {
       if (!casted) {
         LLDB_LOGV(log, "[Matching Clang imported type] - "
                        "Could not cast value object to clang type");
+        return nullptr;
+      }
+
+      // Find the compile unit and module using the frame, because the value
+      // object may not have a module in the case of an expression that
+      // evaluates to a type.
+      if (!valobj.GetFrameSP())
+        return nullptr;
+
+      auto sc = valobj.GetFrameSP()->GetSymbolContext(
+          lldb::SymbolContextItem::eSymbolContextCompUnit |
+          lldb::SymbolContextItem::eSymbolContextModule);
+
+      // If there is a compile unit, use that to check if C++ interop should be
+      // enabled. If there is no compiler unit, use the module. If neither
+      // exist, assume that C++ interop is disabled.
+      if (auto *cu = sc.comp_unit) {
+        if (!SwiftASTContext::ShouldEnableCXXInterop(cu))
+          return nullptr;
+      } else if (sc.module_sp) {
+        if (!sc.module_sp->IsSwiftCxxInteropEnabled())
+          return nullptr;
+      } else {
         return nullptr;
       }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2789,7 +2789,7 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
     swift_ast_sp->m_module = module_sp.get();
     auto &lang_opts = swift_ast_sp->GetLanguageOptions();
     lang_opts.EnableAccessControl = false;
-    lang_opts.EnableCXXInterop = module_sp->IsSwiftCxxInteropEnabled();
+    lang_opts.EnableCXXInterop = ShouldEnableCXXInterop(cu);
     if (module_sp->IsEmbeddedSwift())
       lang_opts.enableFeature(swift::Feature::Embedded);
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2626,7 +2626,7 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 }
 
 /// Determine whether this CU was compiled with C++ interop enabled.
-static bool ShouldEnableCXXInterop(CompileUnit *cu) {
+bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
   AutoBool interop_enabled =
     ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
   switch (interop_enabled) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -209,6 +209,9 @@ public:
                  TypeSystemSwiftTypeRef &typeref_typesystem,
                  const char *extra_options = nullptr);
 
+  /// Returns true if Swift C++ interop is enabled for the given compiler unit.
+  static bool ShouldEnableCXXInterop(CompileUnit *cu);
+
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,
       std::set<lldb::LanguageType> &languages_for_expressions);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -209,8 +209,12 @@ public:
                  TypeSystemSwiftTypeRef &typeref_typesystem,
                  const char *extra_options = nullptr);
 
-  /// Returns true if Swift C++ interop is enabled for the given compiler unit.
+  /// Returns true if the given flag is present in the given compile unit.
+  static bool CheckFlagInCU(CompileUnit *cu, const char *flag);
+
   static bool ShouldEnableCXXInterop(CompileUnit *cu);
+
+  static bool ShouldEnableEmbeddedSwift(CompileUnit *cu);
 
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,


### PR DESCRIPTION
**Explanation**: this fixes a regression where LLDB scans all of the compile units of a module to find out if a program was compiled with C++ interop or Embedded Swift enabled, and instead only parses one compile unit to find out that information. This mainly affects debugging very large programs, which are slowed by multiple seconds without the fix.
**Risk**: Low. The commit with the biggest change was shipped in release/6.0 ([here](https://github.com/swiftlang/llvm-project/pull/8677)) but somehow was not cherry picked into 6.1. The other two, more recent commits simply reuse the functionality in new call sites. 
**Issues**: rdar://147009063
**Original PRs**: https://github.com/swiftlang/llvm-project/pull/10279
**Reviewers**: @adrian-prantl @kastiglione 