### PR TITLE
[clang][CodeGen] Fix ptrauth-restricted-intptr-qualifier.c

### DIFF
--- a/clang/test/CodeGen/ptrauth-restricted-intptr-qualifier.c
+++ b/clang/test/CodeGen/ptrauth-restricted-intptr-qualifier.c
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple arm64-apple-ios -fptrauth-calls -fptrauth-intrinsics -emit-llvm %s -O0 -o - | FileCheck %s
+// RUN: %clang_cc1 -triple arm64-apple-ios -mllvm -ptrauth-emit-wrapper-globals=0 -fptrauth-calls -fptrauth-intrinsics -emit-llvm %s -O0 -o - | FileCheck %s
 
 #define __ptrauth(...) __ptrauth(__VA_ARGS__)
 


### PR DESCRIPTION
Add `-ptrauth-emit-wrapper-globals=0` to fix the test.

rdar://151807291