### PR TITLE
[domain availability] Stop copying attributes from an ObjCMethodDecl to another

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3366,7 +3366,7 @@ void Sema::mergeDeclAttributes(NamedDecl *New, Decl *Old,
     Diag(Old->getLocation(), diag::note_previous_declaration);
   }
 
-  if (auto *ND = dyn_cast<NamedDecl>(Old))
+  if (auto *ND = dyn_cast<NamedDecl>(Old); ND && !isa<ObjCMethodDecl>(ND))
     copyFeatureAvailabilityCheck(New, ND, true);
 
   if (!Old->hasAttrs())
@@ -3399,6 +3399,9 @@ void Sema::mergeDeclAttributes(NamedDecl *New, Decl *Old,
 
     // Already handled.
     if (isa<UsedAttr>(I) || isa<RetainAttr>(I))
+      continue;
+
+    if (isa<ObjCMethodDecl>(Old) && isa<DomainAvailabilityAttr>(I))
       continue;
 
     if (isa<InferredNoReturnAttr>(I)) {

--- a/clang/test/CodeGenObjC/feature-availability.m
+++ b/clang/test/CodeGenObjC/feature-availability.m
@@ -202,7 +202,7 @@ __attribute__((availability(domain:feature2, AVAIL)))
 @implementation C3
 -(void)p1_m1 {
 }
--(void)unavailable_p2_m2 {
+-(void)unavailable_p2_m2 __attribute__((availability(domain:feature2, AVAIL))) {
   unavailable_func1();
 }
 +(void)cm0 {

--- a/clang/test/SemaObjC/feature-availability.m
+++ b/clang/test/SemaObjC/feature-availability.m
@@ -176,3 +176,30 @@ __attribute__((availability(domain:feature1, UNAVAIL)))
 @end
 
 void foo(id<P1>); // expected-error {{use of 'P1' requires feature 'feature1' to be unavailable}}
+
+@interface Base8
+@property (copy) id x;
+@end
+
+__attribute__((availability(domain:feature1, AVAIL)))
+@interface Derived8 : Base8
+@property (copy) id x;
+@end
+
+@interface Base9
+-(void)m4 __attribute__((availability(domain:feature1, AVAIL)));
+@end
+
+@interface Derived9 : Base9
+-(void)m4;
+@end
+
+@implementation Derived9 : Base9
+-(void)m4 {
+  // Check that this method doesn't inherit the domain availablity attribute
+  // from the base class method.
+  func1(); // expected-error {{use of 'func1' requires feature 'feature1' to be available}}
+
+  [super m4]; // expected-error {{use of 'm4' requires feature 'feature1' to be available}}
+}
+@end


### PR DESCRIPTION
Stop copying domain availability attributes between ObjCMethodDecls, except when moving them from a method declaration to its implementation.

rdar://160157241