### PR TITLE
Fix check strings

### DIFF
--- a/clang/test/Sema/feature-availability.c
+++ b/clang/test/Sema/feature-availability.c
@@ -247,14 +247,14 @@ void test7(void) {
 #ifdef USE_DOMAIN
 void test8(void) {
   // FIXME: Use of 'func21()' should not be diagnosed because feature5 is always available.
-  func21(); // expected-error {{use of 'func21' requires feature 'feature5' to be available}}
-  func22(); // expected-error {{use of 'func22' requires feature 'feature5' to be unavailable}}
+  func21(); // expected-error {{cannot use 'func21' because feature 'feature5' is unavailable in this context}}
+  func22(); // expected-error {{cannot use 'func22' because feature 'feature5' is available in this context}}
 
   if (__builtin_available(domain:feature5)) {
     func21();
-    func22(); // expected-error {{use of 'func22' requires feature 'feature5' to be unavailable}}
+    func22(); // expected-error {{cannot use 'func22' because feature 'feature5' is available in this context}}
   } else {
-    func21(); // expected-error {{use of 'func21' requires feature 'feature5' to be available}}
+    func21(); // expected-error {{cannot use 'func21' because feature 'feature5' is unavailable in this context}}
     func22();
   }
 }


### PR DESCRIPTION
The diagnostic message changed after 7db7c0bd82cd17e7924ec8b12c0528fd6671d78f.