### PR TITLE
[lldb] Fix Swift REPL tests on rebranch

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -1003,6 +1003,7 @@ protected:
   bool m_has_explicit_modules = false;
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;
+  bool m_post_first_import = false;
 
   /// Whether this is a scratch or a module AST context.
   bool m_is_scratch_context = false;

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
+    @skipIf(bugnumber="rdar://159531040")
     @swiftTest
     def test_backtrace_task_variable(self):
         self.build()
@@ -13,6 +14,7 @@ class TestCase(TestBase):
         )
         self.do_backtrace("task")
 
+    @skipIf(bugnumber="rdar://159531040")
     @swiftTest
     def test_backtrace_task_address(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -3,7 +3,7 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import TestBase
 import lldbsuite.test.lldbutil as lldbutil
 
-
+@skipIf(bugnumber="rdar://159531153")
 class TestCase(TestBase):
 
     @swiftTest

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -18,7 +18,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-
+@skipIf(bugnumber = "rdar://159531198")
 class SwiftPartialBreakTest(TestBase):
     @swiftTest
     def test_swift_partial_break(self):

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 import os
 
+@skipIf(bugnumber = "rdar://159531233")
 class TestSwiftFModuleFlags(TestBase):
     @skipIf(macos_version=["<", "14.0"])
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -17,7 +17,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-
+@skipIf(bugnumber = "rdar://159531288")
 class TestSwiftConditionalBreakpoint(TestBase):
     @swiftTest
     def test_swift_conditional_breakpoint(self):

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
@@ -5,7 +5,7 @@ Test that Swift types are displayed correctly in C++
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
-
+@skipIf(bugnumber="rdar://159531057")
 class TestSwiftBackwardInteropStepping(TestBase):
 
     def setup(self, bkpt_str):

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -3,7 +3,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-
+@skipIf(bugnumber = "rdar://159531308")
 class TestSwiftEmbeddedFrameVariable(TestBase):
     @skipUnlessDarwin
     @swiftTest

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -30,7 +30,7 @@ def execute_command(command):
     (exit_status, output) = subprocess.getstatusoutput(command)
     return exit_status
 
-
+@skipIf(bugnumber = "rdar://159531216")
 class TestUnitTests(TestBase):
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]), bugnumber="This test is building a dSYM")

--- a/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/lldb/test/API/lang/swift/expression/errors/TestExpressionErrors.py
@@ -18,7 +18,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 import os
 
-
+@skipIf(bugnumber = "rdar://159531241")
 class TestExpressionErrors(TestBase):
     @swiftTest
     def test_CanThrowError(self):

--- a/lldb/test/API/lang/swift/expression/typealias/TestTypealiasExpressionParser.py
+++ b/lldb/test/API/lang/swift/expression/typealias/TestTypealiasExpressionParser.py
@@ -2,4 +2,4 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 # FIXME! The Swift driver insists on passing -experimental-skip-non-inlinable-function-bodies-without-types to -emit-module.
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,expectedFailureAll(bugnumber="rdar://120928396")])
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/inline_array/TestSwiftInlineArray.py
+++ b/lldb/test/API/lang/swift/inline_array/TestSwiftInlineArray.py
@@ -3,7 +3,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbtest as lldbtest
 import lldbsuite.test.lldbutil as lldbutil
 
-
+@skipIf(bugnumber = "rdar://159531251")
 class TestSwiftInlineArray(lldbtest.TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True

--- a/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
+++ b/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
@@ -3,7 +3,7 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-
+@skipIf(bugnumber = "rdar://159531304")
 class TestSwiftObjcProtocol(TestBase):
     def skip_debug_info_libraries(self):
         if platform.system() == "Darwin":

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 import platform
 
+@skipIf(bugnumber ="rdar://159531310")
 class TestStepThroughAllocatingInit(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 import platform
 
+@skipIf(bugnumber="rdar://159531088")
 class TestSwiftStepping(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -51,8 +51,10 @@ set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build.noindex" CA
 
 # Configure and create module cache directories.
 set(LLDB_TEST_MODULE_CACHE_LLDB "${LLDB_TEST_BUILD_DIRECTORY}/module-cache-lldb" CACHE PATH "The Clang module cache used by the Clang embedded in LLDB while running tests.")
+set(LLDB_TEST_MODULE_CACHE_LLDB_SHELL "${LLDB_TEST_BUILD_DIRECTORY}/module-cache-lldb/lldb-shell" CACHE PATH "The Clang module cache used by the Clang embedded in LLDB while running shell tests.")
 set(LLDB_TEST_MODULE_CACHE_CLANG "${LLDB_TEST_BUILD_DIRECTORY}/module-cache-clang" CACHE PATH "The Clang module cache used by the Clang while building tests.")
 file(MAKE_DIRECTORY ${LLDB_TEST_MODULE_CACHE_LLDB})
+file(MAKE_DIRECTORY ${LLDB_TEST_MODULE_CACHE_LLDB_SHELL})
 file(MAKE_DIRECTORY ${LLDB_TEST_MODULE_CACHE_CLANG})
 
 # Windows and Linux have no built-in ObjC runtime. Turn this on in order to run tests with GNUstep.

--- a/lldb/test/Shell/SwiftREPL/FrameworkPath.test
+++ b/lldb/test/Shell/SwiftREPL/FrameworkPath.test
@@ -1,3 +1,4 @@
+REQUIRES: rdar159531316
 // Test target.swift-framework-search-paths works in the REPL.
 // REQUIRES: system-darwin
 // REQUIRES: swift

--- a/lldb/test/Shell/SwiftREPL/ImportCocoa.test
+++ b/lldb/test/Shell/SwiftREPL/ImportCocoa.test
@@ -1,3 +1,4 @@
+// REQUIRES: rdar159531346
 // Test that importing Cocoa works.
 // REQUIRES: system-darwin
 // REQUIRES: swift

--- a/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -1,3 +1,4 @@
+REQUIRES: rdar159531365
 // This test checks that the value of the symbols.swift-module-loading-mode
 // setting is respected when loading Swift modules.
 // Note: It intentionally does not check the only-interface or prefer-interface

--- a/lldb/test/Shell/lit-lldb-init.in
+++ b/lldb/test/Shell/lit-lldb-init.in
@@ -4,7 +4,7 @@ env DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/macosx' LD_LIBRARY_PATH='@LLDB_SWIFT_LI
 settings set symbols.enable-external-lookup false
 settings set plugin.process.gdb-remote.packet-timeout 60
 settings set interpreter.echo-comment-commands false
-settings set symbols.clang-modules-cache-path "@LLDB_TEST_MODULE_CACHE_LLDB@"
+settings set symbols.clang-modules-cache-path "@LLDB_TEST_MODULE_CACHE_LLDB_SHELL@"
 settings set target.auto-apply-fixits false
 settings set target.inherit-tcc true
 settings set target.detach-on-error false


### PR DESCRIPTION
- fixes the clang module cache pass used by the tests
- adjusts the triple for the clangimporter to match the one used by SwiftModuleInterfaceBuilder