### PR TITLE
[ExtractAPI] Cherry-pick multiple correctness fixes

### DIFF
--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -331,10 +331,15 @@ DeclarationFragments DeclarationFragmentsBuilder::getFragmentsForType(
 
   // Declaration fragments of a pointer type is the declaration fragments of
   // the pointee type followed by a `*`,
-  if (T->isPointerType() && !T->isFunctionPointerType())
-    return Fragments
-        .append(getFragmentsForType(T->getPointeeType(), Context, After))
-        .append(" *", DeclarationFragments::FragmentKind::Text);
+  if (T->isPointerType() && !T->isFunctionPointerType()) {
+    QualType PointeeT = T->getPointeeType();
+    Fragments.append(getFragmentsForType(PointeeT, Context, After));
+    // If the pointee is itself a pointer, we do not want to insert a space
+    // before the `*` as the preceding character in the type name is a `*`.
+    if (!PointeeT->isAnyPointerType())
+      Fragments.appendSpace();
+    return Fragments.append("*", DeclarationFragments::FragmentKind::Text);
+  }
 
   // For Objective-C `id` and `Class` pointers
   // we do not spell out the `*`.
@@ -638,7 +643,7 @@ DeclarationFragmentsBuilder::getFragmentsForParam(const ParmVarDecl *Param) {
                 DeclarationFragments::FragmentKind::InternalParam);
   } else {
     Fragments.append(std::move(TypeFragments));
-    if (!T->isBlockPointerType())
+    if (!T->isAnyPointerType() && !T->isBlockPointerType())
       Fragments.appendSpace();
     Fragments
         .append(Param->getName(),
@@ -713,18 +718,20 @@ DeclarationFragmentsBuilder::getFragmentsForFunction(const FunctionDecl *Func) {
 
   // FIXME: Is `after` actually needed here?
   DeclarationFragments After;
+  QualType ReturnType = Func->getReturnType();
   auto ReturnValueFragment =
-      getFragmentsForType(Func->getReturnType(), Func->getASTContext(), After);
+      getFragmentsForType(ReturnType, Func->getASTContext(), After);
   if (StringRef(ReturnValueFragment.begin()->Spelling)
           .starts_with("type-parameter")) {
-    std::string ProperArgName = Func->getReturnType().getAsString();
+    std::string ProperArgName = ReturnType.getAsString();
     ReturnValueFragment.begin()->Spelling.swap(ProperArgName);
   }
 
-  Fragments.append(std::move(ReturnValueFragment))
-      .appendSpace()
-      .append(Func->getNameAsString(),
-              DeclarationFragments::FragmentKind::Identifier);
+  Fragments.append(std::move(ReturnValueFragment));
+  if (!ReturnType->isAnyPointerType())
+    Fragments.appendSpace();
+  Fragments.append(Func->getNameAsString(),
+                   DeclarationFragments::FragmentKind::Identifier);
 
   if (Func->getTemplateSpecializationInfo()) {
     Fragments.append("<", DeclarationFragments::FragmentKind::Text);

--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -890,6 +890,9 @@ DeclarationFragments DeclarationFragmentsBuilder::getFragmentsForCXXMethod(
   if (Method->isVolatile())
     Fragments.append("volatile", DeclarationFragments::FragmentKind::Keyword)
         .appendSpace();
+  if (Method->isVirtual())
+    Fragments.append("virtual", DeclarationFragments::FragmentKind::Keyword)
+        .appendSpace();
 
   // Build return type
   DeclarationFragments After;

--- a/clang/lib/ExtractAPI/DeclarationFragments.cpp
+++ b/clang/lib/ExtractAPI/DeclarationFragments.cpp
@@ -1625,10 +1625,13 @@ DeclarationFragmentsBuilder::getFunctionSignature(const ObjCMethodDecl *);
 DeclarationFragments
 DeclarationFragmentsBuilder::getSubHeading(const NamedDecl *Decl) {
   DeclarationFragments Fragments;
-  if (isa<CXXConstructorDecl>(Decl) || isa<CXXDestructorDecl>(Decl))
+  if (isa<CXXConstructorDecl>(Decl)) {
     Fragments.append(cast<CXXRecordDecl>(Decl->getDeclContext())->getName(),
                      DeclarationFragments::FragmentKind::Identifier);
-  else if (isa<CXXConversionDecl>(Decl)) {
+  } else if (isa<CXXDestructorDecl>(Decl)) {
+    Fragments.append(cast<CXXDestructorDecl>(Decl)->getNameAsString(),
+                     DeclarationFragments::FragmentKind::Identifier);
+  } else if (isa<CXXConversionDecl>(Decl)) {
     Fragments.append(
         cast<CXXConversionDecl>(Decl)->getConversionType().getAsString(),
         DeclarationFragments::FragmentKind::Identifier);
@@ -1642,9 +1645,11 @@ DeclarationFragmentsBuilder::getSubHeading(const NamedDecl *Decl) {
   } else if (Decl->getIdentifier()) {
     Fragments.append(Decl->getName(),
                      DeclarationFragments::FragmentKind::Identifier);
-  } else
+  } else {
     Fragments.append(Decl->getDeclName().getAsString(),
                      DeclarationFragments::FragmentKind::Identifier);
+  }
+
   return Fragments;
 }
 

--- a/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
+++ b/clang/lib/ExtractAPI/Serialization/SymbolGraphSerializer.cpp
@@ -344,6 +344,22 @@ Object serializeNames(const APIRecord *Record) {
   serializeArray(Names, "subHeading",
                  serializeDeclarationFragments(Record->SubHeading));
   DeclarationFragments NavigatorFragments;
+  // The +/- prefix for Objective-C methods is important information, and
+  // should be included in the navigator fragment. The entire subheading is
+  // not included as it can contain too much information for other records.
+  switch (Record->getKind()) {
+  case APIRecord::RK_ObjCClassMethod:
+    NavigatorFragments.append("+ ", DeclarationFragments::FragmentKind::Text,
+                              /*PreciseIdentifier*/ "");
+    break;
+  case APIRecord::RK_ObjCInstanceMethod:
+    NavigatorFragments.append("- ", DeclarationFragments::FragmentKind::Text,
+                              /*PreciseIdentifier*/ "");
+    break;
+  default:
+    break;
+  }
+
   NavigatorFragments.append(Record->Name,
                             DeclarationFragments::FragmentKind::Identifier,
                             /*PreciseIdentifier*/ "");

--- a/clang/test/ExtractAPI/constructor_destructor.cpp
+++ b/clang/test/ExtractAPI/constructor_destructor.cpp
@@ -213,7 +213,7 @@ class Foo {
         "subHeading": [
           {
             "kind": "identifier",
-            "spelling": "Foo"
+            "spelling": "~Foo"
           }
         ],
         "title": "~Foo"

--- a/clang/test/ExtractAPI/global_record.c
+++ b/clang/test/ExtractAPI/global_record.c
@@ -185,7 +185,7 @@ char unavailable __attribute__((unavailable));
         },
         {
           "kind": "text",
-          "spelling": " * "
+          "spelling": " *"
         },
         {
           "kind": "internalParam",
@@ -341,7 +341,7 @@ char unavailable __attribute__((unavailable));
               },
               {
                 "kind": "text",
-                "spelling": " * "
+                "spelling": " *"
               },
               {
                 "kind": "internalParam",

--- a/clang/test/ExtractAPI/global_record_multifile.c
+++ b/clang/test/ExtractAPI/global_record_multifile.c
@@ -187,7 +187,7 @@ char unavailable __attribute__((unavailable));
         },
         {
           "kind": "text",
-          "spelling": " * "
+          "spelling": " *"
         },
         {
           "kind": "internalParam",
@@ -343,7 +343,7 @@ char unavailable __attribute__((unavailable));
               },
               {
                 "kind": "text",
-                "spelling": " * "
+                "spelling": " *"
               },
               {
                 "kind": "internalParam",

--- a/clang/test/ExtractAPI/methods.cpp
+++ b/clang/test/ExtractAPI/methods.cpp
@@ -45,10 +45,18 @@ class Foo {
   // GETCOUNT-NEXT: ]
 
   // RUN: FileCheck %s --input-file %t/output.symbols.json --check-prefix SETL
-  void setLength(int length) noexcept;
+  virtual void setLength(int length) noexcept;
   // SETL: "!testRelLabel": "memberOf $ c:@S@Foo@F@setLength#I# $ c:@S@Foo"
   // SETL-LABEL: "!testLabel": "c:@S@Foo@F@setLength#I#"
   // SETL:      "declarationFragments": [
+  // SETL-NEXT:   {
+  // SETL-NEXT:     "kind": "keyword",
+  // SETL-NEXT:     "spelling": "virtual"
+  // SETL-NEXT:   },
+  // SETL-NEXT:   {
+  // SETL-NEXT:     "kind": "text",
+  // SETL-NEXT:     "spelling": " "
+  // SETL-NEXT:   },
   // SETL-NEXT:   {
   // SETL-NEXT:     "kind": "typeIdentifier",
   // SETL-NEXT:     "preciseIdentifier": "c:v",

--- a/clang/test/ExtractAPI/objc_instancetype.m
+++ b/clang/test/ExtractAPI/objc_instancetype.m
@@ -158,6 +158,10 @@
       "names": {
         "navigator": [
           {
+            "kind": "text",
+            "spelling": "- "
+          },
+          {
             "kind": "identifier",
             "spelling": "init"
           }
@@ -228,6 +232,10 @@
       },
       "names": {
         "navigator": [
+          {
+            "kind": "text",
+            "spelling": "- "
+          },
           {
             "kind": "identifier",
             "spelling": "reset"

--- a/clang/test/ExtractAPI/pointers.c
+++ b/clang/test/ExtractAPI/pointers.c
@@ -2,8 +2,8 @@
 // RUN: split-file %s %t
 // RUN: sed -e "s@INPUT_DIR@%{/t:regex_replacement}@g" \
 // RUN: %t/reference.output.json.in >> %t/reference.output.json
-// RUN: %clang -extract-api --pretty-sgf --product-name=Macros -target arm64-apple-macosx \
-// RUN: -x objective-c-header %t/input.h -o %t/output.json | FileCheck -allow-empty %s
+// RUN: %clang -extract-api --pretty-sgf --product-name=Pointers -target arm64-apple-macosx \
+// RUN: %t/input.h -o %t/output.json | FileCheck -allow-empty %s
 
 // Generator version is not consistent across test runs, normalize it.
 // RUN: sed -e "s@\"generator\": \".*\"@\"generator\": \"?\"@g" \
@@ -14,13 +14,10 @@
 // CHECK-NOT: warning:
 
 //--- input.h
-#define HELLO 1
-#define FUNC_GEN(NAME, ...) void NAME(__VA_ARGS__);
-FUNC_GEN(foo)
-FUNC_GEN(bar, const int *, unsigned);
-#undef FUNC_GEN
-// Undefining a not previously defined macro should not result in a crash.
-#undef FOO
+void foo(int *a);
+void bar(int **a);
+void *baz();
+void **qux();
 
 //--- reference.output.json.in
 {
@@ -33,7 +30,7 @@ FUNC_GEN(bar, const int *, unsigned);
     "generator": "?"
   },
   "module": {
-    "name": "Macros",
+    "name": "Pointers",
     "platform": {
       "architecture": "arm64",
       "operatingSystem": {
@@ -67,10 +64,47 @@ FUNC_GEN(bar, const int *, unsigned);
         },
         {
           "kind": "text",
-          "spelling": "();"
+          "spelling": "("
+        },
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:I",
+          "spelling": "int"
+        },
+        {
+          "kind": "text",
+          "spelling": " *"
+        },
+        {
+          "kind": "internalParam",
+          "spelling": "a"
+        },
+        {
+          "kind": "text",
+          "spelling": ");"
         }
       ],
       "functionSignature": {
+        "parameters": [
+          {
+            "declarationFragments": [
+              {
+                "kind": "typeIdentifier",
+                "preciseIdentifier": "c:I",
+                "spelling": "int"
+              },
+              {
+                "kind": "text",
+                "spelling": " *"
+              },
+              {
+                "kind": "internalParam",
+                "spelling": "a"
+              }
+            ],
+            "name": "a"
+          }
+        ],
         "returns": [
           {
             "kind": "typeIdentifier",
@@ -80,17 +114,17 @@ FUNC_GEN(bar, const int *, unsigned);
         ]
       },
       "identifier": {
-        "interfaceLanguage": "objective-c",
+        "interfaceLanguage": "c",
         "precise": "c:@F@foo"
       },
       "kind": {
         "displayName": "Function",
-        "identifier": "objective-c.func"
+        "identifier": "c.func"
       },
       "location": {
         "position": {
-          "character": 0,
-          "line": 2
+          "character": 5,
+          "line": 0
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -134,42 +168,17 @@ FUNC_GEN(bar, const int *, unsigned);
           "spelling": "("
         },
         {
-          "kind": "keyword",
-          "spelling": "const"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
           "kind": "typeIdentifier",
           "preciseIdentifier": "c:I",
           "spelling": "int"
         },
         {
           "kind": "text",
-          "spelling": " *"
+          "spelling": " **"
         },
         {
           "kind": "internalParam",
-          "spelling": ""
-        },
-        {
-          "kind": "text",
-          "spelling": ", "
-        },
-        {
-          "kind": "typeIdentifier",
-          "preciseIdentifier": "c:i",
-          "spelling": "unsigned int"
-        },
-        {
-          "kind": "text",
-          "spelling": " "
-        },
-        {
-          "kind": "internalParam",
-          "spelling": ""
+          "spelling": "a"
         },
         {
           "kind": "text",
@@ -181,46 +190,20 @@ FUNC_GEN(bar, const int *, unsigned);
           {
             "declarationFragments": [
               {
-                "kind": "keyword",
-                "spelling": "const"
-              },
-              {
-                "kind": "text",
-                "spelling": " "
-              },
-              {
                 "kind": "typeIdentifier",
                 "preciseIdentifier": "c:I",
                 "spelling": "int"
               },
               {
                 "kind": "text",
-                "spelling": " *"
+                "spelling": " **"
               },
               {
                 "kind": "internalParam",
-                "spelling": ""
+                "spelling": "a"
               }
             ],
-            "name": ""
-          },
-          {
-            "declarationFragments": [
-              {
-                "kind": "typeIdentifier",
-                "preciseIdentifier": "c:i",
-                "spelling": "unsigned int"
-              },
-              {
-                "kind": "text",
-                "spelling": " "
-              },
-              {
-                "kind": "internalParam",
-                "spelling": ""
-              }
-            ],
-            "name": ""
+            "name": "a"
           }
         ],
         "returns": [
@@ -232,17 +215,17 @@ FUNC_GEN(bar, const int *, unsigned);
         ]
       },
       "identifier": {
-        "interfaceLanguage": "objective-c",
+        "interfaceLanguage": "c",
         "precise": "c:@F@bar"
       },
       "kind": {
         "displayName": "Function",
-        "identifier": "objective-c.func"
+        "identifier": "c.func"
       },
       "location": {
         "position": {
-          "character": 0,
-          "line": 3
+          "character": 5,
+          "line": 1
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -269,30 +252,48 @@ FUNC_GEN(bar, const int *, unsigned);
       "accessLevel": "public",
       "declarationFragments": [
         {
-          "kind": "keyword",
-          "spelling": "#define"
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
         },
         {
           "kind": "text",
-          "spelling": " "
+          "spelling": " *"
         },
         {
           "kind": "identifier",
-          "spelling": "HELLO"
+          "spelling": "baz"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
         }
       ],
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          },
+          {
+            "kind": "text",
+            "spelling": " *"
+          }
+        ]
+      },
       "identifier": {
-        "interfaceLanguage": "objective-c",
-        "precise": "c:input.h@8@macro@HELLO"
+        "interfaceLanguage": "c",
+        "precise": "c:@F@baz"
       },
       "kind": {
-        "displayName": "Macro",
-        "identifier": "objective-c.macro"
+        "displayName": "Function",
+        "identifier": "c.func"
       },
       "location": {
         "position": {
-          "character": 8,
-          "line": 0
+          "character": 6,
+          "line": 2
         },
         "uri": "file://INPUT_DIR/input.h"
       },
@@ -300,19 +301,87 @@ FUNC_GEN(bar, const int *, unsigned);
         "navigator": [
           {
             "kind": "identifier",
-            "spelling": "HELLO"
+            "spelling": "baz"
           }
         ],
         "subHeading": [
           {
             "kind": "identifier",
-            "spelling": "HELLO"
+            "spelling": "baz"
           }
         ],
-        "title": "HELLO"
+        "title": "baz"
       },
       "pathComponents": [
-        "HELLO"
+        "baz"
+      ]
+    },
+    {
+      "accessLevel": "public",
+      "declarationFragments": [
+        {
+          "kind": "typeIdentifier",
+          "preciseIdentifier": "c:v",
+          "spelling": "void"
+        },
+        {
+          "kind": "text",
+          "spelling": " **"
+        },
+        {
+          "kind": "identifier",
+          "spelling": "qux"
+        },
+        {
+          "kind": "text",
+          "spelling": "();"
+        }
+      ],
+      "functionSignature": {
+        "returns": [
+          {
+            "kind": "typeIdentifier",
+            "preciseIdentifier": "c:v",
+            "spelling": "void"
+          },
+          {
+            "kind": "text",
+            "spelling": " **"
+          }
+        ]
+      },
+      "identifier": {
+        "interfaceLanguage": "c",
+        "precise": "c:@F@qux"
+      },
+      "kind": {
+        "displayName": "Function",
+        "identifier": "c.func"
+      },
+      "location": {
+        "position": {
+          "character": 7,
+          "line": 3
+        },
+        "uri": "file://INPUT_DIR/input.h"
+      },
+      "names": {
+        "navigator": [
+          {
+            "kind": "identifier",
+            "spelling": "qux"
+          }
+        ],
+        "subHeading": [
+          {
+            "kind": "identifier",
+            "spelling": "qux"
+          }
+        ],
+        "title": "qux"
+      },
+      "pathComponents": [
+        "qux"
       ]
     }
   ]


### PR DESCRIPTION
Cherry-pick of the following PRs:

- https://github.com/llvm/llvm-project/pull/145035: ObjC methods include a +/- prefix to indicate if they are a class or instance method. This information is valuable, and must be included in the navigator generated by ExtractAPI. rdar://150870936
- https://github.com/llvm/llvm-project/pull/145412: This information was being left out of the symbol graph. rdar://131780883
- https://github.com/llvm/llvm-project/pull/146001:a The subheading for a destructor contained only the identifier. The tilde must also be included as it is necessary to differentiate the destructor from any constructors present. rdar://129587608
- https://github.com/llvm/llvm-project/pull/146182: Pointer types in function signatures must place the asterisk before the identifier without a space in between. This patch removes the space and also ensures that pointers to pointers are formatted correctly. rdar://131780418, rdar://154533037
