### PR TITLE
[lldb] Disable TestDataFormatterLibcxxStringSimulator on linux

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -15,6 +15,7 @@ class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
 
     @skipIfDarwin
     @skipIfWindows
+    @skipIfLinux
     def _run_test(self, defines):
         cxxflags_extras = " ".join(["-D%s" % d for d in defines])
         self.build(dictionary=dict(CXXFLAGS_EXTRAS=cxxflags_extras))


### PR DESCRIPTION
   This test had been previously disabled by 329e1ef10523d21cc1cfc8c3f6ba01c7490c31d1.

    rdar://150284313
