### PR TITLE
Fix the following CAS-related tests on Windows

### DIFF
--- a/clang/test/ClangScanDeps/cas-trees.c
+++ b/clang/test/ClangScanDeps/cas-trees.c
@@ -6,13 +6,13 @@
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -mode preprocess-dependency-directives > %t/result1.txt
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -mode preprocess > %t/result2.txt
 // RUN: diff -u %t/result1.txt %t/result2.txt
-// RUN: FileCheck %s -input-file %t/result1.txt -DPREFIX=%/t
+// RUN: cat %t/result1.txt | %PathSanitizingFileCheck --sanitize PREFIX=%/t %s
 
-// CHECK:      tree {{.*}} for '[[PREFIX]]/t1.c'
-// CHECK-NEXT: tree {{.*}} for '[[PREFIX]]/t2.c'
+// CHECK:      tree {{.*}} for 'PREFIX{{/|\\}}t1.c'
+// CHECK-NEXT: tree {{.*}} for 'PREFIX{{/|\\}}t2.c'
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree-full -mode preprocess > %t/full_result.json
-// RUN: cat %t/full_result.json | FileCheck %s -DPREFIX=%/t --check-prefix=FULL-TREE
+// RUN: cat %t/full_result.json | %PathSanitizingFileCheck --sanitize PREFIX=%/t --enable-yaml-compatibility %s --check-prefix=FULL-TREE
 
 // FULL-TREE:      {
 // FULL-TREE-NEXT:   "modules": [],
@@ -24,17 +24,17 @@
 // FULL-TREE-NEXT:       "clang-module-deps": [],
 // FULL-TREE-NEXT:       "command-line": [
 // FULL-TREE:              "-fcas-path"
-// FULL-TREE-NEXT:         "[[PREFIX]]{{.}}cas"
+// FULL-TREE-NEXT:         "PREFIX{{/|\\\\}}cas"
 // FULL-TREE:              "-fcas-fs"
 // FULL-TREE-NEXT:         "[[T1_ROOT_ID]]"
 // FULL-TREE:              "-fcache-compile-job"
 // FULL-TREE:            ],
 // FULL-TREE:            "file-deps": [
-// FULL-TREE-NEXT:         "[[PREFIX]]/t1.c",
-// FULL-TREE-NEXT:         "[[PREFIX]]/top.h",
-// FULL-TREE-NEXT:         "[[PREFIX]]/n1.h"
+// FULL-TREE-NEXT:         "PREFIX{{/|\\\\}}t1.c",
+// FULL-TREE-NEXT:         "PREFIX{{/|\\\\}}top.h",
+// FULL-TREE-NEXT:         "PREFIX{{/|\\\\}}n1.h"
 // FULL-TREE-NEXT:       ],
-// FULL-TREE-NEXT:       "input-file": "[[PREFIX]]/t1.c"
+// FULL-TREE-NEXT:       "input-file": "PREFIX{{/|\\\\}}t1.c"
 // FULL-TREE-NEXT:     }
 // FULL-TREE:          {
 // FULL-TREE:            "cache-key": "[[T2_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
@@ -43,16 +43,16 @@
 // FULL-TREE-NEXT:       "clang-module-deps": [],
 // FULL-TREE-NEXT:       "command-line": [
 // FULL-TREE:              "-fcas-path"
-// FULL-TREE-NEXT:         "[[PREFIX]]{{.}}cas"
+// FULL-TREE-NEXT:         "PREFIX{{/|\\\\}}cas"
 // FULL-TREE:              "-fcas-fs"
 // FULL-TREE-NEXT:         "[[T2_ROOT_ID]]"
 // FULL-TREE:              "-fcache-compile-job"
 // FULL-TREE:            ],
 // FULL-TREE:            "file-deps": [
-// FULL-TREE-NEXT:         "[[PREFIX]]/t2.c",
-// FULL-TREE-NEXT:         "[[PREFIX]]/n1.h"
+// FULL-TREE-NEXT:         "PREFIX{{/|\\\\}}t2.c",
+// FULL-TREE-NEXT:         "PREFIX{{/|\\\\}}n1.h"
 // FULL-TREE-NEXT:       ],
-// FULL-TREE-NEXT:       "input-file": "[[PREFIX]]/t2.c"
+// FULL-TREE-NEXT:       "input-file": "PREFIX{{/|\\\\}}t2.c"
 // FULL-TREE-NEXT:     }
 
 // Build with caching
