### PR TITLE
[stable/21.x] clang: Adjust for MSVC's default underlying type for enums

### DIFF
--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -461,7 +461,7 @@ public:
   };
 
   /* TODO(BoundsSafety) Deprecate the flag  */
-  enum BoundsSafetyNewChecks {
+  enum BoundsSafetyNewChecks : uint8_t {
     BS_CHK_None = 0,
 
     BS_CHK_AccessSize = 1 << 0,          // rdar://72252593


### PR DESCRIPTION
🤷🏼‍♂️
```
10:26:31  C:\Users\swift-ci\jenkins\workspace\swift-rebranch-windows-toolchain\llvm-project\clang\lib\Driver\BoundsSafetyArgs.cpp(196): error C2672: 'llvm::has_single_bit': no matching overloaded function found
10:26:34  C:\Users\swift-ci\jenkins\workspace\swift-rebranch-windows-toolchain\llvm-project\llvm\include\llvm/ADT/bit.h(147): note: could be 'bool llvm::has_single_bit(T) noexcept'
10:26:34  C:\Users\swift-ci\jenkins\workspace\swift-rebranch-windows-toolchain\llvm-project\clang\lib\Driver\BoundsSafetyArgs.cpp(196): note: 'bool llvm::has_single_bit(T) noexcept': could not deduce template argument for '<unnamed-symbol>'
10:26:34  C:\Users\swift-ci\jenkins\workspace\swift-rebranch-windows-toolchain\llvm-project\llvm\include\llvm/ADT/bit.h(146): note: 'std::enable_if_t<false,void>' : Failed to specialize alias template
```