### PR TITLE
[clang][modules] Test for llvm#139751

### DIFF
--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -919,10 +919,6 @@ public:
           // undesirable dependency on an intermediate build byproduct.
           if (FE->getName().ends_with("module.modulemap"))
             return;
-          // Not reporting SDKSettings.json so that test checks can remain
-          // (mostly) platform-agnostic.
-          if (FE->getName().ends_with("SDKSettings.json"))
-            return;
 
           visitor(*FE, isSystem);
         });

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -919,6 +919,10 @@ public:
           // undesirable dependency on an intermediate build byproduct.
           if (FE->getName().ends_with("module.modulemap"))
             return;
+          // Not reporting SDKSettings.json so that test checks can remain
+          // (mostly) platform-agnostic.
+          if (FE->getName().ends_with("SDKSettings.json"))
+            return;
 
           visitor(*FE, isSystem);
         });

--- a/clang/test/ClangScanDeps/modules-include-tree-sdk-settings.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-sdk-settings.c
@@ -1,0 +1,37 @@
+// This test checks that the module cache gets invalidated when the
+// SDKSettings.json file changes. This prevents "file changed during build"
+// errors when the TU does get rescanned and recompiled.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+//--- sdk/SDKSettings.json
+{
+  "Version": "11.0",
+  "MaximumDeploymentTarget": "11.0.99"
+}
+
+//--- module.modulemap
+module M { header "M.h" }
+//--- M.h
+//--- tu.c
+#include "M.h"
+
+// RUN: clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -o %t/deps_clean.json \
+// RUN:   -- %clang -target x86_64-apple-macos11 -isysroot %t/sdk \
+// RUN:      -c %t/tu.c -o %t/tu.o -fmodules -fmodules-cache-path=%t/cache
+
+// RUN: sleep 1
+// RUN: echo " " >> %t/sdk/SDKSettings.json
+// RUN: echo " " >> %t/tu.c
+
+// RUN: clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -o %t/deps_incremental.json \
+// RUN:   -- %clang -target x86_64-apple-macos11 -isysroot %t/sdk \
+// RUN:      -c %t/tu.c -o %t/tu.o -fmodules -fmodules-cache-path=%t/cache
+
+// RUN: %deps-to-rsp %t/deps_incremental.json --module-name M > %t/M.rsp
+// RUN: %deps-to-rsp %t/deps_incremental.json --tu-index 0 > %t/tu.rsp
+// RUN: %clang @%t/M.rsp
+// RUN: %clang @%t/tu.rsp

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -861,7 +861,10 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
         llvm::outs() << "      " << ModuleName << "\n";
       llvm::outs() << "    file-deps:\n";
       for (const auto &FileName : ArrayRef(FileDeps.Strings, FileDeps.Count))
-        llvm::outs() << "      " << FileName << "\n";
+        // Not reporting SDKSettings.json so that test checks can remain
+        // (mostly) platform-agnostic.
+        if (!StringRef(FileName).ends_with("SDKSettings.json"))
+          llvm::outs() << "      " << FileName << "\n";
       llvm::outs() << "    build-args:";
       for (const auto &Arg :
            ArrayRef(BuildArguments.Strings, BuildArguments.Count))


### PR DESCRIPTION
The input file section in module files only stored files loaded into the `SourceManager`. When rebuilding the module cache, include-trees also include other files, like the SDKSettings.json file. If we don't invalidate the module cache when that file changes, the corresponding include-trees won't agree with the primary TU include-tree on the file contents. This was fixed in llvm#139751 and this PR adds an include tree test.

I intentionally suppress reporting of this new file in tests, so that I don't have go updating ~all of them. This file is getting reported by the scanning C API, so that the build system is given the ability to eventually act on this file being out-of-date.

rdar://149868539