### PR TITLE
🍒 6.2: modulemap: add arm64 intrinsics header (llvm#142653)

### DIFF
--- a/clang/lib/Headers/module.modulemap
+++ b/clang/lib/Headers/module.modulemap
@@ -35,6 +35,14 @@ module _Builtin_intrinsics [system] [extern_c] {
     }
   }
 
+  explicit module arm64 {
+    requires arm64
+    requires windows
+
+    header "arm64intr.h"
+    export *
+  }
+
   explicit module intel {
     requires x86
     export *


### PR DESCRIPTION
- **Explanation**:
   The header was missing from the modulemap definition, resulting in a breakage for Swift with recent Windows SDK headers.
- **Scope**:
  Limited to the clang headers module map on Windows. This will fix use of the 26100 Windows SDK.
- **Issues**:
  N/A
- **Original PRs**:
  Original LLVM PR: llvm/llvm-project#142653
  Swift cherry-pick PR: swiftlang/llvm-project#10787
- **Risk**:
  Very low. CI should catch any issue.
- **Testing**:
  Local build + CI.
- **Reviewers**:
  @compnerd 
