### PR TITLE
[lldb] Add support for Task names

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1870,13 +1870,15 @@ bool lldb_private::formatters::swift::Task_SummaryProvider(
   };
 
   addr_t task_addr = get_member("address");
-  if (auto name_or_err = GetTaskName(task_addr, valobj.GetProcessSP().get())) {
-    if (auto maybe_name = *name_or_err)
-      stream.Format("\"{0}\" ", *maybe_name);
-  } else {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
-                   name_or_err.takeError(),
-                   "failed to determine name of task {1:x}: {0}", task_addr);
+  if (auto process_sp = valobj.GetProcessSP()) {
+    if (auto name_or_err = GetTaskName(task_addr, *process_sp)) {
+      if (auto maybe_name = *name_or_err)
+        stream.Format("\"{0}\" ", *maybe_name);
+    } else {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
+                     name_or_err.takeError(),
+                     "failed to determine name of task {1:x}: {0}", task_addr);
+    }
   }
 
   stream.Format("id:{0}", get_member("id"));

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1869,6 +1869,16 @@ bool lldb_private::formatters::swift::Task_SummaryProvider(
     return 0;
   };
 
+  addr_t task_addr = get_member("address");
+  if (auto name_or_err = GetTaskName(task_addr, valobj.GetProcessSP().get())) {
+    if (auto maybe_name = *name_or_err)
+      stream.Format("\"{0}\" ", *maybe_name);
+  } else {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
+                   name_or_err.takeError(),
+                   "failed to determine name of task {1:x}: {0}", task_addr);
+  }
+
   stream.Format("id:{0}", get_member("id"));
 
   std::vector<StringRef> flags;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -41,10 +41,12 @@
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/UnwindLLDB.h"
+#include "lldb/Utility/ConstString.h"
 #include "lldb/Utility/ErrorMessages.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/OptionParsing.h"
+#include "lldb/Utility/Status.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/Timer.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -68,6 +70,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FormatAdapters.h"
 #include "llvm/Support/Memory.h"
+#include <optional>
 
 // FIXME: we should not need this
 #include "Plugins/Language/Swift/SwiftFormatters.h"
@@ -2937,4 +2940,87 @@ llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
   return task_addr;
 #endif
 }
+
+namespace {
+
+struct TaskStatusRecord {
+  Process *process;
+  addr_t addr;
+
+  operator bool() const { return addr && addr != LLDB_INVALID_ADDRESS; }
+
+  static constexpr offset_t FlagsOffset = 0x0;
+  static constexpr offset_t ParentOffset = 0x8;
+  static constexpr offset_t TaskNameOffset = 0x10;
+
+  enum Kind : uint64_t {
+    TaskName = 6,
+  };
+
+  uint64_t getKind(Status &status) {
+    if (status.Success())
+      return process->ReadUnsignedIntegerFromMemory(
+          addr + FlagsOffset, sizeof(uint64_t), UINT64_MAX, status);
+    return UINT64_MAX;
+  }
+
+  std::optional<std::string> getName(Status &status) {
+    if (getKind(status) != Kind::TaskName)
+      return {};
+
+    addr_t name_addr =
+        process->ReadPointerFromMemory(addr + TaskNameOffset, status);
+    if (!status.Success())
+      return {};
+
+    std::string name;
+    process->ReadCStringFromMemory(name_addr, name, status);
+    if (status.Success())
+      return name;
+
+    return {};
+  }
+
+  TaskStatusRecord getParent(Status &status) {
+    addr_t parent = LLDB_INVALID_ADDRESS;
+    if (*this && status.Success())
+      parent = process->ReadPointerFromMemory(addr + ParentOffset, status);
+    return {process, parent};
+  }
+};
+
+struct Task {
+  Process *process;
+  addr_t addr;
+
+  operator bool() const { return addr && addr != LLDB_INVALID_ADDRESS; }
+
+  static constexpr offset_t ActiveTaskStatusRecordOffset = 0x8 * 13;
+
+  TaskStatusRecord getActiveTaskStatusRecord(Status &status) {
+    addr_t status_record = LLDB_INVALID_ADDRESS;
+    if (status.Success())
+      status_record = process->ReadPointerFromMemory(
+          addr + ActiveTaskStatusRecordOffset, status);
+    return {process, status_record};
+  }
+};
+
+}; // namespace
+
+llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task_addr,
+                                                       Process *process) {
+  Status status;
+  Task task{process, task_addr};
+  auto status_record = task.getActiveTaskStatusRecord(status);
+  while (status_record) {
+    if (auto name = status_record.getName(status))
+      return *name;
+    status_record = status_record.getParent(status);
+  }
+  if (status.Success())
+    return std::nullopt;
+  return status.takeError();
+}
+
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -39,6 +39,7 @@
 #include "lldb/Symbol/FuncUnwinders.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/VariableList.h"
