### PR TITLE
upgrade Swift plugin to use llvm::Expected for GetIndexOfChildWithName

### DIFF
--- a/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
+++ b/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.cpp
@@ -116,12 +116,14 @@ ObjCRuntimeSyntheticProvider::FrontEnd::GetChildAtIndex(uint32_t idx) {
   return child_sp;
 }
 
-size_t ObjCRuntimeSyntheticProvider::FrontEnd::GetIndexOfChildWithName(
+llvm::Expected<size_t>
+ObjCRuntimeSyntheticProvider::FrontEnd::GetIndexOfChildWithName(
     ConstString name) {
   for (size_t idx = 0; idx < CalculateNumChildrenIgnoringErrors(); idx++) {
     const auto &ivar_info(m_provider->GetIVarAtIndex(idx));
     if (name == ivar_info.m_name)
       return idx + GetNumBases();
   }
-  return UINT32_MAX;
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }

--- a/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.h
+++ b/lldb/source/Plugins/Language/Swift/ObjCRuntimeSyntheticProvider.h
@@ -54,7 +54,7 @@ public:
       return lldb::ChildCacheState::eRefetch;
     }
     bool MightHaveChildren() override { return true; }
-    size_t GetIndexOfChildWithName(ConstString name) override;
+    llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
     typedef std::shared_ptr<SyntheticChildrenFrontEnd> SharedPointer;
 

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -508,14 +508,16 @@ bool lldb_private::formatters::swift::ArraySyntheticFrontEnd::
   return true;
 }
 
-size_t lldb_private::formatters::swift::ArraySyntheticFrontEnd::
+llvm::Expected<size_t> lldb_private::formatters::swift::ArraySyntheticFrontEnd::
     GetIndexOfChildWithName(ConstString name) {
   if (!m_array_buffer)
-    return UINT32_MAX;
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+  if (idx == UINT32_MAX || idx >= CalculateNumChildrenIgnoringErrors())
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.h
@@ -168,7 +168,7 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
   bool IsValid();
 
 private:

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -731,13 +731,15 @@ HashedSyntheticChildrenFrontEnd::MightHaveChildren() {
   return true;
 }
 
-size_t
+llvm::Expected<size_t>
 HashedSyntheticChildrenFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (!m_buffer)
-    return UINT32_MAX;
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   const char *item_name = name.GetCString();
   uint32_t idx = ExtractIndexFromString(item_name);
-  if (idx < UINT32_MAX && idx >= CalculateNumChildrenIgnoringErrors())
-    return UINT32_MAX;
+  if (idx == UINT32_MAX || idx >= CalculateNumChildrenIgnoringErrors())
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
   return idx;
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -138,7 +138,7 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   const HashedCollectionConfig &m_config;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -920,8 +920,12 @@ class ValueObjectWrapperSyntheticChildren : public SyntheticChildren {
       return idx == 0 ? m_backend.GetSP() : nullptr;
     }
 
-    size_t GetIndexOfChildWithName(ConstString name) override {
-      return m_backend.GetName() == name ? 0 : UINT32_MAX;
+    llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override {
+      if (m_backend.GetName() == name) {
+        return 0;
+      }
+      return llvm::createStringError("Type has no child named '%s'",
+                                     name.AsCString());
     }
 
     lldb::ChildCacheState Update() override {

--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.cpp
@@ -271,12 +271,13 @@ bool lldb_private::formatters::swift::SwiftOptionalSyntheticFrontEnd::
   return IsEmpty() ? false : true;
 }
 
-size_t lldb_private::formatters::swift::SwiftOptionalSyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::swift::
+    SwiftOptionalSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   static ConstString g_Some("some");
 
   if (IsEmpty())
-    return UINT32_MAX;
+    return llvm::createStringError("Type has no child named '%s'",
+                                   name.AsCString());
 
   return m_some->GetIndexOfChildWithName(name);
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftOptional.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftOptional.h
@@ -50,7 +50,7 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
   lldb::ValueObjectSP GetSyntheticValue() override;
 
 private:

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -524,7 +524,7 @@ public:
   lldb::ValueObjectSP GetChildAtIndex(uint32_t idx) override;
   lldb::ChildCacheState Update() override;
   bool MightHaveChildren() override;
-  size_t GetIndexOfChildWithName(ConstString name) override;
+  llvm::Expected<size_t> GetIndexOfChildWithName(ConstString name) override;
 
 private:
   std::unique_ptr<SwiftUnsafeType> m_unsafe_ptr;
@@ -592,11 +592,12 @@ bool lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
   return m_unsafe_ptr && m_unsafe_ptr->GetCount();
 }
 
-size_t lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEnd::
-    GetIndexOfChildWithName(ConstString name) {
+llvm::Expected<size_t> lldb_private::formatters::swift::
+    UnsafeTypeSyntheticFrontEnd::GetIndexOfChildWithName(ConstString name) {
   if (m_unsafe_ptr && m_unsafe_ptr->HasPointee() && name == "pointee")
     return 0;
-  return UINT32_MAX;
+  return llvm::createStringError("Type has no child named '%s'",
+                                 name.AsCString());
 }
 
 SyntheticChildrenFrontEnd *


### PR DESCRIPTION
In `llvm/llvm-project`, [this PR](https://github.com/llvm/llvm-project/pull/136693) changed the return type of `GetIndexOfChildWithName`.

This PR reflects those changes in the Swift plugin for LLDB.