### PR TITLE
[stable/21.x][CAS] Move CASConfiguration into LLVM

### DIFF
--- a/llvm/include/llvm/CAS/CASConfiguration.h
+++ b/llvm/include/llvm/CAS/CASConfiguration.h
@@ -1,0 +1,79 @@
+//===- CASOptions.h - Options for configuring the CAS -----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Defines the llvm::cas::CASConfiguration interface.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_CASCONFIGURATION_H
+#define LLVM_CAS_CASCONFIGURATION_H
+
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include <string>
+#include <vector>
+
+namespace llvm::cas {
+
+class ActionCache;
+class ObjectStore;
+
+/// Base class for options configuring which CAS to use.
+class CASConfiguration {
+public:
+  /// Path to a persistent backing store on-disk.
+  ///
+  /// - "" means there is none; falls back to in-memory.
+  /// - "auto" is an alias for an automatically chosen location in the user's
+  ///   system cache.
+  std::string CASPath;
+  /// Path to the CAS plugin library.
+  std::string PluginPath;
+  /// Each entry is a (<option-name>, <value>) pair.
+  std::vector<std::pair<std::string, std::string>> PluginOptions;
+
+  friend bool operator==(const CASConfiguration &LHS,
+                         const CASConfiguration &RHS) {
+    return LHS.CASPath == RHS.CASPath && LHS.PluginPath == RHS.PluginPath &&
+           LHS.PluginOptions == RHS.PluginOptions;
+  }
+  friend bool operator!=(const CASConfiguration &LHS,
+                         const CASConfiguration &RHS) {
+    return !(LHS == RHS);
+  }
+
+  // Get resolved CASPath.
+  void getResolvedCASPath(llvm::SmallVectorImpl<char> &Result) const;
+
+  // Create CASDatabase from the CASConfiguration.
+  llvm::Expected<std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+                           std::shared_ptr<llvm::cas::ActionCache>>>
+  createDatabases() const;
+
+  /// Write CAS configuration file.
+  void writeConfigurationFile(raw_ostream &OS) const;
+
+  /// Create CASConfiguration from config file content.
+  static llvm::Expected<CASConfiguration>
+  createFromConfig(llvm::StringRef Content);
+
+  /// Create CASConfiguration from recurively search config file from a path.
+  ///
+  /// Returns the path to configuration file and its corresponding
+  /// CASConfiguration.
+  static std::optional<std::pair<std::string, CASConfiguration>>
+  createFromSearchConfigFile(
+      StringRef Path,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr);
+};
+
+} // namespace llvm::cas
+
+#endif

