### PR TITLE
Fix the following CAS-related tests with LLVM_ENABLE_ONDISK_CAS=OFF on Windows

### DIFF
--- a/clang/test/ClangScanDeps/modules-include-tree-pch-common-stale.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-pch-common-stale.c
@@ -1,3 +1,5 @@
+// REQUIRES: ondisk_cas
+
 // Test that modifications to a common header (imported from both a PCH and a TU)
 // cause rebuilds of dependent modules imported from the TU on incremental build.
 

--- a/clang/test/Driver/fdepscan-prefix-map-sdk-win.c
+++ b/clang/test/Driver/fdepscan-prefix-map-sdk-win.c
@@ -1,0 +1,10 @@
+// REQUIRES: system-windows
+
+// RUN: %clang -fdepscan-prefix-map-sdk=\^sdk -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+// RUN: %clang -fdepscan-prefix-map-sdk=\^sdk -isysroot relative -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+
+// NONE-NOT: -fdepscan-prefix-map
+
+// RUN: %clang -fdepscan-prefix-map-sdk=\^sdk -isysroot C:\sys\path -### %s 2>&1 | FileCheck %s
+// RUN: %clang -fdepscan-prefix-map-sdk=\^sdk --sysroot C:\sys\path -### %s 2>&1 | FileCheck %s
+// CHECK: "-fdepscan-prefix-map" "C:\\sys\\path" "\\^sdk"

--- a/clang/test/Driver/fdepscan-prefix-map-sdk.c
+++ b/clang/test/Driver/fdepscan-prefix-map-sdk.c
@@ -1,3 +1,5 @@
+// REQUIRES: !system-windows
+
 // RUN: %clang -fdepscan-prefix-map-sdk=/^sdk -### %s 2>&1 | FileCheck %s -check-prefix=NONE
 // RUN: %clang -fdepscan-prefix-map-sdk=/^sdk -isysroot relative -### %s 2>&1 | FileCheck %s -check-prefix=NONE
 

--- a/clang/test/Driver/fdepscan-prefix-map-toolchain-win.c
+++ b/clang/test/Driver/fdepscan-prefix-map-toolchain-win.c
@@ -1,0 +1,17 @@
+// REQUIRES: system-windows
+
+// RUN: %clang -fdepscan-prefix-map-toolchain=\^tc -resource-dir '' -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+// RUN: %clang -fdepscan-prefix-map-toolchain=\^tc -resource-dir relative -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+// RUN: %clang -fdepscan-prefix-map-toolchain=\^tc -resource-dir C:\lib\clang\10 -### %s 2>&1 | FileCheck %s -check-prefix=NONE
+
+// NONE-NOT: -fdepscan-prefix-map
+
+// RUN: %clang -fdepscan-prefix-map-toolchain=\^tc -resource-dir C:\tc\10 -### %s 2>&1 | FileCheck %s
+// RUN: %clang -fdepscan-prefix-map-toolchain=\^tc -resource-dir C:\tc\lib\clang\10 -### %s 2>&1 | FileCheck %s
+// RUN: %clang -fdepscan-prefix-map-toolchain=\^tc -resource-dir C:\tc\usr\lib\clang\10 -### %s 2>&1 | FileCheck %s
+
+// CHECK: "-fdepscan-prefix-map" "C:\\tc" "\\^tc"
+
+// Implicit resource-dir
+// RUN: %clang -fdepscan-prefix-map-toolchain=\^tc -### %s 2>&1 | FileCheck %s -check-prefix=CHECK_IMPLICIT
+// CHECK_IMPLICIT: "-fdepscan-prefix-map" "{{.*}}" "\\^tc"

--- a/clang/test/Driver/fdepscan-prefix-map-toolchain.c
+++ b/clang/test/Driver/fdepscan-prefix-map-toolchain.c
@@ -1,3 +1,5 @@
+// REQUIRES: !system-windows
+
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir '' -### %s 2>&1 | FileCheck %s -check-prefix=NONE
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir relative -### %s 2>&1 | FileCheck %s -check-prefix=NONE
 // RUN: %clang -fdepscan-prefix-map-toolchain=/^tc -resource-dir /lib/clang/10 -### %s 2>&1 | FileCheck %s -check-prefix=NONE

