### PR TITLE
🍒 [lldb] Clear Frames when changing `disable-language-runtime-unwindplans` (#151208)

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -98,6 +98,7 @@ public:
   void SetStopOnSharedLibraryEvents(bool stop);
   bool GetDisableLangRuntimeUnwindPlans() const;
   void SetDisableLangRuntimeUnwindPlans(bool disable);
+  void DisableLanguageRuntimeUnwindPlansCallback();
   bool GetDetachKeepsStopped() const;
   void SetDetachKeepsStopped(bool keep_stopped);
   bool GetWarningsOptimization() const;

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -207,6 +207,9 @@ ProcessProperties::ProcessProperties(lldb_private::Process *process)
     m_collection_sp->SetValueChangedCallback(
         ePropertyPythonOSPluginPath,
         [this] { m_process->LoadOperatingSystemPlugin(true); });
+    m_collection_sp->SetValueChangedCallback(
+        ePropertyDisableLangRuntimeUnwindPlans,
+        [this] { DisableLanguageRuntimeUnwindPlansCallback(); });
   }
 
   m_experimental_properties_up =
@@ -319,6 +322,15 @@ void ProcessProperties::SetDisableLangRuntimeUnwindPlans(bool disable) {
   const uint32_t idx = ePropertyDisableLangRuntimeUnwindPlans;
   SetPropertyAtIndex(idx, disable);
   m_process->Flush();
+}
+
+void ProcessProperties::DisableLanguageRuntimeUnwindPlansCallback() {
+  if (!m_process)
+    return;
+  for (auto thread_sp : m_process->Threads()) {
+    thread_sp->ClearStackFrames();
+    thread_sp->DiscardThreadPlans(/*force*/ true);
+  }
 }
 
 bool ProcessProperties::GetDetachKeepsStopped() const {

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestDisableLanguageUnwinder(lldbtest.TestBase):
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test(self):
+        """Test async unwind"""
+        self.build()
+        src = lldb.SBFileSpec('main.swift')
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', src)
+
+        self.assertIn("syncFunc", thread.GetFrameAtIndex(0).GetFunctionName())
+        self.assertIn("callSyncFunc", thread.GetFrameAtIndex(1).GetFunctionName())
+        self.assertIn("main", thread.GetFrameAtIndex(2).GetFunctionName())
+
+        self.runCmd("settings set target.process.disable-language-runtime-unwindplans true")
+
+        self.assertIn("syncFunc", thread.GetFrameAtIndex(0).GetFunctionName())
+        self.assertIn("callSyncFunc", thread.GetFrameAtIndex(1).GetFunctionName())
+        self.assertNotIn("main", thread.GetFrameAtIndex(2).GetFunctionName())

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/main.swift
@@ -1,0 +1,13 @@
+func syncFunc() {
+  print("break here")
+}
+
+func callSyncFunc() async {
+  syncFunc()
+}
+
+@main struct Main {
+  static func main() async {
+    await callSyncFunc()
+  }
+}


### PR DESCRIPTION
    This patch uses the "setting changed" callback to clear previously
    cached stack frames when
    `target.process.disable-language-runtime-unwindplans` is changed. This
    is necessary so that changing the setting followed by a `backtrace`
    command produces an accurate backtrace.

    With this, a user can create a custom command like below in order to
    quickly inspect a backtrace created without language plugins.

    ```
    debugger.HandleCommand("settings set target.process.disable-language-runtime-unwindplans true")
    debugger.HandleCommand("bt " + command)
    debugger.HandleCommand("settings set target.process.disable-language-runtime-unwindplans false")
    ```

    In the future, we may consider implementing this as an option to
    `backtrace`. Currently, this process setting is the only way of
    affecting the unwinder, and changing the process setting as part of the
    backtrace implementation doesn't feel right.

    There are no upstream users of this flag, so we cannot write a test for
    it here.

    (cherry picked from commit 03bb10bea6edeb6b1cbcb3fc6b590e585ae43ad6)

rdar://156508664