### PR TITLE
[lldb] Remove orphaned block in IRExecutionUnit (NFC)

### DIFF
--- a/lldb/source/Expression/IRExecutionUnit.cpp
+++ b/lldb/source/Expression/IRExecutionUnit.cpp
@@ -839,15 +839,6 @@ IRExecutionUnit::FindInSymbols(const std::vector<ConstString> &names,
         return *load_addr;
     }
 
-    if (sc.target_sp) {
-      ModuleList images = sc.target_sp->GetImages();
-      // BEGIN SWIFT
-      if (m_in_populate_symtab)
-        if (lldb::ModuleSP module_sp = m_jit_module_wp.lock())
-          images.Remove(module_sp);
-      // END SWIFT
-    }
-
     {
       SymbolContextList sc_list;
       m_preferred_modules.FindFunctions(name, lldb::eFunctionNameTypeFull,


### PR DESCRIPTION
Originally added in https://github.com/swiftlang/llvm-project/pull/6048. See the [changes to IRExecutionUnit.cpp](https://github.com/swiftlang/llvm-project/pull/6048/files#diff-717a850c4315286c025e2739ebe9dacbf27e626b7679c72479b05c996d721112)

This code now appears to be unused, as the `images` local variable is constructed, but not later used (unlike the commit that introduced the variable).