### PR TITLE
[llvm][cas] Remove incorrect assertion

### DIFF
--- a/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
@@ -224,7 +224,6 @@ void MappedFileRegionBumpPtr::destroyImpl() {
     if (tryLockFileThreadSafe(*SharedLockFD) == std::error_code()) {
       size_t Size = size();
       size_t Capacity = capacity();
-      assert(Size < Capacity);
       // sync to file system to make sure all contents are up-to-date.
       (void)Region.sync();
       Region.unmap();


### PR DESCRIPTION
This assertion is incorrect in two ways
* It should have been <= instead of <. This can happen in "normal operation".
* Even with <= it could fail if the process that wins the race to increment the size above the capcacity is killed before it returns the allocation. This is an error condition, but it should not result in an assertion failure.

Luckily there doesn't appear to be any code that depends on the condition this assert claimed. If the size is >= the capacity any future allocations will fail with a proper error.