### PR TITLE
[lldb] Clear thread-creation breakpoints in ProcessGDBRemote::Clear (…

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3315,6 +3315,9 @@ Status ProcessGDBRemote::DisableWatchpoint(WatchpointSP wp_sp, bool notify) {
 void ProcessGDBRemote::Clear() {
   m_thread_list_real.Clear();
   m_thread_list.Clear();
+  if (m_thread_create_bp_sp)
+    if (TargetSP target_sp = m_target_wp.lock())
+      target_sp->RemoveBreakpointByID(m_thread_create_bp_sp->GetID());
 }
 
 Status ProcessGDBRemote::DoSignal(int signo) {


### PR DESCRIPTION
…#134397)

Currently, these breakpoints are being accumulated every time a new process if created (e.g. through a `run`). Depending on the circumstances, the old breakpoints are even left enabled, interfering with subsequent processes. This is addressed by removing the breakpoints in ProcessGDBRemote::Clear

Note that these breakpoints are more of a PlatformDarwin thing, so in the future we should look into moving them there.

(cherry picked from commit 232525f06942adb3b9977632e38dcd5f08c0642d) (cherry picked from commit 8afffeb3435e36a854fecd6342552f96cd4424d4)