### PR TITLE
[clang][cas] Fix crash on invalid with IncludeTreeBuilder

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -425,6 +425,13 @@ Error IncludeTreeActionController::finalizeModuleBuild(
       ModuleScanInstance.getInvocation().getLangOpts(),
       ModuleScanInstance.getInvocation().getCodeGenOpts());
   auto Builder = BuilderStack.pop_back_val();
+
+  // If there was an error, bail out early. The state of `Builder` may be
+  // inconsistent since there is no guarantee that exitedInclude or
+  // finalizeModuleBuild have been called for all imports.
+  if (ModuleScanInstance.getDiagnostics().hasUnrecoverableErrorOccurred())
+    return Error::success(); // Already reported.
+
   auto Tree = Builder->finishIncludeTree(ModuleScanInstance,
                                          ModuleScanInstance.getInvocation());
   if (!Tree)

--- a/clang/test/ClangScanDeps/modules-include-tree-missing-header.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-missing-header.c
@@ -1,0 +1,28 @@
+// Tests that a missing header in a module that is itself imported by another
+// module does not crash/assert in the IncludeTreeBuilder.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: not clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -- %clang -fmodules -fmodules-cache-path=%t/cache -c %t/tu0.m -I%t
+// RUN: not clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -- %clang -fmodules -fmodules-cache-path=%t/cache -c %t/tu1.m -I%t
+
+//--- module.modulemap
+module MissingH {
+  header "missing.h"
+}
+
+module Importer {
+  header "importer.h"
+}
+
+//--- not-missing.h
+
+//--- importer.h
+@import MissingH;
+
+//--- tu0.m
+@import MissingH;
+
+//--- tu1.m
+@import Importer;


### PR DESCRIPTION
If an error occurs in FrontendAction::BeginSourceFile after `IncludeTreeActionController::initializeModuleBuild` is called (via `BeginInvocation`), the builder is left in an inconsistent state because there is no call to `finalizeModuleBuild` (via `HandleTranslationUnit`), so we should exit early without attempting to create an include tree for the broken module. Fixes a crash on invalid seen with a missing module header, but there could be other similar cases.

rdar://151878898