### PR TITLE
[Cherry-pick][BoundsSafety][APINotes] Add support for bounds attribute on return value

### DIFF
--- a/clang/include/clang/APINotes/Types.h
+++ b/clang/include/clang/APINotes/Types.h
@@ -623,6 +623,11 @@ public:
   /// Ownership convention for return value
   std::string SwiftReturnOwnership;
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  /// Bounds annotations for the return value
+  std::optional<BoundsSafetyInfo> ReturnBoundsSafety;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+
   /// The function parameters.
   std::vector<ParamInfo> Params;
 

--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1478,6 +1478,11 @@ private:
   /// for each LateParsedAttribute. We consume the saved tokens and
   /// create an attribute with the arguments filled in. We add this
   /// to the Attribute list for the decl.
+  // TO_UPSTREAM(BoundsSafety) ON
+  /// Note: it's important the the LateParsedAttribute is removed after parsing
+  /// to prevent being reparsed later in the wrong context. This is handled
+  /// automatically by Parser::ParseLexedCAttributeList.
+  // TO_UPSTREAM(BoundsSafety) OFF
   void ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
                             ParsedAttributes *OutAttrs = nullptr);
 
@@ -2856,10 +2861,13 @@ private:
   /// \param ParentDecl If a function or method is provided, the parameters are
   ///   added to the current parsing context.
   /// \param IncludeLoc The location at which this parse was triggered.
-  ExprResult ParseBoundsAttributeArgFromString(StringRef ExprStr,
+  /// \param Payload Info to be passed along to the completion handler before
+  /// leaving the current context
+  void ParseBoundsAttributeArgFromString(StringRef ExprStr,
     StringRef Context,
     Decl *ParentDecl,
-    SourceLocation IncludeLoc);
+    SourceLocation IncludeLoc,
+    Sema::IncompleteBoundsAttributeInfo Payload);
   // TO_UPSTREAM(BoundsSafety) OFF
 
   ///@}

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1530,8 +1530,19 @@ public:
       ParseTypeFromStringCallback;
 
   /* TO_UPSTREAM(BoundsSafety) ON */
+  // Info for completing the processing of the attribute after parsing its
+  // argument
+  struct IncompleteBoundsAttributeInfo {
+    AttributeCommonInfo::Kind Kind;
+    unsigned Level;
+    Decl *D;
+  };
+  /// Complete the suspended bounds attribute after argument has been parsed
+  void CompleteBoundsAttribute(Expr *ParsedExpr,
+                               IncompleteBoundsAttributeInfo Info);
   /// Callback to the parser to parse a type expressed as a string.
-  std::function<ExprResult(StringRef, StringRef, Decl *, SourceLocation)>
+  std::function<void(StringRef, StringRef, Decl *, SourceLocation,
+                     IncompleteBoundsAttributeInfo Info)>
       ParseBoundsAttributeArgFromStringCallback;
   /* TO_UPSTREAM(BoundsSafety) OFF */
 

