### PR TITLE
[Cherry-pick into next] [lldb] Use SmallString.str() to ensure NUL-termination

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2980,7 +2980,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
             os << llvm::Triple::getOSTypeName(preferred_triple.getOS());
             os << platform_version.getAsString();
           }
-          computed_triple = llvm::Triple(buffer.data());
+          computed_triple = llvm::Triple(buffer.str());
         } else if (preferred_triple.getObjectFormat() == llvm::Triple::MachO) {
           LOG_PRINTF(GetLog(LLDBLog::Types),
                      "Completing triple based on main binary load commands.");


### PR DESCRIPTION
```
commit 232216d02f07295d1244ed120f8b32691f1bc49d
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Sep 16 17:48:45 2025 -0700

    [lldb] Use SmallString.str() to ensure NUL-termination
```
