### PR TITLE
[lldb][debugserver] Max response size for qSpeedTest (#156099)

### DIFF
--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -4422,12 +4422,12 @@ rnb_err_t RNBRemote::HandlePacket_qSpeedTest(const char *p) {
     return HandlePacket_ILLFORMED(
         __FILE__, __LINE__, p,
         "Didn't find response_size value at right offset");
-  else if (*end == ';') {
-    static char g_data[4 * 1024 * 1024 + 16];
-    strcpy(g_data, "data:");
-    memset(g_data + 5, 'a', response_size);
-    g_data[response_size + 5] = '\0';
-    return SendPacket(g_data);
+  else if (*end == ';' && response_size < (4 * 1024 * 1024)) {
+    std::vector<char> buf(response_size + 6, 'a');
+    memcpy(buf.data(), "data:", 5);
+    buf[buf.size() - 1] = '\0';
+    rnb_err_t return_value = SendPacket(buf.data());
+    return return_value;
   } else {
     return SendErrorPacket("E79");
   }


### PR DESCRIPTION
The qSpeedTest packet is used for experiments to determine the optimal packet size for a given communication medium, e.g. to transfer 10MB of memory, is it faster to send a hundred 100KB packets or ten 1MB packets. It creates a packet of the requested size in a stack allocation, but is not checking that its buffer is large enough for the requested size.

Change this allocation to be on heap, and impose a maximum size that can be tested (4MB, for now).

rdar://158630250
(cherry picked from commit ac8e7be5fbd11f731ffc81bf3bbae50a5a4d83de)