### PR TITLE
Disable test on ASAN

### DIFF
--- a/lldb/test/API/lang/swift/protocols/stepping_through_witness/TestSwiftSteppingThroughWitness.py
+++ b/lldb/test/API/lang/swift/protocols/stepping_through_witness/TestSwiftSteppingThroughWitness.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 @skipIf(oslist=["windows", "linux"])
+@skipIfAsan
 class TestSwiftSteppingThroughWitness(TestBase):
 
     def setUp(self):


### PR DESCRIPTION
We see the ASAN+UBSAN bot on ci.swift.org fail with this test. rdar://149795988 (ci.swift.org lldb test failure on ASAN+UBSAN OSS macOS bot [main])