### PR TITLE
[Cherry-pick into next] [LLDB] Add progress updates for reflection metadata loading

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.h
@@ -105,6 +105,12 @@ public:
   /// Returns whether the filecache optimization is enabled or not.
   bool readMetadataFromFileCacheEnabled() const;
 
+  /// Set or clear the progress callback.
+  void SetProgressCallback(
+      std::function<void(llvm::StringRef)> progress_callback = {}) {
+    m_progress_callback = progress_callback;
+  }
+
 protected:
   bool readRemoteAddressImpl(swift::remote::RemoteAddress address,
                              swift::remote::RemoteAddress &out,
@@ -166,6 +172,8 @@ private:
   /// The set of modules where we should read memory from the symbol file's
   /// object file instead of the main object file.
   llvm::SmallSet<lldb::ModuleSP, 8> m_modules_with_metadata_in_symbol_obj_file;
+  /// A callback to update a progress event.
+  std::function<void(llvm::StringRef)> m_progress_callback;
 };
 } // namespace lldb_private
 #endif

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -608,6 +608,22 @@ std::optional<uint64_t> SwiftLanguageRuntime::GetMemberVariableOffset(
 
 namespace {
 
+class ProgressRAII {
+  Progress m_progress;
+  LLDBMemoryReader &m_memory_reader;
+public:
+  ProgressRAII(std::string title, Debugger *debugger,
+               LLDBMemoryReader &memory_reader)
+      : m_progress(title, {}, {}, debugger,
+                   Progress::kDefaultHighFrequencyReportTime),
+        m_memory_reader(memory_reader) {
+    m_memory_reader.SetProgressCallback([&](StringRef message) {
+      m_progress.Increment(1, message.str());
+    });
+  }
+  ~ProgressRAII() { m_memory_reader.SetProgressCallback(); };
+};
+
 CompilerType GetTypeFromTypeRef(TypeSystemSwiftTypeRef &ts,
                                 const swift::reflection::TypeRef *type_ref,
                                 swift::Mangle::ManglingFlavor flavor) {
@@ -3476,6 +3492,14 @@ SwiftLanguageRuntime::GetSwiftRuntimeTypeInfo(
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
 
+  // On remove connections downloading reflection metadata can be a bottleneck.
+  auto flavor = GetManglingFlavor(type.GetMangledTypeName());
+  static std::string g_debuginfo = "Loading debug info";
+  static std::string g_reflection = "Loading reflection metadata";
+  ProgressRAII progress(
+      flavor == swift::Mangle::ManglingFlavor::Embedded ? g_debuginfo
+                                                        : g_reflection,
+      &GetProcess().GetTarget().GetDebugger(), *GetMemoryReader());
   LLDBTypeInfoProvider provider(*this, ts);
   return reflection_ctx->GetTypeInfo(*type_ref_or_err, &provider,
                                      ts.GetDescriptorFinder());

--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -41,6 +41,7 @@ class TestSwiftProgressReporting(TestBase):
             "Importing dependencies for main.swift",
             "Importing dependencies for main.swift: Foundation",
             "Importing Swift standard library",
+            "Loading reflection metadata",
         ]
 
         importing_swift_reports = []


### PR DESCRIPTION
```
commit 377e888cbe9f5ac3f4a6e88ee5601a3facc88e9f
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Oct 13 15:58:58 2025 -0700

    [LLDB] Add progress updates for reflection metadata loading
    
    When debugging locally, parsing reflection metadata is instant. But
    when debugging over a slow network connection the amount of memory
    read packets being sent back and forth can indtroduce significan
    delays. To meake is easier to diagnose why an operation is stalling
    and to provide users with feedback about what LDB is doing this patch
    introduces a progress update in GetSwiftRuntimTypeInfo().
    
    LLDB only publishes at meast 1 progress event every 20ms, so this is
    (visually) and performance-wise a noop wehen debugging locally.
```
