### PR TITLE
[cherry-pick][lldb] Implement missing queue overloads from ThreadMemory

### DIFF
--- a/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
+++ b/lldb/source/Plugins/OperatingSystem/Python/OperatingSystemPython.cpp
@@ -259,8 +259,8 @@ ThreadSP OperatingSystemPython::CreateThreadFromThreadInfo(
   if (!thread_sp) {
     if (did_create_ptr)
       *did_create_ptr = true;
-    thread_sp = std::make_shared<ThreadMemory>(*m_process, tid, name, queue,
-                                               reg_data_addr);
+    thread_sp = std::make_shared<ThreadMemoryProvidingNameAndQueue>(
+        *m_process, tid, name, queue, reg_data_addr);
   }
 
   if (core_number < core_thread_list.GetSize(false)) {

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -93,10 +93,9 @@ OperatingSystemSwiftTasks::FindOrCreateSwiftThread(ThreadList &old_thread_list,
     return old_thread;
 
   std::string name = llvm::formatv("Swift Task {0}", task_id);
-  llvm::StringRef queue_name = "";
-  return std::make_shared<ThreadMemory>(*m_process, masked_task_id, name,
-                                        queue_name,
-                                        /*register_data_addr*/ 0);
+  return std::make_shared<ThreadMemoryProvidingName>(*m_process, masked_task_id,
+                                                     /*register_data_addr*/ 0,
+                                                     name);
 }
 
 bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,

--- a/lldb/source/Plugins/Process/Utility/ThreadMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/ThreadMemory.cpp
@@ -20,18 +20,17 @@
 using namespace lldb;
 using namespace lldb_private;
 
-ThreadMemory::ThreadMemory(Process &process, lldb::tid_t tid,
-                           const ValueObjectSP &thread_info_valobj_sp)
-    : Thread(process, tid), m_backing_thread_sp(),
-      m_thread_info_valobj_sp(thread_info_valobj_sp), m_name(), m_queue(),
-      m_register_data_addr(LLDB_INVALID_ADDRESS) {}
+ThreadMemoryProvidingNameAndQueue::ThreadMemoryProvidingNameAndQueue(
+    Process &process, lldb::tid_t tid,
+    const ValueObjectSP &thread_info_valobj_sp)
+    : ThreadMemoryProvidingName(process, tid, LLDB_INVALID_ADDRESS, ""),
+      m_thread_info_valobj_sp(thread_info_valobj_sp), m_queue() {}
 
-ThreadMemory::ThreadMemory(Process &process, lldb::tid_t tid,
-                           llvm::StringRef name, llvm::StringRef queue,
-                           lldb::addr_t register_data_addr)
-    : Thread(process, tid), m_backing_thread_sp(), m_thread_info_valobj_sp(),
-      m_name(std::string(name)), m_queue(std::string(queue)),
-      m_register_data_addr(register_data_addr) {}
+ThreadMemoryProvidingNameAndQueue::ThreadMemoryProvidingNameAndQueue(
+    Process &process, lldb::tid_t tid, llvm::StringRef name,
+    llvm::StringRef queue, lldb::addr_t register_data_addr)
+    : ThreadMemoryProvidingName(process, tid, register_data_addr, name),
+      m_thread_info_valobj_sp(), m_queue(std::string(queue)) {}
 
 ThreadMemory::~ThreadMemory() { DestroyThread(); }
 

--- a/lldb/source/Plugins/Process/Utility/ThreadMemory.h
+++ b/lldb/source/Plugins/Process/Utility/ThreadMemory.h
@@ -53,6 +53,69 @@ public:
 
   void WillResume(lldb::StateType resume_state) override;
 
+  void SetQueueName(const char *name) override {
+    if (m_backing_thread_sp)
+      m_backing_thread_sp->SetQueueName(name);
+  }
+
+  lldb::queue_id_t GetQueueID() override {
+    if (m_backing_thread_sp)
+      return m_backing_thread_sp->GetQueueID();
+    return LLDB_INVALID_QUEUE_ID;
+  }
+
+  void SetQueueID(lldb::queue_id_t new_val) override {
+    if (m_backing_thread_sp)
+      m_backing_thread_sp->SetQueueID(new_val);
+  }
+
+  lldb::QueueKind GetQueueKind() override {
+    if (m_backing_thread_sp)
+      return m_backing_thread_sp->GetQueueKind();
+    return lldb::eQueueKindUnknown;
+  }
+
+  void SetQueueKind(lldb::QueueKind kind) override {
+    if (m_backing_thread_sp)
+      m_backing_thread_sp->SetQueueKind(kind);
+  }
+
+  lldb::QueueSP GetQueue() override {
+    if (m_backing_thread_sp)
+      return m_backing_thread_sp->GetQueue();
+    return lldb::QueueSP();
+  }
+
+  lldb::addr_t GetQueueLibdispatchQueueAddress() override {
+    if (m_backing_thread_sp)
+      return m_backing_thread_sp->GetQueueLibdispatchQueueAddress();
+    return LLDB_INVALID_ADDRESS;
+  }
+
+  void SetQueueLibdispatchQueueAddress(lldb::addr_t dispatch_queue_t) override {
+    if (m_backing_thread_sp)
+      m_backing_thread_sp->SetQueueLibdispatchQueueAddress(dispatch_queue_t);
+  }
+
+  lldb_private::LazyBool GetAssociatedWithLibdispatchQueue() override {
+    if (m_backing_thread_sp)
+      return m_backing_thread_sp->GetAssociatedWithLibdispatchQueue();
+    return lldb_private::eLazyBoolNo;
+  }
+
+  void SetAssociatedWithLibdispatchQueue(
+      lldb_private::LazyBool associated_with_libdispatch_queue) override {
+    if (m_backing_thread_sp)
+      m_backing_thread_sp->SetAssociatedWithLibdispatchQueue(
+          associated_with_libdispatch_queue);
+  }
+
+  bool ThreadHasQueueInformation() const override {
+    if (m_backing_thread_sp)
+      return m_backing_thread_sp->ThreadHasQueueInformation();
+    return false;
+  }
+
   void DidResume() override {
     if (m_backing_thread_sp)
       m_backing_thread_sp->DidResume();
@@ -132,6 +195,55 @@ public:
     if (!m_queue.empty())
       return m_queue.c_str();
     return ThreadMemory::GetQueueName();
+  }
+
+  /// TODO: this method should take into account the queue override.
+  void SetQueueName(const char *name) override { Thread::SetQueueName(name); }
+
+  /// TODO: this method should take into account the queue override.
+  lldb::queue_id_t GetQueueID() override { return Thread::GetQueueID(); }
+
+  /// TODO: this method should take into account the queue override.
+  void SetQueueID(lldb::queue_id_t new_val) override {
+    Thread::SetQueueID(new_val);
+  }
+
+  /// TODO: this method should take into account the queue override.
+  lldb::QueueKind GetQueueKind() override { return Thread::GetQueueKind(); }
+
+  /// TODO: this method should take into account the queue override.
+  void SetQueueKind(lldb::QueueKind kind) override {
+    Thread::SetQueueKind(kind);
+  }
+
+  /// TODO: this method should take into account the queue override.
+  lldb::QueueSP GetQueue() override { return Thread::GetQueue(); }
+
+  /// TODO: this method should take into account the queue override.
+  lldb::addr_t GetQueueLibdispatchQueueAddress() override {
+    return Thread::GetQueueLibdispatchQueueAddress();
+  }
+
+  /// TODO: this method should take into account the queue override.
+  void SetQueueLibdispatchQueueAddress(lldb::addr_t dispatch_queue_t) override {
+    Thread::SetQueueLibdispatchQueueAddress(dispatch_queue_t);
+  }
+
+  /// TODO: this method should take into account the queue override.
+  bool ThreadHasQueueInformation() const override {
+    return Thread::ThreadHasQueueInformation();
+  }
+
+  /// TODO: this method should take into account the queue override.
+  lldb_private::LazyBool GetAssociatedWithLibdispatchQueue() override {
+    return Thread::GetAssociatedWithLibdispatchQueue();
+  }
+
+  /// TODO: this method should take into account the queue override.
+  void SetAssociatedWithLibdispatchQueue(
+      lldb_private::LazyBool associated_with_libdispatch_queue) override {
+    Thread::SetAssociatedWithLibdispatchQueue(
+        associated_with_libdispatch_queue);
   }
 
   lldb::ValueObjectSP &GetValueObject() { return m_thread_info_valobj_sp; }

--- a/lldb/test/API/lang/swift/async/queues/Makefile
+++ b/lldb/test/API/lang/swift/async/queues/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -1,0 +1,50 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+import re
+
+
+class TestCase(lldbtest.TestBase):
+    @swiftTest
+    @skipIf(oslist=["windows", "linux"])
+    def test(self):
+        """Test `frame variable` in async functions"""
+        self.build()
+
+        self.runCmd("settings set target.experimental.swift-tasks-plugin-enabled true")
+
+        source_file = lldb.SBFileSpec("main.swift")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "BREAK HERE", source_file
+        )
+
+        self.assertIn("Swift Task", thread.GetName())
+
+        queue_plugin = self.get_queue_from_thread_info_command(False)
+        queue_backing = self.get_queue_from_thread_info_command(True)
+        self.assertEqual(queue_plugin, queue_backing)
+        self.assertEqual(queue_plugin, thread.GetQueueName())
+
+        num_queues = process.GetNumQueues()
+        self.assertEqual(num_queues, 1)
+
+    queue_regex = re.compile(r"queue = '([^']+)'")
+
+    def get_queue_from_thread_info_command(self, use_backing_thread):
+        interp = self.dbg.GetCommandInterpreter()
+        result = lldb.SBCommandReturnObject()
+
+        backing_thread_arg = ""
+        if use_backing_thread:
+            backing_thread_arg = "--backing-thread"
+
+        interp.HandleCommand(
+            "thread info {0}".format(backing_thread_arg),
+            result,
+            True,
+        )
+        self.assertTrue(result.Succeeded(), "failed to run thread info")
+        match = self.queue_regex.search(result.GetOutput())
+        self.assertNotEqual(match, None)
+        return match.group(1)

--- a/lldb/test/API/lang/swift/async/queues/main.swift
+++ b/lldb/test/API/lang/swift/async/queues/main.swift
@@ -1,0 +1,11 @@
+func async_foo() async -> Int {
+  var myvar = 111; // BREAK HERE
+  return myvar
+}
+
+@main struct Main {
+  static func main() async {
+    let result = await async_foo()
+    print(result)
+  }
+}


### PR DESCRIPTION
This is a cherry-pick of 

https://github.com/llvm/llvm-project/pull/132905
https://github.com/llvm/llvm-project/pull/132906

With an extra commit updating the swift plugin to account for the new class name (and a test)

rdar://147154570