### PR TITLE
Fix deprecation warnings for ArrayRef(std::nullopt)

### DIFF
--- a/clang/include/clang/Driver/Job.h
+++ b/clang/include/clang/Driver/Job.h
@@ -269,7 +269,7 @@ public:
                     ResponseFileSupport ResponseSupport, const char *Executable,
                     const llvm::opt::ArgStringList &Arguments,
                     ArrayRef<InputInfo> Inputs,
-                    ArrayRef<InputInfo> Outputs = std::nullopt);
+                    ArrayRef<InputInfo> Outputs = {});
 
   void Print(llvm::raw_ostream &OS, const char *Terminator, bool Quote,
              CrashReportInfo *CrashInfo = nullptr) const override;

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -682,7 +682,7 @@ Expected<llvm::cas::ObjectRef> ObjectStoreCachingOutputs::writeOutputs(
     return SerialDiags.takeError();
   if (*SerialDiags) {
     Expected<llvm::cas::ObjectRef> DiagsRef =
-        CAS->storeFromString(std::nullopt, **SerialDiags);
+        CAS->storeFromString({}, **SerialDiags);
     if (!DiagsRef)
       return DiagsRef.takeError();
     CachedResultBuilder.addOutput(OutputKind::SerializedDiagnostics, *DiagsRef);

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -52,17 +52,14 @@ static llvm::cas::CASID createCompileJobCacheKeyForArgs(
     Builder.push(InputRef, llvm::cas::TreeEntry::Tree, "object");
     break;
   }
-  Builder.push(
-      llvm::cantFail(CAS.storeFromString(std::nullopt, CommandLine)),
-      llvm::cas::TreeEntry::Regular, "command-line");
-  Builder.push(
-      llvm::cantFail(CAS.storeFromString(std::nullopt, "-cc1")),
-      llvm::cas::TreeEntry::Regular, "computation");
+  Builder.push(llvm::cantFail(CAS.storeFromString({}, CommandLine)),
+               llvm::cas::TreeEntry::Regular, "command-line");
+  Builder.push(llvm::cantFail(CAS.storeFromString({}, "-cc1")),
+               llvm::cas::TreeEntry::Regular, "computation");
 
   // FIXME: The version is maybe insufficient...
-  Builder.push(
-      llvm::cantFail(CAS.storeFromString(std::nullopt, getClangFullVersion())),
-      llvm::cas::TreeEntry::Regular, "version");
+  Builder.push(llvm::cantFail(CAS.storeFromString({}, getClangFullVersion())),
+               llvm::cas::TreeEntry::Regular, "version");
 
   return llvm::cantFail(Builder.create(CAS)).getID();
 }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1553,7 +1553,7 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
       llvm::cas::TreeSchema Schema(*CAS);
       // If we cannot create an empty tree, fall back to creating an empty
       // in-memory CAS.
-      if (llvm::Error E = Schema.create(std::nullopt).moveInto(EmptyRootID)) {
+      if (llvm::Error E = Schema.create({}).moveInto(EmptyRootID)) {
         consumeError(std::move(E));
         CAS = nullptr;
       }
@@ -1562,7 +1562,7 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
     if (!CAS) {
       CAS = llvm::cas::createInMemoryCAS();
       llvm::cas::TreeSchema Schema(*CAS);
-      EmptyRootID = llvm::cantFail(Schema.create(std::nullopt));
+      EmptyRootID = llvm::cantFail(Schema.create({}));
     }
     return llvm::cantFail(
         llvm::cas::createCASFileSystem(std::move(CAS), *EmptyRootID));

--- a/clang/lib/Index/IndexRecordReader.cpp
+++ b/clang/lib/Index/IndexRecordReader.cpp
@@ -247,7 +247,7 @@ struct IndexRecordReader::Implementation {
             llvm::function_ref<bool(const IndexRecordOccurrence &)> receiver) {
     // FIXME: Use binary search and make this more efficient.
     unsigned lineEnd = lineStart+lineCount;
-    return foreachOccurrence(std::nullopt, std::nullopt,
+    return foreachOccurrence({}, {},
                              [&](const IndexRecordOccurrence &occur) -> bool {
                                if (occur.Line > lineEnd)
                                  return false; // we're done.
@@ -426,7 +426,7 @@ bool IndexRecordReader::foreachOccurrence(
 
 bool IndexRecordReader::foreachOccurrence(
             llvm::function_ref<bool(const IndexRecordOccurrence &)> Receiver) {
-  return foreachOccurrence(std::nullopt, std::nullopt, std::move(Receiver));
+  return foreachOccurrence({}, {}, std::move(Receiver));
 }
 
 bool IndexRecordReader::foreachOccurrenceInLineRange(unsigned lineStart,

--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningCASFilesystem.cpp
@@ -72,7 +72,7 @@ storeDepDirectives(cas::ObjectStore &CAS,
     TokenIdx += Directive.Tokens.size();
   }
 
-  return CAS.storeFromString(std::nullopt, Buffer);
+  return CAS.storeFromString({}, Buffer);
 }
 
 template <typename T> static void readle(StringRef &Slice, T &Out) {
@@ -139,17 +139,17 @@ void DependencyScanningCASFilesystem::scanForDirectives(
 
   // Get a blob for the clang version string.
   if (!ClangFullVersionID)
-    ClangFullVersionID = reportAsFatalIfError(
-        CAS.storeFromString(std::nullopt, getClangFullVersion()));
+    ClangFullVersionID =
+        reportAsFatalIfError(CAS.storeFromString({}, getClangFullVersion()));
 
   // Get a blob for the dependency directives scan command.
   if (!DepDirectivesID)
     DepDirectivesID =
-        reportAsFatalIfError(CAS.storeFromString(std::nullopt, "directives"));
+        reportAsFatalIfError(CAS.storeFromString({}, "directives"));
 
   // Get an empty blob.
   if (!EmptyBlobID)
-    EmptyBlobID = reportAsFatalIfError(CAS.storeFromString(std::nullopt, ""));
+    EmptyBlobID = reportAsFatalIfError(CAS.storeFromString({}, ""));
 
   // Construct a tree for the input.
   std::optional<CASID> InputID;

--- a/llvm/include/llvm/CAS/TreeSchema.h
+++ b/llvm/include/llvm/CAS/TreeSchema.h
@@ -55,7 +55,7 @@ public:
   Expected<TreeProxy> load(ObjectRef Object) const;
   Expected<TreeProxy> load(ObjectProxy Object) const;
 
-  Expected<TreeProxy> create(ArrayRef<NamedTreeEntry> Entries = std::nullopt);
+  Expected<TreeProxy> create(ArrayRef<NamedTreeEntry> Entries = {});
 
 private:
   static constexpr StringLiteral SchemaName = "llvm::cas::schema::tree::v1";

--- a/llvm/lib/CAS/BuiltinCAS.h
+++ b/llvm/lib/CAS/BuiltinCAS.h
@@ -37,8 +37,7 @@ public:
   virtual Expected<ObjectRef>
   storeFromNullTerminatedRegion(ArrayRef<uint8_t> ComputedHash,
                                 sys::fs::mapped_file_region Map) {
-    return storeImpl(ComputedHash, std::nullopt,
-                     ArrayRef(Map.data(), Map.size()));
+    return storeImpl(ComputedHash, {}, ArrayRef(Map.data(), Map.size()));
   }
 
   /// Both builtin CAS implementations provide lifetime for free, so this can

--- a/llvm/lib/CAS/CASOutputBackend.cpp
+++ b/llvm/lib/CAS/CASOutputBackend.cpp
@@ -57,8 +57,7 @@ CASOutputBackend::createFileImpl(StringRef ResolvedPath,
   return std::make_unique<CASOutputFile>(
       ResolvedPath, [&](StringRef Path, StringRef Bytes) -> Error {
         std::optional<ObjectRef> BytesRef;
-        if (Error E =
-                CAS.storeFromString(std::nullopt, Bytes).moveInto(BytesRef))
+        if (Error E = CAS.storeFromString({}, Bytes).moveInto(BytesRef))
           return E;
         addObject(Path, *BytesRef);
         return Error::success();

--- a/llvm/lib/CAS/CASProvidingFileSystem.cpp
+++ b/llvm/lib/CAS/CASProvidingFileSystem.cpp
@@ -43,7 +43,7 @@ public:
                                             /*RequiresNullTerminator*/ false);
     if (!Buffer)
       return Buffer.getError();
-    auto Blob = DB->storeFromString(std::nullopt, (*Buffer)->getBuffer());
+    auto Blob = DB->storeFromString({}, (*Buffer)->getBuffer());
     if (!Blob)
       return errorToErrorCode(Blob.takeError());
     return *Blob;

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -364,7 +364,7 @@ Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::makeSymlinkTo(DirectoryEntry &Parent,
                                            StringRef TreePath,
                                            StringRef Target) {
-  Expected<ObjectRef> Node = DB.storeFromString(std::nullopt, Target);
+  Expected<ObjectRef> Node = DB.storeFromString({}, Target);
   if (!Node)
     return Node.takeError();
   return &Cache->makeSymlink(Parent, TreePath, *Node, Target);

--- a/llvm/lib/CAS/InMemoryCAS.cpp
+++ b/llvm/lib/CAS/InMemoryCAS.cpp
@@ -287,7 +287,7 @@ InMemoryCAS::storeFromNullTerminatedRegion(ArrayRef<uint8_t> ComputedHash,
     return Objects.Allocate(Size, alignof(InMemoryObject));
   };
   auto Generator = [&]() -> const InMemoryObject * {
-    return &InMemoryRefObject::create(Allocator, I, std::nullopt, Data);
+    return &InMemoryRefObject::create(Allocator, I, {}, Data);
   };
   const InMemoryObject &Node =
       cast<InMemoryObject>(I.Data.loadOrGenerate(Generator));

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -191,7 +191,7 @@ ObjectStore::storeFromOpenFileImpl(sys::fs::file_t FD,
   Data.reserve(ChunkSize * 2);
   if (Error E = sys::fs::readNativeFileToEOF(FD, Data, ChunkSize))
     return std::move(E);
-  return store(std::nullopt, ArrayRef(Data.data(), Data.size()));
+  return store({}, ArrayRef(Data.data(), Data.size()));
 }
 
 Error ObjectStore::validateTree(ObjectRef Root) {

--- a/llvm/lib/CAS/TreeSchema.cpp
+++ b/llvm/lib/CAS/TreeSchema.cpp
@@ -32,7 +32,7 @@ bool TreeSchema::isNode(const ObjectProxy &Node) const {
 }
 
 TreeSchema::TreeSchema(cas::ObjectStore &CAS) : TreeSchema::RTTIExtends(CAS) {
-  TreeKindRef = cantFail(CAS.storeFromString(std::nullopt, SchemaName));
+  TreeKindRef = cantFail(CAS.storeFromString({}, SchemaName));
 }
 
 ObjectRef TreeSchema::getKindRef() const { return *TreeKindRef; }

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -523,7 +523,7 @@ static cas::CASID createCASProxyOrAbort(cas::ObjectStore &CAS, StringRef Key) {
   // the correct context.
   // TODO: We can have an alternative hashing function that doesn't need to
   // store the key into CAS to get the CacheKey.
-  auto CASKey = CAS.createProxy(std::nullopt, Key);
+  auto CASKey = CAS.createProxy({}, Key);
   if (!CASKey)
     report_fatal_error(CASKey.takeError());
   return CASKey->getID();

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -164,8 +164,7 @@ MCSchema::MCSchema(cas::ObjectStore &CAS) : MCSchema::RTTIExtends(CAS) {
 Error MCSchema::fillCache() {
   std::optional<cas::ObjectRef> RootKindID;
   const unsigned Version = 0; // Bump this to error on old object files.
-  if (Error E = CAS.storeFromString(std::nullopt,
-                                    "mc:v1:schema:" + Twine(Version).str())
+  if (Error E = CAS.storeFromString({}, "mc:v1:schema:" + Twine(Version).str())
                     .moveInto(RootKindID))
     return E;
 

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -357,8 +357,7 @@ int makeBlob(ObjectStore &CAS, StringRef DataPath) {
   ExitOnError ExitOnErr("llvm-cas: make-blob: ");
   std::unique_ptr<MemoryBuffer> Buffer = ExitOnErr(openBuffer(DataPath));
 
-  ObjectProxy Blob =
-      ExitOnErr(CAS.createProxy(std::nullopt, Buffer->getBuffer()));
+  ObjectProxy Blob = ExitOnErr(CAS.createProxy({}, Buffer->getBuffer()));
   llvm::outs() << Blob.getID() << "\n";
   return 0;
 }

--- a/llvm/unittests/CAS/ActionCacheTest.cpp
+++ b/llvm/unittests/CAS/ActionCacheTest.cpp
@@ -22,8 +22,7 @@ TEST_P(CASTest, ActionCacheHit) {
   std::unique_ptr<ActionCache> Cache = createActionCache();
 
   std::optional<ObjectProxy> ID;
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID),
-                    Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID), Succeeded());
   std::optional<CASID> ResultID;
   ASSERT_THAT_ERROR(Cache->put(*ID, *ID), Succeeded());
   ASSERT_THAT_ERROR(Cache->get(*ID).moveInto(ResultID), Succeeded());
@@ -38,10 +37,8 @@ TEST_P(CASTest, ActionCacheMiss) {
   std::unique_ptr<ActionCache> Cache = createActionCache();
 
   std::optional<ObjectProxy> ID1, ID2;
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID1),
-                    Succeeded());
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "2").moveInto(ID2),
-                    Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "2").moveInto(ID2), Succeeded());
   ASSERT_THAT_ERROR(Cache->put(*ID1, *ID2), Succeeded());
   // This is a cache miss for looking up a key doesn't exist.
   std::optional<CASID> Result1;
@@ -63,10 +60,8 @@ TEST_P(CASTest, ActionCacheRewrite) {
   std::unique_ptr<ActionCache> Cache = createActionCache();
 
   std::optional<ObjectProxy> ID1, ID2;
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID1),
-                    Succeeded());
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "2").moveInto(ID2),
-                    Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "2").moveInto(ID2), Succeeded());
   ASSERT_THAT_ERROR(Cache->put(*ID1, *ID1), Succeeded());
   // Writing to the same key with different value is error.
   ASSERT_THAT_ERROR(Cache->put(*ID1, *ID2), Failed());
@@ -81,12 +76,9 @@ TEST(OnDiskActionCache, ActionCacheResultInvalid) {
   std::unique_ptr<ObjectStore> CAS2 = createInMemoryCAS();
 
   std::optional<ObjectProxy> ID1, ID2, ID3;
-  ASSERT_THAT_ERROR(CAS1->createProxy(std::nullopt, "1").moveInto(ID1),
-                    Succeeded());
-  ASSERT_THAT_ERROR(CAS1->createProxy(std::nullopt, "2").moveInto(ID2),
-                    Succeeded());
-  ASSERT_THAT_ERROR(CAS2->createProxy(std::nullopt, "1").moveInto(ID3),
-                    Succeeded());
+  ASSERT_THAT_ERROR(CAS1->createProxy({}, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS1->createProxy({}, "2").moveInto(ID2), Succeeded());
+  ASSERT_THAT_ERROR(CAS2->createProxy({}, "1").moveInto(ID3), Succeeded());
 
   std::unique_ptr<ActionCache> Cache1 =
       cantFail(createOnDiskActionCache(Temp.path()));
@@ -115,8 +107,7 @@ TEST_P(CASTest, ActionCacheAsync) {
 
   {
     std::optional<ObjectProxy> ID;
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID),
-                      Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID), Succeeded());
     auto PutFuture = Cache->putFuture(*ID, *ID);
     ASSERT_THAT_ERROR(PutFuture.get().take(), Succeeded());
     auto GetFuture = Cache->getFuture(*ID);
@@ -126,8 +117,7 @@ TEST_P(CASTest, ActionCacheAsync) {
   }
 
   std::optional<ObjectProxy> ID2;
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "2").moveInto(ID2),
-                    Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "2").moveInto(ID2), Succeeded());
   {
     std::promise<AsyncErrorValue> Promise;
     auto Future = Promise.get_future();

--- a/llvm/unittests/CAS/CASFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASFileSystemTest.cpp
@@ -43,7 +43,7 @@ bufferHasContent(ErrorOr<std::unique_ptr<MemoryBuffer>> ErrorOrBuffer,
 }
 
 static ObjectRef createBlobUnchecked(ObjectStore &CAS, StringRef Content) {
-  return llvm::cantFail(CAS.storeFromString(std::nullopt, Content));
+  return llvm::cantFail(CAS.storeFromString({}, Content));
 }
 
 static Expected<ObjectProxy> createEmptyTree(ObjectStore &CAS) {

--- a/llvm/unittests/CAS/CASOutputBackendTest.cpp
+++ b/llvm/unittests/CAS/CASOutputBackendTest.cpp
@@ -32,12 +32,10 @@ TEST(CASOutputBackendTest, createFiles) {
 
   std::optional<ObjectProxy> Content1;
   std::optional<ObjectProxy> Content2;
-  ASSERT_THAT_ERROR(
-      CAS->createProxy(std::nullopt, "content1").moveInto(Content1),
-      Succeeded());
-  ASSERT_THAT_ERROR(
-      CAS->createProxy(std::nullopt, "content2").moveInto(Content2),
-      Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "content1").moveInto(Content1),
+                    Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "content2").moveInto(Content2),
+                    Succeeded());
   std::string AbsolutePath1 = "/absolute/path/1";
   std::string AbsolutePath2 = "/absolute/path/2";
   std::string RelativePath = "relative/path/./2";

--- a/llvm/unittests/CAS/HierarchicalTreeBuilderTest.cpp
+++ b/llvm/unittests/CAS/HierarchicalTreeBuilderTest.cpp
@@ -36,7 +36,7 @@ TEST(HierarchicalTreeBuilderTest, Flat) {
   std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
 
   auto make = [&](StringRef Content) {
-    return *expectedToOptional(CAS->storeFromString(std::nullopt, Content));
+    return *expectedToOptional(CAS->storeFromString({}, Content));
   };
 
   HierarchicalTreeBuilder Builder;
@@ -71,7 +71,7 @@ TEST(HierarchicalTreeBuilderTest, Nested) {
   std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
 
   auto make = [&](StringRef Content) {
-    return *expectedToOptional(CAS->storeFromString(std::nullopt, Content));
+    return *expectedToOptional(CAS->storeFromString({}, Content));
   };
 
   HierarchicalTreeBuilder Builder;
@@ -115,7 +115,7 @@ TEST(HierarchicalTreeBuilderTest, MergeDirectories) {
   std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
 
   auto make = [&](StringRef Content) {
-    return *expectedToOptional(CAS->storeFromString(std::nullopt, Content));
+    return *expectedToOptional(CAS->storeFromString({}, Content));
   };
 
   auto createRoot = [&](StringRef Blob, StringRef Path,
@@ -175,7 +175,7 @@ TEST(HierarchicalTreeBuilderTest, MergeDirectoriesConflict) {
   std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
 
   auto make = [&](StringRef Content) {
-    return *expectedToOptional(CAS->storeFromString(std::nullopt, Content));
+    return *expectedToOptional(CAS->storeFromString({}, Content));
   };
 
   auto createRoot = [&](StringRef Blob, StringRef Path,

--- a/llvm/unittests/CAS/ObjectStoreTest.cpp
+++ b/llvm/unittests/CAS/ObjectStoreTest.cpp
@@ -23,10 +23,8 @@ TEST_P(CASTest, PrintIDs) {
   std::shared_ptr<ObjectStore> CAS = createObjectStore();
 
   std::optional<CASID> ID1, ID2;
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID1),
-                    Succeeded());
-  ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "2").moveInto(ID2),
-                    Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
+  ASSERT_THAT_ERROR(CAS->createProxy({}, "2").moveInto(ID2), Succeeded());
   EXPECT_NE(ID1, ID2);
   std::string PrintedID1 = ID1->toString();
   std::string PrintedID2 = ID2->toString();
@@ -58,7 +56,7 @@ multiline text multiline text multiline text multiline text multiline text)",
     // problems if the CAS is storing references to the input string instead of
     // copying it.
     std::optional<ObjectProxy> Blob;
-    ASSERT_THAT_ERROR(CAS1->createProxy(std::nullopt, Content).moveInto(Blob),
+    ASSERT_THAT_ERROR(CAS1->createProxy({}, Content).moveInto(Blob),
                       Succeeded());
     IDs.push_back(Blob->getID());
 
@@ -71,9 +69,8 @@ multiline text multiline text multiline text multiline text multiline text)",
   // Check that the blobs give the same IDs later.
   for (int I = 0, E = IDs.size(); I != E; ++I) {
     std::optional<ObjectProxy> Blob;
-    ASSERT_THAT_ERROR(
-        CAS1->createProxy(std::nullopt, ContentStrings[I]).moveInto(Blob),
-        Succeeded());
+    ASSERT_THAT_ERROR(CAS1->createProxy({}, ContentStrings[I]).moveInto(Blob),
+                      Succeeded());
     EXPECT_EQ(IDs[I], Blob->getID());
   }
 
@@ -103,7 +100,7 @@ multiline text multiline text multiline text multiline text multiline text)",
     auto &ID = IDs[I - 1];
     auto &Content = ContentStrings[I - 1];
     std::optional<ObjectProxy> Blob;
-    ASSERT_THAT_ERROR(CAS2->createProxy(std::nullopt, Content).moveInto(Blob),
+    ASSERT_THAT_ERROR(CAS2->createProxy({}, Content).moveInto(Blob),
                       Succeeded());
     EXPECT_EQ(ID, Blob->getID());
 
@@ -121,19 +118,15 @@ TEST_P(CASTest, BlobsBig) {
   while (String1.size() < 1024U * 1024U) {
     std::optional<CASID> ID1;
     std::optional<CASID> ID2;
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, String1).moveInto(ID1),
-                      Succeeded());
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, String1).moveInto(ID2),
-                      Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, String1).moveInto(ID1), Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, String1).moveInto(ID2), Succeeded());
     ASSERT_THAT_ERROR(CAS->validateObject(*ID1), Succeeded());
     ASSERT_THAT_ERROR(CAS->validateObject(*ID2), Succeeded());
     ASSERT_EQ(ID1, ID2);
 
     String1.append(String2);
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, String2).moveInto(ID1),
-                      Succeeded());
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, String2).moveInto(ID2),
-                      Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, String2).moveInto(ID1), Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, String2).moveInto(ID2), Succeeded());
     ASSERT_THAT_ERROR(CAS->validateObject(*ID1), Succeeded());
     ASSERT_THAT_ERROR(CAS->validateObject(*ID2), Succeeded());
     ASSERT_EQ(ID1, ID2);
