### PR TITLE
[lldb] Support typed throws for Swift exception breakpoints

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -280,10 +280,11 @@ static lldb::BreakpointResolverSP
 CreateExceptionResolver(const lldb::BreakpointSP &bkpt, bool catch_bp, bool throw_bp) {
   BreakpointResolverSP resolver_sp;
 
+  static const char *names[] = {"swift_willThrow", "swift_willThrowTypedImpl"};
   if (throw_bp)
-    resolver_sp.reset(new BreakpointResolverName(
-        bkpt, "swift_willThrow", eFunctionNameTypeBase, eLanguageTypeUnknown,
-        Breakpoint::Exact, 0, eLazyBoolNo));
+    resolver_sp.reset(
+        new BreakpointResolverName(bkpt, names, 2, eFunctionNameTypeBase,
+                                   eLanguageTypeUnknown, 0, eLazyBoolNo));
   // FIXME: We don't do catch breakpoints for ObjC yet.
   // Should there be some way for the runtime to specify what it can do in this
   // regard?

--- a/lldb/test/API/functionalities/breakpoint/swift_exception/main.swift
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/main.swift
@@ -1,76 +1,35 @@
-// main.swift
-//
-// This source file is part of the Swift.org open source project
-//
-// Copyright (c) 2014 - 2016 Apple Inc. and the Swift project authors
-// Licensed under Apache License v2.0 with Runtime Library Exception
-//
-// See https://swift.org/LICENSE.txt for license information
-// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
-//
-// -----------------------------------------------------------------------------
-enum EnumError : Error
-{
-    case ImportantError
+enum EnumError: Error {
     case TrivialError
+    case ImportantError
 }
 
-class ClassError : Error
-{
-    var _code : Int = 10
-    var _domain : String = "ClassError"
-    var m_message : String
-
-    init (_ message: String)
-    {
-        m_message = message
-    }
-    func SomeMethod (_ input : Int) 
-    {
-        print (m_message)  // Set a breakpoint here to test method contexts
-    }
-}
-
-func IThrowEnumOver10(_ input : Int) throws -> Int
-{
-    if input > 100
-    {
+func untyped(_ input : Int) throws -> Int {
+    if input > 100 {
         throw EnumError.ImportantError
-    }
-    else if input > 10
-    {
+    } else if input > 10 {
         throw EnumError.TrivialError
-    }
-    else
-    {
+    } else {
         return input + 2
     }
 }
 
-func IThrowObjectOver10(_ input : Int) throws -> Int
-{
-    if input > 100
-    {
-        let my_error = ClassError("Over 100")
-        throw  my_error
-    }
-    else if input > 10
-    {
-        let my_error = ClassError("Over 10 but less than 100")
-        throw my_error
-    }
-    else
-    {
+func typed(_ input : Int) throws(EnumError) -> Int {
+    if input > 100 {
+        throw EnumError.ImportantError
+    } else if input > 10 {
+        throw EnumError.TrivialError
+    } else {
         return input + 2
     }
 }
 
-do
-{
-    try IThrowEnumOver10(101)  // Set a breakpoint here to run expressions
-    try IThrowObjectOver10(11)
-}
-catch (let e)
-{
-    print (e, true)
+do {
+    let mode = CommandLine.arguments[1]
+    if mode == "untyped" {
+        try untyped(101)
+    } else if mode == "typed" {
+        try typed(101)
+    }
+} catch {
+    print(error)
 }


### PR DESCRIPTION
Swift typed throws [SE 0413][1] use a new breakpoint hook: `swift_willThrowTypedImpl`.
This is separate from the hook already used for untyped throws: `swift_willThrow`.

This change supports stopping on the new throw hook. However this change does not
support typename filtering, which will require additional changes because
`swift_willThrowTypedImpl` is called differently from `swift_willThrow`. In the new
hook, the exception is passed piecewise as parameters, rather than through a dedicated
register. The changes will be made to `SwiftLanguageRuntime::CalculateErrorValue`.

rdar://148033200

[1]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0413-typed-throws.md "Typed throws"
