### PR TITLE
stable/21.x: [Coro] RetconOnceDynamic: Distinguish frame allocs and pass frame pointers.

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1771,7 +1771,7 @@ def int_coro_id_retcon_once : Intrinsic<[llvm_token_ty],
     []>;
 def int_coro_id_retcon_once_dynamic : Intrinsic<[llvm_token_ty],
     [llvm_i32_ty, llvm_i32_ty, llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty,
-     llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
+     llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty, llvm_ptr_ty],
     []>;
 def int_coro_alloc : Intrinsic<[llvm_i1_ty], [llvm_token_ty], []>;
 def int_coro_id_async : Intrinsic<[llvm_token_ty],
@@ -1818,8 +1818,11 @@ def int_coro_prepare_retcon : Intrinsic<[llvm_ptr_ty], [llvm_ptr_ty],
                                         [IntrNoMem]>;
 def int_coro_alloca_alloc : Intrinsic<[llvm_token_ty],
                                       [llvm_anyint_ty, llvm_i32_ty], []>;
+def int_coro_alloca_alloc_frame : Intrinsic<[llvm_token_ty],
+                                      [llvm_anyint_ty, llvm_i32_ty], []>;
 def int_coro_alloca_get : Intrinsic<[llvm_ptr_ty], [llvm_token_ty], []>;
 def int_coro_alloca_free : Intrinsic<[], [llvm_token_ty], []>;
+def int_coro_alloca_free_frame : Intrinsic<[], [llvm_token_ty], []>;
 
 // Coroutine Manipulation Intrinsics.
 

