### PR TITLE
[DependencyScanning] Fix include-what-you-use error

### DIFF
--- a/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/Tooling/DependencyScanning/DependencyScanningService.h
@@ -15,6 +15,7 @@
 #include "clang/Tooling/DependencyScanning/InProcessModuleCache.h"
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
 #include "llvm/Support/Chrono.h"
 
 namespace clang {


### PR DESCRIPTION
Fix a missing include in DependencyScanningService.h that is needed for template instantiation.