### PR TITLE
Cherry pick prefix mapping option fix from `next`

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8414,11 +8414,15 @@ def fdepscan_include_tree : Flag<["-"], "fdepscan-include-tree">,
 //
 // FIXME: Add DepscanOption flag.
 def fdepscan_prefix_map_EQ : Joined<["-"], "fdepscan-prefix-map=">,
-    Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
+    Group<f_Group>, Visibility<[ClangOption]>,
     MetaVarName<"<old>=<new>">,
     HelpText<"With -fdepscan, seamlessly filter the CAS filesystem to"
-             " apply the given prefix, updating the command-line to match.">,
-    MarshallingInfoStringVector<FrontendOpts<"PathPrefixMappings">>;
+             " apply the given prefix, updating the command-line to match.">;
+def fdepscan_prefix_map : MultiArg<["-"], "fdepscan-prefix-map", 2>,
+    Group<f_Group>, Visibility<[ClangOption, CC1Option]>,
+    MetaVarName<"<old> <new>">,
+    HelpText<"With -fdepscan, seamlessly filter the CAS filesystem to"
+             " apply the given prefix, updating the command-line to match.">;
 def fdepscan_prefix_map_sdk_EQ :
     Joined<["-"], "fdepscan-prefix-map-sdk=">,
     Group<f_Group>, MetaVarName<"<new>">,

--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -40,7 +40,7 @@ struct CompileJobCachingOptions {
   /// See \c FrontendOptions::WriteOutputAsCASID.
   bool WriteOutputAsCASID;
   /// See \c FrontendOptions::PathPrefixMappings.
-  std::vector<std::string> PathPrefixMappings;
+  std::vector<std::pair<std::string, std::string>> PathPrefixMappings;
 };
 
 /// Create a cache key for the given \c CompilerInvocation as a \c CASID. If \p

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -587,7 +587,7 @@ public:
   /// When caching is enabled, represents remappings for all the file paths that
   /// the compilation may access. This is useful for canonicalizing the
   /// compilation for caching purposes.
-  std::vector<std::string> PathPrefixMappings;
+  std::vector<std::pair<std::string, std::string>> PathPrefixMappings;
 
   // Currently this is only used as part of the `-extract-api` action.
   // A comma separated list of files providing a list of APIs to

--- a/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
+++ b/clang/include/clang/Tooling/DependencyScanning/ScanAndUpdateArgs.h
@@ -46,7 +46,7 @@ struct DepscanPrefixMapping {
                                     llvm::PrefixMapper &Mapper);
 
   /// Add path mappings to the \p Mapper.
