### PR TITLE
[clang Dependency Scanning] Out-of-Date Scanning File System Cache Entry Reporting C-APIs

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -585,10 +585,41 @@ const char *clang_experimental_DepGraph_getTUContextHash(CXDepGraph);
 CINDEX_LINKAGE
 CXDiagnosticSet clang_experimental_DepGraph_getDiagnostics(CXDepGraph);
 
-CINDEX_LINKAGE
-CXCStringArray
-    clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
-        CXDependencyScannerService);
+typedef enum { NegativelyCached, SizeChanged } CXDepScanFSCacheOutOfDateKind;
+
+typedef struct CXOpaqueDepScanFSOutOfDateEntrySet *CXDepScanFSOutOfDateEntrySet;
+typedef struct CXOpaqueDepScanFSOutOfDateEntry *CXDepScanFSOutOfDateEntry;
+
+CXDepScanFSOutOfDateEntrySet
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
+    CXDependencyScannerService S);
+
+size_t
+clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries(
+    CXDepScanFSOutOfDateEntrySet Entries);
+
+CXDepScanFSOutOfDateEntry
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntry(
+    CXDepScanFSOutOfDateEntrySet Entries, size_t Idx);
+
+CXDepScanFSCacheOutOfDateKind
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind(
+    CXDepScanFSOutOfDateEntry Entry);
+
+CXString
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryPath(
+    CXDepScanFSOutOfDateEntry Entry);
+
+uint64_t
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryCachedSize(
+    CXDepScanFSOutOfDateEntry Entry);
+
+uint64_t
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryActualSize(
+    CXDepScanFSOutOfDateEntry Entry);
+
+void clang_experimental_DependencyScannerService_disposeFSCacheOutOfDateEntrySet(
+    CXDepScanFSOutOfDateEntrySet Entries);
 
 /**
  * Options used to generate a reproducer.

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -627,15 +627,14 @@ typedef struct CXOpaqueDepScanFSOutOfDateEntry *CXDepScanFSOutOfDateEntry;
  * out-of-date entries are used and disposed.
  */
 CXDepScanFSOutOfDateEntrySet
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
+clang_experimental_DepScanFSCacheOutOfEntrySet_getSet(
     CXDependencyScannerService S);
 
 /**
  * Returns the number of out-of-date entries contained in a
  * \c CXDepScanFSOutOfDateEntrySet .
  */
