### PR TITLE
Return a SwiftArrayEmptyBufferHandler if loc points to an EmptyArray Symbol.

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -15,6 +15,7 @@
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "lldb/Core/Address.h"
 #include "lldb/DataFormatters/FormattersHelpers.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/Target.h"
@@ -459,6 +460,21 @@ SwiftArrayBufferHandler::CreateBufferHandler(ValueObject &static_valobj) {
 
     lldb::addr_t storage_location =
         buffer_sp->GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+
+    lldb_private::Address addr = Address();
+    addr.SetLoadAddress(storage_location, exe_ctx.GetTargetPtr());
+
+    // If the storage_location points to a swiftEmptyArrayStorage symbol, return
+    // a SwiftArrayEmptyBufferHandler.
+    if (auto *symbol = addr.CalculateSymbolContextSymbol()) {
+      auto mangledName = symbol->GetMangled().GetMangledName().GetStringRef();
+      if (mangledName == "$ss19__EmptyArrayStorageCN") {
+        CompilerType elem_type(
+            valobj.GetCompilerType().GetArrayElementType(exe_scope));
+        return std::unique_ptr<SwiftArrayBufferHandler>(
+            new SwiftArrayEmptyBufferHandler(elem_type));
+      }
+    }
 
     if (storage_location != LLDB_INVALID_ADDRESS) {
       ProcessSP process_sp(valobj.GetProcessSP());

--- a/lldb/test/API/lang/swift/swift_empty_arr/Makefile
+++ b/lldb/test/API/lang/swift/swift_empty_arr/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/swift_empty_arr/TestSwiftGlobalEmptyArray.py
+++ b/lldb/test/API/lang/swift/swift_empty_arr/TestSwiftGlobalEmptyArray.py
@@ -1,0 +1,17 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftGlobalEmptyArray(lldbtest.TestBase):
+    @swiftTest
+    def test(self):
+        """Test that printing a global swift array of type SwiftEmptyArrayStorage uses the correct data formatter"""
+
+        self.build()
+        filespec = lldb.SBFileSpec("main.swift")
+        target, process, thread, breakpoint1 = lldbutil.run_to_source_breakpoint(
+            self, "break here", filespec
+        )
+        self.expect("p x", substrs=["([a.P]) 0 values {}"])

--- a/lldb/test/API/lang/swift/swift_empty_arr/main.swift
+++ b/lldb/test/API/lang/swift/swift_empty_arr/main.swift
@@ -1,0 +1,8 @@
+protocol P {}
+
+func go() {
+    let x: [any P] = []
+    print("break here")
+}
+
+go()


### PR DESCRIPTION
If we have a ValueObjectSP who's storage_location points to a `S_swiftEmptyArrayStorage` symbol, return a `SwiftArrayEmptyBufferHandler`