### PR TITLE
[6.2.1] Amazon Linux 2023: find the resource dir when using ...

### DIFF
--- a/clang/lib/Driver/ToolChains/Gnu.cpp
+++ b/clang/lib/Driver/ToolChains/Gnu.cpp
@@ -2464,7 +2464,7 @@ void Generic_GCC::GCCInstallationDetector::AddDefaultGCCPrefixes(
   static const char *const AArch64LibDirs[] = {"/lib64", "/lib"};
   static const char *const AArch64Triples[] = {
       "aarch64-none-linux-gnu", "aarch64-linux-gnu", "aarch64-redhat-linux",
-      "aarch64-suse-linux"};
+      "aarch64-suse-linux", "aarch64-amazon-linux"};
   static const char *const AArch64beLibDirs[] = {"/lib"};
   static const char *const AArch64beTriples[] = {"aarch64_be-none-linux-gnu"};
 


### PR DESCRIPTION
...default triple instead of the vendor one.

This matches the behaviour of clang and clang18 that ships as part of the distribution.

Resolves swiftlang/swift#84363

(cherry picked from commit 20cf54130aeea6a77c1fde8d9f07ce46b935c31d) (cherry picked from commit 698b96d6e3e0a168094d279db05c60b9506049f2) (cherry picked from commit c9ce849214416c6a393b4f955ab1c6271cb66e4e)