### PR TITLE
[clang][Darwin] Add test checking for tls support on xros target triples

### DIFF
--- a/clang/test/Sema/darwin-tls.c
+++ b/clang/test/Sema/darwin-tls.c
@@ -13,6 +13,8 @@
 // RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple thumbv7k-apple-watchos2.0 %s 2>&1 | FileCheck %s --check-prefix TLS
 // RUN: not %clang_cc1 -fsyntax-only -triple i386-apple-watchos2.0-simulator %s 2>&1 | FileCheck %s --check-prefix NO-TLS
 // RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple i386-apple-watchos3.0-simulator %s 2>&1 | FileCheck %s --check-prefix TLS
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple arm64-apple-xros %s 2>&1 | FileCheck %s --check-prefix TLS
+// RUN: %clang_cc1 -fsyntax-only -Wno-error=implicit-int -triple arm64-apple-xros-simulator %s 2>&1 | FileCheck %s --check-prefix TLS
 
 
 __thread int a;


### PR DESCRIPTION
(cherry picked from commit 845121fefce0243426d640989f6fdc7008f0b2ef)