### PR TITLE
[lldb] Update ScriptInterpreterLua for Status changes (NFC)

### DIFF
--- a/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
+++ b/lldb/source/Plugins/ScriptInterpreter/Lua/ScriptInterpreterLua.cpp
@@ -370,16 +370,16 @@ Status ScriptInterpreterLua::SetBreakpointCommandCallback(
 Status ScriptInterpreterLua::RegisterBreakpointCallback(
     BreakpointOptions &bp_options, const char *command_body_text,
     StructuredData::ObjectSP extra_args_sp) {
-  Status error;
   auto data_up = std::make_unique<CommandDataLua>(extra_args_sp);
-  error = m_lua->RegisterBreakpointCallback(data_up.get(), command_body_text);
-  if (error.Fail())
-    return error;
+  llvm::Error err =
+      m_lua->RegisterBreakpointCallback(data_up.get(), command_body_text);
+  if (err)
+    return Status::FromError(std::move(err));
   auto baton_sp =
       std::make_shared<BreakpointOptions::CommandBaton>(std::move(data_up));
   bp_options.SetCallback(ScriptInterpreterLua::BreakpointCallbackFunction,
                          baton_sp);
-  return error;
+  return {};
 }
 
 void ScriptInterpreterLua::SetWatchpointCommandCallback(
@@ -391,16 +391,16 @@ void ScriptInterpreterLua::SetWatchpointCommandCallback(
 Status ScriptInterpreterLua::RegisterWatchpointCallback(
     WatchpointOptions *wp_options, const char *command_body_text,
     StructuredData::ObjectSP extra_args_sp) {
-  Status error;
   auto data_up = std::make_unique<WatchpointOptions::CommandData>();
-  error = m_lua->RegisterWatchpointCallback(data_up.get(), command_body_text);
-  if (error.Fail())
-    return error;
+  llvm::Error err =
+      m_lua->RegisterWatchpointCallback(data_up.get(), command_body_text);
+  if (err)
+    return Status::FromError(std::move(err));
   auto baton_sp =
       std::make_shared<WatchpointOptions::CommandBaton>(std::move(data_up));
   wp_options->SetCallback(ScriptInterpreterLua::WatchpointCallbackFunction,
                           baton_sp);
-  return error;
+  return {};
 }
 
 lldb::ScriptInterpreterSP


### PR DESCRIPTION
The Status constructor that takes an error has been removed in favor of Status::FromError.

(cherry picked from commit b93457073762bb347b6c7f39c23636dec036a815)