### PR TITLE
[Cherry-pick into next] [lldb] Unify implementation of GetNumChildren and GetNumFields

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -376,7 +376,9 @@ public:
 
   /// Ask Remote Mirrors about the children of a composite type.
   llvm::Expected<uint32_t> GetNumChildren(CompilerType type,
-                                          ExecutionContextScope *exe_scope);
+                                          ExecutionContextScope *exe_scope,
+                                          bool include_superclass = true,
+                                          bool include_clang_types = true);
 
   /// Determine the enum case name for the \p data value of the enum \p type.
   /// This is performed using Swift reflection.
@@ -422,7 +424,7 @@ public:
       uint64_t &language_flags);
 
   /// Ask Remote Mirrors about the fields of a composite type.
-  std::optional<unsigned> GetNumFields(CompilerType type,
+  llvm::Expected<unsigned> GetNumFields(CompilerType type,
                                         ExecutionContext *exe_ctx);
 
   /// Ask Remote Mirrors for the size of a Swift type.

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR)
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/P.h
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/P.h
@@ -1,0 +1,2 @@
+@protocol P
+@end

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/TestSwiftObjCProtocol.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftObjCProtocol(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test printing an Objective-C protocol existential member."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift')
+        )
+
+        self.expect("v self", substrs=["obj", "0x"])

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/main.swift
@@ -1,0 +1,14 @@
+import P
+
+class ImplementsP : P {}
+
+class C {
+  init(p: P) { x = p }
+  weak var x : P?
+  
+  func f() {
+    print("break here")
+  }
+}
+
+C(p: ImplementsP()).f()

--- a/lldb/test/API/lang/swift/clangimporter/objc_protocol/module.modulemap
+++ b/lldb/test/API/lang/swift/clangimporter/objc_protocol/module.modulemap
@@ -1,0 +1,1 @@
+module P { header "P.h" }


### PR DESCRIPTION
```
commit 9c840dc8d52c6a52bd0e4260a282cbe8782068ff
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Apr 11 12:40:48 2025 -0700

    [lldb] Unify implementation of GetNumChildren and GetNumFields
    
    These functions had incredibly similar implementations, but
    GetNumFields was missing some of the edge cases implemented in
    GetNumChildren.
    
    rdar://147771956
```
