### PR TITLE
[lldb][swift] Fix handling of pointer metadata in swift tests

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -863,6 +863,8 @@ public:
             m_ts->GetTypeFromMangledTypename(ConstString("$sSVD"));
 
         addr_t value = m_task_ptr;
+        if (auto process_sp = m_backend.GetProcessSP())
+          value = process_sp->FixDataAddress(value);
         DataExtractor data{reinterpret_cast<const void *>(&value),
                            sizeof(value), endian::InlHostByteOrder(),
                            sizeof(void *)};
@@ -903,7 +905,7 @@ public:
             parent_addr = 0;
         }
 
-        addr_t value = parent_addr;
+        addr_t value = process_sp->FixDataAddress(parent_addr);
         DataExtractor data{reinterpret_cast<const void *>(&value),
                            sizeof(value), endian::InlHostByteOrder(),
                            sizeof(void *)};

--- a/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
+++ b/lldb/test/API/lang/swift/async/frame/variables_multiple_frames/TestSwiftAsyncFrameVarMultipleFrames.py
@@ -17,11 +17,14 @@ class TestCase(lldbtest.TestBase):
 
     # Check that the CFA chain is correctly built
     def check_cfas(self, async_frames, process):
-        async_cfas = list(map(lambda frame: frame.GetCFA(), async_frames))
+        async_cfas = list(
+            map(lambda frame: process.FixAddress(frame.GetCFA()), async_frames)
+        )
         expected_cfas = [async_cfas[0]]
         # The CFA chain ends in nullptr.
         while expected_cfas[-1] != 0:
-            expected_cfas.append(self.read_ptr_from_memory(process, expected_cfas[-1]))
+            indirect_ctx = self.read_ptr_from_memory(process, expected_cfas[-1])
+            expected_cfas.append(process.FixAddress(indirect_ctx))
 
         self.assertEqual(async_cfas, expected_cfas[:-1])
 
@@ -43,13 +46,10 @@ class TestCase(lldbtest.TestBase):
 
         cfa = frame.GetCFA()
         is_indirect = "await resume" in frame.GetFunctionName()
-        async_register = frame.FindRegister(async_reg_name).GetValueAsUnsigned()
-
+        async_ctx = frame.FindRegister(async_reg_name).GetValueAsUnsigned()
         if is_indirect:
-            deref_async_reg = self.read_ptr_from_memory(process, async_register)
-            self.assertEqual(deref_async_reg, cfa)
-        else:
-            self.assertEqual(async_register, cfa)
+            async_ctx = self.read_ptr_from_memory(process, async_ctx)
+        self.assertEqual(process.FixAddress(async_ctx), process.FixAddress(cfa))
 
     def check_async_regs(self, async_frames, process):
         for frame in async_frames:


### PR DESCRIPTION
This is tweaking the behavior of tests / formatters so that they work better in the presence of pointer metadata