+#include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
 #include "lldb/Target/UnwindLLDB.h"
 #include "lldb/Utility/ConstString.h"
@@ -2951,21 +2952,30 @@ namespace {
 struct TaskStatusRecord {
   Process &process;
   addr_t addr;
+  size_t addr_size;
+
+  TaskStatusRecord(Process &process, addr_t addr)
+      : process(process), addr(addr) {
+    addr_size = process.GetAddressByteSize();
+  }
 
   operator bool() const { return addr && addr != LLDB_INVALID_ADDRESS; }
 
-  static constexpr offset_t FlagsOffset = 0x0;
-  static constexpr offset_t ParentOffset = 0x8;
-  static constexpr offset_t TaskNameOffset = 0x10;
+  // The offset of TaskStatusRecord members. The unit is pointers, and must be
+  // converted to bytes based on the target's address size.
+  static constexpr offset_t FlagsPointerOffset = 0;
+  static constexpr offset_t ParentPointerOffset = 1;
+  static constexpr offset_t TaskNamePointerOffset = 2;
 
   enum Kind : uint64_t {
     TaskName = 6,
   };
 
   uint64_t getKind(Status &status) {
+    const offset_t flagsByteOffset = FlagsPointerOffset * addr_size;
     if (status.Success())
       return process.ReadUnsignedIntegerFromMemory(
-          addr + FlagsOffset, sizeof(uint64_t), UINT64_MAX, status);
+          addr + flagsByteOffset, addr_size, UINT64_MAX, status);
     return UINT64_MAX;
   }
 
@@ -2973,8 +2983,9 @@ struct TaskStatusRecord {
     if (getKind(status) != Kind::TaskName)
       return {};
 
+    const offset_t taskNameByteOffset = TaskNamePointerOffset * addr_size;
     addr_t name_addr =
-        process.ReadPointerFromMemory(addr + TaskNameOffset, status);
+        process.ReadPointerFromMemory(addr + taskNameByteOffset, status);
     if (!status.Success())
       return {};
 
@@ -2987,9 +2998,10 @@ struct TaskStatusRecord {
   }
 
   addr_t getParent(Status &status) {
+    const offset_t parentByteOffset = ParentPointerOffset * addr_size;
     addr_t parent = LLDB_INVALID_ADDRESS;
     if (*this && status.Success())
-      parent = process.ReadPointerFromMemory(addr + ParentOffset, status);
+      parent = process.ReadPointerFromMemory(addr + parentByteOffset, status);
     return parent;
   }
 };

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3002,13 +3002,17 @@ struct Task {
 
   operator bool() const { return addr && addr != LLDB_INVALID_ADDRESS; }
 
-  static constexpr offset_t ActiveTaskStatusRecordOffset = 0x8 * 13;
+  // The offset of the active TaskStatusRecord pointer. The unit is pointers,
+  // and must be converted to bytes based on the target's address size.
+  static constexpr unsigned ActiveTaskStatusRecordPointerOffset = 13;
 
   TaskStatusRecord getActiveTaskStatusRecord(Status &status) {
+    const offset_t activeTaskStatusRecordByteOffset =
+        ActiveTaskStatusRecordPointerOffset * process.GetAddressByteSize();
     addr_t status_record = LLDB_INVALID_ADDRESS;
     if (status.Success())
       status_record = process.ReadPointerFromMemory(
-          addr + ActiveTaskStatusRecordOffset, status);
+          addr + activeTaskStatusRecordByteOffset, status);
     return {process, status_record};
   }
 };

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2963,9 +2963,9 @@ struct TaskStatusRecord {
 
   // The offset of TaskStatusRecord members. The unit is pointers, and must be
   // converted to bytes based on the target's address size.
-  static constexpr offset_t FlagsPointerOffset = 0;
-  static constexpr offset_t ParentPointerOffset = 1;
-  static constexpr offset_t TaskNamePointerOffset = 2;
+  static constexpr unsigned FlagsPointerOffset = 0;
+  static constexpr unsigned ParentPointerOffset = 1;
+  static constexpr unsigned TaskNamePointerOffset = 2;
 
   enum Kind : uint64_t {
     TaskName = 6,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2943,8 +2943,13 @@ llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
 
 namespace {
 
+/// Lightweight wrapper around TaskStatusRecord pointers, providing:
+///   * traversal over the embedded linnked list of status records
+///   * information contained within records
+///
+/// Currently supports TaskNameStatusRecord. See swift/ABI/TaskStatus.h
 struct TaskStatusRecord {
-  Process *process;
+  Process &process;
   addr_t addr;
 
   operator bool() const { return addr && addr != LLDB_INVALID_ADDRESS; }
@@ -2959,7 +2964,7 @@ struct TaskStatusRecord {
 
   uint64_t getKind(Status &status) {
     if (status.Success())
-      return process->ReadUnsignedIntegerFromMemory(
+      return process.ReadUnsignedIntegerFromMemory(
           addr + FlagsOffset, sizeof(uint64_t), UINT64_MAX, status);
     return UINT64_MAX;
   }
@@ -2969,28 +2974,30 @@ struct TaskStatusRecord {
       return {};
 
     addr_t name_addr =
-        process->ReadPointerFromMemory(addr + TaskNameOffset, status);
+        process.ReadPointerFromMemory(addr + TaskNameOffset, status);
     if (!status.Success())
       return {};
 
     std::string name;
-    process->ReadCStringFromMemory(name_addr, name, status);
+    process.ReadCStringFromMemory(name_addr, name, status);
     if (status.Success())
       return name;
 
     return {};
   }
 
-  TaskStatusRecord getParent(Status &status) {
+  addr_t getParent(Status &status) {
     addr_t parent = LLDB_INVALID_ADDRESS;
     if (*this && status.Success())
-      parent = process->ReadPointerFromMemory(addr + ParentOffset, status);
-    return {process, parent};
+      parent = process.ReadPointerFromMemory(addr + ParentOffset, status);
+    return parent;
   }
 };
 
+/// Lightweight wrapper around Task pointers, providing access to a Task's
+/// active status record. See swift/ABI/Task.h
 struct Task {
-  Process *process;
+  Process &process;
   addr_t addr;
 
   operator bool() const { return addr && addr != LLDB_INVALID_ADDRESS; }
@@ -3000,7 +3007,7 @@ struct Task {
   TaskStatusRecord getActiveTaskStatusRecord(Status &status) {
     addr_t status_record = LLDB_INVALID_ADDRESS;
     if (status.Success())
-      status_record = process->ReadPointerFromMemory(
+      status_record = process.ReadPointerFromMemory(
           addr + ActiveTaskStatusRecordOffset, status);
     return {process, status_record};
   }
@@ -3009,14 +3016,14 @@ struct Task {
 }; // namespace
 
 llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task_addr,
-                                                       Process *process) {
+                                                       Process &process) {
   Status status;
   Task task{process, task_addr};
   auto status_record = task.getActiveTaskStatusRecord(status);
   while (status_record) {
     if (auto name = status_record.getName(status))
       return *name;
-    status_record = status_record.getParent(status);
+    status_record.addr = status_record.getParent(status);
   }
   if (status.Success())
     return std::nullopt;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -19,6 +19,7 @@
 #include "lldb/Breakpoint/BreakpointPrecondition.h"
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Target/LanguageRuntime.h"
+#include "lldb/Target/Process.h"
 #include "lldb/lldb-private.h"
 #include "swift/Demangling/ManglingFlavor.h"
 
@@ -901,6 +902,10 @@ GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 /// Inspects thread local storage to find the address of the currently executing
 /// task.
 llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
+
+llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task,
+                                                       Process *process);
+
 } // namespace lldb_private
 
 #endif // liblldb_SwiftLanguageRuntime_h_

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -904,7 +904,7 @@ GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
 
 llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task,
-                                                       Process *process);
+                                                       Process &process);
 
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -76,12 +76,7 @@ OperatingSystemSwiftTasks::~OperatingSystemSwiftTasks() = default;
 
 OperatingSystemSwiftTasks::OperatingSystemSwiftTasks(
     lldb_private::Process &process)
-    : OperatingSystem(&process) {
-  size_t ptr_size = process.GetAddressByteSize();
-  // Offset of a Task ID inside a Task data structure, guaranteed by the ABI.
-  // See Job in swift/RemoteInspection/RuntimeInternals.h.
-  m_job_id_offset = 4 * ptr_size + 4;
-}
+    : OperatingSystem(&process) {}
 
 ThreadSP OperatingSystemSwiftTasks::FindOrCreateSwiftThread(
     ThreadList &old_thread_list, uint64_t task_id,
@@ -118,13 +113,17 @@ static std::optional<addr_t> FindTaskAddress(Thread &thread) {
   return *task_addr;
 }
 
-std::optional<uint64_t>
-OperatingSystemSwiftTasks::FindTaskId(addr_t task_addr) {
+static std::optional<uint64_t> FindTaskId(addr_t task_addr, Process &process) {
+  size_t ptr_size = process.GetAddressByteSize();
+  // Offset of a Task ID inside a Task data structure, guaranteed by the ABI.
+  // See Job in swift/RemoteInspection/RuntimeInternals.h.
+  const offset_t job_id_offset = 4 * ptr_size + 4;
+
   Status error;
-  // The Task ID is at offset m_job_id_offset from the Task pointer.
+  // The Task ID is at offset job_id_offset from the Task pointer.
   constexpr uint32_t num_bytes_task_id = 4;
-  auto task_id = m_process->ReadUnsignedIntegerFromMemory(
-      task_addr + m_job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
+  auto task_id = process.ReadUnsignedIntegerFromMemory(
+      task_addr + job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
       error);
   if (error.Fail())
     return {};
@@ -163,14 +162,14 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
       continue;
     }
 
-    std::optional<uint64_t> task_id = FindTaskId(*task_addr);
+    assert(m_process != nullptr);
+    std::optional<uint64_t> task_id = FindTaskId(*task_addr, *m_process);
     if (!task_id) {
       LLDB_LOG(log, "OperatingSystemSwiftTasks: could not get ID of Task {0:x}",
                *task_addr);
       continue;
     }
 
-    assert(m_process != nullptr);
     ThreadSP swift_thread = FindOrCreateSwiftThread(
         old_thread_list, *task_id, FindTaskName(*task_addr, *m_process));
     swift_thread->SetBackingThread(real_thread);

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/Support/Error.h"
+#include <optional>
 #if LLDB_ENABLE_SWIFT
 
 #include "OperatingSystemSwiftTasks.h"
@@ -81,9 +83,9 @@ OperatingSystemSwiftTasks::OperatingSystemSwiftTasks(
   m_job_id_offset = 4 * ptr_size + 4;
 }
 
-ThreadSP
-OperatingSystemSwiftTasks::FindOrCreateSwiftThread(ThreadList &old_thread_list,
-                                                   uint64_t task_id) {
+ThreadSP OperatingSystemSwiftTasks::FindOrCreateSwiftThread(
+    ThreadList &old_thread_list, uint64_t task_id,
+    std::optional<std::string> task_name) {
   // Mask higher bits to avoid conflicts with core thread IDs.
   uint64_t masked_task_id = 0x0000000f00000000 | task_id;
 
@@ -92,7 +94,11 @@ OperatingSystemSwiftTasks::FindOrCreateSwiftThread(ThreadList &old_thread_list,
       IsOperatingSystemPluginThread(old_thread))
     return old_thread;
 
-  std::string name = llvm::formatv("Swift Task {0}", task_id);
+  std::string name;
+  if (task_name)
+    name = llvm::formatv("{0} (Task {1})", *task_name, task_id);
+  else
+    name = llvm::formatv("Task {0}", task_id);
   return std::make_shared<ThreadMemoryProvidingName>(*m_process, masked_task_id,
                                                      /*register_data_addr*/ 0,
                                                      name);
@@ -105,7 +111,12 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
   LLDB_LOG(log, "OperatingSystemSwiftTasks: Updating thread list");
 
   for (const ThreadSP &real_thread : core_thread_list.Threads()) {
-    std::optional<uint64_t> task_id = FindTaskId(*real_thread);
+    std::optional<uint64_t> task_id;
+    std::optional<std::string> task_name;
+    if (auto task_addr = FindTaskAddress(*real_thread)) {
+      task_id = FindTaskId(*task_addr);
+      task_name = FindTaskName(*task_addr, m_process);
+    }
 
     // If this is not a thread running a Task, add it to the list as is.
     if (!task_id) {
@@ -117,7 +128,8 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
       continue;
     }
 
-    ThreadSP swift_thread = FindOrCreateSwiftThread(old_thread_list, *task_id);
+    ThreadSP swift_thread = FindOrCreateSwiftThread(old_thread_list, *task_id,
+                                                    std::move(task_name));
     swift_thread->SetBackingThread(real_thread);
     new_thread_list.AddThread(swift_thread);
     LLDB_LOGF(log,
@@ -142,24 +154,42 @@ StopInfoSP OperatingSystemSwiftTasks::CreateThreadStopReason(
   return thread->GetStopInfo();
 }
 
-std::optional<uint64_t> OperatingSystemSwiftTasks::FindTaskId(Thread &thread) {
+std::optional<addr_t>
+OperatingSystemSwiftTasks::FindTaskAddress(Thread &thread) {
   llvm::Expected<addr_t> task_addr = GetTaskAddrFromThreadLocalStorage(thread);
   if (!task_addr) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::OS), task_addr.takeError(),
                    "OperatingSystemSwiftTasks: failed to find task address in "
                    "thread local storage: {0}");
-    return {};
+    return std::nullopt;
   }
+  return *task_addr;
+}
 
+std::optional<uint64_t>
+OperatingSystemSwiftTasks::FindTaskId(addr_t task_addr) {
   Status error;
   // The Task ID is at offset m_job_id_offset from the Task pointer.
   constexpr uint32_t num_bytes_task_id = 4;
   auto task_id = m_process->ReadUnsignedIntegerFromMemory(
-      *task_addr + m_job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
+      task_addr + m_job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
       error);
   if (error.Fail())
     return {};
   return task_id;
+}
+
+std::optional<std::string>
+OperatingSystemSwiftTasks::FindTaskName(addr_t task_addr, Process *process) {
+  auto task_name_or_err = GetTaskName(task_addr, process);
+  if (auto err = task_name_or_err.takeError()) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::OS), std::move(err),
+                   "OperatingSystemSwiftTasks: failed while looking for name "
+                   "of task {1:x}: {0}",
+                   task_addr);
+    return {};
+  }
+  return *task_name_or_err;
 }
 
 #endif // #if LLDB_ENABLE_SWIFT

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -133,11 +133,8 @@ OperatingSystemSwiftTasks::FindTaskId(std::optional<addr_t> task_addr) {
 }
 
 static std::optional<std::string> FindTaskName(addr_t task_addr,
-                                               Process *process) {
-  if (!process)
-    return {};
-
-  auto task_name_or_err = GetTaskName(task_addr, *process);
+                                               Process &process) {
+  auto task_name_or_err = GetTaskName(task_addr, process);
   if (auto err = task_name_or_err.takeError()) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::OS), std::move(err),
                    "OperatingSystemSwiftTasks: failed while looking for name "
@@ -174,8 +171,9 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
       continue;
     }
 
+    assert(m_process != nullptr);
     ThreadSP swift_thread = FindOrCreateSwiftThread(
-        old_thread_list, *task_id, FindTaskName(*task_addr, m_process));
+        old_thread_list, *task_id, FindTaskName(*task_addr, *m_process));
     swift_thread->SetBackingThread(real_thread);
     new_thread_list.AddThread(swift_thread);
     LLDB_LOGF(log,

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -113,19 +113,18 @@ static std::optional<addr_t> FindTaskAddress(Thread &thread) {
                    "thread local storage: {0}");
     return {};
   }
+  if (*task_addr == 0 || *task_addr == LLDB_INVALID_ADDRESS)
+    return std::nullopt;
   return *task_addr;
 }
 
 std::optional<uint64_t>
-OperatingSystemSwiftTasks::FindTaskId(std::optional<addr_t> task_addr) {
-  if (!task_addr || *task_addr == LLDB_INVALID_ADDRESS)
-    return {};
-
+OperatingSystemSwiftTasks::FindTaskId(addr_t task_addr) {
   Status error;
   // The Task ID is at offset m_job_id_offset from the Task pointer.
   constexpr uint32_t num_bytes_task_id = 4;
   auto task_id = m_process->ReadUnsignedIntegerFromMemory(
-      *task_addr + m_job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
+      task_addr + m_job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
       error);
   if (error.Fail())
     return {};
@@ -164,7 +163,7 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
       continue;
     }
 
-    std::optional<uint64_t> task_id = FindTaskId(task_addr);
+    std::optional<uint64_t> task_id = FindTaskId(*task_addr);
     if (!task_id) {
       LLDB_LOG(log, "OperatingSystemSwiftTasks: could not get ID of Task {0:x}",
                *task_addr);

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -99,9 +99,53 @@ ThreadSP OperatingSystemSwiftTasks::FindOrCreateSwiftThread(
     name = llvm::formatv("{0} (Task {1})", *task_name, task_id);
   else
     name = llvm::formatv("Task {0}", task_id);
+
   return std::make_shared<ThreadMemoryProvidingName>(*m_process, masked_task_id,
                                                      /*register_data_addr*/ 0,
                                                      name);
+}
+
+static std::optional<addr_t> FindTaskAddress(Thread &thread) {
+  llvm::Expected<addr_t> task_addr = GetTaskAddrFromThreadLocalStorage(thread);
+  if (!task_addr) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::OS), task_addr.takeError(),
+                   "OperatingSystemSwiftTasks: failed to find task address in "
+                   "thread local storage: {0}");
+    return {};
+  }
+  return *task_addr;
+}
+
+std::optional<uint64_t>
+OperatingSystemSwiftTasks::FindTaskId(std::optional<addr_t> task_addr) {
+  if (!task_addr || *task_addr == LLDB_INVALID_ADDRESS)
+    return {};
+
+  Status error;
+  // The Task ID is at offset m_job_id_offset from the Task pointer.
+  constexpr uint32_t num_bytes_task_id = 4;
+  auto task_id = m_process->ReadUnsignedIntegerFromMemory(
+      *task_addr + m_job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
+      error);
+  if (error.Fail())
+    return {};
+  return task_id;
+}
+
+static std::optional<std::string> FindTaskName(addr_t task_addr,
+                                               Process *process) {
+  if (!process)
+    return {};
+
+  auto task_name_or_err = GetTaskName(task_addr, *process);
+  if (auto err = task_name_or_err.takeError()) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::OS), std::move(err),
+                   "OperatingSystemSwiftTasks: failed while looking for name "
+                   "of task {1:x}: {0}",
+                   task_addr);
+    return {};
+  }
+  return *task_name_or_err;
 }
 
 bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