-  static void configurePrefixMapper(ArrayRef<std::string> PathPrefixMappings,
+  static void configurePrefixMapper(ArrayRef<std::pair<std::string, std::string>> PathPrefixMappings,
                                     llvm::PrefixMapper &Mapper);
 
   /// Apply the mappings from \p Mapper to \p Invocation.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4910,8 +4910,9 @@ void Clang::AddPrefixMappingOptions(const ArgList &Args, ArgStringList &CmdArgs,
 
   if (Arg *A = Args.getLastArg(options::OPT_fdepscan_prefix_map_sdk_EQ)) {
     if (IsPathApplicableAsPrefix(Sysroot)) {
-      CmdArgs.push_back(Args.MakeArgString(Twine("-fdepscan-prefix-map=") +
-                                           *Sysroot + "=" + A->getValue()));
+      CmdArgs.push_back("-fdepscan-prefix-map");
+      CmdArgs.push_back(Args.MakeArgString(*Sysroot));
+      CmdArgs.push_back(Args.MakeArgString(A->getValue()));
     } else {
       // FIXME: warning if we cannot infer sdk
     }
@@ -4926,22 +4927,31 @@ void Clang::AddPrefixMappingOptions(const ArgList &Args, ArgStringList &CmdArgs,
       Guess = llvm::sys::path::parent_path(Guess);
     }
     if (IsPathApplicableAsPrefix(Guess)) {
-      CmdArgs.push_back(Args.MakeArgString(Twine("-fdepscan-prefix-map=") +
-                                           Guess + "=" + A->getValue()));
+      CmdArgs.push_back("-fdepscan-prefix-map");
+      CmdArgs.push_back(Args.MakeArgString(Guess));
+      CmdArgs.push_back(Args.MakeArgString(A->getValue()));
     } else {
       // FIXME: warning if we cannot infer toolchain
     }
   }
 
-  for (const Arg *A : Args.filtered(options::OPT_fdepscan_prefix_map_EQ)) {
+  for (const Arg *A : Args.filtered(options::OPT_fdepscan_prefix_map, options::OPT_fdepscan_prefix_map_EQ)) {
     A->claim();
-    StringRef Map = A->getValue();
-    StringRef Prefix = Map.split('=').first;
-    if (Prefix.size() == Map.size() || !IsPathApplicableAsPrefix(Prefix)) {
+    StringRef Prefix, MapTarget;
+    if (A->getOption().matches(options::OPT_fdepscan_prefix_map_EQ)) {
+      StringRef Map = A->getValue();
+      std::tie(Prefix, MapTarget) = Map.split('=');
+    } else {
+      Prefix = A->getValue(0);
+      MapTarget = A->getValue(1);
+    }
+    if (MapTarget.size() == 0 || !IsPathApplicableAsPrefix(Prefix)) {
       D.Diag(diag::err_drv_invalid_argument_to_option)
           << A->getValue() << A->getOption().getName();
     } else {
-      A->render(Args, CmdArgs);
+      CmdArgs.push_back("-fdepscan-prefix-map");
+      CmdArgs.push_back(Args.MakeArgString(Prefix));
+      CmdArgs.push_back(Args.MakeArgString(MapTarget));
     }
   }
 }

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -319,8 +319,7 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
 
   llvm::PrefixMapper PrefixMapper;
   llvm::SmallVector<llvm::MappedPrefix> Split;
-  llvm::MappedPrefix::transformJoinedIfValid(CacheOpts.PathPrefixMappings,
-                                             Split);
+  llvm::MappedPrefix::transformPairs(CacheOpts.PathPrefixMappings, Split);
   for (const auto &MappedPrefix : Split) {
     // We use the inverse mapping because the \p PrefixMapper will be used for
     // de-canonicalization of paths.
@@ -607,7 +606,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
 
   llvm::PrefixMapper PrefixMapper;
   llvm::SmallVector<llvm::MappedPrefix> Split;
-  llvm::MappedPrefix::transformJoinedIfValid(
+  llvm::MappedPrefix::transformPairs(
       Clang.getFrontendOpts().PathPrefixMappings, Split);
   for (const auto &MappedPrefix : Split) {
     // We use the inverse mapping because the \p PrefixMapper will be used for

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -84,6 +84,7 @@
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/VersionTuple.h"
@@ -3022,6 +3023,9 @@ static void GenerateFrontendArgs(const FrontendOptions &Opts,
   for (const auto &A : Opts.ModuleCacheKeys)
     GenerateMultiArg(Consumer, OPT_fmodule_file_cache_key, {A.first, A.second});
 
+  for (const auto &A : Opts.PathPrefixMappings)
+    GenerateMultiArg(Consumer, OPT_fdepscan_prefix_map, {A.first, A.second});
+
   if (Opts.AuxTargetCPU)
     GenerateArg(Consumer, OPT_aux_target_cpu, *Opts.AuxTargetCPU);
 
@@ -3247,6 +3251,13 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
     ArrayRef<const char *> Values = A->getValues();
     assert(Values.size() == 2);
     Opts.ModuleCacheKeys.emplace_back(Values[0], Values[1]);
+  }
+
+  // Handle path prefix mappings
+  for (const Arg *A : Args.filtered(OPT_fdepscan_prefix_map)) {
+    ArrayRef<const char *> Values = A->getValues();
+    assert(Values.size() == 2);
+    Opts.PathPrefixMappings.emplace_back(Values[0], Values[1]);
   }
 
   if (Opts.ProgramAction != frontend::GenerateModule && Opts.IsSystemModule)

--- a/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
+++ b/clang/lib/Tooling/DependencyScanning/ScanAndUpdateArgs.cpp
@@ -128,7 +128,7 @@ void DepscanPrefixMapping::remapInvocationPaths(CompilerInvocation &Invocation,
   // Pass the remappings so that we can map cached diagnostics to the local
   // paths during diagnostic rendering.
   for (const llvm::MappedPrefix &Map : Mapper.getMappings()) {
-    FrontendOpts.PathPrefixMappings.push_back(Map.Old + "=" + Map.New);
+    FrontendOpts.PathPrefixMappings.emplace_back(Map.Old, Map.New);
   }
 
   auto mapInPlaceAll = [&](std::vector<std::string> &Vector) {
@@ -229,12 +229,12 @@ void DepscanPrefixMapping::configurePrefixMapper(const CompilerInvocation &CI,
 }
 
 void DepscanPrefixMapping::configurePrefixMapper(
-    ArrayRef<std::string> PathPrefixMappings, llvm::PrefixMapper &Mapper) {
+    ArrayRef<std::pair<std::string, std::string>> PathPrefixMappings, llvm::PrefixMapper &Mapper) {
   if (PathPrefixMappings.empty())
     return;
 
   llvm::SmallVector<llvm::MappedPrefix> Split;
-  llvm::MappedPrefix::transformJoinedIfValid(PathPrefixMappings, Split);
+  llvm::MappedPrefix::transformPairs(PathPrefixMappings, Split);
   for (auto &MappedPrefix : Split)
     Mapper.add(MappedPrefix);
 

--- a/clang/test/CAS/cached-diagnostics.c
+++ b/clang/test/CAS/cached-diagnostics.c
@@ -5,7 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src/main.c -I %t/src/inc -Wunknown-pragmas 2> %t/regular-diags1.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t1.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src=/^src \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map %t/src /^src \
 // RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Wunknown-pragmas
 
 // Compare diagnostics after a miss.
@@ -42,7 +42,7 @@
 // RUN: %clang_cc1 -triple x86_64-apple-macos12 -fsyntax-only %t/src2/main.c -I %t/src2/inc -Wunknown-pragmas 2> %t/regular-diags2.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/t2.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src2=/^src \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map %t/src2 /^src \
 // RUN:     -emit-obj %t/src2/main.c -o %t/out2/output.o -I %t/src2/inc -Wunknown-pragmas
 // RUN: %clang @%t/t2.rsp -Rcompile-job-cache 2> %t/diags-hit2.txt
 
@@ -55,7 +55,7 @@
 // RUN: diff -u %t/regular-diags2.txt %t/cached-diags2.txt
 
 // RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t/terr.rsp -cc1-args \
-// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map=%t/src=/^src \
+// RUN:   -cc1 -triple x86_64-apple-macos12 -fcas-path %t/cas -fdepscan-prefix-map %t/src /^src \
 // RUN:     -emit-obj %t/src/main.c -o %t/out/output.o -I %t/src/inc -Rcompile-job-cache -DERROR
 
 // RUN: not %clang @%t/terr.rsp -ferror-limit 1 2> %t/diags_error1.txt

--- a/clang/test/CAS/depscan-prefix-map.c
+++ b/clang/test/CAS/depscan-prefix-map.c
@@ -12,11 +12,11 @@
 // RUN:              -internal-iframework %S/Inputs/SDK/Library/Frameworks \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
-// RUN:              -fdepscan-prefix-map=%S=/^source                     \
-// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
-// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepscan-prefix-map %S /^source                     \
+// RUN:              -fdepscan-prefix-map %t.d /^testdir                  \
+// RUN:              -fdepscan-prefix-map %{objroot} /^objroot            \
+// RUN:              -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:              -fdepscan-prefix-map %S/Inputs/SDK /^sdk             \
 // RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscan -dump-depscan-tree=%t.root -fdepscan=inline    \
@@ -27,11 +27,11 @@
 // RUN:              -internal-iframework %S/Inputs/SDK/Library/Frameworks \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
-// RUN:              -fdepscan-prefix-map=%S=/^source                     \
-// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
-// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepscan-prefix-map %S /^source                     \
+// RUN:              -fdepscan-prefix-map %t.d /^testdir                  \
+// RUN:              -fdepscan-prefix-map %{objroot} /^objroot            \
+// RUN:              -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:              -fdepscan-prefix-map %S/Inputs/SDK /^sdk             \
 // RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
@@ -45,11 +45,11 @@
 // RUN:              -internal-iframework %S/Inputs/SDK/Library/Frameworks \
 // RUN:              -working-directory %t.d                              \
 // RUN:              -fcas-path %t.d/cas                                  \
-// RUN:              -fdepscan-prefix-map=%S=/^source                     \
-// RUN:              -fdepscan-prefix-map=%t.d=/^testdir                  \
-// RUN:              -fdepscan-prefix-map=%{objroot}=/^objroot            \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:              -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk             \
+// RUN:              -fdepscan-prefix-map %S /^source                     \
+// RUN:              -fdepscan-prefix-map %t.d /^testdir                  \
+// RUN:              -fdepscan-prefix-map %{objroot} /^objroot            \
+// RUN:              -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:              -fdepscan-prefix-map %S/Inputs/SDK /^sdk             \
 // RUN:              -fdepfile-entry=%t.d/extra                           \
 // RUN: | FileCheck %s -DPREFIX=%t.d
 //

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -98,15 +98,15 @@
 // SESSION-CMAKE-PREFIX: note: setting LLVM_CACHE_BUILD_SESSION_ID=
 
 // CLANG-CMAKE-PREFIX: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=[[INPUTS]]/SDK=/^sdk"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=[[INPUTS]]/toolchain_dir=/^toolchain"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/build=/^build"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/llvm=/^src"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/clang=/^src-clang"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/clang-tools-extra=/^src-clang-tools-extra"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/third-party/benchmark=/^src-benchmark"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/other/benchmark=/^src-benchmark-1"
-// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map=/llvm/llvm-project/another/benchmark=/^src-benchmark-2"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "[[INPUTS]]/SDK" "/^sdk"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "[[INPUTS]]/toolchain_dir" "/^toolchain"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/build" "/^build"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/llvm" "/^src"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/clang" "/^src-clang"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/clang-tools-extra" "/^src-clang-tools-extra"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/third-party/benchmark" "/^src-benchmark"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/other/benchmark" "/^src-benchmark-1"
+// CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/llvm-project/another/benchmark" "/^src-benchmark-2"
 
 // Make sure `cache-build-session` can invoke an executable script.
 // RUN: cache-build-session %t/clang -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=SESSION-SCRIPT -DSRC=%s -DPREFIX=%t

--- a/clang/test/CAS/fcas-include-tree-prefix-mapping.c
+++ b/clang/test/CAS/fcas-include-tree-prefix-mapping.c
@@ -7,9 +7,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src /^src -fdepscan-prefix-map %t/out /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-llvm %t/src/main.c -o %t/out/output.ll -include %t/src/prefix.h -I %t/src/inc \
 // RUN:       -MT deps -dependency-file %t/t1.d
@@ -47,9 +47,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src2 /^src -fdepscan-prefix-map %t/out2 /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-llvm %t/src2/main.c -o %t/out2/output.ll -include %t/src2/prefix.h -I %t/src2/inc \
 // RUN:       -MT deps -dependency-file %t/t2.d
@@ -85,9 +85,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src /^src -fdepscan-prefix-map %t/out /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-pch -x c-header %t/src/prefix.h -o %t/out/prefix.h.pch -include %t/src/prefix.h -I %t/src/inc
 // RUN: %clang @%t/pch1.rsp
@@ -98,9 +98,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas2 -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src2 /^src -fdepscan-prefix-map %t/out2 /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-pch -x c-header %t/src2/prefix.h -o %t/out2/prefix.h.pch -include %t/src2/prefix.h -I %t/src2/inc
 // RUN: %clang @%t/pch2.rsp
@@ -112,9 +112,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src=/^src -fdepscan-prefix-map=%t/out=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src /^src -fdepscan-prefix-map %t/out /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out \
 // RUN:       -emit-obj %t/src/main.c -o %t/out/main.o -include-pch %t/out/prefix.h.pch -I %t/src/inc \
 // RUN:       -MT deps -dependency-file %t/t1.pch.d
@@ -129,9 +129,9 @@
 // RUN:     -cc1 -triple x86_64-apple-macos11 -fcas-path %t/cas -Rcompile-job-cache \
 // RUN:       -resource-dir %S/Inputs/toolchain_dir/lib/clang/1000 -internal-isystem %S/Inputs/toolchain_dir/lib/clang/1000/include \
 // RUN:       -isysroot %S/Inputs/SDK -internal-externc-isystem %S/Inputs/SDK/usr/include \
-// RUN:       -fdepscan-prefix-map=%t/src2=/^src -fdepscan-prefix-map=%t/out2=/^out \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/toolchain_dir=/^toolchain \
-// RUN:       -fdepscan-prefix-map=%S/Inputs/SDK=/^sdk \
+// RUN:       -fdepscan-prefix-map %t/src2 /^src -fdepscan-prefix-map %t/out2 /^out \
+// RUN:       -fdepscan-prefix-map %S/Inputs/toolchain_dir /^toolchain \
+// RUN:       -fdepscan-prefix-map %S/Inputs/SDK /^sdk \
 // RUN:       -debug-info-kind=standalone -dwarf-version=4 -debugger-tuning=lldb -fdebug-compilation-dir=%t/out2 \
 // RUN:       -emit-obj %t/src2/main.c -o %t/out2/main.o -include-pch %t/out2/prefix.h.pch -I %t/src2/inc \
 // RUN:       -MT deps -dependency-file %t/t2.pch.d

--- a/clang/test/CAS/pgo-profile.c
+++ b/clang/test/CAS/pgo-profile.c
@@ -37,9 +37,9 @@
 // RUN: mkdir -p %t.dir/a && mkdir -p %t.dir/b
 // RUN: cp %t.profdata %t.dir/a/a.profdata
 // RUN: cp %t.profdata %t.dir/b/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/a=/^testdir  \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/a /^testdir  \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/b=/^testdir \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/b /^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
@@ -54,9 +54,9 @@
 // RUN: grep llvmcas %t.dir/cache-key1
 // RUN: diff -u %t.dir/cache-key1 %t.dir/cache-key2
 
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/a=/^testdir \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t4.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/a /^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/a/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map=%t.dir/b=/^testdir \
+// RUN: %clang -cc1depscan -fdepscan=inline -fdepscan-include-tree -o %t5.inc.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/b /^testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.inc.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.inc.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS

--- a/clang/test/Driver/fdepscan-prefix-map-sdk.c
+++ b/clang/test/Driver/fdepscan-prefix-map-sdk.c
@@ -5,4 +5,4 @@
 
 // RUN: %clang -fdepscan-prefix-map-sdk=/^sdk -isysroot /sys/path -### %s 2>&1 | FileCheck %s
 // RUN: %clang -fdepscan-prefix-map-sdk=/^sdk --sysroot /sys/path -### %s 2>&1 | FileCheck %s
-// CHECK: -fdepscan-prefix-map=/sys/path=/^sdk
+// CHECK: "-fdepscan-prefix-map" "/sys/path" "/^sdk"

--- a/clang/test/Driver/fdepscan-prefix-map-toolchain.c
+++ b/clang/test/Driver/fdepscan-prefix-map-toolchain.c
@@ -8,8 +8,8 @@
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /tc/lib/clang/10 -### %s 2>&1 | FileCheck %s
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /tc/usr/lib/clang/10 -### %s 2>&1 | FileCheck %s
 
-// CHECK: -fdepscan-prefix-map=/tc=/^tc
+// CHECK: "-fdepscan-prefix-map" "/tc" "/^tc"
 
 // Implicit resource-dir
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -### %s 2>&1 | FileCheck %s -check-prefix=CHECK_IMPLICIT
-// CHECK_IMPLICIT: -fdepscan-prefix-map={{.*}}=/^tc
+// CHECK_IMPLICIT: "-fdepscan-prefix-map" "{{.*}}" "/^tc"

--- a/clang/test/Driver/fdepscan-prefix-map.c
+++ b/clang/test/Driver/fdepscan-prefix-map.c
@@ -4,5 +4,8 @@
 // RUN: not %clang -fdepscan-prefix-map=/=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
 // INVALID: error: invalid argument '{{.*}}/^bad' to -fdepscan-prefix-map=
 
-// RUN: %clang -fdepscan-prefix-map=/good=/^good -### %s 2>&1 | FileCheck %s
-// CHECK: "-fdepscan-prefix-map=/good=/^good"
+// RUN: %clang -fdepscan-prefix-map=/good=/^good -### %s 2>&1 | FileCheck --check-prefix CHECK_CORRECT %s
+// CHECK_CORRECT: "-fdepscan-prefix-map" "/good" "/^good"
+
+// RUN %clang -fdepscan-prefix-map=/a=/^a -fdepscan-prefix-map /b /^b -fdepscan-prefix-map=/c=/^c -fdepscan-prefix-map /d /^d -### %s 2>&1 | FileCheck --check-prefix=CHECK_MIXED %s
+// CHECK_MIXED: "-fdepscan-prefix-map" "/a" "/^a" "-fdepscan-prefix-map" "/b" "/^b" "-fdepscan-prefix-map" "/c" "/^c" "-fdepscan-prefix-map" "/d" "/^d"

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -11,6 +11,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Path.h"
 #include <optional>
@@ -48,6 +49,8 @@ struct MappedPrefix {
                                      SmallVectorImpl<MappedPrefix> &Split);
   static void transformJoinedIfValid(ArrayRef<std::string> Joined,
                                      SmallVectorImpl<MappedPrefix> &Split);
+  static void transformPairs(ArrayRef<std::pair<std::string, std::string>> Pairs,
+                             SmallVectorImpl<MappedPrefix> & Split);
 };
 
 /// Remap path prefixes.

--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -70,6 +70,13 @@ void MappedPrefix::transformJoinedIfValid(
   transformJoinedImpl</*StopOnInvalid*/ false>(Joined, Split);
 }
 
+void MappedPrefix::transformPairs(
+    ArrayRef<std::pair<std::string, std::string>> Pairs, SmallVectorImpl<MappedPrefix> &Split) {
+  for (auto &Pair : Pairs) {
+    Split.push_back(MappedPrefix{Pair.first, Pair.second});
+  }
+}
+
 /// FIXME: Copy/pasted from llvm/lib/Support/Path.cpp.
 static bool startsWith(StringRef Path, StringRef Prefix,
                        sys::path::Style PathStyle) {

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -125,6 +125,21 @@ TEST(MappedPrefixTest, transformJoinedIfValid) {
   EXPECT_EQ(ArrayRef(ExpectedSplit), ArrayRef(ComputedSplit));
 }
 
+TEST(PrefixMapperTest, transformPairs) {
+  SmallVector<std::pair<std::string, std::string>> PrefixMappings = {
+    {"", ""}, {"a", "b"}, {"", "a"}, {"a", ""}, {"=a=b=", "=c=d==="}
+  };
+  MappedPrefix ExpectedSplit[] = {
+    MappedPrefix{"", ""}, MappedPrefix{"a", "b"},
+    MappedPrefix{"", "a"}, MappedPrefix{"a", ""},
+    MappedPrefix{"=a=b=", "=c=d==="},
+  };
+
+  SmallVector<MappedPrefix> ComputedSplit;
+  MappedPrefix::transformPairs(PrefixMappings, ComputedSplit);
+  EXPECT_EQ(ArrayRef(ExpectedSplit), ArrayRef(ComputedSplit));
+}
+
 TEST(PrefixMapperTest, construct) {
   for (auto PathStyle : {
            sys::path::Style::posix,


### PR DESCRIPTION
- **Explanation**: Add a new prefix mapping option format `-fdepscan-prefix-map <old> <new>` because the previous format could not handle paths including an equal sign. Made the old format driver-only so it gets translated to the new format when emitting the frontend command.

- **Scope**: This should not cause any backward compatibility issues since the old option format is still supported. Only some tests needed to change because they were searching the generated frontend command for the old flag format or they were directly running a frontend command with the old format.

- **Issues**: rdar://129434789

- **Original PRs**: https://github.com/swiftlang/llvm-project/pull/10723

- **Risk**: Low, only adds a new flag.

- **Testing**: I added a unit test to test the `transformPairs` function used to construct the prefix mapping objects, as well as a clang driver test to check that the ordering is handled correctly when using a mix of the old and new flag formats. Old tests have been updated to make sure they don't cause false positives with the old format being driver-only now.

- **Reviewers**: @akyrtzi @cachemeifyoucan @benlangmuir 
