### PR TITLE
[lldb] Exclude redundant task flags from summary

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1659,8 +1659,6 @@ static const std::pair<StringRef, StringRef> TASK_FLAGS[] = {
     {"isEnqueued", "enqueued"},
     {"isGroupChildTask", "groupChildTask"},
     {"isAsyncLetTask", "asyncLetTask"},
-    {"isChildTask", "childTask"},
-    {"isFuture", "future"},
     {"isStatusRecordLocked", "statusRecordLocked"},
 };
 

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
                 textwrap.dedent(
                     r"""
                     \(UnsafeContinuation<Void, Never>\) cont = \{
-                      task = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?future \{
+                      task = id:(\d+) flags:(?:running|enqueued) \{
                         address = 0x[0-9a-f]+
                         id = \1
                         enqueuePriority = 0
@@ -45,7 +45,7 @@ class TestCase(TestBase):
                 textwrap.dedent(
                     r"""
                     \(CheckedContinuation<Int, Never>\) cont = \{
-                      task = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?future \{
+                      task = id:(\d+) flags:(?:running|enqueued) \{
                         address = 0x[0-9a-f]+
                         id = \1
                         enqueuePriority = 0

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             patterns=[
                 textwrap.dedent(
                     r"""
-                    \(Task<\(\), Error>\) task = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?future \{
+                    \(Task<\(\), Error>\) task = id:(\d+) flags:(?:running|enqueued) \{
                       address = 0x[0-9a-f]+
                       id = \1
                       enqueuePriority = \.medium
@@ -45,7 +45,7 @@ class TestCase(TestBase):
             patterns=[
                 textwrap.dedent(
                     r"""
-                    \(UnsafeCurrentTask\) currentTask = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?asyncLetTask|childTask|future \{
+                    \(UnsafeCurrentTask\) currentTask = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?asyncLetTask \{
                       address = 0x[0-9a-f]+
                       id = \1
                       enqueuePriority = \.medium

--- a/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/children/TestSwiftSyntheticTaskChildren.py
@@ -20,12 +20,12 @@ class TestCase(TestBase):
             patterns=[
                 textwrap.dedent(
                     r"""
-                    \(UnsafeCurrentTask\) current_task = id:1 flags:(?:running\|)?(?:enqueued\|)?future \{
+                    \(UnsafeCurrentTask\) current_task = id:1 flags:(?:running|enqueued) \{
                       address = 0x[0-9a-f]+
                       id = 1
                       enqueuePriority = 0
                       children = \{
-                        0 = id:2 flags:(?:running\|)?(?:enqueued\|)?asyncLetTask\|childTask\|future \{
+                        0 = id:2 flags:(?:running\|)?(?:enqueued\|)?asyncLetTask \{
                           address = 0x[0-9a-f]+
                           id = 2
                           enqueuePriority = \.medium

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -32,19 +32,19 @@ class TestCase(TestBase):
                 textwrap.dedent(
                     r"""
                     \((?:Throwing)?TaskGroup<\(\)\??(?:, Error)?>\) group = \{
-                      \[0\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                      \[0\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \1
                         enqueuePriority = \.medium
                         children = \{\}
                       \}
-                      \[1\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                      \[1\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \2
                         enqueuePriority = \.medium
                         children = \{\}
                       \}
-                      \[2\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask\|childTask\|future \{
+                      \[2\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \3
                         enqueuePriority = \.medium


### PR DESCRIPTION
Don't show `future` or `childTask` flags in a Task's summary.

First, `future` is not an official term in Swift Concurrency. There's undetermined value
in showing this. From my reading of the concurrency runtime, in non-embedded Swift all
tasks have the flag `isFuture`. For embedded Swift it's _unset_ for all tasks.

Second, child tasks are already indicated with either `groupChildTask`, or
`asyncLetTask`.

Both values are still available on demand, ex `p task.isFuture` or `p task.isChildTask`.

This change is to reduce the quantity of data in the summary, because a subsequent
change will add the Task's name in its summary.
