### PR TITLE
[clang][Modules] Adding C-API for Negative Stat Caching Diagnostics

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -586,7 +586,7 @@ CINDEX_LINKAGE
 CXDiagnosticSet clang_experimental_DepGraph_getDiagnostics(CXDepGraph);
 
 CINDEX_LINKAGE
-CXStringSet *
+CXCStringArray
     clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
         CXDependencyScannerService);
 

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -585,6 +585,11 @@ const char *clang_experimental_DepGraph_getTUContextHash(CXDepGraph);
 CINDEX_LINKAGE
 CXDiagnosticSet clang_experimental_DepGraph_getDiagnostics(CXDepGraph);
 
+CINDEX_LINKAGE
+CXStringSet *
+    clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
+        CXDependencyScannerService);
+
 /**
  * @}
  */

--- a/clang/test/ClangScanDeps/error-c-api.cpp
+++ b/clang/test/ClangScanDeps/error-c-api.cpp
@@ -4,4 +4,4 @@
 
 // CHECK: error: failed to get dependencies
 // CHECK-NEXT: 'missing.h' file not found
-// CHECk-NEXT: number of invalid negatively stat cached paths: 0
+// CHECK-NEXT: number of invalid negatively stat cached paths: 0

--- a/clang/test/ClangScanDeps/error-c-api.cpp
+++ b/clang/test/ClangScanDeps/error-c-api.cpp
@@ -4,3 +4,4 @@
 
 // CHECK: error: failed to get dependencies
 // CHECK-NEXT: 'missing.h' file not found
+// CHECk-NEXT: number of invalid negatively stat cached paths: 0

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -907,6 +907,16 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
     clang_disposeString(Spelling);
     clang_disposeDiagnostic(Diag);
   }
+
+  CXStringSet *InvalidNegativeStatCachedPaths =
+      clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
+          Service);
+  if (InvalidNegativeStatCachedPaths) {
+    llvm::errs() << "note: number of invalid negatively stat cached paths: "
+                 << InvalidNegativeStatCachedPaths->Count << "\n";
+    clang_disposeStringSet(InvalidNegativeStatCachedPaths);
+  }
+
   return 1;
 }
 

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -908,14 +908,12 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
     clang_disposeDiagnostic(Diag);
   }
 
-  CXStringSet *InvalidNegativeStatCachedPaths =
+  CXCStringArray InvalidNegativeStatCachedPaths =
       clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
           Service);
-  if (InvalidNegativeStatCachedPaths) {
-    llvm::errs() << "note: number of invalid negatively stat cached paths: "
-                 << InvalidNegativeStatCachedPaths->Count << "\n";
-    clang_disposeStringSet(InvalidNegativeStatCachedPaths);
-  }
+
+  llvm::errs() << "note: number of invalid negatively stat cached paths: "
+               << InvalidNegativeStatCachedPaths.Count << "\n";
 
   return 1;
 }

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -566,16 +566,21 @@ clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
     CXDependencyScannerService S) {
   DependencyScanningService *Service = unwrap(S);
 
-  // CASFS does not use the SharedCache, so there is nothing to diagnose.
+  // FIXME: CAS currently does not use the shared cache, and cannot produce
+  // the same diagnostics. We should add such a diagnostics to CAS as well.
   if (Service->useCASFS())
     return nullptr;
 
   DependencyScanningFilesystemSharedCache &SharedCache =
       Service->getSharedCache();
+
+  // Note that it is critical that this FS is the same as the default virtual
+  // file system we pass to the DependencyScanningWorkers.
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
       llvm::vfs::createPhysicalFileSystem();
+
   auto InvaidNegStatCachedPaths =
-      SharedCache.getInvalidNegativeStatCachedPaths(*FS.get());
+      SharedCache.getInvalidNegativeStatCachedPaths(*FS);
   return cxstring::createSet(std::vector<std::string>(
       InvaidNegStatCachedPaths.begin(), InvaidNegStatCachedPaths.end()));
 }

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -581,8 +581,7 @@ clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
 
   auto InvaidNegStatCachedPaths =
       SharedCache.getInvalidNegativeStatCachedPaths(*FS);
-  return cxstring::createSet(std::vector<std::string>(
-      InvaidNegStatCachedPaths.begin(), InvaidNegStatCachedPaths.end()));
+  return cxstring::createRefSet(InvaidNegStatCachedPaths);
 }
 
 static std::string

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -581,7 +581,8 @@ clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
 
   auto InvaidNegStatCachedPaths =
       SharedCache.getInvalidNegativeStatCachedPaths(*FS);
-  return cxstring::createRefSet(InvaidNegStatCachedPaths);
+  return cxstring::createSet(std::vector<std::string>(
+      InvaidNegStatCachedPaths.begin(), InvaidNegStatCachedPaths.end()));
 }
 
 static std::string

--- a/clang/tools/libclang/CXString.cpp
+++ b/clang/tools/libclang/CXString.cpp
@@ -107,22 +107,27 @@ CXString createCXString(CXStringBuf *buf) {
   return Str;
 }
 
