### PR TITLE
[Cherry-pick into next] [lldb] Add a test for calling open resilient functions in expressions

### DIFF
--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/Library.swift
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/Library.swift
@@ -1,0 +1,4 @@
+open class A {
+  public init() {}
+  open func foo() -> Int { return 23 }
+}

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/Makefile
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/Makefile
@@ -1,0 +1,14 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -I.
+LD_EXTRAS = -lLibrary -L$(BUILDDIR)
+all: libLibrary.dylib a.out
+
+lib%.dylib: %.swift
+	"$(MAKE)" MAKE_DSYM=NO DYLIB_ONLY=YES \
+		DYLIB_HIDE_SWIFTMODULE=YES \
+		DYLIB_NAME=$(shell basename $< .swift) \
+		DYLIB_SWIFT_SOURCES=$(shell basename $<) \
+                SWIFTFLAGS_EXTRAS=-enable-library-evolution \
+		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(MAKEFILE_RULES) all
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
@@ -10,6 +10,7 @@ class TestExpressionOpenResilientClass(TestBase):
         """Tests calling an open resilient function"""
         self.build()
         lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('main.swift'))
+            self, 'break here', lldb.SBFileSpec('main.swift'),
+            extra_images=['Library'])
 
         self.expect("expr -- a.foo()", substrs=["23"])

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestExpressionOpenResilientClass(TestBase):
+    NO_DEBUG_INFO_TEST = True
+    @swiftTest
+    def test(self):
+        """Tests calling an open resilient function"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect("expr -- a.foo()", substrs=["23"])

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/main.swift
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/main.swift
@@ -1,0 +1,8 @@
+import Library
+
+func f() {
+  let a  = A()
+  print("break here \(a)")
+}
+
+f()


### PR DESCRIPTION
```
commit 0c2f649f0f1e2e10e046ac13f946ae45c719f7e4
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Apr 10 09:49:09 2025 -0700

    [lldb] Add a test for calling open resilient functions in expressions
    
    See https://github.com/swiftlang/swift/pull/80691

commit 53a9cfde1bbe8df4d6ba9ee356f8289b498c7a97
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Apr 10 13:01:38 2025 -0700

    [lldb] Add dylib to extra_images
```
