### PR TITLE
[windows] change deactivation method for ProtocolMCPServerTest.cpp

### DIFF
--- a/lldb/unittests/Protocol/CMakeLists.txt
+++ b/lldb/unittests/Protocol/CMakeLists.txt
@@ -1,13 +1,6 @@
-set(PROTOCOL_TEST_SOURCES
-  ProtocolMCPTest.cpp
-)
-
-if(NOT WIN32)
-  list(APPEND PROTOCOL_TEST_SOURCES ProtocolMCPServerTest.cpp)
-endif()
-
 add_lldb_unittest(ProtocolTests
-  ${PROTOCOL_TEST_SOURCES}
+  ProtocolMCPTest.cpp
+  ProtocolMCPServerTest.cpp
 
   LINK_LIBS
     lldbCore

--- a/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPServerTest.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
+#ifndef _WIN32 // DISABLE TEST ON WINDOWS
 #include "Plugins/Platform/MacOSX/PlatformRemoteMacOSX.h"
 #include "Plugins/Protocol/MCP/MCPError.h"
 #include "Plugins/Protocol/MCP/ProtocolServerMCP.h"
@@ -325,3 +325,4 @@ TEST_F(ProtocolServerMCPTest, NotificationInitialized) {
   std::unique_lock<std::mutex> lock(mutex);
   cv.wait(lock, [&] { return handler_called; });
 }
+#endif // DISABLE TEST ON WINDOWS


### PR DESCRIPTION
- https://github.com/swiftlang/llvm-project/pull/11242 

Was originally merged to unblock the CI. The way it disables the test was not correct and introduced another build failure. This patch fixes it by using `#if`/`#endif` to deactivate the test.