### PR TITLE
[AArch64] Fix popless ret frame lowering after upstream change.

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
+++ b/llvm/lib/Target/AArch64/AArch64PrologueEpilogue.cpp
@@ -1466,7 +1466,7 @@ void AArch64EpilogueEmitter::emitEpilogue() {
       break;
     } else if (IsSwiftCoroPartialReturn) {
       assert(!EmitCFI);
-      assert(AFL.hasFP(MF));
+      assert(HasFP);
       fixupCalleeSaveRestoreStackOffset(*FirstGPRRestoreI,
                                         AFI->getLocalStackSize());
       // if FP-based addressing, rewrite CSR restores from SP to FP
@@ -1693,6 +1693,10 @@ void AArch64EpilogueEmitter::emitEpilogue() {
 
 bool AArch64EpilogueEmitter::shouldCombineCSRLocalStackBump(
     uint64_t StackBumpBytes) const {
+
+  if (AFI->hasPoplessEpilogue())
+    return false;
+
   if (!AArch64PrologueEpilogueCommon::shouldCombineCSRLocalStackBump(
           StackBumpBytes))
     return false;


### PR DESCRIPTION
This was merged in cee849d52c47, but dropped one bit, causing test failures.