@@ -150,8 +143,7 @@ TEST_P(CASTest, BlobsBig) {
   for (size_t Size = InterestingSize - 2; Size != SizeE; ++Size) {
     StringRef Data(Storage.data(), Size);
     std::optional<ObjectProxy> Blob;
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, Data).moveInto(Blob),
-                      Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, Data).moveInto(Blob), Succeeded());
     ASSERT_EQ(Data, Blob->getData());
     ASSERT_EQ(0, Blob->getData().end()[0]);
   }
@@ -178,7 +170,7 @@ multiline text multiline text multiline text multiline text multiline text)",
     // copying it.
     std::optional<ObjectRef> Node;
     ASSERT_THAT_ERROR(
-        CAS1->store(std::nullopt, arrayRefFromStringRef<char>(Content)).moveInto(Node),
+        CAS1->store({}, arrayRefFromStringRef<char>(Content)).moveInto(Node),
         Succeeded());
     Nodes.push_back(*Node);
 
@@ -198,10 +190,10 @@ multiline text multiline text multiline text multiline text multiline text)",
   // Check that the blobs give the same IDs later.
   for (int I = 0, E = IDs.size(); I != E; ++I) {
     std::optional<ObjectRef> Node;
-    ASSERT_THAT_ERROR(CAS1->store(std::nullopt, arrayRefFromStringRef<char>(
-                                                    ContentStrings[I]))
-                          .moveInto(Node),
-                      Succeeded());
+    ASSERT_THAT_ERROR(
+        CAS1->store({}, arrayRefFromStringRef<char>(ContentStrings[I]))
+            .moveInto(Node),
+        Succeeded());
     EXPECT_EQ(IDs[I], CAS1->getID(*Node));
   }
 
