### PR TITLE
[lldb][ValueObject] Move Objective-C specific lookups into ObjCLanguageRuntime

### DIFF
--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -1104,6 +1104,9 @@ protected:
 
 private:
   virtual CompilerType MaybeCalculateCompleteType();
+  CompilerType LookupInRuntime(ConstString class_name, Process &process);
+  CompilerType LookupInModulesVendor(ConstString class_name, Target &process);
+
   void UpdateChildrenAddressType() {
     GetRoot()->DoUpdateChildrenAddressType(*this);
   }

--- a/lldb/include/lldb/ValueObject/ValueObject.h
+++ b/lldb/include/lldb/ValueObject/ValueObject.h
@@ -1104,9 +1104,6 @@ protected:
 
 private:
   virtual CompilerType MaybeCalculateCompleteType();
-  CompilerType LookupInRuntime(ConstString class_name, Process &process);
-  CompilerType LookupInModulesVendor(ConstString class_name, Target &process);
-
   void UpdateChildrenAddressType() {
     GetRoot()->DoUpdateChildrenAddressType(*this);
   }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.cpp
@@ -446,14 +446,10 @@ ObjCLanguageRuntime::GetRuntimeType(CompilerType base_type) {
   if (!complete_objc_class_type_sp)
     return std::nullopt;
 
-  CompilerType complete_class(
-      complete_objc_class_type_sp->GetFullCompilerType());
-  if (complete_class.GetCompleteType()) {
-    if (is_pointer_type)
-      return complete_class.GetPointerType();
-    else
-      return complete_class;
-  }
+  if (CompilerType complete_class =
+          complete_objc_class_type_sp->GetFullCompilerType();
+      complete_class.GetCompleteType())
+    return is_pointer_type ? complete_class.GetPointerType() : complete_class;
 
   return std::nullopt;
 }

--- a/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/ObjC/ObjCLanguageRuntime.h
@@ -465,6 +465,10 @@ protected:
 
   ObjCLanguageRuntime(const ObjCLanguageRuntime &) = delete;
   const ObjCLanguageRuntime &operator=(const ObjCLanguageRuntime &) = delete;
+
+private:
+  CompilerType LookupInRuntime(ConstString class_name);
+  CompilerType LookupInModulesVendor(ConstString class_name, Target &process);
 };
 
 } // namespace lldb_private

--- a/lldb/test/API/lang/objc/ivar-in-framework-base/Makefile
+++ b/lldb/test/API/lang/objc/ivar-in-framework-base/Makefile
@@ -1,0 +1,6 @@
+OBJC_SOURCES := main.m lib.m
+LD_EXTRAS = -framework Foundation
+
+include Makefile.rules
+
+lib.o: CFLAGS = $(CFLAGS_NO_DEBUG)

--- a/lldb/test/API/lang/objc/ivar-in-framework-base/TestIvarInFrameworkBase.py
+++ b/lldb/test/API/lang/objc/ivar-in-framework-base/TestIvarInFrameworkBase.py
@@ -1,0 +1,39 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class TestIvarInFrameworkBase(TestBase):
+    """
+    Tests whether LLDB's data inspection commands can correctly retrieve
+    information about ivars from the Objective-C runtime.
+    In this test-case we have a base class type for which we don't have access
+    to the debug-info of the implementation (mimicking the scenario of subclassing
+    a type from a system framework). LLDB won't be able to see the backing ivar for
+    'fooProp' from just debug-info, but it will fall back on the runtime to get the
+    necessary information.
+    """
+
+    def test_frame_var(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+        self.expect("frame variable *bar", substrs=["_fooProp = 10", "_barProp = 15"])
+
+    def test_expr(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+        self.expect_expr(
+            "*bar",
+            result_type="Bar",
+            result_children=[
+                ValueCheck(
+                    name="Foo",
+                    children=[
+                        ValueCheck(name="NSObject"),
+                        ValueCheck(name="_fooProp", value="10"),
+                    ],
+                ),
+                ValueCheck(name="_barProp", value="15"),
+            ],
+        )

--- a/lldb/test/API/lang/objc/ivar-in-framework-base/lib.h
+++ b/lldb/test/API/lang/objc/ivar-in-framework-base/lib.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject
+@property int fooProp;
+- (id)init;
+@end

--- a/lldb/test/API/lang/objc/ivar-in-framework-base/lib.m
+++ b/lldb/test/API/lang/objc/ivar-in-framework-base/lib.m
@@ -1,0 +1,8 @@
+#import "lib.h"
+
+@implementation Foo
+- (id)init {
+  self.fooProp = 10;
+  return self;
+}
+@end

--- a/lldb/test/API/lang/objc/ivar-in-framework-base/main.m
+++ b/lldb/test/API/lang/objc/ivar-in-framework-base/main.m
@@ -1,0 +1,22 @@
+#import "lib.h"
+#include <stdio.h>
+
+@interface Bar : Foo
+@property int barProp;
+- (id)init;
+@end
+
+@implementation Bar
+
+- (id)init {
+  self = [super init];
+  self.barProp = 15;
+  return self;
+}
+@end
+
+int main() {
+  Bar *bar = [Bar new];
+  puts("break here");
+  return 0;
+}


### PR DESCRIPTION
I'd like to upstream these lookups. It'd be more acceptable if this lived in the LanguageRuntime.

Added test which fails without these codepaths.

rdar://162069497