### PR TITLE
[Cherry-pick into next] [lldb] Register a summary formatter for CoreFoundation.CFStringRef

### DIFF
--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -86,6 +86,7 @@ bool lldb_private::formatters::swift::NotificationName_SummaryProvider(
   return true;
 }
 
+
 bool lldb_private::formatters::swift::URL_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
   static ConstString g__url("_url");

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -659,6 +659,12 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp,
+      lldb_private::formatters::NSStringSummaryProvider,
+      "CFStringRef summary provider",
+      ConstString("CoreFoundation.CFStringRef"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
+  lldb_private::formatters::AddCXXSummary(
+      swift_category_sp,
       lldb_private::formatters::swift::NotificationName_SummaryProvider,
       "Notification.Name summary provider",
       ConstString("Foundation.Notification.Type.Name"),

--- a/lldb/test/API/lang/swift/foundation_value_types/cfstringref/Makefile
+++ b/lldb/test/API/lang/swift/foundation_value_types/cfstringref/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFT_OBJC_INTEROP := 1
+include Makefile.rules

--- a/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/cfstringref/TestSwiftFoundationTypeCFStringRef.py
@@ -1,0 +1,15 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftFoundationTypeCFStringRef(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+        self.expect("frame variable short", substrs=["Hello"])
+        self.expect("frame variable long", substrs=["longer"])

--- a/lldb/test/API/lang/swift/foundation_value_types/cfstringref/main.swift
+++ b/lldb/test/API/lang/swift/foundation_value_types/cfstringref/main.swift
@@ -1,0 +1,4 @@
+import Foundation
+let short = "Hello" as CFString
+let long = "This is definitely much longer" as CFString
+print("break here")


### PR DESCRIPTION
```
commit 2e4a5a07074320833eb1a7eb82db2b6128e73d05
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jun 5 15:52:43 2025 -0700

    [lldb] Register a summary formatter for CoreFoundation.CFStringRef
```
