### PR TITLE
[lldb][Format] Display only the inlined Swift frame name in backtraces if available

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1761,7 +1761,7 @@ std::string SwiftLanguage::GetFunctionName(const SymbolContext &sc,
   if (sc.function->GetLanguage() != eLanguageTypeSwift)
     return {};
   std::string name = SwiftLanguageRuntime::DemangleSymbolAsString(
-      sc.function->GetMangled().GetMangledName().GetStringRef(),
+      sc.GetPossiblyInlinedFunctionName().GetMangledName(),
       SwiftLanguageRuntime::eSimplified, &sc, exe_ctx);
   if (name.empty())
     return {};
@@ -1879,8 +1879,7 @@ SwiftLanguage::GetDemangledFunctionNameWithoutArguments(Mangled mangled) const {
   ConstString mangled_name = mangled.GetMangledName();
   ConstString demangled_name = mangled.GetDemangledName();
   if (demangled_name && mangled_name) {
-    if (SwiftLanguageRuntime::IsSwiftMangledName(
-            demangled_name.GetStringRef())) {
+    if (SwiftLanguageRuntime::IsSwiftMangledName(mangled_name.GetStringRef())) {
       lldb_private::ConstString basename;
       bool is_method = false;
       if (SwiftLanguageRuntime::MethodName::ExtractFunctionBasenameFromMangled(

--- a/lldb/test/Shell/Swift/inlined-function-name-backtrace.test
+++ b/lldb/test/Shell/Swift/inlined-function-name-backtrace.test
@@ -1,5 +1,6 @@
 # Test Swift function name printing in backtraces.
 
+# XFAIL: system-windows
 # RUN: split-file %s %t
 # RUN: %target-swiftc -g -O %t/main.swift -o %t.out
 # RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \

--- a/lldb/test/Shell/Swift/inlined-function-name-backtrace.test
+++ b/lldb/test/Shell/Swift/inlined-function-name-backtrace.test
@@ -1,0 +1,33 @@
+# Test Swift function name printing in backtraces.
+
+# RUN: split-file %s %t
+# RUN: %target-swiftc -g -O %t/main.swift -o %t.out
+# RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s
+
+#--- main.swift
+@inline(never)
+func baz(_ a: Int) -> Int {
+    return a * 2
+}
+
+@inline(__always)
+func foo(_ a: Int, _ b: Int) -> Int {
+ return a * b * baz(a) 
+}
+
+func bar() {
+    let baz = foo(4, 5)
+}
+
+bar()
+
+#--- commands.input
+b baz
+
+run
+bt
+
+# CHECK: `baz(a={{.*}}) at main.swift:3:14 [opt]
+# CHECK: `foo(a={{.*}}, b={{.*}}) at main.swift:8:17 [opt] [inlined]
+# CHECK: `bar() at main.swift:12:15 [opt] [inlined]


### PR DESCRIPTION
This PR is a port of the changes made in https://github.com/llvm/llvm-project/pull/135343 to the Swift plugin.

We remove the prefix of `[inlined]` to cut on the noise but keep the `[inlined]` itself until we implement a way to use a formatter to display or not.

Also notice that on the screenshots below, the frame had a return type for inlined functions, but not for regular functions. Both now have the same behavior.

**Before:**
<img width="1220" alt="Screenshot 2025-06-04 at 19 06 14" src="https://github.com/user-attachments/assets/7dde6b03-f4c0-4a8c-8594-d12c7df62c20" />

**After:**
<img width="1031" alt="Screenshot 2025-06-04 at 19 06 43" src="https://github.com/user-attachments/assets/89bbecfb-e6b2-439c-8bd2-9206226f3b28" />
