### PR TITLE
Fix bug in cas-friendly-debug-info option.

### DIFF
--- a/llvm/lib/MC/MCDwarf.cpp
+++ b/llvm/lib/MC/MCDwarf.cpp
@@ -190,7 +190,7 @@ void MCDwarfLineTable::emitOne(
   auto init = [&]() {
     // Force emission of DW_LNS_set_file for every function's contribution to
     // the line table to maximize deduplication.
-    FileNum = MCOS->getGenerateCasFriendlyDebugInfo() ? 0 : 1;
+    FileNum = MCOS->getGenerateCasFriendlyDebugInfo() ? -1 : 1;
     LastLine = 1;
     Column = 0;
     Flags = DWARF2_LINE_DEFAULT_IS_STMT ? DWARF2_FLAG_IS_STMT : 0;

--- a/llvm/test/CAS/cas-friendly-debug-info.ll
+++ b/llvm/test/CAS/cas-friendly-debug-info.ll
@@ -1,0 +1,29 @@
+; RUN: rm -rf %t && mkdir -p %t
+; RUN: llc --filetype=obj -cas-friendly-debug-info %s -o %t/cas-friendly.o 
+; RUN: llvm-dwarfdump %t/cas-friendly.o --debug-line | FileCheck %s
+; CHECK: Address            Line   Column File   ISA Discriminator OpIndex Flags
+; CHECK-NEXT: ------------------ ------ ------ ------ --- ------------- ------- -------------
+; CHECK-NOT: 0x0000000000000000      0      0      1   0             0       0  is_stmt
+; CHECK-NEXT: 0x0000000000000000      0      0      0   0             0       0  is_stmt
+; REQUIRES: arm-registered-target
+
+define i32 @_Z3fooi(i32 noundef %x) #0 !dbg !9 {
+entry:
+  %x.addr = alloca i32
+  %0 = load i32, ptr %x.addr, align 4
+  %add = add nsw i32 %0, 1, !dbg !18
+  ret i32 %add
+}
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2, !3, !7}
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, emissionKind: FullDebug, sysroot: "/")
+!1 = !DIFile(filename: "/tmp/a.cpp", directory: "/", checksumkind: CSK_MD5, checksum: "80e82b6b66c04b9cfb438eb7c6672107")
+!2 = !{i32 7, !"Dwarf Version", i32 5}
+!3 = !{i32 2,!"Debug Info Version", i32 3}
+!7 = !{i32 7, !"frame-pointer", i32 1}
+!9 = distinct !DISubprogram(file: !10, type: !11, unit: !0, retainedNodes: !14)
+!10 = !DIFile(filename: "/tmp/a.cpp", directory: "", checksumkind: CSK_MD5, checksum: "80e82b6b66c04b9cfb438eb7c6672107")
+!11 = !DISubroutineType(types: !12)
+!12 = !{}
+!14 = !{}
+!18 = !DILocation(scope: !9)


### PR DESCRIPTION
Fix bug with emitting a DW_LNS_set_file at the beginning of a new function's contribution to a line table, when the
-cas-friendly-debug-info option is passed. We were setting the current FileNum to 0, however, if the LineEntry to be emitted also has the FileNum be 0, we don't emit a DW_LNS_set_file at all, it is only emitted if the current FileNum and the LineEntry to be emitted have different FileNums.

To fix this, in cas-friendly-debug-info, we always set the current FileNum to be -1.

 rdar://161930616