### PR TITLE
[lldb] Fix TestVTableValue.py test_overwrite_vtable test

### DIFF
--- a/lldb/test/API/functionalities/vtable/Makefile
+++ b/lldb/test/API/functionalities/vtable/Makefile
@@ -1,3 +1,9 @@
 CXX_SOURCES := main.cpp
 
+ifeq "$(OS)" "Darwin"
+    # Make vtables writable for test_overwrite_vtable test
+    # The -no_data_const flag prevents vtables from being placed in __DATA_CONST
+    LD_EXTRAS := -Wl,-no_data_const
+endif
+
 include Makefile.rules


### PR DESCRIPTION
Some machines have read-only vtables but this test expects to overwrite them Use -no_data_const to ensure the vtable is writable