### PR TITLE
[BoundsSafety] Fix diagnostics test failures

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12581,7 +12581,7 @@ let CategoryName = "BoundsSafety Pointer Attributes Issue" in {
 def err_bounds_safety_conflicting_pointer_attributes : Error<
   "%select{array|pointer}0 cannot have more than one %select{bound|type|count|end|terminator}1 attribute">;
 def note_bounds_safety_conflicting_pointer_attribute_args : Note<
-  "conflicting arguments for %select{count|end|terminator}0 were '%1' and '%2'">;
+  "conflicting arguments for %select{count|end|terminator}0 were %1 and %2">;
 def warn_bounds_safety_duplicate_pointer_attributes : Warning<
   "%select{array|pointer}0 annotated with %select{__unsafe_indexable|__bidi_indexable|__indexable|__single|__terminated_by}1 "
   "multiple times. Annotate only once to remove this warning">, InGroup<BoundsSafetyRedundantAttribute>;
@@ -12603,7 +12603,7 @@ def err_bounds_safety_dynamic_count_function_call : Error<
   "argument of '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null}0' attribute can only reference "
 	"function with 'const' attribute">;
 def err_bounds_safety_dynamic_count_function_call_argument : Error<
-  "argument of function call '%0' in '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null}1' attribute is not a constant expression">;
+  "argument of function call %0 in '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null}1' attribute is not a constant expression">;
 def err_attribute_invalid_argument_expression_for_pointer_bounds_attribute : Error<
   "invalid argument expression to bounds attribute">;
 def err_invalid_decl_kind_bounds_safety_dynamic_count : Error<
@@ -12761,7 +12761,7 @@ def warn_bounds_safety_conv_single_to_implicit_indexable_unsafe_zeroth_element :
       "returning|" // UnsafeOpKind::Return
       "passing|" // UnsafeOpKind::CallArg
       "UNUSED" // UnsafeOpKind::Cast
-    "}0 __bidi_indexable '%1'"
+    "}0 __bidi_indexable %1"
   "%select{"
     " at any index|||||||}0 "
   "will %select{"
@@ -12774,7 +12774,7 @@ def warn_bounds_safety_conv_single_to_implicit_indexable_unsafe_zeroth_element :
       "pass an out-of-bounds pointer|" // UnsafeOpKind::CallArg
       "UNUSED" // UnsafeOpKind::Cast
   "}0. At runtime %4 is assigned a __single pointer that"
-  " results in '%1' having bounds smaller than a single %2 (%3 byte%s3)">,
+  " results in %1 having bounds smaller than a single %2 (%3 byte%s3)">,
   InGroup<BoundsSafetyConvSingleToImplicitIndexableThenConvertToLargerType>;
 
 def warn_bounds_safety_conv_single_to_implicit_indexable_unsafely_cast :
@@ -12800,7 +12800,7 @@ def note_single_entity_assigned_here_with_pointee_sizes : Note<
   "struct member|" // AssignmentSourceKind::StructMember
   "union member" // AssignmentSourceKind::UnionMember
   "}0 %1 %select{assigned to|used to initialize}9 %2 here results in %2 having the bounds of a single %3 "
-  "(%4 bytes) but %select{'%8'|cast of %2 to %8}7 has pointee type %5 (%6 bytes)">;
+  "(%4 bytes) but %select{%8|cast of %2 to %8}7 has pointee type %5 (%6 bytes)">;
 
 def warn_bounds_safety_conv_single_to_implicit_indexable_dynamic_count_conversion :
   Warning<
@@ -12899,7 +12899,7 @@ def err_bounds_safety_typeof_dbpt : Error<
   "__typeof__ on an expression of type %0 is not yet supported">;
 
 def err_bounds_safety_single_pointer_arithmetic : Error<
-  "pointer arithmetic on single pointer '%0' is out of bounds%select{|; consider adding '__counted_by' to '%2'}1">;
+  "pointer arithmetic on single pointer %0 is out of bounds%select{|; consider adding '__counted_by' to '%2'}1">;
 def err_bounds_safety_flexible_array_member_record_pointer_arithmetic : Error<
   "-fbounds-safety forbids arithmetic on pointers to types with a flexible array "
   "member">;
@@ -12965,16 +12965,16 @@ def err_bounds_safety_counted_by_on_incomplete_type_on_var_decl : Error<
 >;
 
 def err_bounds_safety_pointer_subscript : Error<
-  "array subscript on %select{single|'__terminated_by'}0 pointer '%1' "
+  "array subscript on %select{single|'__terminated_by'}0 pointer %1 "
   "%select{must use a constant index of 0 to be in bounds|is not allowed}0">;
 def err_bounds_safety_indexable_pointer_arithmetic : Error<
-  "decremented indexable pointer '%0' is out of bounds">;
+  "decremented indexable pointer %0 is out of bounds">;
 def err_bounds_safety_indexable_pointer_subscript : Error<
-  "array subscript with a negative index on indexable pointer '%0' is out of bounds">;
+  "array subscript with a negative index on indexable pointer %0 is out of bounds">;
 def err_bounds_safety_terminated_by_pointer_arithmetic_dec : Error<
-  "cannot decrement '__terminated_by' pointer '%0'">;
+  "cannot decrement '__terminated_by' pointer %0">;
 def err_bounds_safety_terminated_by_pointer_arithmetic : Error<
-  "pointer arithmetic on '__terminated_by' pointer '%0' can only increase the "
+  "pointer arithmetic on '__terminated_by' pointer %0 can only increase the "
   "value by one">;
 
 def err_bounds_safety_dynamic_bound_pointer_unary_arithmetic : Error<
@@ -13073,7 +13073,7 @@ def err_bounds_safety_dependent_assignments_order : Error<
 def note_bounds_safety_decl_assignment : Note<
   "'%0' has been assigned here">;
 def err_bounds_safety_dependent_struct_assignment : Error<
-  "cannot assign '%0' because it contains field %1 referred to by flexible array member %2">;
+  "cannot assign %0 because it contains field %1 referred to by flexible array member %2">;
 def note_bounds_safety_count_param_loc : Note<
   "referred to by count parameter here">;
 def err_bounds_safety_dependent_field_duplicates : Error<
@@ -13083,7 +13083,7 @@ def note_bounds_safety_struct_fields_only_in_fam : Note<
 def error_bounds_safety_no_arrow_members : Error<
   "arrow notation not allowed for struct member in count parameter">;
 def error_bounds_safety_no_count_in_unions : Error<
-  "count parameter refers to union '%0' of type %1">;
+  "count parameter refers to union %0 of type %1">;
 
 def err_bounds_safety_taking_address_dynamic_bound_dependent : Error<
   "%select{variable|field}1 referred to by '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null|__ended_by}0' "
@@ -13105,7 +13105,7 @@ def err_bounds_safety_incompatible_dynamic_bound_argument: Error<
 def err_bounds_safety_mismatching_count_type_argument: Error<
   "incompatible pointer types assigning %0 with an expression with mismatching size attributes %1">;
 def err_bounds_safety_incompatible_count_expression: Error<
-  "incompatible count expression (%0) vs. (%1) in argument to function">;
+  "incompatible count expression %0 vs. %1 in argument to function">;
 def err_bounds_safety_unsynchronized_indirect_param: Error<
   "passing%select{| address of}1 %0 as an indirect parameter; "
   "must also pass %2 %select{|or its address }3because the type of %select{%0|%2}4, "
@@ -13190,7 +13190,7 @@ def note_bounds_safety_consider_adding_to_return : Note<
 
 def warn_bounds_safety_initlist_range_partial_null : Warning<
   "%select{|implicitly }0initializing field %1 of type %2 to NULL while "
-  "'%3' is initialized with a value rarely succeeds">, InGroup<BoundsSafetyInitListPartialNull>;
+  "%3 is initialized with a value rarely succeeds">, InGroup<BoundsSafetyInitListPartialNull>;
 
 def err_bounds_safety_dynamic_bound_init_side_effect : Error<
   "initalizer for %select{count|size|'__counted_by' pointer|'__sized_by' pointer|'__counted_by_or_null' pointer|'__sized_by_or_null' pointer|'__ended_by' pointer|end pointer}0 with side effects is not yet supported">;
@@ -13206,7 +13206,7 @@ def err_bounds_safety_flexible_global_wrong_count : Error<
 def err_bounds_safety_flexible_global_not_counted : Error<
   "flexible array member is initialized without a count">;
 def err_bounds_safety_flexible_global_non_int_count_init : Error<
-  "count '%0' has non-integer value '%1' of type %2">;
+  "count %0 has non-integer value %1 of type %2">;
 
 def err_bounds_safety_local_external_dynamic_count : Error<
   "attribute %0 is not allowed for local variables with external storage">;
@@ -13399,7 +13399,7 @@ def err_bounds_safety_terminated_by_wrong_initializer_kind : Error<
   "string literal or an initializer list">;
 def err_bounds_safety_terminated_by_terminator_mismatch : Error<
   "array '%0' with '__terminated_by' attribute is initialized with an "
-  "incorrect terminator (expected: %1; got %2)">;
+  "incorrect terminator (expected: %quoted1; got %quoted2)">;
 
 def err_bounds_safety_irrecoverable_attr : Error<
   "bounds attribute '%select{__bidi_indexable|__indexable|__single|__unsafe_indexable}0' cannot be applied to attributed type %1 in this context%select{| due to the surrounding 'typeof' specifier}2">;
@@ -13769,8 +13769,8 @@ def warn_unsafe_count_attributed_pointer_argument : Warning<
   InGroup<UnsafeBufferUsage>, DefaultIgnore;
 def note_unsafe_count_attributed_pointer_argument : Note<
   "consider using %select{|a safe container and passing '.data()' to the "
-  "parameter%select{| '%3'}2 and '.size()' to its dependent parameter '%4' or }0"
-  "'std::span' and passing '.first(...).data()' to the parameter%select{| '%3'}2">;
+  "parameter%select{| %3}2 and '.size()' to its dependent parameter %4 or }0"
+  "'std::span' and passing '.first(...).data()' to the parameter%select{| %3}2">;
 def warn_unsafe_single_pointer_argument : Warning<
   "unsafe assignment to function parameter of __single pointer type">,
   InGroup<UnsafeBufferUsage>, DefaultIgnore;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13769,8 +13769,8 @@ def warn_unsafe_count_attributed_pointer_argument : Warning<
   InGroup<UnsafeBufferUsage>, DefaultIgnore;
 def note_unsafe_count_attributed_pointer_argument : Note<
   "consider using %select{|a safe container and passing '.data()' to the "
-  "parameter%select{| %3}2 and '.size()' to its dependent parameter %4 or }0"
-  "'std::span' and passing '.first(...).data()' to the parameter%select{| %3}2">;
+  "parameter%select{| '%3'}2 and '.size()' to its dependent parameter '%4' or }0"
+  "'std::span' and passing '.first(...).data()' to the parameter%select{| '%3'}2">;
 def warn_unsafe_single_pointer_argument : Warning<
   "unsafe assignment to function parameter of __single pointer type">,
   InGroup<UnsafeBufferUsage>, DefaultIgnore;

--- a/clang/test/BoundsSafety/AST/struct-init-with-side-effects.c
+++ b/clang/test/BoundsSafety/AST/struct-init-with-side-effects.c
@@ -98,7 +98,7 @@ void test_count_annot() {
   struct s_count_annot s1 = {
     .len = 10,
     .ptr = arr,
-    // expected-warning@+1{{initializer getlen() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'getlen()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .dummy = getlen()
   };
   struct s_count_annot s2;
@@ -157,7 +157,7 @@ void test_range_annot() {
   struct s_range_annot s1 = {
     .end = arr + 10,
     .start = arr,
-    // expected-warning@+1{{initializer getlen() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'getlen()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .dummy = getlen()
   };
   struct s_count_annot s2;

--- a/clang/test/BoundsSafety/CodeGen/bounds-attributed-in-return-null-system-header-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/bounds-attributed-in-return-null-system-header-O2.c
@@ -25,16 +25,10 @@ void consume(int* __bidi_indexable);
 // LEGACY-SAME: i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // LEGACY-NEXT:  [[ENTRY:.*:]]
 // LEGACY-NEXT:    [[BYVAL_TEMP:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable", align 8
-// LEGACY-NEXT:    [[IDX_EXT:%.*]] = sext i32 [[COUNT]] to i64
-// LEGACY-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i32, ptr null, i64 [[IDX_EXT]]
-// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3:[0-9]+]]
-// LEGACY-NEXT:    store ptr null, ptr [[BYVAL_TEMP]], align 8
-// LEGACY-NEXT:    [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 8
-// LEGACY-NEXT:    store ptr [[ADD_PTR]], ptr [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX]], align 8
-// LEGACY-NEXT:    [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 16
-// LEGACY-NEXT:    store ptr null, ptr [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX]], align 8, !tbaa [[TBAA2:![0-9]+]]
-// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
-// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
+// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4:[0-9]+]]
+// LEGACY-NEXT:    call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(24) [[BYVAL_TEMP]], i8 0, i64 24, i1 false)
+// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
+// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
 // LEGACY-NEXT:    ret void
 //
 void use_inline_header_func_unspecified_ptr(int count) {
@@ -62,16 +56,10 @@ void use_inline_header_func_unspecified_ptr(int count) {
 // LEGACY-SAME: i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // LEGACY-NEXT:  [[ENTRY:.*:]]
 // LEGACY-NEXT:    [[BYVAL_TEMP:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable", align 8
-// LEGACY-NEXT:    [[IDX_EXT:%.*]] = sext i32 [[COUNT]] to i64
-// LEGACY-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i32, ptr null, i64 [[IDX_EXT]]
-// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
-// LEGACY-NEXT:    store ptr null, ptr [[BYVAL_TEMP]], align 8
-// LEGACY-NEXT:    [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 8
-// LEGACY-NEXT:    store ptr [[ADD_PTR]], ptr [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX]], align 8
-// LEGACY-NEXT:    [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 16
-// LEGACY-NEXT:    store ptr null, ptr [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX]], align 8, !tbaa [[TBAA2]]
-// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
-// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
+// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
+// LEGACY-NEXT:    call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(24) [[BYVAL_TEMP]], i8 0, i64 24, i1 false)
+// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
+// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
 // LEGACY-NEXT:    ret void
 //
 void use_inline_header_func_unsafe_indexable_ptr(int count) {
@@ -81,10 +69,4 @@ void use_inline_header_func_unsafe_indexable_ptr(int count) {
 //.
 // CHECK: [[META2]] = !{!"bounds-safety-generic"}
 // CHECK: [[PROF3]] = !{!"branch_weights", i32 1048575, i32 1}
-//.
-// LEGACY: [[TBAA2]] = !{[[META3:![0-9]+]], [[META3]], i64 0}
-// LEGACY: [[META3]] = !{!"p1 int", [[META4:![0-9]+]], i64 0}
-// LEGACY: [[META4]] = !{!"any pointer", [[META5:![0-9]+]], i64 0}
-// LEGACY: [[META5]] = !{!"omnipotent char", [[META6:![0-9]+]], i64 0}
-// LEGACY: [[META6]] = !{!"Simple C/C++ TBAA"}
 //.

--- a/clang/test/BoundsSafety/CodeGen/nested-struct-member-count-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/nested-struct-member-count-O2.c
@@ -42,17 +42,12 @@ char access(struct Outer *bar, int index) {
 
 
 
-// CHECK-LABEL: define dso_local ptr @assign(
+// CHECK-LABEL: define dso_local noundef nonnull ptr @assign(
 // CHECK-SAME: ptr noundef readonly captures(none) [[BAR:%.*]], i32 noundef [[LEN:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[BAR]], align 8
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[BAR]], align 8, !nonnull {{![0-9]+}}, !noundef {{![0-9]+}}
 // CHECK-NEXT:    [[AGG_TEMP1_SROA_2_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 8
 // CHECK-NEXT:    [[AGG_TEMP1_SROA_2_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_2_0_BAR_SROA_IDX]], align 8
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 16
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX]], align 8, !tbaa {{![0-9]+}}
-// CHECK-NEXT:    [[FLEX_BASE_NULL_CHECK_NOT:%.*]] = icmp eq ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], null, !annotation {{![0-9]+}}
-// CHECK-NEXT:    br i1 [[FLEX_BASE_NULL_CHECK_NOT]], label [[BOUNDSCHECK_CONT_THREAD:%.*]], label [[FLEX_BASE_NONNULL:%.*]], !annotation {{![0-9]+}}
-// CHECK:       flex.base.nonnull:
 // CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], i64 8
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], [[TMP0]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP:%.*]], label [[CONT:%.*]], !prof {{![0-9]+}}, !annotation {{![0-9]+}}
@@ -60,6 +55,8 @@ char access(struct Outer *bar, int index) {
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR2]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    unreachable, !annotation {{![0-9]+}}
 // CHECK:       cont:
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 16
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX]], align 8, !tbaa {{![0-9]+}}
 // CHECK-NEXT:    [[TMP1:%.*]] = icmp ule ptr [[TMP0]], [[AGG_TEMP1_SROA_2_0_COPYLOAD]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    [[TMP2:%.*]] = icmp ule ptr [[AGG_TEMP1_SROA_3_0_COPYLOAD]], [[AGG_TEMP1_SROA_0_0_COPYLOAD]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    [[OR_COND:%.*]] = select i1 [[TMP1]], i1 [[TMP2]], i1 false, !annotation {{![0-9]+}}
@@ -75,14 +72,9 @@ char access(struct Outer *bar, int index) {
 // CHECK-NEXT:    [[TMP3:%.*]] = icmp ult ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], [[AGG_TEMP1_SROA_2_0_COPYLOAD]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    [[OR_COND60:%.*]] = select i1 [[OR_COND49]], i1 [[TMP3]], i1 false, !annotation {{![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND60]], label [[BOUNDSCHECK_CONT:%.*]], label [[TRAP]], !prof {{![0-9]+}}, !annotation {{![0-9]+}}
-// CHECK:       boundscheck.cont.thread:
-// CHECK-NEXT:    store i32 [[LEN]], ptr inttoptr (i64 4 to ptr), align 4, !tbaa {{![0-9]+}}
-// CHECK-NEXT:    br label [[CONT46:%.*]]
 // CHECK:       boundscheck.cont:
 // CHECK-NEXT:    [[LEN31:%.*]] = getelementptr inbounds nuw i8, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], i64 4
 // CHECK-NEXT:    store i32 [[LEN]], ptr [[LEN31]], align 4, !tbaa {{![0-9]+}}
-// CHECK-NEXT:    br label [[CONT46]], !annotation {{![0-9]+}}
-// CHECK:       cont46:
 // CHECK-NEXT:    ret ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]]
 //
 struct Outer * assign(void * __bidi_indexable bar, int len) {

--- a/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-trivial-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-trivial-O2.c
@@ -41,8 +41,8 @@ const char *__indexable good_chars_unsafe(void) {
 }
 
 // CHECK-LABEL: @bad_null(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    unreachable
+// CHECK-NEXT:  terminated_by.loop_end:
+// CHECK-NEXT:    ret { ptr, ptr } zeroinitializer
 //
 int *__indexable bad_null(void) {
   int *__null_terminated p = 0;
@@ -50,8 +50,8 @@ int *__indexable bad_null(void) {
 }
 
 // CHECK-LABEL: @bad_null_unsafe(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    unreachable
+// CHECK-NEXT:  terminated_by.loop_end:
+// CHECK-NEXT:    ret { ptr, ptr } zeroinitializer
 //
 int *__indexable bad_null_unsafe(void) {
   int *__null_terminated p = 0;

--- a/clang/test/BoundsSafety/Sema/address-taken-dynamic-count-decls.c
+++ b/clang/test/BoundsSafety/Sema/address-taken-dynamic-count-decls.c
@@ -97,7 +97,7 @@ int main() {
 
   foo(&s.len, &s.buf);
   foo(&local_len, &s.buf); // expected-error{{incompatible dynamic count pointer argument to parameter of type}}
-  foo(&t.len, &t.buf);     // expected-error{{incompatible count expression (*out_len) vs. (len + 1) in argument to function}}
+  foo(&t.len, &t.buf);     // expected-error{{incompatible count expression '*out_len' vs. 'len + 1' in argument to function}}
   // expected-error@+1{{passing address of 'len' as an indirect parameter; must also pass 'buf2' or its address because the type of 'buf2', 'int *__single __counted_by(len)' (aka 'int *__single'), refers to 'len'}}
   foo(&u.len, &u.buf);
   bar(&s.len, &s.buf); // expected-error{{passing address of 'len' referred to by '__counted_by' to a parameter that is not referred to by the same attribute}}

--- a/clang/test/BoundsSafety/Sema/arithmetic-ops-in-counted-by-params-assign.c
+++ b/clang/test/BoundsSafety/Sema/arithmetic-ops-in-counted-by-params-assign.c
@@ -21,26 +21,26 @@ void inout_count_buf(int *__counted_by(*len) *buf, int *len);
 void pass_argument_to_inout_count_buf(int *__counted_by(len - 1) buf, int len) {
   // expected-error@+1{{parameter 'buf' with '__counted_by' attribute depending on an indirect count is implicitly read-only and cannot be passed as an indirect argument}}
   inout_count_buf(&buf, &len);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len - 1' in argument to function}}
   inout_count(buf, &len);
 
   int arr[10];
   int len2 = 9;
   int *__counted_by(len2 + 1) buf2 = arr;
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_count_buf(&buf2, &len2);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_count(buf2, &len2);
 
   int len3 = 1;
   int *__counted_by(len3 - 1) buf3 = arr;
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'buf2' as an indirect parameter; must also pass 'len2' or its address because the type of 'buf2', 'int *__single __counted_by(len2 + 1)' (aka 'int *__single'), refers to 'len2'}}
   inout_count_buf(&buf2, &len3);
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'len3' as an indirect parameter; must also pass 'buf3' or its address because the type of 'buf3', 'int *__single __counted_by(len3 - 1)' (aka 'int *__single'), refers to 'len3'}}
   inout_count(buf2, &len3);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len3 - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len3 - 1' in argument to function}}
   inout_count(buf3, &len3);
 }
 
@@ -60,26 +60,26 @@ void inout_size_buf(int *__sized_by(*len) *buf, int *len);
 void pass_argument_to_inout_size_buf(int *__sized_by(len - 1) buf, int len) {
   // expected-error@+1{{parameter 'buf' with '__sized_by' attribute depending on an indirect count is implicitly read-only and cannot be passed as an indirect argument}}
   inout_size_buf(&buf, &len);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len - 1' in argument to function}}
   inout_size(buf, &len);
 
   int arr[10];
   int len2 = 9;
   int *__sized_by(len2 + 1) buf2 = arr;
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_size_buf(&buf2, &len2);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_size(buf2, &len2);
 
   int len3 = 1;
   int *__sized_by(len3 - 1) buf3 = arr;
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'buf2' as an indirect parameter; must also pass 'len2' or its address because the type of 'buf2', 'int *__single __sized_by(len2 + 1)' (aka 'int *__single'), refers to 'len2'}}
   inout_size_buf(&buf2, &len3);
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'len3' as an indirect parameter; must also pass 'buf3' or its address because the type of 'buf3', 'int *__single __sized_by(len3 - 1)' (aka 'int *__single'), refers to 'len3'}}
   inout_size(buf2, &len3);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len3 - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len3 - 1' in argument to function}}
   inout_size(buf3, &len3);
 }
 
