### PR TITLE
[lldb] Add an extra optional did_read_live_memory to Target::ReadMemory  and [lldb] Implement LLDBMemoryReader::readRemoteAddressImpl 

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -1193,11 +1193,14 @@ public:
   // 2 - if there is a process, then read from memory
   // 3 - if there is no process, then read from the file cache
   //
+  // The optional did_read_live_memory parameter will be set true if live memory
+  // was read successfully.
+  //
   // The method is virtual for mocking in the unit tests.
   virtual size_t ReadMemory(const Address &addr, void *dst, size_t dst_len,
                             Status &error, bool force_live_memory = false,
-                            lldb::addr_t *load_addr_ptr = nullptr);
-
+                            lldb::addr_t *load_addr_ptr = nullptr,
+                            bool *did_read_live_memory = nullptr);
   size_t ReadCStringFromMemory(const Address &addr, std::string &out_str,
                                Status &error, bool force_live_memory = false);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -768,11 +768,6 @@ LLDBMemoryReader::resolveRemoteAddressFromSymbolObjectFile(
 }
 
 bool LLDBMemoryReader::readMetadataFromFileCacheEnabled() const {
-  auto &triple = m_process.GetTarget().GetArchitecture().GetTriple();
-
-  // 32 doesn't have a flag bit we can reliably use, so reading from filecache
-  // is disabled on it.
-  return m_process.GetTarget().GetSwiftReadMetadataFromFileCache() &&
-         triple.isArch64Bit();
+  return m_process.GetTarget().GetSwiftReadMetadataFromFileCache();
 }
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -98,6 +98,11 @@ public:
   /// Returns whether the filecache optimization is enabled or not.
   bool readMetadataFromFileCacheEnabled() const;
 
+protected:
+  bool readRemoteAddressImpl(swift::remote::RemoteAddress address,
+                             swift::remote::RemoteAddress &out,
+                             std::size_t integerSize) override;
+
 private:
   friend MemoryReaderLocalBufferHolder;
 
@@ -118,6 +123,12 @@ private:
   /// to an Address.
   std::optional<Address>
   remoteAddressToLLDBAddress(swift::remote::RemoteAddress address) const;
+
+  /// Implementation detail of readBytes. Returns a pair where the first element
+  /// indicates whether the memory was read successfully, the second element
+  /// indicates whether live memory was read.
+  std::pair<bool, bool> readBytesImpl(swift::remote::RemoteAddress address,
+                                      uint8_t *dest, uint64_t size);
 
   /// Reads memory from the symbol rich binary from the address into dest.
   /// \return true if it was able to successfully read memory.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -1921,7 +1921,8 @@ size_t Target::ReadMemoryFromFileCache(const Address &addr, void *dst,
 
 size_t Target::ReadMemory(const Address &addr, void *dst, size_t dst_len,
                           Status &error, bool force_live_memory,
-                          lldb::addr_t *load_addr_ptr) {
+                          lldb::addr_t *load_addr_ptr,
+                          bool *did_read_live_memory) {
   error.Clear();
 
   Address fixed_addr = addr;
@@ -2020,6 +2021,8 @@ size_t Target::ReadMemory(const Address &addr, void *dst, size_t dst_len,
       if (bytes_read) {
         if (load_addr_ptr)
           *load_addr_ptr = load_addr;
+        if (did_read_live_memory)
+          *did_read_live_memory = true;
         return bytes_read;
       }
     }

--- a/lldb/unittests/Expression/DWARFExpressionTest.cpp
+++ b/lldb/unittests/Expression/DWARFExpressionTest.cpp
@@ -111,7 +111,8 @@ public:
 
   size_t ReadMemory(const Address &addr, void *dst, size_t dst_len,
                     Status &error, bool force_live_memory = false,
-                    lldb::addr_t *load_addr_ptr = nullptr) /*override*/ {
+                    lldb::addr_t *load_addr_ptr = nullptr,
+                    bool *did_read_live_memory = nullptr) /*override*/ {
     auto expected_memory = this->ReadMemory(addr.GetOffset(), dst_len);
     if (!expected_memory) {
       llvm::consumeError(expected_memory.takeError());


### PR DESCRIPTION
    [lldb] Add an extra optional did_read_live_memory to Target::ReadMemory

    Target::ReadMemory may or may not read live memory, but whether it did
    read from live memory or from the filecache is opaque to callers. Add an
    extra out parameter to indicate whether live memory was read or not.


    [lldb] Implement LLDBMemoryReader::readRemoteAddressImpl

    Use the new out parameter on Target::ReadMemory to set the correct
    remote address space in readRemoteAddressImpl.

    rdar://148361743