### PR TITLE
[lldb][swift] Call FixCodeAddress on code addresses read from memory

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2806,10 +2806,12 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
   // Get the PC of the parent frame, i.e. the continuation pointer, which is
   // the second field of the CFA.
   addr_t pc_location = cfa + ptr_size;
-  addr_t pc_value = LLDB_INVALID_ADDRESS;
-  process.ReadMemory(pc_location, &pc_value, ptr_size, error);
+  addr_t pc_value = process.ReadPointerFromMemory(pc_location, error);
   if (error.Fail())
     return {};
+  // Clear any high order bits of this code address so that SetLoadAddress works
+  // properly.
+  pc_value = process.FixCodeAddress(pc_value);
 
   Address pc;
   Target &target = process.GetTarget();
@@ -2818,11 +2820,16 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
     return {};
 
   SymbolContext sc;
-  if (!pc.CalculateSymbolContext(&sc,
-                                 eSymbolContextFunction | eSymbolContextSymbol))
+  bool sc_ok = pc.CalculateSymbolContext(&sc, eSymbolContextFunction |
+                                                  eSymbolContextSymbol);
+  if (!sc_ok || (!sc.symbol && !sc.function)) {
+    Log *log = GetLog(LLDBLog::Unwind);
+    LLDB_LOGF(log,
+              "SwiftLanguageRuntime::%s Failed to find a symbol context for "
+              "address 0x%" PRIx64,
+              __FUNCTION__, pc_value);
     return {};
-  if (!sc.symbol && !sc.function)
-    return {};
+  }
 
   auto prologue_size = sc.symbol ? sc.symbol->GetPrologueByteSize()
                                  : sc.function->GetPrologueByteSize();


### PR DESCRIPTION
In the changed code, we read a code address from memory and then attempt to use that value to create a load address. This fails in targets using high order bits for metadata, as we must first call `FixCodeAddress` so that the appropriate plugin can clean-up the address.

Unfortunately, there doesn't seem to be any clean way of testing this, but this patch also adds logging in case we fail to resolve the symbol context again.

rdar://148164938