### PR TITLE
[TEST-ONLY][CAS] Fix clang caching testing after search path change

### DIFF
--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -64,7 +64,6 @@
 //
 // CHECK-ROOT:      tree
 // CHECK-ROOT-SAME:             /^objroot/test/CAS/{{$}}
-// CHECK-ROOT-NEXT: tree {{.*}} /^sdk/Library/Frameworks/{{$}}
 // CHECK-ROOT-NEXT: file {{.*}} /^source/depscan-prefix-map.c{{$}}
 // CHECK-ROOT-NEXT: file {{.*}} /^toolchain/usr/lib/clang/1000/include/stdarg.h{{$}}
 


### PR DESCRIPTION
Update clang CAS tests after search path change that results in less directories being captured.