### PR TITLE
🍒[lldb/DWARF] Downgrade the "parent of variable is not CU" error

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -3936,10 +3936,9 @@ void SymbolFileDWARF::ParseAndAppendGlobalVariable(
     break;
 
   default:
-    GetObjectFile()->GetModule()->ReportError(
-        "didn't find appropriate parent DIE for variable list for {0:x8} "
-        "{1} ({2}).\n",
-        die.GetID(), DW_TAG_value_to_name(die.Tag()), die.Tag());
+    LLDB_LOG(GetLog(DWARFLog::Lookups),
+             "{0} '{1}' ({2:x8}) is not a global variable - ignoring", tag,
+             die.GetName(), die.GetID());
     return;
   }
 


### PR DESCRIPTION
This can legitimately happen for static function-local variables with a non-manual dwarf index. According to the DWARF spec, these variables should be (and are) included in the compiler generated indexes, but they are ignored by our manual index. Encountering them does not indicate any sort of error.

The error message is particularly annoying due to a combination of the fact that we don't cache negative hits (so we print it every time we encounter it), VSCode's aggresive tab completion (which attempts a lookup after every keypress) and the fact that some low-level libraries (e.g. tcmalloc) have several local variables called "v". The result is a console full of error messages everytime you type "v ".

We already have tests (e.g. find-basic-variable.cpp), which check that these variables are not included in the result (and by extension, that their presence does not crash lldb). It would be possible to extend it to make sure it does *not* print this error message, but it doesn't seem like it would be particularly useful.

(cherry picked from commit 1f8e6624e5052d56244b28fef3eb64bd0408f75d)

rdar://146703311