### PR TITLE
[lldb] Prevent Task formatter from showing bogus children

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -887,11 +887,10 @@ public:
         // Remove any bogus child tasks.
         // Very rarely, the child tasks include a bogus task which has an
         // invalid task id of 0.
-        llvm::remove_if(tasks, [&](auto task_ptr) {
-          auto task_info = m_reflection_ctx->asyncTaskInfo(task_ptr);
-          if (task_info)
+        llvm::erase_if(tasks, [&](auto task_ptr) {
+          if (auto task_info =
+                  expectedToOptional(m_reflection_ctx->asyncTaskInfo(task_ptr)))
             return task_info->id == 0;
-          consumeError(task_info.takeError());
           // Don't filter children with errors here. Let these tasks reach the
           // formatter's existing error handling.
           return false;

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -882,7 +882,21 @@ public:
     case 3: {
       if (!m_child_tasks_sp) {
         using task_type = decltype(m_task_info.childTasks)::value_type;
-        const std::vector<task_type> &tasks = m_task_info.childTasks;
+        std::vector<task_type> tasks = m_task_info.childTasks;
+
+        // Remove any bogus child tasks.
+        // Very rarely, the child tasks include a bogus task which has an
+        // invalid task id of 0.
+        llvm::remove_if(tasks, [&](auto task_ptr) {
+          auto task_info = m_reflection_ctx->asyncTaskInfo(task_ptr);
+          if (task_info)
+            return task_info->id == 0;
+          consumeError(task_info.takeError());
+          // Don't filter children with errors here. Let these tasks reach the
+          // formatter's existing error handling.
+          return false;
+        });
+
         std::string mangled_typename =
             mangledTypenameForTasksTuple(tasks.size());
         CompilerType tasks_tuple_type =
@@ -928,15 +942,14 @@ public:
 
   lldb::ChildCacheState Update() override {
     if (auto *runtime = SwiftLanguageRuntime::Get(m_backend.GetProcessSP())) {
-      ThreadSafeReflectionContext reflection_ctx =
-          runtime->GetReflectionContext();
+      m_reflection_ctx = runtime->GetReflectionContext();
       ValueObjectSP task_obj_sp = m_backend.GetChildMemberWithName("_task");
       if (!task_obj_sp)
         return ChildCacheState::eRefetch;
       m_task_ptr = task_obj_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
       if (m_task_ptr != LLDB_INVALID_ADDRESS) {
         llvm::Expected<ReflectionContextInterface::AsyncTaskInfo> task_info =
-            reflection_ctx->asyncTaskInfo(m_task_ptr);
+            m_reflection_ctx->asyncTaskInfo(m_task_ptr);
         if (auto err = task_info.takeError()) {
           LLDB_LOG_ERROR(
               GetLog(LLDBLog::DataFormatters | LLDBLog::Types), std::move(err),
@@ -968,6 +981,7 @@ public:
   }
 
 private:
+  ThreadSafeReflectionContext m_reflection_ctx;
   TypeSystemSwiftTypeRef *m_ts = nullptr;
   addr_t m_task_ptr = LLDB_INVALID_ADDRESS;
   ReflectionContextInterface::AsyncTaskInfo m_task_info;

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -20,7 +20,7 @@ class TestCase(TestBase):
                 textwrap.dedent(
                     r"""
                     \(UnsafeContinuation<Void, Never>\) cont = \{
-                      task = id:(\d+) flags:(?:running|enqueued) \{
+                      task = id:([1-9]\d*) flags:(?:running|enqueued) \{
                         address = 0x[0-9a-f]+
                         id = \1
                         enqueuePriority = 0
@@ -45,7 +45,7 @@ class TestCase(TestBase):
                 textwrap.dedent(
                     r"""
                     \(CheckedContinuation<Int, Never>\) cont = \{
-                      task = id:(\d+) flags:(?:running|enqueued) \{
+                      task = id:([1-9]\d*) flags:(?:running|enqueued) \{
                         address = 0x[0-9a-f]+
                         id = \1
                         enqueuePriority = 0

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             patterns=[
                 textwrap.dedent(
                     r"""
-                    \(Task<\(\), Error>\) task = id:(\d+) flags:(?:running|enqueued) \{
+                    \(Task<\(\), Error>\) task = id:([1-9]\d*) flags:(?:running|enqueued) \{
                       address = 0x[0-9a-f]+
                       id = \1
                       enqueuePriority = \.medium
@@ -45,7 +45,7 @@ class TestCase(TestBase):
             patterns=[
                 textwrap.dedent(
                     r"""
-                    \(UnsafeCurrentTask\) currentTask = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?asyncLetTask \{
+                    \(UnsafeCurrentTask\) currentTask = id:([1-9]\d*) flags:(?:running\|)?(?:enqueued\|)?asyncLetTask \{
                       address = 0x[0-9a-f]+
                       id = \1
                       enqueuePriority = \.medium

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -32,19 +32,19 @@ class TestCase(TestBase):
                 textwrap.dedent(
                     r"""
                     \((?:Throwing)?TaskGroup<\(\)\??(?:, Error)?>\) group = \{
-                      \[0\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
+                      \[0\] = id:([1-9]\d*) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \1
                         enqueuePriority = \.medium
                         children = \{\}
                       \}
-                      \[1\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
+                      \[1\] = id:([1-9]\d*) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \2
                         enqueuePriority = \.medium
                         children = \{\}
                       \}
-                      \[2\] = id:(\d+) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
+                      \[2\] = id:([1-9]\d*) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \3
                         enqueuePriority = \.medium


### PR DESCRIPTION
Very rarely, we've seen a task include a bogus child task. When this has occurred, the task id has been zero, which is invalid. This change filters out a Task's children if they have a task id of 0.