### PR TITLE
[clang][cas] Handle CAS errors from OutputFile::keep()

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -898,6 +898,10 @@ void CompilerInstance::clearOutputFiles(bool EraseFiles) {
           [&](const llvm::vfs::OutputError &E) {
             getDiagnostics().Report(diag::err_fe_unable_to_open_output)
                 << E.getOutputPath() << E.convertToErrorCode().message();
+          },
+          [&](const llvm::ErrorInfoBase &EIB) { // Handle any remaining error
+            getDiagnostics().Report(diag::err_fe_unable_to_open_output)
+                << O.getPath() << EIB.message();
           });
   }
   OutputFiles.clear();


### PR DESCRIPTION
When finishing output files we need to handle all possible Error kinds or we will have undefined behaviour. In particular, if storing to the CAS failed we could silently fail to add the main output leading to mysterious downstream failures if we tried to replay that compilation, or for modules when we tried to load the pcm contents.

rdar://151077068