### PR TITLE
[stable/21.x] Fix windows build failures with MSVC

### DIFF
--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -461,7 +461,7 @@ public:
   };
 
   /* TODO(BoundsSafety) Deprecate the flag  */
-  enum BoundsSafetyNewChecks : uint8_t {
+  enum BoundsSafetyNewChecks : unsigned {
     BS_CHK_None = 0,
 
     BS_CHK_AccessSize = 1 << 0,          // rdar://72252593

--- a/clang/unittests/Tooling/BoundsSafetyBringupMissingChecks.cpp
+++ b/clang/unittests/Tooling/BoundsSafetyBringupMissingChecks.cpp
@@ -179,7 +179,7 @@ TEST(BoundsSafetyBringUpMissingChecks, ChkPairValidMask) {
   static_assert(LangOptions::BS_CHK_None == 0, "expected 0");
   for (size_t Idx = 0; Idx < NumChkDescs; ++Idx) {
     unsigned CurrentMask = CheckKinds[Idx].Mask;
-    EXPECT_EQ(__builtin_popcount(CurrentMask), 1); // Check is a power of 2
+    EXPECT_EQ(llvm::popcount(CurrentMask), 1); // Check is a power of 2
     EXPECT_EQ(SeenBits & CurrentMask,
               0U); // Doesn't overlap with a previously seen value
     SeenBits |= CurrentMask;


### PR DESCRIPTION
Cherry-picks https://github.com/swiftlang/llvm-project/pull/11092. The second commit here is not so much a cherry-pick as a correction upon https://github.com/swiftlang/llvm-project/pull/11120 in favor of `next`, to avoid future conflicts. (I didn’t notice this had already been fixed on next.)