### PR TITLE
[lldb] Include "suspended" flag for Tasks

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -824,6 +824,7 @@ public:
       "isEscalated",
       "isEnqueued",
       "isComplete",
+      "isSuspended",
       "isRunning",
       // clang-format on
   };
@@ -957,7 +958,9 @@ public:
       RETURN_CHILD(m_is_enqueued_sp, isEnqueued, bool_type);
     case 13:
       RETURN_CHILD(m_is_complete_sp, isComplete, bool_type);
-    case 14: {
+    case 14:
+      RETURN_CHILD(m_is_suspended_sp, isSuspended, bool_type);
+    case 15: {
       if (m_task_info.hasIsRunning)
         RETURN_CHILD(m_is_running_sp, isRunning, bool_type);
       return {};
@@ -990,8 +993,8 @@ public:
                 m_is_child_task_sp, m_is_future_sp, m_is_group_child_task_sp,
                 m_is_async_let_task_sp, m_is_cancelled_sp,
                 m_is_status_record_locked_sp, m_is_escalated_sp,
-                m_is_enqueued_sp, m_is_complete_sp, m_parent_task_sp,
-                m_child_tasks_sp, m_is_running_sp})
+                m_is_enqueued_sp, m_is_complete_sp, m_is_suspended_sp,
+                m_parent_task_sp, m_child_tasks_sp, m_is_running_sp})
             child.reset();
         }
       }
@@ -1027,6 +1030,7 @@ private:
   ValueObjectSP m_is_escalated_sp;
   ValueObjectSP m_is_enqueued_sp;
   ValueObjectSP m_is_complete_sp;
+  ValueObjectSP m_is_suspended_sp;
   ValueObjectSP m_parent_task_sp;
   ValueObjectSP m_child_tasks_sp;
   ValueObjectSP m_is_running_sp;
@@ -1917,6 +1921,7 @@ bool lldb_private::formatters::swift::TaskPriority_SummaryProvider(
 
 static const std::pair<StringRef, StringRef> TASK_FLAGS[] = {
     {"isComplete", "complete"},
+    {"isSuspended", "suspended"},
     {"isRunning", "running"},
     {"isCancelled", "cancelled"},
     {"isEscalated", "escalated"},

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -415,6 +415,7 @@ public:
     result.isRunning = task_info.IsRunning;
     result.isEnqueued = task_info.IsEnqueued;
     result.isComplete = task_info.IsComplete;
+    result.isSuspended = task_info.IsSuspended;
     result.id = task_info.Id;
     result.kind = task_info.Kind;
     result.enqueuePriority = task_info.EnqueuePriority;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -169,6 +169,7 @@ public:
     bool isRunning = false;
     bool isEnqueued = false;
     bool isComplete = false;
+    bool isSuspended = false;
     uint64_t id = 0;
     uint32_t kind = 0;
     uint32_t enqueuePriority = 0;

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             patterns=[
                 textwrap.dedent(
                     r"""
-                    \(Task<\(\), Error>\) task = id:([1-9]\d*) flags:(?:suspended\|)(?:running|enqueued) \{
+                    \(Task<\(\), Error>\) task = id:([1-9]\d*) flags:(?:suspended\|)?(?:running|enqueued) \{
                       address = 0x[0-9a-f]+
                       id = \1
                       enqueuePriority = \.medium

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -21,7 +21,7 @@ class TestCase(TestBase):
             patterns=[
                 textwrap.dedent(
                     r"""
-                    \(Task<\(\), Error>\) task = id:([1-9]\d*) flags:(?:running|enqueued) \{
+                    \(Task<\(\), Error>\) task = id:([1-9]\d*) flags:(?:suspended\|)(?:running|enqueued) \{
                       address = 0x[0-9a-f]+
                       id = \1
                       enqueuePriority = \.medium

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/Makefile
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
@@ -1,0 +1,16 @@
+import textwrap
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("v task", substrs=["flags:suspended"])

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/main.swift
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/main.swift
@@ -1,0 +1,9 @@
+@main struct Main {
+    static func main() async {
+        let task = Task {
+            try? await Task.sleep(for: .seconds(100))
+        }
+        try? await Task.sleep(for: .seconds(0.5))
+        print("break here")
+    }
+}

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -32,21 +32,21 @@ class TestCase(TestBase):
                 textwrap.dedent(
                     r"""
                     \((?:Throwing)?TaskGroup<\(\)\??(?:, Error)?>\) group = \{
-                      \[0\] = id:([1-9]\d*) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
+                      \[0\] = id:([1-9]\d*) flags:(?:suspended\|)?(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \1
                         enqueuePriority = \.medium
                         parent = (.+)
                         children = \{\}
                       \}
-                      \[1\] = id:([1-9]\d*) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
+                      \[1\] = id:([1-9]\d*) flags:(?:suspended\|)?(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \3
                         enqueuePriority = \.medium
                         parent = \2
                         children = \{\}
                       \}
-                      \[2\] = id:([1-9]\d*) flags:(?:running\|)?(?:enqueued\|)?groupChildTask \{
+                      \[2\] = id:([1-9]\d*) flags:(?:suspended\|)?(?:running\|)?(?:enqueued\|)?groupChildTask \{
                         address = 0x[0-9a-f]+
                         id = \4
                         enqueuePriority = \.medium


### PR DESCRIPTION
Display a "suspended" flag for Tasks in that state. The other main Task states, "enqueued", "running", and "complete", are already displayed.

From Swift's Task.h:

```cpp
/// A task can have the following states:
///   * suspended: In this state, a task is considered not runnable
///   * enqueued: In this state, a task is considered runnable
///   * running on a thread
///   * completed
```

rdar://148663671