### PR TITLE
Use the root directory as the SDK root on FreeBSD

### DIFF
--- a/lldb/include/lldb/Host/freebsd/HostInfoFreeBSD.h
+++ b/lldb/include/lldb/Host/freebsd/HostInfoFreeBSD.h
@@ -21,6 +21,10 @@ public:
   static llvm::VersionTuple GetOSVersion();
   static std::optional<std::string> GetOSBuildString();
   static FileSpec GetProgramFileSpec();
+
+#ifdef LLDB_ENABLE_SWIFT
+  static llvm::Expected<llvm::StringRef> GetSDKRoot(SDKOptions options); 
+#endif
 };
 }
 

--- a/lldb/source/Host/CMakeLists.txt
+++ b/lldb/source/Host/CMakeLists.txt
@@ -144,6 +144,12 @@ else()
       freebsd/Host.cpp
       freebsd/HostInfoFreeBSD.cpp
       )
+      
+      if(LLDB_ENABLE_SWIFT_SUPPORT)
+        add_host_subdirectory(posix
+	  freebsd/HostInfoFreeBSDSwift.cpp
+          )
+      endif()
 
   elseif (CMAKE_SYSTEM_NAME MATCHES "NetBSD")
     add_host_subdirectory(netbsd

--- a/lldb/source/Host/freebsd/HostInfoFreeBSDSwift.cpp
+++ b/lldb/source/Host/freebsd/HostInfoFreeBSDSwift.cpp
@@ -1,0 +1,25 @@
+//===-- HostInfoFreeBSD.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "lldb/Host/freebsd/HostInfoFreeBSD.h"
+#include "llvm/Support/FormatVariadic.h"
+#include <cstdio>
+#include <cstring>
+#include <optional>
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+using namespace lldb_private;
+
+/// The SDK is the directory where the system C headers, libraries, can be found.
+/// On FreeBSD this is simply the root directory.
+llvm::Expected<llvm::StringRef> HostInfoFreeBSD::GetSDKRoot(SDKOptions options) {
+  return "/";
+}


### PR DESCRIPTION
The Swift REPL needs to know the location of the system libraries and so forth in order to work properly. On FreeBSD, this is just the root directory which lives at /.

We need to implement the appropriate method on `HostInfoFreeBSD` to prevent the use of the default implementation for POSIX platforms which just returns an error. This same fix may need to be made for other platforms as well, but I am not doing so as part of this commit since I lack the ability to test the change for those other platforms.