### PR TITLE
[cas] Fix build of CompileJobCacheResultTest with LLVM_LINK_LLVM_DYLIB

### DIFF
--- a/clang/unittests/Frontend/CMakeLists.txt
+++ b/clang/unittests/Frontend/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(LLVM_LINK_COMPONENTS
   Support
   TargetParser
-  TestingSupport
   )
 
 add_clang_unittest(FrontendTests
@@ -31,4 +30,8 @@ clang_target_link_libraries(FrontendTests
   clangFrontendTool
   clangSerialization
   clangTooling
+  )
+target_link_libraries(FrontendTests
+  PRIVATE
+  LLVMTestingSupport
   )


### PR DESCRIPTION
LLVMTestingSupport is not a component library and should be linked with a normal target_link_libraries. With LLVM_LINK_LLVM_DYLIB this issue causes the link to fail.