@@ -93,26 +93,26 @@ void inout_count_nullable_buf(int *__counted_by_or_null(*len) *buf, int *len);
 void pass_argument_to_inout_count_nullable_buf(int *__counted_by_or_null(len - 1) buf, int len) {
   // expected-error@+1{{parameter 'buf' with '__counted_by_or_null' attribute depending on an indirect count is implicitly read-only and cannot be passed as an indirect argument}}
   inout_count_buf(&buf, &len);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len - 1' in argument to function}}
   inout_count_nullable(buf, &len);
 
   int arr[10];
   int len2 = 9;
   int *__counted_by_or_null(len2 + 1) buf2 = arr;
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_count_buf(&buf2, &len2);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_count_nullable(buf2, &len2);
 
   int len3 = 1;
   int *__counted_by_or_null(len3 - 1) buf3 = arr;
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'buf2' as an indirect parameter; must also pass 'len2' or its address because the type of 'buf2', 'int *__single __counted_by_or_null(len2 + 1)' (aka 'int *__single'), refers to 'len2'}}
   inout_count_buf(&buf2, &len3);
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'len3' as an indirect parameter; must also pass 'buf3' or its address because the type of 'buf3', 'int *__single __counted_by_or_null(len3 - 1)' (aka 'int *__single'), refers to 'len3'}}
   inout_count_nullable(buf2, &len3);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len3 - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len3 - 1' in argument to function}}
   inout_count_nullable(buf3, &len3);
 }
 
