### PR TITLE
[lldb] Fix task ids in task thread names

### DIFF
--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -13,7 +13,7 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, "break outside", lldb.SBFileSpec("main.swift")
         )
-        self.expect("v task", patterns=[r'"Chore" id:[1-9]\d*'])
+        self.expect("v task", patterns=[r'"Chore" id:[1-9]'])
 
     @swiftTest
     @skipIfLinux  # rdar://151471067
@@ -22,4 +22,4 @@ class TestCase(TestBase):
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "break inside", lldb.SBFileSpec("main.swift")
         )
-        self.assertRegex(thread.name, r"Chore \(Task [1-9]\d*\)")
+        self.assertRegex(thread.name, r"Chore \(Task [1-9]\)")

--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -19,7 +19,7 @@ class TestCase(lldbtest.TestBase):
             self, "BREAK HERE", source_file
         )
 
-        self.assertRegex(thread.GetName(), r"^Task [1-9]\d*$")
+        self.assertRegex(thread.GetName(), r"^Task [1-9]$")
 
         queue_plugin = self.get_queue_from_thread_info_command(False)
         queue_backing = self.get_queue_from_thread_info_command(True)


### PR DESCRIPTION
This change ensures that Task Threads have the name `Task 1`, `Task 2`, ..., instead of `Task 64424509441`, `Task 64424509442`, ...

The fix is to unmask the thread ID to recalculate the original task ID.

rdar://154799101