### PR TITLE
[lldb] Annotate check with use_dynamic

### DIFF
--- a/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
+++ b/lldb/test/API/lang/swift/unknown_reference/TestSwiftUnknownReference.py
@@ -21,7 +21,7 @@ class TestSwiftUnknownReference(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     def check_class(self, var_self):
-        lldbutil.check_variable(self, var_self, num_children=2)
+        lldbutil.check_variable(self, var_self, use_dynamic=True, num_children=2)
         m_base_string = var_self.GetChildMemberWithName("base_string")
         m_string = var_self.GetChildMemberWithName("string")
         lldbutil.check_variable(self, m_base_string, summary='"hello"')

--- a/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
+++ b/lldb/test/API/lang/swift/unknown_self/TestSwiftUnknownSelf.py
@@ -20,7 +20,9 @@ class TestSwiftUnknownSelf(lldbtest.TestBase):
 
     def check_class(self, var_self, weak):
         self.expect("v self", substrs=["hello", "world"])
-        lldbutil.check_variable(self, var_self, num_children=2)
+        # FIXME: This is inconsistent. If self is Optional, an extra
+        #        indirection is needed.
+        lldbutil.check_variable(self, var_self, num_children=2 if weak else 1)
         m_base_string = var_self.GetChildMemberWithName("base_string")
         m_string = var_self.GetChildMemberWithName("string")
         # FIXME: This is inconsistent. If self is Optional, an extra


### PR DESCRIPTION
This fixes a mid-air collision between two PRs that were merged today.