### PR TITLE
[lldb/Format] Make progress count show thousands separators (NFC) (#137446)

### DIFF
--- a/lldb/source/Core/FormatEntity.cpp
+++ b/lldb/source/Core/FormatEntity.cpp
@@ -1968,7 +1968,7 @@ bool FormatEntity::Format(const Entry &entry, Stream &s,
     if (Target *target = Target::GetTargetFromContexts(exe_ctx, sc)) {
       if (auto progress = target->GetDebugger().GetCurrentProgressReport()) {
         if (progress->total != UINT64_MAX) {
-          s.Format("[{0}/{1}]", progress->completed, progress->total);
+          s.Format("[{0:N}/{1:N}]", progress->completed, progress->total);
           return true;
         }
       }


### PR DESCRIPTION
This patch changes the progress count formatting show thousands separator making it easier to read big numbers.


(cherry picked from commit 4e4c6d7e273a91d230389b98c280c9dbde0f6c32)