### PR TITLE
[BoundsSafety] Fix dynamic-count-invalid-rhs.c test (NFC)

### DIFF
--- a/clang/test/BoundsSafety/Sema/dynamic-count-invalid-rhs.c
+++ b/clang/test/BoundsSafety/Sema/dynamic-count-invalid-rhs.c
@@ -1,6 +1,5 @@
-
-
 // RUN: %clang_cc1 -fsyntax-only -verify -fbounds-safety %s
+
 #include <stddef.h>
 #include <ptrcheck.h>
 
@@ -16,5 +15,6 @@ void bar(struct S * __bidi_indexable p, int * __counted_by(len) p2, int len) {
     struct S * __single p3 = p;
     // expected-error@+1{{use of undeclared identifier 'asdf'}}
     p3->len = asdf;
+    // expected-error@+1{{assignment to 'int *__single __counted_by(len)' (aka 'int *__single') 'p3->ptr' requires corresponding assignment to 'p3->len'; add self assignment 'p3->len = p3->len' if the value has not changed}}
     p3->ptr = p2;
 }


### PR DESCRIPTION
Since recently, Clang does not attach an invalid statement to function body.  In the modified test, the function body won't have `p3->len = asdf;` statement. This makes our dynamic count pointer assignment analysis think that the assignment to `p3->len` is missing.

We could check `Sema::hasAnyUnrecoverableErrorsInThisFunction()` and not run our analysis if there is any error. But, we still want to diagnose problems in other blocks. I am not sure if there is a good way to check if a given block has already any unrecoverable error.

rdar://153756387