### PR TITLE
[lldb] Fix swift debugging with swift-extra-clang-flags

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1954,10 +1954,20 @@ void SwiftASTContext::AddExtraClangCC1Args(
 
 void SwiftASTContext::AddUserClangArgs(TargetProperties &props) {
   Args args(props.GetSwiftExtraClangFlags());
+  if (args.empty())
+    return;
+
   std::vector<std::string> user_clang_flags;
-  for (const auto &arg : args.entries())
+  for (const auto &arg : args.entries())  {
+    if (arg.ref() == "--")
+      continue;
     user_clang_flags.push_back(arg.ref().str());
-  AddExtraClangArgs(user_clang_flags, {}, {});
+  }
+  if (GetClangImporterOptions().DirectClangCC1ModuleBuild) {
+    llvm::append_range(GetClangImporterOptions().ExtraArgs, user_clang_flags);
+  } else {
+    AddExtraClangArgs(user_clang_flags, {}, {});
+  }
 }
 
 /// Turn relative paths in clang options into absolute paths based on

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -21,6 +21,7 @@ class TestSwiftClangImporterCaching(TestBase):
                                           lldb.SBFileSpec('main.swift'))
         log = self.getBuildArtifact("types.log")
         self.runCmd("settings set target.swift-clang-override-options +-DADDED=1")
+        self.runCmd("settings set target.swift-extra-clang-flags -- -DEXTRA=1")
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["b ="])
@@ -35,6 +36,7 @@ class TestSwiftClangImporterCaching(TestBase):
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -F
 #       CHECK-NEXT:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /FRAMEWORK_DIR
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DADDED=1
+#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DEXTRA=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'ClangA'
 #       CHECK-NOT: -cc1
 #       CHECK-NOT: -fmodule-file-cache-key


### PR DESCRIPTION
When the ClangImporter in SwiftASTContext is setup with DirectCC1, it wasn't working with `swift-extra-clang-flags` because that will trigger the non DirectCC1 code path only. Make the option working with DirectCC1 mode by directly appending the flag.

rdar://150238095