### PR TITLE
[lldb] Remove unconditional include of Swift header on generic code

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFDIE.cpp
@@ -13,7 +13,9 @@
 #include "DWARFDebugInfoEntry.h"
 #include "DWARFDeclContext.h"
 #include "DWARFUnit.h"
+#ifdef LLDB_ENABLE_SWIFT
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#endif
 #include "lldb/Symbol/Type.h"
 
 #include "llvm/ADT/iterator.h"
@@ -393,8 +395,7 @@ static void GetDeclContextImpl(DWARFDIE die,
 
     // Add this DIE's contribution at the end of the chain.
     auto push_ctx = [&](CompilerContextKind kind, llvm::StringRef name) {
-      // BEGIN SWIFT
-      //
+#ifdef LLDB_ENABLE_SWIFT
       // FIXME: This layering violation works around a limitation in
       // LLVM that prevents swiftc from emitting both DW_AT_name and
       // DW_AT_linkage_name on forward declarations and typedefs.
@@ -409,7 +410,7 @@ static void GetDeclContextImpl(DWARFDIE die,
         if (!base_name.empty())
           name = base_name;
       }
-      // END SWIFT
+#endif
       context.push_back({kind, ConstString(name)});
     };
     switch (die.Tag()) {


### PR DESCRIPTION
DWARFDIE can be compiled without Swift support.