### PR TITLE
[lldb] Use the correct Wasm register context (#162942)

### DIFF
--- a/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
+++ b/lldb/source/Plugins/Process/wasm/RegisterContextWasm.cpp
@@ -22,7 +22,7 @@ using namespace lldb_private::process_gdb_remote;
 using namespace lldb_private::wasm;
 
 RegisterContextWasm::RegisterContextWasm(
-    wasm::ThreadWasm &thread, uint32_t concrete_frame_idx,
+    ThreadGDBRemote &thread, uint32_t concrete_frame_idx,
     GDBRemoteDynamicRegisterInfoSP reg_info_sp)
     : GDBRemoteRegisterContext(thread, concrete_frame_idx, reg_info_sp, false,
                                false) {}

--- a/lldb/source/Plugins/Process/wasm/RegisterContextWasm.h
+++ b/lldb/source/Plugins/Process/wasm/RegisterContextWasm.h
@@ -10,6 +10,7 @@
 #define LLDB_SOURCE_PLUGINS_PROCESS_WASM_REGISTERCONTEXTWASM_H
 
 #include "Plugins/Process/gdb-remote/GDBRemoteRegisterContext.h"
+#include "Plugins/Process/gdb-remote/ThreadGDBRemote.h"
 #include "ThreadWasm.h"
 #include "Utility/WasmVirtualRegisters.h"
 #include "lldb/lldb-private-types.h"
@@ -34,7 +35,7 @@ class RegisterContextWasm
     : public process_gdb_remote::GDBRemoteRegisterContext {
 public:
   RegisterContextWasm(
-      wasm::ThreadWasm &thread, uint32_t concrete_frame_idx,
+      process_gdb_remote::ThreadGDBRemote &thread, uint32_t concrete_frame_idx,
       process_gdb_remote::GDBRemoteDynamicRegisterInfoSP reg_info_sp);
 
   ~RegisterContextWasm() override;


### PR DESCRIPTION
When implementing the WebAssembly Process Plugin, I initially added WasmGDBRemoteRegisterContext as a placeholder in the UnwindWasm TU.

After implementing RegisterContextWasm (#151056), I forgot to switch over to the new implementation. This meant we were using the wrong register context for all frames, except frame 0. The register context deals with the virtual registers, so this only becomes an issue when trying to evaluate a `DW_OP_WASM_location`, which is why this went unnoticed.

This PR removes the WasmGDBRemoteRegisterContext placeholder and updates UnwindWasm to use RegisterContextWasm instead for all frames.

In terms of testing, I considered updating TestWasm but that would require adding even more state to the already complicated GDB stub. This doesn't scale and my focus over the next weeks/months will be coming up with a comprehensive testing strategy that involves running (a subset of the) API tests under a Wasm runtime, which will cover this and much more.

rdar://159297244
(cherry picked from commit 14a7c8a741678766953fb5c14acec3fe301f48e1)