### PR TITLE
[libclang] Add API to generate a reproducer for the explicitly-built modules.

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -608,11 +608,16 @@ typedef struct CXOpaqueDependencyScannerReproducerOptions
  *                   the intermediate modules. Otherwise, reproduce building
  *                   the whole translation unit.
  * \param WorkingDirectory the directory in which the invocation runs.
+ * \param ReproducerLocation the directory where to store the reproducer files.
+ *                           If NULL, use a temporary location.
+ * \param UseUniqueReproducerName if reproducer files should have unique names
+ *                                to avoid collisions with existing files.
  */
 CINDEX_LINKAGE CXDependencyScannerReproducerOptions
 clang_experimental_DependencyScannerReproducerOptions_create(
     int argc, const char *const *argv, const char *ModuleName,
-    const char *WorkingDirectory);
+    const char *WorkingDirectory, const char *ReproducerLocation,
+    bool UseUniqueReproducerName);
 
 CINDEX_LINKAGE void
     clang_experimental_DependencyScannerReproducerOptions_dispose(

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -591,6 +591,56 @@ CXCStringArray
         CXDependencyScannerService);
 
 /**
+ * Options used to generate a reproducer.
+ */
+typedef struct CXOpaqueDependencyScannerReproducerOptions
+    *CXDependencyScannerReproducerOptions;
+
+/**
+ * Creates a set of settings for
+ * \c clang_experimental_DependencyScanner_generateReproducer action.
+ * Must be disposed with
+ * \c clang_experimental_DependencyScannerReproducerOptions_dispose.
+ *
+ * \param argc the number of compiler invocation arguments (including argv[0]).
+ * \param argv the compiler driver invocation arguments (including argv[0]).
+ * \param ModuleName If non-NULL, reproduce building the named module and all
+ *                   the intermediate modules. Otherwise, reproduce building
+ *                   the whole translation unit.
+ * \param WorkingDirectory the directory in which the invocation runs.
+ */
+CINDEX_LINKAGE CXDependencyScannerReproducerOptions
+clang_experimental_DependencyScannerReproducerOptions_create(
+    int argc, const char *const *argv, const char *ModuleName,
+    const char *WorkingDirectory);
+
+CINDEX_LINKAGE void
+    clang_experimental_DependencyScannerReproducerOptions_dispose(
+        CXDependencyScannerReproducerOptions);
+
+/**
+ * Generates a reproducer to compile a requested file with required modules.
+ *
+ * Here the reproducer means the required input data with the commands to
+ * compile intermediate modules and a requested file. Required intermediate
+ * modules and the order of their compilation are determined by the function
+ * and don't need to be provided.
+ *
+ * \param CXOptions object created via
+ *     \c clang_experimental_DependencyScannerReproducerOptions_create.
+ * \param [out] MessageOut A pointer to store the human-readable message
+ *                         describing the result of the operation. If non-NULL,
+ *                         owned and should be disposed by the caller.
+ *
+ * \returns \c CXError_Success on success; otherwise a non-zero \c CXErrorCode
+ * indicating the kind of error. \p MessageOut is guaranteed to be populated
+ * for a success case but is allowed to be empty when encountered an error.
+ */
+CINDEX_LINKAGE enum CXErrorCode
+clang_experimental_DependencyScanner_generateReproducer(
+    CXDependencyScannerReproducerOptions CXOptions, CXString *MessageOut);
+
+/**
  * @}
  */
 

