### PR TITLE
[BoundsSafety] Unbreak several codegen tests

### DIFF
--- a/clang/test/BoundsSafety-legacy-checks/CodeGen/nested-struct-member-count-O2.c
+++ b/clang/test/BoundsSafety-legacy-checks/CodeGen/nested-struct-member-count-O2.c
@@ -42,12 +42,17 @@ char access(struct Outer *bar, int index) {
 
 
 
-// CHECK-LABEL: define dso_local noundef nonnull ptr @assign(
+// CHECK-LABEL: define dso_local ptr @assign(
 // CHECK-SAME: ptr noundef readonly captures(none) [[BAR:%.*]], i32 noundef [[LEN:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[BAR]], align 8, !nonnull {{![0-9]+}}, !noundef {{![0-9]+}}
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[BAR]], align 8
 // CHECK-NEXT:    [[AGG_TEMP1_SROA_2_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 8
 // CHECK-NEXT:    [[AGG_TEMP1_SROA_2_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_2_0_BAR_SROA_IDX]], align 8
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 16
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX]], align 8, !tbaa {{![0-9]+}}
+// CHECK-NEXT:    [[FLEX_BASE_NULL_CHECK_NOT:%.*]] = icmp eq ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], null, !annotation {{![0-9]+}}
+// CHECK-NEXT:    br i1 [[FLEX_BASE_NULL_CHECK_NOT]], label [[BOUNDSCHECK_CONT_THREAD:%.*]], label [[FLEX_BASE_NONNULL:%.*]], !annotation {{![0-9]+}}
+// CHECK:       flex.base.nonnull:
 // CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], i64 8
 // CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], [[TMP0]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP:%.*]], label [[CONT:%.*]], !prof {{![0-9]+}}, !annotation {{![0-9]+}}
@@ -55,8 +60,6 @@ char access(struct Outer *bar, int index) {
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR2]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    unreachable, !annotation {{![0-9]+}}
 // CHECK:       cont:
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 16
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX]], align 8, !tbaa {{![0-9]+}}
 // CHECK-NEXT:    [[TMP1:%.*]] = icmp ule ptr [[TMP0]], [[AGG_TEMP1_SROA_2_0_COPYLOAD]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    [[TMP2:%.*]] = icmp ule ptr [[AGG_TEMP1_SROA_3_0_COPYLOAD]], [[AGG_TEMP1_SROA_0_0_COPYLOAD]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    [[OR_COND:%.*]] = select i1 [[TMP1]], i1 [[TMP2]], i1 false, !annotation {{![0-9]+}}
