### PR TITLE
[lldb] Add Swift exception breakpoint frame recognizer

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFrameRecognizers.cpp
@@ -3,11 +3,14 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Symbol/Function.h"
 #include "lldb/Symbol/SymbolContext.h"
+#include "lldb/Target/Platform.h"
 #include "lldb/Target/Process.h"
 #include "lldb/Target/StackFrameRecognizer.h"
 #include "lldb/Target/Target.h"
 #include "lldb/Target/Thread.h"
 
+#include "lldb/Utility/ConstString.h"
+#include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 
@@ -222,6 +225,66 @@ public:
   }
 };
 
+/// A frame recognizer for Swift exception breakpoints.
+class SwiftExceptionBreakpointFrameRecognizer : public StackFrameRecognizer {
+public:
+  class SwiftExceptionFrame : public RecognizedStackFrame {
+  public:
+    SwiftExceptionFrame(StackFrameSP frame) : m_frame_sp(frame) {
+      m_stop_desc = "Swift exception breakpoint";
+    }
+
+    StackFrameSP GetMostRelevantFrame() override {
+      if (!m_frame_sp)
+        return {};
+
+      auto thread_sp = m_frame_sp->GetThread();
+      if (!thread_sp)
+        return {};
+
+      StringRef symbol_name;
+      {
+        const SymbolContext &sc =
+            m_frame_sp->GetSymbolContext(eSymbolContextSymbol);
+        if (!sc.symbol)
+          return {};
+        symbol_name = sc.symbol->GetName();
+      }
+
+      StackFrameSP relevant_frame_sp;
+      if (symbol_name == "swift_willThrow")
+        relevant_frame_sp = thread_sp->GetStackFrameAtIndex(1);
+      else if (symbol_name == "swift_willThrowTypedImpl")
+        relevant_frame_sp = thread_sp->GetStackFrameAtIndex(2);
+      else {
+        assert(false && "unexpected frame name");
+        return {};
+      }
+
+      if (relevant_frame_sp) {
+        // Select the relevant frame only if source is available.
+        const SymbolContext &sc =
+            relevant_frame_sp->GetSymbolContext(eSymbolContextCompUnit);
+        if (sc.comp_unit)
+          return relevant_frame_sp;
+      }
+
+      return {};
+    }
+
+  private:
+    StackFrameSP m_frame_sp;
+  };
+
+  RecognizedStackFrameSP RecognizeFrame(StackFrameSP frame) override {
+    return std::make_shared<SwiftExceptionFrame>(frame);
+  };
+
+  std::string GetName() override {
+    return "Swift exception breakpoint frame recognizer";
+  }
+};
+
 void RegisterSwiftFrameRecognizers(Process &process) {
   RegularExpressionSP module_regex_sp = nullptr;
   auto &manager = process.GetTarget().GetFrameRecognizerManager();
@@ -245,6 +308,16 @@ void RegisterSwiftFrameRecognizers(Process &process) {
     auto symbol_regex_sp = std::make_shared<RegularExpression>("^\\$s.*");
     auto srf_sp = std::make_shared<SwiftHiddenFrameRecognizer>();
     manager.AddRecognizer(srf_sp, module_regex_sp, symbol_regex_sp,
+                          Mangled::NamePreference::ePreferMangled, false);
+  }
+  {
+    auto srf_sp = std::make_shared<SwiftExceptionBreakpointFrameRecognizer>();
+    ConstString module_name = ConstString("swiftCore");
+    if (auto platform_sp = process.GetTarget().GetPlatform())
+      module_name = platform_sp->GetFullNameForDylib(module_name);
+    manager.AddRecognizer(srf_sp, module_name,
+                          {ConstString("swift_willThrow"),
+                           ConstString("swift_willThrowTypedImpl")},
                           Mangled::NamePreference::ePreferMangled, false);
   }
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -2598,7 +2598,9 @@ Function *DWARFASTParserClang::ParseFunctionFromDWARF(
       // If the mangled name is not present in the DWARF, generate the
       // demangled name using the decl context. We skip if the function is
       // "main" as its name is never mangled.
-      func_name.SetValue(ConstructDemangledNameFromDWARF(die));
+      func_name.SetDemangledName(ConstructDemangledNameFromDWARF(die));
+      // Ensure symbol is preserved (as the mangled name).
+      func_name.SetMangledName(ConstString(name));
     } else
       func_name.SetValue(ConstString(name));
 

--- a/lldb/test/API/lang/cpp/extern_c/main.cpp
+++ b/lldb/test/API/lang/cpp/extern_c/main.cpp
@@ -8,8 +8,10 @@ extern "C"
 
 int foo()
 {
-    puts("foo");
-    return 2;
+  puts("foo"); //% self.expect("image lookup -va $pc",
+  //%                          substrs=[' name = "::foo()"',
+  //%                                   ' mangled = "foo"'])
+  return 2;
 }
 
 int main (int argc, char const *argv[], char const *envp[])

--- a/lldb/test/API/lang/swift/exception_breakpoint_recognizer/Makefile
+++ b/lldb/test/API/lang/swift/exception_breakpoint_recognizer/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/exception_breakpoint_recognizer/TestSwiftExceptionBreakpointRecognizer.py
+++ b/lldb/test/API/lang/swift/exception_breakpoint_recognizer/TestSwiftExceptionBreakpointRecognizer.py
@@ -1,0 +1,30 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target = lldbutil.run_to_breakpoint_make_target(self)
+        bp = target.BreakpointCreateForException(lldb.eLanguageTypeSwift, False, True)
+
+        # First breakpoint in an untyped throws function.
+        _, process, _, _ = lldbutil.run_to_breakpoint_do_run(self, target, bp)
+        thread = process.selected_thread
+        stop_desc = thread.GetStopDescription(128)
+        self.assertEqual(stop_desc, "Swift exception breakpoint")
+        self.assertEqual(thread.frame[0].symbol.name, "swift_willThrow")
+        self.assertEqual(thread.selected_frame.idx, 1)
+
+        # Second breakpoint in an typed throws function.
+        process.Continue()
+        thread = process.selected_thread
+        stop_desc = thread.GetStopDescription(128)
+        self.assertEqual(stop_desc, "Swift exception breakpoint")
+        self.assertEqual(thread.frame[0].symbol.name, "swift_willThrowTypedImpl")
+        self.assertEqual(thread.selected_frame.idx, 2)

--- a/lldb/test/API/lang/swift/exception_breakpoint_recognizer/main.swift
+++ b/lldb/test/API/lang/swift/exception_breakpoint_recognizer/main.swift
@@ -1,0 +1,20 @@
+struct OpaqueError: Error {}
+
+func untyped() throws {
+    throw OpaqueError()
+}
+
+func typed() throws(OpaqueError) {
+    throw OpaqueError()
+}
+
+@main struct Entry {
+    static func main() {
+        do {
+            try untyped()
+        } catch {}
+        do {
+            try typed()
+        } catch {}
+    }
+}

--- a/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-address-ranges.s
+++ b/lldb/test/Shell/SymbolFile/DWARF/x86/debug-types-address-ranges.s
@@ -11,7 +11,7 @@
 # RUN: %lldb %t -o "image lookup -a 0x48000 -v" -o exit | FileCheck %s
 
 # CHECK:   CompileUnit: id = {0x00000001}, file = "/tmp/a.cc", language = "c++"
-# CHECK:      Function: id = {0x0000006a}, name = "::_start({{.*}})", range = [0x0000000000048000-0x000000000004800c)
+# CHECK:      Function: id = {0x0000006a}, name = "::_start({{.*}})", mangled = "_start", range = [0x0000000000048000-0x000000000004800c)
 # CHECK:     LineEntry: [0x0000000000048000-0x000000000004800a): /tmp/a.cc:4
 # CHECK:        Symbol: id = {0x00000002}, range = [0x0000000000048000-0x000000000004800c), name="_start"
 # CHECK:      Variable: id = {0x00000075}, name = "v1", {{.*}} decl = a.cc:4


### PR DESCRIPTION
Adds a frame recognizer for Swift breakpoint exceptions (`break set -E swift`).

This initial version does the following:
* provides a stop description ("Swift exception breakpoint")
* selects the frame which is throwing the exception

Selecting the frame where the throw occurs allows more direct inspection of the context that is throwing, and avoids displaying Swift's internal callback hook, which isa frame with no source and no variables – only disassembly.

rdar://156452605