### PR TITLE
[lldb] Add summary formatter for DefaultActorStorage (#10388)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -120,6 +120,9 @@ bool TaskPriority_SummaryProvider(ValueObject &valobj, Stream &stream,
 bool Task_SummaryProvider(ValueObject &valobj, Stream &stream,
                           const TypeSummaryOptions &options);
 
+bool Actor_SummaryProvider(ValueObject &valobj, Stream &stream,
+                           const TypeSummaryOptions &options);
+
 SyntheticChildrenFrontEnd *EnumSyntheticFrontEndCreator(CXXSyntheticChildren *,
                                                         lldb::ValueObjectSP);
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -508,6 +508,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                   lldb_private::formatters::swift::Task_SummaryProvider,
                   "Swift UnsafeCurrentTask summary provider",
                   "Swift.UnsafeCurrentTask", task_summary_flags);
+    AddCXXSummary(swift_category_sp,
+                  lldb_private::formatters::swift::Actor_SummaryProvider,
+                  "Swift Actor summary provider", "Builtin.DefaultActorStorage",
+                  task_summary_flags);
   }
 
   summary_flags.SetSkipPointers(false);

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -15,7 +15,9 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
         frame = thread.GetSelectedFrame()
-        unprioritised_jobs = frame.var("a.$defaultActor.unprioritised_jobs")
+        defaultActor = frame.var("a.$defaultActor")
+        self.assertEqual(defaultActor.summary, "running")
+        unprioritised_jobs = defaultActor.GetChildMemberWithName("unprioritised_jobs")
         # There are 4 child tasks (async let), the first one occupies the actor
         # with a sleep, the next 3 go on to the queue.
         self.assertEqual(unprioritised_jobs.num_children, 3)


### PR DESCRIPTION
Show the actor's state (idle, scheduled, running, or zombie) as its summary.


(cherry-picked from commit b7248c725552d563a6e8fbd9ec4add7e0469a5ce)