### PR TITLE
[feature availablity] Improve diagnostic for goto jumping into if @available(domain: ...)

### DIFF
--- a/clang/include/clang/AST/Stmt.h
+++ b/clang/include/clang/AST/Stmt.h
@@ -2418,6 +2418,8 @@ public:
 
   bool isObjCAvailabilityCheck() const;
 
+  bool isObjCAvailabilityCheckWithDomainName() const;
+
   SourceLocation getBeginLoc() const { return getIfLoc(); }
   SourceLocation getEndLoc() const LLVM_READONLY {
     if (getElse())

--- a/clang/lib/AST/Stmt.cpp
+++ b/clang/lib/AST/Stmt.cpp
@@ -1004,6 +1004,13 @@ bool IfStmt::isObjCAvailabilityCheck() const {
   return isa<ObjCAvailabilityCheckExpr>(getCond());
 }
 
+bool IfStmt::isObjCAvailabilityCheckWithDomainName() const {
+  if (auto *ACE = dyn_cast<ObjCAvailabilityCheckExpr>(getCond());
+      ACE && ACE->hasDomainName())
+    return true;
+  return false;
+}
+
 std::optional<Stmt *> IfStmt::getNondiscardedCase(const ASTContext &Ctx) {
   if (!isConstexpr() || getCond()->isValueDependent())
     return std::nullopt;

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -556,6 +556,8 @@ public:
       auto DomainName = E->getDomainName();
       ASTContext::AvailabilityDomainInfo Info =
           CGF.getContext().getFeatureAvailInfo(DomainName);
+      assert((Info.Kind == FeatureAvailKind::Dynamic && Info.Call) &&
+             "ObjCAvailabilityCheckExpr should have been constant evaluated");
       return CGF.EmitScalarExpr(Info.Call);
     }
 

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -818,7 +818,7 @@ void CodeGenFunction::EmitIfStmt(const IfStmt &S) {
   // the condition and the dead arm of the if/else.
   bool CondConstant;
   if (ConstantFoldsToSimpleInteger(S.getCond(), CondConstant,
-                                   S.isConstexpr())) {
+                                   (S.isConstexpr() || S.isObjCAvailabilityCheckWithDomainName()))) {
     // Figure out which block (then or else) is executed.
     const Stmt *Executed = S.getThen();
     const Stmt *Skipped  = S.getElse();
@@ -827,7 +827,7 @@ void CodeGenFunction::EmitIfStmt(const IfStmt &S) {
 
     // If the skipped block has no labels in it, just emit the executed block.
     // This avoids emitting dead code and simplifies the CFG substantially.
-    if (S.isConstexpr() || !ContainsLabel(Skipped)) {
+    if ((S.isConstexpr() || S.isObjCAvailabilityCheckWithDomainName()) || !ContainsLabel(Skipped)) {
       if (CondConstant)
         incrementProfileCounter(&S);
       if (Executed) {

--- a/clang/lib/Sema/SemaFeatureAvailability.cpp
+++ b/clang/lib/Sema/SemaFeatureAvailability.cpp
@@ -83,13 +83,6 @@ public:
     return true;
   }
 
-  bool VisitLabelStmt(LabelStmt *LS) {
-    if (isConditionallyGuardedByFeature())
-      SemaRef.Diag(LS->getBeginLoc(),
-                   diag::err_label_in_conditionally_guarded_feature);
-    return true;
-  }
-
   bool VisitTypeLoc(TypeLoc Ty);
 
   void IssueDiagnostics() {

--- a/clang/test/CodeGen/feature-availability.c
+++ b/clang/test/CodeGen/feature-availability.c
@@ -106,4 +106,22 @@ void test4(void) {
 
 #endif
 
+// CHECK-LABEL: define void @test5()
+// CHECK: br label %[[L1:.*]]
+// CHECK: [[L1]]:
+// CHECK-NEXT: call i32 @func0()
+// CHECK-NEXT: ret void
+
+void test5(void) {
+  if (__builtin_available(domain:feature1)) {
+    goto L1;
+L1:
+    func0();
+  } else {
+    goto L2;
+L2:
+    func2();
+  }
+}
+
 #endif /* HEADER */

--- a/clang/test/Sema/feature-availability.c
+++ b/clang/test/Sema/feature-availability.c
@@ -175,12 +175,22 @@ void test4(struct S0 *s0) { // expected-error {{use of 'S0' requires feature 'fe
   g11.i0 = 0; // expected-error {{use of 'g11' requires feature 'feature1' to be available}} expected-error {{use of 'i0' requires feature 'feature1' to be available}}
 }
 
-void test5(void) {
-  if (__builtin_available(domain:feature1))
-    label0: // expected-error {{labels cannot appear in regions conditionally guarded by features}}
-      ;
-  label1:
+void test5(int c) {
+  if (c > 100)
+    goto label0; // expected-error {{cannot jump from this goto statement to its label}}
+  else if (c > 50)
+    goto label1; // expected-error {{cannot jump from this goto statement to its label}}
+  if (__builtin_available(domain:feature1)) { // expected-note 2 {{jump enters controlled statement of if available}}
+    label0:
     ;
+  } else {
+    if (c > 80)
+      goto label2;
+    label1:
+    ;
+    label2:
+    ;
+  }
 }
 
 void test6(void) {


### PR DESCRIPTION
Use the existing logic that warns about goto jumping into branches of if
@available.

rdar://137999979