### PR TITLE
[stable/20250601][unittests] LLDB: Fix build failure after removal of `CompilerType::G…

### DIFF
--- a/lldb/unittests/Platform/PlatformSiginfoTest.cpp
+++ b/lldb/unittests/Platform/PlatformSiginfoTest.cpp
@@ -61,7 +61,9 @@ public:
     for (auto field_name : llvm::split(path, '.')) {
       uint64_t bit_offset;
       std::string name;
-      auto index_or_err = field_type.GetIndexOfChildWithName(field_name, false);
+      lldb_private::ExecutionContext exe_ctx{};
+      auto index_or_err =
+          field_type.GetIndexOfChildWithName(field_name, &exe_ctx, false);
       ASSERT_FALSE(!index_or_err);
       field_type = field_type.GetFieldAtIndex(*index_or_err, name, &bit_offset,
                                               nullptr, nullptr);


### PR DESCRIPTION
…etIndexOfFieldWithName` overload

See https://github.com/llvm/llvm-project/pull/135963.

`CompilerType::GetIndexOfChildWithName` has an additional parameter in our fork.