### PR TITLE
[Cherry-pick into swift/release/6.2] [lldb] Add missing whitespace in help text

### DIFF
--- a/lldb/source/Interpreter/CommandInterpreter.cpp
+++ b/lldb/source/Interpreter/CommandInterpreter.cpp
@@ -850,7 +850,7 @@ void CommandInterpreter::LoadCommandDictionary() {
           "argument displays at most that many frames. The argument 'all' "
           "displays all threads. Use 'settings set frame-format' to customize "
           "the printing of individual frames and 'settings set thread-format' "
-          "to customize the thread header. Frame recognizers may filter the"
+          "to customize the thread header. Frame recognizers may filter the "
           "list. Use 'thread backtrace -u (--unfiltered)' to see them all.",
           "bt [<digit> | all]", 0, false));
   if (bt_regex_cmd_up) {


### PR DESCRIPTION
```
commit 2b7e9d27817da54c34a6f02dc00d2466c31f6fa0
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Oct 18 16:54:55 2024 -0700

    [lldb] Add missing whitespace in help text
```
