### PR TITLE
Specify `-swift-version` whenever `-emit-module-interface-path` is specified

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -164,7 +164,7 @@ ALL_SWIFT_SOURCES = $(SWIFT_SOURCES) $(DYLIB_SWIFT_SOURCES)
 SWIFT_OBJECTS = $(strip $(ALL_SWIFT_SOURCES:.swift=.swift.o))
 
 ifeq "$(DISABLE_SWIFT_INTERFACE)" ""
-SWIFT_INTERFACE_FLAGS=-emit-module-interface-path $(BUILDDIR)/$(MODULENAME).swiftinterface
+SWIFT_INTERFACE_FLAGS=-swift-version 5 -emit-module-interface-path $(BUILDDIR)/$(MODULENAME).swiftinterface
 endif
 
 ifeq "$(SWIFT_WMO)" "1"

--- a/lldb/test/Shell/SwiftREPL/SwiftInterface.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftInterface.test
@@ -4,7 +4,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cp %S/Inputs/A.swift %t/AA.swift
-// RUN: %target-swiftc -module-name AA -emit-module-interface-path %t/AA.swiftinterface -emit-library -o %t/libAA%target-shared-library-suffix %t/AA.swift
+// RUN: %target-swiftc -swift-version 5 -module-name AA -emit-module-interface-path %t/AA.swiftinterface -emit-library -o %t/libAA%target-shared-library-suffix %t/AA.swift
 // RUN: rm %t/AA.swift
 // RUN: %lldb --repl="-I%t -L%t -lAA" < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
+++ b/lldb/test/Shell/SwiftREPL/SwiftInterfaceForceModuleLoadMode.test
@@ -16,7 +16,7 @@
 // RUN: mkdir %t/mcp
 // RUN: mkdir %t/lib
 // RUN: cp %S/Inputs/A.swift %t/AA.swift
-// RUN: %target-swiftc -module-name AA -emit-module-interface-path %t/lib/AA.swiftinterface -emit-library -o %t/lib/libAA%target-shared-library-suffix %t/AA.swift
+// RUN: %target-swiftc -swift-version 5 -module-name AA -emit-module-interface-path %t/lib/AA.swiftinterface -emit-library -o %t/lib/libAA%target-shared-library-suffix %t/AA.swift
 // RUN: sed -e 's/FromInterface/FromSerialized/g' %t/AA.swift | %target-swiftc -module-name AA -emit-module -o %t/lib/AA.swiftmodule -
 // RUN: rm %t/AA.swift
 

--- a/llvm/test/tools/dsymutil/ARM/swiftmodule.test
+++ b/llvm/test/tools/dsymutil/ARM/swiftmodule.test
@@ -6,8 +6,8 @@
 # echo ''>I.swift
 # echo ''>B.swift
 # echo 'import I'>main.swift
-# xcrun swiftc -emit-module-interface-path I.swiftinterface -enable-library-evolution I.swift
-# xcrun swiftc -emit-module-path B.swiftmodule B.swift -Xfrontend -no-serialize-debugging-options
+# xcrun swiftc -swift-version 5 -emit-module-interface-path I.swiftinterface -enable-library-evolution I.swift
+# xcrun swiftc -swift-version 5 -emit-module-path B.swiftmodule B.swift -Xfrontend -no-serialize-debugging-options
 # xcrun swiftc -explicit-module-build main.swift -I. -module-cache-path cache -g -Xfrontend  -no-serialize-debugging-options
 # output is "B.swiftmodule" and "cache/I*.swiftmodule"
 #


### PR DESCRIPTION
With https://github.com/swiftlang/swift/pull/84244, `swift-frontend` will start requiring that `-swift-version` (or `-language-mode`) is specified whenever emitting a `.swiftinterface` file. Add the necessary arguments in various tests.