### PR TITLE
[windows][lldb] re-add failing tests to expected failures

### DIFF
--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -10,6 +10,7 @@
 
 xfail lldb-api :: lang/cpp/unique-types4/TestUniqueTypes4.py
 xfail lldb-shell :: Recognizer/verbose_trap.test
+xfail lldb-shell :: Settings/TestEchoCommands.test
 xfail lldb-shell :: Swift/MissingVFSOverlay.test
 xfail lldb-shell :: Swift/No.swiftmodule.test
 xfail lldb-shell :: Swift/ToolchainMismatch.test
@@ -24,6 +25,7 @@ xfail lldb-shell :: SwiftREPL/OpenClass.test
 xfail lldb-shell :: SwiftREPL/OptionalUnowned.test
 xfail lldb-shell :: SwiftREPL/RedirectInputUnreadable.test
 xfail lldb-shell :: SwiftREPL/SwiftInterface.test
+xfail lldb-shell :: SymbolFile/DWARF/x86/dead-code-filtering.yaml
 
 ### Tests that pass locally, but fail in CI reliably ###
 


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/83588 we are migrating the `utils/windows-llvm-lit-test-overrides.txt` file to the `llvm-project` repository.

`Settings/TestEchoCommands.test` and `SymbolFile/DWARF/x86/dead-code-filtering.yaml` are failing on main but not on some release branches.

This patch re-adds those tests to the list of failing tests.