### PR TITLE
[lldb] Fix ThreadPlanStepThroughGenericTrampoline

### DIFF
--- a/lldb/source/Target/ThreadPlanStepThroughGenericTrampoline.cpp
+++ b/lldb/source/Target/ThreadPlanStepThroughGenericTrampoline.cpp
@@ -99,6 +99,8 @@ bool ThreadPlanStepThroughGenericTrampoline::ShouldStop(Event *event_ptr) {
               s.GetData());
   }
 
+  ClearNextBranchBreakpointExplainedStop();
+
   if (IsPlanComplete())
     return true;
 

--- a/lldb/test/API/lang/c/trampoline_stepping/TestTrampolineStepping.py
+++ b/lldb/test/API/lang/c/trampoline_stepping/TestTrampolineStepping.py
@@ -7,7 +7,6 @@ from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
-@skipIf(bugnumber = "rdar://160698178")
 class TestTrampoline(TestBase):
     def setup(self, bkpt_str):
         self.build()
@@ -101,4 +100,4 @@ class TestTrampoline(TestBase):
         thread.StepInto()
         name = thread.frames[0].GetFunctionName()
         self.assertIn('unused_target', name)
-        
+

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
@@ -5,7 +5,6 @@ Test that Swift types are displayed correctly in C++
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
-@skipIf(bugnumber="rdar://159531057")
 class TestSwiftBackwardInteropStepping(TestBase):
 
     def setup(self, bkpt_str):


### PR DESCRIPTION
With the rework upstream of step plans, NextRangeBreakpointExplainsStop was made stateless so the check if the break breakpoints needs to be cleared needs to be moved to the ShoudStop method.

rdar://159531057
rdar://159675204