### PR TITLE
[windows] fix flaky linker error when building LLDB

### DIFF
--- a/lldb/source/API/CMakeLists.txt
+++ b/lldb/source/API/CMakeLists.txt
@@ -152,9 +152,6 @@ add_lldb_library(liblldb SHARED ${option_framework}
     lldbValueObject
     lldbVersion
     ${LLDB_ALL_PLUGINS}
-## BEGIN SWIFT
-    ${SWIFT_ALL_LIBS}
-## END SWIFT
   LINK_COMPONENTS
     Support
 

--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -33,7 +33,9 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
     lldbPluginTypeSystemSwift
     swiftAST
     swiftClangImporter
-    ${SWIFT_CORE_LIB} # fixes a linker issue when building on Windows.
+    ${SWIFT_CORE_LIB} # Fix for a build error when linking lib/liblldb.lib on Windows: 'unresolved external symbol __imp_swift_addNewDSOImage referenced in function "void __cdecl swift_image_constructor(void)"'
+                      # The symbol is present in the file but cannot be resolved.
+                      # This is a temporary workaround.
     clangAST
 
   LINK_COMPONENTS

--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -27,6 +27,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
     lldbPluginTypeSystemSwift
     swiftAST
     swiftClangImporter
+    swiftCore
     clangAST
 
   LINK_COMPONENTS

--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(LLVM_NO_RTTI 1)
 
+set(SWIFT_CORE_LIB)
+
+if(WIN32)
+  list(APPEND SWIFT_CORE_LIB swiftCore)
+endif()
+
 add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   FoundationValueTypes.cpp
   LogChannelSwift.cpp
@@ -27,7 +33,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
     lldbPluginTypeSystemSwift
     swiftAST
     swiftClangImporter
-    swiftCore
+    ${SWIFT_CORE_LIB} # fixes a linker issue when building on Windows.
     clangAST
 
   LINK_COMPONENTS


### PR DESCRIPTION
When building LLDB on Windows with `build.ps1`, the following linker error happens, especially after rebuilding incrementally. The error sometimes goes away after deleting CMakeCache.txt, but that's not reliable.

```
[1/4][ 25%][39.728s] Linking CXX shared library bin\liblldb.dll
FAILED: bin/liblldb.dll lib/liblldb.lib
C:\WINDOWS\system32\cmd.exe /C "cd . && "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E vs_link_dll --intdir=tools\lldb\source\API\CMakeFiles\liblldb.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\arm64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100261~1.0\arm64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1443~1.348\bin\HOSTAR~1\arm64\link.exe /nologo @CMakeFiles\liblldb.rsp  /out:bin\liblldb.dll /implib:lib\liblldb.lib /pdb:bin\liblldb.pdb /dll /version:19.1 /machine:ARM64 /INCREMENTAL:NO && cd ."
LINK: command "C:\PROGRA~1\MICROS~2\2022\COMMUN~1\VC\Tools\MSVC\1443~1.348\bin\HOSTAR~1\arm64\link.exe /nologo @CMakeFiles\liblldb.rsp /out:bin\liblldb.dll /implib:lib\liblldb.lib /pdb:bin\liblldb.pdb /dll /version:19.1 /machine:ARM64 /INCREMENTAL:NO /MANIFEST:EMBED,ID=2" failed (exit code 1120) with the following output:
   Creating library lib\liblldb.lib and object lib\liblldb.exp
swiftrt.obj : error LNK2019: unresolved external symbol __imp_swift_addNewDSOImage referenced in function "void __cdecl swift_image_constructor(void)" (?swift_image_constructor@@YAXXZ)
bin\liblldb.dll : fatal error LNK1120: 1 unresolved externals
ninja: build stopped: subcommand failed.
```

This PR fixes this build error and removes the use of `SWIFT_ALL_LIBS` as it's not referenced anywhere else.