### PR TITLE
[clang][NFC][PAC] Resolve some code drift from upstream pointer auth

### DIFF
--- a/clang/include/clang/Basic/Features.def
+++ b/clang/include/clang/Basic/Features.def
@@ -150,11 +150,6 @@ FEATURE(memory_sanitizer,
 FEATURE(type_sanitizer, LangOpts.Sanitize.has(SanitizerKind::Type))
 FEATURE(thread_sanitizer, LangOpts.Sanitize.has(SanitizerKind::Thread))
 FEATURE(dataflow_sanitizer, LangOpts.Sanitize.has(SanitizerKind::DataFlow))
-FEATURE(ptrauth_intrinsics, LangOpts.PointerAuthIntrinsics)
-FEATURE(ptrauth_qualifier, LangOpts.PointerAuthIntrinsics)
-FEATURE(ptrauth_calls, LangOpts.PointerAuthCalls)
-FEATURE(ptrauth_returns, LangOpts.PointerAuthReturns)
-FEATURE(ptrauth_indirect_gotos, LangOpts.PointerAuthIndirectGotos)
 FEATURE(scudo, LangOpts.Sanitize.hasOneOf(SanitizerKind::Scudo))
 FEATURE(ptrauth_intrinsics, LangOpts.PointerAuthIntrinsics &&
                             PP.getTargetInfo().getTriple().isOSDarwin())

--- a/clang/include/clang/CodeGen/CodeGenABITypes.h
+++ b/clang/include/clang/CodeGen/CodeGenABITypes.h
@@ -120,6 +120,13 @@ llvm::Type *convertTypeForMemory(CodeGenModule &CGM, QualType T);
 unsigned getLLVMFieldNumber(CodeGenModule &CGM,
                             const RecordDecl *RD, const FieldDecl *FD);
 
+/// Return a declaration discriminator for the given global decl.
+uint16_t getPointerAuthDeclDiscriminator(CodeGenModule &CGM, GlobalDecl GD);
+
+/// Return a type discriminator for the given function type.
+uint16_t getPointerAuthTypeDiscriminator(CodeGenModule &CGM,
+                                         QualType FunctionType);
+
 /// Return a signed constant pointer.
 llvm::Constant *getConstantSignedPointer(CodeGenModule &CGM,
                                          llvm::Constant *Pointer, unsigned Key,

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -3452,6 +3452,10 @@ void Darwin::addClangTargetOptions(
   if (!sdkSupportsBuiltinModules(SDKInfo))
     CC1Args.push_back("-fbuiltin-headers-in-system-modules");
 
+  if (!DriverArgs.hasArgNoClaim(options::OPT_fdefine_target_os_macros,
+                                options::OPT_fno_define_target_os_macros))
+    CC1Args.push_back("-fdefine-target-os-macros");
+
   // Disable subdirectory modulemap search on sufficiently recent SDKs.
   if (SDKInfo &&
       !DriverArgs.hasFlag(options::OPT_fmodulemap_allow_subdirectory_search,
@@ -3480,10 +3484,6 @@ void Darwin::addClangTargetOptions(
     if (!RequiresSubdirectorySearch)
       CC1Args.push_back("-fno-modulemap-allow-subdirectory-search");
   }
-
-  if (!DriverArgs.hasArgNoClaim(options::OPT_fdefine_target_os_macros,
-                                options::OPT_fno_define_target_os_macros))
-    CC1Args.push_back("-fdefine-target-os-macros");
 }
 
 void Darwin::addClangCC1ASTargetOptions(


### PR DESCRIPTION
This is correcting some code drift that has occurred during the upstreaming of pointer authentication to upstream llvm