### PR TITLE
[lldb] Add formatters for Swift.Span

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -344,6 +344,12 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
       summary_flags, true);
 
+  AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::swift::UnsafeTypeSummaryProvider,
+                "Swift.[Mutable]Span",
+                ConstString("^Swift\\.(Mutable)?Span<.+>$"), summary_flags,
+                true);
+
   DictionaryConfig::Get().RegisterSummaryProviders(swift_category_sp,
                                                    summary_flags);
   SetConfig::Get().RegisterSummaryProviders(swift_category_sp, summary_flags);
@@ -393,6 +399,12 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEndCreator,
       "Swift.Unsafe[Mutable][Raw][Buffer]Pointer",
       ConstString("^Swift.Unsafe(Mutable)?(Raw)?(Buffer)?Pointer(<.+>)?$"),
+      synth_flags, true);
+
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::UnsafeTypeSyntheticFrontEndCreator,
+      "Swift.[Mutable]Span", ConstString("^Swift\\.(Mutable)?Span<.+>?"),
       synth_flags, true);
 
   DictionaryConfig::Get().RegisterSyntheticChildrenCreators(swift_category_sp,

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -466,11 +466,12 @@ std::unique_ptr<SwiftUnsafeType> SwiftUnsafeType::Create(ValueObject &valobj) {
 
   llvm::StringRef valobj_type_name(type.GetTypeName().GetCString());
   valobj_type_name.consume_front("Swift.");
-  if (valobj_type_name.consume_front("Span"))
+  bool is_unsafe = valobj_type_name.consume_front("Unsafe");
+  valobj_type_name.consume_front("Mutable");
+
+  if (!is_unsafe && valobj_type_name.consume_front("Span"))
     return std::make_unique<SwiftSpan>(valobj);
 
-  valobj_type_name.consume_front("Unsafe");
-  valobj_type_name.consume_front("Mutable");
   bool is_raw = valobj_type_name.consume_front("Raw");
   bool is_buffer_ptr = valobj_type_name.consume_front("Buffer");
   UnsafePointerKind kind =

--- a/lldb/test/API/lang/swift/span/Makefile
+++ b/lldb/test/API/lang/swift/span/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/span/Makefile
+++ b/lldb/test/API/lang/swift/span/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
+SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -disable-availability-checking
 include Makefile.rules

--- a/lldb/test/API/lang/swift/span/TestSwiftSpan.py
+++ b/lldb/test/API/lang/swift/span/TestSwiftSpan.py
@@ -13,10 +13,6 @@ class TestCase(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
 
-        self.expect("frame var ints", substrs=["2 values", "[0] = 6", "[1] = 7"])
-        self.expect(
-            "frame var strings", substrs=["2 values", '[0] = "six"', '[1] = "seven"']
-        )
-        self.expect(
-            "frame var things", substrs=["1 value", "[0] = (id = 67, odd = true)"]
-        )
+        self.expect("frame var ints_span", substrs=["[0] = 6", "[1] = 7"])
+        self.expect("frame var strings_span", substrs=['[0] = "six"', '[1] = "seven"'])
+        self.expect("frame var things_span", substrs=["[0] = (id = 67, odd = true)"])

--- a/lldb/test/API/lang/swift/span/TestSwiftSpan.py
+++ b/lldb/test/API/lang/swift/span/TestSwiftSpan.py
@@ -1,0 +1,22 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("frame var ints", substrs=["2 values", "[0] = 6", "[1] = 7"])
+        self.expect(
+            "frame var strings", substrs=["2 values", '[0] = "six"', '[1] = "seven"']
+        )
+        self.expect(
+            "frame var things", substrs=["1 value", "[0] = (id = 67, odd = true)"]
+        )

--- a/lldb/test/API/lang/swift/span/main.swift
+++ b/lldb/test/API/lang/swift/span/main.swift
@@ -1,0 +1,18 @@
+struct Thing {
+    var id: Int
+    var odd: Bool
+
+    init(_ n: Int) {
+        id = n
+        odd = n % 2 == 1
+    }
+}
+
+@main struct Entry {
+    static func main() {
+        let ints = [6, 7]
+        let strings = ["six", "seven"]
+        let things = [Thing(67)]
+        print("break here")
+    }
+}

--- a/lldb/test/API/lang/swift/span/main.swift
+++ b/lldb/test/API/lang/swift/span/main.swift
@@ -11,8 +11,11 @@ struct Thing {
 @main struct Entry {
     static func main() {
         let ints = [6, 7]
+        let ints_span = ints.span
         let strings = ["six", "seven"]
+        let strings_span = strings.span
         let things = [Thing(67)]
+        let things_span = things.span
         print("break here")
     }
 }


### PR DESCRIPTION
Add synthetic child provider and summary formatter for `Swift.Span` (and `MutableSpan`) which was introduced in [SE-0447](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0447-span-access-shared-contiguous-storage.md).

The implementation of `Span` shares enough similarity with `UnsafeBufferPointer` and `UnsafeRawBufferPointer`, that the same code was refactored and reused to implement support for `Span`.

rdar://151411389