### PR TITLE
[Cherry-pick into next] [lldb] Avoid returning a false positive error when reaching an ObjC base class

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1059,6 +1059,8 @@ SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
       // superclass, and ends on null.
       auto *current_tr = tr;
       while (current_tr) {
+        if (llvm::isa<swift::reflection::ObjCClassTypeRef>(current_tr))
+          break;
         auto cti_or_err = reflection_ctx->GetClassInstanceTypeInfo(
             *current_tr, &tip, ts.GetDescriptorFinder());
         const TypeInfo *cti = nullptr;

--- a/lldb/test/API/lang/swift/clangimporter/objc_baseclass/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objc_baseclass/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/objc_baseclass/TestSwiftObjCBaseClassMemberLookup.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_baseclass/TestSwiftObjCBaseClassMemberLookup.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftObjCBaseClassMemberLookup(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test accessing a static member from a member function"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift')
+        )
+
+        # dwim-print start by checking whether a member 'A' exists in 'self'.
+        self.expect("dwim-print A.shared", substrs=["42"])

--- a/lldb/test/API/lang/swift/clangimporter/objc_baseclass/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/objc_baseclass/main.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+class A {
+  public static var shared = A()
+  let a = 42
+}
+
+class C : NSObject {
+  var c = 0
+  func foo() {
+    print("break here")
+    c = 1
+  }
+}
+
+C().foo()
+


### PR DESCRIPTION
```
commit fb48ea1b0e964cfec1d7e3a82559027072d5cff9
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Apr 16 16:51:09 2025 -0700

    [lldb] Avoid returning a false positive error when reaching an ObjC base class
    
    in SwiftLanguageRuntime::GetIndexOfChildMemberWithName().
    
    My understanding is that the loop should stop once we reach an ObjC
    base class, because any ivars in the base class will be children of
    the artificial base class child.
    
    rdar://149329166
```
