### PR TITLE
[lldb][Modules] Make decls from submodules visible for name lookup

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangModulesDeclVendor.cpp
@@ -379,6 +379,13 @@ bool ClangModulesDeclVendorImpl::AddModule(const SourceModule &module,
     }
   }
 
+  // If we didn't make the submodule visible here, Clang wouldn't allow LLDB to
+  // pick any of the decls in the submodules during C++ name lookup.
+  if (submodule)
+    m_compiler_instance->makeModuleVisible(
+        submodule, clang::Module::NameVisibilityKind::AllVisible,
+        /*ImportLoc=*/{});
+
   clang::Module *requested_module = DoGetModule(clang_path, true);
 
   if (requested_module != nullptr) {


### PR DESCRIPTION
This patch ensures we can find decls in submodules during expression evaluation. Previously, submodules would have all their decls marked as `Hidden`. When Clang asked LLDB for decls, it would see them in the submodule but `clang::Sema` would reject them because they weren't `Visible` (specifically, `getAcceptableDecl` would fail during `CppNameLookup`). Here we just mark the submodule as visible to work around this problem.

(cherry picked from commit 30f524090542d07067234c292c15d4a4129b4aea)