### PR TITLE
[next] lldb: required changes for removing the -enable-ossa-modules option in the swift compiler

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1158,9 +1158,6 @@ static const char *getImportFailureString(swift::serialization::Status status) {
   case swift::serialization::Status::RevisionIncompatible:
     return "The module file was built with library evolution enabled by a "
            "different version of the compiler.";
-  case swift::serialization::Status::NotInOSSA:
-    return "The module file was not compiled with -enable-ossa-modules when it "
-           "was required to do so.";
   case swift::serialization::Status::SDKMismatch:
     return "The module file was built with a different SDK version.";
   case swift::serialization::Status::ChannelIncompatible:
@@ -1347,7 +1344,7 @@ static bool DeserializeAllCompilerFlags(swift::CompilerInvocation &invocation,
       llvm::SmallVector<swift::serialization::SearchPath> searchPaths;
       swift::serialization::ExtendedValidationInfo extended_validation_info;
       info = swift::serialization::validateSerializedAST(
-          buf, invocation.getSILOptions().EnableOSSAModules,
+          buf,
           /*requiredSDK*/ StringRef(), &extended_validation_info,
           /*dependencies*/ nullptr, &searchPaths);
       bool invalid_ast = info.status != swift::serialization::Status::Valid;
@@ -3786,8 +3783,7 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   m_ast_context_ap->addModuleInterfaceChecker(
     std::make_unique<swift::ModuleInterfaceCheckerImpl>(*m_ast_context_ap,
       moduleCachePath, prebuiltModuleCachePath,
-      swift::ModuleInterfaceLoaderOptions(),
-      swift::RequireOSSAModules_t(GetSILOptions())));
+      swift::ModuleInterfaceLoaderOptions()));
 
   // 2. Create and install the module interface loader.
   //


### PR DESCRIPTION
cherry-pick from https://github.com/swiftlang/llvm-project/pull/11505