@@ -111,15 +155,10 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
   LLDB_LOG(log, "OperatingSystemSwiftTasks: Updating thread list");
 
   for (const ThreadSP &real_thread : core_thread_list.Threads()) {
-    std::optional<uint64_t> task_id;
-    std::optional<std::string> task_name;
-    if (auto task_addr = FindTaskAddress(*real_thread)) {
-      task_id = FindTaskId(*task_addr);
-      task_name = FindTaskName(*task_addr, m_process);
-    }
+    std::optional<addr_t> task_addr = FindTaskAddress(*real_thread);
 
     // If this is not a thread running a Task, add it to the list as is.
-    if (!task_id) {
+    if (!task_addr) {
       new_thread_list.AddThread(real_thread);
       LLDB_LOGF(log,
                 "OperatingSystemSwiftTasks: thread %" PRIx64
@@ -128,8 +167,15 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
       continue;
     }
 
-    ThreadSP swift_thread = FindOrCreateSwiftThread(old_thread_list, *task_id,
-                                                    std::move(task_name));
+    std::optional<uint64_t> task_id = FindTaskId(task_addr);
+    if (!task_id) {
+      LLDB_LOG(log, "OperatingSystemSwiftTasks: could not get ID of Task {0:x}",
+               *task_addr);
+      continue;
+    }
+
+    ThreadSP swift_thread = FindOrCreateSwiftThread(
+        old_thread_list, *task_id, FindTaskName(*task_addr, m_process));
     swift_thread->SetBackingThread(real_thread);
     new_thread_list.AddThread(swift_thread);
     LLDB_LOGF(log,
@@ -152,44 +198,6 @@ RegisterContextSP OperatingSystemSwiftTasks::CreateRegisterContextForThread(
 StopInfoSP OperatingSystemSwiftTasks::CreateThreadStopReason(
     lldb_private::Thread *thread) {
   return thread->GetStopInfo();
-}
-
-std::optional<addr_t>
-OperatingSystemSwiftTasks::FindTaskAddress(Thread &thread) {
-  llvm::Expected<addr_t> task_addr = GetTaskAddrFromThreadLocalStorage(thread);
-  if (!task_addr) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::OS), task_addr.takeError(),
-                   "OperatingSystemSwiftTasks: failed to find task address in "
-                   "thread local storage: {0}");
-    return std::nullopt;
-  }
-  return *task_addr;
-}
-
-std::optional<uint64_t>
-OperatingSystemSwiftTasks::FindTaskId(addr_t task_addr) {
-  Status error;
-  // The Task ID is at offset m_job_id_offset from the Task pointer.
-  constexpr uint32_t num_bytes_task_id = 4;
-  auto task_id = m_process->ReadUnsignedIntegerFromMemory(
-      task_addr + m_job_id_offset, num_bytes_task_id, LLDB_INVALID_ADDRESS,
-      error);
-  if (error.Fail())
-    return {};
-  return task_id;
-}
-
-std::optional<std::string>
-OperatingSystemSwiftTasks::FindTaskName(addr_t task_addr, Process *process) {
-  auto task_name_or_err = GetTaskName(task_addr, process);
-  if (auto err = task_name_or_err.takeError()) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::OS), std::move(err),
-                   "OperatingSystemSwiftTasks: failed while looking for name "
-                   "of task {1:x}: {0}",
-                   task_addr);
-    return {};
-  }
-  return *task_name_or_err;
 }
 
 #endif // #if LLDB_ENABLE_SWIFT

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -53,7 +53,7 @@ private:
                                          std::optional<std::string> task_name);
 
   /// Find the ID of the Task at the given address, if any.
