### PR TITLE
[lldb] Fix missing return in TestStepIntoObjCInteropInit

### DIFF
--- a/lldb/test/API/lang/swift/step_into_objc_interop_init/Foo.m
+++ b/lldb/test/API/lang/swift/step_into_objc_interop_init/Foo.m
@@ -3,6 +3,7 @@
 @implementation Foo
 
 - (id)init {
+  return self;
 }
 
 - (id)initWithString:(nonnull NSString *)value {


### PR DESCRIPTION
Objective C constructors must return self.