### PR TITLE
[IncludeTree] IncludeTreeFileList optimizations

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -313,7 +313,7 @@ private:
   FileSizeTy getFileSize(size_t I) const;
 
   llvm::Error
-  forEachFileImpl(llvm::DenseSet<ObjectRef> &Seen,
+  forEachFileImpl(llvm::DenseMap<ObjectRef, ObjectRef> &Seen,
                   llvm::function_ref<llvm::Error(File, FileSizeTy)> Callback);
 
   static bool isValid(const ObjectProxy &Node);
@@ -864,16 +864,16 @@ private:
 
 /// An implementation of a \p vfs::FileSystem that supports the simple queries
 /// of the preprocessor, for creating \p FileEntries using a file path, while
-/// "replaying" an \p IncludeTreeRoot. It is not intended to be a complete
+/// "replaying" an \p IncludeTree::FileList. It is not intended to be a complete
 /// implementation of a file system.
 Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
-createIncludeTreeFileSystem(IncludeTreeRoot &Root);
+createIncludeTreeFileSystem(IncludeTree::FileList &List);
 
 /// Create the same IncludeTreeFileSystem but from
 /// ArrayRef<IncludeTree::FileEntry>.
 Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>> createIncludeTreeFileSystem(
     llvm::cas::ObjectStore &CAS,
-    llvm::ArrayRef<IncludeTree::FileList::FileEntry> List);
+    llvm::ArrayRef<IncludeTree::FileList::FileEntry> Files);
 
 } // namespace cas
 } // namespace clang

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1559,7 +1559,11 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
     auto Root = cas::IncludeTreeRoot::get(*CAS, *Ref);
     if (!Root)
       return Root.takeError();
-    return cas::createIncludeTreeFileSystem(*Root);
+    auto FileList = Root->getFileList();
+    if (!FileList)
+      return FileList.takeError();
+
+    return cas::createIncludeTreeFileSystem(*FileList);
   };
   auto makeCASFS = [&](std::shared_ptr<llvm::cas::ObjectStore> CAS,
                        llvm::cas::CASID &ID)


### PR DESCRIPTION
Optimize IncludeTreeFileList to make creation and iterating to have less overhead and easier to use:

* Unify the conflict file detection code with the code that uniquing the file from nested FileList so there is no need to use separate data structures.
* Extend the conflict file content detection to iterating method `forEachFile` so it is easier to discover the problem with no overhead since no extra data structure is needed.
* Improve the IncludeTreeFileSystem constructor to share more functions between two versions.
* Remove an unnecessary requirement that IncludeTree::FileList must contain FileEntries. It can have an empty file entries list but provides nesting FileList accesses.