### PR TITLE
[lldb] Fix task ids in task thread names (#10940)

### DIFF
--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -13,7 +13,7 @@ class TestCase(TestBase):
         lldbutil.run_to_source_breakpoint(
             self, "break outside", lldb.SBFileSpec("main.swift")
         )
-        self.expect("v task", patterns=[r'"Chore" id:[1-9]\d*'])
+        self.expect("v task", patterns=[r'"Chore" id:[1-9]'])
 
     @swiftTest
     @skipIfLinux  # rdar://151471067
@@ -22,4 +22,4 @@ class TestCase(TestBase):
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "break inside", lldb.SBFileSpec("main.swift")
         )
-        self.assertRegex(thread.name, r"Chore \(Task [1-9]\d*\)")
+        self.assertRegex(thread.name, r"Chore \(Task [1-9]\)")

--- a/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
+++ b/lldb/test/API/lang/swift/async/queues/TestSwiftPluginQueues.py
@@ -19,7 +19,7 @@ class TestCase(lldbtest.TestBase):
             self, "BREAK HERE", source_file
         )
 
-        self.assertRegex(thread.GetName(), r"^Task [1-9]\d*$")
+        self.assertRegex(thread.GetName(), r"^Task [1-9]$")
 
         queue_plugin = self.get_queue_from_thread_info_command(False)
         queue_backing = self.get_queue_from_thread_info_command(True)


### PR DESCRIPTION
* [lldb] Fix task ids in task thread names

* Update task ids in tests
(cherry-picked from commit 16a54eb23290adca20e5e53d8cd5263aa09759d7)