### PR TITLE
[lldb] add syntax highlighting infrastructure to Swift plugin

### DIFF
--- a/lldb/.clang-format-ignore
+++ b/lldb/.clang-format-ignore
@@ -1,0 +1,2 @@
+source/Plugins/Language/CPlusPlus/LanguageCPlusPlusProperties.td
+source/Plugins/Language/Swift/LanguageSwiftProperties.td

--- a/lldb/include/lldb/Core/PluginManager.h
+++ b/lldb/include/lldb/Core/PluginManager.h
@@ -610,6 +610,14 @@ public:
   static bool CreateSettingForCPlusPlusLanguagePlugin(
       Debugger &debugger, const lldb::OptionValuePropertiesSP &properties_sp,
       llvm::StringRef description, bool is_global_property);
+
+  static lldb::OptionValuePropertiesSP
+  GetSettingForSwiftLanguagePlugin(Debugger &debugger,
+                                   llvm::StringRef setting_name);
+
+  static bool CreateSettingForSwiftLanguagePlugin(
+      Debugger &debugger, const lldb::OptionValuePropertiesSP &properties_sp,
+      llvm::StringRef description, bool is_global_property);
 };
 
 } // namespace lldb_private

--- a/lldb/source/Core/PluginManager.cpp
+++ b/lldb/source/Core/PluginManager.cpp
@@ -1766,6 +1766,7 @@ static constexpr llvm::StringLiteral kJITLoaderPluginName("jit-loader");
 static constexpr llvm::StringLiteral
     kStructuredDataPluginName("structured-data");
 static constexpr llvm::StringLiteral kCPlusPlusLanguagePlugin("cplusplus");
