### PR TITLE
[lldb] Add summary formatter for _BridgedURL

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -703,6 +703,10 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       "URL summary provider", ConstString("Foundation._SwiftURL"),
       TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
 
+  lldb_private::formatters::AddStringSummary(
+      swift_category_sp, "${var._url}", ConstString("Foundation._BridgedURL"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
+
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp,
       lldb_private::formatters::swift::IndexPath_SummaryProvider,

--- a/lldb/test/API/lang/swift/bridged_url/Makefile
+++ b/lldb/test/API/lang/swift/bridged_url/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
+++ b/lldb/test/API/lang/swift/bridged_url/TestSwiftBridgedURL.py
@@ -1,0 +1,16 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("v url", substrs=['url = "file:///tmp"'])

--- a/lldb/test/API/lang/swift/bridged_url/main.swift
+++ b/lldb/test/API/lang/swift/bridged_url/main.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@main enum Entry {
+    static func main() {
+        let nsurl = NSURL(fileURLWithPath: "/tmp")
+        let url = nsurl as URL
+        print("break here", url)
+    }
+}


### PR DESCRIPTION
Data wise, `_BridgedURL` is a wrapper around `NSURL`. This fixes printing of these
bridged URLs by simply delegating to the inner `NSURL` (`_url`).

(cherry-picked from commit 9112593a33d08adf3bec7e7a3df194d7ca5b8fc1)