### PR TITLE
[LLDB] Remove high-firing scoped timers from the Swift plugin

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -239,7 +239,6 @@ public:
   bool lookupAdditions(swift::DeclBaseName Name, swift::DeclContext *DC,
                        swift::SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
-    LLDB_SCOPED_TIMER();
     assert(SwiftASTContext::GetSwiftASTContext(&DC->getASTContext()) ==
            m_this_context);
     static unsigned counter = 0;
@@ -402,8 +401,6 @@ public:
   bool lookupAdditions(swift::DeclBaseName Name, swift::DeclContext *DC,
                        swift::SourceLoc Loc, bool IsTypeLookup,
                        ResultVector &RV) override {
-    LLDB_SCOPED_TIMER();
-
     assert(SwiftASTContext::GetSwiftASTContext(&DC->getASTContext()) ==
            m_this_context);
     static unsigned counter = 0;
@@ -462,7 +459,6 @@ public:
 static CompilerType GetSwiftTypeForVariableValueObject(
     lldb::ValueObjectSP valobj_sp, lldb::StackFrameSP &stack_frame_sp,
     SwiftLanguageRuntime *runtime, lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
   // Check that the passed ValueObject is valid.
   if (!valobj_sp || valobj_sp->GetError().Fail())
     return {};
@@ -490,7 +486,6 @@ CompilerType SwiftExpressionParser::ResolveVariable(
     lldb::VariableSP variable_sp, lldb::StackFrameSP &stack_frame_sp,
     SwiftLanguageRuntime *runtime, lldb::DynamicValueType use_dynamic,
     lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
   lldb::ValueObjectSP valobj_sp =
       stack_frame_sp->GetValueObjectForFrameVariable(variable_sp,
                                                      lldb::eNoDynamicValues);
@@ -555,8 +550,6 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
                    SwiftASTManipulator &manipulator,
                    lldb::DynamicValueType use_dynamic,
                    lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
-
   // Alias builtin types, since we can't use them directly in source code.
   auto builtin_ptr_t = swift_ast_context.GetBuiltinRawPointerType();
   auto alias = manipulator.MakeTypealias(
@@ -737,8 +730,6 @@ static void ResolveSpecialNames(
     llvm::SmallVectorImpl<swift::Identifier> &special_names,
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables) {
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-  
   if (!sc.target_sp)
     return;
 
@@ -939,7 +930,6 @@ MaterializeVariable(SwiftASTManipulatorBase::VariableInfo &variable,
                     lldb::StackFrameWP &stack_frame_wp,
                     DiagnosticManager &diagnostic_manager, Log *log,
                     bool repl) {
-  LLDB_SCOPED_TIMER();
   uint64_t offset = 0;
   bool needs_init = false;
 
@@ -1283,9 +1273,6 @@ SwiftExpressionParser::ParseAndImport(
     SwiftExpressionParser::SILVariableMap &variable_map, unsigned &buffer_id,
     DiagnosticManager &diagnostic_manager) {
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-
-
   bool repl = m_options.GetREPLEnabled();
   bool playground = m_options.GetPlaygroundTransformEnabled();
   // If we are using the playground, hand import the necessary
@@ -1747,8 +1734,6 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
   SwiftExpressionParser::SILVariableMap variable_map;
   using ParseResult = SwiftExpressionParser::ParseResult;
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-
   // Get a scoped diagnostics consumer for all diagnostics produced by
   // this expression.
   auto expr_diagnostics = m_swift_ast_ctx.getScopedDiagnosticConsumer();
@@ -2228,7 +2213,6 @@ SwiftExpressionParser::Parse(DiagnosticManager &diagnostic_manager,
 static bool FindFunctionInModule(ConstString &mangled_name,
                                  llvm::Module *module, const char *orig_name,
                                  bool exact) {
-  LLDB_SCOPED_TIMER();
   swift::Demangle::Context demangle_ctx;
   for (llvm::Module::iterator fi = module->getFunctionList().begin(),
                               fe = module->getFunctionList().end();
@@ -2282,7 +2266,6 @@ Status SwiftExpressionParser::DoPrepareForExecution(
     lldb::addr_t &func_addr, lldb::addr_t &func_end,
     lldb::IRExecutionUnitSP &execution_unit_sp, ExecutionContext &exe_ctx,
     bool &can_interpret, ExecutionPolicy execution_policy) {
-  LLDB_SCOPED_TIMER();
   Status err;
   Log *log = GetLog(LLDBLog::Expressions);
 
@@ -2340,7 +2323,6 @@ Status SwiftExpressionParser::DoPrepareForExecution(
 
 bool SwiftExpressionParser::RewriteExpression(
     DiagnosticManager &diagnostic_manager) {
-  LLDB_SCOPED_TIMER();
   // There isn't a Swift equivalent to clang::Rewriter, so we'll just
   // use that.
   Log *log = GetLog(LLDBLog::Expressions);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -185,7 +185,6 @@ findSwiftSelf(StackFrame &frame, lldb::VariableSP self_var_sp) {
 void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
   Log *log = GetLog(LLDBLog::Expressions);
   LLDB_LOG(log, "SwiftUserExpression::ScanContext()");
-  LLDB_SCOPED_TIMER();
 
   m_target = exe_ctx.GetTargetPtr();
   if (!m_target) {
@@ -304,8 +303,6 @@ static llvm::Error AddVariableInfo(
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
     lldb::DynamicValueType use_dynamic,
     lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
-
   StringRef name = variable_sp->GetUnqualifiedName().GetStringRef();
   const char *name_cstr = name.data();
   assert(StringRef(name_cstr) == name && "missing null terminator");
@@ -495,7 +492,6 @@ static llvm::Error RegisterAllVariables(
     llvm::SmallVectorImpl<SwiftASTManipulator::VariableInfo> &local_variables,
     lldb::DynamicValueType use_dynamic,
     lldb::BindGenericTypes bind_generic_types) {
-  LLDB_SCOPED_TIMER();
   SwiftLanguageRuntime *language_runtime = nullptr;
 
   if (stack_frame_sp)
@@ -703,8 +699,6 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
                                 bool keep_result_in_memory,
                                 bool generate_debug_info) {
   Log *log = GetLog(LLDBLog::Expressions);
-  LLDB_SCOPED_TIMER();
-
   Status err;
 
   auto error = [&](const char *error_msg, const char *detail = nullptr) {
@@ -981,7 +975,6 @@ bool SwiftUserExpression::AddArguments(ExecutionContext &exe_ctx,
 
 lldb::ExpressionVariableSP SwiftUserExpression::GetResultAfterDematerialization(
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   lldb::ExpressionVariableSP in_result_sp = m_result_delegate.GetVariable();
   lldb::ExpressionVariableSP in_error_sp = m_error_delegate.GetVariable();
 

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -145,8 +145,6 @@ static bool makeStringGutsSummary(
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options,
     std::optional<StringSlice> slice = std::nullopt) {
-  LLDB_SCOPED_TIMER();
-
   static ConstString g__object("_object");
   static ConstString g__storage("_storage");
   static ConstString g__value("_value");
@@ -518,8 +516,6 @@ bool lldb_private::formatters::swift::StaticString_SummaryProvider(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
-  LLDB_SCOPED_TIMER();
-
   static ConstString g__startPtrOrData("_startPtrOrData");
   static ConstString g__byteSize("_utf8CodeUnitCount");
   static ConstString g__flags("_flags");
@@ -574,7 +570,6 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
     ValueObject &valobj, Stream &stream,
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
-  LLDB_SCOPED_TIMER();
   ProcessSP process(valobj.GetProcessSP());
   if (!process)
     return false;
@@ -603,7 +598,6 @@ bool lldb_private::formatters::swift::SwiftSharedString_SummaryProvider_2(
 
 bool lldb_private::formatters::swift::SwiftStringStorage_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
   ProcessSP process(valobj.GetProcessSP());
   if (!process)
     return false;
@@ -675,7 +669,6 @@ bool lldb_private::formatters::swift::DarwinBoolean_SummaryProvider(
 static bool RangeFamily_SummaryProvider(ValueObject &valobj, Stream &stream,
                                         const TypeSummaryOptions &options,
                                         bool isHalfOpen) {
-  LLDB_SCOPED_TIMER();
   static ConstString g_lowerBound("lowerBound");
   static ConstString g_upperBound("upperBound");
 
@@ -1607,7 +1600,6 @@ lldb_private::formatters::swift::ActorSyntheticFrontEndCreator(
 
 bool lldb_private::formatters::swift::ObjC_Selector_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
   static ConstString g_ptr("ptr");
   static ConstString g__rawValue("_rawValue");
 
@@ -1754,7 +1746,6 @@ bool PrintTypePreservingNSNumber(DataBufferSP buffer_sp, ProcessSP process_sp,
 
 bool lldb_private::formatters::swift::TypePreservingNSNumber_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
   lldb::addr_t ptr_value(valobj.GetValueAsUnsigned(LLDB_INVALID_ADDRESS));
   if (ptr_value == LLDB_INVALID_ADDRESS)
     return false;
@@ -2037,8 +2028,6 @@ void PrintMatrix(Stream &stream,
 
 bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
-
   // SIMD vector contains an inner member `_storage` which is an opaque
   // container. Given SIMD is always in the form SIMDX<Type> where X is a
   // positive integer, we can calculate the number of elements and the
@@ -2112,8 +2101,6 @@ bool lldb_private::formatters::swift::SIMDVector_SummaryProvider(
 
 bool lldb_private::formatters::swift::LegacySIMD_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
-
   Status error;
   ProcessSP process_sp(valobj.GetProcessSP());
   if (!process_sp)
@@ -2198,8 +2185,6 @@ bool lldb_private::formatters::swift::LegacySIMD_SummaryProvider(
 
 bool lldb_private::formatters::swift::GLKit_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-  LLDB_SCOPED_TIMER();
-
   // Get the type name without the "GLKit." prefix.
   ConstString full_type_name = valobj.GetTypeName();
   llvm::StringRef type_name = full_type_name.GetStringRef();

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2732,7 +2732,6 @@ UnwindPlanSP
 SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
                                            RegisterContext *regctx,
                                            bool &behaves_like_zeroth_frame) {
-  LLDB_SCOPED_TIMER();
   auto log_expected = [](llvm::Error error) {
     Log *log = GetLog(LLDBLog::Unwind);
     LLDB_LOG_ERROR(log, std::move(error), "{0}");
@@ -2837,8 +2836,6 @@ SwiftLanguageRuntime::GetRuntimeUnwindPlan(ProcessSP process_sp,
 UnwindPlanSP SwiftLanguageRuntime::GetFollowAsyncContextUnwindPlan(
     ProcessSP process_sp, RegisterContext *regctx, ArchSpec &arch,
     bool &behaves_like_zeroth_frame) {
-  LLDB_SCOPED_TIMER();
-
   UnwindPlan::Row row;
   const int32_t ptr_size = 8;
   row.SetOffset(0);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -547,7 +547,6 @@ SwiftLanguageRuntime::GetMemberVariableOffsetRemoteMirrors(
 std::optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
     CompilerType instance_type, ValueObject *instance,
     llvm::StringRef member_name, Status *error) {
-  LLDB_SCOPED_TIMER();
   std::optional<uint64_t> offset;
 
   if (!instance_type.IsValid())
@@ -1591,7 +1590,6 @@ SwiftLanguageRuntime::GetNumFields(CompilerType type,
 llvm::Expected<uint32_t> SwiftLanguageRuntime::GetNumChildren(
     CompilerType type, ExecutionContextScope *exe_scope,
     bool include_superclass, bool include_clang_types) {
-  LLDB_SCOPED_TIMER();
   SwiftRuntimeTypeVisitor visitor(*this, type, exe_scope, !include_superclass,
                                   include_clang_types);
   return visitor.CountChildren();
@@ -1630,7 +1628,6 @@ std::pair<SwiftLanguageRuntime::LookupResult, std::optional<size_t>>
 SwiftLanguageRuntime::GetIndexOfChildMemberWithName(
     CompilerType type, llvm::StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
-  LLDB_SCOPED_TIMER();
   SwiftRuntimeTypeVisitor visitor(*this, type, exe_ctx, false, false, true);
   bool found = false;
   unsigned i = 0, last_depth = 0;
@@ -2557,7 +2554,6 @@ void SwiftLanguageRuntime::ForEachGenericParameter(
 CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
     CompilerType unbound_type,
     std::function<CompilerType(unsigned, unsigned)> type_resolver) {
-  LLDB_SCOPED_TIMER();
   using namespace swift::Demangle;
 
   auto ts =
@@ -2643,7 +2639,6 @@ llvm::Expected<CompilerType>
 SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
                                                 TypeSystemSwiftTypeRef &ts,
                                                 ConstString mangled_name) {
-  LLDB_SCOPED_TIMER();
   using namespace swift::Demangle;
 
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
@@ -3170,7 +3165,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress(
   if (use_dynamic == lldb::eNoDynamicValues)
     return false;
 
-  LLDB_SCOPED_TIMER();
   CompilerType val_type(in_value.GetCompilerType());
   Value::ValueType static_value_type = Value::ValueType::Invalid;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -270,8 +270,6 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialRemoteAST(
 llvm::Expected<CompilerType>
 SwiftLanguageRuntime::BindGenericTypeParametersRemoteAST(
     StackFrame &stack_frame, CompilerType base_type) {
-  LLDB_SCOPED_TIMER();
-
   // If this is a TypeRef type, bind that.
   auto sc = stack_frame.GetSymbolContext(lldb::eSymbolContextEverything);
   if (auto ts =

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
@@ -60,7 +60,6 @@ SwiftDWARFImporterForClangTypes::SwiftDWARFImporterForClangTypes(
 void SwiftDWARFImporterForClangTypes::lookupValue(
     StringRef name, std::optional<swift::ClangTypeKind> kind,
     StringRef inModule, llvm::SmallVectorImpl<CompilerType> &results) {
-  LLDB_SCOPED_TIMER();
   LLDB_LOG(GetLog(LLDBLog::Types), "{0}::lookupValue(\"{1}\")", m_description,
            name.str());
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -977,8 +977,6 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
                                          swift::Demangle::NodePointer node,
                                          swift::Mangle::ManglingFlavor flavor,
                                          bool prefer_clang_types) {
-  LLDB_SCOPED_TIMER();
-
   // Hardcode that the Swift.AnyObject type alias always resolves to
   // the builtin AnyObject type.
   if (IsAnyObjectTypeAlias(node))
@@ -1210,8 +1208,6 @@ static swift::Demangle::NodePointer
 Desugar(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
         swift::Demangle::Node::Kind bound_kind,
         swift::Demangle::Node::Kind kind, llvm::StringRef name) {
-  LLDB_SCOPED_TIMER();
-
   using namespace swift::Demangle;
   NodePointer desugared = dem.createNode(bound_kind);
   NodePointer type = dem.createNode(Node::Kind::Type);
@@ -1440,7 +1436,6 @@ std::string ExtractSwiftName(
 std::string
 TypeSystemSwiftTypeRef::GetSwiftName(const clang::Decl *clang_decl,
                                      TypeSystemClang &clang_typesystem) {
-  LLDB_SCOPED_TIMER();
   auto *named_decl = llvm::dyn_cast_or_null<const clang::NamedDecl>(clang_decl);
   if (!named_decl)
     return {};
@@ -1498,8 +1493,6 @@ static bool IsImportedType(swift::Demangle::NodePointer node) {
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetSwiftified(
     swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
     swift::Mangle::ManglingFlavor flavor, bool resolve_objc_module) {
-  LLDB_SCOPED_TIMER();
-
   auto mangling = GetMangledName(dem, node, flavor);
   if (!mangling.isSuccess()) {
     LLDB_LOGF(GetLog(LLDBLog::Types), "Failed while getting swiftified (%d:%u)",
@@ -1672,8 +1665,6 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
 swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetDemangleTreeForPrinting(
     swift::Demangle::Demangler &dem, const char *mangled_name,
     bool resolve_objc_module) {
-  LLDB_SCOPED_TIMER();
-
   auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
 
   auto *node = dem.demangleSymbol(mangled_name);
@@ -3188,8 +3179,6 @@ bool TypeSystemSwiftTypeRef::IsPossibleDynamicType(opaque_compiler_type_t type,
                                                    CompilerType *target_type,
                                                    bool check_cplusplus,
                                                    bool check_objc) {
-  LLDB_SCOPED_TIMER();
-
   if (target_type)
     target_type->Clear();
 
@@ -3336,7 +3325,6 @@ ConstString TypeSystemSwiftTypeRef::GetTypeName(opaque_compiler_type_t type,
 ConstString
 TypeSystemSwiftTypeRef::GetDisplayTypeName(opaque_compiler_type_t type,
                                            const SymbolContext *sc) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() {
     using namespace swift::Demangle;
     auto flavor = SwiftLanguageRuntime::GetManglingFlavor(AsMangledName(type));
@@ -3582,7 +3570,6 @@ CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
 llvm::Expected<uint64_t>
 TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
                                    ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> llvm::Expected<uint64_t> {
     auto get_static_size = [&](bool cached_only) -> std::optional<uint64_t> {
       if (IsMeaninglessWithoutDynamicResolution(type))
@@ -3685,7 +3672,6 @@ TypeSystemSwiftTypeRef::GetBitSize(opaque_compiler_type_t type,
 std::optional<uint64_t>
 TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
                                       ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> std::optional<uint64_t> {
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
@@ -3711,7 +3697,6 @@ TypeSystemSwiftTypeRef::GetByteStride(opaque_compiler_type_t type,
 
 lldb::Encoding TypeSystemSwiftTypeRef::GetEncoding(opaque_compiler_type_t type,
                                                    uint64_t &count) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> lldb::Encoding {
     if (!type)
       return lldb::eEncodingInvalid;
@@ -3794,7 +3779,6 @@ llvm::Expected<uint32_t>
 TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
                                        bool omit_empty_base_classes,
                                        const ExecutionContext *exe_ctx) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> llvm::Expected<uint32_t> {
     if (exe_ctx)
       if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
@@ -3841,7 +3825,6 @@ TypeSystemSwiftTypeRef::GetNumChildren(opaque_compiler_type_t type,
 
 uint32_t TypeSystemSwiftTypeRef::GetNumFields(opaque_compiler_type_t type,
                                               ExecutionContext *exe_ctx) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> std::optional<uint32_t> {
     if (exe_ctx)
       if (auto *runtime = SwiftLanguageRuntime::Get(exe_ctx->GetProcessSP())) {
@@ -3909,7 +3892,6 @@ CompilerType TypeSystemSwiftTypeRef::GetFieldAtIndex(
   // this function would require it to have an execution context being passed
   // in. Given the purpose of TypeSystemSwiftTypeRef, it's unlikely this
   // function will be called much.
-  LLDB_SCOPED_TIMER();
   FORWARD_TO_EXPRAST_ONLY(GetFieldAtIndex,
                           (ReconstructType(type), idx, name, bit_offset_ptr,
                            bitfield_bit_size_ptr, is_bitfield_ptr),
@@ -3957,7 +3939,6 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
     uint32_t &child_bitfield_bit_size, uint32_t &child_bitfield_bit_offset,
     bool &child_is_base_class, bool &child_is_deref_of_parent,
     ValueObject *valobj, uint64_t &language_flags) {
-  LLDB_SCOPED_TIMER();
   child_name = "";
   child_byte_size = 0;
   child_byte_offset = 0;
@@ -4230,7 +4211,6 @@ TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex(
 size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
     opaque_compiler_type_t type, StringRef name, ExecutionContext *exe_ctx,
     bool omit_empty_base_classes, std::vector<uint32_t> &child_indexes) {
-  LLDB_SCOPED_TIMER();
   if (auto *exe_scope = exe_ctx->GetBestExecutionContextScope())
     if (auto *runtime =
             SwiftLanguageRuntime::Get(exe_scope->CalculateProcess())) {
@@ -4376,7 +4356,6 @@ TypeSystemSwiftTypeRef::ShouldPrintAsOneLiner(opaque_compiler_type_t type,
 
 bool TypeSystemSwiftTypeRef::IsMeaninglessWithoutDynamicResolution(
     opaque_compiler_type_t type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
@@ -4416,7 +4395,6 @@ TypeSystemSwiftTypeRef::GetAsClangTypeOrNull(lldb::opaque_compiler_type_t type,
 
 bool TypeSystemSwiftTypeRef::IsImportedType(opaque_compiler_type_t type,
                                             CompilerType *original_type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> bool {
     using namespace swift::Demangle;
     Demangler dem;
@@ -4831,7 +4809,6 @@ TypeSystemSwiftTypeRef::GetNonTriviallyManagedReferenceKind(
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
 
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s, level, exe_scope);
@@ -4840,7 +4817,6 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
 void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, Stream &s, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   DumpTypeDescription(type, &s, false, true, level, exe_scope);
 }
 
@@ -4848,7 +4824,6 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, bool print_help_if_available,
     bool print_extensions_if_available, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   StreamFile s(stdout, false);
   DumpTypeDescription(type, &s, print_help_if_available,
                       print_extensions_if_available, level, exe_scope);
@@ -4858,7 +4833,6 @@ void TypeSystemSwiftTypeRef::DumpTypeDescription(
     opaque_compiler_type_t type, Stream *s, bool print_help_if_available,
     bool print_extensions_if_available, lldb::DescriptionLevel level,
     ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   // Currently, we need an execution scope so we can access the runtime, which
   // in turn owns the reflection context, which is used to read the typeref. If
   // we were to decouple the reflection context from the runtime, we'd be able
@@ -4900,7 +4874,6 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     size_t data_byte_size, uint32_t bitfield_bit_size,
     uint32_t bitfield_bit_offset, ExecutionContextScope *exe_scope,
     bool is_base_class) {
-  LLDB_SCOPED_TIMER();
   if (!type)
     return false;
   const char *mangled_name = AsMangledName(type);
@@ -5117,7 +5090,6 @@ bool TypeSystemSwiftTypeRef::IsPointerOrReferenceType(
 std::optional<size_t>
 TypeSystemSwiftTypeRef::GetTypeBitAlign(opaque_compiler_type_t type,
                                         ExecutionContextScope *exe_scope) {
-  LLDB_SCOPED_TIMER();
   // This method doesn't use VALIDATE_AND_RETURN because except for
   // fixed-size types the SwiftASTContext implementation forwards to
   // SwiftLanguageRuntime anyway and for many fixed-size types the
@@ -5246,7 +5218,6 @@ bool TypeSystemSwiftTypeRef::IsTypedefType(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
     Demangler dem;
@@ -5276,7 +5247,6 @@ TypeSystemSwiftTypeRef::GetTypedefedType(opaque_compiler_type_t type) {
 
 CompilerType
 TypeSystemSwiftTypeRef::GetFullyUnqualifiedType(opaque_compiler_type_t type) {
-  LLDB_SCOPED_TIMER();
   auto impl = [&]() -> CompilerType { return {weak_from_this(), type}; };
 
   VALIDATE_AND_RETURN(impl, GetFullyUnqualifiedType, type, g_no_exe_ctx,


### PR DESCRIPTION
I have come to the realization that signposts are more useful for very high level operations, at the level of granularity the removed timers were on, something like an Instruments trace has all the data needed for performance analysis and more.

(cherry picked from commit 3d2f03a41d7f008bd84ac91535473dc8b8a773bc)

 Conflicts:
	lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp