### PR TITLE
[Cherry-pick into next] [lldb] Add a resilience test for binary swiftmodules created from textual swiftinterfaces.

### DIFF
--- a/lldb/test/API/lang/swift/resilience_swiftinterface/ImplA.swift
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/ImplA.swift
@@ -1,0 +1,5 @@
+public struct S {
+    public var a = 100
+    private var b = 200
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/ImplB.swift
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/ImplB.swift
@@ -1,0 +1,5 @@
+public struct S {
+    private var b = 100
+    public var a = 200
+    public init() {}
+}

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
@@ -1,0 +1,40 @@
+SWIFT_SOURCES := main.swift
+
+all: ImplA a.out Postprocess
+
+include Makefile.rules
+# Register a swiftmodule built of an out-of-date interface with the linker.
+LD_EXTRAS = -lImpl -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker Impl.swiftmodule
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+
+ImplB: ImplB.swift
+	echo "Building an out-of-date swift interface"
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=Impl \
+		DYLIB_SWIFT_SOURCES:=ImplB.swift \
+		-f $(MAKEFILE_RULES)
+	mv Impl.swiftinterface ImplB.swiftinterface
+	rm Impl.swiftmodule Impl.private.swiftinterface libImpl.dylib 
+
+ImplA: ImplB ImplA.swift
+	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		DYLIB_ONLY:=YES DYLIB_NAME=Impl \
+		DYLIB_SWIFT_SOURCES:=ImplA.swift \
+		-f $(MAKEFILE_RULES)
+	echo "Moving out-of-date-swiftinterface into place"
+	rm -rf libImpl.dylib.dSYM Impl.swiftmodule Impl.private.swiftinterface
+	rm ImplA.swift.o ImplB.swift.o
+	mv ImplB.swiftinterface Impl.swiftinterface
+
+Postprocess:
+	echo "Compiling Impl.swiftinterfact to Impl.swiftmodule"
+	echo "import Impl" >trigger.swift
+	$(SWIFT_FE) -module-cache-path cache -c trigger.swift -o trigger -I.
+	mv cache/Impl*.swiftmodule Impl.swiftmodule
+	rm Impl.swiftinterface

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/TestSwiftResilienceSwiftInterface.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftResilienceSwiftInterface(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test the odd scenario where a user registers a binary
+        .swiftmodule file that was built from a textual
+        .swiftinterface files with -add_ast_path. We need to make sure
+        LLDB doesn't bypass reilience for it.
+        """
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression s", substrs=["a", "100", "b", "200"])

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/main.swift
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/main.swift
@@ -1,0 +1,8 @@
+import Impl
+
+func f() {
+    var s = Impl.S()
+    print("break here")
+}
+
+f()


### PR DESCRIPTION
```
commit 799412b4210b7c66c636643475964002da735884
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Mar 25 15:30:22 2025 -0700

    [lldb] Add a resilience test for binary swiftmodules created from textual swiftinterfaces.
```
