### PR TITLE
[lldb] Add initial formatter for Swift Actors (#10367)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -136,6 +136,9 @@ CheckedContinuationSyntheticFrontEndCreator(CXXSyntheticChildren *,
 
 SyntheticChildrenFrontEnd *
 TaskGroupSyntheticFrontEndCreator(CXXSyntheticChildren *, lldb::ValueObjectSP);
+
+SyntheticChildrenFrontEnd *ActorSyntheticFrontEndCreator(CXXSyntheticChildren *,
+                                                         lldb::ValueObjectSP);
 }
 }
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -436,6 +436,12 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   AddCXXSynthetic(
       swift_category_sp,
+      lldb_private::formatters::swift::ActorSyntheticFrontEndCreator,
+      "Actor synthetic children", ConstString("Builtin.DefaultActorStorage"),
+      synth_flags);
+
+  AddCXXSynthetic(
+      swift_category_sp,
       lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
       "Swift.Bool", ConstString("Swift.Bool"), basic_synth_flags);
   AddCXXSummary(

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/Makefile
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    @skipUnlessFoundation
+    def test_actor_unprioritised_jobs(self):
+        """Verify that an actor exposes its unprioritised jobs (queue)."""
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.GetSelectedFrame()
+        unprioritised_jobs = frame.var("a.$defaultActor.unprioritised_jobs")
+        # There are 4 child tasks (async let), the first one occupies the actor
+        # with a sleep, the next 3 go on to the queue.
+        self.assertEqual(unprioritised_jobs.num_children, 3)
+        for job in unprioritised_jobs:
+            self.assertRegex(job.name, r"^\d+")
+            self.assertRegex(job.summary, r"^id:\d+ flags:\S+")

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/main.swift
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/main.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+actor Actor {
+    var data: Int = 15
+
+    func occupy() async {
+        Thread.sleep(forTimeInterval: 100)
+    }
+
+    func work() async -> Int {
+        let result = data
+        data += 1
+        return result
+    }
+}
+
+@main struct Entry {
+    static func main() async {
+        let a = Actor()
+        async let _ = a.occupy()
+        async let _ = a.work()
+        async let _ = a.work()
+        async let _ = a.work()
+        print("break here")
+    }
+}


### PR DESCRIPTION
Adds a synthetic formatter for `Builtin.DefaultActorStorage`. Each actor instance has a field named `$defaultActor` which has a type of `DefaultActorStorage`. Prior to this, that field was shown as opaque bytes. With this change, the value now has a single child, `unprioritised_jobs`, which represents the job queue for the actor.

This is the first of a few changes, including a summary formatter which will show which state the actor is in (ie "running", "idle", etc).
(cherry-picked from commit 23f6dc962d60fa139e8818a7295298830a4ed8c8)