### PR TITLE
[lldb] Use Continue instead of StepOver in TestSwiftAsyncBreakpoints

### DIFF
--- a/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
+++ b/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
@@ -36,7 +36,7 @@ class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
         self.assertEquals(thread.GetStopDescription(128), "breakpoint 2.1")
         self.expect("expr timestamp1", substrs=["42"])
 
-        thread.StepOver()
+        process.Continue()
         self.assertIn("breakpoint 3.1", thread.GetStopDescription(128))
         self.expect("expr timestamp1", substrs=["42"])
 


### PR DESCRIPTION
The test was doing a StepOver and checking that the stop reason was a breakpoint; it seems more sensible to do a continue in that case.