### PR TITLE
🍒[cas] Fix PathStorage::Path dangling pointer

### DIFF
--- a/llvm/include/llvm/CAS/FileSystemCache.h
+++ b/llvm/include/llvm/CAS/FileSystemCache.h
@@ -35,6 +35,14 @@ struct PathStorage {
   PathStorage() {}
   PathStorage(const Twine &InputPath,
               sys::path::Style Style = sys::path::Style::native) {
+    assign(InputPath, Style);
+  }
+  PathStorage(StringRef InputPath,
+              sys::path::Style Style = sys::path::Style::native) {
+    assign(InputPath, Style);
+  }
+  void assign(const Twine &InputPath,
+              sys::path::Style Style = sys::path::Style::native) {
     if (is_style_windows(Style)) {
       // Canonicalize to backslahes
       InputPath.toVector(Storage);
@@ -45,7 +53,7 @@ struct PathStorage {
       Path = Storage.str();
     }
   }
-  PathStorage(StringRef InputPath,
+  void assign(StringRef InputPath,
               sys::path::Style Style = sys::path::Style::native) {
     if (is_style_windows(Style)) {
       // Canonicalize to backslahes
@@ -56,6 +64,14 @@ struct PathStorage {
       Path = InputPath;
     }
   }
+
+  // Note: the default implementation of these would leave Path pointing to the
+  // wrong storage. We could implement them, but they are also slower than
+  // calling assign since they would copy the storage again.
+  PathStorage(const PathStorage &) = delete;
+  PathStorage(PathStorage &&) = delete;
+  PathStorage &operator=(PathStorage &&) = delete;
+  PathStorage &operator=(const PathStorage &) = delete;
 };
 
 /// Caching for lazily discovering a CAS-based filesystem.

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -915,7 +915,7 @@ void CachingOnDiskFileSystemImpl::TreeBuilder::pushEntry(
 }
 
 Error CachingOnDiskFileSystemImpl::TreeBuilder::push(const Twine &Path) {
-  Storage = PathStorage(Path);
+  Storage.assign(Path);
   StringRef PathRef = Storage.Path;
 
   // Look for Path without following symlinks. Failure here indicates that Path


### PR DESCRIPTION
The default copy/move for PathStorage leaves Path pointing to the previous storage, which could be a temporary. We could implement the copy/move operations, but they would need to copy the path storage small vector in general, which is slower than constructing it directly.

rdar://160154209
(cherry picked from commit e4d082fbbd9b59fdeaed0d6ada93c2c267c38ac7)