### PR TITLE
[lldb][test] add missing swift_libs_dir (#11503)

### DIFF
--- a/lldb/utils/lldb-dotest/lldb-dotest.in
+++ b/lldb/utils/lldb-dotest/lldb-dotest.in
@@ -56,6 +56,7 @@ if __name__ == '__main__':
     if lldb_build_intel_pt == "1":
         cmd.extend(['--enable-plugin', 'intel-pt'])
     cmd.extend(['--lldb-obj-root', lldb_obj_root])
+    cmd.extend(['--swift-libs-dir', swift_libs_dir])
     cmd.extend(wrapper_args)
     # Invoke dotest.py and return exit code.
     print(' '.join(cmd))


### PR DESCRIPTION
thie swift libs dir is needed for some  cxx-interop tests include path.

(cherry picked from commit 311c6abfa6ac1a36fff8a129cef6c56781a611dd)