### PR TITLE
[NFC][lldb] Adapt LLDB to RemoteInspection's RemoteAddress changes

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -52,7 +52,6 @@ private:
 class LLDBMemoryReader : public swift::remote::MemoryReader {
 public:
 
-
   LLDBMemoryReader(Process &p,
                    std::function<swift::remote::RemoteAbsolutePointer(
                        swift::remote::RemoteAbsolutePointer)>
@@ -122,7 +121,6 @@ private:
   std::optional<Address>
   resolveRemoteAddressFromSymbolObjectFile(uint64_t address) const;
 
-private:
   Process &m_process;
   size_t m_max_read_amount;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1438,7 +1438,7 @@ llvm::Expected<std::string> SwiftLanguageRuntime::GetEnumCaseName(
 
   auto *eti = llvm::cast<EnumTypeInfo>(ti);
   auto buffer_holder = PushLocalBuffer((int64_t)data.GetDataStart(), data.GetByteSize());
-  RemoteAddress addr(data.GetDataStart());
+  RemoteAddress addr = RemoteAddress((uint64_t)data.GetDataStart(), swift::reflection::RemoteAddress::DefaultAddressSpace);
   int case_index;
   if (eti->projectEnumValue(*GetMemoryReader(), addr, &case_index))
     return eti->getCases()[case_index].Name;
@@ -1551,7 +1551,7 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
     }
   }
 
-  swift::reflection::RemoteAddress remote_addr(addr);
+  auto remote_addr = swift::reflection::RemoteAddress(addr, 0);
   int case_index;
   auto *eti = llvm::cast<swift::reflection::EnumTypeInfo>(ti);
   if (!eti->projectEnumValue(*GetMemoryReader(), remote_addr, &case_index))
@@ -2037,7 +2037,7 @@ CompilerType SwiftLanguageRuntime::GetDynamicTypeAndAddress_EmbeddedClass(
   if (pointer->getSymbol().empty() || pointer->getOffset()) {
     // Find the symbol name at this address.
     Address address;
-    address.SetLoadAddress(pointer->getResolvedAddress().getAddressData(),
+    address.SetLoadAddress(pointer->getResolvedAddress().getRawAddress(),
                            &GetProcess().GetTarget());
     Symbol *symbol = address.CalculateSymbolContextSymbol();
     if (!symbol)
@@ -2292,7 +2292,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
           existential_address,
           llvm::expectedToOptional(in_value.GetByteSize()).value_or(0));
 
-    swift::remote::RemoteAddress remote_existential(existential_address);
+    auto remote_existential = swift::remote::RemoteAddress(
+        existential_address, swift::remote::RemoteAddress::DefaultAddressSpace);
 
     ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
     if (!reflection_ctx)
@@ -2317,7 +2318,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
       }
 
       const swift::reflection::TypeRef *typeref;
-      swift::remote::RemoteAddress out_address(nullptr);
+      swift::remote::RemoteAddress out_address;
       std::tie(typeref, out_address) = *pair;
 
       auto ts = tss->GetTypeSystemSwiftTypeRef();
@@ -2326,7 +2327,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
       swift::Demangle::Demangler dem;
       swift::Demangle::NodePointer node = typeref->getDemangling(dem);
       dynamic_type = ts->RemangleAsType(dem, node, flavor);
-      dynamic_address = out_address.getAddressData();
+      dynamic_address = out_address.getRawAddress();
     } else {
       // In the embedded Swift case, the existential container just points to
       // the instance.
@@ -2341,7 +2342,7 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
       uint64_t address = 0;
       if (maybe_addr_or_symbol->getSymbol().empty() &&
           maybe_addr_or_symbol->getOffset() == 0) {
-        address = maybe_addr_or_symbol->getResolvedAddress().getAddressData();
+        address = maybe_addr_or_symbol->getResolvedAddress().getRawAddress();
       } else {
         SymbolContextList sc_list;
         auto &module_list = GetProcess().GetTarget().GetImages();
@@ -2360,7 +2361,8 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
           GetDynamicTypeAndAddress_EmbeddedClass(address, existential_type);
       if (!dynamic_type)
         return false;
-      dynamic_address = maybe_addr_or_symbol->getResolvedAddress().getAddressData();
+      dynamic_address =
+          maybe_addr_or_symbol->getResolvedAddress().getRawAddress();
     }
     class_type_or_name.SetCompilerType(dynamic_type);
     address.SetRawAddress(dynamic_address);
@@ -2829,7 +2831,9 @@ Value::ValueType SwiftLanguageRuntime::GetValueType(
 
       // Read the value witness table and check if the data is inlined in
       // the existential container or not.
-      swift::remote::RemoteAddress remote_existential(existential_address);
+      auto remote_existential = swift::remote::RemoteAddress(
+          existential_address,
+          swift::remote::RemoteAddress::DefaultAddressSpace);
       if (ThreadSafeReflectionContext reflection_ctx = GetReflectionContext()) {
         std::optional<bool> is_inlined =
             reflection_ctx->IsValueInlinedInExistentialContainer(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeRemoteAST.cpp
@@ -106,7 +106,7 @@ std::optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffsetRemoteAST(
 
   // Dig out metadata describing the type, if it's easy to find.
   // FIXME: the Remote AST library should make this easier.
-  swift::remote::RemoteAddress optmeta(nullptr);
+  swift::remote::RemoteAddress optmeta;
   const swift::TypeKind type_kind = swift_type->getKind();
   switch (type_kind) {
   case swift::TypeKind::Class:
@@ -119,13 +119,14 @@ std::optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffsetRemoteAST(
       lldb::addr_t pointer = instance->GetPointerValue();
       if (!pointer || pointer == LLDB_INVALID_ADDRESS)
         break;
-      swift::remote::RemoteAddress address(pointer);
+      auto address = swift::remote::RemoteAddress(
+          pointer, swift::remote::RemoteAddress::DefaultAddressSpace);
       if (auto metadata = remote_ast->getHeapMetadataForObject(address))
         optmeta = metadata.getValue();
     }
     LLDB_LOGF(GetLog(LLDBLog::Types),
               "[MemberVariableOffsetResolver] optmeta = 0x%" PRIx64,
-              optmeta.getAddressData());
+              optmeta.getRawAddress());
     break;
   }
 
@@ -201,8 +202,9 @@ ConstString SwiftLanguageRuntime::GetDynamicTypeName_ClassRemoteAST(
     return {};
 
   auto &remote_ast = GetRemoteASTContext(*swift_ast_ctx);
-  auto remote_ast_metadata_address = remote_ast.getHeapMetadataForObject(
-      swift::remote::RemoteAddress(instance_ptr));
+  auto remote_ast_metadata_address =
+      remote_ast.getHeapMetadataForObject(swift::remote::RemoteAddress(
+          instance_ptr, swift::remote::RemoteAddress::DefaultAddressSpace));
   if (remote_ast_metadata_address) {
     auto instance_type = remote_ast.getTypeForRemoteTypeMetadata(
         remote_ast_metadata_address.getValue(),
@@ -239,7 +241,8 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialRemoteAST(
   if (!swift_ast_ctx)
     return {};
 
-  swift::remote::RemoteAddress remote_existential(existential_address);
+  auto remote_existential = swift::remote::RemoteAddress(
+      existential_address, swift::remote::RemoteAddress::DefaultAddressSpace);
   auto &remote_ast = GetRemoteASTContext(*swift_ast_ctx);
   auto swift_type =
       llvm::expectedToStdOptional(swift_ast_ctx->GetSwiftType(existential_type))
@@ -262,7 +265,7 @@ SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialRemoteAST(
 
   CompilerType type = ToCompilerType(type_and_address.InstanceType);
   Address address;
-  address.SetRawAddress(type_and_address.PayloadAddress.getAddressData());
+  address.SetRawAddress(type_and_address.PayloadAddress.getRawAddress());
   return {{type, address}};
 }
 #endif
@@ -377,7 +380,9 @@ SwiftLanguageRuntime::BindGenericTypeParametersRemoteAST(
                                       ->getAs<swift::GenericTypeParamType>();
               auto underlying_type_result =
                   remote_ast.getUnderlyingTypeForOpaqueType(
-                      swift::remote::RemoteAddress(addr),
+                      swift::remote::RemoteAddress(
+                          addr,
+                          swift::remote::RemoteAddress::DefaultAddressSpace),
                       opaque_type->getSubstitutions(),
                       genericParam->getIndex());
 
@@ -474,8 +479,9 @@ CompilerType SwiftLanguageRuntime::MetadataPromise::FulfillTypePromise(
   }
   auto &remote_ast = m_swift_runtime.GetRemoteASTContext(*swift_ast_ctx);
   swift::remoteAST::Result<swift::Type> result =
-      remote_ast.getTypeForRemoteTypeMetadata(
-          swift::remote::RemoteAddress(m_metadata_location));
+      remote_ast.getTypeForRemoteTypeMetadata(swift::remote::RemoteAddress(
+          m_metadata_location,
+          swift::remote::RemoteAddress::DefaultAddressSpace));
 
   if (result) {
     m_compiler_type = {swift_ast_ctx->weak_from_this(),

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftMetadataCache.cpp
@@ -172,8 +172,9 @@ SwiftMetadataCache::generateHashTableBlob(
     auto &mangled_name = std::get<1>(pair);
     if (mangled_name.empty())
       continue;
-    auto offset = field_descriptor.getAddressData() -
-                  field_descriptors.startAddress().getAddressData();
+    auto offset =
+        field_descriptor.getRemoteAddress().getRawAddress() -
+        field_descriptors.startAddress().getRemoteAddress().getRawAddress();
     table_generator.insert(mangled_name, offset, m_info);
   }
 


### PR DESCRIPTION
Adapts LLDB to the new field in RemoteAddress. This is an NFC that
maintains the current behavior. A follow up patch will be introduced
later that takes advantage of the new behavior to fix a bug in reading
metadata from files instead of the process.

rdar://148361743