--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -384,6 +384,14 @@ void ReadFunctionInfo(const uint8_t *&Data, FunctionInfo &Info) {
   Payload >>= 3;
   Info.NullabilityAudited = Payload & 0x1;
   Payload >>= 1;
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (Payload & 0x01) {
+    BoundsSafetyInfo BSI;
+    ReadBoundsSafetyInfo(Data, BSI);
+    Info.ReturnBoundsSafety = BSI;
+  }
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+  Payload >>= 1;
   assert(Payload == 0 && "Bad API notes");
 
   Info.NumAdjustedNullable =

--- a/clang/lib/APINotes/APINotesTypes.cpp
+++ b/clang/lib/APINotes/APINotesTypes.cpp
@@ -61,6 +61,7 @@ LLVM_DUMP_METHOD void ObjCPropertyInfo::dump(llvm::raw_ostream &OS) const {
   OS << '\n';
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
 LLVM_DUMP_METHOD void BoundsSafetyInfo::dump(llvm::raw_ostream &OS) const {
   if (KindAudited) {
     assert((BoundsSafetyKind)Kind >= BoundsSafetyKind::CountedBy);
@@ -88,6 +89,7 @@ LLVM_DUMP_METHOD void BoundsSafetyInfo::dump(llvm::raw_ostream &OS) const {
   OS << "ExternalBounds: "
      << (ExternalBounds.empty() ? "<missing>" : ExternalBounds) << '\n';
 }
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
   static_cast<const VariableInfo &>(*this).dump(OS);
@@ -97,8 +99,10 @@ LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
     OS << (Lifetimebound ? "[Lifetimebound] " : "");
   OS << "RawRetainCountConvention: " << RawRetainCountConvention << ' ';
   OS << '\n';
+  /* TO_UPSTREAM(BoundsSafety) ON */
   if (BoundsSafety)
     BoundsSafety->dump(OS);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
 LLVM_DUMP_METHOD void FunctionInfo::dump(llvm::raw_ostream &OS) const {
@@ -109,6 +113,12 @@ LLVM_DUMP_METHOD void FunctionInfo::dump(llvm::raw_ostream &OS) const {
     OS << "Result Type: " << ResultType << ' ';
   if (!SwiftReturnOwnership.empty())
     OS << "SwiftReturnOwnership: " << SwiftReturnOwnership << ' ';
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (ReturnBoundsSafety) {
+    OS << "Result bounds: ";
+    ReturnBoundsSafety->dump(OS);
+  }
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   if (!Params.empty())
     OS << '\n';
   for (auto &PI : Params)

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -1138,6 +1138,10 @@ unsigned getFunctionInfoSize(const FunctionInfo &FI) {
     size += getParamInfoSize(P);
   size += sizeof(uint16_t) + FI.ResultType.size();
   size += sizeof(uint16_t) + FI.SwiftReturnOwnership.size();
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (auto BSI = FI.ReturnBoundsSafety)
+    size += getBoundsSafetyInfoSize(*BSI);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   return size;
 }
 
@@ -1146,6 +1150,11 @@ void emitFunctionInfo(raw_ostream &OS, const FunctionInfo &FI) {
   emitCommonEntityInfo(OS, FI);
 
   uint8_t flags = 0;
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (FI.ReturnBoundsSafety)
+    flags |= 0x01;
+  flags <<= 0x01;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   flags |= FI.NullabilityAudited;
   flags <<= 3;
   if (auto RCC = FI.getRetainCountConvention())
@@ -1154,6 +1163,10 @@ void emitFunctionInfo(raw_ostream &OS, const FunctionInfo &FI) {
   llvm::support::endian::Writer writer(OS, llvm::endianness::little);
 
   writer.write<uint8_t>(flags);
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (auto BSI = FI.ReturnBoundsSafety)
+    emitBoundsSafetyInfo(OS, *FI.ReturnBoundsSafety);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   writer.write<uint8_t>(FI.NumAdjustedNullable);
   writer.write<uint64_t>(FI.NullabilityPayload);
 

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -84,9 +84,10 @@ Parser::Parser(Preprocessor &pp, Sema &actions, bool skipFunctionBodies)
   /* TO_UPSTREAM(BoundsSafety) ON */
   Actions.ParseBoundsAttributeArgFromStringCallback =
       [this](StringRef ExprStr, StringRef Context, Decl *Parent,
-             SourceLocation IncludeLoc) {
+             SourceLocation IncludeLoc,
+             Sema::IncompleteBoundsAttributeInfo Payload) {
         return this->ParseBoundsAttributeArgFromString(ExprStr, Context, Parent,
-                                                       IncludeLoc);
+                                                       IncludeLoc, Payload);
       };
   /* TO_UPSTREAM(BoundsSafety) OFF */
 }

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.apinotes
@@ -133,3 +133,79 @@ Functions:
     Parameters:
       - Position:      0
         Type: "int * __attribute__((__terminated_by__(0)))"
+
+  - Name:              asdf_return_counted
+    BoundsSafety:
+        Kind: counted_by
+        Level: 0
+        BoundedBy: len
+  - Name:              asdf_return_sized
+    BoundsSafety:
+        Kind: sized_by
+        Level: 0
+        BoundedBy: size
+  - Name:              asdf_return_counted_n
+    BoundsSafety:
+        Kind: counted_by_or_null
+        Level: 0
+        BoundedBy: len
+  - Name:              asdf_return_sized_n
+    BoundsSafety:
+        Kind: sized_by_or_null
+        Level: 0
+        BoundedBy: size
+  - Name:              asdf_return_ended
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: end
+  - Name:              asdf_return_sized_mul
+    BoundsSafety:
+        Kind: sized_by
+        Level: 0
+        BoundedBy: "size * count"
+  - Name:              asdf_return_counted_out
+    BoundsSafety:
+        Kind: counted_by
+        BoundedBy: "*len"
+  - Name:              asdf_return_counted_const
+    BoundsSafety:
+        Kind: counted_by
+        Level: 0
+        BoundedBy: 7
+  - Name:             asdf_return_counted_nullable
+    BoundsSafety:
+        Kind: counted_by
+        Level: 0
+        BoundedBy: len
+  - Name:              asdf_return_counted_default_level
+    BoundsSafety:
+        Kind: counted_by
+        BoundedBy: len
+  - Name:              asdf_return_counted_redundant
+    BoundsSafety:
+        Kind: counted_by
+        BoundedBy: len
+  - Name:              asdf_return_ended_chained
+    Parameters:
+      - Position:      0
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: mid
+  - Name:              asdf_return_ended_chained_reverse
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: end
+  - Name:              asdf_return_ended_redundant
+    BoundsSafety:
+        Kind: ended_by
+        Level: 0
+        BoundedBy: end
+  - Name:              asdf_return_nterm
+    ResultType: "char * __attribute__((__terminated_by__(0)))"

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafe.h
@@ -19,3 +19,22 @@ void asdf_ended_already_ended(int * buf, int * mid __attribute__((__ended_by__(e
 void asdf_ended_redundant(int * __attribute__((__ended_by__(end))) buf, int * end);
 
 void asdf_nterm(char * buf);
+
+int * asdf_return_counted(int len);
+int * asdf_return_sized(int size);
+int * asdf_return_counted_n(int len);
+int * asdf_return_sized_n(int size);
+int * asdf_return_ended(int * end);
+
+int * asdf_return_sized_mul(int size, int count);
+int * asdf_return_counted_out(int * len);
+int * asdf_return_counted_const(int * buf);
+int * _Nullable asdf_return_counted_nullable(int len);
+int * asdf_return_counted_default_level(int len);
+int * __attribute__((__counted_by__(len))) asdf_return_counted_redundant(int len);
+
+int * asdf_return_ended_chained(int * mid, int * end);
+int * asdf_return_ended_chained_reverse(int * mid, int * end);
+int * __attribute__((__ended_by__(end))) asdf_return_ended_redundant(int * end);
+
+char * asdf_return_nterm();

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.apinotes
@@ -1,0 +1,213 @@
+---
+Name: BoundsUnsafeCxx
+Tags:
+  - Name: Foo
+    Methods:
+      - Name:              asdf_counted
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_sized
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: size
+      - Name:              asdf_counted_n
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by_or_null
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_sized_n
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by_or_null
+                Level: 0
+                BoundedBy: size
+      - Name:              asdf_ended
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_sized_mul
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: sized_by
+                Level: 0
+                BoundedBy: "size * count"
+      - Name:              asdf_counted_out
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 1
+                BoundedBy: "*len"
+      - Name:              asdf_counted_const
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: 7
+      - Name:             asdf_counted_nullable
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_counted_noescape
+        Parameters:
+          - Position:      0
+            NoEscape:      true
+            BoundsSafety:
+                Kind: counted_by
+                Level: 0
+                BoundedBy: len
+      - Name:              asdf_counted_default_level
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                BoundedBy: len
+      - Name:              asdf_counted_redundant
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: counted_by
+                BoundedBy: len
+      - Name:              asdf_ended_chained
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: mid
+          - Position:      1
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_ended_chained_reverse
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: mid
+      - Name:              asdf_ended_already_started
+        Parameters:
+          - Position:      1
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_ended_already_ended
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: mid
+      - Name:              asdf_ended_redundant
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+      - Name:              asdf_nterm
+        Parameters:
+          - Position:      0
+            Type: "int * __attribute__((__terminated_by__(0)))"
+    
+      - Name:              asdf_return_counted
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+      - Name:              asdf_return_sized
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: size
+      - Name:              asdf_return_counted_n
+        BoundsSafety:
+            Kind: counted_by_or_null
+            Level: 0
+            BoundedBy: len
+      - Name:              asdf_return_sized_n
+        BoundsSafety:
+            Kind: sized_by_or_null
+            Level: 0
+            BoundedBy: size
+      - Name:              asdf_return_ended
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Name:              asdf_return_sized_mul
+        BoundsSafety:
+            Kind: sized_by
+            Level: 0
+            BoundedBy: "size * count"
+      - Name:              asdf_return_counted_out
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: "*len"
+      - Name:              asdf_return_counted_const
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: 7
+      - Name:             asdf_return_counted_nullable
+        BoundsSafety:
+            Kind: counted_by
+            Level: 0
+            BoundedBy: len
+      - Name:              asdf_return_counted_default_level
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
+      - Name:              asdf_return_counted_redundant
+        BoundsSafety:
+            Kind: counted_by
+            BoundedBy: len
+      - Name:              asdf_return_ended_chained
+        Parameters:
+          - Position:      0
+            BoundsSafety:
+                Kind: ended_by
+                Level: 0
+                BoundedBy: end
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: mid
+      - Name:              asdf_return_ended_chained_reverse
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Name:              asdf_return_ended_redundant
+        BoundsSafety:
+            Kind: ended_by
+            Level: 0
+            BoundedBy: end
+      - Name:              asdf_return_nterm
+        ResultType: "char * __attribute__((__terminated_by__(0)))"

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.hpp
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeCxx.hpp
@@ -1,0 +1,44 @@
+class Foo {
+    void asdf_counted(int * buf, int len);
+    void asdf_sized(int * buf, int size);
+    void asdf_counted_n(int * buf, int len);
+    void asdf_sized_n(int * buf, int size);
+    void asdf_ended(int * buf, int * end);
+
+    void asdf_sized_mul(int * buf, int size, int count);
+    void asdf_counted_out(int ** buf, int * len);
+    void asdf_counted_const(int * buf);
+    void asdf_counted_nullable(int len, int * _Nullable buf);
+    void asdf_counted_noescape(int * buf, int len);
+    void asdf_counted_default_level(int * buf, int len);
+    void asdf_counted_redundant(int * __attribute__((__counted_by__(len))) buf, int len);
+    
+    void asdf_ended_chained(int * buf, int * mid, int * end);
+    void asdf_ended_chained_reverse(int * buf, int * mid, int * end);
+    void asdf_ended_already_started(int * __attribute__((__ended_by__(mid))) buf, int * mid, int * end);
+    void asdf_ended_already_ended(int * buf, int * mid __attribute__((__ended_by__(end))), int * end);
+    void asdf_ended_redundant(int * __attribute__((__ended_by__(end))) buf, int * end);
+    
+    void asdf_nterm(char * buf);
+
+
+    int * asdf_return_counted(int len);
+    int * asdf_return_sized(int size);
+    int * asdf_return_counted_n(int len);
+    int * asdf_return_sized_n(int size);
+    int * asdf_return_ended(int * end);
+    
+    int * asdf_return_sized_mul(int size, int count);
+    int * asdf_return_counted_out(int * len);
+    int * asdf_return_counted_const(int * buf);
+    int * _Nullable asdf_return_counted_nullable(int len);
+    int * asdf_return_counted_noescape(int len);
+    int * asdf_return_counted_default_level(int len);
+    int * __attribute__((__counted_by__(len))) asdf_return_counted_redundant(int len);
+    
+    int * asdf_return_ended_chained(int * mid, int * end);
+    int * asdf_return_ended_chained_reverse(int * mid, int * end);
+    int * __attribute__((__ended_by__(end))) asdf_return_ended_redundant(int * end);
+    
+    char * asdf_return_nterm();
+};

--- a/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/BoundsUnsafeObjC.apinotes
@@ -1,5 +1,5 @@
 ---
-Name: BoundsUnsafe
+Name: BoundsUnsafeObjC
 Classes:
   - Name: Foo
     Methods:

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -2,6 +2,10 @@ module BoundsUnsafe {
   header "BoundsUnsafe.h"
 }
 
+module BoundsUnsafeCxx {
+  header "BoundsUnsafeCxx.hpp"
+}
+
 module BoundsUnsafeErrors {
   header "BoundsUnsafeErrors.h"
 }


### PR DESCRIPTION
This is a cherry-pick of
https://github.com/swiftlang/llvm-project/pull/10214 (on `stable/20240723` branch) to the `next` branch.

Conflicts:
	clang/include/clang/Parse/Parser.h

Below is the original commit message.

rdar://151880608
---

Previously you could only attach bounds attributes to function parameters. Now return values are also supported, although not yet for ObjectiveC methods. Adds test case for bounds safety API notes in C++, and fixes bug where late parsed bounds attributes on C++ method parameters are parsed twice, due to not being removed from the late attributes list after parsing.

rdar://146332875
(cherry picked from commit b7df4eacbefb3cb5d9df2347c9b3a0c4670aa07d)