### PR TITLE
[lldb] Temporarily disable actor state test (#10451)

### DIFF
--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -8,6 +8,9 @@ class TestCase(TestBase):
 
     @swiftTest
     @skipUnlessFoundation
+    @skipIfWindows  # temporarily skip test until fails can be investigated
+    @skipIfLinux    # temporarily skip test until fails can be investigated
+    @skipIfDarwin   # temporarily skip test until fails can be investigated
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""
         self.build()


### PR DESCRIPTION
* [lldb] Temporarily disable actor state test

The test added in "Add summary formatter for DefaultActorStorage (#10388)" is checking the actor's state, but it is failing sometimes. Temporarily disable until Dave can look into this, to unblock CI/PR testing.

rdar://148754221

(cherry picked from commit 0b855f532cfebf0db3f7a107febea9b96a6b2979)