### PR TITLE
[next] Coro: Add a function attribute for resume from call async functlets

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-async.ll
+++ b/llvm/test/Transforms/Coroutines/coro-async.ll
@@ -58,7 +58,7 @@ entry:
 }
 
 
-define swiftcc void @my_async_function(ptr swiftasync %async.ctxt, ptr %task, ptr %actor) presplitcoroutine !dbg !1 {
+define swiftcc void @my_async_function(ptr swiftasync %async.ctxt, ptr %task, ptr %actor) presplitcoroutine "async_entry" !dbg !1 {
 entry:
   %tmp = alloca { i64, i64 }, align 8
   %vector = alloca <4 x double>, align 16
@@ -145,6 +145,7 @@ define void @my_async_function_pa(ptr %ctxt, ptr %task, ptr %actor) {
 
 ; CHECK-LABEL: define internal swiftcc void @my_async_functionTQ0_(ptr readonly swiftasync captures(none) %0, ptr %1, ptr readnone captures(none) %2)
 ; CHECK-O0-LABEL: define internal swiftcc void @my_async_functionTQ0_(ptr swiftasync %0, ptr %1, ptr %2)
+; CHECK-SAME: #[[ATTRS:[0-9]+]]
 ; CHECK-SAME: !dbg ![[SP2:[0-9]+]] {
 ; CHECK: entryresume.0:
 ; CHECK:   [[CALLER_CONTEXT:%.*]] = load ptr, ptr %0
@@ -513,6 +514,8 @@ declare ptr @hide(ptr)
 
 !llvm.dbg.cu = !{!2}
 !llvm.module.flags = !{!0}
+
+; CHECK: #[[ATTRS]] = {{.*}}async_ret
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 ; CHECK: ![[SP1]] = distinct !DISubprogram(name: "my_async_function",


### PR DESCRIPTION
This change adds a function attribute `async_ret` for any funclet generated from a async function marked with `async_entry` that models a return from an async function.

We recognize these continuations by a `__swift_async_resume_project_context` projection function argument to the suspend function.

rdar://134460666