### PR TITLE
[lldb] Cache Task pointer location and Task names

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -201,6 +201,8 @@ public:
 
   bool GetSwiftUseTasksPlugin() const;
 
+  bool GetSwiftCacheTaskPointerLocation() const;
+
   Args GetSwiftPluginServerForPath() const;
 
   bool GetSwiftAutoImportFrameworks() const;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3017,7 +3017,8 @@ TaskInspector::GetTaskAddrFromThreadLocalStorage(Thread &thread) {
   // If the read from this TLS address is successful, cache the TLS address.
   // Caching without a valid read is dangerous: earlier in the thread
   // lifetime, the result of GetExtendedInfo can be invalid.
-  if (task_addr)
+  if (task_addr &&
+      real_thread.GetProcess()->GetTarget().GetSwiftCacheTaskPointerLocation())
     m_tid_to_task_addr_location.try_emplace(real_thread.GetID(),
                                             *task_addr_location);
   return task_addr;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2325,8 +2325,9 @@ private:
         return;
       }
 
-      auto task_addr_or_err =
-          GetTaskAddrFromThreadLocalStorage(m_exe_ctx.GetThreadRef());
+      TaskInspector task_inspector;
+      auto task_addr_or_err = task_inspector.GetTaskAddrFromThreadLocalStorage(
+          m_exe_ctx.GetThreadRef());
       if (auto error = task_addr_or_err.takeError()) {
         result.AppendError(toString(std::move(error)));
         return;
@@ -2939,7 +2940,23 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
   return pc_value + prologue_size;
 }
 
-llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
+/// Attempts to read the memory location at `task_addr_location`, producing
+/// the Task pointer if possible.
+static llvm::Expected<lldb::addr_t>
+ReadTaskAddr(lldb::addr_t task_addr_location, Process &process) {
+  Status status;
+  addr_t task_addr = process.ReadPointerFromMemory(task_addr_location, status);
+  if (status.Fail())
+    return llvm::joinErrors(
+        llvm::createStringError("could not get current task from thread"),
+        status.takeError());
+  return task_addr;
+}
+
+/// Compute the location where the Task pointer for `real_thread` is stored by
+/// the runtime.
+static llvm::Expected<lldb::addr_t>
+ComputeTaskAddrLocationFromThreadLocalStorage(Thread &real_thread) {
 #if !SWIFT_THREADING_USE_RESERVED_TLS_KEYS
   return llvm::createStringError(
       "getting the current task from a thread is not supported");
@@ -2947,9 +2964,6 @@ llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
   // Compute the thread local storage address for this thread.
   addr_t tsd_addr = LLDB_INVALID_ADDRESS;
 
-  // Look through backing threads when inspecting TLS.
-  Thread &real_thread =
-      thread.GetBackingThread() ? *thread.GetBackingThread() : thread;
   if (auto info_sp = real_thread.GetExtendedInfo())
     if (auto *info_dict = info_sp->GetAsDictionary())
       info_dict->GetValueForKeyAsInteger("tsd_address", tsd_addr);
@@ -2958,18 +2972,55 @@ llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread) {
     return llvm::createStringError("could not read current task from thread");
 
   // Offset of the Task pointer in a Thread's local storage.
-  Process &process = *thread.GetProcess();
+  Process &process = *real_thread.GetProcess();
   size_t ptr_size = process.GetAddressByteSize();
   uint64_t task_ptr_offset_in_tls =
       swift::tls_get_key(swift::tls_key::concurrency_task) * ptr_size;
-  addr_t task_addr_location = tsd_addr + task_ptr_offset_in_tls;
-  Status status;
-  addr_t task_addr = process.ReadPointerFromMemory(task_addr_location, status);
-  if (status.Fail())
-    return llvm::createStringError("could not get current task from thread: %s",
-                                   status.AsCString());
-  return task_addr;
+  return tsd_addr + task_ptr_offset_in_tls;
 #endif
+}
+
+llvm::Expected<lldb::addr_t>
+TaskInspector::GetTaskAddrFromThreadLocalStorage(Thread &thread) {
+  // Look through backing threads when inspecting TLS.
+  Thread &real_thread =
+      thread.GetBackingThread() ? *thread.GetBackingThread() : thread;
+
+  if (auto it = m_tid_to_task_addr_location.find(real_thread.GetID());
+      it != m_tid_to_task_addr_location.end()) {
+#ifndef NDEBUG
+    // In assert builds, check that caching did not produce incorrect results.
+    llvm::Expected<lldb::addr_t> task_addr_location =
+        ComputeTaskAddrLocationFromThreadLocalStorage(real_thread);
+    assert(task_addr_location);
+    assert(it->second == *task_addr_location);
+#endif
+    llvm::Expected<lldb::addr_t> task_addr =
+        ReadTaskAddr(it->second, *thread.GetProcess());
+    if (task_addr)
+      return task_addr;
+    // If the cached task addr location became invalid, invalidate the cache.
+    m_tid_to_task_addr_location.erase(it);
+    LLDB_LOG_ERROR(GetLog(LLDBLog::OS), task_addr.takeError(),
+                   "TaskInspector: evicted task location address due to "
+                   "invalid memory read: {0}");
+  }
+
+  llvm::Expected<lldb::addr_t> task_addr_location =
+      ComputeTaskAddrLocationFromThreadLocalStorage(real_thread);
+  if (!task_addr_location)
+    return task_addr_location;
+
+  llvm::Expected<lldb::addr_t> task_addr =
+      ReadTaskAddr(*task_addr_location, *thread.GetProcess());
+
+  // If the read from this TLS address is successful, cache the TLS address.
+  // Caching without a valid read is dangerous: earlier in the thread
+  // lifetime, the result of GetExtendedInfo can be invalid.
+  if (task_addr)
+    m_tid_to_task_addr_location.try_emplace(real_thread.GetID(),
+                                            *task_addr_location);
+  return task_addr;
 }
 
 namespace {

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -902,9 +902,17 @@ struct AsyncUnwindRegisterNumbers {
 std::optional<AsyncUnwindRegisterNumbers>
 GetAsyncUnwindRegisterNumbers(llvm::Triple::ArchType triple);
 
-/// Inspects thread local storage to find the address of the currently executing
-/// task.
-llvm::Expected<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
+/// A helper class to find and cache the location of Task pointer inside TLS.
+class TaskInspector {
+public:
+  /// Inspects thread local storage to find the address of the currently
+  /// executing task, if any.
+  llvm::Expected<lldb::addr_t>
+  GetTaskAddrFromThreadLocalStorage(Thread &thread);
+
+private:
+  llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
+};
 
 llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task,
                                                        Process &process);

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -100,8 +100,10 @@ ThreadSP OperatingSystemSwiftTasks::FindOrCreateSwiftThread(
                                                      name);
 }
 
