### PR TITLE
Revert "[lldb][windows] deactivate ProtocolMCPServerTest"

### DIFF
--- a/lldb/unittests/Protocol/CMakeLists.txt
+++ b/lldb/unittests/Protocol/CMakeLists.txt
@@ -1,13 +1,6 @@
-set(PROTOCOL_TEST_SOURCES
-  ProtocolMCPTest.cpp
-)
-
-if(NOT WIN32)
-  list(APPEND PROTOCOL_TEST_SOURCES ProtocolMCPServerTest.cpp)
-endif()
-
 add_lldb_unittest(ProtocolTests
-  ${PROTOCOL_TEST_SOURCES}
+  ProtocolMCPTest.cpp
+  ProtocolMCPServerTest.cpp
 
   LINK_LIBS
     lldbCore
@@ -16,4 +9,4 @@ add_lldb_unittest(ProtocolTests
     lldbPluginPlatformMacOSX
     lldbPluginProtocolServerMCP
     LLVMTestingSupport
-)
+  )


### PR DESCRIPTION
Reverts swiftlang/llvm-project#11241 as this was meant for [stable/20240723](https://github.com/swiftlang/llvm-project/tree/stable/20240723).