### PR TITLE
Revert "[lldb][test] Disable TestDataFormatterLibcxxStringSimulator.py for linux to unblock CI"

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -15,7 +15,6 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
 
     @skipIfDarwin
     @skipIfWindows
-    @skipIfLinux
     def _run_test(self, defines):
         cxxflags_extras = " ".join(["-D%s" % d for d in defines])
         self.build(dictionary=dict(CXXFLAGS_EXTRAS=cxxflags_extras))


### PR DESCRIPTION
Reverts swiftlang/llvm-project#10507

Addresses rdar://149562580