### PR TITLE
[clang] Restore profile-use driver support after bad merge.

### DIFF
--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -2206,6 +2206,11 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
             : llvm::codegenoptions::DebugTemplateNamesKind::Mangled);
   }
 
+  if (!Opts.ProfileInstrumentUsePath.empty()) {
+    auto FS = createBaseFS(FSOpts, FEOpts, CASOpts, Diags, nullptr);
+    setPGOUseInstrumentor(Opts, Opts.ProfileInstrumentUsePath, *FS, Diags);
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_ftime_report, OPT_ftime_report_EQ,
                                      OPT_ftime_report_json)) {
     Opts.TimePasses = true;


### PR DESCRIPTION
ceeb20eaa2fe dropped this.  We have tests that catch that.

rdar://150554157