### PR TITLE
[lldb] Fix Swift REPL tests on rebranch

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -1003,6 +1003,7 @@ protected:
   bool m_has_explicit_modules = false;
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;
+  bool m_post_first_import = false;
 
   /// Whether this is a scratch or a module AST context.
   bool m_is_scratch_context = false;

--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -51,8 +51,10 @@ set(LLDB_TEST_BUILD_DIRECTORY "${PROJECT_BINARY_DIR}/lldb-test-build.noindex" CA
 
 # Configure and create module cache directories.
 set(LLDB_TEST_MODULE_CACHE_LLDB "${LLDB_TEST_BUILD_DIRECTORY}/module-cache-lldb" CACHE PATH "The Clang module cache used by the Clang embedded in LLDB while running tests.")
+set(LLDB_TEST_MODULE_CACHE_LLDB_SHELL "${LLDB_TEST_BUILD_DIRECTORY}/module-cache-lldb/lldb-shell" CACHE PATH "The Clang module cache used by the Clang embedded in LLDB while running shell tests.")
 set(LLDB_TEST_MODULE_CACHE_CLANG "${LLDB_TEST_BUILD_DIRECTORY}/module-cache-clang" CACHE PATH "The Clang module cache used by the Clang while building tests.")
 file(MAKE_DIRECTORY ${LLDB_TEST_MODULE_CACHE_LLDB})
+file(MAKE_DIRECTORY ${LLDB_TEST_MODULE_CACHE_LLDB_SHELL})
 file(MAKE_DIRECTORY ${LLDB_TEST_MODULE_CACHE_CLANG})
 
 # Windows and Linux have no built-in ObjC runtime. Turn this on in order to run tests with GNUstep.

--- a/lldb/test/Shell/lit-lldb-init.in
+++ b/lldb/test/Shell/lit-lldb-init.in
@@ -4,7 +4,7 @@ env DYLD_LIBRARY_PATH='@LLDB_SWIFT_LIBS@/macosx' LD_LIBRARY_PATH='@LLDB_SWIFT_LI
 settings set symbols.enable-external-lookup false
 settings set plugin.process.gdb-remote.packet-timeout 60
 settings set interpreter.echo-comment-commands false
-settings set symbols.clang-modules-cache-path "@LLDB_TEST_MODULE_CACHE_LLDB@"
+settings set symbols.clang-modules-cache-path "@LLDB_TEST_MODULE_CACHE_LLDB_SHELL@"
 settings set target.auto-apply-fixits false
 settings set target.inherit-tcc true
 settings set target.detach-on-error false


### PR DESCRIPTION
- fixes the clang module cache pass used by the tests
- adjusts the triple for the clangimporter to match the one used by SwiftModuleInterfaceBuilder

(cherry picked from commit 492f04b8405443c96337f0ada2226c1add26a7f4)