### PR TITLE
Narrow down the memory effects of llvm.swift.async.context.addr

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -807,7 +807,17 @@ def int_objc_arc_annotation_bottomup_bbend  : Intrinsic<[],
 // Returns the location of the Swift asynchronous context (usually stored just
 // before the frame pointer), and triggers the creation of a null context if it
 // would otherwise be unneeded.
-def int_swift_async_context_addr : Intrinsic<[llvm_ptr_ty], [], []>;
+// The intrinsics is used in partial functions to store the current async frame
+// -- the "caller's async frame" in the designated stack slot after returning
+// from the callee. The continutation partial function is passed the callee's
+// async frame pointer.
+// We expected there to be at most one call to this intrinic in await partial
+// function. The returned stack location is assumed no to alias with any program
+// accessible memory. This is valid if the frontend only emits one call to
+// the intrinsic per post coro split partial function. And furthermore, the
+// frontend needs to ensure that inlining of funclets is blocked.
+def int_swift_async_context_addr : Intrinsic<[llvm_ptr_ty], [],
+                                    [IntrInaccessibleMemOnly, NoAlias<RetIndex>]>;
 
 //===--------------------- Code Generator Intrinsics ----------------------===//
 //

--- a/llvm/test/CodeGen/AArch64/swift-async-win.ll
+++ b/llvm/test/CodeGen/AArch64/swift-async-win.ll
@@ -17,20 +17,20 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #0
 ; Function Attrs: nounwind
 define hidden swifttailcc void @"$ss23withCheckedContinuation8function_xSS_yScCyxs5NeverOGXEtYalFTQ0_"(ptr nocapture readonly %0) #1 {
 ; CHECK-LABEL: $ss23withCheckedContinuation8function_xSS_yScCyxs5NeverOGXEtYalFTQ0_:
+
 ; CHECK:       // %bb.0: // %entryresume.0
-; CHECK-NEXT:    sub sp, sp, #48
-; CHECK-NEXT:    stp x30, x29, [sp, #24] // 16-byte Folded Spill
-; CHECK-NEXT:    add x29, sp, #24
-; CHECK-NEXT:    str x19, [sp, #40] // 8-byte Folded Spill
-; CHECK-NEXT:    adrp x19, __imp_swift_task_dealloc
-; CHECK-NEXT:    str xzr, [sp, #16]
-; CHECK-NEXT:    ldr x8, [x0]
-; CHECK-NEXT:    stur x8, [x29, #-8]
-; CHECK-NEXT:    ldr x20, [x0]
-; CHECK-NEXT:    ldp x22, x0, [x8, #16]
-; CHECK-NEXT:    stur x20, [x29, #-8]
-; CHECK-NEXT:    ldr x19, [x19, :lo12:__imp_swift_task_dealloc]
-; CHECK-NEXT:    blr x19
+; CHECK-NEXT:    sub     sp, sp, #48
+; CHECK-NEXT:    stp     x30, x29, [sp, #24]             // 16-byte Folded Spill
+; CHECK-NEXT:    add     x29, sp, #24
+; CHECK-NEXT:    str     x19, [sp, #40]                  // 8-byte Folded Spill
+; CHECK-NEXT:    adrp    x19, __imp_swift_task_dealloc
+; CHECK-NEXT:    str     xzr, [sp, #16]
+; CHECK-NEXT:    ldr     x8, [x0]
+; CHECK-NEXT:    ldr     x20, [x0]
+; CHECK-NEXT:    ldp     x22, x0, [x8, #16]
+; CHECK-NEXT:    stur    x20, [x29, #-8]
+; CHECK-NEXT:    ldr     x19, [x19, :lo12:__imp_swift_task_dealloc]
+; CHECK-NEXT:    blr     x19
 ; CHECK-NEXT:    mov x0, x22
 ; CHECK-NEXT:    blr x19
 ; CHECK-NEXT:    ldp x30, x29, [sp, #24] // 16-byte Folded Reload


### PR DESCRIPTION
We don't want it to be CSE'ed across suspend calls.  Therefore mark it as InaccessibleMemOnly. The memory location on the stack is not aliased by other pointers: the frontend guarantees to not emit two calls within one eventual partial function (i.e. in between suspend intrinsic calls)

rdar://149487929