### PR TITLE
[lldb] Register NSString summary provider for Swift.__StringStorage class

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -498,6 +498,10 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 "Swift.StaticString summary provider",
                 ConstString("Swift.StaticString"), summary_flags);
   AddCXXSummary(swift_category_sp,
+                lldb_private::formatters::NSStringSummaryProvider,
+                "Swift.__StringStorage summary provider",
+                "Swift.__StringStorage", summary_flags);
+  AddCXXSummary(swift_category_sp,
                 lldb_private::formatters::swift::TaskPriority_SummaryProvider,
                 "Swift TaskPriority summary provider", "Swift.TaskPriority",
                 summary_flags);

--- a/lldb/test/API/functionalities/data-formatter/swift/bridged-string/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/swift/bridged-string/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/bridged-string/TestSwiftBridgedStringFormatters.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("v d[0].value", substrs=['value = "one.2.three"'])

--- a/lldb/test/API/functionalities/data-formatter/swift/bridged-string/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/bridged-string/main.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+@main struct Entry {
+    static func main() {
+        let s = "one.two.three"
+        let d = NSMutableDictionary()
+        d["key"] = s.replacingOccurrences(of: "two", with: "2")
+        print("break here")
+    }
+}


### PR DESCRIPTION
Explicitly register the NSString summary formatter as the summary formatter for `__StringStorage`.

`__StringStorage` is an indirect subclass of `NSString`, and is handled correctly by the existing `NSStringSummaryProvider`.

rdar://155567936