### PR TITLE
[Cherry-pick into next] [LLDB] Remove Swift AST-based name translation from MTC

### DIFF
--- a/lldb/test/API/functionalities/mtc/swift/TestMTCSwift.py
+++ b/lldb/test/API/functionalities/mtc/swift/TestMTCSwift.py
@@ -39,7 +39,8 @@ class MTCSwiftTestCase(TestBase):
 
         self.expect("thread info",
                     substrs=['stop reason = ' + view +
-                             '.removeFromSuperview() must be used from main thread only'])
+                             # FIXME: should be: .removeFromSuperview()
+                             '.removeFromSuperview must be used from main thread only'])
 
         self.expect(
             "thread info -s",
@@ -50,7 +51,9 @@ class MTCSwiftTestCase(TestBase):
         json_line = '\n'.join(output_lines[2:])
         data = json.loads(json_line)
         self.assertEqual(data["instrumentation_class"], "MainThreadChecker")
-        self.assertEqual(data["api_name"], view + ".removeFromSuperview()")
+                                          # FIXME: .removeFromSuperview()
+        self.assertEqual(data["api_name"], view + ".removeFromSuperview")
         self.assertEqual(data["class_name"], view)
         self.assertEqual(data["selector"], "removeFromSuperview")
-        self.assertEqual(data["description"], view + ".removeFromSuperview() must be used from main thread only")
+                                             # FIXME: .removeFromSuperview()
+        self.assertEqual(data["description"], view + ".removeFromSuperview must be used from main thread only")


### PR DESCRIPTION
```
commit 1b1fed239062bda4551f5dea2a3544d2648b5f53
Author: Adrian Prantl <aprantl@apple.com>
Date:   Wed Oct 15 17:40:56 2025 -0700

    [LLDB] Remove Swift AST-based name translation from MTC
    
    The name translation only affects selectors and not classes, so it
    already isn't correct in all cases. The translation is implemented on
    top of SwiftASTContext, which is very expensive to start up and on top
    of that may fail if the compiler flags aren't all available.
    
    Right now the cost-benefit trade-off for this feature doesn't work
    out. We should look into reimplementing it on top of
    TypeSystemSwiftTypeRef::GetSwiftName() which uses the APINotes and
    ClangImporter's name translation engine to do the job.
    
    rdar://162496659
```
