### PR TITLE
[lldb] look up function names in the swift language plugin (#11477)

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -661,7 +661,11 @@ Module::LookupInfo::LookupInfo(ConstString name,
     if (language != eLanguageTypeUnknown)
       lang_types.push_back(language);
     else
-      lang_types = {eLanguageTypeObjC, eLanguageTypeC_plus_plus};
+      lang_types = {eLanguageTypeObjC, eLanguageTypeC_plus_plus,
+#ifdef LLDB_ENABLE_SWIFT
+                    eLanguageTypeSwift
+#endif
+      };
 
     for (LanguageType lang_type : lang_types) {
       if (Language *lang = Language::FindPlugin(lang_type))

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -13,11 +13,9 @@
 Tests that we can break on a partial name of a Swift function
 Effectively tests our chopper of Swift demangled names
 """
-import lldb
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
-
 
 class SwiftPartialBreakTest(TestBase):
     @swiftTest


### PR DESCRIPTION
when setting breakpoints if the If the language type not set, try the swift plugin.

(cherry picked from commit 13c116b3de9bb6f2f637ec1f39c25efe43335696)