### PR TITLE
[lldb][NFC] Prepare SwiftLanguageRuntime for vectorized memory reads

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -918,10 +918,24 @@ class TaskInspector {
 public:
   /// Inspects thread local storage to find the address of the currently
   /// executing task, if any.
-  llvm::Expected<lldb::addr_t>
-  GetTaskAddrFromThreadLocalStorage(Thread &thread);
+  std::optional<lldb::addr_t> GetTaskAddrFromThreadLocalStorage(Thread &thread);
+
+  /// Inspects thread local storage to find the address of the currently
+  /// executing task, if any.
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrFromThreadLocalStorage(llvm::ArrayRef<Thread *> threads);
 
 private:
+  /// For each thread in `threads`, return the location of the its task
+  /// pointer, if it exists.
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  GetTaskAddrLocations(llvm::ArrayRef<Thread *> threads);
+
+  /// If reading from a cached task address location failed, invalidate the
+  /// cache and try again.
+  std::optional<lldb::addr_t> RetryRead(Thread &thread,
+                                        lldb::addr_t task_addr_location);
+
   llvm::DenseMap<uint64_t, lldb::addr_t> m_tid_to_task_addr_location;
 };
 


### PR DESCRIPTION
Once the proposal [1] is implemented, the Process class will have the ability to read multiple memory addresses at once. This patch is an NFC refactor to make the code more amenable to that future.

[1]: https://discourse.llvm.org/t/rfc-a-new-vectorized-memory-read-packet/