### PR TITLE
CAS fixes for clang cl mode.

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -8995,6 +8995,7 @@ def fsycl_is_host : Flag<["-"], "fsycl-is-host">,
 // Driver CAS options.
 def fdepscan_EQ : Joined<["-"], "fdepscan=">,
     Group<f_Group>,
+    Visibility<[ClangOption, CLOption]>,
     HelpText<"Scan for dependencies ahead of compiling, generating a"
              " pruned CAS tree to send to -fcas-fs. Values are"
              " 'auto',"
@@ -9048,6 +9049,7 @@ def fdepscan_daemon_EQ : Joined<["-"], "fdepscan-daemon=">, Group<f_Group>,
              " parent processes.">;
 
 def fdepscan_include_tree : Flag<["-"], "fdepscan-include-tree">,
+    Visibility<[ClangOption, CLOption]>,
     Group<f_Group>, HelpText<"Set dep-scanner to produce the include tree">;
 
 // CAS prefix map options.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6362,7 +6362,11 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   // Output to a temporary file?
   if ((!AtTopLevel && !isSaveTempsEnabled() &&
        !C.getArgs().hasArg(options::OPT__SLASH_Fo)) ||
-      CCGenDiagnostics) {
+      CCGenDiagnostics ||
+      // Use a temp file for the depscan reponse file in CL mode
+      // (even with a /Fo flag).
+      (!AtTopLevel && isa<DepscanJobAction>(JA) &&
+       JA.getType() == types::TY_ResponseFile && IsCLMode())) {
     StringRef Name = llvm::sys::path::filename(BaseInput);
     std::pair<StringRef, StringRef> Split = Name.split('.');
     const char *Suffix =

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4721,7 +4721,9 @@ renderDebugOptions(const ToolChain &TC, const Driver &D, const llvm::Triple &T,
   addDebugPrefixMapArg(D, TC, Args, CmdArgs);
 
   // Add the output path to the object file for CodeView debug infos.
-  if (EmitCodeView && Output.isFilename())
+  // Skip this for temp depscan reponse file name.
+  if (EmitCodeView && Output.isFilename() &&
+      Output.getType() != types::TY_ResponseFile)
     addDebugObjectName(Args, CmdArgs, DebugCompilationDir,
                        Output.getFilename());
 }

--- a/clang/test/ClangScanDeps/cas-clang-cl.c
+++ b/clang/test/ClangScanDeps/cas-clang-cl.c
@@ -1,0 +1,17 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cl -c /clang:-fdepscan=inline /clang:-fdepscan-include-tree -Xclang -fcas-path -Xclang %t/cas -Xclang -Rcompile-job-cache -- %t/test.c 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang_cl -c /clang:-fdepscan=inline /clang:-fdepscan-include-tree -Xclang -fcas-path -Xclang %t/cas -Xclang -Rcompile-job-cache -- %t/test.c 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// In debug mode
+// RUN: %clang_cl -c /clang:-fdepscan=inline /clang:-fdepscan-include-tree -Xclang -fcas-path -Xclang %t/cas -Xclang -Rcompile-job-cache /Z7 -- %t/test.c 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: %clang_cl -c /clang:-fdepscan=inline /clang:-fdepscan-include-tree -Xclang -fcas-path -Xclang %t/cas -Xclang -Rcompile-job-cache /Z7 -- %t/test.c 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- test.c
+int main() { return 0; }


### PR DESCRIPTION
Three changes:
- Make depscan flags visible.
- Fix an issue that a depscan reponse file is written in the current directory without a unique id/hash in its path, collides with another for an identical source file and causes a build error.
- Fix an issue that causes unexpected cas cache misses due to a temp depscan reponse file path (with a unique id/hash) being specified (incorrectly/unnecessarily) specified as the output object file (the -object-file-name flag) when for code view / pdb debug info is emitted.