-template <typename StringTy>
-static CXStringSet *createSetImpl(const std::vector<StringTy> &Strings) {
+template <typename StringTy, bool Copy>
+static CXStringSet *createSetImpl(ArrayRef<StringTy> Strings) {
   CXStringSet *Set = new CXStringSet;
   Set->Count = Strings.size();
   Set->Strings = new CXString[Set->Count];
-  for (unsigned SI = 0, SE = Set->Count; SI < SE; ++SI)
-    Set->Strings[SI] = createDup(Strings[SI]);
+  for (unsigned SI = 0, SE = Set->Count; SI < SE; ++SI) {
+    if constexpr (Copy) {
+      Set->Strings[SI] = createDup(Strings[SI]);
+    } else {
+      Set->Strings[SI] = createRef(Strings[SI]);
+    }
+  }
   return Set;
 }
 
 CXStringSet *createSet(const std::vector<std::string> &Strings) {
-  return createSetImpl(Strings);
+  return createSetImpl<std::string, true>(Strings);
 }
 
-CXStringSet *createSet(const std::vector<StringRef> &Strings) {
-  return createSetImpl(Strings);
+CXStringSet *createRefSet(ArrayRef<StringRef> Strings) {
+  return createSetImpl<StringRef, false>(Strings);
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/tools/libclang/CXString.cpp
+++ b/clang/tools/libclang/CXString.cpp
@@ -107,27 +107,22 @@ CXString createCXString(CXStringBuf *buf) {
   return Str;
 }
 
-template <typename StringTy, bool Copy>
-static CXStringSet *createSetImpl(ArrayRef<StringTy> Strings) {
+template <typename StringTy>
+static CXStringSet *createSetImpl(const std::vector<StringTy> &Strings) {
   CXStringSet *Set = new CXStringSet;
   Set->Count = Strings.size();
   Set->Strings = new CXString[Set->Count];
-  for (unsigned SI = 0, SE = Set->Count; SI < SE; ++SI) {
-    if constexpr (Copy) {
-      Set->Strings[SI] = createDup(Strings[SI]);
-    } else {
-      Set->Strings[SI] = createRef(Strings[SI]);
-    }
-  }
+  for (unsigned SI = 0, SE = Set->Count; SI < SE; ++SI)
+    Set->Strings[SI] = createDup(Strings[SI]);
   return Set;
 }
 
 CXStringSet *createSet(const std::vector<std::string> &Strings) {
-  return createSetImpl<std::string, true>(Strings);
+  return createSetImpl(Strings);
 }
 
-CXStringSet *createRefSet(ArrayRef<StringRef> Strings) {
-  return createSetImpl<StringRef, false>(Strings);
+CXStringSet *createSet(const std::vector<StringRef> &Strings) {
+  return createSetImpl(Strings);
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/tools/libclang/CXString.cpp
+++ b/clang/tools/libclang/CXString.cpp
@@ -107,8 +107,7 @@ CXString createCXString(CXStringBuf *buf) {
   return Str;
 }
 
-template <typename StringTy>
-static CXStringSet *createSetImpl(const std::vector<StringTy> &Strings) {
+CXStringSet *createSet(const std::vector<std::string> &Strings) {
   CXStringSet *Set = new CXStringSet;
   Set->Count = Strings.size();
   Set->Strings = new CXString[Set->Count];
@@ -117,12 +116,22 @@ static CXStringSet *createSetImpl(const std::vector<StringTy> &Strings) {
   return Set;
 }
 
-CXStringSet *createSet(const std::vector<std::string> &Strings) {
-  return createSetImpl(Strings);
-}
+CXStringSet *createSet(const llvm::StringSet<> &StringsUnordered) {
+  std::vector<StringRef> Strings;
 
-CXStringSet *createSet(const std::vector<StringRef> &Strings) {
-  return createSetImpl(Strings);
+  for (auto SI = StringsUnordered.begin(), SE = StringsUnordered.end();
+       SI != SE; ++SI)
+    Strings.push_back(SI->getKey());
+
+  llvm::sort(Strings);
+
+  CXStringSet *Set = new CXStringSet;
+  Set->Count = Strings.size();
+  Set->Strings = new CXString[Set->Count];
+  int I = 0;
+  for (auto SI = Strings.begin(), SE = Strings.end(); SI != SE; ++SI)
+    Set->Strings[I++] = createDup(*SI);
+  return Set;
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/tools/libclang/CXString.cpp
+++ b/clang/tools/libclang/CXString.cpp
@@ -107,7 +107,8 @@ CXString createCXString(CXStringBuf *buf) {
   return Str;
 }
 
-CXStringSet *createSet(const std::vector<std::string> &Strings) {
+template <typename StringTy>
+static CXStringSet *createSetImpl(const std::vector<StringTy> &Strings) {
   CXStringSet *Set = new CXStringSet;
   Set->Count = Strings.size();
   Set->Strings = new CXString[Set->Count];
@@ -116,22 +117,12 @@ CXStringSet *createSet(const std::vector<std::string> &Strings) {
   return Set;
 }
 
-CXStringSet *createSet(const llvm::StringSet<> &StringsUnordered) {
-  std::vector<StringRef> Strings;
-  
-  for (auto SI = StringsUnordered.begin(),
-            SE = StringsUnordered.end(); SI != SE; ++SI)
-    Strings.push_back(SI->getKey());
-  
-  llvm::sort(Strings);
-  
-  CXStringSet *Set = new CXStringSet;
-  Set->Count = Strings.size();
-  Set->Strings = new CXString[Set->Count];
-  int I = 0;
-  for (auto SI = Strings.begin(), SE = Strings.end(); SI != SE; ++SI)
-    Set->Strings[I++] = createDup(*SI);
-  return Set;
+CXStringSet *createSet(const std::vector<std::string> &Strings) {
+  return createSetImpl(Strings);
+}
+
+CXStringSet *createSet(const std::vector<StringRef> &Strings) {
+  return createSetImpl(Strings);
 }
 
 //===----------------------------------------------------------------------===//

--- a/clang/tools/libclang/CXString.h
+++ b/clang/tools/libclang/CXString.h
@@ -68,13 +68,10 @@ CXString createRef(std::string String) = delete;
 /// Create a CXString object that is backed by a string buffer.
 CXString createCXString(CXStringBuf *buf);
 
-/// Create a CXStringSet object that owns the strings. Such an object should be
+/// Create a CXStringSet object owns the strings. Such an object should be
 /// disposed with clang_disposeStringSet.
 CXStringSet *createSet(const std::vector<std::string> &Strings);
-
-/// Create a CXStringSet object that does not own the strings. Such an object
-/// should still be disposed with clang_disposeStringSet.
-CXStringSet *createRefSet(ArrayRef<StringRef> Strings);
+CXStringSet *createSet(const std::vector<StringRef> &Strings);
 
 CXStringSet *createSet(const llvm::StringSet<> &Strings);
 
@@ -114,3 +111,4 @@ static inline StringRef getContents(const CXUnsavedFile &UF) {
 }
 
 #endif
+

--- a/clang/tools/libclang/CXString.h
+++ b/clang/tools/libclang/CXString.h
@@ -68,7 +68,10 @@ CXString createRef(std::string String) = delete;
 /// Create a CXString object that is backed by a string buffer.
 CXString createCXString(CXStringBuf *buf);
 
+/// Create a CXStringSet object owns the strings. Such an object should be
+/// disposed with clang_disposeStringSet.
 CXStringSet *createSet(const std::vector<std::string> &Strings);
+CXStringSet *createSet(const std::vector<StringRef> &Strings);
 
 CXStringSet *createSet(const llvm::StringSet<> &Strings);
 

--- a/clang/tools/libclang/CXString.h
+++ b/clang/tools/libclang/CXString.h
@@ -68,10 +68,7 @@ CXString createRef(std::string String) = delete;
 /// Create a CXString object that is backed by a string buffer.
 CXString createCXString(CXStringBuf *buf);
 
-/// Create a CXStringSet object owns the strings. Such an object should be
-/// disposed with clang_disposeStringSet.
 CXStringSet *createSet(const std::vector<std::string> &Strings);
-CXStringSet *createSet(const std::vector<StringRef> &Strings);
 
 CXStringSet *createSet(const llvm::StringSet<> &Strings);
 

--- a/clang/tools/libclang/CXString.h
+++ b/clang/tools/libclang/CXString.h
@@ -68,10 +68,13 @@ CXString createRef(std::string String) = delete;
 /// Create a CXString object that is backed by a string buffer.
 CXString createCXString(CXStringBuf *buf);
 
-/// Create a CXStringSet object owns the strings. Such an object should be
+/// Create a CXStringSet object that owns the strings. Such an object should be
 /// disposed with clang_disposeStringSet.
 CXStringSet *createSet(const std::vector<std::string> &Strings);
-CXStringSet *createSet(const std::vector<StringRef> &Strings);
+
+/// Create a CXStringSet object that does not own the strings. Such an object
+/// should still be disposed with clang_disposeStringSet.
+CXStringSet *createRefSet(ArrayRef<StringRef> Strings);
 
 CXStringSet *createSet(const llvm::StringSet<> &Strings);
 
@@ -111,4 +114,3 @@ static inline StringRef getContents(const CXUnsavedFile &UF) {
 }
 
 #endif
-

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -577,6 +577,7 @@ LLVM_21 {
     clang_experimental_DepGraphModule_isCWDIgnored;
     clang_experimental_DepGraphModule_isInStableDirs; 
     clang_getFullyQualifiedName;
+    clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/135703 added a C++ API to the shared cached to diagnose invalid negatively stat cached paths. This PR adds a C API so an external system can take advantage of the diagnostics. 

rdar://149147920