### PR TITLE
[gdbremote] Document MultiMemRead packet in protocol extensions

### DIFF
--- a/lldb/docs/resources/lldbgdbremote.md
+++ b/lldb/docs/resources/lldbgdbremote.md
@@ -2530,3 +2530,41 @@ read packet: $e0030100#b9
 
 **Priority to Implement:** Only required for Wasm support. Necessary to show
 variables.
+
+### MultiMemRead
+
+Read memory from multiple memory addresses.
+
+There are two arguments to the request:
+
+* `ranges`: a list of base-16 pairs of numbers. Each pair is separated by a
+`,`, as is each number in the pair. The first number of the pair denotes the
+base address of the memory read, the second denotes the number of bytes to be
+read.
+* `options`: an optional string of options. If present, it may be empty. If
+present, it is the last argument of the request.
+
+Both arguments must end with a `;`.
+
+The reply packet starts with a comma-separated list of base-16 numbers,
+denoting how many bytes were read from each address, followed by a `;`,
+followed by a sequence of bytes containing the memory data. The length of this
+sequence must be equal to the sum of the numbers provided at the start of the
+reply.
+
+If the stub is unable to read from any individual address, it should return a
+length of "zero" for that address in the reply packet.
+
+A stub that supports this packet should return `MultiMemRead+` in the reply to
+`qSupported`.
+
+```
+send packet: $MultiMemRead:ranges:100a00,4,200200,a0,400000,4;
+read packet: $4,0,2;<binary encoding of abcd1000><binary encoding of eeff>
+```
+
+In the example above, the first read produced `abcd1000`, the read of `a0`
+bytes from address `200200` failed, and the third read produced two bytes –
+`eeff` – out of the four requested.
+
+**Priority to Implement:** Only required for performance.


### PR DESCRIPTION
This adds a specification for the new packet discussed in the RFC [1].

[1]: https://discourse.llvm.org/t/rfc-a-new-vectorized-memory-read-packet/88441/12