### PR TITLE
[lldb] make check-lldb a disjoint set of check-lldb-swift

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -276,6 +276,9 @@ configure_lit_site_cfg(
 
 add_lit_testsuite(check-lldb "Running lldb lit test suite"
   ${CMAKE_CURRENT_BINARY_DIR}
+  # BEGIN SWIFT MOD
+  ARGS "--filter-out=[sS]wift"
+  # END SWIFT MOD
   DEPENDS
     lldb-api-test-deps
     lldb-shell-test-deps


### PR DESCRIPTION
This patch makes `check-lldb` a disjoint set of `check-lldb-swift` meaning `check-lldb` runs the same set of tests as upstream.