@@ -126,25 +126,25 @@ void inout_size_nullable_buf(int *__sized_by_or_null(*len) *buf, int *len);
 void pass_argument_to_inout_size_nullable_buf(int *__sized_by_or_null(len - 1) buf, int len) {
   // expected-error@+1{{parameter 'buf' with '__sized_by_or_null' attribute depending on an indirect count is implicitly read-only and cannot be passed as an indirect argument}}
   inout_size_nullable_buf(&buf, &len);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len - 1' in argument to function}}
   inout_size_nullable(buf, &len);
 
   int arr[10];
   int len2 = 9;
   int *__sized_by_or_null(len2 + 1) buf2 = arr;
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_size_nullable_buf(&buf2, &len2);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   inout_size_nullable(buf2, &len2);
 
   int len3 = 1;
   int *__sized_by_or_null(len3 - 1) buf3 = arr;
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'buf2' as an indirect parameter; must also pass 'len2' or its address because the type of 'buf2', 'int *__single __sized_by_or_null(len2 + 1)' (aka 'int *__single'), refers to 'len2'}}
   inout_size_nullable_buf(&buf2, &len3);
-  // expected-error@+2{{incompatible count expression (*len) vs. (len2 + 1) in argument to function}}
+  // expected-error@+2{{incompatible count expression '*len' vs. 'len2 + 1' in argument to function}}
   // expected-error@+1{{passing address of 'len3' as an indirect parameter; must also pass 'buf3' or its address because the type of 'buf3', 'int *__single __sized_by_or_null(len3 - 1)' (aka 'int *__single'), refers to 'len3'}}
   inout_size_nullable(buf2, &len3);
