### PR TITLE
🍒[6.2][clang][cas] Handle CAS errors from OutputFile::keep()

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -902,6 +902,10 @@ void CompilerInstance::clearOutputFiles(bool EraseFiles) {
           [&](const llvm::vfs::OutputError &E) {
             getDiagnostics().Report(diag::err_fe_unable_to_open_output)
                 << E.getOutputPath() << E.convertToErrorCode().message();
+          },
+          [&](const llvm::ErrorInfoBase &EIB) { // Handle any remaining error
+            getDiagnostics().Report(diag::err_fe_unable_to_open_output)
+                << O.getPath() << EIB.message();
           });
   }
   OutputFiles.clear();


### PR DESCRIPTION
* **Explanation**: If a CAS error occurred when finishing an output file, it caused undefined behaviour due to the use of `llvm::handleAllErrors` without handling every possible error. In practice, this was causing us to silently drop the output file and cause mysterious downstream failures during module import or cache hit replay.
* **Scope**: Affects builds that enable caching.
* **Risk**: Low, this just adds another handler to the existing `handleAllErrors` that covers any remaining errors that fall through the other handlers.
* **Testing**: Tested manually by creating a tmpfs volume for the CAS and causing it to run out of space. We don't have a good way to inject this kind of error for an automated test.
* **Issue**: rdar://151077068
* **Reviewer**: @cachemeifyoucan 