### PR TITLE
New option format for prefix mapping

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8836,7 +8836,7 @@ def fdepscan_include_tree : Flag<["-"], "fdepscan-include-tree">,
 //
 // FIXME: Add DepscanOption flag.
 def fdepscan_prefix_map_EQ : Joined<["-"], "fdepscan-prefix-map=">,
-    Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
+    Group<f_Group>, Visibility<[ClangOption]>,
     MetaVarName<"<old>=<new>">,
     HelpText<"With -fdepscan, seamlessly filter the CAS filesystem to"
              " apply the given prefix, updating the command-line to match.">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8839,8 +8839,12 @@ def fdepscan_prefix_map_EQ : Joined<["-"], "fdepscan-prefix-map=">,
     Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
     MetaVarName<"<old>=<new>">,
     HelpText<"With -fdepscan, seamlessly filter the CAS filesystem to"
-             " apply the given prefix, updating the command-line to match.">,
-    MarshallingInfoStringVector<FrontendOpts<"PathPrefixMappings">>;
+             " apply the given prefix, updating the command-line to match.">;
+def fdepscan_prefix_map : MultiArg<["-"], "fdepscan-prefix-map", 2>,
+    Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
+    MetaVarName<"<old> <new>">,
+    HelpText<"With -fdepscan, seamlessly filter the CAS filesystem to"
+             " apply the given prefix, updating the command-line to match.">;
 def fdepscan_prefix_map_sdk_EQ :
     Joined<["-"], "fdepscan-prefix-map-sdk=">,
     Group<f_Group>, MetaVarName<"<new>">,

--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -48,7 +48,7 @@ struct CompileJobCachingOptions {
   /// See \c FrontendOptions::WriteOutputAsCASID.
   bool WriteOutputAsCASID;
   /// See \c FrontendOptions::PathPrefixMappings.
-  std::vector<std::string> PathPrefixMappings;
+  std::vector<std::pair<std::string, std::string>> PathPrefixMappings;
 };
 
 /// Create a cache key for the given \c CompilerInvocation as a \c CASID. If \p

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -528,7 +528,7 @@ public:
   /// When caching is enabled, represents remappings for all the file paths that
   /// the compilation may access. This is useful for canonicalizing the
   /// compilation for caching purposes.
-  std::vector<std::string> PathPrefixMappings;
+  std::vector<std::pair<std::string, std::string>> PathPrefixMappings;
 
   // Currently this is only used as part of the `-extract-api` action.
   // A comma separated list of files providing a list of APIs to

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -48,7 +48,7 @@ struct DepscanPrefixMapping {
                                     llvm::PrefixMapper &Mapper);
 
   /// Add path mappings to the \p Mapper.
-  static void configurePrefixMapper(ArrayRef<std::string> PathPrefixMappings,
+  static void configurePrefixMapper(ArrayRef<std::pair<std::string, std::string>> PathPrefixMappings,
                                     llvm::PrefixMapper &Mapper);
 
   /// Apply the mappings from \p Mapper to \p Invocation.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5082,22 +5082,16 @@ void Clang::AddPrefixMappingOptions(const ArgList &Args, ArgStringList &CmdArgs,
     }
   }
 
