### PR TITLE
[llvm][cas] Fix stack-use-after-scope OnDiskCASLoggerTest

### DIFF
--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -106,7 +106,7 @@ TEST(OnDiskCASLoggerTest, MultiThread) {
                     Succeeded());
 
   for (int I = 0; I < 10; ++I) {
-    Pool.async([&] {
+    Pool.async([I, &SharedLogger, &Dir] {
       std::unique_ptr<OnDiskCASLogger> OwnedLogger;
       OnDiskCASLogger *Logger;
       // Mix using a shared instance and opening new instances in the same log.


### PR DESCRIPTION
We were unintentionally capturing the loop induction variable I as a reference instead of a copy. Caught by asan.

(cherry picked from commit ce6efb21ce4399ff0b14f2930361074cbc321dbb)

rdar://147936276