### PR TITLE
[lldb] Skip TestSwiftTaskSwitch under older debugservers and asan.

### DIFF
--- a/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
+++ b/lldb/test/API/lang/swift/async/stepping/step-in/task-switch/TestSwiftTaskSwitch.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(lldbtest.TestBase):
     @swiftTest
     @skipIf(oslist=["windows", "linux"])
+    @skipIf(macos_version=["<", "26.0"], asan=True) # rdar://138777205
     def test(self):
         """Test conditions for async step-in."""
         self.build()


### PR DESCRIPTION
Older debugservers incorrectly report memory region kinds for memory allocated by the sanitizer, making swift stepping fail.