-  std::optional<uint64_t> FindTaskId(std::optional<lldb::addr_t> task_addr);
+  std::optional<uint64_t> FindTaskId(lldb::addr_t task_addr);
 
   /// The offset of the Job ID inside a Task data structure.
   size_t m_job_id_offset;

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -53,15 +53,8 @@ private:
                                          uint64_t task_id,
                                          std::optional<std::string> task_name);
 
-  /// Find the address of the Task being executed by `thread`, if any.
-  std::optional<lldb::addr_t> FindTaskAddress(Thread &thread);
-
   /// Find the ID of the Task at the given address, if any.
-  std::optional<uint64_t> FindTaskId(lldb::addr_t task_addr);
-
-  /// Find the (optional) name of the Task at the given address, if any.
-  std::optional<std::string> FindTaskName(lldb::addr_t task_addr,
-                                          Process *process);
+  std::optional<uint64_t> FindTaskId(std::optional<lldb::addr_t> task_addr);
 
   /// The offset of the Job ID inside a Task data structure.
   size_t m_job_id_offset;

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -9,7 +9,6 @@
 #ifndef liblldb_OperatingSystemSwiftTasks_h_
 #define liblldb_OperatingSystemSwiftTasks_h_
 
-#include "lldb/Target/Process.h"
 #if LLDB_ENABLE_SWIFT
 
 #include "lldb/Target/OperatingSystem.h"

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -51,12 +51,6 @@ private:
   lldb::ThreadSP FindOrCreateSwiftThread(ThreadList &old_thread_list,
                                          uint64_t task_id,
                                          std::optional<std::string> task_name);
