### PR TITLE
[lldb][ClangASTImporter] Don't ASTImport LambdaExpr nodes (#154962)

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Clang/ClangASTImporter.cpp
@@ -1060,6 +1060,16 @@ ClangASTImporter::MapCompleter::~MapCompleter() = default;
 
 llvm::Expected<Decl *>
 ClangASTImporter::ASTImporterDelegate::ImportImpl(Decl *From) {
+  // FIXME: The Minimal import mode of clang::ASTImporter does not correctly
+  // import Lambda definitions. Work around this for now by not importing
+  // lambdas at all. This is most likely encountered when importing decls from
+  // the `std` module (not from debug-info), where lambdas can be defined in
+  // inline function bodies. Those will be imported by LLDB.
+  if (const auto *CXX = llvm::dyn_cast<clang::CXXRecordDecl>(From))
+    if (CXX->isLambda())
+      return llvm::make_error<ASTImportError>(
+          ASTImportError::UnsupportedConstruct);
+
   if (m_std_handler) {
     std::optional<Decl *> D = m_std_handler->Import(From);
     if (D) {

--- a/lldb/test/API/lang/cpp/lambdas/TestLambdas.py
+++ b/lldb/test/API/lang/cpp/lambdas/TestLambdas.py
@@ -1,4 +1,12 @@
 from lldbsuite.test import lldbinline
 from lldbsuite.test import decorators
 
-lldbinline.MakeInlineTest(__file__, globals())
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    [
+        decorators.expectedFailureAll(
+            bugnumber="https://github.com/llvm/llvm-project/issues/149477"
+        )
+    ],
+)

--- a/lldb/test/Shell/Expr/TestLambdaExprImport.test
+++ b/lldb/test/Shell/Expr/TestLambdaExprImport.test
@@ -1,0 +1,26 @@
+# Test that we can successfully ASTImport clang::LambdaExpr nodes.
+# Currently this is not supported in MinimalImport mode (which LLDB
+# uses always).
+
+# RUN: split-file %s %t
+# RUN: %clang_host -g -gdwarf %t/main.cpp -o %t.out
+# RUN: %lldb -o "settings set interpreter.stop-command-source-on-error false" \
+# RUN:       -x -b -s %t/commands.input %t.out 2>&1 \
+# RUN:       | FileCheck %s
+
+#--- main.cpp
+
+int main() {
+  __builtin_debugtrap();
+}
+
+#--- commands.input
+
+run
+expression --top-level -- void method(int x) { [x=x] { ; }; }
+target dump typesystem
+
+# CHECK:      expression
+# CHECK:      target dump typesystem
+# CHECK-NOT:  FunctionDecl
+# CHECK-NOT:  LambdaExpr


### PR DESCRIPTION
This patch works around an assertion that we hit in the `LambdaExpr` constructor when we call it from `ASTNodeImporter::VisitLambdaExpr` (see https://github.com/llvm/llvm-project/issues/149477). The lambda that we imported doesn't have the `NumCaptures` field accurately set to the one on the source decl. This is because in `MinimalImport` mode, we skip importing of lambda definitions:
https://github.com/llvm/llvm-project/blob/e21b0dd81928a3266df0e3ede008fb7a6676ff95/clang/lib/AST/ASTImporter.cpp#L2499

In practice we have seen this assertion occur in our `import-std-module` test-suite when libc++ headers decide to use lambdas inside inline function bodies (the latest failure being caused by https://github.com/llvm/llvm-project/pull/144602).

To avoid running into this whenever libc++ decides to use lambdas in headers, this patch skips `ASTImport` of lambdas alltogether. Ideally this would bubble up to the user or log as an error, but we swallow the `ASTImportError`s currently. The only way this codepath is hit is when lambdas are used inside functions in defined in the expression evaluator, or when importing AST nodes from Clang modules. Both of these are very niche use-cases (for now), so a workaround seemed appropriate.

(cherry picked from commit 0bbb79475432f72ee0e7d99cc5dc48bb8f8ff443)

rdar://160792616