### PR TITLE
[lldb][test] Enable `BackwardInteropExpression` on linux

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
@@ -7,7 +7,6 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftBackwardInteropExpressions(TestBase):
 
-    @skipIfLinux
     @swiftTest
     def test_func_step_in(self):
         self.build()


### PR DESCRIPTION
It was failing because of a missing `swift_build_dir` include from 311c6abfa6ac1a36fff8a129cef6c56781a611dd