### PR TITLE
[Cherry-pick into next] [lldb] Add a test for calling open functions in expressions

### DIFF
--- a/lldb/test/API/lang/swift/expression/classes/open/Makefile
+++ b/lldb/test/API/lang/swift/expression/classes/open/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestExpressionOpenClass(TestBase):
+    NO_DEBUG_INFO_TEST = True
+    @swiftTest
+    def test(self):
+        """Tests calling an open function"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect("expr -- a.foo()", substrs=["23"])

--- a/lldb/test/API/lang/swift/expression/classes/open/main.swift
+++ b/lldb/test/API/lang/swift/expression/classes/open/main.swift
@@ -1,0 +1,10 @@
+open class A {
+  open func foo() -> Int { return 23 }
+}
+
+func f() {
+  let a  = A()
+  print("break here \(a)")
+}
+
+f()


### PR DESCRIPTION
```
commit 7001b416e107b8442732f5bbbfecaed78c87cba4
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Apr 9 14:15:46 2025 -0700

    [lldb] Add a test for calling open functions in expressions
    
    See https://github.com/swiftlang/swift/pull/80691
```
