### PR TITLE
[Test] Fix clang/test/Modules/GH154840.cpp

### DIFF
--- a/clang/test/Modules/GH154840.cpp
+++ b/clang/test/Modules/GH154840.cpp
@@ -1,3 +1,7 @@
+/// Due to module bypass workaround for non-darwin platforms, relative and absolute path do not match after bypass.
+/// See: https://github.com/llvm/llvm-project/issues/130795
+// XFAIL: !system-darwin
+
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file %s %t

--- a/clang/test/Modules/explicit-build-relpath.cpp
+++ b/clang/test/Modules/explicit-build-relpath.cpp
@@ -1,5 +1,6 @@
-/// Due to module bypass workaround in https://reviews.llvm.org/D97850 for ext4 FS, relative and absolute path do not match after bypass.
-// REQUIRES: system-darwin
+/// Due to module bypass workaround for non-darwin platforms, relative and absolute path do not match after bypass.
+/// See: https://github.com/llvm/llvm-project/issues/130795
+// XFAIL: !system-darwin
 
 // RUN: rm -rf %t
 // RUN: mkdir %t


### PR DESCRIPTION
Fix the downstream tests due to the FileEntry bypasses on non-darwin platforms for inode number recycling.

Also adjust the test conditions for similar downstream tests that are disabled for the same reason and add comments references to the upstream bug report.