### PR TITLE
[NFC][-Wunsafe-buffer-usage] Fix a build issue on Linux

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -34,8 +34,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <optional>
-#include <sstream>
+#include <queue>
 #include <set>
+#include <sstream>
 
 using namespace llvm;
 using namespace clang;


### PR DESCRIPTION
https://github.com/swiftlang/llvm-project/pull/10340 introduces a build issue on Linux:
https://ci.swift.org/job/pr-apple-llvm-project-llvm-linux/666/consoleFull

This commit fixes it.