### PR TITLE
[lldb] Relax test constraints on TestSwiftPluginQueues

### DIFF
--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -26,9 +26,6 @@ class TestCase(lldbtest.TestBase):
         self.assertEqual(queue_plugin, queue_backing)
         self.assertEqual(queue_plugin, thread.GetQueueName())
 
-        num_queues = process.GetNumQueues()
-        self.assertEqual(num_queues, 1)
-
     queue_regex = re.compile(r"queue = '([^']+)'")
 
     def get_queue_from_thread_info_command(self, use_backing_thread):


### PR DESCRIPTION
We can't guarantee there will always be two queues in this test.:

rdar://149855090