### PR TITLE
[cmake] lldb: Build libraries with `-DCLANG_BUILD_STATIC` on Windows

### DIFF
--- a/lldb/cmake/modules/AddLLDB.cmake
+++ b/lldb/cmake/modules/AddLLDB.cmake
@@ -92,6 +92,15 @@ function(add_lldb_library name)
     ${pass_NO_INSTALL_RPATH}
   )
 
+  if(MSVC)
+    # LLDB libraries are always linked with Clang libraries statically, so turn
+    # off Clang visibility macros for both the library and its consumers.
+    target_compile_definitions(${name} PUBLIC CLANG_BUILD_STATIC)
+    if(TARGET "obj.${name}")
+      target_compile_definitions("obj.${name}" PUBLIC CLANG_BUILD_STATIC)
+    endif()
+  endif()
+
   if(CLANG_LINK_CLANG_DYLIB)
     target_link_libraries(${name} PRIVATE clang-cpp)
   else()


### PR DESCRIPTION
By default (`CLANG_BUILD_STATIC` and `CLANG_EXPORTS` not defined) some Clang visibility macros expand to `__declspec(dllimport)`. LLDB depends on Clang statically, so needs to turn these macros off.

See: https://github.com/llvm/llvm-project/pull/108276/files#diff-4dd645a8b76bb3886a505258a8c2e598aeddea770e7b0a2b51689124a5ea6e9a.