### PR TITLE
[lldb][swift] Fix GetParentIfClosure for static methods of classes 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -1513,7 +1513,7 @@ std::string SwiftLanguageRuntime::GetParentNameIfClosure(StringRef name) {
                                      Kind::ExplicitClosure};
   static const auto function_kinds = {Kind::ImplicitClosure,
                                       Kind::ExplicitClosure, Kind::Function,
-                                      Kind::Constructor};
+                                      Kind::Constructor, Kind::Static};
   auto *closure_node = swift_demangle::GetFirstChildOfKind(node, closure_kinds);
   auto *parent_func_node =
       swift_demangle::GetFirstChildOfKind(closure_node, function_kinds);

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -45,14 +45,16 @@ def check_no_enhanced_diagnostic(test, frame, var_name):
 
 class TestSwiftClosureVarNotCaptured(TestBase):
     def get_to_bkpt(self, bkpt_name):
-        return lldbutil.run_to_source_breakpoint(
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, bkpt_name, lldb.SBFileSpec("main.swift")
         )
+        target.BreakpointDelete(bkpt.GetID())
+        return (target, process, thread)
 
     @swiftTest
     def test_simple_closure(self):
         self.build()
-        (target, process, thread, bkpt) = self.get_to_bkpt("break_simple_closure")
+        (target, process, thread) = self.get_to_bkpt("break_simple_closure")
         check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_1(arg:)")
         check_not_captured_error(self, thread.frames[0], "arg", "func_1(arg:)")
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
@@ -60,7 +62,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @swiftTest
     def test_nested_closure(self):
         self.build()
-        (target, process, thread, bkpt) = self.get_to_bkpt("break_double_closure_1")
+        (target, process, thread) = self.get_to_bkpt("break_double_closure_1")
         check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_2(arg:)")
         check_not_captured_error(self, thread.frames[0], "arg", "func_2(arg:)")
         check_not_captured_error(
@@ -86,7 +88,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @skipIf(oslist=["windows", "linux"])
     def test_async_closure(self):
         self.build()
-        (target, process, thread, bkpt) = self.get_to_bkpt("break_async_closure_1")
+        (target, process, thread) = self.get_to_bkpt("break_async_closure_1")
         check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_3(arg:)")
         check_not_captured_error(self, thread.frames[0], "arg", "func_3(arg:)")
         check_not_captured_error(
@@ -107,7 +109,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @swiftTest
     def test_ctor_class_closure(self):
         self.build()
-        (target, process, thread, bkpt) = self.get_to_bkpt("break_ctor_class")
+        (target, process, thread) = self.get_to_bkpt("break_ctor_class")
         check_not_captured_error(self, thread.frames[0], "input", "MY_STRUCT.init(input:)")
         check_not_captured_error(self, thread.frames[0], "find_me", "MY_STRUCT.init(input:)")
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -110,8 +110,12 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     def test_ctor_class_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_class")
-        check_not_captured_error(self, thread.frames[0], "input", "MY_STRUCT.init(input:)")
-        check_not_captured_error(self, thread.frames[0], "find_me", "MY_STRUCT.init(input:)")
+        check_not_captured_error(
+            self, thread.frames[0], "input", "MY_STRUCT.init(input:)"
+        )
+        check_not_captured_error(
+            self, thread.frames[0], "find_me", "MY_STRUCT.init(input:)"
+        )
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
         lldbutil.continue_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -113,3 +113,20 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_not_captured_error(self, thread.frames[0], "input", "MY_STRUCT.init(input:)")
         check_not_captured_error(self, thread.frames[0], "find_me", "MY_STRUCT.init(input:)")
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
+
+        lldbutil.continue_to_source_breakpoint(
+            self, process, "break_static_member", lldb.SBFileSpec("main.swift")
+        )
+        check_not_captured_error(
+            self,
+            thread.frames[0],
+            "input_static",
+            "static MY_STRUCT.static_func(input_static:)",
+        )
+        check_not_captured_error(
+            self,
+            thread.frames[0],
+            "find_me_static",
+            "static MY_STRUCT.static_func(input_static:)",
+        )
+        check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me_static")

--- a/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
@@ -95,9 +95,18 @@ class MY_STRUCT {
     }
     let dont_find_me = "hello"
   }
+
+  static func static_func(input_static: [Int]) {
+    let find_me_static = "hello"
+    let _ = input_static.map {
+      return $0  // break_static_member
+    }
+    let dont_find_me_static = "hello"
+  }
 }
 
 func_1(arg: 42)
 func_2(arg: 42)
 await func_3(arg: 42)
 let _ = MY_STRUCT(input: [1, 2])
+MY_STRUCT.static_func(input_static: [42])


### PR DESCRIPTION
These use the Static mangled node, which we were not handling.

Two other commits included: one improving a helper function of the related test, so that it deletes a breakpoint, and a formatting commit from a previously-merged part of the test