### PR TITLE
[lldb] Avoid using `AllowDeserializingImplementationOnly`

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1036,10 +1036,7 @@ void SwiftASTContext::SetCompilerInvocationLLDBOverrides() {
   // In the JIT we don't benefit from the indexed indirections in DWARF 5.
   ir_gen_opts.DWARFVersion = 4;
   ir_gen_opts.DebugInfoFormat = swift::IRGenDebugInfoFormat::DWARF;
-  // Allow deserializing @_implementationOnly dependencies
-  // to avoid crashing due to module recovery issues.
   swift::LangOptions &lang_opts = m_compiler_invocation_ap->getLangOptions();
-  lang_opts.AllowDeserializingImplementationOnly = true;
   lang_opts.DebuggerSupport = true;
 
   // ModuleFileSharedCore::getTransitiveLoadingBehavior() has a


### PR DESCRIPTION
Avoid using `AllowDeserializingImplementationOnly` in LLDB as it's known to cause issues. It forces loading previously ignored dependencies in the middle of active deserialization when they are referenced by other deserialized entities, that is after the upfront loading of dependencies. Loading a dependency during deserialization changes states expected to be immutable at that time. Here it fails at iterating over the list of loaded modules to collect extensions as the list of loaded module changes from discovered extensions triggering loading more modules.

This mode is also incompatible with explicit builds as it loads and builds dependencies on demand.

Hidden dependencies should be loaded upfront when desired. This used to be controlled by `DebuggerSupport`, it has now moved to `ImportNonPublicDependencies` but it seems to be disabled. We should address this feature at that level.

The only use of `AllowDeserializingImplementationOnly` in the compiler was disabled recently https://github.com/swiftlang/swift/pull/82499, LLDB is the last remaining client.

rdar://161130319