### PR TITLE
[lldb] re-add skipIfOutOfTreeDebugserver for TestRegisters

### DIFF
--- a/lldb/test/API/commands/register/register/register_command/TestRegisters.py
+++ b/lldb/test/API/commands/register/register/register_command/TestRegisters.py
@@ -41,6 +41,7 @@ class RegisterCommandsTestCase(TestBase):
 
     @skipIfiOSSimulator
     @skipIf(archs=no_match(["amd64", "arm$", "i386", "x86_64"]))
+    @skipIfOutOfTreeDebugserver
     @expectedFailureAll(oslist=["freebsd", "netbsd"], bugnumber="llvm.org/pr48371")
     def test_register_commands(self):
         """Test commands related to registers, in particular vector registers."""


### PR DESCRIPTION
The swiftlang CI bots are running a pretty old Xcode install that doesn't have the x86 debugserver change that tries to fetch additional registers -- and this test which confirms that they are unavailable is not passing.  If the CI bot debugserver is ever updated, this can be removed again.