### PR TITLE
[lldb][DataFormatter] Surface CalculateNumChildren errors in std::vector summary (#135944)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
+++ b/lldb/packages/Python/lldbsuite/test/make/libcxx-simulators-common/compressed_pair.h
@@ -7,6 +7,12 @@
 namespace std {
 namespace __lldb {
 
+#if __has_cpp_attribute(msvc::no_unique_address)
+#define _LLDB_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#elif __has_cpp_attribute(no_unique_address)
+#define _LLDB_NO_UNIQUE_ADDRESS [[__no_unique_address__]]
+#endif
+
 #if COMPRESSED_PAIR_REV == 0 // Post-c88580c layout
 struct __value_init_tag {};
 struct __default_init_tag {};
@@ -55,7 +61,7 @@ public:
 #elif COMPRESSED_PAIR_REV == 1
 // From libc++ datasizeof.h
 template <class _Tp> struct _FirstPaddingByte {
-  [[no_unique_address]] _Tp __v_;
+  _LLDB_NO_UNIQUE_ADDRESS _Tp __v_;
   char __first_padding_byte_;
 };
 
@@ -75,29 +81,30 @@ template <class _ToPad> class __compressed_pair_padding {
 };
 
 #define _LLDB_COMPRESSED_PAIR(T1, Initializer1, T2, Initializer2)              \
-  [[__gnu__::__aligned__(alignof(T2))]] [[no_unique_address]] T1 Initializer1; \
-  [[no_unique_address]] __compressed_pair_padding<T1> __padding1_;             \
-  [[no_unique_address]] T2 Initializer2;                                       \
-  [[no_unique_address]] __compressed_pair_padding<T2> __padding2_;
+  [[__gnu__::__aligned__(                                                      \
+      alignof(T2))]] _LLDB_NO_UNIQUE_ADDRESS T1 Initializer1;                  \
+  _LLDB_NO_UNIQUE_ADDRESS __compressed_pair_padding<T1> __padding1_;           \
+  _LLDB_NO_UNIQUE_ADDRESS T2 Initializer2;                                     \
+  _LLDB_NO_UNIQUE_ADDRESS __compressed_pair_padding<T2> __padding2_;
 
 #define _LLDB_COMPRESSED_TRIPLE(T1, Initializer1, T2, Initializer2, T3,        \
                                 Initializer3)                                  \
   [[using __gnu__: __aligned__(alignof(T2)),                                   \
-    __aligned__(alignof(T3))]] [[no_unique_address]] T1 Initializer1;          \
-  [[no_unique_address]] __compressed_pair_padding<T1> __padding1_;             \
-  [[no_unique_address]] T2 Initializer2;                                       \
-  [[no_unique_address]] __compressed_pair_padding<T2> __padding2_;             \
-  [[no_unique_address]] T3 Initializer3;                                       \
-  [[no_unique_address]] __compressed_pair_padding<T3> __padding3_;
+    __aligned__(alignof(T3))]] _LLDB_NO_UNIQUE_ADDRESS T1 Initializer1;        \
+  _LLDB_NO_UNIQUE_ADDRESS __compressed_pair_padding<T1> __padding1_;           \
+  _LLDB_NO_UNIQUE_ADDRESS T2 Initializer2;                                     \
+  _LLDB_NO_UNIQUE_ADDRESS __compressed_pair_padding<T2> __padding2_;           \
+  _LLDB_NO_UNIQUE_ADDRESS T3 Initializer3;                                     \
+  _LLDB_NO_UNIQUE_ADDRESS __compressed_pair_padding<T3> __padding3_;
 #elif COMPRESSED_PAIR_REV == 2
 #define _LLDB_COMPRESSED_PAIR(T1, Name1, T2, Name2)                            \
-  [[no_unique_address]] T1 Name1;                                              \
-  [[no_unique_address]] T2 Name2
+  _LLDB_NO_UNIQUE_ADDRESS T1 Name1;                                            \
+  _LLDB_NO_UNIQUE_ADDRESS T2 Name2
 
 #define _LLDB_COMPRESSED_TRIPLE(T1, Name1, T2, Name2, T3, Name3)               \