-
-  /// Find the ID of the Task at the given address, if any.
-  std::optional<uint64_t> FindTaskId(lldb::addr_t task_addr);
-
-  /// The offset of the Job ID inside a Task data structure.
-  size_t m_job_id_offset;
 };
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -9,6 +9,7 @@
 #ifndef liblldb_OperatingSystemSwiftTasks_h_
 #define liblldb_OperatingSystemSwiftTasks_h_
 
+#include "lldb/Target/Process.h"
 #if LLDB_ENABLE_SWIFT
 
 #include "lldb/Target/OperatingSystem.h"
@@ -49,10 +50,18 @@ private:
   /// If a thread for task_id had been created in the last stop, return it.
   /// Otherwise, create a new MemoryThread for it.
   lldb::ThreadSP FindOrCreateSwiftThread(ThreadList &old_thread_list,
-                                         uint64_t task_id);
+                                         uint64_t task_id,
+                                         std::optional<std::string> task_name);
 
-  /// Find the Task ID of the task being executed by `thread`, if any.
-  std::optional<uint64_t> FindTaskId(Thread &thread);
+  /// Find the address of the Task being executed by `thread`, if any.
+  std::optional<lldb::addr_t> FindTaskAddress(Thread &thread);
+
+  /// Find the ID of the Task at the given address, if any.
+  std::optional<uint64_t> FindTaskId(lldb::addr_t task_addr);
+
+  /// Find the (optional) name of the Task at the given address, if any.
+  std::optional<std::string> FindTaskName(lldb::addr_t task_addr,
+                                          Process *process);
 
   /// The offset of the Job ID inside a Task data structure.
   size_t m_job_id_offset;