--- a/llvm/lib/CAS/CASConfiguration.cpp
+++ b/llvm/lib/CAS/CASConfiguration.cpp
@@ -1,0 +1,122 @@
+//===- CASConfiguration.cpp -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/CASConfiguration.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/JSON.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+void CASConfiguration::getResolvedCASPath(
+    llvm::SmallVectorImpl<char> &Result) const {
+  if (CASPath == "auto") {
+    getDefaultOnDiskCASPath(Result);
+  } else {
+    Result.assign(CASPath.begin(), CASPath.end());
+  }
+}
+
+Expected<std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
+CASConfiguration::createDatabases() const {
+  if (!PluginPath.empty())
+    return createPluginCASDatabases(PluginPath, CASPath, PluginOptions);
+
+  if (CASPath.empty()) {
+    return std::pair(createInMemoryCAS(), createInMemoryActionCache());
+  }
+
+  SmallString<128> PathBuf;
+  getResolvedCASPath(PathBuf);
+
+  std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>> DBs;
+  return createOnDiskUnifiedCASDatabases(PathBuf);
+}
+
+void CASConfiguration::writeConfigurationFile(raw_ostream &OS) const {
+  using namespace llvm::json;
+  Object Root;
+  Root["CASPath"] = CASPath;
+  Root["PluginPath"] = PluginPath;
+
+  Array PlugOpts;
+  for (const auto &Opt : PluginOptions) {
+    Object Entry;
+    Entry[Opt.first] = Opt.second;
+    PlugOpts.emplace_back(std::move(Entry));
+  }
+  Root["PluginOptions"] = std::move(PlugOpts);
+
+  OS << formatv("{0:2}", Value(std::move(Root)));
+}
+
+Expected<CASConfiguration>
+CASConfiguration::createFromConfig(StringRef Content) {
+  auto Parsed = json::parse(Content);
+  if (!Parsed)
+    return Parsed.takeError();
+
+  CASConfiguration Config;
+  auto *Root = Parsed->getAsObject();
+  if (!Root)
+    return createStringError(
+        "CASConfiguration file error: top level object missing");
+
+  if (auto CASPath = Root->getString("CASPath"))
+    Config.CASPath = *CASPath;
+
+  if (auto PluginPath = Root->getString("PluginPath"))
+    Config.PluginPath = *PluginPath;
+
+  if (auto *Opts = Root->getArray("PluginOptions")) {
+    for (auto &Opt : *Opts) {
+      if (auto *Arg = Opt.getAsObject()) {
+        for (auto &Entry : *Arg) {
+          if (auto V = Entry.second.getAsString())
+            Config.PluginOptions.emplace_back(Entry.first.str(), *V);
+        }
+      }
+    }
+  }
+
+  return Config;
+}
+
+std::optional<std::pair<std::string, CASConfiguration>>
+CASConfiguration::createFromSearchConfigFile(
+    StringRef Path, IntrusiveRefCntPtr<vfs::FileSystem> VFS) {
+  if (!VFS)
+    VFS = vfs::getRealFileSystem();
+
+  while (!Path.empty()) {
+    SmallString<256> ConfigPath(Path);
+    sys::path::append(ConfigPath, ".cas-config");
+    auto File = VFS->openFileForRead(ConfigPath);
+    if (!File || !*File) {
+      Path = sys::path::parent_path(Path);
+      continue;
+    }
+
+    auto Buffer = (*File)->getBuffer(ConfigPath);
+    if (!Buffer || !*Buffer) {
+      Path = sys::path::parent_path(Path);
+      continue;
+    }
+
+    auto Config = createFromConfig((*Buffer)->getBuffer());
+    if (!Config) {
+      consumeError(Config.takeError());
+      Path = sys::path::parent_path(Path);
+      continue;
+    }
+    return std::pair{ConfigPath.str().str(), *Config};
+  }
+  return std::nullopt;
+}

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -7,6 +7,7 @@ add_llvm_component_library(LLVMCAS
   ActionCaches.cpp
   BuiltinCAS.cpp
   BuiltinUnifiedCASDatabases.cpp
+  CASConfiguration.cpp
   CASFileSystem.cpp
   CASNodeSchema.cpp
   CASOutputBackend.cpp

--- a/llvm/unittests/CAS/CASConfigurationTest.cpp
+++ b/llvm/unittests/CAS/CASConfigurationTest.cpp
@@ -1,0 +1,63 @@
+//===- CASConfiguration.cpp -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/CASConfiguration.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+TEST(CASConfigurationTest, roundTrips) {
+  auto roundTripConfig = [](CASConfiguration &Config) {
+    std::string Serialized;
+    raw_string_ostream OS(Serialized);
+    Config.writeConfigurationFile(OS);
+
+    std::optional<CASConfiguration> NewConfig;
+    ASSERT_THAT_ERROR(
+        CASConfiguration::createFromConfig(Serialized).moveInto(NewConfig),
+        Succeeded());
+    ASSERT_TRUE(Config == *NewConfig);
+  };
+
+  CASConfiguration Config;
+  roundTripConfig(Config);
+
+  Config.CASPath = "/tmp";
+  roundTripConfig(Config);
+
+  Config.PluginPath = "/test.plug";
+  roundTripConfig(Config);
+
+  Config.PluginOptions.emplace_back("a", "b");
+  roundTripConfig(Config);
+
+  Config.PluginOptions.emplace_back("c", "d");
+  roundTripConfig(Config);
+}
+
+TEST(CASConfigurationTest, configFileSearch) {
+  auto VFS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  ASSERT_FALSE(CASConfiguration::createFromSearchConfigFile("/a/b/c/d/e", VFS));
+
+  // Add an empty file.
+  VFS->addFile("/a/b/c/.cas-config", 0,
+               llvm::MemoryBuffer::getMemBufferCopy(""));
+  ASSERT_FALSE(CASConfiguration::createFromSearchConfigFile("/a/b/c/d/e", VFS));
+
+  VFS->addFile("/a/b/c/d/.cas-config", 0,
+               llvm::MemoryBuffer::getMemBufferCopy("{\"CASPath\": \"/tmp\"}"));
+  CASConfiguration Config;
+  Config.CASPath = "/tmp";
+  auto NewConfig =
+      CASConfiguration::createFromSearchConfigFile("/a/b/c/d/e", VFS);
+  ASSERT_TRUE(NewConfig);
+  ASSERT_TRUE(NewConfig->first == "/a/b/c/d/.cas-config");
+  ASSERT_TRUE(Config == NewConfig->second);
+}

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_unittest(CASTests
   ActionCacheTest.cpp
   BuiltinUnifiedCASDatabasesTest.cpp
+  CASConfigurationTest.cpp
   CASFileSystemTest.cpp
   CASTestConfig.cpp
   CASOutputBackendTest.cpp


### PR DESCRIPTION
Move CASConfiguration into LLVM and add a JSON based configuration file to help constructing CAS from init file `.cas-config`.

This is so that tools like lldb/dsymutil can be CAS aware without user explicitly providing the CAS path when invoking the tool.