### PR TITLE
Backport always-on log changes to 6.2

### DIFF
--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -111,17 +111,7 @@ void Host::SystemLog(Severity severity, llvm::StringRef message) {
   syslog(level, "%s", message.data());
 }
 #else
-void Host::SystemLog(Severity severity, llvm::StringRef message) {
-  switch (severity) {
-  case lldb::eSeverityInfo:
-  case lldb::eSeverityWarning:
-    llvm::outs() << message;
-    break;
-  case lldb::eSeverityError:
-    llvm::errs() << message;
-    break;
-  }
-}
+void Host::SystemLog(Severity severity, llvm::StringRef message) {}
 #endif
 #endif
 

--- a/lldb/source/Host/common/Host.cpp
+++ b/lldb/source/Host/common/Host.cpp
@@ -89,30 +89,11 @@ using namespace lldb;
 using namespace lldb_private;
 
 #if !defined(__APPLE__)
-#if !defined(_WIN32)
-#include <syslog.h>
-void Host::SystemLog(Severity severity, llvm::StringRef message) {
-  static llvm::once_flag g_openlog_once;
-  llvm::call_once(g_openlog_once, [] {
-    openlog("lldb", LOG_CONS | LOG_PID | LOG_NDELAY, LOG_USER);
-  });
-  int level = LOG_DEBUG;
-  switch (severity) {
-  case lldb::eSeverityInfo:
-    level = LOG_INFO;
-    break;
-  case lldb::eSeverityWarning:
-    level = LOG_WARNING;
-    break;
-  case lldb::eSeverityError:
-    level = LOG_ERR;
-    break;
-  }
-  syslog(level, "%s", message.data());
-}
-#else
+// The system log is currently only meaningful on Darwin, where this means
+// os_log. The meaning of a "system log" isn't as clear on other platforms, and
+// therefore we don't providate a default implementation. Vendors are free to
+// to implement this function if they have a use for it.
 void Host::SystemLog(Severity severity, llvm::StringRef message) {}
-#endif
 #endif
 
 #if !defined(__APPLE__) && !defined(_WIN32)

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -10,7 +10,6 @@
 
 xfail lldb-api :: lang/cpp/unique-types4/TestUniqueTypes4.py
 xfail lldb-shell :: Recognizer/verbose_trap.test
-xfail lldb-shell :: Settings/TestEchoCommands.test
 xfail lldb-shell :: Swift/MissingVFSOverlay.test
 xfail lldb-shell :: Swift/No.swiftmodule.test
 xfail lldb-shell :: Swift/ToolchainMismatch.test
@@ -25,7 +24,6 @@ xfail lldb-shell :: SwiftREPL/OpenClass.test
 xfail lldb-shell :: SwiftREPL/OptionalUnowned.test
 xfail lldb-shell :: SwiftREPL/RedirectInputUnreadable.test
 xfail lldb-shell :: SwiftREPL/SwiftInterface.test
-xfail lldb-shell :: SymbolFile/DWARF/x86/dead-code-filtering.yaml
 
 ### Tests that pass locally, but fail in CI reliably ###
 


### PR DESCRIPTION
This is equivalent to #10484 but targeting 6.2.