### PR TITLE
[Cherry-pick into next] [lldb] Add a heuristic for handling DW_AT_specification

### DIFF
--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -27,6 +27,8 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         )
         frame = thread.frames[0]
         self.assertTrue(frame, "Frame 0 is valid.")
+        if self.TraceOn():
+            self.expect("frame variable")
 
         varB = frame.FindVariable("varB")
         field = varB.GetChildMemberWithName("a").GetChildMemberWithName("field")


### PR DESCRIPTION
```
commit 2c05201b53dc34bef34c1ee515a60759b92f6490
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Mar 18 17:10:34 2025 -0700

    [lldb] Add a heuristic for handling DW_AT_specification
    
    in sized containers. Due to a limitation of LLVM, the Swift frontend
    cannot add a DW_AT_specification attribute to a forward declaration,
    so it attaches it to the outer, anonymous, sized container. LLDB
    dutyfully follows specification attributes and collects everything
    into one list of attributes, which results in the anonymous container
    inheriting the names of the DIE linked by DW_AT_specification. This
    patch adds a heuristic to detect this situation.
    
    The correct thing to do here would be to fix LLVM to allow a forward
    declaration to have a specification, or potentially even better
    designate a new attribute for this.
```
