### PR TITLE
[Coroutines] Drop size argument from lifetime.start/end.

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
@@ -139,7 +139,7 @@ define swiftcorocc { ptr, ptr } @big_types(ptr noalias %frame, ptr swiftcoro %al
     ptr nonnull @deallocate
   )
   %handle = tail call ptr @llvm.coro.begin(token %id, ptr null)
-  call void @llvm.lifetime.start.p0(i64 1, ptr nonnull %element_addr)
+  call void @llvm.lifetime.start.p0(ptr nonnull %element_addr)
   %vec_original = load <32 x i8>, ptr %vec_addr, align 32
   %vec_stk = alloca <32 x i8>, align 32
   store <32 x i8> %vec_original, ptr %vec_stk, align 32
@@ -152,7 +152,7 @@ define swiftcorocc { ptr, ptr } @big_types(ptr noalias %frame, ptr swiftcoro %al
   %vec_original_3 = load <32 x i8>, ptr %vec_stk, align 32
   %vec_modified = insertelement <32 x i8> %vec_original_3, i8 %element_modified, i32 %index32
   store <32 x i8> %vec_modified, ptr %vec_addr, align 32
-  call void @llvm.lifetime.end.p0(i64 1, ptr nonnull %element_addr)
+  call void @llvm.lifetime.end.p0(ptr nonnull %element_addr)
   call i1 @llvm.coro.end(ptr %handle, i1 false, token none)
   unreachable
 }

--- a/llvm/test/Transforms/Coroutines/coro-split-swift_coroFrameAlloc.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-swift_coroFrameAlloc.ll
@@ -8,7 +8,7 @@ entry:
   %2 = call token (i32, i32, ptr, ptr, ptr, ptr, ...) @llvm.coro.id.retcon.once(i32 32, i32 8, ptr %0, ptr @prototype, ptr @swift_coroFrameAlloc, ptr @free, i64 123)
   %3 = call ptr @llvm.coro.begin(token %2, ptr null)
   call swiftcc void @marker(i32 1000)
-  call void @llvm.lifetime.start.p0(i64 40, ptr %call.aggresult)
+  call void @llvm.lifetime.start.p0(ptr %call.aggresult)
   call swiftcc void @val(ptr noalias nocapture sret(<{ i64, i64, i64, i64, i64 }>) %call.aggresult)
   %call.aggresult.elt = getelementptr inbounds <{ i64, i64, i64, i64, i64 }>, ptr %call.aggresult, i32 0, i32 0
   %4 = load i64, ptr %call.aggresult.elt, align 8
@@ -20,7 +20,7 @@ entry:
   %7 = load i64, ptr %call.aggresult.elt3, align 8
   %call.aggresult.elt4 = getelementptr inbounds <{ i64, i64, i64, i64, i64 }>, ptr %call.aggresult, i32 0, i32 4
   %8 = load i64, ptr %call.aggresult.elt4, align 8
-  call void @llvm.lifetime.end.p0(i64 40, ptr %call.aggresult)
+  call void @llvm.lifetime.end.p0(ptr %call.aggresult)
   %9 = call i1 (...) @llvm.coro.suspend.retcon.i1()
   br i1 %9, label %11, label %10
 


### PR DESCRIPTION
The size argument has been removed.