### PR TITLE
[BoundsSafety] Work around a regression in how macro-defined bounds-s…

### DIFF
--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -1110,6 +1110,18 @@ enum AttributeDeclKind {
   ExpectedTypedef,
 };
 
+inline const StreamingDiagnostic &operator<<(const StreamingDiagnostic &DB,
+                                             const ParsedAttr &At) {
+
+  if (At.printMacroName()) {
+    const IdentifierInfo *AttrName = At.getMacroIdentifier();
+    DB.AddTaggedVal(reinterpret_cast<uint64_t>(AttrName),
+                  DiagnosticsEngine::ak_identifierinfo);
+    return DB;
+  }
+  return DB << &At;
+}
+
 } // namespace clang
 
 #endif // LLVM_CLANG_SEMA_PARSEDATTR_H


### PR DESCRIPTION
…afety attributes are emitted in diagnostics

A recent auto-merged change from upstream
d9ef62ac90a204961c45e05a31bbb629f142dd1d
seemed to remove the special handling on how macro-defined bounds-safety attributes are emitted in diagnostics. Adding the specialization for now to fix the test failure. The task to clean up the special handling of the macro defined attributes is tracked separately.

This fixes test failures in
  Clang :: BoundsSafety/Sema/attributes_in_template_decls_attr_only_mode.cpp
  Clang :: BoundsSafety/Sema/complex-typespecs-with-bounds.c
  Clang :: BoundsSafety/Sema/terminated-by-attr.c
  Clang :: BoundsSafety/Sema/unsafe-late-const.c

rdar://155652853