### PR TITLE
[lldb][swift] Fix GetParentIfClosure for Init methods of classes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -1512,7 +1512,8 @@ std::string SwiftLanguageRuntime::GetParentNameIfClosure(StringRef name) {
   static const auto closure_kinds = {Kind::ImplicitClosure,
                                      Kind::ExplicitClosure};
   static const auto function_kinds = {Kind::ImplicitClosure,
-                                      Kind::ExplicitClosure, Kind::Function};
+                                      Kind::ExplicitClosure, Kind::Function,
+                                      Kind::Constructor};
   auto *closure_node = swift_demangle::GetFirstChildOfKind(node, closure_kinds);
   auto *parent_func_node =
       swift_demangle::GetFirstChildOfKind(closure_node, function_kinds);

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -103,3 +103,11 @@ class TestSwiftClosureVarNotCaptured(TestBase):
             self, thread.frames[0], "var_in_outer_closure", "closure #1 in func_3(arg:)"
         )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
+
+    @swiftTest
+    def test_ctor_class_closure(self):
+        self.build()
+        (target, process, thread, bkpt) = self.get_to_bkpt("break_ctor_class")
+        check_not_captured_error(self, thread.frames[0], "input", "MY_STRUCT.init(input:)")
+        check_not_captured_error(self, thread.frames[0], "find_me", "MY_STRUCT.init(input:)")
+        check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")

--- a/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
@@ -87,6 +87,17 @@ func func_3(arg: Int) async {
   print(dont_find_me)
 }
 
+class MY_STRUCT {
+  init(input: [Int]) {
+    let find_me = "hello"
+    let _ = input.map {
+      return $0  // break_ctor_class
+    }
+    let dont_find_me = "hello"
+  }
+}
+
 func_1(arg: 42)
 func_2(arg: 42)
 await func_3(arg: 42)
+let _ = MY_STRUCT(input: [1, 2])


### PR DESCRIPTION
These have a "Constructor" demangle node kind that should be considered.