### PR TITLE
[clang] Fix CAS initialization after upstream #158381

### DIFF
--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -530,6 +530,12 @@ public:
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::ObjectStore &getOrCreateObjectStore();
   llvm::cas::ActionCache &getOrCreateActionCache();
+  std::shared_ptr<llvm::cas::ObjectStore> getObjectStorePtr() const {
+    return CAS;
+  }
+  std::shared_ptr<llvm::cas::ActionCache> getActionCachePtr() const {
+    return ActionCache;
+  }
 
   /// @}
   /// @name Source Manager

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -530,12 +530,6 @@ public:
   /// Get the CAS, or create it using the configuration in CompilerInvocation.
   llvm::cas::ObjectStore &getOrCreateObjectStore();
   llvm::cas::ActionCache &getOrCreateActionCache();
-  std::shared_ptr<llvm::cas::ObjectStore> getObjectStorePtr() const {
-    return CAS;
-  }
-  std::shared_ptr<llvm::cas::ActionCache> getActionCachePtr() const {
-    return ActionCache;
-  }
 
   /// @}
   /// @name Source Manager
@@ -1046,7 +1040,7 @@ public:
 
   std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
             std::shared_ptr<llvm::cas::ActionCache>>
-  createCASDatabases();
+  getOrCreateCASDatabases();
 };
 
 } // end namespace clang

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -296,8 +296,7 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   if (!CacheCompileJob)
     return std::nullopt;
 
-  CAS = Clang.getObjectStorePtr();
-  Cache = Clang.getActionCachePtr();
+  std::tie(CAS, Cache) = Clang.getOrCreateCASDatabases();
   if (!CAS || !Cache)
     return 1; // Exit with error!
 

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -296,7 +296,8 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   if (!CacheCompileJob)
     return std::nullopt;
 
-  std::tie(CAS, Cache) = Clang.createCASDatabases();
+  CAS = Clang.getObjectStorePtr();
+  Cache = Clang.getActionCachePtr();
   if (!CAS || !Cache)
     return 1; // Exit with error!
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -974,7 +974,7 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputManager() {
 
 std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
           std::shared_ptr<llvm::cas::ActionCache>>
-CompilerInstance::createCASDatabases() {
+CompilerInstance::getOrCreateCASDatabases() {
   // Create a new CAS databases from the CompilerInvocation. Future calls to
   // createFileManager() will use the same CAS.
   std::tie(CAS, ActionCache) =
@@ -986,13 +986,13 @@ CompilerInstance::createCASDatabases() {
 
 llvm::cas::ObjectStore &CompilerInstance::getOrCreateObjectStore() {
   if (!CAS)
-    createCASDatabases();
+    getOrCreateCASDatabases();
   return *CAS;
 }
 
 llvm::cas::ActionCache &CompilerInstance::getOrCreateActionCache() {
   if (!ActionCache)
-    createCASDatabases();
+    getOrCreateCASDatabases();
   return *ActionCache;
 }
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -296,6 +296,10 @@ void CompilerInstance::createVirtualFileSystem(
   DiagnosticsEngine Diags(DiagnosticIDs::create(), DiagOpts, DC,
                           /*ShouldOwnClient=*/false);
 
+  std::tie(CAS, ActionCache) =
+      getInvocation().getCASOpts().getOrCreateDatabases(
+          Diags, /*CreateEmptyCASOnFailure=*/false);
+
   VFS = createVFSFromCompilerInvocation(getInvocation(), Diags,
                                         std::move(BaseFS), CAS);
   // FIXME: Should this go into createVFSFromCompilerInvocation?

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1536,9 +1536,6 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
              const CASOptions &CASOpts, DiagnosticsEngine &Diags,
              IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
              std::shared_ptr<llvm::cas::ObjectStore> OverrideCAS) {
-  if (!OverrideCAS)
-    return BaseFS;
-
   if (FSOpts.CASFileSystemRootID.empty() && FEOpts.CASIncludeTreeID.empty())
     return BaseFS;
 

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -282,10 +282,11 @@ void dependencies::addReversePrefixMappingFileSystem(
   llvm::PrefixMapper ReverseMapper;
   ReverseMapper.addInverseRange(PrefixMapper.getMappings());
   ReverseMapper.sort();
-  std::unique_ptr<llvm::vfs::FileSystem> FS =
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
       llvm::vfs::createPrefixMappingFileSystem(
           std::move(ReverseMapper), &ScanInstance.getVirtualFileSystem());
 
+  ScanInstance.setVirtualFileSystem(FS);
   ScanInstance.getFileManager().setVirtualFileSystem(std::move(FS));
 }
 

--- a/clang/test/CAS/output-path-error.c
+++ b/clang/test/CAS/output-path-error.c
@@ -19,4 +19,4 @@
 // RUN: cat %t/output.txt | FileCheck %s --check-prefix=ERROR
 
 // CACHE-MISS: remark: compile job cache miss
-// ERROR: fatal error: CAS missing expected root-id
+// ERROR: fatal error: CAS filesystem cannot be initialized from root-id 'llvmcas://{{.*}}': cannot get reference to root FS


### PR DESCRIPTION
With the early initialization of the VFS, the CAS is now being initialized too late. This PR initializes CAS along with the VFS so that the CAS filesystem can sit at the bottom.