### PR TITLE
[Cherry-pick into next] [lldb] Convert inline test to regular test (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
+++ b/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
@@ -1,10 +1,19 @@
-import lldbsuite.test.lldbinline as lldbinline
+import lldb
 from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
 
-lldbinline.MakeInlineTest(
-    __file__,
-    globals(),
-    decorators=[
-        expectedFailureAll(oslist=["linux"], bugnumber="rdar://83444822"),
-        swiftTest
-    ])
+class TestSwiftDWARFImporterC(lldbtest.TestBase):
+
+    @swiftTest
+    @expectedFailureAll(oslist=["linux"], bugnumber="rdar://83444822")
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+        self.expect('frame var -d run-target -- ascending', substrs=['OrderedAscending'])
+        self.expect('frame var -d run-target -- descending', substrs=['OrderedDescending'])
+        self.expect('frame var -d run-target -- same', substrs=['OrderedSame'])
+        self.expect('expr -d run-target -- ascending', substrs=['OrderedAscending'])
+        self.expect('expr -d run-target -- descending', substrs=['OrderedDescending'])
+        self.expect('expr -d run-target -- same', substrs=['OrderedSame'])

--- a/lldb/test/API/lang/swift/enum_objc/main.swift
+++ b/lldb/test/API/lang/swift/enum_objc/main.swift
@@ -1,17 +1,10 @@
 import Enum 
 
-func test()
-{
-    let ascending = getReturn(-1)
-    let descending = getReturn(1)
-    let same = getReturn(0)
-    return //%self.expect('frame var -d run-target -- ascending', substrs=['OrderedAscending'])
-           //%self.expect('frame var -d run-target -- descending', substrs=['OrderedDescending'])
-           //%self.expect('frame var -d run-target -- same', substrs=['OrderedSame'])
-           //%self.expect('expr -d run-target -- ascending', substrs=['OrderedAscending'])
-           //%self.expect('expr -d run-target -- descending', substrs=['OrderedDescending'])
-           //%self.expect('expr -d run-target -- same', substrs=['OrderedSame'])
+func test() {
+  let ascending = getReturn(-1)
+  let descending = getReturn(1)
+  let same = getReturn(0)
+  print("break here")
 }
 
-_ = test()
-print("this is needed to load the stdlib")
+test()


### PR DESCRIPTION
```
commit bb00f779a1117b52dde22243461ee05dc82d5611
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Mar 31 15:52:58 2025 -0700

    [lldb] Convert inline test to regular test (NFC)

commit fba81d131340b3e61da0ac1e05821002b11b4274
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Mar 31 16:49:35 2025 -0700

    [lldb] SwiftLanguageRuntime: Support Clang typedef-to-enums.
    
    This also relaxes the check for the name of the member in
    GetIndexOfChildMemberWithName for Clang enums, since the result is
    always 1 anyway.
    
    rdar://147905814
```
