### PR TITLE
[lldb] Fix ThreadPlanStepOut when returning from trampolines

### DIFF
--- a/lldb/source/Target/ThreadPlanStepOut.cpp
+++ b/lldb/source/Target/ThreadPlanStepOut.cpp
@@ -431,8 +431,10 @@ bool ThreadPlanStepOut::ShouldStop(Event *event_ptr) {
     else
       return m_step_through_inline_plan_sp->ShouldStop(event_ptr);
   } else if (m_step_out_further_plan_sp) {
-    if (m_step_out_further_plan_sp->MischiefManaged())
+    if (m_step_out_further_plan_sp->MischiefManaged()) {
       m_step_out_further_plan_sp.reset();
+      done = true;
+    }
     else
       return m_step_out_further_plan_sp->ShouldStop(event_ptr);
   }

--- a/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
+++ b/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
@@ -3,7 +3,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-@skipIf(bugnumber = "rdar://159531304")
 class TestSwiftObjcProtocol(TestBase):
     def skip_debug_info_libraries(self):
         if platform.system() == "Darwin":

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 import platform
 
-@skipIf(bugnumber ="rdar://159531310")
 class TestStepThroughAllocatingInit(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -19,7 +19,6 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 import platform
 
-@skipIf(bugnumber="rdar://159531088")
 class TestSwiftStepping(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)


### PR DESCRIPTION
When ThreadPlanStepOut decides to step out of a frame, it enqueues a subplan to do so. However, when that plan is complete, ThreadPlanStepOut::ShouldStop forget to set the `done` boolean properly. This was exposed by a recent patch in LLVM:
https://github.com/llvm/llvm-project/pull/126838/files