### PR TITLE
[Index] Only hash `Decl` once when generating the hash value for a record

### DIFF
--- a/clang/lib/Index/IndexRecordHasher.cpp
+++ b/clang/lib/Index/IndexRecordHasher.cpp
@@ -29,6 +29,16 @@ struct IndexRecordHasher {
   llvm::HashBuilder<llvm::TruncatedBLAKE3<8>, llvm::endianness::little>
       HashBuilder;
 
+  /// Maps declarations that have already been hashed in this
+  /// `IndexRecordHasher` to a unique ID that identifies this declaration.
+  ///
+  /// The ID assigned to a declaration is consistent across multiple runs of the
+  /// `IndexRecordHasher` on the same AST structure, even across multiple
+  /// process runs.
+  ///
+  /// See `hashDecl` for its use.
+  llvm::DenseMap<const Decl *, size_t> HashedDecls;
+
   explicit IndexRecordHasher(ASTContext &context) : Ctx(context) {}
 
   void hashDecl(const Decl *D);
@@ -185,6 +195,19 @@ void IndexRecordHasher::hashMacro(const IdentifierInfo *name,
 void IndexRecordHasher::hashDecl(const Decl *D) {
   assert(D->isCanonicalDecl());
 
+  auto emplaceResult = HashedDecls.try_emplace(D, HashedDecls.size());
+  bool inserted = emplaceResult.second;
+  if (!inserted) {
+    // If we have already serialized this declaration, just add the
+    // declaration's hash to the hash builder. This is significantly
+    // cheaper than visiting the declaration again.
+    HashBuilder.add(emplaceResult.first->second);
+    return;
+  }
+
+  // If we haven't serialized the declaration yet,`try_emplace` will insert the
+  // new unique ID into `HashedDecls`. We just need to hash the declaration
+  // once.
   if (auto *NS = dyn_cast<NamespaceDecl>(D)) {
     if (NS->isAnonymousNamespace()) {
       HashBuilder.add("@aN");


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10846 to `stable/20240723`.

---

Say we are indexing the header file containing `NSArray`. Almost every declaration in here has a relation to `NSArray` (mostly child-of relations). This means that for every of those declarations we hash `NSArray` again by creating a `DeclHashVisitor` that, among others, adds the string `NSArray` to the hash builder.

To avoid this, keep track of all the declarations that we have already incorporated into the hash. If we did already hash the declaration, only incorporate an integer into the hash.