### PR TITLE
[TEST-ONLY] Label clang/test/CAS/depscan-cas-log.c requirements

### DIFF
--- a/clang/test/CAS/depscan-cas-log.c
+++ b/clang/test/CAS/depscan-cas-log.c
@@ -2,6 +2,8 @@
 // It's hard to check this exhaustively, but in practice if the daemon does not
 // enable logging there are currently zero records in the log.
 
+// REQUIRES: system-darwin, clang-cc1daemon
+
 // RUN: rm -rf %t && mkdir %t
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_LOG=1 LLVM_CAS_DISABLE_VALIDATION=1 %clang \
 // RUN:   -cc1depscan -fdepscan=daemon -fdepscan-include-tree -o - \


### PR DESCRIPTION
The test needs to run clang daemon, thus need to make sure the correct requirement is met.

rdar://150819544