### PR TITLE
Suppress warnings for Swift C++ interop by hiding operator declarations.

### DIFF
--- a/llvm/include/llvm/MC/MCRegisterInfo.h
+++ b/llvm/include/llvm/MC/MCRegisterInfo.h
@@ -227,9 +227,11 @@ private:
       return *this;
     }
 
+#ifndef __swift__
     bool operator==(const DiffListIterator &Other) const {
       return List == Other.List;
     }
+#endif
   };
 
 public:

--- a/llvm/include/llvm/TextAPI/Record.h
+++ b/llvm/include/llvm/TextAPI/Record.h
@@ -219,11 +219,13 @@ private:
     RecordLinkage Class = RecordLinkage::Unknown;
     RecordLinkage MetaClass = RecordLinkage::Unknown;
     RecordLinkage EHType = RecordLinkage::Unknown;
+#ifndef __swift__
     bool operator==(const Linkages &other) const {
       return std::tie(Class, MetaClass, EHType) ==
              std::tie(other.Class, other.MetaClass, other.EHType);
     }
     bool operator!=(const Linkages &other) const { return !(*this == other); }
+#endif
   };
   Linkages Linkages;
 

--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -265,12 +265,14 @@ private:
         Current = Current->Next;
         return *this;
       }
+#ifndef __swift__
       bool operator==(const leader_iterator &Other) const {
         return Current == Other.Current;
       }
       bool operator!=(const leader_iterator &Other) const {
         return Current != Other.Current;
       }
+#endif
       reference operator*() const { return Current->Entry; }
     };
 


### PR DESCRIPTION
Addresses warnings like this that are emitted during the Swift compiler build:

```
include/llvm/Transforms/Scalar/GVN.h:268:12: warning: cycle detected while resolving 'leader_iterator' in swift_name attribute for 'operator==' [#ClangDeclarationImport]
```