### PR TITLE
[llvm][cas] Add validate-if-needed to recover from invalid data

### DIFF
--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -117,7 +117,7 @@ public:
   /// default on-disk CAS, otherwise this is a noop.
   void ensurePersistentCAS();
 
-  std::string getResolvedCASPath() const;
+  void getResolvedCASPath(llvm::SmallVectorImpl<char> &Result) const;
 
 private:
   /// Initialize Cached CAS and ActionCache.

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -117,6 +117,8 @@ public:
   /// default on-disk CAS, otherwise this is a noop.
   void ensurePersistentCAS();
 
+  std::string getResolvedCASPath() const;
+
 private:
   /// Initialize Cached CAS and ActionCache.
   llvm::Error initCache() const;

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -108,6 +108,7 @@ llvm::Error CASOptions::initCache() const {
   }
 
   SmallString<256> PathBuf;
+  getResolvedCASPath(PathBuf);
   if (CASPath == "auto") {
     getDefaultOnDiskCASPath(PathBuf);
     CASPath = PathBuf;
@@ -120,11 +121,10 @@ llvm::Error CASOptions::initCache() const {
   return llvm::Error::success();
 }
 
-std::string CASOptions::getResolvedCASPath() const {
-  if (CASPath != "auto")
-    return CASPath;
-
-  SmallString<256> PathBuf;
-  getDefaultOnDiskCASPath(PathBuf);
-  return std::string(PathBuf);
+void CASOptions::getResolvedCASPath(SmallVectorImpl<char> &Result) const {
+  if (CASPath == "auto") {
+    getDefaultOnDiskCASPath(Result);
+  } else {
+    Result.assign(CASPath.begin(), CASPath.end());
+  }
 }

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -119,3 +119,12 @@ llvm::Error CASOptions::initCache() const {
   std::tie(Cache.CAS, Cache.AC) = std::move(DBs);
   return llvm::Error::success();
 }
+
+std::string CASOptions::getResolvedCASPath() const {
+  if (CASPath != "auto")
+    return CASPath;
+
+  SmallString<256> PathBuf;
+  getDefaultOnDiskCASPath(PathBuf);
+  return std::string(PathBuf);
+}

--- a/clang/test/CAS/depscan-cas-log.c
+++ b/clang/test/CAS/depscan-cas-log.c
@@ -3,7 +3,7 @@
 // enable logging there are currently zero records in the log.
 
 // RUN: rm -rf %t && mkdir %t
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_LOG=1 %clang \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_LOG=1 LLVM_CAS_DISABLE_VALIDATION=1 %clang \
 // RUN:   -cc1depscan -fdepscan=daemon -fdepscan-include-tree -o - \
 // RUN:   -cc1-args -cc1 -triple x86_64-apple-macosx11.0.0 -emit-obj %s -o %t/t.o -fcas-path %t/cas
 // RUN: FileCheck %s --input-file %t/cas/v1.log

--- a/clang/test/CAS/validate-once.c
+++ b/clang/test/CAS/validate-once.c
@@ -1,0 +1,18 @@
+// RUN: rm -rf %t
+
+// RUN: llvm-cas --cas %t/cas --ingest %s
+// RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak
+
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
+// RUN:   %clang -target x86_64-apple-macos11 -I %S/Inputs \
+// RUN:     -Xclang -fcas-path -Xclang %t/cas \
+// RUN:     -fdepscan=daemon -fdepscan-daemon=%{clang-daemon-dir}/%basename_t -fsyntax-only -x c %s
+
+// RUN: ls %t/cas/corrupt.0.v1.1
+
+// RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
+// SKIPPED: validation skipped
+
+#include "test.h"
+
+int func(void);

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -188,7 +188,8 @@ Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
 #endif
 
   static constexpr const char *PassThroughEnv[] = {
-    "LLVM_CAS_LOG",
+      "LLVM_CAS_LOG",
+      "LLVM_CAS_DISABLE_VALIDATION",
   };
   SmallVector<const char *> EnvP;
   for (const char *Name : PassThroughEnv)

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -835,8 +835,10 @@ void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
     if (CASOpts.CASPath.empty() || !CASOpts.PluginPath.empty())
       return;
     SmallString<64> LLVMCasStorage;
+    SmallString<64> CASPath;
+    CASOpts.getResolvedCASPath(CASPath);
     ExitOnErr(llvm::cas::validateOnDiskUnifiedCASDatabasesIfNeeded(
-        CASOpts.getResolvedCASPath(), /*CheckHash=*/true,
+        CASPath, /*CheckHash=*/true,
         /*AllowRecovery=*/true,
         /*Force=*/false, findLLVMCasBinary(Argv0, LLVMCasStorage)));
   });

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -26,9 +26,11 @@
 #include "clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Bitstream/BitstreamReader.h"
 #include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/CASProvidingFileSystem.h"
 #include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
@@ -39,6 +41,7 @@
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
@@ -50,6 +53,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include <cstdio>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 
 #if LLVM_ON_UNIX