@@ -83,20 +83,20 @@
 // COMBINED:      remark: compile job cache miss for '[[T1_CACHE_KEY]]'
 // COMBINED-NEXT: remark: compile job cache miss for '[[T2_CACHE_KEY]]'
 
-// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -emit-cas-compdb | FileCheck %s -DPREFIX=%/t -DCLANG=%clang -check-prefix=COMPDB
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -cas-path %t/cas -format experimental-tree -emit-cas-compdb | %PathSanitizingFileCheck --sanitize PREFIX=%/t --sanitize CLANG=%/clang --enable-yaml-compatibility %s -check-prefix=COMPDB
 // COMPDB: [
 // COMPDB:   {
-// COMPDB:     "file": "[[PREFIX]]/t1.c",
-// COMPDB:     "directory": "[[PREFIX]]",
+// COMPDB:     "file": "PREFIX{{/|\\\\}}t1.c",
+// COMPDB:     "directory": "PREFIX",
 // COMPDB:     "arguments": [
-// COMPDB:       "[[CLANG]]",
+// COMPDB:       "CLANG",
 // COMPDB:       "-cc1",
 // COMPDB:       "-fcas-path",
-// COMPDB:       "[[PREFIX]]/cas",
+// COMPDB:       "PREFIX{{/|\\\\}}cas",
 // COMPDB:       "-fcas-fs",
 // COMPDB:   {
-// COMPDB:     "file": "[[PREFIX]]/t2.c",
-// COMPDB:     "directory": "[[PREFIX]]",
+// COMPDB:     "file": "PREFIX{{/|\\\\}}t2.c",
+// COMPDB:     "directory": "PREFIX",
 // COMPDB:     "arguments": [
 
 

--- a/clang/test/ClangScanDeps/modules-cas-trees-cwd.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-cwd.c
@@ -22,14 +22,14 @@
 // RUN: %clang @%t/tu.rsp
 
 // Check specifics of the command-line
-// RUN: cat %t/deps.json | FileCheck %s -DPREFIX=%/t
+// RUN: cat %t/deps.json | %PathSanitizingFileCheck --sanitize PREFIX=%/t --enable-yaml-compatibility %s
 
 // CHECK:      {
 // CHECK-NEXT:   "modules": [
 // CHECK-NEXT:     {
 // CHECK:            "command-line": [
 // CHECK:              "-fcas-fs-working-directory"
-// CHECK-NEXT:         "[[PREFIX]]/B"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}B"
 // CHECK:            ]
 // CHECK:            "name": "Mod"
 // CHECK:          }
@@ -40,7 +40,7 @@
 // CHECK:              {
 // CHECK:                "command-line": [
 // CHECK:                  "-fcas-fs-working-directory"
-// CHECK-NEXT:             "[[PREFIX]]/B"
+// CHECK-NEXT:             "PREFIX{{/|\\\\}}B"
 // CHECK:                ]
 
 //--- cdb.json.template

--- a/clang/test/ClangScanDeps/modules-cas-trees-with-pch.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees-with-pch.c
@@ -15,7 +15,7 @@
 // RUN:   > %t/deps_pch.json
 
 // == Check specifics of the command-line
-// RUN: cat %t/deps_pch.json | FileCheck %s -DPREFIX=%/t -check-prefix=PCH
+// RUN: cat %t/deps_pch.json | %PathSanitizingFileCheck --sanitize PREFIX=%/t --enable-yaml-compatibility %s -check-prefix=PCH
 
 // == Build PCH
 // RUN: %deps-to-rsp %t/deps_pch.json --module-name A > %t/A.rsp
@@ -36,7 +36,7 @@
 // RUN:   > %t/deps.json
 
 // == Check specifics of the command-line
-// RUN: cat %t/deps.json | FileCheck %s -DPREFIX=%/t
+// RUN: cat %t/deps.json | %PathSanitizingFileCheck --sanitize PREFIX=%/t --enable-yaml-compatibility %s
 
 // == Build TU, including PCH
 // RUN: %deps-to-rsp %t/deps.json --module-name C > %t/C.rsp
@@ -60,7 +60,7 @@
 // PCH:            "command-line": [
 // PCH-NEXT:         "-cc1"
 // PCH:              "-fcas-path"
-// PCH-NEXT:         "[[PREFIX]]{{.}}cas"
+// PCH-NEXT:         "PREFIX{{/|\\\\}}cas"
 // PCH:              "-fcas-fs"
 // PCH-NEXT:         "[[A_ROOT_ID]]"
 // PCH:              "-o"
