### PR TITLE
[BoundsSafety] make alloc_size imply __sized_by_or_null return type

### DIFF
--- a/clang/docs/InternalsManual.rst
+++ b/clang/docs/InternalsManual.rst
@@ -427,6 +427,17 @@ Description:
   This is useful when the argument could be a string in some cases, but
   another class in other cases, and it needs to be quoted consistently.
 
+**"unquoted" format**
+
+Example:
+  ``"conflicting attributes were '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null}0(%unquoted1)' and '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null}2(%unquoted3)'"``
+Class:
+  ``Expr, Decl``
+Description:
+  This is a simple formatter which omits the single quotes from a class
+  that would normally be printed quoted. This is useful when the diagnostic
+  uses the argument to construct a larger type or expression.
+
 .. _internals-producing-diag:
 
 Producing the Diagnostic

--- a/clang/include/clang/AST/Attr.h
+++ b/clang/include/clang/AST/Attr.h
@@ -388,6 +388,22 @@ public:
     assertComparable(I);
     return Idx == I.Idx;
   }
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  /// Unlike operator== which requires isValid to be true for both objects,
+  /// this relaxes that constraint and returns true when comparing two
+  /// invalid objects. An invalid object does not equal any valid object.
+  bool equals(const ParamIdx &I) const {
+    assert(HasThis == I.HasThis &&
+           "ParamIdx must be for the same function to be compared");
+    if (isValid() != I.isValid())
+      return false;
+    if (!isValid()) {
+      assert(!I.isValid());
+      return true;
+    }
+    return Idx == I.Idx;
+  }
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   bool operator!=(const ParamIdx &I) const {
     assertComparable(I);
     return Idx != I.Idx;

--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -2641,6 +2641,7 @@ public:
   bool isBidiIndexablePointerType() const;
   bool isUnspecifiedPointerType() const;
   bool isSafePointerType() const;
+  bool isImplicitSafePointerType() const;
   /* TO_UPSTREAM(BoundsSafety) OFF */
   bool isSignableType(const ASTContext &Ctx) const;
   bool isSignablePointerType() const;
@@ -9011,6 +9012,17 @@ inline bool Type::isSafePointerType() const {
          (isSinglePointerType() || isBidiIndexablePointerType() ||
           isIndexablePointerType() || isBoundsAttributedType() ||
           isValueTerminatedType());
+}
+
+inline bool Type::isImplicitSafePointerType() const {
+  if (auto AT = this->getAs<AttributedType>()) {
+    if (AT->getAttrKind() == attr::PtrAutoAttr) {
+      assert(isSafePointerType());
+      return true;
+    }
+    return AT->getEquivalentType()->isImplicitSafePointerType();
+  }
+  return false;
 }
 
 inline bool Type::isPointerTypeWithBounds() const {

--- a/clang/include/clang/AST/TypeBase.h
+++ b/clang/include/clang/AST/TypeBase.h
@@ -9015,10 +9015,9 @@ inline bool Type::isSafePointerType() const {
 }
 
 inline bool Type::isImplicitSafePointerType() const {
-  if (auto AT = this->getAs<AttributedType>()) {
+  if (const auto *AT = this->getAs<AttributedType>()) {
     if (AT->getAttrKind() == attr::PtrAutoAttr) {
-      assert(isSafePointerType());
-      return true;
+      return isSafePointerType();
     }
     return AT->getEquivalentType()->isImplicitSafePointerType();
   }

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12958,7 +12958,7 @@ def err_bounds_safety_conflicting_pointer_attributes : Error<
 def note_bounds_safety_conflicting_pointer_attribute_args : Note<
   "conflicting arguments for %select{end|terminator}0 were %1 and %2">;
 def warn_bounds_safety_ignored_implicit_sized_by_or_null : Warning<
-  "implicit __sized_by_or_null attribute ignored because of explicit __sized_by">;
+  "implicit __sized_by_or_null attribute ignored because of explicit __sized_by">, InGroup<BoundsSafetyRedundantAttribute>;
 def note_bounds_safety_overriding_implicit_sized_by_or_null_silence : Note<
   "add _Nonnull qualifier to return type to silence this warning">;
 def note_bounds_safety_conflicting_count_attribute : Note<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -3464,6 +3464,9 @@ def err_attribute_only_once_per_parameter : Error<
   "%0 attribute can only be applied once per parameter">;
 def err_mismatched_uuid : Error<"uuid does not match previous declaration">;
 def note_previous_uuid : Note<"previous uuid specified here">;
+/* TO_UPSTREAM(BoundsSafety) ON */
+def err_mismatched_alloc_size : Error<"'alloc_size' attribute does not match previous declaration">;
+/* TO_UPSTREAM(BoundsSafety) OFF */
 def warn_attribute_pointers_only : Warning<
   "%0 attribute only applies to%select{| constant}1 pointer arguments">,
   InGroup<IgnoredAttributes>;
@@ -12953,7 +12956,19 @@ let CategoryName = "BoundsSafety Pointer Attributes Issue" in {
 def err_bounds_safety_conflicting_pointer_attributes : Error<
   "%select{array|pointer}0 cannot have more than one %select{bound|type|count|end|terminator}1 attribute">;
 def note_bounds_safety_conflicting_pointer_attribute_args : Note<
-  "conflicting arguments for %select{count|end|terminator}0 were %1 and %2">;
+  "conflicting arguments for %select{end|terminator}0 were %1 and %2">;
+def warn_bounds_safety_ignored_implicit_sized_by_or_null : Warning<
+  "implicit __sized_by_or_null attribute ignored because of explicit __sized_by">;
+def note_bounds_safety_overriding_implicit_sized_by_or_null_silence : Note<
+  "add _Nonnull qualifier to return type to silence this warning">;
+def note_bounds_safety_conflicting_count_attribute : Note<
+  "conflicting attributes were '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null}0(%unquoted1)' and '%select{__counted_by|__sized_by|__counted_by_or_null|__sized_by_or_null}2(%unquoted3)'">;
+def note_bounds_safety_implicit_size_from_alloc_size_attr : Note<
+  "function return type implicitly __sized_by%select{|_or_null}0 because of the function's 'alloc_size' %select{and 'returns_nonnull' attributes|attribute}0">;
+def err_invalid_return_type_for_alloc_size : Error<
+  "invalid return type %0 for function with alloc_size attribute; '__sized_by_or_null(%unquoted1)' or '__sized_by(%unquoted1)' required">;
+def note_attribute_inherited : Note<
+  "attribute inherited from previous declaration here">;
 def warn_bounds_safety_duplicate_pointer_attributes : Warning<
   "%select{array|pointer}0 annotated with %select{__unsafe_indexable|__bidi_indexable|__indexable|__single|__terminated_by}1 "
   "multiple times. Annotate only once to remove this warning">, InGroup<BoundsSafetyRedundantAttribute>;

--- a/clang/include/clang/Sema/Attr.h
+++ b/clang/include/clang/Sema/Attr.h
@@ -80,6 +80,13 @@ inline const ParmVarDecl *getFunctionOrMethodParam(const Decl *D,
   return nullptr;
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
+inline ParmVarDecl *getFunctionOrMethodParam(Decl *D, unsigned Idx) {
+  return const_cast<ParmVarDecl *>(
+      getFunctionOrMethodParam(const_cast<const Decl *>(D), Idx));
+}
+/* TO_UPSTREAM(BoundsSafety) OFF */
+
 inline QualType getFunctionOrMethodParamType(const Decl *D, unsigned Idx) {
   if (const FunctionType *FnTy = D->getFunctionType())
     return cast<FunctionProtoType>(FnTy)->getParamType(Idx);

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5414,6 +5414,9 @@ public:
   MinSizeAttr *mergeMinSizeAttr(Decl *D, const AttributeCommonInfo &CI);
   OptimizeNoneAttr *mergeOptimizeNoneAttr(Decl *D,
                                           const AttributeCommonInfo &CI);
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  AllocSizeAttr *mergeAllocSizeAttr(NamedDecl *D, const AllocSizeAttr &ASA);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   InternalLinkageAttr *mergeInternalLinkageAttr(Decl *D, const ParsedAttr &AL);
   InternalLinkageAttr *mergeInternalLinkageAttr(Decl *D,
                                                 const InternalLinkageAttr &AL);
@@ -5508,6 +5511,12 @@ public:
   void checkUnusedDeclAttributes(Declarator &D);
 
   void DiagnoseUnknownAttribute(const ParsedAttr &AL);
+
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  QualType
+  PostProcessBoundsSafetyAllocSizeAttribute(FunctionDecl *EnclosingDecl,
+                                            QualType FTy);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// DeclClonePragmaWeak - clone existing decl (maybe definition),
   /// \#pragma weak needs a non-definition decl and source may not have one.

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1204,7 +1204,7 @@ public:
   bool findMacroSpelling(SourceLocation &loc, StringRef name);
 
   /// Calls \c Lexer::getLocForEndOfToken()
-  SourceLocation getLocForEndOfToken(SourceLocation Loc, unsigned Offset = 0) const;
+  SourceLocation getLocForEndOfToken(SourceLocation Loc, unsigned Offset = 0);
 
   /// Calls \c Lexer::findNextToken() to find the next token, and if the
   /// locations of both ends of the token can be resolved it return that
@@ -2825,7 +2825,7 @@ public:
   /// Emit fix-it updating BTy to have the same CountAttributedType kind as ATy.
   void fixCountAttributedTypeKind(Sema::SemaDiagnosticBuilder &D,
                                   const CountAttributedType *ATy,
-                                  const CountAttributedType *BTy) const;
+                                  const CountAttributedType *BTy);
 
   /// Used to record or retrieve if a VarDecl/FieldDecl has a BoundsSafety FixIt
   /// emitted on it. The primary use case for this is preventing emitting

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -1204,7 +1204,7 @@ public:
   bool findMacroSpelling(SourceLocation &loc, StringRef name);
 
   /// Calls \c Lexer::getLocForEndOfToken()
-  SourceLocation getLocForEndOfToken(SourceLocation Loc, unsigned Offset = 0);
+  SourceLocation getLocForEndOfToken(SourceLocation Loc, unsigned Offset = 0) const;
 
   /// Calls \c Lexer::findNextToken() to find the next token, and if the
   /// locations of both ends of the token can be resolved it return that
@@ -2822,6 +2822,10 @@ public:
       const CountAttributedType *CATTy, Expr *Operand,
       std::variant<bool, BinaryOperatorKind> OpInfo);
 
+  /// Emit fix-it updating BTy to have the same CountAttributedType kind as ATy.
+  void fixCountAttributedTypeKind(Sema::SemaDiagnosticBuilder &D,
+                                  const CountAttributedType *ATy,
+                                  const CountAttributedType *BTy) const;
 
   /// Used to record or retrieve if a VarDecl/FieldDecl has a BoundsSafety FixIt
   /// emitted on it. The primary use case for this is preventing emitting

--- a/clang/include/clang/Sema/SemaFixItUtils.h
+++ b/clang/include/clang/Sema/SemaFixItUtils.h
@@ -158,7 +158,7 @@ public:
 
   static void fixCountAttributedTypeLocsInFunctionSignature(
       Sema &S, Sema::SemaDiagnosticBuilder &D, QualType QA, QualType QB,
-      FunctionDecl *ADecl, FunctionDecl *BDecl, bool ExprMismatch,
+      const FunctionDecl *ADecl, FunctionDecl *BDecl, bool ExprMismatch,
       bool KindMismatch);
 
 private:

--- a/clang/include/clang/Sema/SemaFixItUtils.h
+++ b/clang/include/clang/Sema/SemaFixItUtils.h
@@ -13,6 +13,7 @@
 #define LLVM_CLANG_SEMA_SEMAFIXITUTILS_H
 
 #include "clang/AST/Expr.h"
+#include "clang/Sema/Sema.h"
 
 namespace clang {
 
@@ -154,6 +155,11 @@ public:
       const VarDecl *VD, const llvm::StringRef Attribute, Sema &S,
       llvm::SmallVectorImpl<std::tuple<FixItHint, const DeclaratorDecl *>>
           &FixIts);
+
+  static void fixCountAttributedTypeLocsInFunctionSignature(
+      Sema &S, Sema::SemaDiagnosticBuilder &D, QualType QA, QualType QB,
+      FunctionDecl *ADecl, FunctionDecl *BDecl, bool ExprMismatch,
+      bool KindMismatch);
 
 private:
   static FixItHint CreateAnnotateVarDeclOrFieldDeclFixIt(

--- a/clang/lib/AST/ASTDiagnostic.cpp
+++ b/clang/lib/AST/ASTDiagnostic.cpp
@@ -535,6 +535,11 @@ void clang::FormatASTNodeDiagnosticArgument(
     }
   }
 
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (Modifier == "unquoted")
+    NeedQuotes = false;
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+
   if (NeedQuotes) {
     Output.insert(Output.begin()+OldEnd, '\'');
     Output.push_back('\'');

--- a/clang/lib/Sema/BoundsSafetySuggestions.cpp
+++ b/clang/lib/Sema/BoundsSafetySuggestions.cpp
@@ -490,22 +490,6 @@ bool UnsafeOperationVisitor::FindSingleEntity(
       // Don't support indirect calls for now.
       return false;
     }
-    if (DirectCallDecl->hasAttr<AllocSizeAttr>() &&
-        IsReallySinglePtr(DirectCallDecl->getReturnType())) {
-      // Functions declared like
-      // void * custom_malloc(size_t s) __attribute__((alloc_size(1)))
-      //
-      // are currently are annotated as returning `void *__single` rather
-      // than `void *__sized_by(s)`. To make the right thing happen at call
-      // sites `BoundsSafetyPointerPromotionExpr` is used to generate a pointer
-      // with the appropriate bounds from the `void *__single`. For functions
-      // like this the warning needs to be suppressed because from the user's
-      // perspective the returned value is not actually __single.
-      //
-      // This code path can be deleted once allocating functions are properly
-      // annotated with __sized_by_or_null. rdar://117114186
-      return false;
-    }
 
     assert(IsReallySinglePtr(DirectCallDecl->getReturnType()));
 

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -94,7 +94,7 @@ bool Sema::isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */
 
-SourceLocation Sema::getLocForEndOfToken(SourceLocation Loc, unsigned Offset) {
+SourceLocation Sema::getLocForEndOfToken(SourceLocation Loc, unsigned Offset) const {
   return Lexer::getLocForEndOfToken(Loc, Offset, SourceMgr, LangOpts);
 }
 

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -94,7 +94,7 @@ bool Sema::isCXXSafeBuffersBoundsSafetyInteropEnabledAt(
 }
 /* TO_UPSTREAM(BoundsSafety) OFF */
 
-SourceLocation Sema::getLocForEndOfToken(SourceLocation Loc, unsigned Offset) const {
+SourceLocation Sema::getLocForEndOfToken(SourceLocation Loc, unsigned Offset) {
   return Lexer::getLocForEndOfToken(Loc, Offset, SourceMgr, LangOpts);
 }
 

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -271,7 +271,8 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
 }
 
 /* TO_UPSTREAM(BoundsSafety) ON*/
-static SourceRange SourceRangeFor(const CountAttributedType *CATy, Sema &S) {
+static SourceRange SourceRangeFor(const CountAttributedType *CATy,
+                                  const Sema &S, bool AttrNameOnly) {
   // Note: This implementation relies on `CountAttributedType` being unique.
   // E.g.:
   //
@@ -285,7 +286,8 @@ static SourceRange SourceRangeFor(const CountAttributedType *CATy, Sema &S) {
   // unique means the SourceLocation of the `counted_by` expression can be used
   // to find where the attribute was written.
 
-  auto Fallback = CATy->getCountExpr()->getSourceRange();
+  auto Fallback =
+      AttrNameOnly ? SourceRange() : CATy->getCountExpr()->getSourceRange();
   auto CountExprBegin = CATy->getCountExpr()->getBeginLoc();
 
   // FIXME: We currently don't support the count expression being a macro
@@ -347,6 +349,12 @@ static SourceRange SourceRangeFor(const CountAttributedType *CATy, Sema &S) {
 
     // Found the beginning of the `__counted_by` macro
     SourceLocation Begin = LastAttrCharToken.getLocation();
+
+    if (AttrNameOnly) {
+      auto End = S.getLocForEndOfToken(Begin, -1);
+      return SourceRange(Begin, End);
+    }
+
     // Now try to find the closing `)` of the macro.
     auto MaybeRParenTok = FindRParenTokenAfter();
     if (!MaybeRParenTok.has_value())
@@ -385,6 +393,11 @@ static SourceRange SourceRangeFor(const CountAttributedType *CATy, Sema &S) {
     // Found the beginning of the `counted_by`-like attribute
     auto SL = NonAffixedBeginToken.getLocation();
 
+    if (AttrNameOnly) {
+      auto End = S.getLocForEndOfToken(SL, -1);
+      return SourceRange(SL, End);
+    }
+
     // Now try to find the closing `)` of the attribute
     auto MaybeRParenTok = FindRParenTokenAfter();
     if (!MaybeRParenTok.has_value())
@@ -418,6 +431,12 @@ static SourceRange SourceRangeFor(const CountAttributedType *CATy, Sema &S) {
 
   // Found the beginning of the `__counted_by__`-like like attribute.
   auto SL = AffixedBeginToken.getLocation();
+
+  if (AttrNameOnly) {
+    auto End = S.getLocForEndOfToken(SL, -1);
+    return SourceRange(SL, End);
+  }
+
   // Now try to find the closing `)` of the attribute
   auto MaybeRParenTok = FindRParenTokenAfter();
   if (!MaybeRParenTok.has_value())
@@ -465,7 +484,7 @@ static void EmitIncompleteCountedByPointeeNotes(Sema &S,
   // TODO: Upstream probably won't accept `SourceRangeFor` so we should consider
   // removing it and its related tests.
   // SourceRange AttrSrcRange = CATy->getCountExpr()->getSourceRange();
-  SourceRange AttrSrcRange = SourceRangeFor(CATy, S);
+  SourceRange AttrSrcRange = SourceRangeFor(CATy, S, /*AttrNameOnly=*/false);
   /* TO_UPSTREAM(BoundsSafety) OFF*/
   S.Diag(AttrSrcRange.getBegin(), diag::note_counted_by_consider_using_sized_by)
       << CATy->isOrNull() << AttrSrcRange;
@@ -670,7 +689,7 @@ static bool BoundsSafetyCheckFunctionParamOrCountAttrWithIncompletePointeeTy(
   if (ParamDecl)
     ParamName = ParamDecl->getName();
 
-  auto SR = SourceRangeFor(CATy, S);
+  auto SR = SourceRangeFor(CATy, S, /*AttrNameOnly=*/false);
   S.Diag(SR.getBegin(),
          diag::err_bounds_safety_counted_by_on_incomplete_type_on_func_def)
       << /*0*/ CATy->getAttributeName(/*WithMacroPrefix*/ true)
@@ -706,7 +725,7 @@ BoundsSafetyCheckVarDeclCountAttrPtrWithIncompletePointeeTy(Sema &S,
   if (!CATy)
     return true;
 
-  SourceRange SR = SourceRangeFor(CATy, S);
+  SourceRange SR = SourceRangeFor(CATy, S, /*AttrNameOnly=*/false);
   S.Diag(SR.getBegin(),
          diag::err_bounds_safety_counted_by_on_incomplete_type_on_var_decl)
       << /*0*/ CATy->getAttributeName(/*WithMacroPrefix=*/true)
@@ -810,6 +829,17 @@ bool Sema::BoundsSafetyCheckCountAttributedTypeHasConstantCountForAssignmentOp(
     }
   }
   return true;
+}
+
+void Sema::fixCountAttributedTypeKind(Sema::SemaDiagnosticBuilder &D,
+                                      const CountAttributedType *ATy,
+                                      const CountAttributedType *BTy) const {
+  SourceRange SR = SourceRangeFor(BTy, *this, /*AttrNameOnly=*/true);
+  if (SR.isInvalid()) {
+    return;
+  }
+  D << FixItHint::CreateReplacement(
+      SR, ATy->getAttributeName(/*WithMacroPrefix=*/true));
 }
 
 } // namespace clang

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -272,7 +272,7 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
 
 /* TO_UPSTREAM(BoundsSafety) ON*/
 static SourceRange SourceRangeFor(const CountAttributedType *CATy,
-                                  const Sema &S, bool AttrNameOnly) {
+                                  Sema &S, bool AttrNameOnly) {
   // Note: This implementation relies on `CountAttributedType` being unique.
   // E.g.:
   //
@@ -833,7 +833,7 @@ bool Sema::BoundsSafetyCheckCountAttributedTypeHasConstantCountForAssignmentOp(
 
 void Sema::fixCountAttributedTypeKind(Sema::SemaDiagnosticBuilder &D,
                                       const CountAttributedType *ATy,
-                                      const CountAttributedType *BTy) const {
+                                      const CountAttributedType *BTy) {
   SourceRange SR = SourceRangeFor(BTy, *this, /*AttrNameOnly=*/true);
   if (SR.isInvalid()) {
     return;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3016,6 +3016,10 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     NewAttr = S.HLSL().mergeVkConstantIdAttr(D, *CI, CI->getId());
   else if (const auto *SA = dyn_cast<HLSLShaderAttr>(Attr))
     NewAttr = S.HLSL().mergeShaderAttr(D, *SA, SA->getType());
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  else if (const auto *ASA = dyn_cast<AllocSizeAttr>(Attr))
+    NewAttr = S.mergeAllocSizeAttr(D, *ASA);
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   else if (isa<SuppressAttr>(Attr))
     // Do nothing. Each redeclaration should be suppressed separately.
     NewAttr = nullptr;
@@ -3901,6 +3905,34 @@ static void fixBoundsSafetyFunctionDecl(Sema &S, Sema::SemaDiagnosticBuilder &D,
   }
 }
 
+static bool diagnoseConflictingAllocSizeAttribute(FunctionDecl *New,
+                                                  FunctionDecl *Old,
+                                                  Sema &Self) {
+  // System headers that haven't adopted bounds safety are allowed to break
+  // the rules for compatibility reasons, since errors there are hard to fix.
+  if (Self.allowBoundsUnsafeAssignment(New->getLocation()))
+    return true;
+
+  // Different alloc_size attributes will lead to mismatching __sized_by_or_null
+  // return types. Merging of attributes is done after type checking, but we
+  // want to emit the root cause of the type error rather than an error for
+  // mismatcing (implicit) return types.
+  if (auto OldASA = Old->getAttr<AllocSizeAttr>()) {
+    if (auto NewASA = New->getAttr<AllocSizeAttr>()) {
+      if (!OldASA->getElemSizeParam().equals(NewASA->getElemSizeParam()) ||
+          !OldASA->getNumElemsParam().equals(NewASA->getNumElemsParam())) {
+        Self.Diag(NewASA->getLoc(), diag::err_mismatched_alloc_size)
+            << NewASA->getRange();
+        Self.Diag(OldASA->getLoc(), diag::note_conflicting_attribute)
+            << OldASA->getRange();
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 /// diagnoseFunctionConflictWithDynamicBoundTypes - diagnose if \p New
 /// and \p Old have conflicting return or parameter types with repect to
 /// '__counted_by', '__sized_by', or '__ended_by' attributes.
@@ -3908,7 +3940,8 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
                                                           FunctionDecl *Old,
                                                           Sema &Self) {
   std::function<bool(const Expr*, const Expr*)> checkCompatibleBoundExprs;
-  checkCompatibleBoundExprs = [&](const Expr *NewExpr, const Expr *OldExpr) -> bool {
+  checkCompatibleBoundExprs = [&](const Expr *NewExpr,
+                                  const Expr *OldExpr) -> bool {
     llvm::FoldingSetNodeID NewID;
     llvm::FoldingSetNodeID OldID;
     if (NewExpr)
@@ -3919,7 +3952,28 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
       return true;
     return false;
   };
-  std::unique_ptr<Sema::SemaDiagnosticBuilder> D;
+
+  std::function<bool(FunctionDecl * New, FunctionDecl * Old)>
+      newFuncWillInheritOldReturnType = [](FunctionDecl *New,
+                                           FunctionDecl *Old) {
+        QualType NewRetTy = New->getReturnType();
+        if (!NewRetTy->isPointerType())
+          return false;
+        if (NewRetTy->isSafePointerType() &&
+            !NewRetTy->isImplicitSafePointerType())
+          return false;
+        QualType OldRetTy = Old->getReturnType();
+        if (!OldRetTy->isPointerType())
+          return false;
+        if (!OldRetTy->isImplicitSafePointerType())
+          return false;
+        assert(OldRetTy->isSafePointerType());
+
+        bool Ret =
+            !New->hasAttr<AllocSizeAttr>() && Old->hasAttr<AllocSizeAttr>();
+        return Ret;
+      };
+
   std::function<bool(QualType, QualType, TypeLoc, TypeLoc, SourceLocation,
                      SourceLocation)>
       checkCompatibleDynamicBoundTypes =
@@ -3931,6 +3985,8 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
     const auto *OldDCPTy = OldTy->getAs<CountAttributedType>();
     const auto *NewDRPTy = NewTy->getAs<DynamicRangePointerType>();
     const auto *OldDRPTy = OldTy->getAs<DynamicRangePointerType>();
+    const bool NewIsEndedBy = NewDRPTy && NewDRPTy->getEndPointer();
+    const bool OldIsEndedBy = OldDRPTy && OldDRPTy->getEndPointer();
     const auto *NewVTTy = NewTy->getAs<ValueTerminatedType>();
     const auto *OldVTTy = OldTy->getAs<ValueTerminatedType>();
     const unsigned CountDiagIndex = 0;
@@ -3941,14 +3997,11 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
     const unsigned TermDiagIndex = 5;
 
     auto ReportConflict = [&](const unsigned Index) {
-      {
-        if (!D)
-          D.reset(new Sema::SemaDiagnosticBuilder(
-            Self.Diag(NewLoc, diag::err_bounds_safety_dynamic_bound_redeclaration)
-            << Index << 0));
-        fixBoundsSafetyTypeLocs(Self, *D, NewTL, OldTL, NewTy, OldTy, New, Old);
-        fixBoundsSafetyTypeLocs(Self, *D, OldTL, NewTL, OldTy, NewTy, Old, New);
-      }
+      Sema::SemaDiagnosticBuilder D(
+          Self.Diag(NewLoc, diag::err_bounds_safety_dynamic_bound_redeclaration)
+          << Index << 0);
+        fixBoundsSafetyTypeLocs(Self, D, NewTL, OldTL, NewTy, OldTy, New, Old);
+        fixBoundsSafetyTypeLocs(Self, D, OldTL, NewTL, OldTy, NewTy, Old, New);
     };
     auto ReportCountConflict = [&](const CountAttributedType *DCPTy) {
       unsigned Index;
@@ -3971,12 +4024,41 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
       ReportConflict(Index);
     };
 
+    auto ReportCountBothConflict = [&](const CountAttributedType *NewDCPTy,
+                                       const CountAttributedType *OldDCPTy) {
+      ReportCountConflict(NewDCPTy);
+
+      Self.Diag(NewLoc, diag::note_bounds_safety_conflicting_count_attribute)
+          << OldDCPTy->getKind() << OldDCPTy->getCountExpr()
+          << NewDCPTy->getKind() << NewDCPTy->getCountExpr();
+
+      if (auto NewASA = New->getAttr<AllocSizeAttr>()) {
+        Self.Diag(NewASA->getLoc(),
+                  diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
+            << !New->hasAttr<ReturnsNonNullAttr>() << NewASA->getRange();
+      }
+
+      if (auto OldASA = Old->getAttr<AllocSizeAttr>()) {
+        Self.Diag(OldASA->getLoc(),
+                  diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
+            << !Old->hasAttr<ReturnsNonNullAttr>() << OldASA->getRange();
+      }
+    };
+
+    // Check bounds type present in New but not in Old first, then
+    // in Old but now in New. That way if a parameter or return type
+    // is e.g. __counted_by in Old and __null_terminated in New, we
+    // report an error for mismatch on __null_terminated rather than
+    // __counted_by, since it's more local to the error being emitted.
+
     if (NewDCPTy && !OldDCPTy) {
       ReportCountConflict(NewDCPTy);
       return false;
     }
 
-    if (NewDRPTy && !OldDRPTy) {
+    // If implicit __started_by is missing, we have already emitted an error for
+    // the __ended_by mismatch, so don't diagnose that.
+    if (NewIsEndedBy && !OldIsEndedBy) {
       ReportConflict(RangeDiagIndex);
       return false;
     }
@@ -3991,9 +4073,8 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
       ReportCountConflict(OldDCPTy);
       return false;
     }
-    // Implicit __started_by attributes have not yet been added to NewTy, so
-    // don't diagnose that.
-    if (!NewDRPTy && OldDRPTy && OldDRPTy->getEndPointer()) {
+
+    if (!NewIsEndedBy && OldIsEndedBy) {
       ReportConflict(RangeDiagIndex);
       return false;
     }
@@ -4005,27 +4086,31 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
 
     if (NewDCPTy && OldDCPTy) {
       if (!checkCompatibleBoundExprs(NewDCPTy->getCountExpr(), OldDCPTy->getCountExpr())) {
-        ReportCountConflict(NewDCPTy);
+        ReportCountBothConflict(NewDCPTy, OldDCPTy);
         return false;
       }
       // '__sized_by' and '__counted_by'
       if (NewDCPTy->isCountInBytes() != OldDCPTy->isCountInBytes()) {
         CharUnits NewPointeeSize = Self.Context.getTypeSizeInChars(NewDCPTy->getPointeeType());
         if (!NewPointeeSize.isOne() && !NewDCPTy->isVoidPointerType()) {
-          ReportCountConflict(NewDCPTy);
+          ReportCountBothConflict(NewDCPTy, OldDCPTy);
           return false;
         }
       }
       // '__counted_by_or_null' and '__counted_by'
       if (NewDCPTy->isOrNull() != OldDCPTy->isOrNull()) {
-        ReportCountConflict(NewDCPTy);
+        ReportCountBothConflict(NewDCPTy, OldDCPTy);
         return false;
       }
     }
-    if (NewDRPTy && OldDRPTy) {
+    if (NewIsEndedBy && OldIsEndedBy) {
       // Start pointers are implicit so we don't check it here.
       if (!checkCompatibleBoundExprs(NewDRPTy->getEndPointer(), OldDRPTy->getEndPointer())) {
         ReportConflict(RangeDiagIndex);
+        Self.Diag(NewLoc,
+                  diag::note_bounds_safety_conflicting_pointer_attribute_args)
+            << /* end */ 0 << OldDRPTy->getEndPointer()
+            << NewDRPTy->getEndPointer();
         return false;
       }
     }
@@ -4033,6 +4118,9 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
         !llvm::APSInt::isSameValue(NewVTTy->getTerminatorValue(Self.Context),
                                    OldVTTy->getTerminatorValue(Self.Context))) {
       ReportConflict(TermDiagIndex);
+      Self.Diag(NewLoc, diag::note_bounds_safety_conflicting_pointer_attribute_args)
+          << /* terminator */ 1 << OldVTTy->getTerminatorExpr()
+          << NewVTTy->getTerminatorExpr();
       return false;
     }
     TypeLoc NewSubTL, OldSubTL;
@@ -4056,9 +4144,10 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
     OldReturnTL = OldTL.getReturnLoc();
   if (auto NewTL = New->getFunctionTypeLoc())
     NewReturnTL = NewTL.getReturnLoc();
-  bool Compatible = checkCompatibleDynamicBoundTypes(
-          New->getReturnType(), Old->getReturnType(), NewReturnTL, OldReturnTL,
-          New->getBeginLoc(), Old->getBeginLoc());
+  bool Compatible = newFuncWillInheritOldReturnType(New, Old) ||
+                    checkCompatibleDynamicBoundTypes(
+                        New->getReturnType(), Old->getReturnType(), NewReturnTL,
+                        OldReturnTL, New->getBeginLoc(), Old->getBeginLoc());
 
   auto MinNumParams = std::min(New->getNumParams(), Old->getNumParams());
   for (unsigned i = 0; i < MinNumParams; ++i) {
@@ -4071,8 +4160,7 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
             NewParam->getBeginLoc(), OldParam->getBeginLoc());
   }
 
-  if (D) {
-    D.reset();
+  if (!Compatible) {
     Self.Diag(Old->getBeginLoc(), diag::note_previous_declaration);
   }
 
@@ -4667,7 +4755,11 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
     return true;
   }
 
-  /*TO_UPSTREAM(BoundsSafety) ON */
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  if (getLangOpts().BoundsSafety &&
+      !diagnoseConflictingAllocSizeAttribute(New, Old, *this))
+    return true;
+
   if (getLangOpts().BoundsSafetyAttributes) {
     // This is the same logic to suppress warnings in system headers.
     // In case of system functions, we want to inherit counted_by attributes
@@ -4678,7 +4770,9 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
       if (!diagnoseFunctionConflictWithDynamicBoundTypes(New, Old, *this))
         return true;
     } else if (mergeFunctionDeclBoundsAttributes(New, Old, *this)) {
-      NewQType = New->getType();
+      // Stripping sugar is required to inherit alloc_size attribute.
+      // Bounds attributes are not stripped from the function decl.
+      NewQType = Context.getCanonicalType(New->getType());
     }
   }
 
@@ -4686,7 +4780,7 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
       mergeFunctionDeclTerminatedByAttribute(New, Old, *this)) {
     // TODO: Merge __terminated_by() attributes in attribute-only mode.
     // rdar://137984921
-    NewQType = New->getType();
+    NewQType = Context.getCanonicalType(New->getType());
   }
   /*TO_UPSTREAM(BoundsSafety) OFF */
 
@@ -5115,8 +5209,19 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
       = New->getType()->getAs<FunctionProtoType>();
 
     // Determine whether this is the GNU C extension.
-    QualType MergedReturn = Context.mergeTypes(OldProto->getReturnType(),
-                                               NewProto->getReturnType());
+    /* TO_UPSTREAM(BoundsSafety) ON
+     * Diff w/ upstream: reversed parameter order. This aligns better with other
+     * calls to mergeTypes, and makes sure that the new type is used if they are
+     * canonically the same. This is relevant for bounds safety when overriding an
+     * earlier declaration with different bounds. */
+    QualType MergedReturn;
+    if (getLangOpts().BoundsSafety)
+      MergedReturn = Context.mergeTypes(NewProto->getReturnType(),
+                                        OldProto->getReturnType());
+    else
+      /* TO_UPSTREAM(BoundsSafety) OFF */
+      MergedReturn = Context.mergeTypes(OldProto->getReturnType(),
+                                        NewProto->getReturnType());
     bool LooseCompatible = !MergedReturn.isNull();
     for (unsigned Idx = 0, End = Old->getNumParams();
          LooseCompatible && Idx != End; ++Idx) {
@@ -5235,7 +5340,17 @@ bool Sema::MergeCompatibleFunctionDecls(FunctionDecl *New, FunctionDecl *Old,
   // Merge the function types so the we get the composite types for the return
   // and argument types. Per C11 6.2.7/4, only update the type if the old decl
   // was visible.
-  QualType Merged = Context.mergeTypes(Old->getType(), New->getType());
+  /* TO_UPSTREAM(BoundsSafety) ON
+   * Diff w/ upstream: reversed parameter order. This aligns better with other
+   * calls to mergeTypes, and makes sure that the new type is used if they are
+   * canonically the same. This is relevant for bounds safety when overriding an
+   * earlier declaration with different bounds. */
+  QualType Merged;
+  if (getLangOpts().BoundsSafety)
+    Merged = Context.mergeTypes(New->getType(), Old->getType());
+  else
+    Merged = Context.mergeTypes(Old->getType(), New->getType());
+  /* TO_UPSTREAM(BoundsSafety) OFF */
   if (!Merged.isNull() && MergeTypeWithOld)
     New->setType(Merged);
 
@@ -7840,7 +7955,7 @@ void Sema::deduceBoundsSafetyPointerTypes(ValueDecl *Decl) {
       Decl->getType(), CurPointerAbi, ShouldAutoBound));
 }
 
-static QualType deduceBoundsSafetyFuncType(Sema &S, const FunctionDecl *Decl,
+static QualType deduceBoundsSafetyFuncType(Sema &S, FunctionDecl *Decl,
                                         QualType Ty) {
   if (const auto *AttrTy = Ty->getAs<AttributedType>()) {
     QualType ModTy =
@@ -7853,6 +7968,7 @@ static QualType deduceBoundsSafetyFuncType(Sema &S, const FunctionDecl *Decl,
   QualType NewRetTy = S.Context.getBoundsSafetyAutoPointerType(
       Decl->getReturnType(), S.CurPointerAbi,
       /*ShouldAutoBound=*/false);
+  NewRetTy = S.PostProcessBoundsSafetyAllocSizeAttribute(Decl, NewRetTy);
 
   if (NewRetTy == Decl->getReturnType())
     return Ty;
@@ -8171,8 +8287,9 @@ static void checkExternalBoundsRedeclaration(Sema &S, Decl *D) {
   if (!NewVD || NewVD->isFirstDecl())
     return;
 
-  if (NewVD->isFirstDecl())
-    return;
+  // Parameters are handled in diagnoseFunctionConflictWithDynamicBoundTypes().
+  assert(!isa<ParmVarDecl>(NewVD));
+
   VarDecl *PrevVD = NewVD->getFirstDecl();
 
   const auto *PrevTy = PrevVD->getType()->getAs<CountAttributedType>();

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3742,6 +3742,7 @@ static void adjustDeclContextForDeclaratorDecl(DeclaratorDecl *NewD,
 }
 
 /* TO_UPSTREAM(BoundsSafety) ON*/
+// FIXME: Rename to something more accurate
 struct TransposeDynamicBoundsExpr
     : public TreeTransform<TransposeDynamicBoundsExpr> {
   using BaseClass = TreeTransform<TransposeDynamicBoundsExpr>;
@@ -3749,7 +3750,9 @@ struct TransposeDynamicBoundsExpr
   FunctionDecl *NewFD;
   bool Success = true;
 
-  static bool Rewrite(Sema &SemaRef, FunctionDecl *NewFD, Expr *E,
+  /// Check that using the expr `E` in the signature of `NewFD` is okay. This
+  /// won't actually rewrite anything, so it's important to check the result!
+  static bool Check(Sema &SemaRef, FunctionDecl *NewFD, Expr *E,
                       std::string &Result) {
     bool Invalid;
     auto TokRange = CharSourceRange::getTokenRange(E->getSourceRange());
@@ -3758,9 +3761,9 @@ struct TransposeDynamicBoundsExpr
     if (Invalid)
       return false;
 
-    TransposeDynamicBoundsExpr Rewriter(SemaRef, NewFD);
-    Rewriter.TransformExpr(E);
-    return Rewriter.Success;
+    TransposeDynamicBoundsExpr Checker(SemaRef, NewFD);
+    Checker.TransformExpr(E);
+    return Checker.Success;
   }
 
   TransposeDynamicBoundsExpr(Sema &SemaRef, FunctionDecl *NewFD)
@@ -3780,7 +3783,48 @@ struct TransposeDynamicBoundsExpr
     // make them up–the header could be included by files that use macros with
     // the same name as the parameter names we would like to use.
     Success &= OldName == NewName;
+    // NB: don't use this return value for anything, it is not actually rewritten
     return E;
+  }
+};
+
+struct TransposeDynamicBoundsExprForReal
+    : public TreeTransform<TransposeDynamicBoundsExprForReal> {
+  using BaseClass = TreeTransform<TransposeDynamicBoundsExprForReal>;
+
+  FunctionDecl *NewFD;
+  bool Success = true;
+
+  /// Rewrite the expr `E` in the context of `NewFD`.
+  /// If `E` refers to any function parameters, the rewritten version will refer
+  /// to the corresponding parameters in `NewFD`.
+  static bool Rewrite(Sema &SemaRef, FunctionDecl *NewFD, Expr *E,
+                      std::string &Result) {
+
+    TransposeDynamicBoundsExprForReal Rewriter(SemaRef, NewFD);
+    ExprResult ExprRes = Rewriter.TransformExpr(E);
+    if (ExprRes.isInvalid())
+      return false;
+
+    llvm::raw_string_ostream SS(Result);
+    ExprRes.get()->printPretty(SS, nullptr,
+                               SemaRef.getASTContext().getPrintingPolicy());
+    return true;
+  }
+
+  TransposeDynamicBoundsExprForReal(Sema &SemaRef, FunctionDecl *NewFD)
+      : BaseClass(SemaRef), NewFD(NewFD) {}
+
+  ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
+    ASTContext &ctx = SemaRef.getASTContext();
+    assert(isa<ParmVarDecl>(E->getDecl()));
+    auto *OldParm = cast<ParmVarDecl>(E->getDecl());
+    auto *NewParm = NewFD->getParamDecl(OldParm->getFunctionScopeIndex());
+    if (!ctx.hasSameType(OldParm->getType(), NewParm->getType()))
+      return {};
+    return DeclRefExpr::Create(ctx, NestedNameSpecifierLoc(), SourceLocation(),
+                               NewParm, false, SourceLocation(),
+                               NewParm->getType(), E->getValueKind());
   }
 };
 
@@ -3849,7 +3893,7 @@ static void fixBoundsSafetyTypeLocs(Sema &S, Sema::SemaDiagnosticBuilder &D,
     KS << "__bidi_indexable";
   } else if (auto DCPTA = QA->getAs<CountAttributedType>()) {
     std::string Rewritten;
-    if (!TransposeDynamicBoundsExpr::Rewrite(S, BDecl, DCPTA->getCountExpr(),
+    if (!TransposeDynamicBoundsExpr::Check(S, BDecl, DCPTA->getCountExpr(),
                                              Rewritten))
       return;
     const char *Keyword =
@@ -3860,7 +3904,7 @@ static void fixBoundsSafetyTypeLocs(Sema &S, Sema::SemaDiagnosticBuilder &D,
     KS << '(' << Rewritten << ')';
   } else if (auto EndPointer = GetEndPointer(QA)) {
     std::string Rewritten;
-    if (!TransposeDynamicBoundsExpr::Rewrite(S, BDecl, EndPointer, Rewritten))
+    if (!TransposeDynamicBoundsExpr::Check(S, BDecl, EndPointer, Rewritten))
       return;
     KS << "__ended_by(" << Rewritten << ')';
   } else {
@@ -3879,6 +3923,36 @@ static void fixBoundsSafetyTypeLocs(Sema &S, Sema::SemaDiagnosticBuilder &D,
 
   KS.flush();
   D << FixItHint::CreateInsertion(FixItLoc, BoundsAnnotation);
+}
+
+/// Emit fixits on diagnostic D to adjust the CountAttributedType B/QB
+/// to match the bounds and kind indicated on CountAttributedType A/QA. A/QA
+/// is not reciprocally adjusted if B/QB has qualifiers; this function needs
+/// to be called once for each direction.
+void BoundsSafetyFixItUtils::fixCountAttributedTypeLocsInFunctionSignature(
+    Sema &S, Sema::SemaDiagnosticBuilder &D, QualType QA, QualType QB,
+    FunctionDecl *ADecl, FunctionDecl *BDecl, bool ExprMismatch,
+    bool KindMismatch) {
+  auto *ATy = QA->getAs<CountAttributedType>();
+  auto *BTy = QB->getAs<CountAttributedType>();
+  assert(ATy && BTy);
+  if (!ATy || !BTy)
+    return;
+
+  if (ADecl->getNumParams() != BDecl->getNumParams())
+    return;
+
+  if (ExprMismatch) {
+    std::string Rewritten;
+    if (!TransposeDynamicBoundsExprForReal::Rewrite(
+            S, BDecl, ATy->getCountExpr(), Rewritten))
+      return; // don't emit a KindMismatch fix-it either if this fails
+    D << FixItHint::CreateReplacement(BTy->getCountExpr()->getSourceRange(),
+                                      Rewritten);
+  }
+  if (KindMismatch) {
+    S.fixCountAttributedTypeKind(D, ATy, BTy);
+  }
 }
 
 static void fixBoundsSafetyFunctionDecl(Sema &S, Sema::SemaDiagnosticBuilder &D,
@@ -4024,27 +4098,6 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
       ReportConflict(Index);
     };
 
-    auto ReportCountBothConflict = [&](const CountAttributedType *NewDCPTy,
-                                       const CountAttributedType *OldDCPTy) {
-      ReportCountConflict(NewDCPTy);
-
-      Self.Diag(NewLoc, diag::note_bounds_safety_conflicting_count_attribute)
-          << OldDCPTy->getKind() << OldDCPTy->getCountExpr()
-          << NewDCPTy->getKind() << NewDCPTy->getCountExpr();
-
-      if (auto NewASA = New->getAttr<AllocSizeAttr>()) {
-        Self.Diag(NewASA->getLoc(),
-                  diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
-            << !New->hasAttr<ReturnsNonNullAttr>() << NewASA->getRange();
-      }
-
-      if (auto OldASA = Old->getAttr<AllocSizeAttr>()) {
-        Self.Diag(OldASA->getLoc(),
-                  diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
-            << !Old->hasAttr<ReturnsNonNullAttr>() << OldASA->getRange();
-      }
-    };
-
     // Check bounds type present in New but not in Old first, then
     // in Old but now in New. That way if a parameter or return type
     // is e.g. __counted_by in Old and __null_terminated in New, we
@@ -4085,24 +4138,54 @@ static bool diagnoseFunctionConflictWithDynamicBoundTypes(FunctionDecl *New,
     }
 
     if (NewDCPTy && OldDCPTy) {
-      if (!checkCompatibleBoundExprs(NewDCPTy->getCountExpr(), OldDCPTy->getCountExpr())) {
-        ReportCountBothConflict(NewDCPTy, OldDCPTy);
-        return false;
-      }
-      // '__sized_by' and '__counted_by'
+      // Always check both types of mismatch to provide better fix-its
+      bool ExprMismatch = !checkCompatibleBoundExprs(NewDCPTy->getCountExpr(), OldDCPTy->getCountExpr());
+
+      bool KindMismatch = false;
       if (NewDCPTy->isCountInBytes() != OldDCPTy->isCountInBytes()) {
+        // '__sized_by' and '__counted_by'
         CharUnits NewPointeeSize = Self.Context.getTypeSizeInChars(NewDCPTy->getPointeeType());
         if (!NewPointeeSize.isOne() && !NewDCPTy->isVoidPointerType()) {
-          ReportCountBothConflict(NewDCPTy, OldDCPTy);
-          return false;
+          KindMismatch = true;
         }
+      } else if (NewDCPTy->isOrNull() != OldDCPTy->isOrNull()) {
+        // '__counted_by_or_null' and '__counted_by'
+        KindMismatch = true;
       }
-      // '__counted_by_or_null' and '__counted_by'
-      if (NewDCPTy->isOrNull() != OldDCPTy->isOrNull()) {
-        ReportCountBothConflict(NewDCPTy, OldDCPTy);
+
+      if (ExprMismatch || KindMismatch) {
+        ReportCountConflict(NewDCPTy);
+        {
+          auto D = Self.Diag(NewLoc, diag::note_bounds_safety_conflicting_count_attribute)
+             << OldDCPTy->getKind() << OldDCPTy->getCountExpr()
+             << NewDCPTy->getKind() << NewDCPTy->getCountExpr();
+          if (!Old->hasAttr<AllocSizeAttr>()) {
+            BoundsSafetyFixItUtils::
+                fixCountAttributedTypeLocsInFunctionSignature(
+                    Self, D, NewTy, OldTy, New, Old, ExprMismatch,
+                    KindMismatch);
+          }
+          if (!New->hasAttr<AllocSizeAttr>()) {
+            BoundsSafetyFixItUtils::
+                fixCountAttributedTypeLocsInFunctionSignature(
+                    Self, D, OldTy, NewTy, Old, New, ExprMismatch,
+                    KindMismatch);
+          }
+        }
+        if (auto NewASA = New->getAttr<AllocSizeAttr>()) {
+          Self.Diag(NewASA->getLoc(),
+                    diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
+              << !New->hasAttr<ReturnsNonNullAttr>() << NewASA->getRange();
+        }
+        if (auto OldASA = Old->getAttr<AllocSizeAttr>()) {
+          Self.Diag(OldASA->getLoc(),
+                    diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
+              << !Old->hasAttr<ReturnsNonNullAttr>() << OldASA->getRange();
+        }
         return false;
       }
     }
+
     if (NewIsEndedBy && OldIsEndedBy) {
       // Start pointers are implicit so we don't check it here.
       if (!checkCompatibleBoundExprs(NewDRPTy->getEndPointer(), OldDRPTy->getEndPointer())) {

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3743,9 +3743,9 @@ static void adjustDeclContextForDeclaratorDecl(DeclaratorDecl *NewD,
 
 /* TO_UPSTREAM(BoundsSafety) ON*/
 // FIXME: Rename to something more accurate
-struct TransposeDynamicBoundsExpr
-    : public TreeTransform<TransposeDynamicBoundsExpr> {
-  using BaseClass = TreeTransform<TransposeDynamicBoundsExpr>;
+struct CheckSameParameterNames
+    : public TreeTransform<CheckSameParameterNames> {
+  using BaseClass = TreeTransform<CheckSameParameterNames>;
 
   FunctionDecl *NewFD;
   bool Success = true;
@@ -3761,12 +3761,12 @@ struct TransposeDynamicBoundsExpr
     if (Invalid)
       return false;
 
-    TransposeDynamicBoundsExpr Checker(SemaRef, NewFD);
+    CheckSameParameterNames Checker(SemaRef, NewFD);
     Checker.TransformExpr(E);
     return Checker.Success;
   }
 
-  TransposeDynamicBoundsExpr(Sema &SemaRef, FunctionDecl *NewFD)
+  CheckSameParameterNames(Sema &SemaRef, FunctionDecl *NewFD)
       : BaseClass(SemaRef), NewFD(NewFD) {}
 
   ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
@@ -3788,12 +3788,11 @@ struct TransposeDynamicBoundsExpr
   }
 };
 
-struct TransposeDynamicBoundsExprForReal
-    : public TreeTransform<TransposeDynamicBoundsExprForReal> {
-  using BaseClass = TreeTransform<TransposeDynamicBoundsExprForReal>;
+struct TransposeDynamicBoundsExpr
+    : public TreeTransform<TransposeDynamicBoundsExpr> {
+  using BaseClass = TreeTransform<TransposeDynamicBoundsExpr>;
 
   FunctionDecl *NewFD;
-  bool Success = true;
 
   /// Rewrite the expr `E` in the context of `NewFD`.
   /// If `E` refers to any function parameters, the rewritten version will refer
@@ -3801,7 +3800,7 @@ struct TransposeDynamicBoundsExprForReal
   static bool Rewrite(Sema &SemaRef, FunctionDecl *NewFD, Expr *E,
                       std::string &Result) {
 
-    TransposeDynamicBoundsExprForReal Rewriter(SemaRef, NewFD);
+    TransposeDynamicBoundsExpr Rewriter(SemaRef, NewFD);
     ExprResult ExprRes = Rewriter.TransformExpr(E);
     if (ExprRes.isInvalid())
       return false;
@@ -3812,16 +3811,15 @@ struct TransposeDynamicBoundsExprForReal
     return true;
   }
 
-  TransposeDynamicBoundsExprForReal(Sema &SemaRef, FunctionDecl *NewFD)
+  TransposeDynamicBoundsExpr(Sema &SemaRef, FunctionDecl *NewFD)
       : BaseClass(SemaRef), NewFD(NewFD) {}
 
   ExprResult TransformDeclRefExpr(DeclRefExpr *E) {
-    ASTContext &ctx = SemaRef.getASTContext();
-    assert(isa<ParmVarDecl>(E->getDecl()));
-    auto *OldParm = cast<ParmVarDecl>(E->getDecl());
+    const ASTContext &ctx = SemaRef.getASTContext();
+    const auto *OldParm = cast<ParmVarDecl>(E->getDecl());
     auto *NewParm = NewFD->getParamDecl(OldParm->getFunctionScopeIndex());
     if (!ctx.hasSameType(OldParm->getType(), NewParm->getType()))
-      return {};
+      return ExprError();
     return DeclRefExpr::Create(ctx, NestedNameSpecifierLoc(), SourceLocation(),
                                NewParm, false, SourceLocation(),
                                NewParm->getType(), E->getValueKind());
@@ -3893,7 +3891,7 @@ static void fixBoundsSafetyTypeLocs(Sema &S, Sema::SemaDiagnosticBuilder &D,
     KS << "__bidi_indexable";
   } else if (auto DCPTA = QA->getAs<CountAttributedType>()) {
     std::string Rewritten;
-    if (!TransposeDynamicBoundsExpr::Check(S, BDecl, DCPTA->getCountExpr(),
+    if (!CheckSameParameterNames::Check(S, BDecl, DCPTA->getCountExpr(),
                                              Rewritten))
       return;
     const char *Keyword =
@@ -3904,7 +3902,7 @@ static void fixBoundsSafetyTypeLocs(Sema &S, Sema::SemaDiagnosticBuilder &D,
     KS << '(' << Rewritten << ')';
   } else if (auto EndPointer = GetEndPointer(QA)) {
     std::string Rewritten;
-    if (!TransposeDynamicBoundsExpr::Check(S, BDecl, EndPointer, Rewritten))
+    if (!CheckSameParameterNames::Check(S, BDecl, EndPointer, Rewritten))
       return;
     KS << "__ended_by(" << Rewritten << ')';
   } else {
@@ -3931,10 +3929,10 @@ static void fixBoundsSafetyTypeLocs(Sema &S, Sema::SemaDiagnosticBuilder &D,
 /// to be called once for each direction.
 void BoundsSafetyFixItUtils::fixCountAttributedTypeLocsInFunctionSignature(
     Sema &S, Sema::SemaDiagnosticBuilder &D, QualType QA, QualType QB,
-    FunctionDecl *ADecl, FunctionDecl *BDecl, bool ExprMismatch,
+    const FunctionDecl *ADecl, FunctionDecl *BDecl, bool ExprMismatch,
     bool KindMismatch) {
-  auto *ATy = QA->getAs<CountAttributedType>();
-  auto *BTy = QB->getAs<CountAttributedType>();
+  const auto *ATy = QA->getAs<CountAttributedType>();
+  const auto *BTy = QB->getAs<CountAttributedType>();
   assert(ATy && BTy);
   if (!ATy || !BTy)
     return;
@@ -3944,7 +3942,7 @@ void BoundsSafetyFixItUtils::fixCountAttributedTypeLocsInFunctionSignature(
 
   if (ExprMismatch) {
     std::string Rewritten;
-    if (!TransposeDynamicBoundsExprForReal::Rewrite(
+    if (!TransposeDynamicBoundsExpr::Rewrite(
             S, BDecl, ATy->getCountExpr(), Rewritten))
       return; // don't emit a KindMismatch fix-it either if this fails
     D << FixItHint::CreateReplacement(BTy->getCountExpr()->getSourceRange(),
@@ -3979,8 +3977,8 @@ static void fixBoundsSafetyFunctionDecl(Sema &S, Sema::SemaDiagnosticBuilder &D,
   }
 }
 
-static bool diagnoseConflictingAllocSizeAttribute(FunctionDecl *New,
-                                                  FunctionDecl *Old,
+static bool diagnoseConflictingAllocSizeAttribute(const FunctionDecl *New,
+                                                  const FunctionDecl *Old,
                                                   Sema &Self) {
   // System headers that haven't adopted bounds safety are allowed to break
   // the rules for compatibility reasons, since errors there are hard to fix.
@@ -3991,8 +3989,8 @@ static bool diagnoseConflictingAllocSizeAttribute(FunctionDecl *New,
   // return types. Merging of attributes is done after type checking, but we
   // want to emit the root cause of the type error rather than an error for
   // mismatcing (implicit) return types.
-  if (auto OldASA = Old->getAttr<AllocSizeAttr>()) {
-    if (auto NewASA = New->getAttr<AllocSizeAttr>()) {
+  if (const auto *OldASA = Old->getAttr<AllocSizeAttr>()) {
+    if (const auto *NewASA = New->getAttr<AllocSizeAttr>()) {
       if (!OldASA->getElemSizeParam().equals(NewASA->getElemSizeParam()) ||
           !OldASA->getNumElemsParam().equals(NewASA->getNumElemsParam())) {
         Self.Diag(NewASA->getLoc(), diag::err_mismatched_alloc_size)

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -5292,19 +5292,8 @@ bool Sema::MergeFunctionDecl(FunctionDecl *New, NamedDecl *&OldD, Scope *S,
       = New->getType()->getAs<FunctionProtoType>();
 
     // Determine whether this is the GNU C extension.
-    /* TO_UPSTREAM(BoundsSafety) ON
-     * Diff w/ upstream: reversed parameter order. This aligns better with other
-     * calls to mergeTypes, and makes sure that the new type is used if they are
-     * canonically the same. This is relevant for bounds safety when overriding an
-     * earlier declaration with different bounds. */
-    QualType MergedReturn;
-    if (getLangOpts().BoundsSafety)
-      MergedReturn = Context.mergeTypes(NewProto->getReturnType(),
-                                        OldProto->getReturnType());
-    else
-      /* TO_UPSTREAM(BoundsSafety) OFF */
-      MergedReturn = Context.mergeTypes(OldProto->getReturnType(),
-                                        NewProto->getReturnType());
+    QualType MergedReturn = Context.mergeTypes(OldProto->getReturnType(),
+                                               NewProto->getReturnType());
     bool LooseCompatible = !MergedReturn.isNull();
     for (unsigned Idx = 0, End = Old->getNumParams();
          LooseCompatible && Idx != End; ++Idx) {
@@ -5423,17 +5412,7 @@ bool Sema::MergeCompatibleFunctionDecls(FunctionDecl *New, FunctionDecl *Old,
   // Merge the function types so the we get the composite types for the return
   // and argument types. Per C11 6.2.7/4, only update the type if the old decl
   // was visible.
-  /* TO_UPSTREAM(BoundsSafety) ON
-   * Diff w/ upstream: reversed parameter order. This aligns better with other
-   * calls to mergeTypes, and makes sure that the new type is used if they are
-   * canonically the same. This is relevant for bounds safety when overriding an
-   * earlier declaration with different bounds. */
-  QualType Merged;
-  if (getLangOpts().BoundsSafety)
-    Merged = Context.mergeTypes(New->getType(), Old->getType());
-  else
-    Merged = Context.mergeTypes(Old->getType(), New->getType());
-  /* TO_UPSTREAM(BoundsSafety) OFF */
+  QualType Merged = Context.mergeTypes(Old->getType(), New->getType());
   if (!Merged.isNull() && MergeTypeWithOld)
     New->setType(Merged);
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6340,6 +6340,7 @@ public:
           NewDCPTy->isCountInBytes() == T->isCountInBytes()) {
         assert(NewDCPTy->isCountInBytes() &&
                "unexpected implicit __counted_by_or_null");
+        assert(NewDCPTy->isOrNull() != T->isOrNull());
 
         if (!NewDCPTy->isOrNull())
           // Error already emitted for combining returns_nonnull with

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -577,9 +577,9 @@ static QualType CreateImplicitCountAttributedType(Sema &S, unsigned Level,
                                                   bool OrNull, QualType T,
                                                   bool ScopeCheck = false);
 
-static ExprResult getAllocSizeExpr(Sema &S, Decl *D, ParamIdx SizeIdx,
+static ExprResult getAllocSizeExpr(Sema &S, FunctionDecl *D, ParamIdx SizeIdx,
                                    ParamIdx NumberIdx) {
-  auto createParamDeclRef = [&S](Decl *FuncD, ParamIdx Idx) {
+  auto createParamDeclRef = [&S](FunctionDecl *FuncD, ParamIdx Idx) {
     ParmVarDecl *Parm = getFunctionOrMethodParam(FuncD, Idx.getASTIndex());
 
     return DeclRefExpr::Create(
@@ -598,7 +598,7 @@ static ExprResult getAllocSizeExpr(Sema &S, Decl *D, ParamIdx SizeIdx,
 }
 
 static QualType PostProcessBoundsSafetyAllocSizeAttributeImpl(
-    Sema &S, NamedDecl *D, const AllocSizeAttr &ASA, QualType FT) {
+    Sema &S, FunctionDecl *D, const AllocSizeAttr &ASA, QualType FT) {
   ExprResult SizeExpr =
       getAllocSizeExpr(S, D, ASA.getElemSizeParam(), ASA.getNumElemsParam());
   if (SizeExpr.isInvalid())

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -597,26 +597,7 @@ static ExprResult getAllocSizeExpr(Sema &S, FunctionDecl *D, ParamIdx SizeIdx,
   return SizeExpr;
 }
 
-static QualType PostProcessBoundsSafetyAllocSizeAttributeImpl(
-    Sema &S, FunctionDecl *D, const AllocSizeAttr &ASA, QualType FT) {
-  ExprResult SizeExpr =
-      getAllocSizeExpr(S, D, ASA.getElemSizeParam(), ASA.getNumElemsParam());
-  if (SizeExpr.isInvalid())
-    return FT;
-
-  unsigned Level = 0;
-  bool CountInBytes = true;
-  // returns_nonnull is allowed to change program semantics to assume
-  // it cannot return null. _Nonnull does not affect program semantics,
-  // only analysis/diagnostics, so ignore that here.
-  bool OrNull = !D->hasAttr<ReturnsNonNullAttr>();
-
-  const IdentifierInfo *AttrName = ASA.getAttrName();
-  return CreateImplicitCountAttributedType(S, Level, AttrName->getName(), SizeExpr.get(),
-                                           ASA.getLoc(), CountInBytes, OrNull, FT);
-}
-
-void diagnoseInvalidReturnTypeForAllocSize(Sema &S, FunctionDecl *D,
+static void diagnoseInvalidReturnTypeForAllocSize(Sema &S, FunctionDecl *D,
                                            const AllocSizeAttr &ASA) {
   ExprResult SizeExpr =
       getAllocSizeExpr(S, D, ASA.getElemSizeParam(), ASA.getNumElemsParam());
@@ -625,7 +606,7 @@ void diagnoseInvalidReturnTypeForAllocSize(Sema &S, FunctionDecl *D,
   Expr *Size = SizeExpr.get();
 
   QualType RetTy = D->getReturnType();
-  auto CATy = RetTy->getAs<CountAttributedType>();
+  const auto *CATy = RetTy->getAs<CountAttributedType>();
   if (!CATy) {
     S.Diag(D->getBeginLoc(), diag::err_invalid_return_type_for_alloc_size)
         << RetTy << Size << D->getReturnTypeSourceRange();
@@ -670,8 +651,8 @@ static AllocSizeAttr *mergeAllocSizeAttrImpl(Sema &S, Decl *D,
                                              ParamIdx ElemSizeParam,
                                              ParamIdx NumElemsParam) {
   if (S.getLangOpts().BoundsSafety) {
-    if (auto OldASA = D->getAttr<AllocSizeAttr>()) {
-      if (!OldASA->getElemSizeParam().equals(ElemSizeParam) ||
+    if (const auto *OldASA = D->getAttr<AllocSizeAttr>()) {
+      if (OldASA->getElemSizeParam() != ElemSizeParam ||
           !OldASA->getNumElemsParam().equals(NumElemsParam)) {
         S.Diag(CI.getLoc(), diag::err_mismatched_alloc_size) << CI.getRange();
         S.Diag(OldASA->getLoc(), diag::note_conflicting_attribute)
@@ -9656,8 +9637,23 @@ QualType Sema::PostProcessBoundsSafetyAllocSizeAttribute(FunctionDecl *D,
     auto ASA = D->getAttr<AllocSizeAttr>();
     if (!ASA)
       return FT;
-    QualType NewDeclTy =
-        PostProcessBoundsSafetyAllocSizeAttributeImpl(*this, D, *ASA, FT);
+    ExprResult SizeExpr = getAllocSizeExpr(*this, D, ASA->getElemSizeParam(),
+                                           ASA->getNumElemsParam());
+    if (SizeExpr.isInvalid())
+      return FT;
+
+    unsigned Level = 0;
+    bool CountInBytes = true;
+    // returns_nonnull is allowed to change program semantics to assume
+    // it cannot return null. _Nonnull does not affect program semantics,
+    // only analysis/diagnostics, so ignore that here.
+    bool OrNull = !D->hasAttr<ReturnsNonNullAttr>();
+    const IdentifierInfo *AttrName = ASA->getAttrName();
+
+    QualType NewDeclTy = CreateImplicitCountAttributedType(
+        *this, Level, AttrName->getName(), SizeExpr.get(), ASA->getLoc(),
+        CountInBytes, OrNull, FT);
+
     if (NewDeclTy.isNull())
       return FT;
     return NewDeclTy;

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6561,6 +6561,7 @@ public:
 
 class ConstructDynamicRangePointerType :
   public ConstructDynamicBoundType<ConstructDynamicRangePointerType> {
+  using BaseClass = ConstructDynamicBoundType<ConstructDynamicRangePointerType>;
   std::optional<TypeCoupledDeclRefInfo> StartPtrInfo;
 
 public:
@@ -6649,7 +6650,7 @@ public:
       ConstructedType = RetTy->getAs<BoundsAttributedType>();
       return RetTy;
     }
-    return VisitDynamicRangePointerType(T);
+    return BaseClass::VisitDynamicRangePointerType(T);
   }
 
   QualType DiagnoseConflictingType(const CountAttributedType *T) {

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -569,6 +569,121 @@ static bool checkParamIsIntegerType(Sema &S, const Decl *D, const AttrInfo &AI,
   return true;
 }
 
+/* TO_UPSTREAM(BoundsSafety) ON */
+static QualType CreateImplicitCountAttributedType(Sema &S, unsigned Level,
+                                                  const StringRef DiagName, Expr *ArgExpr,
+                                                  SourceLocation Loc,
+                                                  bool CountInBytes,
+                                                  bool OrNull, QualType T,
+                                                  bool ScopeCheck = false);
+
+static ExprResult getAllocSizeExpr(Sema &S, Decl *D, ParamIdx SizeIdx,
+                                   ParamIdx NumberIdx) {
+  auto createParamDeclRef = [&S](Decl *FuncD, ParamIdx Idx) {
+    ParmVarDecl *Parm = getFunctionOrMethodParam(FuncD, Idx.getASTIndex());
+
+    return DeclRefExpr::Create(
+        S.Context, NestedNameSpecifierLoc{}, SourceLocation{}, Parm, false,
+        DeclarationNameInfo{Parm->getDeclName(), Parm->getLocation()},
+        Parm->getType(), VK_LValue);
+  };
+
+  Expr *SizeExpr = createParamDeclRef(D, SizeIdx);
+  if (NumberIdx.isValid()) {
+    Expr *NumExpr = createParamDeclRef(D, NumberIdx);
+    return S.CreateBuiltinBinOp(SourceLocation(), BO_Mul, SizeExpr, NumExpr);
+  }
+
+  return SizeExpr;
+}
+
+static QualType PostProcessBoundsSafetyAllocSizeAttributeImpl(
+    Sema &S, NamedDecl *D, const AllocSizeAttr &ASA, QualType FT) {
+  ExprResult SizeExpr =
+      getAllocSizeExpr(S, D, ASA.getElemSizeParam(), ASA.getNumElemsParam());
+  if (SizeExpr.isInvalid())
+    return FT;
+
+  unsigned Level = 0;
+  bool CountInBytes = true;
+  // returns_nonnull is allowed to change program semantics to assume
+  // it cannot return null. _Nonnull does not affect program semantics,
+  // only analysis/diagnostics, so ignore that here.
+  bool OrNull = !D->hasAttr<ReturnsNonNullAttr>();
+
+  const IdentifierInfo *AttrName = ASA.getAttrName();
+  return CreateImplicitCountAttributedType(S, Level, AttrName->getName(), SizeExpr.get(),
+                                           ASA.getLoc(), CountInBytes, OrNull, FT);
+}
+
+void diagnoseInvalidReturnTypeForAllocSize(Sema &S, FunctionDecl *D,
+                                           const AllocSizeAttr &ASA) {
+  ExprResult SizeExpr =
+      getAllocSizeExpr(S, D, ASA.getElemSizeParam(), ASA.getNumElemsParam());
+  if (SizeExpr.isInvalid())
+    return;
+  Expr *Size = SizeExpr.get();
+
+  QualType RetTy = D->getReturnType();
+  auto CATy = RetTy->getAs<CountAttributedType>();
+  if (!CATy || !CATy->isCountInBytes()) {
+    S.Diag(D->getBeginLoc(), diag::err_invalid_return_type_for_alloc_size)
+        << RetTy << Size << D->getReturnTypeSourceRange();
+    S.Diag(ASA.getLoc(), diag::note_attribute_inherited) << ASA.getRange();
+    return;
+  }
+
+  llvm::FoldingSetNodeID NewID;
+  llvm::FoldingSetNodeID OldID;
+  CATy->getCountExpr()->IgnoreParenImpCasts()->Profile(NewID, S.Context,
+                                                       /*Canonical*/ true);
+  Size->Profile(OldID, S.Context, /*Canonical*/ true);
+  if (NewID != OldID) {
+    S.Diag(D->getBeginLoc(), diag::err_invalid_return_type_for_alloc_size)
+        << RetTy << Size << D->getReturnTypeSourceRange();
+    S.Diag(ASA.getLoc(), diag::note_attribute_inherited) << ASA.getRange();
+  }
+}
+
+/// Note: this only checks alloc_size attributes on the same declaration.
+/// Because type merging is done before attribute merging, alloc_size
+/// attributes between redeclarations are checked in
+/// diagnoseFunctionConflictWithDynamicBoundTypes.
+static AllocSizeAttr *mergeAllocSizeAttrImpl(Sema &S, Decl *D,
+                                             const AttributeCommonInfo &CI,
+                                             ParamIdx ElemSizeParam,
+                                             ParamIdx NumElemsParam) {
+  if (S.getLangOpts().BoundsSafety) {
+    if (auto OldASA = D->getAttr<AllocSizeAttr>()) {
+      if (!OldASA->getElemSizeParam().equals(ElemSizeParam) ||
+          !OldASA->getNumElemsParam().equals(NumElemsParam)) {
+        S.Diag(CI.getLoc(), diag::err_mismatched_alloc_size) << CI.getRange();
+        S.Diag(OldASA->getLoc(), diag::note_conflicting_attribute)
+            << OldASA->getRange();
+      }
+      // Don't add a second attribute regardless, it is just redundant
+      return nullptr;
+    }
+  }
+
+  return ::new (S.Context)
+      AllocSizeAttr(S.Context, CI, ElemSizeParam, NumElemsParam);
+}
+
+AllocSizeAttr *Sema::mergeAllocSizeAttr(NamedDecl *D,
+                                        const AllocSizeAttr &ASA) {
+  assert(ASA.getElemSizeParam().isValid());
+  AllocSizeAttr *NewASA = mergeAllocSizeAttrImpl(
+      *this, D, ASA, ASA.getElemSizeParam(), ASA.getNumElemsParam());
+  if (getLangOpts().BoundsSafety)
+    // If we've reached the merging stage,
+    // PostProcessBoundsSafetyAllocSizeAttribute has already run. Here we check
+    // that the return type has bounds that match the semantics of alloc_size
+    diagnoseInvalidReturnTypeForAllocSize(*this, cast<FunctionDecl>(D), ASA);
+
+  return NewASA;
+}
+
 static void handleAllocSizeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (!AL.checkAtLeastNumArgs(S, 1) || !AL.checkAtMostNumArgs(S, 2))
     return;
@@ -602,8 +717,16 @@ static void handleAllocSizeAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     NumberArgNo = ParamIdx(Val, D);
   }
 
-  D->addAttr(::new (S.Context)
-                 AllocSizeAttr(S.Context, AL, SizeArgNo, NumberArgNo));
+  /* TO_UPSTREAM(BoundsSafety) ON */
+  AllocSizeAttr *A = mergeAllocSizeAttrImpl(S, D, AL, SizeArgNo, NumberArgNo);
+  if (!A)
+    return;
+  // Implicit __sized_by_or_null return type will be inferred later in
+  // PostProcessBoundsSafetyAllocSizeAttribute. This guarantees that all
+  // explicit bounds attributes are applied first.
+  /* TO_UPSTREAM(BoundsSafety) OFF */
+
+  D->addAttr(A);
 }
 
 static bool checkTryLockFunAttrCommon(Sema &S, Decl *D, const ParsedAttr &AL,
@@ -5920,6 +6043,7 @@ protected:
   bool ScopeCheck;
   bool AllowRedecl;
   bool AutoPtrAttributed = false;
+  bool HasNonnullAttr = false;
   bool AtomicErrorEmitted = false;
 
 public:
@@ -6059,6 +6183,9 @@ public:
     llvm::SaveAndRestore<bool> AutoPtrAttributedLocal(AutoPtrAttributed);
     if (T->getAttrKind() == attr::PtrAutoAttr)
       AutoPtrAttributed = true;
+    SaveAndRestore<bool> HasNonnullAttrLocal(HasNonnullAttr);
+    if (T->getAttrKind() == attr::TypeNonNull)
+      HasNonnullAttr = true;
 
     QualType NewModTy = Visit(T->getModifiedType());
     if (NewModTy.isNull())
@@ -6093,16 +6220,21 @@ class ConstructCountAttributedType :
   public ConstructDynamicBoundType<ConstructCountAttributedType> {
   bool CountInBytes;
   bool OrNull;
+  // Apply PtrAutoAttr on top of the CountAttributedType if it's implicit.
+  // So far only alloc_size counts as implicit, while arrays with explicit sizes
+  // being converted to __counted_by pointers still count as explicit.
+  bool IsImplicit;
 
 public:
   explicit ConstructCountAttributedType(Sema &S, unsigned Level,
                                         const StringRef DiagName, Expr *ArgE,
                                         SourceLocation Loc, bool CountInBytes,
                                         bool OrNull, bool AllowRedecl,
-                                        bool ScopeCheck = false)
+                                        bool ScopeCheck = false,
+                                        bool IsImplicit = false)
       : ConstructDynamicBoundType(S, Level, DiagName, ArgE, Loc, ScopeCheck,
                                   AllowRedecl),
-        CountInBytes(CountInBytes), OrNull(OrNull) {
+        CountInBytes(CountInBytes), OrNull(OrNull), IsImplicit(IsImplicit) {
     if (!ArgExpr->getType()->isIntegralOrEnumerationType()) {
       S.Diag(Loc, diag::err_attribute_argument_type_for_bounds_safety_count)
           << DiagName;
@@ -6165,11 +6297,13 @@ public:
                                              OrNull, ScopeCheck);
     assert(ConstructedType == nullptr);
     ConstructedType = Ty->getAs<CountAttributedType>();
+    if (IsImplicit)
+      Ty = S.Context.getAttributedType(attr::PtrAutoAttr, Ty, Ty);
     return Ty;
   }
 
   QualType DiagnoseConflictingType(const CountAttributedType *T) {
-    if (AllowRedecl) {
+    if (AllowRedecl || IsImplicit || AutoPtrAttributed) {
       QualType NewTy = BuildDynamicBoundType(T->desugar());
       const auto *NewDCPTy = NewTy->getAs<CountAttributedType>();
       // We don't have a way to distinguish if '__counted_by' is conflicting or has been
@@ -6183,12 +6317,60 @@ public:
       if (const auto *OldCnt = T->getCountExpr())
         OldCnt->Profile(OldID, S.Context, /*Canonical*/ true);
 
-      if (NewID == OldID)
+      if (NewID == OldID && NewDCPTy->getKind() == T->getKind())
         return NewTy;
+
+      if (IsImplicit && NewID == OldID &&
+          NewDCPTy->isCountInBytes() == T->isCountInBytes()) {
+        assert(NewDCPTy->isCountInBytes() &&
+               "unexpected implicit __counted_by_or_null");
+
+        if (!NewDCPTy->isOrNull())
+          // Error already emitted for combining returns_nonnull with
+          // __sized_by_or_null. No need to clutter with this warning.
+          return QualType();
+
+        // Ignore implicit __sized_by_or_null when explicit __sized_by exists.
+        assert(!T->isOrNull());
+
+        if (HasNonnullAttr)
+          return QualType(); // warning silenced by combining __sized_by and
+                             // _Nonnull
+
+        S.Diag(Loc,
+               diag::warn_bounds_safety_ignored_implicit_sized_by_or_null);
+        S.Diag(Loc,
+               diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
+            << OrNull;
+        S.Diag(T->getCountExpr()->getExprLoc(), diag::note_previous_attribute);
+        S.Diag(
+            T->getCountExpr()->getExprLoc(),
+            diag::note_bounds_safety_overriding_implicit_sized_by_or_null_silence);
+        return QualType();
+      }
     }
 
     S.Diag(Loc, diag::err_bounds_safety_conflicting_pointer_attributes)
         << /* pointer */ T->isPointerType() << /* count */ 2;
+
+    unsigned DiagIdx = CountInBytes;
+    if (OrNull)
+      DiagIdx += 2;
+
+    S.Diag(Loc, diag::note_bounds_safety_conflicting_count_attribute)
+        << T->getKind() << T->getCountExpr() << DiagIdx << ArgExpr;
+
+    if (IsImplicit) {
+      S.Diag(Loc,
+             diag::note_bounds_safety_implicit_size_from_alloc_size_attr)
+          << OrNull;
+    }
+
+    S.Diag(T->getCountExpr()->getBeginLoc(), // FIXME: would like location and
+                                             // range of attribute instead of
+                                             // just count arg rdar://127087868
+           diag::note_previous_attribute);
+
     return QualType();
   }
 
@@ -6381,7 +6563,6 @@ public:
 
 class ConstructDynamicRangePointerType :
   public ConstructDynamicBoundType<ConstructDynamicRangePointerType> {
-  using BaseClass = ConstructDynamicBoundType<ConstructDynamicRangePointerType>;
   std::optional<TypeCoupledDeclRefInfo> StartPtrInfo;
 
 public:
@@ -6470,7 +6651,7 @@ public:
       ConstructedType = RetTy->getAs<BoundsAttributedType>();
       return RetTy;
     }
-    return BaseClass::VisitDynamicRangePointerType(T);
+    return VisitDynamicRangePointerType(T);
   }
 
   QualType DiagnoseConflictingType(const CountAttributedType *T) {
@@ -6500,6 +6681,18 @@ public:
   }
 };
 } // namespace
+
+static QualType CreateImplicitCountAttributedType(Sema &S, unsigned Level,
+                                                  const StringRef DiagName, Expr *ArgExpr,
+                                                  SourceLocation Loc,
+                                                  bool CountInBytes,
+                                                  bool OrNull, QualType T,
+                                                  bool ScopeCheck) {
+  return ConstructCountAttributedType(S, Level, DiagName, ArgExpr, Loc, CountInBytes,
+                                            OrNull, /* AllowRedecl */ false, ScopeCheck,
+                                            /* IsImplicit */ true)
+      .Visit(T);
+}
 
 Sema::LifetimeCheckKind Sema::getLifetimeCheckKind(const VarDecl *Var) {
   if (!Var)
@@ -9438,6 +9631,23 @@ bool Sema::ProcessAccessDeclAttributeList(
   }
   return false;
 }
+
+/* TO_UPSTREAM(BoundsSafety) ON */
+QualType Sema::PostProcessBoundsSafetyAllocSizeAttribute(FunctionDecl *D,
+                                                         QualType FT) {
+  if (getLangOpts().BoundsSafety) {
+    auto ASA = D->getAttr<AllocSizeAttr>();
+    if (!ASA)
+      return FT;
+    QualType NewDeclTy =
+        PostProcessBoundsSafetyAllocSizeAttributeImpl(*this, D, *ASA, FT);
+    if (NewDeclTy.isNull())
+      return FT;
+    return NewDeclTy;
+  }
+  return FT;
+}
+/* TO_UPSTREAM(BoundsSafety) OFF */
 
 /// checkUnusedDeclAttributes - Check a list of attributes to see if it
 /// contains any decl attributes that we should warn about.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -626,7 +626,7 @@ void diagnoseInvalidReturnTypeForAllocSize(Sema &S, FunctionDecl *D,
 
   QualType RetTy = D->getReturnType();
   auto CATy = RetTy->getAs<CountAttributedType>();
-  if (!CATy || !CATy->isCountInBytes()) {
+  if (!CATy) {
     S.Diag(D->getBeginLoc(), diag::err_invalid_return_type_for_alloc_size)
         << RetTy << Size << D->getReturnTypeSourceRange();
     S.Diag(ASA.getLoc(), diag::note_attribute_inherited) << ASA.getRange();
@@ -638,9 +638,25 @@ void diagnoseInvalidReturnTypeForAllocSize(Sema &S, FunctionDecl *D,
   CATy->getCountExpr()->IgnoreParenImpCasts()->Profile(NewID, S.Context,
                                                        /*Canonical*/ true);
   Size->Profile(OldID, S.Context, /*Canonical*/ true);
-  if (NewID != OldID) {
-    S.Diag(D->getBeginLoc(), diag::err_invalid_return_type_for_alloc_size)
-        << RetTy << Size << D->getReturnTypeSourceRange();
+  bool ExprMismatch = NewID != OldID;
+  bool KindMismatch = !CATy->isCountInBytes();
+
+  if (ExprMismatch || KindMismatch) {
+    {
+      // FIXME: include CountAttributedType in TypeLocInfo
+      SourceRange FullReturnSourceRange(
+          D->getReturnTypeSourceRange().getBegin(),
+          CATy->getCountExpr()->getEndLoc());
+      auto Diag =
+          S.Diag(D->getBeginLoc(), diag::err_invalid_return_type_for_alloc_size)
+          << RetTy << Size << FullReturnSourceRange;
+
+      QualType ASATy = S.BuildCountAttributedType(
+          CATy->desugar(), Size, /*CountInBytes=*/true,
+          /*OrNull=*/CATy->isOrNull(), /*ScopeCheck=*/false);
+      BoundsSafetyFixItUtils::fixCountAttributedTypeLocsInFunctionSignature(
+          S, Diag, ASATy, RetTy, D, D, ExprMismatch, KindMismatch);
+    }
     S.Diag(ASA.getLoc(), diag::note_attribute_inherited) << ASA.getRange();
   }
 }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -25798,17 +25798,12 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
     return Call;
 
   // Bail out early if there's nothing to do. (There is something to do if
-  // there's a dynamic bound pointer type in this function prototype, or if
-  // it's annotated with `alloc_size`, in which case we can derive the
-  // equivalent.)
+  // there's a dynamic bound pointer type in this function prototype.)
   QualType FT = CallE->getCallee()->getType();
   if (auto PointerTy = FT->getAs<PointerType>())
     FT = PointerTy->getPointeeType();
-  if (!ContainsBoundsAttributedType::check(FT)) {
-    auto *FDecl = CallE->getDirectCallee();
-    if (!FDecl || !FDecl->getAttr<AllocSizeAttr>())
-      return CallE;
-  }
+  if (!ContainsBoundsAttributedType::check(FT))
+    return CallE;
 
   Expr *ResultExpr = CallE;
   SmallVector<OpaqueValueExpr *, 8> OVEs;
@@ -25941,32 +25936,6 @@ ExprResult Sema::ActOnBoundsSafetyCall(ExprResult Call) {
         *this, RD, ResultExpr);
     if (!(ResultExpr = Promoted.get()))
       return ExprError();
-  } else if (auto *FDecl = CallE->getDirectCallee()) {
-    if (auto Att = FDecl->getAttr<AllocSizeAttr>()) {
-      if (Att->getElemSizeParam().isValid()) {
-        Expr *SizeExpr = OVEs[Att->getElemSizeParam().getASTIndex()];
-        if (Att->getNumElemsParam().isValid()) {
-          Expr *CountExpr = OVEs[Att->getNumElemsParam().getASTIndex()];
-          ExprResult Product = CreateBuiltinBinOp(
-              CallE->getBeginLoc(), BO_Mul, SizeExpr, CountExpr);
-          if (!(SizeExpr = Product.get()))
-            return ExprError();
-        }
-
-        ExprResult SizeRValue = DefaultLvalueConversion(SizeExpr);
-        if (!SizeRValue.get())
-          return ExprError();
-
-        auto *PtrOVE = OpaqueValueExpr::EnsureWrapped(
-            Context, ResultExpr, OVEs);
-        auto *SizeOVE = OpaqueValueExpr::EnsureWrapped(
-            Context, SizeRValue.get(), OVEs);
-        ExprResult Promoted = PromoteBoundsSafetyPointerWithCount(
-            *this, PtrOVE, SizeOVE, true, true);
-        if (!(ResultExpr = Promoted.get()))
-          return ExprError();
-      }
-    }
   }
 
   if (!OVEs.empty()) {

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -9477,7 +9477,7 @@ static bool HandlePtrTerminatedByTypeAttr(TypeProcessingState &state,
           << T->isPointerType() << /* terminator */ 4;
       S.Diag(PAttr.getLoc(),
              diag::note_bounds_safety_conflicting_pointer_attribute_args)
-          << /* terminator */ 2 << VT->getTerminatorExpr() << TerminatorExpr;
+          << /* terminator */ 1 << VT->getTerminatorExpr() << TerminatorExpr;
       PAttr.setInvalid();
       return false;
     }

--- a/clang/test/BoundsSafety-legacy-checks/AST/count-attrs.c
+++ b/clang/test/BoundsSafety-legacy-checks/AST/count-attrs.c
@@ -40,7 +40,7 @@ int *__sized_by(len) byte_frob_body(int len) { return 0; }
 // CHECK-NEXT:| `-ParmVarDecl {{.*}} used len 'int'
 // CHECK-NEXT:|-FunctionDecl {{.*}} byte_frob 'int *__single __sized_by(len)(int)'
 // CHECK-NEXT:| `-ParmVarDecl {{.*}} used len 'int'
-// CHECK-NEXT:|-FunctionDecl {{.*}} alloc_bytes 'void *__single(int)'
+// CHECK-NEXT:|-FunctionDecl {{.*}} alloc_bytes 'void *__single __sized_by_or_null(byte_count)(int)'
 // CHECK-NEXT:| |-ParmVarDecl {{.*}} byte_count 'int'
 // CHECK-NEXT:| `-AllocSizeAttr {{.*}} 1
 // CHECK-NEXT:|-TypedefDecl {{.*}} referenced int_array_t '__array_decay_discards_count_in_parameters int[10]':'int[10]'

--- a/clang/test/BoundsSafety/AST/Inputs/system-merge-dynamic-bound-attr/header-no-attr.h
+++ b/clang/test/BoundsSafety/AST/Inputs/system-merge-dynamic-bound-attr/header-no-attr.h
@@ -1,2 +1,4 @@
-void *myalloc(unsigned);
+#include <ptrcheck.h>
+void *myalloc(unsigned size2);
+void * __single myalloc2(unsigned size2);
 void *memcpy(void *, void *, unsigned long long);

--- a/clang/test/BoundsSafety/AST/Inputs/system-merge-dynamic-bound-attr/header-with-attr.h
+++ b/clang/test/BoundsSafety/AST/Inputs/system-merge-dynamic-bound-attr/header-with-attr.h
@@ -1,1 +1,5 @@
+#include <ptrcheck.h>
 void *myalloc(unsigned) __attribute__((alloc_size(1)));
+void * __sized_by_or_null(size1) myalloc2(unsigned size1);
+void *myalloc3(unsigned size1) __attribute__((alloc_size(1)));
+void * __sized_by_or_null(size1) myalloc4(unsigned size1);

--- a/clang/test/BoundsSafety/AST/alloc-size-attr-dup.c
+++ b/clang/test/BoundsSafety/AST/alloc-size-attr-dup.c
@@ -1,0 +1,24 @@
+// RUN: not %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
+
+__attribute__((alloc_size(1))) __attribute__((alloc_size(1))) void * dup_attr(unsigned);
+
+// CHECK: |-FunctionDecl {{.*}} dup_attr 'void *__single __sized_by_or_null(function-parameter-0-0)(unsigned int)'
+// CHECK-NEXT: | |-ParmVarDecl {{.*}} 'unsigned int'
+// CHECK-NEXT: | `-AllocSizeAttr {{.*}} 1
+//
+// CHECK-NOT: AllocSizeAttr
+
+__attribute__((alloc_size(1, 2))) __attribute__((alloc_size(2, 1))) void * mismatch_attr(unsigned, unsigned);
+void * mismatch_attr(unsigned, unsigned);
+
+// CHECK-NEXT: |-FunctionDecl{{.*}} mismatch_attr 'void *__single __sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
+// CHECK-NEXT: | |-ParmVarDecl {{.*}} 'unsigned int'
+// CHECK-NEXT: | |-ParmVarDecl {{.*}} 'unsigned int'
+// CHECK-NEXT: | `-AllocSizeAttr {{.*}} 1 2
+// CHECK-NEXT: `-FunctionDecl {{.*}} mismatch_attr 'void *__single(unsigned int, unsigned int)'
+// CHECK-NEXT:   |-ParmVarDecl {{.*}} 'unsigned int'
+// CHECK-NEXT:   |-ParmVarDecl {{.*}} 'unsigned int'
+// CHECK-NEXT:   `-AllocSizeAttr {{.*}} Inherited 1 2
+//
+// CHECK-NOT: AllocSizeAttr

--- a/clang/test/BoundsSafety/AST/alloc-size-attr-dup.c
+++ b/clang/test/BoundsSafety/AST/alloc-size-attr-dup.c
@@ -12,11 +12,11 @@ __attribute__((alloc_size(1))) __attribute__((alloc_size(1))) void * dup_attr(un
 __attribute__((alloc_size(1, 2))) __attribute__((alloc_size(2, 1))) void * mismatch_attr(unsigned, unsigned);
 void * mismatch_attr(unsigned, unsigned);
 
-// CHECK-NEXT: |-FunctionDecl{{.*}} mismatch_attr 'void *__single __sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
+// CHECK-NEXT: |-FunctionDecl {{.*}} mismatch_attr 'void *__single __sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
 // CHECK-NEXT: | |-ParmVarDecl {{.*}} 'unsigned int'
 // CHECK-NEXT: | |-ParmVarDecl {{.*}} 'unsigned int'
 // CHECK-NEXT: | `-AllocSizeAttr {{.*}} 1 2
-// CHECK-NEXT: `-FunctionDecl {{.*}} mismatch_attr 'void *__single(unsigned int, unsigned int)'
+// CHECK-NEXT: `-FunctionDecl {{.*}} mismatch_attr 'void *__single __sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
 // CHECK-NEXT:   |-ParmVarDecl {{.*}} 'unsigned int'
 // CHECK-NEXT:   |-ParmVarDecl {{.*}} 'unsigned int'
 // CHECK-NEXT:   `-AllocSizeAttr {{.*}} Inherited 1 2

--- a/clang/test/BoundsSafety/AST/alloc-size-attr-sized-by-or-null-sys-header-override.c
+++ b/clang/test/BoundsSafety/AST/alloc-size-attr-sized-by-or-null-sys-header-override.c
@@ -1,0 +1,152 @@
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -ast-dump %s 2>&1 | FileCheck %S/alloc-size-attr-sized-by-or-null-sys-header.h
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -ast-dump %s 2>&1 | FileCheck --check-prefix CHECK-HEADER %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
+
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %S/alloc-size-attr-sized-by-or-null-sys-header.h
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck --check-prefix CHECK-HEADER %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
+
+#include <ptrcheck.h>
+#include "alloc-size-attr-sized-by-or-null-sys-header.h"
+
+// This makes sure that checks with this prefix don't capture anything from the header
+// CHECK-LABEL: NON_HEADER
+void NON_HEADER();
+
+__attribute__((alloc_size(1))) void * unnamed_param(unsigned size) {
+    return (void*)0;
+}
+// CHECK-HEADER: |-FunctionDecl [[func_unnamed_param:0x[^ ]+]] {{.+}} unnamed_param 'void *__single __sized_by_or_null(function-parameter-0-0)(unsigned int)'
+// CHECK-HEADER: | |-ParmVarDecl
+// CHECK-HEADER: | `-AllocSizeAttr
+
+// CHECK-LABEL: unnamed_param
+// CHECK-SAME: 'void *__single __sized_by_or_null(size)(unsigned int)'
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_9:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-CompoundStmt
+// CHECK-NEXT: {{^}}| | `-ReturnStmt
+// CHECK-NEXT: {{^}}| |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}| |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}| |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(size)':'void *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}| |     | | `-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     | |-OpaqueValueExpr [[ove_3]]
+// CHECK-NEXT: {{^}}| |     | | `-CStyleCastExpr {{.+}} 'void *' <NullToPointer>
+// CHECK-NEXT: {{^}}| |     | |   `-IntegerLiteral {{.+}} 0
+// CHECK-NEXT: {{^}}| |     | `-OpaqueValueExpr [[ove_4:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |     |   `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
+// CHECK-NEXT: {{^}}| |     |     `-DeclRefExpr {{.+}} [[var_size_9]]
+// CHECK-NEXT: {{^}}| |     |-OpaqueValueExpr [[ove_3]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     `-OpaqueValueExpr [[ove_4]] {{.*}} 'unsigned int'
+// CHECK:      {{^}}| `-AllocSizeAttr
+
+void * __sized_by_or_null(size) inherit_attr(unsigned size) {
+    return (void*)0;
+}
+
+// CHECK-HEADER: |-FunctionDecl [[func_inherit_attr:0x[^ ]+]] {{.+}} inherit_attr 'void *__single __sized_by_or_null(size)(unsigned int)'
+// CHECK-HEADER: | |-ParmVarDecl [[var_size_8:0x[^ ]+]]
+// CHECK-HEADER: | `-AllocSizeAttr
+
+// CHECK-LABEL: inherit_attr
+// CHECK-SAME:  'void *__single __sized_by_or_null(size)(unsigned int)'
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_10:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-CompoundStmt
+// CHECK-NEXT: {{^}}| | `-ReturnStmt
+// CHECK-NEXT: {{^}}| |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}| |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}| |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(size)':'void *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}| |     | | `-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     | |-OpaqueValueExpr [[ove_5]]
+// CHECK-NEXT: {{^}}| |     | | `-CStyleCastExpr {{.+}} 'void *' <NullToPointer>
+// CHECK-NEXT: {{^}}| |     | |   `-IntegerLiteral {{.+}} 0
+// CHECK-NEXT: {{^}}| |     | `-OpaqueValueExpr [[ove_6:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |     |   `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
+// CHECK-NEXT: {{^}}| |     |     `-DeclRefExpr {{.+}} [[var_size_10]]
+// CHECK-NEXT: {{^}}| |     |-OpaqueValueExpr [[ove_5]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     `-OpaqueValueExpr [[ove_6]] {{.*}} 'unsigned int'
+// CHECK:      {{^}}| `-AllocSizeAttr
+
+void * unnamed_param_inherit_attr(unsigned size) {
+    return (void*)0;
+}
+
+// CHECK-HEADER: |-FunctionDecl [[func_unnamed_param_inherit_attr:0x[^ ]+]] {{.+}} unnamed_param_inherit_attr 'void *__single __sized_by_or_null(function-parameter-0-0)(unsigned int)'
+// CHECK-HEADER: | |-ParmVarDecl
+// CHECK-HEADER: | `-AllocSizeAttr
+
+// rdar://131622509 This type is being overridden by the system header
+// CHECK-LABEL: unnamed_param_inherit_attr
+// CHECK-SAME: 'void *__single __sized_by_or_null(size)(unsigned int)'
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_11:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-CompoundStmt
+// CHECK-NEXT: {{^}}| | `-ReturnStmt
+// CHECK-NEXT: {{^}}| |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}| |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}| |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(size)':'void *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}| |     | | `-OpaqueValueExpr [[ove_7:0x[^ ]+]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     | |-OpaqueValueExpr [[ove_7]]
+// CHECK-NEXT: {{^}}| |     | | `-CStyleCastExpr {{.+}} 'void *' <NullToPointer>
+// CHECK-NEXT: {{^}}| |     | |   `-IntegerLiteral {{.+}} 0
+// CHECK-NEXT: {{^}}| |     | `-OpaqueValueExpr [[ove_8:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |     |   `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
+// CHECK-NEXT: {{^}}| |     |     `-DeclRefExpr {{.+}} [[var_size_11]]
+// CHECK-NEXT: {{^}}| |     |-OpaqueValueExpr [[ove_7]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     `-OpaqueValueExpr [[ove_8]] {{.*}} 'unsigned int'
+// CHECK:      {{^}}| `-AllocSizeAttr
+
+void * override_nullability(unsigned, unsigned) __attribute__((returns_nonnull)) __attribute__((alloc_size(1, 2)));
+
+// CHECK-HEADER: |-FunctionDecl [[func_override_nullability:0x[^ ]+]] {{.+}} override_nullability 'void *__single __sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
+// CHECK-HEADER: | |-ParmVarDecl
+// CHECK-HEADER: | |-ParmVarDecl
+// CHECK-HEADER: | `-AllocSizeAttr
+
+// CHECK-LABEL: override_nullability
+// CHECK-SAME: 'void *__single __sized_by(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| |-ReturnsNonNullAttr
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * override_nullability2(unsigned, unsigned) __attribute__((alloc_size(1, 2)));
+
+// CHECK-HEADER: |-FunctionDecl [[func_override_nullability2:0x[^ ]+]] {{.+}} override_nullability2 'void *__single __sized_by(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
+// CHECK-HEADER: | |-ParmVarDecl
+// CHECK-HEADER: | |-ParmVarDecl
+// CHECK-HEADER: | |-ReturnsNonNullAttr
+// CHECK-HEADER: | `-AllocSizeAttr
+
+// CHECK-LABEL: override_nullability2
+// CHECK-SAME: 'void *__single __sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)(unsigned int, unsigned int)'
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| |-ReturnsNonNullAttr
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+__attribute__((alloc_size(1))) void * unnamed_param_non_sys(unsigned);
+__attribute__((alloc_size(1))) void * unnamed_param_non_sys(unsigned size) {
+    return (void*)0;
+}
+
+// CHECK: |-FunctionDecl [[func_unnamed_param_non_sys:0x[^ ]+]] {{.+}} unnamed_param_non_sys  'void *__single __sized_by_or_null(function-parameter-0-0)(unsigned int)'
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+// CHECK: `-FunctionDecl [[func_unnamed_param_non_sys_1:0x[^ ]+]] {{.+}} unnamed_param_non_sys  'void *__single __sized_by_or_null(size)(unsigned int)'
+// CHECK-NEXT: {{^}}  |-ParmVarDecl [[var_size_12:0x[^ ]+]]
+// CHECK-NEXT: {{^}}  |-CompoundStmt
+// CHECK-NEXT: {{^}}  | `-ReturnStmt
+// CHECK-NEXT: {{^}}  |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}  |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}  |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(size)':'void *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}  |     | | `-OpaqueValueExpr [[ove_9:0x[^ ]+]] {{.*}} 'void *'
+// CHECK:      {{^}}  |     | |-OpaqueValueExpr [[ove_9]]
+// CHECK-NEXT: {{^}}  |     | | `-CStyleCastExpr {{.+}} 'void *' <NullToPointer>
+// CHECK-NEXT: {{^}}  |     | |   `-IntegerLiteral {{.+}} 0
+// CHECK-NEXT: {{^}}  |     | `-OpaqueValueExpr [[ove_10:0x[^ ]+]]
+// CHECK-NEXT: {{^}}  |     |   `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
+// CHECK-NEXT: {{^}}  |     |     `-DeclRefExpr {{.+}} [[var_size_12]]
+// CHECK-NEXT: {{^}}  |     |-OpaqueValueExpr [[ove_9]] {{.*}} 'void *'
+// CHECK:      {{^}}  |     `-OpaqueValueExpr [[ove_10]] {{.*}} 'unsigned int'
+// CHECK:      {{^}}  `-AllocSizeAttr
+

--- a/clang/test/BoundsSafety/AST/alloc-size-attr-sized-by-or-null-sys-header.h
+++ b/clang/test/BoundsSafety/AST/alloc-size-attr-sized-by-or-null-sys-header.h
@@ -1,0 +1,111 @@
+#pragma clang system_header
+
+void * __sized_by_or_null(size) explicitly_sized(int size) __attribute__((alloc_size(1)));
+
+// CHECK:      {{^}}|-FunctionDecl [[func_explicitly_sized:0x[^ ]+]] {{.+}} explicitly_sized
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * __sized_by(size) explicitly_sized_nonnull(int size) __attribute__((alloc_size(1)));
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_explicitly_sized_nonnull:0x[^ ]+]] {{.+}} explicitly_sized_nonnull
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_1:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * _Nonnull implicitly_sized_nonnull_non_semantic(int size) __attribute__((alloc_size(1)));
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_implicitly_sized_nonnull_non_semantic:0x[^ ]+]] {{.+}} implicitly_sized_nonnull_non_semantic
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_2:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * implicitly_sized_nonnull_semantic(int size) __attribute__((returns_nonnull)) __attribute__((alloc_size(1)));
+//
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_implicitly_sized_nonnull_semantic:0x[^ ]+]] {{.+}} implicitly_sized_nonnull_semantic
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_3:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-ReturnsNonNullAttr
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * implicitly_sized_with_count(int size, int count) __attribute__((alloc_size(1, 2)));
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_implicitly_sized_with_count:0x[^ ]+]] {{.+}} implicitly_sized_with_count
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_4:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_count:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * __sized_by(size * count) explicitly_sized_nonnull_with_count(int size, int count) __attribute__((alloc_size(1, 2)));
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_explicitly_sized_nonnull_with_count:0x[^ ]+]] {{.+}} explicitly_sized_nonnull_with_count
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_5:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_count_1:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * _Nonnull implicitly_sized_nonnull_non_semantic_with_count(int size, int count) __attribute__((alloc_size(1, 2)));
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_implicitly_sized_nonnull_non_semantic_with_count:0x[^ ]+]] {{.+}} implicitly_sized_nonnull_non_semantic_with_count
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_6:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_count_2:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * implicitly_sized_nonnull_semantic_with_count(int size, int count) __attribute__((returns_nonnull)) __attribute__((alloc_size(1, 2)));
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_implicitly_sized_nonnull_semantic_with_count:0x[^ ]+]] {{.+}} implicitly_sized_nonnull_semantic_with_count
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_size_7:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_count_3:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |-ReturnsNonNullAttr
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+void * unnamed_param_with_count(unsigned, unsigned) __attribute__((alloc_size(1, 2)));
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_unnamed_param_with_count:0x[^ ]+]] {{.+}} unnamed_param_with_count
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| `-AllocSizeAttr
+
+__attribute__((alloc_size(1, 2))) void * unnamed_param_with_count(unsigned, unsigned) {
+    return (void*)0;
+}
+
+// CHECK-NEXT: {{^}}|-FunctionDecl [[func_unnamed_param_with_count_1:0x[^ ]+]] {{.+}} unnamed_param_with_count
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| |-ParmVarDecl
+// CHECK-NEXT: {{^}}| |-CompoundStmt
+// CHECK-NEXT: {{^}}| | `-ReturnStmt
+// CHECK-NEXT: {{^}}| |   `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}| |     |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}| |     | |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)':'void *__single' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}| |     | | `-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     | |-OpaqueValueExpr [[ove]]
+// CHECK-NEXT: {{^}}| |     | | `-CStyleCastExpr {{.+}} 'void *' <NullToPointer>
+// CHECK-NEXT: {{^}}| |     | |   `-IntegerLiteral {{.+}} 0
+// CHECK-NEXT: {{^}}| |     | |-OpaqueValueExpr [[ove_1:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |     | | `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
+// CHECK-NEXT: {{^}}| |     | |   `-DeclRefExpr {{.+}}
+// CHECK-NEXT: {{^}}| |     | `-OpaqueValueExpr [[ove_2:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| |     |   `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
+// CHECK-NEXT: {{^}}| |     |     `-DeclRefExpr {{.+}}
+// CHECK-NEXT: {{^}}| |     |-OpaqueValueExpr [[ove]] {{.*}} 'void *'
+// CHECK:      {{^}}| |     |-OpaqueValueExpr [[ove_1]] {{.*}} 'unsigned int'
+// CHECK:      {{^}}| |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'unsigned int'
+// CHECK:      {{^}}| `-AllocSizeAttr
+
+/* --- checked in C file --- */
+
+void * unnamed_param(unsigned) __attribute__((alloc_size(1)));
+
+void * inherit_attr(unsigned size) __attribute__((alloc_size(1)));
+
+void * unnamed_param_inherit_attr(unsigned) __attribute__((alloc_size(1)));
+
+void * unnamed_param_with_count_flipped(unsigned, unsigned)
+    __attribute__((alloc_size(1,2)));
+
+void * unnamed_param_with_count_mismatching_attrs_after_param_list(unsigned, unsigned)
+    __attribute__((alloc_size(1,2)));
+
+void * override_nullability(unsigned, unsigned)
+    __attribute__((alloc_size(1, 2)));
+
+void * override_nullability2(unsigned, unsigned)
+    __attribute__((returns_nonnull))
+    __attribute__((alloc_size(1, 2)));
+

--- a/clang/test/BoundsSafety/AST/alloc-sized-calloc/alloc-sized-calloc.c
+++ b/clang/test/BoundsSafety/AST/alloc-sized-calloc/alloc-sized-calloc.c
@@ -35,13 +35,13 @@ int foo() {
 // CHECK: {{^}}    |     `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}    |       |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}    |       | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: {{^}}    |       | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *'
+// CHECK: {{^}}    |       | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by_or_null(count * size)':'void *__single'
 // CHECK: {{^}}    |       | | |   |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    |       | | |   `-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    |       | | |-ImplicitCastExpr {{.+}} 'void *' <BitCast>
 // CHECK: {{^}}    |       | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}    |       | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
-// CHECK: {{^}}    |       | | |   | `-OpaqueValueExpr [[ove]] {{.*}} 'void *'
+// CHECK: {{^}}    |       | | |   | `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by_or_null(count * size)':'void *__single'
 // CHECK: {{^}}    |       | | |   `-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    |       | |-OpaqueValueExpr [[ove_1]]
 // CHECK: {{^}}    |       | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -51,7 +51,7 @@ int foo() {
 // CHECK: {{^}}    |       | |   `-DeclRefExpr {{.+}} [[var_siz]]
 // CHECK: {{^}}    |       | |-OpaqueValueExpr [[ove]]
 // CHECK: {{^}}    |       | | `-CallExpr
-// CHECK: {{^}}    |       | |   |-ImplicitCastExpr {{.+}} 'void *(*__single)(int, int)' <FunctionToPointerDecay>
+// CHECK: {{^}}    |       | |   |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(count * size)(*__single)(int, int)' <FunctionToPointerDecay>
 // CHECK: {{^}}    |       | |   | `-DeclRefExpr {{.+}} [[func_my_calloc]]
 // CHECK: {{^}}    |       | |   |-OpaqueValueExpr [[ove_1]] {{.*}} 'int'
 // CHECK: {{^}}    |       | |   `-OpaqueValueExpr [[ove_2]] {{.*}} 'int'
@@ -61,7 +61,7 @@ int foo() {
 // CHECK: {{^}}    |       |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'int'
 // CHECK: {{^}}    |       |-OpaqueValueExpr [[ove_1]] {{.*}} 'int'
 // CHECK: {{^}}    |       |-OpaqueValueExpr [[ove_2]] {{.*}} 'int'
-// CHECK: {{^}}    |       |-OpaqueValueExpr [[ove]] {{.*}} 'void *'
+// CHECK: {{^}}    |       |-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by_or_null(count * size)':'void *__single'
 // CHECK: {{^}}    |       `-OpaqueValueExpr [[ove_3]] {{.*}} 'int'
 // CHECK: {{^}}    |-DeclStmt
 // CHECK: {{^}}    | `-VarDecl [[var_ptr2:0x[^ ]+]]
@@ -71,13 +71,13 @@ int foo() {
 // CHECK: {{^}}    |   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}    |     |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}    |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'void *'
+// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove_4:0x[^ ]+]] {{.*}} 'void *__single __sized_by_or_null(count * size)':'void *__single'
 // CHECK: {{^}}    |     | | |   |-OpaqueValueExpr [[ove_5:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    |     | | |   `-OpaqueValueExpr [[ove_6:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    |     | | |-ImplicitCastExpr {{.+}} 'void *' <BitCast>
 // CHECK: {{^}}    |     | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}    |     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
-// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *'
+// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by_or_null(count * size)':'void *__single'
 // CHECK: {{^}}    |     | | |   `-OpaqueValueExpr [[ove_7:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    |     | |-OpaqueValueExpr [[ove_5]]
 // CHECK: {{^}}    |     | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
@@ -87,7 +87,7 @@ int foo() {
 // CHECK: {{^}}    |     | |   `-DeclRefExpr {{.+}} [[var_siz]]
 // CHECK: {{^}}    |     | |-OpaqueValueExpr [[ove_4]]
 // CHECK: {{^}}    |     | | `-CallExpr
-// CHECK: {{^}}    |     | |   |-ImplicitCastExpr {{.+}} 'void *(*__single)(int, int)' <FunctionToPointerDecay>
+// CHECK: {{^}}    |     | |   |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(count * size)(*__single)(int, int)' <FunctionToPointerDecay>
 // CHECK: {{^}}    |     | |   | `-DeclRefExpr {{.+}} [[func_my_calloc]]
 // CHECK: {{^}}    |     | |   |-OpaqueValueExpr [[ove_5]] {{.*}} 'int'
 // CHECK: {{^}}    |     | |   `-OpaqueValueExpr [[ove_6]] {{.*}} 'int'
@@ -97,7 +97,7 @@ int foo() {
 // CHECK: {{^}}    |     |     `-OpaqueValueExpr [[ove_6]] {{.*}} 'int'
 // CHECK: {{^}}    |     |-OpaqueValueExpr [[ove_5]] {{.*}} 'int'
 // CHECK: {{^}}    |     |-OpaqueValueExpr [[ove_6]] {{.*}} 'int'
-// CHECK: {{^}}    |     |-OpaqueValueExpr [[ove_4]] {{.*}} 'void *'
+// CHECK: {{^}}    |     |-OpaqueValueExpr [[ove_4]] {{.*}} 'void *__single __sized_by_or_null(count * size)':'void *__single'
 // CHECK: {{^}}    |     `-OpaqueValueExpr [[ove_7]] {{.*}} 'int'
 // CHECK: {{^}}    `-ReturnStmt
 // CHECK: {{^}}      `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>

--- a/clang/test/BoundsSafety/AST/system-count-return.c
+++ b/clang/test/BoundsSafety/AST/system-count-return.c
@@ -43,11 +43,11 @@ int Test() {
 // CHECK: {{^}}    |   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}    |     |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}    |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'int *__bidi_indexable'
-// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'int *'
+// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'int *__single __sized_by_or_null(len)':'int *__single'
 // CHECK: {{^}}    |     | | |-ImplicitCastExpr {{.+}} 'int *' <BitCast>
 // CHECK: {{^}}    |     | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}    |     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
-// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove_2]] {{.*}} 'int *'
+// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove_2]] {{.*}} 'int *__single __sized_by_or_null(len)':'int *__single'
 // CHECK: {{^}}    |     | | |   `-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'int'
 // CHECK: {{^}}    |     | |-OpaqueValueExpr [[ove_3]]
 // CHECK: {{^}}    |     | | `-ImplicitCastExpr {{.+}} 'int' <IntegralCast>
@@ -57,11 +57,11 @@ int Test() {
 // CHECK: {{^}}    |     | |       `-IntegerLiteral {{.+}} 10
 // CHECK: {{^}}    |     | `-OpaqueValueExpr [[ove_2]]
 // CHECK: {{^}}    |     |   `-CallExpr
-// CHECK: {{^}}    |     |     |-ImplicitCastExpr {{.+}} 'int *(*__single)(int)' <FunctionToPointerDecay>
+// CHECK: {{^}}    |     |     |-ImplicitCastExpr {{.+}} 'int *__single __sized_by_or_null(len)(*__single)(int)' <FunctionToPointerDecay>
 // CHECK: {{^}}    |     |     | `-DeclRefExpr {{.+}} [[func_alloc_attributed]]
 // CHECK: {{^}}    |     |     `-OpaqueValueExpr [[ove_3]] {{.*}} 'int'
 // CHECK: {{^}}    |     |-OpaqueValueExpr [[ove_3]] {{.*}} 'int'
-// CHECK: {{^}}    |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'int *'
+// CHECK: {{^}}    |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'int *__single __sized_by_or_null(len)':'int *__single'
 
     return bufBound[10];
 }

--- a/clang/test/BoundsSafety/AST/system-merge-dynamic-bound-attr-2.c
+++ b/clang/test/BoundsSafety/AST/system-merge-dynamic-bound-attr-2.c
@@ -22,19 +22,19 @@ void Test(unsigned siz) {
 // CHECK: {{^}}        `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}          |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}          | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: {{^}}          | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *'
+// CHECK: {{^}}          | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by_or_null(function-parameter-0-0)':'void *__single'
 // CHECK: {{^}}          | | |-ImplicitCastExpr {{.+}} 'void *' <BitCast>
 // CHECK: {{^}}          | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}          | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
-// CHECK: {{^}}          | | |   | `-OpaqueValueExpr [[ove]] {{.*}} 'void *'
+// CHECK: {{^}}          | | |   | `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by_or_null(function-parameter-0-0)':'void *__single'
 // CHECK: {{^}}          | | |   `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'unsigned int'
 // CHECK: {{^}}          | |-OpaqueValueExpr [[ove_1]]
 // CHECK: {{^}}          | | `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
 // CHECK: {{^}}          | |   `-DeclRefExpr {{.+}} [[var_siz]]
 // CHECK: {{^}}          | `-OpaqueValueExpr [[ove]]
 // CHECK: {{^}}          |   `-CallExpr
-// CHECK: {{^}}          |     |-ImplicitCastExpr {{.+}} 'void *(*__single)(unsigned int)' <FunctionToPointerDecay>
+// CHECK: {{^}}          |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(function-parameter-0-0)(*__single)(unsigned int)' <FunctionToPointerDecay>
 // CHECK: {{^}}          |     | `-DeclRefExpr {{.+}} 'myalloc'
 // CHECK: {{^}}          |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'unsigned int'
 // CHECK: {{^}}          |-OpaqueValueExpr [[ove_1]] {{.*}} 'unsigned int'
-// CHECK: {{^}}          `-OpaqueValueExpr [[ove]] {{.*}} 'void *'
+// CHECK: {{^}}          `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by_or_null(function-parameter-0-0)':'void *__single'

--- a/clang/test/BoundsSafety/AST/system-merge-dynamic-bound-attr.c
+++ b/clang/test/BoundsSafety/AST/system-merge-dynamic-bound-attr.c
@@ -4,17 +4,34 @@
 #include <header-with-attr.h>
 #include <header-no-attr.h>
 
-// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc 'void *__single __sized_by_or_null(function-parameter-0-0)(unsigned int)'
 // CHECK: {{^}}| |-ParmVarDecl
 // CHECK: {{^}}| `-AllocSizeAttr
-// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc2 'void *__single __sized_by_or_null(size1)(unsigned int)'
+// CHECK: {{^}}| `-ParmVarDecl
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc3 'void *__single __sized_by_or_null(size1)(unsigned int)'
 // CHECK: {{^}}| |-ParmVarDecl
 // CHECK: {{^}}| `-AllocSizeAttr
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc4 'void *__single __sized_by_or_null(size1)(unsigned int)'
+// CHECK: {{^}}| `-ParmVarDecl
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc 'void *__single __sized_by_or_null(size2)(unsigned int)'
+// CHECK: {{^}}| |-ParmVarDecl
+// CHECK: {{^}}| `-AllocSizeAttr
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc2 'void *__single __sized_by_or_null(size2)(unsigned int)'
+// CHECK: {{^}}| `-ParmVarDecl
 // CHECK: {{^}}|-FunctionDecl {{.+}} memcpy
 // CHECK: {{^}}| |-ParmVarDecl
 // CHECK: {{^}}| |-ParmVarDecl
 // CHECK: {{^}}| `-ParmVarDecl
 // CHECK: {{^}}|   `-DependerDeclsAttr
+
+void * myalloc3(unsigned size2) { return (void*)0; }
+void * myalloc4(unsigned size2) { return (void*)0; }
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc3 'void *__single __sized_by_or_null(size2)(unsigned int)'
+// CHECK: {{^}}| |-ParmVarDecl
+// CHECK: {{^}}| `-AllocSizeAttr
+// CHECK: {{^}}|-FunctionDecl {{.+}} myalloc4 'void *__single __sized_by_or_null(size2)(unsigned int)'
+// CHECK: {{^}}| |-ParmVarDecl
 
 void Test(unsigned siz) {
 // CHECK: {{^}}`-FunctionDecl [[func_Test:0x[^ ]+]] {{.+}} Test
@@ -26,23 +43,23 @@ void Test(unsigned siz) {
 // CHECK: {{^}}    |   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}    |     |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}    |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *'
+// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'void *__single __sized_by_or_null(size2)':'void *__single'
 // CHECK: {{^}}    |     | | |   `-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'unsigned int'
 // CHECK: {{^}}    |     | | |-ImplicitCastExpr {{.+}} 'void *' <BitCast>
 // CHECK: {{^}}    |     | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}    |     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
-// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove]] {{.*}} 'void *'
+// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by_or_null(size2)':'void *__single'
 // CHECK: {{^}}    |     | | |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'unsigned int'
 // CHECK: {{^}}    |     | |-OpaqueValueExpr [[ove_1]]
 // CHECK: {{^}}    |     | | `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
 // CHECK: {{^}}    |     | |   `-DeclRefExpr {{.+}} [[var_siz]]
 // CHECK: {{^}}    |     | `-OpaqueValueExpr [[ove]]
 // CHECK: {{^}}    |     |   `-CallExpr
-// CHECK: {{^}}    |     |     |-ImplicitCastExpr {{.+}} 'void *(*__single)(unsigned int)' <FunctionToPointerDecay>
+// CHECK: {{^}}    |     |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(size2)(*__single)(unsigned int)' <FunctionToPointerDecay>
 // CHECK: {{^}}    |     |     | `-DeclRefExpr {{.+}} 'myalloc'
 // CHECK: {{^}}    |     |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'unsigned int'
 // CHECK: {{^}}    |     |-OpaqueValueExpr [[ove_1]] {{.*}} 'unsigned int'
-// CHECK: {{^}}    |     `-OpaqueValueExpr [[ove]] {{.*}} 'void *'
+// CHECK: {{^}}    |     `-OpaqueValueExpr [[ove]] {{.*}} 'void *__single __sized_by_or_null(size2)':'void *__single'
 
   void *dst = myalloc(siz);
 // CHECK: {{^}}    |-DeclStmt
@@ -50,23 +67,23 @@ void Test(unsigned siz) {
 // CHECK: {{^}}    |   `-MaterializeSequenceExpr {{.+}} <Unbind>
 // CHECK: {{^}}    |     |-MaterializeSequenceExpr {{.+}} <Bind>
 // CHECK: {{^}}    |     | |-BoundsSafetyPointerPromotionExpr {{.+}} 'void *__bidi_indexable'
-// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'void *'
+// CHECK: {{^}}    |     | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'void *__single __sized_by_or_null(size2)':'void *__single'
 // CHECK: {{^}}    |     | | |   `-OpaqueValueExpr [[ove_3:0x[^ ]+]] {{.*}} 'unsigned int'
 // CHECK: {{^}}    |     | | |-ImplicitCastExpr {{.+}} 'void *' <BitCast>
 // CHECK: {{^}}    |     | | | `-BinaryOperator {{.+}} 'char *' '+'
 // CHECK: {{^}}    |     | | |   |-CStyleCastExpr {{.+}} 'char *' <BitCast>
-// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove_2]] {{.*}} 'void *'
+// CHECK: {{^}}    |     | | |   | `-OpaqueValueExpr [[ove_2]] {{.*}} 'void *__single __sized_by_or_null(size2)':'void *__single'
 // CHECK: {{^}}    |     | | |   `-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned int'
 // CHECK: {{^}}    |     | |-OpaqueValueExpr [[ove_3]]
 // CHECK: {{^}}    |     | | `-ImplicitCastExpr {{.+}} 'unsigned int' <LValueToRValue>
 // CHECK: {{^}}    |     | |   `-DeclRefExpr {{.+}} [[var_siz]]
 // CHECK: {{^}}    |     | `-OpaqueValueExpr [[ove_2]]
 // CHECK: {{^}}    |     |   `-CallExpr
-// CHECK: {{^}}    |     |     |-ImplicitCastExpr {{.+}} 'void *(*__single)(unsigned int)' <FunctionToPointerDecay>
+// CHECK: {{^}}    |     |     |-ImplicitCastExpr {{.+}} 'void *__single __sized_by_or_null(size2)(*__single)(unsigned int)' <FunctionToPointerDecay>
 // CHECK: {{^}}    |     |     | `-DeclRefExpr {{.+}} 'myalloc'
 // CHECK: {{^}}    |     |     `-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned int'
 // CHECK: {{^}}    |     |-OpaqueValueExpr [[ove_3]] {{.*}} 'unsigned int'
-// CHECK: {{^}}    |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'void *'
+// CHECK: {{^}}    |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'void *__single __sized_by_or_null(size2)':'void *__single'
 
   memcpy(dst, src, siz);
 // CHECK: {{^}}    `-MaterializeSequenceExpr {{.+}} <Unbind>

--- a/clang/test/BoundsSafety/AST/terminated-by-conflicting-attrs.c
+++ b/clang/test/BoundsSafety/AST/terminated-by-conflicting-attrs.c
@@ -17,15 +17,15 @@
 */
 
 // CHECK: FunctionDecl {{.+}} foo 'void (int *__single __counted_by(len), int)'
-// CHECK: FunctionDecl {{.+}} foo 'void (int *__single __counted_by(len), int)'
+// CHECK: FunctionDecl {{.+}} foo 'void (int *__single __terminated_by(0), int)'
 // CHECK: FunctionDecl {{.+}} bar 'void (int *__single __terminated_by(0), int)'
 // XXX: rdar://127827450
-// CHECK: FunctionDecl {{.+}} bar 'void (int *__single __terminated_by(0), int)'
+// CHECK: FunctionDecl {{.+}} bar 'void (int *__single __counted_by(len), int)'
 
 void test() {
-  int arr[10];
-  foo(arr, 10);
-
   int *__null_terminated ptr = 0;
-  bar(ptr, 0);
+  foo(ptr, 10);
+
+  int arr[10];
+  bar(arr, 0);
 }

--- a/clang/test/BoundsSafety/AST/terminated-by-conflicting-attrs.c
+++ b/clang/test/BoundsSafety/AST/terminated-by-conflicting-attrs.c
@@ -17,15 +17,15 @@
 */
 
 // CHECK: FunctionDecl {{.+}} foo 'void (int *__single __counted_by(len), int)'
-// CHECK: FunctionDecl {{.+}} foo 'void (int *__single __terminated_by(0), int)'
+// CHECK: FunctionDecl {{.+}} foo 'void (int *__single __counted_by(len), int)'
 // CHECK: FunctionDecl {{.+}} bar 'void (int *__single __terminated_by(0), int)'
 // XXX: rdar://127827450
-// CHECK: FunctionDecl {{.+}} bar 'void (int *__single __counted_by(len), int)'
+// CHECK: FunctionDecl {{.+}} bar 'void (int *__single __terminated_by(0), int)'
 
 void test() {
-  int *__null_terminated ptr = 0;
-  foo(ptr, 10);
-
   int arr[10];
-  bar(arr, 0);
+  foo(arr, 10);
+
+  int *__null_terminated ptr = 0;
+  bar(ptr, 0);
 }

--- a/clang/test/BoundsSafety/FixIt/fixit-function-decl.c
+++ b/clang/test/BoundsSafety/FixIt/fixit-function-decl.c
@@ -126,7 +126,7 @@ typeof(f18) f18;
 // CHECK: int *__counted_by(b) f19(int *__counted_by(b) a, int b);
 // CHECK: typeof(f19) f20;
 // CHECK: int *__counted_by(b) f20(int *__counted_by(b) a, int b);
-// expected-error@+3{{conflicting '__counted_by' attribute with the previous function declaration}}
+// expected-error@+3 2{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *__counted_by(b) f19(int *__counted_by(b) a, int b);
 typeof(f19) f20;
 int *f20(int *a, int b);

--- a/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null-sys-header-override.c
+++ b/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null-sys-header-override.c
@@ -1,0 +1,46 @@
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+#include <ptrcheck.h>
+#include "alloc-size-attr-sized-by-or-null-sys-header.h"
+
+
+__attribute__((alloc_size(1))) void * unnamed_param(unsigned size) {
+    return (void*)0;
+}
+
+void * __sized_by_or_null(size) inherit_attr(unsigned size) {
+    return (void*)0;
+}
+
+void * __sized_by_or_null(size) unnamed_param_inherit_attr(unsigned size) {
+    return (void*)0;
+}
+
+// expected-error@+1{{invalid return type 'void *__single __sized_by_or_null(count * size)' (aka 'void *__single') for function with alloc_size attribute; '__sized_by_or_null(size * count)' or '__sized_by(size * count)' required}}
+void * __sized_by_or_null(count * size)
+    unnamed_param_with_count_flipped(unsigned size, unsigned count) {
+    return (void*)0;
+}
+
+// expected-error@+1{{'alloc_size' attribute does not match previous declaration}}
+__attribute__((alloc_size(2,1)))
+    // expected-warning@+1 2{{omitting the parameter name in a function definition is a C23 extension}}
+    void * unnamed_param_with_count_mismatching_attrs(unsigned, unsigned) {
+    return (void*)0;
+}
+
+// expected-warning@+1 2{{omitting the parameter name in a function definition is a C23 extension}}
+void * unnamed_param_with_count_mismatching_attrs_after_param_list(unsigned, unsigned)
+    // expected-error@+2{{'alloc_size' attribute does not match previous declaration}}
+    // expected-warning@+1{{GCC does not allow 'alloc_size' attribute in this position on a function definition}}
+    __attribute__((alloc_size(2,1))) {
+    return (void*)0;
+}
+
+void * override_nullability(unsigned, unsigned)
+    __attribute__((returns_nonnull))
+    __attribute__((alloc_size(1, 2)));
+
+void * override_nullability2(unsigned, unsigned)
+    __attribute__((alloc_size(1, 2)));

--- a/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null-sys-header-override.c
+++ b/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null-sys-header-override.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -verify %s
+// RUN: not %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s --implicit-check-not fix-it
 // RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
 #include <ptrcheck.h>
@@ -17,7 +18,8 @@ void * __sized_by_or_null(size) unnamed_param_inherit_attr(unsigned size) {
     return (void*)0;
 }
 
-// expected-error@+1{{invalid return type 'void *__single __sized_by_or_null(count * size)' (aka 'void *__single') for function with alloc_size attribute; '__sized_by_or_null(size * count)' or '__sized_by(size * count)' required}}
+// expected-error@+2{{invalid return type 'void *__single __sized_by_or_null(count * size)' (aka 'void *__single') for function with alloc_size attribute; '__sized_by_or_null(size * count)' or '__sized_by(size * count)' required}}
+// CHECK: fix-it:"{{.*}}alloc-size-attr-sized-by-or-null-sys-header-override.c":{[[@LINE+1]]:27-[[@LINE+1]]:39}:"size * count"
 void * __sized_by_or_null(count * size)
     unnamed_param_with_count_flipped(unsigned size, unsigned count) {
     return (void*)0;

--- a/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null-sys-header.h
+++ b/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null-sys-header.h
@@ -1,0 +1,163 @@
+#pragma clang system_header
+
+void * __sized_by_or_null(size) explicitly_sized(int size) __attribute__((alloc_size(1))); // ok, explicit and implicit bounds align
+
+void * __sized_by(size)
+    explicitly_sized_nonnull(int size)
+    __attribute__((alloc_size(1)));
+
+void * __sized_by(size) _Nonnull explicitly_sized_nonnull_silence(int size) __attribute__((alloc_size(1)));
+void * __sized_by(size) explicitly_sized_returns_nonnull_silence(int size) __attribute__((returns_nonnull)) __attribute__((alloc_size(1)));
+void * __sized_by(size) explicitly_sized_returns_nonnull_after_silence(int size) __attribute__((alloc_size(1))) __attribute__((returns_nonnull));
+
+void * __sized_by_or_null(size)
+// expected-note@-1{{previous attribute is here}}
+    __sized_by(size)
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by_or_null(size)' and '__sized_by(size)'}}
+    _Nonnull
+    explicitly_sized_nonnull_redundant(int size)
+    __attribute__((alloc_size(1)));
+
+char * __sized_by(size)
+// expected-note@-1{{previous attribute is here}}
+    _Nonnull
+    __counted_by(size)
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by(size)' and '__counted_by(size)'}}
+    explicitly_sized_nonnull_redundant2(int size)
+    __attribute__((alloc_size(1)));
+
+char * __counted_by_or_null(size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted(int size)
+    __attribute__((alloc_size(1)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by_or_null(size)' and '__sized_by_or_null(size)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+char * __counted_by(size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_returns_nonnull(int size)
+    __attribute__((alloc_size(1))) __attribute__((returns_nonnull));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by(size)' and '__sized_by(size)'}}
+// expected-note@-3{{function return type implicitly __sized_by because of the function's 'alloc_size' and 'returns_nonnull' attributes}}
+
+char * __counted_by(size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_nonnull(int size)
+    __attribute__((alloc_size(1)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by(size)' and '__sized_by_or_null(size)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+
+void * __sized_by_or_null(size * count) explicitly_sized_with_count(int size, int count) __attribute__((alloc_size(1, 2))); // ok, explicit and implicit bounds align
+
+void * __sized_by_or_null(count * size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_sized_with_count_flipped(int size, int count)
+    __attribute__((alloc_size(1, 2))); // unfortunate, but too much complexity to support
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by_or_null(count * size)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void * __sized_by_or_null(size * count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_sized_with_count_flipped2(int size, int count)
+    __attribute__((alloc_size(2, 1))); // unfortunate, but too much complexity to support
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by_or_null(size * count)' and '__sized_by_or_null(count * size)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void * __sized_by(size * count)
+    explicitly_sized_nonnull_with_count(int size, int count)
+    __attribute__((alloc_size(1, 2)));
+
+void * __sized_by(size * count) _Nonnull explicitly_sized_nonnull_with_count_silence(int size, int count) __attribute__((alloc_size(1, 2)));
+void * __sized_by(size * count) explicitly_sized_returns_nonnull_with_count_silence(int size, int count) __attribute__((returns_nonnull)) __attribute__((alloc_size(1, 2)));
+
+char * __counted_by_or_null(size * count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_with_count(int size, int count)
+    __attribute__((alloc_size(1, 2)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by_or_null(size * count)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+char * __counted_by_or_null(count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_with_count2(int size, int count)
+    __attribute__((alloc_size(1, 2))); // no guarantee that size is 1
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by_or_null(count)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+char * __counted_by(size * count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_nonnull_with_count(int size, int count)
+    __attribute__((alloc_size(1, 2)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by(size * count)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+__attribute__((alloc_size(1)))
+    void * __sized_by(size)
+    leading_attr(unsigned size) {
+    return (void*)0;
+}
+
+__attribute__((alloc_size(1))) void * __sized_by(size) _Nonnull leading_attr_silence(unsigned size) {
+    return (void*)0;
+}
+
+__attribute__((alloc_size(1))) void * __sized_by(size) leading_attr_silence_returns_nonnull(unsigned size) __attribute__((returns_nonnull)) {
+    return (void*)0;
+}
+
+__attribute__((alloc_size(1)))
+    // expected-error@-1{{pointer cannot have more than one count attribute}}
+    // expected-note@-2{{conflicting attributes were '__counted_by(size)' and '__sized_by_or_null(size)'}}
+    // expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+    char * __counted_by(size)
+    // expected-note@-1{{previous attribute is here}}
+    leading_attr_clash(unsigned size) {
+    return (void*)0;
+}
+
+void * unnamed_param(unsigned) __attribute__((alloc_size(1)));
+
+void * unnamed_param_with_count(unsigned, unsigned) __attribute__((alloc_size(1, 2)));
+__attribute__((alloc_size(1, 2))) void * unnamed_param_with_count(unsigned, unsigned) {
+    return (void*)0;
+}
+
+void * inherit_attr(unsigned size) __attribute__((alloc_size(1)));
+
+void * unnamed_param_inherit_attr(unsigned) __attribute__((alloc_size(1)));
+
+void * unnamed_param_with_count_flipped(unsigned, unsigned)
+    // expected-note@+1{{attribute inherited from previous declaration here}}
+    __attribute__((alloc_size(1,2)));
+
+void * unnamed_param_with_count_mismatching_attrs(unsigned, unsigned)
+    // expected-note@+1{{conflicting attribute is here}}
+    __attribute__((alloc_size(1,2)));
+
+void * unnamed_param_with_count_mismatching_attrs_after_param_list(unsigned, unsigned)
+    // expected-note@+1{{conflicting attribute is here}}
+    __attribute__((alloc_size(1,2)));
+
+// expected-note@+1{{conflicting attribute is here}}
+__attribute__((alloc_size(1, 2)))
+void * clashing_attrbutes_on_same_decl(unsigned, unsigned)
+    // expected-error@+1{{'alloc_size' attribute does not match previous declaration}}
+    __attribute__((alloc_size(2, 1)));
+
+void * override_nullability(unsigned, unsigned)
+    __attribute__((alloc_size(1, 2)));
+
+void * override_nullability2(unsigned, unsigned)
+    __attribute__((returns_nonnull))
+    __attribute__((alloc_size(1, 2)));

--- a/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null.c
+++ b/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null.c
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -verify %s
+// RUN: not %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s --implicit-check-not fix-it
 // RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
 #include <ptrcheck.h>
@@ -77,6 +78,20 @@ void * __sized_by_or_null(size * count)
 // expected-error@-1{{pointer cannot have more than one count attribute}}
 // expected-note@-2{{conflicting attributes were '__sized_by_or_null(size * count)' and '__sized_by_or_null(count * size)'}}
 // expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void *
+// expected-note@-1{{previous declaration is here}}
+    explicitly_sized_with_count_flipped_redecl(int size, int count)
+    __attribute__((alloc_size(2, 1)));
+// expected-note@-1{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void *
+// expected-error@-1{{conflicting '__sized_by' attribute with the previous function declaration}}
+// expected-note@-2{{conflicting attributes were '__sized_by_or_null(count * size)' and '__sized_by(size * count)'}}
+    __sized_by(size * count)
+// CHECK: fix-it:"{{.*}}alloc-size-attr-sized-by-or-null.c":{[[@LINE-1]]:5-[[@LINE-1]]:15}:"__sized_by_or_null"
+// CHECK: fix-it:"{{.*}}alloc-size-attr-sized-by-or-null.c":{[[@LINE-2]]:16-[[@LINE-2]]:28}:"count * size"
+    explicitly_sized_with_count_flipped_redecl(int size, int count);
 
 void * __sized_by(size * count)
 // expected-note@-1{{previous attribute is here}}
@@ -171,6 +186,7 @@ void * unnamed_param_with_count_flipped(unsigned, unsigned)
 void * __sized_by_or_null(count * size)
     // expected-error@-1{{conflicting '__sized_by_or_null' attribute with the previous function declaration}}
     // expected-note@-2{{conflicting attributes were '__sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)' and '__sized_by_or_null(count * size)'}}
+    // CHECK: fix-it:"{{.*}}alloc-size-attr-sized-by-or-null.c":{[[@LINE-3]]:27-[[@LINE-3]]:39}:"size * count"
     unnamed_param_with_count_flipped(unsigned size, unsigned count) {
     return (void*)0;
 }

--- a/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null.c
+++ b/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null.c
@@ -242,3 +242,9 @@ void * override_nullability2(unsigned, unsigned)
 
 // expected-error@+1{{cannot combine '__sized_by_or_null' and 'returns_nonnull'; did you mean '__sized_by' instead?}}
 void * __sized_by_or_null(x * y) ignore_implicit_type_reverse_nullability(unsigned x, unsigned y) __attribute__((returns_nonnull)) __attribute__((alloc_size(1,2)));
+
+void * invalid_attr1(int) __attribute((alloc_size())); // expected-error{{'alloc_size' attribute takes at least 1 argument}}
+void * invalid_attr2(void) __attribute((alloc_size(1))); // expected-error{{'alloc_size' attribute parameter 1 is out of bounds}}
+void * invalid_attr3(int) __attribute((alloc_size(int))); // expected-error{{expected expression}}
+void invalid_attr4(int) __attribute((alloc_size(1))); // expected-warning{{'alloc_size' attribute only applies to return values that are pointers}}
+void * surprisingly_valid_attr(int) __attribute((alloc_size(sizeof(char))));

--- a/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null.c
+++ b/clang/test/BoundsSafety/Sema/alloc-size-attr-sized-by-or-null.c
@@ -1,0 +1,228 @@
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-strict-prototypes -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+#include <ptrcheck.h>
+
+void * __sized_by_or_null(size) explicitly_sized(int size) __attribute__((alloc_size(1))); // ok, explicit and implicit bounds align
+
+void * __sized_by(size)
+// expected-note@-1{{previous attribute is here}}
+// expected-note@-2{{add _Nonnull qualifier to return type to silence this warning}}
+    explicitly_sized_nonnull(int size)
+    __attribute__((alloc_size(1)));
+// expected-warning@-1{{implicit __sized_by_or_null attribute ignored because of explicit __sized_by}}
+// expected-note@-2{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void * __sized_by(size) _Nonnull explicitly_sized_nonnull_silence(int size) __attribute__((alloc_size(1)));
+void * __sized_by(size) explicitly_sized_returns_nonnull_silence(int size) __attribute__((returns_nonnull)) __attribute__((alloc_size(1)));
+void * __sized_by(size) explicitly_sized_returns_nonnull_after_silence(int size) __attribute__((alloc_size(1))) __attribute__((returns_nonnull));
+
+void * __sized_by_or_null(size)
+// expected-note@-1{{previous attribute is here}}
+    __sized_by(size)
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by_or_null(size)' and '__sized_by(size)'}}
+    _Nonnull
+    explicitly_sized_nonnull_redundant(int size)
+    __attribute__((alloc_size(1)));
+
+char * __sized_by(size)
+// expected-note@-1{{previous attribute is here}}
+    _Nonnull
+    __counted_by(size)
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by(size)' and '__counted_by(size)'}}
+    explicitly_sized_nonnull_redundant2(int size)
+    __attribute__((alloc_size(1)));
+
+char * __counted_by_or_null(size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted(int size)
+    __attribute__((alloc_size(1)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by_or_null(size)' and '__sized_by_or_null(size)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+char * __counted_by(size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_returns_nonnull(int size)
+    __attribute__((alloc_size(1))) __attribute__((returns_nonnull));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by(size)' and '__sized_by(size)'}}
+// expected-note@-3{{function return type implicitly __sized_by because of the function's 'alloc_size' and 'returns_nonnull' attributes}}
+
+char * __counted_by(size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_nonnull(int size)
+    __attribute__((alloc_size(1)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by(size)' and '__sized_by_or_null(size)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+
+void * __sized_by_or_null(size * count) explicitly_sized_with_count(int size, int count) __attribute__((alloc_size(1, 2))); // ok, explicit and implicit bounds align
+
+void * __sized_by_or_null(count * size)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_sized_with_count_flipped(int size, int count)
+    __attribute__((alloc_size(1, 2))); // unfortunate, but too much complexity to support
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by_or_null(count * size)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void * __sized_by_or_null(size * count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_sized_with_count_flipped2(int size, int count)
+    __attribute__((alloc_size(2, 1))); // unfortunate, but too much complexity to support
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__sized_by_or_null(size * count)' and '__sized_by_or_null(count * size)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void * __sized_by(size * count)
+// expected-note@-1{{previous attribute is here}}
+// expected-note@-2{{add _Nonnull qualifier to return type to silence this warning}}
+    explicitly_sized_nonnull_with_count(int size, int count)
+    __attribute__((alloc_size(1, 2)));
+// expected-warning@-1{{implicit __sized_by_or_null attribute ignored because of explicit __sized_by}}
+// expected-note@-2{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+void * __sized_by(size * count) _Nonnull explicitly_sized_nonnull_with_count_silence(int size, int count) __attribute__((alloc_size(1, 2)));
+void * __sized_by(size * count) explicitly_sized_returns_nonnull_with_count_silence(int size, int count) __attribute__((returns_nonnull)) __attribute__((alloc_size(1, 2)));
+
+char * __counted_by_or_null(size * count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_with_count(int size, int count)
+    __attribute__((alloc_size(1, 2)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by_or_null(size * count)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+char * __counted_by_or_null(count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_with_count2(int size, int count)
+    __attribute__((alloc_size(1, 2))); // no guarantee that size is 1
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by_or_null(count)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+char * __counted_by(size * count)
+// expected-note@-1{{previous attribute is here}}
+    explicitly_counted_nonnull_with_count(int size, int count)
+    __attribute__((alloc_size(1, 2)));
+// expected-error@-1{{pointer cannot have more than one count attribute}}
+// expected-note@-2{{conflicting attributes were '__counted_by(size * count)' and '__sized_by_or_null(size * count)'}}
+// expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+
+__attribute__((alloc_size(1)))
+// expected-warning@-1{{implicit __sized_by_or_null attribute ignored because of explicit __sized_by}}
+// expected-note@-2{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+    void * __sized_by(size)
+// expected-note@-1{{previous attribute is here}}
+// expected-note@-2{{add _Nonnull qualifier to return type to silence this warning}}
+    leading_attr(unsigned size) {
+    return (void*)0;
+}
+
+__attribute__((alloc_size(1))) void * __sized_by(size) _Nonnull leading_attr_silence(unsigned size) {
+    return (void*)0; // expected-warning{{null returned from function that requires a non-null return value}}
+}
+
+__attribute__((alloc_size(1))) void * __sized_by(size) leading_attr_silence_returns_nonnull(unsigned size) __attribute__((returns_nonnull)) {
+    // expected-warning@-1{{GCC does not allow 'returns_nonnull' attribute in this position on a function definition}}
+    return (void*)0; // expected-warning{{null returned from function that requires a non-null return value}}
+}
+
+__attribute__((alloc_size(1)))
+    // expected-error@-1{{pointer cannot have more than one count attribute}}
+    // expected-note@-2{{conflicting attributes were '__counted_by(size)' and '__sized_by_or_null(size)'}}
+    // expected-note@-3{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+    char * __counted_by(size)
+    // expected-note@-1{{previous attribute is here}}
+    leading_attr_clash(unsigned size) {
+    return (void*)0;
+}
+
+void * unnamed_param(unsigned) __attribute__((alloc_size(1)));
+
+__attribute__((alloc_size(1))) void * unnamed_param(unsigned size) {
+    return (void*)0;
+}
+
+void * unnamed_param_with_count(unsigned, unsigned) __attribute__((alloc_size(1, 2)));
+__attribute__((alloc_size(1, 2))) void * unnamed_param_with_count(unsigned, unsigned) {
+    // expected-warning@-1 2{{omitting the parameter name in a function definition is a C23 extension}}
+    return (void*)0;
+}
+
+void * inherit_attr(unsigned size) __attribute__((alloc_size(1)));
+void * __sized_by_or_null(size) inherit_attr(unsigned size) {
+    return (void*)0;
+}
+
+void * unnamed_param_inherit_attr(unsigned) __attribute__((alloc_size(1)));
+void * __sized_by_or_null(size) unnamed_param_inherit_attr(unsigned size) {
+    return (void*)0;
+}
+
+void * unnamed_param_with_count_flipped(unsigned, unsigned)
+    // expected-note@-1{{previous declaration is here}}
+    __attribute__((alloc_size(1,2)));
+    // expected-note@-1{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+void * __sized_by_or_null(count * size)
+    // expected-error@-1{{conflicting '__sized_by_or_null' attribute with the previous function declaration}}
+    // expected-note@-2{{conflicting attributes were '__sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)' and '__sized_by_or_null(count * size)'}}
+    unnamed_param_with_count_flipped(unsigned size, unsigned count) {
+    return (void*)0;
+}
+
+void * unnamed_param_with_count_mismatching_attrs(unsigned, unsigned)
+    __attribute__((alloc_size(1,2)));
+    // expected-note@-1{{conflicting attribute is here}}
+__attribute__((alloc_size(2,1)))
+    // expected-error@-1{{'alloc_size' attribute does not match previous declaration}}
+    void * unnamed_param_with_count_mismatching_attrs(unsigned, unsigned) {
+    // expected-warning@-1 2{{omitting the parameter name in a function definition is a C23 extension}}
+    return (void*)0;
+}
+
+void * unnamed_param_with_count_mismatching_attrs_after_param_list(unsigned, unsigned)
+    __attribute__((alloc_size(1,2)));
+    // expected-note@-1{{conflicting attribute is here}}
+void * unnamed_param_with_count_mismatching_attrs_after_param_list(unsigned, unsigned)
+    // expected-warning@-1 2{{omitting the parameter name in a function definition is a C23 extension}}
+    __attribute__((alloc_size(2,1))) {
+    // expected-error@-1{{'alloc_size' attribute does not match previous declaration}}
+    // expected-warning@-2{{GCC does not allow 'alloc_size' attribute in this position on a function definition}}
+    return (void*)0;
+}
+
+__attribute__((alloc_size(1, 2)))
+// expected-note@-1{{conflicting attribute is here}}
+void * clashing_attrbutes_on_same_decl(unsigned, unsigned)
+    __attribute__((alloc_size(2, 1)));
+    // expected-error@-1{{'alloc_size' attribute does not match previous declaration}}
+
+// expected-note@+1{{previous declaration is here}}
+void * override_nullability(unsigned, unsigned)
+    // expected-note@+1{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+    __attribute__((alloc_size(1, 2)));
+// expected-note@+2{{conflicting attributes were '__sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)' and '__sized_by(function-parameter-0-0 * function-parameter-0-1)'}}
+// expected-error@+1{{conflicting '__sized_by' attribute with the previous function declaration}}
+void * override_nullability(unsigned, unsigned)
+    __attribute__((returns_nonnull))
+    // expected-note@+1{{function return type implicitly __sized_by because of the function's 'alloc_size' and 'returns_nonnull' attributes}}
+    __attribute__((alloc_size(1, 2)));
+
+// expected-note@+1{{previous declaration is here}}
+void * override_nullability2(unsigned, unsigned)
+    __attribute__((returns_nonnull))
+    // expected-note@+1{{function return type implicitly __sized_by because of the function's 'alloc_size' and 'returns_nonnull' attributes}}
+    __attribute__((alloc_size(1, 2)));
+// expected-note@+2{{conflicting attributes were '__sized_by(function-parameter-0-0 * function-parameter-0-1)' and '__sized_by_or_null(function-parameter-0-0 * function-parameter-0-1)'}}
+// expected-error@+1{{conflicting '__sized_by_or_null' attribute with the previous function declaration}}
+void * override_nullability2(unsigned, unsigned)
+    // expected-note@+1{{function return type implicitly __sized_by_or_null because of the function's 'alloc_size' attribute}}
+    __attribute__((alloc_size(1, 2)));
+
+// expected-error@+1{{cannot combine '__sized_by_or_null' and 'returns_nonnull'; did you mean '__sized_by' instead?}}
+void * __sized_by_or_null(x * y) ignore_implicit_type_reverse_nullability(unsigned x, unsigned y) __attribute__((returns_nonnull)) __attribute__((alloc_size(1,2)));

--- a/clang/test/BoundsSafety/Sema/count-bound-attrs.c
+++ b/clang/test/BoundsSafety/Sema/count-bound-attrs.c
@@ -17,6 +17,8 @@ void Test(void) {
     int *__counted_by(len6) justCount;
     int len7;
     int *__counted_by(len7) __counted_by(len7+1) thinCountCount; // expected-error{{pointer cannot have more than one count attribute}}
+                                                                 // expected-note@-1{{conflicting attributes were '__counted_by(len7)' and '__counted_by(len7 + 1)'}}
+                                                                 // expected-note@-2{{previous attribute is here}}
 
     int len8;
     int *__counted_by(len8) __single countThin;

--- a/clang/test/BoundsSafety/Sema/counted_by_semantic_checks.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_semantic_checks.c
@@ -7,6 +7,8 @@ struct T1 {
     int len;
     int len2;
     int *__counted_by(len) __counted_by(len+1) buf; // expected-error{{pointer cannot have more than one count attribute}}
+                                                    // expected-note@-1{{conflicting attributes were '__counted_by(len)' and '__counted_by(len + 1)'}}
+                                                    // expected-note@-2{{previous attribute is here}}
     int *__counted_by(len + len2) buf2;
     int *__bidi_indexable __counted_by(len) buf3; // expected-error{{pointer cannot be '__counted_by' and '__bidi_indexable' at the same time}}
     int *__counted_by(len) __bidi_indexable buf4; // expected-error{{pointer cannot be '__counted_by' and '__bidi_indexable' at the same time}}

--- a/clang/test/BoundsSafety/Sema/ptrs-with-multiple-range-attrs.c
+++ b/clang/test/BoundsSafety/Sema/ptrs-with-multiple-range-attrs.c
@@ -1,15 +1,21 @@
-// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -verify %s
-// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify=expected,c %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify=expected,c %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -verify=expected,c %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -verify=expected,cxx %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -verify=expected,c %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -verify=expected,cxx %s
 
 #include <ptrcheck.h>
 
 void foo(int *__counted_by(len) __counted_by(len+2)* buf, int len); // expected-error{{pointer cannot have more than one count attribute}}
+                                                                    // expected-note@-1{{conflicting attributes were '__counted_by(len)' and '__counted_by(len + 2)'}}
+                                                                    // expected-note@-2{{previous attribute is here}}
 void bar(int **__counted_by(len) buf __counted_by(len + 1), int len); // expected-error{{pointer cannot have more than one count attribute}}
+                                                                      // expected-note@-1{{conflicting attributes were '__counted_by(len + 1)' and '__counted_by(len)'}}
+                                                                      // expected-note@-2{{previous attribute is here}}
 int *__counted_by(len) __counted_by(len + 2) baz(int len); // expected-error{{pointer cannot have more than one count attribute}}
+                                                           // expected-note@-1{{conflicting attributes were '__counted_by(len)' and '__counted_by(len + 2)'}}
+                                                           // expected-note@-2{{previous attribute is here}}
 
 int *__counted_by(len) bazx(int len);
 int *__counted_by(len) bazx(int len); // ok - same count expr
@@ -24,12 +30,12 @@ int *bazy();
 // expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *__counted_by(4) bazy() {} // ok
 
-// expected-note@+2{{previous declaration is here}}
-// expected-note@+1{{previous declaration is here}}
+// expected-note@+1 2{{previous declaration is here}}
 int *__counted_by(len) bayz(unsigned len);
 // expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *bayz(unsigned len) {}
-// expected-error@+1{{conflicting '__sized_by' attribute with the previous function declaration}}
+// expected-error@+2{{conflicting '__sized_by' attribute with the previous function declaration}}
+// expected-note@+1{{conflicting attributes were '__counted_by(len)' and '__sized_by(len)'}}
 int *__sized_by(len) bayz(unsigned len) {}
 
 // expected-note@+1{{previous declaration is here}}
@@ -45,12 +51,15 @@ int *baxy(unsigned len, int ** pptr) {}
 char *__counted_by(len) qux(int len);
 // expected-note@+1{{previous declaration is here}}
 char *__sized_by(len) qux(int len);
-// expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
+// expected-error@+2{{conflicting '__counted_by' attribute with the previous function declaration}}
+// expected-note@+1{{conflicting attributes were '__sized_by(len)' and '__counted_by(4)'}}
 char *__counted_by(4) qux(int len) {}
 
 int *__counted_by(len) __counted_by(len) quux(int len) {} // ok - same count expr
 
 int *__counted_by(len) __counted_by(cnt) quuz(int len, int cnt) {} // expected-error{{pointer cannot have more than one count attribute}}
+                                                                   // expected-note@-1{{conflicting attributes were '__counted_by(len)' and '__counted_by(cnt)'}}
+                                                                   // expected-note@-2{{previous attribute is here}}
 
 void corge(int *__counted_by(len) ptr, int len);
 void corge(int *__counted_by(len) ptr, int len); // ok
@@ -66,7 +75,12 @@ int ** grault2(int len);
 int *__counted_by(len)* grault2(int len) {}
 
 struct S {
-    int *__counted_by(l) bp2 __counted_by(l+1); // expected-error{{pointer cannot have more than one count attribute}}
+    int *__counted_by(l) // expected-error{{pointer cannot have more than one count attribute}}
+                         // c-note@-1{{conflicting attributes were '__counted_by(l + 1)' and '__counted_by(l)'}}
+                         // cxx-note@-2{{conflicting attributes were '__counted_by(l + 1)' and '__counted_by(this->l)'}} rdar://139834323 (Struct field in count expression is printed inconsistently in C++ mode)
+    bp2
+    __counted_by(l+1); // c-note{{previous attribute is here}}
+                       // cxx-note@+1{{previous attribute is here}} rdar://139834115 (Count expression has incorrect location in C++ mode)
     int l;
 };
 
@@ -80,13 +94,11 @@ struct T {
 void end1(int *__ended_by(b) a, int *b); // OK
 void end1(int *__ended_by(b) a, int *b); // OK redeclaration
 
-// expected-note@+3{{previous declaration is here}} \
-   expected-note@+3{{previous declaration is here}} \
-   expected-note@+3{{previous declaration is here}}
+// expected-note@+1 3{{previous declaration is here}}
 void end1(int *__ended_by(b) a, int *b) {} // OK definition over declaration
 
 void end1(int *a, int *b); // expected-error{{conflicting '__ended_by' attribute with the previous function declaration}}
-void end1(int *a, int *__ended_by(a) b); // expected-error{{conflicting '__ended_by' attribute with the previous function declaration}}
+void end1(int *a, int *__ended_by(a) b); // expected-error 2{{conflicting '__ended_by' attribute with the previous function declaration}} mismatch on both a and b
 void end1(int *__ended_by(b) a, int *__ended_by(a) b); // expected-error{{conflicting '__ended_by' attribute with the previous function declaration}}
 
 void end2(int *__ended_by(b) a, int *__ended_by(c) b, int *c); // OK

--- a/clang/test/BoundsSafety/Sema/ptrs-with-multiple-range-attrs.c
+++ b/clang/test/BoundsSafety/Sema/ptrs-with-multiple-range-attrs.c
@@ -4,6 +4,9 @@
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -verify=expected,cxx %s
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -verify=expected,c %s
 // RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -verify=expected,cxx %s
+//
+// RUN: not %clang_cc1 -fsyntax-only -fbounds-safety -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s --implicit-check-not 'fix-it:"'
+// RUN: not %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s --implicit-check-not 'fix-it:"'
 
 #include <ptrcheck.h>
 
@@ -27,6 +30,7 @@ int *__counted_by(4) bazz() {} // ok - same count expr
 
 // expected-note@+1{{previous declaration is here}}
 int *bazy();
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-1]]:6-[[@LINE-1]]:6}:"__counted_by(4) "
 // expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *__counted_by(4) bazy() {} // ok
 
@@ -34,12 +38,16 @@ int *__counted_by(4) bazy() {} // ok
 int *__counted_by(len) bayz(unsigned len);
 // expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *bayz(unsigned len) {}
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-1]]:6-[[@LINE-1]]:6}:"__counted_by(len) "
 // expected-error@+2{{conflicting '__sized_by' attribute with the previous function declaration}}
 // expected-note@+1{{conflicting attributes were '__counted_by(len)' and '__sized_by(len)'}}
 int *__sized_by(len) bayz(unsigned len) {}
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-7]]:6-[[@LINE-7]]:18}:"__sized_by"
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-2]]:6-[[@LINE-2]]:16}:"__counted_by"
 
 // expected-note@+1{{previous declaration is here}}
 int *baxz(unsigned len, int **pptr);
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-1]]:30-[[@LINE-1]]:30}:"__counted_by(len)"
 // expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *baxz(unsigned len, int *__counted_by(len)* pptr) {} // ok
 
@@ -47,13 +55,17 @@ int *baxz(unsigned len, int *__counted_by(len)* pptr) {} // ok
 int *baxy(unsigned len, int *__counted_by(len)* pptr);
 // expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *baxy(unsigned len, int ** pptr) {}
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-1]]:30-[[@LINE-1]]:30}:"__counted_by(len)"
 
+typedef int canonically_int_t;
 char *__counted_by(len) qux(int len);
 // expected-note@+1{{previous declaration is here}}
 char *__sized_by(len) qux(int len);
 // expected-error@+2{{conflicting '__counted_by' attribute with the previous function declaration}}
 // expected-note@+1{{conflicting attributes were '__sized_by(len)' and '__counted_by(4)'}}
-char *__counted_by(4) qux(int len) {}
+char * _Nonnull __counted_by(4) qux(canonically_int_t len) {}
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-4]]:18-[[@LINE-4]]:21}:"4"
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-2]]:30-[[@LINE-2]]:31}:"len"
 
 int *__counted_by(len) __counted_by(len) quux(int len) {} // ok - same count expr
 
@@ -67,6 +79,7 @@ void corge(int *__counted_by(len) ptr, int len) {} // ok
 
 // expected-note@+1{{previous declaration is here}}
 int ** grault(int len);
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-1]]:8-[[@LINE-1]]:8}:"__counted_by(len) "
 // expected-error@+1{{conflicting '__counted_by' attribute with the previous function declaration}}
 int *__counted_by(len) grault(int len) {}
 
@@ -98,6 +111,7 @@ void end1(int *__ended_by(b) a, int *b); // OK redeclaration
 void end1(int *__ended_by(b) a, int *b) {} // OK definition over declaration
 
 void end1(int *a, int *b); // expected-error{{conflicting '__ended_by' attribute with the previous function declaration}}
+// CHECK: fix-it:{{.*}}ptrs-with-multiple-range-attrs.c":{[[@LINE-1]]:16-[[@LINE-1]]:16}:"__ended_by(b) "
 void end1(int *a, int *__ended_by(a) b); // expected-error 2{{conflicting '__ended_by' attribute with the previous function declaration}} mismatch on both a and b
 void end1(int *__ended_by(b) a, int *__ended_by(a) b); // expected-error{{conflicting '__ended_by' attribute with the previous function declaration}}
 

--- a/clang/test/BoundsSafety/Sema/redundant-attrs.c
+++ b/clang/test/BoundsSafety/Sema/redundant-attrs.c
@@ -41,21 +41,29 @@ char * __null_terminated __null_terminated ptrBoundBound5; // expected-warning{{
 
 int len = 0;
 int * __counted_by(len) __counted_by(len) ptrBoundBound6; // expected-error{{pointer cannot have more than one count attribute}}
+                                                          // expected-note@-1{{conflicting attributes were '__counted_by(len)' and '__counted_by(len)'}}
+                                                          // expected-note@-2{{previous attribute is here}}
 
 struct S1 {
     int size;
     int arrBoundBound[__counted_by(size) __counted_by(size)]; // expected-error{{array cannot have more than one count attribute}}
+                                                              // expected-note@-1{{conflicting attributes were '__counted_by(size)' and '__counted_by(size)'}}
+                                                              // expected-note@-2{{previous attribute is here}}
 };
 struct S2 {
     int size;
     int len;
     int arrBoundBound[__counted_by(size) __counted_by(len)]; // expected-error{{array cannot have more than one count attribute}}
+                                                             // expected-note@-1{{conflicting attributes were '__counted_by(size)' and '__counted_by(len)'}}
+                                                             // expected-note@-2{{previous attribute is here}}
 };
 
 #define intPtr2 int *
 intPtr2 __single __single ptrBoundBound7; // expected-warning{{pointer annotated with __single multiple times. Annotate only once to remove this warning}}
 intPtr2_header __single __single ptrBoundBound7_header; // expected-warning{{pointer annotated with __single multiple times. Annotate only once to remove this warning}}
 int * __counted_by(len) __counted_by(len) ptrBoundBound8; // expected-error{{pointer cannot have more than one count attribute}}
+                                                          // expected-note@-1{{conflicting attributes were '__counted_by(len)' and '__counted_by(len)'}}
+                                                          // expected-note@-2{{previous attribute is here}}
 
 bidiPtr __indexable ptrBoundBoundMismatch; // expected-error{{pointer cannot have more than one bound attribute}}
 bidiPtr2 __indexable ptrBoundBoundMismatch2; // expected-error{{pointer cannot have more than one bound attribute}}

--- a/clang/test/BoundsSafety/Sema/terminated-by-redecl.c
+++ b/clang/test/BoundsSafety/Sema/terminated-by-redecl.c
@@ -11,7 +11,8 @@ char *__null_terminated test();
 
 // expected-note@+1{{previous declaration is here}}
 const char *test2();
-// expected-error@+1{{conflicting '__terminated_by' attribute with the previous function declaration}}
+// expected-error@+2{{conflicting '__terminated_by' attribute with the previous function declaration}}
+// expected-note@+1{{conflicting arguments for terminator were '0' and '-1'}}
 const char *__terminated_by(-1) test2();
 
 const char *test3();
@@ -24,7 +25,8 @@ void test4(int *arg);
 
 // expected-note@+1{{previous declaration is here}}
 void test5(int *__null_terminated arg);
-// expected-error@+1{{conflicting '__terminated_by' attribute with the previous function declaration}}
+// expected-error@+2{{conflicting '__terminated_by' attribute with the previous function declaration}}
+// expected-note@+1{{conflicting arguments for terminator were '0' and '-1'}}
 void test5(int *__terminated_by(-1) arg);
 
 // expected-note@+1{{previous declaration is here}}
@@ -44,7 +46,8 @@ void test8(int *__ended_by(end) buf, int *end);
 
 // expected-note@+1{{previous declaration is here}}
 void test9(int *__ended_by(end) buf, int *end);
-// expected-error@+1{{conflicting '__ended_by' attribute with the previous function declaration}}
+// expected-error@+2{{conflicting '__ended_by' attribute with the previous function declaration}}
+// expected-error@+1{{conflicting '__terminated_by' attribute with the previous function declaration}}
 void test9(int *buf, int *__null_terminated end);
 
 #include "terminated-by-redecl.h"

--- a/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
+++ b/clang/utils/TableGen/ClangDiagnosticsEmitter.cpp
@@ -421,6 +421,7 @@ enum ModifierType {
   MT_ObjCClass,
   MT_ObjCInstance,
   MT_Quoted,
+  MT_Unquoted,
 };
 
 static StringRef getModifierName(ModifierType MT) {
@@ -450,6 +451,8 @@ static StringRef getModifierName(ModifierType MT) {
     return "objcinstance";
   case MT_Quoted:
     return "quoted";
+  case MT_Unquoted:
+    return "unquoted";
   case MT_Unknown:
     llvm_unreachable("invalid modifier type");
   }
@@ -1117,6 +1120,7 @@ Piece *DiagnosticTextBuilder::DiagText::parseDiagText(StringRef &Text,
                                .Case("objcclass", MT_ObjCClass)
                                .Case("objcinstance", MT_ObjCInstance)
                                .Case("quoted", MT_Quoted)
+                               .Case("unquoted", MT_Unquoted)
                                .Case("", MT_Placeholder)
                                .Default(MT_Unknown);
 
@@ -1269,6 +1273,7 @@ Piece *DiagnosticTextBuilder::DiagText::parseDiagText(StringRef &Text,
     case MT_ObjCClass:
     case MT_ObjCInstance:
     case MT_Quoted:
+    case MT_Unquoted:
     case MT_Ordinal:
     case MT_Human: {
       Parsed.push_back(New<PlaceholderPiece>(ModType, parseModifier(Text)));


### PR DESCRIPTION
When -fbounds-safety is enabled, the semantics of the return value of
functions is that of __sized_by_or_null. Unlike return types annotated
with __sized_by_or_null, it is never included in the type system.
Instead every relevant analysis and transformation has to specifically
check for the alloc_size attribute.

This patch infers a __sized_by_or_null return type for functions
annotated with alloc_size. This enables us to remove those special
cases and reduce complexity.

rdar://118338657
rdar://91017404
rdar://11833865