### PR TITLE
[6.2][CAS] Fix an off-by-one error in CAS validation

### DIFF
--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -966,7 +966,7 @@ Error OnDiskGraphDB::validate(bool Deep, HashingFuncT Hasher) const {
       llvm_unreachable("already handled");
     case TrieRecord::StorageKind::DataPool: {
       auto DataRecord = DataRecordHandle::get(DataPool.beginData(D.Offset));
-      if (DataRecord.getTotalSize() + D.Offset.get() >= DataPool.size())
+      if (DataRecord.getTotalSize() + D.Offset.get() > DataPool.size())
         return dataError("data record span passed the end of the data pool");
       for (auto InternRef : DataRecord.getRefs()) {
         auto Index = getIndexProxyFromRef(InternRef);

--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -1,6 +1,13 @@
 RUN: rm -rf %t
 RUN: mkdir %t
 
+# Ingest a blob which just fits inside the CAS data pool to make sure the validate passes.
+RUN: truncate -s 7 %t/file
+RUN: cat %t/file | \
+RUN:   llvm-cas --cas %t/cas  --make-blob \
+RUN:   --data -
+RUN: llvm-cas --cas %t/cas --validate --check-hash
+
 RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
 RUN: llvm-cas --cas %t/cas --validate
 RUN: llvm-cas --cas %t/cas --validate --check-hash


### PR DESCRIPTION
  - **Explanation**: Fix a false positive in invalid CAS detection that when the last data stored in CAS just fits inside the DataPool, validation is erroneously think the data stored pass the end of the storage.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Allows CAS validation and recovery correctly so the valid CAS doesn't get throw away
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://150386374
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/llvm-project/pull/10595
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: UnitTest
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @benlangmuir 

