### PR TITLE
[lldb][TypeSystemClang] Don't call getInjectedClassNameType when creating class template decls

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -1640,9 +1640,6 @@ ClassTemplateDecl *TypeSystemClang::CreateClassTemplateDecl(
   class_template_decl->init(template_cxx_decl);
   template_cxx_decl->setDescribedClassTemplate(class_template_decl);
   SetOwningModule(class_template_decl, owning_module);
-  ast.getInjectedClassNameType(
-      template_cxx_decl,
-      class_template_decl->getInjectedClassNameSpecialization());
 
   if (access_type != eAccessNone)
     class_template_decl->setAccess(

--- a/lldb/unittests/Symbol/TestTypeSystemClang.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemClang.cpp
@@ -685,9 +685,7 @@ TEST_F(TestCreateClassTemplateDecl, FindExistingTemplates) {
   // The behaviour should follow the C++ rules for redeclaring templates
   // (e.g., parameter names can be changed/omitted.)
 
-  // Test an empty template parameter list: <>
-  // This first expect causes an assert. rdar://159893045
-  // ExpectNewTemplate("<>", {{}, {}});
+  ExpectNewTemplate("<>", {{}, {}});
 
   clang::TemplateArgument intArg(m_ast->getASTContext().IntTy);
   clang::TemplateArgument int47Arg(m_ast->getASTContext(),


### PR DESCRIPTION
This was a remnant of the type completion rework. But that was reverted, and this isn't necessary anymore (and removing it fixes the unit-test failure).

rdar://159893045