### PR TITLE
🍒 [-Wunsafe-buffer-usage] Relax passing to __counted_by_or_null()

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -14094,6 +14094,11 @@ def note_unsafe_count_attributed_pointer_argument : Note<
   "consider using %select{|a safe container and passing '.data()' to the "
   "parameter%select{| '%3'}2 and '.size()' to its dependent parameter '%4' or }0"
   "'std::span' and passing '.first(...).data()' to the parameter%select{| '%3'}2">;
+def note_unsafe_count_attributed_pointer_argument_null_to_nonnull : Note<
+  "passing '%select{__counted_by_or_null()|__sized_by_or_null()}0' to "
+  "'%select{__counted_by()|__sized_by()}1' while "
+  "'%select{__counted_by_or_null()|__sized_by_or_null()}0' can be null with an "
+  "arbirary %select{count|size}0">;
 def warn_unsafe_single_pointer_argument : Warning<
   "unsafe assignment to function parameter of __single pointer type">,
   InGroup<UnsafeBufferUsage>, DefaultIgnore;

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2579,6 +2579,15 @@ public:
     SourceLocation DiagLoc =
         Arg->isDefaultArgument() ? Call->getRParenLoc() : Arg->getBeginLoc();
     S.Diag(DiagLoc, diag::warn_unsafe_count_attributed_pointer_argument);
+
+    if (const auto *ArgCATy = Arg->getType()->getAs<CountAttributedType>();
+        ArgCATy && ArgCATy->isOrNull() && !CATy->isOrNull()) {
+      S.Diag(
+          DiagLoc,
+          diag::note_unsafe_count_attributed_pointer_argument_null_to_nonnull)
+          << ArgCATy->isCountInBytes() << CATy->isCountInBytes();
+    }
+
     S.Diag(PVD->getBeginLoc(),
            diag::note_unsafe_count_attributed_pointer_argument)
         << IsSimpleCount << QualType(CATy, 0) << !PtrParamName.empty()

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct-count-attributed-pointer.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-in-container-span-construct-count-attributed-pointer.cpp
@@ -176,3 +176,15 @@ namespace test_fam {
   }
 
 } // namespace test_fam
+
+void test_nullable(int *__counted_by_or_null(count) cbn_p, size_t count,
+                   char *__sized_by_or_null(size) sbn_p, size_t size) {
+  // __counted_by_or_null(count) pointer can be null with an arbitrary count.
+  // We rely here on the dynamic check performed by std::span constructor, and
+  // allow those patterns.
+  std::span<int>{cbn_p, count};
+  std::span<char>{sbn_p, size};
+
+  std::span<int>{cbn_p, 42};  // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+  std::span<char>{sbn_p, 42}; // expected-warning{{the two-parameter std::span construction is unsafe as it can introduce mismatch between buffer size and the bound information}}
+}


### PR DESCRIPTION
Relax restrictions when passing to
__counted_by_or_null()/__sized_by_or_null() parameters:
- Allow the dependent count var to be anything.
- Allow passing from non-null variant to *_or_null(), but do warn for passing *_or_null() to non-null variant.

rdar://156006635

(cherry picked from commit c86fc87e5f5d4ad464dcb7e4be07947d7252ae60)

Conflicts:
	clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions-interop-annotated.cpp