### PR TITLE
[LLDB] Add progress updates for reflection metadata loading

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -105,6 +105,12 @@ public:
   /// Returns whether the filecache optimization is enabled or not.
   bool readMetadataFromFileCacheEnabled() const;
 
+  /// Set or clear the progress callback.
+  void SetProgressCallback(
+      std::function<void(llvm::StringRef)> progress_callback = {}) {
+    m_progress_callback = progress_callback;
+  }
+
 protected:
   bool readRemoteAddressImpl(swift::remote::RemoteAddress address,
                              swift::remote::RemoteAddress &out,
@@ -166,6 +172,8 @@ private:
   /// The set of modules where we should read memory from the symbol file's
   /// object file instead of the main object file.
   llvm::SmallSet<lldb::ModuleSP, 8> m_modules_with_metadata_in_symbol_obj_file;
+  /// A callback to update a progress event.
+  std::function<void(llvm::StringRef)> m_progress_callback;
 };
 } // namespace lldb_private
 #endif

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -41,6 +41,7 @@ class TestSwiftProgressReporting(TestBase):
             "Importing dependencies for main.swift",
             "Importing dependencies for main.swift: Foundation",
             "Importing Swift standard library",
+            "Loading reflection metadata",
         ]
 
         importing_swift_reports = []


### PR DESCRIPTION
When debugging locally, parsing reflection metadata is instant. But when debugging over a slow network connection the amount of memory read packets being sent back and forth can indtroduce significan delays. To meake is easier to diagnose why an operation is stalling and to provide users with feedback about what LDB is doing this patch introduces a progress update in GetSwiftRuntimTypeInfo().

LLDB only publishes at meast 1 progress event every 20ms, so this is (visually) and performance-wise a noop wehen debugging locally.