### PR TITLE
[lldb] fix `get_python_module_path` indentation

### DIFF
--- a/lldb/bindings/python/prepare_binding_python.py
+++ b/lldb/bindings/python/prepare_binding_python.py
@@ -382,7 +382,8 @@ def get_python_module_path(options):
                 module_path = get_python_lib(True, False, options.prefix)
             else:
                 module_path = get_python_lib(True, False)
-            return os.path.normcase(os.path.join(module_path, "lldb"))
+
+        return os.path.normcase(os.path.join(module_path, "lldb"))
 
 
 def main(options):


### PR DESCRIPTION
The return was at the wrong indention causing python version >= 3.12 to return `None` 