### PR TITLE
Fix the following CAS-related tests with LLVM_ENABLE_ONDISK_CAS=ON on Windows

### DIFF
--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -48,7 +48,6 @@ using AsyncCASIDValue = AsyncValue<CASID>;
 struct AsyncErrorValue {
   Error take() { return std::move(Value); }
 
-  AsyncErrorValue() : Value(Error::success()) {}
   AsyncErrorValue(Error &&E) : Value(std::move(E)) {}
 
 private:

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -131,7 +131,6 @@ private:
 template <typename T> struct AsyncValue {
   Expected<std::optional<T>> take() { return std::move(Value); }
 
-  AsyncValue() : Value(std::nullopt) {}
   AsyncValue(Error &&E) : Value(std::move(E)) {}
   AsyncValue(T &&V) : Value(std::move(V)) {}
   AsyncValue(std::nullopt_t) : Value(std::nullopt) {}

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -410,6 +410,11 @@ LLVM_ABI std::error_code copy_file(const Twine &From, int ToFD);
 ///          platform-specific error_code.
 LLVM_ABI std::error_code resize_file(int FD, uint64_t Size);
 
+/// Resize path to size with sparse files explicitly enabled. It uses
+/// FSCTL_SET_SPARSE On Windows. This is the same as resize_file on
+/// non-Windows
+LLVM_ABI std::error_code resize_file_sparse(int FD, uint64_t Size);
+
 /// Resize \p FD to \p Size before mapping \a mapped_file_region::readwrite. On
 /// non-Windows, this calls \a resize_file(). On Windows, this is a no-op,
 /// since the subsequent mapping (via \c CreateFileMapping) automatically

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -600,6 +600,10 @@ std::error_code resize_file(int FD, uint64_t Size) {
   return std::error_code();
 }
 
+std::error_code resize_file_sparse(int FD, uint64_t Size) {
+  return resize_file(FD, Size);
+}
+
 static int convertAccessMode(AccessMode Mode) {
   switch (Mode) {
   case AccessMode::Exist:

--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -27,6 +27,7 @@
 #include "llvm/Support/Windows/WindowsSupport.h"
 #include <shellapi.h>
 #include <shlobj.h>
+#include <winioctl.h>
 
 #undef max
 
@@ -621,6 +622,22 @@ std::error_code resize_file(int FD, uint64_t Size) {
   errno_t error = ::_chsize(FD, Size);
 #endif
   return std::error_code(error, std::generic_category());
+}
+
+std::error_code resize_file_sparse(int FD, uint64_t Size) {
+  HANDLE hFile = reinterpret_cast<HANDLE>(::_get_osfhandle(FD));
+  DWORD temp;
+  if (!DeviceIoControl(hFile, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &temp,
+                       NULL)) {
+    return mapWindowsError(GetLastError());
+  }
+  LARGE_INTEGER liSize;
+  liSize.QuadPart = Size;
+  if (!SetFilePointerEx(hFile, liSize, NULL, FILE_BEGIN) ||
+      !SetEndOfFile(hFile)) {
+    return mapWindowsError(GetLastError());
+  }
+  return std::error_code();
 }
 
 std::error_code access(const Twine &Path, AccessMode Mode) {

--- a/llvm/unittests/CAS/CASConfigurationTest.cpp
+++ b/llvm/unittests/CAS/CASConfigurationTest.cpp
@@ -43,21 +43,46 @@ TEST(CASConfigurationTest, roundTrips) {
 }
 
 TEST(CASConfigurationTest, configFileSearch) {
+  // /a/b/c
+  SmallString<261> PathToC = sys::path::get_separator();
+  sys::path::append(PathToC, "a", "b", "c");
+  // /a/b/c/d
+  SmallString<261> PathToD = PathToC;
+  sys::path::append(PathToD, "d");
+  // /a/b/c/d/e
+  SmallString<261> PathToE = PathToD;
+  sys::path::append(PathToE, "e");
+  // /a/b/c/.cas-config
+  SmallString<261> PathToCConfig = PathToC;
+  sys::path::append(PathToCConfig, ".cas-config");
+  // /a/b/c/d/.cas-config
+  SmallString<261> PathToDConfig = PathToD;
+  sys::path::append(PathToDConfig, ".cas-config");
+
   auto VFS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
-  ASSERT_FALSE(CASConfiguration::createFromSearchConfigFile("/a/b/c/d/e", VFS));
+  ASSERT_FALSE(
+      CASConfiguration::createFromSearchConfigFile(PathToE.str(), VFS));
 
   // Add an empty file.
-  VFS->addFile("/a/b/c/.cas-config", 0,
+  VFS->addFile(PathToCConfig.str(), 0,
                llvm::MemoryBuffer::getMemBufferCopy(""));
-  ASSERT_FALSE(CASConfiguration::createFromSearchConfigFile("/a/b/c/d/e", VFS));
+  ASSERT_FALSE(
+      CASConfiguration::createFromSearchConfigFile(PathToE.str(), VFS));
 
-  VFS->addFile("/a/b/c/d/.cas-config", 0,
-               llvm::MemoryBuffer::getMemBufferCopy("{\"CASPath\": \"/tmp\"}"));
+  VFS->addFile(PathToDConfig.str(), 0,
+#ifndef _WIN32
+      llvm::MemoryBuffer::getMemBufferCopy("{\"CASPath\": \"/tmp\"}"));  
+#else
+      llvm::MemoryBuffer::getMemBufferCopy("{\"CASPath\": \"\\\\tmp\"}"));
+#endif
+
   CASConfiguration Config;
-  Config.CASPath = "/tmp";
+  SmallString<261> CASPath = sys::path::get_separator();
+  sys::path::append(CASPath, "tmp");
+  Config.CASPath = CASPath.str();
   auto NewConfig =
-      CASConfiguration::createFromSearchConfigFile("/a/b/c/d/e", VFS);
+      CASConfiguration::createFromSearchConfigFile(PathToE.str(), VFS);
   ASSERT_TRUE(NewConfig);
-  ASSERT_TRUE(NewConfig->first == "/a/b/c/d/.cas-config");
+  ASSERT_TRUE(NewConfig->first == PathToDConfig.str());
   ASSERT_TRUE(Config == NewConfig->second);
 }

--- a/llvm/unittests/CAS/ObjectStoreTest.cpp
+++ b/llvm/unittests/CAS/ObjectStoreTest.cpp
@@ -347,6 +347,7 @@ TEST_P(CASTest, BlobsBigParallel) {
 }
 
 #if LLVM_ENABLE_ONDISK_CAS
+#ifndef _WIN32 // create_link won't work for directories on Windows
 TEST(OnDiskCASTest, BlobsParallelMultiCAS) {
   // This test intentionally uses symlinked paths to the same CAS to subvert the
   // shared memory mappings that would normally be created within a single
@@ -402,8 +403,8 @@ TEST(OnDiskCASTest, BlobsBigParallelMultiCAS) {
   uint64_t Size = 100ULL * 1024;
   ASSERT_NO_FATAL_FAILURE(testBlobsParallel(*CAS1, *CAS2, *CAS3, *CAS4, Size));
 }
+#endif // _WIN32
 
-#ifndef _WIN32 // FIXME: resize support on Windows.
 TEST(OnDiskCASTest, DiskSize) {
   setMaxOnDiskCASMappingSize();
   unittest::TempDir Temp("on-disk-cas", /*Unique=*/true);
@@ -451,7 +452,6 @@ TEST(OnDiskCASTest, DiskSize) {
   CAS.reset();
   CheckFileSizes(/*Mapped=*/false);
 }
-#endif // _WIN32
 #endif // LLVM_ENABLE_ONDISK_CAS
 #endif // LLVM_ENABLE_THREADS
 

--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -159,7 +159,12 @@ TEST(OnDiskCASLoggerTest, MultiProcess) {
   SmallVector<ProcessInfo> PIs;
   for (int I = 0; I < 5; ++I) {
     bool ExecutionFailed;
+ #ifndef _WIN32
     auto PI = ExecuteNoWait(Executable, Argv, ArrayRef<StringRef>{}, {}, 0, &Error,
+ #else
+    // CreateProcessW will fail with zero-length env on Windows
+    auto PI = ExecuteNoWait(Executable, Argv, std::nullopt, {}, 0, &Error,
+ #endif
                             &ExecutionFailed);
     ASSERT_FALSE(ExecutionFailed) << Error;
     PIs.push_back(std::move(PI));

--- a/llvm/unittests/CAS/PluginCASTest.cpp
+++ b/llvm/unittests/CAS/PluginCASTest.cpp
@@ -30,8 +30,13 @@ static std::string getCASPluginPath() {
       sys::fs::getMainExecutable(TestMainArgv0, &TestStringArg1);
   llvm::SmallString<256> PathBuf(sys::path::parent_path(
       sys::path::parent_path(sys::path::parent_path(Executable))));
+#ifndef _WIN32
   std::string LibName = "libCASPluginTest";
   sys::path::append(PathBuf, "lib", LibName + LLVM_PLUGIN_EXT);
+#else
+  std::string LibName = "CASPluginTest";
+  sys::path::append(PathBuf, "bin", LibName + LLVM_PLUGIN_EXT);
+#endif
   return std::string(PathBuf);
 }
 


### PR DESCRIPTION
Fix the following CAS-related tests with LLVM_ENABLE_ONDISK_CAS=ON on Windows

Clang :: ClangScanDeps/include-tree-multiple-commands.c
Clang :: ClangScanDeps/include-tree-pragma-system-header.c
Clang :: ClangScanDeps/include-tree-preserve-pch-path.c
Clang :: ClangScanDeps/modules-include-tree-api-notes.c
Clang :: ClangScanDeps/modules-include-tree-by-mod-name.c
Clang :: ClangScanDeps/modules-include-tree-dependency-file.c
Clang :: ClangScanDeps/modules-include-tree-diag-opts.c
Clang :: ClangScanDeps/modules-include-tree-export-as.c
Clang :: ClangScanDeps/modules-include-tree-exports.c
Clang :: ClangScanDeps/modules-include-tree-has-include-umbrella-header.c
Clang :: ClangScanDeps/modules-include-tree-implementation-private.c
Clang :: ClangScanDeps/modules-include-tree-implementation-transitive.c
Clang :: ClangScanDeps/modules-include-tree-implementation-via-spurious.c
Clang :: ClangScanDeps/modules-include-tree-pch-common-stale.c
Clang :: ClangScanDeps/modules-include-tree-sdk-settings.c
Clang :: ClangScanDeps/modules-include-tree-vfsoverlay.c
Clang :: ClangScanDeps/optimize-vfs-pch-tree.m
Clang-Unit :: ./AllClangUnitTests.exe/8/48 DependencyScanningCASFilesystem.FilenameSpelling
Clang-Unit :: ./AllClangUnitTests.exe/9/48 DependencyScanningCASFilesystem.DirectiveScanFailure
LLVM-Unit :: CAS/./CASTests.exe/19/38 InMemoryCAS/CASTest.ActionCacheAsync
LLVM-Unit :: CAS/./CASTests.exe/30/38 OnDiskCAS/CASTest.ActionCacheAsync
LLVM-Unit :: CAS/./CASTests.exe/CASConfigurationTest/configFileSearch
LLVM-Unit :: CAS/./CASTests.exe/OnDiskCASLoggerTest/MultiProcess
LLVM-Unit :: CAS/./CASTests.exe/OnDiskCASTest/BlobsBigParallelMultiCAS
LLVM-Unit :: CAS/./CASTests.exe/OnDiskCASTest/BlobsParallelMultiCAS
LLVM-Unit :: CAS/./CASTests.exe/PluginCASTest/isMaterialized