### PR TITLE
[LLDB] Remove high-firing scoped timers from the Swift plugin

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -239,7 +239,6 @@ public:
   bool lookupAdditions(swift::DeclBaseName Name, swift::DeclContext *DC,
                        swift::SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
-    LLDB_SCOPED_TIMER();
     assert(SwiftASTContext::GetSwiftASTContext(&DC->getASTContext()) ==
            m_this_context);
     static unsigned counter = 0;
@@ -402,8 +401,6 @@ public:
   bool lookupAdditions(swift::DeclBaseName Name, swift::DeclContext *DC,
                        swift::SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
-    LLDB_SCOPED_TIMER();
-
     assert(SwiftASTContext::GetSwiftASTContext(&DC->getASTContext()) ==
            m_this_context);
     static unsigned counter = 0;
@@ -462,7 +459,6 @@ public:
 static CompilerType GetSwiftTypeForVariableValueObject(
     lldb::ValueObjectSP valobj_sp, lldb::StackFrameSP &stack_frame_sp,
     SwiftLanguageRuntime *runtime, lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
   // Check that the passed ValueObject is valid.
   if (!valobj_sp || valobj_sp->GetError().Fail())
     return {};
@@ -490,7 +486,6 @@ CompilerType SwiftExpressionParser::ResolveVariable(
     lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
     SwiftLanguageRuntime *runtime, lldb::DynamicValueType use_dynamic,
     lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
   lldb::ValueObjectSP valobj_sp =
       stack_frame_sp->GetValueObjectForFrameVariable(variable_sp,
                                                      lldb::eNoDynamicValues);
@@ -555,8 +550,6 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
                    SwiftASTManipulator &manipulator,
                    lldb::DynamicValueType use_dynamic,
                    lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
-
   // Alias builtin types, since we can't use them directly in source code.
   auto builtin_ptr_t = swift_ast_context.GetBuiltinRawPointerType();
   auto alias = manipulator.MakeTypealias(
@@ -737,8 +730,6 @@ static void ResolveSpecialNames(
     llvm::SmallVectorImpl<swift::Identifier> &special_names,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables) {
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-  
   if (!sc.target_sp)
     return;
 
@@ -939,7 +930,6 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
                     lldb::StackFrameWP &stack_frame_wp,
                     DiagnosticManager &diagnostic_manager, Log *log,
                     bool repl) {
-  LLDB_SCOPED_TIMER();
   uint64_t offset = 0;
   bool needs_init = false;
 
@@ -1283,9 +1273,6 @@ SwiftExpressionParser::ParseAndImport(
     SwiftExpressionParser::SILVariableMap &variable_map, unsigned &buffer_id,
     DiagnosticManager &diagnostic_manager) {
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-
-
   bool repl = m_options.GetREPLEnabled();
   bool playground = m_options.GetPlaygroundTransformEnabled();
   // If we are using the playground, hand import the necessary
@@ -1747,8 +1734,6 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   SwiftExpressionParser::SILVariableMap variable_map;
   using ParseResult = SwiftExpressionParser::ParseResult;
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-
   // Get a scoped diagnostics consumer for all diagnostics produced by
   // this expression.
   auto expr_diagnostics = m_swift_ast_ctx.getScopedDiagnosticConsumer();
@@ -2228,7 +2213,6 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 static bool FindFunctionInModule(ConstString &mangled_name,
                                  llvm::Module *module, const char *orig_name,
                                  bool exact) {
-  LLDB_SCOPED_TIMER();
   swift::Demangle::Context demangle_ctx;
   for (llvm::Module::iterator fi = module->getFunctionList().begin(),
                               fe = module->getFunctionList().end();
@@ -2282,7 +2266,6 @@ Status SwiftExpressionParser::DoPrepareForExecution(
     lldb::addr_t &func_addr, lldb::addr_t &func_end,
     lldb::IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx,
     bool &can_interpret, ExecutionPolicy execution_policy) {
-  LLDB_SCOPED_TIMER();
   Status err;
   Log *log = GetLog(LLDBLog::Expressions);
 
@@ -2340,7 +2323,6 @@ Status SwiftExpressionParser::DoPrepareForExecution(
 
 bool SwiftExpressionParser::RewriteExpression(
     DiagnosticManager &diagnostic_manager) {
-  LLDB_SCOPED_TIMER();
   // There isn't a Swift equivalent to clang::Rewriter, so we'll just
   // use that.
   Log *log = GetLog(LLDBLog::Expressions);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -185,7 +185,6 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   Log *log = GetLog(LLDBLog::Expressions);
   LLDB_LOG(log, "SwiftUserExpression::ScanContext()");
-  LLDB_SCOPED_TIMER();
 
   m_target = exe_ctx.GetTargetPtr();
   if (!m_target) {
@@ -304,8 +303,6 @@ static llvm::Error AddVariableInfo(
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
     lldb::DynamicValueType use_dynamic,
     lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
-
   StringRef name = variable_sp->GetUnqualifiedName().GetStringRef();
   const char *name_cstr = name.data();
   assert(StringRef(name_cstr) == name && "missing null terminator");
@@ -495,7 +492,6 @@ static llvm::Error RegisterAllVariables(
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
     lldb::DynamicValueType use_dynamic,
     lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
   SwiftLanguageRuntime *language_runtime = nullptr;
 
   if (stack_frame_sp)
@@ -703,8 +699,6 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                                 bool keep_result_in_memory,
                                 bool generate_debug_info) {
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-
   Status err;
 
   auto error = [&](const char *error_msg, const char *detail = nullptr) {
@@ -981,7 +975,6 @@ bool SwiftUserExpression::AddArguments(ExecutionContext &exe_ctx,
 
 lldb::ExpressionVariableSP SwiftUserExpression::GetResultAfterDematerialization(
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   lldb::ExpressionVariableSP in_result_sp = m_result_delegate.GetVariable();
   lldb::ExpressionVariableSP in_error_sp = m_error_delegate.GetVariable();
 

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -145,8 +145,6 @@ static bool makeStringGutsSummary(
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options,
     std::optional<StringSlice> slice = std::nullopt) {
-  LLDB_SCOPED_TIMER();
-
   static ConstString g__object("_object");
   static ConstString g__storage("_storage");
   static ConstString g__value("_value");
@@ -518,8 +516,6 @@ bool lldb_private::formatters::swift::StaticString_SummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
-  LLDB_SCOPED_TIMER();
-
   static ConstString g__startPtrOrData("_startPtrOrData");
   static ConstString g__byteSize("_utf8CodeUnitCount");
   static ConstString g__flags("_flags");
@@ -574,7 +570,6 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
-  LLDB_SCOPED_TIMER();
   ProcessSP process(valobj.GetProcessSP());
   if (!process)
     return false;
@@ -603,7 +598,6 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
 
 bool lldb_private::formatters::swift::SwiftStringStorage_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
   ProcessSP process(valobj.GetProcessSP());
   if (!process)
     return false;
@@ -675,7 +669,6 @@ bool lldb_private::formatters::swift::DarwinBoolean_SummaryProvider(
 static bool RangeFamily_SummaryProvider(ValueObject &valobj, Stream &stream,
                                         const TypeSummaryOptions &options,
                                         bool isHalfOpen) {
-  LLDB_SCOPED_TIMER();
   static ConstString g_lowerBound("lowerBound");
   static ConstString g_upperBound("upperBound");
 
@@ -1610,7 +1603,6 @@ lldb_private::formatters::swift::ActorSyntheticFrontEndCreator(
 
 bool lldb_private::formatters::swift::ObjC_Selector_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
   static ConstString g_ptr("ptr");
   static ConstString g__rawValue("_rawValue");
 
@@ -1757,7 +1749,6 @@ bool PrintTypePreservingNSNumber(DataBufferSP buffer_sp, ProcessSP process_sp,
 
 bool lldb_private::formatters::swift::TypePreservingNSNumber_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
   lldb::addr_t ptr_value(valobj.GetValueAsUnsigned(LLDB_INVALID_ADDRESS));
   if (ptr_value == LLDB_INVALID_ADDRESS)
     return false;
@@ -2040,8 +2031,6 @@ void PrintMatrix(Stream &stream,
 
 bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
-
   // SIMD vector contains an inner member `_storage` which is an opaque
   // container. Given SIMD is always in the form SIMDX<Type> where X is a
   // positive integer, we can calculate the number of elements and the
@@ -2115,8 +2104,6 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
 
 bool lldb_private::formatters::swift::LegacySIMD_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
-
   Status error;
   ProcessSP process_sp(valobj.GetProcessSP());
   if (!process_sp)
@@ -2201,8 +2188,6 @@ bool lldb_private::formatters::swift::LegacySIMD_SummaryProvider(
 
 bool lldb_private::formatters::swift::GLKit_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
-
   // Get the type name without the "GLKit." prefix.
   ConstString full_type_name = valobj.GetTypeName();
   llvm::StringRef type_name = full_type_name.GetStringRef();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2705,7 +2705,6 @@ UnwindPlanSP
 SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
                                            RegisterContext *regctx,
                                            bool &behaves_like_zeroth_frame) {
-  LLDB_SCOPED_TIMER();
   auto log_expected = [](llvm::Error error) {
     Log *log = GetLog(LLDBLog::Unwind);
     LLDB_LOG_ERROR(log, std::move(error), "{0}");
@@ -2810,8 +2809,6 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
 UnwindPlanSP SwiftLanguageRuntime::GetFollowAsyncContextUnwindPlan(
     ProcessSP process_sp, RegisterContext *regctx, ArchSpec &arch,
     bool &behaves_like_zeroth_frame) {
-  LLDB_SCOPED_TIMER();
-
   UnwindPlan::RowSP row(new UnwindPlan::Row);
   const int32_t ptr_size = 8;
   row->SetOffset(0);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -547,7 +547,6 @@ SwiftLanguageRuntime::GetMemberVariableOffsetRemoteMirrors(
 std::optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
     CompilerType instance_type, ValueObject *instance,
     llvm::StringRef member_name, Status *error) {
-  LLDB_SCOPED_TIMER();
   std::optional<uint64_t> offset;
 
   if (!instance_type.IsValid())
@@ -1581,7 +1580,6 @@ SwiftLanguageRuntime::GetNumFields(CompilerType type,
 llvm::Expected<uint32_t> SwiftLanguageRuntime::GetNumChildren(
     CompilerType type, ExecutionContextScope *exe_scope,
     bool include_superclass, bool include_clang_types) {
-  LLDB_SCOPED_TIMER();
   SwiftRuntimeTypeVisitor visitor(*this, type, exe_scope, !include_superclass,
                                   include_clang_types);
   return visitor.CountChildren();
@@ -1620,7 +1618,6 @@ std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>
 SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
     CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
-  LLDB_SCOPED_TIMER();
   SwiftRuntimeTypeVisitor visitor(*this, type, exe_ctx, false, false, true);
   bool found = false;
   unsigned i = 0, last_depth = 0;
@@ -2547,7 +2544,6 @@ void SwiftLanguageRuntime::ForEachGenericParameter(
 CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
     CompilerType unbound_type,
     std::function<CompilerType(unsigned, unsigned)> type_resolver) {
-  LLDB_SCOPED_TIMER();
   using namespace swift::Demangle;
 
   auto ts =
@@ -2633,7 +2629,6 @@ llvm::Expected<CompilerType>
 SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
                                                 TypeSystemSwiftTypeRef &ts,
                                                 ConstString mangled_name) {
-  LLDB_SCOPED_TIMER();
   using namespace swift::Demangle;
 
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
@@ -3161,7 +3156,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
   if (use_dynamic == lldb::eNoDynamicValues)
     return false;
 
-  LLDB_SCOPED_TIMER();
   CompilerType val_type(in_value.GetCompilerType());
   Value::ValueType static_value_type = Value::ValueType::Invalid;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -271,8 +271,6 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialRemoteAST(
 llvm::Expected<CompilerType>
 SwiftLanguageRuntime::BindGenericTypeParametersRemoteAST(
     StackFrame &stack_frame, CompilerType base_type) {
-  LLDB_SCOPED_TIMER();
-
   // If this is a TypeRef type, bind that.
   auto sc = stack_frame.GetSymbolContext(lldb::eSymbolContextEverything);
   if (auto ts =

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2589,7 +2589,6 @@ SwiftASTContext::CreateInstance(lldb::LanguageType language, Module &module,
   }
 
   {
-    LLDB_SCOPED_TIMERF("%s (getStdlibModule)", m_description.c_str());
     const bool can_create = true;
 
     // Report progress on module importing by using a callback function in
@@ -2700,8 +2699,6 @@ lldb::TypeSystemSP
 SwiftASTContext::CreateInstance(const SymbolContext &sc,
                                 TypeSystemSwiftTypeRef &typeref_typesystem,
                                 const char *extra_options) {
-  LLDB_SCOPED_TIMER();
-
   bool is_repl = extra_options;
   bool for_expressions =
       llvm::isa<TypeSystemSwiftTypeRefForExpressions>(&typeref_typesystem);
@@ -2730,6 +2727,8 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
     ss << '"' << ')';
     m_description = ss.GetString();
   }
+
+  LLDB_SCOPED_TIMERF("%s::CreateInstance", m_description.c_str());
 
   if (is_repl)
     LOG_PRINTF(GetLog(LLDBLog::Types), "REPL detected");
@@ -3162,8 +3161,6 @@ SwiftASTContext::CreateInstance(const SymbolContext &sc,
   }
 
   {
-    LLDB_SCOPED_TIMERF("%s (getStdlibModule)", m_description.c_str());
-
     // Report progress on module importing by using a callback function in
     // swift::ASTContext
     Progress progress("Importing Swift standard library");
@@ -3514,7 +3511,6 @@ swift::SearchPathOptions &SwiftASTContext::GetSearchPathOptions() {
 void SwiftASTContext::InitializeSearchPathOptions(
     llvm::ArrayRef<std::pair<std::string, bool>> extra_module_search_paths,
     llvm::ArrayRef<std::pair<std::string, bool>> extra_framework_search_paths) {
-  LLDB_SCOPED_TIMER();
   swift::CompilerInvocation &invocation = GetCompilerInvocation();
 
   assert(!m_initialized_search_path_options);
@@ -3637,7 +3633,6 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   if (m_ast_context_ap.get())
     return {m_ast_context_ap.get(), m_ast_context_mutex};
 
-  LLDB_SCOPED_TIMER();
   m_ast_context_ap.reset(swift::ASTContext::get(
       GetLanguageOptions(), GetTypeCheckerOptions(), GetSILOptions(),
       GetSearchPathOptions(), GetClangImporterOptions(),
@@ -3925,7 +3920,6 @@ SwiftASTContext::GetModule(const SourceModule &module, bool *cached) {
     return *module_decl;
   }
 
-  LLDB_SCOPED_TIMER();
   ThreadSafeASTContext ast = GetASTContext();
   if (!ast) {
     LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") invalid ASTContext",
@@ -4138,7 +4132,6 @@ GetLibrarySearchPaths(const swift::SearchPathOptions &search_path_opts) {
 void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
                                  Process &process, Status &error) {
   VALID_OR_RETURN();
-  LLDB_SCOPED_TIMER();
 
   Status current_error;
   auto addLinkLibrary = [&](swift::LinkLibrary link_lib) {
@@ -4337,7 +4330,6 @@ bool SwiftASTContext::LoadLibraryUsingPaths(
     std::vector<std::string> &search_paths, bool check_rpath,
     StreamString &all_dlopen_errors) {
   VALID_OR_RETURN(false);
-  LLDB_SCOPED_TIMER();
 
   SwiftLanguageRuntime *runtime = SwiftLanguageRuntime::Get(&process);
   if (!runtime) {
@@ -4484,7 +4476,6 @@ static std::string GetBriefModuleName(Module &module) {
 void SwiftASTContext::RegisterSectionModules(
     Module &module, std::vector<std::string> &module_names) {
   VALID_OR_RETURN();
-  LLDB_SCOPED_TIMER();
 
   swift::MemoryBufferSerializedModuleLoader *loader =
       GetMemoryBufferModuleLoader();
@@ -4556,7 +4547,6 @@ void SwiftASTContext::RegisterSectionModules(
 void SwiftASTContext::ImportSectionModules(
     Module &module, const std::vector<std::string> &module_names) {
   VALID_OR_RETURN();
-  LLDB_SCOPED_TIMER();
 
   Progress progress("Loading Swift module dependencies",
                     module.GetFileSpec().GetFilename().GetString(),
@@ -4585,7 +4575,6 @@ swift::Identifier SwiftASTContext::GetIdentifier(const llvm::StringRef &name) {
 
 ConstString SwiftASTContext::GetMangledTypeName(swift::TypeBase *type_base) {
   VALID_OR_RETURN(ConstString());
-  LLDB_SCOPED_TIMER();
 
   auto iter = m_type_to_mangled_name_map.find(type_base),
        end = m_type_to_mangled_name_map.end();
@@ -4657,7 +4646,6 @@ SwiftASTContext::GetTypeFromMangledTypename(ConstString mangled_typename) {
 }
 
 CompilerType SwiftASTContext::GetAsClangType(ConstString mangled_name) {
-  LLDB_SCOPED_TIMER();
   if (!swift::Demangle::isObjCSymbol(mangled_name.GetStringRef()))
     return {};
 
@@ -4765,7 +4753,6 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
   LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- not cached, searching",
              mangled_cstr);
 
-  LLDB_SCOPED_TIMERF("%s (not cached)", LLVM_PRETTY_FUNCTION);
   found_type = swift::Demangle::getTypeForMangling(
                    **ast_ctx, mangled_typename.GetStringRef())
                    .getPointer();
@@ -4946,7 +4933,6 @@ SwiftASTContext::FindContainedTypeOrDecl(llvm::StringRef name,
                                          TypeOrDecl container_type_or_decl,
                                          TypesOrDecls &results, bool append) {
   VALID_OR_RETURN(0);
-  LLDB_SCOPED_TIMER();
 
   if (!append)
     results.clear();
@@ -5042,7 +5028,6 @@ size_t SwiftASTContext::FindTypesOrDecls(const char *name,
                                          swift::ModuleDecl *swift_module,
                                          TypesOrDecls &results, bool append) {
   VALID_OR_RETURN(0);
-  LLDB_SCOPED_TIMER();
 
   if (!append)
     results.clear();
@@ -5081,7 +5066,6 @@ size_t SwiftASTContext::FindTypesOrDecls(const char *name,
 size_t SwiftASTContext::FindType(const char *name,
                                  std::set<CompilerType> &results, bool append) {
   VALID_OR_RETURN(0);
-  LLDB_SCOPED_TIMER();
 
   if (!append)
     results.clear();
@@ -5109,7 +5093,6 @@ size_t SwiftASTContext::FindType(const char *name,
 
 CompilerType SwiftASTContext::ImportType(CompilerType &type, Status &error) {
   VALID_OR_RETURN(CompilerType());
-  LLDB_SCOPED_TIMER();
 
   if (m_ast_context_ap.get() == NULL)
     return CompilerType();
@@ -5220,7 +5203,6 @@ SwiftASTContext::GetIRGenerator(swift::IRGenOptions &opts,
 
 swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
   VALID_OR_RETURN(*m_ir_gen_module_ap);
-  LLDB_SCOPED_TIMER();
 
   llvm::call_once(m_ir_gen_module_once, [this]() {
     // Make sure we have a good ClangImporter.
@@ -5396,7 +5378,6 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
                                        uint32_t bufferID, uint32_t first_line,
                                        uint32_t last_line) const {
   // VALID_OR_RETURN cannot be used here here since would exit on error.
-  LLDB_SCOPED_TIMER();
   if (!m_ast_context_ap.get()) {
     RaiseFatalError("Swift compiler could not be initialized");
     return;
@@ -5784,7 +5765,6 @@ bool SwiftASTContext::IsPossibleDynamicType(opaque_compiler_type_t type,
                                             bool check_cplusplus,
                                             bool check_objc) {
   VALID_OR_RETURN_CHECK_TYPE(type, false);
-  LLDB_SCOPED_TIMER();
 
   auto can_type = GetCanonicalSwiftType(type);
   if (!can_type)
@@ -5905,7 +5885,6 @@ SwiftASTContext::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
 
 bool SwiftASTContext::GetProtocolTypeInfo(const CompilerType &type,
                                           ProtocolInfo &protocol_info) {
-  LLDB_SCOPED_TIMER();
   if (swift::CanType swift_can_type = GetCanonicalSwiftType(type)) {
     if (!swift_can_type.isExistentialType())
       return false;
@@ -5977,7 +5956,6 @@ ConstString SwiftASTContext::GetTypeName(opaque_compiler_type_t type,
                                          bool BaseOnly) {
   VALID_OR_RETURN_CHECK_TYPE(
       type, ConstString("<invalid Swift context or opaque type>"));
-  LLDB_SCOPED_TIMER();
   std::string type_name;
   swift::Type swift_type(GetSwiftType(type));
 
@@ -6002,7 +5980,6 @@ static llvm::DenseMap<swift::CanType, swift::Identifier>
 GetArchetypeNames(swift::Type swift_type, swift::ASTContext &ast_ctx,
                   const SymbolContext *sc,
                   swift::Mangle::ManglingFlavor flavor) {
-  LLDB_SCOPED_TIMER();
   llvm::DenseMap<swift::CanType, swift::Identifier> dict;
 
   assert(&swift_type->getASTContext() == &ast_ctx);
@@ -6031,7 +6008,6 @@ ConstString SwiftASTContext::GetDisplayTypeName(opaque_compiler_type_t type,
                                                 const SymbolContext *sc) {
   VALID_OR_RETURN_CHECK_TYPE(
       type, ConstString("<invalid Swift context or opaque type>"));
-  LLDB_SCOPED_TIMER();
   std::string type_name(GetTypeName(type, false).AsCString(""));
   if (type) {
     swift::Type swift_type(GetSwiftType(type));
@@ -6052,7 +6028,6 @@ uint32_t
 SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
                              CompilerType *pointee_or_element_clang_type) {
   VALID_OR_RETURN_CHECK_TYPE(type, 0);
-  LLDB_SCOPED_TIMER();
 
   if (pointee_or_element_clang_type)
     pointee_or_element_clang_type->Clear();
@@ -6440,7 +6415,6 @@ TypeMemberFunctionImpl
 SwiftASTContext::GetMemberFunctionAtIndex(opaque_compiler_type_t type,
                                           size_t idx) {
   VALID_OR_RETURN_CHECK_TYPE(type, TypeMemberFunctionImpl());
-  LLDB_SCOPED_TIMER();
 
   std::string name("");
   CompilerType result_type;
@@ -6593,7 +6567,6 @@ llvm::Expected<uint64_t>
 SwiftASTContext::GetBitSize(opaque_compiler_type_t type,
                             ExecutionContextScope *exe_scope) {
   VALID_OR_RETURN_CHECK_TYPE(type, llvm::createStringError("invalid context"));
-  LLDB_SCOPED_TIMER();
 
   // If the type has type parameters, bind them first.
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -6651,7 +6624,6 @@ std::optional<uint64_t>
 SwiftASTContext::GetByteStride(opaque_compiler_type_t type,
                                ExecutionContextScope *exe_scope) {
   VALID_OR_RETURN_CHECK_TYPE(type, std::nullopt);
-  LLDB_SCOPED_TIMER();
 
   // If the type has type parameters, bind them first.
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -6694,7 +6666,6 @@ std::optional<size_t>
 SwiftASTContext::GetTypeBitAlign(opaque_compiler_type_t type,
                                  ExecutionContextScope *exe_scope) {
   VALID_OR_RETURN_CHECK_TYPE(type, std::nullopt);
-  LLDB_SCOPED_TIMER();
 
   // If the type has type parameters, bind them first.
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -6843,7 +6814,6 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
                                 bool omit_empty_base_classes,
                                 const ExecutionContext *exe_ctx) {
   VALID_OR_RETURN_CHECK_TYPE(type, llvm::createStringError("invalid type"));
-  LLDB_SCOPED_TIMER();
 
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
 
@@ -7219,7 +7189,6 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
                                               uint32_t *bitfield_bit_size_ptr,
                                               bool *is_bitfield_ptr) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
-  LLDB_SCOPED_TIMER();
 
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
 
@@ -7571,7 +7540,6 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
     bool &child_is_base_class, bool &child_is_deref_of_parent,
     ValueObject *valobj, uint64_t &language_flags) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
-  LLDB_SCOPED_TIMER();
 
   auto get_type_size = [&exe_ctx](CompilerType type) {
     auto *exe_scope =
@@ -7964,7 +7932,6 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     opaque_compiler_type_t type, StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
   VALID_OR_RETURN_CHECK_TYPE(type, 0);
-  LLDB_SCOPED_TIMER();
 
   if (!name.empty()) {
     swift::CanType swift_can_type(GetCanonicalSwiftType(type));
@@ -8368,7 +8335,6 @@ bool SwiftASTContext::DumpTypeValue(
     size_t byte_size, uint32_t bitfield_bit_size, uint32_t bitfield_bit_offset,
     ExecutionContextScope *exe_scope, bool is_base_class) {
   VALID_OR_RETURN_CHECK_TYPE(type, false);
-  LLDB_SCOPED_TIMER();
 
   swift::CanType swift_can_type(GetCanonicalSwiftType(type));
 
@@ -8548,7 +8514,6 @@ bool SwiftASTContext::DumpTypeValue(
 bool SwiftASTContext::IsImportedType(opaque_compiler_type_t type,
                                      CompilerType *original_type) {
   VALID_OR_RETURN_CHECK_TYPE(type, false);
-  LLDB_SCOPED_TIMER();
   bool success = false;
 
   if (swift::Type swift_can_type = GetSwiftType(type)) {
@@ -8700,7 +8665,6 @@ void SwiftASTContext::DumpTypeDescription(opaque_compiler_type_t type,
                                           bool print_extensions_if_available,
                                           lldb::DescriptionLevel level,
                                           ExecutionContextScope *) {
-  LLDB_SCOPED_TIMER();
   const auto initial_written_bytes = s->GetWrittenBytes();
 
   if (type) {
@@ -9021,7 +8985,6 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
                                         lldb::ProcessSP process_sp,
                                         bool import_dylibs,
                                         Status &error) {
-  LLDB_SCOPED_TIMER();
   if (!module.path.size())
     return nullptr;
 
@@ -9093,7 +9056,6 @@ bool SwiftASTContextForExpressions::GetImplicitImports(
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         &modules,
     Status &error) {
-  LLDB_SCOPED_TIMER();
   if (!GetCompileUnitImports(sc, process_sp, modules, error))
     return false;
 
@@ -9262,7 +9224,6 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         *modules,
     Status &error) {
-  LLDB_SCOPED_TIMER();
 
   CompileUnit *compile_unit = sc.comp_unit;
   if (compile_unit && compile_unit->GetModule())

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
@@ -60,7 +60,6 @@ SwiftDWARFImporterForClangTypes::SwiftDWARFImporterForClangTypes(
 void SwiftDWARFImporterForClangTypes::lookupValue(
     StringRef name, std::optional<swift::ClangTypeKind> kind,
     StringRef inModule, llvm::SmallVectorImpl<CompilerType> &results) {
-  LLDB_SCOPED_TIMER();
   LLDB_LOG(GetLog(LLDBLog::Types), "{0}::lookupValue(\"{1}\")", m_description,
            name.str());
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -971,8 +971,6 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
                                          swift::Demangle::NodePointer node,
                                          swift::Mangle::ManglingFlavor flavor,
                                          bool prefer_clang_types) {
-  LLDB_SCOPED_TIMER();
-
   // Hardcode that the Swift.AnyObject type alias always resolves to
   // the builtin AnyObject type.
   if (IsAnyObjectTypeAlias(node))
@@ -1203,8 +1201,6 @@ static swift::Demangle::NodePointer
 Desugar(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
         swift::Demangle::Node::Kind bound_kind,
         swift::Demangle::Node::Kind kind, llvm::StringRef name) {
-  LLDB_SCOPED_TIMER();
-
   using namespace swift::Demangle;
   NodePointer desugared = dem.createNode(bound_kind);
   NodePointer type = dem.createNode(Node::Kind::Type);
@@ -1433,7 +1429,6 @@ std::string ExtractSwiftName(
 std::string
 TypeSystemSwiftTypeRef::GetSwiftName(const clang::Decl *clang_decl,
                                      TypeSystemClang &clang_typesystem) {
-  LLDB_SCOPED_TIMER();
   auto *named_decl = llvm::dyn_cast_or_null<const clang::NamedDecl>(clang_decl);
   if (!named_decl)
     return {};
@@ -1491,8 +1486,6 @@ static bool IsImportedType(swift::Demangle::NodePointer node) {
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetSwiftified(
     swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
     swift::Mangle::ManglingFlavor flavor, bool resolve_objc_module) {
-  LLDB_SCOPED_TIMER();
-
   auto mangling = GetMangledName(dem, node, flavor);
   if (!mangling.isSuccess()) {
     LLDB_LOGF(GetLog(LLDBLog::Types), "Failed while getting swiftified (%d:%u)",
@@ -1663,8 +1656,6 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetDemangleTreeForPrinting(
     swift::Demangle::Demangler &dem, const char *mangled_name,
     bool resolve_objc_module) {
-  LLDB_SCOPED_TIMER();
-
   auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
 
   auto *node = dem.demangleSymbol(mangled_name);
@@ -3164,8 +3155,6 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
                                                    CompilerType *target_type,
                                                    bool check_cplusplus,
                                                    bool check_objc) {
-  LLDB_SCOPED_TIMER();
-
   if (target_type)
     target_type->Clear();
 
@@ -3312,7 +3301,6 @@ ConstString TypeSystemSwiftTypeRef::GetTypeName(opaque_compiler_type_t type,
 ConstString
 TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
                                            const SymbolContext *sc) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() {
     using namespace swift::Demangle;
     auto flavor = SwiftLanguageRuntime::GetManglingFlavor(AsMangledName(type));
@@ -3558,7 +3546,6 @@ CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
 llvm::Expected<uint64_t>
 TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                                    ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> llvm::Expected<uint64_t> {
     auto get_static_size = [&](bool cached_only) -> std::optional<uint64_t> {
       if (IsMeaninglessWithoutDynamicResolution(type))
@@ -3661,7 +3648,6 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
 std::optional<uint64_t>
 TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
                                       ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> std::optional<uint64_t> {
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
@@ -3687,7 +3673,6 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
 
 lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
                                                    uint64_t &count) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> lldb::Encoding {
     if (!type)
       return lldb::eEncodingInvalid;
@@ -3770,7 +3755,6 @@ llvm::Expected<uint32_t>
 TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        bool omit_empty_base_classes,
                                        const ExecutionContext *exe_ctx) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> llvm::Expected<uint32_t> {
     if (exe_ctx)
       if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
@@ -3817,7 +3801,6 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
 
 uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
                                               ExecutionContext *exe_ctx) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> std::optional<uint32_t> {
     if (exe_ctx)
       if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP())) {
@@ -3885,7 +3868,6 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  LLDB_SCOPED_TIMER();
   FORWARD_TO_EXPRAST_ONLY(GetFieldAtIndex,
                           (ReconstructType(type), idx, name, bit_offset_ptr,
                            bitfield_bit_size_ptr, is_bitfield_ptr),
@@ -3933,7 +3915,6 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
     bool &child_is_base_class, bool &child_is_deref_of_parent,
     ValueObject *valobj, uint64_t &language_flags) {
-  LLDB_SCOPED_TIMER();
   child_name = "";
   child_byte_size = 0;
   child_byte_offset = 0;
@@ -4206,7 +4187,6 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
 size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
     opaque_compiler_type_t type, StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
-  LLDB_SCOPED_TIMER();
   if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
@@ -4352,7 +4332,6 @@ TypeSystemSwiftTypeRef::ShouldPrintAsOneLiner(opaque_compiler_type_t type,
 
 bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
     opaque_compiler_type_t type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
@@ -4392,7 +4371,6 @@ TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,
 
 bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
                                             CompilerType *original_type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
     Demangler dem;
@@ -4805,7 +4783,6 @@ TypeSystemSwiftTypeRef::GetNonTriviallyManagedReferenceKind(
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
 
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s, level, exe_scope);
@@ -4814,7 +4791,6 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, Stream &s, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   DumpTypeDescription(type, &s, false, true, level, exe_scope);
 }
 
@@ -4822,7 +4798,6 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, bool print_help_if_available,
     bool print_extensions_if_available, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s, print_help_if_available,
                       print_extensions_if_available, level, exe_scope);
@@ -4832,7 +4807,6 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, Stream *s, bool print_help_if_available,
     bool print_extensions_if_available, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   // Currently, we need an execution scope so we can access the runtime, which
   // in turn owns the reflection context, which is used to read the typeref. If
   // we were to decouple the reflection context from the runtime, we'd be able
@@ -4874,7 +4848,6 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     size_t data_byte_size, uint32_t bitfield_bit_size,
     uint32_t bitfield_bit_offset, ExecutionContextScope *exe_scope,
     bool is_base_class) {
-  LLDB_SCOPED_TIMER();
   if (!type)
     return false;
   const char *mangled_name = AsMangledName(type);
@@ -5091,7 +5064,6 @@ bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
 std::optional<size_t>
 TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
                                         ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   // This method doesn't use VALIDATE_AND_RETURN because except for
   // fixed-size types the SwiftASTContext implementation forwards to
   // SwiftLanguageRuntime anyway and for many fixed-size types the
@@ -5220,7 +5192,6 @@ bool TypeSystemSwiftTypeRef::IsTypedefType(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
     Demangler dem;
@@ -5250,7 +5221,6 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> CompilerType { return {weak_from_this(), type}; };
 
   VALIDATE_AND_RETURN(impl, GetFullyUnqualifiedType, type, g_no_exe_ctx,


### PR DESCRIPTION
I have come to the realization that signposts are more useful for very high level operations, at the level of granularity the removed timers were on, something like an Instruments trace has all the data needed for performance analysis and more.