### PR TITLE
Fix the following CAS related tests for Windows

### DIFF
--- a/clang/test/ClangScanDeps/cas-fs-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/cas-fs-prefix-mapping.c
@@ -4,21 +4,21 @@
 // REQUIRES: ondisk_cas
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed -e "s|DIR|%/t|g" -e "s|CLANG|%/ncclang|g" -e "s|SDK|%/S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
 
 // == Tree
 // Ensure the filesystem has the mapped paths.
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-tree -cas-path %t/cas \
-// RUN:    -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc \
 // RUN:  | sed -E 's/tree ([^ ]+) for.*/\1/' > %t/tree_id.txt
 // RUN: llvm-cas -cas %t/cas -ls-tree-recursive @%t/tree_id.txt > %t/tree_result.txt
-// RUN: FileCheck %s -input-file %t/tree_result.txt -check-prefix=FILES
+// RUN: FileCheck %s -input-file %t/tree_result.txt -DROOT=%{/roott} -check-prefix=FILES
 
-// FILES: file llvmcas://{{.*}} /^sdk/usr/include/stdlib.h
-// FILES: file llvmcas://{{.*}} /^src/t.c
-// FILES: file llvmcas://{{.*}} /^src/top.h
-// FILES: file llvmcas://{{.*}} /^tc/lib/clang/{{.*}}/include/stdarg.h
+// FILES: file llvmcas://{{.*}} [[ROOT]]^sdk/usr/include/stdlib.h
+// FILES: file llvmcas://{{.*}} [[ROOT]]^src/t.c
+// FILES: file llvmcas://{{.*}} [[ROOT]]^src/top.h
+// FILES: file llvmcas://{{.*}} [[ROOT]]^tc/lib/clang/{{.*}}/include/stdarg.h
 
 // == Full Tree
 // This should have the same filesystem as above, and we also check the command-
@@ -26,18 +26,18 @@
 
 // RUN: cat %t/tree_id.txt > %t/full_tree_result.txt
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-tree-full -cas-path %t/cas \
-// RUN:    -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc \
 // RUN:  >> %t/full_tree_result.txt
-// RUN: FileCheck %s -input-file %t/full_tree_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
+// RUN: cat %t/full_tree_result.txt | %PathSanitizingFileCheck --sanitize PREFIX=%/t --sanitize SDK_PREFIX=%/S/Inputs/SDK --sanitize ROOT^=%/root^ --enable-yaml-compatibility %s
 
 // == Full
 // Same as full tree.
 
 // RUN: cat %t/tree_id.txt > %t/full_result.txt
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-full -cas-path %t/cas \
-// RUN:    -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc \
 // RUN:  >> %t/full_result.txt
-// RUN: FileCheck %s -input-file %t/full_result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
+// RUN: cat %t/full_result.txt | %PathSanitizingFileCheck --sanitize PREFIX=%/t --sanitize SDK_PREFIX=%/S/Inputs/SDK --sanitize ROOT^=%/root^ --enable-yaml-compatibility %s
 
 // CHECK: [[MAPPED_FS_ID:llvmcas://[[:xdigit:]]+]]
 // CHECK:      "modules": []
@@ -49,36 +49,36 @@
 // CHECK:              "clang-module-deps": []
 // CHECK:              "command-line": [
 // CHECK:                "-fcas-path"
-// CHECK-NEXT:           "[[PREFIX]]/cas"
+// CHECK-NEXT:           "PREFIX{{/|\\\\}}cas"
 // CHECK:                "-fcas-fs"
 // CHECK-NEXT:           "[[MAPPED_FS_ID]]"
 // CHECK:                "-fcas-fs-working-directory"
-// CHECK-NEXT:           "/^src"
+// CHECK-NEXT:           "ROOT^src"
 // CHECK:                "-x"
 // CHECK-NEXT:           "c"
-// CHECK-NEXT:           "/^src/t.c"
+// CHECK-NEXT:           "ROOT^src{{/|\\\\}}t.c"
 // CHECK:                "-isysroot"
-// CHECK-NEXT:           "/^sdk"
+// CHECK-NEXT:           "ROOT^sdk"
 // CHECK:                "-resource-dir"
-// CHECK-NEXT:           "/^tc/lib/clang/{{.*}}"
+// CHECK-NEXT:           "ROOT^tc{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{.*}}"
 // CHECK:                "-isystem"
-// CHECK-NEXT:           "/^sdk/usr/local/include
+// CHECK-NEXT:           "ROOT^sdk{{/|\\\\}}usr{{/|\\\\}}local{{/|\\\\}}include
 // CHECK:                "-isystem"
-// CHECK-NEXT:           "/^tc/lib/clang/{{.*}}/include"
+// CHECK-NEXT:           "ROOT^tc{{/|\\\\}}lib{{/|\\\\}}clang{{/|\\\\}}{{.*}}{{/|\\\\}}include"
 // CHECK:                "-internal-externc-isystem"
