### PR TITLE
[Cherry-pick into stable/21.x] [LLDB] Update macOS Swift resource directory computation

### DIFF
--- a/lldb/unittests/Host/HostInfoSwiftTest.cpp
+++ b/lldb/unittests/Host/HostInfoSwiftTest.cpp
@@ -73,6 +73,26 @@ TEST_F(SwiftHostTest, ComputeSwiftResourceDirectory) {
 }
 
 #if defined(__APPLE__)
+TEST_F(SwiftHostTest, MacOSXToolchain) {
+  std::string path_to_liblldb =
+      "/Applications/Xcode.app/Contents/Developer/Toolchains/"
+      "OSX26.0.xctoolchain/System/Library/PrivateFrameworks/LLDB.framework";
+  std::string path_to_swift_dir =
+      "/Applications/Xcode.app/Contents/Developer/Toolchains/"
+      "OSX26.0.xctoolchain/usr/lib/swift";
+  EXPECT_EQ(ComputeSwiftResourceDirectoryHelper(path_to_liblldb),
+            path_to_swift_dir);
+}
+TEST_F(SwiftHostTest, MacOSXXcode) {
+  std::string path_to_liblldb =
+      "/Applications/Xcode.app/Contents/SharedFrameworks/LLDB.framework";
+  std::string path_to_swift_dir =
+      "/Applications/Xcode.app/Contents/Developer/Toolchains/"
+      "XcodeDefault.xctoolchain/usr/lib/swift";
+  EXPECT_EQ(ComputeSwiftResourceDirectoryHelper(path_to_liblldb),
+            path_to_swift_dir);
+}
+
 TEST_F(SwiftHostTest, MacOSX) {
   // test for LLDB.framework
   std::string path_to_liblldb = "/foo/bar/lib/LLDB.framework";


### PR DESCRIPTION
```
commit 5c9900cbaa7cb33b1abf1e28077d32309bf4309f
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Sep 11 14:20:51 2025 -0700

    [LLDB] Update macOS Swift resource directory computation
    
    For a while now Xcode no longer ships a separate Swift resource
    directory inside of LLDB.framework, so this method should find the
    matching Swift compiler's resource dir next to its install location.
    
    rdar://160406978
```
