### PR TITLE
[lldb][test] enable reference storage types on linux.

### DIFF
--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -22,7 +22,6 @@ import os
 class TestSwiftReferenceStorageTypes(TestBase):
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
-    @skipIf(oslist=["linux"], bugnumber="rdar://76592966")
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()


### PR DESCRIPTION
(cherry picked from commit 97d099807fa1285491f0456bd8bf679f6471d9c2)