### PR TITLE
Templatize stable sip-hash over result type.

### DIFF
--- a/llvm/include/llvm/Support/SipHash.h
+++ b/llvm/include/llvm/Support/SipHash.h
@@ -48,6 +48,7 @@ LLVM_ABI void getSipHash_2_4_128(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
 /// in the ABI that use a constant zero.
 LLVM_ABI uint16_t getPointerAuthStableSipHash(StringRef S);
 
+template <typename UInt> UInt getPointerAuthStableSipHashImpl(StringRef Str);
 } // end namespace llvm
 
 #endif

--- a/llvm/lib/Support/SipHash.cpp
+++ b/llvm/lib/Support/SipHash.cpp
@@ -37,6 +37,11 @@ void llvm::getSipHash_2_4_128(ArrayRef<uint8_t> In, const uint8_t (&K)[16],
 
 /// Compute an ABI-stable 16-bit hash of the given string.
 uint16_t llvm::getPointerAuthStableSipHash(StringRef Str) {
+  return getPointerAuthStableSipHashImpl<uint16_t>(Str);
+}
+
+template <typename UInt>
+UInt llvm::getPointerAuthStableSipHashImpl(StringRef Str) {
   static const uint8_t K[16] = {0xb5, 0xd4, 0xc9, 0xeb, 0x79, 0x10, 0x4a, 0x79,
                                 0x6f, 0xec, 0x8b, 0x1b, 0x42, 0x87, 0x81, 0xd4};
 
@@ -45,7 +50,7 @@ uint16_t llvm::getPointerAuthStableSipHash(StringRef Str) {
   uint64_t RawHash = endian::read64le(RawHashBytes);
 
   // Produce a non-zero 16-bit discriminator.
-  uint16_t Discriminator = (RawHash % 0xFFFF) + 1;
+  UInt Discriminator = (RawHash % std::numeric_limits<UInt>::max()) + 1;
   LLVM_DEBUG(
       dbgs() << "ptrauth stable hash discriminator: " << utostr(Discriminator)
              << " (0x"
@@ -54,3 +59,9 @@ uint16_t llvm::getPointerAuthStableSipHash(StringRef Str) {
              << " of: " << Str << "\n");
   return Discriminator;
 }
+
+template uint16_t
+llvm::getPointerAuthStableSipHashImpl<uint16_t>(StringRef Str);
+
+template uint32_t
+llvm::getPointerAuthStableSipHashImpl<uint32_t>(StringRef Str);


### PR DESCRIPTION
Preserve the 16-bit entrypoint and add a template function with the former's old implementation which differs only in the second operand to the modulus is the max of the template type (rather than the max of uint16_t).