### PR TITLE
Fix issue where target.source-map didn't apply to SwiftASTContext::CreateInstance

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2555,6 +2555,10 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
 
   // Apply source path remappings found in the module's dSYM.
   swift_ast_sp->RemapClangImporterOptions(module.GetSourceMappingList());
+
+  // Apply source path remappings found in the target settings.
+  if (target)
+    swift_ast_sp->RemapClangImporterOptions(target->GetSourcePathMap());
   swift_ast_sp->FilterClangImporterOptions(
       swift_ast_sp->GetClangImporterOptions().ExtraArgs, swift_ast_sp.get());
 


### PR DESCRIPTION
This specifically is for SwiftASTContext::CreateInstance with a TypeSystemSwiftTypeRef, the other version works as expected.

Same as #10527 but for next.