### PR TITLE
[llvm][coro] Update coroutine tests for void return from coro.end

### DIFF
--- a/llvm/test/Transforms/Coroutines/coro-retcon-frame-old.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-frame-old.ll
@@ -32,7 +32,7 @@ resume:
   br label %end
 
 end:
-  call i1 @llvm.coro.end(ptr %hdl, i1 0, token none)
+  call void @llvm.coro.end(ptr %hdl, i1 0, token none)
   unreachable
 }
 ; Make sure we don't lose writes to the frame.
@@ -52,5 +52,5 @@ end:
 declare token @llvm.coro.id.retcon.once(i32, i32, ptr, ptr, ptr, ptr)
 declare ptr @llvm.coro.begin(token, ptr)
 declare i1 @llvm.coro.suspend.retcon.i1(...)
-declare i1 @llvm.coro.end(ptr, i1, token)
+declare void @llvm.coro.end(ptr, i1, token)
 

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic-nocleanup.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic-nocleanup.ll
@@ -59,7 +59,7 @@ unwind:
   br label %coro.end
 
 coro.end:
-  %8 = call i1 @llvm.coro.end(ptr %handle, i1 false, token none)
+  call void @llvm.coro.end(ptr %handle, i1 false, token none)
   unreachable
 }
 

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic.ll
@@ -108,7 +108,7 @@ negative:
   br label %cleanup
 
 cleanup:
-  call i1 @llvm.coro.end(ptr %handle, i1 0, token none)
+  call void @llvm.coro.end(ptr %handle, i1 false, token none)
   unreachable
 }
 
@@ -163,7 +163,7 @@ define swiftcorocc { ptr, ptr } @big_types(ptr noalias %frame, ptr swiftcoro %al
   %vec_modified = insertelement <32 x i8> %vec_original_3, i8 %element_modified, i32 %index32
   store <32 x i8> %vec_modified, ptr %vec_addr, align 32
   call void @llvm.lifetime.end.p0(ptr nonnull %element_addr)
-  call i1 @llvm.coro.end(ptr %handle, i1 false, token none)
+  call void @llvm.coro.end(ptr %handle, i1 false, token none)
   unreachable
 }
 
@@ -255,6 +255,6 @@ entry:
 
   call void @use(ptr %ptr)
   call void @llvm.coro.alloca.free(token %alloca)
-  call i1 @llvm.coro.end(ptr %hdl, i1 0, token none)
+  call void @llvm.coro.end(ptr %hdl, i1 false, token none)
   unreachable
 }

--- a/llvm/test/Transforms/Coroutines/coro-retcon-swift-coroFrameAlloc.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-swift-coroFrameAlloc.ll
@@ -23,7 +23,7 @@ define hidden swiftcc { ptr, ptr } @no_suspends(ptr %buffer, i64 %arg) #1 {
 
 bb1:
   call void @print(i64 %arg)
-  call i1 @llvm.coro.end(ptr %begin, i1 false, token none)
+  call void @llvm.coro.end(ptr %begin, i1 false, token none)
   unreachable
 }
 
@@ -41,7 +41,7 @@ declare void @llvm.lifetime.start.p0(i64, ptr nocapture) #6
 declare i1 @llvm.coro.suspend.retcon.i1(...) #5
 declare void @llvm.lifetime.end.p0(i64, ptr nocapture) #6
 declare void @llvm.coro.alloca.free(token) #5
-declare i1 @llvm.coro.end(ptr, i1, token) #5
+declare void @llvm.coro.end(ptr, i1, token) #5
 
 declare void @llvm.trap()
 

--- a/llvm/test/Transforms/Coroutines/coro-split-swift_coroFrameAlloc.ll
+++ b/llvm/test/Transforms/Coroutines/coro-split-swift_coroFrameAlloc.ll
@@ -44,7 +44,7 @@ entry:
   br label %coro.end
 
 coro.end:                                         ; preds = %10, %11
-  %12 = call i1 @llvm.coro.end(ptr %3, i1 false, token none)
+  call void @llvm.coro.end(ptr %3, i1 false, token none)
   unreachable
 }
 


### PR DESCRIPTION
This does not correct Transforms/Coroutines/coro-retcon-frame-auto-upgrade-test.ll as that requires regeneration of the bitcode, and I don't know how to determine whether the regenerated code is correct.