### PR TITLE
[CAS] OnDisk update/cleanup. NFCI.

### DIFF
--- a/clang/test/CAS/daemon-cas-recovery.c
+++ b/clang/test/CAS/daemon-cas-recovery.c
@@ -4,7 +4,7 @@
 
 /// Construct a malformed CAS to recovery from.
 // RUN: echo "abc" | llvm-cas --cas %t/cas --make-blob --data -
-// RUN: rm %t/cas/v1.1/v11.data
+// RUN: rm %t/cas/v1.1/data.v1
 // RUN: not llvm-cas --cas %t/cas --validate --check-hash
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_FORCE_VALIDATION=1 %clang-cache \

--- a/clang/test/CAS/depscan-cas-log.c
+++ b/clang/test/CAS/depscan-cas-log.c
@@ -10,11 +10,11 @@
 // RUN:   -cc1-args -cc1 -triple x86_64-apple-macosx11.0.0 -emit-obj %s -o %t/t.o -fcas-path %t/cas
 // RUN: FileCheck %s --input-file %t/cas/v1.log
 
-// CHECK: [[PID1:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v{{[0-9]+}}.index'
+// CHECK: [[PID1:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}index.v{{[0-9]+}}'
 // CHECK: [[PID1]] {{[0-9]*}}: create subtrie
 
 // Even a minimal compilation involves at least 9 records for the cache key.
 // CHECK-COUNT-9: [[PID1]] {{[0-9]*}}: create record
 
-// CHECK: [[PID2:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}v{{[0-9]+}}.index'
-// CHECK: [[PID2]] {{[0-9]*}}: close mmap '{{.*}}v{{[0-9]+}}.index'
+// CHECK: [[PID2:[0-9]*]] {{[0-9]*}}: mmap '{{.*}}index.v{{[0-9]+}}'
+// CHECK: [[PID2]] {{[0-9]*}}: close mmap '{{.*}}index.v{{[0-9]+}}'

--- a/clang/test/CAS/validate-once.c
+++ b/clang/test/CAS/validate-once.c
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 
 // RUN: llvm-cas --cas %t/cas --ingest %s
-// RUN: mv %t/cas/v1.1/v11.data %t/cas/v1.1/v11.data.bak
+// RUN: mv %t/cas/v1.1/data.v1 %t/cas/v1.1/data.v1.bak
 
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \
 // RUN:   %clang -target x86_64-apple-macos11 -I %S/Inputs \

--- a/llvm/include/llvm/CAS/OnDiskDataAllocator.h
+++ b/llvm/include/llvm/CAS/OnDiskDataAllocator.h
@@ -31,8 +31,7 @@ class OnDiskDataAllocator {
 public:
   using ValueProxy = MutableArrayRef<char>;
 
-  /// An iterator-like return value for data insertion. Maybe it should be
-  /// called \c iterator, but it has no increment.
+  /// A pointer to data stored on disk.
   class OnDiskPtr {
   public:
     FileOffset getOffset() const { return Offset; }
@@ -56,7 +55,9 @@ public:
     ValueProxy Value;
   };
 
-  /// Look up the data stored at the given offset.
+  /// Get the data of \p Size stored at the given \p Offset. Note the allocator
+  /// doesn't keep track of the allocation size, thus \p Size doesn't need to
+  /// match the size of allocation but needs to be smaller.
   Expected<ArrayRef<char>> get(FileOffset Offset, size_t Size) const;
 
   /// Allocate at least \p Size with 8-byte alignment.
@@ -64,7 +65,7 @@ public:
 
   /// \returns the buffer that was allocated at \p create time, with size
   /// \p UserHeaderSize.
-  MutableArrayRef<uint8_t> getUserHeader();
+  MutableArrayRef<uint8_t> getUserHeader() const;
 
   size_t size() const;
   size_t capacity() const;

--- a/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
+++ b/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
@@ -1,8 +1,14 @@
-//===- OnDiskKeyValueDB.h ---------------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// This declares OnDiskKeyValueDB, a key value storage database of fixed size
+/// key and value.
 //
 //===----------------------------------------------------------------------===//
 
@@ -35,9 +41,7 @@ public:
   Expected<std::optional<ArrayRef<char>>> get(ArrayRef<uint8_t> Key);
 
   /// \returns Total size of stored data.
-  size_t getStorageSize() const {
-    return Cache.size();
-  }
+  size_t getStorageSize() const { return Cache.size(); }
 
   /// \returns The precentage of space utilization of hard space limits.
   ///
@@ -60,7 +64,10 @@ public:
        StringRef ValueName, size_t ValueSize,
        std::shared_ptr<OnDiskCASLogger> Logger = nullptr);
 
-  using CheckValueT = function_ref<Error(FileOffset Offset, ArrayRef<char>)>;
+  using CheckValueT =
+      function_ref<Error(FileOffset Offset, ArrayRef<char> Data)>;
+  /// Validate the storage with a callback \p CheckValue to check the stored
+  /// value.
   Error validate(CheckValueT CheckValue) const;
 
 private:

--- a/llvm/include/llvm/Config/llvm-config.h.cmake
+++ b/llvm/include/llvm/Config/llvm-config.h.cmake
@@ -146,4 +146,7 @@
    coverage bugs, and to 0 otherwise. */
 #cmakedefine01 LLVM_ENABLE_DEBUGLOC_TRACKING_ORIGIN
 