-// CHECK-NEXT:           "/^sdk/usr/include"
-// CHECK:                "-fdebug-compilation-dir=/^src"
-// CHECK:                "-fcoverage-compilation-dir=/^src"
-// CHECK-NOT: [[PREFIX]]
-// CHECK-NOT: [[SDK_PREFIX]]
+// CHECK-NEXT:           "ROOT^sdk{{/|\\\\}}usr{{/|\\\\}}include"
+// CHECK:                "-fdebug-compilation-dir=ROOT^src"
+// CHECK:                "-fcoverage-compilation-dir=ROOT^src"
+// CHECK-NOT: PREFIX
+// CHECK-NOT: SDK_PREFIX
 // CHECK:              ]
 // CHECK:              "file-deps": [
-// CHECK:                "[[PREFIX]]/t.c"
-// CHECK:                "[[PREFIX]]/top.h"
-// CHECK:                "{{.*}}include/stdarg.h"
-// CHECK:                "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// CHECK:                "PREFIX{{/|\\\\}}t.c"
+// CHECK:                "PREFIX{{/|\\\\}}top.h"
+// CHECK:                "{{.*}}include{{/|\\\\}}stdarg.h"
+// CHECK:                "SDK_PREFIX{{/|\\\\}}usr{{/|\\\\}}include{{/|\\\\}}stdlib.h"
 // CHECK:              ]
