### PR TITLE
[🍒 swift/release/6.2] Fix issue where target.source-map didn't apply to SwiftASTContext::Create

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2555,6 +2555,10 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 
   // Apply source path remappings found in the module's dSYM.
   swift_ast_sp->RemapClangImporterOptions(module.GetSourceMappingList());
+
+  // Apply source path remappings found in the target settings.
+  if (target)
+    swift_ast_sp->RemapClangImporterOptions(target->GetSourcePathMap());
   swift_ast_sp->FilterClangImporterOptions(
       swift_ast_sp->GetClangImporterOptions().ExtraArgs, swift_ast_sp.get());
 


### PR DESCRIPTION
This specifically is for SwiftASTContext::CreateInstance with a TypeSystemSwiftTypeRef, the other version works as expected.

 - **Explanation**:
    This fixes an issue in one version SwiftASTContext::CreateInstance where source mappings were not properly applied like they are in the ohter version.

  - **Scope**:
    Very limited, fixes inconsistent application of `target.source-map`, no other changes

  - **Issues**:
    We're seeing ClangImporter failures due to the remappings not being applied, but haven't filed upstream issues.
  - **Original PRs**: #10527 
  - **Risk**: Low, only applies to lldb sessions with `target.source-map` and is a correctness fix. The previous behavior is incorrect.
  - **Testing**: All tests passed. Tried to update TestSwiftRewriteClangPaths but was able to trigger the modified version of `SwiftASTContext::CreateInstance`, I think a new test suite can be added / this test could be modified in a follow up if needed.
  - **Reviewers**:
    Not yet approved, TBD