### PR TITLE
[lldb/crashlog] Use raw strings to silence escape sequence warnings

### DIFF
--- a/lldb/examples/python/crashlog.py
+++ b/lldb/examples/python/crashlog.py
@@ -296,7 +296,7 @@ class CrashLog(symbolication.Symbolicator):
             except:
                 dsymForUUIDBinary = ""
 
-        dwarfdump_uuid_regex = re.compile("UUID: ([-0-9a-fA-F]+) \(([^\(]+)\) .*")
+        dwarfdump_uuid_regex = re.compile(r"UUID: ([-0-9a-fA-F]+) \(([^\(]+)\) .*")
 
         def __init__(
             self, text_addr_lo, text_addr_hi, identifier, version, uuid, path, verbose
@@ -501,7 +501,7 @@ class CrashLog(symbolication.Symbolicator):
         for image in self.images:
             if image.identifier == identifier:
                 return image
-        regex_text = "^.*\.%s$" % (re.escape(identifier))
+        regex_text = r"^.*\.%s$" % (re.escape(identifier))
         regex = re.compile(regex_text)
         for image in self.images:
             if regex.match(image.identifier):
@@ -925,7 +925,7 @@ class TextCrashLogParser(CrashLogParser):
             version = r"(?:" + super().version + r"\s+)?"
             address = r"(0x[0-9a-fA-F]{4,})"  # 4 digits or more
 
-            symbol = """
+            symbol = r"""
                         (?:
                             [ ]+
                             (?P<symbol>.+)
@@ -1095,7 +1095,7 @@ class TextCrashLogParser(CrashLogParser):
             self.crashlog.process_identifier = line[11:].strip()
         elif line.startswith("Version:"):
             version_string = line[8:].strip()
-            matched_pair = re.search("(.+)\((.+)\)", version_string)
+            matched_pair = re.search(r"(.+)\((.+)\)", version_string)
             if matched_pair:
                 self.crashlog.process_version = matched_pair.group(1)
                 self.crashlog.process_compatability_version = matched_pair.group(2)

--- a/lldb/examples/python/symbolication.py
+++ b/lldb/examples/python/symbolication.py
@@ -177,9 +177,9 @@ class Section:
     """Class that represents an load address range"""
 
     sect_info_regex = re.compile("(?P<name>[^=]+)=(?P<range>.*)")
-    addr_regex = re.compile("^\s*(?P<start>0x[0-9A-Fa-f]+)\s*$")
+    addr_regex = re.compile(r"^\s*(?P<start>0x[0-9A-Fa-f]+)\s*$")
     range_regex = re.compile(
-        "^\s*(?P<start>0x[0-9A-Fa-f]+)\s*(?P<op>[-+])\s*(?P<end>0x[0-9A-Fa-f]+)\s*$"
+        r"^\s*(?P<start>0x[0-9A-Fa-f]+)\s*(?P<op>[-+])\s*(?P<end>0x[0-9A-Fa-f]+)\s*$"
     )
 
     def __init__(self, start_addr=None, end_addr=None, name=None):
@@ -557,7 +557,7 @@ class Symbolicator:
             if image.identifier == identifier:
                 images.append(image)
         if len(images) == 0:
-            regex_text = "^.*\.%s$" % (re.escape(identifier))
+            regex_text = r"^.*\.%s$" % (re.escape(identifier))
             regex = re.compile(regex_text)
             for image in self.images:
                 if regex.match(image.identifier):


### PR DESCRIPTION
This patch silences from escape sequence warnings from the crashlog
script that were mostly due to regular expression strings.

This is addresses by using raw strings so the escape character isn't
interpreted by python and gets passed straight to the regular expression
engine.

Signed-off-by: Med Ismail Bennani <ismail@bennani.ma>