### PR TITLE
[lldb] Remove the Swift-specific diagnosis frame callback

### DIFF
--- a/lldb/include/lldb/Symbol/TypeSystem.h
+++ b/lldb/include/lldb/Symbol/TypeSystem.h
@@ -578,13 +578,6 @@ public:
   // meaningless type itself, instead preferring to use the dynamic type
   virtual bool IsMeaninglessWithoutDynamicResolution(void *type);
 
-  /// A TypeSystem may belong to more than one debugger, so it doesn't
-  /// have a way to communicate errors. This method can be called by a
-  /// process to tell the TypeSystem to send any diagnostics to the
-  /// process so they can be surfaced to the user.
-  virtual void DiagnoseWarnings(Process &process,
-                                const SymbolContext &sc) const;
-
   virtual std::optional<llvm::json::Value> ReportStatistics();
 
   bool GetHasForcefullyCompletedTypes() const {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -482,15 +482,12 @@ public:
   void RaiseFatalError(std::string msg) const { m_fatal_errors = Status(msg); }
   static bool HasFatalErrors(swift::ASTContext *ast_context);
   bool HasFatalErrors() const {
-    return m_fatal_errors.Fail() || HasFatalErrors(m_ast_context_ap.get());
+    return m_logged_fatal_error || m_fatal_errors.Fail() ||
+           HasFatalErrors(m_ast_context_ap.get());
   }
 
   /// Return only fatal errors.
   Status GetFatalErrors() const;
-  /// Notify the Process about any Swift or ClangImporter errors.
-  void DiagnoseWarnings(Process &process,
-                        const SymbolContext &sc) const override;
-
   void PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                         uint32_t bufferID = UINT32_MAX, uint32_t first_line = 0,
                         uint32_t last_line = UINT32_MAX) const;
@@ -884,8 +881,6 @@ protected:
   /// Called by the VALID_OR_RETURN macro to log all errors.
   void LogFatalErrors() const;
   Status GetAllDiagnostics() const;
-  /// Stream all diagnostics to the Debugger and clear them.
-  void StreamAllDiagnostics(std::optional<lldb::user_id_t> debugger_id) const;
 
   llvm::TargetOptions *getTargetOptions();
 
@@ -945,7 +940,6 @@ protected:
   std::unique_ptr<swift::irgen::IRGenModule> m_ir_gen_module_ap;
   llvm::once_flag m_ir_gen_module_once;
   mutable std::once_flag m_swift_import_warning;
-  mutable std::once_flag m_swift_diags_streamed;
   mutable std::once_flag m_swift_warning_streamed;
   std::unique_ptr<swift::DiagnosticConsumer> m_diagnostic_consumer_ap;
   std::unique_ptr<swift::DependencyTracker> m_dependency_tracker;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2378,13 +2378,6 @@ Status TypeSystemSwiftTypeRef::IsCompatible() {
   return {};
 }
 
-void TypeSystemSwiftTypeRef::DiagnoseWarnings(Process &process,
-                                              const SymbolContext &sc) const {
-  // This gets called only from Thread::FrameSelectedCallback(StackFrame).
-  if (auto swift_ast_context = GetSwiftASTContextOrNull(sc))
-    swift_ast_context->DiagnoseWarnings(process, sc);
-}
-
 plugin::dwarf::DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {
   if (!m_dwarf_ast_parser_up)
     m_dwarf_ast_parser_up.reset(new DWARFASTParserSwift(*this));

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -116,8 +116,6 @@ public:
   bool SupportsLanguage(lldb::LanguageType language) override;
   Status IsCompatible() override;
 
-  void DiagnoseWarnings(Process &process,
-                        const SymbolContext &sc) const override;
   plugin::dwarf::DWARFASTParser *GetDWARFParser() override;
   // CompilerDecl functions
   ConstString DeclGetName(void *opaque_decl) override {

--- a/lldb/source/Symbol/TypeSystem.cpp
+++ b/lldb/source/Symbol/TypeSystem.cpp
@@ -183,9 +183,6 @@ bool TypeSystem::IsMeaninglessWithoutDynamicResolution(void *type) {
   return false;
 }
 
-void TypeSystem::DiagnoseWarnings(Process &process,
-                                  const SymbolContext &sc) const {}
-
 Status TypeSystem::IsCompatible() {
   // Assume a language is compatible. Override this virtual function
   // in your TypeSystem plug-in if version checking is desired.

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -53,10 +53,6 @@
 #include "lldb/ValueObject/ValueObjectConstResult.h"
 #include "lldb/lldb-enumerations.h"
 
-#ifdef LLDB_ENABLE_SWIFT
-#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
-#endif
-
 #include <memory>
 #include <optional>
 
@@ -348,19 +344,6 @@ void Thread::FrameSelectedCallback(StackFrame *frame) {
     GetProcess()->PrintWarningToolchainMismatch(sc);
 #endif
   }
-#ifdef LLDB_ENABLE_SWIFT
-  {
-    SymbolContext msc =
-        frame->GetSymbolContext(eSymbolContextFunction | eSymbolContextModule);
-    Status error;
-    ExecutionContext exe_ctx;
-    frame->CalculateExecutionContext(exe_ctx);
-    if (auto target = frame->CalculateTarget())
-      if (auto swift_ast_ctx =
-              TypeSystemSwiftTypeRefForExpressions::GetForTarget(*target))
-        swift_ast_ctx->DiagnoseWarnings(*GetProcess(), msc);
-  }
-#endif
 }
 
 lldb::StopInfoSP Thread::GetStopInfo() {

--- a/lldb/test/Shell/Swift/DeserializationFailure.test
+++ b/lldb/test/Shell/Swift/DeserializationFailure.test
@@ -18,5 +18,4 @@ run
 expression 1
 
 # The {{ }} avoids accidentally matching the input script!
-# CHECK: {{ }}a.out
 # CHECK: {{ }}The serialized module is corrupted.

--- a/lldb/test/Shell/Swift/MissingVFSOverlay.test
+++ b/lldb/test/Shell/Swift/MissingVFSOverlay.test
@@ -15,5 +15,4 @@ run
 expression 1
 
 # The {{ }} avoids accidentally matching the input script!
-# CHECK: warning:{{ }}{{.*}}Swift{{.*}}a.out
 # CHECK: warning:{{ }}{{.*}}Ignoring missing VFS{{.*}}overlay.yaml


### PR DESCRIPTION
This feature was originally added to communicate Swift module import failures in per-module SwiftASTContext instances powering "frame variable" to the user. We no longer rely on per-module SwiftASTContexts so it's no longer needed to store these diagnostics long-term to display them to all debuggers using the same lldb::Module. Instead this patch diagnoses them immediately using Debugger::ReportWarning/Error, and since they can only happen when setting up an expression evaluator, they will also be displayed in a timely manner.

rdar://150066908