### PR TITLE
[Index] Add option to compress unit and record files

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -737,6 +737,11 @@ def index_ignore_pcms : Flag<["-"], "index-ignore-pcms">,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Ignore symbols from imported pcm modules">,
   MarshallingInfoFlag<FrontendOpts<"IndexIgnorePcms">>;
+def index_store_record_compression
+    : Flag<["-"], "index-store-compress">,
+      Visibility<[ClangOption, CC1Option]>,
+      HelpText<"Whether to compress unit and record files in the index store">,
+      MarshallingInfoFlag<FrontendOpts<"IndexStoreCompress">>;
 
 // Make sure all other -ccc- options are rejected.
 def ccc_ : Joined<["-"], "ccc-">, Group<internal_Group>, Flags<[Unsupported]>;

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -477,6 +477,9 @@ public:
   std::string IndexStorePath;
   std::string IndexUnitOutputPath;
 
+  /// Whether to compress the unit and record files in the index store.
+  bool IndexStoreCompress = false;
+
   /// The input kind, either specified via -x argument or deduced from the input
   /// file name.
   InputKind DashX;

--- a/clang/include/clang/Index/IndexRecordWriter.h
+++ b/clang/include/clang/Index/IndexRecordWriter.h
@@ -53,10 +53,12 @@ typedef llvm::function_ref<Symbol(OpaqueDecl, SmallVectorImpl<char> &Scratch)>
 /// beginRecord, and if the file does not already exist, then proceed to add
 /// all symbol occurrences (addOccurrence) and finally finish with endRecord.
 class IndexRecordWriter {
+  /// Whether to compress the index record using zlib.
+  bool Compress;
   SmallString<64> RecordsPath; ///< The records directory path.
   void *Record = nullptr;      ///< The state of the current record.
 public:
-  IndexRecordWriter(StringRef IndexPath);
+  IndexRecordWriter(StringRef IndexPath, bool Compress);
 
   enum class Result {
     Success,

--- a/clang/include/clang/Index/IndexUnitWriter.h
+++ b/clang/include/clang/Index/IndexUnitWriter.h
@@ -50,6 +50,8 @@ class IndexUnitWriter {
   SmallString<64> UnitsPath;
   std::string ProviderIdentifier;
   std::string ProviderVersion;
+  /// Whether to compress the index unit using zlib.
+  bool Compress;
   std::string OutputFile;
   std::string ModuleName;
   OptionalFileEntryRef MainFile;
@@ -92,17 +94,12 @@ public:
   /// \param IsSystem true for system module units, false otherwise.
   /// \param Remapper Remapper to use to standardize file paths to make them
   /// hermetic/reproducible. This applies to all paths emitted in the unit file.
-  IndexUnitWriter(FileManager &FileMgr,
-                  StringRef StorePath,
+  IndexUnitWriter(FileManager &FileMgr, StringRef StorePath,
                   StringRef ProviderIdentifier, StringRef ProviderVersion,
-                  StringRef OutputFile,
-                  StringRef ModuleName,
-                  OptionalFileEntryRef MainFile,
-                  bool IsSystem,
-                  bool IsModuleUnit,
-                  bool IsDebugCompilation,
-                  StringRef TargetTriple,
-                  StringRef SysrootPath,
+                  bool Compress, StringRef OutputFile, StringRef ModuleName,
+                  OptionalFileEntryRef MainFile, bool IsSystem,
+                  bool IsModuleUnit, bool IsDebugCompilation,
+                  StringRef TargetTriple, StringRef SysrootPath,
                   const PathRemapper &Remapper,
                   writer::ModuleInfoWriterCallback GetInfoForModule);
   ~IndexUnitWriter();

--- a/clang/lib/Index/ClangIndexRecordWriter.cpp
+++ b/clang/lib/Index/ClangIndexRecordWriter.cpp
@@ -61,9 +61,9 @@ StringRef ClangIndexRecordWriter::getUSRNonCached(const IdentifierInfo *Name,
   return StringRef(Ptr, USR.size());
 }
 
-ClangIndexRecordWriter::ClangIndexRecordWriter(ASTContext &Ctx,
+ClangIndexRecordWriter::ClangIndexRecordWriter(ASTContext &Ctx, bool Compress,
                                                RecordingOptions Opts)
-    : Impl(Opts.DataDirPath), Ctx(Ctx), RecordOpts(std::move(Opts)) {
+    : Impl(Opts.DataDirPath, Compress), Ctx(Ctx), RecordOpts(std::move(Opts)) {
   if (Opts.RecordSymbolCodeGenName)
     ASTNameGen.reset(new ASTNameGenerator(Ctx));
 }

--- a/clang/lib/Index/ClangIndexRecordWriter.h
+++ b/clang/lib/Index/ClangIndexRecordWriter.h
@@ -35,7 +35,7 @@ class ClangIndexRecordWriter {
   llvm::DenseMap<const void *, StringRef> USRByDecl;
 
 public:
-  ClangIndexRecordWriter(ASTContext &Ctx, RecordingOptions Opts);
+  ClangIndexRecordWriter(ASTContext &Ctx, bool Compress, RecordingOptions Opts);
   ~ClangIndexRecordWriter();
 
   ASTContext &getASTContext() { return Ctx; }

--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -843,9 +843,10 @@ static void writeUnitData(const CompilerInstance &CI,
     Remapper.addMapping(It->first, It->second);
 
   IndexUnitWriter UnitWriter(
-      CI.getFileManager(), DataPath, "clang", getClangVersion(), OutputFile,
-      ModuleName, RootFile, IsSystemUnit, IsModuleUnit, IsDebugCompilation,
-      CI.getTargetOpts().Triple, SysrootPath, Remapper, getModuleInfo);
+      CI.getFileManager(), DataPath, "clang", getClangVersion(),
+      CI.getFrontendOpts().IndexStoreCompress, OutputFile, ModuleName, RootFile,
+      IsSystemUnit, IsModuleUnit, IsDebugCompilation, CI.getTargetOpts().Triple,
+      SysrootPath, Remapper, getModuleInfo);
 
   DepProvider.visitFileDependencies(
       CI, [&](FileEntryRef FE, bool isSystemFile) {
@@ -868,7 +869,8 @@ static void writeUnitData(const CompilerInstance &CI,
     }
   });
 
-  ClangIndexRecordWriter RecordWriter(CI.getASTContext(), RecordOpts);
+  ClangIndexRecordWriter RecordWriter(
+      CI.getASTContext(), CI.getFrontendOpts().IndexStoreCompress, RecordOpts);
   for (auto I = Recorder.record_begin(), E = Recorder.record_end(); I != E;
        ++I) {
     FileID FID = I->first;

--- a/clang/test/Index/Store/compress-index-store.c
+++ b/clang/test/Index/Store/compress-index-store.c
@@ -1,0 +1,8 @@
+// RUN: rm -rf %t.idx
+// RUN: %clang_cc1 %s -index-store-path %t.idx -index-store-compress
+// RUN: c-index-test core -print-unit %t.idx | FileCheck --check-prefix=UNIT %s
+// RUN: c-index-test core -print-record %t.idx | FileCheck --check-prefix=RECORD %s
+
+// UNIT: main-path: {{.*}}/compress-index-store.c
+// RECORD: [[@LINE+1]]:6 | function/C | c:@F@foo | Decl | rel: 0
+void foo(int *p);

--- a/clang/tools/c-index-test/JSONAggregation.cpp
+++ b/clang/tools/c-index-test/JSONAggregation.cpp
@@ -215,7 +215,8 @@ std::unique_ptr<RecordInfo> Aggregator::processRecord(StringRef recordFile) {
   std::string error;
   auto recordReader = IndexRecordReader(Store, recordFile, error);
   if (!recordReader) {
-    errs() << "failed reading record file: " << recordFile << '\n';
+    errs() << "failed reading record file: " << recordFile << ": " << error
+           << '\n';
     ::exit(1);
   }
   auto record = std::make_unique<RecordInfo>();


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/10977.

---

This option reduces the size of the index in a mixed clang + Swift project I have tested by about 70% while increasing the indexing overhead by about 10-15% overhead (from 1.07% to ~1.2%).