### PR TITLE
Fix the following CAS-related tests on Windows

### DIFF
--- a/clang/test/ClangScanDeps/include-tree.c
+++ b/clang/test/ClangScanDeps/include-tree.c
@@ -12,21 +12,21 @@
 // Make sure order is as expected.
 // RUN: FileCheck %s -input-file %t/result1.txt -DPREFIX=%/t -check-prefix ORDER
 
-// ORDER:      {{.*}} - [[PREFIX]]/t.c
-// ORDER-NEXT: [[PREFIX]]/t.c
+// ORDER:      {{.*}} - [[PREFIX]]{{[/\\]}}t.c
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}t.c
 // ORDER-NEXT: 1:1 <built-in>
-// ORDER-NEXT:   [[PREFIX]]/top.h
-// ORDER-NEXT:     [[PREFIX]]/n1.h
-// ORDER-NEXT:       [[PREFIX]]/n2.h
-// ORDER-NEXT:     [[PREFIX]]/n3.h
-// ORDER-NEXT: [[PREFIX]]/n3.h
-// ORDER-NEXT: [[PREFIX]]/n2.h
+// ORDER-NEXT:   [[PREFIX]]{{[/\\]}}top.h
+// ORDER-NEXT:     [[PREFIX]]{{[/\\]}}n1.h
+// ORDER-NEXT:       [[PREFIX]]{{[/\\]}}n2.h
+// ORDER-NEXT:     [[PREFIX]]{{[/\\]}}n3.h
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}n3.h
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}n2.h
 // ORDER-NEXT: Files:
-// ORDER-NEXT: [[PREFIX]]/t.c
-// ORDER-NEXT: [[PREFIX]]/top.h
-// ORDER-NEXT: [[PREFIX]]/n1.h
-// ORDER-NEXT: [[PREFIX]]/n2.h
-// ORDER-NEXT: [[PREFIX]]/n3.h
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}t.c
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}top.h
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}n1.h
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}n2.h
+// ORDER-NEXT: [[PREFIX]]{{[/\\]}}n3.h
 // ORDER-NOT: [[PREFIX]]
 
 // Full dependency output
@@ -40,7 +40,7 @@
 
 // Capture the tree id from experimental-include-tree ; ensure that it matches
 // the result from experimental-full.
-// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]{{[/\\]}}t.c
 // FULL: FULL DEPS START
 
 // FULL-NEXT: {
@@ -67,7 +67,7 @@
 // FULL-NEXT:             "t.c"
 // FULL-NOT:              "t.c"
 // FULL:                ]
-// FULL:                "executable": "[[CLANG]]"
+// FULL:                "{{.*[\\/]clang(\.exe)?}}",
 // FULL:                "file-deps": [
 // FULL-NEXT:             "[[PREFIX]]/t.c"
 // FULL-NEXT:             "[[PREFIX]]/top.h"
@@ -110,16 +110,16 @@
 //--- t.c
 
 #include "top.h" // this is top
-// CHECK: [[@LINE]]:1 [[PREFIX]]/top.h
+// CHECK: [[@LINE]]:1 [[PREFIX]]{{[/\\]}}top.h
 
 // Skipped because of macro guard.
 #include "n1.h"
 
 #include "n3.h"
-// CHECK-DAG: [[@LINE]]:1 [[PREFIX]]/n3.h
+// CHECK-DAG: [[@LINE]]:1 [[PREFIX]]{{[/\\]}}n3.h
 
 #include "n2.h"
-// CHECK-DAG: [[@LINE]]:1 [[PREFIX]]/n2.h
+// CHECK-DAG: [[@LINE]]:1 [[PREFIX]]{{[/\\]}}n2.h
 
 //--- top.h
 #ifndef _TOP_H_
@@ -131,10 +131,10 @@ typedef int MyT;
 
 #define WHATEVER 1
 #include "n1.h"
-// CHECK-DAG:   [[@LINE]]:1 [[PREFIX]]/n1.h
+// CHECK-DAG:   [[@LINE]]:1 [[PREFIX]]{{[/\\]}}n1.h
 
 #include "n3.h"
-// CHECK-DAG:   [[@LINE]]:1 [[PREFIX]]/n3.h
+// CHECK-DAG:   [[@LINE]]:1 [[PREFIX]]{{[/\\]}}n3.h
 
 #define ANOTHER 2
 
