### PR TITLE
[lldb] Remove old reference to swift-enable-cxx-interop setting (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
@@ -1,4 +1,3 @@
-
 """
 Test that evaluating expressions works on backward interop mode.
 """
@@ -12,9 +11,9 @@ class TestSwiftBackwardInteropExpressions(TestBase):
     @swiftTest
     def test_func_step_in(self):
         self.build()
-        self.runCmd('setting set target.experimental.swift-enable-cxx-interop true')
-        _, _, _, _ = lldbutil.run_to_source_breakpoint(
-            self, 'Break here', lldb.SBFileSpec('main.cpp'))
+        lldbutil.run_to_source_breakpoint(
+            self, "Break here", lldb.SBFileSpec("main.cpp")
+        )
         self.expect('expr swiftFunc()', substrs=["Inside a Swift function"])
         self.expect('expr swiftClass.swiftMethod()', substrs=["Inside a Swift method"])
         self.expect('expr a::SwiftClass::swiftStaticMethod()', substrs=["In a Swift static method"])


### PR DESCRIPTION
The setting is now named `symbols.swift-enable-cxx-interop`.

(cherry-picked from commit 5e6f4c4a82f6d2e72a40de9d683d9d081a738d16)