### PR TITLE
[Cherry-pick into next] [lldb] Diagnose a fallback warning for type aliases

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3309,6 +3309,11 @@ SwiftLanguageRuntime::GetSwiftRuntimeTypeInfo(
 
   // Resolve all type aliases.
   type = type.GetCanonicalType();
+  if (!type)
+    // FIXME: We could print a better error message if
+    // GetCanonicalType() returned an Expected.
+    return llvm::createStringError(
+        "could not get canonical type (possibly due to unresolved typealias)");
 
   // Resolve all generic type parameters in the type for the current
   // frame. Generic parameter binding has to happen in the scratch

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3309,11 +3309,12 @@ SwiftLanguageRuntime::GetSwiftRuntimeTypeInfo(
 
   // Resolve all type aliases.
   type = type.GetCanonicalType();
-  if (!type)
+  if (!type)  {
     // FIXME: We could print a better error message if
     // GetCanonicalType() returned an Expected.
     return llvm::createStringError(
         "could not get canonical type (possibly due to unresolved typealias)");
+}
 
   // Resolve all generic type parameters in the type for the current
   // frame. Generic parameter binding has to happen in the scratch

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3420,7 +3420,11 @@ TypeSystemSwiftTypeRef::GetCanonicalType(opaque_compiler_type_t type) {
       // then we don't have debug info to resolve it from.
       CompilerType ast_type =
         ReconstructType({weak_from_this(), type}, nullptr).GetCanonicalType();
-      return GetTypeFromMangledTypename(ast_type.GetMangledTypeName());
+      CompilerType result =
+          GetTypeFromMangledTypename(ast_type.GetMangledTypeName());
+      if (result && !llvm::isa<TypeSystemSwiftTypeRefForExpressions>(this))
+        DiagnoseSwiftASTContextFallback(__FUNCTION__, type);
+      return result;
     }
     auto flavor = SwiftLanguageRuntime::GetManglingFlavor(AsMangledName(type));
     auto mangling = mangleNode(canonical, flavor);


### PR DESCRIPTION
```
commit 1e36c9373295b39f14e7fe90ff3b49dd3fccc9d2
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Apr 24 12:26:12 2025 -0700

    [lldb] Diagnose a fallback warning for type aliases

commit 708b410c4c596974e3ee99eb636ebd5b66ebacfa
Author: Adrian Prantl <adrian.prantl@gmail.com>
Date:   Thu Apr 24 16:40:07 2025 -0700

    Update lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
    
    Co-authored-by: Jonas Devlieghere <jonas@devlieghere.com>
```
