### PR TITLE
[Cherry-pick into next] [lldb] Add missing case to switch and turn on -Werror=switch for TypeSystemSwift (#10935)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -13,3 +13,9 @@ add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
   LINK_COMPONENTS
     Support
 )
+
+# Enforce synchronization between Swift compiler updates and LLDB via PR testing.
+check_cxx_compiler_flag("-Werror=switch" CXX_SUPPORTS_ERROR_SWITCH)
+if (CXX_SUPPORTS_ERROR_SWITCH)
+  target_compile_options(lldbPluginTypeSystemSwift PRIVATE -Werror=switch)
+endif()

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4851,6 +4851,7 @@ static SwiftASTContext::TypeOrDecl DeclToTypeOrDecl(swift::Decl *decl) {
     case swift::DeclKind::Module:
     case swift::DeclKind::Missing:
     case swift::DeclKind::MissingMember:
+    case swift::DeclKind::Using:
       break;
 
     case swift::DeclKind::InfixOperator:


### PR DESCRIPTION
```
commit df9ea01ef38e3232a0d705f2a3a50c657a5b1e01
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jul 1 07:58:37 2025 -0700

    [lldb] Add missing case to switch and turn on -Werror=switch for TypeSystemSwift (#10935)
```