@@ -73,8 +73,8 @@
 // PCH:              "-fmodule-file={{(B=)?}}[[B_PCM]]"
 // PCH:            ]
 // PCH:            "file-deps": [
-// PCH-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
-// PCH-NEXT:         "[[PREFIX]]{{.}}A.h"
+// PCH-NEXT:         "PREFIX{{/|\\\\}}module.modulemap"
+// PCH-NEXT:         "PREFIX{{/|\\\\}}A.h"
 // PCH-NEXT:       ]
 // PCH:            "name": "A"
 // PCH:          }
@@ -84,7 +84,7 @@
 // PCH:            "command-line": [
 // PCH-NEXT:         "-cc1"
 // PCH:              "-fcas-path"
-// PCH-NEXT:         "[[PREFIX]]{{.}}cas"
+// PCH-NEXT:         "PREFIX{{/|\\\\}}cas"
 // PCH:              "-fcas-fs"
 // PCH-NEXT:         "[[B_ROOT_ID]]"
 // PCH:              "-o"
@@ -93,8 +93,8 @@
 // PCH:              "-emit-module"
 // PCH:            ]
 // PCH:            "file-deps": [
-// PCH-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
-// PCH-NEXT:         "[[PREFIX]]{{.}}B.h"
+// PCH-NEXT:         "PREFIX{{/|\\\\}}module.modulemap"
+// PCH-NEXT:         "PREFIX{{/|\\\\}}B.h"
 // PCH-NEXT:       ]
 // PCH:            "name": "B"
 // PCH:          }
@@ -112,7 +112,7 @@
 // PCH:                "command-line": [
 // PCH-NEXT:             "-cc1"
 // PCH:                  "-fcas-path"
-// PCH-NEXT:             "[[PREFIX]]{{.}}cas"
+// PCH-NEXT:             "PREFIX{{/|\\\\}}cas"
 // PCH:                  "-fcas-fs"
 // PCH-NEXT:             "[[PCH_ROOT_ID]]"
 // PCH:                  "-fno-pch-timestamp"
@@ -124,7 +124,7 @@
 // PCH:                  "-fmodule-file={{(A=)?}}[[A_PCM]]"
 // PCH:                ]
 // PCH:                "file-deps": [
-// PCH-NEXT:             "[[PREFIX]]{{.}}prefix.h"
+// PCH-NEXT:             "PREFIX{{/|\\\\}}prefix.h"
 // PCH-NEXT:           ]
 // PCH:              }
 
@@ -136,7 +136,7 @@
 // CHECK:            "command-line": [
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}cas"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[C_ROOT_ID]]"
 // CHECK:              "-o"
@@ -149,8 +149,8 @@
 // CHECK:              "[[B_CACHE_KEY:llvmcas://[[:xdigit:]]+]]"
 // CHECK:            ]
 // CHECK:            "file-deps": [
-// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}C.h"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}module.modulemap"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}C.h"
 // CHECK-NEXT:       ]
 // CHECK:            "name": "C"
 // CHECK:          }
@@ -168,7 +168,7 @@
 // CHECK:                "command-line": [
 // CHECK-NEXT:             "-cc1"
 // CHECK:                  "-fcas-path"
-// CHECK-NEXT:             "[[PREFIX]]{{.}}cas"
+// CHECK-NEXT:             "PREFIX{{/|\\\\}}cas"
 // CHECK:                  "-fcas-fs"
 // CHECK-NEXT:             "[[TU_ROOT_ID]]"
 // CHECK:                  "-fno-pch-timestamp"
@@ -179,8 +179,8 @@
 // CHECK:                  "-fmodule-file={{(C=)?}}[[C_PCM]]"
 // CHECK:                ]
 // CHECK:                "file-deps": [
-// CHECK-NEXT:             "[[PREFIX]]{{.}}tu.c"
-// CHECK-NEXT:             "[[PREFIX]]{{.}}prefix.h.pch"
+// CHECK-NEXT:             "PREFIX{{/|\\\\}}tu.c"
+// CHECK-NEXT:             "PREFIX{{/|\\\\}}prefix.h.pch"
 // CHECK-NEXT:           ]
 // CHECK:              }
 

--- a/clang/test/ClangScanDeps/modules-cas-trees.c
+++ b/clang/test/ClangScanDeps/modules-cas-trees.c
@@ -59,7 +59,7 @@
 // CACHE-MISS: remark: compile job cache miss
 
 // Check specifics of the command-line
