### PR TITLE
[Cherry-pick into next] [LLDB] Clamp the ClangImporter DWARF version to 4

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3053,7 +3053,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
       ci_args.push_back(sdk_triple.str());
     }
     ci_args.push_back("-gmodules");
-    ci_args.push_back("-g");
+    ci_args.push_back("-gdwarf-4");
   }
 
   std::vector<swift::PluginSearchOption> plugin_search_options;
@@ -3192,7 +3192,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
       swift_ast_sp->RegisterSectionModules(*image_sp, module_names);
   }
 
-  {
+  if (!for_expressions && module_sp) {
     auto ast_context = swift_ast_sp->GetASTContext();
     if (!ast_context) {
       logError("couldn't initialize Swift compiler");


### PR DESCRIPTION
```
commit 743ec8632d5198f8544570ce30e45f5da11906cb
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Sep 9 10:27:36 2025 -0700

    [LLDB] Clamp the ClangImporter DWARF version to 4
```
