### PR TITLE
[`next` 🍒][clang] Fix missing target info specifier on Global Variable linkage computation

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2989,7 +2989,7 @@ void CodeGenModule::SetInternalFunctionAttributes(GlobalDecl GD,
 }
 
 static void setLinkageForGV(llvm::GlobalValue *GV, const NamedDecl *ND,
-                            VersionTuple EnclosingVersion = VersionTuple()) {
+                            VersionTuple EnclosingVersion) {
   // Set linkage and visibility in case we never see a definition.
   LinkageInfo LV = ND->getLinkageAndVisibility();
   // Don't set internal linkage on declarations.
@@ -5284,7 +5284,7 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName, llvm::Type *Ty,
 
     GV->setAlignment(getContext().getDeclAlign(D).getAsAlign());
 
-    setLinkageForGV(GV, D);
+    setLinkageForGV(GV, D, Target.getPlatformMinVersion());
 
     if (D->getTLSKind()) {
       if (D->getTLSKind() == VarDecl::TLS_Dynamic)


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/11006
-----------------------------------------------
A previous change (https://github.com/swiftlang/llvm-project/pull/10555) added support for querying 'isWeakImported' to be parameterized on the enclosing target version to match 'CheckAvailability' and 'getAvailability'. We missed passing in this parameter in the Clang module code-gen when querying linkage for a global variable. This change adds the missing parameter and removes the default parameter from the query in order to avoid this kind of bug in the future.

Resolves rdar://154677999