### PR TITLE
Make flag-only options work in the ParsedCommand mode of adding commands

### DIFF
--- a/lldb/examples/python/cmdtemplate.py
+++ b/lldb/examples/python/cmdtemplate.py
@@ -71,6 +71,11 @@ class FrameStatCommand(ParsedCommand):
             dest = "statics",
             default = True,
         )
+        ov_parser.add_option(
+            "t",
+            "test-flag",
+            help="test a flag value.",
+        )
 
     def get_repeat_command(self, args):
         """As an example, make the command not auto-repeat:"""
@@ -120,6 +125,11 @@ class FrameStatCommand(ParsedCommand):
                 % (variables_count, total_size, average_size),
                 file=result,
             )
+        if ov_parser.was_set("test-flag"):
+            print("Got the test flag")
+        else:
+            print("Got no test flag")
+
         # not returning anything is akin to returning success
 
 

--- a/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
+++ b/lldb/test/API/commands/command/script/add/TestAddParsedCommand.py
@@ -34,6 +34,7 @@ class ParsedCommandTestCase(TestBase):
             else:
                 (short_opt, type, long_opt) = elem
                 substrs.append(f"-{short_opt} <{type}> ( --{long_opt} <{type}> )")
+
         self.expect("help " + cmd_name, substrs=substrs)
 
     def run_one_repeat(self, commands, expected_num_errors):
@@ -215,6 +216,19 @@ class ParsedCommandTestCase(TestBase):
                 "bool-arg (set: True): False",
                 "shlib-name (set: True): Something",
                 "disk-file-name (set: False):",
+                "flag-value (set: False):",
+                "line-num (set: False):",
+                "enum-option (set: False):",
+            ],
+        )
+        # Make sure flag values work:
+        self.expect(
+            "no-args -b false -s Something -f",
+            substrs=[
+                "bool-arg (set: True): False",
+                "shlib-name (set: True): Something",
+                "disk-file-name (set: False):",
+                "flag-value (set: True):",
                 "line-num (set: False):",
                 "enum-option (set: False):",
             ],

--- a/lldb/test/API/commands/command/script/add/test_commands.py
+++ b/lldb/test/API/commands/command/script/add/test_commands.py
@@ -16,10 +16,16 @@ class ReportingCmd(ParsedCommand):
         if len(opt_def):
             result.AppendMessage("Options:\n")
             for long_option, elem in opt_def.items():
-                dest = elem["dest"]
-                result.AppendMessage(
-                    f"{long_option} (set: {elem['_value_set']}): {object.__getattribute__(self.get_parser(), dest)}\n"
-                )
+                if "value_type" in elem:
+                    print(f"Looking at {long_option} - {elem}")
+                    dest = elem["dest"]
+                    result.AppendMessage(
+                        f"{long_option} (set: {elem['_value_set']}): {object.__getattribute__(self.get_parser(), dest)}\n"
+                    )
+                else:
+                    result.AppendMessage(
+                        f"{long_option} (set: {elem['_value_set']}): flag value\n"
+                    )
         else:
             result.AppendMessage("No options\n")
 
@@ -77,6 +83,8 @@ class NoArgsCommand(ReportingCmd):
             dest="disk_file_name",
             default=None,
         )
+
+        ov_parser.add_option("f", "flag-value", "This is a flag value")
 
         ov_parser.add_option(
             "l",


### PR DESCRIPTION
 (#157756)

I neglected to add a test when I was writing tests for this, so of course it broke. This makes it work again and adds a test.

rdar://159459160
(cherry picked from commit e2d9420272e2f479dc714706be5a4aa0a4b2c90d)