+static constexpr llvm::StringLiteral kSwiftLanguagePlugin("swift");
 
 lldb::OptionValuePropertiesSP
 PluginManager::GetSettingForDynamicLoaderPlugin(Debugger &debugger,
@@ -1935,5 +1936,19 @@ bool PluginManager::CreateSettingForCPlusPlusLanguagePlugin(
     llvm::StringRef description, bool is_global_property) {
   return CreateSettingForPlugin(debugger, kCPlusPlusLanguagePlugin,
                                 "Settings for CPlusPlus language plug-ins",
+                                properties_sp, description, is_global_property);
+}
+
+lldb::OptionValuePropertiesSP
+PluginManager::GetSettingForSwiftLanguagePlugin(Debugger &debugger,
+                                                llvm::StringRef setting_name) {
+  return GetSettingForPlugin(debugger, setting_name, kSwiftLanguagePlugin);
+}
+
+bool PluginManager::CreateSettingForSwiftLanguagePlugin(
+    Debugger &debugger, const lldb::OptionValuePropertiesSP &properties_sp,
+    llvm::StringRef description, bool is_global_property) {
+  return CreateSettingForPlugin(debugger, kSwiftLanguagePlugin,
+                                "Settings for Swift language plug-ins",
                                 properties_sp, description, is_global_property);
 }

--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -1,3 +1,11 @@
+lldb_tablegen(LanguageSwiftProperties.inc -gen-lldb-property-defs
+  SOURCE LanguageSwiftProperties.td
+  TARGET LLDBPluginLanguageSwiftPropertiesGen)
+
+lldb_tablegen(LanguageSwiftPropertiesEnum.inc -gen-lldb-property-enum-defs
+  SOURCE LanguageSwiftProperties.td
+  TARGET LLDBPluginLanguageSwiftPropertiesEnumGen)
+
 set(LLVM_NO_RTTI 1)
 
 add_lldb_library(lldbPluginSwiftLanguage PLUGIN
@@ -36,3 +44,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL Clang AND NOT SWIFT_COMPILER_MSVC_LIKE)
   target_compile_options(lldbPluginSwiftLanguage PRIVATE
     -Wno-dollar-in-identifier-extension)
 endif()
+
+add_dependencies(lldbPluginSwiftLanguage
+  LLDBPluginLanguageSwiftPropertiesGen
+  LLDBPluginLanguageSwiftPropertiesEnumGen)

--- a/lldb/source/Plugins/Language/Swift/LanguageSwiftProperties.td
+++ b/lldb/source/Plugins/Language/Swift/LanguageSwiftProperties.td
@@ -1,0 +1,8 @@
+include "../../../../include/lldb/Core/PropertiesBase.td"
+
+let Definition = "language_swift" in {
+  def FunctionNameFormat: Property<"function-name-format", "FormatEntity">,
+    Global,
+    DefaultStringValue<"${function.prefix}${ansi.fg.yellow}${function.basename}${ansi.normal}${function.formatted-arguments}${function.suffix}">,
+    Desc<"Swift specific frame format string to use when displaying stack frame information for threads.">;
+}

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -68,7 +68,7 @@ void SwiftLanguage::Initialize() {
   static ConstString g_SwiftStringStorageClass("_TtCs15__StringStorage");
   static ConstString g_NSArrayClass1("_TtCs22__SwiftDeferredNSArray");
   PluginManager::RegisterPlugin(GetPluginNameStatic(), "Swift Language",
-                                CreateInstance);
+                                CreateInstance, &DebuggerInitialize);
 
   lldb_private::formatters::NSString_Additionals::GetAdditionalSummaries()
       .emplace(
@@ -1892,6 +1892,144 @@ SwiftLanguage::GetDemangledFunctionNameWithoutArguments(Mangled mangled) const {
   if (demangled_name)
     return demangled_name;
   return mangled_name;
+}
+
+static std::optional<llvm::StringRef>
+GetDemangledBasename(const SymbolContext &sc) {
+  return std::nullopt;
+}
+
+static std::optional<llvm::StringRef>
+GetDemangledFunctionPrefix(const SymbolContext &sc) {
+  return std::nullopt;
+}
+
+static std::optional<llvm::StringRef>
+GetDemangledFunctionSuffix(const SymbolContext &sc) {
+  return std::nullopt;
+}
+
+static bool PrintDemangledArgumentList(Stream &s, const SymbolContext &sc) {
+  return false;
+}
+
+static VariableListSP GetFunctionVariableList(const SymbolContext &sc) {
+  assert(sc.function);
+
+  if (sc.block)
+    if (Block *inline_block = sc.block->GetContainingInlinedBlock())
+      return inline_block->GetBlockVariableList(true);
+
+  return sc.function->GetBlock(true).GetBlockVariableList(true);
+}
+
+bool SwiftLanguage::HandleFrameFormatVariable(const SymbolContext &sc,
+                                              const ExecutionContext *exe_ctx,
+                                              FormatEntity::Entry::Type type,
+                                              Stream &s) {
+  switch (type) {
+  case FormatEntity::Entry::Type::FunctionBasename: {
+    std::optional<llvm::StringRef> name = GetDemangledBasename(sc);
+    if (!name)
+      return false;
+
+    s << *name;
+
+    return true;
+  }
+  case FormatEntity::Entry::Type::FunctionFormattedArguments: {
+    // This ensures we print the arguments even when no debug-info is available.
+    //
+    // FIXME: we should have a Entry::Type::FunctionArguments and
+    // use it in the plugin.cplusplus.display.function-name-format
+    // once we have a "fallback operator" in the frame-format language.
+    if (!sc.function && sc.symbol)
+      return PrintDemangledArgumentList(s, sc);
+    std::string display_name = SwiftLanguageRuntime::DemangleSymbolAsString(
+        sc.function->GetMangled().GetMangledName().GetStringRef(),
+        SwiftLanguageRuntime::eSimplified, &sc, exe_ctx);
+    if (display_name.empty())
+      return false;
+
+    VariableList args;
+    if (auto variable_list_sp = GetFunctionVariableList(sc))
+      variable_list_sp->AppendVariablesWithScope(eValueTypeVariableArgument,
+                                                 args);
+
+    s << GetFunctionDisplayArgs(sc, args, exe_ctx);
+    return true;
+  }
+  case FormatEntity::Entry::Type::FunctionPrefix: {
+    std::optional<llvm::StringRef> prefix = GetDemangledFunctionPrefix(sc);
+    if (!prefix)
+      return false;
+
+    s << *prefix;
+
+    return true;
+  }
+  case FormatEntity::Entry::Type::FunctionSuffix: {
+    std::optional<llvm::StringRef> suffix = GetDemangledFunctionSuffix(sc);
+    if (!suffix)
+      return false;
+
+    s << *suffix;
+
+    return true;
+  }
+
+  case FormatEntity::Entry::Type::FunctionScope:
+  case FormatEntity::Entry::Type::FunctionTemplateArguments:
+  case FormatEntity::Entry::Type::FunctionReturnRight:
+  case FormatEntity::Entry::Type::FunctionReturnLeft:
+  case FormatEntity::Entry::Type::FunctionQualifiers:
+  default:
+    return true;
+  }
+}
+
+#define LLDB_PROPERTIES_language_swift
+#include "LanguageSwiftProperties.inc"
+
+enum {
+#define LLDB_PROPERTIES_language_swift
+#include "LanguageSwiftPropertiesEnum.inc"
+};
+
+namespace {
+class PluginProperties : public Properties {
+public:
+  static llvm::StringRef GetSettingName() { return "display"; }
+
+  PluginProperties() {
+    m_collection_sp = std::make_shared<OptionValueProperties>(GetSettingName());
+    m_collection_sp->Initialize(g_language_swift_properties);
+  }
+
+  FormatEntity::Entry GetFunctionNameFormat() const {
+    return GetPropertyAtIndexAs<const FormatEntity::Entry>(
+        ePropertyFunctionNameFormat, {});
+  }
+};
+} // namespace
+
+static PluginProperties &GetGlobalPluginProperties() {
+  static PluginProperties g_settings;
+  return g_settings;
+}
+
+FormatEntity::Entry SwiftLanguage::GetFunctionNameFormat() const {
+  return GetGlobalPluginProperties().GetFunctionNameFormat();
+}
+
+void SwiftLanguage::DebuggerInitialize(Debugger &debugger) {
+  if (!PluginManager::GetSettingForSwiftLanguagePlugin(
+          debugger, PluginProperties::GetSettingName())) {
+    PluginManager::CreateSettingForSwiftLanguagePlugin(
+        debugger, GetGlobalPluginProperties().GetValueProperties(),
+        "Properties for the Swift language plug-in.",
+        /*is_global_property=*/true);
+  }
 }
 
 namespace {

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.h
@@ -130,6 +130,13 @@ public:
 
   llvm::StringRef GetInstanceVariableName() override { return "self"; }
 
+  bool HandleFrameFormatVariable(const SymbolContext &sc,
+                                 const ExecutionContext *exe_ctx,
+                                 FormatEntity::Entry::Type type,
+                                 Stream &s) override;
+
+  FormatEntity::Entry GetFunctionNameFormat() const override;
+
   /// Override that skips breakpoints inside await resume ("Q") async funclets.
   void FilterForLineBreakpoints(
       llvm::SmallVectorImpl<SymbolContext> &) const override;
@@ -138,6 +145,9 @@ public:
   // PluginInterface protocol
   //------------------------------------------------------------------
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+
+private:
+  static void DebuggerInitialize(Debugger &);
 };
 
 } // namespace lldb_private


### PR DESCRIPTION
This PR adds the infrastructure needed to implement function name syntax highlighting in LLDB Swift backtraces.

# Motivation

In [this patch](https://github.com/swiftlang/llvm-project/pull/10556), @Michael137 implemented name highlighting for methods in the C++ plugin of LLDB. This results in better readability when reading backtraces of functions with long scopes.

# Implementation details

This patch only adds the infrastructure/boilerplate needed to implement the feature. The rest of the modifications will be added in https://github.com/swiftlang/llvm-project/pull/10710.