### PR TITLE
[lldb][test] Disable TestCxxFrameFormatRecursive on Linux

### DIFF
--- a/lldb/test/Shell/Settings/TestCxxFrameFormatRecursive.test
+++ b/lldb/test/Shell/Settings/TestCxxFrameFormatRecursive.test
@@ -1,3 +1,5 @@
+# Flaky on Linux, see https://github.com/llvm/llvm-project/issues/142726
+# UNSUPPORTED: system-linux
 # XFAIL: *
 
 # Test disallowed variables inside the


### PR DESCRIPTION
It was always expected to fail and now it sometimes times out instead.

See https://github.com/llvm/llvm-project/issues/142726.

(cherry picked from commit da8271e88793909b738e2afdf17d0ae11dade455)