### PR TITLE
Revert "Strip the full path from __FILE__ in the LDBG macro and keep only the filename (#150677)"

### DIFF
--- a/llvm/cmake/modules/LLVMProcessSources.cmake
+++ b/llvm/cmake/modules/LLVMProcessSources.cmake
@@ -58,21 +58,6 @@ function(llvm_process_sources OUT_VAR)
   set(sources ${ARG_UNPARSED_ARGUMENTS})
   llvm_check_source_file_list(${sources})
 
-  # Don't generate __SHORT_FILE__ on VS builds as it can prevent build parallelisation.
-  if(NOT CMAKE_GENERATOR MATCHES "Visual Studio")
-    foreach(fn ${sources})
-      get_filename_component(suf ${fn} EXT)
-      if("${suf}" STREQUAL ".cpp" OR "${suf}" STREQUAL ".c")
-        get_filename_component(short_name ${fn} NAME)
-        set_property(
-            SOURCE ${fn}
-            APPEND
-            PROPERTY COMPILE_DEFINITIONS __SHORT_FILE__="${short_name}")
-      endif()
-    endforeach()
-  endif()
-
-
   # This adds .td and .h files to the Visual Studio solution:
   add_td_sources(sources)
   find_all_header_files(hdrs "${ARG_ADDITIONAL_HEADER_DIRS}")


### PR DESCRIPTION
This reverts commit 5d26e3c227f4b4a1761a8b0001b3165198def479.

It breaks the modules build of clang, since every source file has a different version of this macro, which causes
https://green.lab.llvm.org/job/clang-stage2-Rthinlto/ to run out of space. We should probably be using __FILE_NAME__ instead when the host compiler supports it, but until then let's revert-to-green, and un-block some of the bots.

see: https://github.com/llvm/llvm-project/pull/150677
see: https://github.com/llvm/llvm-project/pull/150677#issuecomment-3156779021

rdar://157465825