### PR TITLE
[lldb-dap] Add a -v/--version command line argument (#134114)

### DIFF
--- a/lldb/test/Shell/DAP/TestHelp.test
+++ b/lldb/test/Shell/DAP/TestHelp.test
@@ -2,7 +2,6 @@
 # CHECK: -g
 # CHECK: --help
 # CHECK: -h
-# CHECK: --port
-# CHECK: -p
+# CHECK: --repl-mode
+# CHECK: --version
 # CHECK: --wait-for-debugger
-

--- a/lldb/test/Shell/DAP/TestVersion.test
+++ b/lldb/test/Shell/DAP/TestVersion.test
@@ -1,0 +1,3 @@
+# RUN: lldb-dap --version | FileCheck %s
+# CHECK: lldb-dap:
+# CHECK: liblldb:

--- a/lldb/tools/lldb-dap/Options.td
+++ b/lldb/tools/lldb-dap/Options.td
@@ -11,6 +11,12 @@ def: Flag<["-"], "h">,
   Alias<help>,
   HelpText<"Alias for --help">;
 
+def version: F<"version">,
+  HelpText<"Prints out the lldb-dap version.">;
+def: Flag<["-"], "v">,
+  Alias<version>,
+  HelpText<"Alias for --version">;
+
 def wait_for_debugger: F<"wait-for-debugger">,
   HelpText<"Pause the program at startup.">;
 def: Flag<["-"], "g">,

--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -30,7 +30,9 @@
 #include "llvm/Option/OptTable.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/Base64.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Errno.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Path.h"
@@ -5140,6 +5142,12 @@ EXAMPLES:
   llvm::outs() << examples;
 }
 
+static void PrintVersion() {
+  llvm::outs() << "lldb-dap: ";
+  llvm::cl::PrintVersionMessage();
+  llvm::outs() << "liblldb: " << lldb::SBDebugger::GetVersionString() << '\n';
+}
+
 // If --launch-target is provided, this instance of lldb-dap becomes a
 // runInTerminal launcher. It will ultimately launch the program specified in
 // the --launch-target argument, which is the original program the user wanted
@@ -5243,6 +5251,11 @@ int main(int argc, char *argv[]) {
 
   if (input_args.hasArg(OPT_help)) {
     printHelp(T, llvm::sys::path::filename(argv[0]));
+    return EXIT_SUCCESS;
+  }
+
+  if (input_args.hasArg(OPT_version)) {
+    PrintVersion();
     return EXIT_SUCCESS;
   }
 


### PR DESCRIPTION
Add a -v/--version command line argument to print the version of both the lldb-dap binary and the liblldb it's linked against.

This is motivated by me trying to figure out which lldb-dap I had in my PATH.

(cherry picked from commit 18c43d01fc61648369fef50999e7df62b3ec292f)