@@ -229,7 +221,7 @@ multiline text multiline text multiline text multiline text multiline text)",
     auto &Content = ContentStrings[I - 1];
     std::optional<ObjectRef> Node;
     ASSERT_THAT_ERROR(
-        CAS2->store(std::nullopt, arrayRefFromStringRef<char>(Content)).moveInto(Node),
+        CAS2->store({}, arrayRefFromStringRef<char>(Content)).moveInto(Node),
         Succeeded());
     EXPECT_EQ(ID, CAS2->getID(*Node));
 

--- a/llvm/unittests/CAS/PluginCASTest.cpp
+++ b/llvm/unittests/CAS/PluginCASTest.cpp
@@ -55,10 +55,8 @@ TEST(PluginCASTest, isMaterialized) {
     std::tie(CAS, AC) = std::move(*DBs);
 
     std::optional<CASID> ID1, ID2;
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID1),
-                      Succeeded());
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "2").moveInto(ID2),
-                      Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, "2").moveInto(ID2), Succeeded());
     std::optional<ObjectRef> ID2Ref = CAS->getReference(*ID2);
     ASSERT_TRUE(ID2Ref);
     bool IsMaterialized = false;
@@ -84,8 +82,7 @@ TEST(PluginCASTest, isMaterialized) {
     std::tie(CAS, AC) = std::move(*DBs);
 
     std::optional<CASID> ID1, ID2;
-    ASSERT_THAT_ERROR(CAS->createProxy(std::nullopt, "1").moveInto(ID1),
-                      Succeeded());
+    ASSERT_THAT_ERROR(CAS->createProxy({}, "1").moveInto(ID1), Succeeded());
     ASSERT_THAT_ERROR(AC->get(*ID1, /*Globally=*/true).moveInto(ID2),
                       Succeeded());
     std::optional<ObjectRef> ID2Ref = CAS->getReference(*ID2);

--- a/llvm/unittests/CAS/TreeSchemaTest.cpp
+++ b/llvm/unittests/CAS/TreeSchemaTest.cpp
@@ -24,9 +24,9 @@ TEST(TreeSchemaTest, Trees) {
 
   auto createBlobInBoth = [&](StringRef Content) {
     std::optional<ObjectRef> H1, H2;
-    EXPECT_THAT_ERROR(CAS1->storeFromString(std::nullopt, Content).moveInto(H1),
+    EXPECT_THAT_ERROR(CAS1->storeFromString({}, Content).moveInto(H1),
                       Succeeded());
-    EXPECT_THAT_ERROR(CAS2->storeFromString(std::nullopt, Content).moveInto(H2),
+    EXPECT_THAT_ERROR(CAS2->storeFromString({}, Content).moveInto(H2),
                       Succeeded());
     EXPECT_EQ(CAS1->getID(*H1), CAS2->getID(*H2));
     return *H1;
@@ -193,7 +193,7 @@ TEST(TreeSchemaTest, Trees) {
 TEST(TreeSchemaTest, Lookup) {
   std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
   std::optional<ObjectRef> Node;
-  EXPECT_THAT_ERROR(CAS->storeFromString(std::nullopt, "blob").moveInto(Node),
+  EXPECT_THAT_ERROR(CAS->storeFromString({}, "blob").moveInto(Node),
                     Succeeded());
   ObjectRef Blob = *Node;
   SmallVector<NamedTreeEntry> FlatTreeEntries = {
@@ -228,7 +228,7 @@ TEST(TreeSchemaTest, walkFileTreeRecursively) {
   std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
 
   auto make = [&](StringRef Content) {
-    return cantFail(CAS->storeFromString(std::nullopt, Content));
+    return cantFail(CAS->storeFromString({}, Content));
   };
 
   HierarchicalTreeBuilder Builder;


### PR DESCRIPTION
Fix downstream warnings caused by the deprecation of `ArrayRef(std::nullopt)`.