### PR TITLE
[lldb] Check for ErrorType in SwiftASTContext::ReconstructType

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -16,6 +16,7 @@
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 
 #include "SwiftASTContext.h"
+#include "SwiftDemangle.h"
 #include "TypeSystemSwift.h"
 #include "TypeSystemSwiftTypeRef.h"
 #include "lldb/Utility/Log.h"
@@ -4692,6 +4693,12 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
     return llvm::createStringError("typename \"" +
                                    mangled_typename.GetStringRef() +
                                    "\" is not a valid Swift mangled name");
+  }
+
+  if (swift_demangle::ContainsError(mangled_typename)) {
+    LOG_PRINTF(GetLog(LLDBLog::Types),
+               "(\"%s\") -- cannot reconstruct ErrorType", mangled_cstr);
+    return llvm::createStringError("cannot reconstruct ErrorType");
   }
 
   LOG_VERBOSE_PRINTF(GetLog(LLDBLog::Types), "(\"%s\")", mangled_cstr);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -224,6 +224,20 @@ GetMangledName(swift::Demangle::Demangler &dem,
   return mangleNode(global, flavor);
 }
 
+/// Returns true if this type contains an error node anywhere.
+inline bool ContainsError(StringRef mangled_name) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodePointer node = GetDemangledType(dem, mangled_name);
+  return swift_demangle::FindIf(node, [](NodePointer node) -> bool {
+    // This node is an in-band error, not a Swift.Error type, which is a
+    // protocol.
+    if (node->getKind() == Node::Kind::ErrorType)
+      return true;
+    return false;
+  });
+}
+
 } // namespace swift_demangle
 } // namespace lldb_private
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2301,7 +2301,7 @@ void *TypeSystemSwiftTypeRef::ReconstructType(opaque_compiler_type_t type,
     return nullptr;
 
   // This can crash SwiftASTContext.
-  if (ContainsError(type))
+  if (swift_demangle::ContainsError(AsMangledName(type)))
     return nullptr;
 
   auto swift_ast_context = GetSwiftASTContext(GetSymbolContext(exe_ctx));
@@ -2914,20 +2914,6 @@ bool TypeSystemSwiftTypeRef::IsExpressionEvaluatorDefined(
   return swift_demangle::FindIf(node, [](NodePointer node) -> bool {
     if (node->getKind() == Node::Kind::Module &&
         node->getText().starts_with("__lldb_expr"))
-      return true;
-    return false;
-  });
-}
-
-bool TypeSystemSwiftTypeRef::ContainsError(
-    lldb::opaque_compiler_type_t type) {
-  using namespace swift::Demangle;
-  const auto *mangled_name = AsMangledName(type);
-  Demangler dem;
-  NodePointer node = GetDemangledType(dem, mangled_name);
-  return swift_demangle::FindIf(node, [](NodePointer node) -> bool {
-    // This node is an in-band error, not a Swift.Error type, which is a protocol.
-    if (node->getKind() == Node::Kind::ErrorType)
       return true;
     return false;
   });

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -458,9 +458,6 @@ public:
   swift::Mangle::ManglingFlavor
   GetManglingFlavor(ExecutionContext *exe_ctx = nullptr);
 
-  /// Returns true if this type contains an error node anywhere.
-  bool ContainsError(lldb::opaque_compiler_type_t type);
-
 protected:
   /// Determine whether the fallback is enabled via setting.
   bool UseSwiftASTContextFallback(const char *func_name,

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -12,12 +12,13 @@
 
 #include "gtest/gtest.h"
 
-#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
-#include "llvm/ADT/StringRef.h"
+#include "Plugins/TypeSystem/Swift/SwiftDemangle.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/Strings.h"
+#include "llvm/ADT/StringRef.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -1036,9 +1037,7 @@ TEST_F(TestTypeSystemSwiftTypeRef, Error) {
   NodeBuilder b(dem);
   {
     NodePointer n = b.GlobalType(b.Node(Node::Kind::ErrorType, "Fatal Error"));
-    CompilerType t = GetCompilerType(b.Mangle(n));
-    lldb::opaque_compiler_type_t opaque = t.GetOpaqueQualType();
-    ASSERT_TRUE(m_swift_ts->ContainsError(opaque));
+    ASSERT_TRUE(swift_demangle::ContainsError(b.Mangle(n)));
   }
 }
 


### PR DESCRIPTION
This matches the same logic used in `TypeSystemSwiftTypeRef::ReconstructType` added in https://github.com/swiftlang/llvm-project/pull/10119

rdar://150211941
