### PR TITLE
[lldb] Add test for @objc @implementation

### DIFF
--- a/lldb/test/API/lang/swift/objc_implementation/Gadget.h
+++ b/lldb/test/API/lang/swift/objc_implementation/Gadget.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface Gadget : NSObject
+@property(nonatomic, assign) NSInteger integer;
+@property(nonatomic, assign) BOOL boolean;
+@property(nonatomic, strong) NSObject *object;
+@property(nonatomic, copy) NSString *string;
+@property(nonatomic, copy) NSObject *stringObject;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/lldb/test/API/lang/swift/objc_implementation/Makefile
+++ b/lldb/test/API/lang/swift/objc_implementation/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES = main.swift
+SWIFT_BRIDGING_HEADER = Gadget.h
+SWIFT_PRECOMPILE_BRIDGING_HEADER = NO
+include Makefile.rules

--- a/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
+++ b/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame var g",
+            substrs=[
+                "integer = 15",
+                "boolean = true",
+                "object = some",
+                'stringObject = "Joker"',
+            ],
+        )
+        # Swift types that are not representable in ObjC (bridged types such as
+        # String) are not currently listed in the children. rdar://154046212
+        self.expect("frame var g", matching=False, substrs=['string = "Ace"'])

--- a/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
+++ b/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
@@ -17,10 +17,12 @@ class TestCase(TestBase):
             "frame var g",
             substrs=[
                 "integer = 15",
-                "boolean = true",
                 "object = some",
                 'stringObject = "Joker"',
             ],
+            # On x86_64, BOOL types have an objc encoding of 'c', which is a
+            # signed char. The result is in an output of '\x01'.
+            patterns=[r"boolean = (true|'\x01')"],
         )
         # Swift types that are not representable in ObjC (bridged types such as
         # String) are not currently listed in the children. rdar://154046212

--- a/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
+++ b/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
@@ -22,7 +22,7 @@ class TestCase(TestBase):
             ],
             # On x86_64, BOOL types have an objc encoding of 'c', which is a
             # signed char. The result is in an output of '\x01'.
-            patterns=[r"boolean = (true|'\x01')"],
+            patterns=[r"boolean = (true|'\\x01')"],
         )
         # Swift types that are not representable in ObjC (bridged types such as
         # String) are not currently listed in the children. rdar://154046212

--- a/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
+++ b/lldb/test/API/lang/swift/objc_implementation/TestSwiftObjCImplementation.py
@@ -5,6 +5,9 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+
+    @swiftTest
+    @skipUnlessFoundation
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/objc_implementation/main.swift
+++ b/lldb/test/API/lang/swift/objc_implementation/main.swift
@@ -1,0 +1,15 @@
+@objc @implementation
+extension Gadget {
+    var integer: Int = 15
+    var boolean: Bool = true
+    var object: NSObject = NSObject()
+    var string: String = "Ace"
+    var stringObject: NSObject = "Joker" as NSString
+}
+
+func main() {
+    let g = Gadget()
+    print("break here")
+}
+
+main()


### PR DESCRIPTION
Add tests for [SE-0436](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0436-objc-implementation.md). Depends on https://github.com/swiftlang/swift/pull/81967