### PR TITLE
[lldb][cmake] Error out when building debugserver with CMake 4

### DIFF
--- a/lldb/tools/debugserver/source/CMakeLists.txt
+++ b/lldb/tools/debugserver/source/CMakeLists.txt
@@ -154,6 +154,21 @@ endif()
 
 add_definitions(-DLLDB_USE_OS_LOG)
 
+# Make sure we have the macOS SDK root as mig needs it and will silently
+# fail to generate its output files without it.
+if(CMAKE_OSX_SYSROOT)
+  set(MIG_SYSROOT ${CMAKE_OSX_SYSROOT})
+else()
+  execute_process(COMMAND xcrun --show-sdk-path
+    OUTPUT_VARIABLE MIG_SYSROOT
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+if(NOT MIG_SYSROOT)
+  message(FATAL_ERROR "Unable to obtain sysroot required by mig (Mach Interface Generator). Set CMAKE_OSX_SYSROOT to explicitly specify a sysroot.")
+endif()
+
 if(${CMAKE_OSX_SYSROOT} MATCHES ".Internal.sdk$")
   message(STATUS "LLDB debugserver energy support is enabled")
   add_definitions(-DLLDB_ENERGY)
@@ -177,7 +192,7 @@ endif()
 separate_arguments(MIG_ARCH_FLAGS_SEPARTED NATIVE_COMMAND "${MIG_ARCH_FLAGS}")
 
 add_custom_command(OUTPUT ${generated_mach_interfaces}
-  VERBATIM COMMAND mig ${MIG_ARCH_FLAGS_SEPARTED} -isysroot ${CMAKE_OSX_SYSROOT} ${CMAKE_CURRENT_SOURCE_DIR}/MacOSX/dbgnub-mig.defs
+  VERBATIM COMMAND mig ${MIG_ARCH_FLAGS_SEPARTED} -isysroot ${MIG_SYSROOT} ${CMAKE_CURRENT_SOURCE_DIR}/MacOSX/dbgnub-mig.defs
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/MacOSX/dbgnub-mig.defs
   )
 


### PR DESCRIPTION
CMake 4 no longer sets the `CMAKE_OSX_SYSROOT` variable by default. If you've updated to CMake 4 on macOS (e.g. with brew) and try building LLDB with CMake/ninja, this will yield an error when building debugserver that clang is unable to run since it tries to compile files that don't exist.

These files are supposed to be generated by the `mig` process. `mig` needs the `CMAKE_OSX_SYSROOT` variable in order to work and without it, it silently fails to generate the files that later on need to be compiled.

This commit sets this SDK path for mig and will fatal error out of config when building debugserver without having set CMAKE_OSX_SYSROOT.

(cherry picked from commit f6f7c911998de85d54600466a83983f62e51e30b)