### PR TITLE
🍒 [BoundsSafety] Re-introduce `-funique-traps` as a legacy alias of `-fbounds-safety-unique-traps`

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2025,14 +2025,26 @@ def fno_bounds_safety_bringup_missing_checks : Flag<["-"], "fno-bounds-safety-br
 
 defm bounds_safety_unique_traps : BoolFOption<"bounds-safety-unique-traps",
   CodeGenOpts<"BoundsSafetyUniqueTraps">, DefaultFalse,
-  PosFlag<SetTrue, [], [CC1Option],
+  PosFlag<SetTrue, [], [ClangOption, CC1Option],
     "Make trap instructions unique by preventing traps from being merged by the"
     " optimizer. This is useful for preserving the debug information on traps "
     "in optimized code. This makes it easier to debug programs at the cost of "
     "increased code size">,
-  NegFlag<SetFalse, [], [CC1Option],
+  NegFlag<SetFalse, [], [ClangOption, CC1Option],
     "Don't try to make trap instructions unique. This allows trap instructions "
     "to be merged by the optimizer.">>;
+
+// Legacy aliases
+// TODO(dliew): Remove these (rdar://162215869).
+// This isn't declared using `Alias<fbounds_safety_unique_traps>` because that
+// prevents identifying that this flag as distinct from
+// `fbounds_safety_unique_traps`.
+defm bounds_safety_legacy_unique_traps : BoolOptionWithoutMarshalling<"f", "unique-traps",
+  PosFlag<SetTrue, [], [ClangOption],
+    "legacy alias for -fbounds-safety-unique-traps">,
+  NegFlag<SetFalse, [], [ClangOption],
+    "legacy alias for -fno-bounds-safety-unique-traps">>;
+
 // TO_UPSTREAM(BoundsSafety) OFF
 
 defm lifetime_safety : BoolFOption<

--- a/clang/test/BoundsSafety/Driver/unique-traps-legacy-flag.c
+++ b/clang/test/BoundsSafety/Driver/unique-traps-legacy-flag.c
@@ -1,0 +1,20 @@
+// Simple use of legacy flag
+// RUN: %clang -fbounds-safety -funique-traps -### %s 2>&1 | FileCheck --check-prefix=POS %s
+// RUN: %clang -fbounds-safety -fno-unique-traps -### %s 2>&1 | FileCheck --check-prefix=NEG %s
+
+// Mix legacy flag with new flag
+// RUN: %clang -fbounds-safety -funique-traps -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=POS %s
+// RUN: %clang -fbounds-safety -fno-unique-traps -fbounds-safety-unique-traps  -### %s 2>&1 | FileCheck --check-prefix=NEG %s
+
+// Last legacy flag wins for warning
+// RUN: %clang -fbounds-safety -funique-traps -fno-unique-traps -funique-traps  -### %s 2>&1 | FileCheck --check-prefix=POS %s
+// RUN: %clang -fbounds-safety -funique-traps -fno-unique-traps -### %s 2>&1 | FileCheck --check-prefix=NEG %s
+
+// No warning
+// RUN: %clang -fbounds-safety -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=NONE %s
+// RUN: %clang -fbounds-safety -fno-bounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=NONE %s
+// RUN: %clang -fbounds-safety -### %s 2>&1 | FileCheck --check-prefix=NONE %s
+
+// POS: warning: argument '-funique-traps' is deprecated, use 'fbounds-safety-unique-traps' instead [-Wdeprecated]
+// NEG: warning: argument '-fno-unique-traps' is deprecated, use 'fno-bounds-safety-unique-traps' instead [-Wdeprecated]
+// NONE-NOT: warning: argument '-f{{(no-)?}}unique-traps' is deprecated

--- a/clang/test/BoundsSafety/Driver/unique-traps.c
+++ b/clang/test/BoundsSafety/Driver/unique-traps.c
@@ -1,0 +1,38 @@
+// RUN: %clang -fbounds-safety -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+
+// Simple use of new flag
+// RUN: %clang -fbounds-safety -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+// RUN: %clang -fbounds-safety -fno-bounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+
+// New flag used multiple times
+// RUN: %clang -fbounds-safety -fbounds-safety-unique-traps -fno-bounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+// RUN: %clang -fbounds-safety -fno-bounds-safety-unique-traps -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+// RUN: %clang -fbounds-safety -fbounds-safety-unique-traps -fno-bounds-safety-unique-traps -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+// RUN: %clang -fbounds-safety -fno-bounds-safety-unique-traps -fbounds-safety-unique-traps -fno-bounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+
+// Simple use of legacy flag
+// RUN: %clang -fbounds-safety -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+// RUN: %clang -fbounds-safety -fno-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+
+// Legacy flag used multiple times
+// RUN: %clang -fbounds-safety -funique-traps -fno-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+// RUN: %clang -fbounds-safety -fno-unique-traps -funique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+// RUN: %clang -fbounds-safety -funique-traps -fno-unique-traps -funique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+// RUN: %clang -fbounds-safety -fno-unique-traps -funique-traps -fno-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+
+// Mixed use of legacy and new flag
+// RUN: %clang -fbounds-safety -funique-traps -fno-bounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+// RUN: %clang -fbounds-safety -funique-traps -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+
+// RUN: %clang -fbounds-safety -fno-unique-traps -fno-bounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+// RUN: %clang -fbounds-safety -fno-unique-traps -fbounds-safety-unique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+
+// RUN: %clang -fbounds-safety -fbounds-safety-unique-traps -fno-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+// RUN: %clang -fbounds-safety -fbounds-safety-unique-traps -funique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+
+// RUN: %clang -fbounds-safety -fno-bounds-safety-unique-traps -fno-unique-traps -### %s 2>&1 | FileCheck --check-prefix=DISABLED %s
+// RUN: %clang -fbounds-safety -fno-bounds-safety-unique-traps -funique-traps -### %s 2>&1 | FileCheck --check-prefix=ENABLED %s
+
+
+// ENABLED: -fbounds-safety-unique-traps
+// DISABLED-NOT: -fbounds-safety-unique-traps


### PR DESCRIPTION
In rdar://158088410
(https://github.com/swiftlang/llvm-project/pull/11455) the `-funique-traps` flag was removed in favor of a different implementation controlled by the `-fbounds-safety-unique-traps` flag.

It turns out the `-funique-traps` flag is being used by an adopter of `-fbounds-safety`. To unbreak adopters of the flag this patch reintroduces the old flag (and its negation) as an alias of
`-fbounds-safety-unique-traps` (`-fno-bounds-safety-unique-traps`) along with a diagnostic warning that `-funique-traps` (`-fno-unique-traps`) is deprecated.

This patch doesn't use the `Alias<>` mixin in the
`clang/Driver/Options.td` so "technically" at the implementation level `-funique-traps` isn't an alias of `-fbounds-safety-unique-traps`. This is done so that is possible distinguish use of the legacy flag from the new flag so that it is possible emit a deprecation warning. However, from the user's perspective `-funique-traps` and
`-fbounds-safety-unique-traps` are aliases.

We should remove `-funique-traps` eventually and that is tracked by rdar://162215869.

rdar://162204734
(cherry picked from commit 38b7776a1170235645399006b5fa1e471901b532)