--- a/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
+++ b/llvm/include/llvm/Transforms/Coroutines/CoroShape.h
@@ -135,7 +135,9 @@ struct Shape {
   struct RetconLoweringStorage {
     Function *ResumePrototype;
     Function *Alloc;
+    Function *AllocFrame;
     Function *Dealloc;
+    Function *DeallocFrame;
     Value *Allocator;
     BasicBlock *ReturnBlock;
     bool IsFrameInlineInStorage;
@@ -278,13 +280,13 @@ struct Shape {
   ///
   /// \param CG - if non-null, will be updated for the new call
   LLVM_ABI Value *emitAlloc(IRBuilder<> &Builder, Value *Size,
-                            CallGraph *CG) const;
+                            AnyCoroAllocaAllocInst *AI, CallGraph *CG) const;
 
   /// Deallocate memory according to the rules of the active lowering.
   ///
   /// \param CG - if non-null, will be updated for the new call
   LLVM_ABI void emitDealloc(IRBuilder<> &Builder, Value *Ptr,
-                            CallGraph *CG) const;
+                            AnyCoroAllocaAllocInst *AI, CallGraph *CG) const;
 
   Shape() = delete;
   explicit Shape(Function &F) {

--- a/llvm/include/llvm/Transforms/Coroutines/SpillUtils.h
+++ b/llvm/include/llvm/Transforms/Coroutines/SpillUtils.h
@@ -35,7 +35,7 @@ void collectSpillsFromArgs(SpillInfo &Spills, Function &F,
 void collectSpillsAndAllocasFromInsts(
     SpillInfo &Spills, SmallVector<AllocaInfo, 8> &Allocas,
     SmallVector<Instruction *, 4> &DeadInstructions,
-    SmallVector<CoroAllocaAllocInst *, 4> &LocalAllocas, Function &F,
+    SmallVector<AnyCoroAllocaAllocInst *, 4> &LocalAllocas, Function &F,
     const SuspendCrossingInfo &Checker, const DominatorTree &DT,
     const coro::Shape &Shape);
 void collectSpillsFromDbgInfo(SpillInfo &Spills, Function &F,

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -163,7 +163,7 @@ static void maybeFreeRetconStorage(IRBuilder<> &Builder,
   if (Shape.RetconLowering.IsFrameInlineInStorage)
     return;
 
-  Shape.emitDealloc(Builder, FramePtr, CG);
+  Shape.emitDealloc(Builder, FramePtr, nullptr, CG);
 }
 
 /// Replace an llvm.coro.end.async.
@@ -1903,7 +1903,8 @@ void coro::AnyRetconABI::splitCoroutine(Function &F, coro::Shape &Shape,
     // Allocate.  We don't need to update the call graph node because we're
     // going to recompute it from scratch after splitting.
     // FIXME: pass the required alignment
-    RawFramePtr = Shape.emitAlloc(Builder, Builder.getInt64(Size), nullptr);
+    RawFramePtr =
+        Shape.emitAlloc(Builder, Builder.getInt64(Size), nullptr, nullptr);
     RawFramePtr =
         Builder.CreateBitCast(RawFramePtr, Shape.CoroBegin->getType());
 

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -325,7 +325,9 @@ void coro::Shape::analyze(Function &F,
     auto Prototype = ContinuationId->getPrototype();
     RetconLowering.ResumePrototype = Prototype;
     RetconLowering.Alloc = ContinuationId->getAllocFunction();
+    RetconLowering.AllocFrame = ContinuationId->getAllocFrameFunction();
     RetconLowering.Dealloc = ContinuationId->getDeallocFunction();
+    RetconLowering.DeallocFrame = ContinuationId->getDeallocFrameFunction();
     RetconLowering.Storage = ContinuationId->getStorage();
     RetconLowering.Allocator = ContinuationId->getAllocator();
     RetconLowering.ReturnBlock = nullptr;
@@ -523,7 +525,7 @@ static void addCallToCallGraph(CallGraph *CG, CallInst *Call, Function *Callee){
 }
 
 Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
-                              CallGraph *CG) const {
+                              AnyCoroAllocaAllocInst *AI, CallGraph *CG) const {
   switch (ABI) {
   case coro::ABI::Switch:
     llvm_unreachable("can't allocate memory in coro switch-lowering");
@@ -537,7 +539,13 @@ Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
       sizeParamIndex = 1;
       Args.push_back(RetconLowering.Allocator);
     }
-    auto Alloc = RetconLowering.Alloc;
+    Function *Alloc = nullptr;
+    if (isa_and_nonnull<CoroAllocaAllocFrameInst>(AI)) {
+      assert(ABI == coro::ABI::RetconOnceDynamic);
+      Alloc = RetconLowering.AllocFrame;
+    } else {
+      Alloc = RetconLowering.Alloc;
+    }
     Size = Builder.CreateIntCast(
         Size, Alloc->getFunctionType()->getParamType(sizeParamIndex),
         /*is signed*/ false);
@@ -559,7 +567,7 @@ Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
 }
 
 void coro::Shape::emitDealloc(IRBuilder<> &Builder, Value *Ptr,
-                              CallGraph *CG) const {
+                              AnyCoroAllocaAllocInst *AI, CallGraph *CG) const {
   switch (ABI) {
   case coro::ABI::Switch:
     llvm_unreachable("can't allocate memory in coro switch-lowering");
@@ -567,7 +575,13 @@ void coro::Shape::emitDealloc(IRBuilder<> &Builder, Value *Ptr,
   case coro::ABI::Retcon:
   case coro::ABI::RetconOnce:
   case coro::ABI::RetconOnceDynamic: {
-    auto Dealloc = RetconLowering.Dealloc;
+    Function *Dealloc = nullptr;
+    if (isa_and_nonnull<CoroAllocaAllocFrameInst>(AI)) {
+      assert(ABI == coro::ABI::RetconOnceDynamic);
+      Dealloc = RetconLowering.DeallocFrame;
+    } else {
+      Dealloc = RetconLowering.Dealloc;
+    }
     SmallVector<Value *, 2> Args;
     unsigned allocationParamIndex = 0;
     if (ABI == coro::ABI::RetconOnceDynamic) {

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -559,6 +559,9 @@ Value *coro::Shape::emitAlloc(IRBuilder<> &Builder, Value *Size,
         Args.push_back(TypeId);
     }
     auto *Call = Builder.CreateCall(Alloc, Args);
+    if (ABI == coro::ABI::RetconOnceDynamic) {
+      Call->addParamAttr(1, Attribute::SwiftCoro);
+    }
     propagateCallAttrsFromCallee(Call, Alloc);
     addCallToCallGraph(CG, Call, Alloc);
     return Call;
@@ -598,6 +601,9 @@ void coro::Shape::emitDealloc(IRBuilder<> &Builder, Value *Ptr,
         Ptr, Dealloc->getFunctionType()->getParamType(allocationParamIndex));
     Args.push_back(Ptr);
     auto *Call = Builder.CreateCall(Dealloc, Args);
+    if (ABI == coro::ABI::RetconOnceDynamic) {
+      Call->addParamAttr(1, Attribute::SwiftCoro);
+    }
     propagateCallAttrsFromCallee(Call, Dealloc);
     addCallToCallGraph(CG, Call, Dealloc);
     return;

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -569,13 +569,13 @@ void coro::Shape::emitDealloc(IRBuilder<> &Builder, Value *Ptr,
   case coro::ABI::RetconOnceDynamic: {
     auto Dealloc = RetconLowering.Dealloc;
     SmallVector<Value *, 2> Args;
-    unsigned sizeParamIndex = 0;
+    unsigned allocationParamIndex = 0;
     if (ABI == coro::ABI::RetconOnceDynamic) {
-      sizeParamIndex = 1;
+      allocationParamIndex = 1;
       Args.push_back(RetconLowering.Allocator);
     }
     Ptr = Builder.CreateBitCast(
-        Ptr, Dealloc->getFunctionType()->getParamType(sizeParamIndex));
+        Ptr, Dealloc->getFunctionType()->getParamType(allocationParamIndex));
     Args.push_back(Ptr);
     auto *Call = Builder.CreateCall(Dealloc, Args);
     propagateCallAttrsFromCallee(Call, Dealloc);

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic-nocleanup.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic-nocleanup.ll
@@ -24,7 +24,7 @@ target triple = "arm64-apple-macos99.99"
 declare swiftcorocc void @func_continuation_prototype(ptr noalias, ptr)
 
 ; CHECK-LABEL: @func.resume.0(
-; CHECK-SAME:      ptr noalias %0, 
+; CHECK-SAME:      ptr noalias %0,
 ; CHECK-SAME:      ptr %1
 ; CHECK-SAME:  ) {
 ; CHECK:       coro.return.popless:
@@ -36,14 +36,16 @@ declare swiftcorocc void @func_continuation_prototype(ptr noalias, ptr)
 define swiftcorocc { ptr, ptr } @func(ptr noalias %buffer, ptr %allocator, ptr nocapture swiftself dereferenceable(16) %2) {
 entry:
   %3 = call token @llvm.coro.id.retcon.once.dynamic(
-    i32 -1, 
+    i32 -1,
     i32 16,
     ptr @func_cfp,
     ptr %allocator,
     ptr %buffer,
     ptr @func_continuation_prototype,
-    ptr @allocate, 
-    ptr @deallocate
+    ptr nonnull @allocate,
+    ptr nonnull @deallocate,
+    ptr nonnull @allocate_frame,
+    ptr nonnull @deallocate_frame
   )
   %handle = call ptr @llvm.coro.begin(token %3, ptr null)
   %yielded = getelementptr inbounds %func_self, ptr %2, i32 0, i32 0
@@ -63,3 +65,5 @@ coro.end:
 
 declare swiftcorocc noalias ptr @allocate(i32 %size)
 declare void @deallocate(ptr %ptr)
+declare swiftcorocc noalias ptr @allocate_frame(i32 %size)
+declare void @deallocate_frame(ptr %ptr)

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
@@ -114,10 +114,10 @@ cleanup:
 
 declare void @continuation_prototype(ptr, ptr)
 
-declare swiftcorocc noalias ptr @allocate(ptr swiftcoro %cator, i32 %size)
-declare void @deallocate(ptr swiftcoro %cator, ptr %ptr)
-declare swiftcorocc noalias ptr @allocate_frame(ptr swiftcoro %cator, i32 %size)
-declare void @deallocate_frame(ptr swiftcoro %cator, ptr %ptr)
+declare swiftcorocc noalias ptr @allocate(ptr %frame, ptr swiftcoro %cator, i32 %size)
+declare void @deallocate(ptr %frame, ptr swiftcoro %cator, ptr %ptr)
+declare swiftcorocc noalias ptr @allocate_frame(ptr %frame, ptr swiftcoro %cator, i32 %size)
+declare void @deallocate_frame(ptr %frame, ptr swiftcoro %cator, ptr %ptr)
 
 declare void @use(ptr %ptr)
 
@@ -186,10 +186,12 @@ declare { ptr, ptr } @allocating_something_else(ptr noalias %frame, ptr swiftcor
 ; CHECK-SAME:  {
 ; CHECK:         %size = call i32 @getSize()
 ; CHECK:         call swiftcorocc ptr @allocate(
+; CHECK-SAME:      ptr %frame,
 ; CHECK-SAME:      ptr %allocator,
 ; CHECK-SAME:      i32 %size
 ; CHECK-SAME:    )
 ; CHECK:         call swiftcorocc ptr @allocate_frame(
+; CHECK-SAME:      ptr %frame,
 ; CHECK-SAME:      ptr %allocator,
 ; CHECK-SAME:      i32
 ; CHECK-SAME:    )
@@ -199,10 +201,12 @@ declare { ptr, ptr } @allocating_something_else(ptr noalias %frame, ptr swiftcor
 ; CHECK-SAME:  )
 ; CHECK-SAME:  {
 ; CHECK:         call void @deallocate_frame(
+; CHECK-SAME:      ptr %0,
 ; CHECK-SAME:      ptr %1,
 ; CHECK-SAME:      ptr
 ; CHECK-SAME:    )
 ; CHECK:         call void @deallocate(
+; CHECK-SAME:      ptr %0,
 ; CHECK-SAME:      ptr %1,
 ; CHECK-SAME:      ptr
 ; CHECK-SAME:    )

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
@@ -187,12 +187,12 @@ declare { ptr, ptr } @allocating_something_else(ptr noalias %frame, ptr swiftcor
 ; CHECK:         %size = call i32 @getSize()
 ; CHECK:         call swiftcorocc ptr @allocate(
 ; CHECK-SAME:      ptr %frame,
-; CHECK-SAME:      ptr %allocator,
+; CHECK-SAME:      ptr swiftcoro %allocator,
 ; CHECK-SAME:      i32 %size
 ; CHECK-SAME:    )
 ; CHECK:         call swiftcorocc ptr @allocate_frame(
 ; CHECK-SAME:      ptr %frame,
-; CHECK-SAME:      ptr %allocator,
+; CHECK-SAME:      ptr swiftcoro %allocator,
 ; CHECK-SAME:      i32
 ; CHECK-SAME:    )
 ; CHECK-LABEL: @allocating_something.resume.0(
@@ -202,12 +202,12 @@ declare { ptr, ptr } @allocating_something_else(ptr noalias %frame, ptr swiftcor
 ; CHECK-SAME:  {
 ; CHECK:         call void @deallocate_frame(
 ; CHECK-SAME:      ptr %0,
-; CHECK-SAME:      ptr %1,
+; CHECK-SAME:      ptr swiftcoro %1,
 ; CHECK-SAME:      ptr
 ; CHECK-SAME:    )
 ; CHECK:         call void @deallocate(
 ; CHECK-SAME:      ptr %0,
-; CHECK-SAME:      ptr %1,
+; CHECK-SAME:      ptr swiftcoro %1,
 ; CHECK-SAME:      ptr
 ; CHECK-SAME:    )
 @allocating_something_cfp = constant <{ i32, i32 }>

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
@@ -3,11 +3,13 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "arm64-apple-macos99.99"
 
+%coro_func_pointer = type <{ i32, i32 }>
+
 ; CHECK-LABEL: %func.Frame = type { ptr }
 ; CHECK-LABEL: %big_types.Frame = type { <32 x i8>, [16 x i8], i64, ptr, %Integer8 }
 
-; CHECK-LABEL: @func_cfp = constant <{ i32, i32 }> 
-; CHECK-SAME:  <{ 
+; CHECK-LABEL: @func_cfp = constant <{ i32, i32 }>
+; CHECK-SAME:  <{
 ; CHECK-SAME:    i32 trunc
 ; CHECK-SAME:    i32 16
 ; CHECK-SAME:  }>
@@ -79,14 +81,16 @@ target triple = "arm64-apple-macos99.99"
 define swiftcorocc {ptr, i32} @func(ptr %buffer, ptr %allocator, ptr %array) {
 entry:
   %id = call token @llvm.coro.id.retcon.once.dynamic(
-    i32 -1, 
-    i32 16, 
-    ptr @func_cfp, 
-    ptr %allocator, 
-    ptr %buffer, 
-    ptr @continuation_prototype, 
-    ptr @allocate, 
-    ptr @deallocate
+    i32 -1,
+    i32 16,
+    ptr @func_cfp,
+    ptr %allocator,
+    ptr %buffer,
+    ptr @continuation_prototype,
+    ptr nonnull @allocate,
+    ptr nonnull @deallocate,
+    ptr nonnull @allocate_frame,
+    ptr nonnull @deallocate_frame
   )
   %handle = call ptr @llvm.coro.begin(token %id, ptr null)
   %load = load i32, ptr %array
@@ -110,8 +114,12 @@ cleanup:
 
 declare void @continuation_prototype(ptr, ptr)
 
-declare swiftcorocc noalias ptr @allocate(i32 %size)
-declare void @deallocate(ptr %ptr)
+declare swiftcorocc noalias ptr @allocate(ptr swiftcoro %cator, i32 %size)
+declare void @deallocate(ptr swiftcoro %cator, ptr %ptr)
+declare swiftcorocc noalias ptr @allocate_frame(ptr swiftcoro %cator, i32 %size)
+declare void @deallocate_frame(ptr swiftcoro %cator, ptr %ptr)
+
+declare void @use(ptr %ptr)
 
 %Integer8 = type { i8 }
 
@@ -129,14 +137,16 @@ declare void @deallocate(ptr %ptr)
 define swiftcorocc { ptr, ptr } @big_types(ptr noalias %frame, ptr swiftcoro %allocator, i64 %index, ptr nocapture swiftself dereferenceable(32) %vec_addr) {
   %element_addr = alloca %Integer8, align 1
   %id = tail call token @llvm.coro.id.retcon.once.dynamic(
-    i32 -1, 
-    i32 16, 
-    ptr nonnull @big_types_cfp, 
-    ptr %allocator, 
-    ptr %frame, 
-    ptr @continuation_prototype, 
-    ptr nonnull @allocate, 
-    ptr nonnull @deallocate
+    i32 -1,
+    i32 16,
+    ptr nonnull @big_types_cfp,
+    ptr %allocator,
+    ptr %frame,
+    ptr @continuation_prototype,
+    ptr nonnull @allocate,
+    ptr nonnull @deallocate,
+    ptr nonnull @allocate_frame,
+    ptr nonnull @deallocate_frame
   )
   %handle = tail call ptr @llvm.coro.begin(token %id, ptr null)
   call void @llvm.lifetime.start.p0(i64 1, ptr nonnull %element_addr)
@@ -157,3 +167,90 @@ define swiftcorocc { ptr, ptr } @big_types(ptr noalias %frame, ptr swiftcoro %al
   unreachable
 }
 
+declare i32 @getSize()
+@allocating_something_else_cfp = constant <{ i32, i32 }>
+  <{ i32 trunc ( ; offset to @func from @allocating_something_else_cfp
+       i64 sub (
+         i64 ptrtoint (ptr @allocating_something_else to i64),
+         i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32 }>, ptr @allocating_something_else_cfp, i32 0, i32 1) to i64)
+       )
+     to i32),
+     i32 64 ; frame size
+}>
+declare { ptr, ptr } @allocating_something_else(ptr noalias %frame, ptr swiftcoro %allocator)
+
+; CHECK-LABEL: @allocating_something(
+; CHECK-SAME:    ptr noalias %frame
+; CHECK-SAME:    ptr swiftcoro %allocator
+; CHECK-SAME:  )
+; CHECK-SAME:  {
+; CHECK:         %size = call i32 @getSize()
+; CHECK:         call swiftcorocc ptr @allocate(
+; CHECK-SAME:      ptr %allocator,
+; CHECK-SAME:      i32 %size
+; CHECK-SAME:    )
+; CHECK:         call swiftcorocc ptr @allocate_frame(
+; CHECK-SAME:      ptr %allocator,
+; CHECK-SAME:      i32
+; CHECK-SAME:    )
+; CHECK-LABEL: @allocating_something.resume.0(
+; CHECK-SAME:    ptr %0,
+; CHECK-SAME:    ptr %1
+; CHECK-SAME:  )
+; CHECK-SAME:  {
+; CHECK:         call void @deallocate_frame(
+; CHECK-SAME:      ptr %1,
+; CHECK-SAME:      ptr
+; CHECK-SAME:    )
+; CHECK:         call void @deallocate(
+; CHECK-SAME:      ptr %1,
+; CHECK-SAME:      ptr
+; CHECK-SAME:    )
+@allocating_something_cfp = constant <{ i32, i32 }>
+  <{ i32 trunc ( ; offset to @func from @allocating_something_cfp
+       i64 sub (
+         i64 ptrtoint (ptr @allocating_something to i64),
+         i64 ptrtoint (ptr getelementptr inbounds (<{ i32, i32 }>, ptr @allocating_something_cfp, i32 0, i32 1) to i64)
+       )
+     to i32),
+     i32 64 ; frame size
+}>
+define { ptr, ptr } @allocating_something(ptr noalias %frame, ptr swiftcoro %allocator) {
+entry:
+  %id = tail call token @llvm.coro.id.retcon.once.dynamic(
+    i32 -1,
+    i32 16,
+    ptr nonnull @allocating_something_cfp,
+    ptr %allocator,
+    ptr %frame,
+    ptr @continuation_prototype,
+    ptr nonnull @allocate,
+    ptr nonnull @deallocate,
+    ptr nonnull @allocate_frame,
+    ptr nonnull @deallocate_frame
+  )
+  %hdl = call ptr @llvm.coro.begin(token %id, ptr null)
+  %size = call i32 @getSize()
+  %alloca = call token @llvm.coro.alloca.alloc.i64(i32 %size, i32 8)
+  %ptr = call ptr @llvm.coro.alloca.get(token %alloca)
+
+  %callee_frame_size = load i32, ptr getelementptr inbounds nuw (%coro_func_pointer, ptr @allocating_something_else_cfp, i32 0, i32 1), align 8
+  %callee_frame_size_64 = zext i32 %callee_frame_size to i64
+  %callee_frame_token = call token @llvm.coro.alloca.alloc.frame.i64(i64 %callee_frame_size_64, i32 16)
+  %callee_frame = call ptr @llvm.coro.alloca.get(token %callee_frame_token)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %callee_frame)
+  %allocating_something_else = call ptr @llvm.coro.prepare.retcon(ptr @allocating_something_else)
+  %10 = call swiftcc { ptr, ptr } %allocating_something_else(ptr noalias %callee_frame, ptr swiftcoro %allocator)
+
+  call void @use(ptr %ptr)
+  call ptr (...) @llvm.coro.suspend.retcon.p0(ptr null)
+
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %callee_frame)
+  call void @llvm.coro.alloca.free.frame(token %callee_frame_token)
+
+
+  call void @use(ptr %ptr)
+  call void @llvm.coro.alloca.free(token %alloca)
+  call i1 @llvm.coro.end(ptr %hdl, i1 0, token none)
+  unreachable
+}


### PR DESCRIPTION
To enable allocator implementations that store context in a frame header.