### PR TITLE
[lldb] Fix TestSwiftSubstringFormatters

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -43,7 +43,7 @@ class TestCase(TestBase):
         subalphabets = [alphabet[i:] for i in range(27)]
 
         self.expect(
-            "v substrings",
+            "v -A -- substrings",
             substrs=[
                 f'[{i}] = "{substring}"'
                 for i, substring in enumerate(subalphabets)


### PR DESCRIPTION
Something changed upstream with the default number of children being shown.