-// RUN: cat %t/deps.json | FileCheck %s -DPREFIX=%/t
+// RUN: cat %t/deps.json | %PathSanitizingFileCheck --sanitize PREFIX=%/t --enable-yaml-compatibility %s
 
 // CHECK:      {
 // CHECK-NEXT:   "modules": [
@@ -74,7 +74,7 @@
 // CHECK:            "command-line": [
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}cas"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[LEFT_ROOT_ID]]"
 // CHECK:              "-o"
@@ -87,8 +87,8 @@
 // CHECK:              "-fmodule-file={{(Top=)?}}[[TOP_PCM]]"
 // CHECK:            ]
 // CHECK:            "file-deps": [
-// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}Left.h"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}module.modulemap"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}Left.h"
 // CHECK-NEXT:       ]
 // CHECK:            "name": "Left"
 // CHECK:          }
@@ -103,7 +103,7 @@
 // CHECK:            "command-line": [
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}cas"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[RIGHT_ROOT_ID]]"
 // CHECK:              "-o"
@@ -116,8 +116,8 @@
 // CHECK:              "-fmodule-file={{(Top=)?}}[[TOP_PCM]]"
 // CHECK:            ]
 // CHECK:            "file-deps": [
-// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}Right.h"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}module.modulemap"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}Right.h"
 // CHECK:            ]
 // CHECK:            "name": "Right"
 // CHECK:          }
@@ -128,7 +128,7 @@
 // CHECK:            "command-line": [
 // CHECK-NEXT:         "-cc1"
 // CHECK:              "-fcas-path"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}cas"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}cas"
 // CHECK:              "-fcas-fs"
 // CHECK-NEXT:         "[[TOP_ROOT_ID]]"
 // CHECK:              "-o"
@@ -137,8 +137,8 @@
 // CHECK:              "-emit-module"
 // CHECK:            ]
 // CHECK:            "file-deps": [
-// CHECK-NEXT:         "[[PREFIX]]{{.}}module.modulemap"
-// CHECK-NEXT:         "[[PREFIX]]{{.}}Top.h"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}module.modulemap"
+// CHECK-NEXT:         "PREFIX{{/|\\\\}}Top.h"
 // CHECK:            ]
 // CHECK:            "name": "Top"
 // CHECK:          }
@@ -160,7 +160,7 @@
 // CHECK:                "command-line": [
 // CHECK-NEXT:             "-cc1"
 // CHECK:                  "-fcas-path"
-// CHECK-NEXT:             "[[PREFIX]]{{.}}cas"
+// CHECK-NEXT:             "PREFIX{{/|\\\\}}cas"
 // CHECK:                  "-fcas-fs"
 // CHECK-NEXT:             "[[TU_ROOT_ID]]"
 // CHECK:                  "-fcache-compile-job"
@@ -174,7 +174,7 @@
 // CHECK:                  "-fmodule-file={{(Right=)?}}[[RIGHT_PCM]]"
 // CHECK:                ]
 // CHECK:                "file-deps": [
-// CHECK-NEXT:             "[[PREFIX]]{{.}}tu.c"
+// CHECK-NEXT:             "PREFIX{{/|\\\\}}tu.c"
 // CHECK-NEXT:           ]
 // CHECK:              }
 

--- a/llvm/include/llvm/CAS/FileSystemCache.h
+++ b/llvm/include/llvm/CAS/FileSystemCache.h
@@ -223,7 +223,6 @@ public:
 
   DirectoryEntry &getRoot(StringRef root_path,
                           std::optional<ObjectRef> RootRef = std::nullopt);
-  StringRef getRootPathFor(StringRef Path) const;
   sys::path::Style getPathStyle() const { return PathStyle; }
 
   using LookupSymlinkPathType =


### PR DESCRIPTION
Fix the following CAS-related tests on Windows

Clang :: ClangScanDeps/cas-trees.c
Clang :: ClangScanDeps/modules-availability-check.c
Clang :: ClangScanDeps/modules-cas-fs-vfsoverlay.c
Clang :: ClangScanDeps/modules-cas-implicit-module-cache.c
Clang :: ClangScanDeps/modules-cas-trees-cwd.c
Clang :: ClangScanDeps/modules-cas-trees-input-files.c
Clang :: ClangScanDeps/modules-cas-trees-with-pch.c
Clang :: ClangScanDeps/modules-cas-trees.c