### PR TITLE
[stable/20250402 🍒][clang] Allow parameterized 'isWeakImport' based on an enclosing platform version

### DIFF
--- a/clang/include/clang/AST/DeclBase.h
+++ b/clang/include/clang/AST/DeclBase.h
@@ -771,7 +771,7 @@ public:
   /// 'weak_import' attribute, but may also be marked with an
   /// 'availability' attribute where we're targing a platform prior to
   /// the introduction of this feature.
-  bool isWeakImported() const;
+  bool isWeakImported(VersionTuple EnclosingVersion = VersionTuple()) const;
 
   /// Determines whether this symbol can be weak-imported,
   /// e.g., whether it would be well-formed to add the weak_import

--- a/clang/lib/AST/DeclBase.cpp
+++ b/clang/lib/AST/DeclBase.cpp
@@ -846,7 +846,7 @@ bool Decl::canBeWeakImported(bool &IsDefinition) const {
   return false;
 }
 
-bool Decl::isWeakImported() const {
+bool Decl::isWeakImported(VersionTuple EnclosingVersion) const {
   bool IsDefinition;
   if (!canBeWeakImported(IsDefinition))
     return false;
@@ -857,7 +857,7 @@ bool Decl::isWeakImported() const {
 
     if (const auto *Availability = dyn_cast<AvailabilityAttr>(A)) {
       if (CheckAvailability(getASTContext(), Availability, nullptr,
-                            VersionTuple()) == AR_NotYetIntroduced)
+                            EnclosingVersion) == AR_NotYetIntroduced)
         return true;
     } else if (const auto *DA = dyn_cast<DomainAvailabilityAttr>(A)) {
       auto DomainName = DA->getDomain();

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2860,14 +2860,15 @@ void CodeGenModule::SetInternalFunctionAttributes(GlobalDecl GD,
   setNonAliasAttributes(GD, F);
 }
 
-static void setLinkageForGV(llvm::GlobalValue *GV, const NamedDecl *ND) {
+static void setLinkageForGV(llvm::GlobalValue *GV, const NamedDecl *ND,
+                            VersionTuple EnclosingVersion = VersionTuple()) {
   // Set linkage and visibility in case we never see a definition.
   LinkageInfo LV = ND->getLinkageAndVisibility();
   // Don't set internal linkage on declarations.
   // "extern_weak" is overloaded in LLVM; we probably should have
   // separate linkage types for this.
   if (isExternallyVisible(LV.getLinkage()) &&
-      (ND->hasAttr<WeakAttr>() || ND->isWeakImported()))
+      (ND->hasAttr<WeakAttr>() || ND->isWeakImported(EnclosingVersion)))
     GV->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
 }
 
@@ -2971,7 +2972,7 @@ void CodeGenModule::SetFunctionAttributes(GlobalDecl GD, llvm::Function *F,
   // Only a few attributes are set on declarations; these may later be
   // overridden by a definition.
 
-  setLinkageForGV(F, FD);
+  setLinkageForGV(F, FD, Target.getPlatformMinVersion());
   setGVProperties(F, FD);
 
   // Setup target-specific attributes.

--- a/clang/unittests/AST/DeclTest.cpp
+++ b/clang/unittests/AST/DeclTest.cpp
@@ -108,6 +108,12 @@ TEST(Decl, Availability) {
           clang::AR_Unavailable) {
         setFailure("failed obsoleted");
       }
+      if (Node.isWeakImported(clang::VersionTuple(10, 1)) != true) {
+        setFailure("failed not weak imported");
+      }
+      if (Node.isWeakImported(clang::VersionTuple(10, 10)) != false) {
+        setFailure("failed weak imported");
+      }
 
       if (Node.getAvailability() != clang::AR_Deprecated)
         setFailure("did not default to target OS version");


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10555
----------------------------------------------

Similarly to 'CheckAvailability' and 'getAvailability', set 'Decl::isWeakImported' to allow querying using an external target platform version.

In https://github.com/swiftlang/llvm-project/pull/7916 we have added support for configuring 'clang::CodeGenerator' with a differently-versioned target info, and this change adopts the code generator's target info in order to also determine weakly-imported linkage on declarations during code-gen. Before this change, they were relying on the 'ASTContext' to specify the target info, which may differ from code-gen's.