### PR TITLE
[bugfix] NestedNameSpecifier might not have a Namespace.

### DIFF
--- a/clang/lib/Tooling/Refactor/USRFinder.cpp
+++ b/clang/lib/Tooling/Refactor/USRFinder.cpp
@@ -368,8 +368,9 @@ public:
   // \returns false on success and sets Result.
   void handleNestedNameSpecifierLoc(NestedNameSpecifierLoc NameLoc) {
     while (NameLoc) {
-      const NamespaceDecl *Decl =
-          NameLoc.getNestedNameSpecifier()->getAsNamespace()->getNamespace();
+      const NamespaceDecl *Decl = nullptr;
+      if (auto *NS = NameLoc.getNestedNameSpecifier()->getAsNamespace())
+        Decl = NS->getNamespace();
       checkOccurrence(Decl, NameLoc.getLocalBeginLoc(),
                       NameLoc.getLocalEndLoc());
       NameLoc = NameLoc.getPrefix();


### PR DESCRIPTION
This fixes a compiler crash.

rdar://156408725