### PR TITLE
[llvm][cas] Prevent corruption on ENOSPC on sparse filesystems

### DIFF
--- a/clang/test/CAS/depscan-cas-log.c
+++ b/clang/test/CAS/depscan-cas-log.c
@@ -10,11 +10,11 @@
 // RUN:   -cc1-args -cc1 -triple x86_64-apple-macosx11.0.0 -emit-obj %s -o %t/t.o -fcas-path %t/cas
 // RUN: FileCheck %s --input-file %t/cas/v1.log
 
-// CHECK: [[PID1:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v8.index'
+// CHECK: [[PID1:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v9.index'
 // CHECK: [[PID1]] {{[0-9]*}}: create subtrie
 
-// CHECK: [[PID2:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v8.index'
+// CHECK: [[PID2:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v9.index'
 // Even a minimal compilation involves at least 9 records for the cache key.
 // CHECK-COUNT-9: [[PID2]] {{[0-9]*}}: create record
 
-// CHECK: [[PID1]] {{[0-9]*}}: close mmap '{{.*}}v8.index'
+// CHECK: [[PID1]] {{[0-9]*}}: close mmap '{{.*}}v9.index'

--- a/clang/test/CAS/validate-once.c
+++ b/clang/test/CAS/validate-once.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 
 // RUN: llvm-cas --cas %t/cas --ingest %s
-// RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak
+// RUN: mv %t/cas/v1.1/v9.data %t/cas/v1.1/v9.data.bak
 
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
 // RUN:   %clang -target x86_64-apple-macos11 -I %S/Inputs \

--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -379,6 +379,7 @@ check_symbol_exists(mallinfo2 malloc.h HAVE_MALLINFO2)
 check_symbol_exists(malloc_zone_statistics malloc/malloc.h
                     HAVE_MALLOC_ZONE_STATISTICS)
 check_symbol_exists(posix_spawn spawn.h HAVE_POSIX_SPAWN)
+check_symbol_exists(posix_fallocate fcntl.h HAVE_POSIX_FALLOCATE)
 check_symbol_exists(pread unistd.h HAVE_PREAD)
 check_symbol_exists(sbrk unistd.h HAVE_SBRK)
 check_symbol_exists(strerror_r string.h HAVE_STRERROR_R)

--- a/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
@@ -78,7 +78,7 @@ public:
   Expected<int64_t> allocateOffset(uint64_t AllocSize);
 
   char *data() const { return Region.data(); }
-  uint64_t size() const { return *BumpPtr; }
+  uint64_t size() const { return H->BumpPtr; }
   uint64_t capacity() const { return Region.size(); }
 
   RegionT &getRegion() { return Region; }
@@ -100,7 +100,7 @@ private:
   void destroyImpl();
   void moveImpl(MappedFileRegionBumpPtr &RHS) {
     std::swap(Region, RHS.Region);
-    std::swap(BumpPtr, RHS.BumpPtr);
+    std::swap(H, RHS.H);
     std::swap(Path, RHS.Path);
     std::swap(FD, RHS.FD);
     std::swap(SharedLockFD, RHS.SharedLockFD);
@@ -108,8 +108,12 @@ private:
   }
 
 private:
+  struct Header {
+    std::atomic<int64_t> BumpPtr;
+    std::atomic<int64_t> AllocatedSize;
+  };
   RegionT Region;
-  std::atomic<int64_t> *BumpPtr = nullptr;
+  Header *H = nullptr;
   std::string Path;
   std::optional<int> FD;
   std::optional<int> SharedLockFD;

--- a/llvm/include/llvm/Config/config.h.cmake
+++ b/llvm/include/llvm/Config/config.h.cmake
@@ -134,6 +134,9 @@
 /* Define to 1 if you have the `posix_spawn' function. */
 #cmakedefine HAVE_POSIX_SPAWN ${HAVE_POSIX_SPAWN}
 
+/* Define to 1 if you have the `posix_fallocate' function. */
+#cmakedefine HAVE_POSIX_FALLOCATE ${HAVE_POSIX_FALLOCATE}
+
 /* Define to 1 if you have the `pread' function. */
 #cmakedefine HAVE_PREAD ${HAVE_PREAD}
 

--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -8,6 +8,7 @@
 
 #include "OnDiskCommon.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Config/config.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Process.h"
 #include <mutex>
