### PR TITLE
[lldb] Improve determinism of TestSwiftActorUnprioritisedJobs

### DIFF
--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -7,7 +7,6 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipUnlessFoundation
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""
         self.build()
@@ -20,8 +19,7 @@ class TestCase(TestBase):
         unprioritised_jobs = defaultActor.GetChildMemberWithName("unprioritised_jobs")
         # There are 4 child tasks (async let), the first one occupies the actor
         # with a sleep, the next 3 go on to the queue.
-        # TODO: rdar://148377173
-        # self.assertEqual(unprioritised_jobs.num_children, 3)
+        self.assertEqual(unprioritised_jobs.num_children, 3)
         for job in unprioritised_jobs:
             self.assertRegex(job.name, r"^\d+")
             self.assertRegex(job.summary, r"^id:\d+ flags:\S+")

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/main.swift
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/main.swift
@@ -1,10 +1,9 @@
-import Foundation
-
 actor Actor {
     var data: Int = 15
 
     func occupy() async {
-        Thread.sleep(forTimeInterval: 100)
+        // Block on input that will never be received.
+        _ = readLine()
     }
 
     func work() async -> Int {
@@ -21,6 +20,11 @@ actor Actor {
         async let _ = a.work()
         async let _ = a.work()
         async let _ = a.work()
+
+        // Yield to fully prepare the queue used to run the actor. Without this,
+        // the test can sometimes fail.
+        try? await Task.sleep(for: .seconds(2))
+
         print("break here")
     }
 }


### PR DESCRIPTION
Change TestSwiftActorUnprioritisedJobs to prevent non-deterministic failures.

1. Removes the sleep, replacing it with an indefinite read from stdin
2. Makes the test not dependent on Foundation
3. Delays the breakpoint by inserting a stalling Task.sleep

The last one needs explanation. The failures happen when the queue (used to serially
execute actor work) has not finished preparing by the time the breakpoint is hit. The
sleep delays the breakpoint from being hit, and that delay should give the queue the
time needed to be in a state needed by this test.
