### PR TITLE
[next] Revert "[ADT] Deprecate PointerUnion::{is,get} (NFC) (#122623)"

### DIFF
--- a/llvm/include/llvm/ADT/PointerUnion.h
+++ b/llvm/include/llvm/ADT/PointerUnion.h
@@ -147,18 +147,12 @@ public:
   //        isa<T>, cast<T> and the llvm::dyn_cast<T>
 
   /// Test if the Union currently holds the type matching T.
-  template <typename T>
-  [[deprecated("Use isa instead")]]
-  inline bool is() const {
-    return isa<T>(*this);
-  }
+  template <typename T> inline bool is() const { return isa<T>(*this); }
 
   /// Returns the value of the specified pointer type.
   ///
   /// If the specified pointer type is incorrect, assert.
-  template <typename T>
-  [[deprecated("Use cast instead")]]
-  inline T get() const {
+  template <typename T> inline T get() const {
     assert(isa<T>(*this) && "Invalid accessor called");
     return cast<T>(*this);
   }


### PR DESCRIPTION
This reverts commit abba01adad5dfc54f781357d924c8021c9306615.

We will address these deprecations later once all the other failures are dealt with and Swift's release/6.2 starts converging. Right now they're just getting in the way.