### PR TITLE
[cherry-pick][lldb][NFC] Reduce scope of Swift customizations

### DIFF
--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -759,6 +759,46 @@ BreakpointSiteMatchesREPLBreakpoint(const BreakpointSiteSP &bp_site_sp) {
   return false;
 }
 
+/// Returns true if reason is Trace/Breakpoint/Watchpoint/PlanComplete.
+static bool IsDebuggerCausedStop(StopReason reason) {
+  switch (reason) {
+  case eStopReasonInvalid:
+  case eStopReasonNone:
+  case eStopReasonSignal:
+  case eStopReasonException:
+  case eStopReasonExec:
+  case eStopReasonFork:
+  case eStopReasonVFork:
+  case eStopReasonVForkDone:
+  case eStopReasonThreadExiting:
+  case eStopReasonInstrumentation:
+  case eStopReasonProcessorTrace:
+  case eStopReasonInterrupt:
+  case eStopReasonHistoryBoundary:
+    return false;
+
+  case eStopReasonTrace:
+  case eStopReasonBreakpoint:
+  case eStopReasonWatchpoint:
+  case eStopReasonPlanComplete:
+    return true;
+  }
+  return false;
+}
+
+/// Returns true if any thread in thread_list has a stop reason of
+/// Trace/Breakpoint/Watchpoint/PlanComplete.
+static bool AnyDebuggerCausedStop(ThreadList &thread_list) {
+  for (const auto &thread_sp : thread_list.Threads()) {
+    if (!thread_sp)
+      continue;
+    StopReason stop_reason = thread_sp->GetStopReason();
+    if (IsDebuggerCausedStop(stop_reason))
+      return true;
+  }
+  return false;
+}
+
 bool Process::HandleProcessStateChangedEvent(
     const EventSP &event_sp, Stream *stream,
     SelectMostRelevant select_most_relevant,
@@ -911,8 +951,6 @@ bool Process::HandleProcessStateChangedEvent(
             case eStopReasonTrace:
             case eStopReasonBreakpoint:
             case eStopReasonWatchpoint:
-              check_for_repl_breakpoint = repl_is_enabled;
-              LLVM_FALLTHROUGH;
             case eStopReasonException:
             case eStopReasonExec:
             case eStopReasonFork:
@@ -926,7 +964,6 @@ bool Process::HandleProcessStateChangedEvent(
                 other_thread = thread;
               break;
             case eStopReasonPlanComplete:
-              check_for_repl_breakpoint = repl_is_enabled;
               if (!plan_thread)
                 plan_thread = thread;
               break;
@@ -949,26 +986,15 @@ bool Process::HandleProcessStateChangedEvent(
             if (thread)
               thread_list.SetSelectedThreadByID(thread->GetID());
           }
-        } else {
-          switch (curr_thread_stop_reason) {
-          case eStopReasonBreakpoint:
-          case eStopReasonWatchpoint:
-            check_for_repl_breakpoint = repl_is_enabled;
-            break;
-          case eStopReasonPlanComplete:
-            // We might have hit a breakpoint during our REPL evaluation and be
-            // stopped
-            // at the REPL breakpoint
-            check_for_repl_breakpoint = repl_is_enabled;
-            break;
-          default:
-            break;
-          }
         }
+
+        check_for_repl_breakpoint =
+            prefer_curr_thread ? IsDebuggerCausedStop(curr_thread_stop_reason)
+                               : AnyDebuggerCausedStop(thread_list);
       }
 
       BreakpointSiteSP bp_site_sp;
-      if (check_for_repl_breakpoint) {
+      if (repl_is_enabled && check_for_repl_breakpoint) {
         // Make sure this isn't the internal "REPL" breakpoint
         if (curr_thread) {
           StopInfoSP stop_info_sp = curr_thread->GetStopInfo();


### PR DESCRIPTION
The code in Process::HandleProcessStateChangedEvent is pretty complicated, and a lot of Swift customizations were added on top of it to support the repl. This commit reduces the area of those customizations by moving them into a separate function; in particular, the code computing whether to "check for a repl breakpoint" was factored out.

The main motivation is that we would like to make some changes in HandleProcessStateChangedEvent, which would run into nasty merge conflicts otherwise.

(cherry picked from commit 0b5e136f2f29fb36ddedee1931f0eaab7e39f4a9)