### PR TITLE
[cherry-pick][lldb] Make `RegisterContextThreadMemory` thread safe (#134469)

### DIFF
--- a/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.cpp
@@ -25,6 +25,8 @@ RegisterContextThreadMemory::RegisterContextThreadMemory(
 RegisterContextThreadMemory::~RegisterContextThreadMemory() = default;
 
 void RegisterContextThreadMemory::UpdateRegisterContext() {
+  std::lock_guard<std::mutex> lock(m_update_register_ctx_lock);
+
   ThreadSP thread_sp(m_thread_wp.lock());
   if (thread_sp) {
     ProcessSP process_sp(thread_sp->GetProcess());

--- a/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.h
+++ b/lldb/source/Plugins/Process/Utility/RegisterContextThreadMemory.h
@@ -99,6 +99,8 @@ private:
   RegisterContextThreadMemory(const RegisterContextThreadMemory &) = delete;
   const RegisterContextThreadMemory &
   operator=(const RegisterContextThreadMemory &) = delete;
+
+  std::mutex m_update_register_ctx_lock;
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
The UpdateRegisterContext method can be called from multiple threads.

(cherry picked from commit 6272e1f37e0710b51d38cb98b905a3f2ffea7966)

rdar://148392773