### PR TITLE
[amtool] Add ability to override uncommitted change guard

### DIFF
--- a/apple-ci/amtool
+++ b/apple-ci/amtool
@@ -338,6 +338,7 @@ def main():
             else:
                 log.error('Looks like you have unstaged or uncommitted changes.')
                 log.error('Please make sure everything has been added to the commit.')
+                log.error('Use `--ignore-uncommitted-changes` to ignore, and push anyway.')
                 return 1
 
         # Save the commit sha so that we can include it in the output message.

--- a/apple-ci/amtool
+++ b/apple-ci/amtool
@@ -223,6 +223,10 @@ def parse_args():
     # Push
     parser_push = subparsers.add_parser('push',
             help='push the resolution, so that the automerger can pick it up')
+    # Override push uncommitted change error
+    parser_push.add_argument('--ignore-uncommitted-changes', dest='ignore_uncommitted',
+                             action='store_true', required=False,
+                             help='allowing pushing a commit even if uncommitted changes exist')
 
     args = parser.parse_args()
     return args
@@ -329,9 +333,12 @@ def main():
 
         # Check if we have any unstaged or uncommitted changes in the tree.
         if len(git('diff-index', 'HEAD')):
-            log.error('Looks like you have unstaged or uncommitted changes.')
-            log.error('Please make sure everything has been added to the commit.')
-            return 1
+            if args.ignore_uncommitted:
+                log.warning('Ignoring uncommitted changes.')
+            else:
+                log.error('Looks like you have unstaged or uncommitted changes.')
+                log.error('Please make sure everything has been added to the commit.')
+                return 1
 
         # Save the commit sha so that we can include it in the output message.
         merge_commit = git('rev-parse', 'HEAD')


### PR DESCRIPTION
Adds an `--ignore-uncommitted-changes` argument to `push` to allow pushing a change even if there are uncommitted changes in the tree.