### PR TITLE
[6.2][CAS] Improve error message when module cache key is missing

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCASKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCASKinds.td
@@ -23,8 +23,10 @@ def err_cas_depscan_daemon_connection: Error<
 def err_cas_depscan_failed: Error<
   "CAS-based dependency scan failed: %0">, DefaultFatal;
 def err_cas_store: Error<"failed to store to CAS: %0">, DefaultFatal;
-def err_cas_cannot_get_module_cache_key : Error<
-  "CAS cannot load module with key '%0' from %1: %2">, DefaultFatal;
+def err_cas_unloadable_module : Error<
+  "module file '%0' not found: unloadable module cache key %1: %2">, DefaultFatal;
+def err_cas_missing_module : Error<
+  "module file '%0' not found: missing module cache key %1: %2">, DefaultFatal;
 def err_cas_missing_root_id : Error<
   "CAS missing expected root-id '%0'">, DefaultFatal;
 def err_cas_cannot_parse_root_id_for_module : Error<

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -304,12 +304,7 @@ Error clang::printCompileJobCacheKey(ObjectStore &CAS, const CASID &Key,
   if (!H)
     return H.takeError();
   TreeSchema Schema(CAS);
-  if (!Schema.isNode(*H)) {
-    std::string ErrStr;
-    llvm::raw_string_ostream Err(ErrStr);
-    Err << "expected cache key to be a CAS tree; got ";
-    H->getID().print(Err);
-    return createStringError(inconvertibleErrorCode(), Err.str());
-  }
+  if (!Schema.isNode(*H))
+    return createStringError("unexpected cache key schema");
   return ::printCompileJobCacheKey(CAS, *H, OS);
 }

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -2543,31 +2543,36 @@ static bool addCachedModuleFileToInMemoryCache(
 
   auto ID = CAS.parseID(CacheKey);
   if (!ID) {
-    Diags.Report(diag::err_cas_cannot_get_module_cache_key)
-        << CacheKey << Provider << ID.takeError();
+    Diags.Report(diag::err_cas_unloadable_module)
+        << Path << CacheKey << ID.takeError();
     return true;
   }
 
   auto Value = Cache.get(*ID);
-  if (!Value || !*Value) {
-    auto Diag = Diags.Report(diag::err_cas_cannot_get_module_cache_key)
-                << CacheKey << Provider;
-    if (!Value) {
-      Diag << Value.takeError();
-    } else {
-      std::string ErrStr("no such entry in action cache; expected compile:\n");
-      llvm::raw_string_ostream Err(ErrStr);
-      if (auto E = printCompileJobCacheKey(CAS, *ID, Err))
-        Diag << std::move(E);
-      else
-        Diag << Err.str();
-    }
+  if (!Value) {
+    Diags.Report(diag::err_cas_unloadable_module)
+        << Path << CacheKey << Value.takeError();
+    return true;
+  }
+  if (!*Value) {
+    auto Diag = Diags.Report(diag::err_cas_missing_module)
+                << Path << CacheKey;
+    std::string ErrStr("expected to be produced by:\n");
+    llvm::raw_string_ostream Err(ErrStr);
+    if (auto E = printCompileJobCacheKey(CAS, *ID, Err)) {
+      // Ignore the error and skip printing the cache key. The cache key can
+      // be setup by a different compiler that is using an unknown schema.
+      llvm::consumeError(std::move(E));
+      Diag << "module file is not available in the CAS";
+    } else
+      Diag << Err.str();
+
     return true;
   }
   auto ValueRef = CAS.getReference(**Value);
   if (!ValueRef) {
-    Diags.Report(diag::err_cas_cannot_get_module_cache_key)
-        << CacheKey << Provider << "result module doesn't exist in CAS";
+    Diags.Report(diag::err_cas_unloadable_module)
+        << Path << CacheKey << "result module cannot be loaded from CAS";
 
     return true;
   }
@@ -2575,8 +2580,8 @@ static bool addCachedModuleFileToInMemoryCache(
   std::optional<cas::CompileJobCacheResult> Result;
   cas::CompileJobResultSchema Schema(CAS);
   if (llvm::Error E = Schema.load(*ValueRef).moveInto(Result)) {
-    Diags.Report(diag::err_cas_cannot_get_module_cache_key)
-        << CacheKey << Provider << std::move(E);
+    Diags.Report(diag::err_cas_unloadable_module)
+        << Path << CacheKey << std::move(E);
     return true;
   }
   auto Output =
@@ -2589,8 +2594,8 @@ static bool addCachedModuleFileToInMemoryCache(
   // better network utilization.
   auto OutputProxy = CAS.getProxy(Output->Object);
   if (!OutputProxy) {
-    Diags.Report(diag::err_cas_cannot_get_module_cache_key)
-        << CacheKey << Provider << OutputProxy.takeError();
+    Diags.Report(diag::err_cas_unloadable_module)
+        << Path << CacheKey << OutputProxy.takeError();
     return true;
   }
 

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -657,10 +657,11 @@ static void checkCompileCacheKeyMatch(cas::ObjectStore &CAS,
     llvm::report_fatal_error(OldKey.takeError());
   SmallString<256> Err;
   llvm::raw_svector_ostream OS(Err);
-  OS << "Compile cache key for module changed; previously:";
+  OS << "Compile cache key for module changed; previously: "
+     << OldKey->toString() << ": ";
   if (auto E = printCompileJobCacheKey(CAS, *OldKey, OS))
     OS << std::move(E);
-  OS << "\nkey is now:";
+  OS << "\nkey is now: " << NewKey.toString() << ": ";
   if (auto E = printCompileJobCacheKey(CAS, NewKey, OS))
     OS << std::move(E);
   llvm::report_fatal_error(OS.str());

--- a/clang/test/CAS/fmodule-file-cache-key-errors.c
+++ b/clang/test/CAS/fmodule-file-cache-key-errors.c
@@ -26,7 +26,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/invalid2.txt
 // RUN: FileCheck %s -check-prefix=INVALID2 -input-file=%t/invalid2.txt
 
-// INVALID2: error: CAS cannot load module with key '-fsyntax-only' from -fmodule-file-cache-key
+// INVALID2: error: module file 'INVALID' not found: unloadable module cache key -fsyntax-only: invalid cas-id '-fsyntax-only'
 
 // RUN: not %clang_cc1 -triple x86_64-apple-macos11 \
 // RUN:   -fmodules -fno-implicit-modules \
@@ -46,7 +46,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key.txt
 // RUN: cat %t/bad_key.txt | FileCheck %s -check-prefix=BAD_KEY
 
-// BAD_KEY: error: CAS cannot load module with key 'KEY' from -fmodule-file-cache-key: invalid cas-id 'KEY'
+// BAD_KEY: error: module file 'PATH' not found: unloadable module cache key KEY: invalid cas-id 'KEY'
 
 // RUN: echo -n '-fmodule-file-cache-key PATH ' > %t/bad_key2.rsp
 // RUN: cat %t/casid >> %t/bad_key2.rsp
@@ -59,7 +59,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/bad_key2.txt
 // RUN: cat %t/bad_key2.txt | FileCheck %s -check-prefix=BAD_KEY2
 
-// BAD_KEY2: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: cas object is not a valid cache key
+// BAD_KEY2: error: module file 'PATH' not found: missing module cache key {{.*}}: module file is not available in the CAS
 
 // == Build A
 
@@ -87,7 +87,7 @@
 // RUN:   -fcache-compile-job -Rcompile-job-cache &> %t/not_in_cache.txt
 // RUN: cat %t/not_in_cache.txt | FileCheck %s -check-prefix=NOT_IN_CACHE -DPREFIX=%/t
 
-// NOT_IN_CACHE: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache; expected compile:
+// NOT_IN_CACHE: error: module file 'PATH' not found: missing module cache key {{.*}}: expected to be produced by:
 // NOT_IN_CACHE: command-line:
 // NOT_IN_CACHE:   -cc1
 // NOT_IN_CACHE: filesystem:

--- a/clang/test/ClangScanDeps/modules-cas-trees.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees.c
@@ -42,7 +42,7 @@
 // Missing pcm in action cache
 // RUN: not %clang @%t/Left.rsp 2> %t/error.txt
 // RUN: cat %t/error.txt | FileCheck %s -check-prefix=MISSING
-// MISSING: error: CAS cannot load module with key '{{.*}}' from -fmodule-file-cache-key: no such entry in action cache
+// MISSING: error: module file '{{.*}}.pcm' not found: missing module cache key {{.*}}: expected to be produced by:
 
 // Build everything
 // RUN: %clang @%t/Top.rsp 2>&1 | FileCheck %s -check-prefix=CACHE-MISS


### PR DESCRIPTION
  - **Explanation**: Make the diagnostics from clang module loading from CAS clearly, especially seen by the swift compiler.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Diagnostic update for error message. 
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://149707188
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/llvm-project/pull/10517
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low. Diagnostic message change only.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Unit Test.
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @benlangmuir 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
