### PR TITLE
[clang][Dependency Scanning] Testing Config Macro Canonicalization with CAS

### DIFF
--- a/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
+++ b/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
@@ -7,6 +7,10 @@
 // RUN: clang-scan-deps -compilation-database %t/build/compile-commands.json \
 // RUN:   -j 1 -format experimental-full -optimize-args=canonicalize-macros > %t/deps.db
 // RUN: cat %t/deps.db | FileCheck %s -DPREFIX=%/t
+// RUN: clang-scan-deps -compilation-database %t/build/compile-commands.json \
+// RUN:   -j 1 -format experimental-include-tree-full -cas-path %t/cas \
+// RUN:   -optimize-args=canonicalize-macros > %t/deps_cas.db
+// RUN: cat %t/deps_cas.db | FileCheck %s --check-prefixes=CAS
 
 // Verify that there are only two variants and that the expected merges have
 // happened.
@@ -46,6 +50,41 @@
 // CHECK-NEXT:   "translation-units": [
 // CHECK:        ]
 // CHECK:      }
+
+
+// Check that when CAS is on, we still only have two variants of A.
+// CAS:      {
+// CAS-NEXT:   "modules": [
+// CAS-NEXT:     {
+// CAS-NEXT:       "cache-key": "{{.*}}",
+// CAS-NEXT:       "cas-include-tree-id": "{{.*}}",
+// CAS-NEXT:       "clang-module-deps": [],
+// CAS-NEXT:       "clang-modulemap-file":
+// CAS-NEXT:       "command-line": [
+// CAS:            ],
+// CAS-NEXT:       "context-hash": "{{.*}}",
+// CAS-NEXT:       "file-deps": [
+// CAS:            ],
+// CAS-NEXT:       "link-libraries": [],
+// CAS-NEXT:       "name": "A"
+// CAS-NEXT:     },
+// CAS-NEXT:     {
+// CAS-NEXT:       "cache-key": "{{.*}}",
+// CAS-NEXT:       "cas-include-tree-id": "{{.*}}",
+// CAS-NEXT:       "clang-module-deps": [],
+// CAS-NEXT:       "clang-modulemap-file":
+// CAS-NEXT:       "command-line": [
+// CAS:            ],
+// CAS-NEXT:       "context-hash": "{{.*}}",
+// CAS-NEXT:       "file-deps": [
+// CAS:            ],
+// CAS-NEXT:       "link-libraries": [],
+// CAS-NEXT:       "name": "A"
+// CAS-NEXT:     }
+// CAS-NEXT:   ],
+// CAS-NEXT:   "translation-units": [
+// CAS:        ]
+// CAS:      }
 
 
 //--- build/compile-commands.json.in


### PR DESCRIPTION
This is a test accompanying https://github.com/llvm/llvm-project/pull/159620. Without https://github.com/llvm/llvm-project/pull/159620, this test fails. 

Specifically, without the fix, when CAS is on, there are three variants of A. With the fix, there should be only two variants. 

Part of work for rdar://136303612