### PR TITLE
[lldb] Construct ThreadTask fully from AsyncTaskInfo fields (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -413,6 +413,7 @@ public:
     result.kind = task_info.Kind;
     result.enqueuePriority = task_info.EnqueuePriority;
     result.resumeAsyncContext = task_info.ResumeAsyncContext;
+    result.runJob = task_info.RunJob;
     for (auto child : task_info.ChildTasks)
       result.childTasks.push_back(child);
     return result;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -172,6 +172,7 @@ public:
     uint32_t kind = 0;
     uint32_t enqueuePriority = 0;
     lldb::addr_t resumeAsyncContext = LLDB_INVALID_ADDRESS;
+    lldb::addr_t runJob = LLDB_INVALID_ADDRESS;
     std::vector<lldb::addr_t> childTasks;
   };
   // The default limits are copied from swift-inspect.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2197,8 +2197,9 @@ ThreadForTaskArgument(Args &command, ExecutionContext &exe_ctx) {
   if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx.GetProcessSP()))
     if (auto reflection_ctx = runtime->GetReflectionContext()) {
       if (auto task_info = reflection_ctx->asyncTaskInfo(task_ptr))
-        return ThreadTask::Create(task_info->id, task_info->resumeAsyncContext,
-                                  exe_ctx);
+        return std::make_shared<ThreadTask>(task_info->id,
+                                            task_info->resumeAsyncContext,
+                                            task_info->runJob, exe_ctx);
       else
         return task_info.takeError();
     }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.cpp
@@ -22,28 +22,6 @@ RegisterContextSP lldb_private::ThreadTask::GetRegisterContext() {
   return m_async_reg_ctx_sp;
 }
 
-llvm::Expected<std::shared_ptr<ThreadTask>>
-ThreadTask::Create(tid_t tid, addr_t async_ctx, ExecutionContext &exe_ctx) {
-  auto &process = exe_ctx.GetProcessRef();
-  auto &target = exe_ctx.GetTargetRef();
-
-  // A simplified description of AsyncContext. See swift/Task/ABI.h
-  // struct AsyncContext {
-  //   AsyncContext *Parent;                    // offset 0
-  //   TaskContinuationFunction *ResumeParent;  // offset 8
-  // };
-  // The resume function is stored at `offsetof(AsyncContext, ResumeParent)`,
-  // which is the async context's base address plus the size of a pointer.
-  uint32_t ptr_size = target.GetArchitecture().GetAddressByteSize();
-  addr_t resume_ptr = async_ctx + ptr_size;
-  Status status;
-  addr_t resume_fn = process.ReadPointerFromMemory(resume_ptr, status);
-  if (status.Fail() || resume_fn == LLDB_INVALID_ADDRESS)
-    return createStringError("failed to read task's resume function");
-
-  return std::make_shared<ThreadTask>(tid, async_ctx, resume_fn, exe_ctx);
-}
-
 RegisterContextTask::RegisterContextTask(Thread &thread,
                                          RegisterContextSP reg_info_sp,
                                          addr_t resume_fn, addr_t async_ctx)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftTask.h
@@ -20,9 +20,6 @@ public:
   ThreadTask(tid_t tid, addr_t async_ctx, addr_t resume_fn,
              ExecutionContext &exe_ctx);
 
-  static llvm::Expected<std::shared_ptr<ThreadTask>>
-  Create(tid_t tid, addr_t async_ctx, ExecutionContext &exe_ctx);
-
   /// Returns a Task specific register context (RegisterContextTask).
   RegisterContextSP GetRegisterContext() override;
 


### PR DESCRIPTION
Instead of determining the resume function by reading memory out of the `AsyncContext` pointer, use the already available `RunJob` field of `AsyncTaskInfo`.