### PR TITLE
Use the root directory as the SDK root on POSIX platforms

### DIFF
--- a/lldb/include/lldb/Host/posix/HostInfoPosix.h
+++ b/lldb/include/lldb/Host/posix/HostInfoPosix.h
@@ -43,7 +43,9 @@ public:
   static bool ComputeSwiftResourceDirectory(FileSpec &lldb_shlib_spec,
                                             FileSpec &file_spec, bool verify);
 #endif
-  
+
+  static llvm::Expected<llvm::StringRef> GetSDKRoot(SDKOptions options);
+
 protected:
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);
   static bool ComputeHeaderDirectory(FileSpec &file_spec);

--- a/lldb/source/Host/posix/HostInfoPosix.cpp
+++ b/lldb/source/Host/posix/HostInfoPosix.cpp
@@ -117,6 +117,12 @@ std::optional<std::string> PosixUserIDResolver::DoGetGroupName(id_t gid) {
   return std::nullopt;
 }
 
+/// The SDK is the directory where the system C headers, libraries, can be found.
+/// On POSIX platforms this is simply the root directory.
+llvm::Expected<llvm::StringRef> HostInfoPosix::GetSDKRoot(SDKOptions options) {
+  return "/";
+}
+
 static llvm::ManagedStatic<PosixUserIDResolver> g_user_id_resolver;
 
 UserIDResolver &HostInfoPosix::GetUserIDResolver() {


### PR DESCRIPTION
LLDB has the concept of an "SDK root", which expresses where the system libraries and so on which are necessary for debugging can be found. On POSIX platforms, the SDK root is just the root of the file system, or /.

We need to implement the appropriate method on HostInfoPosix to prevent the use of the default implementation which just returns an error.

This change is needed to support the Swift REPL but may be useful for other use cases as well.

(cherry picked from commit 0b98b27930dad5ff59de050605c3f101330a2b5c)