### PR TITLE
Ignore SDKSettings.json in IndexingAction.cpp

### DIFF
--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -919,6 +919,10 @@ public:
           // undesirable dependency on an intermediate build byproduct.
           if (FE->getName().ends_with("module.modulemap"))
             return;
+          // Ignore SDKSettings.json, they are not important to track for
+          // indexing.
+          if (FE->getName().ends_with("SDKSettings.json"))
+            return;
 
           visitor(*FE, isSystem);
         });


### PR DESCRIPTION
This fixes the Index/Store/handle-prebuilt-module.m test that started failing after llvm#139751.