### PR TITLE
[Cherry-pick into next] [lldb] Support counting the children of metatypes using reflection metadata

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1396,7 +1396,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
     // consider handling them here, but
     // TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex can also
     // handle them and without a Process.
-    if (!TypeSystemSwiftTypeRef::IsBuiltinType(m_type)) {
+    if (!TypeSystemSwiftTypeRef::IsBuiltinType(m_type) &&
+        !Flags(m_type.GetTypeInfo()).AnySet(eTypeIsMetatype)) {
       LLDB_LOG(GetLog(LLDBLog::Types),
                "{0}: unrecognized builtin type info or this is a Clang type "
                "without DWARF debug info",

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -29,12 +29,16 @@ class TestSwiftMetatype(TestBase):
 
         frame = thread.frames[0]
         self.assertTrue(frame, "Frame 0 is valid.")
-
         var_s = frame.FindVariable("s")
         var_c = frame.FindVariable("c")
         var_f = frame.FindVariable("f")
         var_t = frame.FindVariable("t")
         var_p = frame.FindVariable("p")
+        self.assertEqual(var_s.GetNumChildren(), 0)
+        self.assertEqual(var_c.GetNumChildren(), 0)
+        self.assertEqual(var_f.GetNumChildren(), 0)
+        self.assertEqual(var_p.GetNumChildren(), 0)
+        self.assertEqual(var_t.GetNumChildren(), 0)
         lldbutil.check_variable(self, var_s, False, "String")
         lldbutil.check_variable(self, var_c, False, "@thick a.D.Type")
         lldbutil.check_variable(self, var_f, True, '@thick ((Int) -> Int).Type')


### PR DESCRIPTION
```
commit a0b203a60e220547deeee295d72c79ebf9a78da0
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Jun 6 17:10:08 2025 -0700

    [lldb] Support counting the children of metatypes using reflection metadata
    
    This eliminates yet another SwiftASTContext fallback.
    
    rdar://151330021
```
