### PR TITLE
[lldb] Rework PCM validation disable for Swift

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -275,6 +275,8 @@ public:
 
   bool AddModuleSearchPath(llvm::StringRef path);
 
+  void ConfigureModuleValidation(std::vector<std::string> &extra_args);
+
   /// Add a list of Clang arguments to the ClangImporter options and
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(


### PR DESCRIPTION
The `Preprocessor`'s options have changed to be `const` in https://github.com/llvm/llvm-project/commit/277ab85d1ccf80750f5193495c0665808c2863de. Since lldb can no longer mutate the options before constructing a clang importer, this change is to setup the options ahead of time.