### PR TITLE
🍒[NFC][libclang][Dependency Scanning] Document Link Library Related C-…

### DIFF
--- a/clang/include/clang-c/Dependencies.h
+++ b/clang/include/clang-c/Dependencies.h
@@ -750,7 +750,8 @@ typedef struct CXOpaqueDepGraphModuleLinkLibrary *CXDepGraphModuleLinkLibrary;
 /**
  * Get the set of link libraries given a \c CXDepGraphModule instance.
  * The returned set is a pointer into memory that the \c CXDepGraphModule
- * instance owns. Therefore the set does not need to be disposed.
+ * instance owns. Therefore the set does not need to be disposed, and it has
+ * the same lifetime as the \c CXDepGraphModule instance.
  */
 CINDEX_LINKAGE CXDepGraphModuleLinkLibrarySet
     clang_experimental_DepGraphModule_getLinkLibrarySet(CXDepGraphModule);
@@ -763,7 +764,10 @@ CINDEX_LINKAGE size_t clang_experimental_DepGraphModuleLinkLibrarySet_getSize(
 
 /**
  * Retrieve the \c CXDepGraphModuleLinkLibrary instance at index \p Idx from the
- * \c CXDepGraphModuleLinkLibrarySet instance.
+ * \c CXDepGraphModuleLinkLibrarySet instance. The returned object is owned
+ * by the \c CXDepGraphModule instance where the
+ * \c CXDepGraphModuleLinkLibrarySet was retrieved from, and has the same
+ * lifetime as the \c CXDepGraphModule instance.
  */
 CINDEX_LINKAGE CXDepGraphModuleLinkLibrary
 clang_experimental_DepGraphModuleLinkLibrarySet_getLinkLibrary(
@@ -773,7 +777,9 @@ clang_experimental_DepGraphModuleLinkLibrarySet_getLinkLibrary(
  * Get the `Library` string from the \c CXDepGraphModuleLinkLibrary instance.
  * `Library` could be a library name, or an absolute path to a library or a
  * framework, as specified in the corresponding \c CXDepGraphModule instance's
- * modulemap.
+ * modulemap. The returned \c CXString is a reference to a string owned
+ * by the \c CXDepGraphModule instance, and has the same lifetime as the
+ * the \c CXDepGraphModule instance.
  */
 CINDEX_LINKAGE CXString clang_experimental_DepGraphModuleLinkLibrary_getLibrary(
     CXDepGraphModuleLinkLibrary);


### PR DESCRIPTION
…APIs' Return Values' Lifetimes #11009

https://github.com/swiftlang/llvm-project/pull/10994 added C-APIs to query link library information from dependency scanning results. This PR adds documentation on the return values' lifetimes. (cherry picked from commit f539fb518d2d42f27819c6a9dc05a14fcbfdc964)