### PR TITLE
[6.2][clang][DependencyScanning] Add API to expose module CompilerInvocation

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ModuleDepCollector.h
@@ -170,6 +170,11 @@ struct ModuleDeps {
   /// module. Does not include argv[0].
   const std::vector<std::string> &getBuildArguments() const;
 
+  /// Experimental: get a copy of the underlying CompilerInvocation before
+  /// calling `getBuildArguments`. This provides a short cut to inspect/modify
+  /// the compiler invocation state.
+  CowCompilerInvocation getUnderlyingCompilerInvocation() const;
+
 private:
   friend class ModuleDepCollector;
   friend class ModuleDepCollectorPP;

--- a/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ModuleDepCollector.cpp
@@ -46,6 +46,13 @@ const std::vector<std::string> &ModuleDeps::getBuildArguments() const {
   return std::get<std::vector<std::string>>(BuildInfo);
 }
 
+
+CowCompilerInvocation ModuleDeps::getUnderlyingCompilerInvocation() const {
+  assert(std::holds_alternative<CowCompilerInvocation>(BuildInfo) &&
+         "ModuleDeps doesn't hold compiler invocation");
+  return *std::get_if<CowCompilerInvocation>(&BuildInfo);
+}
+
 static void
 optimizeHeaderSearchOpts(HeaderSearchOptions &Opts, ASTReader &Reader,
                          const serialization::ModuleFile &MF,


### PR DESCRIPTION
- **Explanation**: Add a new API that returns underlying CompilerInvocation from ModuleDep. This allows clients to inspect and modify the state inside CompilerInvocation before turning that into build arguments.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This enables swift scanner performance improvements to avoid round trip cc1 arguments.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://151705822
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**:  https://github.com/swiftlang/llvm-project/pull/10705
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Add a new API only.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: N/A. Adding API only. Swift change will be tested separately.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @jansvoboda11 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
