### PR TITLE
Fix the following CAS-related tests on Windows

### DIFF
--- a/clang/test/ClangScanDeps/cas-case-sensitivity.c
+++ b/clang/test/ClangScanDeps/cas-case-sensitivity.c
@@ -10,14 +10,14 @@
 // RUN: sed -e 's/^.*llvmcas/llvmcas/' -e 's/ for.*$//' %t/result1.txt > %t/casid1
 // RUN: sed -e 's/^.*llvmcas/llvmcas/' -e 's/ for.*$//' %t/result2.txt > %t/casid2
 
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid1 | FileCheck -check-prefix=TREE %s -DPREFIX=%/t
-// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid2 | FileCheck -check-prefix=TREE %s -DPREFIX=%/t
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid1 | FileCheck -check-prefix=TREE %s -DPREFIX=%{t-tree-/}
+// RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/casid2 | FileCheck -check-prefix=TREE %s -DPREFIX=%{t-tree-/}
 
 // asdf: FileCheck -check-prefix=TREE %s -input-file %t/result1.txt -DPREFIX=%/t
 
-// TREE: file llvmcas://{{.*}} [[PREFIX]]/Header.h
-// TREE: syml llvmcas://{{.*}} [[PREFIX]]/header.h -> Header
-// TREE: file llvmcas://{{.*}} [[PREFIX]]/t{{[12]}}.c
+// TREE: file llvmcas://{{.*}} [[PREFIX]]{{/|\\}}Header.h
+// TREE: syml llvmcas://{{.*}} [[PREFIX]]{{/|\\}}header.h -> Header
+// TREE: file llvmcas://{{.*}} [[PREFIX]]{{/|\\}}t{{[12]}}.c
 
 //--- cdb1.json.template
 [

--- a/clang/test/ClangScanDeps/cas-fs-multiple-commands.c
+++ b/clang/test/ClangScanDeps/cas-fs-multiple-commands.c
@@ -19,7 +19,7 @@
 
 // RUN: cat %t/deps.0.json | sed 's:\\\\\?:/:g' | FileCheck %s -DPREFIX=%/t
 
-// RUN: CLANG_CACHE_USE_CASFS_DEPSCAN=1 c-index-test core -scan-deps -working-dir %t -cas-path %t/cas -output-dir %t/modules -- \
+// RUN: env CLANG_CACHE_USE_CASFS_DEPSCAN=1 c-index-test core -scan-deps -working-dir %t -cas-path %t/cas -output-dir %t/modules -- \
 // RUN:   %clang -target x86_64-apple-darwin -c %t/tu.c -save-temps=obj -o %t/tu.o \
 // RUN:   -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=%t/cache \
 // RUN:   > %t/deps.txt

--- a/clang/test/ClangScanDeps/include-tree-preserve-pch-path.c
+++ b/clang/test/ClangScanDeps/include-tree-preserve-pch-path.c
@@ -22,9 +22,9 @@
 // RUN: %deps-to-rsp %t/deps_tu.json --tu-index 0 > %t/tu.rsp
 // RUN: %clang @%t/tu.rsp
 
-// RUN: cat %t/tu.ll | FileCheck %s -check-prefix=LLVMIR -DPREFIX=%/t
-// LLVMIR: !DIFile(filename: "[[PREFIX]]/tu.c", directory: "")
-// LLVMIR: !DICompileUnit({{.*}}, splitDebugFilename: "[[PREFIX]]/prefix.pch"
+// RUN: cat %t/tu.ll | %PathSanitizingFileCheck --sanitize PREFIX=%/t --enable-yaml-compatibility %s -check-prefix=LLVMIR
+// LLVMIR: !DIFile(filename: "PREFIX{{/|\\\\}}tu.c", directory: "")
+// LLVMIR: !DICompileUnit({{.*}}, splitDebugFilename: "PREFIX{{/|\\\\}}prefix.pch"
 // LLVMIR: !DIFile(filename: "prefix.h", directory: "")
 
 // Extract include-tree casid

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -356,6 +356,21 @@ CachingOnDiskFileSystemImpl::makeSymlinkTo(DirectoryEntry &Parent,
                              TargetStorage.Path);
 }
 
+static bool is_executable(StringRef TreePath, sys::fs::file_status Status,
+                          sys::path::Style PathStyle) {
+#ifndef _WIN32
+  return Status.permissions() & sys::fs::perms::owner_exe;
+#else
+  // This isn't the most reliable way but does better than just
+  // checking owner_exe because most owned files have all_all
+  // permission regardless of they are executable files.
+  StringRef FilePath = getFilePath(TreePath, PathStyle);
+  return (Status.permissions() & sys::fs::perms::owner_exe) &&
+      (FilePath.ends_with_insensitive(".exe") ||
+       sys::fs::exists(FilePath + ".exe"));
+#endif
+}
+
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::makeFile(DirectoryEntry &Parent,
                                       StringRef TreePath, sys::fs::file_t F,
@@ -371,8 +386,8 @@ CachingOnDiskFileSystemImpl::makeFile(DirectoryEntry &Parent,
     return Handle.takeError();
   // Do not trust Status.size() in case the file is volatile.
   return &Cache->makeFile(Parent, TreePathStorage.Path, *Node,
-                          Handle->getData().size(),
-                          Status.permissions() & sys::fs::perms::owner_exe);
+      Handle->getData().size(),
+      is_executable(TreePath, Status, Cache->getPathStyle()));
 }
 
 Expected<FileSystemCache::DirectoryEntry *>

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1512,6 +1512,14 @@ def getDefaultSubstitutions(test, tmpDir, tmpBase, normalize_slashes=False):
         # a leading slash.
         substitutions.append(("%:" + letter, colonNormalizePath(path)))
 
+    substitutions.extend(
+        [
+            # %t (tmpName) in tree path forms for Windows
+            ("%{t-tree}", "\\" + tmpName if kIsWindows else tmpName),
+            ("%{t-tree-/}", "/" + tmpName.replace("\\", "/") if kIsWindows else tmpName),
+        ]
+    )
+
     return substitutions
 
 


### PR DESCRIPTION
Fix the following CAS-related tests on Windows

Clang :: ClangScanDeps/cas-case-sensitivity.c
Clang :: ClangScanDeps/cas-fs-multiple-commands.c
Clang :: ClangScanDeps/include-tree-preserve-pch-path.c