### PR TITLE
[6.2][swift] Add support for BuiltinImplicitActor to SwifASTContext.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -6069,6 +6069,7 @@ SwiftASTContext::GetTypeInfo(opaque_compiler_type_t type,
   case swift::TypeKind::BuiltinRawUnsafeContinuation:
   case swift::TypeKind::BuiltinTuple:
   case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::ElementArchetype:
   case swift::TypeKind::Error:
   case swift::TypeKind::ErrorUnion:
@@ -6237,6 +6238,7 @@ lldb::TypeClass SwiftASTContext::GetTypeClass(opaque_compiler_type_t type) {
   case swift::TypeKind::BuiltinPackIndex:    
   case swift::TypeKind::BuiltinTuple:
   case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::Locatable:
   case swift::TypeKind::Integer:
   case swift::TypeKind::Pack:
@@ -6739,6 +6741,7 @@ lldb::Encoding SwiftASTContext::GetEncoding(opaque_compiler_type_t type,
   case swift::TypeKind::BuiltinJob:
   case swift::TypeKind::BuiltinTuple:
   case swift::TypeKind::BuiltinRawUnsafeContinuation:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::Error:
   case swift::TypeKind::InOut:
   case swift::TypeKind::Locatable:
@@ -6856,6 +6859,7 @@ SwiftASTContext::GetNumChildren(opaque_compiler_type_t type,
   case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::BuiltinUnsafeValueBuffer:
   case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::DependentMember:
   case swift::TypeKind::DynamicSelf:
   case swift::TypeKind::ElementArchetype:
@@ -6996,6 +7000,7 @@ uint32_t SwiftASTContext::GetNumFields(opaque_compiler_type_t type,
   case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::BuiltinUnsafeValueBuffer:
   case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::Error:
   case swift::TypeKind::ErrorUnion:
   case swift::TypeKind::InOut:
@@ -7225,6 +7230,7 @@ CompilerType SwiftASTContext::GetFieldAtIndex(opaque_compiler_type_t type,
   case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::BuiltinUnsafeValueBuffer:
   case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::Error:
   case swift::TypeKind::ErrorUnion:
   case swift::TypeKind::InOut:
@@ -7425,6 +7431,7 @@ uint32_t SwiftASTContext::GetNumPointeeChildren(opaque_compiler_type_t type) {
   case swift::TypeKind::BuiltinRawUnsafeContinuation:
   case swift::TypeKind::BuiltinTuple:
   case swift::TypeKind::BuiltinUnboundGeneric:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::Class:
   case swift::TypeKind::DependentMember:
   case swift::TypeKind::DynamicSelf:
@@ -7585,6 +7592,7 @@ llvm::Expected<CompilerType> SwiftASTContext::GetChildCompilerTypeAtIndex(
   case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::BuiltinUnsafeValueBuffer:
   case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::DependentMember:
   case swift::TypeKind::DynamicSelf:
   case swift::TypeKind::ElementArchetype:
@@ -7983,6 +7991,7 @@ size_t SwiftASTContext::GetIndexOfChildMemberWithName(
     case swift::TypeKind::BuiltinUnboundGeneric:
     case swift::TypeKind::BuiltinUnsafeValueBuffer:
     case swift::TypeKind::BuiltinVector:
+    case swift::TypeKind::BuiltinImplicitActor:
     case swift::TypeKind::DynamicSelf:
     case swift::TypeKind::ElementArchetype:
     case swift::TypeKind::Error:
@@ -8381,6 +8390,7 @@ bool SwiftASTContext::DumpTypeValue(
   case swift::TypeKind::BuiltinTuple:
   case swift::TypeKind::BuiltinUnboundGeneric:
   case swift::TypeKind::BuiltinVector:
+  case swift::TypeKind::BuiltinImplicitActor:
   case swift::TypeKind::DynamicSelf:
   case swift::TypeKind::Error:
   case swift::TypeKind::ErrorUnion:


### PR DESCRIPTION
rdar://156525771
(cherry picked from commit 6eaa30db12f28262d56442661c1c2ee217679367)