### PR TITLE
[lldb] Fix statusline terminal resizing

### DIFF
--- a/lldb/include/lldb/Core/Statusline.h
+++ b/lldb/include/lldb/Core/Statusline.h
@@ -10,8 +10,6 @@
 #define LLDB_CORE_STATUSLINE_H
 
 #include "lldb/lldb-forward.h"
-#include "llvm/ADT/StringRef.h"
-#include <csignal>
 #include <cstdint>
 #include <string>
 
@@ -34,10 +32,6 @@ public:
   /// Inform the statusline that the terminal dimensions have changed.
   void TerminalSizeChanged();
 
-protected:
-  /// Pad and trim the given string to fit to the given width.
-  static std::string TrimAndPad(std::string str, size_t width);
-
 private:
   /// Draw the statusline with the given text.
   void Draw(std::string msg);
@@ -46,20 +40,15 @@ private:
   void UpdateTerminalProperties();
 
   enum ScrollWindowMode {
-    ScrollWindowExtend,
-    ScrollWindowShrink,
+    EnableStatusline,
+    DisableStatusline,
   };
 
   /// Set the scroll window for the given mode.
   void UpdateScrollWindow(ScrollWindowMode mode);
 
-  /// Clear the statusline (without redrawing the background).
-  void Reset();
-
   Debugger &m_debugger;
   std::string m_last_str;
-
-  volatile std::sig_atomic_t m_terminal_size_has_changed = 1;
   uint64_t m_terminal_width = 0;
   uint64_t m_terminal_height = 0;
 };


### PR DESCRIPTION
Simplify and fix the logic to clear the old statusline when the terminal window dimensions have changed. I accidentally broke the terminal resizing behavior when addressing code review feedback.

I'd really like to figure out a way to test this. PExpect isn't a good fit for this, because I really need to check the result, rather than the control characters, as the latter doesn't tell me whether any part of the old statusline is still visible.

(cherry picked from commit aa889ed129ff26d9341c50a9eaba4db728ca6212)