### PR TITLE
[stable/21.x][lldb] Disable a `TestDAP_commands` test on Windows

### DIFF
--- a/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
+++ b/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
@@ -7,6 +7,7 @@ from lldbsuite.test.decorators import *
 
 
 class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
+    @skipIfWindows	# rdar://163316257
     def test_command_directive_quiet_on_success(self):
         program = self.getBuildArtifact("a.out")
         command_quiet = (


### PR DESCRIPTION
It is blocking PR testing on Windows for the Swift compiler.

rdar://163316257