### PR TITLE
[BoundsSafety] Fix CodeGen/terminated-by-to-indexable-loop-O2.c (NFC)

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-loop-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-loop-O2.c
@@ -2,8 +2,10 @@
 
 // REQUIRES: x86-registered-target
 
-// RUN: %clang_cc1 -O2 -triple x86_64 -fbounds-safety -emit-llvm %s -o - | FileCheck %s
-// RUN: %clang_cc1 -O2 -triple x86_64 -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -emit-llvm %s -o - | FileCheck %s
+// Disable loop idiom recognize for wcslen(), since we actually want to check
+// if we generate correct loops.
+// RUN: %clang_cc1 -O2 -triple x86_64 -fbounds-safety -mllvm -disable-loop-idiom-wcslen -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -O2 -triple x86_64 -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -mllvm -disable-loop-idiom-wcslen -emit-llvm %s -o - | FileCheck %s
 
 #include <ptrcheck.h>
 


### PR DESCRIPTION
This test start failing after 9694844d7e36fd5e01011ab56b64f27b867aa72d, which recognizes the loops that the test generates and replaces them by calls to strlen()/wcslen().

This fix disables this optimization for the test, since we want to check if such loops are correctly generated.

rdar://147802428