### PR TITLE
[lldb] Fix handling of addresses given to swift task commands (#11314)

### DIFF
--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskBacktrace.py
@@ -31,6 +31,6 @@ class TestCase(TestBase):
                 ".sleep(",
                 "`second() at main.swift:6",
                 "`first() at main.swift:2",
-                "`closure #1 in static Main.main() at main.swift:12:19",
+                "`closure #1 in static Main.main() at main.swift:12",
             ],
         )

--- a/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
+++ b/lldb/test/API/lang/swift/async/tasks/TestSwiftTaskSelect.py
@@ -31,9 +31,9 @@ class TestCase(TestBase):
             "thread backtrace",
             substrs=[
                 ".sleep(",
-                "`second() at main.swift:6:",
-                "`first() at main.swift:2:",
-                "`closure #1 in static Main.main() at main.swift:12:",
+                "`second() at main.swift:6",
+                "`first() at main.swift:2",
+                "`closure #1 in static Main.main() at main.swift:12",
             ],
         )
 


### PR DESCRIPTION
The DIL implementation of `GetValueForVariableExpressionPath` succeeds when the "variable expression path" is an integer. This code expected the old behavior, where `GetValueForVariableExpressionPath` would fail for an integer value.

The fix is to try parsing the command arg as an address first (instead of as a fallback). If the command arg does not parse as an address, then it is tried as a variable expression path.

rdar://159531040
(cherry picked from commit 88636f039bf584e59c6aee57b7deb216e9bc662b)

(cherry-picked from commit 329119d52e0004b1f73f71b01f819a05e06c4e7d)