### PR TITLE
Fix Build Break Due to #11633

### DIFF
--- a/llvm/unittests/Support/SourceMgrTest.cpp
+++ b/llvm/unittests/Support/SourceMgrTest.cpp
@@ -523,7 +523,7 @@ TEST_F(SourceMgrTest, AddIncludedFile) {
                                MemoryBufferRef(IncludesContent, IncludesPath)));
 
   // Set up SM.
-  SM.setFileSystem(FS);
+  SM.setVirtualFileSystem(FS);
   SM.setIncludeDirs({Includes.str()});
 
   setMainBuffer("include-top\n", "file.in");


### PR DESCRIPTION
#11633 missed updating a use of `SourceMgr::setFileSystem` with `SourceMgr::setVirtualFileSystem` in an llvm unit test, causing a build failure. This PR fixes the failure.