### PR TITLE
🍒 [clang] Add features.json entry for "print-headers-direct-per-file"

### DIFF
--- a/clang/tools/driver/features.json
+++ b/clang/tools/driver/features.json
@@ -40,6 +40,9 @@
     },
     {
       "name": "extract-api-supports-cpp"
+    },
+    {
+      "name": "print-headers-direct-per-file"
     }
   ]
 }


### PR DESCRIPTION
Swift Build needs to know when "-header-include-filtering=direct-per-file" is supported by Clang. We already added a fake feature flag in Swift Build based on a check of the Apple Clang version number. Adding a real entry in features.json will let us replace that hack.

rdar://161691058

(cherry picked from commit ca4827f8d403d3dfad86bacd5170ee962437d9a9)