### PR TITLE
[lldb] Disable TestRegisters.test_register_commands

### DIFF
--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -42,6 +42,7 @@ class RegisterCommandsTestCase(TestBase):
     @skipIfiOSSimulator
     @skipIf(archs=no_match(["amd64", "arm$", "i386", "x86_64"]))
     @expectedFailureAll(oslist=["freebsd", "netbsd"], bugnumber="llvm.org/pr48371")
+    @skipIf(bugnumber="rdar://159864305")
     def test_register_commands(self):
         """Test commands related to registers, in particular vector registers."""
         self.build()


### PR DESCRIPTION
This is failing in PR CI tests.
