### PR TITLE
[BoundsSafety] Add missing `CursorKind` for some `-fbounds-safety` specific Expr kinds

### DIFF
--- a/clang/bindings/python/clang/cindex.py
+++ b/clang/bindings/python/clang/cindex.py
@@ -1109,6 +1109,12 @@ class CursorKind(BaseEnumeration):
     # Represents a C++26 pack indexing expression.
     PACK_INDEXING_EXPR = 156
 
+    # TO_UPSTREAM(BoundsSafety) ON
+    FORGE_PTR_EXPR = 198
+    GET_BOUND_EXPR = 199
+    LAST_EXPR = GET_BOUND_EXPR
+    # TO_UPSTREAM(BoundsSafety) OFF
+
     # A statement whose specific kind is not exposed via this interface.
     #
     # Unexposed statements have the same operations as any other kind of


### PR DESCRIPTION
This fixes running the `ninja check-clang-python` target that previously failed with:

```
.....................................................................................F.................................................................................
======================================================================
FAIL: test_all_variants (tests.cindex.test_enums.TestEnums.test_all_variants) [<enum 'CursorKind'>]
Check that all libclang enum values are also defined in cindex.py
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/user_data/dev/llvm/upstream_swift/next/src/llvm-project/clang/bindings/python/tests/cindex/test_enums.py", line 87, in test_all_variants
    self.assertEqual(
AssertionError: {'CXCursor_ForgePtrExpr', 'CXCursor_LastExpr'} variants are missing. Please ensure these are defined in <enum 'CursorKind'> in cindex.py.
```

rdar://161075623