### PR TITLE
[Cherry-pick into next] [lldb] Factor our binding generic variadic types (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -868,8 +868,14 @@ std::string SwiftLanguageRuntime::GetObjectDescriptionExpr_Copy(
 
   auto swift_ast_ctx =
       static_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (swift_ast_ctx)
-    static_type = BindGenericTypeParameters(*frame_sp, static_type);
+  if (swift_ast_ctx) {
+    auto bound_type_or_err = BindGenericTypeParameters(*frame_sp, static_type);
+    if (!bound_type_or_err) {
+      LLDB_LOG_ERROR(log, bound_type_or_err.takeError(), "{0}");
+      return {};
+    }
+    static_type = *bound_type_or_err;
+  }
 
   auto stride = 0;
   auto opt_stride = static_type.GetByteStride(frame_sp.get());

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -273,6 +273,9 @@ public:
                                 Address &address, Value::ValueType &value_type,
                                 llvm::ArrayRef<uint8_t> &local_buffer) override;
 
+  llvm::Expected<CompilerType> BindGenericPackType(StackFrame &frame,
+                                                   CompilerType pack_type,
+                                                   bool *indirect = nullptr);
   CompilerType BindGenericTypeParameters(
       CompilerType unbound_type,
       std::function<CompilerType(unsigned, unsigned)> finder);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -346,12 +346,20 @@ public:
     unsigned dependent_generic_param_count = 0;
     unsigned num_counts = 0;
 
-    unsigned GetNumValuePacks() { return count_for_value_pack.size(); }
-    unsigned GetNumTypePacks() { return count_for_type_pack.size(); }
-    unsigned GetCountForValuePack(unsigned i) {
+    unsigned GetNumValuePacks() const { return count_for_value_pack.size(); }
+    unsigned GetNumTypePacks() const { return count_for_type_pack.size(); }
+    unsigned GetCountForValuePack(unsigned i) const {
       return count_for_value_pack[i];
     }
-    unsigned GetCountForTypePack(unsigned i) { return count_for_type_pack[i]; }
+    unsigned GetCountForTypePack(unsigned i) const { return count_for_type_pack[i]; }
+    bool HasPacks() const { return pack_expansions.size(); }
+    bool IsPack(unsigned depth, unsigned index) const {
+      if (HasPacks())
+        for (auto param : generic_params)
+          if (param.depth == depth && param.index == index)
+            return param.is_pack;
+      return false;
+    }
   };
   /// Extract the generic signature out of a mangled Swift function name.
   static std::optional<GenericSignature>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -370,8 +370,8 @@ public:
   /// version of \p base_type that replaces all generic type
   /// parameters with bound generic types. If a generic type parameter
   /// cannot be resolved, the input type is returned.
-  CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
-                                         CompilerType base_type);
+  llvm::Expected<CompilerType>
+  BindGenericTypeParameters(StackFrame &stack_frame, CompilerType base_type);
 
   bool IsStoredInlineInBuffer(CompilerType type) override;
 
@@ -591,13 +591,14 @@ protected:
   GetRemoteASTContext(SwiftASTContext &swift_ast_ctx);
 
   /// Like \p BindGenericTypeParameters but for TypeSystemSwiftTypeRef.
-  CompilerType BindGenericTypeParameters(StackFrame &stack_frame,
-                                         TypeSystemSwiftTypeRef &ts,
-                                         ConstString mangled_name);
+  llvm::Expected<CompilerType>
+  BindGenericTypeParameters(StackFrame &stack_frame, TypeSystemSwiftTypeRef &ts,
+                            ConstString mangled_name);
 
   /// Like \p BindGenericTypeParameters but for RemoteAST.
