### PR TITLE
[lldb] remove unittest2 from tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplaygroundrepl.py
@@ -120,4 +120,4 @@ if __name__ == '__main__':
     import atexit
     lldb.SBDebugger.Initialize()
     atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()
+    unittest.main()

--- a/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
+++ b/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
@@ -66,4 +66,4 @@ if __name__ == '__main__':
     import atexit
     lldb.SBDebugger.Initialize()
     atexit.register(lldb.SBDebugger.Terminate)
-    unittest2.main()
+    unittest.main()


### PR DESCRIPTION
From unittest2's Readme: _unittest2 is a backport of the new features added to the unittest testing framework in Python 2.7 and onwards. It is tested to run on Python 2.6, 2.7, 3.2, 3.3, 3.4 and pypy._

Since, we use Python `3.9.10` to test LLDB, there is no need for `unittest2` anymore.

This patch is a follow up to https://github.com/swiftlang/llvm-project/commit/d26912dbd389e99215a2e78accf2ffd76f0c26bf, which removes the use of `unittest2` in all of LLDB testing.