### PR TITLE
Return nullopt if Reg is undef.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -10139,6 +10139,9 @@ describeORRLoadedValue(const MachineInstr &MI, Register DescribedReg,
   Register DestReg = DestSrc->Destination->getReg();
   Register SrcReg = DestSrc->Source->getReg();
 
+  if (!DestReg.isValid() || !SrcReg.isValid())
+    return std::nullopt;
+
   auto Expr = DIExpression::get(MI.getMF()->getFunction().getContext(), {});
 
   // If the described register is the destination, just return the source.

--- a/llvm/test/DebugInfo/AArch64/callsite.mir
+++ b/llvm/test/DebugInfo/AArch64/callsite.mir
@@ -1,0 +1,52 @@
+# This test should not crash when generating call-site information. 
+# It was created to make sure that if isCopyLikeInstr in TargetInstrInfo.h 
+# returns an undef Dest Reg or Src Reg, we don't try to get a SubReg for it.
+
+# RUN: llc  -start-before=aarch64-asm-printer %s -filetype=obj -o /dev/null --emit-call-site-info | FileCheck %s
+
+--- |
+  define noundef i32 @wladihawlihalhlad(ptr noundef %0, ptr noundef %1) local_unnamed_addr #0 !dbg !23 {
+    ret i32 0
+  }
+  define void @__fooo(ptr noundef %0, ptr noundef %1, i8 noundef zeroext %2) local_unnamed_addr #0 !dbg !53 {
+    ret void
+  }
+  !llvm.module.flags = !{!2, !8}
+  !llvm.dbg.cu = !{!9}
+  !2 = !{i32 2,!"Debug Info Version",i32 3}
+  !8 = !{i32 7,!"frame-pointer",i32 1}
+  !9 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_11,file: !10,emissionKind: FullDebug,sysroot: "/")
+  !10 = !DIFile(filename: "afhjacs.cpp",directory: "wkudawkudbakwdbku")
+  !23 = distinct !DISubprogram(  type: !27,flags: DIFlagPrototyped | DIFlagAllCallsDescribed,unit: !9,retainedNodes: !46)
+  !27 = !DISubroutineType(types: !28)
+  !28 = !{}
+  !30 = !DIDerivedType(tag: DW_TAG_pointer_type,baseType: !33)
+  !33 = distinct !DICompositeType(tag: DW_TAG_structure_type,identifier: "laihfaelhaleheaf")
+  !35 = !DISubprogram(  spFlags: DISPFlagOptimized)
+  !46 = !{  }
+  !47 = !DILocalVariable(  arg: 1,scope: !23,flags: DIFlagArtificial | DIFlagObjectPointer)
+  !49 = !DILocalVariable(  scope: !23,type: !30)
+  !50 = !DILocation(  scope: !23)
+  !51 = !DILocation(  scope: !23)
+  !53 = distinct !DISubprogram(  unit: !9,declaration: !35)
+name:            wladihawlihalhlad
+stack:
+  - { id: 0, name: '', type: spill-slot, offset: -8, size: 8, alignment: 8, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  - { id: 1, name: '', type: spill-slot, offset: -16, size: 8, alignment: 8, 
+      debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+callSites:
+  - { bb: 0, offset: 9, fwdArgRegs: 
+      - { arg: 2, reg: '$w2' } }
+body:             |
+  bb.0 (%ir-block.2):
+    DBG_VALUE $x0, $noreg, !47, !DIExpression(),  debug-location !50
+    DBG_VALUE $x1, $noreg, !49, !DIExpression(),  debug-location !50
+    frame-setup PACIBSP implicit-def $lr, implicit killed $lr, implicit $sp
+    early-clobber $sp = frame-setup STPXpre $fp, killed $lr, $sp, -2 :: (store (s64) into %stack.1), (store (s64) into %stack.0)
+    $fp = frame-setup ADDXri $sp, 0, 0
+    frame-setup CFI_INSTRUCTION def_cfa $w29, 16
+    frame-setup CFI_INSTRUCTION offset $w30, -8
+    frame-setup CFI_INSTRUCTION offset $w29, -16
+    $x2 = ORRXrs $xzr, undef $noreg, 0, implicit $wzr,  debug-location !51
+    BL @__fooo, csr_darwin_aarch64_aapcs, implicit-def dead $lr, implicit $sp, implicit killed $x0, implicit killed $x1, implicit killed $w2, implicit-def $sp,  debug-location !51


### PR DESCRIPTION
In describeORRLoadedValue in AArch64InstrInfo.cpp, we try to check if an instruction is a copy like instruction, the isCopyLikeInstr function returns a pair of destination and source registers. If any of them are undef, we should just return a nullopt to avoid any crashes later in the code when trying to get the SubReg for one of those registers.

rdar://158581204