### PR TITLE
[Index] Don't generate a unit file when building implicit modules

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1357,6 +1357,15 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompileImpl(
   HSOpts.ModulesHashContent = true;
   FrontendOpts.Inputs = {Input};
   FrontendOpts.MayEmitDiagnosticsAfterProcessingSourceFiles = false;
+  // Clear `IndexUnitOutputPath`. Otherwise the unit for the pcm will be named
+  // after the primary source file, and will be overwritten when that file's
+  // unit is finally written.
+  FrontendOpts.IndexUnitOutputPath = "";
+  if (FrontendOpts.IndexIgnorePcms) {
+    // If we shouldn't index pcms, disable indexing by clearing the index store
+    // path.
+    FrontendOpts.IndexStorePath = "";
+  }
 
   // Don't free the remapped file buffers; they are owned by our caller.
   PPOpts.RetainRemappedFileBuffers = true;

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -682,12 +682,17 @@ protected:
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
                                                  StringRef InFile) override {
     auto OtherConsumer = WrapperFrontendAction::CreateASTConsumer(CI, InFile);
-    if (!OtherConsumer)
-      return nullptr;
+
+    if (CI.getFrontendOpts().IndexStorePath.empty()) {
+      // We are not generating an index store. Nothing to do.
+      return OtherConsumer;
+    }
 
     CreatedASTConsumer = true;
     std::vector<std::unique_ptr<ASTConsumer>> Consumers;
-    Consumers.push_back(std::move(OtherConsumer));
+    if (OtherConsumer) {
+      Consumers.push_back(std::move(OtherConsumer));
+    }
     Consumers.push_back(createIndexASTConsumer(CI));
     return std::make_unique<MultiplexConsumer>(std::move(Consumers));
   }


### PR DESCRIPTION
When compiling a file that requires a module to be compiled, we cloned the compiler instance for the module compile. This means that the cloned compiler instance still had the index store path and index unit output path of the original file. We were thus generating a unit file with the original file name for the compiled module. This unit file would ultimately get overwritten when the original source file was compiled, so there was no correctness issue per se but this means we were doing unnecessary work.

Disable emitting an index store for module compiles to fix this.

Compared to https://github.com/swiftlang/llvm-project/pull/10846, this reduces the overhead of index-while-building by 8.2% (3.00% to 2.76%), based on a single test project with indexing of PCMs disabled.