### PR TITLE
[Cherry-pick into next] [lldb] Implement TypeSystemSwiftTypeRef::GetNumDirectBaseClasses and friends (#10692)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -297,6 +297,7 @@ public:
   llvm::Error GetObjectDescription(Stream &str, ValueObject &object) override;
   CompilerType GetConcreteType(ExecutionContextScope *exe_scope,
                                ConstString abstract_type_name) override;
+  CompilerType GetBaseClass(CompilerType class_ty);
 
   CompilerType GetTypeFromMetadata(TypeSystemSwift &tss, Address address);
   /// Build the artificial type metadata variable name for \p swift_type.

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/TestSwiftNSClassBaseClass.py
@@ -1,0 +1,20 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftNSClassBaseClass(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    @skipUnlessDarwin
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        c = self.frame().FindVariable("c")
+        c_type = c.GetType()
+        self.assertIn("C", c_type.GetName())
+        self.assertEqual(c_type.GetNumberOfDirectBaseClasses(), 1)
+        nsobject = c_type.GetDirectBaseClassAtIndex(0)
+        self.assertIn("NSObject", nsobject.GetName())

--- a/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/main.swift
+++ b/lldb/test/API/lang/swift/clangimporter/class_nsbaseclass/main.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@objc class C : NSObject {}
+
+func main() {
+  var c = C()
+  print("break here \(c)")
+}
+
+main()

--- a/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
+++ b/lldb/test/API/lang/swift/clangimporter/protocol_composition/TestSwiftClangImporterProtocolComposition.py
@@ -10,6 +10,7 @@ class TestSwiftClangImporterProtocolComposition(TestBase):
         """Test that protocol composition types can be resolved
            through the Swift language runtime"""
         self.build()
+        self.expect('settings set symbols.swift-validate-typesystem false')
         lldbutil.run_to_source_breakpoint(self, 'break here',
                                           lldb.SBFileSpec('main.swift'))
         obj = self.frame().FindVariable("obj", lldb.eDynamicDontRunTarget)

--- a/lldb/test/API/lang/swift/class_baseclass/Makefile
+++ b/lldb/test/API/lang/swift/class_baseclass/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
+++ b/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
@@ -1,0 +1,19 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftClassBaseClass(TestBase):
+
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here",
+                                          lldb.SBFileSpec('main.swift'))
+        c = self.frame().FindVariable("c")
+        c1 = c.GetType()
+        self.assertIn("C1", c1.GetName())
+        self.assertEqual(c1.GetNumberOfDirectBaseClasses(), 1)
+        c0 = c1.GetDirectBaseClassAtIndex(0)
+        self.assertIn("C0", c0.GetName())

--- a/lldb/test/API/lang/swift/class_baseclass/main.swift
+++ b/lldb/test/API/lang/swift/class_baseclass/main.swift
@@ -1,0 +1,9 @@
+class C0 {}
+class C1 : C0 {}
+
+func main() {
+  var c = C1()
+  print("break here \(c)")
+}
+
+main()


### PR DESCRIPTION
```
commit 4e25a1b3b69ddb46ef70e4c140e8248fffc62c85
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon May 19 14:37:24 2025 -0700

    [lldb] Implement TypeSystemSwiftTypeRef::GetNumDirectBaseClasses and friends (#10692)
    
    The main problem and reason why this hasn't been done earlier is that
    it requires a call to the Reflection API, which requires a
    Process. This patch enables the functionality for dynamic value types
    (i.e., the result of
    SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class) by moving those
    types into the Target's scratch context. This is arguably the right
    thing to do because the type was created with help of extra
    information from a Process. Before TypeSystemSwiftTypeRef we avoided
    doing this because the target-wide SwiftASTContext had necessarily
    worse reliability due to incompatible search paths and flags. This is
    no longer a concern for TypeSystemSwiftTypeRef.
    
    rdar://141319988
```
