### PR TITLE
[lldb] Fix mangled name being overwritten on type with DW_AT_specific…

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -103,7 +103,12 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
           break;
         case llvm::dwarf::DW_AT_linkage_name:
         case llvm::dwarf::DW_AT_MIPS_linkage_name: {
-          mangled_name.SetCString(form_value.AsCString());
+          // This could be a type with DW_AT_specification, in which case,
+          // don't overwrite the mangled name if it's already set (the 
+          // order of the attributes is deterministic, and the "specifier" 
+          // attributes will always come before the specified).
+          if (mangled_name.IsEmpty())
+            mangled_name.SetCString(form_value.AsCString());
           auto HasSpecificationOf = [&](){
             if (has_specification_of)
               return true;


### PR DESCRIPTION
…ation

The order of the attributes wasn't deterministic, and it just happened that the DW_AT_linkage_name of the specifier type used to always come last. Now the algorithm for parsing attributes has changed and made deterministic, and the current algorithm will parse the attributes of the specifier TAG first, and specified last.

Make sure to not overwrite the mangled name of a specified type.

rdar://158634690