### PR TITLE
[lldb] Change LLDBTypeInfoProvider to a local (per-module) TypeSystem…

### DIFF
--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/CTypes.h
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/CTypes.h
@@ -1,0 +1,5 @@
+typedef enum { someValue } TDEnum;
+
+typedef struct {
+  TDEnum e;
+} TDStruct;

--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/Makefile
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR) -Xcc -I$(SRCDIR)
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftDWARFImporterC(lldbtest.TestBase):
+
+    @swiftTest
+    def test(self):
+        """Test looking up a Clang typedef type that isn't directly
+        referenced by debug info in the Swift object file.
+        """
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+        s = self.frame().FindVariable("s", lldb.eDynamicDontRunTarget)
+        s_e = s.GetChildAtIndex(0)
+        lldbutil.check_variable(self, s_e, value="someValue")
+

--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/main.swift
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/main.swift
@@ -1,0 +1,8 @@
+import CTypes
+
+func f() {
+  var s = TDStruct(e: someValue)
+  print("break here")
+}
+
+f()

--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/module.modulemap
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/module.modulemap
@@ -1,0 +1,4 @@
+module CTypes {
+  header "CTypes.h"
+  export *
+}

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/TestSwiftLateSwiftDylibClangDeps.py
@@ -23,6 +23,11 @@ class TestSwiftLateSwiftDylibClangDeps(TestBase):
             lldb.SBFileSpec('dylib.swift'), 5)
         threads = lldbutil.continue_to_breakpoint(process, bkpt)
 
-        self.expect("v x", substrs=['42'])
+        self.expect("v fromClang", substrs=['42'])
         self.expect("frame select 1")
-        self.expect("v fromClang", substrs=['23'])
+        # Note that in earlier versions the lookup was a global one and
+        # thus re-evaluating the variable after adding dylib would
+        # have produced a different result. Currently these lookups
+        # are per-module so this expectedly still fails.
+        self.expect("v fromClang",
+                    substrs=["missing debug info", "FromClang"])

--- a/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/dylib.swift
+++ b/lldb/test/API/lang/swift/late_swift_dylib_clangdeps/dylib.swift
@@ -1,6 +1,6 @@
 import ClangMod
 
 @_silgen_name("f") public func f() {
-  let x = FromClang(x: 42)
-  print(x) // line 5
+  let fromClang = FromClang(x: 42)
+  print(fromClang) // line 5
 }


### PR DESCRIPTION
…Swift

The decision of using a scratch context in TIP was made because reading types from a Process' reflection metadata can return types outside of the current lldb_private::Module. That'd be a huge problem for SwiftASTContext because it would pollute the context with ASTs from outside the Module, but TypeSystemSwiftTypeRef only deals in type names, which makes it immune to these risks.

This change allows TypeAlias lookups to be made locally, which can dramatically speed up type resolution.  In a real-world benchmark of printing self in a large Swift/ObjC application the time spent in FindTypes() goes from 50% to it not even showing up on the profile.

rdar://145884579