### PR TITLE
[BoundsSafety] Fix compound-literal-ended_by* tests (NFC)

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O0-disabled-checks.c
+++ b/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O0-disabled-checks.c
@@ -182,8 +182,8 @@ void local_var_init(char* __bidi_indexable new_start, char* new_end) {
 // CHECK-NEXT:    [[END:%.*]] = getelementptr inbounds nuw [[STRUCT_EB]], ptr [[DOTCOMPOUNDLITERAL]], i32 0, i32 1
 // CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[NEW_END_ADDR]], align 8
 // CHECK-NEXT:    store ptr [[TMP0]], ptr [[END]], align 8
-// CHECK-NEXT:    [[TMP1:%.*]] = load [2 x i64], ptr [[DOTCOMPOUNDLITERAL]], align 8
-// CHECK-NEXT:    call void @consume_eb([2 x i64] [[TMP1]])
+// CHECK-NEXT:    [[TMP1:%.*]] = load [2 x ptr], ptr [[DOTCOMPOUNDLITERAL]], align 8
+// CHECK-NEXT:    call void @consume_eb([2 x ptr] [[TMP1]])
 // CHECK-NEXT:    ret void
 //
 void call_arg(char* __bidi_indexable new_start, char* new_end) {
@@ -875,8 +875,8 @@ void local_var_init_from_eb(char* __ended_by(new_end) new_start, char* new_end) 
 // CHECK-NEXT:    [[WIDE_PTR_LB_ADDR6:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP1]], i32 0, i32 2
 // CHECK-NEXT:    [[WIDE_PTR_LB7:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR6]], align 8
 // CHECK-NEXT:    store ptr [[WIDE_PTR_PTR3]], ptr [[END]], align 8
-// CHECK-NEXT:    [[TMP12:%.*]] = load [2 x i64], ptr [[DOTCOMPOUNDLITERAL]], align 8
-// CHECK-NEXT:    call void @consume_eb([2 x i64] [[TMP12]])
+// CHECK-NEXT:    [[TMP12:%.*]] = load [2 x ptr], ptr [[DOTCOMPOUNDLITERAL]], align 8
+// CHECK-NEXT:    call void @consume_eb([2 x ptr] [[TMP12]])
 // CHECK-NEXT:    ret void
 //
 void call_arg_from_eb(char* __ended_by(new_end) new_start, char* new_end) {

--- a/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O0.c
@@ -342,8 +342,8 @@ void local_var_init(char* __bidi_indexable new_start, char* new_end) {
 // CHECK-NEXT:    store ptr [[WIDE_PTR_PTR18]], ptr [[START]], align 8
 // CHECK-NEXT:    [[END:%.*]] = getelementptr inbounds nuw [[STRUCT_EB]], ptr [[DOTCOMPOUNDLITERAL]], i32 0, i32 1
 // CHECK-NEXT:    store ptr [[TMP0]], ptr [[END]], align 8
-// CHECK-NEXT:    [[TMP3:%.*]] = load [2 x i64], ptr [[DOTCOMPOUNDLITERAL]], align 8
-// CHECK-NEXT:    call void @consume_eb([2 x i64] [[TMP3]])
+// CHECK-NEXT:    [[TMP3:%.*]] = load [2 x ptr], ptr [[DOTCOMPOUNDLITERAL]], align 8
+// CHECK-NEXT:    call void @consume_eb([2 x ptr] [[TMP3]])
 // CHECK-NEXT:    ret void
 //
 void call_arg(char* __bidi_indexable new_start, char* new_end) {
@@ -1720,8 +1720,8 @@ void local_var_init_from_eb(char* __ended_by(new_end) new_start, char* new_end) 
 // CHECK-NEXT:    [[WIDE_PTR_LB_ADDR43:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP38]], i32 0, i32 2
 // CHECK-NEXT:    [[WIDE_PTR_LB44:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR43]], align 8
 // CHECK-NEXT:    store ptr [[WIDE_PTR_PTR40]], ptr [[END]], align 8
-// CHECK-NEXT:    [[TMP13:%.*]] = load [2 x i64], ptr [[DOTCOMPOUNDLITERAL]], align 8
-// CHECK-NEXT:    call void @consume_eb([2 x i64] [[TMP13]])
+// CHECK-NEXT:    [[TMP13:%.*]] = load [2 x ptr], ptr [[DOTCOMPOUNDLITERAL]], align 8
+// CHECK-NEXT:    call void @consume_eb([2 x ptr] [[TMP13]])
 // CHECK-NEXT:    ret void
 //
 void call_arg_from_eb(char* __ended_by(new_end) new_start, char* new_end) {

--- a/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O2-disabled-checks.c
+++ b/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O2-disabled-checks.c
@@ -103,11 +103,9 @@ void local_var_init(char* __bidi_indexable new_start, char* new_end) {
 // CHECK-SAME: ptr noundef readonly captures(none) [[NEW_START:%.*]], ptr noundef [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR3:[0-9]+]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
 // CHECK-NEXT:    [[AGG_TEMP_SROA_0_0_COPYLOAD:%.*]] = load ptr, ptr [[NEW_START]], align 8
-// CHECK-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[AGG_TEMP_SROA_0_0_COPYLOAD]] to i64
-// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x i64] poison, i64 [[TMP0]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[NEW_END]] to i64
-// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x i64] [[DOTFCA_0_INSERT]], i64 [[TMP1]], 1
-// CHECK-NEXT:    tail call void @consume_eb([2 x i64] [[DOTFCA_1_INSERT]]) #[[ATTR8:[0-9]+]]
+// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x ptr] poison, ptr [[AGG_TEMP_SROA_0_0_COPYLOAD]], 0
+// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x ptr] [[DOTFCA_0_INSERT]], ptr [[NEW_END]], 1
+// CHECK-NEXT:    tail call void @consume_eb([2 x ptr] [[DOTFCA_1_INSERT]]) #[[ATTR8:[0-9]+]]
 // CHECK-NEXT:    ret void
 //
 void call_arg(char* __bidi_indexable new_start, char* new_end) {
@@ -412,11 +410,9 @@ void local_var_init_from_eb(char* __ended_by(new_end) new_start, char* new_end) 
 // CHECK-LABEL: define dso_local void @call_arg_from_eb(
 // CHECK-SAME: ptr noundef [[NEW_START:%.*]], ptr noundef [[NEW_END:%.*]]) local_unnamed_addr #[[ATTR3]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[NEW_START]] to i64
-// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x i64] poison, i64 [[TMP0]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[NEW_END]] to i64
-// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x i64] [[DOTFCA_0_INSERT]], i64 [[TMP1]], 1
-// CHECK-NEXT:    tail call void @consume_eb([2 x i64] [[DOTFCA_1_INSERT]]) #[[ATTR8]]
+// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x ptr] poison, ptr [[NEW_START]], 0
+// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x ptr] [[DOTFCA_0_INSERT]], ptr [[NEW_END]], 1
+// CHECK-NEXT:    tail call void @consume_eb([2 x ptr] [[DOTFCA_1_INSERT]]) #[[ATTR8]]
 // CHECK-NEXT:    ret void
 //
 void call_arg_from_eb(char* __ended_by(new_end) new_start, char* new_end) {

--- a/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/compound-literal-ended_by-O2.c
@@ -170,11 +170,9 @@ void local_var_init(char* __bidi_indexable new_start, char* new_end) {
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR5]], !annotation [[META2]]
 // CHECK-NEXT:    unreachable, !annotation [[META2]]
 // CHECK:       [[CONT]]:
-// CHECK-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]] to i64
-// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x i64] poison, i64 [[TMP0]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[NEW_END]] to i64
-// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x i64] [[DOTFCA_0_INSERT]], i64 [[TMP1]], 1
-// CHECK-NEXT:    tail call void @consume_eb([2 x i64] [[DOTFCA_1_INSERT]]) #[[ATTR6:[0-9]+]]
+// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x ptr] poison, ptr [[AGG_TEMP1_SROA_0_0_COPYLOAD]], 0
+// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x ptr] [[DOTFCA_0_INSERT]], ptr [[NEW_END]], 1
+// CHECK-NEXT:    tail call void @consume_eb([2 x ptr] [[DOTFCA_1_INSERT]]) #[[ATTR6:[0-9]+]]
 // CHECK-NEXT:    ret void
 //
 void call_arg(char* __bidi_indexable new_start, char* new_end) {
@@ -660,11 +658,9 @@ void local_var_init_from_eb(char* __ended_by(new_end) new_start, char* new_end) 
 // CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR5]], !annotation [[META2]]
 // CHECK-NEXT:    unreachable, !annotation [[META2]]
 // CHECK:       [[CONT]]:
-// CHECK-NEXT:    [[TMP0:%.*]] = ptrtoint ptr [[NEW_START]] to i64
-// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x i64] poison, i64 [[TMP0]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = ptrtoint ptr [[NEW_END]] to i64
-// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x i64] [[DOTFCA_0_INSERT]], i64 [[TMP1]], 1
-// CHECK-NEXT:    tail call void @consume_eb([2 x i64] [[DOTFCA_1_INSERT]]) #[[ATTR6]]
+// CHECK-NEXT:    [[DOTFCA_0_INSERT:%.*]] = insertvalue [2 x ptr] poison, ptr [[NEW_START]], 0
+// CHECK-NEXT:    [[DOTFCA_1_INSERT:%.*]] = insertvalue [2 x ptr] [[DOTFCA_0_INSERT]], ptr [[NEW_END]], 1
+// CHECK-NEXT:    tail call void @consume_eb([2 x ptr] [[DOTFCA_1_INSERT]]) #[[ATTR6]]
 // CHECK-NEXT:    ret void
 //
 void call_arg_from_eb(char* __ended_by(new_end) new_start, char* new_end) {


### PR DESCRIPTION
rdar://153661594