### PR TITLE
6.2: [Coro] Retcon.Dynamic: Cap spill alignment.

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -1311,6 +1311,8 @@ static StructType *buildFrameType(Function &F, coro::Shape &Shape,
   std::optional<Align> MaxFrameAlignment;
   if (Shape.ABI == coro::ABI::Async)
     MaxFrameAlignment = Shape.AsyncLowering.getContextAlignment();
+  if (Shape.ABI == coro::ABI::RetconOnceDynamic)
+    MaxFrameAlignment = Shape.RetconLowering.getStorageAlignment();
   FrameTypeBuilder B(C, DL, MaxFrameAlignment);
 
   AllocaInst *PromiseAlloca = Shape.getPromiseAlloca();

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
@@ -4,6 +4,7 @@ target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "arm64-apple-macos99.99"
 
 ; CHECK-LABEL: %func.Frame = type { ptr }
+; CHECK-LABEL: %big_types.Frame = type { <32 x i8>, [16 x i8], i64, ptr, %Integer8 }
 
 ; CHECK-LABEL: @func_cfp = constant <{ i32, i32 }> 
 ; CHECK-SAME:  <{ 
@@ -15,6 +16,16 @@ target triple = "arm64-apple-macos99.99"
        i64 sub (
          i64 ptrtoint (ptr @func to i64),
          i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32 }>, ptr @func_cfp, i32 0, i32 1) to i64)
+       )
+     to i32),
+     i32 64 ; frame size
+}>
+
+@big_types_cfp = constant <{ i32, i32 }>
+  <{ i32 trunc ( ; offset to @func from @big_types_cfp
+       i64 sub (
+         i64 ptrtoint (ptr @big_types to i64),
+         i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32 }>, ptr @big_types_cfp, i32 0, i32 1) to i64)
        )
      to i32),
      i32 64 ; frame size
@@ -101,3 +112,48 @@ declare void @continuation_prototype(ptr, ptr)
 
 declare swiftcorocc noalias ptr @allocate(i32 %size)
 declare void @deallocate(ptr %ptr)
+
+%Integer8 = type { i8 }
+
+; CHECK-LABEL: @big_types(
+; CHECK-SAME:      ptr noalias %frame,
+; CHECK-SAME:      ptr swiftcoro %allocator,
+; CHECK-SAME:      i64 %index,
+; CHECK-SAME:      ptr swiftself dereferenceable(32) %vec_addr
+; CHECK-SAME:  ) {
+; CHECK:         [[VEC_STK_BASE_PTR:%.*]] = getelementptr inbounds %big_types.Frame, ptr %frame, i32 0, i32 0
+; CHECK:         [[VEC_STK_BASE_INT:%.*]] = ptrtoint ptr [[VEC_STK_BASE_PTR]] to i64
+; CHECK:         [[VEC_STK_BIASED_INT:%.*]] = add i64 [[VEC_STK_BASE_INT]], 31
+; CHECK:         [[VEC_STK_ALIGNED_INT:%.*]] = and i64 [[VEC_STK_BIASED_INT]], -32
+; CHECK:         %vec_stk = inttoptr i64 [[VEC_STK_ALIGNED_INT]] to ptr
+define swiftcorocc { ptr, ptr } @big_types(ptr noalias %frame, ptr swiftcoro %allocator, i64 %index, ptr nocapture swiftself dereferenceable(32) %vec_addr) {
+  %element_addr = alloca %Integer8, align 1
+  %id = tail call token @llvm.coro.id.retcon.once.dynamic(
+    i32 -1, 
+    i32 16, 
+    ptr nonnull @big_types_cfp, 
+    ptr %allocator, 
+    ptr %frame, 
+    ptr @continuation_prototype, 
+    ptr nonnull @allocate, 
+    ptr nonnull @deallocate
+  )
+  %handle = tail call ptr @llvm.coro.begin(token %id, ptr null)
+  call void @llvm.lifetime.start.p0(i64 1, ptr nonnull %element_addr)
+  %vec_original = load <32 x i8>, ptr %vec_addr, align 32
+  %vec_stk = alloca <32 x i8>, align 32
+  store <32 x i8> %vec_original, ptr %vec_stk, align 32
+  %vec_original_2 = load <32 x i8>, ptr %vec_stk, align 32
+  %index32 = trunc i64 %index to i32
+  %element_original = extractelement <32 x i8> %vec_original_2, i32 %index32
+  store i8 %element_original, ptr %element_addr, align 1
+  call ptr (...) @llvm.coro.suspend.retcon.p0(ptr nonnull %element_addr)
+  %element_modified = load i8, ptr %element_addr, align 1
+  %vec_original_3 = load <32 x i8>, ptr %vec_stk, align 32
+  %vec_modified = insertelement <32 x i8> %vec_original_3, i8 %element_modified, i32 %index32
+  store <32 x i8> %vec_modified, ptr %vec_addr, align 32
+  call void @llvm.lifetime.end.p0(i64 1, ptr nonnull %element_addr)
+  call i1 @llvm.coro.end(ptr %handle, i1 false, token none)
+  unreachable
+}
+


### PR DESCRIPTION
**Explanation**: Cap alignment of spills to dynamic retcon coro frame.
**Scope**: Affects dynamic retcon once coroutines only.
**Issue**: rdar://148782254
**Original PR**: https://github.com/swiftlang/llvm-project/pull/10449
**Risk**: Low, only affects the dynamic retcon once coro ABI which is only used by swift's coroutine accessors feature.
**Testing**: Added test.
**Reviewer**: Arnold Schwaighofer ( @aschwaighofer )