### PR TITLE
[stable/20250601] Target: Add target option for disabling `AArch64_ELFTargetObjectFile:…

### DIFF
--- a/llvm/include/llvm/Target/TargetOptions.h
+++ b/llvm/include/llvm/Target/TargetOptions.h
@@ -154,6 +154,7 @@ namespace llvm {
           XRayFunctionIndex(true), DebugStrictDwarf(false), Hotpatch(false),
           PPCGenScalarMASSEntries(false), JMCInstrument(false),
           EnableCFIFixup(false), MisExpect(false), XCOFFReadOnlyPointers(false),
+          SupportIndirectSymViaGOTPCRel_AArch64_ELF(true),
           VerifyArgABICompliance(true),
           FPDenormalMode(DenormalMode::IEEE, DenormalMode::IEEE) {}
 
@@ -388,6 +389,10 @@ namespace llvm {
     /// When set to true, const objects with relocatable address values are put
     /// into the RO data section.
     unsigned XCOFFReadOnlyPointers : 1;
+
+    /// When set to true, enables indirect symbol replacement with GOTPCREL for
+    /// AArch64/ELF.
+    unsigned SupportIndirectSymViaGOTPCRel_AArch64_ELF : 1;
 
     /// When set to true, call/return argument extensions of narrow integers
     /// are verified in the target backend if it cares about them. This is

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -278,13 +278,15 @@ void AArch64TargetMachine::reset() { SubtargetMap.clear(); }
 //===----------------------------------------------------------------------===//
 // AArch64 Lowering public interface.
 //===----------------------------------------------------------------------===//
-static std::unique_ptr<TargetLoweringObjectFile> createTLOF(const Triple &TT) {
+static std::unique_ptr<TargetLoweringObjectFile>
+createTLOF(const Triple &TT, const TargetOptions &Options) {
   if (TT.isOSBinFormatMachO())
     return std::make_unique<AArch64_MachoTargetObjectFile>();
   if (TT.isOSBinFormatCOFF())
     return std::make_unique<AArch64_COFFTargetObjectFile>();
 
-  return std::make_unique<AArch64_ELFTargetObjectFile>();
+  return std::make_unique<AArch64_ELFTargetObjectFile>(
+      Options.SupportIndirectSymViaGOTPCRel_AArch64_ELF);
 }
 
 // Helper function to build a DataLayout string
@@ -365,7 +367,7 @@ AArch64TargetMachine::AArch64TargetMachine(const Target &T, const Triple &TT,
           computeDefaultCPU(TT, CPU), FS, Options,
           getEffectiveRelocModel(TT, RM),
           getEffectiveAArch64CodeModel(TT, CM, JIT), OL),
-      TLOF(createTLOF(getTargetTriple())), isLittle(LittleEndian) {
+      TLOF(createTLOF(getTargetTriple(), Options)), isLittle(LittleEndian) {
   initAsmInfo();
 
   if (TT.isOSBinFormatMachO()) {

--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.cpp
@@ -27,7 +27,6 @@ void AArch64_ELFTargetObjectFile::Initialize(MCContext &Ctx,
                                              const TargetMachine &TM) {
   TargetLoweringObjectFileELF::Initialize(Ctx, TM);
   PLTRelativeSpecifier = AArch64MCExpr::VK_PLT;
-  SupportIndirectSymViaGOTPCRel = true;
 
   // AARCH64 ELF ABI does not define static relocation type for TLS offset
   // within a module.  Do not generate AT_location for TLS variables.

--- a/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
+++ b/llvm/lib/Target/AArch64/AArch64TargetObjectFile.h
@@ -20,6 +20,10 @@ class AArch64_ELFTargetObjectFile : public TargetLoweringObjectFileELF {
   void Initialize(MCContext &Ctx, const TargetMachine &TM) override;
 
 public:
+  AArch64_ELFTargetObjectFile(bool SupportIndirectSymViaGOTPCRel) {
+    this->SupportIndirectSymViaGOTPCRel = SupportIndirectSymViaGOTPCRel;
+  }
+
   const MCExpr *getIndirectSymViaGOTPCRel(const GlobalValue *GV,
                                           const MCSymbol *Sym,
                                           const MCValue &MV, int64_t Offset,


### PR DESCRIPTION
…:SupportIndirectSymViaGOTPCRel`

The Swift compiler needs to disable this option in order for the standard library to link successfully on Linux.

See:
- https://github.com/swiftlang/llvm-project/pull/9339
- https://github.com/llvm/llvm-project/pull/78003

Paired with https://github.com/swiftlang/swift/pull/82060.