### PR TITLE
[CAS] Improve CAS ObjectStore initialization

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -833,7 +833,12 @@ void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
       return;
     SmallString<64> LLVMCasStorage;
     SmallString<64> CASPath;
-    CASOpts.getResolvedCASPath(CASPath);
+    if (auto Err = CASOpts.getResolvedCASPath(CASPath)) {
+      // Failure to resolve a cas path for validation is ignored, because any
+      // error will be reported when attempting to open the cas.
+      llvm::consumeError(std::move(Err));
+      return;
+    }
     ExitOnErr(llvm::cas::validateOnDiskUnifiedCASDatabasesIfNeeded(
         CASPath, /*CheckHash=*/true,
         /*AllowRecovery=*/true,

--- a/llvm/include/llvm/CAS/CASConfiguration.h
+++ b/llvm/include/llvm/CAS/CASConfiguration.h
@@ -49,9 +49,6 @@ public:
     return !(LHS == RHS);
   }
 
-  // Get resolved CASPath.
-  void getResolvedCASPath(llvm::SmallVectorImpl<char> &Result) const;
-
   // Create CASDatabase from the CASConfiguration.
   llvm::Expected<std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
                            std::shared_ptr<llvm::cas::ActionCache>>>
@@ -72,6 +69,9 @@ public:
   createFromSearchConfigFile(
       StringRef Path,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr);
+
+  /// Get resolved CASPath.
+  Error getResolvedCASPath(llvm::SmallVectorImpl<char> &Result) const;
 };
 
 } // namespace llvm::cas

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -358,27 +358,15 @@ std::unique_ptr<ObjectStore> createInMemoryCAS();
 bool isOnDiskCASEnabled();
 
 /// Gets or creates a persistent on-disk path at \p Path.
-///
-/// Deprecated: if \p Path resolves to \a getDefaultOnDiskCASStableID(),
-/// automatically opens \a getDefaultOnDiskCASPath() instead.
-///
-/// FIXME: Remove the special behaviour for getDefaultOnDiskCASStableID(). The
-/// client should handle this logic, if/when desired.
 Expected<std::unique_ptr<ObjectStore>> createOnDiskCAS(const Twine &Path);
 
 /// Set \p Path to a reasonable default on-disk path for a persistent CAS for
 /// the current user.
-void getDefaultOnDiskCASPath(SmallVectorImpl<char> &Path);
+Error getDefaultOnDiskCASPath(SmallVectorImpl<char> &Path);
 
 /// Get a reasonable default on-disk path for a persistent CAS for the current
 /// user.
-std::string getDefaultOnDiskCASPath();
-
-/// FIXME: Remove.
-void getDefaultOnDiskCASStableID(SmallVectorImpl<char> &Path);
-
-/// FIXME: Remove.
-std::string getDefaultOnDiskCASStableID();
+llvm::Expected<std::string> getDefaultOnDiskCASPath();
 
 /// Create ObjectStore from a string identifier.
 /// Currently the string identifier is using URL scheme with following supported

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -346,10 +346,7 @@ static std::unique_ptr<ToolOutputFile> GetOutputStream(const char *TargetName,
 static std::shared_ptr<cas::ObjectStore> getCAS() {
   if (CASPath.empty())
     return cas::createInMemoryCAS();
-  auto MaybeCAS =
-      CASPath == "auto"
-          ? cas::createCASFromIdentifier(cas::getDefaultOnDiskCASPath())
-          : cas::createCASFromIdentifier(CASPath);
+  auto MaybeCAS = cas::createCASFromIdentifier(CASPath);
   if (MaybeCAS)
     return std::move(*MaybeCAS);
   reportError(toString(MaybeCAS.takeError()));


### PR DESCRIPTION
Make `getDefaultOnDiskCASPath` return error types as the function can fail (current fatal errors) on certain OS configurations.

Also deprecate the API that uses DefaultOnDiskStableID.