### PR TITLE
[lldb] Stop demangling every swift symbol into strings

### DIFF
--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -366,14 +366,18 @@ void Symtab::InitNameIndexes() {
                 else
                   basename_to_index.Append(basename, value);
               }
+              continue;
             }
-            continue;
           }
 #endif // LLDB_ENABLE_SWIFT
         }
       }
 
 #ifdef LLDB_ENABLE_SWIFT
+      // Skip demangling of remaining Swift symbols. The preceeding block
+      // demangles Swift symbols into node trees, to extract method names. The
+      // subsequent block demangles symbols into strings, and for Swift this
+      // serves no purpose.
       if (SwiftLanguageRuntime::IsSwiftMangledName(mangled.GetMangledName()))
         continue;
 #endif

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -366,8 +366,8 @@ void Symtab::InitNameIndexes() {
                 else
                   basename_to_index.Append(basename, value);
               }
-              continue;
             }
+            continue;
           }
 #endif // LLDB_ENABLE_SWIFT
         }

--- a/lldb/source/Symbol/Symtab.cpp
+++ b/lldb/source/Symbol/Symtab.cpp
@@ -373,6 +373,11 @@ void Symtab::InitNameIndexes() {
         }
       }
 
+#ifdef LLDB_ENABLE_SWIFT
+      if (SwiftLanguageRuntime::IsSwiftMangledName(mangled.GetMangledName()))
+        continue;
+#endif
+
       // Symbol name strings that didn't match a Mangled::ManglingScheme, are
       // stored in the demangled field.
       SymbolContext sc;


### PR DESCRIPTION
`InitNameIndexes` loops over symbols and builds internal indexes. For Swift symbols (of type `eSymbolTypeCode`), the symbol is demangled into a node tree, and the node tree is used to extract method names, etc.

Previously, all other Swift symbols (non-code), were being demangled into strings. However this appears unnecessary, skipping such Swift symbols has the following benefits:
* saves time and memory costs of demangling into a string
* reduces entries in the string pool
* reduces sizes of the symbol table indexes

In a trivial example, the number of log entries for demangling _to strings_ went from 58682 to 0.