### PR TITLE
🍒 [lldb][swift] Add test for disable-language-runtime-unwindplans

### DIFF
--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/TestDisableLanguageUnwinder.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestDisableLanguageUnwinder(lldbtest.TestBase):
+
+    @swiftTest
+    @skipIf(oslist=['windows', 'linux'])
+    def test(self):
+        """Test async unwind"""
+        self.build()
+        src = lldb.SBFileSpec('main.swift')
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', src)
+
+        self.assertIn("syncFunc", thread.GetFrameAtIndex(0).GetFunctionName())
+        self.assertIn("callSyncFunc", thread.GetFrameAtIndex(1).GetFunctionName())
+        self.assertIn("main", thread.GetFrameAtIndex(2).GetFunctionName())
+
+        self.runCmd("settings set target.process.disable-language-runtime-unwindplans true")
+
+        self.assertIn("syncFunc", thread.GetFrameAtIndex(0).GetFunctionName())
+        self.assertIn("callSyncFunc", thread.GetFrameAtIndex(1).GetFunctionName())
+        self.assertNotIn("main", thread.GetFrameAtIndex(2).GetFunctionName())

--- a/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/main.swift
+++ b/lldb/test/API/lang/swift/async/unwind/disable_language_unwinder/main.swift
@@ -1,0 +1,13 @@
+func syncFunc() {
+  print("break here")
+}
+
+func callSyncFunc() async {
+  syncFunc()
+}
+
+@main struct Main {
+  static func main() async {
+    await callSyncFunc()
+  }
+}


### PR DESCRIPTION
This can only be tested on downstream LLDB, as it requires a language with a custom unwind plan.

(cherry picked from commit e89cc2955cfe219749c6c1b2f6e28d6bc77c82d7)