### PR TITLE
[lldb] Fix handling of addresses given to swift task commands

### DIFF
--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -31,6 +31,6 @@ class TestCase(TestBase):
                 ".sleep(",
                 "`second() at main.swift:6",
                 "`first() at main.swift:2",
-                "`closure #1 in static Main.main() at main.swift:12:19",
+                "`closure #1 in static Main.main() at main.swift:12",
             ],
         )

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
 
-    @skipIf(bugnumber="rdar://159531040")
     @swiftTest
     def test_backtrace_task_variable(self):
         self.build()
@@ -14,7 +13,6 @@ class TestCase(TestBase):
         )
         self.do_backtrace("task")
 
-    @skipIf(bugnumber="rdar://159531040")
     @swiftTest
     def test_backtrace_task_address(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -30,9 +30,9 @@ class TestCase(TestBase):
             "thread backtrace",
             substrs=[
                 ".sleep(",
-                "`second() at main.swift:6:",
-                "`first() at main.swift:2:",
-                "`closure #1 in static Main.main() at main.swift:12:",
+                "`second() at main.swift:6",
+                "`first() at main.swift:2",
+                "`closure #1 in static Main.main() at main.swift:12",
             ],
         )
 

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -3,7 +3,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import TestBase
 import lldbsuite.test.lldbutil as lldbutil
 
-@skipIf(bugnumber="rdar://159531153")
 class TestCase(TestBase):
 
     @swiftTest


### PR DESCRIPTION
The DIL implementation of `GetValueForVariableExpressionPath` succeeds when the "variable expression path" is an integer. This code expected the old behavior, where `GetValueForVariableExpressionPath` would fail for an integer value.

The fix is to try parsing the command arg as an address first (instead of as a fallback). If the command arg does not parse as an address, then it is tried as a variable expression path.

rdar://159531040