### PR TITLE
[Cherry-pick into next] [lldb] Improve the wording of the error message if no type info is found

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -204,9 +204,10 @@ public:
     auto type_info = m_reflection_ctx.getTypeInfo(&type_ref, provider);
     if (!type_info) {
       std::stringstream ss;
+      ss << "Could not find type info for ";
       type_ref.dump(ss);
-      return llvm::createStringError("Could not get type info for typeref: " +
-                                     ss.str());
+      ss << " in reflection metadata";
+      return llvm::createStringError(ss.str());
     }
 
     if (log && log->GetVerbose()) {


### PR DESCRIPTION
```
commit c5a0fe887f25aeb7bad16e7a7ba4672af6533000
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Apr 7 16:25:38 2025 -0700

    [lldb] Improve the wording of the error message if no type info is found
    
    rdar://145099577
```
