### PR TITLE
[6.2][cherrypick] Backport upstream cherrypicks for OpenBSD from stable.

### DIFF
--- a/compiler-rt/lib/builtins/cpu_model/aarch64.c
+++ b/compiler-rt/lib/builtins/cpu_model/aarch64.c
@@ -47,7 +47,7 @@ _Bool __aarch64_have_lse_atomics = false;
 #elif defined(__ANDROID__)
 #include "aarch64/hwcap.inc"
 #include "aarch64/lse_atomics/android.inc"
-#elif __has_include(<sys/auxv.h>)
+#elif defined(__linux__) && __has_include(<sys/auxv.h>)
 #include "aarch64/hwcap.inc"
 #include "aarch64/lse_atomics/sysauxv.inc"
 #else
@@ -80,7 +80,7 @@ __attribute__((__visibility__("hidden"), __nocommon__))
 #elif defined(__ANDROID__)
 #include "aarch64/fmv/mrs.inc"
 #include "aarch64/fmv/android.inc"
-#elif __has_include(<sys/auxv.h>)
+#elif defined(__linux__) && __has_include(<sys/auxv.h>)
 #include "aarch64/fmv/mrs.inc"
 #include "aarch64/fmv/sysauxv.inc"
 #else

--- a/llvm/lib/CodeGen/TargetLoweringBase.cpp
+++ b/llvm/lib/CodeGen/TargetLoweringBase.cpp
@@ -1961,6 +1961,9 @@ void TargetLoweringBase::insertSSPDeclarations(Module &M) const {
 // Currently only support "standard" __stack_chk_guard.
 // TODO: add LOAD_STACK_GUARD support.
 Value *TargetLoweringBase::getSDagStackGuard(const Module &M) const {
+  if (getTargetMachine().getTargetTriple().isOSOpenBSD()) {
+    return M.getNamedValue("__guard_local");
+  }
   return M.getNamedValue("__stack_chk_guard");
 }
 


### PR DESCRIPTION
- **Explanation**:

To reduce the need for manual patching of the swift/release/6.2 branch to ensure that the LLVM fork builds and runs successfully, backport these cherrypicks here too.

- **Scope**:

Changes are intended to affect OpenBSD only.

- **Issues**:

See OpenBSD port issue in swiftlang/swift#78437

- **Original PRs**:

#10883 

- **Risk**:

Minimal, as changes  are intended to affect only OpenBSD, have been upstreamed in LLVM HEAD and in the 20.x release for some time.

- **Testing**:

Original change has passed CI.

- **Reviewers**:

@JDevlieghere 















