### PR TITLE
[C++ BoundsSafety] Fix false positives when pointer argument is a function call

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -486,54 +486,63 @@ struct CompatibleCountExprVisitor
   const DependentValuesTy *DependentValuesSelf, *DependentValuesOther;
   ASTContext &Ctx;
 
-  // If `Deref` has the form `*&e`, return `e`; otherwise return nullptr.
-  const Expr *trySimplifyDerefAddressof(
-      const UnaryOperator *Deref,
-      const DependentValuesTy *DependentValues, // Deref may need subsitution
-      bool &hasBeenSubstituted) {
-    const Expr *DerefOperand = Deref->getSubExpr()->IgnoreParenImpCasts();
+  // Attempts to perform substitution on E and simplify the result, if the
+  // result has the form "*&e".
+  //
+  //  This function will be repeatedly called on the "Other" Expr. Because the
+  //  kind of "Other" stays unknown during the traversal.
+  const std::pair<const Expr *, bool>
+  trySubstituteAndSimplify(const Expr *E,
+                           const DependentValuesTy *DependentValues) {
+    // Attempts to simplify `E`: if `E` has the form `*&e`, return `e`;
+    // otherwise
+    // return `E` without change.
+    auto trySimplifyDerefAddressof =
+        [](const Expr *E,
+           const DependentValuesTy
+               *DependentValues, // Deref may need subsitution
+           bool &hasBeenSubstituted) -> const Expr * {
+      auto *Deref = dyn_cast<UnaryOperator>(E->IgnoreParenImpCasts());
 
-    if (const auto *UO = dyn_cast<UnaryOperator>(DerefOperand))
-      if (UO->getOpcode() == UO_AddrOf)
-        return UO->getSubExpr();
-    if (const auto *DRE = dyn_cast<DeclRefExpr>(DerefOperand)) {
-      if (!DependentValues || hasBeenSubstituted)
-        return nullptr;
+      if (!Deref || Deref->getOpcode() != UO_Deref)
+        return E;
 
-      auto I = DependentValues->find(DRE->getDecl());
+      const Expr *DerefOperand = Deref->getSubExpr()->IgnoreParenImpCasts();
 
-      if (I != DependentValues->end())
-        if (const auto *UO = dyn_cast<UnaryOperator>(I->getSecond()))
-          if (UO->getOpcode() == UO_AddrOf) {
-            hasBeenSubstituted = true;
-            return UO->getSubExpr();
-          }
-    }
-    return nullptr;
-  }
+      if (const auto *UO = dyn_cast<UnaryOperator>(DerefOperand))
+        if (UO->getOpcode() == UO_AddrOf)
+          return UO->getSubExpr();
+      if (const auto *DRE = dyn_cast<DeclRefExpr>(DerefOperand)) {
+        if (!DependentValues || hasBeenSubstituted)
+          return E;
 
-  inline const std::pair<const Expr *, bool>
-  trySubstitute(const Expr *E, const DependentValuesTy *DependentValues) {
-    if (auto DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
+        auto I = DependentValues->find(DRE->getDecl());
+
+        if (I != DependentValues->end())
+          if (const auto *UO = dyn_cast<UnaryOperator>(I->getSecond()))
+            if (UO->getOpcode() == UO_AddrOf) {
+              hasBeenSubstituted = true;
+              return UO->getSubExpr();
+            }
+      }
+      return E;
+    };
+
+    if (auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
         DRE && DependentValues) {
       auto It = DependentValues->find(DRE->getDecl());
 
       if (It != DependentValues->end()) {
-        return {It->second, true};
+        bool Ignore;
+        return {trySimplifyDerefAddressof(It->second, nullptr, Ignore), true};
       }
     }
-    if (auto UO = dyn_cast<UnaryOperator>(E->IgnoreParenImpCasts())) {
-      if (UO->getOpcode() == UnaryOperator::Opcode::UO_Deref) {
-        bool hasBeenSubstituted = false;
-        const Expr *NewE =
-            trySimplifyDerefAddressof(UO, DependentValues, hasBeenSubstituted);
 
-        if (NewE &&NewE != E) {
-          return {NewE, hasBeenSubstituted};
-        }
-      }
-    }
-    return {E, false};
+    bool hasBeenSubstituted = false;
+    const Expr *NewE =
+        trySimplifyDerefAddressof(E, DependentValues, hasBeenSubstituted);
+
+    return {NewE, hasBeenSubstituted};
   }
 
   explicit CompatibleCountExprVisitor(
@@ -566,7 +575,7 @@ struct CompatibleCountExprVisitor
                            bool hasOtherBeenSubstituted) {
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
     if (const auto *IntLit =
             dyn_cast<IntegerLiteral>(Other->IgnoreParenImpCasts())) {
       return SelfIL == IntLit ||
@@ -581,7 +590,7 @@ struct CompatibleCountExprVisitor
                                      bool hasOtherBeenSubstituted) {
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
 
     // If `Self` is a `sizeof` expression, try to evaluate and compare the two
     // expressions as constants:
@@ -604,7 +613,7 @@ struct CompatibleCountExprVisitor
                         bool hasOtherBeenSubstituted) {
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
     return isa<CXXThisExpr>(Other->IgnoreParenImpCasts());
   }
 
@@ -620,7 +629,7 @@ struct CompatibleCountExprVisitor
     }
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
 
     const auto *O = Other->IgnoreParenImpCasts();
 
@@ -646,7 +655,7 @@ struct CompatibleCountExprVisitor
                        bool hasOtherBeenSubstituted) {
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
     // Even though we don't support member expression in counted-by, actual
     // arguments can be member expressions.
     if (Self == Other)
@@ -669,7 +678,7 @@ struct CompatibleCountExprVisitor
                           bool hasOtherBeenSubstituted) {
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
     if (SelfUO->getOpcode() != UO_Deref)
       return false; // We don't support any other unary operator
 
@@ -680,11 +689,11 @@ struct CompatibleCountExprVisitor
                      hasSelfBeenSubstituted, hasOtherBeenSubstituted);
     }
     // If `Other` is not a dereference expression, try to simplify `SelfUO`:
-    if (const auto *SimplifiedSelf = trySimplifyDerefAddressof(
-            SelfUO, DependentValuesSelf, hasSelfBeenSubstituted)) {
-      return Visit(SimplifiedSelf, Other, hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
-    }
+    auto [SimplifiedSelf, HasSubst] = trySubstituteAndSimplify(
+        SelfUO, hasSelfBeenSubstituted ? nullptr : DependentValuesSelf);
+
+    if (SimplifiedSelf != SelfUO)
+      return Visit(SimplifiedSelf, Other, HasSubst, hasOtherBeenSubstituted);
     return false;
   }
 
