### PR TITLE
[lldb] Disable statusline on Windows (#138111)

### DIFF
--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -228,7 +228,7 @@ let Definition = "debugger" in {
   def ShowStatusline: Property<"show-statusline", "Boolean">,
     Global,
     DefaultTrue,
-    Desc<"Whether to show a statusline at the bottom of the terminal.">;
+    Desc<"Whether to show a statusline at the bottom of the terminal (not supported on Windows).">;
   def Separator : Property<"separator", "String">,
                   Global,
                   DefaultStringValue<"│ ">,

--- a/lldb/source/Core/Debugger.cpp
+++ b/lldb/source/Core/Debugger.cpp
@@ -2040,6 +2040,9 @@ void Debugger::CancelForwardEvents(const ListenerSP &listener_sp) {
 }
 
 bool Debugger::StatuslineSupported() {
+// We have trouble with the contol codes on Windows, see
+// https://github.com/llvm/llvm-project/issues/134846.
+#ifndef _WIN32
   if (GetShowStatusline()) {
     if (lldb::LockableStreamFileSP stream_sp = GetOutputStreamSP()) {
       File &file = stream_sp->GetUnlockedFile();
@@ -2047,6 +2050,7 @@ bool Debugger::StatuslineSupported() {
              file.GetIsTerminalWithColors();
     }
   }
+#endif
   return false;
 }
 


### PR DESCRIPTION
Something to do with control code handling in Windows terminals breaks the statusline in various ways. It makes LLDB unusable and even if you set the setting to disable statusline, it's too late, and the terminal session is now in a weird state.

See https://github.com/llvm/llvm-project/issues/134846 for more details.

Until we figure this out, don't allow it to be used on Windows.

(cherry picked from commit 09488bcfba77d1a16b0b83c2d6b1135e5e7d5302)