### PR TITLE
[6.2][lldb] Skip TestSwiftForwardInteropExpressions

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
@@ -15,6 +15,7 @@ class TestSwiftForwardInteropExpressions(TestBase):
              self, bkpt_str, lldb.SBFileSpec('main.swift'))
          return thread
 
+    @skipIf(bugnumber='rdar://152745034')
     @skipIfLinux # rdar://106871422"
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false')) # rdar://106871275
     @swiftTest


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10805 to unblock Swift CI.