### PR TITLE
[Cherry-pick into next] [lldb] Add (broken) testcase for enum projection

### DIFF
--- a/lldb/test/API/lang/swift/optional_clangtype/Makefile
+++ b/lldb/test/API/lang/swift/optional_clangtype/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_BRIDGING_HEADER := bridging.h
+SWIFT_OBJC_INTEROP := 1
+include Makefile.rules

--- a/lldb/test/API/lang/swift/optional_clangtype/TestSwiftOptionalClangType.py
+++ b/lldb/test/API/lang/swift/optional_clangtype/TestSwiftOptionalClangType.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftOptionalClangTyoe(lldbtest.TestBase):
+
+    @swiftTest
+    # This enum cannot be projected.
+    @skipIf(bugnumber='rdar://148275422')
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+        self.expect('target variable opt')
+

--- a/lldb/test/API/lang/swift/optional_clangtype/bridging.h
+++ b/lldb/test/API/lang/swift/optional_clangtype/bridging.h
@@ -1,0 +1,3 @@
+typedef struct {
+  int i;
+} ClangStruct;

--- a/lldb/test/API/lang/swift/optional_clangtype/main.swift
+++ b/lldb/test/API/lang/swift/optional_clangtype/main.swift
@@ -1,0 +1,2 @@
+let opt : ClangStruct? = ClangStruct(i: 23)
+print("break here")


### PR DESCRIPTION
```
commit 2fbf67fd00c790a51c4984e5e274defd357caa82
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Mar 31 14:08:42 2025 -0700

    [lldb] Add (broken) testcase for enum projection
```
