### PR TITLE
Qualify "Decl" type in a member named "Decl"

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -804,7 +804,7 @@ public:
 
   struct AvailabilityDomainInfo {
     FeatureAvailKind Kind = FeatureAvailKind::None;
-    Decl *Decl = nullptr;
+    clang::Decl *Decl = nullptr;
     ImplicitCastExpr *Call = nullptr;
     bool isInvalid() const { return Kind == FeatureAvailKind::None; }
   };


### PR DESCRIPTION
  - **Explanation**: Fixes a compilation error due to C++ name lookup fun,
  - **Scope**: One header used everywhere in Clang.
  - **Issues**: None.
  - **Original PRs**: https://github.com/swiftlang/llvm-project/pull/10509
  - **Risk**: Zero.
  - **Testing**: CI.
  - **Reviewers**: @adrian-prantl 
