### PR TITLE
[BoundsSafety] Partially Upstream support for `BS_CHK_LibCAttributes` for Apple platforms

### DIFF
--- a/clang/test/BoundsSafety/Driver/libc_staged_bounds_safety_attributes_macro.c
+++ b/clang/test/BoundsSafety/Driver/libc_staged_bounds_safety_attributes_macro.c
@@ -1,0 +1,93 @@
+// =============================================================================
+// Supported target triples
+// =============================================================================
+
+// MACRO: -D__LIBC_STAGED_BOUNDS_SAFETY_ATTRIBUTES
+// NO_MACRO-NOT: -D__LIBC_STAGED_BOUNDS_SAFETY_ATTRIBUTES
+
+// ios
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=MACRO %s
+
+// macos
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-macos \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-macos \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=MACRO %s
+
+// macos (legacy `darwin` os name in triple)
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-darwin \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-darwin \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=MACRO %s
+
+// watchos
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-watchos \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-watchos \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=MACRO %s
+
+// tvos
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-tvos \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-tvos \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=MACRO %s
+
+// =============================================================================
+// Check option is included in all and option variant without `=all` suffix
+// =============================================================================
+
+// ios
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=all \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fno-bounds-safety-bringup-missing-checks \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fbounds-safety-bringup-missing-checks=all \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fbounds-safety-bringup-missing-checks \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=MACRO %s
+
+// =============================================================================
+// Unsupported target triples
+// =============================================================================
+
+// linux
+// RUN: %clang -Wno-incompatible-sysroot -target x86_64-unknown-linux \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s
+// RUN: %clang -Wno-incompatible-sysroot -target x86_64-unknown-linux \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -### -fbounds-safety %s 2>&1 \
+// RUN: | FileCheck --check-prefix=NO_MACRO %s

--- a/clang/test/BoundsSafety/Frontend/libc_staged_bounds_safety_attributes_macro.c
+++ b/clang/test/BoundsSafety/Frontend/libc_staged_bounds_safety_attributes_macro.c
@@ -1,0 +1,84 @@
+// This is similar to the driver test of the same name but we verify that
+// the macro is actually set/unset as expected.
+
+// =============================================================================
+// Supported target triples
+// =============================================================================
+
+// ios
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=macro -fbounds-safety -fsyntax-only %s
+
+// macos
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-macos \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-macos \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=macro -fbounds-safety -fsyntax-only %s
+
+// macos (legacy `darwin` os name in triple)
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-darwin \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-darwin \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=macro -fbounds-safety -fsyntax-only %s
+
+// watchos
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-watchos \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-watchos \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=macro -fbounds-safety -fsyntax-only %s
+
+// tvos
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-tvos \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-tvos \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=macro -fbounds-safety -fsyntax-only %s
+
+// =============================================================================
+// Unsupported target triples
+// =============================================================================
+
+// linux
+// RUN: %clang -Wno-incompatible-sysroot -target x86_64-unknown-linux \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target x86_64-unknown-linux \
+// RUN:  -fbounds-safety-bringup-missing-checks=libc_attributes \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+
+// =============================================================================
+// Check option is included in all and option variant without `=all` suffix
+// =============================================================================
+
+// ios
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fno-bounds-safety-bringup-missing-checks=all \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fno-bounds-safety-bringup-missing-checks \
+// RUN:  -x c -Xclang -verify=no_macro -fbounds-safety -fsyntax-only %s
+
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fbounds-safety-bringup-missing-checks=all \
+// RUN:  -x c -Xclang -verify=macro -fbounds-safety -fsyntax-only %s
+// RUN: %clang -Wno-incompatible-sysroot -target arm64-apple-ios \
+// RUN:  -fbounds-safety-bringup-missing-checks \
+// RUN:  -x c -Xclang -verify=macro -fbounds-safety -fsyntax-only %s
+
+#ifndef __LIBC_STAGED_BOUNDS_SAFETY_ATTRIBUTES
+// no_macro-error@+1{{expected __LIBC_STAGED_BOUNDS_SAFETY_ATTRIBUTES macro}}
+#error expected __LIBC_STAGED_BOUNDS_SAFETY_ATTRIBUTES macro
+#endif
+
+// macro-no-diagnostics


### PR DESCRIPTION
This adds the compiler side implementation of the new `BS_CHK_LibCAttributes` bounds check for the Darwin toolchain. When `-fbounds-safety-bringup-missing-checks=libc_attributes` is enabled and when compiling for Apple platforms with a userspace Libc the `__LIBC_STAGED_BOUNDS_SAFETY_ATTRIBUTES` macro is enabled. This macro communicates to Libc that it should switch on the new `-fbounds-safety` annotations.

rdar://149243724