### PR TITLE
Fix race condition during iteration through modules (#139283) (#139862)

### DIFF
--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1452,8 +1452,7 @@ bool Target::IgnoreWatchpointByID(lldb::watch_id_t watch_id,
 
 ModuleSP Target::GetExecutableModule() {
   // search for the first executable in the module list
-  for (size_t i = 0; i < m_images.GetSize(); ++i) {
-    ModuleSP module_sp = m_images.GetModuleAtIndex(i);
+  for (ModuleSP module_sp : m_images.Modules()) {
     lldb_private::ObjectFile *obj = module_sp->GetObjectFile();
     if (obj == nullptr)
       continue;

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1451,15 +1451,18 @@ bool Target::IgnoreWatchpointByID(lldb::watch_id_t watch_id,
 }
 
 ModuleSP Target::GetExecutableModule() {
-  // search for the first executable in the module list
-  for (ModuleSP module_sp : m_images.Modules()) {
+  std::lock_guard<std::recursive_mutex> lock(m_images.GetMutex());
+
+  // Search for the first executable in the module list.
+  for (ModuleSP module_sp : m_images.ModulesNoLocking()) {
     lldb_private::ObjectFile *obj = module_sp->GetObjectFile();
     if (obj == nullptr)
       continue;
     if (obj->GetType() == ObjectFile::Type::eTypeExecutable)
       return module_sp;
   }
-  // as fall back return the first module loaded
+
+  // If there is none, fall back return the first module loaded.
   return m_images.GetModuleAtIndex(0);
 }
 


### PR DESCRIPTION
Use the locking iterator to ensure module don't change during iteration.

(cherry picked from commit c72c0b298c13ebc4d374e84b8ea20f8ca4f5ace2)