### PR TITLE
[-Wunsafe-buffer-usage] Add basic support for C++ default args

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -687,6 +687,11 @@ struct CompatibleCountExprVisitor
     }
     return false;
   }
+
+  bool VisitCXXDefaultArgExpr(const CXXDefaultArgExpr *SelfDAE,
+                              const Expr *Other, bool hasBeenSubstituted) {
+    return Visit(SelfDAE->getExpr(), Other, hasBeenSubstituted);
+  }
 };
 
 // TL'DR:
@@ -931,7 +936,10 @@ static bool isCountAttributedPointerArgumentSafeImpl(
   assert((CountedByExpr || !DependentValueMap) &&
          "If the __counted_by information is hardcoded, there is no "
          "dependent value map.");
+
   const Expr *PtrArgNoImp = PtrArg->IgnoreParenImpCasts();
+  if (const auto *DAE = dyn_cast<CXXDefaultArgExpr>(PtrArgNoImp))
+    PtrArgNoImp = DAE->getExpr()->IgnoreParenImpCasts();
 
   // check form 0:
   if (PtrArgNoImp->getType()->isNullPtrType()) {

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2590,8 +2590,9 @@ public:
         IsSimpleCount ? CATy->dependent_decls().begin()->getDecl()->getName()
                       : "";
 
-    S.Diag(Arg->getBeginLoc(),
-           diag::warn_unsafe_count_attributed_pointer_argument);
+    SourceLocation DiagLoc =
+        Arg->isDefaultArgument() ? Call->getRParenLoc() : Arg->getBeginLoc();
+    S.Diag(DiagLoc, diag::warn_unsafe_count_attributed_pointer_argument);
     S.Diag(PVD->getBeginLoc(),
            diag::note_unsafe_count_attributed_pointer_argument)
         << IsSimpleCount << QualType(CATy, 0) << !PtrParamName.empty()


### PR DESCRIPTION
This commit changes two things:
- Allows the count-attributed pointer analysis see through `CXXDefaultArgExpr` for both pointer and count arguments.
- Fixes the diagnostic location. Since `CXXDefaultArgExpr` has no source representation, we emit the diagnostic at the right parenthesis of the call expression.

rdar://156005108