### PR TITLE
[windows][lldb] implement system logging on Windows

### DIFF
--- a/lldb/include/lldb/Host/Host.h
+++ b/lldb/include/lldb/Host/Host.h
@@ -90,6 +90,10 @@ public:
   /// Emit the given message to the operating system log.
   static void SystemLog(lldb::Severity severity, llvm::StringRef message);
 
+  /// Emit the given message to the stdout or stderr depending on severity.
+  static void SystemLogFallback(lldb::Severity severity,
+                                llvm::StringRef message);
+
   /// Get the process ID for the calling process.
   ///
   /// \return

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -110,18 +110,6 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
   }
   syslog(level, "%s", message.data());
 }
-#else
-void Host::SystemLog(Severity severity, llvm::StringRef message) {
-  switch (severity) {
-  case lldb::eSeverityInfo:
-  case lldb::eSeverityWarning:
-    llvm::outs() << message;
-    break;
-  case lldb::eSeverityError:
-    llvm::errs() << message;
-    break;
-  }
-}
 #endif
 #endif
 

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -113,6 +113,18 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
 #endif
 #endif
 
+void Host::SystemLogFallback(Severity severity, llvm::StringRef message) {
+  switch (severity) {
+  case lldb::eSeverityInfo:
+  case lldb::eSeverityWarning:
+    llvm::outs() << message;
+    return;
+  case lldb::eSeverityError:
+    llvm::errs() << message;
+    return;
+  }
+}
+
 #if !defined(__APPLE__) && !defined(_WIN32)
 static thread_result_t
 MonitorChildProcessThreadFunction(::pid_t pid,

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -352,7 +352,6 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
   }
 
   WORD event_type;
-  WORD event_id;
 
   switch (severity) {
   case lldb::eSeverityWarning:

--- a/lldb/source/Host/windows/Host.cpp
+++ b/lldb/source/Host/windows/Host.cpp
@@ -340,8 +340,15 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
   LPCWSTR wide_message = AnsiToUtf16(message.str().c_str());
 
   if (!h || !wide_message) {
-    SystemLogFallback(severity, message);
-    return;
+    switch (severity) {
+    case lldb::eSeverityInfo:
+    case lldb::eSeverityWarning:
+      llvm::outs() << message;
+      return;
+    case lldb::eSeverityError:
+      llvm::errs() << message;
+      return;
+    }
   }
 
   WORD event_type;


### PR DESCRIPTION
This patch makes LLDB use system logging on Windows rather than piping to the standard output.

Darwin, Linux and FreeBSD based systems pipe the health logs to system events. On Windows that's not the case, everything is redirected to the standard output/error. This leads to confusing diagnostics messages when running the REPL for example. This is fixes with this PR.

rdar://156039517