@@ -693,7 +702,7 @@ struct CompatibleCountExprVisitor
                            bool hasOtherBeenSubstituted) {
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
 
     const auto *OtherBO =
         dyn_cast<BinaryOperator>(Other->IgnoreParenImpCasts());
@@ -720,7 +729,7 @@ struct CompatibleCountExprVisitor
       return false;
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
     if (const auto *OtherOpCall =
             dyn_cast<CXXOperatorCallExpr>(Other->IgnoreParenImpCasts()))
       if (SelfOpCall->getOperator() == OtherOpCall->getOperator()) {
@@ -740,7 +749,7 @@ struct CompatibleCountExprVisitor
                                bool hasOtherBeenSubstituted) {
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
     if (const auto *OtherAS =
             dyn_cast<ArraySubscriptExpr>(Other->IgnoreParenImpCasts()))
       return Visit(SelfAS->getLHS(), OtherAS->getLHS(), hasSelfBeenSubstituted,
@@ -758,7 +767,7 @@ struct CompatibleCountExprVisitor
 
     if (!hasOtherBeenSubstituted)
       std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstitute(Other, DependentValuesOther);
+          trySubstituteAndSimplify(Other, DependentValuesOther);
     // The callee member function must be a const function with no parameter:
     if (MD->isConst() && MD->param_empty()) {
       if (auto *OtherCall =
@@ -1089,10 +1098,10 @@ static bool isCountAttributedPointerArgumentSafeImpl(
   // 'c',  `DependentValueMapForActual` is the map for 'c':
   std::optional<DependentValuesTy> DependentValueMapForActual = std::nullopt;
 
-  // Handle `PtrArgNoImp` has the form of `(char *) p` and `p` is a sized_by
-  // pointer.  This will be of pattern 5 after stripping the cast:
-  if (const auto *CastE = dyn_cast<CastExpr>(PtrArgNoImp); CastE && isSizedBy)
-    PtrArgNoImp = CastE->getSubExpr();
+  // // Handle `PtrArgNoImp` has the form of `(char *) p` and `p` is a sized_by
+  // // pointer.  This will be of pattern 5 after stripping the cast:
+  // if (const auto *CastE = dyn_cast<CastExpr>(PtrArgNoImp); CastE && isSizedBy)
+  //   PtrArgNoImp = CastE->getSubExpr();
 
   if (const auto *ME = dyn_cast<MemberExpr>(PtrArgNoImp))
     MemberBase = ME->getBase();

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -465,29 +465,32 @@ getDependentValuesFromCall(const CountAttributedType *CAT,
 //   form `f(...)` is not supported.
 struct CompatibleCountExprVisitor
     : public ConstStmtVisitor<CompatibleCountExprVisitor, bool, const Expr *,
-                              bool> {
-  // The third 'bool' type parameter for each visit method indicates whether the
-  // current visiting expression is the result of the formal parameter to actual
-  // argument substitution.  Since the argument expression may contain DREs
-  // referencing to back to those parameters (in cases of recursive calls), the
-  // analysis may hit an infinite loop if not knowing whether the substitution
-  // has happened.  A typical example that could introduce infinite loop without
-  // this knowledge is shown below.
+                              bool, bool> {
+  // The third and forth 'bool' type parameters for each visit method indicates
+  // whether the current visiting expression is the result of the formal
+  // parameter to actual argument substitution (for `Self` and `Other` resp.).
+  // Since the argument expression may contain DREs referencing to back to those
+  // parameters (in cases of recursive calls), the analysis may hit an infinite
+  // loop if not knowing whether the substitution has happened.  A typical
+  // example that could introduce infinite loop without this knowledge is shown
+  // below.
   // ```
   //  void f(int * __counted_by(n) p, size_t n) {
   //    f(p, n);
   //  }
   // ```
-  using BaseVisitor =
-      ConstStmtVisitor<CompatibleCountExprVisitor, bool, const Expr *, bool>;
+  using BaseVisitor = ConstStmtVisitor<CompatibleCountExprVisitor, bool,
+                                       const Expr *, bool, bool>;
 
   const Expr *MemberBase;
-  const DependentValuesTy *DependentValues;
+  const DependentValuesTy *DependentValuesSelf, *DependentValuesOther;
   ASTContext &Ctx;
 
   // If `Deref` has the form `*&e`, return `e`; otherwise return nullptr.
-  const Expr *trySimplifyDerefAddressof(const UnaryOperator *Deref,
-                                        bool hasBeenSubstituted) {
+  const Expr *trySimplifyDerefAddressof(
+      const UnaryOperator *Deref,
+      const DependentValuesTy *DependentValues, // Deref may need subsitution
+      bool &hasBeenSubstituted) {
     const Expr *DerefOperand = Deref->getSubExpr()->IgnoreParenImpCasts();
 
     if (const auto *UO = dyn_cast<UnaryOperator>(DerefOperand))
@@ -501,33 +504,69 @@ struct CompatibleCountExprVisitor
 
       if (I != DependentValues->end())
         if (const auto *UO = dyn_cast<UnaryOperator>(I->getSecond()))
-          if (UO->getOpcode() == UO_AddrOf)
+          if (UO->getOpcode() == UO_AddrOf) {
+            hasBeenSubstituted = true;
             return UO->getSubExpr();
+          }
     }
     return nullptr;
   }
 
-  explicit CompatibleCountExprVisitor(const Expr *MemberBase,
-                                      const DependentValuesTy *DependentValues,
-                                      ASTContext &Ctx)
-      : MemberBase(MemberBase), DependentValues(DependentValues), Ctx(Ctx) {}
+  inline const std::pair<const Expr *, bool>
+  trySubstitute(const Expr *E, const DependentValuesTy *DependentValues) {
+    if (auto DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
+        DRE && DependentValues) {
+      auto It = DependentValues->find(DRE->getDecl());
 
-  bool VisitStmt(const Stmt *S, const Expr *E, bool hasBeenSubstituted) {
+      if (It != DependentValues->end()) {
+        return {It->second, true};
+      }
+    }
+    if (auto UO = dyn_cast<UnaryOperator>(E->IgnoreParenImpCasts())) {
+      if (UO->getOpcode() == UnaryOperator::Opcode::UO_Deref) {
+        bool hasBeenSubstituted = false;
+        const Expr *NewE =
+            trySimplifyDerefAddressof(UO, DependentValues, hasBeenSubstituted);
+
+        if (NewE &&NewE != E) {
+          return {NewE, hasBeenSubstituted};
+        }
+      }
+    }
+    return {E, false};
+  }
+
+  explicit CompatibleCountExprVisitor(
+      const Expr *MemberBase, const DependentValuesTy *DependentValuesSelf,
+      const DependentValuesTy *DependentValuesOther, ASTContext &Ctx)
+      : MemberBase(MemberBase), DependentValuesSelf(DependentValuesSelf),
+        DependentValuesOther(DependentValuesOther), Ctx(Ctx) {}
+
+  bool VisitStmt(const Stmt *Self, const Expr *Other,
+                 bool hasSelfBeenSubstituted, bool hasOtherBeenSubstituted) {
     return false;
   }
 
   bool VisitImplicitCastExpr(const ImplicitCastExpr *SelfICE, const Expr *Other,
-                             bool hasBeenSubstituted) {
-    return Visit(SelfICE->getSubExpr(), Other, hasBeenSubstituted);
+                             bool hasSelfBeenSubstituted,
+                             bool hasOtherBeenSubstituted) {
+    return Visit(SelfICE->getSubExpr(), Other, hasSelfBeenSubstituted,
+                 hasOtherBeenSubstituted);
   }
 
   bool VisitParenExpr(const ParenExpr *SelfPE, const Expr *Other,
-                      bool hasBeenSubstituted) {
-    return Visit(SelfPE->getSubExpr(), Other, hasBeenSubstituted);
+                      bool hasSelfBeenSubstituted,
+                      bool hasOtherBeenSubstituted) {
+    return Visit(SelfPE->getSubExpr(), Other, hasSelfBeenSubstituted,
+                 hasOtherBeenSubstituted);
   }
 
   bool VisitIntegerLiteral(const IntegerLiteral *SelfIL, const Expr *Other,
-                           bool hasBeenSubstituted) {
+                           bool hasSelfBeenSubstituted,
+                           bool hasOtherBeenSubstituted) {
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
     if (const auto *IntLit =
             dyn_cast<IntegerLiteral>(Other->IgnoreParenImpCasts())) {
       return SelfIL == IntLit ||
@@ -538,7 +577,12 @@ struct CompatibleCountExprVisitor
 
   bool VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *Self,
                                      const Expr *Other,
-                                     bool hasBeenSubstituted) {
+                                     bool hasSelfBeenSubstituted,
+                                     bool hasOtherBeenSubstituted) {
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
+
     // If `Self` is a `sizeof` expression, try to evaluate and compare the two
     // expressions as constants:
     if (Self->getKind() == UnaryExprOrTypeTrait::UETT_SizeOf) {
@@ -556,19 +600,27 @@ struct CompatibleCountExprVisitor
   }
 
   bool VisitCXXThisExpr(const CXXThisExpr *SelfThis, const Expr *Other,
-                        bool hasBeenSubstituted) {
+                        bool hasSelfBeenSubstituted,
+                        bool hasOtherBeenSubstituted) {
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
     return isa<CXXThisExpr>(Other->IgnoreParenImpCasts());
   }
 
   bool VisitDeclRefExpr(const DeclRefExpr *SelfDRE, const Expr *Other,
-                        bool hasBeenSubstituted) {
+                        bool hasSelfBeenSubstituted,
+                        bool hasOtherBeenSubstituted) {
     const ValueDecl *SelfVD = SelfDRE->getDecl();
 
-    if (DependentValues && !hasBeenSubstituted) {
-      const auto It = DependentValues->find(SelfVD);
-      if (It != DependentValues->end())
-        return Visit(It->second, Other, true);
+    if (DependentValuesSelf && !hasSelfBeenSubstituted) {
+      const auto It = DependentValuesSelf->find(SelfVD);
+      if (It != DependentValuesSelf->end())
+        return Visit(It->second, Other, true, hasOtherBeenSubstituted);
     }
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
 
     const auto *O = Other->IgnoreParenImpCasts();
 
@@ -582,31 +634,42 @@ struct CompatibleCountExprVisitor
     const auto *OtherME = dyn_cast<MemberExpr>(O);
     if (MemberBase && OtherME) {
       return OtherME->getMemberDecl() == SelfVD &&
-             Visit(OtherME->getBase(), MemberBase, hasBeenSubstituted);
+             Visit(OtherME->getBase(), MemberBase, hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
     }
 
     return false;
   }
 
   bool VisitMemberExpr(const MemberExpr *Self, const Expr *Other,
-                       bool hasBeenSubstituted) {
+                       bool hasSelfBeenSubstituted,
+                       bool hasOtherBeenSubstituted) {
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
     // Even though we don't support member expression in counted-by, actual
     // arguments can be member expressions.
     if (Self == Other)
       return true;
     if (const auto *DRE = dyn_cast<DeclRefExpr>(Other->IgnoreParenImpCasts()))
       return MemberBase && Self->getMemberDecl() == DRE->getDecl() &&
-             Visit(Self->getBase(), MemberBase, hasBeenSubstituted);
+             Visit(Self->getBase(), MemberBase, hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
     if (const auto *OtherME =
             dyn_cast<MemberExpr>(Other->IgnoreParenImpCasts())) {
       return Self->getMemberDecl() == OtherME->getMemberDecl() &&
-             Visit(Self->getBase(), OtherME->getBase(), hasBeenSubstituted);
+             Visit(Self->getBase(), OtherME->getBase(), hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
     }
     return false;
   }
 
   bool VisitUnaryOperator(const UnaryOperator *SelfUO, const Expr *Other,
-                          bool hasBeenSubstituted) {
+                          bool hasSelfBeenSubstituted,
+                          bool hasOtherBeenSubstituted) {
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
     if (SelfUO->getOpcode() != UO_Deref)
       return false; // We don't support any other unary operator
 
@@ -614,23 +677,31 @@ struct CompatibleCountExprVisitor
             dyn_cast<UnaryOperator>(Other->IgnoreParenImpCasts())) {
       if (SelfUO->getOpcode() == OtherUO->getOpcode())
         return Visit(SelfUO->getSubExpr(), OtherUO->getSubExpr(),
-                     hasBeenSubstituted);
+                     hasSelfBeenSubstituted, hasOtherBeenSubstituted);
     }
     // If `Other` is not a dereference expression, try to simplify `SelfUO`:
-    if (const auto *SimplifiedSelf =
-            trySimplifyDerefAddressof(SelfUO, hasBeenSubstituted)) {
-      return Visit(SimplifiedSelf, Other, hasBeenSubstituted);
+    if (const auto *SimplifiedSelf = trySimplifyDerefAddressof(
+            SelfUO, DependentValuesSelf, hasSelfBeenSubstituted)) {
+      return Visit(SimplifiedSelf, Other, hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
     }
     return false;
   }
 
   bool VisitBinaryOperator(const BinaryOperator *SelfBO, const Expr *Other,
-                           bool hasBeenSubstituted) {
+                           bool hasSelfBeenSubstituted,
+                           bool hasOtherBeenSubstituted) {
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
+
     const auto *OtherBO =
         dyn_cast<BinaryOperator>(Other->IgnoreParenImpCasts());
     if (OtherBO && OtherBO->getOpcode() == SelfBO->getOpcode()) {
-      return Visit(SelfBO->getLHS(), OtherBO->getLHS(), hasBeenSubstituted) &&
-             Visit(SelfBO->getRHS(), OtherBO->getRHS(), hasBeenSubstituted);
+      return Visit(SelfBO->getLHS(), OtherBO->getLHS(), hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted) &&
+             Visit(SelfBO->getRHS(), OtherBO->getRHS(), hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
     }
 
     return false;
@@ -638,7 +709,8 @@ struct CompatibleCountExprVisitor
 
   // Support any overloaded operator[] so long as it is a const method.
   bool VisitCXXOperatorCallExpr(const CXXOperatorCallExpr *SelfOpCall,
-                                const Expr *Other, bool hasBeenSubstituted) {
+                                const Expr *Other, bool hasSelfBeenSubstituted,
+                                bool hasOtherBeenSubstituted) {
     if (SelfOpCall->getOperator() != OverloadedOperatorKind::OO_Subscript)
       return false;
 
@@ -646,13 +718,16 @@ struct CompatibleCountExprVisitor
 
     if (!MD || !MD->isConst())
       return false;
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
     if (const auto *OtherOpCall =
             dyn_cast<CXXOperatorCallExpr>(Other->IgnoreParenImpCasts()))
       if (SelfOpCall->getOperator() == OtherOpCall->getOperator()) {
         return Visit(SelfOpCall->getArg(0), OtherOpCall->getArg(0),
-                     hasBeenSubstituted) &&
+                     hasSelfBeenSubstituted, hasOtherBeenSubstituted) &&
                Visit(SelfOpCall->getArg(1), OtherOpCall->getArg(1),
-                     hasBeenSubstituted);
+                     hasSelfBeenSubstituted, hasOtherBeenSubstituted);
       }
     return false;
   }
@@ -661,19 +736,29 @@ struct CompatibleCountExprVisitor
   // considered unsafe, they can be safely used on constant arrays with
   // known-safe literal indexes.
   bool VisitArraySubscriptExpr(const ArraySubscriptExpr *SelfAS,
-                               const Expr *Other, bool hasBeenSubstituted) {
+                               const Expr *Other, bool hasSelfBeenSubstituted,
+                               bool hasOtherBeenSubstituted) {
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
     if (const auto *OtherAS =
             dyn_cast<ArraySubscriptExpr>(Other->IgnoreParenImpCasts()))
-      return Visit(SelfAS->getLHS(), OtherAS->getLHS(), hasBeenSubstituted) &&
-             Visit(SelfAS->getRHS(), OtherAS->getRHS(), hasBeenSubstituted);
+      return Visit(SelfAS->getLHS(), OtherAS->getLHS(), hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted) &&
+             Visit(SelfAS->getRHS(), OtherAS->getRHS(), hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
     return false;
   }
 
   // Support non-static member call:
   bool VisitCXXMemberCallExpr(const CXXMemberCallExpr *SelfCall,
-                              const Expr *Other, bool hasBeenSubstituted) {
+                              const Expr *Other, bool hasSelfBeenSubstituted,
+                              bool hasOtherBeenSubstituted) {
     const CXXMethodDecl *MD = SelfCall->getMethodDecl();
 
+    if (!hasOtherBeenSubstituted)
+      std::tie(Other, hasOtherBeenSubstituted) =
+          trySubstitute(Other, DependentValuesOther);
     // The callee member function must be a const function with no parameter:
     if (MD->isConst() && MD->param_empty()) {
       if (auto *OtherCall =
@@ -681,7 +766,7 @@ struct CompatibleCountExprVisitor
         return OtherCall->getMethodDecl() == MD &&
                Visit(SelfCall->getImplicitObjectArgument(),
                      OtherCall->getImplicitObjectArgument(),
-                     hasBeenSubstituted);
+                     hasSelfBeenSubstituted, hasOtherBeenSubstituted);
       }
     }
     return false;
@@ -702,13 +787,17 @@ struct CompatibleCountExprVisitor
 //                      `ExpectedCountExpr` may be transformed to a DRE
 //                      representing just `f`.  Therefore we need to keep track
 //                      of the base for them in that case.
-// `DependentValues`:   is a mapping from parameter DREs to actual argument
-//                      expressions.  It serves as a "state" where
-//                      `ExpectedCountExpr` is "interpreted".
+// `DependentValues`:   is a mapping from parameters to arguments,
+//                      serving as a "state" where `E` is "interpreted".
+// `DependentValuesExpectedCount`:
+//                      is a mapping from parameters to arguments, serving as a
+//                      "state" where `ExpectedCountExpr` is "interpreted".
 //
-// This function then checks for a pointer with a known count `E` that `E` is
-// equivalent to the count `ExpectedCountExpr` of a counted-by type attribute at
-// the state `DependentValues`.
+//
+// This function checks for a pointer with a known count `E` that `E`,
+// interpreted at the state `DependentValues`, is equivalent to the expected
+// count `ExpectedCountExpr`, which is interpreted at the state
+// `DependentValuesExpectedCount`.
 //
 // For example, suppose there is a call to a function `foo(int *__counted_by(n)
 // p, size_t n)`:
@@ -722,12 +811,17 @@ struct CompatibleCountExprVisitor
 // already know that `E` is the count of 'x'.  So we just need to compare `E`
 // to 'n' with 'n' being interpreted under '{n -> y+z}'.  That is, this function
 // will return true iff `E` is same as 'y+z'.
-bool isCompatibleWithCountExpr(const Expr *E, const Expr *ExpectedCountExpr,
-                               const Expr *MemberBase,
-                               const DependentValuesTy *DependentValues,
-                               ASTContext &Ctx) {
-  CompatibleCountExprVisitor Visitor(MemberBase, DependentValues, Ctx);
-  return Visitor.Visit(ExpectedCountExpr, E, /* hasBeenSubstituted*/ false);
+// (Note that if `x` has the form of a function call, a mapping (i.e.,
+// `DependentValues` for `E`) for `x` is needed as well.)
+bool isCompatibleWithCountExpr(
+    ASTContext &Ctx, const Expr *E, const Expr *ExpectedCountExpr,
+    const Expr *MemberBase = nullptr,
+    const DependentValuesTy *DependentValuesActualCount = nullptr,
+    const DependentValuesTy *DependentValuesExpectedCount = nullptr) {
+  CompatibleCountExprVisitor Visitor(MemberBase, DependentValuesExpectedCount,
+                                     DependentValuesActualCount, Ctx);
+  return Visitor.Visit(ExpectedCountExpr, E, /* hasBeenSubstituted*/ false,
+                       false);
 }
 
 // Returns true iff `C` is a C++ nclass method call to the function
@@ -990,6 +1084,15 @@ static bool isCountAttributedPointerArgumentSafeImpl(
   // the actual count of the pointer inferred through patterns below:
   const Expr *ActualCount = nullptr;
   const Expr *MemberBase = nullptr;
+  // While `DependentValueMap` maps formal parameters to actual arguments of the
+  // call being checked, when the pointer argument is another call expression
+  // 'c',  `DependentValueMapForActual` is the map for 'c':
+  std::optional<DependentValuesTy> DependentValueMapForActual = std::nullopt;
+
+  // Handle `PtrArgNoImp` has the form of `(char *) p` and `p` is a sized_by
+  // pointer.  This will be of pattern 5 after stripping the cast:
+  if (const auto *CastE = dyn_cast<CastExpr>(PtrArgNoImp); CastE && isSizedBy)
+    PtrArgNoImp = CastE->getSubExpr();
 
   if (const auto *ME = dyn_cast<MemberExpr>(PtrArgNoImp))
     MemberBase = ME->getBase();
@@ -1006,6 +1109,11 @@ static bool isCountAttributedPointerArgumentSafeImpl(
 
     if (ArgCAT->isOrNull() == isOrNull && areBoundsAttributesCompatible)
       ActualCount = ArgCAT->getCountExpr();
+    // In case `PtrArgNoImp` is a function call expression of counted_by type
+    // (i.e., return type is a CAT), create a map for the call:
+    if (auto *PtrArgCall = dyn_cast<CallExpr>(PtrArgNoImp))
+      DependentValueMapForActual =
+          getDependentValuesFromCall(ArgCAT, PtrArgCall);
   } else {
     // Form 6-7.
     const Expr *ArrArg = PtrArgNoImp;
@@ -1031,8 +1139,11 @@ static bool isCountAttributedPointerArgumentSafeImpl(
     // In case (b), the actual count of the pointer must match the argument
     // passed to the parameter representing the count:
     CountedByExpr = CountArg;
-  return isCompatibleWithCountExpr(ActualCount, CountedByExpr, MemberBase,
-                                   DependentValueMap, Context);
+  return isCompatibleWithCountExpr(
+      Context, ActualCount, CountedByExpr, MemberBase,
+      (DependentValueMapForActual.has_value() ? &*DependentValueMapForActual
+                                              : nullptr),
+      DependentValueMap);
 }
 
 // Checks if the argument passed to a count-attributed pointer is safe.  This
@@ -1303,12 +1414,12 @@ static bool isPtrBufferSafe(const Expr *Ptr, const Expr *Size,
       auto ValuesOpt = getDependentValuesFromCall(CAT, Call);
       if (!ValuesOpt.has_value())
         return false;
-      return isCompatibleWithCountExpr(Size, CAT->getCountExpr(), MemberBase,
-                                       &*ValuesOpt, Ctx);
+      return isCompatibleWithCountExpr(Ctx, Size, CAT->getCountExpr(),
+                                       MemberBase, nullptr, &*ValuesOpt);
     }
 
-    return isCompatibleWithCountExpr(Size, CAT->getCountExpr(), MemberBase,
-                                     /*DependentValues=*/nullptr, Ctx);
+    return isCompatibleWithCountExpr(Ctx, Size, CAT->getCountExpr(),
+                                     MemberBase);
   }
   /* TO_UPSTREAM(BoundsSafetyInterop) OFF */
   return false;

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -489,20 +489,19 @@ struct CompatibleCountExprVisitor
   // Attempts to perform substitution on E and simplify the result, if the
   // result has the form "*&e".
   //
-  //  This function will be repeatedly called on the "Other" Expr. Because the
+  //  This function will be repeatedly called on the "Other" Expr, because the
   //  kind of "Other" stays unknown during the traversal.
-  const std::pair<const Expr *, bool>
-  trySubstituteAndSimplify(const Expr *E,
-                           const DependentValuesTy *DependentValues) {
+  const Expr *
+  trySubstituteAndSimplify(const Expr *E, bool &hasBeenSubstituted,
+                           const DependentValuesTy *DependentValues) const {
     // Attempts to simplify `E`: if `E` has the form `*&e`, return `e`;
-    // otherwise
-    // return `E` without change.
+    // return `E` without change otherwise:
     auto trySimplifyDerefAddressof =
         [](const Expr *E,
            const DependentValuesTy
                *DependentValues, // Deref may need subsitution
            bool &hasBeenSubstituted) -> const Expr * {
-      auto *Deref = dyn_cast<UnaryOperator>(E->IgnoreParenImpCasts());
+      const auto *Deref = dyn_cast<UnaryOperator>(E->IgnoreParenImpCasts());
 
       if (!Deref || Deref->getOpcode() != UO_Deref)
         return E;
@@ -516,10 +515,10 @@ struct CompatibleCountExprVisitor
         if (!DependentValues || hasBeenSubstituted)
           return E;
 
-        auto I = DependentValues->find(DRE->getDecl());
-
-        if (I != DependentValues->end())
-          if (const auto *UO = dyn_cast<UnaryOperator>(I->getSecond()))
+        if (auto I = DependentValues->find(DRE->getDecl());
+            I != DependentValues->end())
+          if (const auto *UO = dyn_cast<UnaryOperator>(
+                  I->getSecond()->IgnoreParenImpCasts()))
             if (UO->getOpcode() == UO_AddrOf) {
               hasBeenSubstituted = true;
               return UO->getSubExpr();
@@ -528,21 +527,17 @@ struct CompatibleCountExprVisitor
       return E;
     };
 
-    if (auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts());
-        DRE && DependentValues) {
-      auto It = DependentValues->find(DRE->getDecl());
-
-      if (It != DependentValues->end()) {
-        bool Ignore;
-        return {trySimplifyDerefAddressof(It->second, nullptr, Ignore), true};
+    if (!hasBeenSubstituted && DependentValues) {
+      if (const auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts())) {
+        if (auto It = DependentValues->find(DRE->getDecl());
+            It != DependentValues->end()) {
+          hasBeenSubstituted = true;
+          return trySimplifyDerefAddressof(It->second, nullptr,
+                                           hasBeenSubstituted);
+        }
       }
     }
-
-    bool hasBeenSubstituted = false;
-    const Expr *NewE =
-        trySimplifyDerefAddressof(E, DependentValues, hasBeenSubstituted);
-
-    return {NewE, hasBeenSubstituted};
+    return trySimplifyDerefAddressof(E, DependentValues, hasBeenSubstituted);
   }
 
   explicit CompatibleCountExprVisitor(
@@ -573,9 +568,8 @@ struct CompatibleCountExprVisitor
   bool VisitIntegerLiteral(const IntegerLiteral *SelfIL, const Expr *Other,
                            bool hasSelfBeenSubstituted,
                            bool hasOtherBeenSubstituted) {
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
     if (const auto *IntLit =
             dyn_cast<IntegerLiteral>(Other->IgnoreParenImpCasts())) {
       return SelfIL == IntLit ||
@@ -588,10 +582,8 @@ struct CompatibleCountExprVisitor
                                      const Expr *Other,
                                      bool hasSelfBeenSubstituted,
                                      bool hasOtherBeenSubstituted) {
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
-
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
     // If `Self` is a `sizeof` expression, try to evaluate and compare the two
     // expressions as constants:
     if (Self->getKind() == UnaryExprOrTypeTrait::UETT_SizeOf) {
@@ -611,38 +603,35 @@ struct CompatibleCountExprVisitor
   bool VisitCXXThisExpr(const CXXThisExpr *SelfThis, const Expr *Other,
                         bool hasSelfBeenSubstituted,
                         bool hasOtherBeenSubstituted) {
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    Other = trySubstituteAndSimplify(Other, hasSelfBeenSubstituted,
+                                     DependentValuesOther);
     return isa<CXXThisExpr>(Other->IgnoreParenImpCasts());
   }
 
   bool VisitDeclRefExpr(const DeclRefExpr *SelfDRE, const Expr *Other,
                         bool hasSelfBeenSubstituted,
                         bool hasOtherBeenSubstituted) {
-    const ValueDecl *SelfVD = SelfDRE->getDecl();
+    const auto *SubstSelf = trySubstituteAndSimplify(SelfDRE, hasSelfBeenSubstituted,
+                                               DependentValuesSelf);
 
-    if (DependentValuesSelf && !hasSelfBeenSubstituted) {
-      const auto It = DependentValuesSelf->find(SelfVD);
-      if (It != DependentValuesSelf->end())
-        return Visit(It->second, Other, true, hasOtherBeenSubstituted);
-    }
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    if (SubstSelf != SelfDRE)
+      return Visit(SubstSelf, Other, hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
 
     const auto *O = Other->IgnoreParenImpCasts();
 
     if (const auto *OtherDRE = dyn_cast<DeclRefExpr>(O)) {
       // Both SelfDRE and OtherDRE can be transformed from member expressions:
-      if (OtherDRE->getDecl() == SelfVD)
+      if (OtherDRE->getDecl() == SelfDRE->getDecl())
         return true;
       return false;
     }
 
     const auto *OtherME = dyn_cast<MemberExpr>(O);
     if (MemberBase && OtherME) {
-      return OtherME->getMemberDecl() == SelfVD &&
+      return OtherME->getMemberDecl() == SelfDRE->getDecl() &&
              Visit(OtherME->getBase(), MemberBase, hasSelfBeenSubstituted,
                    hasOtherBeenSubstituted);
     }
@@ -653,9 +642,8 @@ struct CompatibleCountExprVisitor
   bool VisitMemberExpr(const MemberExpr *Self, const Expr *Other,
                        bool hasSelfBeenSubstituted,
                        bool hasOtherBeenSubstituted) {
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
     // Even though we don't support member expression in counted-by, actual
     // arguments can be member expressions.
     if (Self == Other)
@@ -676,12 +664,10 @@ struct CompatibleCountExprVisitor
   bool VisitUnaryOperator(const UnaryOperator *SelfUO, const Expr *Other,
                           bool hasSelfBeenSubstituted,
                           bool hasOtherBeenSubstituted) {
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
     if (SelfUO->getOpcode() != UO_Deref)
       return false; // We don't support any other unary operator
-
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
     if (const auto *OtherUO =
             dyn_cast<UnaryOperator>(Other->IgnoreParenImpCasts())) {
       if (SelfUO->getOpcode() == OtherUO->getOpcode())
@@ -689,20 +675,20 @@ struct CompatibleCountExprVisitor
                      hasSelfBeenSubstituted, hasOtherBeenSubstituted);
     }
     // If `Other` is not a dereference expression, try to simplify `SelfUO`:
-    auto [SimplifiedSelf, HasSubst] = trySubstituteAndSimplify(
-        SelfUO, hasSelfBeenSubstituted ? nullptr : DependentValuesSelf);
+    const auto *SimplifiedSelf = trySubstituteAndSimplify(
+        SelfUO, hasSelfBeenSubstituted, DependentValuesSelf);
 
     if (SimplifiedSelf != SelfUO)
-      return Visit(SimplifiedSelf, Other, HasSubst, hasOtherBeenSubstituted);
+      return Visit(SimplifiedSelf, Other, hasSelfBeenSubstituted,
+                   hasOtherBeenSubstituted);
     return false;
   }
 
   bool VisitBinaryOperator(const BinaryOperator *SelfBO, const Expr *Other,
                            bool hasSelfBeenSubstituted,
                            bool hasOtherBeenSubstituted) {
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
 
     const auto *OtherBO =
         dyn_cast<BinaryOperator>(Other->IgnoreParenImpCasts());
@@ -727,9 +713,8 @@ struct CompatibleCountExprVisitor
 
     if (!MD || !MD->isConst())
       return false;
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
     if (const auto *OtherOpCall =
             dyn_cast<CXXOperatorCallExpr>(Other->IgnoreParenImpCasts()))
       if (SelfOpCall->getOperator() == OtherOpCall->getOperator()) {
@@ -747,9 +732,8 @@ struct CompatibleCountExprVisitor
   bool VisitArraySubscriptExpr(const ArraySubscriptExpr *SelfAS,
                                const Expr *Other, bool hasSelfBeenSubstituted,
                                bool hasOtherBeenSubstituted) {
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
     if (const auto *OtherAS =
             dyn_cast<ArraySubscriptExpr>(Other->IgnoreParenImpCasts()))
       return Visit(SelfAS->getLHS(), OtherAS->getLHS(), hasSelfBeenSubstituted,
@@ -765,9 +749,8 @@ struct CompatibleCountExprVisitor
                               bool hasOtherBeenSubstituted) {
     const CXXMethodDecl *MD = SelfCall->getMethodDecl();
 
-    if (!hasOtherBeenSubstituted)
-      std::tie(Other, hasOtherBeenSubstituted) =
-          trySubstituteAndSimplify(Other, DependentValuesOther);
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
+                                     DependentValuesOther);
     // The callee member function must be a const function with no parameter:
     if (MD->isConst() && MD->param_empty()) {
       if (auto *OtherCall =

--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -603,7 +603,7 @@ struct CompatibleCountExprVisitor
   bool VisitCXXThisExpr(const CXXThisExpr *SelfThis, const Expr *Other,
                         bool hasSelfBeenSubstituted,
                         bool hasOtherBeenSubstituted) {
-    Other = trySubstituteAndSimplify(Other, hasSelfBeenSubstituted,
+    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
                                      DependentValuesOther);
     return isa<CXXThisExpr>(Other->IgnoreParenImpCasts());
   }
@@ -611,8 +611,8 @@ struct CompatibleCountExprVisitor
   bool VisitDeclRefExpr(const DeclRefExpr *SelfDRE, const Expr *Other,
                         bool hasSelfBeenSubstituted,
                         bool hasOtherBeenSubstituted) {
-    const auto *SubstSelf = trySubstituteAndSimplify(SelfDRE, hasSelfBeenSubstituted,
-                                               DependentValuesSelf);
+    const auto *SubstSelf = trySubstituteAndSimplify(
+        SelfDRE, hasSelfBeenSubstituted, DependentValuesSelf);
 
     if (SubstSelf != SelfDRE)
       return Visit(SubstSelf, Other, hasSelfBeenSubstituted,
@@ -766,54 +766,38 @@ struct CompatibleCountExprVisitor
 };
 
 // TL'DR:
-// Checks if `E` is the same as `ExpectedCountExpr` modulo implicit casts and
+// Checks if `Self` is the same as `Other` modulo implicit casts and
 // parens.
 //
 // Lengthy description:
-// `E`:                 represents the actual count/size associated to a
-//                      pointer.
-// `ExpectedCountExpr`: represents the counted-by expression of a counted-by
-//                      type attribute.
+// `Self`:              an expression, one of the comparands
+// `Other`:             an expression, the other comparands
 // `MemberBase`:        represents "this" member base.  A MemberExpr
-//                      representing `this->f` in both `E` and
-//                      `ExpectedCountExpr` may be transformed to a DRE
+//                      representing `this->f` in either `Self` and
+//                      `Other` may be transformed to a DRE
 //                      representing just `f`.  Therefore we need to keep track
-//                      of the base for them in that case.
-// `DependentValues`:   is a mapping from parameters to arguments,
-//                      serving as a "state" where `E` is "interpreted".
-// `DependentValuesExpectedCount`:
-//                      is a mapping from parameters to arguments, serving as a
-//                      "state" where `ExpectedCountExpr` is "interpreted".
+//                      of the base for them in that case.  The two comparands
+//                      must share a member base if it exists.
+// `DependentValuesSelf`:
+//                      a mapping from parameters to arguments for the parameter
+//                      references appearing in `Self`.
+// `DependentValuesOther`:
+//                      a mapping from parameters to arguments for the parameter
+//                      references appearing in `Other`.
 //
-//
-// This function checks for a pointer with a known count `E` that `E`,
-// interpreted at the state `DependentValues`, is equivalent to the expected
-// count `ExpectedCountExpr`, which is interpreted at the state
-// `DependentValuesExpectedCount`.
-//
-// For example, suppose there is a call to a function `foo(int *__counted_by(n)
-// p, size_t n)`:
-//
-//    foo(x, y+z);
-//
-// We check that the count associated to the pointer 'x' is same as the
-// expected count expression 'n' with the mapping (state) '{n -> y+z}'.  The
-// count of 'x' is determined by pre-defined knowledge, e.g., if 'x' has the
-// form of 'span.data()', its' count is 'span.size()', etc.  At this point, we
-// already know that `E` is the count of 'x'.  So we just need to compare `E`
-// to 'n' with 'n' being interpreted under '{n -> y+z}'.  That is, this function
-// will return true iff `E` is same as 'y+z'.
-// (Note that if `x` has the form of a function call, a mapping (i.e.,
-// `DependentValues` for `E`) for `x` is needed as well.)
+// The comparison is on the two expressions `Self` and `Other` with the
+// substitution maps  `DependentValuesSelf` and `DependentValuesOther` being
+// applied to them, respectively.
 bool isCompatibleWithCountExpr(
-    ASTContext &Ctx, const Expr *E, const Expr *ExpectedCountExpr,
+    ASTContext &Ctx, const Expr *Self, const Expr *Other,
     const Expr *MemberBase = nullptr,
-    const DependentValuesTy *DependentValuesActualCount = nullptr,
-    const DependentValuesTy *DependentValuesExpectedCount = nullptr) {
-  CompatibleCountExprVisitor Visitor(MemberBase, DependentValuesExpectedCount,
-                                     DependentValuesActualCount, Ctx);
-  return Visitor.Visit(ExpectedCountExpr, E, /* hasBeenSubstituted*/ false,
-                       false);
+    const DependentValuesTy *DependentValuesSelf = nullptr,
+    const DependentValuesTy *DependentValuesOther = nullptr) {
+  CompatibleCountExprVisitor Visitor(MemberBase, DependentValuesSelf,
+                                     DependentValuesOther, Ctx);
+  return Visitor.Visit(Self, Other,
+                       /* hasSelfBeenSubstituted */ false,
+                       /* hasOtherBeenSubstituted */ false);
 }
 
 // Returns true iff `C` is a C++ nclass method call to the function
@@ -1080,11 +1064,6 @@ static bool isCountAttributedPointerArgumentSafeImpl(
   // call being checked, when the pointer argument is another call expression
   // 'c',  `DependentValueMapForActual` is the map for 'c':
   std::optional<DependentValuesTy> DependentValueMapForActual = std::nullopt;
-
-  // // Handle `PtrArgNoImp` has the form of `(char *) p` and `p` is a sized_by
-  // // pointer.  This will be of pattern 5 after stripping the cast:
-  // if (const auto *CastE = dyn_cast<CastExpr>(PtrArgNoImp); CastE && isSizedBy)
-  //   PtrArgNoImp = CastE->getSubExpr();
 
   if (const auto *ME = dyn_cast<MemberExpr>(PtrArgNoImp))
     MemberBase = ME->getBase();

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-argument.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-argument.cpp
@@ -654,19 +654,20 @@ int *__counted_by(a + b) fn_cb_plus(size_t a, size_t b);
 int *__counted_by(*p) fn_cb_deref(size_t *p);
 
 struct T {
-  size_t size();
+  size_t size() const;
   size_t n;
 };
 
 void test1(size_t n, size_t n2, size_t *p, T * t) {
   cb_int(fn_cb(n), n);
   //cb_int(fn_cb(*&n), n);
-  cb_int(fn_cb(n), *&n); 
+  //cb_int(fn_cb(*&n), *&n);
+  cb_int(fn_cb(n), *&n);
   cb_int(fn_cb(n), 42);    // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
   cb_int(fn_cb(n2), n);   // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
   cb_int(fn_cb(n), n + 1); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
 
-  //cb_int(fn_cb(t->size()), t->size());
+  cb_int(fn_cb(t->size()), t->size());
   cb_int(fn_cb(t->n), t->n);
   cb_int(fn_cb(t->size()), t->n); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
   cb_int(fn_cb(t->n), t->size()); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
@@ -683,6 +684,7 @@ void test1(size_t n, size_t n2, size_t *p, T * t) {
 
   cb_int(fn_cb_deref(p), *p);
   cb_int(fn_cb_deref(&n), n);
+  cb_int(fn_cb_deref(&n), *&n);
   cb_int(fn_cb_deref(p), n);    // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
   cb_int(fn_cb_deref(&n), *p);  // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
 }

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-argument.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-argument.cpp
@@ -69,7 +69,7 @@ void cb_cchar(const char *__counted_by(len) s, size_t len);
 // expected-note@+1 3{{consider using 'std::span' and passing '.first(...).data()' to the parameter 's'}}
 void cb_cchar_42(const char *__counted_by(42) s);
 
-// expected-note@+1 19{{consider using a safe container and passing '.data()' to the parameter 'p' and '.size()' to its dependent parameter 'count' or 'std::span' and passing '.first(...).data()' to the parameter 'p'}}
+// expected-note@+1 31{{consider using a safe container and passing '.data()' to the parameter 'p' and '.size()' to its dependent parameter 'count' or 'std::span' and passing '.first(...).data()' to the parameter 'p'}}
 void cb_int(int *__counted_by(count) p, size_t count);
 
 // expected-note@+1 34{{consider using a safe container and passing '.data()' to the parameter 'p' and '.size()' to its dependent parameter 'count' or 'std::span' and passing '.first(...).data()' to the parameter 'p'}}
@@ -646,6 +646,47 @@ namespace output_param_test {
   };
 
 } // namespace output_param_test
+
+namespace pointer_is_call_test {
+int *__counted_by(len) fn_cb(size_t len);
+int *__counted_by(42) fn_cb_const();
+int *__counted_by(a + b) fn_cb_plus(size_t a, size_t b);
+int *__counted_by(*p) fn_cb_deref(size_t *p);
+
+struct T {
+  size_t size();
+  size_t n;
+};
+
+void test1(size_t n, size_t n2, size_t *p, T * t) {
+  cb_int(fn_cb(n), n);
+  //cb_int(fn_cb(*&n), n);
+  cb_int(fn_cb(n), *&n); 
+  cb_int(fn_cb(n), 42);    // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+  cb_int(fn_cb(n2), n);   // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+  cb_int(fn_cb(n), n + 1); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+
+  //cb_int(fn_cb(t->size()), t->size());
+  cb_int(fn_cb(t->n), t->n);
+  cb_int(fn_cb(t->size()), t->n); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+  cb_int(fn_cb(t->n), t->size()); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+
+  cb_int(fn_cb_const(), 42);
+  cb_int(fn_cb_const(), 43);     // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+  cb_int(fn_cb_const(), n);      // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+  cb_int(fn_cb_const(), n + 1);  // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+
+  cb_int(fn_cb_plus(n, n2), n + n2);
+  cb_int(fn_cb_plus(n, n), n + n);
+  cb_int(fn_cb_plus(n, n2), n + n);  // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+  cb_int(fn_cb_plus(n, n), n * 2);   // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+
+  cb_int(fn_cb_deref(p), *p);
+  cb_int(fn_cb_deref(&n), n);
+  cb_int(fn_cb_deref(p), n);    // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+  cb_int(fn_cb_deref(&n), *p);  // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
+}
+} // namespace pointer_is_call_test
 
 
 static void previous_infinite_loop(int * __counted_by(n) p, size_t n) {


### PR DESCRIPTION
This PR attempts to fix false positives in such an example:
```
void cb(int *__counted_by(count) p, size_t count);
int *__counted_by(n) f(size_t n);

void test(size_t len) {
  cb(f(len), len); // false positive
}
```
The analysis needs to compare the size of `f(len)`, which is specified by `__counted_by(n)`, with the expected count of the first argument of `cb`, which is specified by `__counted_by(count)`.   The comparison interprets the two comparands at two "call contexts" respectively:  the count `n` needs to be interpreted at the call `f(len)` with a mapping `{n -> len}` and the count `count` needs to be interpreted at the call `cb(f(len), len)` with a mapping `{p -> f(len), count -> len}`.

The existing compare algorithm is extended from assuming only one comparand needs a substitution map to assuming both comparands need substitution maps.


rdar://155952016