### PR TITLE
[BoundsSafety] Fix Sema/compound-literal-ended_by.c test

### DIFF
--- a/clang/test/BoundsSafety-legacy-checks/Sema/compound-literal-ended_by.c
+++ b/clang/test/BoundsSafety-legacy-checks/Sema/compound-literal-ended_by.c
@@ -176,10 +176,9 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
 
 struct eb_with_other_data global_eb_with_other_data_side_effect_init = 
   (struct eb_with_other_data) {
-    // FIXME: Location of first non-constant is wrong (rdar://81135826)
-    .start = 0x0, // both-error{{initializer element is not a compile-time constant}}
+    .start = 0x0,
     .end = 0x0,
-    .other = side_effect() 
+    .other = side_effect() // both-error{{initializer element is not a compile-time constant}}
 };
 
 struct eb_with_other_data side_effects_in_ptrs(struct eb_with_other_data* s) {

--- a/clang/test/BoundsSafety/Sema/compound-literal-ended_by.c
+++ b/clang/test/BoundsSafety/Sema/compound-literal-ended_by.c
@@ -172,10 +172,9 @@ struct eb_with_other_data field_initializers_with_side_effects(struct eb_with_ot
 
 struct eb_with_other_data global_eb_with_other_data_side_effect_init = 
   (struct eb_with_other_data) {
-    // FIXME: Location of first non-constant is wrong (rdar://81135826)
-    .start = 0x0, // both-error{{initializer element is not a compile-time constant}}
+    .start = 0x0,
     .end = 0x0,
-    .other = side_effect() 
+    .other = side_effect() // both-error{{initializer element is not a compile-time constant}}
 };
 
 struct eb_with_other_data side_effects_in_ptrs(struct eb_with_other_data* s) {


### PR DESCRIPTION
After d58d5d6e9d6761f88344f439e7fdf63d41c8c384, we emit an error earlier for compound literals that occur outside the body of a function and are not constant expressions.

rdar://151424542