### PR TITLE
[CAS] Provide an API to canonicalize a CompilerInvocation

### DIFF
--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -79,6 +79,9 @@ llvm::Error printCompileJobCacheKey(llvm::cas::ObjectStore &CAS,
                                     const llvm::cas::CASID &Key,
                                     llvm::raw_ostream &OS);
 
+void canonicalizeCASCompilerInvocation(const llvm::cas::ObjectStore &CAS,
+                                       CompilerInvocation &CI);
+
 } // namespace clang
 
 #endif // LLVM_CLANG_FRONTEND_COMPILEJOBCACHEKEY_H

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -296,7 +296,7 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   if (!CacheCompileJob)
     return std::nullopt;
 
-  std::tie(CAS, Cache) = Invocation.getCASOpts().getOrCreateDatabases(Diags);
+  std::tie(CAS, Cache) = Clang.createCASDatabases();
   if (!CAS || !Cache)
     return 1; // Exit with error!
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -954,13 +954,16 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputBackend() {
   return getOutputBackend();
 }
 
-void CompilerInstance::createCASDatabases() {
+std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+          std::shared_ptr<llvm::cas::ActionCache>>
+CompilerInstance::createCASDatabases() {
   // Create a new CAS databases from the CompilerInvocation. Future calls to
   // createFileManager() will use the same CAS.
   std::tie(CAS, ActionCache) =
       getInvocation().getCASOpts().getOrCreateDatabases(
           getDiagnostics(),
           /*CreateEmptyCASOnFailure=*/true);
+  return {CAS, ActionCache};
 }
 
 llvm::cas::ObjectStore &CompilerInstance::getOrCreateObjectStore() {


### PR DESCRIPTION
This patch adds a new function that canonicalizes the CompilerInvocation. An initial use case is to allow serialization of the invocation, where serializing a non canonical invocation might lead to cache poisoning.