### PR TITLE
[llvm] Temporarily disable split stacks

### DIFF
--- a/llvm/include/llvm/Support/ProgramStack.h
+++ b/llvm/include/llvm/Support/ProgramStack.h
@@ -12,6 +12,8 @@
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/Compiler.h"
 
+// FIXME: Temporarily disable split stacks. rdar://154158529
+#if 0
 // LLVM_HAS_SPLIT_STACKS is exposed in the header because CrashRecoveryContext
 // needs to know if it's running on another thread or not.
 //
@@ -21,6 +23,7 @@
     __has_extension(gnu_asm)
 # define LLVM_HAS_SPLIT_STACKS
 # define LLVM_HAS_SPLIT_STACKS_AARCH64
+#endif
 #endif
 
 namespace llvm {


### PR DESCRIPTION
This appears to be causing:
"stack nearly exhausted; compilation time may suffer, and crashes due to stack overflow are likely" warnings in Swift, so disable it while this issue is investigated.

workarounds: rdar://154158529 rdar://160812776 

cherry-picked from d3a19b58d973346a2fc7a644b11b7d03b90fc81c
