### PR TITLE
[lldb][Windows] convert HEALTH log to a VERBOSE log when failing to load swift-plugin-driver

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1284,8 +1284,9 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
     if (server.empty())
       server = fallback();
     if (server.empty()) {
-      HEALTH_LOG_PRINTF("Could not find swift-plugin-server for %s",
-                        plugin.str().c_str());
+      LOG_VERBOSE_PRINTF(GetLog(LLDBLog::Types),
+                         "Could not find swift-plugin-server for %s",
+                         plugin.str().c_str());
       return std::string();
     }
     if (!FileSystem::Instance().Exists(server)) {


### PR DESCRIPTION
Fixed the following issue:
-  https://github.com/swiftlang/swift/issues/78749

The compiler adds plugin search path by default which don't necessarily exist. On Windows this causes a log that should only appear in Verbose mode as it's not a fatal error.

This patch changes the logging from `HEALTH_LOG_PRINTF` to `LOG_VERBOSE_PRINTF`. This helps to reduce the noise when debugging on Windows.