### PR TITLE
[lldb] Skip TestConsecutiveWatchpoints.py if out of tree debugserver

### DIFF
--- a/lldb/test/API/functionalities/watchpoint/consecutive-watchpoints/TestConsecutiveWatchpoints.py
+++ b/lldb/test/API/functionalities/watchpoint/consecutive-watchpoints/TestConsecutiveWatchpoints.py
@@ -22,6 +22,7 @@ class ConsecutiveWatchpointsTestCase(TestBase):
 
     # debugserver only gained the ability to watch larger regions
     # with this patch.
+    @skipIfOutOfTreeDebugserver
     def test_consecutive_watchpoints(self):
         """Test watchpoint that covers a large region of memory."""
         self.build()


### PR DESCRIPTION
The GreenDragon CI bots are currently passing because the installed Xcode is a bit old, and doesn't have the watchpoint handling bug that was fixed April with this test being added.

But on other CI running newer Xcode debugservers, this test will fail.  Skip this test if we're using an out of tree debugserver.

(cherry picked from commit cea82573bb39230f6ddf47f8ee5a83f85c255025)