### PR TITLE
[lldb] Rework PCM validation disable for Swift (#10974)

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1818,10 +1818,10 @@ void SwiftASTContext::ConfigureModuleValidation(
 #endif
   }
 
-  if (!validate_pcm)
+  if (!validate_pcm) {
     extra_args.push_back("-fno-modules-check-relocated");
-  LOG_PRINTF(GetLog(LLDBLog::Types), "PCM validation is %s",
-             validate_pcm ? "disabled" : "enabled");
+    LOG_PRINTF(GetLog(LLDBLog::Types), "PCM validation is disabled");
+  }
 }
 
 void SwiftASTContext::AddExtraClangArgs(


### PR DESCRIPTION
The `Preprocessor`'s options have changed to be `const` in https://github.com/llvm/llvm-project/commit/277ab85d1ccf80750f5193495c0665808c2863de. Since lldb can no longer mutate the options before constructing a clang importer, this change is to setup the options ahead of time.

(cherry picked from commit de06c52fa3982a6961d7db5f9371137723b16519)

(cherry-picked from commit 30f191f9e843501231cf64c58ae4e47bd6d97a3f)