### PR TITLE
🍒 [llvm][MetadataLoader] Make sure we correctly load DW_APPLE_ENUM_KIND from bitcode

### DIFF
--- a/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
+++ b/llvm/lib/Bitcode/Reader/MetadataLoader.cpp
@@ -1689,8 +1689,8 @@ Error MetadataLoader::MetadataLoaderImpl::parseOneMetadata(
       }
     }
 
-    if (Record.size() > 25 && Record[25] != dwarf::DW_APPLE_ENUM_KIND_invalid)
-      EnumKind = Record[25];
+    if (Record.size() > 24 && Record[24] != dwarf::DW_APPLE_ENUM_KIND_invalid)
+      EnumKind = Record[24];
 
     DICompositeType *CT = nullptr;
     if (Identifier)

--- a/llvm/test/Bitcode/DW_AT_APPLE_enum_kind.ll
+++ b/llvm/test/Bitcode/DW_AT_APPLE_enum_kind.ll
@@ -1,0 +1,42 @@
+; RUN: llvm-as < %s | llvm-dis | llvm-as | llvm-dis | FileCheck %s --check-prefix=CHECK-METADATA
+
+ ; C++ source to regenerate:
+ ; enum __attribute__((enum_extensibility(open))) OpenEnum {
+ ;   oe1
+ ; } oe;
+ ; 
+ ; enum __attribute__((enum_extensibility(closed))) ClosedEnum {
+ ;   ce1
+ ; } ce;
+ ; 
+ ; $ clang++ -O0 -g debug-info-enum-kind.cpp -c
+
+ ; CHECK-METADATA: enumKind: DW_APPLE_ENUM_KIND_Open
+ ; CHECK-METADATA: enumKind: DW_APPLE_ENUM_KIND_Closed
+
+ source_filename = "enum.cpp"
+ target triple = "arm64-apple-macosx"
+
+ @oe = global i32 0, align 4, !dbg !0
+ @ce = global i32 0, align 4, !dbg !13
+
+ !llvm.dbg.cu = !{!2}
+ !llvm.module.flags = !{!15, !16}
+
+ !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+ !1 = distinct !DIGlobalVariable(name: "oe", scope: !2, file: !3, line: 3, type: !5, isLocal: false, isDefinition: true)
+ !2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !3, producer: "clang version 21.0.0git", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !12, splitDebugInlining: false, nameTableKind: Apple, sysroot: "/")
+ !3 = !DIFile(filename: "enum.cpp", directory: "/tmp")
+ !4 = !{!5, !9}
+ !5 = !DICompositeType(tag: DW_TAG_enumeration_type, name: "OpenEnum", file: !3, line: 1, baseType: !6, size: 32, elements: !7, identifier: "_ZTS8OpenEnum", enumKind: DW_APPLE_ENUM_KIND_Open)
+ !6 = !DIBasicType(name: "unsigned int", size: 32, encoding: DW_ATE_unsigned)
+ !7 = !{!8}
+ !8 = !DIEnumerator(name: "oe1", value: 0, isUnsigned: true)
+ !9 = !DICompositeType(tag: DW_TAG_enumeration_type, name: "ClosedEnum", file: !3, line: 5, baseType: !6, size: 32, elements: !10, identifier: "_ZTS10ClosedEnum", enumKind: DW_APPLE_ENUM_KIND_Closed)
+ !10 = !{!11}
+ !11 = !DIEnumerator(name: "ce1", value: 0, isUnsigned: true)
+ !12 = !{!0, !13}
+ !13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression())
+ !14 = distinct !DIGlobalVariable(name: "ce", scope: !2, file: !3, line: 7, type: !9, isLocal: false, isDefinition: true)
+ !15 = !{i32 7, !"Dwarf Version", i32 5}
+ !16 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
This was pointed out in https://github.com/llvm/llvm-project/pull/124752#issuecomment-2730052773

There was no test that roundtrips this attribute through LLVM bitcode, so this was never caught.