### PR TITLE
[lldb][Modules] Fix error handling of loadModuleMapFile

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -325,7 +325,7 @@ bool ClangModulesDeclVendorImpl::AddModule(const SourceModule &module,
       auto file = HS.lookupModuleMapFile(*dir, is_framework);
       if (!file)
         return error();
-      if (!HS.loadModuleMapFile(*file, is_system))
+      if (HS.loadModuleMapFile(*file, is_system))
         return error();
     }
   }


### PR DESCRIPTION
`loadModuleMapFile` returns true on error. This seems to have always been an issue? This is now preventing me from fixing a different modules related issue. So this patch checks the return value correctly.