### PR TITLE
[feature availability] Don't disallow annotating ObjC interfaces and protocols with features when there are unannotated forward declarations of them

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3658,9 +3658,25 @@ void Sema::copyFeatureAvailability(Decl *Dst, Decl *Src) {
   }
 }
 
+static bool isForwardDeclaration(Decl *Prev, Decl *D) {
+  if (Prev->getCanonicalDecl() != D->getCanonicalDecl())
+    return false;
+  if (auto *ID = dyn_cast<ObjCInterfaceDecl>(Prev))
+    return !ID->getPreviousDecl();
+  if (auto *PD = dyn_cast<ObjCProtocolDecl>(Prev))
+    return !PD->getPreviousDecl();
+  return false;
+}
+
 void Sema::copyFeatureAvailabilityCheck(Decl *Dst, NamedDecl *Src,
                                         bool Redeclaration) {
   if (Dst->isInvalidDecl())
+    return;
+
+  // Don't check whether a new feature is being added if Src is a
+  // forward declaration of classes and protocols as they cannnot be
+  // annotated with attributes.
+  if (isForwardDeclaration(Src, Dst))
     return;
 
   llvm::SmallDenseMap<StringRef, DomainAvailabilityAttr *> DstToAttr;

--- a/clang/test/SemaObjC/feature-availability.m
+++ b/clang/test/SemaObjC/feature-availability.m
@@ -34,6 +34,8 @@ struct __attribute__((availability(domain:feature1, AVAIL))) S1 {};
 -(struct S1)m3 __attribute__((availability(domain:feature1, UNAVAIL))); // expected-error {{use of 'S1' requires feature 'feature1' to be available}}
 @end
 
+@class Base0;
+
 __attribute__((availability(domain:feature1, AVAIL))) // expected-note 2 {{is incompatible with __attribute__((availability(domain:feature1, 0)))}}
 @interface Base0 {
   struct S0 ivar0; // expected-error {{use of 'S0' requires feature 'feature1' to be unavailable}}
@@ -133,6 +135,8 @@ __attribute__((availability(domain:feature1, AVAIL)))
 __attribute__((availability(domain:feature1, AVAIL))) // expected-error {{feature attributes cannot be applied to ObjC category implementations}}
 @implementation Derived2(Cat1)
 @end
+
+@protocol P1;
 
 __attribute__((availability(domain:feature1, UNAVAIL)))
 @protocol P1


### PR DESCRIPTION
clang shouldn't reject this as forward declarations of ObjC interfaces and protocols cannot be annotated with attributes.

rdar://154522966