### PR TITLE
[clang] Enable making `CompilerInstance` output backend thread-safe

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1418,10 +1418,15 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompileImpl(
   auto WrapGenModuleAction = getGenModuleActionWrapper();
   Instance.setGenModuleActionWrapper(WrapGenModuleAction);
 
-  // Share an output manager.
   assert(hasOutputBackend() &&
          "Expected an output manager to already be set up");
-  Instance.setOutputBackend(&getOutputBackend());
+  if (ThreadSafeConfig) {
+    // Create a clone of the existing output (pointing to the same destination).
+    Instance.setOutputBackend(getOutputBackend().clone());
+  } else {
+    // Share the existing output manager.
+    Instance.setOutputBackend(&getOutputBackend());
+  }
 
   if (ThreadSafeConfig) {
     Instance.setModuleDepCollector(ThreadSafeConfig->getModuleDepCollector());


### PR DESCRIPTION
This is a continuation of upstream PRs that aim to allow creating copies of a parent `CompilerInstance` that can be used concurrently:
* https://github.com/llvm/llvm-project/pull/135473
* https://github.com/llvm/llvm-project/pull/135737
* https://github.com/llvm/llvm-project/pull/136178
* https://github.com/llvm/llvm-project/pull/136601
* https://github.com/llvm/llvm-project/pull/137059
* https://github.com/llvm/llvm-project/pull/137227

This PR implements that property to the output backend.