### PR TITLE
[-Wunsafe-buffer-usage] Restore be48c0df7741 change lost in merge.

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1423,7 +1423,7 @@ static bool isNullTermPointer(const Expr *Ptr, ASTContext &Ctx) {
     const CXXMethodDecl *MD = MCE->getMethodDecl();
     const CXXRecordDecl *RD = MCE->getRecordDecl()->getCanonicalDecl();
 
-    if (MD && RD && RD->isInStdNamespace())
+    if (MD && RD && RD->isInStdNamespace() && MD->getIdentifier())
       if (MD->getName() == "c_str" && RD->getName() == "basic_string")
         return true;
   }


### PR DESCRIPTION
The only actual change was somehow dropped in merges 4de73d17a19b and 47144fcd1448.

rdar://150485090