### PR TITLE
Fix the following CAS related tests for Windows

### DIFF
--- a/llvm/test/tools/llvm-cas/ingest-remap.test
+++ b/llvm/test/tools/llvm-cas/ingest-remap.test
@@ -1,3 +1,5 @@
+REQUIRES: symlinks
+
 RUN: rm -rf %t && mkdir -p %t
 
 RUN: llvm-cas --cas %t/cas --ingest --prefix-map %S/Inputs=/^input %S/Inputs > %t/cas.id

--- a/llvm/test/tools/llvm-cas/ingest.test
+++ b/llvm/test/tools/llvm-cas/ingest.test
@@ -1,3 +1,5 @@
+REQUIRES: symlinks
+
 RUN: rm -rf %t
 RUN: mkdir %t
 


### PR DESCRIPTION
Fix the following CAS related tests for Windows

LLVM :: tools/llvm-cas/ingest-remap.test
LLVM :: tools/llvm-cas/ingest.test