-  // expected-error@+1{{incompatible count expression (*len) vs. (len3 - 1) in argument to function}}
+  // expected-error@+1{{incompatible count expression '*len' vs. 'len3 - 1' in argument to function}}
   inout_size_nullable(buf3, &len3);
 }

--- a/clang/test/BoundsSafety/Sema/compound-literal-counted_by.c
+++ b/clang/test/BoundsSafety/Sema/compound-literal-counted_by.c
@@ -58,32 +58,32 @@ struct cb_with_other_data field_initializers_with_side_effects(struct cb_with_ot
   *s = (struct cb_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   struct cb_with_other_data s2 = (struct cb_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   consume_cb_with_other_data((struct cb_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()}
   );
   consume_cb_with_other_data((struct cb_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0}
   );
 
   (void) (struct cb_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0};
@@ -102,7 +102,7 @@ struct cb_with_other_data field_initializers_with_side_effects(struct cb_with_ot
   };
   (void)(struct Contains_cb_with_other_data) {
     .s = {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -112,22 +112,22 @@ struct cb_with_other_data field_initializers_with_side_effects(struct cb_with_ot
 
   // Nested CompoundLiteralExpr
   (void)(struct NestedCB) {
-    // expected-warning@+1{{initializer (struct cb_with_other_data){.count = 0, .buf = 0, .other = side_effect()} has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer '(struct cb_with_other_data){.count = 0, .buf = 0, .other = side_effect()}' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .inner = (struct cb_with_other_data) {
       .count = 0,
       .buf = 0x0,
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
       .other = side_effect()
     },
     .count = 0,
     .buf = 0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect()
   };
 
   // Test array initializer list that initializes structs
   (void)(struct cb_with_other_data[]){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {0, 0x0, side_effect()},
     {0, 0x0, 0x0}
   };
@@ -139,7 +139,7 @@ struct cb_with_other_data field_initializers_with_side_effects(struct cb_with_ot
 
   (void)(union UnionWith_cb_with_other_data) {
     {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -151,7 +151,7 @@ struct cb_with_other_data field_initializers_with_side_effects(struct cb_with_ot
     // Test very "untransparent"
     (union TransparentUnion) {.cb = 
       {
-        // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+        // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
         .other = side_effect(),
         .buf = 0x0,
         .count = 0
@@ -162,14 +162,14 @@ struct cb_with_other_data field_initializers_with_side_effects(struct cb_with_ot
   receive_transparent_union(
     // Transparent
     (struct cb_with_other_data){
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
     }
   );
 
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   return (struct cb_with_other_data) { 0, 0x0, side_effect()};
 }
 
@@ -415,7 +415,7 @@ void var_init_from_compound_literal_with_side_effect(char*__bidi_indexable ptr) 
   // both-error@+1{{cannot initialize array of type 'struct cb_with_other_data[]' with non-constant array of type 'struct cb_with_other_data[2]'}}
   struct cb_with_other_data arr[] = (struct cb_with_other_data[]){
     {.buf = ptr, .count = 0x0, .other = 0x0},
-    // expected-warning@+1{{initializer get_count() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'get_count()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {.buf = ptr, .count = 0x0, .other = get_count()},
   };
 }

--- a/clang/test/BoundsSafety/Sema/compound-literal-counted_by_or_null.c
+++ b/clang/test/BoundsSafety/Sema/compound-literal-counted_by_or_null.c
@@ -57,32 +57,32 @@ struct cbon_with_other_data field_initializers_with_side_effects(struct cbon_wit
   *s = (struct cbon_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   struct cbon_with_other_data s2 = (struct cbon_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   consume_cbon_with_other_data((struct cbon_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()}
   );
   consume_cbon_with_other_data((struct cbon_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0}
   );
 
   (void) (struct cbon_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0};
@@ -101,7 +101,7 @@ struct cbon_with_other_data field_initializers_with_side_effects(struct cbon_wit
   };
   (void)(struct Contains_cbon_with_other_data) {
     .s = {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -111,22 +111,22 @@ struct cbon_with_other_data field_initializers_with_side_effects(struct cbon_wit
 
   // Nested CompoundLiteralExpr
   (void)(struct NestedCBON) {
-    // expected-warning@+1{{initializer (struct cbon_with_other_data){.count = 0, .buf = 0, .other = side_effect()} has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer '(struct cbon_with_other_data){.count = 0, .buf = 0, .other = side_effect()}' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .inner = (struct cbon_with_other_data) {
       .count = 0,
       .buf = 0x0,
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
       .other = side_effect()
     },
     .count = 0,
     .buf = 0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect()
   };
 
   // Test array initializer list that initializes structs
   (void)(struct cbon_with_other_data[]){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {0, 0x0, side_effect()},
     {0, 0x0, 0x0}
   };
@@ -138,7 +138,7 @@ struct cbon_with_other_data field_initializers_with_side_effects(struct cbon_wit
 
   (void)(union UnionWith_cbon_with_other_data) {
     {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -150,7 +150,7 @@ struct cbon_with_other_data field_initializers_with_side_effects(struct cbon_wit
     // Test very "untransparent"
     (union TransparentUnion) {.cb = 
       {
-        // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+        // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
         .other = side_effect(),
         .buf = 0x0,
         .count = 0
@@ -161,14 +161,14 @@ struct cbon_with_other_data field_initializers_with_side_effects(struct cbon_wit
   receive_transparent_union(
     // Transparent
     (struct cbon_with_other_data){
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
     }
   );
 
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   return (struct cbon_with_other_data) { 0, 0x0, side_effect()};
 }
 
@@ -396,7 +396,7 @@ void var_init_from_compound_literal_with_side_effect(char*__bidi_indexable ptr) 
   // both-error@+1{{cannot initialize array of type 'struct cbon_with_other_data[]' with non-constant array of type 'struct cbon_with_other_data[2]'}}
   struct cbon_with_other_data arr[] = (struct cbon_with_other_data[]){
     {.buf = ptr, .count = 0x0, .other = 0x0},
-    // expected-warning@+1{{initializer get_count() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'get_count()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {.buf = ptr, .count = 0x0, .other = get_count()},
   };
 }

--- a/clang/test/BoundsSafety/Sema/compound-literal-ended_by.c
+++ b/clang/test/BoundsSafety/Sema/compound-literal-ended_by.c
@@ -58,32 +58,32 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
    *s = (struct eb_with_other_data){
     0x0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   struct eb_with_other_data s2 = (struct eb_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   consume_eb_with_other_data((struct eb_with_other_data){
     0x0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()}
   );
   consume_eb_with_other_data((struct eb_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .start = 0x0,
     .end = 0x0}
   );
 
   (void) (struct eb_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .start = 0x0,
     .end = 0x0};
@@ -103,7 +103,7 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
   };
   (void)(struct Contains_eb_with_other_data) {
     .s = {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .start = 0x0,
       .end = 0x0
@@ -113,22 +113,22 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
 
   // Nested CompoundLiteralExpr
   (void)(struct NestedEB) {
-    // expected-warning@+1{{initializer (struct eb_with_other_data){.start = 0, .end = 0, .other = side_effect()} has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer '(struct eb_with_other_data){.start = 0, .end = 0, .other = side_effect()}' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .inner = (struct eb_with_other_data) {
       .start = 0x0,
       .end = 0x0,
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
       .other = side_effect()
     },
     .start = 0x0,
     .end = 0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect()
   };
 
   // Test array initializer list that initializes structs
   (void)(struct eb_with_other_data[]){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {0x0, 0x0, side_effect()},
     {0x0, 0x0, 0x0}
   };
@@ -140,7 +140,7 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
 
   (void)(union UnionWith_eb_with_other_data) {
     {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .start = 0x0,
       .end = 0x0
@@ -152,7 +152,7 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
     // Test very "untransparent"
     (union TransparentUnion) {.cb = 
       {
-        // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+        // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
         .other = side_effect(),
         .start = 0x0,
         .end = 0x0
@@ -163,14 +163,14 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
   receive_transparent_union(
     // Transparent
     (struct eb_with_other_data){
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .start = 0x0,
       .end = 0x0
     }
   );
 
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   return (struct eb_with_other_data) { 0x0, 0x0, side_effect()};
 };
 
@@ -318,7 +318,7 @@ void var_init_from_compound_literal_with_side_effect(char*__bidi_indexable ptr) 
   // both-error@+1{{cannot initialize array of type 'struct eb_with_other_data[]' with non-constant array of type 'struct eb_with_other_data[2]'}}
   struct eb_with_other_data arr[] = (struct eb_with_other_data[]){
     {.start = ptr, .end = ptr + 1, .other = 0x0},
-    // expected-warning@+1{{initializer get_count() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'get_count()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {.start = ptr, .end = ptr + 1, .other = get_count()},
   };
 }

--- a/clang/test/BoundsSafety/Sema/compound-literal-sized_by.c
+++ b/clang/test/BoundsSafety/Sema/compound-literal-sized_by.c
@@ -58,32 +58,32 @@ struct sb_with_other_data field_initializers_with_side_effects(struct sb_with_ot
   *s = (struct sb_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   struct sb_with_other_data s2 = (struct sb_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   consume_sb_with_other_data((struct sb_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()}
   );
   consume_sb_with_other_data((struct sb_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0}
   );
 
   (void) (struct sb_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0};
@@ -102,7 +102,7 @@ struct sb_with_other_data field_initializers_with_side_effects(struct sb_with_ot
   };
   (void)(struct Contains_sb_with_other_data) {
     .s = {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -112,22 +112,22 @@ struct sb_with_other_data field_initializers_with_side_effects(struct sb_with_ot
 
   // Nested CompoundLiteralExpr
   (void)(struct NestedSB) {
-    // expected-warning@+1{{initializer (struct sb_with_other_data){.count = 0, .buf = 0, .other = side_effect()} has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer '(struct sb_with_other_data){.count = 0, .buf = 0, .other = side_effect()}' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .inner = (struct sb_with_other_data) {
       .count = 0,
       .buf = 0x0,
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
       .other = side_effect()
     },
     .count = 0,
     .buf = 0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect()
   };
 
   // Test array initializer list that initializes structs
   (void)(struct sb_with_other_data[]){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {0, 0x0, side_effect()},
     {0, 0x0, 0x0}
   };
@@ -139,7 +139,7 @@ struct sb_with_other_data field_initializers_with_side_effects(struct sb_with_ot
 
   (void)(union UnionWith_sb_with_other_data) {
     {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -151,7 +151,7 @@ struct sb_with_other_data field_initializers_with_side_effects(struct sb_with_ot
     // Test very "untransparent"
     (union TransparentUnion) {.cb = 
       {
-        // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+        // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
         .other = side_effect(),
         .buf = 0x0,
         .count = 0
@@ -162,14 +162,14 @@ struct sb_with_other_data field_initializers_with_side_effects(struct sb_with_ot
   receive_transparent_union(
     // Transparent
     (struct sb_with_other_data){
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
     }
   );
 
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   return (struct sb_with_other_data) { 0, 0x0, side_effect()};
 }
 
@@ -411,7 +411,7 @@ void var_init_from_compound_literal_with_side_effect(char*__bidi_indexable ptr) 
   // both-error@+1{{cannot initialize array of type 'struct sb_with_other_data[]' with non-constant array of type 'struct sb_with_other_data[2]'}}
   struct sb_with_other_data arr[] = (struct sb_with_other_data[]){
     {.buf = ptr, .count = 0x0, .other = 0x0},
-    // expected-warning@+1{{initializer get_count() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'get_count()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {.buf = ptr, .count = 0x0, .other = get_count()},
   };
 }

--- a/clang/test/BoundsSafety/Sema/compound-literal-sized_by_or_null.c
+++ b/clang/test/BoundsSafety/Sema/compound-literal-sized_by_or_null.c
@@ -57,32 +57,32 @@ struct sbon_with_other_data field_initializers_with_side_effects(struct sbon_wit
   *s = (struct sbon_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   struct sbon_with_other_data s2 = (struct sbon_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()
   };
 
   consume_sbon_with_other_data((struct sbon_with_other_data){
     0,
     0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     side_effect()}
   );
   consume_sbon_with_other_data((struct sbon_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0}
   );
 
   (void) (struct sbon_with_other_data){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect(),
     .buf = 0x0,
     .count = 0};
@@ -101,7 +101,7 @@ struct sbon_with_other_data field_initializers_with_side_effects(struct sbon_wit
   };
   (void)(struct Contains_sbon_with_other_data) {
     .s = {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -111,22 +111,22 @@ struct sbon_with_other_data field_initializers_with_side_effects(struct sbon_wit
 
   // Nested CompoundLiteralExpr
   (void)(struct NestedSBON) {
-    // expected-warning@+1{{initializer (struct sbon_with_other_data){.count = 0, .buf = 0, .other = side_effect()} has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer '(struct sbon_with_other_data){.count = 0, .buf = 0, .other = side_effect()}' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .inner = (struct sbon_with_other_data) {
       .count = 0,
       .buf = 0x0,
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminat}}
       .other = side_effect()
     },
     .count = 0,
     .buf = 0x0,
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     .other = side_effect()
   };
 
   // Test array initializer list that initializes structs
   (void)(struct sbon_with_other_data[]){
-    // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}} 
+    // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {0, 0x0, side_effect()},
     {0, 0x0, 0x0}
   };
@@ -138,7 +138,7 @@ struct sbon_with_other_data field_initializers_with_side_effects(struct sbon_wit
 
   (void)(union UnionWith_sbon_with_other_data) {
     {
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
@@ -150,7 +150,7 @@ struct sbon_with_other_data field_initializers_with_side_effects(struct sbon_wit
     // Test very "untransparent"
     (union TransparentUnion) {.cb = 
       {
-        // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+        // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
         .other = side_effect(),
         .buf = 0x0,
         .count = 0
@@ -161,14 +161,14 @@ struct sbon_with_other_data field_initializers_with_side_effects(struct sbon_wit
   receive_transparent_union(
     // Transparent
     (struct sbon_with_other_data){
-      // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+      // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
       .other = side_effect(),
       .buf = 0x0,
       .count = 0
     }
   );
 
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   return (struct sbon_with_other_data) { 0, 0x0, side_effect()};
 }
 
@@ -404,7 +404,7 @@ void var_init_from_compound_literal_with_side_effect(char*__bidi_indexable ptr) 
   // both-error@+1{{cannot initialize array of type 'struct sbon_with_other_data[]' with non-constant array of type 'struct sbon_with_other_data[2]'}}
   struct sbon_with_other_data arr[] = (struct sbon_with_other_data[]){
     {.buf = ptr, .count = 0x0, .other = 0x0},
-    // expected-warning@+1{{initializer get_count() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+    // expected-warning@+1{{initializer 'get_count()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
     {.buf = ptr, .count = 0x0, .other = get_count()},
   };
 }

--- a/clang/test/BoundsSafety/Sema/dependent-count-arithmetic-check.c
+++ b/clang/test/BoundsSafety/Sema/dependent-count-arithmetic-check.c
@@ -22,6 +22,6 @@ int main() {
     // expected-error@+1{{passing address of 'n' referred to by '__counted_by' to a parameter that is not referred to by the same attribute}}
     foo(&buf, &n);
 
-    bar(&buf, &n); // expected-error{{incompatible count expression (*out_n) vs. (n + 1) in argument to function}}
+    bar(&buf, &n); // expected-error{{incompatible count expression '*out_n' vs. 'n + 1' in argument to function}}
     return 0;
 }

--- a/clang/test/BoundsSafety/Sema/dynamic-bound-init-list-side-effect.c
+++ b/clang/test/BoundsSafety/Sema/dynamic-bound-init-list-side-effect.c
@@ -87,13 +87,13 @@ void TestCountedBy(void) {
 
   int* ptr;
   struct CountedByDataWithSubStruct c9 = {ptr, 4, {0}}; // OK
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   struct CountedByDataWithSubStruct c10 = {ptr, 4, {side_effect()}};
   struct CountedByDataWithSubStructAtStart c11 = {{0}, ptr, 4}; // OK
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   struct CountedByDataWithSubStructAtStart c12 = {{side_effect()}, ptr, 4};
   struct CountedByDataWithOtherField c13 = {ptr, 4, 0}; // OK
-  // expected-warning@+1{{initializer side_effect() has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
+  // expected-warning@+1{{initializer 'side_effect()' has a side effect; this may lead to an unexpected result because the evaluation order of initialization list expressions is indeterminate}}
   struct CountedByDataWithOtherField c14 = {ptr, 4, side_effect()};
 }
 

--- a/clang/test/BoundsSafety/Sema/mismatching-out-parameter.c
+++ b/clang/test/BoundsSafety/Sema/mismatching-out-parameter.c
@@ -119,7 +119,7 @@ int main() {
 
   foo(&s.len, &s.buf);
   foo(&local_len, &s.buf); // expected-error{{incompatible dynamic count pointer argument to parameter of type}}
-  foo(&t.len, &t.buf);     // expected-error{{incompatible count expression (*out_len) vs. (len + 1) in argument to function}}
+  foo(&t.len, &t.buf);     // expected-error{{incompatible count expression '*out_len' vs. 'len + 1' in argument to function}}
   foo(&u.len, &u.buf);
   // expected-error@-1{{passing address of 'len' as an indirect parameter; must also pass 'buf2' or its address because the type of 'buf2', 'int *__single __counted_by(len)' (aka 'int *__single'), refers to 'len'}}
   bar(&s.len, &s.buf); // expected-error{{passing address of 'len' referred to by '__counted_by' to a parameter that is not referred to by the same attribute}}
@@ -146,14 +146,14 @@ int main() {
 
   foo(&s_n.len, &s_n.buf);
   foo(&local_len, &s_n.buf); // expected-error{{incompatible dynamic count pointer argument to parameter of type}}
-  foo(&t_n.len, &t_n.buf);     // expected-error{{incompatible count expression (*out_len) vs. (len + 1) in argument to function}}
+  foo(&t_n.len, &t_n.buf);     // expected-error{{incompatible count expression '*out_len' vs. 'len + 1' in argument to function}}
   foo(&u_n.len, &u_n.buf);
   // expected-error@-1{{passing address of 'len' as an indirect parameter; must also pass 'buf2' or its address because the type of 'buf2', 'int *__single __counted_by_or_null(len)' (aka 'int *__single'), refers to 'len'}}
   bar(&s_n.len, &s_n.buf); // expected-error{{passing address of 'len' referred to by '__counted_by_or_null' to a parameter that is not referred to by the same attribute}}
 
   foo_nullable(&s.len, &s.buf);
   foo_nullable(&local_len, &s.buf); // expected-error{{incompatible dynamic count pointer argument to parameter of type}}
-  foo_nullable(&t.len, &t.buf);     // expected-error{{incompatible count expression (*out_len) vs. (len + 1) in argument to function}}
+  foo_nullable(&t.len, &t.buf);     // expected-error{{incompatible count expression '*out_len' vs. 'len + 1' in argument to function}}
   foo_nullable(&u.len, &u.buf);
   // expected-error@-1{{passing address of 'len' as an indirect parameter; must also pass 'buf2' or its address because the type of 'buf2', 'int *__single __counted_by(len)' (aka 'int *__single'), refers to 'len'}}
   bar_nullable(&s.len, &s.buf); // expected-error{{passing address of 'len' referred to by '__counted_by' to a parameter that is not referred to by the same attribute}}
@@ -180,7 +180,7 @@ int main() {
 
   foo_nullable(&s_n.len, &s_n.buf);
   foo_nullable(&local_len, &s_n.buf); // expected-error{{incompatible dynamic count pointer argument to parameter of type}}
-  foo_nullable(&t_n.len, &t_n.buf);     // expected-error{{incompatible count expression (*out_len) vs. (len + 1) in argument to function}}
+  foo_nullable(&t_n.len, &t_n.buf);     // expected-error{{incompatible count expression '*out_len' vs. 'len + 1' in argument to function}}
   foo_nullable(&u_n.len, &u_n.buf);
   // expected-error@-1{{passing address of 'len' as an indirect parameter; must also pass 'buf2' or its address because the type of 'buf2', 'int *__single __counted_by_or_null(len)' (aka 'int *__single'), refers to 'len'}}
   bar_nullable(&s_n.len, &s_n.buf); // expected-error{{passing address of 'len' referred to by '__counted_by_or_null' to a parameter that is not referred to by the same attribute}}

--- a/clang/test/BoundsSafety/Sema/terminated-by-array-init.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-array-init.c
@@ -37,39 +37,39 @@ void explicit_const_init(void) {
   // ok
   int a1[__null_terminated 3] = {1, 2, 0};
 
-  // expected-error@+1{{array 'a2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 3)}}
+  // expected-error@+1{{array 'a2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '3')}}
   int a2[__null_terminated 3] = {1, 2, 3};
 
   // ok
   int a3[__terminated_by(42) 3] = {1, 2, 42};
 
-  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   int a4[__terminated_by(42) 3] = {1, 2, 0};
 
   // ok
   char s1[__null_terminated 3] = "HI";
 
-  // expected-error@+1{{array 's2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+1{{array 's2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   char s2[__terminated_by('X') 3] = "HI";
 
   // ok
   struct Foo foo1 = {{1, 0}, {2, 42}};
 
-  // expected-error@+1{{array 'foo2.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 1)}}
+  // expected-error@+1{{array 'foo2.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '1')}}
   struct Foo foo2 = {{1, 1}, {2, 42}};
 
-  // expected-error@+2{{array 'foo3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 1)}}
-  // expected-error@+1{{array 'foo3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 2)}}
+  // expected-error@+2{{array 'foo3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '1')}}
+  // expected-error@+1{{array 'foo3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '2')}}
   struct Foo foo3 = {{1, 1}, {2, 2}};
 
   // ok
   struct Qux qux1 = {{{1, 0}, {2, 42}}, {{1, 0}}, {{'Z', 'Y', 'X'}, "HI"}};
 
-  // expected-error@+5{{array 'qux2.foo.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 1)}}
-  // expected-error@+4{{array 'qux2.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 2)}}
-  // expected-error@+3{{array 'qux2.bar.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 3)}}
-  // expected-error@+2{{array 'qux2.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
-  // expected-error@+1{{array 'qux2.baz.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'X')}}
+  // expected-error@+5{{array 'qux2.foo.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '1')}}
+  // expected-error@+4{{array 'qux2.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '2')}}
+  // expected-error@+3{{array 'qux2.bar.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '3')}}
+  // expected-error@+2{{array 'qux2.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
+  // expected-error@+1{{array 'qux2.baz.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got ''X'')}}
   struct Qux qux2 = {{{1, 1}, {2, 2}}, {{1, 3}}, {"HI", {'Z', 'Y', 'X'}}};
 }
 
@@ -78,27 +78,27 @@ void explicit_const_init_excess(void) {
   int a1[__null_terminated 3] = {1, 2, 0, 4};
 
   // expected-warning@+2{{excess elements in array initializer}}
-  // expected-error@+1{{array 'a2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 3)}}
+  // expected-error@+1{{array 'a2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '3')}}
   int a2[__null_terminated 3] = {1, 2, 3, 4};
 
   // expected-warning@+1{{excess elements in array initializer}}
   int a3[__terminated_by(42) 3] = {1, 2, 42, 4};
 
   // expected-warning@+2{{excess elements in array initializer}}
-  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   int a4[__terminated_by(42) 3] = {1, 2, 0, 42};
 
   // ok
   char s1[__null_terminated 3] = "HI\0";
 
-  // expected-error@+1{{array 's2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 'J')}}
+  // expected-error@+1{{array 's2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got ''J'')}}
   char s2[__terminated_by('X') 3] = "HEJ";
 
   // expected-warning@+1{{initializer-string for char array is too long}}
   char s3[__null_terminated 3] = "HI\0HI";
 
   // expected-warning@+2{{initializer-string for char array is too long}}
-  // expected-error@+1{{array 's4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 'C')}}
+  // expected-error@+1{{array 's4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got ''C'')}}
   char s4[__terminated_by('X') 3] = "ABCD";
 
   // expected-warning@+2{{excess elements in array initializer}}
@@ -106,13 +106,13 @@ void explicit_const_init_excess(void) {
   struct Foo foo1 = {{1, 0, 1}, {2, 42, 0}};
 
   // expected-warning@+2{{excess elements in array initializer}}
-  // expected-error@+1{{array 'foo2.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 1)}}
+  // expected-error@+1{{array 'foo2.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '1')}}
   struct Foo foo2 = {{1, 1, 0}, {2, 42}};
 
   // expected-warning@+4{{excess elements in array initializer}}
   // expected-warning@+3{{excess elements in array initializer}}
-  // expected-error@+2{{array 'foo3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 1)}}
-  // expected-error@+1{{array 'foo3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 2)}}
+  // expected-error@+2{{array 'foo3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '1')}}
+  // expected-error@+1{{array 'foo3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '2')}}
   struct Foo foo3 = {{1, 1, 0}, {2, 2, 42}};
 
   // ok
@@ -124,8 +124,8 @@ void explicit_const_init_excess(void) {
 
   // expected-warning@+4{{initializer-string for char array is too long}}
   // expected-warning@+3{{initializer-string for char array is too long}}
-  // expected-error@+2{{array 'baz3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 'C')}}
-  // expected-error@+1{{array 'baz3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'X')}}
+  // expected-error@+2{{array 'baz3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got ''C'')}}
+  // expected-error@+1{{array 'baz3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got ''X'')}}
   struct Baz baz3 = {"ABCD", "ZYXW"};
 
   // expected-warning@+4{{excess elements in array initializer}}
@@ -137,11 +137,11 @@ void explicit_const_init_excess(void) {
   // expected-warning@+8{{excess elements in array initializer}}
   // expected-warning@+7{{excess elements in array initializer}}
   // expected-warning@+6{{excess elements in array initializer}}
-  // expected-error@+5{{array 'qux2.foo.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 1)}}
-  // expected-error@+4{{array 'qux2.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 2)}}
-  // expected-error@+3{{array 'qux2.bar.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 3)}}
-  // expected-error@+2{{array 'qux2.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 'A')}}
-  // expected-error@+1{{array 'qux2.baz.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'J')}}
+  // expected-error@+5{{array 'qux2.foo.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '1')}}
+  // expected-error@+4{{array 'qux2.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '2')}}
+  // expected-error@+3{{array 'qux2.bar.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '3')}}
+  // expected-error@+2{{array 'qux2.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got ''A'')}}
+  // expected-error@+1{{array 'qux2.baz.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got ''J'')}}
   struct Qux qux2 = {{{1, 1, 0}, {2, 2}}, {{1, 3, 0}}, {{'Z', 'Y', 'A', 'W'}, "HEJ"}};
 }
 
@@ -152,10 +152,10 @@ void implicit_init(void) {
   // ok
   int a2[__null_terminated 3] = {1, 2};
 
-  // expected-error@+1{{array 'a3' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'a3' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   int a3[__terminated_by(42) 3] = {};
 
-  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   int a4[__terminated_by(42) 3] = {1, 2};
 
   // ok
@@ -164,13 +164,13 @@ void implicit_init(void) {
   // ok
   char s2[__null_terminated 3] = "X";
 
-  // expected-error@+1{{array 'foo1.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'foo1.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   struct Foo foo1 = {};
 
-  // expected-error@+1{{array 'foo2.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'foo2.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   struct Foo foo2 = {{}};
 
-  // expected-error@+1{{array 'foo3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'foo3.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   struct Foo foo3 = {{}, {}};
 
   // ok
@@ -185,28 +185,28 @@ void implicit_init(void) {
   // ok
   struct Bar bar2 = {{}};
 
-  // expected-error@+1{{array 'baz1.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+1{{array 'baz1.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   struct Baz baz1 = {};
 
-  // expected-error@+1{{array 'baz2.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+1{{array 'baz2.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   struct Baz baz2 = {{}};
 
-  // expected-error@+1{{array 'baz3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+1{{array 'baz3.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   struct Baz baz3 = {{}, {}};
 
   // ok
   struct Baz baz4 = {"ZYX"};
 
-  // expected-error@+2{{array 'qux1.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
-  // expected-error@+1{{array 'qux1.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+2{{array 'qux1.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
+  // expected-error@+1{{array 'qux1.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   struct Qux qux1 = {};
 
-  // expected-error@+2{{array 'qux2.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
-  // expected-error@+1{{array 'qux2.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+2{{array 'qux2.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
+  // expected-error@+1{{array 'qux2.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   struct Qux qux2 = {{}, {}, {}};
 
-  // expected-error@+2{{array 'qux3.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
-  // expected-error@+1{{array 'qux3.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+2{{array 'qux3.foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
+  // expected-error@+1{{array 'qux3.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   struct Qux qux3 = {{{}, {}}, {{}}, {{}, {}}};
 
   // ok
@@ -238,19 +238,19 @@ void incomplete_array_init(void) {
   // ok
   int a1[__null_terminated] = {1, 2, 0};
 
-  // expected-error@+1{{array 'a2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 3)}}
+  // expected-error@+1{{array 'a2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '3')}}
   int a2[__null_terminated] = {1, 2, 3};
 
   // ok
   int a3[__null_terminated] = (int[3]){1, 2, 0};
 
-  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 3)}}
+  // expected-error@+1{{array 'a4' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '3')}}
   int a4[__null_terminated] = (int[3]){1, 2, 3};
 
   // ok
   char s1[__null_terminated] = "HI";
 
-  // expected-error@+1{{array 's2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0)}}
+  // expected-error@+1{{array 's2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0')}}
   char s2[__terminated_by('X')] = "HI";
 }
 
@@ -279,16 +279,16 @@ void string_literal_init(void) {
   // ok
   char32_t s8[__terminated_by(U'X') 3] = U"ZYX";
 
-  // expected-error@+1{{array 's9' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 'C')}}
+  // expected-error@+1{{array 's9' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got ''C'')}}
   char s9[__terminated_by('X') 3] = "ABC";
 
-  // expected-error@+1{{array 's10' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: L'X'; got L'C')}}
+  // expected-error@+1{{array 's10' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'L'X''; got 'L'C'')}}
   wchar_t s10[__terminated_by(L'X') 3] = L"ABC";
 
-  // expected-error@+1{{array 's11' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: u'X'; got u'C')}}
+  // expected-error@+1{{array 's11' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'u'X''; got 'u'C'')}}
   char16_t s11[__terminated_by(u'X') 3] = u"ABC";
 
-  // expected-error@+1{{array 's12' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: U'X'; got U'C')}}
+  // expected-error@+1{{array 's12' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'U'X''; got 'U'C'')}}
   char32_t s12[__terminated_by(U'X') 3] = U"ABC";
 
   // ok
@@ -346,11 +346,11 @@ void bar_as_param(struct Bar bar);
 void quux_as_param(struct Quux quux);
 
 void as_param(void) {
-  // expected-error@+1{{array 'foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   foo_as_param((struct Foo){});
 
-  // expected-error@+2{{array 'foo.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 2)}}
-  // expected-error@+1{{array 'foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 4)}}
+  // expected-error@+2{{array 'foo.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '2')}}
+  // expected-error@+1{{array 'foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '4')}}
   foo_as_param((struct Foo){{1, 2}, {3, 4}});
 
   // ok
@@ -359,7 +359,7 @@ void as_param(void) {
   // ok
   bar_as_param((struct Bar){});
 
-  // expected-error@+1{{array 'bar.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 2)}}
+  // expected-error@+1{{array 'bar.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '2')}}
   bar_as_param((struct Bar){{1, 2}});
 
   // ok
@@ -367,11 +367,11 @@ void as_param(void) {
 }
 
 struct Foo foo_as_ret(void) {
-  // expected-error@+1{{array '.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array '.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   return (struct Foo){};
 
-  // expected-error@+2{{array '.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 2)}}
-  // expected-error@+1{{array '.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 4)}}
+  // expected-error@+2{{array '.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '2')}}
+  // expected-error@+1{{array '.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '4')}}
   return (struct Foo){{1, 2}, {3, 4}};
 
   // ok
@@ -382,7 +382,7 @@ struct Bar bar_as_ret(void) {
   // ok
   return (struct Bar){};
 
-  // expected-error@+1{{array '.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 2)}}
+  // expected-error@+1{{array '.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got '2')}}
   return (struct Bar){{1, 2}};
 
   // ok
@@ -403,7 +403,7 @@ struct Foo copy_init(void) {
   // ok
   struct Qux qux2 = { .foo = foo1, /* .bar = ... */ .baz = baz1 };
 
-  // expected-error@+1{{array 'qux3.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 'X'; got 0}}
+  // expected-error@+1{{array 'qux3.baz.a' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: ''X''; got '0'}}
   struct Qux qux3 = { .foo = foo1, .bar = bar1 /* .baz = ... */ };
 
   // ok

--- a/clang/test/BoundsSafety/Sema/terminated-by-array-uninit.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-array-uninit.c
@@ -21,32 +21,32 @@ struct Baz {
 // ok
 int g_a[__null_terminated 8];
 
-// expected-error@+1{{array 'g_b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+// expected-error@+1{{array 'g_b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
 int g_b[__terminated_by(42) 8];
 
-// expected-error@+1{{array 'g_foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+// expected-error@+1{{array 'g_foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
 struct Foo g_foo;
 
 // ok
 struct Bar g_bar;
 
-// expected-error@+1{{array 'g_baz.f.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+// expected-error@+1{{array 'g_baz.f.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
 struct Baz g_baz;
 
 void no_init_static_local(void) {
   // ok
   static int a[__null_terminated 8];
 
-  // expected-error@+1{{array 'b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   static int b[__terminated_by(42) 8];
 
-  // expected-error@+1{{array 'foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'foo.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   static struct Foo foo;
 
   // ok
   static struct Bar bar;
 
-  // expected-error@+1{{array 'baz.f.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  // expected-error@+1{{array 'baz.f.b' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
   static struct Baz baz;
 }
 

--- a/clang/test/BoundsSafety/Sema/terminated-by-attr.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-attr.c
@@ -15,7 +15,7 @@ void multiple_attrs(void) {
   char a1[__null_terminated __null_terminated] = "";    // expected-warning{{array annotated with __terminated_by multiple times. Annotate only once to remove this warning}}
   char a2[__null_terminated __terminated_by(42)] = ""; // expected-error{{array cannot have more than one terminator attribute}}
                                                        // expected-note@-1{{conflicting arguments for terminator were '0' and '42'}}
-  char a3[__terminated_by(42)] = ""; // expected-error{{array 'a3' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 42; got 0)}}
+  char a3[__terminated_by(42)] = ""; // expected-error{{array 'a3' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '42'; got '0')}}
 
   char *__null_terminated __null_terminated p1 = "";    // expected-warning{{pointer annotated with __terminated_by multiple times. Annotate only once to remove this warning}}
   char *__null_terminated __terminated_by(42) p2 = ""; // expected-error{{pointer cannot have more than one terminator attribute}}

--- a/clang/test/BoundsSafety/Sema/terminated-by-to-indexable.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-to-indexable.c
@@ -43,20 +43,20 @@ void unsafe_term_ice(int *__null_terminated p, int val) {
 
 void null(int *__null_terminated p, int *__terminated_by(42) q) {
   __null_terminated_to_indexable(p); // ok
-  __null_terminated_to_indexable(q); // expected-error{{pointer argument must be terminated by 0 (got 42)}}
+  __null_terminated_to_indexable(q); // expected-error{{pointer argument must be terminated by '0' (got '42')}}
 }
 
 void unsafe_null(int *__null_terminated p, int *__terminated_by(42) q) {
   __unsafe_null_terminated_to_indexable(p); // ok
-  __unsafe_null_terminated_to_indexable(q); // expected-error{{pointer argument must be terminated by 0 (got 42)}}
+  __unsafe_null_terminated_to_indexable(q); // expected-error{{pointer argument must be terminated by '0' (got '42')}}
 }
 
 void _42(int *__null_terminated p, int *__terminated_by(42) q) {
-  (void)__builtin_terminated_by_to_indexable(p, 42); // expected-error{{pointer argument must be terminated by 42 (got 0)}}
+  (void)__builtin_terminated_by_to_indexable(p, 42); // expected-error{{pointer argument must be terminated by '42' (got '0')}}
   (void)__builtin_terminated_by_to_indexable(q, 42); // ok
 }
 
 void unsafe_42(int *__null_terminated p, int *__terminated_by(42) q) {
-  (void)__builtin_unsafe_terminated_by_to_indexable(p, 42); // expected-error{{pointer argument must be terminated by 42 (got 0)}}
+  (void)__builtin_unsafe_terminated_by_to_indexable(p, 42); // expected-error{{pointer argument must be terminated by '42' (got '0')}}
   (void)__builtin_unsafe_terminated_by_to_indexable(q, 42); // ok
 }

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-null-terminated.cpp
@@ -126,7 +126,7 @@ const char * __null_terminated test_return(const char * p, char * q, std::string
 
 void test_array(char * cstr) {
   const char arr[__null_terminated 3] = {'h', 'i', '\0'};
-  // expected-error@+1 {{array 'arr2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: 0; got 'i')}}
+  // expected-error@+1 {{array 'arr2' with '__terminated_by' attribute is initialized with an incorrect terminator (expected: '0'; got ''i'')}}
   const char arr2[__null_terminated 2] = {'h', 'i'};
   const char * __null_terminated arr3[] = {"hello", "world"};
   // expected-error@+1 {{initializing 'const char * __terminated_by(0)' (aka 'const char *') with an expression of incompatible type 'char *' is an unsafe operation}}


### PR DESCRIPTION
In fceb9cecdf6264eb773ee826b72a51a9ec68ec74 (https://github.com/llvm/llvm-project/pull/134769) upstream changed the diagnostic engine to always wrap expressions in single quotes. We already had manual wrapping for most of those, so the manual single quotes needed to be removed. In other placed the test cases needed to be updated to reflect the new output.

rdar://149359009