-  [[no_unique_address]] T1 Name1;                                              \
-  [[no_unique_address]] T2 Name2;                                              \
-  [[no_unique_address]] T3 Name3
+  _LLDB_NO_UNIQUE_ADDRESS T1 Name1;                                            \
+  _LLDB_NO_UNIQUE_ADDRESS T2 Name2;                                            \
+  _LLDB_NO_UNIQUE_ADDRESS T3 Name3
 #endif
 } // namespace __lldb
 } // namespace std

--- a/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
+++ b/lldb/source/Plugins/Language/CPlusPlus/LibCxxVector.cpp
@@ -87,19 +87,30 @@ lldb_private::formatters::LibcxxStdVectorSyntheticFrontEnd::
 llvm::Expected<uint32_t> lldb_private::formatters::
     LibcxxStdVectorSyntheticFrontEnd::CalculateNumChildren() {
   if (!m_start || !m_finish)
-    return 0;
+    return llvm::createStringError(
+        "Failed to determine start/end of vector data.");
+
   uint64_t start_val = m_start->GetValueAsUnsigned(0);
   uint64_t finish_val = m_finish->GetValueAsUnsigned(0);
 
-  if (start_val == 0 || finish_val == 0)
+  // A default-initialized empty vector.
+  if (start_val == 0 && finish_val == 0)
     return 0;
 
-  if (start_val >= finish_val)
-    return 0;
+  if (start_val == 0)
+    return llvm::createStringError("Invalid value for start of vector.");
+
+  if (finish_val == 0)
+    return llvm::createStringError("Invalid value for end of vector.");
+
+  if (start_val > finish_val)
+    return llvm::createStringError(
+        "Start of vector data begins after end pointer.");
 
   size_t num_children = (finish_val - start_val);
   if (num_children % m_element_size)
-    return 0;
+    return llvm::createStringError("Size not multiple of element size.");
+
   return num_children / m_element_size;
 }
 

