### PR TITLE
FreeBSD: SwiftREPL: Find swiftCore.so

### DIFF
--- a/lldb/tools/repl/swift/CMakeLists.txt
+++ b/lldb/tools/repl/swift/CMakeLists.txt
@@ -20,17 +20,18 @@ target_link_libraries(repl_swift PRIVATE ${CMAKE_DL_LIBS})
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   set_target_properties(repl_swift PROPERTIES
     WIN32_EXECUTABLE TRUE)
-elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|Android|OpenBSD|FreeBSD")
+  string(TOLOWER "${CMAKE_SYSTEM_NAME}" platform)
   if(CMAKE_SYSTEM_PROCESSOR MATCHES ppc64le)
     set_target_properties(repl_swift PROPERTIES
-      BUILD_RPATH ${SWIFT_LIBRARY_DIR}/swift/linux/powerpc64le)
+      BUILD_RPATH "${SWIFT_LIBRARY_DIR}/swift/${platform}/powerpc64le")
   else()
     set_target_properties(repl_swift PROPERTIES
-      BUILD_RPATH ${SWIFT_LIBRARY_DIR}/swift/linux)
+      BUILD_RPATH "${SWIFT_LIBRARY_DIR}/swift/${platform}")
   endif()
   set_target_properties(repl_swift PROPERTIES
     BUILD_WITH_INSTALL_RPATH NO
-    INSTALL_RPATH "$ORIGIN/../lib/swift/linux")
+    INSTALL_RPATH "$ORIGIN/../lib/swift/${platform}")
 endif()
 
 # The dummy repl executable is a C program, but we always look for a mangled

--- a/lldb/tools/repl/swift/main.c
+++ b/lldb/tools/repl/swift/main.c
@@ -15,7 +15,7 @@
 #include <dlfcn.h>
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <dlfcn.h>
 #endif
 
@@ -60,7 +60,7 @@ int main() {
   // We load the system's libswiftCore, but this is overriden on tests to 
   // use the just built one by setting DYLD_LIBRARY_PATH.
   dlopen("/usr/lib/swift/libswiftCore.dylib", RTLD_LAZY);
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
   dlopen("libswiftCore.so", RTLD_LAZY);
 #elif defined(_WIN32)
   HMODULE hModule = LoadLibraryW(L"swiftCore.dll");


### PR DESCRIPTION
The REPL keys off of the location of swiftCore.so loaded in the REPL itself. The image is loaded lazily by dlopen. This was disabled on FreeBSD though, so the repl couldn't find the Swift runtime.

rdar://158057010