### PR TITLE
[Index] Remove %T usage in index tests

### DIFF
--- a/clang/test/Index/Store/json-with-module.m
+++ b/clang/test/Index/Store/json-with-module.m
@@ -1,9 +1,11 @@
-// RUN: rm -rf %t.idx %t.mcp
-// RUN: %clang -target x86_64-apple-darwin -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t.o -index-store-path %t.idx -fmodules -fmodules-cache-path=%t.mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
-// RUN: c-index-test core -aggregate-json %t.idx -o %t.json
-// RUN: sed -e "s:%S::g" -e "s:%T::g" %t.json > %t.final.json
-// RUN: diff -u %s.json %t.final.json
-
 @import ModDep;
 
 // REQUIRES: shell
+
+// RUN: rm -rf %t
+// RUN: mkdir %t
+
+// RUN: %clang -target x86_64-apple-darwin -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t/json.o -index-store-path %t/idx -fmodules -fmodules-cache-path=%t/mcp -Xclang -fdisable-module-hash -I %S/Inputs/module
+// RUN: c-index-test core -aggregate-json %t/idx -o %t/output.json
+// RUN: sed -e "s:%S::g" -e "s:%t::g" %t/output.json > %t/final.json
+// RUN: diff -u %s.json %t/final.json

--- a/clang/test/Index/Store/json-with-module.m.json
+++ b/clang/test/Index/Store/json-with-module.m.json
@@ -1,12 +1,12 @@
 {
   "files": [
-    "/json-with-module.m.tmp.mcp/ModDep.pcm",
-    "/json-with-module.m.tmp.mcp/ModTop.pcm",
+    "/mcp/ModDep.pcm",
+    "/mcp/ModTop.pcm",
     "/Inputs/module/ModDep.h",
     "/Inputs/module/ModTop.h",
     "/Inputs/module/ModTopSub1.h",
     "/Inputs/module/ModTopSub2.h",
-    "/json-with-module.m.tmp.o",
+    "/json.o",
     "/json-with-module.m",
     "/Inputs/module/module.modulemap"
   ],

--- a/clang/test/Index/Store/json-with-pch.c
+++ b/clang/test/Index/Store/json-with-pch.c
@@ -1,12 +1,14 @@
-// RUN: rm -rf %t.idx
-// RUN: %clang -target x86_64-apple-darwin -arch x86_64 -mmacosx-version-min=10.7 -x c-header %S/Inputs/head.h -o %t.h.pch -index-store-path %t.idx
-// RUN: %clang -target x86_64-apple-darwin -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t.o -index-store-path %t.idx -include %t.h -Werror
-// RUN: c-index-test core -aggregate-json %t.idx -o %t.json
-// RUN: sed -e "s:%S::g" -e "s:%T::g" %t.json > %t.final.json
-// RUN: diff -u %s.json %t.final.json
-
 int main() {
   test1_func();
 }
 
 // REQUIRES: shell
+
+// RUN: rm -rf %t
+// RUN: mkdir %t
+
+// RUN: %clang -target x86_64-apple-darwin -arch x86_64 -mmacosx-version-min=10.7 -x c-header %S/Inputs/head.h -o %t/head.h.pch -index-store-path %t/idx
+// RUN: %clang -target x86_64-apple-darwin -arch x86_64 -mmacosx-version-min=10.7 -c %s -o %t/head.o -index-store-path %t/idx -include %t/head.h -Werror
+// RUN: c-index-test core -aggregate-json %t/idx -o %t/output.json
+// RUN: sed -e "s:%S::g" -e "s:%t::g" %t/output.json > %t/final.json
+// RUN: diff -u %s.json %t/final.json

--- a/clang/test/Index/Store/json-with-pch.c.json
+++ b/clang/test/Index/Store/json-with-pch.c.json
@@ -1,8 +1,8 @@
 {
   "files": [
-    "/json-with-pch.c.tmp.h.pch",
+    "/head.h.pch",
     "/Inputs/head.h",
-    "/json-with-pch.c.tmp.o",
+    "/head.o",
     "/json-with-pch.c"
   ],
   "symbols": [
@@ -50,13 +50,13 @@
       "occurrences": [
         {
           "symbol": 2,
-          "line": 8,
+          "line": 1,
           "col": 5,
           "roles": "Def"
         },
         {
           "symbol": 0,
-          "line": 9,
+          "line": 2,
           "col": 3,
           "roles": "Ref,Call,RelCall,RelCont",
           "relations": [

--- a/clang/test/Index/Store/syntax-only.c
+++ b/clang/test/Index/Store/syntax-only.c
@@ -1,7 +1,9 @@
-// RUN: rm -rf %t.idx
-// RUN: %clang -fsyntax-only %s -index-store-path %t.idx -o %T/syntax-only.c.myoutfile
-// RUN: c-index-test core -print-unit %t.idx | FileCheck %s -check-prefix=CHECK-UNIT
-// RUN: c-index-test core -print-record %t.idx | FileCheck %s -check-prefix=CHECK-RECORD
+// RUN: rm -rf %t
+// RUN: mkdir %t
+//
+// RUN: %clang -fsyntax-only %s -index-store-path %t/idx -o %t/syntax-only.c.myoutfile
+// RUN: c-index-test core -print-unit %t/idx | FileCheck %s -check-prefix=CHECK-UNIT
+// RUN: c-index-test core -print-record %t/idx | FileCheck %s -check-prefix=CHECK-RECORD
 
 // CHECK-UNIT: out-file: {{.*}}/syntax-only.c.myoutfile
 // CHECK-RECORD: function/C | foo | c:@F@foo


### PR DESCRIPTION
This was removed in https://github.com/llvm/llvm-project/pull/160028. Update to use the unique %t instead.

Resolves rdar://161469815.