@@ -21,6 +22,10 @@
 #else
 #define HAVE_FLOCK 0
 #endif
+#endif
+
+#if __has_include(<fcntl.h>)
+#include <fcntl.h>
 #endif
 
 using namespace llvm;
@@ -106,5 +111,33 @@ cas::ondisk::tryLockFileThreadSafe(int FD, std::chrono::milliseconds Timeout,
   return sys::fs::tryLockFile(FD, Timeout, Exclusive);
 #else
   return make_error_code(std::errc::no_lock_available);
+#endif
+}
+
+Expected<size_t> cas::ondisk::preallocateFileTail(int FD, size_t CurrentSize, size_t NewSize) {
+  auto CreateErrorFromErrno = [&]() -> Expected<size_t> {
+    std::error_code EC = errnoAsErrorCode();
+    if (EC == std::errc::not_supported)
+      // Ignore ENOTSUP in case the filesystem cannot preallocate.
+      return NewSize;
+    return createStringError(EC, "failed to allocate to CAS file: " + EC.message());
+  };
+#if defined(HAVE_POSIX_FALLOCATE)
+  if (posix_fallocate(FD, CurrentSize, NewSize - CurrentSize))
+    return CreateErrorFromErrno();
+  return NewSize;
+#elif defined(__APPLE__)
+  fstore_t FAlloc;
+  FAlloc.fst_flags = F_ALLOCATEALL | F_ALLOCATEPERSIST;
+  FAlloc.fst_posmode = F_PEOFPOSMODE;
+  FAlloc.fst_offset = 0;
+  FAlloc.fst_length = NewSize - CurrentSize;
+  FAlloc.fst_bytesalloc = 0;
+  if (fcntl(FD, F_PREALLOCATE, &FAlloc))
+    return CreateErrorFromErrno();
+  assert(CurrentSize + FAlloc.fst_bytesalloc >= NewSize);
+  return CurrentSize + FAlloc.fst_bytesalloc;
+#else
+  return NewSize; // Pretend it worked.
 #endif
 }

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -43,6 +43,14 @@ std::error_code tryLockFileThreadSafe(
     int FD, std::chrono::milliseconds Timeout = std::chrono::milliseconds(0),
     bool Exclusive = true);
 
+/// Allocate space for the file \p FD on disk, if the filesystem supports it.
+///
+/// On filesystems that support this operation, this ensures errors such as
+/// \c std::errc::no_space_on_device are detected before we write data.
+///
+/// \returns the new size of the file, or an \c Error.
+Expected<size_t> preallocateFileTail(int FD, size_t CurrentSize, size_t NewSize);
+
 } // namespace llvm::cas::ondisk
 
 #endif // LLVM_LIB_CAS_ONDISKCOMMON_H

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -81,7 +81,7 @@ static constexpr StringLiteral DataPoolTableName = "llvm.cas.data";
 static constexpr StringLiteral IndexFile = "index";
 static constexpr StringLiteral DataPoolFile = "data";
 
-static constexpr StringLiteral FilePrefix = "v8.";
+static constexpr StringLiteral FilePrefix = "v9.";
 static constexpr StringLiteral FileSuffixData = ".data";
 static constexpr StringLiteral FileSuffixLeaf = ".leaf";
 static constexpr StringLiteral FileSuffixLeaf0 = ".leaf+0";
