### PR TITLE
[lldb] Resolve Swift-implemented Objective-C classes using Swift runtime

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -182,7 +182,7 @@ public:
 
 protected:
   // Constructors and destructors
-  SwiftASTContext(std::string description,
+  SwiftASTContext(std::string description, lldb::ModuleSP module_sp,
                   TypeSystemSwiftTypeRefSP typeref_typesystem);
 
 public:
@@ -923,6 +923,20 @@ protected:
 
   CompilerType GetAsClangType(ConstString mangled_name);
 
+  /// Retrieve the stored properties for the given nominal type declaration.
+  llvm::ArrayRef<swift::VarDecl *>
+  GetStoredProperties(swift::NominalTypeDecl *nominal);
+
+  SwiftEnumDescriptor *GetCachedEnumInfo(lldb::opaque_compiler_type_t type);
+
+  friend class CompilerType;
+
+  void ApplyDiagnosticOptions();
+
+  /// Apply a PathMappingList dictionary on all search paths in the
+  /// ClangImporterOptions.
+  void RemapClangImporterOptions(const PathMappingList &path_map);
+
   /// Data members.
   /// @{
   std::weak_ptr<TypeSystemSwiftTypeRef> m_typeref_typesystem;
@@ -993,8 +1007,6 @@ protected:
   typedef ThreadSafeDenseSet<const char *> SwiftMangledNameSet;
   SwiftMangledNameSet m_negative_type_cache;
 
-  /// @}
-
   /// Record the set of stored properties for each nominal type declaration
   /// for which we've asked this question.
   ///
@@ -1004,19 +1016,7 @@ protected:
   llvm::DenseMap<swift::NominalTypeDecl *, std::vector<swift::VarDecl *>>
       m_stored_properties;
 
-  /// Retrieve the stored properties for the given nominal type declaration.
-  llvm::ArrayRef<swift::VarDecl *>
-  GetStoredProperties(swift::NominalTypeDecl *nominal);
-
-  SwiftEnumDescriptor *GetCachedEnumInfo(lldb::opaque_compiler_type_t type);
-
-  friend class CompilerType;
-
-  void ApplyDiagnosticOptions();
-
-  /// Apply a PathMappingList dictionary on all search paths in the
-  /// ClangImporterOptions.
-  void RemapClangImporterOptions(const PathMappingList &path_map);
+  /// @}
 };
 
 /// Deprecated.
@@ -1033,9 +1033,9 @@ public:
   static bool classof(const TypeSystem *ts) { return ts->isA(&ID); }
   /// \}
 
-  SwiftASTContextForModule(std::string description,
+  SwiftASTContextForModule(std::string description, lldb::ModuleSP module_sp,
                            TypeSystemSwiftTypeRefSP typeref_typesystem)
-      : SwiftASTContext(description, typeref_typesystem) {}
+      : SwiftASTContext(description, module_sp, typeref_typesystem) {}
   virtual ~SwiftASTContextForModule();
 };
 
@@ -1053,6 +1053,7 @@ public:
   /// \}
 
   SwiftASTContextForExpressions(std::string description,
+                                lldb::ModuleSP module_sp,
                                 TypeSystemSwiftTypeRefSP typeref_typesystem);
   virtual ~SwiftASTContextForExpressions();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -421,14 +421,14 @@ public:
   /// Search the debug info for a non-nested Clang type with the specified name
   /// and cache the result. Users should prefer the version that takes in the
   /// decl_context.
-  lldb::TypeSP LookupClangType(llvm::StringRef name_ref);
+  lldb::TypeSP LookupClangType(llvm::StringRef name_ref, SymbolContext sc = {});
 
   /// Search the debug info for a Clang type with the specified name and decl
   /// context.
   virtual lldb::TypeSP
   LookupClangType(llvm::StringRef name_ref,
                   llvm::ArrayRef<CompilerContext> decl_context,
-                  bool ignore_modules, ExecutionContext *exe_ctx = nullptr);
+                  bool ignore_modules, SymbolContext sc = {});
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.
@@ -655,7 +655,7 @@ public:
   lldb::TypeSP LookupClangType(llvm::StringRef name_ref,
                                llvm::ArrayRef<CompilerContext> decl_context,
                                bool ignore_modules,
-                               ExecutionContext *exe_ctx) override;
+                               SymbolContext sc = {}) override;
 
   friend class SwiftASTContextForExpressions;
 protected:

--- a/lldb/test/API/lang/swift/first_expr_module_load/TestFirstExprModuleLoad.py
+++ b/lldb/test/API/lang/swift/first_expr_module_load/TestFirstExprModuleLoad.py
@@ -1,5 +1,0 @@
-import lldbsuite.test.lldbinline as lldbinline
-from lldbsuite.test.decorators import *
-
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipUnlessFoundation, skipIf(oslist=['windows'])
-])

