### PR TITLE
[OutputBackend] Make adding outputs to HashingOutputBackend thread-safe

### DIFF
--- a/llvm/include/llvm/Support/HashingOutputBackend.h
+++ b/llvm/include/llvm/Support/HashingOutputBackend.h
@@ -11,11 +11,11 @@
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/Support/Endian.h"
 #include "llvm/Support/HashBuilder.h"
 #include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/VirtualOutputConfig.h"
 #include "llvm/Support/raw_ostream.h"
+#include <mutex>
 
 namespace llvm {
 namespace vfs {
@@ -56,6 +56,7 @@ template <typename HasherT> class HashingOutputBackend : public OutputBackend {
 private:
   friend class HashingOutputFile<HasherT>;
   void addOutputFile(StringRef Path, StringRef Hash) {
+    std::lock_guard<std::mutex> Lock(OutputHashLock);
     OutputHashes[Path] = std::string(Hash);
   }
 
@@ -83,6 +84,7 @@ public:
   }
 
 private:
+  std::mutex OutputHashLock;
   StringMap<std::string> OutputHashes;
 };
 


### PR DESCRIPTION
Make adding outputs to `HashingOutputBackend` thread-safe. This is needed when compiler can write multiple outputs at the same time to the output backend and StringMap can lose output or crash during rehashing. Iterating and checking the hashing outputs still requires synchronization and is not thread-safe.