### PR TITLE
[BoundsSafety] Allow using bounds-attributed types when deducing auto

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -13591,7 +13591,10 @@ def err_bounds_safety_ptrauth_on_indexable_pointer : Error<
 
 def err_bounds_safety_auto_dynamic_bound : Error<
   "passing %select{'__counted_by'|'__sized_by'|'__counted_by_or_null'|'__sized_by_or_null'|'__ended_by'|end}0 pointer "
-  "as __auto_type initializer is not yet supported">;
+  "as %select{'auto'|'decltype(auto)'|'__auto_type'}1 initializer is not yet supported">;
+def warn_bounds_safety_auto_dynamic_bound : Warning<
+  err_bounds_safety_auto_dynamic_bound.Summary>,
+  InGroup<DiagGroup<"bounds-safety-auto-bounds-attributed">>;
 
 def err_bounds_safety_unsupported_address_of_incomplete_array : Error<
   "cannot take address of incomplete __counted_by array">;

--- a/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -5236,6 +5236,44 @@ static bool CheckDeducedPlaceholderConstraints(Sema &S, const AutoType &Type,
   return false;
 }
 
+// TO_UPSTREAM(BoundsSafety) ON
+static bool CheckAutoCanInferTypeFromBoundsAttributed(Sema &S,
+                                                      const AutoType *AT,
+                                                      Expr *Init,
+                                                      QualType &Result) {
+  if (!S.getLangOpts().BoundsSafetyAttributes)
+    return true;
+
+  QualType InitTy = Init->getType();
+  const auto *BATy = InitTy->getAs<BoundsAttributedType>();
+  if (!BATy)
+    return true;
+
+  QualType DesugaredTy;
+  unsigned Kind;
+  if (const auto *CATy = dyn_cast<CountAttributedType>(BATy)) {
+    DesugaredTy = CATy->desugar();
+    Kind = CATy->getKind();
+  } else {
+    const auto *DRPTy = cast<DynamicRangePointerType>(BATy);
+    DesugaredTy = DRPTy->desugar();
+    Kind = DRPTy->getEndPointer() ? /* ended_by() */ 4 : /* end */ 5;
+  }
+
+  if (S.getLangOpts().BoundsSafety) {
+    S.Diag(Init->getExprLoc(), diag::err_bounds_safety_auto_dynamic_bound)
+        << Kind << (int)AT->getKeyword();
+    return false;
+  }
+
+  // Drop the sugar and emit a warning.
+  S.Diag(Init->getExprLoc(), diag::warn_bounds_safety_auto_dynamic_bound)
+      << Kind << (int)AT->getKeyword();
+  Result = DesugaredTy;
+  return true;
+}
+// TO_UPSTREAM(BoundsSafety) OFF
+
 TemplateDeductionResult
 Sema::DeduceAutoType(TypeLoc Type, Expr *Init, QualType &Result,
                      TemplateDeductionInfo &Info, bool DependentDeduction,
@@ -5316,6 +5354,12 @@ Sema::DeduceAutoType(TypeLoc Type, Expr *Init, QualType &Result,
 
     DeducedType = getDecltypeForExpr(Init);
     assert(!DeducedType.isNull());
+
+    // TO_UPSTREAM(BoundsSafety) ON
+    if (!CheckAutoCanInferTypeFromBoundsAttributed(*this, AT, Init,
+                                                   DeducedType))
+      return DeductionFailed(TemplateDeductionResult::AlreadyDiagnosed);
+    // TO_UPSTREAM(BoundsSafety) OFF
   } else {
     LocalInstantiationScope InstScope(*this);
 
@@ -5380,27 +5424,16 @@ Sema::DeduceAutoType(TypeLoc Type, Expr *Init, QualType &Result,
         return DeductionFailed(TDK);
     }
 
-    /* TO_UPSTREAM(BoundsSafety) ON*/
-    if (getLangOpts().BoundsSafetyAttributes &&
-        Init->getType()->isBoundsAttributedType()) {
-      unsigned ErrIdx;
-      QualType Ty = Init->getType();
-      if (auto *DCPTy = Ty->getAs<CountAttributedType>()) {
-        ErrIdx = DCPTy->getKind();
-      } else {
-        auto *DRPTy = Ty->getAs<DynamicRangePointerType>();
-        assert(DRPTy);
-        ErrIdx = DRPTy->getEndPointer() ? 4 : 5;
-      }
-      Diag(Loc, diag::err_bounds_safety_auto_dynamic_bound) << ErrIdx;
-      return DeductionFailed(TemplateDeductionResult::AlreadyDiagnosed);
-    }
-    /* TO_UPSTREAM(BoundsSafety) OFF*/
-
     // Could be null if somehow 'auto' appears in a non-deduced context.
     if (Deduced[0].getKind() != TemplateArgument::Type)
       return DeductionFailed(TemplateDeductionResult::Incomplete);
     DeducedType = Deduced[0].getAsType();
+
+    // TO_UPSTREAM(BoundsSafety) ON
+    if (!CheckAutoCanInferTypeFromBoundsAttributed(*this, AT, Init,
+                                                   DeducedType))
+      return DeductionFailed(TemplateDeductionResult::AlreadyDiagnosed);
+    // TO_UPSTREAM(BoundsSafety) OFF
 
     if (InitList) {
       DeducedType = BuildStdInitializerList(DeducedType, Loc);

--- a/clang/test/BoundsSafety/AST/auto-type-attribute-only-mode.c
+++ b/clang/test/BoundsSafety/AST/auto-type-attribute-only-mode.c
@@ -1,0 +1,118 @@
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c -ast-dump %s 2>&1 | FileCheck --check-prefix=C %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x c++ -ast-dump %s 2>&1 | FileCheck --check-prefixes=C,CXX %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c -ast-dump %s 2>&1 | FileCheck --check-prefix=C %s
+// RUN: %clang_cc1 -fsyntax-only -fexperimental-bounds-safety-attributes -x objective-c++ -ast-dump %s 2>&1 | FileCheck --check-prefixes=C,CXX %s
+
+#include <ptrcheck.h>
+
+// Check that we drop the sugar.
+
+// C:      FunctionDecl {{.+}} foo 'void (int * __counted_by(len), int)'
+// C-NEXT: |-ParmVarDecl {{.+}} used ptr 'int * __counted_by(len)':'int *'
+// C-NEXT: |-ParmVarDecl {{.+}} used len 'int'
+// C-NEXT: | `-DependerDeclsAttr {{.+}} <<invalid sloc>> Implicit {{.+}} 0
+void foo(int *__counted_by(len) ptr, int len) {
+  // C: VarDecl {{.+}} p 'int *' cinit
+  __auto_type p = ptr;
+
+#ifdef __cplusplus
+  // CXX: VarDecl {{.+}} q 'int *' cinit
+  auto q = ptr;
+
+  // CXX: VarDecl {{.+}} r 'int *' cinit
+  decltype(auto) r = ptr;
+#endif
+}
+
+#ifdef __cplusplus
+template<typename T>
+struct cxx_dep {
+  int len;
+  T __counted_by(len) ptr;
+
+  void f() {
+    __auto_type p = ptr;
+    auto q = ptr;
+    decltype(auto) r = ptr;
+  }
+};
+
+// CXX: ClassTemplateSpecializationDecl {{.+}} struct cxx_dep
+// CXX: VarDecl {{.+}} p 'int *' cinit
+// CXX: VarDecl {{.+}} q 'int *' cinit
+// CXX: VarDecl {{.+}} r 'int *' cinit
+template struct cxx_dep<int *>;
+#endif
+
+// C:      FunctionDecl {{.+}} bar 'void (int * __counted_by(42))'
+// C-NEXT: |-ParmVarDecl {{.+}} used ptr 'int * __counted_by(42)':'int *'
+void bar(int *__counted_by(42) ptr) {
+  // C: VarDecl {{.+}} p 'int *' cinit
+  __auto_type p = ptr;
+
+#ifdef __cplusplus
+  // CXX: VarDecl {{.+}} q 'int *' cinit
+  auto q = ptr;
+
+  // CXX: VarDecl {{.+}} r 'int *' cinit
+  decltype(auto) r = ptr;
+#endif
+}
+
+// C: FunctionDecl {{.+}} used get_magic_bytes 'void * __sized_by(5)({{.*}})'
+void *__sized_by(5) get_magic_bytes(void);
+
+void baz(void) {
+  // C: VarDecl {{.+}} p 'void *' cinit
+  __auto_type p = get_magic_bytes();
+
+#ifdef __cplusplus
+  // CXX: VarDecl {{.+}} q 'void *' cinit
+  auto q = get_magic_bytes();
+
+  // CXX: VarDecl {{.+}} r 'void *' cinit
+  decltype(auto) r = get_magic_bytes();
+#endif
+}
+
+#ifdef __cplusplus
+template<typename T>
+struct cxx_const {
+  T __counted_by(7) ptr;
+
+  void f() {
+    __auto_type p = ptr;
+    auto q = ptr;
+    decltype(auto) r = ptr;
+  }
+};
+
+// CXX: ClassTemplateSpecializationDecl {{.+}} struct cxx_const
+// CXX: VarDecl {{.+}} p 'int *' cinit
+// CXX: VarDecl {{.+}} q 'int *' cinit
+// CXX: VarDecl {{.+}} r 'int *' cinit
+template struct cxx_const<int *>;
+
+template<typename T, int len>
+struct cxx_const2 {
+  T __counted_by(len) ptr;
+
+  void f() {
+    __auto_type p = ptr;
+    auto q = ptr;
+    decltype(auto) r = ptr;
+  }
+};
+
+// CXX: ClassTemplateSpecializationDecl {{.+}} struct cxx_const2
+// CXX: VarDecl {{.+}} p 'int *' cinit
+// CXX: VarDecl {{.+}} q 'int *' cinit
+// CXX: VarDecl {{.+}} r 'int *' cinit
+template struct cxx_const2<int *, 123>;
+
+// CXX: ClassTemplateSpecializationDecl {{.+}} struct cxx_const2
+// CXX: VarDecl {{.+}} p 'unsigned int *' cinit
+// CXX: VarDecl {{.+}} q 'unsigned int *' cinit
+// CXX: VarDecl {{.+}} r 'unsigned int *' cinit
+template struct cxx_const2<unsigned *, 99>;
+#endif

--- a/clang/test/BoundsSafety/Sema/auto-type-attribute-only-mode.c
+++ b/clang/test/BoundsSafety/Sema/auto-type-attribute-only-mode.c
@@ -1,14 +1,114 @@
-
-
-// RUN: %clang_cc1 -fbounds-safety -verify %s
-// RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
-// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x c -verify %s
-// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x c++ -verify %s
-// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c -verify %s
-// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c++ -verify %s
+// RUN: %clang_cc1 -fbounds-safety -verify=bs %s
+// RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify=bs %s
+// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x c -verify=bsa %s
+// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x c++ -verify=bsa,bsa-cxx %s
+// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c -verify=bsa %s
+// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c++ -verify=bsa,bsa-cxx %s
 
 #include <ptrcheck.h>
 
-void foo(int *__counted_by(len) ptr, int len) {
-  __auto_type p = ptr; // expected-error{{passing '__counted_by' pointer as __auto_type initializer is not yet supported}}
+void cb(int *__counted_by(len) ptr, int len) {
+  // bs-error@+2{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
+  // bsa-warning@+1{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type p = ptr;
+
+#ifdef __cplusplus
+  // bsa-cxx-warning@+1{{passing '__counted_by' pointer as 'auto' initializer is not yet supported}}
+  auto q = ptr;
+
+  // bsa-cxx-warning@+1{{passing '__counted_by' pointer as 'decltype(auto)' initializer is not yet supported}}
+  decltype(auto) r = ptr;
+#endif
 }
+
+void cbn(int *__counted_by_or_null(len) ptr, int len) {
+  // bs-error@+2{{passing '__counted_by_or_null' pointer as '__auto_type' initializer is not yet supported}}
+  // bsa-warning@+1{{passing '__counted_by_or_null' pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type p = ptr;
+
+#ifdef __cplusplus
+  // bsa-cxx-warning@+1{{passing '__counted_by_or_null' pointer as 'auto' initializer is not yet supported}}
+  auto q = ptr;
+
+  // bsa-cxx-warning@+1{{passing '__counted_by_or_null' pointer as 'decltype(auto)' initializer is not yet supported}}
+  decltype(auto) r = ptr;
+#endif
+}
+
+void sb(void *__sized_by(size) ptr, int size) {
+  // bs-error@+2{{passing '__sized_by' pointer as '__auto_type' initializer is not yet supported}}
+  // bsa-warning@+1{{passing '__sized_by' pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type p = ptr;
+
+#ifdef __cplusplus
+  // bsa-cxx-warning@+1{{passing '__sized_by' pointer as 'auto' initializer is not yet supported}}
+  auto q = ptr;
+
+  // bsa-cxx-warning@+1{{passing '__sized_by' pointer as 'decltype(auto)' initializer is not yet supported}}
+  decltype(auto) r = ptr;
+#endif
+}
+
+void eb(void *__ended_by(e) ptr, void *e) {
+  // bs-error@+2{{passing '__ended_by' pointer as '__auto_type' initializer is not yet supported}}
+  // bsa-warning@+1{{passing '__ended_by' pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type p = ptr;
+
+#ifdef __cplusplus
+  // bsa-cxx-warning@+1{{passing '__ended_by' pointer as 'auto' initializer is not yet supported}}
+  auto q = ptr;
+
+  // bsa-cxx-warning@+1{{passing '__ended_by' pointer as 'decltype(auto)' initializer is not yet supported}}
+  decltype(auto) r = ptr;
+#endif
+}
+
+void eb_end(void *__ended_by(e) ptr, void *e) {
+  // bs-error@+2{{passing end pointer as '__auto_type' initializer is not yet supported}}
+  // bsa-warning@+1{{passing end pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type p = e;
+
+#ifdef __cplusplus
+  // bsa-cxx-warning@+1{{passing end pointer as 'auto' initializer is not yet supported}}
+  auto q = e;
+
+  // bsa-cxx-warning@+1{{passing end pointer as 'decltype(auto)' initializer is not yet supported}}
+  decltype(auto) r = e;
+#endif
+}
+
+void cb_const(int *__counted_by(42) ptr) {
+  // bs-error@+2{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
+  // bsa-warning@+1{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type p = ptr;
+
+#ifdef __cplusplus
+  // bsa-cxx-warning@+1{{passing '__counted_by' pointer as 'auto' initializer is not yet supported}}
+  auto q = ptr;
+
+  // bsa-cxx-warning@+1{{passing '__counted_by' pointer as 'decltype(auto)' initializer is not yet supported}}
+  decltype(auto) r = ptr;
+#endif
+}
+
+#ifdef __cplusplus
+template<typename T>
+struct cxx_dep {
+  int len;
+  T __counted_by(len) ptr;
+
+  void f() {
+    // bsa-cxx-warning@+1{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
+    __auto_type p = ptr;
+
+    // bsa-cxx-warning@+1{{passing '__counted_by' pointer as 'auto' initializer is not yet supported}}
+    auto q = ptr;
+
+    // bsa-cxx-warning@+1{{passing '__counted_by' pointer as 'decltype(auto)' initializer is not yet supported}}
+    decltype(auto) r = ptr;
+  }
+};
+
+// bsa-cxx-note@+1{{in instantiation of member function 'cxx_dep<int *>::f' requested here}}
+template struct cxx_dep<int *>;
+#endif

--- a/clang/test/BoundsSafety/Sema/auto-type-from-bound-pointers.c
+++ b/clang/test/BoundsSafety/Sema/auto-type-from-bound-pointers.c
@@ -1,5 +1,3 @@
-
-
 // RUN: %clang_cc1 -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
@@ -12,20 +10,20 @@ struct SequencePtrs {
 };
 
 void TestEndedBy(struct SequencePtrs *sp) {
-  __auto_type local_start = sp->start; // expected-error{{passing '__ended_by' pointer as __auto_type initializer is not yet supported}}
-  __auto_type local_iter = sp->iter; // expected-error{{passing '__ended_by' pointer as __auto_type initializer is not yet supported}}
-  __auto_type local_end = sp->end; // expected-error{{passing end pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_start = sp->start; // expected-error{{passing '__ended_by' pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type local_iter = sp->iter; // expected-error{{passing '__ended_by' pointer as '__auto_type' initializer is not yet supported}}
+  __auto_type local_end = sp->end; // expected-error{{passing end pointer as '__auto_type' initializer is not yet supported}}
 }
 
 void TestCountedBy(int *__counted_by(len) ptr, int len) {
-  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__counted_by' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
   __auto_type local_len = len;
   __auto_type local_counted_ptr_addrof = &ptr; // expected-error{{pointer with '__counted_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len_addrof = &len;         // expected-error{{variable referred to by '__counted_by' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
 }
 
 void TestSizedBy(void *__sized_by(len) ptr, unsigned len) {
-  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__sized_by' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__sized_by' pointer as '__auto_type' initializer is not yet supported}}
   __auto_type local_len = len;
   __auto_type local_counted_ptr_addrof = &ptr; // expected-error{{pointer with '__sized_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len_addrof = &len;         // expected-error{{variable referred to by '__sized_by' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
@@ -34,7 +32,7 @@ void TestSizedBy(void *__sized_by(len) ptr, unsigned len) {
 void TestOutCountedBy(int *__counted_by(*len) *ptr, int *len) {
   __auto_type local_counted_ptr = ptr; // expected-error{{pointer with '__counted_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len = len; // expected-error{{variable referred to by '__counted_by' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
-  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__counted_by' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
   __auto_type local_len_deref = *len;
   __auto_type local_counted_ptr_addrof = &ptr; // expected-error{{pointer with '__counted_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
 }
@@ -42,18 +40,18 @@ void TestOutCountedBy(int *__counted_by(*len) *ptr, int *len) {
 void TestOutSizedBy(void *__sized_by(*len) *ptr, unsigned *len) {
   __auto_type local_counted_ptr = ptr; // expected-error{{pointer with '__sized_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len = len;  // expected-error{{variable referred to by '__sized_by' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
-  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__sized_by' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__sized_by' pointer as '__auto_type' initializer is not yet supported}}
 }
 
 void TestCountedByOrNull(int *__counted_by_or_null(len) ptr, int len) {
-  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__counted_by_or_null' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__counted_by_or_null' pointer as '__auto_type' initializer is not yet supported}}
   __auto_type local_len = len;
   __auto_type local_counted_ptr_addrof = &ptr; // expected-error{{pointer with '__counted_by_or_null' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len_addrof = &len;         // expected-error{{variable referred to by '__counted_by_or_null' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
 }
 
 void TestSizedByOrNull(void *__sized_by_or_null(len) ptr, unsigned len) {
-  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__sized_by_or_null' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr = ptr; // expected-error{{passing '__sized_by_or_null' pointer as '__auto_type' initializer is not yet supported}}
   __auto_type local_len = len;
   __auto_type local_counted_ptr_addrof = &ptr; // expected-error{{pointer with '__sized_by_or_null' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len_addrof = &len;         // expected-error{{variable referred to by '__sized_by_or_null' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
@@ -62,7 +60,7 @@ void TestSizedByOrNull(void *__sized_by_or_null(len) ptr, unsigned len) {
 void TestOutCountedByOrNull(int *__counted_by_or_null(*len) *ptr, int *len) {
   __auto_type local_counted_ptr = ptr; // expected-error{{pointer with '__counted_by_or_null' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len = len; // expected-error{{variable referred to by '__counted_by_or_null' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
-  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__counted_by_or_null' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__counted_by_or_null' pointer as '__auto_type' initializer is not yet supported}}
   __auto_type local_len_deref = *len;
   __auto_type local_counted_ptr_addrof = &ptr; // expected-error{{pointer with '__counted_by_or_null' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
 }
@@ -70,13 +68,13 @@ void TestOutCountedByOrNull(int *__counted_by_or_null(*len) *ptr, int *len) {
 void TestOutSizedByOrNull(void *__sized_by_or_null(*len) *ptr, unsigned *len) {
   __auto_type local_counted_ptr = ptr; // expected-error{{pointer with '__sized_by_or_null' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len = len;  // expected-error{{variable referred to by '__sized_by_or_null' cannot be pointed to by any other variable; exception is when the pointer is passed as a compatible argument to a function}}
-  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__sized_by_or_null' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__sized_by_or_null' pointer as '__auto_type' initializer is not yet supported}}
 }
 
 void TestOutCountedByArray(int (*ptr)[__counted_by(*len)], int *len) { // expected-error{{pointer to incomplete __counted_by array type 'int[]' not allowed; did you mean to use a nested pointer type?}}
   __auto_type local_counted_ptr = ptr; // expected-error{{array with '__counted_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
   __auto_type local_len = len; // expected-error{{variable referred to by '__counted_by' cannot be pointed to by any other variable}}
-  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__counted_by' pointer as __auto_type initializer is not yet supported}}
+  __auto_type local_counted_ptr_deref = *ptr; // expected-error{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
   __auto_type local_len_deref = *len;
   __auto_type local_counted_ptr_addrof = &ptr; // expected-error{{array with '__counted_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
 }
