### PR TITLE
[lldb] Fix tagged-pointer info address parsing (#134123)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/AppleObjCRuntime/AppleObjCRuntimeV2.cpp
@@ -1060,7 +1060,7 @@ protected:
         continue;
 
       Status error;
-      lldb::addr_t arg_addr = OptionArgParser::ToAddress(
+      lldb::addr_t arg_addr = OptionArgParser::ToRawAddress(
           &exe_ctx, arg_str, LLDB_INVALID_ADDRESS, &error);
       if (arg_addr == 0 || arg_addr == LLDB_INVALID_ADDRESS || error.Fail()) {
         result.AppendErrorWithFormatv(

--- a/lldb/test/API/lang/objc/tagged-pointer/TestTaggedPointerCmd.py
+++ b/lldb/test/API/lang/objc/tagged-pointer/TestTaggedPointerCmd.py
@@ -8,8 +8,20 @@ class TestTaggedPointerCommand(TestBase):
     @no_debug_info_test
     def test(self):
         self.build()
-        lldbutil.run_to_source_breakpoint(
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "// break here", lldb.SBFileSpec("main.m")
+        )
+
+        n1 = thread.GetSelectedFrame().FindVariable("n1")
+        self.expect(
+            f"lang objc tagged-pointer info {n1.addr}",
+            substrs=[
+                f"{n1.addr} is tagged",
+                "payload = 0x0000000000000012",
+                "value = 0x0000000000000001",
+                "info bits = 0x0000000000000002",
+                "class = __NSCFNumber",
+            ],
         )
 
         self.expect(


### PR DESCRIPTION
Change `objc tagged-pointer info` to call
`OptionArgParser::ToRawAddress`.

Previously `ToAddress` was used, but it calls `FixCodeAddress`, which
can erroneously mutate the bits of a tagged pointer.

(cherry picked from commit 93d3775da8810e1542873b1cdcec2ea142704561)
