### PR TITLE
Pass -sdk to Windows in LLDB tests

### DIFF
--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -233,6 +233,9 @@ def use_support_substitutions(config):
         # Required in SwiftREPL tests
         sdk_path = os.environ.get("SDKROOT")
         if sdk_path:
+            # Wrap in quotes so that paths with spaces don't get mangled into
+            # multiple arguments when used as an arg.
+            sdk_path = f"'{sdk_path}'"
             llvm_config.lit_config.note(f"using SDKROOT: {sdk_path}")
             llvm_config.with_environment("SDKROOT", sdk_path)
         else:
@@ -258,7 +261,7 @@ def use_support_substitutions(config):
         ),
     ]
     swift_driver_args = []
-    if platform.system() in ["Darwin"]:
+    if platform.system() in ["Darwin", "Windows"]:
         swift_args += ["-sdk", sdk_path]
     tools = [
         ToolSubst(


### PR DESCRIPTION
Currently all LLDB tests that run `swift` are disabled or xfailed on Windows. https://github.com/swiftlang/swift/pull/85178 helps, but without explicitly passing `-sdk`, we look for `swiftrt.obj` in the wrong place.

This is the *expedient* version. It's documented that [setting `SDKROOT` makes `-sdk` default to the value of `SDKROOT`](https://github.com/swiftlang/swift/blob/fc168a077356487797d2d1121fff5ee0d4ac5b73/lib/Driver/Driver.cpp#L1404), but in this case we [explicitly check the option value](https://github.com/swiftlang/swift/blob/fc168a077356487797d2d1121fff5ee0d4ac5b73/lib/Driver/ToolChains.cpp#L1626) instead of using the derived `OutputInfo.SDKPath`. If we fix that, we don't have to pass it explicitly here at the cost of threading `SDKPath` through a bunch of places (see https://github.com/swiftlang/swift/pull/85202)