### PR TITLE
[clang][modules] backout of downstream merge conflict resolution

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -230,7 +230,7 @@ def err_module_build_requires_fmodules : Error<
 def err_module_interface_requires_cpp_modules : Error<
   "module interface compilation requires '-std=c++20'">;
 def warn_module_config_mismatch : Warning<
-  "precompiled file '%0' cannot be loaded due to a configuration mismatch with the current "
+  "module file '%0' cannot be loaded due to a configuration mismatch with the current "
   "compilation">, InGroup<DiagGroup<"module-file-config-mismatch">>, DefaultError;
 def err_module_map_not_found : Error<"module map file '%0' not found">,
   DefaultFatal;

--- a/clang/test/Modules/explicit-build.cpp
+++ b/clang/test/Modules/explicit-build.cpp
@@ -153,7 +153,7 @@
 // RUN:            -fmodule-file=%t/a.pch \
 // RUN:            %s 2>&1 | FileCheck --check-prefix=CHECK-A-AS-PCH %s
 //
-// CHECK-A-AS-PCH: error: precompiled file '{{.*}}a.pch' cannot be loaded due to a configuration mismatch with the current compilation
+// CHECK-A-AS-PCH: error: module file '{{.*}}a.pch' cannot be loaded due to a configuration mismatch with the current compilation
 
 // -------------------------------
 // Try to import a non-AST file with -fmodule-file=

--- a/clang/test/Modules/mismatch-diagnostics.cpp
+++ b/clang/test/Modules/mismatch-diagnostics.cpp
@@ -30,4 +30,4 @@ export module mismatching_module;
 //--- use.cpp
 import mismatching_module;
 // CHECK: error: POSIX thread support was enabled in precompiled file '{{.*[/|\\\\]}}mismatching_module.pcm' but is currently disabled
-// CHECK-NEXT: precompiled file '{{.*[/|\\\\]}}mismatching_module.pcm' cannot be loaded due to a configuration mismatch with the current compilation
+// CHECK-NEXT: module file '{{.*[/|\\\\]}}mismatching_module.pcm' cannot be loaded due to a configuration mismatch with the current compilation


### PR DESCRIPTION
To resolve a downstream merge conflict in a2a1591c046ee483e4c4acdf7e8b21d25b8047c8, I mistakenly renamed a diagnostic thinking it only existed downstream. It turns out that it does exist in llvm proper & seems to be used or invoked somewhat often. While the diagnostic can result in incorrect matchings between pch and pcm's, I am not sure how to resolve that entirely right now and want to avoid uncessary downstream changes.