### PR TITLE
[lldb] Temporarily disable actor state test

### DIFF
--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -8,6 +8,9 @@ class TestCase(TestBase):
 
     @swiftTest
     @skipUnlessFoundation
+    @skipIfWindows  # temporarily skip test until fails can be investigated
+    @skipIfLinux    # temporarily skip test until fails can be investigated
+    @skipIfDarwin   # temporarily skip test until fails can be investigated
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""
         self.build()

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -15,10 +15,9 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
         frame = thread.GetSelectedFrame()
-        unprioritised_jobs = frame.var("a.$defaultActor.unprioritised_jobs")
-        #defaultActor = frame.var("a.$defaultActor")
-        #self.assertEqual(defaultActor.summary, "running")
-        #unprioritised_jobs = defaultActor.GetChildMemberWithName("unprioritised_jobs")
+        defaultActor = frame.var("a.$defaultActor")
+        self.assertEqual(defaultActor.summary, "running")
+        unprioritised_jobs = defaultActor.GetChildMemberWithName("unprioritised_jobs")
         # There are 4 child tasks (async let), the first one occupies the actor
         # with a sleep, the next 3 go on to the queue.
         # TODO: rdar://148377173

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -15,9 +15,10 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
         frame = thread.GetSelectedFrame()
-        defaultActor = frame.var("a.$defaultActor")
-        self.assertEqual(defaultActor.summary, "running")
-        unprioritised_jobs = defaultActor.GetChildMemberWithName("unprioritised_jobs")
+        unprioritised_jobs = frame.var("a.$defaultActor.unprioritised_jobs")
+        #defaultActor = frame.var("a.$defaultActor")
+        #self.assertEqual(defaultActor.summary, "running")
+        #unprioritised_jobs = defaultActor.GetChildMemberWithName("unprioritised_jobs")
         # There are 4 child tasks (async let), the first one occupies the actor
         # with a sleep, the next 3 go on to the queue.
         # TODO: rdar://148377173


### PR DESCRIPTION
The test added in "Add summary formatter for DefaultActorStorage (#10388)" is checking the actor's state, but it is failing sometimes. Temporarily disable until Dave can look into this, to unblock CI/PR testing.

rdar://148754221