### PR TITLE
[Cherry-pick into next] [lldb] Avoid spinnning up a SwiftASTContext just to determine the mangling flavor.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2643,47 +2643,6 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   return swift_ast_sp;
 }
 
-bool SwiftASTContext::CheckFlagInCU(CompileUnit *cu, const char *flag) {
-  AutoBool interop_enabled =
-    ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
-  switch (interop_enabled) {
-  case AutoBool::True:
-    return true;
-  case AutoBool::False:
-    return false;
-  case AutoBool::Auto: {
-    if (!cu)
-      return false;
-    lldb::ModuleSP module = cu->CalculateSymbolContextModule();
-    if (!module)
-      return false;
-    auto *sym_file = module->GetSymbolFile();
-    if (!sym_file)
-      return false;
-    auto options = sym_file->GetCompileOptions();
-    for (auto &[unit, args] : options) {
-      if (unit.get() == cu) {
-        if (cu->GetLanguage() == eLanguageTypeSwift)
-          for (const char *arg : args.GetArgumentArrayRef())
-            if (strcmp(arg, flag) == 0)
-              return true;
-        return false;
-      }
-    }
-  }
-  }
-  return false;
-}
-
-/// Determine whether this CU was compiled with C++ interop enabled.
-bool SwiftASTContext::ShouldEnableCXXInterop(CompileUnit *cu) {
-  return CheckFlagInCU(cu, "-enable-experimental-cxx-interop");
-}
-
-bool SwiftASTContext::ShouldEnableEmbeddedSwift(CompileUnit *cu) {
-  return CheckFlagInCU(cu, "-enable-embedded-swift");
-}
-
 static bool IsUnitTestExecutable(lldb_private::Module &module) {
   static ConstString s_xctest("xctest");
   static ConstString s_XCTRunner("XCTRunner");

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -210,13 +210,6 @@ public:
                  TypeSystemSwiftTypeRef &typeref_typesystem,
                  const char *extra_options = nullptr);
 
-  /// Returns true if the given flag is present in the given compile unit.
-  static bool CheckFlagInCU(CompileUnit *cu, const char *flag);
-
-  static bool ShouldEnableCXXInterop(CompileUnit *cu);
-
-  static bool ShouldEnableEmbeddedSwift(CompileUnit *cu);
-
   static void EnumerateSupportedLanguages(
       std::set<lldb::LanguageType> &languages_for_types,
       std::set<lldb::LanguageType> &languages_for_expressions);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -15,6 +15,7 @@
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "lldb/Core/PluginManager.h"
+#include "lldb/Symbol/CompileUnit.h"
 #include <lldb/lldb-enumerations.h>
 #include <llvm/ADT/StringRef.h>
 
@@ -70,6 +71,47 @@ void TypeSystemSwift::Terminate() {
 }
 
 /// \}
+
+bool TypeSystemSwift::CheckFlagInCU(CompileUnit *cu, const char *flag) {
+  AutoBool interop_enabled =
+    ModuleList::GetGlobalModuleListProperties().GetSwiftEnableCxxInterop();
+  switch (interop_enabled) {
+  case AutoBool::True:
+    return true;
+  case AutoBool::False:
+    return false;
+  case AutoBool::Auto: {
+    if (!cu)
+      return false;
+    lldb::ModuleSP module = cu->CalculateSymbolContextModule();
+    if (!module)
+      return false;
+    auto *sym_file = module->GetSymbolFile();
+    if (!sym_file)
+      return false;
+    auto options = sym_file->GetCompileOptions();
+    for (auto &[unit, args] : options) {
+      if (unit.get() == cu) {
+        if (cu->GetLanguage() == eLanguageTypeSwift)
+          for (const char *arg : args.GetArgumentArrayRef())
+            if (strcmp(arg, flag) == 0)
+              return true;
+        return false;
+      }
+    }
+  }
+  }
+  return false;
+}
+
+/// Determine whether this CU was compiled with C++ interop enabled.
+bool TypeSystemSwift::ShouldEnableCXXInterop(CompileUnit *cu) {
+  return CheckFlagInCU(cu, "-enable-experimental-cxx-interop");
+}
+
+bool TypeSystemSwift::ShouldEnableEmbeddedSwift(CompileUnit *cu) {
+  return CheckFlagInCU(cu, "-enable-embedded-swift");
+}
 
 void TypeSystemSwift::Dump(llvm::raw_ostream &output) {
   // TODO: What to dump?

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -127,6 +127,11 @@ public:
 
   const std::string &GetDescription() const { return m_description; }
   static LanguageSet GetSupportedLanguagesForTypes();
+  /// Returns true if the given flag is present in the given compile unit.
+  static bool CheckFlagInCU(CompileUnit *cu, const char *flag);
+  static bool ShouldEnableCXXInterop(CompileUnit *cu);
+  static bool ShouldEnableEmbeddedSwift(CompileUnit *cu);
+
   virtual SwiftASTContextSP
   GetSwiftASTContext(const SymbolContext &sc) const = 0;
   virtual TypeSystemSwiftTypeRefSP GetTypeSystemSwiftTypeRef() = 0;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -601,6 +601,9 @@ protected:
 
   /// All lldb::Type pointers produced by DWARFASTParser Swift go here.
   ThreadSafeDenseMap<const char *, lldb::TypeSP> m_swift_type_map;
+  /// An LRU cache for \ref GetManglingFlavor().
+  std::pair<CompileUnit *, swift::Mangle::ManglingFlavor> m_lru_is_embedded = {
+      nullptr, swift::Mangle::ManglingFlavor::Default};
 };
 
 /// This one owns a SwiftASTContextForExpressions.


### PR DESCRIPTION
```
commit 5aed050c0d43eaff1708876151e3738186711db1
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed May 7 15:50:04 2025 -0700

    [lldb] Avoid spinnning up a SwiftASTContext just to determine the mangling flavor.
```
