### PR TITLE
[libclang] Add C interface for querying against ModuleDeps

### DIFF
--- a/clang/test/ClangScanDeps/stable-dirs-c-api.c
+++ b/clang/test/ClangScanDeps/stable-dirs-c-api.c
@@ -1,0 +1,25 @@
+// REQUIRES: shell
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: c-index-test core -scan-deps -working-dir %S -- %clang \
+// RUN:   -c %t/client.c -fmodules -fmodules-cache-path=%t/module-cache \
+// RUN:   -isysroot %t/Sysroot -I %t/Sysroot/usr/include 2>&1 | FileCheck %s \
+// RUN:   -implicit-check-not error: -implicit-check-not=warning:
+
+//--- Sysroot/usr/include/A/module.modulemap
+module A {
+  umbrella "."
+}
+
+//--- Sysroot/usr/include/A/A.h
+typedef int A_t;
+
+//--- client.c
+#include <A/A.h>
+
+
+// CHECK:       module: 
+// CHECK-NEXT:    name: A
+// CHECK:         is-in-stable-directories: 1 
+

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -822,6 +822,8 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
       const char *ContextHash =
           clang_experimental_DepGraphModule_getContextHash(Mod);
       int CwdIgnored = clang_experimental_DepGraphModule_isCWDIgnored(Mod);
+      bool IsInStableDir =
+          clang_experimental_DepGraphModule_isInStableDirs(Mod);
       const char *ModuleMapPath =
           clang_experimental_DepGraphModule_getModuleMapPath(Mod);
       const char *ModuleFilesystemRootID =
@@ -844,6 +846,9 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
                    << "    cwd-ignored: " << CwdIgnored << "\n"
                    << "    module-map-path: "
                    << (ModuleMapPath ? ModuleMapPath : "<none>") << "\n";
+      if (IsInStableDir)
+        llvm::outs() << "    is-in-stable-directories: " << IsInStableDir
+                     << "\n";
       if (ModuleFilesystemRootID)
         llvm::outs() << "    casfs-root-id: " << ModuleFilesystemRootID << "\n";
       if (ModuleIncludeTreeID)

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -575,6 +575,7 @@ LLVM_21 {
   global:
     clang_experimental_DependencyScannerServiceOptions_setCWDOptimization;
     clang_experimental_DepGraphModule_isCWDIgnored;
+    clang_experimental_DepGraphModule_isInStableDirs; 
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol


### PR DESCRIPTION
Previously the callback used for getting the output path of pcm's took in the ModuleID, which represents the name & context hash. Now that there are more attributes to determine the output path, like the attribute `isInStableDirectories`. To support this case, allow clients to override the callback's signature to pass along a reference to the whole `ModuleDep` object instead.

Additionally, this patch:

* Makes calls that unwrap `CXDepGraphModule` const correct.
* Provides an API to query whether a module comes from
      stable directories.