--- a/lldb/test/API/lang/swift/async/formatters/task/name/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -disable-availability-checking
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -18,7 +18,7 @@ class TestCase(TestBase):
     @swiftTest
     def test_thread_contains_name(self):
         self.build()
-        lldbutil.run_to_source_breakpoint(
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "break inside", lldb.SBFileSpec("main.swift")
         )
-        self.expect("thread info", patterns=[r"Chore \(Task [1-9]\d*\)"])
+        self.assertRegex(thread.name, r"Chore \(Task [1-9]\d*\)")

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -16,6 +16,7 @@ class TestCase(TestBase):
         self.expect("v task", patterns=[r'"Chore" id:[1-9]\d*'])
 
     @swiftTest
+    @skipIfLinux  # rdar://151471067
     def test_thread_contains_name(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -1,0 +1,24 @@
+import textwrap
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test_summary_contains_name(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break outside", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("v task", patterns=[r'"Chore" id:[1-9]\d*'])
+
+    @swiftTest
+    def test_thread_contains_name(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break inside", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("thread info", patterns=[r"Chore \(Task [1-9]\d*\)"])

--- a/lldb/test/API/lang/swift/async/formatters/task/name/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/main.swift
@@ -1,0 +1,11 @@
+@main struct Main {
+    static func main() async {
+        let task = Task(name: "Chore") {
+            print("break inside")
+            _ = readLine()
+            return 15
+        }
+        print("break outside")
+        _ = await task.value
+    }
+}

--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -19,7 +19,7 @@ class TestCase(lldbtest.TestBase):
             self, "BREAK HERE", source_file
         )
 
-        self.assertIn("Swift Task", thread.GetName())
+        self.assertRegex(thread.GetName(), r"^Task [1-9]\d*$")
 
         queue_plugin = self.get_queue_from_thread_info_command(False)
         queue_backing = self.get_queue_from_thread_info_command(True)


### PR DESCRIPTION
This updates both `OperatingSystemSwiftTasks` and `Task_SummaryProvider` to include a
Task's name, if available. See [SE-0469][] for the introduction of task names.

The result is that threads representing Swift Tasks will show the given name, and when
printing a task, its name will be shown in the summary string.

rdar://146940592

[SE-0469]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0469-task-names.md