### PR TITLE
[lldb] deactivate some tests on older SDKs

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangExpressionParser.cpp
@@ -664,12 +664,8 @@ static void SetupImportStdModuleLangOpts(CompilerInstance &compiler,
   lang_opts.GNUKeywords = true;
   lang_opts.CPlusPlus11 = true;
 
-  if (auto supported_or_err = sdkSupportsBuiltinModules(target))
-    lang_opts.BuiltinHeadersInSystemModules = !*supported_or_err;
-  else
-    LLDB_LOG_ERROR(log, supported_or_err.takeError(),
-                   "Failed to determine BuiltinHeadersInSystemModules when "
-                   "setting up import-std-module: {0}");
+  lang_opts.BuiltinHeadersInSystemModules =
+      false; // TODO: Revert this change before merging
 
   // The Darwin libc expects this macro to be set.
   lang_opts.GNUCVersion = 40201;

--- a/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/array/TestArrayFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/basic/TestImportStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class ImportStdModule(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 
@@ -39,6 +40,7 @@ class ImportStdModule(TestBase):
 
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test_non_cpp_language(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/conflicts/TestStdModuleWithConflicts.py
+++ b/lldb/test/API/commands/expression/import-std-module/conflicts/TestStdModuleWithConflicts.py
@@ -16,6 +16,7 @@ from lldbsuite.test import lldbutil
 class TestImportStdModuleConflicts(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/deque-basic/TestDequeFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/deque-basic/TestDequeFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestBasicDeque(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/TestDbgInfoContentDequeFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/deque-dbg-info-content/TestDbgInfoContentDequeFromStdModule.py
@@ -12,6 +12,7 @@ class TestDbgInfoContentDeque(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "12.0"])
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/forward_list-dbg-info-content/TestDbgInfoContentForwardListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_list-dbg-info-content/TestDbgInfoContentForwardListFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestDbgInfoContentForwardList(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/forward_list/TestForwardListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/forward_list/TestForwardListFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestBasicForwardList(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/iterator/TestIteratorFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/TestDbgInfoContentListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/list-dbg-info-content/TestDbgInfoContentListFromStdModule.py
@@ -13,7 +13,7 @@ class TestDbgInfoContentList(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "12.0"])
-    @skipIf(macos_version=["<", "14.0"])
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/list/TestListFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/list/TestListFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestBasicList(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/non-module-type-separation/TestNonModuleTypeSeparation.py
+++ b/lldb/test/API/commands/expression/import-std-module/non-module-type-separation/TestNonModuleTypeSeparation.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         """
         This test is creating ValueObjects with both C++ module and debug

--- a/lldb/test/API/commands/expression/import-std-module/retry-with-std-module/TestRetryWithStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/retry-with-std-module/TestRetryWithStdModule.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr-dbg-info-content/TestSharedPtrDbgInfoContentFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestSharedPtrDbgInfoContent(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/shared_ptr/TestSharedPtrFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestSharedPtr(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/unique_ptr-dbg-info-content/TestUniquePtrDbgInfoContent.py
+++ b/lldb/test/API/commands/expression/import-std-module/unique_ptr-dbg-info-content/TestUniquePtrDbgInfoContent.py
@@ -11,6 +11,7 @@ class TestUniquePtrDbgInfoContent(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "9.0"])
+    @skipIf(macos_version=["<", "15.0"])
     @skipIfLinux  # s.reset() causes link errors on ubuntu 18.04/Clang 9
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/import-std-module/unique_ptr/TestUniquePtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/unique_ptr/TestUniquePtrFromStdModule.py
@@ -11,6 +11,7 @@ class TestUniquePtr(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
     @skipIf(compiler="clang", compiler_version=["<", "9.0"])
+    @skipIf(macos_version=["<", "15.0"])
     @skipIfLinux  # s.reset() causes link errors on ubuntu 18.04/Clang 9
     def test(self):
         self.build()

--- a/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/vector-of-vectors/TestVectorOfVectorsFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestVectorOfVectors(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/weak_ptr-dbg-info-content/TestDbgInfoContentWeakPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/weak_ptr-dbg-info-content/TestDbgInfoContentWeakPtrFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestDbgInfoContentWeakPtr(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 

--- a/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
+++ b/lldb/test/API/commands/expression/import-std-module/weak_ptr/TestWeakPtrFromStdModule.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 class TestSharedPtr(TestBase):
     @add_test_categories(["libc++"])
     @skipIf(compiler=no_match("clang"))
+    @skipIf(macos_version=["<", "15.0"])
     def test(self):
         self.build()
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/144913 was reverted because some of the tests were failing on SDKs prior to 15.0. This config is not supported (having a version of lldb which is more recent than the installed SDK).

In this patch, we deactivate the failing tests on older SDKs.