### PR TITLE
[Cherry-pick into stable/21.x] [LLDB] Support nested generic type aliases (and thus Swift.Array) in Embedded Swift

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -184,10 +184,9 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         if (TypeSP desugared_type = get_type(die)) {
           // For a typedef, store the once desugared type as the name.
           CompilerType type = desugared_type->GetForwardCompilerType();
-          if (auto swift_ast_ctx =
+          if (auto ts =
                   type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>())
-            preferred_name =
-                swift_ast_ctx->GetMangledTypeName(type.GetOpaqueQualType());
+            preferred_name = ts->GetMangledTypeName(type.GetOpaqueQualType());
         }
     }
   }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h
@@ -37,6 +37,8 @@ public:
 
   virtual ~DWARFASTParserSwift();
 
+  static std::pair<lldb::TypeSP, lldb_private::CompilerType>
+  ResolveTypeAlias(lldb_private::CompilerType alias);
   lldb::TypeSP ParseTypeFromDWARF(const lldb_private::SymbolContext &sc,
                                   const DWARFDIE &die,
                                   bool *type_is_new_ptr) override;

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -98,7 +98,7 @@ DWARFASTParserSwift::ResolveTypeAlias(lldb_private::CompilerType alias) {
   std::string alias_name = ts.GetBaseName(alias.GetOpaqueQualType());
   for (DWARFDIE child_die : parent_die.children()) {
     auto tag = child_die.Tag();
-    if (tag == DW_TAG_member)
+    if (tag == llvm::dwarf::DW_TAG_member)
       continue;
     std::string base_name;
     const auto *name =

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1076,7 +1076,7 @@ TypeSystemSwiftTypeRef::ResolveTypeAlias(swift::Demangle::Demangler &dem,
     type = results.GetFirstType();
 
   // Find the type by declcontext (-gdwarf-types).
-  if (!type) {
+  if (!type && flavor == swift::Mangle::ManglingFlavor::Embedded) {
     auto resolved = DWARFASTParserSwift::ResolveTypeAlias(
         GetTypeFromMangledTypename(mangled));
     if (resolved.second) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -19,6 +19,7 @@
 #include "lldb/Target/ExecutionContext.h"
 #include "lldb/Utility/ThreadSafeDenseMap.h"
 #include "lldb/Utility/ThreadSafeStringMap.h"
+#include "lldb/lldb-types.h"
 #include "swift/Demangling/ManglingFlavor.h"
 
 // FIXME: needed only for the DenseMap.
@@ -136,6 +137,12 @@ public:
       return true;
     return false;
   }
+
+  CompilerType GetParentType(lldb::opaque_compiler_type_t type);
+  std::vector<std::vector<CompilerType>>
+  GetSubstitutions(lldb::opaque_compiler_type_t type);
+  CompilerType ApplySubstitutions(lldb::opaque_compiler_type_t type,
+                                  std::vector<std::vector<CompilerType>> subs);
 
   Module *GetModule() const { return m_module; }
 
@@ -358,6 +365,7 @@ public:
   CompilerType GetRawPointerType();
   /// Determine whether \p type is a protocol.
   bool IsExistentialType(lldb::opaque_compiler_type_t type);
+  bool IsBoundGenericAliasType(lldb::opaque_compiler_type_t type);
 
   /// Recursively transform the demangle tree starting a \p node by
   /// doing a post-order traversal and replacing each node with
@@ -416,6 +424,7 @@ public:
                            llvm::StringRef mangled_name);
   /// Return the base name of the topmost nominal type.
   static llvm::StringRef GetBaseName(swift::Demangle::NodePointer node);
+  static std::string GetBaseName(lldb::opaque_compiler_type_t type);
 
   /// Given a mangled name that mangles a "type metadata for Type", return a
   /// CompilerType with that Type.
@@ -457,7 +466,7 @@ public:
   /// Returns the mangling flavor associated with the ASTContext corresponding
   /// with this TypeSystem.
   swift::Mangle::ManglingFlavor
-  GetManglingFlavor(ExecutionContext *exe_ctx = nullptr);
+  GetManglingFlavor(const ExecutionContext *exe_ctx = nullptr);
 
 protected:
   /// Determine whether the fallback is enabled via setting.

--- a/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/TestSwiftEmbeddedFrameVariable.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 @skipIf(bugnumber = "rdar://159531308")
 class TestSwiftEmbeddedFrameVariable(TestBase):
+ 
     @skipUnlessDarwin
     @swiftTest
     def test(self):
@@ -21,17 +22,54 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
 
     def implementation(self, ast):
         self.runCmd("setting set symbols.swift-enable-full-dwarf-debugging true")
-        # FIXME: "$s1a1BVD" cannot be found.
-        self.runCmd("settings set symbols.swift-typesystem-compiler-fallback true")
-        self.runCmd("settings set symbols.swift-validate-typesystem false")
 
         target, process, thread, _ = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
         frame = thread.frames[0]
         self.assertTrue(frame, "Frame 0 is valid.")
+
         if self.TraceOn():
+            self.expect("log enable lldb types")
             self.expect("frame variable")
+ 
+        alias1 = frame.FindVariable("alias1")
+        field = alias1.GetChildMemberWithName("t")
+        lldbutil.check_variable(self, field, False, value='1')
+ 
+        alias2 = frame.FindVariable("alias2")
+        a3 = alias2.GetChildMemberWithName("a3")
+        lldbutil.check_variable(self, a3.GetChildAtIndex(0), False, value='3')
+        a4 = alias2.GetChildMemberWithName("a4")
+        lldbutil.check_variable(self, a4.GetChildAtIndex(0), False, value='4')
+        a5 = alias2.GetChildMemberWithName("a5")
+        a5t = a5.GetChildAtIndex(0)
+        lldbutil.check_variable(self, a5t.GetChildAtIndex(0), False, value='5')
+        lldbutil.check_variable(self, a5t.GetChildAtIndex(1), False, value='6')
+
+        alias3 = frame.FindVariable("alias3")
+        r = alias3.GetChildMemberWithName("r")
+        a3 = r.GetChildMemberWithName("a3")
+        lldbutil.check_variable(self, a3.GetChildAtIndex(0), False, value='3')
+        a4 = r.GetChildMemberWithName("a4")
+        lldbutil.check_variable(self, a4.GetChildAtIndex(0), False, value='4')
+        a5 = r.GetChildMemberWithName("a5")
+        a5t = a5.GetChildAtIndex(0)
+        lldbutil.check_variable(self, a5t.GetChildAtIndex(0), False, value='5')
+        lldbutil.check_variable(self, a5t.GetChildAtIndex(1), False, value='6')
+        q1 = alias3.GetChildMemberWithName("q1")
+        lldbutil.check_variable(self, q1.GetChildAtIndex(0), False, value='11')
+        q2 = alias3.GetChildMemberWithName("q2")
+        q2t = q2.GetChildAtIndex(0)
+        lldbutil.check_variable(self, q2t.GetChildAtIndex(0), False, value='12')
+        lldbutil.check_variable(self, q2t.GetChildAtIndex(1), False, value='13')
+
+        
+        array = frame.FindVariable("array")
+        lldbutil.check_variable(self, array, False, num_children=4)
+        for i in range(4):
+            lldbutil.check_variable(self, array.GetChildAtIndex(i),
+                                    False, value=str(i+1))
 
         varB = frame.FindVariable("varB")
         field = varB.GetChildMemberWithName("a").GetChildMemberWithName("field")
@@ -59,55 +97,53 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         singlePayload = frame.FindVariable("singlePayload")
         payload = singlePayload.GetChildMemberWithName("payload")
         field = payload.GetChildMemberWithName("a").GetChildMemberWithName("field")
-        # FIXME:
-        if str(payload.GetError()) != 'error: Cannot compute size of type $s1a1BVD using static debug info.':
-          lldbutil.check_variable(self, field, False, value="4.5")
-          b = payload.GetChildMemberWithName("b")
-          lldbutil.check_variable(self, b, False, value="123456")
+        lldbutil.check_variable(self, field, False, value="4.5")
+        b = payload.GetChildMemberWithName("b")
+        lldbutil.check_variable(self, b, False, value="123456")
 
-          emptySinglePayload = frame.FindVariable("emptySinglePayload")
-          lldbutil.check_variable(self, emptySinglePayload, False, value="nonPayloadTwo")
+        emptySinglePayload = frame.FindVariable("emptySinglePayload")
+        lldbutil.check_variable(self, emptySinglePayload, False, value="nonPayloadTwo")
 
-          smallMultipayloadEnum1 = frame.FindVariable("smallMultipayloadEnum1")
-          one = smallMultipayloadEnum1.GetChildMemberWithName("one")
-          if not ast: # FIXME!
-              lldbutil.check_variable(self, one, False, value="two")
+        smallMultipayloadEnum1 = frame.FindVariable("smallMultipayloadEnum1")
+        one = smallMultipayloadEnum1.GetChildMemberWithName("one")
+        lldbutil.check_variable(self, one, False, value="two")
 
-          smallMultipayloadEnum2 = frame.FindVariable("smallMultipayloadEnum2")
-          two = smallMultipayloadEnum2.GetChildMemberWithName("two")
-          if not ast: # FIXME!
-              lldbutil.check_variable(self, two, False, value="one")
+        smallMultipayloadEnum2 = frame.FindVariable("smallMultipayloadEnum2")
+        two = smallMultipayloadEnum2.GetChildMemberWithName("two")
+        lldbutil.check_variable(self, two, False, value="one")
 
-          bigMultipayloadEnum1 = frame.FindVariable("bigMultipayloadEnum1")
-          one = bigMultipayloadEnum1.GetChildMemberWithName("one")
-          first = one.GetChildAtIndex(0).GetChildMemberWithName("supField")
-          second = one.GetChildAtIndex(1).GetChildMemberWithName("supField")
-          third = one.GetChildAtIndex(2).GetChildMemberWithName("supField")
-          lldbutil.check_variable(self, first, False, value="42")
-          lldbutil.check_variable(self, second, False, value="43")
-          lldbutil.check_variable(self, third, False, value="44")
+        bigMultipayloadEnum1 = frame.FindVariable("bigMultipayloadEnum1")
+        one = bigMultipayloadEnum1.GetChildMemberWithName("one")
+        first = one.GetChildAtIndex(0).GetChildMemberWithName("supField")
+        second = one.GetChildAtIndex(1).GetChildMemberWithName("supField")
+        third = one.GetChildAtIndex(2).GetChildMemberWithName("supField")
 
-          fullMultipayloadEnum1 = frame.FindVariable("fullMultipayloadEnum1")
-          one = fullMultipayloadEnum1.GetChildMemberWithName("one")
-          lldbutil.check_variable(self, one, False, value="120")
+        if False: # FIXME!
+            lldbutil.check_variable(self, first, False, value="42")
+            lldbutil.check_variable(self, second, False, value="43")
+            lldbutil.check_variable(self, third, False, value="44")
 
-          fullMultipayloadEnum2 = frame.FindVariable("fullMultipayloadEnum2")
-          two = fullMultipayloadEnum2.GetChildMemberWithName("two")
-          lldbutil.check_variable(self, two, False, value="9.5")
+        fullMultipayloadEnum1 = frame.FindVariable("fullMultipayloadEnum1")
+        one = fullMultipayloadEnum1.GetChildMemberWithName("one")
+        lldbutil.check_variable(self, one, False, value="120")
 
-          bigFullMultipayloadEnum1 = frame.FindVariable("bigFullMultipayloadEnum1")
-          one = bigFullMultipayloadEnum1.GetChildMemberWithName("one")
-          first = one.GetChildAtIndex(0)
-          second = one.GetChildAtIndex(1)
-          lldbutil.check_variable(self, first, False, value="209")
-          lldbutil.check_variable(self, second, False, value="315")
-
-          bigFullMultipayloadEnum2 = frame.FindVariable("bigFullMultipayloadEnum2")
-          two = bigFullMultipayloadEnum2.GetChildMemberWithName("two")
-          first = two.GetChildAtIndex(0)
-          second = two.GetChildAtIndex(1)
-          lldbutil.check_variable(self, first, False, value="452.5")
-          lldbutil.check_variable(self, second, False, value="753.5")
+        fullMultipayloadEnum2 = frame.FindVariable("fullMultipayloadEnum2")
+        two = fullMultipayloadEnum2.GetChildMemberWithName("two")
+        lldbutil.check_variable(self, two, False, value="9.5")
+        
+        bigFullMultipayloadEnum1 = frame.FindVariable("bigFullMultipayloadEnum1")
+        one = bigFullMultipayloadEnum1.GetChildMemberWithName("one")
+        first = one.GetChildAtIndex(0)
+        second = one.GetChildAtIndex(1)
+        lldbutil.check_variable(self, first, False, value="209")
+        lldbutil.check_variable(self, second, False, value="315")
+        
+        bigFullMultipayloadEnum2 = frame.FindVariable("bigFullMultipayloadEnum2")
+        two = bigFullMultipayloadEnum2.GetChildMemberWithName("two")
+        first = two.GetChildAtIndex(0)
+        second = two.GetChildAtIndex(1)
+        lldbutil.check_variable(self, first, False, value="452.5")
+        lldbutil.check_variable(self, second, False, value="753.5")
 
         sup = frame.FindVariable("sup")
         supField = sup.GetChildMemberWithName("supField")
@@ -160,13 +196,11 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         one = t.GetChildMemberWithName("one")
         first = one.GetChildAtIndex(0)
         second = one.GetChildAtIndex(1)
-        if str(one.GetError()) != 'error: Cannot compute size of type $sSi_SitD using static debug info.':
-            lldbutil.check_variable(self, first, False, value="209")
-            lldbutil.check_variable(self, second, False, value="315")
-            u = gsp3.GetChildMemberWithName("u")
-            two = u.GetChildMemberWithName("two")
-            if not ast: # FIXME!
-                lldbutil.check_variable(self, two, False, value="one")
+        lldbutil.check_variable(self, first, False, value="209")
+        lldbutil.check_variable(self, second, False, value="315")
+        u = gsp3.GetChildMemberWithName("u")
+        two = u.GetChildMemberWithName("two")
+        lldbutil.check_variable(self, two, False, value="one")
 
         gcp = frame.FindVariable("gcp")
         t = gcp.GetChildMemberWithName("t")
@@ -176,21 +210,19 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
 
         either = frame.FindVariable("either")
         left = either.GetChildMemberWithName("left")
-        if str(left.GetError()) != 'error: Cannot compute size of type $sSiD using static debug info.':
-            lldbutil.check_variable(self, left, False, value="1234")
+        lldbutil.check_variable(self, left, False, value="1234")
 
-            either2 = frame.FindVariable("either2")
-            right = either2.GetChildMemberWithName("right")
-            t = right.GetChildMemberWithName("t")
-            one = t.GetChildMemberWithName("one")
-            first = one.GetChildAtIndex(0)
-            second = one.GetChildAtIndex(1)
-            if not ast: # FIXME!
-                lldbutil.check_variable(self, first, False, value="209")
-                lldbutil.check_variable(self, second, False, value="315")
-                u = right.GetChildMemberWithName("u")
-                two = u.GetChildMemberWithName("two")
-                lldbutil.check_variable(self, two, False, value='one')
+        either2 = frame.FindVariable("either2")
+        right = either2.GetChildMemberWithName("right")
+        t = right.GetChildMemberWithName("t")
+        one = t.GetChildMemberWithName("one")
+        first = one.GetChildAtIndex(0)
+        second = one.GetChildAtIndex(1)
+        lldbutil.check_variable(self, first, False, value="209")
+        lldbutil.check_variable(self, second, False, value="315")
+        u = right.GetChildMemberWithName("u")
+        two = u.GetChildMemberWithName("two")
+        lldbutil.check_variable(self, two, False, value='one')
 
         inner = frame.FindVariable("inner")
         value = inner.GetChildMemberWithName("value")
@@ -222,8 +254,11 @@ class TestSwiftEmbeddedFrameVariable(TestBase):
         innerFuncField = innerFunctionType.GetChildMemberWithName("innerFuncField")
         lldbutil.check_variable(self, innerFuncField, False, value='8479')
 
-        array = frame.FindVariable("array")
-        lldbutil.check_variable(self, array, False, num_children=4)
+        inlineArray = frame.FindVariable("inlineArray")
+        lldbutil.check_variable(self, inlineArray, False, num_children=4)
         for i in range(4):
-            lldbutil.check_variable(self, array.GetChildAtIndex(i),
+            lldbutil.check_variable(self, inlineArray.GetChildAtIndex(i),
                                     False, value=str(i+1))
+
+        string = frame.FindVariable("string")
+        lldbutil.check_variable(self, string, False, summary='"Hello"')

--- a/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
+++ b/lldb/test/API/lang/swift/embedded/frame_variable/main.swift
@@ -109,6 +109,29 @@ struct OuterGeneric<T> {
   }
 }
 
+struct TypeAliases {
+  struct Q<T> { let t: T }
+   
+  struct S<T> {
+    typealias A1 = Q<T>
+    typealias A2<R> = Q<R>
+    struct R<U, V> {
+      typealias A3 = Q<T> // Q<tau_0_0>
+      typealias A4 = Q<U> // Q<tau_1_0>
+      typealias A5 = Q<V> // Q<tau_1_1>
+      typealias A6<R> = Q<(R, V, T)>
+      let a3 : A3
+      let a4 : A4
+      let a5 : A5
+      let a6 : A6<T>
+    }
+    let r : R<T, (T, T)>
+    let q1 : A2<T>
+    let q2 : A2<(T, T)>
+  }
+  typealias A7 = Q<Int>
+}
+
 func g() {
   struct FunctionType {
     let funcField = 67
@@ -120,6 +143,18 @@ func g() {
 
     let varB = B()
     let tuple = (A(), B())
+    let alias1 = TypeAliases.A7(t: 1)
+    let alias2 = TypeAliases.S<Int>.R<Int, (Int, Int)>(
+      a3: TypeAliases.Q(t: 3),
+      a4: TypeAliases.Q(t: 4),
+      a5: TypeAliases.Q(t: (5, 6)),
+      a6: TypeAliases.Q(t: (7, (8, 9), 10))
+    )
+    let alias3 = TypeAliases.S<Int>(r: alias2,
+      q1: TypeAliases.Q(t: 11),
+      q2: TypeAliases.Q(t: (12, 13))
+    )
+    let array : [Int] = [1, 2, 3, 4]
     let trivial = TrivialEnum.theCase
     let nonPayload1 = NonPayloadEnum.one
     let nonPayload2 = NonPayloadEnum.two
@@ -158,13 +193,11 @@ func g() {
     let genericInner = OuterGeneric<Int>.GenericInner(t: 647, u: 674.5)
     let functionType = FunctionType()
     let innerFunctionType = InnerFunctionType()
+    var inlineArray: InlineArray<4, Int> = [1, 2, 3, 4]
 
-    var array: InlineArray<4, Int> = [1, 2, 3, 4]
-
-    // Dummy statement to set breakpoint print can't be used in embedded Swift for now.
-    let dummy = A() // break here
+    let dummy = A() 
     let string = StaticString("Hello") 
-    print(string) 
+    print(string) // break here
   }
   f()
 }


### PR DESCRIPTION
```
commit b74f2e9f0373fbdfd49274b412f71840e946b5c6
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Sep 23 17:40:19 2025 -0700

    [LLDB] Support nested generic type aliases (and thus Swift.Array) in Embedded Swift
    
    In order to format a Swift.Array in Swift it is necessary to properly
    resolve type aliases to generic types from DWARF. This patch adds
    support for properly generic type aliases in and out of context when
    reconstructing them from DWARF.
    
    rdar://159429896
    (cherry picked from commit 4d607884bf906381df01806bb4e97d255faf2cd2)
    
     Conflicts:
            lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp

commit 9fd171930df5a148e35bedf7bfb2e786b6448fcb
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Sep 29 17:01:01 2025 -0700

    Restrict DWARF alias type resolution to embedded Swift
```
