### PR TITLE
[6.2][CAS] sync memory mapped file when closing CAS

### DIFF
--- a/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
@@ -53,7 +53,6 @@
 
 #include "llvm/CAS/MappedFileRegionBumpPtr.h"
 #include "OnDiskCommon.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/OnDiskCASLogger.h"
 
 using namespace llvm;
@@ -196,6 +195,8 @@ void MappedFileRegionBumpPtr::destroyImpl() {
       size_t Size = size();
       size_t Capacity = capacity();
       assert(Size < Capacity);
+      // sync to file system to make sure all contents are up-to-date.
+      (void)Region.sync();
       (void)sys::fs::resize_file(*FD, size());
       (void)unlockFileThreadSafe(*SharedLockFD);
 

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -876,6 +876,12 @@ void mapped_file_region::unmapImpl() {
     ::munmap(Mapping, Size);
 }
 
+std::error_code mapped_file_region::sync() const {
+  if (int Res = ::msync(Mapping, Size, MS_SYNC))
+    return std::error_code(Res, std::generic_category());
+  return std::error_code();
+}
+
 void mapped_file_region::dontNeedImpl() {
   assert(Mode == mapped_file_region::readonly);
   if (!Mapping)

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1011,6 +1011,12 @@ void mapped_file_region::unmapImpl() {
 
 void mapped_file_region::dontNeedImpl() {}
 
+std::error_code mapped_file_region::sync() const {
+  if (::FlushViewOfFile(Mapping, 0))
+    return std::error_code();
+  return mapWindowsError(::GetLastError());
+}
+
 int mapped_file_region::alignment() {
   SYSTEM_INFO SysInfo;
   ::GetSystemInfo(&SysInfo);


### PR DESCRIPTION
  - **Explanation**: To avoid unnecessary data lost due to power lost immediately after the build, make sure the mapped files in the CAS are sync'ed back to the file system when the last user of the CAS closed the file.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: For better caching usage and unexpected data lost.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://150379440
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/llvm-project/pull/10625
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low. Caching build only.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Local Performance benchmark.
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @akyrtzi 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->
