### PR TITLE
[lldb] Avoid mangling empty opaque types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2855,6 +2855,13 @@ TypeSystemSwiftTypeRef::RemangleAsType(swift::Demangle::Demangler &dem,
   if (!node)
     return {};
 
+  // Guard against an empty opaque type. This can happen when demangling an
+  // OpaqueTypeRef (ex `$sBpD`). An empty opaque will assert when mangled.
+  if (auto *opaque_type =
+          swift_demangle::ChildAtPath(node, {Node::Kind::OpaqueType}))
+    if (!opaque_type->hasChildren())
+      return {};
+
   using namespace swift::Demangle;
   if (node->getKind() != Node::Kind::Global) {
     auto global = dem.createNode(Node::Kind::Global);


### PR DESCRIPTION
Update `TypeSystemSwiftTypeRef::RemangleAsType` to handle empty opaque types. Without this change, assertions will occur when running unit tests with an asserts-build of lldb.

An example of where this happens is `Builtin.RawPointer` (`$sBpD`). For values with that type, the typeref is:

```
(swift::reflection::OpaqueTypeRef *) typeref = 0x000060000309c000 {
  swift::reflection::TypeRef = {
    Kind = Opaque
  }
}
```

When demangling the above typeref, the resulting demangle tree is an empty `OpaqueType`:

```
(swift::Demangle::NodePointer) node = 0x0000000105240420 Type, 1 child {
  NodeKind = Type
  [0] = 0x0000000105240408 OpaqueType, 0 children {
    NodeKind = OpaqueType
  }
}
```

In Swift's `Remangler::mangleOpaqueType`, it's expected that the opaque type have 3 children:

```cpp
DEMANGLER_ASSERT(node->getNumChildren() >= 3, node);
```