### PR TITLE
🍒 [lldb] Skip prologue when stepping through swift_task_switch

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2924,31 +2924,15 @@ std::optional<lldb::addr_t> SwiftLanguageRuntime::TrySkipVirtualParentProlog(
   addr_t pc_value = process.ReadPointerFromMemory(pc_location, error);
   if (error.Fail())
     return {};
-  // Clear any high order bits of this code address so that SetLoadAddress works
-  // properly.
-  pc_value = process.FixCodeAddress(pc_value);
 
-  Address pc;
-  Target &target = process.GetTarget();
-  pc.SetLoadAddress(pc_value, &target);
-  if (!pc.IsValid())
-    return {};
+  llvm::Expected<uint64_t> maybe_prologue_size =
+      FindPrologueSize(process, pc_value);
+  if (maybe_prologue_size)
+    return pc_value + *maybe_prologue_size;
 
-  SymbolContext sc;
-  bool sc_ok = pc.CalculateSymbolContext(&sc, eSymbolContextFunction |
-                                                  eSymbolContextSymbol);
-  if (!sc_ok || (!sc.symbol && !sc.function)) {
-    Log *log = GetLog(LLDBLog::Unwind);
-    LLDB_LOGF(log,
-              "SwiftLanguageRuntime::%s Failed to find a symbol context for "
-              "address 0x%" PRIx64,
-              __FUNCTION__, pc_value);
-    return {};
-  }
-
-  auto prologue_size = sc.symbol ? sc.symbol->GetPrologueByteSize()
-                                 : sc.function->GetPrologueByteSize();
-  return pc_value + prologue_size;
+  LLDB_LOG_ERROR(GetLog(LLDBLog::Unwind), maybe_prologue_size.takeError(),
+                 "{1}::{0}", __FUNCTION__);
+  return pc_value;
 }
 
 /// Attempts to read the memory location at `task_addr_location`, producing
@@ -3139,4 +3123,30 @@ llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task_addr,
   return status.takeError();
 }
 
+llvm::Expected<uint64_t> FindPrologueSize(Process &process,
+                                          uint64_t load_address) {
+  Address addr;
+  Target &target = process.GetTarget();
+  addr.SetLoadAddress(process.FixCodeAddress(load_address), &target);
+  if (!addr.IsValid())
+    return llvm::createStringError(
+        llvm::formatv("Invalid load address for {0:x}", load_address));
+
+  SymbolContext sc;
+  bool sc_ok = addr.CalculateSymbolContext(&sc, eSymbolContextFunction |
+                                                    eSymbolContextSymbol);
+  if (!sc_ok || (!sc.symbol && !sc.function))
+    return llvm::createStringError(llvm::formatv(
+        "Failed to find a symbol context for address {1:x}", load_address));
+
+  uint64_t prologue_size = sc.symbol ? sc.symbol->GetPrologueByteSize()
+                                     : sc.function->GetPrologueByteSize();
+
+  if (prologue_size == 0)
+    return llvm::createStringError(llvm::formatv(
+        "Prologue size is 0 for function {0}",
+        sc.GetFunctionName(Mangled::NamePreference::ePreferMangled)));
+
+  return prologue_size;
+}
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -944,6 +944,10 @@ private:
 llvm::Expected<std::optional<std::string>> GetTaskName(lldb::addr_t task,
                                                        Process &process);
 
+/// Finds the function for which `load_address` belongs, and returns its
+/// prologue size.
+llvm::Expected<uint64_t> FindPrologueSize(Process &process,
+                                          uint64_t load_address);
 } // namespace lldb_private
 
 #endif // liblldb_SwiftLanguageRuntime_h_

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -7,6 +7,11 @@ import lldbsuite.test.lldbutil as lldbutil
 @skipIfAsan  # rdar://138777205
 class TestCase(lldbtest.TestBase):
 
+    def check_x_is_available(self, frame):
+        x_var = frame.FindVariable("x")
+        self.assertTrue(x_var.IsValid(), f"Failed to find x in {frame}")
+        self.assertEqual(x_var.GetValueAsUnsigned(), 30)
+
     def check_is_in_line(self, thread, linenum):
         frame = thread.frames[0]
         line_entry = frame.GetLineEntry()
@@ -25,10 +30,11 @@ class TestCase(lldbtest.TestBase):
         bkpt.SetEnabled(False) # avoid hitting multiple locations in async breakpoints
 
         expected_line_nums = [4]  # print(x)
-        expected_line_nums += [5, 6, 7, 5, 6, 7, 5]  # two runs over the loop
-        expected_line_nums += [8, 9]  # if line + if block
+        expected_line_nums += [5, 6, 7, 8, 5, 6, 7, 8, 5]  # two runs over the loop
+        expected_line_nums += [9, 10]  # if line + if block
         for expected_line_num in expected_line_nums:
             thread.StepOver()
             stop_reason = thread.GetStopReason()
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.check_is_in_line(thread, expected_line_num)
+            self.check_x_is_available(thread.frames[0])

--- a/lldb/test/API/lang/swift/async/stepping/step_over/main.swift
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/main.swift
@@ -4,6 +4,7 @@
     print(x)
     for i in 1...2 {
       await f()
+      print("hello!")
     }
     if (await f() == 30) {
       print("here!")


### PR DESCRIPTION
The first commit just factors out a helper function to be reused by the second commit.
We should find a place for that function in an upstream file later.

Plans stepping through a swift_task_switch are often the last sub-plan
for a StepOver action, meaning the plan's destination is also the PC
where users will take control of the program. As such, it is crucial
that these plans skip over the prologue of their destination function,
otherwise most variables won't be in scope.

rdar://149391650