### PR TITLE
[lldb] Fail when running task select or backtrace with a completed task (#10325)

### DIFF
--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -14,3 +14,13 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
         self.expect("v task", substrs=["flags:complete"])
+        self.expect(
+            "language swift task backtrace task",
+            error=True,
+            substrs=["task has completed"],
+        )
+        self.expect(
+            "language swift task select task",
+            error=True,
+            substrs=["task has completed"],
+        )


### PR DESCRIPTION
A task that has completed has no backtrace, and makes no sense to select.

rdar://147601734
(cherry-picked from commit 89adb9bd1a7ebd72a3dde312a1761e461dae5d3a)