### PR TITLE
[lldb] Ignore swiftCore library for TestStepThroughAllocatingInit

### DIFF
--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -32,6 +32,10 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
         exe_name = "a.out"
         exe = self.getBuildArtifact(exe_name)
 
+        self.runCmd(
+            "settings set target.process.thread.step-avoid-libraries libswiftCore.dylib"
+        )
+
         target, process, thread, breakpoint = lldbutil.run_to_source_breakpoint(self,
         'Break here to step into init', self.main_source_spec)
 


### PR DESCRIPTION
This is causing the test to fail on CI, as we build the standard library with debug symbols.

This does not yet re-enable the test because of a separate issue with rebranch.

rdar://158610467