--- a/clang/test/Driver/fdepscan-prefix-map-win.c
+++ b/clang/test/Driver/fdepscan-prefix-map-win.c
@@ -1,0 +1,13 @@
+// REQUIRES: system-windows
+
+// RUN: not %clang -fdepscan-prefix-map=\^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: not %clang -fdepscan-prefix-map==\^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: not %clang -fdepscan-prefix-map=relative=\^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// RUN: not %clang -fdepscan-prefix-map=\=\^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
+// INVALID: error: invalid argument '{{.*}}\^bad' to -fdepscan-prefix-map=
+
+// RUN: %clang -fdepscan-prefix-map=C:\good=\^good -### %s 2>&1 | FileCheck --check-prefix CHECK_CORRECT %s
+// CHECK_CORRECT: "-fdepscan-prefix-map" "C:\\good" "\\^good"
+
+// RUN %clang -fdepscan-prefix-map=C:\a=\^a -fdepscan-prefix-map C:\b \^b -fdepscan-prefix-map=C:\c=\^c -fdepscan-prefix-map C:\d \^d -### %s 2>&1 | FileCheck --check-prefix=CHECK_MIXED %s
+// CHECK_MIXED: "-fdepscan-prefix-map" "C:\\a" "\\^a" "-fdepscan-prefix-map" "C:\\b" "\\^b" "-fdepscan-prefix-map" "C:\\c" "\\^c" "-fdepscan-prefix-map" "C:\\d" "\\^d"

--- a/clang/test/Driver/fdepscan-prefix-map.c
+++ b/clang/test/Driver/fdepscan-prefix-map.c
@@ -1,3 +1,5 @@
+// REQUIRES: !system-windows
+
 // RUN: not %clang -fdepscan-prefix-map=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
 // RUN: not %clang -fdepscan-prefix-map==/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID
 // RUN: not %clang -fdepscan-prefix-map=relative=/^bad -### %s 2>&1 | FileCheck %s -check-prefix=INVALID

--- a/clang/unittests/Tooling/DependencyScanningCASFilesystemTest.cpp
+++ b/clang/unittests/Tooling/DependencyScanningCASFilesystemTest.cpp
@@ -24,7 +24,13 @@ using llvm::unittest::TempLink;
 TEST(DependencyScanningCASFilesystem, FilenameSpelling) {
   TempDir TestDir("DependencyScanningCASFilesystemTest", /*Unique=*/true);
   TempFile TestFile(TestDir.path("File.h"), "", "#define FOO\n");
+#ifndef _WIN32
   TempLink TestLink("File.h", TestDir.path("SymFile.h"));
+#else
+  // As the create_link uses a hard link on Windows, the full path is
+  // required for the link target.
+  TempLink TestLink(TestDir.path("File.h"), TestDir.path("SymFile.h"));
+#endif
 
   std::unique_ptr<ObjectStore> CAS = llvm::cas::createInMemoryCAS();
   std::unique_ptr<ActionCache> Cache = llvm::cas::createInMemoryActionCache();

--- a/llvm/include/llvm/CAS/CASFileSystem.h
+++ b/llvm/include/llvm/CAS/CASFileSystem.h
@@ -17,15 +17,13 @@ namespace cas {
 class ObjectStore;
 class CASID;
 
-// FIXME: Consider taking a "mount point". Then this could perhaps be
-// generalized for windows.
 Expected<std::unique_ptr<vfs::FileSystem>>
-createCASFileSystem(std::shared_ptr<ObjectStore> DB, const CASID &RootID);
+createCASFileSystem(std::shared_ptr<ObjectStore> DB, const CASID &RootID,
+                    sys::path::Style PathStyle = sys::path::Style::native);
 
-// FIXME: Consider taking a "mount point". Then this could perhaps be
-// generalized for windows.
 Expected<std::unique_ptr<vfs::FileSystem>>
-createCASFileSystem(ObjectStore &DB, const CASID &RootID);
+createCASFileSystem(ObjectStore &DB, const CASID &RootID,
+                    sys::path::Style PathStyle = sys::path::Style::native);
 
 } // namespace cas
 } // namespace llvm

