### PR TITLE
[clang][DependencyScanning] Add API to expose module CompilerInvocation

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -225,6 +225,11 @@ struct ModuleDeps {
   /// module. Does not include argv[0].
   const std::vector<std::string> &getBuildArguments() const;
 
+  /// Experimental: get a copy of the underlying CompilerInvocation before
+  /// calling `getBuildArguments`. This provides a short cut to inspect/modify
+  /// the compiler invocation state.
+  CowCompilerInvocation getUnderlyingCompilerInvocation() const;
+
 private:
   friend class ModuleDepCollector;
   friend class ModuleDepCollectorPP;

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -56,6 +56,12 @@ void PrebuiltModuleASTAttrs::updateDependentsNotInStableDirs(
   }
 }
 
+CowCompilerInvocation ModuleDeps::getUnderlyingCompilerInvocation() const {
+  assert(std::holds_alternative<CowCompilerInvocation>(BuildInfo) &&
+         "ModuleDeps doesn't hold compiler invocation");
+  return *std::get_if<CowCompilerInvocation>(&BuildInfo);
+}
+
 static void
 optimizeHeaderSearchOpts(HeaderSearchOptions &Opts, ASTReader &Reader,
                          const serialization::ModuleFile &MF,


### PR DESCRIPTION
Add a new API that returns underlying CompilerInvocation from ModuleDep. This allows clients to inspect and modify the state inside CompilerInvocation before turning that into build arguments.