--- a/clang/test/Modules/reproducer-with-module-dependencies.c
+++ b/clang/test/Modules/reproducer-with-module-dependencies.c
@@ -1,0 +1,32 @@
+// Test generating a reproducer for a modular build where required modules are
+// built explicitly as separate steps.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+//
+// RUN: c-index-test core -gen-deps-reproducer -working-dir %t \
+// RUN:   -- clang-executable -c %t/reproducer.c -o %t/reproducer.o \
+// RUN:      -fmodules -fmodules-cache-path=%t | FileCheck %t/reproducer.c
+
+// Test a failed attempt at generating a reproducer.
+// RUN: not c-index-test core -gen-deps-reproducer -working-dir %t \
+// RUN:   -- clang-executable -c %t/failed-reproducer.c -o %t/reproducer.o \
+// RUN:      -fmodules -fmodules-cache-path=%t 2>&1 | FileCheck %t/failed-reproducer.c
+
+//--- modular-header.h
+void fn_in_modular_header(void);
+
+//--- module.modulemap
+module Test { header "modular-header.h" export * }
+
+//--- reproducer.c
+// CHECK: Sources and associated run script(s) are located at:
+#include "modular-header.h"
+
+void test(void) {
+  fn_in_modular_header();
+}
+
+//--- failed-reproducer.c
+// CHECK: fatal error: 'non-existing-header.h' file not found
+#include "non-existing-header.h"

--- a/clang/test/Modules/reproducer-with-module-dependencies.c
+++ b/clang/test/Modules/reproducer-with-module-dependencies.c
@@ -13,6 +13,12 @@
 // RUN:   -- clang-executable -c %t/failed-reproducer.c -o %t/reproducer.o \
 // RUN:      -fmodules -fmodules-cache-path=%t 2>&1 | FileCheck %t/failed-reproducer.c
 
+// Test the content of a reproducer script.
+// RUN: c-index-test core -gen-deps-reproducer -working-dir %t -o %t/repro-content \
+// RUN:   -- clang-executable -c %t/reproducer.c -o %t/reproducer.o \
+// RUN:      -fmodules -fmodules-cache-path=%t
+// RUN: FileCheck %t/script-expectations.txt --input-file %t/repro-content/reproducer.sh
+
 //--- modular-header.h
 void fn_in_modular_header(void);
 
@@ -30,3 +36,7 @@ void test(void) {
 //--- failed-reproducer.c
 // CHECK: fatal error: 'non-existing-header.h' file not found
 #include "non-existing-header.h"
+
+//--- script-expectations.txt
+CHECK: clang-executable
+CHECK: -fmodule-file=Test=reproducer.cache/explicitly-built-modules/Test-{{.*}}.pcm

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -927,11 +927,14 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
 }
 
 static int generateDepsReproducer(ArrayRef<const char *> Args,
-                                  std::string WorkingDirectory) {
+                                  std::string WorkingDirectory,
+                                  std::string ReproLocation) {
   CXDependencyScannerReproducerOptions Opts =
       clang_experimental_DependencyScannerReproducerOptions_create(
           Args.size(), Args.data(), /*ModuleName=*/nullptr,
-          WorkingDirectory.c_str());
+          WorkingDirectory.c_str(),
+          ReproLocation.empty() ? nullptr : ReproLocation.c_str(),
+          /*UseUniqueReproducerName=*/ReproLocation.empty());
   auto DisposeOpts = llvm::make_scope_exit([&] {
     clang_experimental_DependencyScannerReproducerOptions_dispose(Opts);
   });
@@ -1580,7 +1583,8 @@ int indextest_core_main(int argc, const char **argv) {
       errs() << "error: missing -working-dir\n";
       return 1;
     }
-    return generateDepsReproducer(CompArgs, options::WorkingDir);
+    return generateDepsReproducer(CompArgs, options::WorkingDir,
+                                  options::OutputFile);
   }
 
   if (options::Action == ActionType::UploadCachedJob) {

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -578,6 +578,9 @@ LLVM_21 {
     clang_experimental_DepGraphModule_isInStableDirs; 
     clang_getFullyQualifiedName;
     clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths;
+    clang_experimental_DependencyScannerReproducerOptions_create;
+    clang_experimental_DependencyScannerReproducerOptions_dispose;
+    clang_experimental_DependencyScanner_generateReproducer;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol


### PR DESCRIPTION
Capturing a single `-cc1` command to reproduce a bug with the explicitly-built modules isn't sufficient, we need to know what .pcm files were built and how.

rdar://59743925