### PR TITLE
🍒 [-Wunsafe-buffer-usage] Check for too complex count-attributed assignments

### DIFF
--- a/clang/include/clang/Analysis/Analyses/UnsafeBufferUsage.h
+++ b/clang/include/clang/Analysis/Analyses/UnsafeBufferUsage.h
@@ -142,6 +142,13 @@ public:
                                                  ASTContext &Ctx) {
     handleUnsafeOperation(Arg, IsRelatedToDecl, Ctx);
   }
+
+  virtual void handleTooComplexCountAttributedAssign(const Expr *E,
+                                                     const ValueDecl *VD,
+                                                     bool IsRelatedToDecl,
+                                                     ASTContext &Ctx) {
+    handleUnsafeOperation(E, IsRelatedToDecl, Ctx);
+  }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// Invoked when a fix is suggested against a variable. This function groups
@@ -196,7 +203,8 @@ public:
 // This function invokes the analysis and allows the caller to react to it
 // through the handler class.
 void checkUnsafeBufferUsage(const Decl *D, UnsafeBufferUsageHandler &Handler,
-                            bool EmitSuggestions);
+                            bool EmitSuggestions,
+                            bool BoundsSafetyAttributesEnabled = false);
 
 namespace internal {
 // Tests if any two `FixItHint`s in `FixIts` conflict.  Two `FixItHint`s

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -14110,6 +14110,10 @@ def note_unsafe_count_attributed_pointer_argument_null_to_nonnull : Note<
 def warn_unsafe_single_pointer_argument : Warning<
   "unsafe assignment to function parameter of __single pointer type">,
   InGroup<UnsafeBufferUsage>, DefaultIgnore;
+def warn_assign_to_count_attributed_must_be_simple_stmt : Warning<
+  "assignment to %select{count-attributed pointer|dependent count}0 '%1' "
+  "must be a simple statement '%1 = ...'">,
+  InGroup<UnsafeBufferUsage>, DefaultIgnore;
 #ifndef NDEBUG
 // Not a user-facing diagnostic. Useful for debugging false negatives in
 // -fsafe-buffer-usage-suggestions (i.e. lack of -Wunsafe-buffer-usage fixits).

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-assignment.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-assignment.cpp
@@ -1,0 +1,127 @@
+// RUN: %clang_cc1 -fsyntax-only -std=c++20 -Wno-all -Wunsafe-buffer-usage -fexperimental-bounds-safety-attributes -verify %s
+
+#include <ptrcheck.h>
+#include <stddef.h>
+
+namespace std {
+template <typename T> struct span {
+  T *data() const noexcept;
+  size_t size() const noexcept;
+  size_t size_bytes() const noexcept;
+  span<T> first(size_t count) const noexcept;
+  span<T> last(size_t count) const noexcept;
+  span<T> subspan(size_t offset, size_t count) const noexcept;
+  const T &operator[](const size_t idx) const;
+};
+} // namespace std
+
+struct cb {
+  int *__counted_by(count) p;
+  size_t count;
+};
+
+// Simple pointer and count
+
+void good_null(int *__counted_by(count) p, int count) {
+  p = nullptr;
+  count = 0;
+}
+
+void good_null_loop(int *__counted_by(count) p, int count) {
+  for (int i = 0; i < 2; i++) {
+    p = nullptr;
+    count = 0;
+  }
+}
+
+void good_null_ifelse(int *__counted_by(count) p, int count) {
+  if (count > 10) {
+    p = nullptr;
+    count = 0;
+  } else {
+    count = 0;
+    p = nullptr;
+  }
+}
+
+void good_null_loop_if(int *__counted_by(count) p, int count) {
+  for (int i = 0; i < 2; ++i) {
+    if (i == 0) {
+      p = nullptr;
+      count = 0;
+    }
+    count = 0;
+    p = nullptr;
+  }
+}
+
+// Simple pointer and count in struct
+
+void good_struct_self(cb *c) {
+  c->p = c->p;
+  c->count = c->count;
+}
+
+void good_struct_self_loop(cb *c) {
+  for (int i = 0; i < 2; i++) {
+    c->p = c->p;
+    c->count = c->count;
+  }
+}
+
+// Assigns to bounds-attributed that we consider too complex to analyze.
+
+void too_complex_assign_to_ptr(int *__counted_by(count) p, int count, int *q) {
+  q = p;
+  q = p = q;     // expected-warning{{assignment to count-attributed pointer 'p' must be a simple statement 'p = ...'}}
+  q = q = p = q; // expected-warning{{assignment to count-attributed pointer 'p' must be a simple statement 'p = ...'}}
+
+  p++; // expected-warning{{unsafe pointer arithmetic}} expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+
+  if (count > 2) {
+    q = p;
+    q = p = q;     // expected-warning{{assignment to count-attributed pointer 'p' must be a simple statement 'p = ...'}}
+    q = q = p = q; // expected-warning{{assignment to count-attributed pointer 'p' must be a simple statement 'p = ...'}}
+
+    p++; // expected-warning{{unsafe pointer arithmetic}} expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+  }
+
+  if (count > 2) {
+    if (count > 4)
+      for (int i = 0; i < 2; i++)
+        q = p = q; // expected-warning{{assignment to count-attributed pointer 'p' must be a simple statement 'p = ...'}}
+  }
+
+  for (; ; p++); // expected-warning{{unsafe pointer arithmetic}} expected-note{{pass -fsafe-buffer-usage-suggestions to receive code hardening suggestions}}
+}
+
+void too_complex_assign_to_count(int *__counted_by(count) p, int count, int n) {
+  n = count;
+  n = count = n;     // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+  n = n = count = n; // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+
+  count++;         // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+  --count;         // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+  count += 42;     // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+  count -= 42;     // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+  n = n + count++; // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+
+  if (n > 42) {
+    n = count;
+    n = count = n;     // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+    n = n = count = n; // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+  } else {
+    count++;         // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+    --count;         // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+    count += 42;     // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+    count -= 42;     // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+    n = n + count++; // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+  }
+
+  if (n > 42)
+    if (count > 0)
+      for (int i = 0; i < 2; i++)
+        count++; // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+
+  for (; ; count += 42); // expected-warning{{assignment to dependent count 'count' must be a simple statement 'count = ...'}}
+}


### PR DESCRIPTION
This is an initial part of an analysis of count-attributed assignment groups. This commit adds an AST visitor that is responsible for finding bounds-attributed assignment groups and assignments to bounds-attributed objects (pointers and dependent counts) that are too complex to verify.

As a PoC, this commit adds checks for too complex assignments, which are assignments that are not directly inside of a compound statement (like other assignment groups) and modify the pointer or count in some way. Our model rejects those and requires the user to simplify their code. For example:

```
  void foo(int *__counted_by(count) p, int count) {
    q = p = ...;
          ^ this is rejected
    n = count = ...;
              ^ this is rejected
    // the following is fine:
    p = ...;
    count = ...;
  }
```

rdar://161607826

(cherry picked from commit 0227c6f89fa2021b76b039a37cec5b5009518dd5)

Conflicts:
	clang/include/clang/Basic/DiagnosticSemaKinds.td