### PR TITLE
[libclang][reproducers] Output the executable as an environment variable with a default value.

### DIFF
--- a/clang/test/Modules/reproducer-with-module-dependencies.c
+++ b/clang/test/Modules/reproducer-with-module-dependencies.c
@@ -38,5 +38,5 @@ void test(void) {
 #include "non-existing-header.h"
 
 //--- script-expectations.txt
-CHECK: clang-executable
+CHECK: CLANG:-clang-executable
 CHECK: -fmodule-file=Test=reproducer.cache/explicitly-built-modules/Test-{{.*}}.pcm

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -788,7 +788,10 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
   ScriptOS << "\n\n";
 
   ScriptOS << "# Dependencies:\n";
-  std::string ReproExecutable = Opts.BuildArgs.front();
+  // Output the executable as an environment variable with a default value, so
+  // it is easier to run the reproducer with a different compiler and to
+  // simplify running an individual command manually.
+  std::string ReproExecutable = "\"${CLANG:-" + Opts.BuildArgs.front() + "}\"";
   auto PrintArguments = [&ReproExecutable,
                          &FileCacheName](llvm::raw_fd_ostream &OS,
                                          ArrayRef<std::string> Arguments) {


### PR DESCRIPTION
It makes it easier to run the reproducer with a different compiler (for example, bisecting). And the default value simplifies running an individual command manually.