### PR TITLE
[clang][Modules] Fix the Size of `RecordDecl`'s `BitCodeAbbrevOp`

### DIFF
--- a/clang/lib/Serialization/ASTWriterDecl.cpp
+++ b/clang/lib/Serialization/ASTWriterDecl.cpp
@@ -2594,7 +2594,7 @@ void ASTWriter::WriteDeclAbbrevs() {
   // RecordDecl
   Abv->Add(BitCodeAbbrevOp(
       BitCodeAbbrevOp::Fixed,
-      13)); // Packed Record Decl Bits: FlexibleArrayMember,
+      14)); // Packed Record Decl Bits: FlexibleArrayMember,
             // AnonymousStructUnion, hasObjectMember, hasVolatileMember,
             // isNonTrivialToPrimitiveDefaultInitialize,
             // isNonTrivialToPrimitiveCopy, isNonTrivialToPrimitiveDestroy,


### PR DESCRIPTION
 (llvm/llvm-project PR#133500)

https://github.com/llvm/llvm-project/pull/102040/files#diff-125f472e690aa3d973bc42aa3c5d580226c5c47661551aca2889f960681aa64dR2477 added 1 bit to `RecordDecl`'s serialization format, but did not increment its abbreviation size.

This can lead to rare cases where a record may overflow if the `RecordDecl`'s `getArgPassingRestrictions()` returns something bigger than 1 (see
[here](https://github.com/llvm/llvm-project/blob/b3f01a6aa45b00240cec1c64286b85d7ba87e2af/clang/lib/Serialization/ASTWriterDecl.cpp#L688)).

rdar://143763558
(cherry picked from commit 4a73c99329ed36712a6faa8e37aa895cfeac23ce)