### PR TITLE
Revert "[lldb] Reenable TestSwiftForwardInteropExpressions"

### DIFF
--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
@@ -5,6 +5,7 @@ Test that evaluating expressions works on forward interop mode.
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
+@skipIf(bugnumber = "rdar://159675331")
 class TestSwiftForwardInteropExpressions(TestBase):
 
     def setup(self, bkpt_str):


### PR DESCRIPTION
Reverts swiftlang/llvm-project#11533. Looks like one of the other reverts has caused it to fail again.