### PR TITLE
[next] Temporarily workaround the cycle after CAS upstreaming

### DIFF
--- a/llvm/include/module.modulemap
+++ b/llvm/include/module.modulemap
@@ -111,6 +111,7 @@ module LLVM_CAS {
   requires cplusplus
   umbrella "llvm/CAS"
   module * { export * }
+  textual header "llvm/CAS/CASReference.h"
 }
 
 module LLVM_Config {


### PR DESCRIPTION
Make CASReference.h textual to workaround the current moduel cycle between LLVM_Utils and LLVM_CAS.