-  CompilerType BindGenericTypeParametersRemoteAST(StackFrame &stack_frame,
-                                                  CompilerType base_type);
+  llvm::Expected<CompilerType>
+  BindGenericTypeParametersRemoteAST(StackFrame &stack_frame,
+                                     CompilerType base_type);
 
   bool GetDynamicTypeAndAddress_Pack(ValueObject &in_value,
                                      CompilerType pack_type,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -694,9 +694,15 @@ void SwiftLanguageRuntime::GetGenericParameterNamesForFunction(
         break;
       CompilerType generic_type =
           ts->CreateGenericTypeParamType(depth, index, flavor);
-      CompilerType bound_type =
+      llvm::Expected<CompilerType> bound_type_or_err =
           runtime->BindGenericTypeParameters(*frame, generic_type);
-      type_name = bound_type.GetDisplayTypeName();
+      if (!bound_type_or_err) {
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions | LLDBLog::Types),
+                       bound_type_or_err.takeError(), "{0}");
+        break;
+      }
+
+      type_name = bound_type_or_err->GetDisplayTypeName();
       break;
     }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -132,7 +132,9 @@ std::optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffsetRemoteAST(
     // Bind generic parameters if necessary.
     if (instance && swift_type->hasTypeParameter())
       if (auto *frame = instance->GetExecutionContextRef().GetFrameSP().get())
-        if (auto bound = BindGenericTypeParameters(*frame, instance_type)) {
+        if (auto bound = llvm::expectedToOptional(
+                             BindGenericTypeParameters(*frame, instance_type))
+                             .value_or(CompilerType())) {
           LLDB_LOGF(
               GetLog(LLDBLog::Types),
               "[MemberVariableOffsetResolver] resolved non-class type = %s",
@@ -265,7 +267,8 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialRemoteAST(
 }
 #endif
 
-CompilerType SwiftLanguageRuntime::BindGenericTypeParametersRemoteAST(
+llvm::Expected<CompilerType>
+SwiftLanguageRuntime::BindGenericTypeParametersRemoteAST(
     StackFrame &stack_frame, CompilerType base_type) {
   LLDB_SCOPED_TIMER();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5863,7 +5863,9 @@ BindGenericTypeParameters(CompilerType type, ExecutionContextScope *exe_scope) {
     return type;
   ExecutionContext exe_ctx;
   exe_scope->CalculateExecutionContext(exe_ctx);
-  if (auto bound = runtime->BindGenericTypeParameters(*frame, type))
+  if (auto bound = llvm::expectedToOptional(
+                       runtime->BindGenericTypeParameters(*frame, type))
+                       .value_or(CompilerType()))
     return bound;
   return type;
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -366,6 +366,17 @@ public:
       std::function<swift::Demangle::NodePointer(swift::Demangle::NodePointer)>
           visitor);
 
+  /// Recursively transform the demangle tree starting a \p node by
+  /// doing a post-order traversal and replacing each node with
+  /// fn(node).
+  /// The NodePointer passed to \p fn is guaranteed to be non-null.
+  static llvm::Expected<swift::Demangle::NodePointer>
+  TryTransform(swift::Demangle::Demangler &dem,
+               swift::Demangle::NodePointer node,
+               std::function<llvm::Expected<swift::Demangle::NodePointer>(
+                   swift::Demangle::NodePointer)>
+                   visitor);
+
   /// A left-to-right preorder traversal. Don't visit children if
   /// visitor returns false.
   static void


### PR DESCRIPTION
```
commit d7572b37c29c9adf9ff9f1c5aafbf13575e6d3ff
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue May 13 09:50:35 2025 -0700

    [lldb] Factor our binding generic variadic types (NFC)

commit 50f15f2a48716ab000b0ff906b163e5813da6a3d
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue May 13 16:12:21 2025 -0700

    [lldb] Make variadic generic types work with TypeSystemSwiftTypeRef
    
    The missing ingredient were the reflection support for pack types, and
    binding pack type in BindGenericParameters().
    
    rdar://145257088

commit e48e8aad0b3b1808260e520b1f92f0e608f15ce9
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue May 13 16:58:07 2025 -0700

    [lldb] Convert BindGenericTypeParameters to llvm::Expected
```
