### PR TITLE
[Cherry-pick into next] [lldb] Delete copy constructor to avoid accidentally holding a lock (NFC)

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LockGuarded.h
@@ -23,6 +23,8 @@ template <typename Resource> struct LockGuarded {
       : m_resource(resource), m_lock(mutex, std::adopt_lock) {}
 
   LockGuarded() = default;
+  LockGuarded(const LockGuarded &) = delete;
+  LockGuarded &operator=(const LockGuarded &) = delete;
 
   Resource *operator->() const { return m_resource; }
 


### PR DESCRIPTION
```
commit 5cafdf6f2375dadfda6a9a344f7204fb73041861
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Aug 6 12:46:37 2025 -0700

    [lldb] Delete copy constructor to avoid accidentally holding a lock (NFC)
```