-// CHECK:              "input-file": "[[PREFIX]]/t.c"
+// CHECK:              "input-file": "PREFIX{{/|\\\\}}t.c"
 
 //--- cdb.json.template
 [

--- a/clang/test/ClangScanDeps/include-tree-prefix-mapping-pch-remap.c
+++ b/clang/test/ClangScanDeps/include-tree-prefix-mapping-pch-remap.c
@@ -1,11 +1,11 @@
 // REQUIRES: ondisk_cas
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: sed -e "s|DIR|%t|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
 // RUN:   -format experimental-include-tree-full -cas-path %t/cas \
-// RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/deps.json
+// RUN:   -prefix-map=%t=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc > %t/deps.json
 
 //--- cdb.json.template
 [{

--- a/clang/test/ClangScanDeps/include-tree-prefix-mapping.c
+++ b/clang/test/ClangScanDeps/include-tree-prefix-mapping.c
@@ -1,33 +1,33 @@
 // REQUIRES: ondisk_cas
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: sed -e "s|DIR|%t|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
+// RUN: sed -e "s|DIR|%/t|g" -e "s|CLANG|%/ncclang|g" -e "s|SDK|%/S/Inputs/SDK|g" %t/cdb.json.template > %t/cdb.json
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json -format experimental-include-tree -cas-path %t/cas \
-// RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/result.txt
-// RUN: FileCheck %s -input-file %t/result.txt -DPREFIX=%t -DSDK_PREFIX=%S/Inputs/SDK
+// RUN:   -prefix-map=%t=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc > %t/result.txt
+// RUN: cat %t/result.txt | %PathSanitizingFileCheck --sanitize PREFIX=%/t --sanitize SDK_PREFIX=%/S/Inputs/SDK --sanitize ROOT^=%/root^ %s
 
-// CHECK:      {{.*}} - [[PREFIX]]/t.c
-// CHECK-NOT: [[PREFIX]]
-// CHECK-NOT: [[SDK_PREFIX]]
-// CHECK: /^src{{[/\\]}}t.c
-// CHECK: /^src{{[/\\]}}top.h
-// CHECK: /^tc{{[/\\]}}lib{{[/\\]}}clang{{[/\\]}}{{.*}}{{[/\\]}}include{{[/\\]}}stdarg.h
-// CHECK: /^sdk{{[/\\]}}usr{{[/\\]}}include{{[/\\]}}stdlib.h
+// CHECK:      {{.*}} - PREFIX{{/|\\}}t.c
+// CHECK-NOT: PREFIX
+// CHECK-NOT: SDK_PREFIX
+// CHECK: ROOT^src{{[/\\]}}t.c
+// CHECK: ROOT^src{{[/\\]}}top.h
+// CHECK: ROOT^tc{{[/\\]}}lib{{[/\\]}}clang{{[/\\]}}{{.*}}{{[/\\]}}include{{[/\\]}}stdarg.h
+// CHECK: ROOT^sdk{{[/\\]}}usr{{[/\\]}}include{{[/\\]}}stdlib.h
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
 // RUN:   -format experimental-include-tree-full -cas-path %t/cas \
-// RUN:   -prefix-map=%t=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc > %t/deps.json
+// RUN:   -prefix-map=%t=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc > %t/deps.json
 
 // RUN: cat %t/result.txt > %t/full.txt
 // RUN: echo "FULL DEPS START" >> %t/full.txt
-// RUN: cat %t/deps.json | sed 's:\\\\\?:/:g' >> %t/full.txt
+// RUN: cat %t/deps.json >> %t/full.txt
 
-// RUN: FileCheck %s -DPREFIX=%/t -DSDK_PREFIX=%S/Inputs/SDK -check-prefix=FULL -input-file %t/full.txt
+// RUN: cat %t/full.txt | %PathSanitizingFileCheck --sanitize PREFIX=%/t --sanitize SDK_PREFIX=%/S/Inputs/SDK --sanitize ROOT^=%/root^ --enable-yaml-compatibility %s -check-prefix=FULL
 
 // Capture the tree id from experimental-include-tree ; ensure that it matches
 // the result from experimental-full.
-// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - [[PREFIX]]/t.c
+// FULL: [[TREE_ID:llvmcas://[[:xdigit:]]+]] - PREFIX{{/|\\}}t.c
 // FULL: FULL DEPS START
 
 // FULL-NEXT: {
@@ -40,7 +40,7 @@
 // FULL:                "command-line": [
 // FULL-NEXT:             "-cc1"
 // FULL:                  "-fcas-path"
-// FULL-NEXT:             "[[PREFIX]]/cas"
+// FULL-NEXT:             "PREFIX{{/|\\\\}}cas"
 // FULL:                  "-disable-free"
 // FULL:                  "-fcas-include-tree"
 // FULL-NEXT:             "[[TREE_ID]]"
@@ -49,15 +49,15 @@
 // FULL:                  "-x"
 // FULL-NEXT:             "c"
 // FULL:                  "-isysroot"
-// FULL-NEXT:             "/^sdk"
+// FULL-NEXT:             "ROOT^sdk"
 // FULL:                ]
 // FULL:                "file-deps": [
-// FULL-DAG:              "[[PREFIX]]/t.c"
-// FULL-DAG:              "[[PREFIX]]/top.h"
-// FULL-DAG:              "{{.*}}/stdarg.h"
-// FULL-DAG:              "[[SDK_PREFIX]]/usr/include/stdlib.h"
+// FULL-DAG:              "PREFIX{{/|\\\\}}t.c"
+// FULL-DAG:              "PREFIX{{/|\\\\}}top.h"
+// FULL-DAG:              "{{.*}}{{/|\\\\}}stdarg.h"
+// FULL-DAG:              "SDK_PREFIX{{/|\\\\}}usr{{/|\\\\}}include{{/|\\\\}}stdlib.h"
 // FULL:                ]
-// FULL:                "input-file": "[[PREFIX]]/t.c"
+// FULL:                "input-file": "PREFIX{{/|\\\\}}t.c"
 // FULL:              }
 // FULL:            ]
 // FULL:          }

--- a/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
+++ b/clang/test/ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
@@ -5,62 +5,72 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: cp -r %t/dir1 %t/dir2
-// RUN: sed -e "s|DIR|%t/dir1|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/dir1/cdb.json
-// RUN: sed -e "s|DIR|%t/dir1|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb_pch.json.template > %t/dir1/cdb_pch.json
-// RUN: sed -e "s|DIR|%t/dir2|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb.json.template > %t/dir2/cdb.json
-// RUN: sed -e "s|DIR|%t/dir2|g" -e "s|CLANG|%clang|g" -e "s|SDK|%S/Inputs/SDK|g" %t/cdb_pch.json.template > %t/dir2/cdb_pch.json
+// RUN: sed -e "s|DIR|%/t/dir1|g" -e "s|CLANG|%/ncclang|g" -e "s|SDK|%/S/Inputs/SDK|g" %t/cdb.json.template > %t/dir1/cdb.json
+// RUN: sed -e "s|DIR|%/t/dir1|g" -e "s|CLANG|%/ncclang|g" -e "s|SDK|%/S/Inputs/SDK|g" %t/cdb_pch.json.template > %t/dir1/cdb_pch.json
+// RUN: sed -e "s|DIR|%/t/dir2|g" -e "s|CLANG|%/ncclang|g" -e "s|SDK|%/S/Inputs/SDK|g" %t/cdb.json.template > %t/dir2/cdb.json
+// RUN: sed -e "s|DIR|%/t/dir2|g" -e "s|CLANG|%/ncclang|g" -e "s|SDK|%/S/Inputs/SDK|g" %t/cdb_pch.json.template > %t/dir2/cdb_pch.json
 
 // == Scan PCH
 // RUN: clang-scan-deps -compilation-database %t/dir1/cdb_pch.json -format experimental-full -optimize-args=none \
 // RUN:    -cas-path %t/cas -module-files-dir %t/dir1/modules \
-// RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t/dir1/modules=%/root^modules -prefix-map=%t/dir1=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc \
 // RUN:  > %t/pch_dir1.txt
 
 // RUN: clang-scan-deps -compilation-database %t/dir2/cdb_pch.json -format experimental-full -optimize-args=none \
 // RUN:    -cas-path %t/cas -module-files-dir %t/dir2/modules \
-// RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t/dir2/modules=%/root^modules -prefix-map=%t/dir2=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc \
 // RUN:  > %t/pch_dir2.txt
 
 // == Build PCH
 // RUN: %deps-to-rsp %t/pch_dir1.txt --module-name=B > %t/dir1/B.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir1.txt --module-name=A > %t/dir1/A.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir1.txt --tu-index 0 > %t/dir1/pch.cc1.rsp
-// RUN: (cd %t/dir1; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: (cd %t/dir1; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: (cd %t/dir1; %clang @pch.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: cd %t/dir1 && %clang @B.cc1.rsp > %t/miss-B.txt 2>&1
+// RUN: cat %t/miss-B.txt | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: cd %t/dir1 && %clang @A.cc1.rsp > %t/miss-A.txt 2>&1
+// RUN: cat %t/miss-A.txt | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: cd %t/dir1 && %clang @pch.cc1.rsp > %t/miss-pch.txt 2>&1
+// RUN: cat %t/miss-pch.txt | FileCheck %s -check-prefix=CACHE-MISS
 
 // CACHE-MISS: compile job cache miss
 
 // RUN: %deps-to-rsp %t/pch_dir2.txt --module-name=B > %t/dir2/B.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir2.txt --module-name=A > %t/dir2/A.cc1.rsp
 // RUN: %deps-to-rsp %t/pch_dir2.txt --tu-index 0 > %t/dir2/pch.cc1.rsp
-// RUN: (cd %t/dir2; %clang @B.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
-// RUN: (cd %t/dir2; %clang @A.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
-// RUN: (cd %t/dir2; %clang @pch.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: cd %t/dir2 && %clang @B.cc1.rsp > %t/hit-B.txt 2>&1
+// RUN: cat %t/hit-B.txt | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: cd %t/dir2 && %clang @A.cc1.rsp > %t/hit-A.txt 2>&1
+// RUN: cat %t/hit-B.txt | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: cd %t/dir2 && %clang @pch.cc1.rsp > %t/hit-pch.txt 2>&1
+// RUN: cat %t/hit-pch.txt | FileCheck %s -check-prefix=CACHE-HIT
 
 // CACHE-HIT: compile job cache hit
 
 // == Scan TU, including PCH
 // RUN: clang-scan-deps -compilation-database %t/dir1/cdb.json -format experimental-full -optimize-args=none \
 // RUN:    -cas-path %t/cas -module-files-dir %t/dir1/modules \
-// RUN:    -prefix-map=%t/dir1/modules=/^modules -prefix-map=%t/dir1=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t/dir1/modules=%/root^modules -prefix-map=%t/dir1=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc \
 // RUN:  > %t/dir1.txt
 
 // RUN: clang-scan-deps -compilation-database %t/dir2/cdb.json -format experimental-full -optimize-args=none \
 // RUN:    -cas-path %t/cas -module-files-dir %t/dir2/modules \
-// RUN:    -prefix-map=%t/dir2/modules=/^modules -prefix-map=%t/dir2=/^src -prefix-map-sdk=/^sdk -prefix-map-toolchain=/^tc \
+// RUN:    -prefix-map=%t/dir2/modules=%/root^modules -prefix-map=%t/dir2=%/root^src -prefix-map-sdk=%/root^sdk -prefix-map-toolchain=%/root^tc \
 // RUN:  > %t/dir2.txt
 
 // == Build TU
 // RUN: %deps-to-rsp %t/dir1.txt --module-name=C > %t/dir1/C.cc1.rsp
 // RUN: %deps-to-rsp %t/dir1.txt --tu-index 0 > %t/dir1/tu.cc1.rsp
-// RUN: (cd %t/dir1; %clang @C.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
-// RUN: (cd %t/dir1; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: cd %t/dir1 && %clang @C.cc1.rsp > %t/c-miss.txt 2>&1
+// RUN: cat %t/c-miss.txt | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: cd %t/dir1 && %clang @tu.cc1.rsp > %t/tu-miss.txt 2>&1
+// RUN: cat %t/tu-miss.txt | FileCheck %s -check-prefix=CACHE-MISS
 
 // RUN: %deps-to-rsp %t/dir2.txt --module-name=C > %t/dir2/C.cc1.rsp
 // RUN: %deps-to-rsp %t/dir2.txt --tu-index 0 > %t/dir2/tu.cc1.rsp
-// RUN: (cd %t/dir2; %clang @C.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
-// RUN: (cd %t/dir2; %clang @tu.cc1.rsp) 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: cd %t/dir2 && %clang @C.cc1.rsp > %t/c-hit.txt 2>&1
+// RUN: cat %t/c-hit.txt | FileCheck %s -check-prefix=CACHE-HIT
+// RUN: cd %t/dir2 && %clang @tu.cc1.rsp > %t/tu-hit.txt  2>&1
+// RUN: cat %t/tu-hit.txt | FileCheck %s -check-prefix=CACHE-HIT
 
 // RUN: diff -u %t/dir1/prefix.h.pch %t/dir2/prefix.h.pch
 // RUN: diff -r -u %t/dir1/modules %t/dir2/modules

--- a/clang/utils/PathSanitizingFileCheck
+++ b/clang/utils/PathSanitizingFileCheck
@@ -70,7 +70,9 @@ constants.""")
 
     if args.enable_windows_compatibility:
         if args.enable_yaml_compatibility:
-            slashes_re = r'(/|\\\\|\\\\\\\\)'
+            # Put the double escaped backslahes before the single
+            # escaped to ensure longest match
+            slashes_re = r'(/|\\\\\\\\|\\\\)'
         else:
             slashes_re = r'(/|\\\\)'
     else:

--- a/llvm/include/llvm/CAS/TreePath.h
+++ b/llvm/include/llvm/CAS/TreePath.h
@@ -1,0 +1,45 @@
+//===- llvm/CAS/TreePath.h - Tree path utility ------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_TREEPATH_H
+#define LLVM_CAS_TREEPATH_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
+#include <string>
+
+namespace llvm::cas {
+
+// On Windows, prepend a dummy root backslash to tree paths internally
+// (\C:\foo) and distinguish them from normal file paths (C:\foo) that
+// come from and return to clients and are passed to sys::fs
+// functions. This is so that we can have a single root and CAS ID
+// representing the root of the filesystem (that may otherwise spread
+// across multiple trees / drives) and the path handling to be more
+// uniform with the Posix systems. These convert paths between them.
+// TODO: Reassess this way of handling multiple roots for Windows later.
+inline std::string getTreePath(StringRef FilePath, sys::path::Style PathStyle) {
+  if (sys::path::is_style_windows(PathStyle)) {
+    assert(FilePath[0] != '\\');
+    std::string TreePath = "\\" + std::string(FilePath);
+    return TreePath;
+  }
+  return FilePath.str();
+}
+
+inline StringRef getFilePath(StringRef TreePath, sys::path::Style PathStyle) {
+  if (sys::path::is_style_windows(PathStyle)) {
+    assert(TreePath[0] == '\\');
+    return TreePath.drop_front(1);
+  }
+  return TreePath;
+}
+
+} // namespace llvm::cas
+
+#endif // LLVM_CAS_TREEPATH_H

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -170,8 +170,8 @@ private:
   /// Find the tree path for \p Path, getting the real path for its parent
   /// directory but not following symlinks in \a sys::path::filename().
   ///
-  /// \returns The tree path, or the original path if there are any errors.
-  StringRef getTreePath(StringRef Path);
+  /// \returns The tree path, or none if there are any errors.
+  std::optional<StringRef> getTreePath(StringRef Path);
 
 public:
   void add(const MappedPrefix &Mapping) override;

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -12,6 +12,7 @@
 #include "llvm/CAS/FileSystemCache.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/CAS/TreePath.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/FileSystem.h"
 #include <mutex>
@@ -23,31 +24,6 @@ const char CachingOnDiskFileSystem::ID = 0;
 void CachingOnDiskFileSystem::anchor() {}
 
 namespace {
-
-// On Windows, prepend a dummy root backslash to tree paths internally
-// (\C:\foo) and distinguish them from normal file paths (C:\foo) that
-// come from and return to clients and are passed to sys::fs
-// functions. This is so that we can have a single root and CAS ID
-// representing the root of the filesystem (that may otherwise spread
-// across multiple trees / drives) and the path handling to be more
-// uniform with the Posix systems. These convert paths between them.
-// TODO: Reassess this way of handling multiple roots for Windows later.
-static std::string getTreePath(StringRef FilePath, sys::path::Style PathStyle) {
-  if (sys::path::is_style_windows(PathStyle)) {
-    assert(FilePath[0] != '\\');
-    std::string TreePath = "\\" + std::string(FilePath);
-    return TreePath;
-  }
-  return FilePath.str();
-}
-
-static StringRef getFilePath(StringRef TreePath, sys::path::Style PathStyle) {
-  if (sys::path::is_style_windows(PathStyle)) {
-    assert(TreePath[0] == '\\');
-    return TreePath.drop_front(1);
-  }
-  return TreePath;
-}
 
 class CachingOnDiskFileSystemImpl final : public CachingOnDiskFileSystem {
   struct WorkingDirectoryType {
@@ -338,7 +314,8 @@ CachingOnDiskFileSystemImpl::makeSymlink(DirectoryEntry &Parent,
   PathStorage TreePathStorage(TreePath);
   SmallString<128> Target;
   if (auto Err = readLink(
-          getFilePath(TreePathStorage.Path, Cache->getPathStyle()), Target))
+          llvm::cas::getFilePath(TreePathStorage.Path, Cache->getPathStyle()),
+          Target))
     return std::move(Err);
   return makeSymlinkTo(Parent, TreePathStorage.Path, Target);
 }
@@ -364,7 +341,7 @@ static bool is_executable(StringRef TreePath, sys::fs::file_status Status,
   // This isn't the most reliable way but does better than just
   // checking owner_exe because most owned files have all_all
   // permission regardless of they are executable files.
-  StringRef FilePath = getFilePath(TreePath, PathStyle);
+  StringRef FilePath = llvm::cas::getFilePath(TreePath, PathStyle);
   return (Status.permissions() & sys::fs::perms::owner_exe) &&
       (FilePath.ends_with_insensitive(".exe") ||
        sys::fs::exists(FilePath + ".exe"));
@@ -396,7 +373,8 @@ CachingOnDiskFileSystemImpl::makeEntry(
     std::optional<sys::fs::file_status> KnownStatus) {
   assert(Parent.isDirectory() && "Expected a directory");
   PathStorage TreePathStorage(TreePath);
-  StringRef FilePath = getFilePath(TreePathStorage.Path, Cache->getPathStyle());
+  StringRef FilePath = llvm::cas::getFilePath(TreePathStorage.Path,
+      Cache->getPathStyle());
 
   // lstat is extremely slow...
   sys::fs::file_status Status;
@@ -467,7 +445,7 @@ CachingOnDiskFileSystemImpl::getRealPath(const Twine &Path,
           getDirectoryEntry(Path, /*FollowSymlinks=*/true).moveInto(Entry))
     return errorToErrorCode(std::move(E));
 
-  StringRef RealFilePath = getFilePath(Entry->getTreePath(),
+  StringRef RealFilePath = llvm::cas::getFilePath(Entry->getTreePath(),
       Cache->getPathStyle());
   Output.resize(RealFilePath.size());
   llvm::copy(RealFilePath, Output.begin());
@@ -525,11 +503,12 @@ CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
   // Walk the directory on-disk to discover entries.
   std::error_code EC;
   SmallVector<std::string> TreePaths;
-  StringRef EntryFilePath = getFilePath(Entry->getTreePath(),
+  StringRef EntryFilePath = llvm::cas::getFilePath(Entry->getTreePath(),
       Cache->getPathStyle());
   for (sys::fs::directory_iterator I(EntryFilePath, EC), E;
        !EC && I != E; I.increment(EC)) {
-    TreePaths.emplace_back(getTreePath(I->path(), Cache->getPathStyle()));
+    TreePaths.emplace_back(llvm::cas::getTreePath(I->path(),
+        Cache->getPathStyle()));
   }
   if (EC)
     return EC;
@@ -565,8 +544,8 @@ CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
   SmallString<256> ExpectedRealTreePath;
   ExpectedRealTreePath = From.getTreePath();
   sys::path::append(ExpectedRealTreePath, RemainingStorage.Path);
-  SmallString<256> ExpectedRealPath = getFilePath(ExpectedRealTreePath.str(),
-                                                  Cache->getPathStyle());
+  SmallString<256> ExpectedRealPath = llvm::cas::getFilePath(
+      ExpectedRealTreePath.str(), Cache->getPathStyle());
 
   // Most paths don't exist. Start with a stat. Profiling says this is faster
   // on Darwin when running clang-scan-deps (looks like allocation traffic in
@@ -588,7 +567,7 @@ CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
       /* expand_tilde */false))
     return errorCodeToError(EC);
 
-  SmallString<256> RealTreePath = StringRef(getTreePath(RealPath,
+  SmallString<256> RealTreePath = StringRef(llvm::cas::getTreePath(RealPath,
       Cache->getPathStyle()));
   FileSystemCache::LookupPathState State(Cache->getPathStyle(),
       Cache->getRoot(get_separator(Cache->getPathStyle())), RealTreePath);
@@ -803,7 +782,7 @@ DiscoveryInstanceImpl::requestDirectoryEntry(DirectoryEntry &Parent,
   assert(Parent.isDirectory() && "Expected a directory");
   SmallString<256> Path(Parent.getTreePath());
   sys::path::append(Path, Name);
-  StringRef FilePath = getFilePath(Path.str(), FS.getPathStyle());
+  StringRef FilePath = llvm::cas::getFilePath(Path.str(), FS.getPathStyle());
 
   // lstat is extremely slow...
   sys::fs::file_status Status;
@@ -832,7 +811,7 @@ DiscoveryInstanceImpl::requestDirectoryEntry(DirectoryEntry &Parent,
     if (Name.equals_insensitive(NextName) || !isASCII(Name)) {
       // Might be a case-insensitive match, check if it's the same entity.
       // FIXME: put this unique id in the cache.
-      StringRef NextFilePath = getFilePath(Next->getTreePath(),
+      StringRef NextFilePath = llvm::cas::getFilePath(Next->getTreePath(),
           FS.getPathStyle());
       sys::fs::file_status StatNext;
       if (std::error_code EC =

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -402,6 +402,15 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccesses) {
     ASSERT_THAT_ERROR(Schema.load(Tree->getRef()).moveInto(TreeNode),
                       Succeeded());
 
+#ifdef _WIN32
+    ASSERT_NE(TreeNode, std::nullopt);
+    EXPECT_EQ(TreeNode->size(), 1u);
+    auto DriveNode = TreeNode->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    ASSERT_THAT_ERROR(Schema.load(DriveNode->getRef()).moveInto(TreeNode),
+                      Succeeded());
+#endif
+
     // Check that all the files are found.
     EXPECT_EQ(Files.size(), TreeNode->size());
     for (const auto &F : Files)
@@ -451,6 +460,14 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesStack) {
     std::optional<llvm::cas::TreeProxy> TreeNode;
     ASSERT_THAT_ERROR(Schema.load(Tree->getRef()).moveInto(TreeNode),
                       Succeeded());
+#ifdef _WIN32
+    ASSERT_NE(TreeNode, std::nullopt);
+    EXPECT_EQ(TreeNode->size(), 1u);
+    auto DriveNode = TreeNode->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    ASSERT_THAT_ERROR(Schema.load(DriveNode->getRef()).moveInto(TreeNode),
+                      Succeeded());
+#endif
     ASSERT_EQ(TreeNode->size(), 2u);
     EXPECT_TRUE(TreeNode->lookup(sys::path::filename(Temps[2].path())));
     EXPECT_TRUE(TreeNode->lookup(sys::path::filename(Temps[3].path())));
@@ -472,6 +489,14 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesStack) {
     std::optional<llvm::cas::TreeProxy> TreeNode;
     ASSERT_THAT_ERROR(Schema.load(Tree->getRef()).moveInto(TreeNode),
                       Succeeded());
+#ifdef _WIN32
+    ASSERT_NE(TreeNode, std::nullopt);
+    EXPECT_EQ(TreeNode->size(), 1u);
+    auto DriveNode = TreeNode->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    ASSERT_THAT_ERROR(Schema.load(DriveNode->getRef()).moveInto(TreeNode),
+                      Succeeded());
+#endif
     ASSERT_EQ(TreeNode->size(), 2u);
     EXPECT_TRUE(TreeNode->lookup(sys::path::filename(Temps[0].path())));
     EXPECT_TRUE(TreeNode->lookup(sys::path::filename(Temps[1].path())));
@@ -534,6 +559,14 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesExists) {
     std::optional<llvm::cas::TreeProxy> TreeNode;
     ASSERT_THAT_ERROR(Schema.load(Tree->getRef()).moveInto(TreeNode),
                       Succeeded());
+#ifdef _WIN32
+    ASSERT_NE(TreeNode, std::nullopt);
+    EXPECT_EQ(TreeNode->size(), 1u);
+    auto DriveNode = TreeNode->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    ASSERT_THAT_ERROR(Schema.load(DriveNode->getRef()).moveInto(TreeNode),
+                      Succeeded());
+#endif
     auto Node0 = TreeNode->lookup(sys::path::filename(Temps[0].path()));
     auto Node1 = TreeNode->lookup(sys::path::filename(Temps[1].path()));
     ASSERT_TRUE(Node0);
@@ -558,6 +591,14 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesExists) {
     std::optional<llvm::cas::TreeProxy> TreeNode;
     ASSERT_THAT_ERROR(Schema.load(Tree->getRef()).moveInto(TreeNode),
                       Succeeded());
+#ifdef _WIN32
+    ASSERT_NE(TreeNode, std::nullopt);
+    EXPECT_EQ(TreeNode->size(), 1u);
+    auto DriveNode = TreeNode->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    ASSERT_THAT_ERROR(Schema.load(DriveNode->getRef()).moveInto(TreeNode),
+                      Succeeded());
+#endif
     auto Node0 = TreeNode->lookup(sys::path::filename(Temps[0].path()));
     auto Node1 = TreeNode->lookup(sys::path::filename(Temps[1].path()));
     ASSERT_TRUE(Node0);
@@ -582,6 +623,14 @@ TEST(CachingOnDiskFileSystemTest, TrackNewAccessesExists) {
     std::optional<llvm::cas::TreeProxy> TreeNode;
     ASSERT_THAT_ERROR(Schema.load(Tree->getRef()).moveInto(TreeNode),
                       Succeeded());
+#ifdef _WIN32
+    ASSERT_NE(TreeNode, std::nullopt);
+    EXPECT_EQ(TreeNode->size(), 1u);
+    auto DriveNode = TreeNode->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    ASSERT_THAT_ERROR(Schema.load(DriveNode->getRef()).moveInto(TreeNode),
+                      Succeeded());
+#endif
     auto Node0 = TreeNode->lookup(sys::path::filename(Temps[0].path()));
     auto Node1 = TreeNode->lookup(sys::path::filename(Temps[1].path()));
     ASSERT_TRUE(Node0);
@@ -684,6 +733,15 @@ TEST(CachingOnDiskFileSystemTest, ExcludeFromTacking) {
     EXPECT_EQ(FS->excludeFromTracking(F21.path()), std::error_code());
     AccessAllFiles();
     auto Tree = CreateTreeFromNewAccesses();
+#ifdef _WIN32
+    ASSERT_NE(Tree, std::nullopt);
+    EXPECT_EQ(Tree->size(), 1u);
+    auto DriveNode = Tree->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    auto DriveDir = Schema.load(DriveNode->getRef());
+    ASSERT_THAT_EXPECTED(DriveDir, Succeeded());
+    Tree = *DriveDir;
+#endif
     ASSERT_NE(Tree, std::nullopt);
     EXPECT_EQ(Tree->size(), 1u);
     EXPECT_FALSE(Tree->lookup("d1"));
@@ -702,6 +760,15 @@ TEST(CachingOnDiskFileSystemTest, ExcludeFromTacking) {
     EXPECT_EQ(FS->excludeFromTracking(D1.path()), std::error_code());
     EXPECT_EQ(FS->excludeFromTracking(F21.path()), std::error_code());
     auto Tree = CreateTreeFromNewAccesses();
+#ifdef _WIN32
+    ASSERT_NE(Tree, std::nullopt);
+    EXPECT_EQ(Tree->size(), 1u);
+    auto DriveNode = Tree->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    auto DriveDir = Schema.load(DriveNode->getRef());
+    ASSERT_THAT_EXPECTED(DriveDir, Succeeded());
+    Tree = *DriveDir;
+#endif
     ASSERT_NE(Tree, std::nullopt);
     EXPECT_EQ(Tree->size(), 1u);
     EXPECT_FALSE(Tree->lookup("d1"));
@@ -720,6 +787,15 @@ TEST(CachingOnDiskFileSystemTest, ExcludeFromTacking) {
     EXPECT_EQ(FS->excludeFromTracking(D1Sub.path()), std::error_code());
     EXPECT_EQ(FS->excludeFromTracking(D2.path()), std::error_code());
     auto Tree = CreateTreeFromNewAccesses();
+#ifdef _WIN32
+    ASSERT_NE(Tree, std::nullopt);
+    EXPECT_EQ(Tree->size(), 1u);
+    auto DriveNode = Tree->lookup(sys::path::root_name(TestDirectory.path()));
+    ASSERT_TRUE(DriveNode);
+    auto DriveDir = Schema.load(DriveNode->getRef());
+    ASSERT_THAT_EXPECTED(DriveDir, Succeeded());
+    Tree = *DriveDir;
+#endif
     ASSERT_NE(Tree, std::nullopt);
     EXPECT_EQ(Tree->size(), 1u);
     EXPECT_FALSE(Tree->lookup("d2"));

--- a/llvm/unittests/Support/PrefixMapperTest.cpp
+++ b/llvm/unittests/Support/PrefixMapperTest.cpp
@@ -416,7 +416,7 @@ TEST(TreePathPrefixMapperTest, construct) {
 
 TEST(TreePathPrefixMapperTest, add) {
   auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
-  TreePathPrefixMapper PM(FS);
+  TreePathPrefixMapper PM(FS, sys::path::Style::posix);
 
   // Non-canonical paths create two map entries: one for the canonical and one
   // for the non-canonical path.
@@ -440,7 +440,7 @@ TEST(TreePathPrefixMapperTest, add) {
 
 TEST(TreePathPrefixMapperTest, addRange) {
   auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
-  TreePathPrefixMapper PM(FS);
+  TreePathPrefixMapper PM(FS, sys::path::Style::posix);
 
   MappedPrefix MissingMapping[] = {
       {"missing", "/new"},
@@ -465,7 +465,7 @@ TEST(TreePathPrefixMapperTest, addRange) {
 
 TEST(TreePathPrefixMapperTest, addInverseRange) {
   auto FS = makeIntrusiveRefCnt<GetDirectoryEntryFileSystem>();
-  TreePathPrefixMapper PM(FS);
+  TreePathPrefixMapper PM(FS, sys::path::Style::posix);
 
   MappedPrefix MissingMapping[] = {
       {"/new", "missing"},

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1553,6 +1553,17 @@ def getDefaultSubstitutions(test, tmpDir, tmpBase, normalize_slashes=False):
         ]
     )
 
+    substitutions.extend(
+        [
+            # The filesystem root and their tree path forms for
+            # Windows for CAS prefix mapping. The t suffix stands for
+            # tree path. Those with suffixes need to use {} because
+            # lit macro names cannot be a prefix of another macro.
+            ("%/root", os.environ.get('SystemDrive') + "/" if kIsWindows else "/"),
+            ("%{/roott}", "/" + os.environ.get('SystemDrive') + "/" if kIsWindows else "/"),
+        ]
+    )
+
     return substitutions
 
 

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import pathlib
 import platform
 import re
 import subprocess
@@ -755,6 +756,17 @@ class LLVMConfig(object):
                     "%clangxx",
                     command=self.config.clang,
                     extra_args=["--driver-mode=g++"] + additional_flags,
+                ),
+                # A clang path with natural casing on Windows. Same as
+                # %/clang on non-Windows.
+                ToolSubst(
+                    "%/ncclang",
+                    command = (
+                        str(pathlib.Path(self.config.clang).resolve(strict=False)).replace("\\", "/")
+                        if platform.system() == "Windows"
+                        else self.config.clang.replace("\\", "/")
+                    ),
+                    extra_args=additional_flags
                 ),
             ]
             self.add_tool_substitutions(tool_substitutions)


### PR DESCRIPTION
Fix the following CAS related tests for Windows

Clang :: ClangScanDeps/cas-fs-prefix-mapping.c
Clang :: ClangScanDeps/include-tree-prefix-mapping-pch-remap.c
Clang :: ClangScanDeps/include-tree-prefix-mapping.c
Clang :: ClangScanDeps/modules-cas-fs-prefix-mapping-caching.c
Clang :: ClangScanDeps/modules-cas-fs-prefix-mapping.c
Clang :: ClangScanDeps/modules-include-tree-prefix-map.c
Clang :: ClangScanDeps/modules-pch-cas-fs-prefix-mapping-caching.c
Clang :: ClangScanDeps/modules-pch-cas-fs-prefix-mapping.c