### PR TITLE
[Cherry-pick into next] [lldb] Sink timer into the initialization path

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -426,12 +426,12 @@ SwiftLanguageRuntime::GetConformances(llvm::StringRef mangled_name) {
 }
 
 void SwiftLanguageRuntime::SetupReflection() {
-  LLDB_SCOPED_TIMER();
-
   std::lock_guard<std::recursive_mutex> lock(m_reflection_ctx_mutex);
   if (m_initialized_reflection_ctx)
     return;
 
+  LLDB_SCOPED_TIMER();
+  
   // The global ABI bit is read by the Swift runtime library.
   SetupABIBit();
   SetupExclusivity();


### PR DESCRIPTION
```
commit a32c7c972140cc4575128cfeb29ff242c8ffd3f8
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Apr 1 16:40:20 2025 -0700

    [lldb] Sink timer into the initialization path
```
