### PR TITLE
Cherrypick lldbassert fixes to 6.2

### DIFF
--- a/lldb/include/lldb/Utility/LLDBAssert.h
+++ b/lldb/include/lldb/Utility/LLDBAssert.h
@@ -23,7 +23,7 @@
   do {                                                                         \
     static std::once_flag _once_flag;                                          \
     lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__,         \
-                               __FILE_NAME__, __LINE__, _once_flag)            \
+                               __FILE_NAME__, __LINE__, _once_flag);           \
   } while (0)
 #else
 #define lldbassert(x)                                                          \

--- a/lldb/include/lldb/Utility/LLDBAssert.h
+++ b/lldb/include/lldb/Utility/LLDBAssert.h
@@ -10,6 +10,7 @@
 #define LLDB_UTILITY_LLDBASSERT_H
 
 #include "llvm/ADT/StringRef.h"
+#include <mutex>
 
 #ifndef NDEBUG
 #define lldbassert(x) assert(x)
@@ -19,8 +20,11 @@
 // __FILE__ but only renders the last path component (the filename) instead of
 // an invocation dependent full path to that file.
 #define lldbassert(x)                                                          \
-  lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__,           \
-                             __FILE_NAME__, __LINE__)
+  do {                                                                         \
+    static std::once_flag _once_flag;                                          \
+    lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__,         \
+                               __FILE_NAME__, __LINE__, _once_flag)            \
+  } while (0)
 #else
 #define lldbassert(x)                                                          \
   lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__, __FILE__, \
@@ -33,7 +37,8 @@ namespace lldb_private {
 /// Don't use _lldb_assert directly. Use the lldbassert macro instead so that
 /// LLDB asserts become regular asserts in NDEBUG builds.
 void _lldb_assert(bool expression, const char *expr_text, const char *func,
-                  const char *file, unsigned int line);
+                  const char *file, unsigned int line,
+                  std::once_flag &once_flag);
 
 /// The default LLDB assert callback, which prints to stderr.
 typedef void (*LLDBAssertCallback)(llvm::StringRef message,

--- a/lldb/source/Core/CMakeLists.txt
+++ b/lldb/source/Core/CMakeLists.txt
@@ -71,6 +71,7 @@ add_lldb_library(lldbCore
     lldbTarget
     lldbUtility
     lldbValueObject
+    lldbVersion
     lldbPluginCPlusPlusLanguage
     lldbPluginObjCLanguage
     ${LLDB_CURSES_LIBS}

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -52,6 +52,7 @@
 #include "lldb/Utility/State.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/Utility/StreamString.h"
+#include "lldb/Version/Version.h"
 #include "lldb/lldb-enumerations.h"
 
 #if defined(_WIN32)

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -1553,8 +1553,9 @@ bool Debugger::FormatDisassemblerAddress(const FormatEntity::Entry *format,
 void Debugger::AssertCallback(llvm::StringRef message,
                               llvm::StringRef backtrace,
                               llvm::StringRef prompt) {
-  Debugger::ReportError(
-      llvm::formatv("{0}\n{1}{2}", message, backtrace, prompt).str());
+  Debugger::ReportError(llvm::formatv("{0}\n{1}{2}\n{3}", message, backtrace,
+                                      GetVersion(), prompt)
+                            .str());
 }
 
 void Debugger::SetLoggingCallback(lldb::LogOutputCallback log_callback,

--- a/lldb/source/Utility/LLDBAssert.cpp
+++ b/lldb/source/Utility/LLDBAssert.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/raw_ostream.h"
+#include <mutex>
 
 #if LLVM_SUPPORT_XCODE_SIGNPOSTS
 #include <os/log.h>
@@ -33,29 +34,33 @@ static std::atomic<LLDBAssertCallback> g_lldb_assert_callback =
     &DefaultAssertCallback;
 
 void _lldb_assert(bool expression, const char *expr_text, const char *func,
-                  const char *file, unsigned int line) {
+                  const char *file, unsigned int line,
+                  std::once_flag &once_flag) {
   if (LLVM_LIKELY(expression))
     return;
 
+  std::call_once(once_flag, [&]() {
 #if LLVM_SUPPORT_XCODE_SIGNPOSTS
-  if (__builtin_available(macos 10.12, iOS 10, tvOS 10, watchOS 3, *)) {
-    os_log_fault(OS_LOG_DEFAULT,
-                 "Assertion failed: (%s), function %s, file %s, line %u\n",
-                 expr_text, func, file, line);
-  }
+    if (__builtin_available(macos 10.12, iOS 10, tvOS 10, watchOS 3, *)) {
+      os_log_fault(OS_LOG_DEFAULT,
+                   "Assertion failed: (%s), function %s, file %s, line %u\n",
+                   expr_text, func, file, line);
+    }
 #endif
 
-  std::string buffer;
-  llvm::raw_string_ostream backtrace(buffer);
-  llvm::sys::PrintStackTrace(backtrace);
+    std::string buffer;
+    llvm::raw_string_ostream backtrace(buffer);
+    llvm::sys::PrintStackTrace(backtrace);
 
-  (*g_lldb_assert_callback.load())(
-      llvm::formatv("Assertion failed: ({0}), function {1}, file {2}, line {3}",
-                    expr_text, func, file, line)
-          .str(),
-      buffer,
-      "Please file a bug report against lldb and include the backtrace, the "
-      "version and as many details as possible.");
+    (*g_lldb_assert_callback.load())(
+        llvm::formatv(
+            "Assertion failed: ({0}), function {1}, file {2}, line {3}",
+            expr_text, func, file, line)
+            .str(),
+        buffer,
+        "Please file a bug report against lldb and include the backtrace, the "
+        "version and as many details as possible.");
+  });
 }
 
 void SetLLDBAssertCallback(LLDBAssertCallback callback) {

--- a/lldb/source/Utility/LLDBAssert.cpp
+++ b/lldb/source/Utility/LLDBAssert.cpp
@@ -54,8 +54,8 @@ void _lldb_assert(bool expression, const char *expr_text, const char *func,
                     expr_text, func, file, line)
           .str(),
       buffer,
-      "Please file a bug report against lldb reporting this failure log, and "
-      "as many details as possible");
+      "Please file a bug report against lldb and include the backtrace, the "
+      "version and as many details as possible.");
 }
 
 void SetLLDBAssertCallback(LLDBAssertCallback callback) {


### PR DESCRIPTION
Identical to https://github.com/swiftlang/llvm-project/pull/10433, but that one got merged while the 6.2 branch was being created.