### PR TITLE
[windows] fix flaky linker error when building LLDB

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -152,9 +152,7 @@ add_lldb_library(liblldb SHARED ${option_framework}
     lldbValueObject
     lldbVersion
     ${LLDB_ALL_PLUGINS}
-## BEGIN SWIFT
-    ${SWIFT_ALL_LIBS}
-## END SWIFT
+    swiftCore
   LINK_COMPONENTS
     Support
 


### PR DESCRIPTION
When building LLDB on Windows with `build.ps1`, the following linker error happens, especially after rebuilding incrementally. The error sometimes goes away after deleting CMakeCache.txt, but that's not reliable.

```
[1/4][ 25%][39.728s] Linking CXX shared library bin\liblldb.dll
FAILED: bin/liblldb.dll lib/liblldb.lib
C:\WINDOWS\system32\cmd.exe /C "cd . && "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E vs_link_dll --intdir=tools\lldb\source\API\CMakeFiles\liblldb.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\arm64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\arm64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1443~1.348\bin\HOSTAR~1\arm64\link.exe /nologo @CMakeFiles\liblldb.rsp  /out:bin\liblldb.dll /implib:lib\liblldb.lib /pdb:bin\liblldb.pdb /dll /version:19.1 /machine:ARM64 /INCREMENTAL:NO && cd ."
LINK: command "C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1443~1.348\bin\HOSTAR~1\arm64\link.exe /nologo @CMakeFiles\liblldb.rsp /out:bin\liblldb.dll /implib:lib\liblldb.lib /pdb:bin\liblldb.pdb /dll /version:19.1 /machine:ARM64 /INCREMENTAL:NO /MANIFEST:EMBED,ID=2" failed (exit code 1120) with the following output:
   Creating library lib\liblldb.lib and object lib\liblldb.exp
swiftrt.obj : error LNK2019: unresolved external symbol __imp_swift_addNewDSOImage referenced in function "void __cdecl swift_image_constructor(void)" (?swift_image_constructor@@YAXXZ)
bin\liblldb.dll : fatal error LNK1120: 1 unresolved externals
ninja: build stopped: subcommand failed.
```

This PR fixes this build error and removes the use of `SWIFT_ALL_LIBS` as it's not referenced anywhere else.