### PR TITLE
[lldb] Implement Process::{ReadPointers,ReadUnsignedIntegers}FromMemory

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -1721,10 +1721,23 @@ public:
                                          size_t byte_size, uint64_t fail_value,
                                          Status &error);
 
+  /// Use Process::ReadMemoryRanges to efficiently read multiple unsigned
+  /// integers from memory at once.
+  /// TODO: this should be upstream once there is a use for it there.
+  llvm::SmallVector<std::optional<uint64_t>>
+  ReadUnsignedIntegersFromMemory(llvm::ArrayRef<lldb::addr_t> addresses,
+                                 unsigned byte_size);
+
   int64_t ReadSignedIntegerFromMemory(lldb::addr_t load_addr, size_t byte_size,
                                       int64_t fail_value, Status &error);
 
   lldb::addr_t ReadPointerFromMemory(lldb::addr_t vm_addr, Status &error);
+
+  /// Use Process::ReadMemoryRanges to efficiently read multiple pointers from
+  /// memory at once.
+  /// TODO: this should be upstream once there is a use for it there.
+  llvm::SmallVector<std::optional<lldb::addr_t>>
+  ReadPointersFromMemory(llvm::ArrayRef<lldb::addr_t> ptr_locs);
 
   bool WritePointerToMemory(lldb::addr_t vm_addr, lldb::addr_t ptr_value,
                             Status &error);


### PR DESCRIPTION
These are methods that use the MultiMemRead packet to speed up reading unsigned numbers / pointers from memory.
As the comments say, they should go upstream once we find a use for them there (and the timing constraints are a bit more favourable).

(cherry picked from commit 7ef61a7ccf5308ab1cb8a085bd0b90d2754b4844)