### PR TITLE
[lldb] Fix assertion caused by invalid SupportFileSP (#162710)

### DIFF
--- a/lldb/source/Symbol/Function.cpp
+++ b/lldb/source/Symbol/Function.cpp
@@ -280,7 +280,7 @@ Function::~Function() = default;
 void Function::GetStartLineSourceInfo(SupportFileSP &source_file_sp,
                                       uint32_t &line_no) {
   line_no = 0;
-  source_file_sp.reset();
+  source_file_sp = std::make_shared<SupportFile>();
 
   if (m_comp_unit == nullptr)
     return;


### PR DESCRIPTION
SupportFileSP should never be null, and instead should use a default constructed SupportFile to represent an invalid instance. This is because the class used to be a value type before it became polymorphic.

We have various places in LLDB where we check this precondition, including in DisplaySourceLinesWithLineNumbers. The assertion was tripped when calling GetStartLineSourceInfo which starts by resetting the SupportFileSP and has a series of early returns which leave the shared pointer in that state.

rdar://161607247
(cherry picked from commit eb06c7e7d25da30dd611812a9bec56bf5c3f5ac3)