### PR TITLE
[lldb] Implement diagnostics detecting when a variable is not captured

### DIFF
--- a/lldb/include/lldb/Expression/DiagnosticManager.h
+++ b/lldb/include/lldb/Expression/DiagnosticManager.h
@@ -107,7 +107,8 @@ public:
     m_fixed_expression.clear();
   }
 
-  const DiagnosticList &Diagnostics() { return m_diagnostics; }
+  const DiagnosticList &Diagnostics() const { return m_diagnostics; }
+  DiagnosticList &Diagnostics() { return m_diagnostics; }
 
   bool HasFixIts() const {
     return llvm::any_of(m_diagnostics,

--- a/lldb/include/lldb/Symbol/Variable.h
+++ b/lldb/include/lldb/Symbol/Variable.h
@@ -91,6 +91,9 @@ public:
 
   bool IsInScope(StackFrame *frame);
 
+  /// Returns true if this variable is in scope at `addr` inside `block`.
+  bool IsInScope(const Block &block, const Address &addr);
+
   bool LocationIsValidForFrame(StackFrame *frame);
 
   bool LocationIsValidForAddress(const Address &address);

--- a/lldb/include/lldb/Symbol/VariableList.h
+++ b/lldb/include/lldb/Symbol/VariableList.h
@@ -24,6 +24,9 @@ public:
   VariableList();
   virtual ~VariableList();
 
+  VariableList(VariableList &&) = default;
+  VariableList &operator=(VariableList &&) = default;
+
   void AddVariable(const lldb::VariableSP &var_sp);
 
   bool AddVariableIfUnique(const lldb::VariableSP &var_sp);

--- a/lldb/include/lldb/Target/Language.h
+++ b/lldb/include/lldb/Target/Language.h
@@ -403,6 +403,28 @@ public:
     return nullptr;
   }
 
+  // BEGIN SWIFT
+  // Implement LanguageCPlusPlus::GetParentNameIfClosure and upstream this.
+  // rdar://152321823
+
+  /// If `mangled_name` refers to a function that is a "closure-like" function,
+  /// returns the name of the parent function where the input closure was
+  /// defined. Returns an empty string if there is no such parent, or if the
+  /// query does not make sense for this language.
+  virtual std::string
+  GetParentNameIfClosure(llvm::StringRef mangled_name) const {
+    return "";
+  }
+
+  /// If `sc` corresponds to a "closure-like" function (as defined in
+  /// `GetParentNameIfClosure`), returns the parent Function*
+  /// where a variable named `variable_name` exists.
+  /// Returns nullptr if `sc` is not a closure, or if the query does
+  /// not make sense for this language.
+  Function *FindParentOfClosureWithVariable(llvm::StringRef variable_name,
+                                            const SymbolContext &sc) const;
+  // END SWIFT
+
 protected:
   // Classes that inherit from Language can see and modify these
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -2001,6 +2001,11 @@ SwiftLanguage::AreEqualForFrameComparison(const SymbolContext &sc1,
   llvm_unreachable("unhandled enumeration in AreEquivalentFunctions");
 }
 
+std::string
+SwiftLanguage::GetParentNameIfClosure(llvm::StringRef mangled_name) const {
+  return SwiftLanguageRuntime::GetParentNameIfClosure(mangled_name);
+}
+
 //------------------------------------------------------------------
 // Static Functions
 //------------------------------------------------------------------

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -81,6 +81,9 @@ public:
   std::optional<bool>
   AreEqualForFrameComparison(const SymbolContext &sc1,
                              const SymbolContext &sc2) const override;
+
+  std::string
+  GetParentNameIfClosure(llvm::StringRef mangled_name) const override;
   //------------------------------------------------------------------
   // Static Functions
   //------------------------------------------------------------------

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -205,6 +205,8 @@ public:
                          const SymbolContext *sc = nullptr,
                          const ExecutionContext *exe_ctx = nullptr);
 
+  static std::string GetParentNameIfClosure(llvm::StringRef mangled_name);
+
   /// Demangle a symbol to a swift::Demangle node tree.
   ///
   /// This is a central point of access, for purposes such as logging.

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
+#include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
 #include "SwiftLanguageRuntime.h"
 
 #include "lldb/Breakpoint/StoppointCallbackContext.h"
@@ -1496,4 +1498,30 @@ SwiftLanguageRuntime::GetGenericSignature(llvm::StringRef function_name,
   return signature;
 }
 