@@ -72,9 +75,14 @@ char access(struct Outer *bar, int index) {
 // CHECK-NEXT:    [[TMP3:%.*]] = icmp ult ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], [[AGG_TEMP1_SROA_2_0_COPYLOAD]], !annotation {{![0-9]+}}
 // CHECK-NEXT:    [[OR_COND60:%.*]] = select i1 [[OR_COND49]], i1 [[TMP3]], i1 false, !annotation {{![0-9]+}}
 // CHECK-NEXT:    br i1 [[OR_COND60]], label [[BOUNDSCHECK_CONT:%.*]], label [[TRAP]], !prof {{![0-9]+}}, !annotation {{![0-9]+}}
+// CHECK:       boundscheck.cont.thread:
+// CHECK-NEXT:    store i32 [[LEN]], ptr inttoptr (i64 4 to ptr), align 4, !tbaa {{![0-9]+}}
+// CHECK-NEXT:    br label [[CONT46:%.*]]
 // CHECK:       boundscheck.cont:
 // CHECK-NEXT:    [[LEN31:%.*]] = getelementptr inbounds nuw i8, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], i64 4
 // CHECK-NEXT:    store i32 [[LEN]], ptr [[LEN31]], align 4, !tbaa {{![0-9]+}}
+// CHECK-NEXT:    br label [[CONT46]], !annotation {{![0-9]+}}
+// CHECK:       cont46:
 // CHECK-NEXT:    ret ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]]
 //
 struct Outer * assign(void * __bidi_indexable bar, int len) {

--- a/clang/test/BoundsSafety/CodeGen/bounds-attributed-in-return-null-system-header-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/bounds-attributed-in-return-null-system-header-O2.c
@@ -25,10 +25,16 @@ void consume(int* __bidi_indexable);
 // LEGACY-SAME: i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0:[0-9]+]] {
 // LEGACY-NEXT:  [[ENTRY:.*:]]
 // LEGACY-NEXT:    [[BYVAL_TEMP:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable", align 8
-// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4:[0-9]+]]
-// LEGACY-NEXT:    call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(24) [[BYVAL_TEMP]], i8 0, i64 24, i1 false)
-// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
-// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
+// LEGACY-NEXT:    [[IDX_EXT:%.*]] = sext i32 [[COUNT]] to i64
+// LEGACY-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i32, ptr null, i64 [[IDX_EXT]]
+// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3:[0-9]+]]
+// LEGACY-NEXT:    store ptr null, ptr [[BYVAL_TEMP]], align 8
+// LEGACY-NEXT:    [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 8
+// LEGACY-NEXT:    store ptr [[ADD_PTR]], ptr [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX]], align 8
+// LEGACY-NEXT:    [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 16
+// LEGACY-NEXT:    store ptr null, ptr [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX]], align 8, !tbaa [[TBAA2:![0-9]+]]
+// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
+// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
 // LEGACY-NEXT:    ret void
 //
 void use_inline_header_func_unspecified_ptr(int count) {
@@ -56,10 +62,16 @@ void use_inline_header_func_unspecified_ptr(int count) {
 // LEGACY-SAME: i32 noundef [[COUNT:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // LEGACY-NEXT:  [[ENTRY:.*:]]
 // LEGACY-NEXT:    [[BYVAL_TEMP:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable", align 8
-// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
-// LEGACY-NEXT:    call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(24) [[BYVAL_TEMP]], i8 0, i64 24, i1 false)
-// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
-// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR4]]
+// LEGACY-NEXT:    [[IDX_EXT:%.*]] = sext i32 [[COUNT]] to i64
+// LEGACY-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i32, ptr null, i64 [[IDX_EXT]]
+// LEGACY-NEXT:    call void @llvm.lifetime.start.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
+// LEGACY-NEXT:    store ptr null, ptr [[BYVAL_TEMP]], align 8
+// LEGACY-NEXT:    [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 8
+// LEGACY-NEXT:    store ptr [[ADD_PTR]], ptr [[PTR_SROA_4_0_BYVAL_TEMP_SROA_IDX]], align 8
+// LEGACY-NEXT:    [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BYVAL_TEMP]], i64 16
+// LEGACY-NEXT:    store ptr null, ptr [[PTR_SROA_5_0_BYVAL_TEMP_SROA_IDX]], align 8, !tbaa [[TBAA2]]
+// LEGACY-NEXT:    call void @consume(ptr noundef nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
+// LEGACY-NEXT:    call void @llvm.lifetime.end.p0(i64 24, ptr nonnull [[BYVAL_TEMP]]) #[[ATTR3]]
 // LEGACY-NEXT:    ret void
 //
 void use_inline_header_func_unsafe_indexable_ptr(int count) {
@@ -69,4 +81,10 @@ void use_inline_header_func_unsafe_indexable_ptr(int count) {
 //.
 // CHECK: [[META2]] = !{!"bounds-safety-generic"}
 // CHECK: [[PROF3]] = !{!"branch_weights", i32 1048575, i32 1}
+//.
+// LEGACY: [[TBAA2]] = !{[[META3:![0-9]+]], [[META3]], i64 0}
+// LEGACY: [[META3]] = !{!"p1 int", [[META4:![0-9]+]], i64 0}
+// LEGACY: [[META4]] = !{!"any pointer", [[META5:![0-9]+]], i64 0}
+// LEGACY: [[META5]] = !{!"omnipotent char", [[META6:![0-9]+]], i64 0}
+// LEGACY: [[META6]] = !{!"Simple C/C++ TBAA"}
 //.

--- a/clang/test/BoundsSafety/CodeGen/nested-struct-member-count-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/nested-struct-member-count-O2.c
@@ -41,21 +41,24 @@ char access(struct Outer *bar, int index) {
 
 
 
-// CHECK-LABEL: define dso_local noundef nonnull ptr @assign(
+// CHECK-LABEL: define dso_local ptr @assign(
 // CHECK-SAME: ptr noundef readonly captures(none) [[BAR:%.*]], i32 noundef [[LEN:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[BAR]], align 8, !nonnull [[META12:![0-9]+]], !noundef [[META12]]
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[BAR]], align 8
 // CHECK-NEXT:    [[AGG_TEMP1_SROA_2_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 8
 // CHECK-NEXT:    [[AGG_TEMP1_SROA_2_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_2_0_BAR_SROA_IDX]], align 8
-// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], i64 8
-// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], [[TMP0]], !annotation [[META13:![0-9]+]]
-// CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP:%.*]], label [[CONT:%.*]], !prof [[PROF14:![0-9]+]], !annotation [[META13]]
-// CHECK:       trap:
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR2]], !annotation [[META15:![0-9]+]]
-// CHECK-NEXT:    unreachable, !annotation [[META15]]
-// CHECK:       cont:
 // CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX:%.*]] = getelementptr inbounds nuw i8, ptr [[BAR]], i64 16
-// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX]], align 8, !tbaa [[TBAA16:![0-9]+]]
+// CHECK-NEXT:    [[AGG_TEMP1_SROA_3_0_COPYLOAD:%.*]] = load ptr, ptr [[AGG_TEMP1_SROA_3_0_BAR_SROA_IDX]], align 8, !tbaa [[TBAA12:![0-9]+]]
+// CHECK-NEXT:    [[FLEX_BASE_NULL_CHECK_NOT:%.*]] = icmp eq ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], null, !annotation [[META14:![0-9]+]]
+// CHECK-NEXT:    br i1 [[FLEX_BASE_NULL_CHECK_NOT]], label [[BOUNDSCHECK_CONT_THREAD:%.*]], label [[FLEX_BASE_NONNULL:%.*]], !annotation [[META14]]
+// CHECK:       flex.base.nonnull:
+// CHECK-NEXT:    [[TMP0:%.*]] = getelementptr i8, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], i64 8
+// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp ugt ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], [[TMP0]], !annotation [[META15:![0-9]+]]
+// CHECK-NEXT:    br i1 [[DOTNOT]], label [[TRAP:%.*]], label [[CONT:%.*]], !prof [[PROF16:![0-9]+]], !annotation [[META15]]
+// CHECK:       trap:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR2]], !annotation [[META17:![0-9]+]]
+// CHECK-NEXT:    unreachable, !annotation [[META17]]
+// CHECK:       cont:
 // CHECK-NEXT:    [[TMP1:%.*]] = icmp ule ptr [[TMP0]], [[AGG_TEMP1_SROA_2_0_COPYLOAD]], !annotation [[META7]]
 // CHECK-NEXT:    [[TMP2:%.*]] = icmp ule ptr [[AGG_TEMP1_SROA_3_0_COPYLOAD]], [[AGG_TEMP1_SROA_0_0_COPYLOAD]], !annotation [[META8]]
 // CHECK-NEXT:    [[OR_COND:%.*]] = select i1 [[TMP1]], i1 [[TMP2]], i1 false, !annotation [[META8]]
@@ -69,9 +72,14 @@ char access(struct Outer *bar, int index) {
 // CHECK-NEXT:    [[FLEX_COUNT_CHECK:%.*]] = icmp uge i64 [[FLEX_AVAIL_COUNT]], [[FLEX_COUNT_INTPTR]], !annotation [[META19]]
 // CHECK-NEXT:    [[OR_COND51:%.*]] = select i1 [[FLEX_COUNT_MINUS]], i1 [[FLEX_COUNT_CHECK]], i1 false, !annotation [[META19]]
 // CHECK-NEXT:    br i1 [[OR_COND51]], label [[BOUNDSCHECK_NOTNULL45:%.*]], label [[TRAP]], !prof [[PROF20:![0-9]+]], !annotation [[META18]]
+// CHECK:       boundscheck.cont.thread:
+// CHECK-NEXT:    store i32 [[LEN]], ptr inttoptr (i64 4 to ptr), align 4, !tbaa [[TBAA2]]
+// CHECK-NEXT:    br label [[CONT48:%.*]]
 // CHECK:       boundscheck.notnull45:
 // CHECK-NEXT:    [[LEN32:%.*]] = getelementptr inbounds nuw i8, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], i64 4
 // CHECK-NEXT:    store i32 [[LEN]], ptr [[LEN32]], align 4, !tbaa [[TBAA2]]
+// CHECK-NEXT:    br label [[CONT48]]
+// CHECK:       cont48:
 // CHECK-NEXT:    ret ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]]
 //
 struct Outer * assign(void * __bidi_indexable bar, int len) {
@@ -90,12 +98,12 @@ struct Outer * assign(void * __bidi_indexable bar, int len) {
 // CHECK: [[PROF9]] = !{!"branch_weights", i32 -8192, i32 8191}
 // CHECK: [[META10]] = !{!"bounds-safety-check-ptr-lt-upper-bound", !"bounds-safety-check-ptr-ge-lower-bound"}
 // CHECK: [[TBAA11]] = !{[[META5]], [[META5]], i64 0}
-// CHECK: [[META12]] = !{}
-// CHECK: [[META13]] = !{!"bounds-safety-check-one-past-end-overflow"}
-// CHECK: [[PROF14]] = !{!"branch_weights", i32 1, i32 1048575}
-// CHECK: [[META15]] = !{!"bounds-safety-check-one-past-end-overflow", !"bounds-safety-check-ptr-lt-upper-bound", !"bounds-safety-check-ptr-ge-lower-bound", !"bounds-safety-check-count-negative", !"bounds-safety-check-ptr-le-upper-bound", !"bounds-safety-check-flexible-count-gt-bounds"}
-// CHECK: [[TBAA16]] = !{[[META17:![0-9]+]], [[META17]], i64 0}
-// CHECK: [[META17]] = !{!"any pointer", [[META5]], i64 0}
+// CHECK: [[TBAA12]] = !{[[META13:![0-9]+]], [[META13]], i64 0}
+// CHECK: [[META13]] = !{!"any pointer", [[META5]], i64 0}
+// CHECK: [[META14]] = !{!"bounds-safety-check-ptr-neq-null"}
+// CHECK: [[META15]] = !{!"bounds-safety-check-one-past-end-overflow"}
+// CHECK: [[PROF16]] = !{!"branch_weights", i32 1, i32 1048575}
+// CHECK: [[META17]] = !{!"bounds-safety-check-one-past-end-overflow", !"bounds-safety-check-ptr-lt-upper-bound", !"bounds-safety-check-ptr-ge-lower-bound", !"bounds-safety-check-count-negative", !"bounds-safety-check-ptr-le-upper-bound", !"bounds-safety-check-flexible-count-gt-bounds"}
 // CHECK: [[META18]] = !{!"bounds-safety-check-count-negative"}
 // CHECK: [[META19]] = !{!"bounds-safety-check-flexible-count-gt-bounds"}
 // CHECK: [[PROF20]] = !{!"branch_weights", i32 -16384, i32 16381}

--- a/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-trivial-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/terminated-by-to-indexable-trivial-O2.c
@@ -41,8 +41,8 @@ const char *__indexable good_chars_unsafe(void) {
 }
 
 // CHECK-LABEL: @bad_null(
-// CHECK-NEXT:  terminated_by.loop_end:
-// CHECK-NEXT:    ret { ptr, ptr } zeroinitializer
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    unreachable
 //
 int *__indexable bad_null(void) {
   int *__null_terminated p = 0;
@@ -50,8 +50,8 @@ int *__indexable bad_null(void) {
 }
 
 // CHECK-LABEL: @bad_null_unsafe(
-// CHECK-NEXT:  terminated_by.loop_end:
-// CHECK-NEXT:    ret { ptr, ptr } zeroinitializer
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    unreachable
 //
 int *__indexable bad_null_unsafe(void) {
   int *__null_terminated p = 0;


### PR DESCRIPTION
This commit (and its corresponding merge commit) broke several codegen tests.

```
commit 4b59b95733c1e89755f3f92272bc662e0db68712
Merge: c5ca74521067 c37b2549ff01
Author: git apple-llvm automerger <am@git-apple-llvm>
Date:   Fri May 2 23:22:29 2025 -0700

    Merge commit 'c37b2549ff01' from llvm.org/main into next

commit c37b2549ff0150301eb23bd28c2802efc426b7f2
error: cannot run gpg: No such file or directory
Author: Yingwei Zheng <dtcxzyw2333@gmail.com>
Date:   Fri May 2 05:21:59 2025 +0800

    Revert "[InstSimplify] Fold getelementptr inbounds null, idx -> null (#130742)" (#138168)

    Revert #130742 for now to avoid breaking glibc failures until the
    workaround patches are landed.
```

This commit re-generates the failing codegen tests.

rdar://150697626