### PR TITLE
[lldb] Unify implementation of GetNumChildren and GetNumFields 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -376,7 +376,9 @@ public:
 
   /// Ask Remote Mirrors about the children of a composite type.
   llvm::Expected<uint32_t> GetNumChildren(CompilerType type,
-                                          ExecutionContextScope *exe_scope);
+                                          ExecutionContextScope *exe_scope,
+                                          bool include_superclass = true,
+                                          bool include_clang_types = true);
 
   /// Determine the enum case name for the \p data value of the enum \p type.
   /// This is performed using Swift reflection.
@@ -422,7 +424,7 @@ public:
       uint64_t &language_flags);
 
   /// Ask Remote Mirrors about the fields of a composite type.
-  std::optional<unsigned> GetNumFields(CompilerType type,
+  llvm::Expected<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);
 
   /// Ask Remote Mirrors for the size of a Swift type.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3782,10 +3782,15 @@ uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
   LLDB_SCOPED_TIMER();
   auto impl = [&]() -> std::optional<uint32_t> {
     if (exe_ctx)
-      if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP()))
-        if (auto num_fields =
-                runtime->GetNumFields(GetCanonicalType(type), exe_ctx))
-          return num_fields;
+      if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP())) {
+        auto num_fields_or_err =
+            runtime->GetNumFields(GetCanonicalType(type), exe_ctx);
+        if (num_fields_or_err)
+          return *num_fields_or_err;
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Types), num_fields_or_err.takeError(),
+                       "GetNumFields failed for type {1}: {0}",
+                       AsMangledName(type));
+      }
 
     bool is_imported = false;
     if (auto clang_type = GetAsClangTypeOrNull(type, &is_imported)) {
@@ -4983,6 +4988,8 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
             is_base_class);
       return false;
     }
+    case Node::Kind::ProtocolList:
+      return false;
     default:
       assert(false && "Unhandled node kind");
       LLDB_LOGF(GetLog(LLDBLog::Types),

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR)
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/P.h
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/P.h
@@ -1,0 +1,2 @@
+@protocol P
+@end

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftObjCProtocol(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test printing an Objective-C protocol existential member."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift')
+        )
+
+        self.expect("v self", substrs=["obj", "0x"])

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/main.swift
@@ -1,0 +1,14 @@
+import P
+
+class ImplementsP : P {}
+
+class C {
+  init(p: P) { x = p }
+  weak var x : P?
+  
+  func f() {
+    print("break here")
+  }
+}
+
+C(p: ImplementsP()).f()

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/module.modulemap
@@ -1,0 +1,1 @@
+module P { header "P.h" }


### PR DESCRIPTION
These functions had incredibly similar implementations, but GetNumFields was missing some of the edge cases implemented in GetNumChildren.

rdar://147771956