### PR TITLE
[NFC] Fix test failures

### DIFF
--- a/clang/test/BoundsSafety-legacy-checks/CodeGen/runtime-checks/length-check-bound-check-removal.c
+++ b/clang/test/BoundsSafety-legacy-checks/CodeGen/runtime-checks/length-check-bound-check-removal.c
@@ -16,13 +16,27 @@ void use(int *, int);
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[LEN:%.*]] = getelementptr inbounds nuw i8, ptr [[P]], i64 8
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[LEN]], align 8, !tbaa [[TBAA2:![0-9]+]]
-// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP0]], 2
-// CHECK-NEXT:    br i1 [[CMP]], label [[CLEANUP:%.*]], label [[CONT11:%.*]]
-// CHECK:       cont11:
 // CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[P]], align 8, !tbaa [[TBAA9:![0-9]+]]
+// CHECK-NEXT:    [[IDX_EXT:%.*]] = sext i32 [[TMP0]] to i64
+// CHECK-NEXT:    [[ADD_PTR_IDX:%.*]] = shl nsw i64 [[IDX_EXT]], 2, !annotation [[META10:![0-9]+]]
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i8, ptr [[TMP1]], i64 [[ADD_PTR_IDX]], !annotation [[META12:![0-9]+]]
+// CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP0]], 2
+// CHECK-NEXT:    br i1 [[CMP]], label [[CLEANUP:%.*]], label [[IF_END:%.*]]
+// CHECK:       if.end:
 // CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[TMP1]], i64 4
-// CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[TMP1]], align 4, !tbaa [[TBAA10:![0-9]+]]
-// CHECK-NEXT:    tail call void @use(ptr noundef [[BOUND_PTR_ARITH]], i32 noundef [[TMP2]]) #[[ATTR3:[0-9]+]]
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[TMP1]], align 4, !tbaa [[TBAA13:![0-9]+]]
+// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq ptr [[BOUND_PTR_ARITH]], null, !annotation [[META14:![0-9]+]]
+// CHECK-NEXT:    br i1 [[DOTNOT]], label [[CONT11:%.*]], label [[BOUNDSCHECK_NOTNULL:%.*]], !annotation [[META14]]
+// CHECK:       trap:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3:[0-9]+]], !annotation [[META15:![0-9]+]]
+// CHECK-NEXT:    unreachable, !annotation [[META15]]
+// CHECK:       boundscheck.notnull:
+// CHECK-NEXT:    [[TMP3:%.*]] = icmp ult ptr [[BOUND_PTR_ARITH]], [[ADD_PTR]], !annotation [[META12]]
+// CHECK-NEXT:    [[TMP4:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH]], [[TMP1]], !annotation [[META16:![0-9]+]]
+// CHECK-NEXT:    [[OR_COND13:%.*]] = and i1 [[TMP4]], [[TMP3]], !annotation [[META16]]
+// CHECK-NEXT:    br i1 [[OR_COND13]], label [[CONT11]], label [[TRAP:%.*]], !prof [[PROF17:![0-9]+]], !annotation [[META12]]
+// CHECK:       cont11:
+// CHECK-NEXT:    tail call void @use(ptr noundef [[BOUND_PTR_ARITH]], i32 noundef [[TMP2]]) #[[ATTR4:[0-9]+]]
 // CHECK-NEXT:    br label [[CLEANUP]]
 // CHECK:       cleanup:
 // CHECK-NEXT:    [[RETVAL_0:%.*]] = phi i32 [ 0, [[CONT11]] ], [ -1, [[ENTRY:%.*]] ]
