### PR TITLE
🍒 [lldb] make lit use the same PYTHONHOME for building and running the API tests

### DIFF
--- a/lldb/test/API/lit.cfg.py
+++ b/lldb/test/API/lit.cfg.py
@@ -371,6 +371,7 @@ if "XDG_CACHE_HOME" in os.environ:
 # Some steps required to initialize the tests dynamically link with python.dll
 # and need to know the location of the Python libraries. This ensures that we
 # use the same version of Python that was used to build lldb to run our tests.
+config.environment["PYTHONHOME"] = config.python_root_dir
 config.environment["PATH"] = os.path.pathsep.join(
     (config.python_root_dir, config.environment.get("PATH", ""))
 )


### PR DESCRIPTION
This patch is needed to test and merge https://github.com/swiftlang/swift/pull/83615.

The original PR upstream is:
- https://github.com/llvm/llvm-project/pull/154396/