### PR TITLE
[lldb] Script determinism of TestSwiftActorUnprioritisedJobs (#10435)

### DIFF
--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -7,21 +7,21 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @skipUnlessFoundation
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""
         self.build()
-        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
-            self, "break here", lldb.SBFileSpec("main.swift")
-        )
-        frame = thread.GetSelectedFrame()
+        _, _, thread, _ = lldbutil.run_to_name_breakpoint(self, "breakHere")
+
+        frame = thread.frames[0]
+        self.assertEqual(frame.var("a.data").unsigned, 15)
+
         defaultActor = frame.var("a.$defaultActor")
         self.assertEqual(defaultActor.summary, "running")
+
         unprioritised_jobs = defaultActor.GetChildMemberWithName("unprioritised_jobs")
         # There are 4 child tasks (async let), the first one occupies the actor
-        # with a sleep, the next 3 go on to the queue.
-        # TODO: rdar://148377173
-        # self.assertEqual(unprioritised_jobs.num_children, 3)
+        # with a call to readLine, the next 3 go on the queue.
+        self.assertEqual(unprioritised_jobs.num_children, 3)
         for job in unprioritised_jobs:
             self.assertRegex(job.name, r"^\d+")
-            self.assertRegex(job.summary, r"^id:\d+ flags:\S+")
+            self.assertRegex(job.summary, r"^id:[1-9]\d* flags:\S+")

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/main.swift
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/main.swift
@@ -1,10 +1,8 @@
-import Foundation
-
 actor Actor {
     var data: Int = 15
 
     func occupy() async {
-        Thread.sleep(forTimeInterval: 100)
+        _ = readLine()
     }
 
     func work() async -> Int {
@@ -14,13 +12,25 @@ actor Actor {
     }
 }
 
+func breakHere(_ a: Actor) {}
+
 @main struct Entry {
     static func main() async {
         let a = Actor()
-        async let _ = a.occupy()
-        async let _ = a.work()
-        async let _ = a.work()
-        async let _ = a.work()
-        print("break here")
+
+        async let w: Void = a.occupy()
+        // Provide time for the global concurrent executor to run this async
+        // let, which enqueues a "blocking" job on the actor.
+        try? await Task.sleep(for: .seconds(2))
+
+        async let x = a.work()
+        async let y = a.work()
+        async let z = a.work()
+        // Provide time for the global concurrent executor to kick off of these
+        // async let tasks, which in turn enqueue jobs on the busy actor.
+        try? await Task.sleep(for: .seconds(2))
+
+        breakHere(a)
+        await print(w, x, y, z)
     }
 }


### PR DESCRIPTION
* [lldb] Make TestSwiftActorUnprioritisedJobs deterministic

* Run and show `bt all`

* Attempt forward progress of other threads

* Add missing thread.Suspend()

* Unconditionally run other threads

* Increase sleep wait

* Add actor call to hopefully initialize swift concurrency threads

* New algorithm to ensure actor is sufficiently setup

Credit Adrian for the idea.

* Add IsValid asserts

* New approach did not work, restore previous

* Another round of changes

* Remove dead test code; Run the test 20x

* Pause to allow for occupy() call

* Remove stress testing of multiple test runs

(cherry picked from commit 14ea9a3ebd8c02493b6161f835d02985bee15e56)

(cherry-picked from commit 9a32a3a538ec30e8252c4d6be71d17d1b289ce29)