### PR TITLE
[feature availability] Don't warn about unguarded uses of ObjC protocols adopted by interfaces

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -377,7 +377,8 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
   DiagnoseAvailabilityOfDecl(D, Locs, UnknownObjCClass, ObjCPropertyAccess,
                              AvoidPartialAvailabilityChecks, ClassReceiver);
 
-  DiagnoseFeatureAvailabilityOfDecl(D, Locs);
+  if (!AvoidPartialAvailabilityChecks)
+    DiagnoseFeatureAvailabilityOfDecl(D, Locs);
 
   DiagnoseUnusedOfDecl(*this, D, Loc);
 

--- a/clang/test/SemaObjC/feature-availability.m
+++ b/clang/test/SemaObjC/feature-availability.m
@@ -147,7 +147,7 @@ __attribute__((availability(domain:feature1, UNAVAIL)))
 @end
 
 __attribute__((availability(domain:feature1, AVAIL)))
-@interface Base4 <P1> // expected-error {{use of 'P1' requires feature 'feature1' to be unavailable}}
+@interface Base4 <P1>
 @end
 
 __attribute__((availability(domain:feature1, AVAIL)))
@@ -166,8 +166,10 @@ __attribute__((availability(domain:feature1, AVAIL)))
 @end
 
 __attribute__((availability(domain:feature1, UNAVAIL)))
-@interface Base5(Cat4) <P2> // expected-error {{use of 'P2' requires feature 'feature1' to be available}}
+@interface Base5(Cat4) <P2>
 @end
 
-@interface Base6 <P1, P2> // expected-error {{use of 'P1' requires feature 'feature1' to be unavailable}} expected-error {{use of 'P2' requires feature 'feature1' to be available}}
+@interface Base6 <P1, P2>
 @end
+
+void foo(id<P1>); // expected-error {{use of 'P1' requires feature 'feature1' to be unavailable}}


### PR DESCRIPTION
We don't want to force users to annotate interfaces/protocols/categories adopting the annotated protocol with feature attributes.

rdar://155690040