### PR TITLE
[BoundsSafety][LLDB] Fix `lldb/test/Shell/BoundsSafety/boundssafetytrap.test`

### DIFF
--- a/lldb/test/Shell/BoundsSafety/boundssafetytrap.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafetytrap.test
@@ -2,7 +2,7 @@
 # RUN: %clang_host -Xclang -fbounds-safety -g -O0 %S/Inputs/boundsSafetyTrap.c -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 run
-# CHECK: thread #{{.*}}stop reason = Bounds check failed: Dereferencing above bounds
+# CHECK: thread #{{.*}}stop reason = Bounds check failed: indexing above upper bound in 'array[index]'
 frame info
 # CHECK: frame #{{.*}}`bad_read(index=10) at boundsSafetyTrap.c
 frame recognizer info 0


### PR DESCRIPTION
When https://github.com/swiftlang/llvm-project/pull/11621
(a4898c253d9bb9e1c066b1021a0b1d2a0664910b) landed it broke this test
because the trap reason string changed and this test wasn't updated.

rdar://162886933