@@ -630,8 +634,8 @@ namespace {
 struct ScanServer {
   const char *Argv0 = nullptr;
   SmallString<128> BasePath;
-  /// List of cas options.
-  ArrayRef<const char *> CASArgs;
+  CASOptions CASOpts;
+  bool ProduceIncludeTree = true;
   int PidFD = -1;
   int ListenSocket = -1;
   /// \p std::nullopt means it runs indefinitely.
@@ -640,7 +644,7 @@ struct ScanServer {
 
   ~ScanServer() { shutdown(); }
 
-  void start(bool Exclusive);
+  void start(bool Exclusive, ArrayRef<const char *> CASArgs);
   int listen();
 
   /// Tear down the socket and bind file immediately but wait till all existing
@@ -705,13 +709,13 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   // particular "build session", to shutdown, then have it stay alive until the
   // session is finished.
   bool LongRunning = false;
-
+  ArrayRef<const char *> CASArgs;
   for (const auto *A = Argv.begin() + 2; A != Argv.end(); ++A) {
     StringRef Arg(*A);
     if (Arg == "-long-running")
       LongRunning = true;
     else if (Arg == "-cas-args") {
-      Server.CASArgs = ArrayRef(A + 1, Argv.end());
+      CASArgs = ArrayRef(A + 1, Argv.end());
       break;
     }
   }
@@ -722,7 +726,7 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
     reportError(Twine("cannot create basedir: ") + EC.message());
 
   if (Command == "-serve") {
-    Server.start(/*Exclusive*/ true);
+    Server.start(/*Exclusive*/ true, CASArgs);
     return Server.listen();
 
   } else if (Command == "-execute") {
@@ -733,7 +737,7 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
     }
 
     // Make sure to start the server before executing the command.
-    Server.start(/*Exclusive*/ true);
+    Server.start(/*Exclusive*/ true, CASArgs);
     std::thread ServerThread([&Server]() { Server.listen(); });
 
     setenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH", Server.BasePath.c_str(),
@@ -784,11 +788,59 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
   openAndReplaceFD(1, LogOutPath);
   openAndReplaceFD(2, LogErrPath);
 
-  Server.start(/*Exclusive*/ false);
+  Server.start(/*Exclusive*/ false, CASArgs);
   return Server.listen();
 }
 
-void ScanServer::start(bool Exclusive) {
+static std::optional<StringRef>
+findLLVMCasBinary(const char *Argv0, llvm::SmallVectorImpl<char> &Storage) {
+  using namespace llvm::sys;
+  std::string Path = fs::getMainExecutable(Argv0, (void *)cc1depscan_main);
+  Storage.assign(Path.begin(), Path.end());
+  path::remove_filename(Storage);
+  path::append(Storage, "llvm-cas");
+  StringRef PathStr(Storage.data(), Storage.size());
+  if (fs::exists(PathStr))
+    return PathStr;
+  // Look for a corresponding usr/local/bin/llvm-cas
+  PathStr = path::parent_path(PathStr);
+  if (path::filename(PathStr) != "bin")
+    return std::nullopt;
+  PathStr = path::parent_path(PathStr);
+  Storage.truncate(PathStr.size());
+  path::append(Storage, "local", "bin", "llvm-cas");
+  PathStr = StringRef{Storage.data(), Storage.size()};
+  if (fs::exists(PathStr))
+    return PathStr;
+  return std::nullopt;
+}
+
+void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
+  // Parse CAS options and validate if needed.
+  DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
+
+  const OptTable &Opts = clang::driver::getDriverOptTable();
+  unsigned MissingArgIndex, MissingArgCount;
+  auto ParsedCASArgs =
+      Opts.ParseArgs(CASArgs, MissingArgIndex, MissingArgCount);
+  CompilerInvocation::ParseCASArgs(CASOpts, ParsedCASArgs, Diags);
+  CASOpts.ensurePersistentCAS();
+  ProduceIncludeTree =
+      ParsedCASArgs.hasArg(driver::options::OPT_fdepscan_include_tree);
+
+  static std::once_flag ValidateOnce;
+  std::call_once(ValidateOnce, [&] {
+    if (getenv("LLVM_CAS_DISABLE_VALIDATION"))
+      return;
+    if (CASOpts.CASPath.empty() || !CASOpts.PluginPath.empty())
+      return;
+    SmallString<64> LLVMCasStorage;
+    ExitOnErr(llvm::cas::validateOnDiskUnifiedCASDatabasesIfNeeded(
+        CASOpts.getResolvedCASPath(), /*CheckHash=*/true,
+        /*AllowRecovery=*/true,
+        /*Force=*/false, findLLVMCasBinary(Argv0, LLVMCasStorage)));
+  });
+
   // Check the pidfile.
   SmallString<128> PidPath;
   (BasePath + ".pid").toVector(PidPath);
@@ -827,16 +879,6 @@ int ScanServer::listen() {
   llvm::DefaultThreadPool Pool;
 
   DiagnosticsEngine Diags(new DiagnosticIDs(), new DiagnosticOptions());
-  CASOptions CASOpts;
-  const OptTable &Opts = clang::driver::getDriverOptTable();
-  unsigned MissingArgIndex, MissingArgCount;
-  auto ParsedCASArgs =
-      Opts.ParseArgs(CASArgs, MissingArgIndex, MissingArgCount);
-  CompilerInvocation::ParseCASArgs(CASOpts, ParsedCASArgs, Diags);
-  CASOpts.ensurePersistentCAS();
-  bool ProduceIncludeTree =
-      ParsedCASArgs.hasArg(driver::options::OPT_fdepscan_include_tree);
-
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
   std::tie(CAS, Cache) = CASOpts.getOrCreateDatabases(Diags);

--- a/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
+++ b/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
@@ -29,7 +29,7 @@ enum class ValidationResult {
   /// The data is already valid.
   Valid,
   /// The data was invalid, but was recovered.
-  RecoveredValid,
+  Recovered,
   /// Validation was skipped, as it was not needed.
   Skipped,
 };
@@ -46,7 +46,7 @@ enum class ValidationResult {
 /// using the given \c llvm-cas executable which protects against crashes
 /// during validation. Otherwise validation is performed in-process.
 ///
-/// \returns \c Valid if the data is already valid, \c RecoveredValid if data
+/// \returns \c Valid if the data is already valid, \c Recovered if data
 /// was invalid but has been cleared, \c Skipped if validation is not needed,
 /// or an \c Error if validation cannot be performed or if the data is left
 /// in an invalid state because \p AllowRecovery is false.

--- a/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
+++ b/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
@@ -21,6 +21,39 @@ class ObjectStore;
 Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
 createOnDiskUnifiedCASDatabases(StringRef Path);
 
+/// Represents the result of validating the contents using
+/// \c validateOnDiskUnifiedCASDatabasesIfNeeded.
+///
+/// Note: invalid results are handled as an \c Error.
+enum class ValidationResult {
+  /// The data is already valid.
+  Valid,
+  /// The data was invalid, but was recovered.
+  RecoveredValid,
+  /// Validation was skipped, as it was not needed.
+  Skipped,
+};
+
+/// Validate the data in \p Path, if needed to ensure correctness.
+///
+/// \param Path directory for the on-disk database.
+/// \param CheckHash Whether to validate hashes match the data.
+/// \param AllowRecovery Whether to automatically recover from invalid data by
+/// marking the files for garbage collection.
+/// \param ForceValidation Whether to force validation to occur even if it
+/// should not be necessary.
+/// \param LLVMCasBinary If provided, validation is performed out-of-process
+/// using the given \c llvm-cas executable which protects against crashes
+/// during validation. Otherwise validation is performed in-process.
+///
+/// \returns \c Valid if the data is already valid, \c RecoveredValid if data
+/// was invalid but has been cleared, \c Skipped if validation is not needed,
+/// or an \c Error if validation cannot be performed or if the data is left
+/// in an invalid state because \p AllowRecovery is false.
+Expected<ValidationResult> validateOnDiskUnifiedCASDatabasesIfNeeded(
+    StringRef Path, bool CheckHash, bool AllowRecovery, bool ForceValidation,
+    std::optional<StringRef> LLVMCasBinary);
+
 } // namespace llvm::cas
 
 #endif // LLVM_CAS_BUILTINUNIFIEDCASDATABASES_H

--- a/llvm/include/llvm/CAS/OnDiskCASLogger.h
+++ b/llvm/include/llvm/CAS/OnDiskCASLogger.h
@@ -62,6 +62,11 @@ public:
   void log_MappedFileRegionBumpPtr_allocate(void *Region, TrieOffset Off,
                                             size_t Size);
   void log_UnifiedOnDiskCache_collectGarbage(StringRef Path);
+  void log_UnifiedOnDiskCache_validateIfNeeded(
+      StringRef Path, uint64_t BootTime, uint64_t ValidationTime,
+      bool CheckHash, bool AllowRecovery, bool Force,
+      std::optional<StringRef> LLVMCas, StringRef ValidationError, bool Skipped,
+      bool Recovered);
   void log_TempFile_create(StringRef Name);
   void log_TempFile_keep(StringRef TmpName, StringRef Name, std::error_code EC);
   void log_TempFile_remove(StringRef TmpName, std::error_code EC);

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -102,7 +102,7 @@ public:
   /// using the given \c llvm-cas executable which protects against crashes
   /// during validation. Otherwise validation is performed in-process.
   ///
-  /// \returns \c Valid if the data is already valid, \c RecoveredValid if data
+  /// \returns \c Valid if the data is already valid, \c Recovered if data
   /// was invalid but has been cleared, \c Skipped if validation is not needed,
   /// or an \c Error if validation cannot be performed or if the data is left
   /// in an invalid state because \p AllowRecovery is false.

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_CAS_UNIFIEDONDISKCACHE_H
 #define LLVM_CAS_UNIFIEDONDISKCACHE_H
 
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/OnDiskGraphDB.h"
 
 namespace llvm::cas::ondisk {
@@ -81,6 +82,34 @@ public:
        unsigned HashByteSize,
        OnDiskGraphDB::FaultInPolicy FaultInPolicy =
            OnDiskGraphDB::FaultInPolicy::FullTree);
+
+  /// Validate the data in \p Path, if needed to ensure correctness.
+  ///
+  /// Note: if invalid data is detected and \p AllowRecovery is true, then
+  /// recovery requires exclusive access to the CAS and it is an error to
+  /// attempt recovery if there is concurrent use of the CAS.
+  ///
+  /// \param Path directory for the on-disk database.
+  /// \param HashName Identifier name for the hashing algorithm that is going to
+  /// be used.
+  /// \param HashByteSize Size for the object digest hash bytes.
+  /// \param CheckHash Whether to validate hashes match the data.
+  /// \param AllowRecovery Whether to automatically recover from invalid data by
+  /// marking the files for garbage collection.
+  /// \param ForceValidation Whether to force validation to occur even if it
+  /// should not be necessary.
+  /// \param LLVMCasBinary If provided, validation is performed out-of-process
+  /// using the given \c llvm-cas executable which protects against crashes
+  /// during validation. Otherwise validation is performed in-process.
+  ///
+  /// \returns \c Valid if the data is already valid, \c RecoveredValid if data
+  /// was invalid but has been cleared, \c Skipped if validation is not needed,
+  /// or an \c Error if validation cannot be performed or if the data is left
+  /// in an invalid state because \p AllowRecovery is false.
+  static Expected<ValidationResult>
+  validateIfNeeded(StringRef Path, StringRef HashName, unsigned HashByteSize,
+                   bool CheckHash, bool AllowRecovery, bool ForceValidation,
+                   std::optional<StringRef> LLVMCasBinary);
 
   /// This is called implicitly at destruction time, so it is not required for a
   /// client to call this. After calling \p close the only method that is valid

--- a/llvm/lib/CAS/BuiltinUnifiedCASDatabases.cpp
+++ b/llvm/lib/CAS/BuiltinUnifiedCASDatabases.cpp
@@ -23,3 +23,16 @@ cas::createOnDiskUnifiedCASDatabases(StringRef Path) {
   auto AC = builtin::createActionCacheFromUnifiedOnDiskCache(std::move(UniDB));
   return std::make_pair(std::move(CAS), std::move(AC));
 }
+
+Expected<ValidationResult> cas::validateOnDiskUnifiedCASDatabasesIfNeeded(
+    StringRef Path, bool CheckHash, bool AllowRecovery, bool ForceValidation,
+    std::optional<StringRef> LLVMCasBinary) {
+#if LLVM_ENABLE_ONDISK_CAS
+  return ondisk::UnifiedOnDiskCache::validateIfNeeded(
+      Path, builtin::BuiltinCASContext::getHashName(),
+      sizeof(builtin::HashType), CheckHash, AllowRecovery, ForceValidation,
+      LLVMCasBinary);
+#else
+  return createStringError(inconvertibleErrorCode(), "OnDiskCache is disabled");
+#endif
+}

--- a/llvm/lib/CAS/OnDiskCASLogger.cpp
+++ b/llvm/lib/CAS/OnDiskCASLogger.cpp
@@ -211,6 +211,25 @@ void OnDiskCASLogger::log_UnifiedOnDiskCache_collectGarbage(StringRef Path) {
   Log << "collect garbage '" << Path << "'";
 }
 
+void OnDiskCASLogger::log_UnifiedOnDiskCache_validateIfNeeded(
+    StringRef Path, uint64_t BootTime, uint64_t ValidationTime, bool CheckHash,
+    bool AllowRecovery, bool Force, std::optional<StringRef> LLVMCas,
+    StringRef ValidationError, bool Skipped, bool Recovered) {
+  TextLogLine Log(OS);
+  Log << "validate-if-needed '" << Path << "'";
+  Log << " boot=" << BootTime << " last-valid=" << ValidationTime;
+  Log << " check-hash=" << CheckHash << " allow-recovery=" << AllowRecovery;
+  Log << " force=" << Force;
+  if (LLVMCas)
+    Log << " llvm-cas=" << *LLVMCas;
+  if (Skipped)
+    Log << " skipped";
+  if (Recovered)
+    Log << " recovered";
+  if (!ValidationError.empty())
+    Log << " data was invalid " << ValidationError;
+}
+
 void OnDiskCASLogger::log_TempFile_create(StringRef Name) {
   TextLogLine Log(OS);
   Log << "standalone file create '" << Name << "'";

--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -469,7 +469,7 @@ UnifiedOnDiskCache::validateIfNeeded(StringRef RootPath, StringRef HashName,
       return createFileError(PathBuf, OS.error());
   }
 
-  return NeedsRecovery ? ValidationResult::RecoveredValid
+  return NeedsRecovery ? ValidationResult::Recovered
                        : ValidationResult::Valid;
 }
 

--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -47,18 +47,48 @@
 // without affecting any active readers/writers in the same process or other
 // processes.
 //
+// The \c UnifiedOnDiskCache also provides validation and recovery on top of the
+// underlying on-disk storage. The low-level storage is designed to remain
+// coherent across regular process crashes, but may be invalid after power loss
+// or similar system failures. \c UnifiedOnDiskCache::validateIfNeeded allows
+// validating the contents once per boot and can recover by marking invalid
+// data for garbage collection.
+//
+// The data recovery described above requires exclusive access to the CAS, and
+// it is an error to attempt recovery if the CAS is open in any process/thread.
+// In order to maximize backwards compatibility with tools that do not perform
+// validation before opening the CAS, we do not attempt to get exclusive access
+// until recovery is actually performed, meaning as long as the data is valid
+// it will not conflict with concurrent use.
+//
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/UnifiedOnDiskCache.h"
+#include "BuiltinCAS.h"
 #include "OnDiskCommon.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/CAS/OnDiskCASLogger.h"
+#include "llvm/CAS/OnDiskGraphDB.h"
 #include "llvm/CAS/OnDiskKeyValueDB.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FileUtilities.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
+#include "llvm/Support/raw_ostream.h"
+#include <optional>
+
+#if __has_include(<sys/sysctl.h>)
+#include <sys/sysctl.h>
+#endif
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -68,6 +98,9 @@ using namespace llvm::cas::ondisk;
 /// how to handle the leftover sub-directories of the previous version, within
 /// the \p UnifiedOnDiskCache::collectGarbage function.
 static constexpr StringLiteral DBDirPrefix = "v1.";
+
+static constexpr StringLiteral ValidationFilename = "v1.validation";
+static constexpr StringLiteral CorruptPrefix = "corrupt.";
 
 Expected<ObjectID> UnifiedOnDiskCache::KVPut(ObjectID Key, ObjectID Value) {
   return KVPut(PrimaryGraphDB->getDigest(Key), Value);
@@ -149,9 +182,10 @@ Error UnifiedOnDiskCache::validateActionCache() {
 }
 
 /// \returns all the 'v<version>.<x>' names of sub-directories, sorted with
-/// ascending order of the integer after the dot.
-static Error getAllDBDirs(StringRef Path,
-                          SmallVectorImpl<std::string> &DBDirs) {
+/// ascending order of the integer after the dot. Corrupt directories, if
+/// included, will come first.
+static Error getAllDBDirs(StringRef Path, SmallVectorImpl<std::string> &DBDirs,
+                          bool IncludeCorrupt = false) {
   struct DBDir {
     uint64_t Order;
     std::string Name;
@@ -164,6 +198,10 @@ static Error getAllDBDirs(StringRef Path,
     if (DirI->type() != sys::fs::file_type::directory_file)
       continue;
     StringRef SubDir = sys::path::filename(DirI->path());
+    if (IncludeCorrupt && SubDir.starts_with(CorruptPrefix)) {
+      FoundDBDirs.push_back({0, std::string(SubDir)});
+      continue;
+    }
     if (!SubDir.starts_with(DBDirPrefix))
       continue;
     uint64_t Order;
@@ -183,6 +221,23 @@ static Error getAllDBDirs(StringRef Path,
   return Error::success();
 }
 
+static Error getAllGarbageDirs(StringRef Path,
+                               SmallVectorImpl<std::string> &DBDirs) {
+  if (Error E = getAllDBDirs(Path, DBDirs, /*IncludeCorrupt=*/true))
+    return E;
+
+  // FIXME: When the version of \p DBDirPrefix is bumped up we need to figure
+  // out how to handle the leftover sub-directories of the previous version.
+
+  for (unsigned Keep = 2; Keep > 0 && !DBDirs.empty(); --Keep) {
+    StringRef Back(DBDirs.back());
+    if (Back.starts_with(CorruptPrefix))
+      break;
+    DBDirs.pop_back();
+  }
+  return Error::success();
+}
+
 /// \returns Given a sub-directory named 'v<version>.<x>', it outputs the
 /// 'v<version>.<x+1>' name.
 static void getNextDBDirName(StringRef DBDir, llvm::raw_ostream &OS) {
@@ -192,6 +247,230 @@ static void getNextDBDirName(StringRef DBDir, llvm::raw_ostream &OS) {
   assert(!Failed);
   (void)Failed;
   OS << DBDirPrefix << Count + 1;
+}
+
+static Error validateOutOfProcess(StringRef LLVMCasBinary, StringRef RootPath,
+                                  bool CheckHash) {
+  SmallVector<StringRef> Args{LLVMCasBinary, "-cas", RootPath, "-validate"};
+  if (CheckHash)
+    Args.push_back("-check-hash");
+
+  llvm::SmallString<128> StdErrPath;
+  int StdErrFD = -1;
+  if (std::error_code EC = sys::fs::createTemporaryFile(
+          "llvm-cas-validate-stderr", "txt", StdErrFD, StdErrPath,
+          llvm::sys::fs::OF_Text))
+    return createStringError(EC, "failed to create temporary file");
+  FileRemover OutputRemover(StdErrPath.c_str());
+
+  std::optional<llvm::StringRef> Redirects[] = {
+      {""}, // stdin = /dev/null
+      {""}, // stdout = /dev/null
+      StdErrPath.str(),
+  };
+
+  std::string ErrMsg;
+  int Result =
+      sys::ExecuteAndWait(LLVMCasBinary, Args, /*Env=*/std::nullopt, Redirects,
+                          /*SecondsToWait=*/120, /*MemoryLimit=*/0, &ErrMsg);
+
+  if (Result == -1)
+    return createStringError("failed to exec " + join(Args, " ") + ": " +
+                             ErrMsg);
+  if (Result != 0) {
+    llvm::SmallString<64> Err("cas contents invalid");
+    if (!ErrMsg.empty()) {
+      Err += ": ";
+      Err += ErrMsg;
+    }
+    auto StdErrBuf = MemoryBuffer::getFile(StdErrPath.c_str());
+    if (StdErrBuf && !(*StdErrBuf)->getBuffer().empty()) {
+      Err += ": ";
+      Err += (*StdErrBuf)->getBuffer();
+    }
+    return createStringError(Err);
+  }
+  return Error::success();
+}
+
+static Error validateInProcess(StringRef RootPath, StringRef HashName,
+                               unsigned HashByteSize, bool CheckHash) {
+  std::shared_ptr<UnifiedOnDiskCache> UniDB;
+  if (Error E = UnifiedOnDiskCache::open(RootPath, std::nullopt, HashName,
+                                         HashByteSize)
+                    .moveInto(UniDB))
+    return E;
+  auto CAS = builtin::createObjectStoreFromUnifiedOnDiskCache(UniDB);
+  if (Error E = CAS->validate(CheckHash))
+    return E;
+  if (Error E = UniDB->validateActionCache())
+    return E;
+  return Error::success();
+}
+
+static Expected<uint64_t> getBootTime() {
+#if __has_include(<sys/sysctl.h>) && defined(KERN_BOOTTIME)
+  struct timeval TV;
+  size_t TVLen = sizeof(TV);
+  int KernBoot[2] = {CTL_KERN, KERN_BOOTTIME};
+  if (sysctl(KernBoot, 2, &TV, &TVLen, nullptr, 0) < 0)
+    return createStringError(llvm::errnoAsErrorCode(),
+                             "failed to get boottime");
+  if (TVLen != sizeof(TV))
+    return createStringError("sysctl kern.boottime unexpected format");
+  return TV.tv_sec;
+#elif defined(__linux__)
+  // Use the mtime for /proc, which is recreated during system boot.
+  // We could also read /proc/stat and search for 'btime'.
+  sys::fs::file_status Status;
+  if (std::error_code EC = sys::fs::status("/proc", Status))
+    return createFileError("/proc", EC);
+  return Status.getLastModificationTime().time_since_epoch().count();
+#else
+  llvm::report_fatal_error("unimplemented");
+#endif
+}
+
+Expected<ValidationResult>
+UnifiedOnDiskCache::validateIfNeeded(StringRef RootPath, StringRef HashName,
+                                     unsigned HashByteSize, bool CheckHash,
+                                     bool AllowRecovery, bool ForceValidation,
+                                     std::optional<StringRef> LLVMCasBinary) {
+  if (std::error_code EC = sys::fs::create_directories(RootPath))
+    return createFileError(RootPath, EC);
+
+  SmallString<256> PathBuf(RootPath);
+  sys::path::append(PathBuf, ValidationFilename);
+  int FD = -1;
+  if (std::error_code EC = sys::fs::openFileForReadWrite(
+          PathBuf, FD, sys::fs::CD_OpenAlways, sys::fs::OF_None))
+    return createFileError(PathBuf, EC);
+  assert(FD != -1);
+
+  sys::fs::file_t File = sys::fs::convertFDToNativeFile(FD);
+  auto CloseFile = make_scope_exit([&]() { sys::fs::closeFile(File); });
+
+  if (std::error_code EC = lockFileThreadSafe(FD, /*Exclusive=*/true))
+    return createFileError(PathBuf, EC);
+  auto UnlockFD = make_scope_exit([&]() { unlockFileThreadSafe(FD); });
+
+  std::shared_ptr<ondisk::OnDiskCASLogger> Logger;
+  if (Error E =
+          ondisk::OnDiskCASLogger::openIfEnabled(RootPath).moveInto(Logger))
+    return std::move(E);
+
+  SmallString<8> Bytes;
+  if (Error E = sys::fs::readNativeFileToEOF(File, Bytes))
+    return createFileError(PathBuf, std::move(E));
+
+  uint64_t ValidationBootTime = 0;
+  if (!Bytes.empty() &&
+      StringRef(Bytes).trim().getAsInteger(10, ValidationBootTime))
+    return createFileError(PathBuf, errc::illegal_byte_sequence,
+                           "expected integer");
+
+  static uint64_t BootTime = 0;
+  if (BootTime == 0)
+    if (Error E = getBootTime().moveInto(BootTime))
+      return std::move(E);
+
+  bool Recovered = false;
+  bool Skipped = false;
+  std::string LogValidationError;
+
+  auto Log = llvm::make_scope_exit([&] {
+    if (!Logger)
+      return;
+    Logger->log_UnifiedOnDiskCache_validateIfNeeded(
+        RootPath, BootTime, ValidationBootTime, CheckHash, AllowRecovery,
+        ForceValidation, LLVMCasBinary, LogValidationError, Skipped, Recovered);
+  });
+
+  if (ValidationBootTime == BootTime && !ForceValidation) {
+    Skipped = true;
+    return ValidationResult::Skipped;
+  }
+
+  // Validate!
+  bool NeedsRecovery = false;
+  Error E =
+      LLVMCasBinary
+          ? validateOutOfProcess(*LLVMCasBinary, RootPath, CheckHash)
+          : validateInProcess(RootPath, HashName, HashByteSize, CheckHash);
+  if (E) {
+    if (Logger)
+      LogValidationError = toStringWithoutConsuming(E);
+    if (AllowRecovery) {
+      consumeError(std::move(E));
+      NeedsRecovery = true;
+    } else {
+      return std::move(E);
+    }
+  }
+
+  if (NeedsRecovery) {
+    sys::path::remove_filename(PathBuf);
+    sys::path::append(PathBuf, "lock");
+
+    int LockFD = -1;
+    if (std::error_code EC = sys::fs::openFileForReadWrite(
+            PathBuf, LockFD, sys::fs::CD_OpenAlways, sys::fs::OF_None))
+      return createFileError(PathBuf, EC);
+    sys::fs::file_t LockFile = sys::fs::convertFDToNativeFile(LockFD);
+    auto CloseLock = make_scope_exit([&]() { sys::fs::closeFile(LockFile); });
+    if (std::error_code EC = tryLockFileThreadSafe(LockFD)) {
+      if (EC == std::errc::no_lock_available)
+        return createFileError(
+            PathBuf, EC,
+            "CAS validation requires exclusive access but CAS was in use");
+      return createFileError(PathBuf, EC);
+    }
+    auto UnlockFD = make_scope_exit([&]() { unlockFileThreadSafe(LockFD); });
+
+    SmallVector<std::string, 4> DBDirs;
+    if (Error E = getAllDBDirs(RootPath, DBDirs))
+      return std::move(E);
+
+    for (StringRef DBDir : DBDirs) {
+      sys::path::remove_filename(PathBuf);
+      sys::path::append(PathBuf, DBDir);
+      std::error_code EC;
+      int Attempt = 0, MaxAttempts = 100;
+      SmallString<128> GCPath;
+      for (; Attempt < MaxAttempts; ++Attempt) {
+        GCPath.assign(RootPath);
+        sys::path::append(GCPath, CorruptPrefix + std::to_string(Attempt) +
+                                      "." + DBDir);
+        EC = sys::fs::rename(PathBuf, GCPath);
+        if (EC != errc::directory_not_empty)
+          break;
+      }
+      if (Attempt == MaxAttempts)
+        return createStringError(
+            EC, "rename " + PathBuf +
+                    " failed: too many CAS directories awaiting pruning");
+      if (EC)
+        return createStringError(EC, "rename " + PathBuf + " to " + GCPath +
+                                         " failed");
+    }
+    Recovered = true;
+  }
+
+  if (ValidationBootTime != BootTime) {
+    // Fix filename in case we have error to report.
+    sys::path::remove_filename(PathBuf);
+    sys::path::append(PathBuf, ValidationFilename);
+    if (std::error_code EC = sys::fs::resize_file(FD, 0))
+      return createFileError(PathBuf, EC);
+    raw_fd_ostream OS(FD, /*shouldClose=*/false);
+    OS.seek(0); // resize does not reset position
+    OS << BootTime << '\n';
+    if (OS.has_error())
+      return createFileError(PathBuf, OS.error());
+  }
+
+  return NeedsRecovery ? ValidationResult::RecoveredValid
+                       : ValidationResult::Valid;
 }
 
 Expected<std::unique_ptr<UnifiedOnDiskCache>>
@@ -384,16 +663,11 @@ UnifiedOnDiskCache::~UnifiedOnDiskCache() { consumeError(close()); }
 Error UnifiedOnDiskCache::collectGarbage(StringRef Path,
                                          ondisk::OnDiskCASLogger *Logger) {
   SmallVector<std::string, 4> DBDirs;
-  if (Error E = getAllDBDirs(Path, DBDirs))
+  if (Error E = getAllGarbageDirs(Path, DBDirs))
     return E;
-  if (DBDirs.size() <= 2)
-    return Error::success(); // no unused directories.
-
-  // FIXME: When the version of \p DBDirPrefix is bumped up we need to figure
-  // out how to handle the leftover sub-directories of the previous version.
 
   SmallString<256> PathBuf(Path);
-  for (StringRef UnusedSubDir : ArrayRef(DBDirs).drop_back(2)) {
+  for (StringRef UnusedSubDir : DBDirs) {
     sys::path::append(PathBuf, UnusedSubDir);
     if (Logger)
       Logger->log_UnifiedOnDiskCache_collectGarbage(PathBuf);

--- a/llvm/test/CAS/logging.test
+++ b/llvm/test/CAS/logging.test
@@ -2,8 +2,11 @@ RUN: rm -rf %t
 RUN: split-file %s %t
 RUN: %python -c "with open(r'%t/input/large', 'w') as file: file.truncate(100000)"
 RUN: env LLVM_CAS_LOG=2 llvm-cas --cas %t/cas --ingest %t/input
+RUN: env LLVM_CAS_LOG=2 llvm-cas --cas %t/cas --validate-if-needed -check-hash
+RUN: env LLVM_CAS_LOG=2 llvm-cas --cas %t/cas --validate-if-needed -force -allow-recovery
 RUN: FileCheck %s --input-file %t/cas/v1.log
 RUN: FileCheck %s --input-file %t/cas/v1.log --check-prefix=STANDALONE
+
 
 // CHECK: resize mapped file '{{.*}}v8.index'
 // CHECK: mmap '{{.*}}v8.index' [[INDEX:0x[0-9a-f]+]]
@@ -23,6 +26,9 @@ RUN: FileCheck %s --input-file %t/cas/v1.log --check-prefix=STANDALONE
 // CHECK: close mmap '{{.*}}v8.data'
 // CHECK: resize mapped file '{{.*}}v8.index'
 // CHECK: close mmap '{{.*}}v8.index'
+
+// CHECK: validate-if-needed '{{.*}}cas' boot=[[BOOT:[0-9]+]] last-valid=0 check-hash=1 allow-recovery=0 force=0 llvm-cas={{.*}}llvm-cas
+// CHECK: validate-if-needed '{{.*}}cas' boot=[[BOOT]] last-valid=[[BOOT]] check-hash=0 allow-recovery=1 force=1 llvm-cas={{.*}}llvm-cas
 
 // STANDALONE: standalone file create '[[PATH:.*v8.[0-9a-f]*.leaf]].[[SUFFIX:[0-9a-f]*]]'
 // STANDALONE: standalone file rename '[[PATH]].[[SUFFIX]]' to '[[PATH]]'

--- a/llvm/test/CAS/validate-if-needed.test
+++ b/llvm/test/CAS/validate-if-needed.test
@@ -1,0 +1,43 @@
+RUN: rm -rf %t && mkdir %t
+RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
+RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak 
+
+# INVALID: bad record
+# VALID: validated successfully
+# SKIPPED: validation skipped
+# RECOVERED: recovered from invalid data
+
+# Validation failures are not saved.
+RUN: not llvm-cas --cas %t/cas --validate-if-needed 2>&1 | FileCheck %s -check-prefix=INVALID
+RUN: not llvm-cas --cas %t/cas --validate-if-needed 2>&1 | FileCheck %s -check-prefix=INVALID
+
+# Validation happens once per boot.
+RUN: mv %t/cas/v1.1/v8.data.bak %t/cas/v1.1/v8.data
+RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=VALID
+RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
+# Wrong timestamp triggers re-validation.
+RUN: echo '123' > %t/cas/v1.validation
+RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=VALID
+RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
+# Skipped validation does not catch errors.
+RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak
+RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
+
+# Unless forced.
+RUN: not llvm-cas --cas %t/cas --validate-if-needed --force 2>&1 | FileCheck %s -check-prefix=INVALID
+
+# Recovering from invalid data.
+RUN: llvm-cas --cas %t/cas --validate-if-needed --allow-recovery --force | FileCheck %s -check-prefix=RECOVERED
+RUN: ls %t/cas/corrupt.0.v1.1
+RUN: llvm-cas --cas %t/cas --validate-if-needed --allow-recovery | FileCheck %s -check-prefix=SKIPPED
+RUN: llvm-cas --cas %t/cas --validate-if-needed --force | FileCheck %s -check-prefix=VALID
+RUN: rm -rf %t/cas/v1.1
+RUN: cp -r %t/cas/corrupt.0.v1.1 %t/cas/v1.1
+RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak
+RUN: llvm-cas --cas %t/cas --validate-if-needed --allow-recovery --force | FileCheck %s -check-prefix=RECOVERED
+RUN: ls %t/cas/corrupt.1.v1.1
+
+# Corrupt data is pruned.
+RUN: llvm-cas --cas %t/cas --prune
+RUN: not ls %t/cas/corrupt.0.v1.1
+RUN: not ls %t/cas/corrupt.1.v1.1

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -776,7 +776,7 @@ int validateIfNeeded(StringRef Path, StringRef PluginPath,
   case ValidationResult::Valid:
     outs() << "validated successfully\n";
     break;
-  case ValidationResult::RecoveredValid:
+  case ValidationResult::Recovered:
     outs() << "recovered from invalid data\n";
     break;
   case ValidationResult::Skipped:

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -13,6 +13,7 @@
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/CAS/TreeSchema.h"
+#include "llvm/CAS/UnifiedOnDiskCache.h"
 #include "llvm/CAS/Utils.h"
 #include "llvm/RemoteCachingService/RemoteCachingService.h"
 #include "llvm/Support/CommandLine.h"
@@ -65,8 +66,13 @@ static int putCacheKey(ObjectStore &CAS, ActionCache &AC,
 static int getCacheResult(ObjectStore &CAS, ActionCache &AC, const CASID &ID);
 static int validateObject(ObjectStore &CAS, const CASID &ID);
 static int validate(ObjectStore &CAS, ActionCache &AC, bool CheckHash);
+static int validateIfNeeded(StringRef Path, StringRef PluginPath,
+                            ArrayRef<std::string> PluginOpts, bool CheckHash,
+                            bool Force, bool AllowRecovery, bool InProcess,
+                            const char *Argv0);
 static int ingestCasIDFile(cas::ObjectStore &CAS, ArrayRef<std::string> CASIDs);
 static int checkLockFiles(StringRef CASPath);
+static int prune(cas::ObjectStore &CAS);
 
 int main(int Argc, char **Argv) {
   InitLLVM X(Argc, Argv);
@@ -86,6 +92,11 @@ int main(int Argc, char **Argv) {
                                 cl::value_desc("path"));
   cl::opt<bool> CheckHash("check-hash",
                           cl::desc("check all hashes during validation"));
+  cl::opt<bool> AllowRecovery("allow-recovery",
+                              cl::desc("allow recovery of cas data"));
+  cl::opt<bool> Force("force",
+                      cl::desc("force validation even if unnecessary"));
+  cl::opt<bool> InProcess("in-process", cl::desc("validate in-process"));
 
   enum CommandKind {
     Invalid,
@@ -109,6 +120,8 @@ int main(int Argc, char **Argv) {
     CheckLockFiles,
     Validate,
     ValidateObject,
+    ValidateIfNeeded,
+    Prune,
   };
   cl::opt<CommandKind> Command(
       cl::desc("choose command action:"),
@@ -137,7 +150,10 @@ int main(int Argc, char **Argv) {
                      "Test file locking behaviour of on-disk CAS"),
           clEnumValN(Validate, "validate", "validate ObjectStore"),
           clEnumValN(ValidateObject, "validate-object",
-                     "validate the object for CASID")),
+                     "validate the object for CASID"),
+          clEnumValN(ValidateIfNeeded, "validate-if-needed",
+                     "validate cas contents if needed"),
+          clEnumValN(Prune, "prune", "prune local cas storage")),
       cl::init(CommandKind::Invalid));
 
   cl::ParseCommandLineOptions(Argc, Argv, "llvm-cas CAS tool\n");
@@ -154,6 +170,10 @@ int main(int Argc, char **Argv) {
 
   if (Command == CheckLockFiles)
     return checkLockFiles(CASPath);
+
+  if (Command == ValidateIfNeeded)
+    return validateIfNeeded(CASPath, CASPluginPath, CASPluginOpts, CheckHash,
+                            Force, AllowRecovery, InProcess, Argv[0]);
 
   std::shared_ptr<ObjectStore> CAS;
   std::shared_ptr<ActionCache> AC;
@@ -209,6 +229,9 @@ int main(int Argc, char **Argv) {
 
   if (Command == MergeTrees)
     return mergeTrees(*CAS, Inputs);
+
+  if (Command == Prune)
+    return prune(*CAS);
 
   if (Inputs.empty())
     ExitOnErr(createStringError(inconvertibleErrorCode(),
@@ -727,5 +750,44 @@ int validate(ObjectStore &CAS, ActionCache &AC, bool CheckHash) {
   ExitOnErr(CAS.validate(CheckHash));
   ExitOnErr(AC.validate());
   outs() << "validated successfully\n";
+  return 0;
+}
+
+int validateIfNeeded(StringRef Path, StringRef PluginPath,
+                     ArrayRef<std::string> PluginOpts, bool CheckHash,
+                     bool Force, bool AllowRecovery, bool InProcess,
+                     const char *Argv0) {
+  ExitOnError ExitOnErr("llvm-cas: validate-if-needed: ");
+  std::string ExecStorage;
+  std::optional<StringRef> Exec;
+  if (!InProcess) {
+    ExecStorage = sys::fs::getMainExecutable(Argv0, (void *)validateIfNeeded);
+    Exec = ExecStorage;
+  }
+  ValidationResult Result;
+  if (PluginPath.empty()) {
+    Result = ExitOnErr(validateOnDiskUnifiedCASDatabasesIfNeeded(
+        Path, CheckHash, AllowRecovery, Force, Exec));
+  } else {
+    // FIXME: add a hook for plugin validation
+    Result = ValidationResult::Skipped;
+  }
+  switch (Result) {
+  case ValidationResult::Valid:
+    outs() << "validated successfully\n";
+    break;
+  case ValidationResult::RecoveredValid:
+    outs() << "recovered from invalid data\n";
+    break;
+  case ValidationResult::Skipped:
+    outs() << "validation skipped\n";
+    break;
+  }
+  return 0;
+}
+
+static int prune(cas::ObjectStore &CAS) {
+  ExitOnError ExitOnErr("llvm-cas: prune: ");
+  ExitOnErr(CAS.pruneStorageData());
   return 0;
 }


### PR DESCRIPTION
Introduce a new validate-if-needed API to the UnifiedOnDiskCache and
llvm-cas tool that triggers out-of-process validation of the CAS once
for every machine boot, and optionally recovers from invalid data by
marking it for garbage collection. This fixes a hole in the CAS data
coherence when a power loss or similar failure causes the OS to not
flush all of the pages in the mmaped on-disk CAS files.

The intent is that clients such as the clang scanning daemon or a build
system should trigger this validation at least once before using the
CAS.

rdar://123542312