### PR TITLE
[stable/20240723] Store the backing decl on AvailabilityDomainInfo

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -804,6 +804,7 @@ public:
 
   struct AvailabilityDomainInfo {
     FeatureAvailKind Kind = FeatureAvailKind::None;
+    Decl *Decl = nullptr;
     ImplicitCastExpr *Call = nullptr;
     bool isInvalid() const { return Kind == FeatureAvailKind::None; }
   };

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -950,7 +950,7 @@ ASTContext::getFeatureAvailInfo(Decl *D) const {
     llvm_unreachable("invalid feature kind");
   }
 
-  ASTContext::AvailabilityDomainInfo Info{Kind, nullptr};
+  ASTContext::AvailabilityDomainInfo Info{Kind, D, nullptr};
 
   if (Kind == FeatureAvailKind::Dynamic) {
     Expr *FnExpr = Init->getInit(1);


### PR DESCRIPTION
Swift needs to be able to look up the `VarDecl` that defines a given feature availability domain.

Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10437.