### PR TITLE
[lldb] Use RemoteAddress's address space for the file cache optimization

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -727,8 +727,8 @@ std::optional<uint32_t> SwiftLanguageRuntime::AddObjectFileToReflectionContext(
         assert(address <= end_address && "Address outside of range!");
 
         swift::remote::RemoteRef<void> remote_ref(
-            swift::remote::RemoteAddress(
-                address, swift::remote::RemoteAddress::DefaultAddressSpace),
+            swift::remote::RemoteAddress(address,
+                                         LLDBMemoryReader::LLDBAddressSpace),
             Buf);
         return {remote_ref, size};
       }


### PR DESCRIPTION
Now that RemoteAddress carries its address space, instead of using a high bit to turn on the filecache optimization, use that instead. This way we are guaranteed to not clash with any pointer authentication masks.

rdar://148361743