### PR TITLE
[CAS] Improve error message when module cache key is missing

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -23,8 +23,10 @@ def err_cas_depscan_daemon_connection: Error<
 def err_cas_depscan_failed: Error<
   "CAS-based dependency scan failed: %0">, DefaultFatal;
 def err_cas_store: Error<"failed to store to CAS: %0">, DefaultFatal;
-def err_cas_cannot_get_module_cache_key : Error<
-  "CAS cannot load module with key '%0' from %1: %2">, DefaultFatal;
+def err_cas_unloadable_module : Error<
+  "module file '%0' not found: unloadable module cache key %1: %2">, DefaultFatal;
+def err_cas_missing_module : Error<
+  "module file '%0' not found: missing module cache key %1: %2">, DefaultFatal;
 def err_cas_missing_root_id : Error<
   "CAS missing expected root-id '%0'">, DefaultFatal;
 def err_cas_cannot_parse_include_tree_id : Error<

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -364,12 +364,7 @@ Error clang::printCompileJobCacheKey(ObjectStore &CAS, const CASID &Key,
   if (!H)
     return H.takeError();
   TreeSchema Schema(CAS);
-  if (!Schema.isNode(*H)) {
-    std::string ErrStr;
-    llvm::raw_string_ostream Err(ErrStr);
-    Err << "expected cache key to be a CAS tree; got ";
-    H->getID().print(Err);
-    return createStringError(inconvertibleErrorCode(), Err.str());
-  }
+  if (!Schema.isNode(*H))
+    return createStringError("unexpected cache key schema");
   return ::printCompileJobCacheKey(CAS, *H, OS);
 }

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -667,10 +667,11 @@ static void checkCompileCacheKeyMatch(cas::ObjectStore &CAS,
     llvm::report_fatal_error(OldKey.takeError());
   SmallString<256> Err;
   llvm::raw_svector_ostream OS(Err);
-  OS << "Compile cache key for module changed; previously:";
+  OS << "Compile cache key for module changed; previously: "
+     << OldKey->toString() << ": ";
   if (auto E = printCompileJobCacheKey(CAS, *OldKey, OS))
     OS << std::move(E);
-  OS << "\nkey is now:";
+  OS << "\nkey is now: " << NewKey.toString() << ": ";
   if (auto E = printCompileJobCacheKey(CAS, NewKey, OS))
     OS << std::move(E);
   llvm::report_fatal_error(OS.str());

--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -26,7 +26,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/invalid2.txt
 // RUN: FileCheck %s -check-prefix=INVALID2 -input-file=%t/invalid2.txt
 
-// INVALID2: error: CAS cannot load module with key '-fsyntax-only' from -fmodule-file-cache-key
+// INVALID2: error: module file 'INVALID' not found: unloadable module cache key -fsyntax-only: invalid cas-id '-fsyntax-only'
 
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fno-implicit-modules \
@@ -46,7 +46,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key.txt
 // RUN: cat %t/bad_key.txt | FileCheck %s -check-prefix=BAD_KEY
 
-// BAD_KEY: error: CAS cannot load module with key 'KEY' from -fmodule-file-cache-key: invalid cas-id 'KEY'
+// BAD_KEY: error: module file 'PATH' not found: unloadable module cache key KEY: invalid cas-id 'KEY'
 
 // RUN: echo -n '-fmodule-file-cache-key PATH ' > %t/bad_key2.rsp
 // RUN: cat %t/casid >> %t/bad_key2.rsp
@@ -59,7 +59,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key2.txt
 // RUN: cat %t/bad_key2.txt | FileCheck %s -check-prefix=BAD_KEY2
 
-// BAD_KEY2: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: cas object is not a valid cache key
+// BAD_KEY2: error: module file 'PATH' not found: missing module cache key {{.*}}: module file is not available in the CAS
 
 // == Build A
 
@@ -87,7 +87,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/not_in_cache.txt
 // RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE -DPREFIX=%/t
 
-// NOT_IN_CACHE: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache; expected compile:
+// NOT_IN_CACHE: error: module file 'PATH' not found: missing module cache key {{.*}}: expected to be produced by:
 // NOT_IN_CACHE: command-line:
 // NOT_IN_CACHE:   -cc1
 // NOT_IN_CACHE: filesystem:

--- a/clang/test/ClangScanDeps/modules-cas-trees.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees.c
@@ -42,7 +42,7 @@
 // Missing pcm in action cache
 // RUN: not %clang @%t/Left.rsp 2> %t/error.txt
 // RUN: cat %t/error.txt | FileCheck %s -check-prefix=MISSING
-// MISSING: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache
+// MISSING: error: module file '{{.*}}.pcm' not found: missing module cache key {{.*}}: expected to be produced by:
 
 // Build everything
 // RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS


### PR DESCRIPTION
When a module cache key is missing, emit better diagnostics that

* It is clear it is a cache key missing, so a potential dependency missing, not a CAS error
* For other compiler consumers, like a swift compiler that uses a different cache key schema than the clang include tree, it is possible that a detailed cache key cannot be printed. Don't emit extra schema mismatch message that can confuse the users

rdar://149707188