### PR TITLE
🍒 [lldb] Fix building with GCC without asserts (llvm@fcead25) 

### DIFF
--- a/lldb/include/lldb/Utility/LLDBAssert.h
+++ b/lldb/include/lldb/Utility/LLDBAssert.h
@@ -27,8 +27,11 @@
   } while (0)
 #else
 #define lldbassert(x)                                                          \
-  lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__, __FILE__, \
-                             __LINE__)
+  do {                                                                         \
+    static std::once_flag _once_flag;                                          \
+    lldb_private::_lldb_assert(static_cast<bool>(x), #x, __FUNCTION__,         \
+                               __FILE__,  __LINE__, _once_flag);               \
+  } while (0)
 #endif
 #endif
 


### PR DESCRIPTION
  - **Explanation**:
    Upstream LLVM landed a fix for toolchain builds without asserts, which was missed in 03604a784011bec2292f900b118d825f34f8cf89. This was cherry-picked into the swiftlang fork, but not in the 6.2 branch. As it is, the 6.2 branch does not build without asserts enabled.
  - **Scope**:
    This only affects the NoAsserts toolchain build.
  - **Issues**:
    N/A
  - **Original PRs**:
    Original LLVM commit llvm/llvm-project@fcead25
    Cherry-picked from swiftlang/llvm-project#10453
  - **Risk**:
    Very low. Should be a no-op for most users.
  - **Testing**:
    Same error on our toolchain build as the one witnessed on main a month ago.
  - **Reviewers**:
    @compnerd 
