### PR TITLE
[lldb] Delete copy constructor to avoid accidentally holding a lock (…

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
@@ -23,6 +23,8 @@ template <typename Resource> struct LockGuarded {
       : m_resource(resource), m_lock(mutex, std::adopt_lock) {}
 
   LockGuarded() = default;
+  LockGuarded(const LockGuarded &) = delete;
+  LockGuarded &operator=(const LockGuarded &) = delete;
 
   Resource *operator->() const { return m_resource; }
 


### PR DESCRIPTION
…NFC)

see https://github.com/swiftlang/llvm-project/pull/11136