@@ -45,29 +59,41 @@ int access1(S *p) {
 // CHECK-NEXT:    [[TMP0:%.*]] = load i32, ptr [[LEN]], align 8, !tbaa [[TBAA2]]
 // CHECK-NEXT:    [[TMP1:%.*]] = load ptr, ptr [[P]], align 8, !tbaa [[TBAA9]]
 // CHECK-NEXT:    [[IDX_EXT:%.*]] = sext i32 [[TMP0]] to i64
-// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i32, ptr [[TMP1]], i64 [[IDX_EXT]]
+// CHECK-NEXT:    [[ADD_PTR_IDX:%.*]] = shl nsw i64 [[IDX_EXT]], 2, !annotation [[META10]]
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds i8, ptr [[TMP1]], i64 [[ADD_PTR_IDX]], !annotation [[META12]]
 // CHECK-NEXT:    [[CMP:%.*]] = icmp slt i32 [[TMP0]], 2
-// CHECK-NEXT:    br i1 [[CMP]], label [[CLEANUP:%.*]], label [[CONT11:%.*]]
-// CHECK:       trap:
-// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR4:[0-9]+]], !annotation [[META11:![0-9]+]]
-// CHECK-NEXT:    unreachable, !annotation [[META11]]
-// CHECK:       cont11:
+// CHECK-NEXT:    br i1 [[CMP]], label [[CLEANUP:%.*]], label [[IF_END:%.*]]
+// CHECK:       if.end:
 // CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[TMP1]], i64 4
-// CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[TMP1]], align 4, !tbaa [[TBAA10]]
-// CHECK-NEXT:    tail call void @use(ptr noundef [[BOUND_PTR_ARITH]], i32 noundef [[TMP2]]) #[[ATTR3]]
+// CHECK-NEXT:    [[TMP2:%.*]] = load i32, ptr [[TMP1]], align 4, !tbaa [[TBAA13]]
+// CHECK-NEXT:    [[DOTNOT:%.*]] = icmp eq ptr [[BOUND_PTR_ARITH]], null, !annotation [[META14]]
+// CHECK-NEXT:    br i1 [[DOTNOT]], label [[CONT11:%.*]], label [[BOUNDSCHECK_NOTNULL:%.*]], !annotation [[META14]]
+// CHECK:       trap:
+// CHECK-NEXT:    tail call void @llvm.ubsantrap(i8 25) #[[ATTR3]], !annotation [[META15]]
+// CHECK-NEXT:    unreachable, !annotation [[META15]]
+// CHECK:       boundscheck.notnull:
+// CHECK-NEXT:    [[TMP3:%.*]] = icmp ult ptr [[BOUND_PTR_ARITH]], [[ADD_PTR]], !annotation [[META12]]
+// CHECK-NEXT:    [[TMP4:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH]], [[TMP1]], !annotation [[META16]]
+// CHECK-NEXT:    [[OR_COND34:%.*]] = and i1 [[TMP4]], [[TMP3]], !annotation [[META16]]
+// CHECK-NEXT:    br i1 [[OR_COND34]], label [[CONT11]], label [[TRAP:%.*]], !prof [[PROF17]], !annotation [[META12]]
+// CHECK:       cont11:
+// CHECK-NEXT:    tail call void @use(ptr noundef [[BOUND_PTR_ARITH]], i32 noundef [[TMP2]]) #[[ATTR4]]
 // CHECK-NEXT:    [[BOUND_PTR_ARITH14:%.*]] = getelementptr i8, ptr [[TMP1]], i64 8
-// CHECK-NEXT:    [[TMP3:%.*]] = icmp ult ptr [[BOUND_PTR_ARITH]], [[ADD_PTR]], !annotation [[META12:![0-9]+]]
-// CHECK-NEXT:    [[TMP4:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH]], [[TMP1]], !annotation [[META13:![0-9]+]]
-// CHECK-NEXT:    [[OR_COND35:%.*]] = and i1 [[TMP3]], [[TMP4]], !annotation [[META13]]
-// CHECK-NEXT:    br i1 [[OR_COND35]], label [[CONT22:%.*]], label [[TRAP:%.*]], !prof [[PROF14:![0-9]+]], !annotation [[META12]]
+// CHECK-NEXT:    [[TMP5:%.*]] = icmp ult ptr [[BOUND_PTR_ARITH]], [[ADD_PTR]], !annotation [[META12]]
+// CHECK-NEXT:    [[TMP6:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH]], [[TMP1]], !annotation [[META16]]
+// CHECK-NEXT:    [[OR_COND35:%.*]] = and i1 [[TMP6]], [[TMP5]], !annotation [[META16]]
+// CHECK-NEXT:    br i1 [[OR_COND35]], label [[CONT22:%.*]], label [[TRAP]], !prof [[PROF17]], !annotation [[META12]]
 // CHECK:       cont22:
-// CHECK-NEXT:    [[DOTNOT39:%.*]] = icmp eq ptr [[BOUND_PTR_ARITH14]], null, !annotation [[META15:![0-9]+]]
-// CHECK-NEXT:    [[TMP5:%.*]] = icmp ult ptr [[BOUND_PTR_ARITH14]], [[ADD_PTR]], !annotation [[META12]]
-// CHECK-NEXT:    [[OR_COND40:%.*]] = select i1 [[DOTNOT39]], i1 true, i1 [[TMP5]], !annotation [[META12]]
-// CHECK-NEXT:    br i1 [[OR_COND40]], label [[CONT32:%.*]], label [[TRAP]], !prof [[PROF16:![0-9]+]], !annotation [[META15]]
+// CHECK-NEXT:    [[TMP7:%.*]] = load i32, ptr [[BOUND_PTR_ARITH]], align 4, !tbaa [[TBAA13]]
+// CHECK-NEXT:    [[DOTNOT39:%.*]] = icmp eq ptr [[BOUND_PTR_ARITH14]], null, !annotation [[META14]]
+// CHECK-NEXT:    br i1 [[DOTNOT39]], label [[CONT32:%.*]], label [[BOUNDSCHECK_NOTNULL30:%.*]], !annotation [[META14]]
+// CHECK:       boundscheck.notnull30:
+// CHECK-NEXT:    [[TMP8:%.*]] = icmp ult ptr [[BOUND_PTR_ARITH14]], [[ADD_PTR]], !annotation [[META12]]
+// CHECK-NEXT:    [[TMP9:%.*]] = icmp uge ptr [[BOUND_PTR_ARITH14]], [[TMP1]], !annotation [[META16]]
+// CHECK-NEXT:    [[OR_COND36:%.*]] = and i1 [[TMP9]], [[TMP8]], !annotation [[META16]]
+// CHECK-NEXT:    br i1 [[OR_COND36]], label [[CONT32]], label [[TRAP]], !prof [[PROF17]], !annotation [[META12]]
 // CHECK:       cont32:
-// CHECK-NEXT:    [[TMP6:%.*]] = load i32, ptr [[BOUND_PTR_ARITH]], align 4, !tbaa [[TBAA10]]
-// CHECK-NEXT:    tail call void @use(ptr noundef [[BOUND_PTR_ARITH14]], i32 noundef [[TMP6]]) #[[ATTR3]]
+// CHECK-NEXT:    tail call void @use(ptr noundef [[BOUND_PTR_ARITH14]], i32 noundef [[TMP7]]) #[[ATTR4]]
 // CHECK-NEXT:    br label [[CLEANUP]]
 // CHECK:       cleanup:
 // CHECK-NEXT:    [[RETVAL_0:%.*]] = phi i32 [ 0, [[CONT32]] ], [ -1, [[ENTRY:%.*]] ]

--- a/clang/test/BoundsSafety/CodeGen/bounds-attributed-return-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/bounds-attributed-return-O2.c
@@ -98,10 +98,8 @@ int *__counted_by(count) cb_in_from_cb(int count, int *__counted_by(count) p) {
 // CHECK-LABEL: define dso_local noundef ptr @cb_in_from_cb2(
 // CHECK-SAME: i32 noundef [[COUNT:%.*]], ptr noundef readnone returned captures(ret: address, provenance) [[P:%.*]], i32 noundef [[LEN:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  [[ENTRY:.*:]]
-// CHECK-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[LEN]] to i64
 // CHECK-NEXT:    [[CMP_NOT:%.*]] = icmp slt i32 [[LEN]], 0, !annotation [[META2]]
-// CHECK-NEXT:    [[CONV:%.*]] = sext i32 [[COUNT]] to i64, !annotation [[META2]]
-// CHECK-NEXT:    [[SPEC_SELECT_NOT:%.*]] = icmp ugt i64 [[CONV]], [[IDX_EXT]]
+// CHECK-NEXT:    [[SPEC_SELECT_NOT:%.*]] = icmp ugt i32 [[COUNT]], [[LEN]]
 // CHECK-NEXT:    [[OR_COND:%.*]] = or i1 [[CMP_NOT]], [[SPEC_SELECT_NOT]], !annotation [[META2]]
 // CHECK-NEXT:    br i1 [[OR_COND]], label %[[TRAP:.*]], label %[[CONT:.*]], !prof [[PROF11:![0-9]+]], !annotation [[META2]]
 // CHECK:       [[TRAP]]:


### PR DESCRIPTION
Fixed tests:

* BoundsSafety/CodeGen/bounds-attributed-return-O2.c
* BoundsSafety-legacy-checks/CodeGen/runtime-checks/length-check-bound-check-removal.c

rdar://154865941