### PR TITLE
[lldb][test] enable `thread_contains_name` on linux

### DIFF
--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -1,4 +1,4 @@
-import textwrap
+import platfrom
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -16,10 +16,15 @@ class TestCase(TestBase):
         self.expect("v task", patterns=[r'"Chore" id:[1-9]'])
 
     @swiftTest
-    @skipIfLinux  # rdar://151471067
     def test_thread_contains_name(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "break inside", lldb.SBFileSpec("main.swift")
         )
-        self.assertRegex(thread.name, r"Chore \(Task [1-9]\)")
+
+        expected_name = (
+            r"DispatchWorker"
+            if platform.system() == "Linux"
+            else r"Chore \(Task [1-9]\)"
+        )
+        self.assertRegex(thread.name, expected_name)


### PR DESCRIPTION
On linux `libdispatch` set all the theads name as `DispatchWorker` because of the 16 byte limit of thread names.

 https://github.com/swiftlang/swift-corelibs-libdispatch/blob/0bb6c10fa556722654917b4a18ba2dc39b18392a/src/queue.c#L6266-L6270
```cpp
	#if HAVE_PTHREAD_SETNAME_NP 
	// pthread thread names are restricted to just 16 characters
	// including NUL. It does not make sense to pass the queue's
	// label as a name.
	pthread_setname_np(pthread_self(), "DispatchWorker");
	#endif
```

[`rust`](https://codebrowser.dev/rust/crates/std/src/sys/pal/unix/thread.rs.html#131)  truncates the name that given 

`llvm::set_thread_name` on linux currently uses the last 16 characters on linux as it tends to the more unique. 
https://github.com/swiftlang/llvm-project/blob/88cb9d6ac1c93ab7f3d5c09427609ff629e430bf/llvm/lib/Support/Unix/Threading.inc#L183-L196

`zig` returns an error if the name is too long. 
