### PR TITLE
[clang][test] Fix Scanning Module Variant Check in `clang/test/ClangScanDeps/optimize-canonicalize-macros.m`

### DIFF
--- a/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
+++ b/clang/test/ClangScanDeps/optimize-canonicalize-macros.m
@@ -7,13 +7,14 @@
 // RUN: clang-scan-deps -compilation-database %t/build/compile-commands.json \
 // RUN:   -j 1 -format experimental-full -optimize-args=canonicalize-macros > %t/deps.db
 // RUN: cat %t/deps.db | FileCheck %s -DPREFIX=%/t
+
+// This tests that we have two scanning module variants.
+// RUN: find %t/module-cache -name "*.pcm" | wc -l | grep 2
+
 // RUN: clang-scan-deps -compilation-database %t/build/compile-commands.json \
 // RUN:   -j 1 -format experimental-include-tree-full -cas-path %t/cas \
 // RUN:   -optimize-args=canonicalize-macros > %t/deps_cas.db
 // RUN: cat %t/deps_cas.db | FileCheck %s --check-prefixes=CAS
-
-// This tests that we have two scanning module variants.
-// RUN: find %t/module-cache -name "*.pcm" | wc -l | grep 2
 
 // Verify that there are only two variants and that the expected merges have
 // happened.


### PR DESCRIPTION
[9d6062c](https://github.com/qiongsiwu/llvm-project/commit/9d6062c490548a5e6fea103e010ab3c9bc73a86d) and [df09cb2](https://github.com/swiftlang/llvm-project/commit/df09cb2e7eb372fbcfe6a0fabd8d9e02111ab2ed) had some unintended interaction leading to an incorrect check against the number of module variants. 

This PR moves the check against the number of module variant early to avoid the extra variants generated by CAS. This fix makes sure that we are checking the exact same things as [9d6062c](https://github.com/qiongsiwu/llvm-project/commit/9d6062c490548a5e6fea103e010ab3c9bc73a86d) and [df09cb2](https://github.com/swiftlang/llvm-project/commit/df09cb2e7eb372fbcfe6a0fabd8d9e02111ab2ed) is added on top. 