### PR TITLE
[stable/21.x] Introduce `FeatureAvailKind::AlwaysAvailable`

### DIFF
--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -66,7 +66,13 @@ enum class PointerAuthenticationMode : unsigned {
   SignAndAuth
 };
 
-enum class FeatureAvailKind { None, Available, Unavailable, Dynamic };
+enum class FeatureAvailKind {
+  None,
+  Available,
+  Unavailable,
+  Dynamic,
+  AlwaysAvailable,
+};
 
 /// Bitfields of LangOptions, split out from LangOptions in order to ensure that
 /// this large collection of bitfields is a trivial class type.

--- a/clang/lib/AST/ExprConstant.cpp
+++ b/clang/lib/AST/ExprConstant.cpp
@@ -12531,6 +12531,7 @@ public:
 
     switch (FeatureInfo.Kind) {
     case FeatureAvailKind::Available:
+    case FeatureAvailKind::AlwaysAvailable:
       ResultInt = 1;
       break;
     case FeatureAvailKind::Unavailable:

--- a/clang/lib/Headers/availability_domain.h
+++ b/clang/lib/Headers/availability_domain.h
@@ -15,6 +15,7 @@
 #define __AVAILABILITY_DOMAIN_ENABLED 0
 #define __AVAILABILITY_DOMAIN_DISABLED 1
 #define __AVAILABILITY_DOMAIN_DYNAMIC 2
+#define __AVAILABILITY_DOMAIN_ALWAYS_ENABLED 3
 
 /// Describes the fields of a Clang availability domain. This struct is an
 /// implementation detail of the compiler and is subject to change so don't
@@ -43,11 +44,8 @@ struct __AvailabilityDomain {
       availability_domain(domain))) = {__AVAILABILITY_DOMAIN_DISABLED, 0}
 
 #define CLANG_ALWAYS_ENABLED_AVAILABILITY_DOMAIN(domain)                       \
-  static struct __AvailabilityDomain domain __attribute__((                    \
-      availability_domain(domain))) = {__AVAILABILITY_DOMAIN_ENABLED, 0}
-
-#define CLANG_ALWAYS_DISABLED_AVAILABILITY_DOMAIN(domain)                      \
-  static struct __AvailabilityDomain domain __attribute__((                    \
-      availability_domain(domain))) = {__AVAILABILITY_DOMAIN_DISABLED, 0}
+  static struct __AvailabilityDomain domain                                    \
+      __attribute__((availability_domain(domain))) = {                         \
+          __AVAILABILITY_DOMAIN_ALWAYS_ENABLED, 0}
 
 #endif /* __AVAILABILITY_DOMAIN_H */

--- a/clang/test/Sema/feature-availability.c
+++ b/clang/test/Sema/feature-availability.c
@@ -13,6 +13,7 @@ CLANG_ENABLED_AVAILABILITY_DOMAIN(feature1);
 CLANG_DISABLED_AVAILABILITY_DOMAIN(feature2);
 CLANG_ENABLED_AVAILABILITY_DOMAIN(feature3);
 CLANG_DYNAMIC_AVAILABILITY_DOMAIN(feature4, pred1);
+CLANG_ALWAYS_ENABLED_AVAILABILITY_DOMAIN(feature5);
 #endif
 
 #pragma clang attribute push (__attribute__((availability(domain:feature1, AVAIL))), apply_to=any(function))
@@ -34,6 +35,8 @@ __attribute__((availability(domain:feature4, AVAIL))) void func10(void);
 __attribute__((availability(domain:feature4, UNAVAIL))) void func11(void);
 __attribute__((availability(domain:feature4, AVAIL))) int g4;
 __attribute__((availability(domain:feature4, UNAVAIL))) int g5;
+__attribute__((availability(domain:feature5, AVAIL))) void func21(void);
+__attribute__((availability(domain:feature5, UNAVAIL))) void func22(void);
 #endif
 
 void test_unreachable_code(void) {
@@ -240,3 +243,19 @@ void test7(void) {
     e = EB; // expected-error {{use of 'EB' requires feature 'feature1' to be available}}
   }
 }
+
+#ifdef USE_DOMAIN
+void test8(void) {
+  // FIXME: Use of 'func21()' should not be diagnosed because feature5 is always available.
+  func21(); // expected-error {{use of 'func21' requires feature 'feature5' to be available}}
+  func22(); // expected-error {{use of 'func22' requires feature 'feature5' to be unavailable}}
+
+  if (__builtin_available(domain:feature5)) {
+    func21();
+    func22(); // expected-error {{use of 'func22' requires feature 'feature5' to be unavailable}}
+  } else {
+    func21(); // expected-error {{use of 'func21' requires feature 'feature5' to be available}}
+    func22();
+  }
+}
+#endif


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/11366.

Represent availability domains that are always available regardless of context by introducing a new `FeatureAvailKind`. The Sema support for these domains will added later; this change is designed to unblock Swift's implementation of support for always available domains.

Resolves rdar://160244138.