-size_t
-clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries(
+size_t clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries(
     CXDepScanFSOutOfDateEntrySet Entries);
 
 /**
@@ -643,43 +642,40 @@ clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries(
  * CXDepScanFSOutOfDateEntrySet instance.
  */
 CXDepScanFSOutOfDateEntry
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntry(
+clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(
     CXDepScanFSOutOfDateEntrySet Entries, size_t Idx);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry, returns its Kind.
  */
 CXDepScanFSCacheOutOfDateKind
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind(
+clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry, returns the path.
  */
-CXString
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryPath(
+CXString clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry of kind SizeChanged,
  * returns the cached size.
  */
-uint64_t
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryCachedSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry of kind SizeChanged,
  * returns the actual size on the underlying file system.
  */
-uint64_t
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryActualSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Dispose the \c CXDepScanFSOutOfDateEntrySet instance.
  */
-void clang_experimental_DependencyScannerService_disposeFSCacheOutOfDateEntrySet(
+void clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet(
     CXDepScanFSOutOfDateEntrySet Entries);
 
 /**

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -585,39 +585,100 @@ const char *clang_experimental_DepGraph_getTUContextHash(CXDepGraph);
 CINDEX_LINKAGE
 CXDiagnosticSet clang_experimental_DepGraph_getDiagnostics(CXDepGraph);
 
-typedef enum { NegativelyCached, SizeChanged } CXDepScanFSCacheOutOfDateKind;
+/**
+ * The kind of scanning file system cache out-of-date entries.
+ */
+typedef enum {
+  /**
+   * The entry is negatively stat cached (which indicates the file did not exist
+   * the first time it was looked up during scanning), but the cached file
+   * exists on the underlying file system.
+   */
+  NegativelyCached,
 
+  /**
+   * The entry indicates that for the cached file, its cached size
+   * is different from its size reported by the underlying file system.
+   */
+  SizeChanged
+} CXDepScanFSCacheOutOfDateKind;
+
+/**
+ * The opaque object that contains the scanning file system cache's out-of-date
+ * entires.
+ */
 typedef struct CXOpaqueDepScanFSOutOfDateEntrySet *CXDepScanFSOutOfDateEntrySet;
+
+/**
+ * The opaque object that represents a single scanning file system cache's out-
+ * of-date entry.
+ */
 typedef struct CXOpaqueDepScanFSOutOfDateEntry *CXDepScanFSOutOfDateEntry;
 
+/**
+ * Returns all the file system cache out-of-date entries given a
+ * \c CXDependencyScannerService .
+ *
+ * This function is intended to be called when the build has finished,
+ * and the \c CXDependencyScannerService instance is about to be disposed.
+ *
+ * The \c CXDependencyScannerService instance owns the strings used
+ * by the out-of-date entries and should be disposed after the
+ * out-of-date entries are used and disposed.
+ */
 CXDepScanFSOutOfDateEntrySet
 clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
     CXDependencyScannerService S);
 
+/**
+ * Returns the number of out-of-date entries contained in a
+ * \c CXDepScanFSOutOfDateEntrySet .
+ */
 size_t
 clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries(
     CXDepScanFSOutOfDateEntrySet Entries);
 
+/**
+ * Returns the out-of-date entry at offset \p Idx of the \c
+ * CXDepScanFSOutOfDateEntrySet instance.
+ */
 CXDepScanFSOutOfDateEntry
 clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntry(
     CXDepScanFSOutOfDateEntrySet Entries, size_t Idx);
 
+/**
+ * Given an instance of \c CXDepScanFSOutOfDateEntry, returns its Kind.
+ */
 CXDepScanFSCacheOutOfDateKind
 clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind(
     CXDepScanFSOutOfDateEntry Entry);
 
+/**
+ * Given an instance of \c CXDepScanFSOutOfDateEntry, returns the path.
+ */
 CXString
 clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryPath(
     CXDepScanFSOutOfDateEntry Entry);
 
+/**
+ * Given an instance of \c CXDepScanFSOutOfDateEntry of kind SizeChanged,
+ * returns the cached size.
+ */
 uint64_t
 clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryCachedSize(
     CXDepScanFSOutOfDateEntry Entry);
 
+/**
+ * Given an instance of \c CXDepScanFSOutOfDateEntry of kind SizeChanged,
+ * returns the actual size on the underlying file system.
+ */
 uint64_t
 clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryActualSize(
     CXDepScanFSOutOfDateEntry Entry);
 
+/**
+ * Dispose the \c CXDepScanFSOutOfDateEntrySet instance.
+ */
 void clang_experimental_DependencyScannerService_disposeFSCacheOutOfDateEntrySet(
     CXDepScanFSOutOfDateEntrySet Entries);
 

--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -627,14 +627,14 @@ typedef struct CXOpaqueDepScanFSOutOfDateEntry *CXDepScanFSOutOfDateEntry;
  * out-of-date entries are used and disposed.
  */
 CXDepScanFSOutOfDateEntrySet
-clang_experimental_DepScanFSCacheOutOfEntrySet_getSet(
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
     CXDependencyScannerService S);
 
 /**
  * Returns the number of out-of-date entries contained in a
  * \c CXDepScanFSOutOfDateEntrySet .
  */
-size_t clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries(
+size_t clang_experimental_DepScanFSCacheOutOfDateEntrySet_getNumOfEntries(
     CXDepScanFSOutOfDateEntrySet Entries);
 
 /**
@@ -642,40 +642,40 @@ size_t clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries(
  * CXDepScanFSOutOfDateEntrySet instance.
  */
 CXDepScanFSOutOfDateEntry
-clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(
+clang_experimental_DepScanFSCacheOutOfDateEntrySet_getEntry(
     CXDepScanFSOutOfDateEntrySet Entries, size_t Idx);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry, returns its Kind.
  */
 CXDepScanFSCacheOutOfDateKind
-clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(
+clang_experimental_DepScanFSCacheOutOfDateEntry_getKind(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry, returns the path.
  */
-CXString clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath(
+CXString clang_experimental_DepScanFSCacheOutOfDateEntry_getPath(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry of kind SizeChanged,
  * returns the cached size.
  */
-uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfDateEntry_getCachedSize(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Given an instance of \c CXDepScanFSOutOfDateEntry of kind SizeChanged,
  * returns the actual size on the underlying file system.
  */
-uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfDateEntry_getActualSize(
     CXDepScanFSOutOfDateEntry Entry);
 
 /**
  * Dispose the \c CXDepScanFSOutOfDateEntrySet instance.
  */
-void clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet(
+void clang_experimental_DepScanFSCacheOutOfDateEntrySet_disposeSet(
     CXDepScanFSOutOfDateEntrySet Entries);
 
 /**

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -131,7 +131,11 @@ DependencyScanningFilesystemSharedCache::getOutOfDateEntries(
           // later. The cache entry is not invalidated (as we have no good
           // way to do it now), which may lead to missing file build errors.
           InvalidDiagInfo.emplace_back(Path.data());
-        } else {
+        } else if (Status->getType() ==
+                   llvm::sys::fs::file_type::regular_file) {
+          // We only check regular files. Directory files sizes could change due
+          // to content changes, and reporting directory size changes can lead
+          // to false positives.
           llvm::vfs::Status CachedStatus = Entry->getStatus();
           uint64_t CachedSize = CachedStatus.getSize();
           uint64_t ActualSize = Status->getSize();

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningFilesystem.cpp
@@ -131,18 +131,24 @@ DependencyScanningFilesystemSharedCache::getOutOfDateEntries(
           // later. The cache entry is not invalidated (as we have no good
           // way to do it now), which may lead to missing file build errors.
           InvalidDiagInfo.emplace_back(Path.data());
-        } else if (Status->getType() ==
-                   llvm::sys::fs::file_type::regular_file) {
-          // We only check regular files. Directory files sizes could change due
-          // to content changes, and reporting directory size changes can lead
-          // to false positives.
+        } else {
           llvm::vfs::Status CachedStatus = Entry->getStatus();
-          uint64_t CachedSize = CachedStatus.getSize();
-          uint64_t ActualSize = Status->getSize();
-          if (CachedSize != ActualSize) {
-            // This is the case where the cached file has a different size
-            // from the actual file that comes from the underlying FS.
-            InvalidDiagInfo.emplace_back(Path.data(), CachedSize, ActualSize);
+          if (Status->getType() == llvm::sys::fs::file_type::regular_file &&
+              Status->getType() == CachedStatus.getType()) {
+            // We only check regular files. Directory files sizes could change
+            // due to content changes, and reporting directory size changes can
+            // lead to false positives.
+            // TODO: At the moment, we do not detect symlinks to files whose
+            // size may change. We need to decide if we want to detect cached
+            // symlink size changes. We can also expand this to detect file
+            // type changes.
+            uint64_t CachedSize = CachedStatus.getSize();
+            uint64_t ActualSize = Status->getSize();
+            if (CachedSize != ActualSize) {
+              // This is the case where the cached file has a different size
+              // from the actual file that comes from the underlying FS.
+              InvalidDiagInfo.emplace_back(Path.data(), CachedSize, ActualSize);
+            }
           }
         }
       }

--- a/clang/test/ClangScanDeps/error-c-api.cpp
+++ b/clang/test/ClangScanDeps/error-c-api.cpp
@@ -4,3 +4,4 @@
 
 // CHECK: error: failed to get dependencies
 // CHECK-NEXT: 'missing.h' file not found
+// CHECK-NEXT: number of out of date file system cache entries: 0

--- a/clang/test/ClangScanDeps/error-c-api.cpp
+++ b/clang/test/ClangScanDeps/error-c-api.cpp
@@ -4,4 +4,3 @@
 
 // CHECK: error: failed to get dependencies
 // CHECK-NEXT: 'missing.h' file not found
-// CHECK-NEXT: number of invalid negatively stat cached paths: 0

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -916,12 +916,8 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
     clang_disposeDiagnostic(Diag);
   }
 
-  CXCStringArray InvalidNegativeStatCachedPaths =
-      clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
-          Service);
-
-  llvm::errs() << "note: number of invalid negatively stat cached paths: "
-               << InvalidNegativeStatCachedPaths.Count << "\n";
+  llvm::errs() << "note: number of invalid negatively stat cached paths: " << 0
+               << "\n";
 
   return 1;
 }

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -916,6 +916,19 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
     clang_disposeDiagnostic(Diag);
   }
 
+  CXDepScanFSOutOfDateEntrySet OutOfDateEntrySet =
+      clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
+          Service);
+
+  llvm::errs()
+      << "note: number of out of date file system cache entries: "
+      << clang_experimental_DepScanFSCacheOutOfDateEntrySet_getNumOfEntries(
+             OutOfDateEntrySet)
+      << "\n";
+
+  clang_experimental_DepScanFSCacheOutOfDateEntrySet_disposeSet(
+      OutOfDateEntrySet);
+
   return 1;
 }
 

--- a/clang/tools/c-index-test/core_main.cpp
+++ b/clang/tools/c-index-test/core_main.cpp
@@ -916,9 +916,6 @@ static int scanDeps(ArrayRef<const char *> Args, std::string WorkingDirectory,
     clang_disposeDiagnostic(Diag);
   }
 
-  llvm::errs() << "note: number of invalid negatively stat cached paths: " << 0
-               << "\n";
-
   return 1;
 }
 

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -617,10 +617,12 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DependencyScannerFSOutOfDateEntry,
                                    CXDepScanFSOutOfDateEntry)
 
 CXDepScanFSOutOfDateEntrySet
-clang_experimental_DepScanFSCacheOutOfEntrySet_getSet(
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
     CXDependencyScannerService S) {
   DependencyScanningService &Service = *unwrap(S);
 
+  // FIXME: CAS FS currently does not use the shared cache, and cannot produce
+  // the same diagnostics. We should add such a diagnostics to CAS as well.
   if (Service.useCASFS())
     return nullptr;
 
@@ -636,20 +638,20 @@ clang_experimental_DepScanFSCacheOutOfEntrySet_getSet(
   return wrap(OODEntrySet);
 }
 
-size_t clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries(
+size_t clang_experimental_DepScanFSCacheOutOfDateEntrySet_getNumOfEntries(
     CXDepScanFSOutOfDateEntrySet Entries) {
   return unwrap(Entries)->size();
 }
 
 CXDepScanFSOutOfDateEntry
-clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(
+clang_experimental_DepScanFSCacheOutOfDateEntrySet_getEntry(
     CXDepScanFSOutOfDateEntrySet Entries, size_t Idx) {
   DependencyScannerFSOutOfDateEntrySet *EntSet = unwrap(Entries);
   return wrap(&(*EntSet)[Idx]);
 }
 
 CXDepScanFSCacheOutOfDateKind
-clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(
+clang_experimental_DepScanFSCacheOutOfDateEntry_getKind(
     CXDepScanFSOutOfDateEntry Entry) {
   DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
   auto &Info = E->Info;
@@ -663,7 +665,7 @@ clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(
       Info);
 }
 
-CXString clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath(
+CXString clang_experimental_DepScanFSCacheOutOfDateEntry_getPath(
     CXDepScanFSOutOfDateEntry Entry) {
   return cxstring::createRef(unwrap(Entry)->Path);
 }
@@ -676,19 +678,19 @@ getOutOfDateEntrySizeChangedInfo(DependencyScannerFSOutOfDateEntry *E) {
   return SizeInfo;
 }
 
-uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfDateEntry_getCachedSize(
     CXDepScanFSOutOfDateEntry Entry) {
   DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
   return getOutOfDateEntrySizeChangedInfo(E)->CachedSize;
 }
 
-uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfDateEntry_getActualSize(
     CXDepScanFSOutOfDateEntry Entry) {
   DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
   return getOutOfDateEntrySizeChangedInfo(E)->ActualSize;
 }
 
-void clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet(
+void clang_experimental_DepScanFSCacheOutOfDateEntrySet_disposeSet(
     CXDepScanFSOutOfDateEntrySet Entries) {
   delete unwrap(Entries);
 }

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -566,43 +566,6 @@ CXDiagnosticSet clang_experimental_DepGraph_getDiagnostics(CXDepGraph Graph) {
   return unwrap(Graph)->getDiagnosticSet();
 }
 
-CXCStringArray
-clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths(
-    CXDependencyScannerService S) {
-  DependencyScanningService &Service = unwrap(S)->Service;
-  CStringsManager &StrMgr = unwrap(S)->StrMgr;
-
-  // FIXME: CAS currently does not use the shared cache, and cannot produce
-  // the same diagnostics. We should add such a diagnostics to CAS as well.
-  if (Service.useCASFS())
-    return {nullptr, 0};
-
-  DependencyScanningFilesystemSharedCache &SharedCache =
-      Service.getSharedCache();
-
-  // Note that it is critical that this FS is the same as the default virtual
-  // file system we pass to the DependencyScanningWorkers.
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
-      llvm::vfs::createPhysicalFileSystem();
-
-  auto OutOfDateEntries = SharedCache.getOutOfDateEntries(*FS);
-
-  // FIXME: replace this code with proper APIs that handles the
-  // OutOfDateEntries.
-  std::vector<const char *> OutOfDatePaths;
-  for (const auto &E : OutOfDateEntries)
-    OutOfDatePaths.emplace_back(E.Path);
-
-  // FIXME: This code here creates copies of strings from
-  // InvaidNegStatCachedPaths. It is acceptable because this C-API is expected
-  // to be called only at the end of a CXDependencyScannerService's lifetime.
-  // In other words, it is called very infrequently. We can change
-  // CStringsManager's interface to accommodate handling arbitrary StringRefs
-  // (which may not be null terminated) if we want to avoid copying.
-  return StrMgr.createCStringsOwned(
-      {OutOfDatePaths.begin(), OutOfDatePaths.end()});
-}
-
 static std::string
 lookupModuleOutput(const ModuleDeps &MD, ModuleOutputKind MOK, void *MLOContext,
                    std::variant<CXModuleLookupOutputCallback *,
@@ -644,6 +607,100 @@ std::string OutputLookup::lookupModuleOutput(const ModuleDeps &MD,
   if (PCMPath.second)
     PCMPath.first->second = ::lookupModuleOutput(MD, MOK, MLOContext, MLO);
   return PCMPath.first->second;
+}
+
+namespace {
+typedef std::vector<DependencyScanningFilesystemSharedCache::OutOfDateEntry>
+    DependencyScannerFSOutOfDateEntrySet;
+
+typedef DependencyScanningFilesystemSharedCache::OutOfDateEntry
+    DependencyScannerFSOutOfDateEntry;
+} // namespace
+
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DependencyScannerFSOutOfDateEntrySet,
+                                   CXDepScanFSOutOfDateEntrySet)
+DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DependencyScannerFSOutOfDateEntry,
+                                   CXDepScanFSOutOfDateEntry)
+
+CXDepScanFSOutOfDateEntrySet
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
+    CXDependencyScannerService S) {
+  DependencyScanningService &Service = unwrap(S)->Service;
+
+  if (Service.useCASFS())
+    return nullptr;
+
+  // Note that it is critical that this FS is the same as the default virtual
+  // file system we pass to the DependencyScanningWorkers.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
+      llvm::vfs::createPhysicalFileSystem();
+
+  DependencyScannerFSOutOfDateEntrySet *OODEntrySet =
+      new DependencyScannerFSOutOfDateEntrySet();
+  *OODEntrySet = Service.getSharedCache().getOutOfDateEntries(*FS);
+
+  return wrap(OODEntrySet);
+}
+
+size_t
+clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries(
+    CXDepScanFSOutOfDateEntrySet Entries) {
+  return unwrap(Entries)->size();
+}
+
+CXDepScanFSOutOfDateEntry
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntry(
+    CXDepScanFSOutOfDateEntrySet Entries, size_t Idx) {
+  DependencyScannerFSOutOfDateEntrySet *EntSet = unwrap(Entries);
+  return wrap(&(*EntSet)[Idx]);
+}
+
+CXDepScanFSCacheOutOfDateKind
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind(
+    CXDepScanFSOutOfDateEntry Entry) {
+  DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
+  auto &Info = E->Info;
+  return std::visit(
+      llvm::makeVisitor(
+          [](const DependencyScannerFSOutOfDateEntry::NegativelyCachedInfo
+                 &Info) { return NegativelyCached; },
+          [](const DependencyScannerFSOutOfDateEntry::SizeChangedInfo &Info) {
+            return SizeChanged;
+          }),
+      Info);
+}
+
+CXString
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryPath(
+    CXDepScanFSOutOfDateEntry Entry) {
+  return cxstring::createRef(unwrap(Entry)->Path);
+}
+
+static DependencyScannerFSOutOfDateEntry::SizeChangedInfo *
+getOutOfDateEntrySizeChangedInfo(DependencyScannerFSOutOfDateEntry *E) {
+  auto *SizeInfo =
+      std::get_if<DependencyScannerFSOutOfDateEntry::SizeChangedInfo>(&E->Info);
+  assert(SizeInfo && "Wrong entry kind to get the original size!");
+  return SizeInfo;
+}
+
+uint64_t
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryCachedSize(
+    CXDepScanFSOutOfDateEntry Entry) {
+  DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
+  return getOutOfDateEntrySizeChangedInfo(E)->CachedSize;
+}
+
+uint64_t
+clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryActualSize(
+    CXDepScanFSOutOfDateEntry Entry) {
+  DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
+  return getOutOfDateEntrySizeChangedInfo(E)->ActualSize;
+}
+
+void clang_experimental_DependencyScannerService_disposeFSCacheOutOfDateEntrySet(
+    CXDepScanFSOutOfDateEntrySet Entries) {
+  delete unwrap(Entries);
 }
 
 namespace {

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -623,7 +623,7 @@ DEFINE_SIMPLE_CONVERSION_FUNCTIONS(DependencyScannerFSOutOfDateEntry,
                                    CXDepScanFSOutOfDateEntry)
 
 CXDepScanFSOutOfDateEntrySet
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
+clang_experimental_DepScanFSCacheOutOfEntrySet_getSet(
     CXDependencyScannerService S) {
   DependencyScanningService &Service = unwrap(S)->Service;
 
@@ -642,21 +642,20 @@ clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
   return wrap(OODEntrySet);
 }
 
-size_t
-clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries(
+size_t clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries(
     CXDepScanFSOutOfDateEntrySet Entries) {
   return unwrap(Entries)->size();
 }
 
 CXDepScanFSOutOfDateEntry
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntry(
+clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(
     CXDepScanFSOutOfDateEntrySet Entries, size_t Idx) {
   DependencyScannerFSOutOfDateEntrySet *EntSet = unwrap(Entries);
   return wrap(&(*EntSet)[Idx]);
 }
 
 CXDepScanFSCacheOutOfDateKind
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind(
+clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(
     CXDepScanFSOutOfDateEntry Entry) {
   DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
   auto &Info = E->Info;
@@ -670,8 +669,7 @@ clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind(
       Info);
 }
 
-CXString
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryPath(
+CXString clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath(
     CXDepScanFSOutOfDateEntry Entry) {
   return cxstring::createRef(unwrap(Entry)->Path);
 }
@@ -684,21 +682,19 @@ getOutOfDateEntrySizeChangedInfo(DependencyScannerFSOutOfDateEntry *E) {
   return SizeInfo;
 }
 
-uint64_t
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryCachedSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize(
     CXDepScanFSOutOfDateEntry Entry) {
   DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
   return getOutOfDateEntrySizeChangedInfo(E)->CachedSize;
 }
 
-uint64_t
-clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryActualSize(
+uint64_t clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize(
     CXDepScanFSOutOfDateEntry Entry) {
   DependencyScannerFSOutOfDateEntry *E = unwrap(Entry);
   return getOutOfDateEntrySizeChangedInfo(E)->ActualSize;
 }
 
-void clang_experimental_DependencyScannerService_disposeFSCacheOutOfDateEntrySet(
+void clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet(
     CXDepScanFSOutOfDateEntrySet Entries) {
   delete unwrap(Entries);
 }

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -589,14 +589,14 @@ LLVM_21 {
     clang_Cursor_getGCCAssemblyNumClobbers;
     clang_Cursor_getGCCAssemblyClobber;
     clang_Cursor_isGCCAssemblyVolatile;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_getSet;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize;
-    clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet;
+    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet;
+    clang_experimental_DepScanFSCacheOutOfDateEntrySet_getNumOfEntries;
+    clang_experimental_DepScanFSCacheOutOfDateEntrySet_getEntry;
+    clang_experimental_DepScanFSCacheOutOfDateEntry_getKind;
+    clang_experimental_DepScanFSCacheOutOfDateEntry_getPath;
+    clang_experimental_DepScanFSCacheOutOfDateEntry_getCachedSize;
+    clang_experimental_DepScanFSCacheOutOfDateEntry_getActualSize;
+    clang_experimental_DepScanFSCacheOutOfDateEntrySet_disposeSet;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -577,7 +577,6 @@ LLVM_21 {
     clang_experimental_DepGraphModule_isCWDIgnored;
     clang_experimental_DepGraphModule_isInStableDirs; 
     clang_getFullyQualifiedName;
-    clang_experimental_DependencyScannerService_getInvalidNegStatCachedPaths;
     clang_experimental_DependencyScannerReproducerOptions_create;
     clang_experimental_DependencyScannerReproducerOptions_dispose;
     clang_experimental_DependencyScanner_generateReproducer;
@@ -590,6 +589,14 @@ LLVM_21 {
     clang_Cursor_getGCCAssemblyNumClobbers;
     clang_Cursor_getGCCAssemblyClobber;
     clang_Cursor_isGCCAssemblyVolatile;
+    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet;
+    clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries;
+    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntry;
+    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind;
+    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryPath;
+    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryCachedSize;
+    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryActualSize;
+    clang_experimental_DependencyScannerService_disposeFSCacheOutOfDateEntrySet;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol

--- a/clang/tools/libclang/libclang.map
+++ b/clang/tools/libclang/libclang.map
@@ -589,14 +589,14 @@ LLVM_21 {
     clang_Cursor_getGCCAssemblyNumClobbers;
     clang_Cursor_getGCCAssemblyClobber;
     clang_Cursor_isGCCAssemblyVolatile;
-    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet;
-    clang_experimental_DependencyScannerService_getNumOfFSCacheOutOfDateEntries;
-    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntry;
-    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryKind;
-    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryPath;
-    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryCachedSize;
-    clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntryActualSize;
-    clang_experimental_DependencyScannerService_disposeFSCacheOutOfDateEntrySet;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_getSet;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize;
+    clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet;
 };
 
 # Example of how to add a new symbol version entry.  If you do add a new symbol

--- a/clang/unittests/libclang/CMakeLists.txt
+++ b/clang/unittests/libclang/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_clang_unittest(libclangTests
   LibclangTest.cpp
   DriverTest.cpp
-  DependencyScanningFSCacheOutOfDateTests.cpp
+  DependencyScanningCAPITests.cpp
   LINK_LIBS
   libclang
   )

--- a/clang/unittests/libclang/CMakeLists.txt
+++ b/clang/unittests/libclang/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_clang_unittest(libclangTests
   LibclangTest.cpp
   DriverTest.cpp
+  DependencyScanningFSCacheOutOfDateTests.cpp
   LINK_LIBS
   libclang
   )

--- a/clang/unittests/libclang/DependencyScanningCAPITests.cpp
+++ b/clang/unittests/libclang/DependencyScanningCAPITests.cpp
@@ -1,4 +1,4 @@
-//===- unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp ---- ===//
+//===- unittests/libclang/DependencyScanningCAPITests.cpp ---------------- ===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,7 +14,7 @@ using namespace clang;
 using namespace tooling;
 using namespace dependencies;
 
-TEST(DependencyScanningFSCacheOutOfDate, Basic) {
+TEST(DependencyScanningCAPITests, DependencyScanningFSCacheOutOfDate) {
   DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
                                     ScanningOutputFormat::Full, CASOptions(),
                                     nullptr, nullptr, nullptr);

--- a/clang/unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp
+++ b/clang/unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp
@@ -48,20 +48,22 @@ TEST(DependencyScanningFSCacheOutOfDate, Basic) {
   ASSERT_TRUE(PathExists);
 
   CXDepScanFSOutOfDateEntrySet Entries =
-      clang_experimental_DepScanFSCacheOutOfEntrySet_getSet(
+      clang_experimental_DependencyScannerService_getFSCacheOutOfDateEntrySet(
           reinterpret_cast<CXDependencyScannerService>(&Service));
 
   size_t NumEntries =
-      clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries(Entries);
+      clang_experimental_DepScanFSCacheOutOfDateEntrySet_getNumOfEntries(
+          Entries);
   EXPECT_EQ(NumEntries, 2u);
 
   for (size_t Idx = 0; Idx < NumEntries; Idx++) {
     CXDepScanFSOutOfDateEntry Entry =
-        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(Entries, Idx);
+        clang_experimental_DepScanFSCacheOutOfDateEntrySet_getEntry(Entries,
+                                                                    Idx);
     CXDepScanFSCacheOutOfDateKind Kind =
-        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(Entry);
+        clang_experimental_DepScanFSCacheOutOfDateEntry_getKind(Entry);
     CXString Path =
-        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath(Entry);
+        clang_experimental_DepScanFSCacheOutOfDateEntry_getPath(Entry);
     ASSERT_TRUE(Kind == NegativelyCached || Kind == SizeChanged);
     switch (Kind) {
     case NegativelyCached:
@@ -70,16 +72,14 @@ TEST(DependencyScanningFSCacheOutOfDate, Basic) {
     case SizeChanged:
       ASSERT_STREQ(clang_getCString(Path), File2Path.c_str());
       ASSERT_EQ(
-          clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize(
-              Entry),
+          clang_experimental_DepScanFSCacheOutOfDateEntry_getCachedSize(Entry),
           8u);
       ASSERT_EQ(
-          clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize(
-              Entry),
+          clang_experimental_DepScanFSCacheOutOfDateEntry_getActualSize(Entry),
           0u);
       break;
     }
   }
 
-  clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet(Entries);
+  clang_experimental_DepScanFSCacheOutOfDateEntrySet_disposeSet(Entries);
 }

--- a/clang/unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp
+++ b/clang/unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp
@@ -1,0 +1,85 @@
+//===- unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp ---- ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang-c/Dependencies.h"
+#include "clang/Tooling/DependencyScanning/DependencyScanningService.h"
+#include "gtest/gtest.h"
+
+using namespace clang;
+using namespace tooling;
+using namespace dependencies;
+
+TEST(DependencyScanningFSCacheOutOfDate, Basic) {
+  DependencyScanningService Service(ScanningMode::DependencyDirectivesScan,
+                                    ScanningOutputFormat::Full, CASOptions(),
+                                    nullptr, nullptr, nullptr);
+
+  auto &SharedCache = Service.getSharedCache();
+
+  auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+  DependencyScanningWorkerFilesystem DepFS(SharedCache, InMemoryFS);
+
+  // file1 is negatively stat cached.
+  // file2 has different sizes in the cache and on the physical file system.
+  // The test creates file1 and file2 on the physical file system.
+  // Service's cache is setup to use an in-memory file system so we
+  // can leave out file1 and have a file2 with size 8 (instead of 0).
+  int fd;
+  llvm::SmallString<128> File1Path;
+  llvm::SmallString<128> File2Path;
+  auto EC = llvm::sys::fs::createTemporaryFile("file1", "h", fd, File1Path);
+  ASSERT_FALSE(EC);
+  EC = llvm::sys::fs::createTemporaryFile("file2", "h", fd, File2Path);
+  ASSERT_FALSE(EC);
+
+  // Trigger negative stat caching on DepFS.
+  bool PathExists = DepFS.exists(File1Path);
+  ASSERT_FALSE(PathExists);
+
+  // Add file2 to the in memory FS with non-zero size.
+  InMemoryFS->addFile(File2Path, 1,
+                      llvm::MemoryBuffer::getMemBuffer("        "));
+  PathExists = DepFS.exists(File2Path);
+  ASSERT_TRUE(PathExists);
+
+  CXDepScanFSOutOfDateEntrySet Entries =
+      clang_experimental_DepScanFSCacheOutOfEntrySet_getSet(
+          reinterpret_cast<CXDependencyScannerService>(&Service));
+
+  size_t NumEntries =
+      clang_experimental_DepScanFSCacheOutOfEntrySet_getNumOfEntries(Entries);
+  EXPECT_EQ(NumEntries, 2u);
+
+  for (size_t Idx = 0; Idx < NumEntries; Idx++) {
+    CXDepScanFSOutOfDateEntry Entry =
+        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(Entries, 0);
+    CXDepScanFSCacheOutOfDateKind Kind =
+        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(Entry);
+    CXString Path =
+        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryPath(Entry);
+    ASSERT_TRUE(Kind == NegativelyCached || Kind == SizeChanged);
+    switch (Kind) {
+    case NegativelyCached:
+      ASSERT_STREQ(clang_getCString(Path), File1Path.c_str());
+      break;
+    case SizeChanged:
+      ASSERT_STREQ(clang_getCString(Path), File2Path.c_str());
+      ASSERT_EQ(
+          clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryCachedSize(
+              Entry),
+          8u);
+      ASSERT_EQ(
+          clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryActualSize(
+              Entry),
+          0u);
+      break;
+    }
+  }
+
+  clang_experimental_DepScanFSCacheOutOfEntrySet_disposeSet(Entries);
+}

--- a/clang/unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp
+++ b/clang/unittests/libclang/DependencyScanningFSCacheOutOfDateTests.cpp
@@ -57,7 +57,7 @@ TEST(DependencyScanningFSCacheOutOfDate, Basic) {
 
   for (size_t Idx = 0; Idx < NumEntries; Idx++) {
     CXDepScanFSOutOfDateEntry Entry =
-        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(Entries, 0);
+        clang_experimental_DepScanFSCacheOutOfEntrySet_getEntry(Entries, Idx);
     CXDepScanFSCacheOutOfDateKind Kind =
         clang_experimental_DepScanFSCacheOutOfEntrySet_getEntryKind(Entry);
     CXString Path =


### PR DESCRIPTION
This PR implements the C-APIs to report a scanning file system cache's out-of-date entries. The C-APIs contains a function to return a set of file system cache out-of-date entries, functions to facilitate looping through all the entries, and reporting the relevant information from the entries. 

The APIs are based on https://github.com/llvm/llvm-project/pull/144105. 

rdar://152247357