### PR TITLE
Revert "[lldb] Customize the statusline for the Swift REPL"

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -303,16 +303,7 @@ Status SwiftREPL::DoInitialization() {
   std::static_pointer_cast<TypeSystemSwiftTypeRefForExpressions>(
       *type_system_or_err)
       ->SetCompilerOptions(m_compiler_options.c_str());
-
-  std::string format_str = "${ansi.negative}Swift " +
-                           swift::version::getCompilerVersion() +
-                           "{ | {${progress.count} }${progress.message}}";
-  FormatEntity::Entry format_entry;
-  Status error = FormatEntity::Parse(format_str, format_entry);
-  if (error.Success())
-    m_target.GetDebugger().SetStatuslineFormat(format_entry);
-
-  return error;
+  return Status();
 }
 
 llvm::StringRef SwiftREPL::GetSourceFileBasename() {


### PR DESCRIPTION
Speculatively reverts swiftlang/llvm-project#10476 to see if it's the cause of the TestSwiftREPLCompletion.py failure on Linux.