### PR TITLE
[6.2][clang][DebugInfo] Handle empty comp_dir in CodeGen

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3119,6 +3119,9 @@ llvm::DIModule *CGDebugInfo::getOrCreateModuleRef(ASTSourceDescriptor Mod,
     std::string Remapped = remapDIPath(Path);
     StringRef Relative(Remapped);
     StringRef CompDir = TheCU->getDirectory();
+    if (CompDir.empty())
+      return Remapped;
+
     if (Relative.consume_front(CompDir))
       Relative.consume_front(llvm::sys::path::get_separator());
 


### PR DESCRIPTION
- **Explanation**: Fix a logic mistake in DebugInfo CodeGen that if the compilation directory is empty, the leading separator is dropped with emitting path. This code path is usually not possible in current state unless the compilation is done from a file system that do not have current working directory and compilation caching include tree file system is such a file system. 
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: This is affecting all swift caching compilation, and can cause dsymutil warning, loss of debug info that can lead to variable view missing items, debugging inline functions when using swift caching. 
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://156759645
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**:  https://github.com/llvm/llvm-project/pull/150130 (only a subset from upstream is taken)
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. This code path should affect only caching compilation and the logic is quite simple.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Unit test (tests are in swift repo https://github.com/swiftlang/swift/pull/83549).
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @adrian-prantl 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->