### PR TITLE
Fix a bug where using "thread backtrace unique" would switch you to (…

### DIFF
--- a/lldb/source/Commands/CommandObjectThreadUtil.cpp
+++ b/lldb/source/Commands/CommandObjectThreadUtil.cpp
@@ -37,6 +37,8 @@ void CommandObjectIterateOverThreads::DoExecute(Args &command,
   result.SetStatus(m_success_return);
 
   bool all_threads = false;
+  m_unique_stacks = false;
+
   if (command.GetArgumentCount() == 0) {
     Thread *thread = m_exe_ctx.GetThreadPtr();
     if (thread)


### PR DESCRIPTION
…#140993)

always using the "frame-format-unique" even when you weren't doing the unique backtrace mode.

(cherry picked from commit 8e3f44d68bf2f5318406dac73e86333d7c34976d)