### PR TITLE
[cherry-pick][lldb][swift] Create thread plan for stepping through Allocating Init

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
@@ -53,7 +53,6 @@ class TestSwiftBackwardInteropStepping(TestBase):
         thread = self.setup('Break here for method - class')
         self.check_step_over(thread, 'testMethod')
 
-    @expectedFailureAll(bugnumber="rdar://106670255")
     @swiftTest
     def test_init_step_in_class(self):
         thread = self.setup('Break here for constructor - class')
@@ -115,7 +114,6 @@ class TestSwiftBackwardInteropStepping(TestBase):
         thread = self.setup('Break here for method - struct')
         self.check_step_over(thread, 'testMethod')
 
-    @expectedFailureAll(bugnumber="rdar://106670255")
     @swiftTest
     def test_init_step_in_struct_class(self):
         thread = self.setup('Break here for constructor - struct')

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -25,18 +25,6 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
         lldbtest.TestBase.setUp(self)
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
-        # If you are running against a debug swift you are going to
-        # end up stepping into the stdlib and that will make stepping
-        # tests impossible to write.  So avoid that.
-
-        if platform.system() == 'Darwin':
-            lib_name = "libswiftCore.dylib"
-        else:
-            lib_name = "libswiftCore.so"
-
-        self.dbg.HandleCommand(
-            "settings set "
-            "target.process.thread.step-avoid-libraries {}".format(lib_name))
 
     def do_test(self, use_api):
         """Tests that we can step reliably in swift code."""


### PR DESCRIPTION
These trampolines have a well defined target, which can be extracted from the demangle tree. A similar strategy is already adopted for stepping into conformance code. This allows LLDB to create a RunToAddress plan with a target address, which is obtained by searching the Module for functions matching `<class_name>.Init`.

We already had a test for this, but we rely on the "step avoid libraries" setting to emulate the case of "avoid libraries without debug info". However, they are not exactly equivalent, so the test mislead us into believing stepping was working. A future patch should try to fold the setting-checking code into
ThreadPlanShouldStopHere::DefaultShouldStopCallback.

With this patch, the test now works regardless of whether debug info is present or not.

To make this work, this commit also teaches the Swift language runtime how to recognize "type metadata accessors". These are thunks in the sense that they jump to some other code, but not user code. Their purposes is to eventually send the "self" message to the SwiftObject the first time they run. As such, they should just be stepped out from, which is accomplished by having the runtime recognize them as trampolines but not provide any specific actions, relying on the default behavior of ShouldStopHere.

Prior to this change, this would sometimes work accidentally because all the functions involved had line 0 debug information, and the debugger would keep stepping through _all_ of them. However, in debug builds of x86, this strategy failed; sometimes the computed Symbol size is larger than the line entry for these functions, and so the detection "all line 0" fails. Relying on this is error-prone and slow, as it causes the debugger to stop many times.

(cherry picked from commit 30aa4dc18f9b45887d3611989def1b235825b1d0)