### PR TITLE
[CherryPick][StaticAnalyzer] Fix crashing __builtin_bit_cast (#139188)

### DIFF
--- a/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
+++ b/clang/lib/StaticAnalyzer/Core/ExprEngineC.cpp
@@ -282,15 +282,47 @@ ProgramStateRef ExprEngine::handleLValueBitCast(
 void ExprEngine::VisitCast(const CastExpr *CastE, const Expr *Ex,
                            ExplodedNode *Pred, ExplodedNodeSet &Dst) {
 
-  ExplodedNodeSet dstPreStmt;
-  getCheckerManager().runCheckersForPreStmt(dstPreStmt, Pred, CastE, *this);
+  ExplodedNodeSet DstPreStmt;
+  getCheckerManager().runCheckersForPreStmt(DstPreStmt, Pred, CastE, *this);
 
-  if (CastE->getCastKind() == CK_LValueToRValue ||
-      CastE->getCastKind() == CK_LValueToRValueBitCast) {
-    for (ExplodedNode *subExprNode : dstPreStmt) {
-      ProgramStateRef state = subExprNode->getState();
-      const LocationContext *LCtx = subExprNode->getLocationContext();
-      evalLoad(Dst, CastE, CastE, subExprNode, state, state->getSVal(Ex, LCtx));
+  if (CastE->getCastKind() == CK_LValueToRValue) {
+    for (ExplodedNode *Node : DstPreStmt) {
+      ProgramStateRef State = Node->getState();
+      const LocationContext *LCtx = Node->getLocationContext();
+      evalLoad(Dst, CastE, CastE, Node, State, State->getSVal(Ex, LCtx));
+    }
+    return;
+  }
+  if (CastE->getCastKind() == CK_LValueToRValueBitCast) {
+    // Handle `__builtin_bit_cast`:
+    ExplodedNodeSet DstEvalLoc;
+
+    // Simulate the lvalue-to-rvalue conversion on `Ex`:
+    for (ExplodedNode *Node : DstPreStmt) {
+      ProgramStateRef State = Node->getState();
+      const LocationContext *LCtx = Node->getLocationContext();
+      evalLocation(DstEvalLoc, CastE, Ex, Node, State, State->getSVal(Ex, LCtx),
+                   true);
+    }
+    // Simulate the operation that actually casts the original value to a new
+    // value of the destination type :
+    StmtNodeBuilder Bldr(DstEvalLoc, Dst, *currBldrCtx);
+
+    for (ExplodedNode *Node : DstEvalLoc) {
+      ProgramStateRef State = Node->getState();
+      const LocationContext *LCtx = Node->getLocationContext();
+      // Although `Ex` is an lvalue, it could have `Loc::ConcreteInt` kind
+      // (e.g., `(int *)123456`).  In such cases, there is no MemRegion
+      // available and we can't get the value to be casted.
+      SVal CastedV = UnknownVal();
+
+      if (const MemRegion *MR = State->getSVal(Ex, LCtx).getAsRegion()) {
+        SVal OrigV = State->getSVal(MR);
+        CastedV = svalBuilder.evalCast(svalBuilder.simplifySVal(State, OrigV),
+                                       CastE->getType(), Ex->getType());
+      }
+      State = State->BindExpr(CastE, LCtx, CastedV);
+      Bldr.generateNode(CastE, Node, State);
     }
     return;
   }
@@ -302,8 +334,8 @@ void ExprEngine::VisitCast(const CastExpr *CastE, const Expr *Ex,
   if (const ExplicitCastExpr *ExCast=dyn_cast_or_null<ExplicitCastExpr>(CastE))
     T = ExCast->getTypeAsWritten();
 
-  StmtNodeBuilder Bldr(dstPreStmt, Dst, *currBldrCtx);
-  for (ExplodedNode *Pred : dstPreStmt) {
+  StmtNodeBuilder Bldr(DstPreStmt, Dst, *currBldrCtx);
+  for (ExplodedNode *Pred : DstPreStmt) {
     ProgramStateRef state = Pred->getState();
     const LocationContext *LCtx = Pred->getLocationContext();
 

--- a/clang/test/Analysis/builtin_bitcast.cpp
+++ b/clang/test/Analysis/builtin_bitcast.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_analyze_cc1 -triple x86_64-unknown-unknown -verify %s \
-// RUN:   -analyzer-checker=core,debug.ExprInspection -analyzer-disable-checker=core.FixedAddressDereference
+// RUN:   -analyzer-checker=core,debug.ExprInspection
 
 template <typename T> void clang_analyzer_dump(T);
 using size_t = decltype(sizeof(int));

--- a/clang/test/Analysis/exercise-ps.c
+++ b/clang/test/Analysis/exercise-ps.c
@@ -41,7 +41,7 @@ void f4(char *array) {
 
   _Static_assert(sizeof(int) == 4, "Wrong triple for the test");
 
-  clang_analyzer_dump_int(__builtin_bit_cast(int, b)); // expected-warning {{lazyCompoundVal}}
+  clang_analyzer_dump_int(__builtin_bit_cast(int, b)); // expected-warning {{Unknown}}
   clang_analyzer_dump_int(array[__builtin_bit_cast(int, b)]); // expected-warning {{Unknown}}
 
   array[__builtin_bit_cast(int, b)] = 0x10; // no crash


### PR DESCRIPTION
Previously, CSA did not handle __builtin_bit_cast correctly. It evaluated the LvalueToRvalue conversion for the casting expression, but did not actually convert the value of the expression to be of the destination type.
This commit fixes the problem.

rdar://149987320