### PR TITLE
[Cherry-pick into next] [LLDB] Prefer serialized bridging headers.

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -87,6 +87,7 @@ public:
   bool GetSwiftLoadConformances() const;
   SwiftModuleLoadingMode GetSwiftModuleLoadingMode() const;
   bool SetSwiftModuleLoadingMode(SwiftModuleLoadingMode);
+  bool GetSwiftPreferSerializedBridgingHeader() const;
 
   bool GetEnableSwiftMetadataCache() const;
   uint64_t GetSwiftMetadataCacheMaxByteSize();

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -40,6 +40,9 @@ let Definition = "modulelist" in {
     DefaultEnumValue<"eSwiftModuleLoadingModePreferSerialized">,
     EnumValues<"OptionEnumValues(g_swift_module_loading_mode_enums)">,
     Desc<"The module loading mode to use when loading modules for Swift.">;
+  def SwiftPreferSerializedBridgingHeader: Property<"swift-prefer-serialized-bridging-header", "Boolean">,
+    DefaultTrue,
+    Desc<"Prefer serialized preprocessed bridging headers in Swift modules over on-disk headers.">;
   def EnableSwiftMetadataCache: Property<"enable-swift-metadata-cache", "Boolean">,
     Global,
     DefaultTrue,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -224,6 +224,12 @@ bool ModuleListProperties::SetSwiftModuleLoadingMode(SwiftModuleLoadingMode mode
   return SetPropertyAtIndex(idx, mode);
 }
 
+bool ModuleListProperties::GetSwiftPreferSerializedBridgingHeader() const {
+  const uint32_t idx = ePropertySwiftPreferSerializedBridgingHeader;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
 FileSpec ModuleListProperties::GetSwiftMetadataCachePath() const {
   return m_collection_sp
       ->GetPropertyAtIndexAsOptionValueFileSpec(ePropertySwiftMetadataCachePath)

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3502,6 +3502,8 @@ swift::ClangImporterOptions &SwiftASTContext::GetClangImporterOptions() {
     if (FileSystem::Instance().Exists(clang_dir_spec))
       clang_importer_options.OverrideResourceDir = clang_dir_spec.GetPath();
     clang_importer_options.DebuggerSupport = true;
+    clang_importer_options.PreferSerializedBridgingHeader =
+        props.GetSwiftPreferSerializedBridgingHeader();
 
     clang_importer_options.DisableSourceImport =
         !props.GetUseSwiftClangImporter();

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.cpp
@@ -88,7 +88,8 @@ void SwiftDWARFImporterForClangTypes::lookupValue(
         continue;
       auto ts = module_sp->GetTypeSystemForLanguage(lldb::eLanguageTypeSwift);
       if (!ts) {
-        llvm::consumeError(ts.takeError());
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Types), ts.takeError(),
+                       "no Swift type system: {0}");
         continue;
       }
       auto swift_ts = llvm::dyn_cast_or_null<TypeSystemSwift>(ts->get());
@@ -127,7 +128,9 @@ void SwiftDWARFImporterDelegate::importType(
       from_ctx.getSourceManager().getFileManager(), false);
   llvm::Expected<clang::QualType> clang_type(importer.Import(qual_type));
   if (!clang_type) {
-    llvm::consumeError(clang_type.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), clang_type.takeError(),
+                   "could not import DWARF type {1} into Clang AST: {0}",
+                   qual_type.getAsString());
     return;
   }
 

--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -29,6 +29,7 @@ class TestSwiftExtraClangFlags(TestBase):
         # Because the bridging header isn't precompiled or in a module
         # we don't have DWARF type information for the types it contains.
         self.expect("settings set symbols.swift-typesystem-compiler-fallback true")
+        self.expect("settings set symbols.swift-prefer-serialized-bridging-header false")
 
         # FIXME: this doesn't work if LLDB's build dir contains a space.
         overlay = self.getBuildArtifact('overlay.yaml')
@@ -71,6 +72,7 @@ class TestSwiftExtraClangFlags(TestBase):
         self.addTearDownHook(
             lambda: self.runCmd("settings clear target.swift-extra-clang-flags"))
 
+        self.expect("settings set symbols.swift-prefer-serialized-bridging-header false")
         self.expect('settings set target.swift-extra-clang-flags -- -v')
 
         lldbutil.run_to_source_breakpoint(self, "break here",

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/M.h
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/M.h
@@ -1,0 +1,1 @@
+struct M { int j; };

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/Makefile
@@ -1,0 +1,14 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_EXPLICIT_MODULES := Yes
+SWIFT_BRIDGING_HEADER := bridging.h
+SWIFTFLAGS_EXTRAS = -Xcc -I$(BUILDDIR)/secret
+
+all: secret.h $(EXE)
+
+include Makefile.rules
+
+.PHONY: secret.h
+
+secret.h:
+	mkdir -p $(BUILDDIR)/secret
+	echo "struct S { int i; };" > $(BUILDDIR)/secret/secret.h

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
@@ -1,0 +1,30 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftExplicitModules(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+    @swiftTest
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
+    def test(self):
+        """Test explicit Swift modules with bridging headers"""
+        self.build()
+        secret = self.getBuildArtifact("secret")
+        import shutil
+        shutil.rmtree(secret)
+
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))
+        log = self.getBuildArtifact("types.log")
+        self.expect('log enable lldb types -f "%s"' % log)
+
+        self.expect("frame variable s", substrs=['i = 23'])
+        self.expect("frame variable m", substrs=['j = 42'])
+        self.expect("expression s", substrs=['i = 23'])
+        self.expect("expression m", substrs=['j = 42'])
+        self.filecheck('platform shell cat "%s"' % log, __file__)
+        # CHECK: LogConfiguration
+        # CHECK-NOT: secret
+        # CHECK: Import 

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/bridging.h
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/bridging.h
@@ -1,0 +1,4 @@
+// A non-modular header.
+#include "secret.h"
+// A modular header.
+#include "M.h"

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/main.swift
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/main.swift
@@ -1,0 +1,7 @@
+func main() {
+  let s = S(i: 23)
+  let m = M(j: 42)
+  print(s) // Set breakpoint here
+}
+
+main()

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/module.modulemap
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/module.modulemap
@@ -1,0 +1,1 @@
+module M { header "M.h" }


### PR DESCRIPTION
```
commit 500bed467d9c577c5a9ab57ede9902e01bdb5f9b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jul 29 17:10:27 2025 -0700

    [LLDB] Prefer serialized bridging headers.
    
    Especially in an explicit modules project, LLDB might not know all the
    search paths needed to imported the on disk header.
    
    rdar://156542351
```
