### PR TITLE
🍒[next][compiler-rt][profile] Exclude signal.h on WASI

### DIFF
--- a/compiler-rt/lib/profile/InstrProfilingFile.c
+++ b/compiler-rt/lib/profile/InstrProfilingFile.c
@@ -13,7 +13,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if !defined(__wasi__)
 #include <signal.h>
+#endif
 #ifdef _MSC_VER
 /* For _alloca. */
 #include <malloc.h>

--- a/compiler-rt/lib/profile/InstrProfilingUtil.c
+++ b/compiler-rt/lib/profile/InstrProfilingUtil.c
@@ -34,7 +34,9 @@ typedef uint_t uint;
 #include <sys/utsname.h>
 #endif
 
+#if !defined(__wasi__)
 #include <signal.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 
@@ -462,6 +464,8 @@ COMPILER_RT_VISIBILITY void lprofInstallSignalHandler(int sig,
   if (err == SIG_ERR)
     PROF_WARN("Unable to install an exit signal handler for %d (errno = %d).\n",
               sig, errno);
+#elif defined(__wasi__)
+  // WASI doesn't support signal.
 #else
   struct sigaction sigact;
   memset(&sigact, 0, sizeof(sigact));


### PR DESCRIPTION
Cherry-pick a downstream specific patch a1a7a17504f50681f5230690abfa941142e1c286 from https://github.com/swiftlang/llvm-project/pull/9418