### PR TITLE
🍒[Clang] Use [[clang::lifetimebound]] syntax when supported

### DIFF
--- a/clang/lib/Headers/lifetimebound.h
+++ b/clang/lib/Headers/lifetimebound.h
@@ -10,10 +10,28 @@
 #ifndef __LIFETIMEBOUND_H
 #define __LIFETIMEBOUND_H
 
+#if defined(__cplusplus) && defined(__has_cpp_attribute)
+#define __use_cpp_spelling(x) __has_cpp_attribute(x)
+#else
+#define __use_cpp_spelling(x) 0
+#endif
+
+#if __use_cpp_spelling(clang::lifetimebound)
+#define __lifetimebound [[clang::lifetimebound]]
+#else
 #define __lifetimebound __attribute__((lifetimebound))
+#endif
 
+#if __use_cpp_spelling(clang::lifetime_capture_by)
+#define __lifetime_capture_by(X) [[clang::lifetime_capture_by(X)]]
+#else
 #define __lifetime_capture_by(X) __attribute__((lifetime_capture_by(X)))
+#endif
 
+#if __use_cpp_spelling(clang::noescape)
+#define __noescape [[clang::noescape]]
+#else
 #define __noescape __attribute__((noescape))
+#endif
 
 #endif /* __LIFETIMEBOUND_H */

--- a/clang/test/Headers/lifetimebound.c
+++ b/clang/test/Headers/lifetimebound.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+// expected-no-diagnostics
+
+// Verify that we can include <lifetimebound.h>
+#include <lifetimebound.h>
+
+struct foo {};
+
+struct foo* get_foo(char *ptr __lifetimebound);
+
+void non_escaping(char *ptr __noescape);

--- a/clang/test/Headers/lifetimebound.cpp
+++ b/clang/test/Headers/lifetimebound.cpp
@@ -6,6 +6,7 @@
 
 struct has_lifetimebound_method {
   const char* get_ptr(char* ptr __lifetimebound) const;
+  const char* get_ptr() const __lifetimebound;
 };
 
 struct has_lifetime_capture_by_method {


### PR DESCRIPTION
This allows the usage of `__lifetimebound` for the implicit self parameter, while keeping it possible to use it in C code.

rdar://157316328

Original PR: https://github.com/swiftlang/llvm-project/pull/11107