--- a/lldb/test/API/lang/swift/first_expr_module_load/TestSwiftFirstExprModuleLoad.py
+++ b/lldb/test/API/lang/swift/first_expr_module_load/TestSwiftFirstExprModuleLoad.py
@@ -1,0 +1,20 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftFirstExprModuleLoad(lldbtest.TestBase):
+
+    @skipIf(oslist='windows')
+    @swiftTest
+    @skipUnlessFoundation
+    def test_unknown_self_objc_ref(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+        # FIXME: This runs into a known bug where the mangled names
+        # for private types from reflection metadata contain pointer
+        # values as discriminators, but the ones from debug info /
+        # Swift modules contain UUIDs. (rdar://74374120)
+        self.runCmd("settings set symbols.swift-validate-typesystem false")
+        self.expect('expr -d run -- self', substrs=['NSAttributedString'])

--- a/lldb/test/API/lang/swift/first_expr_module_load/main.swift
+++ b/lldb/test/API/lang/swift/first_expr_module_load/main.swift
@@ -5,9 +5,10 @@ protocol MyProtocol {
 }
 
 extension MyProtocol {
-    func foo() -> String {
-        return "\(self)" //%self.expect('expr -d run -- self', substrs=['NSAttributedString'])
-    }
+  func foo() -> String {
+    print("break here")
+    return "\(self)"
+  }
 }
 
 extension NSAttributedString: MyProtocol {}

--- a/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
+++ b/lldb/test/Shell/Swift/Inputs/No.swiftmodule-ObjC.swift
@@ -11,7 +11,7 @@ func f() {
   // FIXME: (ObjCClass) object = {{.*}}Hello from Objective-C!
   let object = ObjCClass()
   // The Objective-C runtime recognizes this as a tagged pointer.
-  // CHECK-DAG: (NSNumber) inlined = {{.*}}Int64(42)
+  // CHECK-DAG: ({{.*}}NS{{.*}}Number) inlined = {{.*}}Int64(42)
   let inlined = NSNumber(value: 42)
   // CHECK-DAG: (CMYK) enumerator = .yellow
   let enumerator = yellow

--- a/lldb/test/Shell/SwiftREPL/DictBridging.test
+++ b/lldb/test/Shell/SwiftREPL/DictBridging.test
@@ -55,7 +55,7 @@ let d_objc1 = NSArray(object: [:] as [NSNumber: NSNumber] as NSDictionary)
 // Verbatim bridging
 let d_objc2 = NSArray(object: [1: 2] as [NSNumber: NSNumber] as NSDictionary)
 // DICT-LABEL: d_objc2: NSArray = 1 element {
-// DICT-NEXT:    [0] = 1 key/value pair {
+// DICT:          = 1 key/value pair {
 // DICT-NEXT:      [0] = {
 // DICT-NEXT:        key = Int64(1)
 // DICT-NEXT:        value = Int64(2)
@@ -66,8 +66,9 @@ let d_objc2 = NSArray(object: [1: 2] as [NSNumber: NSNumber] as NSDictionary)
 // Non-verbatim bridging
 let d_objc3 = NSArray(object: [1: 2] as [Int: Int] as NSDictionary)
 // DICT-LABEL: d_objc3: NSArray = 1 element {
-// DICT-NEXT:    [0] = 1 key/value pair {
-// DICT-NEXT:      [0] = (key = 1, value = 2)
+// DICT:         = 1 key/value pair {
+// DICT:           key = 1
+// DICT:           value = 2
 // DICT-NEXT:    }
 // DICT-NEXT:  }
 

--- a/lldb/test/Shell/SwiftREPL/SetBridging.test
+++ b/lldb/test/Shell/SwiftREPL/SetBridging.test
@@ -44,7 +44,7 @@ let s_objc1 = NSArray(object: [] as Set<NSNumber> as NSSet)
 // Verbatim bridging
 let s_objc2 = NSArray(object: [1] as Set<NSNumber> as NSSet)
 // SET-LABEL: s_objc2: NSArray = 1 element {
-// SET-NEXT:    [0] = 1 value {
+// SET:         = 1 value {
 // SET-NEXT:      [0] = Int64(1)
 // SET-NEXT:    }
 // SET-NEXT:  }
@@ -52,7 +52,7 @@ let s_objc2 = NSArray(object: [1] as Set<NSNumber> as NSSet)
 // Non-verbatim bridging
 let s_objc3 = NSArray(object: [1] as Set<Int> as NSSet)
 // SET-LABEL: s_objc3: NSArray = 1 element {
-// SET-NEXT:    [0] = 1 value {
+// SET:         = 1 value {
 // SET-NEXT:      [0] = 1
 // SET-NEXT:    }
 // SET-NEXT:  }


### PR DESCRIPTION
if the Objective-C runtime fails. If an Objective-C class is lazy, the Objective-C runtie may not have materialized class metadata for it. However, if the class is actually implemented in Swift, we can still resolve it using the Swift runtime. We should probably also add the same logic to the Objective-C runtime, but I don't want risk adding an inifinite recursion at this point in the release.

rdar://145253225
(cherry picked from commit 8458d1033d56e4bc23267eb73830f267a14e1b7e)

 Conflicts:
	lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
	lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h