### PR TITLE
Fix the OnDiskCASLoggerTest/MultiProcess test on Windows

### DIFF
--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -159,12 +159,7 @@ TEST(OnDiskCASLoggerTest, MultiProcess) {
   SmallVector<ProcessInfo> PIs;
   for (int I = 0; I < 5; ++I) {
     bool ExecutionFailed;
- #ifndef _WIN32
     auto PI = ExecuteNoWait(Executable, Argv, ArrayRef<StringRef>{}, {}, 0, &Error,
- #else
-    // CreateProcessW will fail with zero-length env on Windows
-    auto PI = ExecuteNoWait(Executable, Argv, std::nullopt, {}, 0, &Error,
- #endif
                             &ExecutionFailed);
     ASSERT_FALSE(ExecutionFailed) << Error;
     PIs.push_back(std::move(PI));


### PR DESCRIPTION
Fix the OnDiskCASLoggerTest/MultiProcess test on Windows

LLVM-Unit :: CAS/./CASTests.exe/OnDiskCASLoggerTest/MultiProcess