-static std::optional<addr_t> FindTaskAddress(Thread &thread) {
-  llvm::Expected<addr_t> task_addr = GetTaskAddrFromThreadLocalStorage(thread);
+static std::optional<addr_t> FindTaskAddress(TaskInspector &task_inspector,
+                                             Thread &thread) {
+  llvm::Expected<addr_t> task_addr =
+      task_inspector.GetTaskAddrFromThreadLocalStorage(thread);
   if (!task_addr) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::OS), task_addr.takeError(),
                    "OperatingSystemSwiftTasks: failed to find task address in "
@@ -150,7 +152,8 @@ bool OperatingSystemSwiftTasks::UpdateThreadList(ThreadList &old_thread_list,
   LLDB_LOG(log, "OperatingSystemSwiftTasks: Updating thread list");
 
   for (const ThreadSP &real_thread : core_thread_list.Threads()) {
-    std::optional<addr_t> task_addr = FindTaskAddress(*real_thread);
+    std::optional<addr_t> task_addr =
+        FindTaskAddress(m_task_inspector, *real_thread);
 
     // If this is not a thread running a Task, add it to the list as is.
     if (!task_addr) {

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -50,8 +50,7 @@ private:
   /// If a thread for task_id had been created in the last stop, return it.
   /// Otherwise, create a new MemoryThread for it.
   lldb::ThreadSP FindOrCreateSwiftThread(ThreadList &old_thread_list,
-                                         uint64_t task_id,
-                                         std::optional<std::string> task_name);
+                                         uint64_t task_id);
 
   /// A cache for task addr locations, which are expensive to compute but
   /// immutable.

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.h
@@ -11,6 +11,7 @@
 
 #if LLDB_ENABLE_SWIFT
 
+#include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "lldb/Target/OperatingSystem.h"
 
 namespace lldb_private {
@@ -51,6 +52,10 @@ private:
   lldb::ThreadSP FindOrCreateSwiftThread(ThreadList &old_thread_list,
                                          uint64_t task_id,
                                          std::optional<std::string> task_name);
+
+  /// A cache for task addr locations, which are expensive to compute but
+  /// immutable.
+  TaskInspector m_task_inspector;
 };
 } // namespace lldb_private
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4529,6 +4529,18 @@ bool TargetProperties::GetSwiftUseTasksPlugin() const {
   return true;
 }
 
+bool TargetProperties::GetSwiftCacheTaskPointerLocation() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftCacheTaskPointerLocation)
+        .value_or(true);
+  return true;
+}
+
 Args TargetProperties::GetSwiftPluginServerForPath() const {
   const uint32_t idx = ePropertySwiftPluginServerForPath;
 

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -34,6 +34,9 @@ let Definition = "target_experimental" in {
   def SwiftUseTasksPlugin: Property<"swift-tasks-plugin-enabled", "Boolean">,
     DefaultTrue,
     Desc<"Enables the swift plugin converting tasks into threads">;
+  def SwiftCacheTaskPointerLocation: Property<"swift-cache-task-pointer-location", "Boolean">,
+    DefaultTrue,
+    Desc<"Enables caching of task pointers inside the swift tasks plugin">;
 }
 
 let Definition = "target" in {


### PR DESCRIPTION
This PR reduces the number of packets that need to be communicated between debugserver and LLDB when deciding whether a thread is executing a task. This is accomplished in two ways:

A) Caching the TLS location of the task pointer for each real thread.
B) Caching and lazily evaluating the name of a task

rdar://151400459