### PR TITLE
[🍒6.2]: [compiler-rt] Fix detecting _Float16 support for secondary targets

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -849,15 +849,17 @@ else ()
       cmake_push_check_state()
       # TODO: we should probably make most of the checks in builtin-config depend on the target flags.
       set(BUILTIN_CFLAGS_${arch} ${BUILTIN_CFLAGS})
-      # CMAKE_REQUIRED_FLAGS must be a space separated string but unlike TARGET_${arch}_CFLAGS,
-      # BUILTIN_CFLAGS_${arch} is a CMake list, so we have to join it to create a valid command line.
-      list(JOIN BUILTIN_CFLAGS " " CMAKE_REQUIRED_FLAGS)
-      set(CMAKE_REQUIRED_FLAGS "${TARGET_${arch}_CFLAGS} ${BUILTIN_CFLAGS_${arch}}")
+      # CMAKE_REQUIRED_FLAGS must be a space separated string
+      # Join BUILTIN_CFLAGS_${arch} and TARGET_${arch}_CFLAGS as a
+      # space-separated string.
+      list(APPEND CMAKE_REQUIRED_FLAGS
+        ${BUILTIN_CFLAGS_${arch}}
+        ${TARGET_${arch}_CFLAGS})
+      list(JOIN CMAKE_REQUIRED_FLAGS " " CMAKE_REQUIRED_FLAGS)
       message(STATUS "Performing additional configure checks with target flags: ${CMAKE_REQUIRED_FLAGS}")
       # For ARM archs, exclude any VFP builtins if VFP is not supported
       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
-        string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")
-        check_compile_definition(__ARM_FP "${CMAKE_C_FLAGS} ${_TARGET_${arch}_CFLAGS}" COMPILER_RT_HAS_${arch}_VFP)
+        check_compile_definition(__ARM_FP "${CMAKE_C_FLAGS}" COMPILER_RT_HAS_${arch}_VFP)
         if(NOT COMPILER_RT_HAS_${arch}_VFP)
           list(REMOVE_ITEM ${arch}_SOURCES ${arm_Thumb1_VFPv2_DP_SOURCES} ${arm_Thumb1_VFPv2_SP_SOURCES} ${arm_Thumb1_SjLj_EH_SOURCES})
         else()

--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -848,9 +848,12 @@ else ()
     if (CAN_TARGET_${arch})
       cmake_push_check_state()
       # TODO: we should probably make most of the checks in builtin-config depend on the target flags.
-      message(STATUS "Performing additional configure checks with target flags: ${TARGET_${arch}_CFLAGS}")
       set(BUILTIN_CFLAGS_${arch} ${BUILTIN_CFLAGS})
-      list(APPEND CMAKE_REQUIRED_FLAGS ${TARGET_${arch}_CFLAGS} ${BUILTIN_CFLAGS_${arch}})
+      # CMAKE_REQUIRED_FLAGS must be a space separated string but unlike TARGET_${arch}_CFLAGS,
+      # BUILTIN_CFLAGS_${arch} is a CMake list, so we have to join it to create a valid command line.
+      list(JOIN BUILTIN_CFLAGS " " CMAKE_REQUIRED_FLAGS)
+      set(CMAKE_REQUIRED_FLAGS "${TARGET_${arch}_CFLAGS} ${BUILTIN_CFLAGS_${arch}}")
+      message(STATUS "Performing additional configure checks with target flags: ${CMAKE_REQUIRED_FLAGS}")
       # For ARM archs, exclude any VFP builtins if VFP is not supported
       if (${arch} MATCHES "^(arm|armhf|armv7|armv7s|armv7k|armv7m|armv7em|armv8m.main|armv8.1m.main)$")
         string(REPLACE ";" " " _TARGET_${arch}_CFLAGS "${TARGET_${arch}_CFLAGS}")


### PR DESCRIPTION
Cherry-picked from: https://github.com/swiftlang/llvm-project/pull/10366
Which is a cherry-pick of: https://github.com/llvm/llvm-project/pull/117813 and https://github.com/llvm/llvm-project/pull/133952

This fixes the float16 detection when building compiler-rt, which is required for building on FreeBSD.

 - **Explanation:**
This change fixes how arguments are passed into the try-compile used to determine whether the platform that compiler-rt is being built for has Float16 capabilities. This ensures that all of the required flags are actually passed into the try-compile instead of only passing the first.
 - **Scope**:
This impacts how compiler-rt detects whether the platform has support for Float16 and BFloat16.
  - **Issues**:
    - rdar://148052531
  - **Original PRs**:
    - https://github.com/llvm/llvm-project/pull/117813
    - https://github.com/llvm/llvm-project/pull/133952
  - **Risk**:
This affects how the build system detects Float16 support when compiling for the specified platform. If this is wrong, compiler-rt fails to compile.
  - **Testing**:
  LLVM Testing. Local verification that compiler-rt builds.
  Verified that the compiler-rt build as part of the Swift build reports that the Float16/BFloat16 type check fails for arm64, arm64e, x86_64h, x86_64, and i386, as it does prior to this change. Given that the configuration is the same, this has no impact on the Apple builds.
  - **Reviewers**:
    - https://github.com/llvm/llvm-project/pull/117813
      - @compnerd 
      - [DimitryAndric](https://github.com/DimitryAndric)
    - https://github.com/llvm/llvm-project/pull/133952
      - [petrhosek](https://github.com/petrhosek)
      - [arichardson](https://github.com/arichardson)
    - Changes were also reviewed by @edymtt  