### PR TITLE
[Index] Don't generate a unit file when building implicit modules

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1352,6 +1352,15 @@ compileModuleImpl(CompilerInstance &ImportingInstance, SourceLocation ImportLoc,
   HSOpts.ModulesHashContent = true;
   FrontendOpts.Inputs = {Input};
   FrontendOpts.MayEmitDiagnosticsAfterProcessingSourceFiles = false;
+  // Clear `IndexUnitOutputPath`. Otherwise the unit for the pcm will be named
+  // after the primary source file, and will be overwritten when that file's
+  // unit is finally written.
+  FrontendOpts.IndexUnitOutputPath = "";
+  if (FrontendOpts.IndexIgnorePcms) {
+    // If we shouldn't index pcms, disable indexing by clearing the index store
+    // path.
+    FrontendOpts.IndexStorePath = "";
+  }
 
   // Don't free the remapped file buffers; they are owned by our caller.
   PPOpts.RetainRemappedFileBuffers = true;

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -683,12 +683,17 @@ protected:
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
                                                  StringRef InFile) override {
     auto OtherConsumer = WrapperFrontendAction::CreateASTConsumer(CI, InFile);
-    if (!OtherConsumer)
-      return nullptr;
+
+    if (CI.getFrontendOpts().IndexStorePath.empty()) {
+      // We are not generating an index store. Nothing to do.
+      return OtherConsumer;
+    }
 
     CreatedASTConsumer = true;
     std::vector<std::unique_ptr<ASTConsumer>> Consumers;
-    Consumers.push_back(std::move(OtherConsumer));
+    if (OtherConsumer) {
+      Consumers.push_back(std::move(OtherConsumer));
+    }
     Consumers.push_back(createIndexASTConsumer(CI));
     return std::make_unique<MultiplexConsumer>(std::move(Consumers));
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10848 to `stable/20240723`

---

When compiling a file that requires a module to be compiled, we cloned the compiler instance for the module compile. If that compiler instance had an index unit output path set, we would use that name for the unit file of the pcm, which would get overwritten as soon as the unit for that source file is written at the end of that compilation process. Fix this issue by clearning the index unit output path for the PCM compilation process.

Also respect `IndexIgnorePcms` and don’t generate an index for the PCMs by clearning the `IndexStorePath` to disable indexing of the PCMs