### PR TITLE
:cherries:[lldb][swift] Handle `asyncLet_get_throwing` trampoline (#10783)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -423,6 +423,7 @@ CreateRunThroughTaskSwitchingTrampolines(Thread &thread,
   //                         void *,
   //                         TaskContinuationFunction *,
   if (trampoline_name == "swift_asyncLet_get" ||
+      trampoline_name == "swift_asyncLet_get_throwing" ||
       trampoline_name == "swift_asyncLet_finish")
     return CreateRunThroughTaskSwitchThreadPlan(thread,
                                                 LLDB_REGNUM_GENERIC_ARG3);

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/TestSwiftAsyncStepOverAsyncLet.py
@@ -14,17 +14,36 @@ class TestCase(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
-    def test(self):
+    def test_nothrow(self):
         """Test conditions for async step-over."""
         self.build()
 
         source_file = lldb.SBFileSpec("main.swift")
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, "BREAK HERE", source_file
+            self, "BREAK_NOTHROW", source_file
         )
 
         # Step over should reach every line in the interval [10, 20]
         expected_line_nums = range(10, 21)
+        for expected_line_num in expected_line_nums:
+            thread.StepOver()
+            stop_reason = thread.GetStopReason()
+            self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
+            self.check_is_in_line(thread, expected_line_num)
+
+    @swiftTest
+    @skipIf(oslist=["windows", "linux"])
+    def test_throw(self):
+        """Test conditions for async step-over."""
+        self.build()
+
+        source_file = lldb.SBFileSpec("main.swift")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "BREAK_THROW", source_file
+        )
+
+        # Step over should reach every line in the interval [34, 40]
+        expected_line_nums = range(34, 41)
         for expected_line_num in expected_line_nums:
             thread.StepOver()
             stop_reason = thread.GetStopReason()

--- a/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/main.swift
+++ b/lldb/test/API/lang/swift/async/stepping/step_over_asynclet/main.swift
@@ -6,7 +6,7 @@ func work() {}
 
 func foo() async {
   do {
-    work() // BREAK HERE
+    work() // BREAK_NOTHROW
     async let timestamp1 = getTimestamp(x:1)
     work()
     async let timestamp2 = getTimestamp(x:2)
@@ -20,8 +20,30 @@ func foo() async {
   print(actual_timestamp3)
 }
 
+struct NegativeInputError: Error {}
+func getTimestamp_throwing(x: Int) async throws -> Int {
+  if (x < 0) {
+    throw NegativeInputError()
+  }
+  return 40 + x
+}
+
+func foo_throwing() async {
+  do {
+    work() // BREAK_THROW
+    async let timestamp1 = getTimestamp_throwing(x:1)
+    work()
+    async let timestamp2 = getTimestamp_throwing(x:2)
+    work()
+    let timestamps = try await [timestamp1, timestamp2]
+    print(timestamps)
+  } catch {print(error)}
+  work()
+}
+
 @main enum entry {
   static func main() async {
     await foo()
+    await foo_throwing()
   }
 }


### PR DESCRIPTION
This can also cause a task switch and should be handled like `swift_task_switch` and `asyncLet_get`.

(cherry picked from commit cf4a54e0c5597bc19de737cb5330921b5437468e)