### PR TITLE
[Cherry-pick into next] [lldb] Fix verbose log output

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3368,7 +3368,7 @@ SwiftLanguageRuntime::GetTypeRef(CompilerType type,
     type_ref_or_err->dump(ss);
     LLDB_LOG(log,
              "[SwiftLanguageRuntime::GetTypeRef] Found typeref for "
-             "type: {0}:\n{0}",
+             "type: {0}:\n{1}",
              type.GetMangledTypeName(), ss.str());
   }
   return type_ref_or_err;


### PR DESCRIPTION
```
commit 34c2a737a3bf1089e96d7eb1d933e0c2be4fce81
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Aug 26 15:55:10 2025 -0700

    [lldb] Fix verbose log output
```
