### PR TITLE
Suppress warnings for Swift C++ interop by hiding an operator declaration

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -1388,9 +1388,11 @@ public:
                                       reinterpret_cast<uintptr_t>(Ty)));
     }
 
+#ifndef __swift__
     bool operator==(const FoldID &RHS) const {
       return std::tie(Op, Ty, C) == std::tie(RHS.Op, RHS.Ty, RHS.C);
     }
+#endif
   };
 
 private:


### PR DESCRIPTION
Solves the same kind of issue as https://github.com/swiftlang/llvm-project/pull/9590.