### PR TITLE
[lldb] Make private type reflection metadata available from the file …

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -605,6 +605,19 @@ LLDBMemoryReader::getFileAddressAndModuleForTaggedAddress(
   return {{file_address, module}};
 }
 
+std::optional<swift::reflection::RemoteAddress>
+LLDBMemoryReader::resolveRemoteAddress(
+    swift::reflection::RemoteAddress address) const {
+  std::optional<Address> lldb_address =
+      LLDBMemoryReader::resolveRemoteAddress(address.getAddressData());
+  if (!lldb_address)
+    return {};
+  lldb::addr_t addr = lldb_address->GetLoadAddress(&m_process.GetTarget());
+  if (addr != LLDB_INVALID_ADDRESS)
+    return swift::reflection::RemoteAddress(addr);
+  return {};
+}
+
 std::optional<Address>
 LLDBMemoryReader::resolveRemoteAddress(uint64_t address) const {
   Log *log(GetLog(LLDBLog::Types));

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -77,6 +77,9 @@ public:
   resolvePointer(swift::remote::RemoteAddress address,
                  uint64_t readValue) override;
 
+  std::optional<swift::remote::RemoteAddress>
+  resolveRemoteAddress(swift::remote::RemoteAddress address) const override;
+
   bool readBytes(swift::remote::RemoteAddress address, uint8_t *dest,
                  uint64_t size) override;
 

--- a/lldb/test/API/lang/swift/observation/Makefile
+++ b/lldb/test/API/lang/swift/observation/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
+++ b/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftObservation(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    def test(self):
+        """Test that types with private discriminators read from the file cache work"""
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+        # FIXME: Private discriminators are UUIDs in DWARF and pointers
+        # in Reflection metafdata, making tham not comparable.
+        # rdar://74374120 
+        self.expect("settings set symbols.swift-validate-typesystem false")
+        self.expect("settings set target.experimental.swift-read-metadata-from-file-cache true")
+        r = self.frame().FindVariable("r")
+        extent = r.GetChildAtIndex(0)
+        self.assertEqual(extent.GetName(), "extent")

--- a/lldb/test/API/lang/swift/observation/main.swift
+++ b/lldb/test/API/lang/swift/observation/main.swift
@@ -1,0 +1,8 @@
+import Observation
+
+func f() {
+  let r = ObservationRegistrar()
+  print("break here")
+}
+
+f()


### PR DESCRIPTION
…cache

This fixes a bug in LLDB's file cache. Private types have anonymous context descriptors, which are just a string that is the metadata pointer in hex. This is a problem when the meatdata was read from a file because then the address isn't comparable against the same type constructed from in-process memory. This patch fixes this by implementing a new hook to canonicalize file addresses to in-process addresses in MemoryReader.

rdar://151330005