### PR TITLE
[stable/20250601] Revert "[clang] Remove dead incremental Parser code (#102450)"

### DIFF
--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -629,6 +629,11 @@ bool Parser::ParseTopLevelDecl(DeclGroupPtrTy &Result,
                                Sema::ModuleImportState &ImportState) {
   DestroyTemplateIdAnnotationsRAIIObj CleanupRAII(*this);
 
+  // Skip over the EOF token, flagging end of previous input for incremental
+  // processing
+  if (PP.isIncrementalProcessingEnabled() && Tok.is(tok::eof))
+    ConsumeToken();
+
   Result = nullptr;
   switch (Tok.getKind()) {
   case tok::annot_pragma_unused:


### PR DESCRIPTION
This reverts commit 67cb04035fe831a3b5df98dabc44b53ba5ff7126. When importing headers, the Swift ClangImporter library depends on `clang::Parser::ParseTopLevelDecl` consuming an EOF token when `IncrementalProcessing` is set.