### PR TITLE
[lldb][test] Re-enable reference storage types

### DIFF
--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -22,7 +22,6 @@ import os
 class TestSwiftReferenceStorageTypes(TestBase):
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
-    @skipIf(oslist=["linux"], bugnumber="rdar://76592966")
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()


### PR DESCRIPTION
Re-enable `SwiftStorageReferenceTypes` 

I tested it on linux-x86_64, did not experience any crash. 

