### PR TITLE
Revert "[C++ BoundsSafety] Fix false positives when pointer argument is a function call (#11046)"

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -470,111 +470,69 @@ getDependentValuesFromCall(const CountAttributedType *CAT,
 //   form `f(...)` is not supported.
 struct CompatibleCountExprVisitor
     : public ConstStmtVisitor<CompatibleCountExprVisitor, bool, const Expr *,
-                              bool, bool> {
-  // The third and forth 'bool' type parameters for each visit method indicates
-  // whether the current visiting expression is the result of the formal
-  // parameter to actual argument substitution (for `Self` and `Other` resp.).
-  // Since the argument expression may contain DREs referencing to back to those
-  // parameters (in cases of recursive calls), the analysis may hit an infinite
-  // loop if not knowing whether the substitution has happened.  A typical
-  // example that could introduce infinite loop without this knowledge is shown
-  // below.
+                              bool> {
+  // The third 'bool' type parameter for each visit method indicates whether the
+  // current visiting expression is the result of the formal parameter to actual
+  // argument substitution.  Since the argument expression may contain DREs
+  // referencing to back to those parameters (in cases of recursive calls), the
+  // analysis may hit an infinite loop if not knowing whether the substitution
+  // has happened.  A typical example that could introduce infinite loop without
+  // this knowledge is shown below.
   // ```
   //  void f(int * __counted_by(n) p, size_t n) {
   //    f(p, n);
   //  }
   // ```
-  using BaseVisitor = ConstStmtVisitor<CompatibleCountExprVisitor, bool,
-                                       const Expr *, bool, bool>;
+  using BaseVisitor =
+      ConstStmtVisitor<CompatibleCountExprVisitor, bool, const Expr *, bool>;
 
   const Expr *MemberBase;
-  const DependentValuesTy *DependentValuesSelf, *DependentValuesOther;
+  const DependentValuesTy *DependentValues;
   ASTContext &Ctx;
 
-  // Attempts to perform substitution on E and simplify the result, if the
-  // result has the form "*&e".
-  //
-  //  This function will be repeatedly called on the "Other" Expr, because the
-  //  kind of "Other" stays unknown during the traversal.
-  const Expr *
-  trySubstituteAndSimplify(const Expr *E, bool &hasBeenSubstituted,
-                           const DependentValuesTy *DependentValues) const {
-    // Attempts to simplify `E`: if `E` has the form `*&e`, return `e`;
-    // return `E` without change otherwise:
-    auto trySimplifyDerefAddressof =
-        [](const Expr *E,
-           const DependentValuesTy
-               *DependentValues, // Deref may need subsitution
-           bool &hasBeenSubstituted) -> const Expr * {
-      const auto *Deref = dyn_cast<UnaryOperator>(E->IgnoreParenImpCasts());
+  // If `Deref` has the form `*&e`, return `e`; otherwise return nullptr.
+  const Expr *trySimplifyDerefAddressof(const UnaryOperator *Deref,
+                                        bool hasBeenSubstituted) {
+    const Expr *DerefOperand = Deref->getSubExpr()->IgnoreParenImpCasts();
 
-      if (!Deref || Deref->getOpcode() != UO_Deref)
-        return E;
+    if (const auto *UO = dyn_cast<UnaryOperator>(DerefOperand))
+      if (UO->getOpcode() == UO_AddrOf)
+        return UO->getSubExpr();
+    if (const auto *DRE = dyn_cast<DeclRefExpr>(DerefOperand)) {
+      if (!DependentValues || hasBeenSubstituted)
+        return nullptr;
 
-      const Expr *DerefOperand = Deref->getSubExpr()->IgnoreParenImpCasts();
+      auto I = DependentValues->find(DRE->getDecl());
 
-      if (const auto *UO = dyn_cast<UnaryOperator>(DerefOperand))
-        if (UO->getOpcode() == UO_AddrOf)
-          return UO->getSubExpr();
-      if (const auto *DRE = dyn_cast<DeclRefExpr>(DerefOperand)) {
-        if (!DependentValues || hasBeenSubstituted)
-          return E;
-
-        if (auto I = DependentValues->find(DRE->getDecl());
-            I != DependentValues->end())
-          if (const auto *UO = dyn_cast<UnaryOperator>(
-                  I->getSecond()->IgnoreParenImpCasts()))
-            if (UO->getOpcode() == UO_AddrOf) {
-              hasBeenSubstituted = true;
-              return UO->getSubExpr();
-            }
-      }
-      return E;
-    };
-
-    if (!hasBeenSubstituted && DependentValues) {
-      if (const auto *DRE = dyn_cast<DeclRefExpr>(E->IgnoreParenImpCasts())) {
-        if (auto It = DependentValues->find(DRE->getDecl());
-            It != DependentValues->end()) {
-          hasBeenSubstituted = true;
-          return trySimplifyDerefAddressof(It->second, nullptr,
-                                           hasBeenSubstituted);
-        }
-      }
+      if (I != DependentValues->end())
+        if (const auto *UO = dyn_cast<UnaryOperator>(I->getSecond()))
+          if (UO->getOpcode() == UO_AddrOf)
+            return UO->getSubExpr();
     }
-    return trySimplifyDerefAddressof(E, DependentValues, hasBeenSubstituted);
+    return nullptr;
   }
 
-  explicit CompatibleCountExprVisitor(
-      const Expr *MemberBase, const DependentValuesTy *DependentValuesSelf,
-      const DependentValuesTy *DependentValuesOther, ASTContext &Ctx)
-      : MemberBase(MemberBase), DependentValuesSelf(DependentValuesSelf),
-        DependentValuesOther(DependentValuesOther), Ctx(Ctx) {}
+  explicit CompatibleCountExprVisitor(const Expr *MemberBase,
+                                      const DependentValuesTy *DependentValues,
+                                      ASTContext &Ctx)
+      : MemberBase(MemberBase), DependentValues(DependentValues), Ctx(Ctx) {}
 
-  bool VisitStmt(const Stmt *Self, const Expr *Other,
-                 bool hasSelfBeenSubstituted, bool hasOtherBeenSubstituted) {
+  bool VisitStmt(const Stmt *S, const Expr *E, bool hasBeenSubstituted) {
     return false;
   }
 
   bool VisitImplicitCastExpr(const ImplicitCastExpr *SelfICE, const Expr *Other,
-                             bool hasSelfBeenSubstituted,
-                             bool hasOtherBeenSubstituted) {
-    return Visit(SelfICE->getSubExpr(), Other, hasSelfBeenSubstituted,
-                 hasOtherBeenSubstituted);
+                             bool hasBeenSubstituted) {
+    return Visit(SelfICE->getSubExpr(), Other, hasBeenSubstituted);
   }
 
   bool VisitParenExpr(const ParenExpr *SelfPE, const Expr *Other,
-                      bool hasSelfBeenSubstituted,
-                      bool hasOtherBeenSubstituted) {
-    return Visit(SelfPE->getSubExpr(), Other, hasSelfBeenSubstituted,
-                 hasOtherBeenSubstituted);
+                      bool hasBeenSubstituted) {
+    return Visit(SelfPE->getSubExpr(), Other, hasBeenSubstituted);
   }
 
   bool VisitIntegerLiteral(const IntegerLiteral *SelfIL, const Expr *Other,
-                           bool hasSelfBeenSubstituted,
-                           bool hasOtherBeenSubstituted) {
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
+                           bool hasBeenSubstituted) {
     if (const auto *IntLit =
             dyn_cast<IntegerLiteral>(Other->IgnoreParenImpCasts())) {
       return SelfIL == IntLit ||
@@ -585,10 +543,7 @@ struct CompatibleCountExprVisitor
 
   bool VisitUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *Self,
                                      const Expr *Other,
-                                     bool hasSelfBeenSubstituted,
-                                     bool hasOtherBeenSubstituted) {
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
+                                     bool hasBeenSubstituted) {
     // If `Self` is a `sizeof` expression, try to evaluate and compare the two
     // expressions as constants:
     if (Self->getKind() == UnaryExprOrTypeTrait::UETT_SizeOf) {
@@ -606,102 +561,81 @@ struct CompatibleCountExprVisitor
   }
 
   bool VisitCXXThisExpr(const CXXThisExpr *SelfThis, const Expr *Other,
-                        bool hasSelfBeenSubstituted,
-                        bool hasOtherBeenSubstituted) {
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
+                        bool hasBeenSubstituted) {
     return isa<CXXThisExpr>(Other->IgnoreParenImpCasts());
   }
 
   bool VisitDeclRefExpr(const DeclRefExpr *SelfDRE, const Expr *Other,
-                        bool hasSelfBeenSubstituted,
-                        bool hasOtherBeenSubstituted) {
-    const auto *SubstSelf = trySubstituteAndSimplify(
-        SelfDRE, hasSelfBeenSubstituted, DependentValuesSelf);
+                        bool hasBeenSubstituted) {
+    const ValueDecl *SelfVD = SelfDRE->getDecl();
 
-    if (SubstSelf != SelfDRE)
-      return Visit(SubstSelf, Other, hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
+    if (DependentValues && !hasBeenSubstituted) {
+      const auto It = DependentValues->find(SelfVD);
+      if (It != DependentValues->end())
+        return Visit(It->second, Other, true);
+    }
 
     const auto *O = Other->IgnoreParenImpCasts();
 
     if (const auto *OtherDRE = dyn_cast<DeclRefExpr>(O)) {
       // Both SelfDRE and OtherDRE can be transformed from member expressions:
-      if (OtherDRE->getDecl() == SelfDRE->getDecl())
+      if (OtherDRE->getDecl() == SelfVD)
         return true;
       return false;
     }
 
     const auto *OtherME = dyn_cast<MemberExpr>(O);
     if (MemberBase && OtherME) {
-      return OtherME->getMemberDecl() == SelfDRE->getDecl() &&
-             Visit(OtherME->getBase(), MemberBase, hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
+      return OtherME->getMemberDecl() == SelfVD &&
+             Visit(OtherME->getBase(), MemberBase, hasBeenSubstituted);
     }
 
     return false;
   }
 
   bool VisitMemberExpr(const MemberExpr *Self, const Expr *Other,
-                       bool hasSelfBeenSubstituted,
-                       bool hasOtherBeenSubstituted) {
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
+                       bool hasBeenSubstituted) {
     // Even though we don't support member expression in counted-by, actual
     // arguments can be member expressions.
     if (Self == Other)
       return true;
     if (const auto *DRE = dyn_cast<DeclRefExpr>(Other->IgnoreParenImpCasts()))
       return MemberBase && Self->getMemberDecl() == DRE->getDecl() &&
-             Visit(Self->getBase(), MemberBase, hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
+             Visit(Self->getBase(), MemberBase, hasBeenSubstituted);
     if (const auto *OtherME =
             dyn_cast<MemberExpr>(Other->IgnoreParenImpCasts())) {
       return Self->getMemberDecl() == OtherME->getMemberDecl() &&
-             Visit(Self->getBase(), OtherME->getBase(), hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
+             Visit(Self->getBase(), OtherME->getBase(), hasBeenSubstituted);
     }
     return false;
   }
 
   bool VisitUnaryOperator(const UnaryOperator *SelfUO, const Expr *Other,
-                          bool hasSelfBeenSubstituted,
-                          bool hasOtherBeenSubstituted) {
+                          bool hasBeenSubstituted) {
     if (SelfUO->getOpcode() != UO_Deref)
       return false; // We don't support any other unary operator
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
+
     if (const auto *OtherUO =
             dyn_cast<UnaryOperator>(Other->IgnoreParenImpCasts())) {
       if (SelfUO->getOpcode() == OtherUO->getOpcode())
         return Visit(SelfUO->getSubExpr(), OtherUO->getSubExpr(),
-                     hasSelfBeenSubstituted, hasOtherBeenSubstituted);
+                     hasBeenSubstituted);
     }
     // If `Other` is not a dereference expression, try to simplify `SelfUO`:
-    const auto *SimplifiedSelf = trySubstituteAndSimplify(
-        SelfUO, hasSelfBeenSubstituted, DependentValuesSelf);
-
-    if (SimplifiedSelf != SelfUO)
-      return Visit(SimplifiedSelf, Other, hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
+    if (const auto *SimplifiedSelf =
+            trySimplifyDerefAddressof(SelfUO, hasBeenSubstituted)) {
+      return Visit(SimplifiedSelf, Other, hasBeenSubstituted);
+    }
     return false;
   }
 
   bool VisitBinaryOperator(const BinaryOperator *SelfBO, const Expr *Other,
-                           bool hasSelfBeenSubstituted,
-                           bool hasOtherBeenSubstituted) {
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
-
+                           bool hasBeenSubstituted) {
     const auto *OtherBO =
         dyn_cast<BinaryOperator>(Other->IgnoreParenImpCasts());
     if (OtherBO && OtherBO->getOpcode() == SelfBO->getOpcode()) {
-      return Visit(SelfBO->getLHS(), OtherBO->getLHS(), hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted) &&
-             Visit(SelfBO->getRHS(), OtherBO->getRHS(), hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
+      return Visit(SelfBO->getLHS(), OtherBO->getLHS(), hasBeenSubstituted) &&
+             Visit(SelfBO->getRHS(), OtherBO->getRHS(), hasBeenSubstituted);
     }
 
     return false;
@@ -709,8 +643,7 @@ struct CompatibleCountExprVisitor
 
   // Support any overloaded operator[] so long as it is a const method.
   bool VisitCXXOperatorCallExpr(const CXXOperatorCallExpr *SelfOpCall,
-                                const Expr *Other, bool hasSelfBeenSubstituted,
-                                bool hasOtherBeenSubstituted) {
+                                const Expr *Other, bool hasBeenSubstituted) {
     if (SelfOpCall->getOperator() != OverloadedOperatorKind::OO_Subscript)
       return false;
 
@@ -718,15 +651,13 @@ struct CompatibleCountExprVisitor
 
     if (!MD || !MD->isConst())
       return false;
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
     if (const auto *OtherOpCall =
             dyn_cast<CXXOperatorCallExpr>(Other->IgnoreParenImpCasts()))
       if (SelfOpCall->getOperator() == OtherOpCall->getOperator()) {
         return Visit(SelfOpCall->getArg(0), OtherOpCall->getArg(0),
-                     hasSelfBeenSubstituted, hasOtherBeenSubstituted) &&
+                     hasBeenSubstituted) &&
                Visit(SelfOpCall->getArg(1), OtherOpCall->getArg(1),
-                     hasSelfBeenSubstituted, hasOtherBeenSubstituted);
+                     hasBeenSubstituted);
       }
     return false;
   }
@@ -735,27 +666,19 @@ struct CompatibleCountExprVisitor
   // considered unsafe, they can be safely used on constant arrays with
   // known-safe literal indexes.
   bool VisitArraySubscriptExpr(const ArraySubscriptExpr *SelfAS,
-                               const Expr *Other, bool hasSelfBeenSubstituted,
-                               bool hasOtherBeenSubstituted) {
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
+                               const Expr *Other, bool hasBeenSubstituted) {
     if (const auto *OtherAS =
             dyn_cast<ArraySubscriptExpr>(Other->IgnoreParenImpCasts()))
-      return Visit(SelfAS->getLHS(), OtherAS->getLHS(), hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted) &&
-             Visit(SelfAS->getRHS(), OtherAS->getRHS(), hasSelfBeenSubstituted,
-                   hasOtherBeenSubstituted);
+      return Visit(SelfAS->getLHS(), OtherAS->getLHS(), hasBeenSubstituted) &&
+             Visit(SelfAS->getRHS(), OtherAS->getRHS(), hasBeenSubstituted);
     return false;
   }
 
   // Support non-static member call:
   bool VisitCXXMemberCallExpr(const CXXMemberCallExpr *SelfCall,
-                              const Expr *Other, bool hasSelfBeenSubstituted,
-                              bool hasOtherBeenSubstituted) {
+                              const Expr *Other, bool hasBeenSubstituted) {
     const CXXMethodDecl *MD = SelfCall->getMethodDecl();
 
-    Other = trySubstituteAndSimplify(Other, hasOtherBeenSubstituted,
-                                     DependentValuesOther);
     // The callee member function must be a const function with no parameter:
     if (MD->isConst() && MD->param_empty()) {
       if (auto *OtherCall =
@@ -763,7 +686,7 @@ struct CompatibleCountExprVisitor
         return OtherCall->getMethodDecl() == MD &&
                Visit(SelfCall->getImplicitObjectArgument(),
                      OtherCall->getImplicitObjectArgument(),
-                     hasSelfBeenSubstituted, hasOtherBeenSubstituted);
+                     hasBeenSubstituted);
       }
     }
     return false;
@@ -776,38 +699,45 @@ struct CompatibleCountExprVisitor
 };
 
 // TL'DR:
-// Checks if `Self` is the same as `Other` modulo implicit casts and
+// Checks if `E` is the same as `ExpectedCountExpr` modulo implicit casts and
 // parens.
 //
 // Lengthy description:
-// `Self`:              an expression, one of the comparands
-// `Other`:             an expression, the other comparands
+// `E`:                 represents the actual count/size associated to a
+//                      pointer.
+// `ExpectedCountExpr`: represents the counted-by expression of a counted-by
+//                      type attribute.
 // `MemberBase`:        represents "this" member base.  A MemberExpr
-//                      representing `this->f` in either `Self` and
-//                      `Other` may be transformed to a DRE
+//                      representing `this->f` in both `E` and
+//                      `ExpectedCountExpr` may be transformed to a DRE
 //                      representing just `f`.  Therefore we need to keep track
-//                      of the base for them in that case.  The two comparands
-//                      must share a member base if it exists.
-// `DependentValuesSelf`:
-//                      a mapping from parameters to arguments for the parameter
-//                      references appearing in `Self`.
-// `DependentValuesOther`:
-//                      a mapping from parameters to arguments for the parameter
-//                      references appearing in `Other`.
+//                      of the base for them in that case.
+// `DependentValues`:   is a mapping from parameter DREs to actual argument
+//                      expressions.  It serves as a "state" where
+//                      `ExpectedCountExpr` is "interpreted".
 //
-// The comparison is on the two expressions `Self` and `Other` with the
-// substitution maps  `DependentValuesSelf` and `DependentValuesOther` being
-// applied to them, respectively.
-bool isCompatibleWithCountExpr(
-    ASTContext &Ctx, const Expr *Self, const Expr *Other,
-    const Expr *MemberBase = nullptr,
-    const DependentValuesTy *DependentValuesSelf = nullptr,
-    const DependentValuesTy *DependentValuesOther = nullptr) {
-  CompatibleCountExprVisitor Visitor(MemberBase, DependentValuesSelf,
-                                     DependentValuesOther, Ctx);
-  return Visitor.Visit(Self, Other,
-                       /* hasSelfBeenSubstituted */ false,
-                       /* hasOtherBeenSubstituted */ false);
+// This function then checks for a pointer with a known count `E` that `E` is
+// equivalent to the count `ExpectedCountExpr` of a counted-by type attribute at
+// the state `DependentValues`.
+//
+// For example, suppose there is a call to a function `foo(int *__counted_by(n)
+// p, size_t n)`:
+//
+//    foo(x, y+z);
+//
+// We check that the count associated to the pointer 'x' is same as the
+// expected count expression 'n' with the mapping (state) '{n -> y+z}'.  The
+// count of 'x' is determined by pre-defined knowledge, e.g., if 'x' has the
+// form of 'span.data()', its' count is 'span.size()', etc.  At this point, we
+// already know that `E` is the count of 'x'.  So we just need to compare `E`
+// to 'n' with 'n' being interpreted under '{n -> y+z}'.  That is, this function
+// will return true iff `E` is same as 'y+z'.
+bool isCompatibleWithCountExpr(const Expr *E, const Expr *ExpectedCountExpr,
+                               const Expr *MemberBase,
+                               const DependentValuesTy *DependentValues,
+                               ASTContext &Ctx) {
+  CompatibleCountExprVisitor Visitor(MemberBase, DependentValues, Ctx);
+  return Visitor.Visit(ExpectedCountExpr, E, /* hasBeenSubstituted*/ false);
 }
 
 // Returns true iff `C` is a C++ nclass method call to the function
@@ -1073,10 +1003,6 @@ static bool isCountAttributedPointerArgumentSafeImpl(
   // the actual count of the pointer inferred through patterns below:
   const Expr *ActualCount = nullptr;
   const Expr *MemberBase = nullptr;
-  // While `DependentValueMap` maps formal parameters to actual arguments of the
-  // call being checked, when the pointer argument is another call expression
-  // 'c',  `DependentValueMapForActual` is the map for 'c':
-  std::optional<DependentValuesTy> DependentValueMapForActual = std::nullopt;
 
   if (const auto *ME = dyn_cast<MemberExpr>(PtrArgNoImp))
     MemberBase = ME->getBase();
@@ -1093,11 +1019,6 @@ static bool isCountAttributedPointerArgumentSafeImpl(
 
     if (ArgCAT->isOrNull() == isOrNull && areBoundsAttributesCompatible)
       ActualCount = ArgCAT->getCountExpr();
-    // In case `PtrArgNoImp` is a function call expression of counted_by type
-    // (i.e., return type is a CAT), create a map for the call:
-    if (auto *PtrArgCall = dyn_cast<CallExpr>(PtrArgNoImp))
-      DependentValueMapForActual =
-          getDependentValuesFromCall(ArgCAT, PtrArgCall);
   } else {
     // Form 6-7.
     const Expr *ArrArg = PtrArgNoImp;
@@ -1123,11 +1044,8 @@ static bool isCountAttributedPointerArgumentSafeImpl(
     // In case (b), the actual count of the pointer must match the argument
     // passed to the parameter representing the count:
     CountedByExpr = CountArg;
-  return isCompatibleWithCountExpr(
-      Context, ActualCount, CountedByExpr, MemberBase,
-      (DependentValueMapForActual.has_value() ? &*DependentValueMapForActual
-                                              : nullptr),
-      DependentValueMap);
+  return isCompatibleWithCountExpr(ActualCount, CountedByExpr, MemberBase,
+                                   DependentValueMap, Context);
 }
 
 // Checks if the argument passed to a count-attributed pointer is safe.  This
@@ -1406,12 +1324,12 @@ static bool isPtrBufferSafe(const Expr *Ptr, const Expr *Size,
       auto ValuesOpt = getDependentValuesFromCall(CAT, Call);
       if (!ValuesOpt.has_value())
         return false;
-      return isCompatibleWithCountExpr(Ctx, Size, CAT->getCountExpr(),
-                                       MemberBase, nullptr, &*ValuesOpt);
+      return isCompatibleWithCountExpr(Size, CAT->getCountExpr(), MemberBase,
+                                       &*ValuesOpt, Ctx);
     }
 
-    return isCompatibleWithCountExpr(Ctx, Size, CAT->getCountExpr(),
-                                     MemberBase);
+    return isCompatibleWithCountExpr(Size, CAT->getCountExpr(), MemberBase,
+                                     /*DependentValues=*/nullptr, Ctx);
   }
   /* TO_UPSTREAM(BoundsSafetyInterop) OFF */
   return false;

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-argument.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-argument.cpp
@@ -69,7 +69,7 @@ void cb_cchar(const char *__counted_by(len) s, size_t len);
 // expected-note@+1 3{{consider using 'std::span' and passing '.first(...).data()' to the parameter 's'}}
 void cb_cchar_42(const char *__counted_by(42) s);
 
-// expected-note@+1 31{{consider using a safe container and passing '.data()' to the parameter 'p' and '.size()' to its dependent parameter 'count' or 'std::span' and passing '.first(...).data()' to the parameter 'p'}}
+// expected-note@+1 19{{consider using a safe container and passing '.data()' to the parameter 'p' and '.size()' to its dependent parameter 'count' or 'std::span' and passing '.first(...).data()' to the parameter 'p'}}
 void cb_int(int *__counted_by(count) p, size_t count);
 
 // expected-note@+1 34{{consider using a safe container and passing '.data()' to the parameter 'p' and '.size()' to its dependent parameter 'count' or 'std::span' and passing '.first(...).data()' to the parameter 'p'}}
@@ -646,49 +646,6 @@ namespace output_param_test {
   };
 
 } // namespace output_param_test
-
-namespace pointer_is_call_test {
-int *__counted_by(len) fn_cb(size_t len);
-int *__counted_by(42) fn_cb_const();
-int *__counted_by(a + b) fn_cb_plus(size_t a, size_t b);
-int *__counted_by(*p) fn_cb_deref(size_t *p);
-
-struct T {
-  size_t size() const;
-  size_t n;
-};
-
-void test1(size_t n, size_t n2, size_t *p, T * t) {
-  cb_int(fn_cb(n), n);
-  //cb_int(fn_cb(*&n), n);
-  //cb_int(fn_cb(*&n), *&n);
-  cb_int(fn_cb(n), *&n);
-  cb_int(fn_cb(n), 42);    // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-  cb_int(fn_cb(n2), n);   // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-  cb_int(fn_cb(n), n + 1); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-
-  cb_int(fn_cb(t->size()), t->size());
-  cb_int(fn_cb(t->n), t->n);
-  cb_int(fn_cb(t->size()), t->n); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-  cb_int(fn_cb(t->n), t->size()); // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-
-  cb_int(fn_cb_const(), 42);
-  cb_int(fn_cb_const(), 43);     // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-  cb_int(fn_cb_const(), n);      // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-  cb_int(fn_cb_const(), n + 1);  // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-
-  cb_int(fn_cb_plus(n, n2), n + n2);
-  cb_int(fn_cb_plus(n, n), n + n);
-  cb_int(fn_cb_plus(n, n2), n + n);  // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-  cb_int(fn_cb_plus(n, n), n * 2);   // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-
-  cb_int(fn_cb_deref(p), *p);
-  cb_int(fn_cb_deref(&n), n);
-  cb_int(fn_cb_deref(&n), *&n);
-  cb_int(fn_cb_deref(p), n);    // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-  cb_int(fn_cb_deref(&n), *p);  // expected-warning {{unsafe assignment to function parameter of count-attributed type}}
-}
-} // namespace pointer_is_call_test
 
 
 static void previous_infinite_loop(int * __counted_by(n) p, size_t n) {


### PR DESCRIPTION
This reverts commit 972f834f48eea4536540e53954dcd6ae544c8890. 
This commit breaks the build.