### PR TITLE
[BoundsSafety][APINotes] Add support for bounds safety annotations

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -2842,6 +2842,26 @@ private:
   TypeResult ParseTypeFromString(StringRef TypeStr, StringRef Context,
                                  SourceLocation IncludeLoc);
 
+  // TO_UPSTREAM(BoundsSafety) ON
+  /// Parse the given string as an expression in the argument position for a
+  /// bounds safety attribute.
+  ///
+  /// This is a dangerous utility function currently employed only by API notes.
+  /// It is not a general entry-point for safely parsing expressions from
+  /// strings.
+  ///
+  /// \param ExprStr The string to be parsed as an expression.
+  /// \param Context The name of the context in which this string is being
+  /// parsed, which will be used in diagnostics.
+  /// \param ParentDecl If a function or method is provided, the parameters are
+  ///   added to the current parsing context.
+  /// \param IncludeLoc The location at which this parse was triggered.
+  ExprResult ParseBoundsAttributeArgFromString(StringRef ExprStr,
+    StringRef Context,
+    Decl *ParentDecl,
+    SourceLocation IncludeLoc);
+  // TO_UPSTREAM(BoundsSafety) OFF
+
   ///@}
 
   //

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1529,6 +1529,12 @@ public:
   std::function<TypeResult(StringRef, StringRef, SourceLocation)>
       ParseTypeFromStringCallback;
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  /// Callback to the parser to parse a type expressed as a string.
+  std::function<ExprResult(StringRef, StringRef, Decl *, SourceLocation)>
+      ParseBoundsAttributeArgFromStringCallback;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+
   /// VAListTagName - The declaration name corresponding to __va_list_tag.
   /// This is used as part of a hack to omit that class from ADL results.
   DeclarationName VAListTagName;
@@ -2781,6 +2787,12 @@ public:
   ///
   bool BoundsSafetyFixItWasEmittedFor(const DeclaratorDecl *DD,
                                       bool Set = false);
+
+  void applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
+                                    AttributeCommonInfo::Kind Kind,
+                                    Expr *AttrArg, SourceLocation Loc,
+                                    SourceRange Range, StringRef DiagName,
+                                    bool OriginatesInAPINotes = false);
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
 

--- a/clang/include/clang/Serialization/ASTRecordWriter.h
+++ b/clang/include/clang/Serialization/ASTRecordWriter.h
@@ -149,6 +149,7 @@ public:
   void writeTypeCoupledDeclRefInfo(TypeCoupledDeclRefInfo Info) {
     writeDeclRef(Info.getDecl());
     writeBool(Info.isDeref());
+    writeBool(Info.isMember());
   }
 
   /// Emit a source range.

--- a/clang/lib/APINotes/APINotesFormat.h
+++ b/clang/lib/APINotes/APINotesFormat.h
@@ -24,7 +24,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 35; // SwiftDefaultOwnership
+const uint16_t VERSION_MINOR = 36; // TO_UPSTREAM(BoundsSafety)
 
 const uint8_t kSwiftConforms = 1;
 const uint8_t kSwiftDoesNotConform = 2;

--- a/clang/lib/APINotes/APINotesTypes.cpp
+++ b/clang/lib/APINotes/APINotesTypes.cpp
@@ -61,6 +61,34 @@ LLVM_DUMP_METHOD void ObjCPropertyInfo::dump(llvm::raw_ostream &OS) const {
   OS << '\n';
 }
 
+LLVM_DUMP_METHOD void BoundsSafetyInfo::dump(llvm::raw_ostream &OS) const {
+  if (KindAudited) {
+    assert((BoundsSafetyKind)Kind >= BoundsSafetyKind::CountedBy);
+    assert((BoundsSafetyKind)Kind <= BoundsSafetyKind::EndedBy);
+    switch ((BoundsSafetyKind)Kind) {
+    case BoundsSafetyKind::CountedBy:
+      OS << "[counted_by] ";
+      break;
+    case BoundsSafetyKind::CountedByOrNull:
+      OS << "[counted_by_or_null] ";
+      break;
+    case BoundsSafetyKind::SizedBy:
+      OS << "[sized_by] ";
+      break;
+    case BoundsSafetyKind::SizedByOrNull:
+      OS << "[sized_by_or_null] ";
+      break;
+    case BoundsSafetyKind::EndedBy:
+      OS << "[ended_by] ";
+      break;
+    }
+  }
+  if (LevelAudited)
+    OS << "Level: " << Level << " ";
+  OS << "ExternalBounds: "
+     << (ExternalBounds.empty() ? "<missing>" : ExternalBounds) << '\n';
+}
+
 LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
   static_cast<const VariableInfo &>(*this).dump(OS);
   if (NoEscapeSpecified)
@@ -69,6 +97,8 @@ LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
     OS << (Lifetimebound ? "[Lifetimebound] " : "");
   OS << "RawRetainCountConvention: " << RawRetainCountConvention << ' ';
   OS << '\n';
