### PR TITLE
[Cherry-pick into next] [LLDB] Support GetNumChildren on thin function types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3088,9 +3088,8 @@ bool TypeSystemSwiftTypeRef::IsFunctionType(opaque_compiler_type_t type) {
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = DemangleCanonicalOutermostType(dem, type);
-    // Note: There are a number of other candidates, and this list may need
-    // updating. Ex: `NoEscapeFunctionType`, `ThinFunctionType`, etc.
     return node && (node->getKind() == Node::Kind::FunctionType ||
+                    node->getKind() == Node::Kind::ThinFunctionType ||
                     node->getKind() == Node::Kind::NoEscapeFunctionType ||
                     node->getKind() == Node::Kind::ImplFunctionType);
   };

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -150,6 +150,18 @@ TEST_F(TestTypeSystemSwiftTypeRef, Function) {
   }
   {
     NodePointer n = b.GlobalType(
+        b.Node(Node::Kind::ThinFunctionType,
+               b.Node(Node::Kind::ArgumentTuple,
+                      b.Node(Node::Kind::Type, b.Node(Node::Kind::Tuple))),
+               b.Node(Node::Kind::ReturnType,
+                      b.Node(Node::Kind::Type, b.Node(Node::Kind::Tuple)))));
+    CompilerType void_void = GetCompilerType(b.Mangle(n));
+    ASSERT_TRUE(void_void.IsFunctionType());
+    ASSERT_TRUE(void_void.IsFunctionPointerType());
+    ASSERT_EQ(void_void.GetNumberOfFunctionArguments(), 0UL);
+  }
+  {
+    NodePointer n = b.GlobalType(
         b.Node(Node::Kind::ImplFunctionType, b.Node(Node::Kind::ImplEscaping),
                b.Node(Node::Kind::ImplConvention, "@callee_guaranteed")));
     CompilerType impl_void_void = GetCompilerType(b.Mangle(n));


### PR DESCRIPTION
```
commit ea133b5c51a039df05dabd9bb0831da4126b28d1
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Sep 17 17:21:52 2025 -0700

    [LLDB] Support GetNumChildren on thin function types
    
    This fixes a performance problem by eliminating a SwiftASTContext fallback.
    rdar://160730897
```
