### PR TITLE
 Reland "[lldb] Clear thread-creation breakpoints in ProcessGDBRemote::Clear (#134397)"

### DIFF
--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -3315,9 +3315,6 @@ Status ProcessGDBRemote::DisableWatchpoint(WatchpointSP wp_sp, bool notify) {
 void ProcessGDBRemote::Clear() {
   m_thread_list_real.Clear();
   m_thread_list.Clear();
-  if (m_thread_create_bp_sp)
-    if (TargetSP target_sp = m_target_wp.lock())
-      target_sp->RemoveBreakpointByID(m_thread_create_bp_sp->GetID());
 }
 
 Status ProcessGDBRemote::DoSignal(int signo) {

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -2486,7 +2486,16 @@ Status ProcessGDBRemote::DoDestroy() {
 
   StopAsyncThread();
   KillDebugserverProcess();
+  RemoveNewThreadBreakpoints();
   return Status();
+}
+
+void ProcessGDBRemote::RemoveNewThreadBreakpoints() {
+  if (m_thread_create_bp_sp) {
+    if (TargetSP target_sp = m_target_wp.lock())
+      target_sp->RemoveBreakpointByID(m_thread_create_bp_sp->GetID());
+    m_thread_create_bp_sp.reset();
+  }
 }
 
 void ProcessGDBRemote::SetLastStopPacket(

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.h
@@ -434,6 +434,9 @@ private:
                                            lldb::user_id_t break_id,
                                            lldb::user_id_t break_loc_id);
 
+  /// Remove the breakpoints associated with thread creation from the Target.
+  void RemoveNewThreadBreakpoints();
+
   // ContinueDelegate interface
   void HandleAsyncStdout(llvm::StringRef out) override;
   void HandleAsyncMisc(llvm::StringRef data) override;

--- a/lldb/test/API/macosx/thread_start_bps/TestBreakpointsThreadInit.py
+++ b/lldb/test/API/macosx/thread_start_bps/TestBreakpointsThreadInit.py
@@ -35,23 +35,3 @@ class TestInterruptThreadNames(TestBase):
         for bp in bps:
             num_resolved += bp.GetNumResolvedLocations()
         self.assertGreater(num_resolved, 0)
-
-    @skipUnlessDarwin
-    def test_internal_bps_deleted_on_relaunch(self):
-        self.build()
-
-        source_file = lldb.SBFileSpec("main.c")
-        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, "initial hello", source_file
-        )
-
-        self.runCmd("break list --internal")
-        output = self.res.GetOutput()
-        self.assertEqual(output.count("thread-creation"), 1)
-
-        process.Kill()
-        self.runCmd("run", RUN_SUCCEEDED)
-
-        self.runCmd("break list --internal")
-        output = self.res.GetOutput()
-        self.assertEqual(output.count("thread-creation"), 1)


### PR DESCRIPTION
This reverts and relands the commit above, as per upstream discussions: https://github.com/llvm/llvm-project/pull/135296