+  if (BoundsSafety)
+    BoundsSafety->dump(OS);
 }
 
 LLVM_DUMP_METHOD void FunctionInfo::dump(llvm::raw_ostream &OS) const {

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -152,7 +152,7 @@ enum class APIAvailability {
 
 /* TO_UPSTREAM(BoundsSafety) ON */
 namespace {
-struct BoundsSafety {
+struct BoundsSafetyNotes {
   BoundsSafetyInfo::BoundsSafetyKind Kind;
   unsigned Level = 0;
   StringRef BoundsExpr = "";
@@ -215,7 +215,7 @@ struct Param {
   std::optional<NullabilityKind> Nullability;
   std::optional<RetainCountConventionKind> RetainCountConvention;
   /* TO_UPSTREAM(BoundsSafety) ON */
-  std::optional<BoundsSafety> BoundsSafety;
+  std::optional<BoundsSafetyNotes> BoundsSafety;
   /* TO_UPSTREAM(BoundsSafety) OFF */
   StringRef Type;
 };
@@ -275,8 +275,8 @@ template <> struct MappingTraits<Param> {
 };
 
 /* TO_UPSTREAM(BoundsSafety) ON */
-template <> struct MappingTraits<BoundsSafety> {
-  static void mapping(IO &IO, BoundsSafety &BS) {
+template <> struct MappingTraits<BoundsSafetyNotes> {
+  static void mapping(IO &IO, BoundsSafetyNotes &BS) {
     IO.mapRequired("Kind", BS.Kind);
     IO.mapRequired("BoundedBy", BS.BoundsExpr);
     IO.mapOptional("Level", BS.Level, 0);

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -81,6 +81,14 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
       [this](StringRef TypeStr, StringRef Context, SourceLocation IncludeLoc) {
         return this->ParseTypeFromString(TypeStr, Context, IncludeLoc);
       };
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  Actions.ParseBoundsAttributeArgFromStringCallback =
+      [this](StringRef ExprStr, StringRef Context, Decl *Parent,
+             SourceLocation IncludeLoc) {
+        return this->ParseBoundsAttributeArgFromString(ExprStr, Context, Parent,
+                                                       IncludeLoc);
+      };
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 DiagnosticBuilder Parser::Diag(SourceLocation Loc, unsigned DiagID) {
@@ -464,8 +472,9 @@ Parser::ParseScopeFlags::~ParseScopeFlags() {
 //===----------------------------------------------------------------------===//
 
 Parser::~Parser() {
-  // Clear out the parse-type-from-string callback.
+  // Clear out the parse-*-from-string callbacks.
   Actions.ParseTypeFromStringCallback = nullptr;
+  Actions.ParseBoundsAttributeArgFromStringCallback = nullptr;
 
   // If we still have scopes active, delete the scope tree.
   delete getCurScope();

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5970,20 +5970,23 @@ class ConstructDynamicBoundType
 
 protected:
   Sema &S;
-  const ParsedAttr &AL;
+  const StringRef DiagName;
   Expr *ArgExpr;
+  SourceLocation Loc;
   const BoundsAttributedType *ConstructedType = nullptr;
   unsigned Level;
   bool ScopeCheck;
+  bool AllowRedecl;
   bool AutoPtrAttributed = false;
-  bool AllowCountRedecl = false;
   bool AtomicErrorEmitted = false;
 
 public:
   explicit ConstructDynamicBoundType(Sema &S, unsigned Level,
-                                     const ParsedAttr &AL, bool ScopeCheck)
-      : S(S), AL(AL), ArgExpr(AL.getArgAsExpr(0)), Level(Level),
-        ScopeCheck(ScopeCheck) {}
+                                     const StringRef DiagName, Expr *ArgExpr,
+                                     SourceLocation Loc, bool ScopeCheck,
+                                     bool AllowRedecl)
+      : S(S), DiagName(DiagName), ArgExpr(ArgExpr), Loc(Loc), Level(Level),
+        ScopeCheck(ScopeCheck), AllowRedecl(AllowRedecl) {}
 
   QualType Visit(QualType T) {
     SplitQualType SQT = T.split();
@@ -6001,7 +6004,7 @@ public:
   QualType VisitType(const Type *T) {
     if (const auto *PTy = T->getAs<PointerType>())
       return VisitPointerType(PTy);
-    S.Diag(S.getAttrLoc(AL), diag::err_attribute_pointers_only) << AL << 0;
+    S.Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
     return QualType();
   }
 
@@ -6012,7 +6015,6 @@ public:
 
   QualType VisitFunctionProtoType(const FunctionProtoType *FPT) {
     // The attribute applies to the return type.
-    SaveAndRestore<bool> AllowCountRedeclLocal(AllowCountRedecl, true);
     QualType QT = Visit(FPT->getReturnType());
     if (QT.isNull())
       return QualType();
@@ -6024,7 +6026,6 @@ public:
 
   QualType VisitFunctionNoProtoType(const FunctionNoProtoType *FPT) {
     // The attribute applies to the return type.
-    SaveAndRestore<bool> AllowCountRedeclLocal(AllowCountRedecl, true);
     QualType QT = Visit(FPT->getReturnType());
     if (QT.isNull())
       return QualType();
@@ -6038,9 +6039,8 @@ public:
     BoundsSafetyPointerAttributes FAttr = T->getPointerAttributes();
 
     if (FAttr.hasUpperBound() && !AutoPtrAttributed) {
-      S.Diag(S.getAttrLoc(AL),
-             diag::err_bounds_safety_conflicting_count_bound_attributes)
-          << AL << (FAttr.hasLowerBound() ? 0 : 1);
+      S.Diag(Loc, diag::err_bounds_safety_conflicting_count_bound_attributes)
+          << DiagName << (FAttr.hasLowerBound() ? 0 : 1);
       return QualType();
     }
 
@@ -6135,7 +6135,7 @@ public:
 
   QualType VisitValueTerminatedType(const ValueTerminatedType *T) {
     if (Level == 0 && !AutoPtrAttributed) {
-      S.Diag(AL.getLoc(), diag::err_bounds_safety_terminated_by_wrong_pointer_type);
+      S.Diag(Loc, diag::err_bounds_safety_terminated_by_wrong_pointer_type);
       return QualType();
     }
     QualType NewTy = Visit(T->desugar());
@@ -6154,12 +6154,16 @@ class ConstructCountAttributedType :
 
 public:
   explicit ConstructCountAttributedType(Sema &S, unsigned Level,
-                                        const ParsedAttr &AL, bool CountInBytes,
-                                        bool OrNull, bool ScopeCheck = false)
-      : ConstructDynamicBoundType(S, Level, AL, ScopeCheck),
+                                        const StringRef DiagName, Expr *ArgE,
+                                        SourceLocation Loc, bool CountInBytes,
+                                        bool OrNull, bool AllowRedecl,
+                                        bool ScopeCheck = false)
+      : ConstructDynamicBoundType(S, Level, DiagName, ArgE, Loc, ScopeCheck,
+                                  AllowRedecl),
         CountInBytes(CountInBytes), OrNull(OrNull) {
     if (!ArgExpr->getType()->isIntegralOrEnumerationType()) {
-      S.Diag(AL.getLoc(), diag::err_attribute_argument_type_for_bounds_safety_count) << AL;
+      S.Diag(Loc, diag::err_attribute_argument_type_for_bounds_safety_count)
+          << DiagName;
       // Recover by using the integer literal 0 as the count. If we get to
       // DefaultLvalueConversion and the count is itself a __counted_by value,
       // clang will go down a fiery stack overflow.
@@ -6190,26 +6194,26 @@ public:
         // directly (i.e. without the macro) because it is not expected that
         // users will use it.
         int SuggestFixIt = 0; // Default don't suggest __sized_by
-        if (S.getAttrLoc(AL).isMacroID()) {
+        if (Loc.isMacroID()) {
           // FIXME(dliew): Use `AL.MacroII` to get the name. Unfortunately
           // `AL.MacroII` is not set so we can't simply check the macro name is
           // what we expect. So instead we have the lexer tell us the contents
           // of the token and check against that.
           // rdar://100631458
-          auto MacroName = Lexer::getImmediateMacroName(
-              S.getAttrLoc(AL), S.SourceMgr, S.LangOpts);
+          auto MacroName =
+              Lexer::getImmediateMacroName(Loc, S.SourceMgr, S.LangOpts);
           if (MacroName == "__counted_by") {
             SuggestFixIt = 1; // Emit text to suggest __sized_by
-            auto MacroLoc = S.SourceMgr.getExpansionLoc(S.getAttrLoc(AL));
+            auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
             PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by");
           } else if (MacroName == "__counted_by_or_null") {
             SuggestFixIt = 1; // Emit text to suggest __sized_by_or_null
-            auto MacroLoc = S.SourceMgr.getExpansionLoc(S.getAttrLoc(AL));
+            auto MacroLoc = S.SourceMgr.getExpansionLoc(Loc);
             PD << FixItHint::CreateReplacement(MacroLoc, "__sized_by_or_null");
           }
         }
         PD << SuggestFixIt;
-        S.Diag(S.getAttrLoc(AL), PD);
+        S.Diag(Loc, PD);
 
         // Recover by assuming a byte count.
         CountInBytes = true;
@@ -6223,7 +6227,7 @@ public:
   }
 
   QualType DiagnoseConflictingType(const CountAttributedType *T) {
-    if (AllowCountRedecl) {
+    if (AllowRedecl) {
       QualType NewTy = BuildDynamicBoundType(T->desugar());
       const auto *NewDCPTy = NewTy->getAs<CountAttributedType>();
       // We don't have a way to distinguish if '__counted_by' is conflicting or has been
@@ -6241,14 +6245,23 @@ public:
         return NewTy;
     }
 
-    S.Diag(S.getAttrLoc(AL), diag::err_bounds_safety_conflicting_pointer_attributes)
+    S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
         << /* pointer */ T->isPointerType() << /* count */ 2;
     return QualType();
   }
 
+  QualType VisitFunctionProtoType(const FunctionProtoType *FPT) {
+    SaveAndRestore<bool> AllowRedeclLocal(AllowRedecl, true);
+    return ConstructDynamicBoundType::VisitFunctionProtoType(FPT);
+  }
+
+  QualType VisitFunctionNoProtoType(const FunctionNoProtoType *FPT) {
+    SaveAndRestore<bool> AllowRedeclLocal(AllowRedecl, true);
+    return ConstructDynamicBoundType::VisitFunctionNoProtoType(FPT);
+  }
+
   QualType DiagnoseConflictingType(const DynamicRangePointerType *T) {
-    S.Diag(S.getAttrLoc(AL),
-           diag::err_bounds_safety_conflicting_count_range_attributes);
+    S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
     return QualType();
   }
 
@@ -6257,7 +6270,7 @@ public:
       if (T->hasAttr(attr::ArrayDecayDiscardsCountInParameters)) {
         return Visit(S.Context.getArrayDecayedType(QualType(T, 0)));
       } else {
-        S.Diag(AL.getLoc(), diag::err_bounds_safety_complete_array_with_count);
+        S.Diag(Loc, diag::err_bounds_safety_complete_array_with_count);
         return QualType();
       }
     }
@@ -6273,7 +6286,7 @@ public:
 
     if (T->getPointeeType() != NewElementTy) {
       // Count attributes on the element of an array type are not supported yet
-      S.Diag(AL.getLoc(),
+      S.Diag(Loc,
              diag::err_multiple_coupled_decls_in_bounds_safety_dynamic_count);
       return QualType();
     }
@@ -6284,7 +6297,7 @@ public:
   QualType VisitIncompleteArrayType(const IncompleteArrayType *T) {
     if (Level == 0) {
       if (CountInBytes) {
-        S.Diag(AL.getLoc(), diag::err_bounds_safety_sized_by_array) << AL;
+        S.Diag(Loc, diag::err_bounds_safety_sized_by_array) << DiagName;
         return QualType();
       }
 
@@ -6300,8 +6313,7 @@ public:
         unsigned DiagIndex = CountInBytes ? 3 : 2;
         if (OrNull)
           DiagIndex += 2;
-        S.Diag(S.getAttrLoc(AL),
-               diag::err_bounds_safety_atomic_unsupported_attribute)
+        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
             << DiagIndex;
         AtomicErrorEmitted = true;
       }
@@ -6432,9 +6444,11 @@ class ConstructDynamicRangePointerType :
 
 public:
   explicit ConstructDynamicRangePointerType(
-      Sema &S, unsigned Level, const ParsedAttr &AL, bool ScopeCheck = false,
+      Sema &S, unsigned Level, const StringRef DiagName, Expr *ArgExpr,
+      SourceLocation Loc, bool AllowRedecl, bool ScopeCheck = false,
       std::optional<TypeCoupledDeclRefInfo> StartPtrInfo = std::nullopt)
-      : ConstructDynamicBoundType(S, Level, AL, ScopeCheck),
+      : ConstructDynamicBoundType(S, Level, DiagName, ArgExpr, Loc, ScopeCheck,
+                                  AllowRedecl),
         StartPtrInfo(StartPtrInfo) {
     assert(ArgExpr->getType()->isPointerType());
   }
@@ -6474,11 +6488,11 @@ public:
   }
 
   QualType VisitDynamicRangePointerType(const DynamicRangePointerType *T) {
-    if (Level == 0 && T->getEndPointer() == nullptr) {
-      // T is a started_by() pointer type.
+    if (Level == 0 && (AllowRedecl || T->getEndPointer() == nullptr)) {
+      // T could be a started_by() pointer type.
       Expr *StartPtr = T->getStartPointer();
       auto StartPtrDecls = T->getStartPtrDecls();
-      assert(StartPtr);
+      assert(StartPtr || AllowRedecl);
 
       assert(ConstructedType == nullptr);
       // Construct an ended_by() pointer type.
@@ -6491,6 +6505,20 @@ public:
       Expr *EndPtr = DRPT->getEndPointer();
       auto EndPtrDecls = DRPT->getEndPtrDecls();
       assert(EndPtr);
+      if (auto OldEndPtr = T->getEndPointer()) {
+        assert(AllowRedecl);
+        llvm::FoldingSetNodeID NewID;
+        llvm::FoldingSetNodeID OldID;
+        EndPtr->Profile(NewID, S.Context, /*Canonical*/ true);
+        OldEndPtr->Profile(OldID, S.Context, /*Canonical*/ true);
+
+        if (NewID != OldID) {
+          S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
+              << /* pointer */ 1 << /* end */ 3;
+          ConstructedType = nullptr;
+          return QualType();
+        }
+      }
 
       // ConstructType was already set while visiting the nested PointerType.
       // Reconstruct DRPT by merging started_by and ended_by.
@@ -6504,13 +6532,12 @@ public:
   }
 
   QualType DiagnoseConflictingType(const CountAttributedType *T) {
-    S.Diag(S.getAttrLoc(AL),
-           diag::err_bounds_safety_conflicting_count_range_attributes);
+    S.Diag(Loc, diag::err_bounds_safety_conflicting_count_range_attributes);
     return QualType();
   }
 
   QualType DiagnoseConflictingType(const DynamicRangePointerType *T) {
-    S.Diag(S.getAttrLoc(AL), diag::err_bounds_safety_conflicting_pointer_attributes)
+    S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
         << /* pointer */ 1 << /* end */ 3;
     return QualType();
   }
@@ -6519,8 +6546,7 @@ public:
     QualType ValTy = T->getValueType();
     if (ValTy->isPointerType()) {
       if (!AtomicErrorEmitted) {
-        S.Diag(S.getAttrLoc(AL),
-               diag::err_bounds_safety_atomic_unsupported_attribute)
+        S.Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
             << /*ended_by*/ 6;
         AtomicErrorEmitted = true;
       }
@@ -6956,11 +6982,11 @@ diagnoseRangeDependentDecls(Sema &S, const ValueDecl *TheDepender,
   return HadError;
 }
 
-static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
-                                          const ParsedAttr &AL) {
-  unsigned Level;
-  if (!S.checkUInt32Argument(AL, AL.getArgAsExpr(1), Level))
-    return;
+void Sema::applyPtrCountedByEndedByAttr(Decl *D, unsigned Level,
+                                        AttributeCommonInfo::Kind Kind,
+                                        Expr *AttrArg, SourceLocation Loc,
+                                        SourceRange Range, StringRef DiagName,
+                                        bool OriginatesInAPINotes) {
   // If the decl is invalid, the indirection Level might not exist in the type,
   // since the type may have not been constructed correctly. Example:
   // 'int (*param)[__counted_by_or_null(10)][]'
@@ -6990,14 +7016,14 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
 
   // Don't allow typedefs with __counted_by on non-function types.
   if (TND && (!DeclTy->isFunctionType() && !IsFPtr)) {
-    S.Diag(AL.getLoc(), diag::err_bounds_safety_typedef_dynamic_bound) << AL;
+    Diag(Loc, diag::err_bounds_safety_typedef_dynamic_bound) << DiagName;
     return;
   }
 
   bool CountInBytes = false;
   bool IsEndedBy = false;
   bool OrNull = false;
-  switch (AL.getKind()) {
+  switch (Kind) {
   case ParsedAttr::AT_SizedBy:
     CountInBytes = true;
     break;
@@ -7030,45 +7056,42 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
       // checked in attrNonNullArgCheck & handleNonNullAttr.
       if (auto NNAttr = D->getAttr<NonNullAttr>();
           NNAttr && isa<ParmVarDecl>(D)) {
-        S.Diag(AL.getLoc(),
-               diag::err_bounds_safety_nullable_dynamic_count_nonnullable)
-            << CountInBytes << NNAttr << AL.getRange() << NNAttr->getRange();
+        Diag(Loc, diag::err_bounds_safety_nullable_dynamic_count_nonnullable)
+            << CountInBytes << NNAttr << Range << NNAttr->getRange();
         return;
       }
       if (auto RNNAttr = D->getAttr<ReturnsNonNullAttr>()) {
-        S.Diag(AL.getLoc(),
-               diag::err_bounds_safety_nullable_dynamic_count_nonnullable)
-            << CountInBytes << RNNAttr << AL.getRange() << RNNAttr->getRange();
+        Diag(Loc, diag::err_bounds_safety_nullable_dynamic_count_nonnullable)
+            << CountInBytes << RNNAttr << Range << RNNAttr->getRange();
         return;
       }
 
       if (AttrNullability == NullabilityKind::NonNull) {
-        S.Diag(AL.getLoc(),
-               diag::warn_bounds_safety_nullable_dynamic_count_nonnullable)
-            << CountInBytes << AL;
+        Diag(Loc, diag::warn_bounds_safety_nullable_dynamic_count_nonnullable)
+            << CountInBytes << DiagName;
       }
     }
 
-    if (auto CountArg = AL.getArgAsExpr(0)->getIntegerConstantExpr(S.Context)) {
+    if (auto CountArg = AttrArg->getIntegerConstantExpr(Context)) {
       if (CountArg > 0 && !OrNull &&
           AttrNullability == NullabilityKind::Nullable)
-        S.Diag(AL.getArgAsExpr(0)->getExprLoc(),
-               diag::warn_bounds_safety_nonnullable_dynamic_count_nullable)
-            << CountInBytes << AL.getRange();
+        Diag(AttrArg->getExprLoc(),
+             diag::warn_bounds_safety_nonnullable_dynamic_count_nullable)
+            << CountInBytes << Range;
     }
   }
 
   if (VD) {
     const auto *FD = dyn_cast<FieldDecl>(VD);
     if (FD && FD->getParent()->isUnion()) {
-      S.Diag(AL.getLoc(), diag::err_invalid_decl_kind_bounds_safety_union_count)
-          << AL;
+      Diag(Loc, diag::err_invalid_decl_kind_bounds_safety_union_count)
+          << DiagName;
       return;
     }
 
     if (EffectiveLevel != 0 &&
         (!isa<ParmVarDecl>(VD) || DeclTy->isBoundsAttributedType())) {
-      S.Diag(AL.getLoc(), diag::err_bounds_safety_nested_dynamic_bound) << AL;
+      Diag(Loc, diag::err_bounds_safety_nested_dynamic_bound) << DiagName;
       return;
     }
 
@@ -7082,14 +7105,14 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
       QualType TSITy = PVD->getTypeSourceInfo()->getType();
       if (IsEndedBy) {
         if (Level == 0 && TSITy->isArrayType()) {
-          S.Diag(AL.getLoc(), diag::err_attribute_pointers_only) << AL << 0;
+          Diag(Loc, diag::err_attribute_pointers_only) << DiagName << 0;
           return;
         }
       } else {
-        const auto *ATy = S.Context.getAsArrayType(TSITy);
+        const auto *ATy = Context.getAsArrayType(TSITy);
         if (Level == 0 && ATy && !ATy->isIncompleteArrayType() &&
             !TSITy->hasAttr(attr::ArrayDecayDiscardsCountInParameters)) {
-          S.Diag(AL.getLoc(), diag::err_bounds_safety_complete_array_with_count);
+          Diag(Loc, diag::err_bounds_safety_complete_array_with_count);
           return;
         }
       }
@@ -7097,18 +7120,17 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
 
     if (Ty->isArrayType() && OrNull &&
         (FD || EffectiveLevel > 0 || (Var && Var->hasExternalStorage()))) {
-      auto ErrDiag = S.Diag(AL.getLoc(), diag::err_bounds_safety_nullable_fam);
+      auto ErrDiag = Diag(Loc, diag::err_bounds_safety_nullable_fam);
       // Pointers to dynamic count types are only allowed for parameters, so any
       // FieldDecl containing a dynamic count type is a FAM. I.e. a struct field
       // with type 'int(*)[__counted_by(...)]' is not valid.
-      ErrDiag << CountInBytes << /*is FAM?*/ !!FD << AL;
+      ErrDiag << CountInBytes << /*is FAM?*/ !!FD << DiagName;
       assert(!FD || EffectiveLevel == 0);
 
-      SourceLocation FixItLoc =
-          S.getSourceManager().getExpansionLoc(AL.getLoc());
+      SourceLocation FixItLoc = getSourceManager().getExpansionLoc(Loc);
       SourceLocation EndLoc =
           Lexer::getLocForEndOfToken(FixItLoc, /* Don't include '(' */ -1,
-                                     S.getSourceManager(), S.getLangOpts());
+                                     getSourceManager(), getLangOpts());
       std::string Attribute = CountInBytes ? "__sized_by" : "__counted_by";
       ErrDiag << FixItHint::CreateReplacement({FixItLoc, EndLoc}, Attribute);
 
@@ -7117,9 +7139,10 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
 
     if (Ty->isArrayType() && EffectiveLevel > 0) {
       auto ErrDiag =
-          S.Diag(
-              AL.getLoc(),
-              diag::err_bounds_safety_unsupported_address_of_incomplete_array_type)
+          Diag(
+              Loc,
+              diag::
+                  err_bounds_safety_unsupported_address_of_incomplete_array_type)
           << Ty;
       // apply attribute anyways to avoid too misleading follow-up diagnostics
     }
@@ -7131,15 +7154,14 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
 
   bool HadAtomicError = false;
   if (IsEndedBy) {
-    const Expr *ArgExpr = AL.getArgAsExpr(0);
-    if (ArgExpr && ArgExpr->getType()->isAtomicType()) {
-      S.Diag(AL.getLoc(), diag::err_bounds_safety_atomic_unsupported_attribute)
+    if (AttrArg && AttrArg->getType()->isAtomicType()) {
+      Diag(Loc, diag::err_bounds_safety_atomic_unsupported_attribute)
           << /*started_by*/ 8;
       return;
     }
-    if (!ArgExpr || !ArgExpr->getType()->isPointerType()) {
-      S.Diag(AL.getLoc(), diag::err_attribute_argument_type_for_bounds_safety_range)
-          << AL;
+    if (!AttrArg || !AttrArg->getType()->isPointerType()) {
+      Diag(Loc, diag::err_attribute_argument_type_for_bounds_safety_range)
+          << DiagName;
       return;
     }
 
@@ -7152,13 +7174,15 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
     }
 
     auto TypeConstructor = ConstructDynamicRangePointerType(
-        S, Level, AL, ScopeCheck, StartPtrInfo);
+        *this, Level, DiagName, AttrArg, Loc, OriginatesInAPINotes, ScopeCheck,
+        StartPtrInfo);
     NewDeclTy = TypeConstructor.Visit(DeclTy);
     HadAtomicError = TypeConstructor.hadAtomicError();
     ConstructedType = TypeConstructor.getConstructedType();
   } else {
     auto TypeConstructor = ConstructCountAttributedType(
-        S, Level, AL, CountInBytes, OrNull, ScopeCheck);
+        *this, Level, DiagName, AttrArg, Loc, CountInBytes, OrNull,
+        OriginatesInAPINotes, ScopeCheck);
     NewDeclTy = TypeConstructor.Visit(DeclTy);
     HadAtomicError = TypeConstructor.hadAtomicError();
     ConstructedType = TypeConstructor.getConstructedType();
@@ -7167,25 +7191,25 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
   if (NewDeclTy.isNull())
     return;
 
-  // `NewDeclTy` is the new type of the declaration `D`, whereas `ConstructedType` is exact
-  // `BoundsAttributedType` that's created for this attribute. The bounds
-  // attribute can be added to a nested pointer or some nested type, so
-  // `ConstructedType` can be different from `NewDeclTy`.
+  // `NewDeclTy` is the new type of the declaration `D`, whereas
+  // `ConstructedType` is exact `BoundsAttributedType` that's created for this
+  // attribute. The bounds attribute can be added to a nested pointer or some
+  // nested type, so `ConstructedType` can be different from `NewDeclTy`.
   assert(ConstructedType);
 
   auto LifetimeCheck =
       IsFPtr ? Sema::LifetimeCheckKind::None : Sema::getLifetimeCheckKind(Var);
-  if (diagnoseBoundsAttrLifetimeAndScope(S, ConstructedType, ScopeCheck,
+  if (diagnoseBoundsAttrLifetimeAndScope(*this, ConstructedType, ScopeCheck,
                                          LifetimeCheck))
     return;
 
   if (VD && !isa<FunctionDecl>(VD) && !HadAtomicError) {
     if (const auto *BDTy = dyn_cast<CountAttributedType>(ConstructedType)) {
-      if (!diagnoseCountDependentDecls(S, VD, BDTy, EffectiveLevel, IsFPtr))
-        S.AttachDependerDeclsAttr(VD, BDTy, EffectiveLevel);
+      if (!diagnoseCountDependentDecls(*this, VD, BDTy, EffectiveLevel, IsFPtr))
+        AttachDependerDeclsAttr(VD, BDTy, EffectiveLevel);
     } else if (const auto *BDTy =
                    dyn_cast<DynamicRangePointerType>(ConstructedType)) {
-      diagnoseRangeDependentDecls(S, VD, BDTy, EffectiveLevel, IsFPtr);
+      diagnoseRangeDependentDecls(*this, VD, BDTy, EffectiveLevel, IsFPtr);
     } else {
       llvm_unreachable("Unexpected bounds attributed type");
     }
@@ -7195,19 +7219,32 @@ static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
     // We need to create a TypeSourceInfo, as TypedefNameDecl is not a ValueDecl
     // and thus doesn't have setType() method.
     SourceLocation Loc = TND->getTypeSourceInfo()->getTypeLoc().getBeginLoc();
-    TypeSourceInfo *Info = S.Context.getTrivialTypeSourceInfo(NewDeclTy, Loc);
+    TypeSourceInfo *Info = Context.getTrivialTypeSourceInfo(NewDeclTy, Loc);
     TND->setTypeSourceInfo(Info);
   } else {
     VD->setType(NewDeclTy);
     // Reconstruct implicit cast for initializer after variable type change.
     if (Var && Var->hasInit()) {
       Expr *Init = Var->getInit();
-      ExprResult Res = removeUnusedOVEs(S, Init, Init->IgnoreImpCasts());
+      ExprResult Res = removeUnusedOVEs(*this, Init, Init->IgnoreImpCasts());
       if (Res.isInvalid())
         return;
-      S.AddInitializerToDecl(Var, Res.get(), Var->isDirectInit());
+      AddInitializerToDecl(Var, Res.get(), Var->isDirectInit());
     }
   }
+}
+
+static void handlePtrCountedByEndedByAttr(Sema &S, Decl *D,
+                                          const ParsedAttr &AL) {
+  unsigned Level;
+  if (!S.checkUInt32Argument(AL, AL.getArgAsExpr(1), Level))
+    return;
+  AttributeCommonInfo::Kind Kind = AL.getKind();
+  const IdentifierInfo *AttrName =
+      AL.printMacroName() ? AL.getMacroIdentifier() : AL.getAttrName();
+  S.applyPtrCountedByEndedByAttr(D, Level, Kind, AL.getArgAsExpr(0),
+                                 AL.getLoc(), AL.getRange(),
+                                 ("\'" + AttrName->getName() + "\'").str());
 }
 
 static void handleUnsafeLateConst(Sema &S, Decl *D,

--- a/clang/lib/Serialization/ASTReader.cpp
+++ b/clang/lib/Serialization/ASTReader.cpp
@@ -9953,7 +9953,10 @@ DeclarationNameInfo ASTRecordReader::readDeclarationNameInfo() {
 }
 
 TypeCoupledDeclRefInfo ASTRecordReader::readTypeCoupledDeclRefInfo() {
-  return TypeCoupledDeclRefInfo(readDeclAs<ValueDecl>(), readBool());
+  ValueDecl *D = readDeclAs<ValueDecl>();
+  bool IsDeref = readBool();
+  bool IsMember = readBool();
+  return TypeCoupledDeclRefInfo(D, IsDeref, IsMember);
 }
 
 void ASTRecordReader::readQualifierInfo(QualifierInfo &Info) {

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
@@ -1,0 +1,135 @@
+---
+Name: BoundsUnsafe
+Functions:
+  - Name:              asdf_counted
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              asdf_sized
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: size
+  - Name:              asdf_counted_n
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by_or_null
+            Level: 0
+            BoundedBy: len
+  - Name:              asdf_sized_n
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: sized_by_or_null
+            Level: 0
+            BoundedBy: size
+  - Name:              asdf_ended
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+  - Name:              asdf_sized_mul
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: "size * count"
+  - Name:              asdf_counted_out
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 1
+            BoundedBy: "*len"
+  - Name:              asdf_counted_const
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: 7
+  - Name:             asdf_counted_nullable
+    Parameters:
+      - Position:      1
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              asdf_counted_noescape
+    Parameters:
+      - Position:      0
+        NoEscape:      true
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              asdf_counted_default_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
+  - Name:              asdf_counted_redundant
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
+  - Name:              asdf_ended_chained
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+      - Position:      1
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+  - Name:              asdf_ended_chained_reverse
+    Parameters:
+      - Position:      1
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+  - Name:              asdf_ended_already_started
+    Parameters:
+      - Position:      1
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+  - Name:              asdf_ended_already_ended
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+  - Name:              asdf_ended_redundant
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+  - Name:              asdf_nterm
+    Parameters:
+      - Position:      0
+        Type: "int * __attribute__((__terminated_by__(0)))"

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
@@ -1,0 +1,21 @@
+void asdf_counted(int * buf, int len);
+void asdf_sized(int * buf, int size);
+void asdf_counted_n(int * buf, int len);
+void asdf_sized_n(int * buf, int size);
+void asdf_ended(int * buf, int * end);
+
+void asdf_sized_mul(int * buf, int size, int count);
+void asdf_counted_out(int ** buf, int * len);
+void asdf_counted_const(int * buf);
+void asdf_counted_nullable(int len, int * _Nullable buf);
+void asdf_counted_noescape(int * buf, int len);
+void asdf_counted_default_level(int * buf, int len);
+void asdf_counted_redundant(int * __attribute__((__counted_by__(len))) buf, int len);
+
+void asdf_ended_chained(int * buf, int * mid, int * end);
+void asdf_ended_chained_reverse(int * buf, int * mid, int * end);
+void asdf_ended_already_started(int * __attribute__((__ended_by__(mid))) buf, int * mid, int * end);
+void asdf_ended_already_ended(int * buf, int * mid __attribute__((__ended_by__(end))), int * end);
+void asdf_ended_redundant(int * __attribute__((__ended_by__(end))) buf, int * end);
+
+void asdf_nterm(char * buf);

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
@@ -1,0 +1,92 @@
+---
+Name: BoundsUnsafe
+Classes:
+  - Name: Foo
+    Methods:
+      - Selector:              "asdf_counted:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Selector:              "asdf_sized:size:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: size
+      - Selector:              "asdf_counted_n:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by_or_null
+                Level: 0
+                BoundedBy: len
+      - Selector:              "asdf_sized_n:size:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by_or_null
+                Level: 0
+                BoundedBy: size
+      - Selector:              "asdf_ended:end:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Selector:              "asdf_sized_mul:size:count:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: "size * count"
+      - Selector:              "asdf_counted_out:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 1
+                BoundedBy: "*len"
+      - Selector:              "asdf_counted_const:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: 7
+      - Selector:             "asdf_counted_nullable:buf:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Selector:              "asdf_counted_noescape:len:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            NoEscape:      true
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Selector:              "asdf_nterm:"
+        MethodKind: Instance
+        Parameters:
+          - Position:      0
+            Type: "int * __attribute__((__terminated_by__(0)))"
+

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.h
@@ -1,0 +1,16 @@
+@interface Foo
+- (void) asdf_counted: (int *)buf len: (int)len;
+- (void) asdf_sized: (int *)buf size: (int)size;
+- (void) asdf_counted_n: (int *)buf len: (int)len;
+- (void) asdf_sized_n: (int *)buf size: (int)size;
+- (void) asdf_ended: (int *)buf end: (int *)end;
+
+- (void) asdf_sized_mul: (int *)buf size:(int)size count:(int)count;
+- (void) asdf_counted_out: (int **)buf len:(int *)len;
+- (void) asdf_counted_const: (int *)buf;
+- (void) asdf_counted_nullable: (int)len buf:(int * _Nullable)buf;
+- (void) asdf_counted_noescape: (int *)buf len: (int)len;
+
+- (void) asdf_nterm: (char *) buf;
+@end
+

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -1,3 +1,15 @@
+module BoundsUnsafe {
+  header "BoundsUnsafe.h"
+}
+
+module BoundsUnsafeErrors {
+  header "BoundsUnsafeErrors.h"
+}
+
+module BoundsUnsafeObjC {
+  header "BoundsUnsafeObjC.h"
+}
+
 module ExternCtx {
   header "ExternCtx.h"
 }

--- a/clang/test/APINotes/boundssafety-errors.c
+++ b/clang/test/APINotes/boundssafety-errors.c
@@ -1,6 +1,3 @@
-// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t/Headers
 // RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/SemaErrors.c 2>&1 | FileCheck %s

--- a/clang/test/APINotes/boundssafety-errors.c
+++ b/clang/test/APINotes/boundssafety-errors.c
@@ -1,0 +1,135 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: split-file %s %t/Headers
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/SemaErrors.c 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/NegLevel.c 2>&1 | FileCheck %s --check-prefix NEGLEVEL
+// RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/InvalidKind.c 2>&1 | FileCheck %s --check-prefix INVALIDKIND
+
+//--- module.modulemap
+module SemaErrors {
+  header "SemaErrors.h"
+}
+module NegLevel {
+  header "NegLevel.h"
+}
+module InvalidKind {
+  header "InvalidKind.h"
+}
+
+//--- SemaErrors.c
+#include "SemaErrors.h"
+//--- SemaErrors.apinotes
+Name: OOBLevel
+Functions:
+  - Name:              oob_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 42
+            BoundedBy: len
+  - Name:              off_by_1_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 1
+            BoundedBy: len
+  - Name:              nonpointer_param
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              wrong_name
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+  - Name:              wrong_scope
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: static_len
+  - Name:              mismatching_count
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: apinote_len
+  - Name:              mismatching_end
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: apinote_end
+//--- SemaErrors.h
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK-NEXT: oob_level
+void oob_level(int * buf, int len);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK-NEXT: off_by_1_level
+void off_by_1_level(int * buf, int len);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: __counted_by attribute only applies to pointer arguments
+// CHECK-NEXT: nonpointer_param
+void nonpointer_param(int buf, int len);
+// CHECK: <API Notes>:1:1: error: use of undeclared identifier 'len'; did you mean 'len2'?
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: note: 'len2' declared here
+// CHECK-NEXT: wrong_name
+void wrong_name(int * buf, int len2);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: count expression in function declaration may only reference parameters of that function
+// CHECK-NEXT: wrong_scope
+int static_len = 5;
+void wrong_scope(int * buf);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: pointer cannot have more than one count attribute
+// CHECK-NEXT: mismatching_count
+void mismatching_count(int * __attribute__((__counted_by__(header_len))) buf, int apinote_len, int header_len);
+// CHECK: SemaErrors.h:{{.*}}:{{.*}}: error: pointer cannot have more than one end attribute
+// CHECK-NEXT: mismatching_end
+void mismatching_end(int * __attribute__((__ended_by__(header_end))) buf, int * apinote_end, int * header_end);
+// CHECK: SemaErrors.c:{{.*}}:{{.*}}: fatal error: could not build module 'SemaErrors'
+
+
+//--- NegLevel.apinotes
+Name: NegLevel
+Functions:
+  - Name:              neg_level
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: counted_by
+            Level: -1
+            BoundedBy: len
+//--- NegLevel.h
+void neg_level(int * buf, int len);
+//--- NegLevel.c
+#include "NegLevel.h"
+// NEGLEVEL: NegLevel.apinotes:{{.*}}:{{.*}}: error: invalid number
+// NEGLEVEL-NEXT: Level: -1
+// NEGLEVEL: NegLevel.c:{{.*}}:{{.*}}: fatal error: could not build module 'NegLevel'
+
+
+//--- InvalidKind.apinotes
+Name: InvalidKind
+Functions:
+  - Name:              invalid_kind
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: __counted_by
+            Level: 0
+            BoundedBy: len
+//--- InvalidKind.h
+void invalid_kind(int * buf, int len);
+//--- InvalidKind.c
+#include "InvalidKind.h"
+// INVALIDKIND: InvalidKind.apinotes:{{.*}}:{{.*}}: error: unknown enumerated scalar
+// INVALIDKIND-NEXT: Kind: __counted_by
+// INVALIDKIND: InvalidKind.c:{{.*}}:{{.*}}: fatal error: could not build module 'InvalidKind'
+

--- a/clang/test/APINotes/boundssafety-errors.c
+++ b/clang/test/APINotes/boundssafety-errors.c
@@ -1,3 +1,6 @@
+// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
+// REQUIRES: system-darwin
+
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t/Headers
 // RUN: not %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %t/Headers -fexperimental-bounds-safety-attributes %t/Headers/SemaErrors.c 2>&1 | FileCheck %s

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -1,3 +1,6 @@
+// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
+// REQUIRES: system-darwin
+
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
 

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -1,0 +1,69 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
+
+#include "BoundsUnsafe.h"
+
+// CHECK: asdf_counted 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+
+// CHECK: asdf_sized 'void (int * __sized_by(size), int)'
+// CHECK: buf 'int * __sized_by(size)':'int *'
+
+// CHECK: asdf_counted_n 'void (int * __counted_by_or_null(len), int)'
+// CHECK: buf 'int * __counted_by_or_null(len)':'int *'
+
+// CHECK: asdf_sized_n 'void (int * __sized_by_or_null(size), int)'
+// CHECK: buf 'int * __sized_by_or_null(size)':'int *'
+
+// CHECK: asdf_ended 'void (int * __ended_by(end), int * /* __started_by(buf) */ )'
+// CHECK: buf 'int * __ended_by(end)':'int *'
+// CHECK: end 'int * /* __started_by(buf) */ ':'int *'
+
+// CHECK: asdf_sized_mul 'void (int * __sized_by(size * count), int, int)'
+// CHECK: buf 'int * __sized_by(size * count)':'int *'
+
+// CHECK: asdf_counted_out 'void (int * __counted_by(*len)*, int *)'
+// CHECK: buf 'int * __counted_by(*len)*'
+
+// CHECK: asdf_counted_const 'void (int * __counted_by(7))'
+// CHECK: buf 'int * __counted_by(7)':'int *'
+
+// CHECK: asdf_counted_nullable 'void (int, int * __counted_by(len) _Nullable)'
+// CHECK: buf 'int * __counted_by(len) _Nullable':'int *'
+
+// CHECK: asdf_counted_noescape 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+// CHECK-NEXT: NoEscapeAttr
+
+// CHECK: asdf_counted_default_level 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+
+// CHECK: asdf_counted_redundant 'void (int * __counted_by(len), int)'
+// CHECK: buf 'int * __counted_by(len)':'int *'
+
+// CHECK: asdf_ended_chained 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_chained_reverse 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_already_started 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_already_ended 'void (int * __ended_by(mid), int * __ended_by(end) /* __started_by(buf) */ , int * /* __started_by(mid) */ )'
+// CHECK: buf 'int * __ended_by(mid)':'int *'
+// CHECK: mid 'int * __ended_by(end) /* __started_by(buf) */ ':'int *'
+// CHECK: end 'int * /* __started_by(mid) */ ':'int *'
+
+// CHECK: asdf_ended_redundant 'void (int * __ended_by(end), int * /* __started_by(buf) */ )'
+// CHECK: buf 'int * __ended_by(end)':'int *'
+// CHECK: end 'int * /* __started_by(buf) */ ':'int *'
+
+// CHECK: asdf_nterm 'void (int * __terminated_by(0))'
+// CHECK: buf 'int * __terminated_by(0)':'int *'

--- a/clang/test/APINotes/boundssafety.c
+++ b/clang/test/APINotes/boundssafety.c
@@ -1,6 +1,3 @@
-// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
 

--- a/clang/test/APINotes/boundssafety.m
+++ b/clang/test/APINotes/boundssafety.m
@@ -1,0 +1,55 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s
+
+#include "BoundsUnsafeObjC.h"
+
+// CHECK-LABEL: asdf_counted
+// CHECK: buf 'int * __counted_by(len)':'int *'
+// CHECK-NEXT: len 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_sized
+// CHECK: buf 'int * __sized_by(size)':'int *'
+// CHECK-NEXT: size 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_counted_n
+// CHECK: buf 'int * __counted_by_or_null(len)':'int *'
+// CHECK-NEXT: len 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_sized_n
+// CHECK: buf 'int * __sized_by_or_null(size)':'int *'
+// CHECK-NEXT: size 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_ended
+// CHECK: buf 'int * __ended_by(end)':'int *'
+// CHECK: end 'int * /* __started_by(buf) */ ':'int *'
+
+// CHECK-LABEL: asdf_sized_mul
+// CHECK: buf 'int * __sized_by(size * count)':'int *'
+// CHECK-NEXT: size 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+// CHECK-NEXT: count 'int'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} 0
+
+// CHECK-LABEL: asdf_counted_out
+// CHECK: buf 'int * __counted_by(*len)*'
+// CHECK-NEXT: len 'int *'
+// CHECK-NEXT: DependerDeclsAttr {{.*}} IsDeref {{.*}} 1
+
+// CHECK-LABEL: asdf_counted_const
+// CHECK: buf 'int * __counted_by(7)':'int *'
+
+// CHECK-LABEL: asdf_counted_nullable
+// CHECK: buf 'int * __counted_by(len) _Nullable':'int *'
+
+// CHECK-LABEL: asdf_counted_noescape
+// CHECK: buf 'int * __counted_by(len)':'int *'
+// CHECK-NEXT: NoEscapeAttr
+
+// CHECK-LABEL: asdf_nterm
+// CHECK: buf 'int * __terminated_by(0)':'int *'
+

--- a/clang/test/APINotes/boundssafety.m
+++ b/clang/test/APINotes/boundssafety.m
@@ -1,6 +1,3 @@
-// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
-// REQUIRES: system-darwin
-
 // RUN: rm -rf %t && mkdir -p %t
 
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s

--- a/clang/test/APINotes/boundssafety.m
+++ b/clang/test/APINotes/boundssafety.m
@@ -1,3 +1,6 @@
+// rdar://144275431: Clang module support for TypeCoupledDeclRefInfo is broken on Linux
+// REQUIRES: system-darwin
+
 // RUN: rm -rf %t && mkdir -p %t
 
 // RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fsyntax-only -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks -fexperimental-bounds-safety-attributes %s -ast-dump -ast-dump-filter asdf | FileCheck %s

--- a/clang/test/BoundsSafety/Modules/count-assign.c
+++ b/clang/test/BoundsSafety/Modules/count-assign.c
@@ -1,4 +1,3 @@
-// REQUIRES: system-darwin
 // RUN: rm -rf %t
 // RUN: %clang_cc1 -fbounds-safety -fmodules -fno-implicit-modules -x c -I%S/Inputs/count-assign -emit-module %S/Inputs/count-assign/module.modulemap -fmodule-name=ca -o %t/count-assign.pcm
 // RUN: %clang_cc1 -fbounds-safety  -fmodules -fno-implicit-modules -x c -I%S/Inputs/count-assign -ast-dump-all -o - %s -fmodule-file=%t/count-assign.pcm | FileCheck %s

--- a/clang/test/BoundsSafety/PCH/count-assign-with-pch.c
+++ b/clang/test/BoundsSafety/PCH/count-assign-with-pch.c
@@ -1,4 +1,3 @@
-// REQUIRES: system-darwin
 // Test without pch.
 // RUN: %clang_cc1 -fbounds-safety -include %s -fsyntax-only -verify %s
 

--- a/clang/test/BoundsSafety/PCH/nested-struct-member-count.c
+++ b/clang/test/BoundsSafety/PCH/nested-struct-member-count.c
@@ -1,0 +1,59 @@
+// Test without pch.
+// RUN: %clang_cc1 -fbounds-safety -include %s %s -ast-dump 2>&1 | FileCheck %s
+
+// Test with pch.
+// RUN: %clang_cc1 -fbounds-safety -emit-pch -o %t %s
+// RUN: %clang_cc1 -fbounds-safety -include-pch %t %s -ast-dump 2>&1 | FileCheck %s
+
+#ifndef HEADER
+#define HEADER
+#include <ptrcheck.h>
+
+struct Inner {
+    int dummy;
+    int len;
+};
+
+struct Outer {
+    struct Inner hdr;
+    char fam[__counted_by(hdr.len)];
+};
+
+#else
+
+char access(struct Outer *bar, int index) {
+    return bar->fam[index];
+}
+
+// CHECK:  -FunctionDecl [[func_access:0x[^ ]+]] {{.+}} access
+// CHECK:   |-ParmVarDecl [[var_bar:0x[^ ]+]]
+// CHECK:   |-ParmVarDecl [[var_index:0x[^ ]+]]
+// CHECK:   `-CompoundStmt
+// CHECK:     `-ReturnStmt
+// CHECK:       `-ImplicitCastExpr {{.+}} 'char' <LValueToRValue>
+// CHECK:         `-ArraySubscriptExpr
+// CHECK:           |-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK:           | |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK:           | | |-BoundsSafetyPointerPromotionExpr {{.+}} 'char *__bidi_indexable'
+// CHECK:           | | | |-ImplicitCastExpr {{.+}} 'char *' <ArrayToPointerDecay>
+// CHECK:           | | | | `-MemberExpr {{.+}} ->fam
+// CHECK:           | | | |   `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | | |-GetBoundExpr {{.+}} upper
+// CHECK:           | | | | `-BoundsSafetyPointerPromotionExpr {{.+}} 'struct Outer *__bidi_indexable'
+// CHECK:           | | | |   |-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | | |   |-BinaryOperator {{.+}} 'char *' '+'
+// CHECK:           | | | |   | |-ImplicitCastExpr {{.+}} 'char *' <ArrayToPointerDecay>
+// CHECK:           | | | |   | | `-MemberExpr {{.+}} ->fam
+// CHECK:           | | | |   | |   `-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | | |   | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK:           | | | |   |   `-MemberExpr {{.+}} .len
+// CHECK:           | | | |   |     `-MemberExpr {{.+}} ->hdr
+// CHECK:           | | | |   |       `-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           | | `-OpaqueValueExpr [[ove]]
+// CHECK:           | |   `-ImplicitCastExpr {{.+}} 'struct Outer *__single' <LValueToRValue>
+// CHECK:           | |     `-DeclRefExpr {{.+}} [[var_bar]]
+// CHECK:           | `-OpaqueValueExpr [[ove]] {{.*}} 'struct Outer *__single'
+// CHECK:           `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK:             `-DeclRefExpr {{.+}} [[var_index]]
+
+#endif


### PR DESCRIPTION
This cherry-picks e5e04cdee487fa58c5ad26812857c90c073403b1 (https://github.com/swiftlang/llvm-project/pull/9942) and 013accafe07b26c094069251ab52308107d42814 (https://github.com/swiftlang/llvm-project/pull/9901) which were landed in `stable/20240723` but not the `main` branch.