@@ -1310,6 +1310,9 @@ OnDiskGraphDB::createTempFile(StringRef FinalPath, uint64_t Size) {
       TempFile::create(FinalPath + ".%%%%%%", Logger.get());
   if (!File)
     return File.takeError();
+
+  if (Error E = preallocateFileTail(File->FD, 0, Size).takeError())
+    return createFileError(File->TmpName, std::move(E));
 
   if (auto EC = sys::fs::resize_file_before_mapping_readwrite(File->FD, Size))
     return createFileError(File->TmpName, EC);

--- a/llvm/lib/CAS/OnDiskKeyValueDB.cpp
+++ b/llvm/lib/CAS/OnDiskKeyValueDB.cpp
@@ -19,7 +19,7 @@ using namespace llvm::cas;
 using namespace llvm::cas::ondisk;
 
 static constexpr StringLiteral ActionCacheFile = "actions";
-static constexpr StringLiteral FilePrefix = "v3.";
+static constexpr StringLiteral FilePrefix = "v4.";
 
 Expected<ArrayRef<char>> OnDiskKeyValueDB::put(ArrayRef<uint8_t> Key,
                                                ArrayRef<char> Value) {

--- a/llvm/test/CAS/logging.test
+++ b/llvm/test/CAS/logging.test
@@ -8,29 +8,29 @@ RUN: FileCheck %s --input-file %t/cas/v1.log
 RUN: FileCheck %s --input-file %t/cas/v1.log --check-prefix=STANDALONE
 
 
-// CHECK: resize mapped file '{{.*}}v8.index'
-// CHECK: mmap '{{.*}}v8.index' [[INDEX:0x[0-9a-f]+]]
-// CHECK: resize mapped file '{{.*}}v8.data'
-// CHECK: mmap '{{.*}}v8.data' [[DATA:0x[0-9a-f]+]]
-// CHECK: resize mapped file '{{.*}}v3.actions'
-// CHECK: mmap '{{.*}}v3.actions' [[ACTIONS:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}v9.index'
+// CHECK: mmap '{{.*}}v9.index' [[INDEX:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}v9.data'
+// CHECK: mmap '{{.*}}v9.data' [[DATA:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}v4.actions'
+// CHECK: mmap '{{.*}}v4.actions' [[ACTIONS:0x[0-9a-f]+]]
 
 // store input/a contents into the datapool
 // CHECK: create record region=[[INDEX]] offset=[[INPUT_A_OFF:0x[0-9a-f]+]] hash=9b096cd140f119
 // CHECK: cmpxcgh subtrie region=[[INDEX]] offset={{.*}} slot={{.*}} expected=0x0 new=[[INPUT_A_OFF]] prev=0x0
 // CHECK: alloc [[DATA]]
 
-// CHECK: resize mapped file '{{.*}}v3.actions'
-// CHECK: close mmap '{{.*}}v3.actions'
-// CHECK: resize mapped file '{{.*}}v8.data'
-// CHECK: close mmap '{{.*}}v8.data'
-// CHECK: resize mapped file '{{.*}}v8.index'
-// CHECK: close mmap '{{.*}}v8.index'
+// CHECK: resize mapped file '{{.*}}v4.actions'
+// CHECK: close mmap '{{.*}}v4.actions'
+// CHECK: resize mapped file '{{.*}}v9.data'
+// CHECK: close mmap '{{.*}}v9.data'
+// CHECK: resize mapped file '{{.*}}v9.index'
+// CHECK: close mmap '{{.*}}v9.index'
 
 // CHECK: validate-if-needed '{{.*}}cas' boot=[[BOOT:[0-9]+]] last-valid=0 check-hash=1 allow-recovery=0 force=0 llvm-cas={{.*}}llvm-cas
 // CHECK: validate-if-needed '{{.*}}cas' boot=[[BOOT]] last-valid=[[BOOT]] check-hash=0 allow-recovery=1 force=1 llvm-cas={{.*}}llvm-cas
 
-// STANDALONE: standalone file create '[[PATH:.*v8.[0-9a-f]*.leaf]].[[SUFFIX:[0-9a-f]*]]'
+// STANDALONE: standalone file create '[[PATH:.*v9.[0-9a-f]*.leaf]].[[SUFFIX:[0-9a-f]*]]'
 // STANDALONE: standalone file rename '[[PATH]].[[SUFFIX]]' to '[[PATH]]'
 
 //--- input/a

--- a/llvm/test/CAS/validate-if-needed.test
+++ b/llvm/test/CAS/validate-if-needed.test
@@ -1,6 +1,6 @@
 RUN: rm -rf %t && mkdir %t
 RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
-RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak 
+RUN: mv %t/cas/v1.1/v9.data %t/cas/v1.1/v9.data.bak
 
 # INVALID: bad record
 # VALID: validated successfully
@@ -12,7 +12,7 @@ RUN: not llvm-cas --cas %t/cas --validate-if-needed 2>&1 | FileCheck %s -check-p
 RUN: not llvm-cas --cas %t/cas --validate-if-needed 2>&1 | FileCheck %s -check-prefix=INVALID
 
 # Validation happens once per boot.
-RUN: mv %t/cas/v1.1/v8.data.bak %t/cas/v1.1/v8.data
+RUN: mv %t/cas/v1.1/v9.data.bak %t/cas/v1.1/v9.data
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=VALID
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
 # Wrong timestamp triggers re-validation.
@@ -20,7 +20,7 @@ RUN: echo '123' > %t/cas/v1.validation
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=VALID
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
 # Skipped validation does not catch errors.
-RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak
+RUN: mv %t/cas/v1.1/v9.data %t/cas/v1.1/v9.data.bak
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
 
 # Unless forced.
@@ -33,7 +33,7 @@ RUN: llvm-cas --cas %t/cas --validate-if-needed --allow-recovery | FileCheck %s 
 RUN: llvm-cas --cas %t/cas --validate-if-needed --force | FileCheck %s -check-prefix=VALID
 RUN: rm -rf %t/cas/v1.1
 RUN: cp -r %t/cas/corrupt.0.v1.1 %t/cas/v1.1
-RUN: mv %t/cas/v1.1/v8.data %t/cas/v1.1/v8.data.bak
+RUN: mv %t/cas/v1.1/v9.data %t/cas/v1.1/v9.data.bak
 RUN: llvm-cas --cas %t/cas --validate-if-needed --allow-recovery --force | FileCheck %s -check-prefix=RECOVERED
 RUN: ls %t/cas/corrupt.1.v1.1
 

--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -12,7 +12,7 @@ RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
 RUN: llvm-cas --cas %t/cas --validate
 RUN: llvm-cas --cas %t/cas --validate --check-hash
 
-RUN: rm %t/cas/v1.1/v8.data
+RUN: rm %t/cas/v1.1/v9.data
 RUN: not llvm-cas --cas %t/cas --validate
 RUN: not llvm-cas --cas %t/cas --validate --check-hash
 
@@ -28,5 +28,5 @@ RUN: llvm-cas --cas %t/ac --put-cache-key @%t/abc.casid @%t/empty.casid
 RUN: llvm-cas --cas %t/ac --validate
 # Note: records are 40 bytes (32 hash bytes + 8 byte value), so trim the last
 # allocated record, leaving it invalid.
-RUN: truncate -s -40 %t/ac/v1.1/v3.actions 
+RUN: truncate -s -40 %t/ac/v1.1/v4.actions
 RUN: not llvm-cas --cas %t/ac --validate

--- a/llvm/tools/llvm-cas-test/llvm-cas-test.cpp
+++ b/llvm/tools/llvm-cas-test/llvm-cas-test.cpp
@@ -262,7 +262,7 @@ static int checkLockFiles() {
   ExitOnError ExitOnErr("llvm-cas-test: check-lock-files: ");
 
   SmallString<128> DataPoolPath(CASPath);
-  sys::path::append(DataPoolPath, "v1.1/v8.data");
+  sys::path::append(DataPoolPath, "v1.1/v9.data");
 
   auto OpenCASAndGetDataPoolSize = [&]() -> Expected<uint64_t> {
     auto Result = createOnDiskUnifiedCASDatabases(CASPath);

--- a/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
+++ b/llvm/unittests/CAS/OnDiskHashMappedTrieTest.cpp
@@ -160,7 +160,7 @@ TEST(OnDiskHashMappedTrieTest, OutOfSpace) {
   // Just enough for root node but not enough for any insertion.
   ASSERT_THAT_ERROR(OnDiskHashMappedTrie::create(
                         Temp.path("NoSpace2").str(), "index",
-                        /*NumHashBits=*/8, /*DataSize=*/8, /*MaxFileSize=*/100,
+                        /*NumHashBits=*/8, /*DataSize=*/8, /*MaxFileSize=*/108,
                         /*NewInitialFileSize=*/std::nullopt, /*Logger=*/nullptr,
                         /*NewTableNumRootBits=*/1, /*NewTableNumSubtrieBits=*/1)
                         .moveInto(Trie),


### PR DESCRIPTION
If a platform and filesystem do not detect disk out of space errors during page fault but instead defer it to page flush, we can corrupt the CAS data without receiving an error until it is too late. Fix that on platforms that support preallocating disk space by ensuring all CAS allocations are allocated to disk before writing. For standalone files, we ensure the entire file is allocated up front. For bump pointer allocated files (index, datapool, cache), we allocate in chunks of 1 MB to amortize the cost, and store the current disk-allocated size into the database file next to the bump pointer so that every thread and process can check their allocations.

The overhead from these additional checks is <1% in a store-heavy stress test on Darwin/APFS, and effectively zero overhead on a non-sparse filesystem Darwin/tmpfs.

rdar://152273395