### PR TITLE
[🍒 release/6.1.1] [lldb] Clear thread name container before writing UTF8 bytes (#134150)

### DIFF
--- a/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
+++ b/lldb/source/Plugins/Process/Windows/Common/TargetThreadWindows.cpp
@@ -191,6 +191,7 @@ const char *TargetThreadWindows::GetName() {
   if (SUCCEEDED(GetThreadDescription(
           m_host_thread.GetNativeThread().GetSystemHandle(), &pszThreadName))) {
     LLDB_LOGF(log, "GetThreadDescription: %ls", pszThreadName);
+    m_name.clear();
     llvm::convertUTF16ToUTF8String(
         llvm::ArrayRef(reinterpret_cast<char *>(pszThreadName),
                        wcslen(pszThreadName) * sizeof(wchar_t)),


### PR DESCRIPTION
- **Explanation**:
Clear out the thread name container before refilling it to avoid triggering an assertion that the target string container is empty in `llvm::convertUTF16ToUTF8String`.

- **Scope**:
This change is trivial. Either the string container was already empty, in which case clearing it does nothing, or it was not empty, in which case clearing it prevents a crash.

- **Issues**:
https://github.com/llvm/llvm-project/issues/133904

- **Original PRs**:
https://github.com/llvm/llvm-project/pull/134150

- **Risk**:
Very low risk. This code is Windows only and the change is small, easy to understand, and fixes a known crash that has been observed by users.

- **Testing**:
No additional testing on this release specifically, but the fix has been verified externally: https://forums.swift.org/t/lldb-crashes-during-vs-code-debug-session-on-windows-10/79902/3

- **Reviewers**:
@compnerd 

(cherry picked from commit be3abfc00f37d07c641b3e2f93eef5d1a446af8e)