### PR TITLE
Temporarily skip repl completion test while investigating bot failure

### DIFF
--- a/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
+++ b/lldb/test/API/lang/swift/completion/TestSwiftREPLCompletion.py
@@ -10,6 +10,7 @@ class SwiftCompletionTest(PExpectTest):
     @skipIfAsan
     @skipUnlessDarwin
     @swiftTest
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://149326255')
     def test_basic_completion(self):
 
         self.launch(extra_args=["--repl"], executable=None, dimensions=(100,500))
@@ -40,6 +41,7 @@ class SwiftCompletionTest(PExpectTest):
     @skipIfAsan
     @skipIf(oslist=['windows'])
     @swiftTest
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://149326255')
     def test_lldb_command_completion(self):
 
         self.launch(extra_args=["--repl"], executable=None, dimensions=(100,500))


### PR DESCRIPTION
There seems to be an interaction between the DWARF progress updates and the status line.