### PR TITLE
[stable/21.x] Suppress warnings for Swift C++ interop by hiding an operator declaration

### DIFF
--- a/llvm/include/llvm/Support/Registry.h
+++ b/llvm/include/llvm/Support/Registry.h
@@ -100,7 +100,9 @@ namespace llvm {
     public:
       explicit iterator(const node *N) : Cur(N) {}
 
+#ifndef __swift__
       bool operator==(const iterator &That) const { return Cur == That.Cur; }
+#endif
       iterator &operator++() { Cur = Cur->Next; return *this; }
       const entry &operator*() const { return Cur->Val; }
     };

--- a/llvm/include/llvm/TextAPI/Record.h
+++ b/llvm/include/llvm/TextAPI/Record.h
@@ -221,11 +221,13 @@ private:
     RecordLinkage Class = RecordLinkage::Unknown;
     RecordLinkage MetaClass = RecordLinkage::Unknown;
     RecordLinkage EHType = RecordLinkage::Unknown;
+#ifndef __swift__
     bool operator==(const Linkages &other) const {
       return std::tie(Class, MetaClass, EHType) ==
              std::tie(other.Class, other.MetaClass, other.EHType);
     }
     bool operator!=(const Linkages &other) const { return !(*this == other); }
+#endif
   };
   Linkages Linkages;
 

--- a/llvm/include/llvm/Transforms/IPO/Attributor.h
+++ b/llvm/include/llvm/Transforms/IPO/Attributor.h
@@ -5852,11 +5852,13 @@ struct AAPointerInfo : public AbstractAttribute {
     const_iterator begin() const { return Offsets.begin(); }
     const_iterator end() const { return Offsets.end(); }
 
+#ifndef __swift__
     bool operator==(const OffsetInfo &RHS) const {
       return Offsets == RHS.Offsets;
     }
 
     bool operator!=(const OffsetInfo &RHS) const { return !(*this == RHS); }
+#endif
 
     bool insert(int64_t Offset) { return Offsets.insert(Offset).second; }
     bool isUnassigned() const { return Offsets.size() == 0; }

--- a/llvm/include/llvm/Transforms/Scalar/GVN.h
+++ b/llvm/include/llvm/Transforms/Scalar/GVN.h
@@ -292,12 +292,14 @@ private:
         Current = Current->Next;
         return *this;
       }
+#ifndef __swift__
       bool operator==(const leader_iterator &Other) const {
         return Current == Other.Current;
       }
       bool operator!=(const leader_iterator &Other) const {
         return Current != Other.Current;
       }
+#endif
       reference operator*() const { return Current->Entry; }
     };
 

--- a/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
+++ b/llvm/include/llvm/Transforms/Vectorize/SandboxVectorizer/SeedCollector.h
@@ -260,11 +260,13 @@ public:
       ++(*this);
       return Copy;
     }
+#ifndef __swift__
     bool operator==(const iterator &Other) const {
       assert(Map == Other.Map && "Iterator of different objects!");
       return MapIt == Other.MapIt && VecIdx == Other.VecIdx;
     }
     bool operator!=(const iterator &Other) const { return !(*this == Other); }
+#endif
   };
   using const_iterator = BundleMapT::const_iterator;
   template <typename LoadOrStoreT> void insert(LoadOrStoreT *LSI);


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/llvm-project/pull/11707.

Works around a Swift compiler bug that generates a lot of spurious warnings while building the Swift compiler.