### PR TITLE
Suppress CXX interop cycle warning for the Swift compiler

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -1383,9 +1383,11 @@ public:
                                       reinterpret_cast<uintptr_t>(Ty)));
     }
 
+#ifndef __swift__
     bool operator==(const FoldID &RHS) const {
       return std::tie(Op, Ty, C) == std::tie(RHS.Op, RHS.Ty, RHS.C);
     }
+#endif
   };
 
 private:
@@ -2446,10 +2448,12 @@ template <> struct DenseMapInfo<ScalarEvolution::FoldID> {
     return Val.computeHash();
   }
 
+#ifndef __swift__
   static bool isEqual(const ScalarEvolution::FoldID &LHS,
                       const ScalarEvolution::FoldID &RHS) {
     return LHS == RHS;
   }
+#endif
 };
 
 } // end namespace llvm


### PR DESCRIPTION
Solves the same kind of issue as https://github.com/swiftlang/llvm-project/pull/9590.

Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10359.