### PR TITLE
[Frontend] Destroy compiling compiler instance before read

### DIFF
--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -1643,16 +1643,18 @@ static bool compileModuleAndReadASTImpl(CompilerInstance &ImportingInstance,
                                         SourceLocation ModuleNameLoc,
                                         Module *Module,
                                         StringRef ModuleFileName) {
-  auto Instance = ImportingInstance.cloneForModuleCompile(ModuleNameLoc, Module,
-                                                          ModuleFileName);
+  {
+    auto Instance = ImportingInstance.cloneForModuleCompile(ModuleNameLoc, Module,
+                                                            ModuleFileName);
 
-  if (!ImportingInstance.compileModule(ModuleNameLoc,
-                                       Module->getTopLevelModuleName(),
-                                       ModuleFileName, *Instance)) {
-    ImportingInstance.getDiagnostics().Report(ModuleNameLoc,
-                                              diag::err_module_not_built)
-        << Module->Name << SourceRange(ImportLoc, ModuleNameLoc);
-    return false;
+    if (!ImportingInstance.compileModule(ModuleNameLoc,
+                                         Module->getTopLevelModuleName(),
+                                         ModuleFileName, *Instance)) {
+      ImportingInstance.getDiagnostics().Report(ModuleNameLoc,
+                                                diag::err_module_not_built)
+          << Module->Name << SourceRange(ImportLoc, ModuleNameLoc);
+      return false;
+    }
   }
 
   return readASTAfterCompileModule(ImportingInstance, ImportLoc, ModuleNameLoc,


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/134887 added a clone for the compiler instance in `compileModuleAndReadASTImpl`, which would then be destroyed *after* the corresponding read in the importing instance.

Swift has a `SwiftNameLookupExtension` module extension which updates (effectively) global state - populating the lookup table for a module on read and removing it when the module is destroyed.

With newly cloned instance, we would then see:
  - Module compiled with cloned instance
  - Module read with importing instance
  - Lookup table for that module added
  - Cloned instance destroyed
  - Module from that cloned instance destroyed
  - Lookup table for that module name removed

Depending on the original semantics is incredibly fragile, but for now it's good enough to ensure that the read in the importing instance is after the cloned instanced is destroyed. Ideally we'd only ever add to the lookup tables in the original importing instance, never its clones.