### PR TITLE
[lldb] Add swift regression test for RegisterContextThreadMemory fixes

### DIFF
--- a/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
+++ b/lldb/test/API/lang/swift/async/expr/TestSwiftAsyncExpressions.py
@@ -18,3 +18,6 @@ class TestSwiftAsyncExpressions(lldbtest.TestBase):
         target, process, thread, main_bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec("main.swift"))
         self.expect("expr n", substrs=["42"])
+        process.Continue()
+        stop_desc = process.GetSelectedThread().GetStopDescription(1024)
+        self.assertNotIn("EXC_BAD_ACCESS", stop_desc)


### PR DESCRIPTION
(cherry picked from commit 6a060bd1cc1d03d92eae14e0d8ca12345c6d0683)