### PR TITLE
[lldb] Update for extension binding cleanup

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftASTManipulator.cpp
@@ -848,11 +848,15 @@ GetPatternBindingForVarDecl(swift::VarDecl *var_decl,
 
   // Since lldb does not call bindExtensions, must ensure that any enclosing
   // extension is bound
+  // FIXME: This won't correctly handle cases that rely on other extensions
+  // being bound first, e.g for nested types defined in extensions.
   for (auto *context = containing_context; context;
        context = context->getParent()) {
     if (auto *d = context->getAsDecl()) {
-      if (auto *ext = swift::dyn_cast<swift::ExtensionDecl>(d))
-        ext->computeExtendedNominal();
+      if (auto *ext = swift::dyn_cast<swift::ExtensionDecl>(d)) {
+        if (!ext->hasBeenBound())
+          ext->setExtendedNominal(ext->computeExtendedNominal());
+      }
     }
   }
   swift::Type type = containing_context->mapTypeIntoContext(


### PR DESCRIPTION
`computeExtendedNominal` no longer caches its result, it's meant to be used by extension binding itself. We ought to migrate LLDB off it, but for now update to set the result.