### PR TITLE
[lldb] Add support for Task names (#10684)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -1870,6 +1870,18 @@ bool lldb_private::formatters::swift::Task_SummaryProvider(
     return 0;
   };
 
+  addr_t task_addr = get_member("address");
+  if (auto process_sp = valobj.GetProcessSP()) {
+    if (auto name_or_err = GetTaskName(task_addr, *process_sp)) {
+      if (auto maybe_name = *name_or_err)
+        stream.Format("\"{0}\" ", *maybe_name);
+    } else {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
+                     name_or_err.takeError(),
+                     "failed to determine name of task {1:x}: {0}", task_addr);
+    }
+  }
+
   stream.Format("id:{0}", get_member("id"));
 
   std::vector<StringRef> flags;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -19,6 +19,7 @@
 #include "lldb/Breakpoint/BreakpointPrecondition.h"
 #include "lldb/Core/PluginInterface.h"
 #include "lldb/Target/LanguageRuntime.h"
+#include "lldb/Target/Process.h"
 #include "lldb/lldb-private.h"
 #include "swift/Demangling/ManglingFlavor.h"
 
@@ -902,6 +903,10 @@ GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 /// Inspects thread local storage to find the address of the currently executing
 /// task.
 llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
+
+llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task,
+                                                       Process &process);
+
 } // namespace lldb_private
 
 #endif // liblldb_SwiftLanguageRuntime_h_

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -49,13 +49,8 @@ private:
   /// If a thread for task_id had been created in the last stop, return it.
   /// Otherwise, create a new MemoryThread for it.
   lldb::ThreadSP FindOrCreateSwiftThread(ThreadList &old_thread_list,
-                                         uint64_t task_id);
-
-  /// Find the Task ID of the task being executed by `thread`, if any.
-  std::optional<uint64_t> FindTaskId(Thread &thread);
-
-  /// The offset of the Job ID inside a Task data structure.
-  size_t m_job_id_offset;
+                                         uint64_t task_id,
+                                         std::optional<std::string> task_name);
 };
 } // namespace lldb_private
 

--- a/lldb/test/API/lang/swift/async/formatters/task/name/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -disable-availability-checking
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -1,0 +1,25 @@
+import textwrap
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test_summary_contains_name(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break outside", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("v task", patterns=[r'"Chore" id:[1-9]\d*'])
+
+    @swiftTest
+    @skipIfLinux  # rdar://151471067
+    def test_thread_contains_name(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break inside", lldb.SBFileSpec("main.swift")
+        )
+        self.assertRegex(thread.name, r"Chore \(Task [1-9]\d*\)")

--- a/lldb/test/API/lang/swift/async/formatters/task/name/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/main.swift
@@ -1,0 +1,11 @@
+@main struct Main {
+    static func main() async {
+        let task = Task(name: "Chore") {
+            print("break inside")
+            _ = readLine()
+            return 15
+        }
+        print("break outside")
+        _ = await task.value
+    }
+}

--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -19,7 +19,7 @@ class TestCase(lldbtest.TestBase):
             self, "BREAK HERE", source_file
         )
 
-        self.assertIn("Swift Task", thread.GetName())
+        self.assertRegex(thread.GetName(), r"^Task [1-9]\d*$")
 
         queue_plugin = self.get_queue_from_thread_info_command(False)
         queue_backing = self.get_queue_from_thread_info_command(True)


### PR DESCRIPTION
* [lldb] Add support for Task names

This updates both `OperatingSystemSwiftTasks` and `Task_SummaryProvider` to include a
Task's name, if available. See [SE-0469][] for the introduction of task names.

The result is that threads representing Swift Tasks will show the given name, and when
printing a task, its name will be shown in the summary string.

[SE-0469]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0469-task-names.md

* Add tests

* Add docstrings; Switch to process reference; Make functions static; Change UpdateThreadList to handle task failures more granularly

* Another switch from pointer to reference; Use GetAddressByteSize

* Support 32 bit in TaskStatusRecord

* Fix bug in handling of non-Task threads

* Change int type of TaskStatusRecord offsets

* Make FindTaskId static

* Refactor test to (hopefully) work on Linux

* Disable test_thread_contains_name on Linux
(cherry-picked from commit 262cfab9ef42e8a2eb25998343f8cf19adc82006)