### PR TITLE
[🍒][libFuzzer] Change sig-trap test to allow expected output strings in any order

### DIFF
--- a/compiler-rt/test/fuzzer/sig-trap.test
+++ b/compiler-rt/test/fuzzer/sig-trap.test
@@ -5,7 +5,7 @@ UNSUPPORTED: target={{.*windows.*}}
 RUN: %cpp_compiler %S/SigTrapTest.cpp -o %t
 
 RUN: not %run %t            2>&1 | FileCheck %s
-CHECK: BINGO
-CHECK: ERROR: libFuzzer: deadly signal
+CHECK-DAG: BINGO
+CHECK-DAG: ERROR: libFuzzer: deadly signal
 
 RUN: trap "%run %t -handle_trap=0" TRAP


### PR DESCRIPTION
I have seen some flakiness in this test where the 2 checked strings appear in a different order. Due to buffering of writes, and that one of these strings is written during the signal handler, I think this is valid.

This PR relaxes the test to allow those strings to appear in either order.

Originally reviewed at: https://github.com/llvm/llvm-project/pull/157407

rdar://160097852