### PR TITLE
[lldb] Pass execution context to CompilerType::GetByteSize - in CommandObjectMemoryRead (NFC)

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -364,6 +364,8 @@ protected:
       return;
     }
 
+    ExecutionContextScope *exe_scope = m_exe_ctx.GetBestExecutionContextScope();
+
     CompilerType compiler_type;
     Status error;
 
@@ -519,7 +521,7 @@ protected:
         --pointer_count;
       }
 
-      auto size_or_err = compiler_type.GetByteSize(nullptr);
+      auto size_or_err = compiler_type.GetByteSize(exe_scope);
       if (!size_or_err) {
         result.AppendErrorWithFormat(
             "unable to get the byte size of the type '%s'\n%s",
@@ -639,7 +641,7 @@ protected:
       if (!m_format_options.GetFormatValue().OptionWasSet())
         m_format_options.GetFormatValue().SetCurrentValue(eFormatDefault);
 
-      auto size_or_err = compiler_type.GetByteSize(nullptr);
+      auto size_or_err = compiler_type.GetByteSize(exe_scope);
       if (!size_or_err) {
         result.AppendError(llvm::toString(size_or_err.takeError()));
         return;
@@ -799,7 +801,6 @@ protected:
       output_stream_p = &result.GetOutputStream();
     }
 
-    ExecutionContextScope *exe_scope = m_exe_ctx.GetBestExecutionContextScope();
     if (compiler_type.GetOpaqueQualType()) {
       for (uint32_t i = 0; i < item_count; ++i) {
         addr_t item_addr = addr + (i * item_byte_size);

--- a/lldb/test/API/lang/swift/command_memory_read/Makefile
+++ b/lldb/test/API/lang/swift/command_memory_read/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
+++ b/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
@@ -1,0 +1,58 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test_scalar_types(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.selected_frame
+
+        child = frame.var("name")
+        for t in ("String", "$sSSD"):
+            self.expect(
+                f"memory read -t {t} {child.load_addr}",
+                substrs=[f'(String) 0x{child.load_addr:x} = "dirk"'],
+            )
+
+        child = frame.var("number")
+        for t in ("Int", "$sSiD"):
+            self.expect(
+                f"memory read -t {t} {child.load_addr}",
+                substrs=[f"(Int) 0x{child.load_addr:x} = 41"],
+            )
+
+        child = frame.var("fact")
+        for t in ("Bool", "$sSbD"):
+            self.expect(
+                f"memory read -t {t} {child.load_addr}",
+                substrs=[f"(Bool) 0x{child.load_addr:x} = true"],
+            )
+
+    @swiftTest
+    @expectedFailureAll
+    def test_generic_types(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.selected_frame
+
+        child = frame.var("maybe")
+        for t in ("UInt64?", "$ss6UInt64VSgD"):
+            self.expect(
+                f"memory read -t {t} {child.load_addr}",
+                substrs=[f"(UInt64?) 0x{child.load_addr:x} = nil"],
+            )
+
+        child = frame.var("bytes")
+        for t in ("[UInt8]", "$sSays5UInt8VGD"):
+            self.expect(
+                f"memory read -t {t} {child.load_addr}",
+                substrs=[f"([UInt8]) 0x{child.load_addr:x} = [1, 2, 4, 8]"],
+            )

--- a/lldb/test/API/lang/swift/command_memory_read/main.swift
+++ b/lldb/test/API/lang/swift/command_memory_read/main.swift
@@ -1,0 +1,10 @@
+@main enum Entry {
+    static func main() {
+        var name: String = "dirk"
+        var number: Int = 41
+        var fact: Bool = true
+        var maybe: UInt64? = nil
+        var bytes: [UInt8] = [1, 2, 4, 8]
+        print("break here", name, number, fact, maybe, bytes)
+    }
+}


### PR DESCRIPTION
Some type systems require an execution context be available when working with types
(ex: Swift). This fixes `memory read --type` to support such type systems, by passing in
an execution context to `GetByteSize()`, instead of passing null.

rdar://158968545
(cherry picked from commit b574e63f9fd1adb52786f9dc03ec6f479229e1a7)
