### PR TITLE
[swift/release/6.2][clang][headers][Apple] Don't include_next float.h to avoid an unnecessary module dependency

### DIFF
--- a/clang/lib/Headers/float.h
+++ b/clang/lib/Headers/float.h
@@ -17,17 +17,9 @@
 /* On various platforms, fall back to the system's float.h, which might have
  * additional definitions and/or implementation-defined values.
  */
-#if (defined(__APPLE__) || defined(__MINGW32__) || defined(_MSC_VER) ||        \
-     defined(_AIX) || defined(__musl__)) &&                                    \
+#if (defined(__MINGW32__) || defined(_MSC_VER) || defined(_AIX) ||             \
+     defined(__musl__)) &&                                                     \
     __STDC_HOSTED__ && __has_include_next(<float.h>)
-
-/* Prior to Apple's 10.7 SDK, float.h SDK header used to apply an extra level
- * of #include_next<float.h> to keep Metrowerks compilers happy. Avoid this
- * extra indirection.
- */
-#ifdef __APPLE__
-#define _FLOAT_H_
-#endif
 
 #  include_next <float.h>
 


### PR DESCRIPTION
float.h doesn't define anything in Apple's SDKs that the clang float.h doesn't undefine, so all the include_next does is add an unnecessary module dependency. Skip the include_next and completely shadow the SDK header.

rdar://150062938