### PR TITLE
[Clang][Sema] Emit noescape diagnostic with a type name instead of `0`

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1353,7 +1353,7 @@ static void handleNoEscapeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (!isValidPointerAttrType(T, /* RefOkay */ true) && !T->isRecordType()) {
     S.Diag(AL.getLoc(),
            diag::warn_attribute_pointer_or_reference_or_record_only)
-        << AL << AL.getRange() << 0;
+        << AL << AL.getRange() << T;
     return;
   }
 

--- a/clang/test/Sema/attr-noescape.c
+++ b/clang/test/Sema/attr-noescape.c
@@ -8,5 +8,5 @@ int *global_var __attribute((noescape)); // expected-warning{{'noescape' attribu
 
 void foo(__attribute__((noescape)) int *int_ptr,
          __attribute__((noescape)) int (^block)(int),
-         __attribute((noescape)) int integer) { // expected-warning{{'noescape' attribute only applies to a pointer, reference, class, struct, or union (0 is invalid)}}
+         __attribute((noescape)) int integer) { // expected-warning{{'noescape' attribute only applies to a pointer, reference, class, struct, or union ('int' is invalid)}}
 }


### PR DESCRIPTION
rdar://152087076