--- a/lldb/source/ValueObject/ValueObject.cpp
+++ b/lldb/source/ValueObject/ValueObject.cpp
@@ -1589,10 +1589,16 @@ bool ValueObject::DumpPrintableRepresentation(
       str = GetLocationAsCString();
       break;
 
-    case eValueObjectRepresentationStyleChildrenCount:
-      strm.Printf("%" PRIu64 "", (uint64_t)GetNumChildrenIgnoringErrors());
-      str = strm.GetString();
+    case eValueObjectRepresentationStyleChildrenCount: {
+      if (auto err = GetNumChildren()) {
+        strm.Printf("%" PRIu32, *err);
+        str = strm.GetString();
+      } else {
+        strm << "error: " << toString(err.takeError());
+        str = strm.GetString();
+      }
       break;
+    }
 
     case eValueObjectRepresentationStyleType:
       str = GetTypeName().GetStringRef();

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+override CXXFLAGS_EXTRAS += -std=c++14
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/Makefile
@@ -1,3 +1,3 @@
 CXX_SOURCES := main.cpp
-override CXXFLAGS_EXTRAS += -std=c++14
+override CXXFLAGS_EXTRAS += -std=c++20
 include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/TestDataFormatterLibcxxInvalidVectorSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/TestDataFormatterLibcxxInvalidVectorSimulator.py
@@ -1,0 +1,39 @@
+"""
+Test we can understand various layouts of the libc++'s std::string
+"""
+
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+import functools
+
+
+class LibcxxInvalidVectorDataFormatterSimulatorTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "return 0", lldb.SBFileSpec("main.cpp"))
+
+        self.expect(
+            "frame variable v1",
+            substrs=["size=error: Invalid value for end of vector."],
+        )
+        self.expect(
+            "frame variable v2",
+            substrs=["size=error: Invalid value for start of vector."],
+        )
+        self.expect(
+            "frame variable v3",
+            substrs=["size=error: Start of vector data begins after end pointer."],
+        )
+        self.expect(
+            "frame variable v4",
+            substrs=["size=error: Failed to determine start/end of vector data."],
+        )
+        self.expect(
+            "frame variable v5",
+            substrs=["size=error: Size not multiple of element size."],
+        )

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/main.cpp
@@ -1,0 +1,37 @@
+#define COMPRESSED_PAIR_REV 2
+#include <libcxx-simulators-common/compressed_pair.h>
+
+namespace std {
+namespace __1 {
+template <typename T> struct vector {
+  T *__begin_;
+  T *__end_;
+  _LLDB_COMPRESSED_PAIR(T *, __cap_ = nullptr, void *, __alloc_);
+};
+} // namespace __1
+
+namespace __2 {
+template <typename T> struct vector {};
+} // namespace __2
+
+namespace __3 {
+template <typename T> struct vector {
+  T *__begin_;
+  T *__end_;
+  _LLDB_COMPRESSED_PAIR(short *, __cap_ = nullptr, void *, __alloc_);
+};
+} // namespace __3
+} // namespace std
+
+int main() {
+  int arr[] = {1, 2, 3};
+  std::__1::vector<int> v1{.__begin_ = arr, .__end_ = nullptr};
+  std::__1::vector<int> v2{.__begin_ = nullptr, .__end_ = arr};
+  std::__1::vector<int> v3{.__begin_ = &arr[2], .__end_ = arr};
+  std::__2::vector<int> v4;
+
+  char carr[] = {'a'};
+  std::__3::vector<char> v5{.__begin_ = carr, .__end_ = carr + 1};
+
+  return 0;
+}

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/invalid-vector/main.cpp
@@ -2,7 +2,7 @@
 #include <libcxx-simulators-common/compressed_pair.h>
 
 namespace std {
-namespace __1 {
+inline namespace __1 {
 template <typename T> struct vector {
   T *__begin_;
   T *__end_;
@@ -10,11 +10,11 @@ template <typename T> struct vector {
 };
 } // namespace __1
 
-namespace __2 {
+inline namespace __2 {
 template <typename T> struct vector {};
 } // namespace __2
 
-namespace __3 {
+inline namespace __3 {
 template <typename T> struct vector {
   T *__begin_;
   T *__end_;

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -22,6 +22,9 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
         self.expect_var_path("shortstring", summary='"short"')
         self.expect_var_path("longstring", summary='"I am a very long string"')
 
+        self.expect_expr("shortstring", result_summary='"short"')
+        self.expect_expr("longstring", result_summary='"I am a very long string"')
+
 
 for v in [None, "ALTERNATE_LAYOUT"]:
     for r in range(5):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -27,7 +27,7 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
 
 
 for v in [None, "ALTERNATE_LAYOUT"]:
-    for r in range(5):
+    for r in range(6):
         for c in range(3):
             name = "test_r%d_c%d" % (r, c)
             defines = ["REVISION=%d" % r, "COMPRESSED_PAIR_REV=%d" % c]

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -25,12 +25,13 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
 
 for v in [None, "ALTERNATE_LAYOUT"]:
     for r in range(5):
-        name = "test_r%d" % r
-        defines = ["REVISION=%d" % r]
-        if v:
-            name += "_" + v
-            defines += [v]
-        f = functools.partialmethod(
-            LibcxxStringDataFormatterSimulatorTestCase._run_test, defines
-        )
-        setattr(LibcxxStringDataFormatterSimulatorTestCase, name, f)
+        for c in range(3):
+            name = "test_r%d_c%d" % (r, c)
+            defines = ["REVISION=%d" % r, "COMPRESSED_PAIR_REV=%d" % c]
+            if v:
+                name += "_" + v
+                defines += [v]
+            f = functools.partialmethod(
+                LibcxxStringDataFormatterSimulatorTestCase._run_test, defines
+            )
+            setattr(LibcxxStringDataFormatterSimulatorTestCase, name, f)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -27,7 +27,7 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
 
 
 for v in [None, "ALTERNATE_LAYOUT"]:
-    for r in range(6):
+    for r in range(5):
         for c in range(3):
             name = "test_r%d_c%d" % (r, c)
             defines = ["REVISION=%d" % r, "COMPRESSED_PAIR_REV=%d" % c]

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -13,6 +13,8 @@ import functools
 class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfDarwin
+    @skipIfWindows
     def _run_test(self, defines):
         cxxflags_extras = " ".join(["-D%s" % d for d in defines])
         self.build(dictionary=dict(CXXFLAGS_EXTRAS=cxxflags_extras))

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -71,19 +71,20 @@ public:
 
   struct __short {
     value_type __data_[__min_cap];
-#ifdef BITMASKS
 #ifdef SUBCLASS_PADDING
     struct : __padding<value_type> {
       unsigned char __size_;
     };
-#else
+#else // !SUBCLASS_PADDING
+
     unsigned char __padding[sizeof(value_type) - 1];
+#ifdef BITMASKS
     unsigned char __size_;
-#endif
 #else // !BITMASKS
     unsigned char __size_ : 7;
     unsigned char __is_long_ : 1;
-#endif
+#endif // BITMASKS
+#endif // SUBCLASS_PADDING
   };
 
 #ifdef BITMASKS

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -20,7 +20,11 @@
 // Pre-D128285 layout.
 #define PACKED_ANON_STRUCT
 #endif
-// REVISION == 4: current layout
+#if REVISION <= 4
+// Pre-2a1ef74 layout.
+#define NON_STANDARD_PADDING
+#endif
+// REVISION == 5: current layout
 
 #ifdef PACKED_ANON_STRUCT
 #define BEGIN_PACKED_ANON_STRUCT struct __attribute__((packed)) {
@@ -34,12 +38,20 @@
 namespace std {
 namespace __lldb {
 
+#ifdef NON_STANDARD_PADDING
 #if defined(ALTERNATE_LAYOUT) && defined(SUBCLASS_PADDING)
 template <class _CharT, size_t = sizeof(_CharT)> struct __padding {
   unsigned char __xx[sizeof(_CharT) - 1];
 };
 
 template <class _CharT> struct __padding<_CharT, 1> {};
+#endif
+#else // !NON_STANDARD_PADDING
+template <size_t _PaddingSize> struct __padding {
+  char __padding_[_PaddingSize];
+};
+
+template <> struct __padding<0> {};
 #endif
 
 template <class _CharT, class _Traits, class _Allocator> class basic_string {
@@ -77,7 +89,12 @@ public:
     };
 #else // !SUBCLASS_PADDING
 
+#ifdef NON_STANDARD_PADDING
     unsigned char __padding[sizeof(value_type) - 1];
+#else
+    [[no_unique_address]] __padding<sizeof(value_type) - 1> __padding_;
+#endif
+
 #ifdef BITMASKS
     unsigned char __size_;
 #else // !BITMASKS
@@ -129,21 +146,26 @@ public:
     union {
 #ifdef BITMASKS
       unsigned char __size_;
-#else
+#else  // !BITMASKS
       struct {
         unsigned char __is_long_ : 1;
         unsigned char __size_ : 7;
       };
-#endif
+#endif // BITMASKS
       value_type __lx;
     };
-#else
+#else  // !SHORT_UNION
     BEGIN_PACKED_ANON_STRUCT
     unsigned char __is_long_ : 1;
     unsigned char __size_ : 7;
     END_PACKED_ANON_STRUCT
-    char __padding_[sizeof(value_type) - 1];
-#endif
+#ifdef NON_STANDARD_PADDING
+    unsigned char __padding[sizeof(value_type) - 1];
+#else  // !NON_STANDARD_PADDING
+    [[no_unique_address]] __padding<sizeof(value_type) - 1> __padding_;
+#endif // NON_STANDARD_PADDING
+
+#endif // SHORT_UNION
     value_type __data_[__min_cap];
   };
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -20,11 +20,7 @@
 // Pre-D128285 layout.
 #define PACKED_ANON_STRUCT
 #endif
-#if REVISION <= 4
-// Pre-2a1ef74 layout.
-#define NON_STANDARD_PADDING
-#endif
-// REVISION == 5: current layout
+// REVISION == 4: current layout
 
 #ifdef PACKED_ANON_STRUCT
 #define BEGIN_PACKED_ANON_STRUCT struct __attribute__((packed)) {
@@ -38,20 +34,12 @@
 namespace std {
 namespace __lldb {
 
-#ifdef NON_STANDARD_PADDING
 #if defined(ALTERNATE_LAYOUT) && defined(SUBCLASS_PADDING)
 template <class _CharT, size_t = sizeof(_CharT)> struct __padding {
   unsigned char __xx[sizeof(_CharT) - 1];
 };
 
 template <class _CharT> struct __padding<_CharT, 1> {};
-#endif
-#else // !NON_STANDARD_PADDING
-template <size_t _PaddingSize> struct __padding {
-  char __padding_[_PaddingSize];
-};
-
-template <> struct __padding<0> {};
 #endif
 
 template <class _CharT, class _Traits, class _Allocator> class basic_string {
@@ -89,12 +77,7 @@ public:
     };
 #else // !SUBCLASS_PADDING
 
-#ifdef NON_STANDARD_PADDING
     unsigned char __padding[sizeof(value_type) - 1];
-#else
-    [[no_unique_address]] __padding<sizeof(value_type) - 1> __padding_;
-#endif
-
 #ifdef BITMASKS
     unsigned char __size_;
 #else // !BITMASKS
@@ -146,26 +129,21 @@ public:
     union {
 #ifdef BITMASKS
       unsigned char __size_;
-#else  // !BITMASKS
+#else
       struct {
         unsigned char __is_long_ : 1;
         unsigned char __size_ : 7;
       };
-#endif // BITMASKS
+#endif
       value_type __lx;
     };
-#else  // !SHORT_UNION
+#else
     BEGIN_PACKED_ANON_STRUCT
     unsigned char __is_long_ : 1;
     unsigned char __size_ : 7;
     END_PACKED_ANON_STRUCT
-#ifdef NON_STANDARD_PADDING
-    unsigned char __padding[sizeof(value_type) - 1];
-#else  // !NON_STANDARD_PADDING
-    [[no_unique_address]] __padding<sizeof(value_type) - 1> __padding_;
-#endif // NON_STANDARD_PADDING
-
-#endif // SHORT_UNION
+    char __padding_[sizeof(value_type) - 1];
+#endif
     value_type __data_[__min_cap];
   };
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/main.cpp
@@ -183,31 +183,50 @@ public:
     };
   };
 
+  __long &getLongRep() {
+#if COMPRESSED_PAIR_REV == 0
+    return __r_.first().__l;
+#elif COMPRESSED_PAIR_REV <= 2
+    return __rep_.__l;
+#endif
+  }
+
+  __short &getShortRep() {
+#if COMPRESSED_PAIR_REV == 0
+    return __r_.first().__s;
+#elif COMPRESSED_PAIR_REV <= 2
+    return __rep_.__s;
+#endif
+  }
+
+#if COMPRESSED_PAIR_REV == 0
   std::__lldb::__compressed_pair<__rep, allocator_type> __r_;
+#elif COMPRESSED_PAIR_REV <= 2
+  _LLDB_COMPRESSED_PAIR(__rep, __rep_, allocator_type, __alloc_);
+#endif
 
 public:
   template <size_t __N>
-  basic_string(unsigned char __size, const value_type (&__data)[__N])
-      : __r_({}, {}) {
+  basic_string(unsigned char __size, const value_type (&__data)[__N]) {
     static_assert(__N < __min_cap, "");
 #ifdef BITMASKS
-    __r_.first().__s.__size_ = __size << __short_shift;
+    getShortRep().__size_ = __size << __short_shift;
 #else
-    __r_.first().__s.__size_ = __size;
-    __r_.first().__s.__is_long_ = false;
+    getShortRep().__size_ = __size;
+    getShortRep().__is_long_ = false;
 #endif
     for (size_t __i = 0; __i < __N; ++__i)
-      __r_.first().__s.__data_[__i] = __data[__i];
+      getShortRep().__data_[__i] = __data[__i];
   }
-  basic_string(size_t __cap, size_type __size, pointer __data) : __r_({}, {}) {
+  basic_string(size_t __cap, size_type __size, pointer __data) {
 #ifdef BITMASKS
-    __r_.first().__l.__cap_ = __cap | __long_mask;
+    getLongRep().__cap_ = __cap | __long_mask;
 #else
-    __r_.first().__l.__cap_ = __cap / __endian_factor;
-    __r_.first().__l.__is_long_ = true;
+    getLongRep().__cap_ = __cap / __endian_factor;
+    getLongRep().__is_long_ = true;
 #endif
-    __r_.first().__l.__size_ = __size;
-    __r_.first().__l.__data_ = __data;
+    getLongRep().__size_ = __size;
+    getLongRep().__data_ = __data;
   }
 };
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
@@ -7,13 +7,15 @@ import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
+import functools
 
 
 class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
-    def test(self):
-        self.build()
+    def _run_test(self, defines):
+        cxxflags_extras = " ".join(["-D%s" % d for d in defines])
+        self.build(dictionary=dict(CXXFLAGS_EXTRAS=cxxflags_extras))
         lldbutil.run_to_source_breakpoint(
             self, "Break here", lldb.SBFileSpec("main.cpp")
         )
@@ -22,3 +24,12 @@ class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
         self.expect(
             "frame variable var_with_deleter_up", substrs=["pointer =", "deleter ="]
         )
+
+
+for r in range(3):
+    name = "test_r%d" % r
+    defines = ["COMPRESSED_PAIR_REV=%d" % r]
+    f = functools.partialmethod(
+        LibcxxUniquePtrDataFormatterSimulatorTestCase._run_test, defines
+    )
+    setattr(LibcxxUniquePtrDataFormatterSimulatorTestCase, name, f)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/main.cpp
@@ -16,9 +16,14 @@ public:
   typedef _Dp deleter_type;
   typedef _Tp *pointer;
 
+#if COMPRESSED_PAIR_REV == 0
   std::__lldb::__compressed_pair<pointer, deleter_type> __ptr_;
   explicit unique_ptr(pointer __p) noexcept
       : __ptr_(__p, std::__lldb::__value_init_tag()) {}
+#elif COMPRESSED_PAIR_REV == 1 || COMPRESSED_PAIR_REV == 2
+  _LLDB_COMPRESSED_PAIR(pointer, __ptr_, deleter_type, __deleter_);
+  explicit unique_ptr(pointer __p) noexcept : __ptr_(__p), __deleter_() {}
+#endif
 };
 } // namespace __lldb
 } // namespace std

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/string/TestDataFormatterLibcxxString.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx/string/TestDataFormatterLibcxxString.py
@@ -100,6 +100,16 @@ class LibcxxStringDataFormatterTestCase(TestBase):
             "s", result_type=ns + "::wstring", result_summary='L"hello world! מזל טוב!"'
         )
 
+        self.expect_expr(
+            "q", result_type=ns + "::string", result_summary='"hello world"'
+        )
+
+        self.expect_expr(
+            "Q",
+            result_type=ns + "::string",
+            result_summary='"quite a long std::strin with lots of info inside it"',
+        )
+
         self.expect(
             "frame variable",
             substrs=[


### PR DESCRIPTION
When the data-formatters happen to break (e.g., due to layout changes in libc++), there's no clear indicator of them failing from a user's perspective. E.g., for `std::vector`s we would just show:
```
(std::vector<int>) v = size=0 {}
```
which is highly misleading, especially if `v.size()` returns a non-zero size.

This patch surfaces the various errors that could occur when calculating the number of children of a vector.

rdar://146964266
(cherry picked from commit 419fa1b06a36336ad85f1c71fc72ffa719ceb659)