### PR TITLE
[lldb][test] disable TestSwiftFoundationTypeNotification.py to unblock swift PR testing

### DIFF
--- a/lldb/test/API/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 @skipUnlessDarwin
+@skipIf(bugnumber='rdar://156138054')  # fails sometimes in swift PR testing
 class TestSwiftFoundationTypeNotification(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)


### PR DESCRIPTION
This test sometimes fails in swift PR testing with an assert in the remangler

rdar://156138054