### PR TITLE
[lldb] Reduce max-children-depth default for readability (#10683)

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -129,7 +129,7 @@ let Definition = "target" in {
     DefaultUnsignedValue<24>,
     Desc<"Maximum number of children to expand in any level of depth.">;
   def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
-    DefaultUnsignedValue<6>,
+    DefaultUnsignedValue<4>,
     Desc<"Maximum depth to expand children.">;
   def MaxSummaryLength: Property<"max-string-summary-length", "UInt64">,
     DefaultUnsignedValue<1024>,

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
@@ -359,13 +359,13 @@ class AdvDataFormatterTestCase(TestBase):
         self.runCmd("type format delete int")
 
         # First, check the following:
-        #   1. Verify the default max-children-depth (6) is applied
+        #   1. Verify the default max-children-depth (4) is applied
         #   2. Ensure the one-time warning is printed
         warning = "*** Some of the displayed variables have a greater depth"
         self.expect(
             "frame variable quite_nested",
             matching=True,
-            substrs=["six ={...}", warning],
+            substrs=["four ={...}", warning],
         )
         self.expect(
             "frame variable quite_nested",

--- a/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
@@ -120,6 +120,8 @@ class NSDictionarySyntheticTestCase(TestBase):
                 '@"2 elements"',
             ],
         )
+
+        self.runCmd("settings set target.max-children-depth 6")
         self.expect(
             "frame variable mutabledict --ptr-depth 3",
             substrs=[

--- a/lldb/test/Shell/SymbolFile/PDB/Inputs/UdtLayoutTest.script
+++ b/lldb/test/Shell/SymbolFile/PDB/Inputs/UdtLayoutTest.script
@@ -1,3 +1,4 @@
+settings set target.max-children-depth 6
 breakpoint set --file UdtLayoutTest.cpp --line 60
 run
 target variable


### PR DESCRIPTION
* [lldb] Reduce max-children-depth default for readability

Decrease `target.max-children-depth` from 6 to 4. Often the value of 6 produces too much
output, particularly with Swift data where, unlike ObjC, classes are not treated as
pointers and thus are traversed just like structs.

For a hypothetical recursive struct with just two members/properties, a depth of 6
results in 63 (2^6-1) child values printed. In practice, data types commonly have more
than two fields, and so hundred of child values can be printed. An output of only 63
would be closer to a best case scenario. This doesn't factor in lldb's data output
syntax, which adds additional non-data lines to the output.

When all children must be shown, frame variable and expression both support the -A
(--show-all-children) flag.

rdar://145327522

* Fix tests for max-children-depth

* Fix test/Shell/SymbolFile/PDB/udt-layout.test
(cherry-picked from commit d077c2d6a423ca48336074c8a1ac6e3d66bb1524)