### PR TITLE
[next] Various JIT failure workarounds

### DIFF
--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -513,7 +513,14 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySymbols() {
         TargetFlagsType Flags = makeTargetFlags(Sym);
         orc::ExecutorAddrDiff Offset = getRawOffset(Sym, Flags);
 
-        if (Offset + Sym.st_size > B->getSize()) {
+        // Truncate symbol if it would overflow -- ELF size fields can't be
+        // trusted.
+        // FIXME: this makes the following error check unreachable, but it's
+        // left here to reduce merge conflicts.
+        uint64_t Size =
+          std::min(static_cast<uint64_t>(Sym.st_size), B->getSize() - Offset);
+
+        if (Offset + Size > B->getSize()) {
           std::string ErrMsg;
           raw_string_ostream ErrStream(ErrMsg);
           ErrStream << "In " << G->getName() << ", symbol ";
@@ -528,11 +535,6 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySymbols() {
                     << B->getRange() << ")";
           return make_error<JITLinkError>(std::move(ErrMsg));
         }
-
-        // Truncate symbol if it would overflow -- ELF size fields can't be
-        // trusted.
-        uint64_t Size =
-          std::min(static_cast<uint64_t>(Sym.st_size), B->getSize() - Offset);
 
         // In RISCV, temporary symbols (Used to generate dwarf, eh_frame
         // sections...) will appear in object code's symbol table, and LLVM does

--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -529,6 +529,11 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySymbols() {
           return make_error<JITLinkError>(std::move(ErrMsg));
         }
 
+        // Truncate symbol if it would overflow -- ELF size fields can't be
+        // trusted.
+        uint64_t Size =
+          std::min(static_cast<uint64_t>(Sym.st_size), B->getSize() - Offset);
+
         // In RISCV, temporary symbols (Used to generate dwarf, eh_frame
         // sections...) will appear in object code's symbol table, and LLVM does
         // not use names on these temporary symbols (RISCV gnu toolchain uses
@@ -536,11 +541,9 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySymbols() {
         // anonymous symbol.
         auto &GSym =
             Name->empty()
-                ? G->addAnonymousSymbol(*B, Offset, Sym.st_size,
-                                        false, false)
-                : G->addDefinedSymbol(*B, Offset, *Name, Sym.st_size, L,
-                                      S, Sym.getType() == ELF::STT_FUNC,
-                                      false);
+                ? G->addAnonymousSymbol(*B, Offset, Size, false, false)
+                : G->addDefinedSymbol(*B, Offset, *Name, Size, L, S,
+                                      Sym.getType() == ELF::STT_FUNC, false);
 
         GSym.setTargetFlags(Flags);
         setGraphSymbol(SymIndex, GSym);

--- a/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
+++ b/llvm/lib/ExecutionEngine/JITLink/ELFLinkGraphBuilder.h
@@ -375,14 +375,7 @@ template <typename ELFT> Error ELFLinkGraphBuilder<ELFT>::graphifySections() {
       }
     }
 
-    if (GraphSec->getMemProt() != Prot) {
-      std::string ErrMsg;
-      raw_string_ostream(ErrMsg)
-          << "In " << G->getName() << ", section " << *Name
-          << " is present more than once with different permissions: "
-          << GraphSec->getMemProt() << " vs " << Prot;
-      return make_error<JITLinkError>(std::move(ErrMsg));
-    }
+    GraphSec->setMemProt(GraphSec->getMemProt() | Prot);
 
     Block *B = nullptr;
     if (Sec.sh_type != ELF::SHT_NOBITS) {


### PR DESCRIPTION
Cherry-picks from `stable/20240723`: 
* https://github.com/swiftlang/llvm-project/pull/9135
* https://github.com/swiftlang/llvm-project/pull/9168

rdar://133510063
___

The ETA for an upstream resolution to these issues is uncertain, so avoid having to keep carrying these around across stable branches.