### PR TITLE
[lldb][windows] Skip TestPlatformConnect.py which times out on Windows

### DIFF
--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -168,6 +168,7 @@ skip lldb-api :: lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers
 skip lldb-api :: lang/BoundsSafety/out_of_bounds_pointer/TestOutOfBoundsPointer.py
 skip lldb-shell :: Commands/command-expr-diagnostics.test
 skip lldb-unit :: Host/./HostTests.exe
+skip lldb-api :: commands/platform/connect/TestPlatformConnect.py
 
 # https://github.com/llvm/llvm-project/issues/62983
 skip lldb-api :: functionalities/var_path/TestVarPath.py


### PR DESCRIPTION
In https://github.com/swiftlang/llvm-project/pull/11143 we moved `lldb/test/windows-swift-llvm-lit-test-overrides.txt` from the swift repository to the llvm-project repository.

In the middle of this move, https://github.com/swiftlang/llvm-project/pull/11251 was merged. This patch ports the change of https://github.com/swiftlang/llvm-project/pull/11251 to the new file.