### PR TITLE
[lldb] Eliminate SwiftASTContext fallback for thin function types

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1382,7 +1382,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
     // TypeSystemSwiftTypeRef::GetChildCompilerTypeAtIndex can also
     // handle them and without a Process.
     if (!TypeSystemSwiftTypeRef::IsBuiltinType(m_type) &&
-        !Flags(m_type.GetTypeInfo()).AnySet(eTypeIsMetatype)) {
+        !Flags(m_type.GetTypeInfo()).AnySet(eTypeIsMetatype) &&
+        !m_type.IsFunctionType()) {
       LLDB_LOG(GetLog(LLDBLog::Types),
                "{0}: unrecognized builtin type info or this is a Clang type "
                "without DWARF debug info",

--- a/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
+++ b/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
@@ -10,13 +10,12 @@
 #
 # ------------------------------------------------------------------------------
 """
-Tests that Enum variables display correctly
+Tests that function variables display correctly
 """
 import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
-import os
 
 
 class TestFunctionVariables(TestBase):
@@ -27,11 +26,12 @@ class TestFunctionVariables(TestBase):
         target, process, thread, _ = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
 
-        self.assertGreater(thread.GetNumFrames(), 0)
-        frame = thread.GetSelectedFrame()
+        thin_ptr_value = self.frame().FindVariable('c')
+        self.assertEqual(thin_ptr_value.GetNumChildren(), 0)
 
         # Get the function pointer variable from our frame
-        func_ptr_value = frame.FindVariable('func_ptr')
+        func_ptr_value = self.frame().FindVariable('func_ptr')
+        self.assertEqual(func_ptr_value.GetNumChildren(), 2)
 
         # Grab the function pointer value as an unsigned load address
         func_ptr_addr = func_ptr_value.GetValueAsUnsigned()

--- a/lldb/test/API/lang/swift/variables/func/main.swift
+++ b/lldb/test/API/lang/swift/variables/func/main.swift
@@ -10,13 +10,12 @@
 //
 // -----------------------------------------------------------------------------
 func bar() {
-    print ("bar()")
+    print("bar()")
 }
 
-func main() -> Int {
+func main(_ c : (@convention(thin) () -> ())) {
     var func_ptr = bar
-    func_ptr(); // Set breakpoint here
-    return 0
+    func_ptr() // Set breakpoint here
 }
 
-main()
+main() {}


### PR DESCRIPTION
rdar://153772806