### PR TITLE
[lldb-dap] Support the Module Event (#137380)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
+++ b/lldb/packages/Python/lldbsuite/test/tools/lldb-dap/dap_server.py
@@ -127,6 +127,7 @@ class DebugCommunication(object):
         self.breakpoint_events = []
         self.progress_events = []
         self.reverse_requests = []
+        self.module_events = []
         self.sequence = 1
         self.threads = None
         self.recv_thread.start()
@@ -247,7 +248,10 @@ class DebugCommunication(object):
                 # and 'progressEnd' events. Keep these around in case test
                 # cases want to verify them.
                 self.progress_events.append(packet)
-                # No need to add 'progress' event packets to our packets list.
+            elif event == "module":
+                # Module events indicate that some information about a module has changed.
+                self.module_events.append(packet)
+                # no need to add 'module' event packets to our packets list
                 return keepGoing
 
         elif packet_type == "response":

--- a/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
+++ b/lldb/test/API/tools/lldb-dap/module/TestDAP_module.py
@@ -57,6 +57,27 @@ class TestDAP_module(lldbdap_testcase.DAPTestCaseBase):
         self.assertEqual(program, program_module["path"])
         self.assertIn("addressRange", program_module)
 
+        # Collect all the module names we saw as events.
+        module_new_names = []
+        module_changed_names = []
+        for module_event in self.dap_server.module_events:
+            module_name = module_event["body"]["module"]["name"]
+            reason = module_event["body"]["reason"]
+            if reason == "new":
+                module_new_names.append(module_name)
+            elif reason == "changed":
+                module_changed_names.append(module_name)
+
+        # Make sure we got an event for every active module.
+        self.assertNotEqual(len(module_new_names), 0)
+        for module in active_modules:
+            self.assertIn(module, module_new_names)
+
+        # Make sure we got an update event for the program module when the
+        # symbols got added.
+        self.assertNotEqual(len(module_changed_names), 0)
+        self.assertIn(program_module["name"], module_changed_names)
+
     @skipIfWindows
     def test_modules(self):
         """

--- a/lldb/tools/lldb-dap/DAP.cpp
+++ b/lldb/tools/lldb-dap/DAP.cpp
@@ -702,7 +702,11 @@ void DAP::SetTarget(const lldb::SBTarget target) {
     lldb::SBListener listener = this->debugger.GetListener();
     listener.StartListeningForEvents(
         this->target.GetBroadcaster(),
-        lldb::SBTarget::eBroadcastBitBreakpointChanged);
+        lldb::SBTarget::eBroadcastBitBreakpointChanged |
+            lldb::SBTarget::eBroadcastBitModulesLoaded |
+            lldb::SBTarget::eBroadcastBitModulesUnloaded |
+            lldb::SBTarget::eBroadcastBitSymbolsLoaded |
+            lldb::SBTarget::eBroadcastBitSymbolsChanged);
     listener.StartListeningForEvents(this->broadcaster,
                                      eBroadcastBitStopEventThread);
   }

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -438,6 +438,16 @@ void ProgressEventThreadFunction(DAP &dap) {
   }
 }
 
+static llvm::StringRef GetModuleEventReason(uint32_t event_mask) {
+  if (event_mask & lldb::SBTarget::eBroadcastBitModulesLoaded)
+    return "new";
+  if (event_mask & lldb::SBTarget::eBroadcastBitModulesUnloaded)
+    return "removed";
+  assert(event_mask & lldb::SBTarget::eBroadcastBitSymbolsLoaded ||
+         event_mask & lldb::SBTarget::eBroadcastBitSymbolsChanged);
+  return "changed";
+}
+
 // All events from the debugger, target, process, thread and frames are
 // received in this function that runs in its own thread. We are using a
 // "FILE *" to output packets back to VS Code and they have mutexes in them
@@ -518,6 +528,28 @@ void EventThreadFunction(DAP &dap) {
         } else if ((event_mask & lldb::SBProcess::eBroadcastBitSTDOUT) ||
                    (event_mask & lldb::SBProcess::eBroadcastBitSTDERR)) {
           SendStdOutStdErr(dap, process);
+        }
+      } else if (lldb::SBTarget::EventIsTargetEvent(event)) {
+        if (event_mask & lldb::SBTarget::eBroadcastBitModulesLoaded ||
+            event_mask & lldb::SBTarget::eBroadcastBitModulesUnloaded ||
+            event_mask & lldb::SBTarget::eBroadcastBitSymbolsLoaded ||
+            event_mask & lldb::SBTarget::eBroadcastBitSymbolsChanged) {
+          llvm::StringRef reason = GetModuleEventReason(event_mask);
+          const uint32_t num_modules =
+              lldb::SBTarget::GetNumModulesFromEvent(event);
+          for (uint32_t i = 0; i < num_modules; ++i) {
+            lldb::SBModule module =
+                lldb::SBTarget::GetModuleAtIndexFromEvent(i, event);
+            if (!module.IsValid())
+              continue;
+
+            llvm::json::Object body;
+            body.try_emplace("reason", reason);
+            body.try_emplace("module", CreateModule(dap.target, module));
+            llvm::json::Object module_event = CreateEventObject("module");
+            module_event.try_emplace("body", std::move(body));
+            dap.SendJSON(llvm::json::Value(std::move(module_event)));
+          }
         }
       } else if (lldb::SBBreakpoint::EventIsBreakpointEvent(event)) {
         if (event_mask & lldb::SBTarget::eBroadcastBitBreakpointChanged) {


### PR DESCRIPTION
The module event indicates that some information about a module has changed. The event is supported by the Emacs and Visual Studio DAP clients. This PR adds support for emitting the event from lldb-dap.

Fixes #137058

Back-ported from commit b546baff48767d54da03049d4f30690649a5e599