### PR TITLE
Make SBBreakpoint/SBBreakpointLocation.SetCondition(nullptr) work again

### DIFF
--- a/lldb/source/API/SBBreakpoint.cpp
+++ b/lldb/source/API/SBBreakpoint.cpp
@@ -275,7 +275,11 @@ void SBBreakpoint::SetCondition(const char *condition) {
   if (bkpt_sp) {
     std::lock_guard<std::recursive_mutex> guard(
         bkpt_sp->GetTarget().GetAPIMutex());
-    bkpt_sp->SetCondition(StopCondition(condition));
+    // Treat a null pointer as resetting the condition.
+    if (!condition)
+      bkpt_sp->SetCondition(StopCondition());
+    else
+      bkpt_sp->SetCondition(StopCondition(condition));
   }
 }
 
@@ -288,7 +292,10 @@ const char *SBBreakpoint::GetCondition() {
 
   std::lock_guard<std::recursive_mutex> guard(
       bkpt_sp->GetTarget().GetAPIMutex());
-  return ConstString(bkpt_sp->GetCondition().GetText()).GetCString();
+  StopCondition cond = bkpt_sp->GetCondition();
+  if (!cond)
+    return nullptr;
+  return ConstString(cond.GetText()).GetCString();
 }
 
 void SBBreakpoint::SetAutoContinue(bool auto_continue) {

--- a/lldb/source/API/SBBreakpointLocation.cpp
+++ b/lldb/source/API/SBBreakpointLocation.cpp
@@ -160,7 +160,11 @@ void SBBreakpointLocation::SetCondition(const char *condition) {
   if (loc_sp) {
     std::lock_guard<std::recursive_mutex> guard(
         loc_sp->GetTarget().GetAPIMutex());
-    loc_sp->SetCondition(StopCondition(condition));
+    // Treat a nullptr as clearing the condition
+    if (!condition)
+      loc_sp->SetCondition(StopCondition());
+    else
+      loc_sp->SetCondition(StopCondition(condition));
   }
 }
 
@@ -173,7 +177,10 @@ const char *SBBreakpointLocation::GetCondition() {
 
   std::lock_guard<std::recursive_mutex> guard(
       loc_sp->GetTarget().GetAPIMutex());
-  return ConstString(loc_sp->GetCondition().GetText()).GetCString();
+  StopCondition cond = loc_sp->GetCondition();
+  if (!cond)
+    return nullptr;
+  return ConstString(cond.GetText()).GetCString();
 }
 
 void SBBreakpointLocation::SetAutoContinue(bool auto_continue) {

--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -4,6 +4,8 @@ add_lldb_unittest(APITests
   SBMutexTest.cpp
   SBBreakpointClearConditionTest.cpp
 
+  SBAPITEST
+
   LINK_LIBS
     liblldb
   )

--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -11,7 +11,8 @@ add_lldb_unittest(APITests
   )
 
 # Build with -Wdocumentation. This relies on the tests including all the API
-# headers through API/LLDB.h.
+# headers through API/LLDB.h. It also means that the API tests cannot include
+# private headers.
 check_cxx_compiler_flag("-Wdocumentation"
                         CXX_SUPPORTS_DOCUMENTATION)
 if (CXX_SUPPORTS_DOCUMENTATION)

--- a/lldb/unittests/API/CMakeLists.txt
+++ b/lldb/unittests/API/CMakeLists.txt
@@ -2,6 +2,7 @@ add_lldb_unittest(APITests
   SBCommandInterpreterTest.cpp
   SBLineEntryTest.cpp
   SBMutexTest.cpp
+  SBBreakpointClearConditionTest.cpp
 
   LINK_LIBS
     liblldb

--- a/lldb/unittests/API/SBBreakpointClearConditionTest.cpp
+++ b/lldb/unittests/API/SBBreakpointClearConditionTest.cpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Use the umbrella header for -Wdocumentation.
+#include "lldb/API/LLDB.h"
+
+#include "TestingSupport/SubsystemRAII.h"
+#include "lldb/API/SBBreakpoint.h"
+#include "lldb/API/SBBreakpointLocation.h"
+#include "lldb/API/SBDebugger.h"
+#include "lldb/API/SBTarget.h"
+#include "gtest/gtest.h"
+#include <memory>
+#include <mutex>
+
+using namespace lldb_private;
+using namespace lldb;
+
+class BreakpointClearConditionTest : public ::testing::Test {
+public:
+  void SetUp() override {
+    m_sb_debugger = SBDebugger::Create(/*source_init_files=*/false);
+  };
+
+  void TearDown() override { SBDebugger::Destroy(m_sb_debugger); }
+  SBDebugger m_sb_debugger;
+  SubsystemRAII<lldb::SBDebugger> subsystems;
+};
+
+template <typename T> void test_condition(T sb_object) {
+  const char *in_cond_str = "Here is a condition";
+  sb_object.SetCondition(in_cond_str);
+  // Make sure we set the condition correctly:
+  const char *out_cond_str = sb_object.GetCondition();
+  EXPECT_STREQ(in_cond_str, out_cond_str);
+  // Now unset it by passing in nullptr and make sure that works:
+  const char *empty_tokens[2] = {nullptr, ""};
+  for (auto token : empty_tokens) {
+    sb_object.SetCondition(token);
+    out_cond_str = sb_object.GetCondition();
+    // And make sure an unset condition returns nullptr:
+    EXPECT_EQ(nullptr, out_cond_str);
+  }
+}
+
+TEST_F(BreakpointClearConditionTest, BreakpointClearConditionTest) {
+  // Create target
+  SBTarget sb_target;
+  SBError error;
+  sb_target =
+      m_sb_debugger.CreateTarget("", "x86_64-apple-macosx-", "remote-macosx",
+                                 /*add_dependent=*/false, error);
+
+  EXPECT_EQ(sb_target.IsValid(), true);
+
+  // Create breakpoint
+  SBBreakpoint sb_breakpoint = sb_target.BreakpointCreateByAddress(0xDEADBEEF);
+  test_condition(sb_breakpoint);
+
+  // Address breakpoints always have one location, so we can also use this
+  // to test the location:
+  SBBreakpointLocation sb_loc = sb_breakpoint.GetLocationAtIndex(0);
+  EXPECT_EQ(sb_loc.IsValid(), true);
+  test_condition(sb_loc);
+}

--- a/lldb/unittests/Breakpoint/CMakeLists.txt
+++ b/lldb/unittests/Breakpoint/CMakeLists.txt
@@ -1,10 +1,14 @@
-add_lldb_unittest(LLDBBreakpointTests
+add_lldb_unittest(LLDBBreakpointTests      
   BreakpointIDTest.cpp
   WatchpointAlgorithmsTests.cpp
 
   LINK_COMPONENTS
     Support
   LINK_LIBS
+    liblldb
     lldbBreakpoint
     lldbCore
+    LLVMTestingSupport
+    lldbUtilityHelpers
+    lldbPluginPlatformMacOSX
   )

--- a/lldb/unittests/Breakpoint/CMakeLists.txt
+++ b/lldb/unittests/Breakpoint/CMakeLists.txt
@@ -1,14 +1,10 @@
-add_lldb_unittest(LLDBBreakpointTests      
+add_lldb_unittest(LLDBBreakpointTests
   BreakpointIDTest.cpp
   WatchpointAlgorithmsTests.cpp
 
   LINK_COMPONENTS
     Support
   LINK_LIBS
-    liblldb
     lldbBreakpoint
     lldbCore
-    LLVMTestingSupport
-    lldbUtilityHelpers
-    lldbPluginPlatformMacOSX
   )

--- a/lldb/unittests/CMakeLists.txt
+++ b/lldb/unittests/CMakeLists.txt
@@ -12,13 +12,17 @@ endif()
 
 function(add_lldb_unittest test_name)
   cmake_parse_arguments(ARG
-    ""
+    "SBAPITEST"
     ""
     "LINK_LIBS;LINK_COMPONENTS"
     ${ARGN})
 
   if (NOT ${test_name} MATCHES "Tests$")
     message(FATAL_ERROR "Unit test name must end with 'Tests' for lit to find it.")
+  endif()
+
+  if ("liblldb" IN_LIST ARG_LINK_LIBS AND NOT ARG_SBAPITEST)
+    message(FATAL_ERROR "The ${test_name} are not allowed to link liblldb.")
   endif()
 
   list(APPEND LLVM_LINK_COMPONENTS ${ARG_LINK_COMPONENTS})

--- a/lldb/unittests/DAP/CMakeLists.txt
+++ b/lldb/unittests/DAP/CMakeLists.txt
@@ -11,6 +11,8 @@ add_lldb_unittest(DAPTests
   TestBase.cpp
   VariablesTest.cpp
 
+  SBAPITEST
+
   LINK_COMPONENTS
     Support
   LINK_LIBS


### PR DESCRIPTION
The addition of the StopCondition in the lldb_private layer meant that clearing a breakpoint condition with:

sb_break.SetCondition(nullptr);

now crashes. Also, GetCondition for an empty condition used to return a nullptr, but now it returns "".

This patch fixes that crash and makes the SB GetCondition always return nullptr for an empty condition.

(cherry picked from commit f3e2c20a23b11fbe1149e5d2e3631109af6d3238)