### PR TITLE
[CAS] Delay CAS initialization on server side after daemon starts

### DIFF
--- a/clang/test/CAS/daemon-cas-recovery.c
+++ b/clang/test/CAS/daemon-cas-recovery.c
@@ -1,0 +1,13 @@
+// REQUIRES: system-darwin, clang-cc1daemon
+
+// RUN: rm -rf %t && mkdir -p %t
+
+/// Construct a malformed CAS to recovery from.
+// RUN: echo "abc" | llvm-cas --cas %t/cas --make-blob --data -
+// RUN: rm %t/cas/v1.1/v9.data
+// RUN: not llvm-cas --cas %t/cas --validate --check-hash
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_FORCE_VALIDATION=1 %clang-cache \
+// RUN:   %clang -fsyntax-only -x c %s
+
+int func(void);

--- a/clang/test/CAS/depscan-cas-log.c
+++ b/clang/test/CAS/depscan-cas-log.c
@@ -13,8 +13,8 @@
 // CHECK: [[PID1:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v9.index'
 // CHECK: [[PID1]] {{[0-9]*}}: create subtrie
 
-// CHECK: [[PID2:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v9.index'
 // Even a minimal compilation involves at least 9 records for the cache key.
-// CHECK-COUNT-9: [[PID2]] {{[0-9]*}}: create record
+// CHECK-COUNT-9: [[PID1]] {{[0-9]*}}: create record
 
-// CHECK: [[PID1]] {{[0-9]*}}: close mmap '{{.*}}v9.index'
+// CHECK: [[PID2:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v9.index'
+// CHECK: [[PID2]] {{[0-9]*}}: close mmap '{{.*}}v9.index'


### PR DESCRIPTION
For auto CAS validation and recovery, it is important that server does not open the CAS until daemon replies so daemon has the chance to validate and recovery from broken CAS if needed. Otherwise, this is going to be a dead lock on daemon waiting for server to close the CAS before deletion.

rdar://155342429