### PR TITLE
[lldb-dap] Avoid double 'new' events for dyld on Darwin (#140810)

### DIFF
--- a/lldb/tools/lldb-dap/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/lldb-dap.cpp
@@ -540,15 +540,7 @@ void EventThreadFunction(DAP &dap) {
 
             llvm::StringRef reason;
             bool id_only = false;
-            if (event_mask & lldb::SBTarget::eBroadcastBitModulesLoaded) {
-              dap.modules.insert(module_id);
-              reason = "new";
-            } else {
-              // If this is a module we've never told the client about, don't
-              // send an event.
-              if (!dap.modules.contains(module_id))
-                continue;
-
+            if (dap.modules.contains(module_id)) {
               if (event_mask & lldb::SBTarget::eBroadcastBitModulesUnloaded) {
                 dap.modules.erase(module_id);
                 reason = "removed";
@@ -556,6 +548,9 @@ void EventThreadFunction(DAP &dap) {
               } else {
                 reason = "changed";
               }
+            } else {
+              dap.modules.insert(module_id);
+              reason = "new";
             }
 
             llvm::json::Object body;


### PR DESCRIPTION
I got a bug report where a pedantic DAP client complains about getting two "new" module events for the same UUID. This is caused by the dyld transition from the on-disk dyld to the shared cache dyld, which share the same UUID. The transition is not generating an unloaded event (because we're not really unloading dyld) but we do get a loaded event (because the load address changed). This PR fixes the issue by relying on the modules set as the source of truth instead of relying on the event type.

Back-ported from commit 7b513393872fe608721ce4014606b03dd780a5c9