### PR TITLE
[NFC][lldb] de duplicate TrackingNodePrinter finalize logic

### DIFF
--- a/lldb/source/Core/Mangled.cpp
+++ b/lldb/source/Core/Mangled.cpp
@@ -168,21 +168,6 @@ GetSwiftDemangledStr(ConstString m_mangled, const SymbolContext *sc,
   }
   auto [demangled, info] = SwiftLanguageRuntime::TrackedDemangleSymbolAsString(
       mangled_name, demangle_mode, sc);
-  // TODO: The logic below should be in the NodePrinter.
-  info.PrefixRange.second =
-      std::min(info.BasenameRange.first, info.ArgumentsRange.first);
-  info.SuffixRange.first =
-      std::max(info.BasenameRange.second, info.ArgumentsRange.second);
-  info.SuffixRange.second = demangled.length();
-  if (info.hasBasename() && info.hasArguments()) {
-    if (info.hasTemplateArguments() && info.TemplateArgumentsRange.first > 0) {
-      info.NameQualifiersRange.second = std::min(
-          info.ArgumentsRange.first, info.TemplateArgumentsRange.first);
-    } else {
-      info.NameQualifiersRange.second = info.ArgumentsRange.first;
-    }
-    info.NameQualifiersRange.first = info.BasenameRange.second;
-  }
 
   // Don't cache the demangled name if the function isn't available yet.
   // Only cache eFullName demangled functions to keep the cache consistent.

--- a/lldb/unittests/Core/SwiftDemanglingPartsTest.cpp
+++ b/lldb/unittests/Core/SwiftDemanglingPartsTest.cpp
@@ -1580,21 +1580,6 @@ TEST_P(SwiftDemanglingPartsTestFixture, SwiftDemanglingParts) {
   swift::Demangle::demangleSymbolAsString(std::string(mangled), printer);
   std::string demangled = printer.takeString();
   DemangledNameInfo nameInfo = printer.getInfo();
-  nameInfo.PrefixRange.second =
-      std::min(nameInfo.BasenameRange.first, nameInfo.ArgumentsRange.first);
-  nameInfo.SuffixRange.first =
-      std::max(nameInfo.BasenameRange.second, nameInfo.ArgumentsRange.second);
-  nameInfo.SuffixRange.second = demangled.length();
-  if (nameInfo.hasBasename() && nameInfo.hasArguments()) {
-    if (nameInfo.hasTemplateArguments() &&
-        nameInfo.TemplateArgumentsRange.first > 0) {
-      nameInfo.NameQualifiersRange.second = std::min(
-          nameInfo.ArgumentsRange.first, nameInfo.TemplateArgumentsRange.first);
-    } else {
-      nameInfo.NameQualifiersRange.second = info.ArgumentsRange.first;
-    }
-    nameInfo.NameQualifiersRange.first = info.BasenameRange.second;
-  }
 
   EXPECT_EQ(nameInfo.BasenameRange, info.BasenameRange);
   EXPECT_EQ(nameInfo.NameQualifiersRange, info.NameQualifiersRange);


### PR DESCRIPTION
This patch deduplicates the finalizing logic in the `TrackingNodePrinter`. It is no longer duplicated in the tests and the rest of the code.