### PR TITLE
[lldb] Disable ProtocolMCPTest on Windows

### DIFF
--- a/lldb/unittests/Protocol/ProtocolMCPTest.cpp
+++ b/lldb/unittests/Protocol/ProtocolMCPTest.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
+#ifndef _WIN32 // DISABLE TEST ON WINDOWS
 #include "Plugins/Protocol/MCP/Protocol.h"
 #include "TestingSupport/TestUtilities.h"
 #include "llvm/Testing/Support/Error.h"
@@ -328,3 +328,4 @@ TEST(ProtocolMCPTest, ResourceResultEmpty) {
 
   EXPECT_TRUE(deserialized_result->contents.empty());
 }
+#endif // DISABLE TEST ON WINDOWS


### PR DESCRIPTION
ProtocolMCPServerTest was disabled in https://github.com/swiftlang/llvm-project/pull/11242, but not this one. Looking at the logs I'm fairly sure that one had actual failures (with timeouts) where as this test is the cause of the full hang.