### PR TITLE
[CASFS] Fix `FileWithFixedStatus` after CASFS refactoring #11235

### DIFF
--- a/clang/include/clang/Basic/FileManager.h
+++ b/clang/include/clang/Basic/FileManager.h
@@ -274,7 +274,7 @@ public:
   /// for its contents if supported by the file system, and then closes the
   /// file. If both the buffer and its `cas::ObjectRef` are needed use \p
   /// getBufferForFile to avoid the extra file lookup.
-  llvm::ErrorOr<std::optional<cas::ObjectRef>>
+  llvm::ErrorOr<cas::ObjectRef>
   getObjectRefForFileContent(const Twine &Filename);
 
 private:

--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -580,17 +580,17 @@ FileManager::getBufferForFileImpl(StringRef Filename, int64_t FileSize,
   return getBufferImpl(FilePath);
 }
 
-llvm::ErrorOr<std::optional<cas::ObjectRef>>
+llvm::ErrorOr<cas::ObjectRef>
 FileManager::getObjectRefForFileContent(const Twine &Filename) {
   auto getObjectRefImpl =
-      [&](const Twine &Name) -> llvm::ErrorOr<std::optional<cas::ObjectRef>> {
+      [&](const Twine &Name) -> llvm::ErrorOr<cas::ObjectRef> {
     auto F = FS->openFileForRead(Name);
     if (!F)
       return F.getError();
 
     auto *CASFile = dyn_cast<llvm::cas::CASBackedFile>(F->get());
     if (!CASFile)
-      return std::nullopt;
+      return std::make_error_code(std::errc::not_supported);
 
     return CASFile->getObjectRefForContent();
   };

--- a/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/Tooling/DependencyScanning/IncludeTreeActionController.cpp
@@ -701,7 +701,7 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
     if (PPOpts.ImplicitPCHInclude.empty())
       return Error::success(); // no need for additional work.
 
-    llvm::ErrorOr<std::optional<cas::ObjectRef>> CASContents =
+    llvm::ErrorOr<cas::ObjectRef> CASContents =
         FM.getObjectRefForFileContent(PPOpts.ImplicitPCHInclude);
     if (!CASContents)
       return llvm::errorCodeToError(CASContents.getError());
@@ -711,7 +711,7 @@ IncludeTreeBuilder::finishIncludeTree(CompilerInstance &ScanInstance,
       PCHFilename = PPOpts.ImplicitPCHInclude;
 
     auto PCHFile =
-        cas::IncludeTree::File::create(DB, PCHFilename, **CASContents);
+        cas::IncludeTree::File::create(DB, PCHFilename, *CASContents);
     if (!PCHFile)
       return PCHFile.takeError();
     PCHRef = PCHFile->getRef();
@@ -898,15 +898,14 @@ Expected<cas::ObjectRef> IncludeTreeBuilder::addToFileList(FileManager &FM,
     Filename = PathStorage;
   }
 
-  llvm::ErrorOr<std::optional<cas::ObjectRef>> CASContents =
+  llvm::ErrorOr<cas::ObjectRef> CASContents =
       FM.getObjectRefForFileContent(Filename);
   if (!CASContents)
     return llvm::errorCodeToError(CASContents.getError());
-  assert(*CASContents);
 
   auto addFile = [&](StringRef Filename) -> Expected<cas::ObjectRef> {
     assert(!Filename.empty());
-    auto FileNode = createIncludeFile(Filename, **CASContents);
+    auto FileNode = createIncludeFile(Filename, *CASContents);
     if (!FileNode)
       return FileNode.takeError();
     IncludedFiles.push_back(

--- a/clang/test/ClangScanDeps/include-tree-vfs-overlay.c
+++ b/clang/test/ClangScanDeps/include-tree-vfs-overlay.c
@@ -1,0 +1,36 @@
+// REQUIRES: ondisk_cas
+
+// This is a reduced test for https://github.com/swiftlang/llvm-project/issues/11616
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed -e "s|DIR|%/t|g" %t/vfs-overlay.yaml.template > %t/vfs-overlay.yaml
+
+// RUN: %clang -I%t -fdepscan=inline -fdepscan-include-tree -Xclang -fcas-path -Xclang %t/cas -Xclang -ivfsoverlay -Xclang %t/vfs-overlay.yaml -c %t/test.c
+
+//--- test.c
+#include "header.h"
+#include "header1.h"
+
+//--- header.h
+
+//--- header2.h
+
+//--- header3.h
+
+//--- vfs-overlay.yaml.template
+version: 0
+case-sensitive: false
+roots:
+  - name: "DIR"
+    type: directory
+    contents:
+      - name: header.h
+        type: file
+        external-contents: "DIR/header.h"
+      - name: header1.h
+        type: file
+        external-contents: "DIR/header2.h"
+      - name: header2.h
+        type: file
+        external-contents: "DIR/header3.h"

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -14,7 +14,6 @@
 using namespace llvm;
 using namespace llvm::cas;
 
-const char CASBackedFile::ID = 0;
 const char CASBackedFileSystem::ID = 0;
 
 llvm::Expected<std::pair<std::unique_ptr<llvm::MemoryBuffer>, cas::ObjectRef>>

--- a/llvm/lib/Support/VirtualFileSystem.cpp
+++ b/llvm/lib/Support/VirtualFileSystem.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/Twine.h"
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/CAS/CASReference.h"
+#include "llvm/CAS/CASFileSystem.h"
 #include "llvm/Config/llvm-config.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Chrono.h"
@@ -2540,6 +2541,33 @@ public:
   void setPath(const Twine &Path) override { S = S.copyWithNewName(S, Path); }
 };
 
+
+class CASFileWithFixedStatus : public cas::CASBackedFile {
+  std::unique_ptr<cas::CASBackedFile> InnerFile;
+  Status S;
+
+public:
+  CASFileWithFixedStatus(std::unique_ptr<CASBackedFile> InnerFile, Status S)
+      : InnerFile(std::move(InnerFile)), S(std::move(S)) {}
+
+  ErrorOr<Status> status() override { return S; }
+  ErrorOr<std::unique_ptr<llvm::MemoryBuffer>>
+
+  getBuffer(const Twine &Name, int64_t FileSize, bool RequiresNullTerminator,
+            bool IsVolatile) override {
+    return InnerFile->getBuffer(Name, FileSize, RequiresNullTerminator,
+                                IsVolatile);
+  }
+
+  std::error_code close() override { return InnerFile->close(); }
+
+  void setPath(const Twine &Path) override { S = S.copyWithNewName(S, Path); }
+
+  cas::ObjectRef getObjectRefForContent() override {
+    return InnerFile->getObjectRefForContent();
+  }
+};
+
 } // namespace
 
 ErrorOr<std::unique_ptr<File>>
@@ -2613,6 +2641,12 @@ RedirectingFileSystem::openFileForRead(const Twine &OriginalPath) {
   // replace the underlying path if the external name is being used.
   Status S = getRedirectedFileStatus(
       OriginalPath, RE->useExternalName(UseExternalNames), *ExternalStatus);
+
+  if (std::unique_ptr<cas::CASBackedFile> CASFile =
+          dyn_cast<cas::CASBackedFile>(*ExternalFile)) {
+    return std::unique_ptr<File>(
+        std::make_unique<CASFileWithFixedStatus>(std::move(CASFile), S));
+  }
   return std::unique_ptr<File>(
       std::make_unique<FileWithFixedStatus>(std::move(*ExternalFile), S));
 }
@@ -2987,3 +3021,7 @@ const char ProxyFileSystem::ID = 0;
 const char InMemoryFileSystem::ID = 0;
 const char RedirectingFileSystem::ID = 0;
 const char TracingFileSystem::ID = 0;
+
+// FIXME: Temporarily put the CASBackedFile::ID in Support library to workaround
+// the layer issue that `dyn_cast` check for the type needs to happen here.
+const char cas::CASBackedFile::ID = 0;


### PR DESCRIPTION
Add CASFileWithFixedStatus to keep CAS references when fetching VFS overlayed file from CASBackedFileSystem.

Fixes: https://github.com/swiftlang/llvm-project/issues/11616