### PR TITLE
[BoundsSafety] Unbreak `AST/typedef-function-attrs-late-parsed-call` test

### DIFF
--- a/clang/test/BoundsSafety/AST/typedef-function-attrs-late-parsed-call.c
+++ b/clang/test/BoundsSafety/AST/typedef-function-attrs-late-parsed-call.c
@@ -1,6 +1,6 @@
 
-// RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -fbounds-safety -x objective-c -fbounds-attributes-objc-experimental -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fbounds-safety -Wno-default-const-init-unsafe -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fbounds-safety -x objective-c -Wno-default-const-init-unsafe -fbounds-attributes-objc-experimental -ast-dump %s 2>&1 | FileCheck %s
 
 #include <ptrcheck.h>
 


### PR DESCRIPTION
The test broke because a new diagnostic from upstream started firing and was mixed in with the AST dump.

The upstream diagnostic is from:

```
commit 576161cb6069e2c7656a8ef530727a0f4aefff30
Author: Aaron Ballman <aaron@aaronballman.com>
Date:   Fri Apr 25 08:21:41 2025 -0400

    [C] Warn on uninitialized const objects (#137166)
```

The simplest solution is to surpress the new diagnostic.

rdar://150458872