### PR TITLE
[lldb] Re-enble Shell/Swift/caching.test

### DIFF
--- a/lldb/test/Shell/Swift/caching.test
+++ b/lldb/test/Shell/Swift/caching.test
@@ -1,6 +1,5 @@
 # REQUIRES: swift
 # REQUIRES: system-darwin
-# REQUIRES: rdar150334469
 
 # RUN: rm -rf %t && mkdir %t
 # RUN: split-file %s %t


### PR DESCRIPTION
Re-enable test after swift-driver fix.