### PR TITLE
🍒[Clang][Sema] Emit noescape diagnostic with a type name instead of `0`

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -1353,7 +1353,7 @@ static void handleNoEscapeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (!isValidPointerAttrType(T, /* RefOkay */ true) && !T->isRecordType()) {
     S.Diag(AL.getLoc(),
            diag::warn_attribute_pointer_or_reference_or_record_only)
-        << AL << AL.getRange() << 0;
+        << AL << AL.getRange() << T;
     return;
   }
 

--- a/clang/test/Sema/attr-noescape.c
+++ b/clang/test/Sema/attr-noescape.c
@@ -8,5 +8,5 @@ int *global_var __attribute((noescape)); // expected-warning{{'noescape' attribu
 
 void foo(__attribute__((noescape)) int *int_ptr,
          __attribute__((noescape)) int (^block)(int),
-         __attribute((noescape)) int integer) { // expected-warning{{'noescape' attribute only applies to a pointer, reference, class, struct, or union (0 is invalid)}}
+         __attribute((noescape)) int integer) { // expected-warning{{'noescape' attribute only applies to a pointer, reference, class, struct, or union ('int' is invalid)}}
 }

--- a/clang/test/SemaCXX/noescape-attr.cpp
+++ b/clang/test/SemaCXX/noescape-attr.cpp
@@ -3,7 +3,7 @@
 template<typename T>
 void test1(T __attribute__((noescape)) arr, int size);
 
-void test2(int __attribute__((noescape)) a, int b); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union (0 is invalid)}}
+void test2(int __attribute__((noescape)) a, int b); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union ('int' is invalid)}}
 
 struct S { int *p; };
 void test3(S __attribute__((noescape)) s);

--- a/clang/test/SemaObjCXX/noescape.mm
+++ b/clang/test/SemaObjCXX/noescape.mm
@@ -23,11 +23,11 @@ void noescapeFunc6(__attribute__((noescape)) const T &);
 template <class T>
 void noescapeFunc7(__attribute__((noescape)) T &&);
 
-void invalidFunc0(int __attribute__((noescape))); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union (0 is invalid)}}
+void invalidFunc0(int __attribute__((noescape))); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union ('int' is invalid)}}
 void invalidFunc1(int __attribute__((noescape(0)))); // expected-error {{'noescape' attribute takes no arguments}}
 void invalidFunc2(int0 *__attribute__((noescape))); // expected-error {{use of undeclared identifier 'int0'; did you mean 'int'?}}
-void invalidFunc3(__attribute__((noescape)) int (S::*Ty)); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union (0 is invalid)}}
-void invalidFunc4(__attribute__((noescape)) void (S::*Ty)()); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union (0 is invalid)}}
+void invalidFunc3(__attribute__((noescape)) int (S::*Ty)); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union ('int (S::*)' is invalid)}}
+void invalidFunc4(__attribute__((noescape)) void (S::*Ty)()); // expected-warning {{'noescape' attribute only applies to a pointer, reference, class, struct, or union ('void (S::*)()' is invalid)}}
 int __attribute__((noescape)) g; // expected-warning {{'noescape' attribute only applies to parameters}}
 
 struct S1 {


### PR DESCRIPTION
This fixes a bug in the diagnostic message: instead of a type name, `0` was always emitted.

rdar://152087076
(cherry picked from commit 0565b0243f35b90e05d4979a9542a60d7cf98ead)