### PR TITLE
🍒 [lldb][Format] Display only the inlined Swift frame name in backtraces if available

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -1767,7 +1767,7 @@ std::string SwiftLanguage::GetFunctionName(const SymbolContext &sc,
   if (sc.function->GetLanguage() != eLanguageTypeSwift)
     return {};
   std::string name = SwiftLanguageRuntime::DemangleSymbolAsString(
-      sc.function->GetMangled().GetMangledName().GetStringRef(),
+      sc.GetPossiblyInlinedFunctionName().GetMangledName(),
       SwiftLanguageRuntime::eSimplified, &sc, exe_ctx);
   if (name.empty())
     return {};
@@ -1885,8 +1885,7 @@ SwiftLanguage::GetDemangledFunctionNameWithoutArguments(Mangled mangled) const {
   ConstString mangled_name = mangled.GetMangledName();
   ConstString demangled_name = mangled.GetDemangledName();
   if (demangled_name && mangled_name) {
-    if (SwiftLanguageRuntime::IsSwiftMangledName(
-            demangled_name.GetStringRef())) {
+    if (SwiftLanguageRuntime::IsSwiftMangledName(mangled_name.GetStringRef())) {
       lldb_private::ConstString basename;
       bool is_method = false;
       if (SwiftLanguageRuntime::MethodName::ExtractFunctionBasenameFromMangled(

--- a/lldb/test/Shell/Swift/inlined-function-name-backtrace.test
+++ b/lldb/test/Shell/Swift/inlined-function-name-backtrace.test
@@ -1,0 +1,34 @@
+# Test Swift function name printing in backtraces.
+
+# XFAIL: system-windows
+# RUN: split-file %s %t
+# RUN: %target-swiftc -g -O %t/main.swift -o %t.out
+# RUN: %lldb -x -b -s %t/commands.input %t.out -o exit 2>&1 \
+# RUN:       | FileCheck %s
+
+#--- main.swift
+@inline(never)
+func baz(_ a: Int) -> Int {
+    return a * 2
+}
+
+@inline(__always)
+func foo(_ a: Int, _ b: Int) -> Int {
+ return a * b * baz(a) 
+}
+
+func bar() {
+    let baz = foo(4, 5)
+}
+
+bar()
+
+#--- commands.input
+b baz
+
+run
+bt
+
+# CHECK: `baz(a={{.*}}) at main.swift:3:14 [opt]
+# CHECK: `foo(a={{.*}}, b={{.*}}) at main.swift:8:17 [opt] [inlined]
+# CHECK: `bar() at main.swift:12:15 [opt] [inlined]


### PR DESCRIPTION
- https://github.com/swiftlang/llvm-project/pull/10786