### PR TITLE
[Index] Mark `-index-store-compress` as used when `-index-store-path` is set

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -737,7 +737,7 @@ def index_ignore_pcms : Flag<["-"], "index-ignore-pcms">,
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Ignore symbols from imported pcm modules">,
   MarshallingInfoFlag<FrontendOpts<"IndexIgnorePcms">>;
-def index_store_record_compression
+def index_store_compress
     : Flag<["-"], "index-store-compress">,
       Visibility<[ClangOption, CC1Option]>,
       HelpText<"Whether to compress unit and record files in the index store">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6433,6 +6433,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
     Args.AddLastArg(CmdArgs, options::OPT_index_unit_output_path);
     Args.AddLastArg(CmdArgs, options::OPT_index_ignore_macros);
     Args.AddLastArg(CmdArgs, options::OPT_index_ignore_pcms);
+    Args.AddLastArg(CmdArgs, options::OPT_index_store_compress);
 
     // If '-o' is passed along with '-fsyntax-only' pass it along the cc1
     // invocation so that the index action knows what the out file is.

--- a/clang/test/Index/Store/compress-index-store.c
+++ b/clang/test/Index/Store/compress-index-store.c
@@ -1,5 +1,5 @@
 // RUN: rm -rf %t.idx
-// RUN: %clang_cc1 %s -index-store-path %t.idx -index-store-compress
+// RUN: %clang -Werror=unused-command-line-argument -fsyntax-only %s -index-store-path %t.idx -index-store-compress
 // RUN: c-index-test core -print-unit %t.idx | FileCheck --check-prefix=UNIT %s
 // RUN: c-index-test core -print-record %t.idx | FileCheck --check-prefix=RECORD %s
 


### PR DESCRIPTION
Otherwise we get a warning `argument unused during compilation: '-index-store-compress'`, which prevents projects from building if they treat erros as warnings using `-Werror`.