-  for (const Arg *A : Args.filtered(options::OPT_fdepscan_prefix_map_EQ)) {
+  for (const Arg *A : Args.filtered(options::OPT_fdepscan_prefix_map, options::OPT_fdepscan_prefix_map_EQ)) {
     A->claim();
-    StringRef Map = A->getValue();
-    StringRef Prefix = Map.split('=').first;
-    if (Prefix.size() == Map.size() || !IsPathApplicableAsPrefix(Prefix)) {
-      D.Diag(diag::err_drv_invalid_argument_to_option)
-          << A->getValue() << A->getOption().getName();
+    StringRef Prefix, MapTarget;
+    if (A->getOption().matches(options::OPT_fdepscan_prefix_map_EQ)) {
+      StringRef Map = A->getValue();
+      std::tie(Prefix, MapTarget) = Map.split('=');
     } else {
-      A->render(Args, CmdArgs);
+      Prefix = A->getValue(0);
+      MapTarget = A->getValue(1);
     }
-  }
-
-  for (const Arg *A : Args.filtered(options::OPT_fdepscan_prefix_map)) {
-    A->claim();
-    StringRef Prefix = A->getValue(0);
-    StringRef MapTarget = A->getValue(1);
     if (MapTarget.size() == 0 || !IsPathApplicableAsPrefix(Prefix)) {
       D.Diag(diag::err_drv_invalid_argument_to_option)
           << A->getValue() << A->getOption().getName();

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5059,8 +5059,9 @@ void Clang::AddPrefixMappingOptions(const ArgList &Args, ArgStringList &CmdArgs,
 
   if (Arg *A = Args.getLastArg(options::OPT_fdepscan_prefix_map_sdk_EQ)) {
     if (IsPathApplicableAsPrefix(Sysroot)) {
-      CmdArgs.push_back(Args.MakeArgString(Twine("-fdepscan-prefix-map=") +
-                                           *Sysroot + "=" + A->getValue()));
+      CmdArgs.push_back("-fdepscan-prefix-map");
+      CmdArgs.push_back(Args.MakeArgString(*Sysroot));
+      CmdArgs.push_back(Args.MakeArgString(A->getValue()));
     } else {
       // FIXME: warning if we cannot infer sdk
     }
@@ -5075,8 +5076,9 @@ void Clang::AddPrefixMappingOptions(const ArgList &Args, ArgStringList &CmdArgs,
       Guess = llvm::sys::path::parent_path(Guess);
     }
     if (IsPathApplicableAsPrefix(Guess)) {
-      CmdArgs.push_back(Args.MakeArgString(Twine("-fdepscan-prefix-map=") +
-                                           Guess + "=" + A->getValue()));
+      CmdArgs.push_back("-fdepscan-prefix-map");
+      CmdArgs.push_back(Args.MakeArgString(Guess));
+      CmdArgs.push_back(Args.MakeArgString(A->getValue()));
     } else {
       // FIXME: warning if we cannot infer toolchain
     }
@@ -5096,7 +5098,9 @@ void Clang::AddPrefixMappingOptions(const ArgList &Args, ArgStringList &CmdArgs,
       D.Diag(diag::err_drv_invalid_argument_to_option)
           << A->getValue() << A->getOption().getName();
     } else {
-      A->render(Args, CmdArgs);
+      CmdArgs.push_back("-fdepscan-prefix-map");
+      CmdArgs.push_back(Args.MakeArgString(Prefix));
+      CmdArgs.push_back(Args.MakeArgString(MapTarget));
     }
   }
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5093,6 +5093,18 @@ void Clang::AddPrefixMappingOptions(const ArgList &Args, ArgStringList &CmdArgs,
       A->render(Args, CmdArgs);
     }
   }
+
+  for (const Arg *A : Args.filtered(options::OPT_fdepscan_prefix_map)) {
+    A->claim();
+    StringRef Prefix = A->getValue(0);
+    StringRef MapTarget = A->getValue(1);
+    if (MapTarget.size() == 0 || !IsPathApplicableAsPrefix(Prefix)) {
+      D.Diag(diag::err_drv_invalid_argument_to_option)
+          << A->getValue() << A->getOption().getName();
+    } else {
+      A->render(Args, CmdArgs);
+    }
+  }
 }
 
 static void addCachingOptions(ArgStringList &CmdArgs) {

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -330,8 +330,7 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
 
   llvm::PrefixMapper PrefixMapper;
   llvm::SmallVector<llvm::MappedPrefix> Split;
-  llvm::MappedPrefix::transformJoinedIfValid(CacheOpts.PathPrefixMappings,
-                                             Split);
+  llvm::MappedPrefix::transformPairs(CacheOpts.PathPrefixMappings, Split);
   for (const auto &MappedPrefix : Split) {
     // We use the inverse mapping because the \p PrefixMapper will be used for
     // de-canonicalization of paths.
@@ -629,7 +628,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
 
   llvm::PrefixMapper PrefixMapper;
   llvm::SmallVector<llvm::MappedPrefix> Split;
-  llvm::MappedPrefix::transformJoinedIfValid(
+  llvm::MappedPrefix::transformPairs(
       Clang.getFrontendOpts().PathPrefixMappings, Split);
   for (const auto &MappedPrefix : Split) {
     // We use the inverse mapping because the \p PrefixMapper will be used for

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3391,12 +3391,6 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     assert(Values.size() == 2);
     Opts.PathPrefixMappings.emplace_back(Values[0], Values[1]);
   }
-  for (const Arg *A : Args.filtered(OPT_fdepscan_prefix_map_EQ)) {
-    StringRef Val = A->getValue();
-    if (std::optional<llvm::MappedPrefix> mapping = llvm::MappedPrefix::getFromJoined(Val)) {
-      Opts.PathPrefixMappings.emplace_back(mapping->Old, mapping->New);
-    }
-  }
 
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)
     Diags.Report(diag::err_drv_argument_only_allowed_with) << "-fsystem-module"

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -86,6 +86,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/VersionTuple.h"
@@ -3155,6 +3156,9 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
   for (const auto &A : Opts.ModuleCacheKeys)
     GenerateMultiArg(Consumer, OPT_fmodule_file_cache_key, {A.first, A.second});
 
+  for (const auto &A : Opts.PathPrefixMappings)
+    GenerateMultiArg(Consumer, OPT_fdepscan_prefix_map, {A.first, A.second});
+
   if (Opts.AuxTargetCPU)
     GenerateArg(Consumer, OPT_aux_target_cpu, *Opts.AuxTargetCPU);
 
@@ -3379,6 +3383,19 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     ArrayRef<const char *> Values = A->getValues();
     assert(Values.size() == 2);
     Opts.ModuleCacheKeys.emplace_back(Values[0], Values[1]);
+  }
+
+  // Handle path prefix mappings
+  for (const Arg *A : Args.filtered(OPT_fdepscan_prefix_map)) {
+    ArrayRef<const char *> Values = A->getValues();
+    assert(Values.size() == 2);
+    Opts.PathPrefixMappings.emplace_back(Values[0], Values[1]);
+  }
+  for (const Arg *A : Args.filtered(OPT_fdepscan_prefix_map_EQ)) {
+    StringRef Val = A->getValue();
+    if (std::optional<llvm::MappedPrefix> mapping = llvm::MappedPrefix::getFromJoined(Val)) {
+      Opts.PathPrefixMappings.emplace_back(mapping->Old, mapping->New);
+    }
   }
 
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -143,7 +143,7 @@ void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
   // Pass the remappings so that we can map cached diagnostics to the local
   // paths during diagnostic rendering.
   for (const llvm::MappedPrefix &Map : Mapper.getMappings()) {
-    FrontendOpts.PathPrefixMappings.push_back(Map.Old + "=" + Map.New);
+    FrontendOpts.PathPrefixMappings.emplace_back(Map.Old, Map.New);
   }
 
   auto mapInPlaceAll = [&](std::vector<std::string> &Vector) {
@@ -244,12 +244,12 @@ void DepscanPrefixMapping::configurePrefixMapper(const CompilerInvocation &CI,
 }
 
 void DepscanPrefixMapping::configurePrefixMapper(
-    ArrayRef<std::string> PathPrefixMappings, llvm::PrefixMapper &Mapper) {
+    ArrayRef<std::pair<std::string, std::string>> PathPrefixMappings, llvm::PrefixMapper &Mapper) {
   if (PathPrefixMappings.empty())
     return;
 
   llvm::SmallVector<llvm::MappedPrefix> Split;
-  llvm::MappedPrefix::transformJoinedIfValid(PathPrefixMappings, Split);
+  llvm::MappedPrefix::transformPairs(PathPrefixMappings, Split);
   for (auto &MappedPrefix : Split)
     Mapper.add(MappedPrefix);
 

--- a/clang/test/CAS/cached-diagnostics.c
+++ b/clang/test/CAS/cached-diagnostics.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src/main.c -I %t/src/inc -Wunknown-pragmas 2> %t/regular-diags1.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t1.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src=/^src \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map %t/src /^src \
 // RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Wunknown-pragmas
 
 // Compare diagnostics after a miss.
@@ -42,7 +42,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src2/main.c -I %t/src2/inc -Wunknown-pragmas 2> %t/regular-diags2.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t2.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src2=/^src \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map %t/src2 /^src \
 // RUN:     -emit-obj %t/src2/main.c -o %t/out2/output.o -I %t/src2/inc -Wunknown-pragmas
 // RUN: %clang @%t/t2.rsp -Rcompile-job-cache 2> %t/diags-hit2.txt
 
@@ -55,7 +55,7 @@
 // RUN: diff -u %t/regular-diags2.txt %t/cached-diags2.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/terr.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src=/^src \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map %t/src /^src \
 // RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Rcompile-job-cache -DERROR
 
 // RUN: not %clang @%t/terr.rsp -ferror-limit 1 2> %t/diags_error1.txt

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -11,11 +11,11 @@
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/usr/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
-// RUN:              -fdepscan-prefix-map=%S=/^source                     \
-// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
-// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepscan-prefix-map %S /^source                     \
+// RUN:              -fdepscan-prefix-map %t.d /^testdir                  \
+// RUN:              -fdepscan-prefix-map %{objroot} /^objroot            \
+// RUN:              -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:              -fdepscan-prefix-map %S/Inputs/SDK /^sdk             \
 // RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=inline    \
@@ -25,11 +25,11 @@
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
-// RUN:              -fdepscan-prefix-map=%S=/^source                     \
-// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
-// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepscan-prefix-map %S /^source                     \
+// RUN:              -fdepscan-prefix-map %t.d /^testdir                  \
+// RUN:              -fdepscan-prefix-map %{objroot} /^objroot            \
+// RUN:              -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:              -fdepscan-prefix-map %S/Inputs/SDK /^sdk             \
 // RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
@@ -42,11 +42,11 @@
 // RUN:              -internal-isystem %S/Inputs/toolchain_dir/usr/lib/clang/1000/include \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
-// RUN:              -fdepscan-prefix-map=%S=/^source                     \
-// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
-// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepscan-prefix-map %S /^source                     \
+// RUN:              -fdepscan-prefix-map %t.d /^testdir                  \
+// RUN:              -fdepscan-prefix-map %{objroot} /^objroot            \
+// RUN:              -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:              -fdepscan-prefix-map %S/Inputs/SDK /^sdk             \
 // RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 //

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -98,15 +98,15 @@
 // SESSION-CMAKE-PREFIX: note: setting LLVM_CACHE_BUILD_SESSION_ID=
 
 // CLANG-CMAKE-PREFIX: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=[[INPUTS]]/SDK=/^sdk"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=[[INPUTS]]/toolchain_dir=/^toolchain"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/build=/^build"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/llvm=/^src"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/clang=/^src-clang"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/clang-tools-extra=/^src-clang-tools-extra"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/third-party/benchmark=/^src-benchmark"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/other/benchmark=/^src-benchmark-1"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/another/benchmark=/^src-benchmark-2"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "[[INPUTS]]/SDK" "/^sdk"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "[[INPUTS]]/toolchain_dir" "/^toolchain"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/build" "/^build"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/llvm" "/^src"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/clang" "/^src-clang"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/clang-tools-extra" "/^src-clang-tools-extra"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/third-party/benchmark" "/^src-benchmark"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/other/benchmark" "/^src-benchmark-1"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/another/benchmark" "/^src-benchmark-2"
 
 // Make sure `cache-build-session` can invoke an executable script.
 // RUN: cache-build-session %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=SESSION-SCRIPT -DSRC=%s -DPREFIX=%t

--- a/clang/test/CAS/fcas-include-tree-prefix-mapping.c
+++ b/clang/test/CAS/fcas-include-tree-prefix-mapping.c
@@ -7,9 +7,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src /^src -fdepscan-prefix-map %t/out /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-llvm %t/src/main.c -o %t/out/output.ll -include %t/src/prefix.h -I %t/src/inc \
 // RUN:       -MT deps -dependency-file %t/t1.d
@@ -47,9 +47,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src2 /^src -fdepscan-prefix-map %t/out2 /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-llvm %t/src2/main.c -o %t/out2/output.ll -include %t/src2/prefix.h -I %t/src2/inc \
 // RUN:       -MT deps -dependency-file %t/t2.d
@@ -85,9 +85,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src /^src -fdepscan-prefix-map %t/out /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-pch -x c-header %t/src/prefix.h -o %t/out/prefix.h.pch -include %t/src/prefix.h -I %t/src/inc
 // RUN: %clang @%t/pch1.rsp
@@ -98,9 +98,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas2 -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src2 /^src -fdepscan-prefix-map %t/out2 /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-pch -x c-header %t/src2/prefix.h -o %t/out2/prefix.h.pch -include %t/src2/prefix.h -I %t/src2/inc
 // RUN: %clang @%t/pch2.rsp
@@ -112,9 +112,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src /^src -fdepscan-prefix-map %t/out /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-obj %t/src/main.c -o %t/out/main.o -include-pch %t/out/prefix.h.pch -I %t/src/inc \
 // RUN:       -MT deps -dependency-file %t/t1.pch.d
@@ -129,9 +129,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src2 /^src -fdepscan-prefix-map %t/out2 /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-obj %t/src2/main.c -o %t/out2/main.o -include-pch %t/out2/prefix.h.pch -I %t/src2/inc \
 // RUN:       -MT deps -dependency-file %t/t2.pch.d

--- a/clang/test/CAS/pgo-profile.c
+++ b/clang/test/CAS/pgo-profile.c
@@ -37,9 +37,9 @@
 // RUN: mkdir -p %t.dir/a && mkdir -p %t.dir/b
 // RUN: cp %t.profdata %t.dir/a/a.profdata
 // RUN: cp %t.profdata %t.dir/b/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/a=/^testdir  \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/a /^testdir  \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/b=/^testdir \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/b /^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
@@ -54,9 +54,9 @@
 // RUN: grep llvmcas %t.dir/cache-key1
 // RUN: diff -u %t.dir/cache-key1 %t.dir/cache-key2
 
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/a=/^testdir \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/a /^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/b=/^testdir \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/b /^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.inc.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.inc.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS

--- a/clang/test/ClangScanDeps/include-tree-multiple-commands.c
+++ b/clang/test/ClangScanDeps/include-tree-multiple-commands.c
@@ -218,7 +218,7 @@
 // CHECK-LIBCLANG-NEXT:       [[SRC]]/header.h
 // CHECK-LIBCLANG-NOT:             -fcas-input-file-cache-key
 // CHECK-LIBCLANG-NOT:             {{.*}}tu.c
-// CHECK-LIBCLANG-NEXT:     build-args: -cc1 {{.*}} -o [[DST]]/tu.i {{.*}} -E -fmodule-file-cache-key {{.*}} [[M_CACHE_KEY]] -x c {{.*}} -fmodule-file={{.*}}[[PREFIX]]/modules/Mod_{{.*}}.pcm
+// CHECK-LIBCLANG-NEXT:     build-args: -cc1 {{.*}} -o [[DST]]/tu.i {{.*}} -E -fmodule-file-cache-key {{.*}} [[M_CACHE_KEY]] {{.*}} -x c {{.*}} -fmodule-file={{.*}}[[PREFIX]]/modules/Mod_{{.*}}.pcm
 // CHECK-LIBCLANG-NEXT:   command 1:
 // CHECK-LIBCLANG-NEXT:     context-hash: {{.*}}
 // FIXME: This should be empty.
@@ -231,7 +231,7 @@
 // CHECK-LIBCLANG-NEXT:       [[SRC]]/header.h
 // CHECK-LIBCLANG-NOT:                  -fcas-include-tree
 // CHECK-LIBCLANG-NOT:                  {{.*}}tu.i
-// CHECK-LIBCLANG-NEXT:     build-args: -cc1 {{.*}} -o [[DST]]/tu.bc {{.*}} -fcas-input-file-cache-key [[CPP_CACHE_KEY]] {{.*}} -emit-llvm-bc -fmodule-file-cache-key {{.*}} [[M_CACHE_KEY]] -x c-cpp-output {{.*}} -fmodule-file={{.*}}[[PREFIX]]/modules/Mod_{{.*}}.pcm
+// CHECK-LIBCLANG-NEXT:     build-args: -cc1 {{.*}} -o [[DST]]/tu.bc {{.*}} -fcas-input-file-cache-key [[CPP_CACHE_KEY]] {{.*}} -emit-llvm-bc -fmodule-file-cache-key {{.*}} [[M_CACHE_KEY]] {{.*}} -x c-cpp-output {{.*}} -fmodule-file={{.*}}[[PREFIX]]/modules/Mod_{{.*}}.pcm
 // CHECK-LIBCLANG-NEXT:   command 2:
 // CHECK-LIBCLANG-NEXT:     context-hash: {{.*}}
 // FIXME: This should be empty.
@@ -243,7 +243,7 @@
 // CHECK-LIBCLANG-NEXT:     file-deps:
 // CHECK-LIBCLANG-NEXT:       [[SRC]]/tu.c
 // CHECK-LIBCLANG-NEXT:       [[SRC]]/header.h
-// CHECK-LIBCLANG-NEXT:     build-args: -cc1 {{.*}} -o [[DST]]/tu.s {{.*}} -fcas-input-file-cache-key [[COMPILER_CACHE_KEY]] {{.*}} -S -x ir
+// CHECK-LIBCLANG-NEXT:     build-args: -cc1 {{.*}} -o [[DST]]/tu.s {{.*}} -fcas-input-file-cache-key [[COMPILER_CACHE_KEY]] {{.*}} -S {{.*}} -x ir
 // CHECK-LIBCLANG-NEXT:   command 3:
 // CHECK-LIBCLANG-NEXT:     context-hash: {{.*}}
 // FIXME: This should be empty.

--- a/clang/test/Driver/fdepscan-prefix-map-sdk.c
+++ b/clang/test/Driver/fdepscan-prefix-map-sdk.c
@@ -5,4 +5,4 @@
 
 // RUN: %clang -fdepscan-prefix-map-sdk=/^sdk -isysroot /sys/path -### %s 2>&1 | FileCheck %s
 // RUN: %clang -fdepscan-prefix-map-sdk=/^sdk --sysroot /sys/path -### %s 2>&1 | FileCheck %s
-// CHECK: -fdepscan-prefix-map=/sys/path=/^sdk
+// CHECK: "-fdepscan-prefix-map" "/sys/path" "/^sdk"

--- a/clang/test/Driver/fdepscan-prefix-map-toolchain.c
+++ b/clang/test/Driver/fdepscan-prefix-map-toolchain.c
@@ -8,8 +8,8 @@
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /tc/lib/clang/10 -### %s 2>&1 | FileCheck %s
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /tc/usr/lib/clang/10 -### %s 2>&1 | FileCheck %s
 
-// CHECK: -fdepscan-prefix-map=/tc=/^tc
+// CHECK: "-fdepscan-prefix-map" "/tc" "/^tc"
 
 // Implicit resource-dir
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -### %s 2>&1 | FileCheck %s -check-prefix=CHECK_IMPLICIT
-// CHECK_IMPLICIT: -fdepscan-prefix-map={{.*}}=/^tc
+// CHECK_IMPLICIT: "-fdepscan-prefix-map" "{{.*}}" "/^tc"

--- a/clang/test/Driver/fdepscan-prefix-map.c
+++ b/clang/test/Driver/fdepscan-prefix-map.c
@@ -4,5 +4,8 @@
 // RUN: not %clang -fdepscan-prefix-map=/=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
 // INVALID: error: invalid argument '{{.*}}/^bad' to -fdepscan-prefix-map=
 
-// RUN: %clang -fdepscan-prefix-map=/good=/^good -### %s 2>&1 | FileCheck %s
-// CHECK: "-fdepscan-prefix-map=/good=/^good"
+// RUN: %clang -fdepscan-prefix-map=/good=/^good -### %s 2>&1 | FileCheck --check-prefix CHECK_CORRECT %s
+// CHECK_CORRECT: "-fdepscan-prefix-map" "/good" "/^good"
+
+// RUN %clang -fdepscan-prefix-map=/a=/^a -fdepscan-prefix-map /b /^b -fdepscan-prefix-map=/c=/^c -fdepscan-prefix-map /d /^d -### %s 2>&1 | FileCheck --check-prefix=CHECK_MIXED %s
+// CHECK_MIXED: "-fdepscan-prefix-map" "/a" "/^a" "-fdepscan-prefix-map" "/b" "/^b" "-fdepscan-prefix-map" "/c" "/^c" "-fdepscan-prefix-map" "/d" "/^d"

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -11,6 +11,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Path.h"
 #include <optional>
@@ -48,6 +49,8 @@ struct MappedPrefix {
                                      SmallVectorImpl<MappedPrefix> &Split);
   static void transformJoinedIfValid(ArrayRef<std::string> Joined,
                                      SmallVectorImpl<MappedPrefix> &Split);
+  static void transformPairs(ArrayRef<std::pair<std::string, std::string>> Pairs,
+                             SmallVectorImpl<MappedPrefix> & Split);
 };
 
 /// Remap path prefixes.

--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -70,6 +70,13 @@ void MappedPrefix::transformJoinedIfValid(
   transformJoinedImpl</*StopOnInvalid*/ false>(Joined, Split);
 }
 
+void MappedPrefix::transformPairs(
+    ArrayRef<std::pair<std::string, std::string>> Pairs, SmallVectorImpl<MappedPrefix> &Split) {
+  for (auto &Pair : Pairs) {
+    Split.push_back(MappedPrefix{Pair.first, Pair.second});
+  }
+}
+
 /// FIXME: Copy/pasted from llvm/lib/Support/Path.cpp.
 static bool startsWith(StringRef Path, StringRef Prefix,
                        sys::path::Style PathStyle) {

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -125,6 +125,21 @@ TEST(MappedPrefixTest, transformJoinedIfValid) {
   EXPECT_EQ(ArrayRef(ExpectedSplit), ArrayRef(ComputedSplit));
 }
 
+TEST(PrefixMapperTest, transformPairs) {
+  SmallVector<std::pair<std::string, std::string>> PrefixMappings = {
+    {"", ""}, {"a", "b"}, {"", "a"}, {"a", ""}, {"=a=b=", "=c=d==="}
+  };
+  MappedPrefix ExpectedSplit[] = {
+    MappedPrefix{"", ""}, MappedPrefix{"a", "b"},
+    MappedPrefix{"", "a"}, MappedPrefix{"a", ""},
+    MappedPrefix{"=a=b=", "=c=d==="},
+  };
+
+  SmallVector<MappedPrefix> ComputedSplit;
+  MappedPrefix::transformPairs(PrefixMappings, ComputedSplit);
+  EXPECT_EQ(ArrayRef(ExpectedSplit), ArrayRef(ComputedSplit));
+}
+
 TEST(PrefixMapperTest, construct) {
   for (auto PathStyle : {
            sys::path::Style::posix,


### PR DESCRIPTION
The current option for specifying prefix mappings `-fdepscan-prefix-map=<old>=<new>` fails to handle paths containing `=` characters properly. This PR adds a 2nd form of that option `-fdepscan-prefix-map old new` while keeping the old format as well to fix this problem.