### PR TITLE
[lldb][windows] deactivate ProtocolMCPServerTest

### DIFF
--- a/lldb/unittests/Protocol/CMakeLists.txt
+++ b/lldb/unittests/Protocol/CMakeLists.txt
@@ -1,6 +1,13 @@
-add_lldb_unittest(ProtocolTests
+set(PROTOCOL_TEST_SOURCES
   ProtocolMCPTest.cpp
-  ProtocolMCPServerTest.cpp
+)
+
+if(NOT WIN32)
+  list(APPEND PROTOCOL_TEST_SOURCES ProtocolMCPServerTest.cpp)
+endif()
+
+add_lldb_unittest(ProtocolTests
+  ${PROTOCOL_TEST_SOURCES}
 
   LINK_LIBS
     lldbCore
@@ -9,4 +16,4 @@ add_lldb_unittest(ProtocolTests
     lldbPluginPlatformMacOSX
     lldbPluginProtocolServerMCP
     LLVMTestingSupport
-  )
+)


### PR DESCRIPTION
This patch deactivates ProtocolMCPServerTest.cpp on Windows while we investigate the CI failure.