### PR TITLE
🍒[lldb][test] Don't run libc++ API tests without a locally built libc++

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -786,6 +786,10 @@ def canRunLibcxxTests():
         return True, "libc++ always present"
 
     if platform == "linux":
+        if not configuration.libcxx_include_dir or not configuration.libcxx_library_dir:
+            return False, "API tests require a locally built libc++."
+
+        # Make sure -stdlib=libc++ works since that's how the tests will be built.
         with tempfile.NamedTemporaryFile() as f:
             cmd = [configuration.compiler, "-xc++", "-stdlib=libc++", "-o", f.name, "-"]
             p = subprocess.Popen(


### PR DESCRIPTION
API tests in the `libc++` category will try their best to build against a locally built libc++. If none exists, the `Makefile.rules` currently fall back to using the system libc++.

The issue with falling back to the system libc++ is that we are now potentially not testing what we intended to. But we also can't rely on certain libc++ features being available that the tests are trying to use. On Apple platforms this is a configuration error (because libc++ is the only stdlib supported), but we can't make it an error on Linux because a user might want to run the API tests with libstdc++.

The Ubunutu 22.04 bots on the Apple fork are failing to run following tests are failing:
* `TestLibcxxInternalsRecognizer.py`
* `TestDataFormatterStdRangesRefView.py` because the system stdlib doesn't have `std::ranges` support yet. And the tests just fail to build. Building libc++ on those bots is also not possible because the system compiler is too old (and the Apple fork builds all the subprojects standalone, so it requires the system compiler).

This patch marks tests in the `libc++` category as `UNSUPPORTED` if no local libc++ is available.

The downside is that we will inevitably lose coverage on bots that were running these tests without a local libc++. Arguably those weren't really testing the right thing. But for vendors with LLDB forks it might have been useful to at least know that the tests on the fork don't fail against the system libc++.

Confirmed that the libc++ pre-merge CI still runs these tests (since it uses the explicit `--category libc++` dotest flag). Also confirmed that LLDB pre-merge CI runs the tests (because it builds `libcxx` locally).

**Workaround**

If you do need want to run libc++ tests against the system stdlib, you can invoke `lldb-dotest` with the `--category libc++` flag:
```
./path/to/build/lldb-dotest --category libc++

OR

./path/to/build/bin/llvm-lit -sv --param dotest-args='--category libc++' "/path/to/monorepo/lldb/test/API
```

rdar://136231390
(cherry picked from commit 4188e18a5b0746e1aecee827551934a981848898)