### PR TITLE
Handle YieldResult type in LLDB swift plugin

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6139,6 +6139,7 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   case swift::TypeKind::SILToken:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     LOG_PRINTF(GetLog(LLDBLog::Types), "Unexpected type: %s",
                swift_can_type.getString().c_str());
     assert(false && "Internal compiler type");
@@ -6303,6 +6304,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   case swift::TypeKind::SILToken:
   case swift::TypeKind::PackArchetype:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     assert(false && "Internal compiler type");
     break;
   case swift::TypeKind::BuiltinBridgeObject:
@@ -6809,6 +6811,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type) {
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::ErrorUnion:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     break;
   case swift::TypeKind::BuiltinInteger:
   case swift::TypeKind::BuiltinIntegerLiteral:
@@ -6936,6 +6939,7 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
   case swift::TypeKind::SILToken:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     break;
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
@@ -7065,6 +7069,7 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
   case swift::TypeKind::SILToken:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     break;
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
@@ -7294,6 +7299,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
   case swift::TypeKind::SILToken:
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     break;
   case swift::TypeKind::UnmanagedStorage:
   case swift::TypeKind::UnownedStorage:
@@ -7513,6 +7519,7 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     return 0;
   case swift::TypeKind::BuiltinInteger:
   case swift::TypeKind::BuiltinIntegerLiteral:
@@ -7666,6 +7673,7 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     break;
 
   case swift::TypeKind::UnmanagedStorage:
@@ -8062,6 +8070,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     case swift::TypeKind::TypeVariable:
     case swift::TypeKind::UnboundGeneric:
     case swift::TypeKind::VariadicSequence:
+    case swift::TypeKind::YieldResult:
       break;
 
     case swift::TypeKind::UnmanagedStorage:
@@ -8455,6 +8464,7 @@ bool SwiftASTContext::DumpTypeValue(
   case swift::TypeKind::TypeVariable:
   case swift::TypeKind::UnboundGeneric:
   case swift::TypeKind::VariadicSequence:
+  case swift::TypeKind::YieldResult:
     break;
 
   case swift::TypeKind::Class:


### PR DESCRIPTION
The type was introduced in https://github.com/swiftlang/swift/pull/78508 as a way to decorate/distinguish between normal results and yields. It does exist on Swift AST level only and is lowered down to native SIL coroutine yields. So we'd just ignore it in LLDB type system plugin, similar to other "compiler internal" types.