+/* Define to 1 to enable LLVM OnDisk Content Addressable Storage */
+#cmakedefine01 LLVM_ENABLE_ONDISK_CAS
+
 #endif

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (LLVM_ENABLE_ONDISK_CAS)
-  add_definitions(-DLLVM_ENABLE_ONDISK_CAS=1)
-endif()
-
 add_llvm_component_library(LLVMCAS
   ActionCache.cpp
   ActionCaches.cpp

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -52,7 +52,7 @@ private:
   }
 
   ondisk::ObjectHandle convertHandle(ObjectHandle Node) const {
-    return ondisk::ObjectHandle::fromOpaqueData(Node.getInternalRef(*this));
+    return ondisk::ObjectHandle(Node.getInternalRef(*this));
   }
 
   ObjectRef convertRef(ondisk::ObjectID Ref) const {

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -16,6 +16,10 @@
 
 namespace llvm::cas::ondisk {
 
+/// The version for all the ondisk database files. It needs to be bumped when
+/// compatibility breaking changes are introduced.
+constexpr StringLiteral CASFormatVersion = "v1";
+
 /// Retrieves an overridden maximum mapping size for CAS files, if any,
 /// speicified by LLVM_CAS_MAX_MAPPING_SIZE in the environment or set by
 /// `setMaxMappingSize()`. If the value from environment is unreadable, returns
@@ -27,11 +31,16 @@ Expected<std::optional<uint64_t>> getOverriddenMaxMappingSize();
 /// created. Set value 0 to use default size.
 void setMaxMappingSize(uint64_t Size);
 
+/// Whether to use a small file mapping for ondisk databases created in \p Path.
+///
+/// For some file system that doesn't support sparse file, use a smaller file
+/// mapping to avoid consuming too much disk space on creation.
+bool useSmallMappingSize(const Twine &Path);
+
 /// Thread-safe alternative to \c sys::fs::lockFile. This does not support all
 /// the platforms that \c sys::fs::lockFile does, so keep it in the CAS library
 /// for now.
-std::error_code lockFileThreadSafe(
-    int FD, llvm::sys::fs::LockKind Kind = llvm::sys::fs::LockKind::Exclusive);
+std::error_code lockFileThreadSafe(int FD, llvm::sys::fs::LockKind Kind);
 
 /// Thread-safe alternative to \c sys::fs::unlockFile. This does not support all
 /// the platforms that \c sys::fs::lockFile does, so keep it in the CAS library
@@ -51,7 +60,8 @@ std::error_code tryLockFileThreadSafe(
 /// \c std::errc::no_space_on_device are detected before we write data.
 ///
 /// \returns the new size of the file, or an \c Error.
-Expected<size_t> preallocateFileTail(int FD, size_t CurrentSize, size_t NewSize);
+Expected<size_t> preallocateFileTail(int FD, size_t CurrentSize,
+                                     size_t NewSize);
 
 } // namespace llvm::cas::ondisk
 

--- a/llvm/lib/CAS/OnDiskDataAllocator.cpp
+++ b/llvm/lib/CAS/OnDiskDataAllocator.cpp
@@ -187,7 +187,7 @@ Expected<ArrayRef<char>> OnDiskDataAllocator::get(FileOffset Offset,
   return ArrayRef<char>{Impl->File.getRegion().data() + Offset.get(), Size};
 }
 
-MutableArrayRef<uint8_t> OnDiskDataAllocator::getUserHeader() {
+MutableArrayRef<uint8_t> OnDiskDataAllocator::getUserHeader() const {
   return Impl->Store.getUserHeader();
 }
 
@@ -204,7 +204,7 @@ OnDiskDataAllocator::OnDiskDataAllocator(std::unique_ptr<ImplType> Impl)
 struct OnDiskDataAllocator::ImplType {};
 
 Expected<OnDiskDataAllocator> OnDiskDataAllocator::create(
-    const Twine &PathTwine, const Twine &TableNameTwine, uint64_t MaxFileSize,
+    const Twine &Path, const Twine &TableName, uint64_t MaxFileSize,
     std::optional<uint64_t> NewFileInitialSize, uint32_t UserHeaderSize,
     std::shared_ptr<ondisk::OnDiskCASLogger> Logger,
     function_ref<void(void *)> UserHeaderInit) {
@@ -224,7 +224,9 @@ Expected<ArrayRef<char>> OnDiskDataAllocator::get(FileOffset Offset,
                            "OnDiskDataAllocator is not supported");
 }
 
-MutableArrayRef<uint8_t> OnDiskDataAllocator::getUserHeader() { return {}; }
+MutableArrayRef<uint8_t> OnDiskDataAllocator::getUserHeader() const {
+  return {};
+}
 
 size_t OnDiskDataAllocator::size() const { return 0; }
 size_t OnDiskDataAllocator::capacity() const { return 0; }

--- a/llvm/lib/CAS/OnDiskKeyValueDB.cpp
+++ b/llvm/lib/CAS/OnDiskKeyValueDB.cpp
@@ -5,6 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
+/// \file
+/// This file implements OnDiskKeyValueDB, an ondisk key value database.
+///
+/// The KeyValue database file is named `actions.<version>` inside the CAS
+/// directory. The database stores a mapping between a fixed-sized key and a
+/// fixed-sized value, where the size of key and value can be configured when
+/// opening the database.
+///
+//
+//===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/OnDiskKeyValueDB.h"
 #include "OnDiskCommon.h"
@@ -18,8 +29,7 @@ using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::cas::ondisk;
 
-static constexpr StringLiteral ActionCacheFile = "actions";
-static constexpr StringLiteral FilePrefix = "v6.";
+static constexpr StringLiteral ActionCacheFile = "actions.";
 
 Expected<ArrayRef<char>> OnDiskKeyValueDB::put(ArrayRef<uint8_t> Key,
                                                ArrayRef<char> Value) {
@@ -57,7 +67,7 @@ OnDiskKeyValueDB::open(StringRef Path, StringRef HashName, unsigned KeySize,
     return createFileError(Path, EC);
 
   SmallString<256> CachePath(Path);
-  sys::path::append(CachePath, FilePrefix + ActionCacheFile);
+  sys::path::append(CachePath, ActionCacheFile + CASFormatVersion);
   constexpr uint64_t MB = 1024ull * 1024ull;
   constexpr uint64_t GB = 1024ull * 1024ull * 1024ull;
 
@@ -96,7 +106,7 @@ Error OnDiskKeyValueDB::validate(CheckValueT CheckValue) const {
 
         if (Record.Data.size() != ValueSize)
           return formatError("wrong cache value size");
-        if (!isAligned(Align(8), Record.Data.size()))
+        if (!isAddrAligned(Align(8), Record.Data.data()))
           return formatError("wrong cache value alignment");
         if (CheckValue)
           return CheckValue(Offset, Record.Data);

--- a/llvm/test/CAS/logging.test
+++ b/llvm/test/CAS/logging.test
@@ -8,29 +8,29 @@ RUN: FileCheck %s --input-file %t/cas/v1.log
 RUN: FileCheck %s --input-file %t/cas/v1.log --check-prefix=STANDALONE
 
 
-// CHECK: resize mapped file '{{.*}}v{{[0-9]+}}.index'
-// CHECK: mmap '{{.*}}v{{[0-9]+}}.index' [[INDEX:0x[0-9a-f]+]]
-// CHECK: resize mapped file '{{.*}}v{{[0-9]+}}.data'
-// CHECK: mmap '{{.*}}v{{[0-9]+}}.data' [[DATA:0x[0-9a-f]+]]
-// CHECK: resize mapped file '{{.*}}v{{[0-9]+}}.actions'
-// CHECK: mmap '{{.*}}v{{[0-9]+}}.actions' [[ACTIONS:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}index.v{{[0-9]+}}'
+// CHECK: mmap '{{.*}}index.v{{[0-9]+}}' [[INDEX:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}data.v{{[0-9]+}}'
+// CHECK: mmap '{{.*}}data.v{{[0-9]+}}' [[DATA:0x[0-9a-f]+]]
+// CHECK: resize mapped file '{{.*}}actions.v{{[0-9]+}}'
+// CHECK: mmap '{{.*}}actions.v{{[0-9]+}}' [[ACTIONS:0x[0-9a-f]+]]
 
 // store input/a contents into the datapool
 // CHECK: create record region=[[INDEX]] offset=[[INPUT_A_OFF:0x[0-9a-f]+]] hash=9b096cd140f119
 // CHECK: cmpxcgh subtrie region=[[INDEX]] offset={{.*}} slot={{.*}} expected=0x0 new=[[INPUT_A_OFF]] prev=0x0
 // CHECK: alloc [[DATA]]
 
-// CHECK: resize mapped file '{{.*}}v{{[0-9]+}}.actions'
-// CHECK: close mmap '{{.*}}v{{[0-9]+}}.actions'
-// CHECK: resize mapped file '{{.*}}v{{[0-9]+}}.data'
-// CHECK: close mmap '{{.*}}v{{[0-9]+}}.data'
-// CHECK: resize mapped file '{{.*}}v{{[0-9]+}}.index'
-// CHECK: close mmap '{{.*}}v{{[0-9]+}}.index'
+// CHECK: resize mapped file '{{.*}}actions.v{{[0-9]+}}'
+// CHECK: close mmap '{{.*}}actions.v{{[0-9]+}}'
+// CHECK: resize mapped file '{{.*}}data.v{{[0-9]+}}'
+// CHECK: close mmap '{{.*}}data.v{{[0-9]+}}'
+// CHECK: resize mapped file '{{.*}}index.v{{[0-9]+}}'
+// CHECK: close mmap '{{.*}}index.v{{[0-9]+}}'
 
 // CHECK: validate-if-needed '{{.*}}cas' boot=[[BOOT:[0-9]+]] last-valid=0 check-hash=1 allow-recovery=0 force=0 llvm-cas={{.*}}llvm-cas
 // CHECK: validate-if-needed '{{.*}}cas' boot=[[BOOT]] last-valid=[[BOOT]] check-hash=0 allow-recovery=1 force=1 llvm-cas={{.*}}llvm-cas
 
-// STANDALONE: standalone file create '[[PATH:.*v[0-9]+.[0-9a-f]*.leaf]].[[SUFFIX:[0-9a-f]*]]'
+// STANDALONE: standalone file create '[[PATH:.*leaf.[0-9a-f]*.v[0-9]+]].[[SUFFIX:[0-9a-f]*]]'
 // STANDALONE: standalone file rename '[[PATH]].[[SUFFIX]]' to '[[PATH]]'
 
 //--- input/a

--- a/llvm/test/CAS/validate-if-needed.test
+++ b/llvm/test/CAS/validate-if-needed.test
@@ -1,6 +1,6 @@
 RUN: rm -rf %t && mkdir %t
 RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
-RUN: mv %t/cas/v1.1/v11.data %t/cas/v1.1/v11.data.bak
+RUN: mv %t/cas/v1.1/data.v1 %t/cas/v1.1/data.v1.bak
 
 # INVALID: bad record
 # VALID: validated successfully
@@ -12,7 +12,7 @@ RUN: not llvm-cas --cas %t/cas --validate-if-needed 2>&1 | FileCheck %s -check-p
 RUN: not llvm-cas --cas %t/cas --validate-if-needed 2>&1 | FileCheck %s -check-prefix=INVALID
 
 # Validation happens once per boot.
-RUN: mv %t/cas/v1.1/v11.data.bak %t/cas/v1.1/v11.data
+RUN: mv %t/cas/v1.1/data.v1.bak %t/cas/v1.1/data.v1
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=VALID
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
 # Wrong timestamp triggers re-validation.
@@ -20,7 +20,7 @@ RUN: echo '123' > %t/cas/v1.validation
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=VALID
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
 # Skipped validation does not catch errors.
-RUN: mv %t/cas/v1.1/v11.data %t/cas/v1.1/v11.data.bak
+RUN: mv %t/cas/v1.1/data.v1 %t/cas/v1.1/data.v1.bak
 RUN: llvm-cas --cas %t/cas --validate-if-needed | FileCheck %s -check-prefix=SKIPPED
 
 # Unless forced.
@@ -33,7 +33,7 @@ RUN: llvm-cas --cas %t/cas --validate-if-needed --allow-recovery | FileCheck %s 
 RUN: llvm-cas --cas %t/cas --validate-if-needed --force | FileCheck %s -check-prefix=VALID
 RUN: rm -rf %t/cas/v1.1
 RUN: cp -r %t/cas/corrupt.0.v1.1 %t/cas/v1.1
-RUN: mv %t/cas/v1.1/v11.data %t/cas/v1.1/v11.data.bak
+RUN: mv %t/cas/v1.1/data.v1 %t/cas/v1.1/data.v1.bak
 RUN: llvm-cas --cas %t/cas --validate-if-needed --allow-recovery --force | FileCheck %s -check-prefix=RECOVERED
 RUN: ls %t/cas/corrupt.1.v1.1
 

--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -12,7 +12,7 @@ RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
 RUN: llvm-cas --cas %t/cas --validate
 RUN: llvm-cas --cas %t/cas --validate --check-hash
 
-RUN: rm %t/cas/v1.1/v11.data
+RUN: rm %t/cas/v1.1/data.v1
 RUN: not llvm-cas --cas %t/cas --validate
 RUN: not llvm-cas --cas %t/cas --validate --check-hash
 
@@ -28,5 +28,5 @@ RUN: llvm-cas --cas %t/ac --put-cache-key @%t/abc.casid @%t/empty.casid
 RUN: llvm-cas --cas %t/ac --validate
 # Note: records are 40 bytes (32 hash bytes + 8 byte value), so trim the last
 # allocated record, leaving it invalid.
-RUN: truncate -s -40 %t/ac/v1.1/v6.actions
+RUN: truncate -s -40 %t/ac/v1.1/actions.v1
 RUN: not llvm-cas --cas %t/ac --validate

--- a/llvm/tools/libCASPluginTest/libCASPluginTest.cpp
+++ b/llvm/tools/libCASPluginTest/libCASPluginTest.cpp
@@ -591,7 +591,7 @@ bool llcas_cas_store_object(llcas_cas_t c_cas, llcas_data_t c_data,
 llcas_data_t llcas_loaded_object_get_data(llcas_cas_t c_cas,
                                           llcas_loaded_object_t c_obj) {
   auto &CAS = unwrap(c_cas)->DB->getGraphDB();
-  ondisk::ObjectHandle Obj = ondisk::ObjectHandle::fromOpaqueData(c_obj.opaque);
+  ondisk::ObjectHandle Obj = ondisk::ObjectHandle(c_obj.opaque);
   auto Data = CAS.getObjectData(Obj);
   return llcas_data_t{Data.data(), Data.size()};
 }
@@ -599,7 +599,7 @@ llcas_data_t llcas_loaded_object_get_data(llcas_cas_t c_cas,
 llcas_object_refs_t llcas_loaded_object_get_refs(llcas_cas_t c_cas,
                                                  llcas_loaded_object_t c_obj) {
   auto &CAS = unwrap(c_cas)->DB->getGraphDB();
-  ondisk::ObjectHandle Obj = ondisk::ObjectHandle::fromOpaqueData(c_obj.opaque);
+  ondisk::ObjectHandle Obj = ondisk::ObjectHandle(c_obj.opaque);
   auto Refs = CAS.getObjectRefs(Obj);
   return llcas_object_refs_t{Refs.begin().getOpaqueData(),
                              Refs.end().getOpaqueData()};

--- a/llvm/tools/llvm-cas-test/llvm-cas-test.cpp
+++ b/llvm/tools/llvm-cas-test/llvm-cas-test.cpp
@@ -285,7 +285,7 @@ static int checkLockFiles() {
   ExitOnError ExitOnErr("llvm-cas-test: check-lock-files: ");
 
   SmallString<128> DataPoolPath(CASPath);
-  sys::path::append(DataPoolPath, "v1.1/v11.data");
+  sys::path::append(DataPoolPath, "v1.1/data.v1");
 
   auto OpenCASAndGetDataPoolSize = [&]() -> Expected<uint64_t> {
     auto Result = createOnDiskUnifiedCASDatabases(CASPath);

--- a/llvm/unittests/CAS/ActionCacheTest.cpp
+++ b/llvm/unittests/CAS/ActionCacheTest.cpp
@@ -14,7 +14,7 @@
 #include "llvm/CAS/ActionCache.h"
 #include "CASTestConfig.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Support/FileSystem.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
@@ -74,8 +74,7 @@ TEST_P(CASTest, ActionCacheRewrite) {
   ASSERT_THAT_ERROR(Cache->put(*ID1, *ID1), Succeeded());
 }
 
-#if LLVM_ENABLE_ONDISK_CAS
-TEST(OnDiskActionCache, ActionCacheResultInvalid) {
+TEST_F(OnDiskCASTest, ActionCacheResultInvalid) {
   unittest::TempDir Temp("on-disk-cache", /*Unique=*/true);
   std::unique_ptr<ObjectStore> CAS1 = createInMemoryCAS();
   std::unique_ptr<ObjectStore> CAS2 = createInMemoryCAS();
@@ -85,12 +84,7 @@ TEST(OnDiskActionCache, ActionCacheResultInvalid) {
   ASSERT_THAT_ERROR(CAS1->createProxy({}, "2").moveInto(ID2), Succeeded());
   ASSERT_THAT_ERROR(CAS2->createProxy({}, "1").moveInto(ID3), Succeeded());
 
-#if !defined(LLVM_ENABLE_ONDISK_CAS)
-  // The following won't work without LLVM_ENABLE_ONDISK_CAS enabled.
-  // TODO: enable LLVM_ENABLE_ONDISK_CAS on windows
-  return;
-#endif
-
+#if LLVM_ENABLE_ONDISK_CAS
   std::unique_ptr<ActionCache> Cache1 =
       cantFail(createOnDiskActionCache(Temp.path()));
   // Test put and get.
@@ -109,8 +103,8 @@ TEST(OnDiskActionCache, ActionCacheResultInvalid) {
   ASSERT_FALSE(CAS2->getReference(*Result2));
   // Write a different value will cause error.
   ASSERT_THAT_ERROR(Cache2->put(*ID3, *ID3), Failed());
-}
 #endif
+}
 
 TEST_P(CASTest, ActionCacheAsync) {
   std::shared_ptr<ObjectStore> CAS = createObjectStore();

--- a/llvm/unittests/CAS/BuiltinUnifiedCASDatabasesTest.cpp
+++ b/llvm/unittests/CAS/BuiltinUnifiedCASDatabasesTest.cpp
@@ -1,4 +1,13 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
+#include "CASTestConfig.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Testing/Support/Error.h"
@@ -8,9 +17,7 @@
 using namespace llvm;
 using namespace llvm::cas;
 
-#if LLVM_ENABLE_ONDISK_CAS
-TEST(BuiltinUnifiedCASDatabases,
-     MaterializationCheckPreventsGarbageCollection) {
+TEST_F(OnDiskCASTest, UnifiedCASMaterializationCheckPreventsGarbageCollection) {
   unittest::TempDir Temp("on-disk-unified-cas", /*Unique=*/true);
 
   auto WithCAS = [&](llvm::function_ref<void(ObjectStore &)> Action) {
@@ -58,4 +65,3 @@ TEST(BuiltinUnifiedCASDatabases,
     ASSERT_TRUE(IsMaterialized);
   });
 }
-#endif

--- a/llvm/unittests/CAS/CASConfigurationTest.cpp
+++ b/llvm/unittests/CAS/CASConfigurationTest.cpp
@@ -1,4 +1,4 @@
-//===- CASConfiguration.cpp -----------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/CASFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASFileSystemTest.cpp
@@ -1,4 +1,4 @@
-//===- CASFileSystemTest.cpp ----------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/CASOutputBackendTest.cpp
+++ b/llvm/unittests/CAS/CASOutputBackendTest.cpp
@@ -1,4 +1,4 @@
-//===- CASOutputBackendTest.cpp -------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASProvidingFileSystemTest.cpp
@@ -1,4 +1,4 @@
-//===- CASProvidingFileSystemTest.cpp -------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/CASTestConfig.cpp
+++ b/llvm/unittests/CAS/CASTestConfig.cpp
@@ -1,4 +1,4 @@
-//===- CASTestConfig.cpp --------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,8 +9,10 @@
 #include "CASTestConfig.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/Config/llvm-config.h"
 #include "llvm/RemoteCachingService/RemoteCachingService.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Testing/Support/Error.h"
 #include "gtest/gtest.h"
 #include <mutex>
 

--- a/llvm/unittests/CAS/CASTestConfig.h
+++ b/llvm/unittests/CAS/CASTestConfig.h
@@ -11,7 +11,6 @@
 
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
 #include <memory>
@@ -34,6 +33,16 @@ struct CASTestingEnv {
 
 void setMaxOnDiskCASMappingSize();
 
+// Test fixture for on-disk data base tests.
+class OnDiskCASTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Use a smaller database size for testing to conserve disk space.
+    setMaxOnDiskCASMappingSize();
+  }
+};
+
+// Parametered test fixture for ObjectStore and ActionCache tests.
 class CASTest
     : public testing::TestWithParam<std::function<CASTestingEnv(int)>> {
 protected:

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -1,10 +1,36 @@
-if (LLVM_ENABLE_ONDISK_CAS)
-  add_definitions(-DLLVM_ENABLE_ONDISK_CAS=1)
-endif()
-
 if (LLVM_CAS_ENABLE_REMOTE_CACHE)
   add_definitions(-DLLVM_CAS_ENABLE_REMOTE_CACHE=1)
   set(ADDITIONAL_CAS_TEST_DEPS "RemoteCacheServer")
+endif()
+
+set(ONDISK_CAS_TEST_SOURCES
+  BuiltinUnifiedCASDatabasesTest.cpp
+  CASConfigurationTest.cpp
+  OnDiskCASLoggerTest.cpp
+  OnDiskGraphDBTest.cpp
+  OnDiskDataAllocatorTest.cpp
+  OnDiskKeyValueDBTest.cpp
+  OnDiskTrieRawHashMapTest.cpp
+  PluginCASTest.cpp
+  ProgramTest.cpp
+  UnifiedOnDiskCacheTest.cpp
+  )
+
+set(REMOTE_CACHE_TEST_SOURCES
+  MockGRPCServer.cpp
+  )
+
+set(LLVM_OPTIONAL_SOURCES
+  ${ONDISK_CAS_TEST_SOURCES}
+  ${REMOTE_CACHE_TEST_SOURCES}
+  )
+
+if (NOT LLVM_ENABLE_ONDISK_CAS)
+  unset(ONDISK_CAS_TEST_SOURCES)
+endif()
+
+if (NOT LLVM_CAS_ENABLE_REMOTE_CACHE)
+  unset(REMOTE_CACHE_TEST_SOURCES)
 endif()
 
 set(LLVM_LINK_COMPONENTS
@@ -17,26 +43,18 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(CASTests
   ActionCacheTest.cpp
-  BuiltinUnifiedCASDatabasesTest.cpp
-  CASConfigurationTest.cpp
   CASFileSystemTest.cpp
   CASTestConfig.cpp
   CASOutputBackendTest.cpp
   CASProvidingFileSystemTest.cpp
   CachingOnDiskFileSystemTest.cpp
   HierarchicalTreeBuilderTest.cpp
-  MockGRPCServer.cpp
   ObjectStoreTest.cpp
-  OnDiskCASLoggerTest.cpp
-  OnDiskGraphDBTest.cpp
-  OnDiskDataAllocatorTest.cpp
-  OnDiskKeyValueDBTest.cpp
-  OnDiskTrieRawHashMapTest.cpp
-  PluginCASTest.cpp
-  ProgramTest.cpp
   ThreadSafeAllocatorTest.cpp
   TreeSchemaTest.cpp
-  UnifiedOnDiskCacheTest.cpp
+
+  ${ONDISK_CAS_TEST_SOURCES}
+  ${REMOTE_CACHE_TEST_SOURCES}
   )
 
 target_link_libraries(CASTests PRIVATE LLVMTestingSupport)

--- a/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CachingOnDiskFileSystemTest.cpp
@@ -1,4 +1,4 @@
-//===- CachingOnDiskFileSystemTest.cpp ------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,7 +14,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/StringSaver.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gmock/gmock.h"

--- a/llvm/unittests/CAS/HierarchicalTreeBuilderTest.cpp
+++ b/llvm/unittests/CAS/HierarchicalTreeBuilderTest.cpp
@@ -1,4 +1,4 @@
-//===- HierarchicalTreeBuilderTest.cpp ------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/MockGRPCServer.cpp
+++ b/llvm/unittests/CAS/MockGRPCServer.cpp
@@ -1,4 +1,4 @@
-//===- MockGRPCServer.cpp -------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
+++ b/llvm/unittests/CAS/OnDiskCASLoggerTest.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/CAS/OnDiskCASLoggerTest.cpp --------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -1,8 +1,12 @@
-//===- llvm/unittest/CAS/OnDiskCommonUtils.h --------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file Helper functions to test OnDiskCASDatabases.
 //
 //===----------------------------------------------------------------------===//
 

--- a/llvm/unittests/CAS/OnDiskDataAllocatorTest.cpp
+++ b/llvm/unittests/CAS/OnDiskDataAllocatorTest.cpp
@@ -8,12 +8,9 @@
 
 #include "llvm/CAS/OnDiskDataAllocator.h"
 #include "llvm/CAS/MappedFileRegionArena.h"
-#include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
-
-#if LLVM_ENABLE_ONDISK_CAS
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -51,5 +48,3 @@ TEST(OnDiskDataAllocatorTest, Allocate) {
     ASSERT_LE(Allocator->size(), MB);
   }
 }
-
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/CAS/OnDiskGraphDBTest.cpp ----------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,14 +12,12 @@
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
 
-#if LLVM_ENABLE_ONDISK_CAS
-
 using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::cas::ondisk;
 using namespace llvm::unittest::cas;
 
-TEST(OnDiskGraphDBTest, Basic) {
+TEST_F(OnDiskCASTest, OnDiskGraphDBTest) {
   unittest::TempDir Temp("ondiskcas", /*Unique=*/true);
   std::unique_ptr<OnDiskGraphDB> DB;
   ASSERT_THAT_ERROR(
@@ -81,7 +79,7 @@ TEST(OnDiskGraphDBTest, Basic) {
   EXPECT_EQ(DB->getStorageSize(), StorageSize);
 }
 
-TEST(OnDiskGraphDBTest, FaultInSingleNode) {
+TEST_F(OnDiskCASTest, OnDiskGraphDBFaultInSingleNode) {
   unittest::TempDir TempUpstream("ondiskcas-upstream", /*Unique=*/true);
   std::unique_ptr<OnDiskGraphDB> UpstreamDB;
   ASSERT_THAT_ERROR(
@@ -171,7 +169,7 @@ TEST(OnDiskGraphDBTest, FaultInSingleNode) {
   }
 }
 
-TEST(OnDiskGraphDBTest, FaultInFullTree) {
+TEST_F(OnDiskCASTest, OnDiskGraphDBFaultInFullTree) {
   unittest::TempDir TempUpstream("ondiskcas-upstream", /*Unique=*/true);
   std::unique_ptr<OnDiskGraphDB> UpstreamDB;
   ASSERT_THAT_ERROR(
@@ -255,7 +253,7 @@ TEST(OnDiskGraphDBTest, FaultInFullTree) {
   EXPECT_EQ(PrintedTree, Expected);
 }
 
-TEST(OnDiskGraphDBTest, FaultInPolicyConflict) {
+TEST_F(OnDiskCASTest, OnDiskGraphDBFaultInPolicyConflict) {
   auto tryFaultInPolicyConflict = [](OnDiskGraphDB::FaultInPolicy Policy1,
                                      OnDiskGraphDB::FaultInPolicy Policy2) {
     unittest::TempDir TempUpstream("ondiskcas-upstream", /*Unique=*/true);
@@ -288,7 +286,7 @@ TEST(OnDiskGraphDBTest, FaultInPolicyConflict) {
 }
 
 #if defined(EXPENSIVE_CHECKS)
-TEST(OnDiskGraphDBTest, SpaceLimit) {
+TEST_F(OnDiskCASTest, OnDiskGraphDBSpaceLimit) {
   setMaxOnDiskCASMappingSize();
   unittest::TempDir Temp("ondiskcas", /*Unique=*/true);
   std::unique_ptr<OnDiskGraphDB> DB;
@@ -312,4 +310,3 @@ TEST(OnDiskGraphDBTest, SpaceLimit) {
   EXPECT_GE(DB->getHardStorageLimitUtilization(), 99U);
 }
 #endif
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/unittests/CAS/OnDiskKeyValueDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskKeyValueDBTest.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/CAS/OnDiskKeyValueDBTest.cpp -------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,19 +7,18 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/OnDiskKeyValueDB.h"
+#include "CASTestConfig.h"
 #include "OnDiskCommonUtils.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
-
-#if LLVM_ENABLE_ONDISK_CAS
 
 using namespace llvm;
 using namespace llvm::cas;
 using namespace llvm::cas::ondisk;
 using namespace llvm::unittest::cas;
 
-TEST(OnDiskKeyValueDBTest, Basic) {
+TEST_F(OnDiskCASTest, OnDiskKeyValueDBTest) {
   unittest::TempDir Temp("ondiskkv", /*Unique=*/true);
   std::unique_ptr<OnDiskKeyValueDB> DB;
   ASSERT_THAT_ERROR(OnDiskKeyValueDB::open(Temp.path(), "blake3",
@@ -27,7 +26,6 @@ TEST(OnDiskKeyValueDBTest, Basic) {
                                            sizeof(ValueType))
                         .moveInto(DB),
                     Succeeded());
-
   {
     std::optional<ArrayRef<char>> Val;
     ASSERT_THAT_ERROR(DB->get(digest("hello")).moveInto(Val), Succeeded());
@@ -49,6 +47,31 @@ TEST(OnDiskKeyValueDBTest, Basic) {
     EXPECT_TRUE(Val.has_value());
     EXPECT_EQ(*Val, ArrayRef(ValW));
   }
-}
 
-#endif // LLVM_ENABLE_ONDISK_CAS
+  // Validate
+  {
+    auto ValidateFunc = [](FileOffset Offset, ArrayRef<char> Data) -> Error {
+      EXPECT_EQ(Data.size(), sizeof(ValueType));
+      return Error::success();
+    };
+    ASSERT_THAT_ERROR(DB->validate(ValidateFunc), Succeeded());
+  }
+
+  // Size
+  {
+    size_t InitSize = DB->getStorageSize();
+    unsigned InitPrecent = DB->getHardStorageLimitUtilization();
+
+    // Insert a lot of entries.
+    for (unsigned I = 0; I < 1024 * 100; ++I) {
+      std::string Index = Twine(I).str();
+      ArrayRef<char> Val;
+      ASSERT_THAT_ERROR(
+          DB->put(digest(Index), valueFromString(Index)).moveInto(Val),
+          Succeeded());
+    }
+
+    EXPECT_GT(DB->getStorageSize(), InitSize);
+    EXPECT_GT(DB->getHardStorageLimitUtilization(), InitPrecent);
+  }
+}

--- a/llvm/unittests/CAS/OnDiskTrieRawHashMapTest.cpp
+++ b/llvm/unittests/CAS/OnDiskTrieRawHashMapTest.cpp
@@ -8,17 +8,13 @@
 
 #include "llvm/CAS/OnDiskTrieRawHashMap.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Alignment.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
 
-#if LLVM_ENABLE_ONDISK_CAS
 using namespace llvm;
 using namespace llvm::cas;
-
-namespace {
 
 struct OnDiskTrieRawHashMapTestFixture
     : public ::testing::TestWithParam<size_t> {
@@ -214,7 +210,3 @@ TEST(OnDiskTrieRawHashMapTest, OutOfSpace) {
   ASSERT_THAT_ERROR(Trie->insert({Hash0, Data0v1}).moveInto(Insertion),
                     Failed());
 }
-
-} // namespace
-
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/unittests/CAS/PluginCASTest.cpp
+++ b/llvm/unittests/CAS/PluginCASTest.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/CAS/PluginCASTest.cpp --------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -13,8 +13,6 @@
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
-
-#if LLVM_ENABLE_ONDISK_CAS
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -104,5 +102,3 @@ TEST(PluginCASTest, isMaterialized) {
     EXPECT_TRUE(IsMaterialized);
   }
 }
-
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/unittests/CAS/ProgramTest.cpp
+++ b/llvm/unittests/CAS/ProgramTest.cpp
@@ -8,7 +8,6 @@
 
 #include "llvm/Support/Program.h"
 #include "llvm/CAS/MappedFileRegionArena.h"
-#include "llvm/Config/llvm-config.h"
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/ExponentialBackoff.h"
 #include "llvm/Support/FileSystem.h"
@@ -25,8 +24,6 @@ extern char **environ;
 
 using namespace llvm;
 using namespace llvm::cas;
-
-#if LLVM_ENABLE_ONDISK_CAS
 
 extern const char *TestMainArgv0;
 static char ProgramID = 0;
@@ -241,5 +238,3 @@ TEST_F(CASProgramTest, MappedFileRegionArenaSizeTest) {
   sys::fs::remove(FilePath);
   sys::fs::remove_directories(sys::path::parent_path(FilePath));
 }
-
-#endif // LLVM_ENABLE_ONDISK_CAS

--- a/llvm/unittests/CAS/ThreadSafeAllocatorTest.cpp
+++ b/llvm/unittests/CAS/ThreadSafeAllocatorTest.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/CAS/ThreadSafeAllocatorTest.cpp ----------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/llvm/unittests/CAS/TreeSchemaTest.cpp
+++ b/llvm/unittests/CAS/TreeSchemaTest.cpp
@@ -1,4 +1,4 @@
-//===- TreeSchemaTest.cpp -------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,10 +9,7 @@
 #include "llvm/CAS/TreeSchema.h"
 #include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/Config/llvm-config.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Testing/Support/Error.h"
-#include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
 
 using namespace llvm;

--- a/llvm/unittests/CAS/UnifiedOnDiskCacheTest.cpp
+++ b/llvm/unittests/CAS/UnifiedOnDiskCacheTest.cpp
@@ -1,4 +1,4 @@
-//===- llvm/unittest/CAS/UnifiedOnDiskCacheTest.cpp -----------------------===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,12 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/UnifiedOnDiskCache.h"
+#include "CASTestConfig.h"
 #include "OnDiskCommonUtils.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
-
-#if LLVM_ENABLE_ONDISK_CAS
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -43,7 +42,7 @@ static Expected<size_t> countFileSizes(StringRef Path) {
   return TotalSize;
 }
 
-TEST(UnifiedOnDiskCacheTest, Basic) {
+TEST_F(OnDiskCASTest, UnifiedOnDiskCacheTest) {
   unittest::TempDir Temp("ondisk-unified", /*Unique=*/true);
   std::unique_ptr<UnifiedOnDiskCache> UniDB;
 
@@ -190,5 +189,3 @@ TEST(UnifiedOnDiskCacheTest, Basic) {
     EXPECT_FALSE(Val.has_value());
   }
 }
-
-#endif // LLVM_ENABLE_ONDISK_CAS


### PR DESCRIPTION
Cleanup for code upstreaming. Noticeable changes:
    * Hide some forward declared typesA.
    * Rename all the database files and use a unified version across index
      and dabasefile. This allows reset the version while not introduce
      downstream incompatibility.
    * Change unit-test to properly set a smaller file size and just not
      building OnDiskCAS test