### PR TITLE
[21.x][Support] System include SipHash.h (#149499)

### DIFF
--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -389,7 +389,7 @@ if(LLVM_WITH_Z3)
     )
 endif()
 
-target_include_directories(LLVMSupport SYSTEM
+target_include_directories(LLVMSupport
   PRIVATE
   ${LLVM_THIRD_PARTY_DIR}/siphash/include
-  )
+)


### PR DESCRIPTION
A regular include may not search the system include path.

(cherry picked from commit 802ea0eb78f7c974d4097c38587f4c207451d7ee)