@@ -88,7 +86,7 @@ struct CountedStruct {
 };
 
 void foo(struct CountedStruct * __single p) {
-    __auto_type ebuf = p->buf; // expected-error{{passing '__counted_by' pointer as __auto_type initializer is not yet supported}}
+    __auto_type ebuf = p->buf; // expected-error{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
     __auto_type *__single eptr = &(p->buf); // expected-error{{pointer with '__counted_by' cannot be pointed to by any other variable; exception is when the variable is passed as a compatible argument to a function}}
 }
 
@@ -110,7 +108,7 @@ struct FAMStruct {
 };
 
 void foo_fam(struct FAMStruct * __single p) {
-    __auto_type ebuf = p->buf; // expected-error{{passing '__counted_by' pointer as __auto_type initializer is not yet supported}}
+    __auto_type ebuf = p->buf; // expected-error{{passing '__counted_by' pointer as '__auto_type' initializer is not yet supported}}
     __auto_type *__single eptr = &(p->buf); // expected-error{{cannot take address of incomplete __counted_by array}}
                                             // expected-note@-1{{remove '&' to get address as 'char *' instead of 'char (*)[__counted_by(n)]'}}
 }


### PR DESCRIPTION
Allow using bounds-attributed types when deducing auto type in attribute-only mode. Since the bounds-attributed sugar would depend on a variable in a different scope etc, we drop the sugar and emit a warning.

rdar://140995829