### PR TITLE
[Cherry-pick into next] [lldb] Add missing recursion when desugaring a type

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1294,9 +1294,7 @@ TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
   // SomeAlias<WhatSomeOtherAliasResolvesTo> because it tries to
   // preserve all sugar.
   using namespace swift::Demangle;
-  NodePointer transformed = Canonicalize(dem, node, flavor);
-  if (node != transformed)
-    return transformed;
+  node = Canonicalize(dem, node, flavor);
 
   llvm::SmallVector<NodePointer, 2> children;
   bool changed = false;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -67,7 +67,10 @@ public:
   /// \}
 
   /// Provided only for unit tests.
+  /// \{
+  friend struct TestTypeSystemSwiftTypeRef;
   TypeSystemSwiftTypeRef();
+  /// \}
   ~TypeSystemSwiftTypeRef();
   TypeSystemSwiftTypeRef(Module &module);
   /// Get the corresponding SwiftASTContext, and create one if necessary.

--- a/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
+++ b/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/TestSwiftObjCOptionalDict.py
@@ -1,0 +1,17 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftObjCOptionalDict(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        # This should from DWRAF, without loading a Swift module.
+        self.expect("settings set symbols.swift-typesystem-compiler-fallback false")
+        d = self.frame().FindVariable("dict")
+        lldbutil.check_variable(self, d, summary='0 key/value pairs', value='some')

--- a/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/objc_optional_dict/main.swift
@@ -1,0 +1,7 @@
+import Foundation
+func f() {
+  var dict : [NSKeyValueChangeKey : Any]? = [:]
+  print("break here")
+}
+
+f()


### PR DESCRIPTION
```
commit c8807f7c70a6a453fc40eb474e4fa8a961198842
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Apr 24 15:13:17 2025 -0700

    [lldb] Add missing recursion when desugaring a type
    
    The type canonicalization would early-exit when desugaring of an outer
    node was successful, which means that GetCanonicalNode() would behave
    like DemangleCanonicalOutermostType() for types like sugared Optionals.
    
    rdar://149273756
```