--- a/llvm/include/llvm/CAS/HierarchicalTreeBuilder.h
+++ b/llvm/include/llvm/CAS/HierarchicalTreeBuilder.h
@@ -16,6 +16,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h" // FIXME: Split out sys::fs::file_status.
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
 #include <cstddef>
 
 namespace llvm {
@@ -43,6 +44,8 @@ class HierarchicalTreeBuilder {
     std::string Path;
   };
 
+  sys::path::Style PathStyle;
+
   /// Preallocate space for small trees, common when creating cache keys.
   SmallVector<HierarchicalEntry, 8> Entries;
   SmallVector<HierarchicalEntry, 0> TreeContents;
@@ -51,6 +54,9 @@ class HierarchicalTreeBuilder {
                 const Twine &Path);
 
 public:
+  HierarchicalTreeBuilder(sys::path::Style PathStyle = sys::path::Style::native)
+      : PathStyle(PathStyle) {}
+
   /// Add a hierarchical entry at \p Path, which is expected to be from the
   /// top-level (otherwise, the caller should prepend a working directory).
   ///

--- a/llvm/lib/CAS/FileSystemCache.cpp
+++ b/llvm/lib/CAS/FileSystemCache.cpp
@@ -22,41 +22,52 @@ using namespace llvm::cas;
 
 using DirectoryEntry = FileSystemCache::DirectoryEntry;
 
-FileSystemCache::FileSystemCache(std::optional<ObjectRef> RootRef) {
-  // FIXME: Only correct for posix. To generalize this (for both posix and
-  // windows) we should refactor so that the root node has no name (instead of
-  // "/").
-  Root = new (EntryAlloc.Allocate())
-      DirectoryEntry(nullptr, "/", DirectoryEntry::Directory, RootRef);
+DirectoryEntry &FileSystemCache::getRoot(StringRef root_path,
+                                         std::optional<ObjectRef> RootRef) {
+  auto it = Roots.find(root_path);
+  if (it != Roots.end()) {
+    return *it->second;
+  }
+  DirectoryEntry *Root = new (EntryAlloc.Allocate())
+      DirectoryEntry(nullptr, root_path, DirectoryEntry::Directory, RootRef);
   Root->setDirectory(*new (DirectoryAlloc.Allocate()) Directory);
+  Roots[root_path] = Root;
+  return *Root;
+}
+
+StringRef FileSystemCache::getRootPathFor(StringRef Path) const {
+  if (is_absolute(Path, PathStyle))
+    return sys::path::root_path(Path, PathStyle);
+  else
+    return sys::path::root_path(WorkingDirectory.Path, PathStyle);
 }
 
 StringRef
 FileSystemCache::canonicalizeWorkingDirectory(const Twine &Path,
+                                              sys::path::Style PathStyle,
                                               StringRef WorkingDirectory,
                                               SmallVectorImpl<char> &Storage) {
-  // Not portable.
-  assert(WorkingDirectory.starts_with("/"));
+  const char PathSeparatorChar = get_separator(PathStyle)[0];
   Path.toVector(Storage);
   if (Storage.empty())
     return WorkingDirectory;
 
-  if (Storage[0] != '/') {
+  if (!is_absolute(Path, PathStyle)) {
+    assert(is_absolute(WorkingDirectory, PathStyle));
     SmallString<128> Prefix = StringRef(WorkingDirectory);
-    Prefix.push_back('/');
+    Prefix.push_back(PathSeparatorChar);
     Storage.insert(Storage.begin(), Prefix.begin(), Prefix.end());
   }
 
   // Remove ".." components based on working directory string, not based on
   // real path. This matches shell behaviour.
-  sys::path::remove_dots(Storage, /*remove_dot_dot=*/true,
-                         sys::path::Style::posix);
+  sys::path::remove_dots(Storage, /*remove_dot_dot=*/true, PathStyle);
 
   // Remove double slashes.
   int W = 0;
   bool WasSlash = false;
   for (int R = 0, E = Storage.size(); R != E; ++R) {
-    bool IsSlash = Storage[R] == '/';
+    bool IsSlash = Storage[R] == PathSeparatorChar;
     if (IsSlash && WasSlash)
       continue;
     WasSlash = IsSlash;
@@ -65,7 +76,9 @@ FileSystemCache::canonicalizeWorkingDirectory(const Twine &Path,
   Storage.resize(W);
 
   // Remove final slash.
-  if (Storage.size() > 1 && Storage.back() == '/')
+  if (sys::path::root_path(StringRef(Storage.begin(), Storage.size()), PathStyle)
+          != StringRef(Storage.begin(), Storage.size()) &&
+      Storage.back() == PathSeparatorChar)
     Storage.pop_back();
 
   return StringRef(Storage.begin(), Storage.size());
@@ -84,8 +97,8 @@ static StringRef allocateTreePath(
   // Use constant strings when reasonable.
   if (TreePath.empty())
     return "";
-  if (TreePath == "/")
-    return "/";
+  if (sys::path::root_path(TreePath) == TreePath)
+    return TreePath;
 
   char *AllocatedTreePath = TreePathAlloc.Allocate(TreePath.size() + 1);
   llvm::copy(TreePath, AllocatedTreePath);
@@ -97,9 +110,10 @@ static DirectoryEntry &makeLazyEntry(
     ThreadSafeAllocator<SpecificBumpPtrAllocator<char>> &TreePathAlloc,
     ThreadSafeAllocator<SpecificBumpPtrAllocator<DirectoryEntry>> &EntryAlloc,
     DirectoryEntry &Parent, FileSystemCache::Directory &D, StringRef TreePath,
-    DirectoryEntry::EntryKind Kind, std::optional<ObjectRef> Ref) {
-  assert(sys::path::parent_path(TreePath) == Parent.getTreePath());
-  assert(!D.lookup(sys::path::filename(TreePath)));
+    DirectoryEntry::EntryKind Kind, std::optional<ObjectRef> Ref,
+    sys::path::Style PathStyle) {
+  assert(sys::path::parent_path(TreePath, PathStyle) == Parent.getTreePath());
+  assert(!D.lookup(sys::path::filename(TreePath, PathStyle)));
   assert(!D.isComplete());
 
   TreePath = allocateTreePath(TreePathAlloc, TreePath);
@@ -112,7 +126,7 @@ static DirectoryEntry &makeLazyEntry(
 DirectoryEntry &FileSystemCache::makeLazySymlinkAlreadyLocked(
     DirectoryEntry &Parent, StringRef TreePath, ObjectRef Ref) {
   return makeLazyEntry(TreePathAlloc, EntryAlloc, Parent, Parent.asDirectory(),
-                       TreePath, DirectoryEntry::Symlink, Ref);
+                       TreePath, DirectoryEntry::Symlink, Ref, PathStyle);
 }
 
 DirectoryEntry &
@@ -121,7 +135,8 @@ FileSystemCache::makeLazyFileAlreadyLocked(DirectoryEntry &Parent,
                                            bool IsExecutable) {
   return makeLazyEntry(
       TreePathAlloc, EntryAlloc, Parent, Parent.asDirectory(), TreePath,
-      IsExecutable ? DirectoryEntry::Executable : DirectoryEntry::Regular, Ref);
+      IsExecutable ? DirectoryEntry::Executable : DirectoryEntry::Regular, Ref,
+      PathStyle);
 }
 
 DirectoryEntry &FileSystemCache::makeDirectory(DirectoryEntry &Parent,
@@ -129,7 +144,7 @@ DirectoryEntry &FileSystemCache::makeDirectory(DirectoryEntry &Parent,
                                                std::optional<ObjectRef> Ref) {
   Directory &D = Parent.asDirectory();
   Directory::Writer W(D);
-  if (DirectoryEntry *Existing = D.lookup(sys::path::filename(TreePath)))
+  if (DirectoryEntry *Existing = D.lookup(sys::path::filename(TreePath, PathStyle)))
     return *Existing;
 
   return makeDirectoryAlreadyLocked(Parent, TreePath, Ref);
@@ -139,7 +154,7 @@ DirectoryEntry &FileSystemCache::makeDirectoryAlreadyLocked(
     DirectoryEntry &Parent, StringRef TreePath, std::optional<ObjectRef> Ref) {
   DirectoryEntry &Entry =
       makeLazyEntry(TreePathAlloc, EntryAlloc, Parent, Parent.asDirectory(),
-                    TreePath, DirectoryEntry::Directory, Ref);
+                    TreePath, DirectoryEntry::Directory, Ref, PathStyle);
   Entry.setDirectory(*new (DirectoryAlloc.Allocate()) Directory);
   return Entry;
 }
@@ -149,7 +164,7 @@ DirectoryEntry &FileSystemCache::makeSymlink(DirectoryEntry &Parent,
                                              StringRef Target) {
   Directory &D = Parent.asDirectory();
   Directory::Writer W(D);
-  if (DirectoryEntry *Existing = D.lookup(sys::path::filename(TreePath)))
+  if (DirectoryEntry *Existing = D.lookup(sys::path::filename(TreePath, PathStyle)))
     return *Existing;
 
   DirectoryEntry &Entry = makeLazySymlinkAlreadyLocked(Parent, TreePath, Ref);
@@ -175,7 +190,7 @@ DirectoryEntry &FileSystemCache::makeFile(DirectoryEntry &Parent,
                                           size_t Size, bool IsExecutable) {
   Directory &D = Parent.asDirectory();
   Directory::Writer W(D);
-  if (DirectoryEntry *Existing = D.lookup(sys::path::filename(TreePath)))
+  if (DirectoryEntry *Existing = D.lookup(sys::path::filename(TreePath, PathStyle)))
     return *Existing;
 
   DirectoryEntry &Entry =
@@ -250,8 +265,6 @@ Expected<DirectoryEntry *>
 FileSystemCache::lookupPath(DiscoveryInstance &DI, StringRef Path,
                             DirectoryEntry &WorkingDirectory,
                             bool FollowSymlinks) {
-  assert(Root && "Expected root filesystem to exist");
-
   struct WorklistNode {
     StringRef Remaining;
     unsigned SymlinkDepth;
@@ -266,15 +279,18 @@ FileSystemCache::lookupPath(DiscoveryInstance &DI, StringRef Path,
 
   // Start at the current working directory, unless the path is absolute.
   DirectoryEntry *Current = &WorkingDirectory;
-  if (Path.consume_front("/"))
-    Current = Root;
+  if (is_absolute(Path, PathStyle)) {
+    StringRef root_path = sys::path::root_path(Path, PathStyle);
+    Current = &getRoot(root_path);
+    Path.consume_front(root_path);
+  }
 
   pushWork(Path);
   while (!Worklist.empty()) {
     assert(Current);
     auto Work = Worklist.pop_back_val();
-    Expected<LookupPathState> Found =
-        lookupRealPathPrefixFrom(DI, LookupPathState(*Current, Work.Remaining));
+    Expected<LookupPathState> Found = lookupRealPathPrefixFrom(DI,
+        LookupPathState(PathStyle, *Current, Work.Remaining));
     if (!Found)
       return createFileError(Path, Found.takeError());
     Current = Found->Entry;
@@ -307,9 +323,11 @@ FileSystemCache::lookupPath(DiscoveryInstance &DI, StringRef Path,
       if (Error E = DI.requestSymlinkTarget(*Current))
         return createFileError(Path, std::move(E));
     StringRef Target = Current->asSymlink().getTarget();
-    if (Target.consume_front("/"))
-      Current = Root;
-    else
+    if (is_absolute(Target, PathStyle)) {
+      StringRef root_path = sys::path::root_path(Target, PathStyle);
+      Current = &getRoot(root_path);
+      Target.consume_front(root_path);
+    } else
       Current = Current->getParent();
     pushWork(Target, SymlinkDepth);
   }
@@ -419,14 +437,14 @@ vfs::directory_iterator FileSystemCache::getCachedVFSDirIter(
   SmallString<128> Storage;
   if (RequestedName.empty()) {
     RequestedName = WorkingDirectory;
-  } else if (!RequestedName.starts_with("/")) {
+  } else if (!is_absolute(RequestedName, PathStyle)) {
     Storage.append(WorkingDirectory);
-    sys::path::append(Storage, sys::path::Style::posix, RequestedName);
+    sys::path::append(Storage, PathStyle, RequestedName);
     RequestedName = Storage;
   }
-  RequestedName = RequestedName.rtrim("/");
+  RequestedName = RequestedName.rtrim(get_separator(PathStyle));
   std::shared_ptr<VFSDirIterImpl> DirIter = VFSDirIterImpl::create(
-      std::move(LookupSymlinkPath), RequestedName, Entries);
+      this, std::move(LookupSymlinkPath), RequestedName, Entries);
   return vfs::directory_iterator(std::move(DirIter));
 }
 
@@ -436,7 +454,8 @@ void FileSystemCache::VFSDirIterImpl::setEntry() {
     return;
   }
   const DirectoryEntry &Entry = **I;
-  std::string Path = (ParentPath + "/" + Entry.getName()).str();
+  std::string Path =
+      (ParentPath + get_separator(Cache->PathStyle) + Entry.getName()).str();
   if (!Entry.isSymlink()) {
     CurrentEntry = vfs::directory_entry(std::move(Path), Entry.getFileType());
     return;
@@ -461,8 +480,8 @@ std::error_code FileSystemCache::VFSDirIterImpl::increment() {
 
 std::shared_ptr<FileSystemCache::VFSDirIterImpl>
 FileSystemCache::VFSDirIterImpl::create(
-    LookupSymlinkPathType LookupSymlinkPath, StringRef ParentPath,
-    ArrayRef<const DirectoryEntry *> Entries) {
+    FileSystemCache *Cache, LookupSymlinkPathType LookupSymlinkPath,
+    StringRef ParentPath, ArrayRef<const DirectoryEntry *> Entries) {
   // Compute where to put the entry pointers and allocate.
   size_t IterSize = sizeof(VFSDirIterImpl);
   IterSize = alignTo(IterSize, alignof(DirectoryEntry *));
@@ -488,6 +507,7 @@ FileSystemCache::VFSDirIterImpl::create(
 
   // Construct the iterator, pointing at the co-allocated entries.
   return std::shared_ptr<VFSDirIterImpl>(new (IterPtr) VFSDirIterImpl(
+      Cache,
       std::move(LookupSymlinkPath),
       StringRef(HungOffParentPath, ParentPath.size()),
       ArrayRef(HungOffEntries, Entries.size())));

--- a/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
+++ b/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
@@ -19,25 +19,26 @@ using namespace llvm::cas;
 /// Critical to canonicalize components so that paths come up next to each
 /// other when sorted.
 static StringRef canonicalize(SmallVectorImpl<char> &Path,
-                              TreeEntry::EntryKind Kind) {
+                              TreeEntry::EntryKind Kind,
+                              sys::path::Style PathStyle) {
+  const char PathSeparatorChar = get_separator(PathStyle)[0];
   // Make absolute.
-  if (Path.empty() || Path.front() != '/')
-    Path.insert(Path.begin(), '/');
+  if (Path.empty() || !is_absolute(Path, PathStyle))
+    Path.insert(Path.begin(), PathSeparatorChar);
 
   // FIXME: consider rejecting ".." instead of removing them.
-  sys::path::remove_dots(Path, /*remove_dot_dot=*/true,
-                         sys::path::Style::posix);
+  sys::path::remove_dots(Path, /*remove_dot_dot=*/true, PathStyle);
 
   // Canonicalize slashes.
   bool PendingSlash = false;
   char *NewEnd = Path.begin();
   for (int I = 0, E = Path.size(); I != E; ++I) {
-    if (Path[I] == '/') {
+    if (Path[I] == PathSeparatorChar) {
       PendingSlash = true;
       continue;
     }
     if (PendingSlash)
-      *NewEnd++ = '/';
+      *NewEnd++ = PathSeparatorChar;
     PendingSlash = false;
     *NewEnd++ = Path[I];
   }
@@ -45,7 +46,7 @@ static StringRef canonicalize(SmallVectorImpl<char> &Path,
 
   // For correct sorting, all explicit trees need to end with a '/'.
   if (Path.empty() || Kind == TreeEntry::Tree)
-    Path.push_back('/');
+    Path.push_back(PathSeparatorChar);
   return StringRef(Path.begin(), Path.size());
 }
 
@@ -54,7 +55,7 @@ void HierarchicalTreeBuilder::pushImpl(std::optional<ObjectRef> Ref,
                                        const Twine &Path) {
   SmallVector<char, 256> CanonicalPath;
   Path.toVector(CanonicalPath);
-  Entries.emplace_back(Ref, Kind, canonicalize(CanonicalPath, Kind));
+  Entries.emplace_back(Ref, Kind, canonicalize(CanonicalPath, Kind, PathStyle));
 }
 
 void HierarchicalTreeBuilder::pushTreeContent(ObjectRef Ref,
@@ -62,10 +63,12 @@ void HierarchicalTreeBuilder::pushTreeContent(ObjectRef Ref,
   SmallVector<char, 256> CanonicalPath;
   Path.toVector(CanonicalPath);
   TreeEntry::EntryKind Kind = TreeEntry::Tree;
-  TreeContents.emplace_back(Ref, Kind, canonicalize(CanonicalPath, Kind));
+  TreeContents.emplace_back(Ref, Kind, canonicalize(CanonicalPath, Kind, PathStyle));
 }
 
 Expected<ObjectProxy> HierarchicalTreeBuilder::create(ObjectStore &CAS) {
+  StringRef PathSeparator = get_separator(PathStyle);
+  const char PathSeparatorChar = PathSeparator[0];
   // FIXME: It is inefficient expanding the whole tree recursively like this,
   // use a more efficient algorithm to merge contents.
   TreeSchema Schema(CAS);
@@ -150,11 +153,13 @@ Expected<ObjectProxy> HierarchicalTreeBuilder::create(ObjectStore &CAS) {
     Tree *Current = &Root;
     StringRef Path = Entry.getPath();
     {
-      bool Consumed = Path.consume_front("/");
-      (void)Consumed;
-      assert(Consumed && "Expected canonical POSIX absolute paths");
+      assert(is_absolute(Path, PathStyle) && "Expected absolute paths");
+      StringRef root_path = sys::path::root_path(Path, PathStyle);
+      assert(!root_path.empty() && "Expected canonical POSIX absolute paths");
+      Path.consume_front(root_path);
     }
-    for (auto Slash = Path.find('/'); !Path.empty(); Slash = Path.find('/')) {
+    for (auto Slash = Path.find(PathSeparatorChar); !Path.empty();
+         Slash = Path.find(PathSeparatorChar)) {
       StringRef Name;
       if (Slash == StringRef::npos) {
         Name = Path;
@@ -173,7 +178,7 @@ Expected<ObjectProxy> HierarchicalTreeBuilder::create(ObjectStore &CAS) {
 
       // Need to canonicalize first, or else the sorting trick doesn't work.
       assert(Name != "");
-      assert(Name != "/");
+      assert(Name != PathSeparator);
       assert(Name != ".");
       assert(Name != "..");
 

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -1190,6 +1190,12 @@ static DWORD nativeAccess(FileAccess Access, OpenFlags Flags) {
     Result |= DELETE;
   if (Flags & OF_UpdateAtime)
     Result |= FILE_WRITE_ATTRIBUTES;
+  // If a combination of FA_Write and OF_Append are used, the supposed
+  // intent is to enable atomic appends, which requires using
+  // FILE_APPEND_DATA without GENERIC_WRITE. Otherwise, atomicity
+  // isn't enabled.
+  if (Access == FA_Write && Flags == OF_Append)
+    Result = FILE_APPEND_DATA;
   return Result;
 }
 

--- a/llvm/unittests/CAS/ActionCacheTest.cpp
+++ b/llvm/unittests/CAS/ActionCacheTest.cpp
@@ -80,6 +80,12 @@ TEST(OnDiskActionCache, ActionCacheResultInvalid) {
   ASSERT_THAT_ERROR(CAS1->createProxy({}, "2").moveInto(ID2), Succeeded());
   ASSERT_THAT_ERROR(CAS2->createProxy({}, "1").moveInto(ID3), Succeeded());
 
+#if !defined(LLVM_ENABLE_ONDISK_CAS)
+  // The following won't work without LLVM_ENABLE_ONDISK_CAS enabled.
+  // TODO: enable LLVM_ENABLE_ONDISK_CAS on windows
+  return;
+#endif
+
   std::unique_ptr<ActionCache> Cache1 =
       cantFail(createOnDiskActionCache(Temp.path()));
   // Test put and get.

--- a/llvm/unittests/CAS/CASFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASFileSystemTest.cpp
@@ -47,12 +47,12 @@ static ObjectRef createBlobUnchecked(ObjectStore &CAS, StringRef Content) {
 }
 
 static Expected<ObjectProxy> createEmptyTree(ObjectStore &CAS) {
-  HierarchicalTreeBuilder Builder;
+  HierarchicalTreeBuilder Builder(sys::path::Style::posix);
   return Builder.create(CAS);
 }
 
 static Expected<ObjectProxy> createFlatTree(ObjectStore &CAS) {
-  HierarchicalTreeBuilder Builder;
+  HierarchicalTreeBuilder Builder(sys::path::Style::posix);
   Builder.push(createBlobUnchecked(CAS, "1"), TreeEntry::Regular, "file1");
   Builder.push(createBlobUnchecked(CAS, "1"), TreeEntry::Regular, "1");
   Builder.push(createBlobUnchecked(CAS, "2"), TreeEntry::Regular, "2");
@@ -64,7 +64,7 @@ static Expected<ObjectProxy> createNestedTree(ObjectStore &CAS) {
   ObjectRef Data2 = createBlobUnchecked(CAS, "blob2");
   ObjectRef Data3 = createBlobUnchecked(CAS, "blob3");
 
-  HierarchicalTreeBuilder Builder;
+  HierarchicalTreeBuilder Builder(sys::path::Style::posix);
   Builder.push(Data2, TreeEntry::Regular, "/d2");
   Builder.push(Data1, TreeEntry::Regular, "/t1/d1");
   Builder.push(Data3, TreeEntry::Regular, "/t3/d3");
@@ -77,7 +77,7 @@ static Expected<ObjectProxy> createNestedTree(ObjectStore &CAS) {
 static Expected<ObjectProxy> createSymlinksTree(ObjectStore &CAS) {
   auto make = [&](StringRef Bytes) { return createBlobUnchecked(CAS, Bytes); };
 
-  HierarchicalTreeBuilder Builder;
+  HierarchicalTreeBuilder Builder(sys::path::Style::posix);
   Builder.push(make("broken"), TreeEntry::Symlink, "/s0");
   Builder.push(make("b1"), TreeEntry::Symlink, "/s1");
   Builder.push(make("blob1"), TreeEntry::Regular, "/b1");
@@ -97,7 +97,7 @@ static Expected<ObjectProxy> createSymlinksTree(ObjectStore &CAS) {
 static Expected<ObjectProxy> createSymlinkLoopsTree(ObjectStore &CAS) {
   auto make = [&](StringRef Bytes) { return createBlobUnchecked(CAS, Bytes); };
 
-  HierarchicalTreeBuilder Builder;
+  HierarchicalTreeBuilder Builder(sys::path::Style::posix);
   Builder.push(make("s0"), TreeEntry::Symlink, "/s0");
   Builder.push(make("s1"), TreeEntry::Symlink, "/s2");
   Builder.push(make("s2"), TreeEntry::Symlink, "/s1");
@@ -111,7 +111,7 @@ static Expected<std::unique_ptr<vfs::FileSystem>>
 createFS(ObjectStore &CAS, Expected<ObjectProxy> Tree) {
   if (!Tree)
     return Tree.takeError();
-  return createCASFileSystem(CAS, Tree->getID());
+  return createCASFileSystem(CAS, Tree->getID(), sys::path::Style::posix);
 }
 
 template <class IteratorType>

--- a/llvm/unittests/CAS/TreeSchemaTest.cpp
+++ b/llvm/unittests/CAS/TreeSchemaTest.cpp
@@ -231,7 +231,7 @@ TEST(TreeSchemaTest, walkFileTreeRecursively) {
     return cantFail(CAS->storeFromString({}, Content));
   };
 
-  HierarchicalTreeBuilder Builder;
+  HierarchicalTreeBuilder Builder(sys::path::Style::posix);
   Builder.push(make("blob2"), TreeEntry::Regular, "/d2");
   Builder.push(make("blob1"), TreeEntry::Regular, "/t1/d1");
   Builder.push(make("blob3"), TreeEntry::Regular, "/t3/d3");

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -513,7 +513,7 @@ struct MapState {
       {"/missing/nested", "/missing/nested"},
       {"/relative/nested", "/relative/nested"},
   };
-  MapState() : PM(FS) {
+  MapState() : PM(FS, sys::path::Style::posix) {
     PM.add(MappedPrefix{"relative", "/new1"});
     PM.add(MappedPrefix{"/absolute", "/new2"});
   }


### PR DESCRIPTION
Fix the following CAS-related tests with LLVM_ENABLE_ONDISK_CAS=OFF on Windows

    Clang :: ClangScanDeps/modules-include-tree-pch-common-stale.c
    Clang :: Driver/fdepscan-prefix-map-sdk.c
    Clang :: Driver/fdepscan-prefix-map-toolchain.c
    Clang :: Driver/fdepscan-prefix-map.c
    Clang-Unit :: ./AllClangUnitTests.exe/DependencyScanningCASFilesystem/DirectiveScanFailure
    Clang-Unit :: ./AllClangUnitTests.exe/DependencyScanningCASFilesystem/FilenameSpelling
    Clang-Unit :: ./AllClangUnitTests.exe/IncludeTree/IncludeTreeFileSystemOverlay
    Clang-Unit :: ./AllClangUnitTests.exe/IncludeTree/IncludeTreeScan
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/BasicRealFSIteration
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/BasicRealFSRecursiveIteration
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/BasicRealFSRecursiveIterationNoPush
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/BrokenSymlinkRealFSIteration
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/BrokenSymlinkRealFSRecursiveIteration
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/ExcludeFromTacking
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/Exists
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/MultipleWorkingDirs
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/TrackNewAccesses
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/TrackNewAccessesExists
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/TrackNewAccessesStack
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/caseSensitivityDir
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/caseSensitivityFile
    LLVM-Unit :: CAS/./CASTests.exe/CachingOnDiskFileSystemTest/getRealPath
    LLVM-Unit :: CAS/./CASTests.exe/OnDiskCASLoggerTest/MultiProcess
    LLVM-Unit :: CAS/./CASTests.exe/OnDiskCASLoggerTest/MultiThread
    LLVM-Unit :: Support/./SupportTests.exe/OnDiskBackendTest/OnlyIfDifferent
    LLVM-Unit :: Support/./SupportTests.exe/SourceMgrTest/AddIncludedFile
    LLVM-Unit :: Support/./SupportTests.exe/TreePathPrefixMapperTest/map
    LLVM-Unit :: Support/./SupportTests.exe/TreePathPrefixMapperTest/mapInPlace
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/Keep/OnDisk
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/Keep/OnDisk_DisableRemoveOnSignal
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepEmpty/OnDisk
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepEmpty/OnDisk_DisableRemoveOnSignal
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepFlush/OnDisk
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepFlush/OnDisk_DisableRemoveOnSignal
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepFlushProxy/OnDisk
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepFlushProxy/OnDisk_DisableRemoveOnSignal
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectory/OnDisk
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectory/OnDisk_DisableRemoveOnSignal
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectory/OnDisk_DisableTemporaries
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectoryNested/OnDisk
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectoryNested/OnDisk_DisableRemoveOnSignal
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectoryNested/OnDisk_DisableTemporaries
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectoryNoImply/OnDisk
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectoryNoImply/OnDisk_DisableRemoveOnSignal
    LLVM-Unit :: Support/./SupportTests.exe/VirtualOutput/BackendTest/KeepMissingDirectoryNoImply/OnDisk_DisableTemporaries