+std::string SwiftLanguageRuntime::GetParentNameIfClosure(StringRef name) {
+  using Kind = Node::Kind;
+  swift::Demangle::Context ctx;
+  auto *node = SwiftLanguageRuntime::DemangleSymbolAsNode(name, ctx);
+  if (!node || node->getKind() != Node::Kind::Global)
+    return "";
+
+  // Replace the top level closure node with the child function-like node, and
+  // attempt to remangle. If successful, this produces the parent function-like
+  // entity.
+  static const auto closure_kinds = {Kind::ImplicitClosure,
+                                     Kind::ExplicitClosure};
+  static const auto function_kinds = {Kind::ImplicitClosure,
+                                      Kind::ExplicitClosure, Kind::Function};
+  auto *closure_node = swift_demangle::GetFirstChildOfKind(node, closure_kinds);
+  auto *parent_func_node =
+      swift_demangle::GetFirstChildOfKind(closure_node, function_kinds);
+  if (!parent_func_node)
+    return "";
+  swift_demangle::ReplaceChildWith(*node, *closure_node, *parent_func_node);
+
+  if (ManglingErrorOr<std::string> mangled = swift::Demangle::mangleNode(node);
+      mangled.isSuccess())
+    return mangled.result();
+  return "";
+}
 } // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -22,6 +22,32 @@
 namespace lldb_private {
 namespace swift_demangle {
 
+using NodePointer = swift::Demangle::NodePointer;
+using Node = swift::Demangle::Node;
+
+/// Returns the first child of `node` whose kind is in `kinds`.
+inline NodePointer GetFirstChildOfKind(NodePointer node,
+                                       llvm::ArrayRef<Node::Kind> kinds) {
+  if (!node)
+    return nullptr;
+  for (auto *child : *node)
+    if (llvm::is_contained(kinds, child->getKind()))
+      return child;
+  return nullptr;
+}
+
+/// Assumes that `to_replace` is a child of `parent`, and replaces it with
+/// `new_child`. The Nodes must all be owned by the same context.
+inline void ReplaceChildWith(Node &parent, Node &to_replace, Node &new_child) {
+  for (unsigned idx = 0; idx < parent.getNumChildren(); idx++) {
+    auto *child = parent.getChild(idx);
+    if (child == &to_replace)
+      parent.replaceChild(idx, &new_child);
+    return;
+  }
+  llvm_unreachable("invalid child passed to replaceChildWith");
+}
+
 /// Access an inner node by following the given Node::Kind path.
 ///
 /// Note: The Node::Kind path is relative to the given root node. The root

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -291,28 +291,9 @@ bool Variable::IsInScope(StackFrame *frame) {
       // this variable was defined in is currently
       Block *deepest_frame_block =
           frame->GetSymbolContext(eSymbolContextBlock).block;
-      if (deepest_frame_block) {
-        SymbolContext variable_sc;
-        CalculateSymbolContext(&variable_sc);
-
-        // Check for static or global variable defined at the compile unit
-        // level that wasn't defined in a block
-        if (variable_sc.block == nullptr)
-          return true;
-
-        // Check if the variable is valid in the current block
-        if (variable_sc.block != deepest_frame_block &&
-            !variable_sc.block->Contains(deepest_frame_block))
-          return false;
-
-        // If no scope range is specified then it means that the scope is the
-        // same as the scope of the enclosing lexical block.
-        if (m_scope_range.IsEmpty())
-          return true;
-
-        addr_t file_address = frame->GetFrameCodeAddress().GetFileAddress();
-        return m_scope_range.FindEntryThatContains(file_address) != nullptr;
-      }
+      Address frame_addr = frame->GetFrameCodeAddress();
+      if (deepest_frame_block)
+        return IsInScope(*deepest_frame_block, frame_addr);
     }
     break;
 
@@ -320,6 +301,27 @@ bool Variable::IsInScope(StackFrame *frame) {
     break;
   }
   return false;
+}
+
+bool Variable::IsInScope(const Block &block, const Address &addr) {
+  SymbolContext variable_sc;
+  CalculateSymbolContext(&variable_sc);
+
+  // Check for static or global variable defined at the compile unit
+  // level that wasn't defined in a block
+  if (variable_sc.block == nullptr)
+    return true;
+
+  // Check if the variable is valid in the current block
+  if (variable_sc.block != &block && !variable_sc.block->Contains(&block))
+    return false;
+
+  // If no scope range is specified then it means that the scope is the
+  // same as the scope of the enclosing lexical block.
+  if (m_scope_range.IsEmpty())
+    return true;
+
+  return m_scope_range.FindEntryThatContains(addr.GetFileAddress()) != nullptr;
 }
 
 Status Variable::GetValuesForVariableExpressionPath(

--- a/lldb/source/Target/StackFrame.cpp
+++ b/lldb/source/Target/StackFrame.cpp
@@ -22,6 +22,7 @@
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Target/ABI.h"
 #include "lldb/Target/ExecutionContext.h"
+#include "lldb/Target/Language.h"
 #include "lldb/Target/LanguageRuntime.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/RegisterContext.h"
@@ -475,6 +476,31 @@ VariableList *StackFrame::GetVariableList(bool get_file_globals,
   return m_variable_list_sp.get();
 }
 
+// BEGIN SWIFT
+// Implement LanguageCPlusPlus::GetParentNameIfClosure and upstream this.
+// rdar://152321823
+
+/// If `sc` represents a "closure-like" function according to `lang`, and
+/// `missing_var_name` can be found in a parent context, create a diagnostic
+/// explaining that this variable is available but not captured by the closure.
+static std::string
+GetVariableNotCapturedDiagnostic(SymbolContext &sc, SourceLanguage lang,
+                                 ConstString missing_var_name) {
+  Language *lang_plugin = Language::FindPlugin(lang.AsLanguageType());
+  if (lang_plugin == nullptr)
+    return "";
+  Function *parent_func =
+      lang_plugin->FindParentOfClosureWithVariable(missing_var_name, sc);
+  if (!parent_func)
+    return "";
+  return llvm::formatv("A variable named '{0}' existed in function '{1}', but "
+                       "it was not captured in the closure.\nHint: the "
+                       "variable may be available in a parent frame.",
+                       missing_var_name,
+                       parent_func->GetDisplayName().GetStringRef());
+}
+// END SWIFT
+
 VariableListSP
 StackFrame::GetInScopeVariableList(bool get_file_globals,
                                    bool must_have_valid_location) {
@@ -620,6 +646,15 @@ ValueObjectSP StackFrame::GetValueForVariableExpressionPath(
       return valobj_sp;
   }
   if (!valobj_sp) {
+    // BEGIN SWIFT
+    // Implement LanguageCPlusPlus::GetParentNameIfClosure and upstream this.
+    // rdar://152321823
+    if (std::string message = GetVariableNotCapturedDiagnostic(
+            m_sc, GetLanguage(), name_const_string);
+        !message.empty())
+      error = Status::FromErrorString(message.c_str());
+    else
+    // END SWIFT
     error = Status::FromErrorStringWithFormatv(
         "no variable named '{0}' found in this frame", name_const_string);
     return ValueObjectSP();

--- a/lldb/test/API/lang/swift/closures_var_not_captured/Makefile
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -14,6 +14,14 @@ def check_not_captured_error(test, frame, var_name, parent_function):
     expected_error = (
         f"A variable named '{var_name}' existed in function '{parent_function}'"
     )
+    value = frame.EvaluateExpression(var_name)
+    error = value.GetError().GetCString()
+    test.assertIn(expected_error, error)
+
+    value = frame.EvaluateExpression(f"1 + {var_name} + 1")
+    error = value.GetError().GetCString()
+    test.assertIn(expected_error, error)
+
     test.expect(f"frame variable {var_name}", substrs=[expected_error], error=True)
 
 

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -1,0 +1,97 @@
+"""
+Test that we can print and call closures passed in various contexts
+"""
+
+import os
+import re
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+def check_not_captured_error(test, frame, var_name, parent_function):
+    expected_error = (
+        f"A variable named '{var_name}' existed in function '{parent_function}'"
+    )
+    test.expect(f"frame variable {var_name}", substrs=[expected_error], error=True)
+
+
+def check_no_enhanced_diagnostic(test, frame, var_name):
+    forbidden_str = "A variable named"
+    value = frame.EvaluateExpression(var_name)
+    error = value.GetError().GetCString()
+    test.assertNotIn(forbidden_str, error)
+
+    value = frame.EvaluateExpression(f"1 + {var_name} + 1")
+    error = value.GetError().GetCString()
+    test.assertNotIn(forbidden_str, error)
+
+    test.expect(
+        f"frame variable {var_name}",
+        substrs=[forbidden_str],
+        matching=False,
+        error=True,
+    )
+
+
+class TestSwiftClosureVarNotCaptured(TestBase):
+    def get_to_bkpt(self, bkpt_name):
+        return lldbutil.run_to_source_breakpoint(
+            self, bkpt_name, lldb.SBFileSpec("main.swift")
+        )
+
+    @swiftTest
+    def test_simple_closure(self):
+        self.build()
+        (target, process, thread, bkpt) = self.get_to_bkpt("break_simple_closure")
+        check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_1(arg:)")
+        check_not_captured_error(self, thread.frames[0], "arg", "func_1(arg:)")
+        check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
+
+    @swiftTest
+    def test_nested_closure(self):
+        self.build()
+        (target, process, thread, bkpt) = self.get_to_bkpt("break_double_closure_1")
+        check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_2(arg:)")
+        check_not_captured_error(self, thread.frames[0], "arg", "func_2(arg:)")
+        check_not_captured_error(
+            self, thread.frames[0], "var_in_outer_closure", "closure #1 in func_2(arg:)"
+        )
+        check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
+
+        lldbutil.continue_to_source_breakpoint(
+            self, process, "break_double_closure_2", lldb.SBFileSpec("main.swift")
+        )
+        check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_2(arg:)")
+        check_not_captured_error(self, thread.frames[0], "arg", "func_2(arg:)")
+        check_not_captured_error(
+            self, thread.frames[0], "var_in_outer_closure", "closure #1 in func_2(arg:)"
+        )
+        check_not_captured_error(
+            self, thread.frames[0], "shadowed_var", "closure #1 in func_2(arg:)"
+        )
+        check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
+
+    @swiftTest
+    # Async variable inspection on Linux/Windows are still problematic.
+    @skipIf(oslist=["windows", "linux"])
+    def test_async_closure(self):
+        self.build()
+        (target, process, thread, bkpt) = self.get_to_bkpt("break_async_closure_1")
+        check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_3(arg:)")
+        check_not_captured_error(self, thread.frames[0], "arg", "func_3(arg:)")
+        check_not_captured_error(
+            self, thread.frames[0], "var_in_outer_closure", "closure #1 in func_3(arg:)"
+        )
+        check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
+
+        lldbutil.continue_to_source_breakpoint(
+            self, process, "break_async_closure_2", lldb.SBFileSpec("main.swift")
+        )
+        check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_3(arg:)")
+        check_not_captured_error(self, thread.frames[0], "arg", "func_3(arg:)")
+        check_not_captured_error(
+            self, thread.frames[0], "var_in_outer_closure", "closure #1 in func_3(arg:)"
+        )
+        check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")

--- a/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
@@ -1,0 +1,92 @@
+func func_1(arg: Int) {
+  let var_in_foo = "Alice"
+  do {
+    let dont_find_me = "haha"
+    print(dont_find_me)
+  }
+  let simple_closure = {
+    print("Hi there!")  // break_simple_closure
+  }
+  simple_closure()
+  let dont_find_me = "haha"
+  print(dont_find_me)
+}
+
+func func_2(arg: Int) {
+  do {
+    let dont_find_me = "haha"
+    print(dont_find_me)
+  }
+  let var_in_foo = "Alice"
+  let shadowed_var = "shadow"
+  let outer_closure = {
+    do {
+      let dont_find_me = "haha"
+      print(dont_find_me)
+    }
+    let var_in_outer_closure = "Alice"
+    let shadowed_var = "shadow2"
+    let inner_closure_1 = {
+      print("Hi inside!")  // break_double_closure_1
+    }
+    inner_closure_1()
+
+    do {
+      let dont_find_me = "haha"
+      print(dont_find_me)
+    }
+    let inner_closure_2 = {
+      print("Hi inside!")  // break_double_closure_2
+    }
+    inner_closure_2()
+    let dont_find_me = "haha"
+    print(dont_find_me)
+  }
+  let dont_find_me = "haha"
+  print(dont_find_me)
+  outer_closure()
+}
+
+func func_3(arg: Int) async {
+  do {
+    let dont_find_me = "haha"
+    print(dont_find_me)
+  }
+  let var_in_foo = "Alice"
+
+  // FIXME: if we comment the line below, the test fails. For some reason,
+  // without this line, most variables don't have debug info in the entry
+  // funclet, which is the "parent name" derived from the closure name.
+  // rdar://152271048
+  try! await Task.sleep(for: .seconds(0))
+
+  let outer_closure = {
+    do {
+      let dont_find_me = "haha"
+      print(dont_find_me)
+    }
+    let var_in_outer_closure = "Alice"
+
+    let inner_closure_1 = {
+      print("Hi inside!")  // break_async_closure_1
+    }
+    inner_closure_1()
+
+    try await Task.sleep(for: .seconds(0))
+
+    let inner_closure_2 = {
+      print("Hi inside!")  // break_async_closure_2
+    }
+    inner_closure_2()
+    let dont_find_me = "haha"
+    print(dont_find_me)
+  }
+
+  try! await outer_closure()
+  let dont_find_me = "haha"
+  print(dont_find_me)
+}
+
+func_1(arg: 42)
+func_2(arg: 42)
+await func_3(arg: 42)


### PR DESCRIPTION
This series of commits implement diagnostics for when a variable could have been available for `v` or `expr` commads, had it been captured inside a closure.

* The first/second commit are NFC patches cherry-picked from upstream.
* The third commit implements the `v` diagnostics in a language agnostic way. It is what should be upstreamed to LLVM once we can support this in C++. I punted on doing this because C++ mangling is a bit `<redacted>` to work with. 
* The fourth commit implements Swift support for `v` by doing the demangling work inside the SwiftLanguage plugin.
* The fifth commit builds upon the third and adds support for `expr`.