### PR TITLE
[lldb] fix `get_python_module_path` for python 3.12 and greater

### DIFF
--- a/lldb/bindings/python/prepare_binding_python.py
+++ b/lldb/bindings/python/prepare_binding_python.py
@@ -366,14 +366,22 @@ def get_python_module_path(options):
             "Python",
             "lldb")
     else:
-        from distutils.sysconfig import get_python_lib
+        if sys.version_info.major == 3 and sys.version_info.minor >= 12:
+            from sysconfig import get_path
 
-        if options.prefix is not None:
-            module_path = get_python_lib(True, False, options.prefix)
+            if options.prefix is not None:
+                module_path = get_path("platlib", vars={"prefix": options.prefix})
+            else:
+                module_path = get_path("platlib")
+
         else:
-            module_path = get_python_lib(True, False)
-        return os.path.normcase(
-            os.path.join(module_path, "lldb"))
+            from distutils.sysconfig import get_python_lib
+
+            if options.prefix is not None:
+                module_path = get_python_lib(True, False, options.prefix)
+            else:
+                module_path = get_python_lib(True, False)
+            return os.path.normcase(os.path.join(module_path, "lldb"))
 
 
 def main(options):


### PR DESCRIPTION
[distutils](https://docs.python.org/3/library/distutils.html) was deprecated in 3.10 and removed in 3.11 this causes it to fail on python 3.12 or greater.

Added the alternative api.

(cherry picked from commit 01bbaaf36566a68774f7abb71677d0d00a8d3e4a)