### PR TITLE
[lldb][test] check if CoreDumping info is supported (#160333)

### DIFF
--- a/lldb/unittests/Host/posix/HostTest.cpp
+++ b/lldb/unittests/Host/posix/HostTest.cpp
@@ -15,6 +15,10 @@
 #include <cerrno>
 #include <sys/resource.h>
 
+#ifdef __linux__
+#include <linux/version.h>
+#endif // __linux__
+
 using namespace lldb_private;
 
 namespace {
@@ -116,7 +120,12 @@ TEST_F(HostTest, GetProcessInfoSetsPriority) {
   ASSERT_TRUE(Info.IsZombie().has_value());
   ASSERT_FALSE(Info.IsZombie().value());
 
+  // CoreDumping was added in kernel version 4.15.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
   ASSERT_TRUE(Info.IsCoreDumping().has_value());
   ASSERT_FALSE(Info.IsCoreDumping().value());
+#else
+  ASSERT_FALSE(Info.IsCoreDumping().has_value());
+#endif
 }
 #endif


### PR DESCRIPTION
CoreDumping in /proc/<pid>/status was added in kernel 4.15, this causes the test to fail in older kernel versions. see
https://man7.org/linux/man-pages/man5/proc_pid_status.5.html

(cherry picked from commit 02d8fb5789f64ed9cff3f42b005105a51c6c7550)