### PR TITLE
Fix error in ScalarEvolution.h when building the Swift compiler

### DIFF
--- a/llvm/include/llvm/Analysis/ScalarEvolution.h
+++ b/llvm/include/llvm/Analysis/ScalarEvolution.h
@@ -2492,10 +2492,12 @@ template <> struct DenseMapInfo<ScalarEvolution::FoldID> {
     return Val.computeHash();
   }
 
+#ifndef __swift__
   static bool isEqual(const ScalarEvolution::FoldID &LHS,
                       const ScalarEvolution::FoldID &RHS) {
     return LHS == RHS;
   }
+#endif
 };
 
 } // end namespace llvm


### PR DESCRIPTION
Follow up to https://github.com/swiftlang/llvm-project/pull/10359.