### PR TITLE
[BoundsSafety][NFC] Add some clarifying comments to a test case

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-loop-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-loop-O2.c
@@ -2,8 +2,8 @@
 
 // REQUIRES: x86-registered-target
 
-// Disable loop idiom recognize for wcslen(), since we actually want to check
-// if we generate correct loops.
+// Disable loop idiom recognize for wcslen() as a workaround for rdar://148775324
+// (https://github.com/llvm/llvm-project/issues/134736).
 // RUN: %clang_cc1 -O2 -triple x86_64 -fbounds-safety -mllvm -disable-loop-idiom-wcslen -emit-llvm %s -o - | FileCheck %s
 // RUN: %clang_cc1 -O2 -triple x86_64 -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -mllvm -disable-loop-idiom-wcslen -emit-llvm %s -o - | FileCheck %s
 


### PR DESCRIPTION
The new code generated when strlen/wcslen are recognized as a loop idiom is worse because the loop body doesn't get removed after the transform. We should fix but for now clarify the comments and refer to the upstream issue and internal radar tracking the problem (rdar://148775324).

rdar://148605489