### PR TITLE
[lldb] Implement TypeSystemSwiftTypeRef::GetNumDirectBaseClasses and … 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -297,6 +297,7 @@ public:
   llvm::Error GetObjectDescription(Stream &str, ValueObject &object) override;
   CompilerType GetConcreteType(ExecutionContextScope *exe_scope,
                                ConstString abstract_type_name) override;
+  CompilerType GetBaseClass(CompilerType class_ty);
 
   CompilerType GetTypeFromMetadata(TypeSystemSwift &tss, Address address);
   /// Build the artificial type metadata variable name for \p swift_type.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1695,6 +1695,29 @@ llvm::Expected<CompilerType> SwiftLanguageRuntime::GetChildCompilerTypeAtIndex(
   return child_type;
 }
 
+CompilerType SwiftLanguageRuntime::GetBaseClass(CompilerType class_ty) {
+  ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return {};
+  auto ts_sp = class_ty.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!ts_sp)
+    return {};
+  auto tr_ts = ts_sp->GetTypeSystemSwiftTypeRef();
+  if (!tr_ts)
+    return {};
+  auto type_ref_or_err =
+      reflection_ctx->GetTypeRef(class_ty.GetMangledTypeName().GetStringRef(),
+                                 tr_ts->GetDescriptorFinder());
+  if (!type_ref_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions | LLDBLog::Types),
+                   type_ref_or_err.takeError(), "{0}");
+    return {};
+  }
+  auto *super_tr = reflection_ctx->LookupSuperclass(
+      *type_ref_or_err, tr_ts->GetDescriptorFinder());
+  return GetTypeFromTypeRef(*tr_ts, super_tr);
+}
+
 bool SwiftLanguageRuntime::ForEachSuperClassType(
     ValueObject &instance, std::function<bool(SuperClassType)> fn) {
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
@@ -2087,38 +2110,22 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
   instance_ptr = FixupAddress(instance_ptr, class_type, error);
   if (!error.Success())
     return false;
-
-  auto tss = class_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
-  if (!tss) {
-    // This could be an Objective-C type implemented in Swift. Get the
-    // Swift typesystem.
-    if (auto module_sp = in_value.GetModule()) {
-      auto type_system_or_err =
-          module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-      if (!type_system_or_err) {
-        llvm::consumeError(type_system_or_err.takeError());
-        return false;
-      }
-      auto ts_sp = *type_system_or_err;
-      tss =
-          llvm::cast<TypeSystemSwift>(ts_sp.get())->GetTypeSystemSwiftTypeRef();
-    } else if (auto target_sp = in_value.GetTargetSP()) {
-      auto type_system_or_err =
-          target_sp->GetScratchTypeSystemForLanguage(lldb::eLanguageTypeSwift);
-      if (!type_system_or_err) {
-        llvm::consumeError(type_system_or_err.takeError());
-        return false;
-      }
-      auto ts_sp = *type_system_or_err;
-      tss =
-          llvm::cast<TypeSystemSwift>(ts_sp.get())->GetTypeSystemSwiftTypeRef();
-    }
-  }
-  if (!tss)
-    return false;
-
   address.SetRawAddress(instance_ptr);
-  auto ts = tss->GetTypeSystemSwiftTypeRef();
+
+  // We are going to use process information to resolve the type, so
+  // the result needs to be in the target's scratch context, not a
+  // long-lived per-module typesystem.
+  TypeSystemSwiftTypeRefSP ts;
+  if (auto target_sp = in_value.GetTargetSP()) {
+    auto type_system_or_err =
+        target_sp->GetScratchTypeSystemForLanguage(lldb::eLanguageTypeSwift);
+    if (!type_system_or_err) {
+      llvm::consumeError(type_system_or_err.takeError());
+      return false;
+    }
+    auto ts_sp = *type_system_or_err;
+    ts = llvm::cast<TypeSystemSwift>(ts_sp.get())->GetTypeSystemSwiftTypeRef();
+  }
   if (!ts)
     return false;
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -5258,20 +5258,32 @@ TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
 }
 uint32_t
 TypeSystemSwiftTypeRef::GetNumDirectBaseClasses(opaque_compiler_type_t type) {
-  // We forward the call to SwiftASTContext because an implementation of
-  // this function would require it to have an execution context being passed
-  // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
-  // function will be called much.
-  FORWARD_TO_EXPRAST_ONLY(GetNumDirectBaseClasses, (ReconstructType(type)), {});
+  auto impl = [&]() -> uint32_t {
+    CompilerType class_ty(weak_from_this(), type);
+    if (auto target_sp = GetTargetWP().lock())
+      if (auto *runtime = SwiftLanguageRuntime::Get(target_sp->GetProcessSP()))
+        if (runtime->GetBaseClass(class_ty))
+          return 1;
+    return 0;
+  };
+
+  VALIDATE_AND_RETURN(impl, GetNumDirectBaseClasses, type, g_no_exe_ctx,
+                      (ReconstructType(type)));
 }
 CompilerType TypeSystemSwiftTypeRef::GetDirectBaseClassAtIndex(
     opaque_compiler_type_t type, size_t idx, uint32_t *bit_offset_ptr) {
-  // We forward the call to SwiftASTContext because an implementation of
-  // this function would require it to have an execution context being passed
-  // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
-  // function will be called much.
-  FORWARD_TO_EXPRAST_ONLY(GetDirectBaseClassAtIndex,
-                          (ReconstructType(type), idx, bit_offset_ptr), {});
+  auto impl = [&]() {
+    if (idx != 0)
+      return CompilerType();
+    CompilerType class_ty(weak_from_this(), type);
+    if (auto target_sp = GetTargetWP().lock())
+      if (auto *runtime = SwiftLanguageRuntime::Get(target_sp->GetProcessSP()))
+        return runtime->GetBaseClass(class_ty);
+    return CompilerType();
+  };
+
+  VALIDATE_AND_RETURN(impl, GetDirectBaseClassAtIndex, type, g_no_exe_ctx,
+                      (ReconstructType(type), idx, nullptr));
 }
 bool TypeSystemSwiftTypeRef::IsReferenceType(opaque_compiler_type_t type,
                                              CompilerType *pointee_type,

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
@@ -1,0 +1,20 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftNSClassBaseClass(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    @skipUnlessDarwin
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        c = self.frame().FindVariable("c")
+        c_type = c.GetType()
+        self.assertIn("C", c_type.GetName())
+        self.assertEqual(c_type.GetNumberOfDirectBaseClasses(), 1)
+        nsobject = c_type.GetDirectBaseClassAtIndex(0)
+        self.assertIn("NSObject", nsobject.GetName())

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/main.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@objc class C : NSObject {}
+
+func main() {
+  var c = C()
+  print("break here \(c)")
+}
+
+main()

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
@@ -10,6 +10,7 @@ class TestSwiftClangImporterProtocolComposition(TestBase):
         """Test that protocol composition types can be resolved
            through the Swift language runtime"""
         self.build()
+        self.expect('settings set symbols.swift-validate-typesystem false')
         lldbutil.run_to_source_breakpoint(self, 'break here',
                                           lldb.SBFileSpec('main.swift'))
         obj = self.frame().FindVariable("obj", lldb.eDynamicDontRunTarget)

--- a/lldb/test/API/lang/swift/class_baseclass/Makefile
+++ b/lldb/test/API/lang/swift/class_baseclass/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
+++ b/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftClassBaseClass(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        c = self.frame().FindVariable("c")
+        c1 = c.GetType()
+        self.assertIn("C1", c1.GetName())
+        self.assertEqual(c1.GetNumberOfDirectBaseClasses(), 1)
+        c0 = c1.GetDirectBaseClassAtIndex(0)
+        self.assertIn("C0", c0.GetName())

--- a/lldb/test/API/lang/swift/class_baseclass/main.swift
+++ b/lldb/test/API/lang/swift/class_baseclass/main.swift
@@ -1,0 +1,9 @@
+class C0 {}
+class C1 : C0 {}
+
+func main() {
+  var c = C1()
+  print("break here \(c)")
+}
+
+main()


### PR DESCRIPTION
…friends

The main problem and reason why this hasn't been done earlier is that it requires a call to the Reflection API, which requires a Process. This patch enables the functionality for dynamic value types (i.e., the result of
SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class) by moving those types into the Target's scratch context. This is arguably the right thing to do because the type was created with help of extra information from a Process. Before TypeSystemSwiftTypeRef we avoided doing this because the target-wide SwiftASTContext had necessarily worse reliability due to incompatible search paths and flags. This is no longer a concern for TypeSystemSwiftTypeRef.

rdar://141319988