@@ -149,7 +149,7 @@ struct S {
 
 int x1;
 #include "n2.h"
-// CHECK-DAG:     [[@LINE]]:1 [[PREFIX]]/n2.h
+// CHECK-DAG:     [[@LINE]]:1 [[PREFIX]]{{[/\\]}}n2.h
 
 int x2;
 

--- a/clang/test/ClangScanDeps/modules-cas-context-hash.c
+++ b/clang/test/ClangScanDeps/modules-cas-context-hash.c
@@ -12,7 +12,7 @@
 // RUN:   -cas-path %t/cas2 -format experimental-include-tree-full \
 // RUN:   >> %t/result.json
 
-// RUN: cat %t/result.json | FileCheck %s -DPREFIX=%/t
+// RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t
 
 // CHECK: "modules": [
 // CHECK:   {

--- a/clang/test/ClangScanDeps/modules-include-tree-implementation.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-implementation.c
@@ -17,7 +17,7 @@
 // RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid | FileCheck %s -DPREFIX=%/t
 // RUN: %clang @%t/tu.rsp
 
-// CHECK: [[PREFIX]]/tu.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK: [[PREFIX]]{{[/\\]}}tu.c llvmcas://{{[[:xdigit:]]+}}
 // CHECK: 1:1 <built-in> llvmcas://{{[[:xdigit:]]+}}
 
 // Note: this is surprising, but correct: when building the implementation files
@@ -25,14 +25,14 @@
 // machinery. The second include is treated as a module import (unless in a PCH)
 // but will not actually import the module only trigger visibility changes.
 
-// CHECK: 2:1 [[PREFIX]]/Mod.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK: 2:1 [[PREFIX]]{{[/\\]}}Mod.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK:   Submodule: Mod
 // CHECK: 3:1 (Module for visibility only) Mod
 
 // CHECK: Files:
-// CHECK: [[PREFIX]]/tu.c llvmcas://{{[[:xdigit:]]+}}
+// CHECK: [[PREFIX]]{{[/\\]}}tu.c llvmcas://{{[[:xdigit:]]+}}
 // CHECK-NOT: [[PREFIX]]/module.modulemap
-// CHECK: [[PREFIX]]/Mod.h llvmcas://{{[[:xdigit:]]+}}
+// CHECK: [[PREFIX]]{{[/\\]}}Mod.h llvmcas://{{[[:xdigit:]]+}}
 // CHECK-NOT: [[PREFIX]]/module.modulemap
 
 // RUN: %deps-to-rsp %t/deps.json --tu-index 1 > %t/tu_missing_module.rsp

--- a/clang/test/ClangScanDeps/modules-include-tree-inferred.m
+++ b/clang/test/ClangScanDeps/modules-include-tree-inferred.m
@@ -18,15 +18,15 @@
 
 // CHECK: <module-includes> llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
-// CHECK: 2:1 [[PREFIX]]/Mod.framework/Headers/Mod.h llvmcas://
+// CHECK: 2:1 [[PREFIX]]{{[/\\]}}Mod.framework{{[/\\]}}Headers{{[/\\]}}Mod.h llvmcas://
 // CHECK:   Submodule: Mod
 // CHECK: Module Map:
 // CHECK: Mod (framework)
 // CHECK:   link Mod (framework)
 // CHECK: Files:
-// CHECK-NOT: [[PREFIX]]/module.modulemap
-// CHECK: [[PREFIX]]/Mod.framework/Headers/Mod.h llvmcas://
-// CHECK-NOT: [[PREFIX]]/module.modulemap
+// CHECK-NOT: [[PREFIX]]{{[/\\]}}module.modulemap
+// CHECK: [[PREFIX]]{{[/\\]}}Mod.framework{{[/\\]}}Headers{{[/\\]}}Mod.h llvmcas://
+// CHECK-NOT: [[PREFIX]]{{[/\\]}}module.modulemap
 
 //--- cdb.json.template
 [{

--- a/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-missing-submodule.c
@@ -37,7 +37,7 @@
 // CHECK-LABEL: MODULE Foo
 // CHECK: <module-includes> llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
-// CHECK: 2:1 [[PREFIX]]/Foo.framework/Headers/Foo.h llvmcas://
+// CHECK: 2:1 [[PREFIX]]{{[/\\]}}Foo.framework{{[/\\]}}Headers{{[/\\]}}Foo.h llvmcas://
 // CHECK:   Submodule: Foo
 // CHECK-NOT: Bar
 // CHECK: Module Map:
@@ -50,7 +50,7 @@
 // CHECK: (PCH) <PCH> llvmcas://
 // CHECK: [[PREFIX]]/tu.c llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
-// CHECK: 2:1 (Spurious import) (Module) Foo.Bar [[PREFIX]]/Foo.framework/Headers/Bar.h llvmcas://
+// CHECK: 2:1 (Spurious import) (Module) Foo.Bar [[PREFIX]]{{[/\\]}}Foo.framework{{[/\\]}}Headers{{[/\\]}}Bar.h llvmcas://
 
 // RUN: %clang @%t/tu.rsp
 

--- a/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-pch-with-private.c
@@ -47,7 +47,7 @@
 // CHECK-LABEL: MODULE Indirect2
 // CHECK: <module-includes> llvmcas://
 // CHECK: 1:1 <built-in> llvmcas://
-// CHECK: 2:1 [[PREFIX]]/indirect2.h llvmcas://
+// CHECK: 2:1 [[PREFIX]]{{[/\\]}}indirect2.h llvmcas://
 // CHECK:   Submodule: Indirect2
 // CHECK:   2:1 (Module) Indirect1
 // CHECK:   3:1 (Module) Mod_Private

--- a/clang/test/ClangScanDeps/modules-include-tree-submodules.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-submodules.c
@@ -30,7 +30,7 @@
 // RUN: echo "TRANSLATION UNIT 2" >> %t/result.txt
 // RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu2.casid >> %t/result.txt
 
-// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%/t
+// RUN: cat %t/result.txt | sed 's/\\/\//g' | FileCheck %s -DPREFIX=%/t
 
 // Build the include-tree commands
 // RUN: %clang @%t/TwoSubs.rsp

--- a/clang/test/ClangScanDeps/modules-include-tree-with-pch.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-with-pch.c
@@ -34,7 +34,7 @@
 // RUN: rm -rf %t/outputs
 // RUN: %clang @%t/tu.rsp
 
-// RUN: FileCheck %s -input-file %t/deps.json -DPREFIX=%/t
+// RUN: cat %t/deps.json | sed 's/\\\\/\//g' | FileCheck %s -DPREFIX=%/t
 
 // CHECK:      {
 // CHECK-NEXT:  "modules": [

--- a/clang/test/ClangScanDeps/modules-include-tree-working-directory.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-working-directory.c
@@ -23,9 +23,9 @@
 // RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/H.casid | FileCheck %s -DPREFIX=%/t
 
 // CHEK:C <module-includes>
-// CHECK: 2:1 [[PREFIX]]/relative/h1.h llvmcas://
+// CHECK: 2:1 [[PREFIX]]{{[/\\]}}relative{{[/\\]}}h1.h llvmcas://
 // CHECK: Files:
-// CHECK: [[PREFIX]]/relative/h1.h llvmcas://
+// CHECK: [[PREFIX]]{{[/\\]}}relative{{[/\\]}}h1.h llvmcas://
 
 //--- cdb.json.template
 [{

--- a/clang/test/ClangScanDeps/modules-include-tree.c
+++ b/clang/test/ClangScanDeps/modules-include-tree.c
@@ -33,7 +33,7 @@
 // RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/tu.casid >> %t/result.txt
 // RUN: cat %t/deps.json >> %t/result.txt
 
-// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%/t
+// RUN: cat %t/result.txt | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t
 
 // CHECK-LABEL: MODULE Top
 // CHECK: <module-includes> llvmcas://{{[[:xdigit:]]+}}

--- a/clang/test/Index/Core/scan-deps-cas.m
+++ b/clang/test/Index/Core/scan-deps-cas.m
@@ -6,19 +6,19 @@
 // RUN:  -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t/mcpit \
 // RUN:     -o FoE.o -x objective-c %s > %t.result
-// RUN: cat %t.result | sed 's/\\/\//g' | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t -check-prefix=INCLUDE_TREE
+// RUN: cat %t.result | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t -check-prefix=INCLUDE_TREE
 
 // RUN: env CLANG_CACHE_USE_CASFS_DEPSCAN=1 c-index-test core --scan-deps -working-dir %S -output-dir=%t -cas-path %t/cas \
 // RUN:  -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t/mcp \
 // RUN:     -o FoE.o -x objective-c %s > %t.casfs.result
-// RUN: cat %t.casfs.result | sed 's/\\/\//g' | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t
+// RUN: cat %t.casfs.result | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t
 
 // RUN: env CLANG_CACHE_USE_INCLUDE_TREE=1 c-index-test core --scan-deps -working-dir %S -output-dir=%t -cas-path %t/cas \
 // RUN:  -- %clang -c -I %S/Inputs/module \
 // RUN:     -fmodules -fmodules-cache-path=%t/mcpit \
 // RUN:     -o FoE.o -x objective-c %s > %t.includetree.result
-// RUN: cat %t.includetree.result | sed 's/\\/\//g' | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t -check-prefix=INCLUDE_TREE
+// RUN: cat %t.includetree.result | FileCheck %s -DPREFIX=%S -DOUTPUTS=%/t -check-prefix=INCLUDE_TREE
 
 // RUN: c-index-test core --scan-deps -working-dir %S -output-dir=%t \
 // RUN:  -- %clang -c -I %S/Inputs/module \
@@ -35,15 +35,15 @@
 // CHECK-NEXT:     name: ModA
 // CHECK-NEXT:     context-hash: [[HASH_MOD_A:[A-Z0-9]+]]
 // CHECK-NEXT:     cwd-ignored: 0
-// CHECK-NEXT:     module-map-path: [[PREFIX]]/Inputs/module/module.modulemap
+// CHECK-NEXT:     module-map-path: [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}module.modulemap
 // CHECK-NEXT:     casfs-root-id: [[CASFS_MODA_ROOT_ID:llvmcas://[[:xdigit:]]+]]
 // CHECK-NEXT:     cache-key: [[CASFS_MODA_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // CHECK-NEXT:     module-deps:
 // CHECK-NEXT:     file-deps:
-// CHECK-NEXT:       [[PREFIX]]/Inputs/module/module.modulemap
-// CHECK-NEXT:       [[PREFIX]]/Inputs/module/ModA.h
-// CHECK-NEXT:       [[PREFIX]]/Inputs/module/SubModA.h
-// CHECK-NEXT:       [[PREFIX]]/Inputs/module/SubSubModA.h
+// CHECK-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}module.modulemap
+// CHECK-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}ModA.h
+// CHECK-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}SubModA.h
+// CHECK-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}SubSubModA.h
 // CHECK-NEXT:     link libraries:
 // CHECK-NEXT:         libModA(framework)
 // CHECK-NEXT:         libModB
@@ -65,7 +65,7 @@
 // CHECK-NEXT:     module-deps:
 // CHECK-NEXT:       ModA:[[HASH_MOD_A]]
 // CHECK-NEXT:     file-deps:
-// CHECK-NEXT:       [[PREFIX]]/scan-deps-cas.m
+// CHECK-NEXT:       [[PREFIX]]{{[/\\]}}scan-deps-cas.m
 // CHECK-NEXT:     build-args:
 // CHECK-SAME:       -cc1
 // CHECK-SAME:       -fcas-path
@@ -80,15 +80,15 @@
 // INCLUDE_TREE-NEXT:     name: ModA
 // INCLUDE_TREE-NEXT:     context-hash: [[HASH_MOD_A:[A-Z0-9]+]]
 // INCLUDE_TREE-NEXT:     cwd-ignored: 0
-// INCLUDE_TREE-NEXT:     module-map-path: [[PREFIX]]/Inputs/module/module.modulemap
+// INCLUDE_TREE-NEXT:     module-map-path: [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}module.modulemap
 // INCLUDE_TREE-NEXT:     include-tree-id: [[ModA_INCLUDE_TREE_ID:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     cache-key: [[ModA_CACHE_KEY:llvmcas://[[:xdigit:]]+]]
 // INCLUDE_TREE-NEXT:     module-deps:
 // INCLUDE_TREE-NEXT:     file-deps:
-// INCLUDE_TREE-NEXT:       [[PREFIX]]/Inputs/module/module.modulemap
-// INCLUDE_TREE-NEXT:       [[PREFIX]]/Inputs/module/ModA.h
-// INCLUDE_TREE-NEXT:       [[PREFIX]]/Inputs/module/SubModA.h
-// INCLUDE_TREE-NEXT:       [[PREFIX]]/Inputs/module/SubSubModA.h
+// INCLUDE_TREE-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}module.modulemap
+// INCLUDE_TREE-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}ModA.h
+// INCLUDE_TREE-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}SubModA.h
+// INCLUDE_TREE-NEXT:       [[PREFIX]]{{[/\\]}}Inputs{{[/\\]}}module{{[/\\]}}SubSubModA.h
 // INCLUDE_TREE-NEXT:     link libraries:
 // INCLUDE_TREE-NEXT:         libModA(framework)
 // INCLUDE_TREE-NEXT:         libModB
@@ -107,7 +107,7 @@
 // INCLUDE_TREE-NEXT:     module-deps:
 // INCLUDE_TREE-NEXT:       ModA:[[HASH_MOD_A]]
 // INCLUDE_TREE-NEXT:     file-deps:
-// INCLUDE_TREE-NEXT:       [[PREFIX]]/scan-deps-cas.m
+// INCLUDE_TREE-NEXT:       [[PREFIX]]{{[/\\]}}scan-deps-cas.m
 // INCLUDE_TREE-NEXT:     build-args:
 // INCLUDE_TREE-SAME:       -cc1
 // INCLUDE_TREE-SAME:       -fcas-path

--- a/llvm/include/llvm/CAS/FileSystemCache.h
+++ b/llvm/include/llvm/CAS/FileSystemCache.h
@@ -26,6 +26,37 @@
 namespace llvm {
 namespace cas {
 
+// Used to create StringRef from Twine and slash canonicalization on
+// Windows.
+struct PathStorage {
+  SmallString<261> Storage;
+  StringRef Path;
+  PathStorage() {}
+  PathStorage(const Twine &InputPath,
+              sys::path::Style Style = sys::path::Style::native) {
+    if (is_style_windows(Style)) {
+      // Canonicalize to backslahes
+      InputPath.toVector(Storage);
+      llvm::sys::path::make_preferred(Storage, Style);
+      Path = Storage.str();
+    } else {
+      InputPath.toVector(Storage);
+      Path = Storage.str();
+    }
+  }
+  PathStorage(StringRef InputPath,
+              sys::path::Style Style = sys::path::Style::native) {
+    if (is_style_windows(Style)) {
+      // Canonicalize to backslahes
+      Storage = InputPath;
+      llvm::sys::path::make_preferred(Storage, Style);
+      Path = Storage.str();
+    } else {
+      Path = InputPath;
+    }
+  }
+};
+
 /// Caching for lazily discovering a CAS-based filesystem.
 ///
 /// FIXME: Extract most of this into llvm::vfs::FileSystemCache, so that it can
@@ -186,8 +217,7 @@ public:
 
   std::error_code setCurrentWorkingDirectory(const Twine &Path);
 
-  static StringRef canonicalizeWorkingDirectory(const Twine &Path,
-                                                sys::path::Style PathStyle,
+  static StringRef canonicalizeWorkingDirectory(sys::path::Style PathStyle,
                                                 StringRef WorkingDirectory,
                                                 SmallVectorImpl<char> &Storage);
 

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -106,10 +106,6 @@ public:
     return WorkingDirectory.Path;
   }
 
-  static StringRef canonicalizeWorkingDirectory(const Twine &Path,
-                                                StringRef WorkingDirectory,
-                                                SmallVectorImpl<char> &Storage);
-
   void trackNewAccesses() final;
   std::error_code excludeFromTracking(const Twine &Path) final;
   Expected<ObjectProxy>
@@ -272,9 +268,9 @@ void CachingOnDiskFileSystemImpl::initializeWorkingDirectory() {
 
 std::error_code
 CachingOnDiskFileSystemImpl::setCurrentWorkingDirectory(const Twine &Path) {
-  SmallString<128> Storage;
-  StringRef CanonicalPath =
-      canonicalizeWorkingDirectory(Path, WorkingDirectory.Path, Storage);
+  PathStorage PathStorage(Path);
+  StringRef CanonicalPath = FileSystemCache::canonicalizeWorkingDirectory(
+      sys::path::Style::native, WorkingDirectory.Path, PathStorage.Storage);
 
   // Read and cache all the symlinks in the path by looking it up. Return any
   // error encountered.
@@ -287,51 +283,11 @@ CachingOnDiskFileSystemImpl::setCurrentWorkingDirectory(const Twine &Path) {
   return std::error_code();
 }
 
-StringRef CachingOnDiskFileSystemImpl::canonicalizeWorkingDirectory(
-    const Twine &Path, StringRef WorkingDirectory,
-    SmallVectorImpl<char> &Storage) {
-  const char separator = get_separator(sys::path::Style::native)[0];
-  Path.toVector(Storage);
-  if (Storage.empty())
-    return WorkingDirectory;
-
-  if (!is_absolute(Path, sys::path::Style::native) && Storage.size() != 0) {
-    assert(is_absolute(WorkingDirectory, sys::path::Style::native));
-    SmallString<128> Prefix = StringRef(WorkingDirectory);
-    Prefix.push_back(separator);
-    Storage.insert(Storage.begin(), Prefix.begin(), Prefix.end());
-  }
-
-  // Remove ".." components based on working directory string, not based on
-  // real path. This matches shell behaviour.
-  sys::path::remove_dots(Storage, /*remove_dot_dot=*/true,
-                         sys::path::Style::native);
-
-  // Remove double slashes.
-  int W = 0;
-  bool WasSlash = false;
-  for (int R = 0, E = Storage.size(); R != E; ++R) {
-    bool IsSlash = Storage[R] == separator;
-    if (IsSlash && WasSlash)
-      continue;
-    WasSlash = IsSlash;
-    Storage[W++] = Storage[R];
-  }
-  Storage.resize(W);
-
-  // Remove final slash.
-  if (llvm::sys::path::root_path(StringRef(Storage.begin(), Storage.size()))
-          != StringRef(Storage.begin(), Storage.size()) &&
-      Storage.back() == separator)
-    Storage.pop_back();
-
-  return StringRef(Storage.begin(), Storage.size());
-}
-
 FileSystemCache::DirectoryEntry *
 CachingOnDiskFileSystemImpl::makeDirectory(DirectoryEntry &Parent,
                                            StringRef TreePath) {
-  return &Cache->makeDirectory(Parent, TreePath);
+  PathStorage TreePathStorage(TreePath);
+  return &Cache->makeDirectory(Parent, TreePathStorage.Path);
 }
 
 #if defined(HAVE_UNISTD_H)
@@ -358,26 +314,31 @@ static Error readLink(const llvm::Twine &Path, SmallVectorImpl<char> &Dest) {
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::makeSymlink(DirectoryEntry &Parent,
                                          StringRef TreePath) {
+  PathStorage TreePathStorage(TreePath);
   SmallString<128> Target;
-  if (auto Err = readLink(TreePath, Target))
+  if (auto Err = readLink(TreePathStorage.Path, Target))
     return std::move(Err);
-  return makeSymlinkTo(Parent, TreePath, Target);
+  return makeSymlinkTo(Parent, TreePathStorage.Path, Target);
 }
 
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::makeSymlinkTo(DirectoryEntry &Parent,
                                            StringRef TreePath,
                                            StringRef Target) {
-  Expected<ObjectRef> Node = DB.storeFromString({}, Target);
+  PathStorage TreePathStorage(TreePath);
+  PathStorage TargetStorage(Target);
+  Expected<ObjectRef> Node = DB.storeFromString({}, TargetStorage.Path);
   if (!Node)
     return Node.takeError();
-  return &Cache->makeSymlink(Parent, TreePath, *Node, Target);
+  return &Cache->makeSymlink(Parent, TreePathStorage.Path, *Node,
+                             TargetStorage.Path);
 }
 
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::makeFile(DirectoryEntry &Parent,
                                       StringRef TreePath, sys::fs::file_t F,
                                       sys::fs::file_status Status) {
+  PathStorage TreePathStorage(TreePath);
   Expected<ObjectRef> Node = DB.storeFromOpenFile(F, Status);
   if (!Node)
     return Node.takeError();
@@ -387,7 +348,8 @@ CachingOnDiskFileSystemImpl::makeFile(DirectoryEntry &Parent,
   if (!Handle)
     return Handle.takeError();
   // Do not trust Status.size() in case the file is volatile.
-  return &Cache->makeFile(Parent, TreePath, *Node, Handle->getData().size(),
+  return &Cache->makeFile(Parent, TreePathStorage.Path, *Node,
+                          Handle->getData().size(),
                           Status.permissions() & sys::fs::perms::owner_exe);
 }
 
@@ -396,36 +358,38 @@ CachingOnDiskFileSystemImpl::makeEntry(
     DirectoryEntry &Parent, StringRef TreePath,
     std::optional<sys::fs::file_status> KnownStatus) {
   assert(Parent.isDirectory() && "Expected a directory");
+  PathStorage TreePathStorage(TreePath);
 
   // lstat is extremely slow...
   sys::fs::file_status Status;
   if (KnownStatus) {
     Status = std::move(*KnownStatus);
-  } else if (auto EC = sys::fs::status(TreePath, Status, /*follow=*/false)) {
+  } else if (auto EC = sys::fs::status(TreePathStorage.Path, Status,
+                                       /*follow=*/false)) {
     return errorCodeToError(EC);
   }
 
   if (Status.type() == sys::fs::file_type::directory_file)
-    return makeDirectory(Parent, TreePath);
+    return makeDirectory(Parent, TreePathStorage.Path);
 
   if (Status.type() == sys::fs::file_type::symlink_file)
-    return makeSymlink(Parent, TreePath);
+    return makeSymlink(Parent, TreePathStorage.Path);
 
-  auto F = sys::fs::openNativeFile(TreePath, sys::fs::CD_OpenExisting,
-                                   sys::fs::FA_Read, sys::fs::OF_None);
+  auto F = sys::fs::openNativeFile(TreePathStorage.Path,
+      sys::fs::CD_OpenExisting, sys::fs::FA_Read, sys::fs::OF_None);
   if (!F)
     return F.takeError();
 
   auto CloseOnExit = make_scope_exit([&F]() { sys::fs::closeFile(*F); });
-  return makeFile(Parent, TreePath, *F, Status);
+  return makeFile(Parent, TreePathStorage.Path, *F, Status);
 }
 
 ErrorOr<vfs::Status>
 CachingOnDiskFileSystemImpl::statusAndFileID(const Twine &Path,
                                              std::optional<CASID> &FileID) {
   FileID = std::nullopt;
-  SmallString<128> Storage;
-  StringRef PathRef = Path.toStringRef(Storage);
+  PathStorage PathStorage(Path);
+  StringRef PathRef = PathStorage.Path;
 
   // Lookup only returns an Error if there's a problem communicating with the
   // CAS, or there's data corruption.
@@ -449,12 +413,11 @@ CachingOnDiskFileSystemImpl::statusAndFileID(const Twine &Path,
 Expected<const vfs::CachedDirectoryEntry *>
 CachingOnDiskFileSystemImpl::getDirectoryEntry(const Twine &Path,
                                                bool FollowSymlinks) const {
-  SmallString<128> Storage;
-  StringRef PathRef = Path.toStringRef(Storage);
+  PathStorage PathStorage(Path);
 
   // It's not a const operation, but it's thread-safe.
   return const_cast<CachingOnDiskFileSystemImpl *>(this)->lookupPath(
-      PathRef, FollowSymlinks);
+      PathStorage.Path, FollowSymlinks);
 }
 
 std::error_code
@@ -492,8 +455,8 @@ bool CachingOnDiskFileSystemImpl::exists(const Twine &Path) {
 
 ErrorOr<std::unique_ptr<vfs::File>>
 CachingOnDiskFileSystemImpl::openFileForRead(const Twine &Path) {
-  SmallString<128> Storage;
-  StringRef PathRef = Path.toStringRef(Storage);
+  PathStorage PathStorage(Path);
+  StringRef PathRef = PathStorage.Path;
 
   Expected<DirectoryEntry *> ExpectedEntry = lookupPath(PathRef);
   if (!ExpectedEntry)
@@ -508,8 +471,8 @@ CachingOnDiskFileSystemImpl::openFileForRead(const Twine &Path) {
 
 ErrorOr<vfs::directory_iterator>
 CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
-  SmallString<128> Storage;
-  StringRef PathRef = Path.toStringRef(Storage);
+  PathStorage PathStorage(Path);
+  StringRef PathRef = PathStorage.Path;
 
   Expected<DirectoryEntry *> ExpectedEntry = lookupPath(PathRef);
   if (!ExpectedEntry)
@@ -555,9 +518,10 @@ CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
                                              StringRef Remaining) {
+  PathStorage RemainingStorage(Remaining);
   SmallString<256> ExpectedRealPath;
   ExpectedRealPath = From.getTreePath();
-  sys::path::append(ExpectedRealPath, Remaining);
+  sys::path::append(ExpectedRealPath, RemainingStorage.Path);
 
   // Most paths don't exist. Start with a stat. Profiling says this is faster
   // on Darwin when running clang-scan-deps (looks like allocation traffic in
@@ -585,8 +549,12 @@ CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
   // Advance through the cached directories. Note: no need to pass through
   // TrackNonRealPathEntries because we're navigating a real path.
   StringRef ExpectedPrefix =
-      StringRef(ExpectedRealPath).drop_back(Remaining.size());
-  if (RealPath.starts_with(ExpectedPrefix))
+      StringRef(ExpectedRealPath).drop_back(RemainingStorage.Path.size());
+#ifndef _WIN32
+  if (RealPath.str().starts_with(ExpectedPrefix))
+#else
+  if (RealPath.str().starts_with_insensitive(ExpectedPrefix))
+#endif
     State = FileSystemCache::LookupPathState(
         Cache->getPathStyle(), From, RealPath.substr(ExpectedPrefix.size()));
   else
@@ -645,11 +613,13 @@ CachingOnDiskFileSystemImpl::lookupPath(
     bool ForceDisableTracking, bool NeedsContent,
     function_ref<void(FileSystemCache::DirectoryEntry &)>
         TrackNonRealPathEntries) {
+  PathStorage PathStorage(Path);
   bool IsTrackingStats = ForceDisableTracking ? false : isTrackingAccess();
   DiscoveryInstanceImpl DI(*this, TrackNonRealPathEntries, IsTrackingStats,
                            LookupOnDisk);
   Expected<DirectoryEntry *> ExpectedEntry =
-      Cache->lookupPath(DI, Path, *WorkingDirectory.Entry, FollowSymlinks);
+      Cache->lookupPath(DI, PathStorage.Path, *WorkingDirectory.Entry,
+                        FollowSymlinks);
   if (IsTrackingStats && ExpectedEntry && *ExpectedEntry)
     trackAccess(**ExpectedEntry, NeedsContent);
   return ExpectedEntry;
@@ -693,8 +663,8 @@ void CachingOnDiskFileSystemImpl::trackNewAccesses() {
 
 std::error_code
 CachingOnDiskFileSystemImpl::excludeFromTracking(const Twine &Path) {
-  SmallString<128> Storage;
-  StringRef PathRef = Path.toStringRef(Storage);
+  PathStorage PathStorage(Path);
+  StringRef PathRef = PathStorage.Path;
   DirectoryEntry *Entry = nullptr;
   if (auto Err =
           lookupPath(PathRef, /*FollowSymlinks=*/true, /*LookupOnDisk=*/true,
@@ -886,7 +856,7 @@ public:
   HierarchicalTreeBuilder Builder;
   CachingOnDiskFileSystemImpl &FS;
 
-  SmallString<128> PathStorage;
+  PathStorage Storage;
   SmallVector<const DirectoryEntry *> Worklist;
   DenseSet<const DirectoryEntry *> Seen;
 };
@@ -914,8 +884,8 @@ void CachingOnDiskFileSystemImpl::TreeBuilder::pushEntry(
 }
 
 Error CachingOnDiskFileSystemImpl::TreeBuilder::push(const Twine &Path) {
-  PathStorage.clear();
-  StringRef PathRef = Path.toStringRef(PathStorage);
+  Storage = PathStorage(Path);
+  StringRef PathRef = Storage.Path;
 
   // Look for Path without following symlinks. Failure here indicates that Path
   // does not exist or has a broken symlink in its parent path. Keep track of

--- a/llvm/lib/CAS/FileSystemCache.cpp
+++ b/llvm/lib/CAS/FileSystemCache.cpp
@@ -36,12 +36,11 @@ StringRef FileSystemCache::getRootPathFor(StringRef Path) const {
 }
 
 StringRef
-FileSystemCache::canonicalizeWorkingDirectory(const Twine &Path,
-                                              sys::path::Style PathStyle,
+FileSystemCache::canonicalizeWorkingDirectory(sys::path::Style PathStyle,
                                               StringRef WorkingDirectory,
                                               SmallVectorImpl<char> &Storage) {
   const char PathSeparatorChar = get_separator(PathStyle)[0];
-  Path.toVector(Storage);
+  StringRef Path = StringRef(Storage.begin(), Storage.size());
   if (Storage.empty())
     return WorkingDirectory;
 
@@ -105,7 +104,11 @@ static DirectoryEntry &makeLazyEntry(
     DirectoryEntry &Parent, FileSystemCache::Directory &D, StringRef TreePath,
     DirectoryEntry::EntryKind Kind, std::optional<ObjectRef> Ref,
     sys::path::Style PathStyle) {
+#ifndef _WIN32
   assert(sys::path::parent_path(TreePath, PathStyle) == Parent.getTreePath());
+#else
+  assert(sys::path::parent_path(TreePath, PathStyle).equals_insensitive(Parent.getTreePath()));
+#endif
   assert(!D.lookup(sys::path::filename(TreePath, PathStyle)));
   assert(!D.isComplete());
 


### PR DESCRIPTION
Fix the following CAS-related tests on Windows

Clang :: ClangScanDeps/include-tree.c
Clang :: ClangScanDeps/modules-cas-context-hash.c
Clang :: ClangScanDeps/modules-cas-full-by-mod-name.c
Clang :: ClangScanDeps/modules-cas-module-cache-hash.c
Clang :: ClangScanDeps/modules-cas-trees-exclude-files-from-casfs.c
Clang :: ClangScanDeps/modules-include-tree-implementation.c
Clang :: ClangScanDeps/modules-include-tree-inferred.m
Clang :: ClangScanDeps/modules-include-tree-missing-submodule.c
Clang :: ClangScanDeps/modules-include-tree-pch-with-private.c
Clang :: ClangScanDeps/modules-include-tree-submodules.c
Clang :: ClangScanDeps/modules-include-tree-with-pch.c
Clang :: ClangScanDeps/modules-include-tree-working-directory.c
Clang :: ClangScanDeps/modules-include-tree.c
Clang :: Index/Core/scan-deps-cas.m
LLVM :: tools/llvm-cas/merge.test
LLVM :: tools/llvm-cas/print-id.test
LLVM :: tools/llvm-cas/validation.test