### PR TITLE
[Cherry-pick into next] [lldb] Add a safety limit for walking parent classes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -246,7 +246,9 @@ public:
                         swift::reflection::DescriptorFinder *descriptor_finder,
                         const swift::reflection::TypeRef *tr,
                         std::function<bool(SuperClassType)> fn) override {
-    while (tr) {
+    // Guard against faulty self-referential metadata.
+    unsigned limit = 256;
+    while (tr && --limit) {
       if (fn({[=]() -> const swift::reflection::RecordTypeInfo * {
                 auto ti_or_err = GetRecordTypeInfo(*tr, tip, descriptor_finder);
                 if (!ti_or_err) {


### PR DESCRIPTION
```
commit da31a02059a8b00659643099131f753ca6514621
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Jun 6 16:27:57 2025 -0700

    [lldb] Add a safety limit for walking parent classes
```
