### PR TITLE
[Cherry-pick into next] [lldb] Use the static value in lldbutil.check_variable when use_dynamic=False

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1541,6 +1541,8 @@ def check_variable(
             valobj.IsDynamic(),
             "dynamic value of %s is not dynamic" % (name if valobj else "<unknown>"),
         )
+    else:
+        valobj = valobj.GetStaticValue()
     if use_synthetic:
         valobj.SetPreferSyntheticValue(True)
     if summary:

--- a/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
+++ b/lldb/test/API/lang/swift/async/frame/variable/TestSwiftAsyncFrameVar.py
@@ -25,7 +25,7 @@ class TestCase(lldbtest.TestBase):
         b = frame.FindVariable("b")
         self.assertFalse(b.IsValid())
         d = frame.FindVariable("d")
-        lldbutil.check_variable(self, d, False, value='23')
+        lldbutil.check_variable(self, d, use_dynamic=True, value='23')
 
         # The first breakpoint resolves to multiple locations, but only the
         # first location is needed. Now that we've stopped, delete it to
@@ -46,4 +46,4 @@ class TestCase(lldbtest.TestBase):
         self.assertTrue(b.IsValid())
         self.assertGreater(b.unsigned, 0)
         d = frame.FindVariable("d")
-        lldbutil.check_variable(self, d, False, value='23')
+        lldbutil.check_variable(self, d, use_dynamic=True, value='23')

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -37,6 +37,6 @@ class TestSwiftMetatype(TestBase):
         var_p = frame.FindVariable("p")
         lldbutil.check_variable(self, var_s, False, "String")
         lldbutil.check_variable(self, var_c, False, "@thick a.D.Type")
-        lldbutil.check_variable(self, var_f, False, '@thick ((Int) -> Int).Type')
+        lldbutil.check_variable(self, var_f, True, '@thick ((Int) -> Int).Type')
         lldbutil.check_variable(self, var_t, False, "(Int, Int, String)")
         lldbutil.check_variable(self, var_p, False, "a.P")


### PR DESCRIPTION
```
commit 6d148b48a247ed24ec158008607f610c196efe55
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Apr 24 18:35:49 2025 -0700

    [lldb] Use the static value in lldbutil.check_variable when use_dynamic=False
```
