### PR TITLE
[index] Add new symbol kinds for borrow and mutate accessors

### DIFF
--- a/clang/include/clang/Index/IndexSymbol.h
+++ b/clang/include/clang/Index/IndexSymbol.h
@@ -103,6 +103,8 @@ enum class SymbolSubKind : uint8_t {
   SwiftAssociatedType,
   SwiftGenericTypeParam,
   SwiftAccessorInit,
+  SwiftAccessorBorrow,
+  SwiftAccessorMutate,
 };
 
 typedef uint32_t SymbolPropertySet;

--- a/clang/include/indexstore/indexstore.h
+++ b/clang/include/indexstore/indexstore.h
@@ -25,7 +25,7 @@
  * INDEXSTORE_VERSION_MAJOR is intended for "major" source/ABI breaking changes.
  */
 #define INDEXSTORE_VERSION_MAJOR 0
-#define INDEXSTORE_VERSION_MINOR 15 /* added Swift init accessor sub-symbol */
+#define INDEXSTORE_VERSION_MINOR 16 /* added Swift borrow and mutate accessor sub-symbol */
 
 #define INDEXSTORE_VERSION_ENCODE(major, minor) ( \
       ((major) * 10000)                           \
@@ -314,6 +314,8 @@ typedef enum {
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORREAD = 1014,
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMODIFY = 1015,
   INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORINIT = 1016,
+  INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORBORROW = 1017,
+  INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMUTATE = 1018,
 } indexstore_symbol_subkind_t;
 
 INDEXSTORE_OPTIONS(uint64_t, indexstore_symbol_property_t) {

--- a/clang/lib/Index/IndexDataStoreUtils.cpp
+++ b/clang/lib/Index/IndexDataStoreUtils.cpp
@@ -191,6 +191,10 @@ SymbolSubKind index::getSymbolSubKind(indexstore_symbol_subkind_t K) {
     return SymbolSubKind::SwiftAssociatedType;
   case INDEXSTORE_SYMBOL_SUBKIND_SWIFTGENERICTYPEPARAM:
     return SymbolSubKind::SwiftGenericTypeParam;
+  case INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORBORROW:
+    return SymbolSubKind::SwiftAccessorBorrow;
+  case INDEXSTORE_SYMBOL_SUBKIND_SWIFTACCESSORMUTATE:
+    return SymbolSubKind::SwiftAccessorMutate;
   }
 }
 

--- a/clang/lib/Index/IndexSymbol.cpp
+++ b/clang/lib/Index/IndexSymbol.cpp
@@ -561,6 +561,8 @@ StringRef index::getSymbolSubKindString(SymbolSubKind K) {
   case SymbolSubKind::SwiftAccessorRead: return "acc-read";
   case SymbolSubKind::SwiftAccessorModify: return "acc-modify";
   case SymbolSubKind::SwiftAccessorInit: return "acc-init";
+  case SymbolSubKind::SwiftAccessorBorrow: return "acc-borrow";
+  case SymbolSubKind::SwiftAccessorMutate: return "acc-mutate";
   case SymbolSubKind::SwiftExtensionOfStruct: return "ext-struct";
   case SymbolSubKind::SwiftExtensionOfClass: return "ext-class";
   case SymbolSubKind::SwiftExtensionOfEnum: return "ext-enum";


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/11371