### PR TITLE
[BoundsSafety] Fix tests broken by change to how debug info in macros are handled

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-ptr-conversion-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/bounds-safety-ptr-conversion-O0.c
@@ -17,8 +17,8 @@ int main(int argc, char **argv) {
 // IR: store ptr %argv, ptr %[[ARGV_ALLOCA:[a-z0-9.]+]]
 // IR: %[[ARGV:[a-z0-9.]+]] = load ptr, ptr %[[ARGV_ALLOCA]]{{.*}}
 // IR: %[[ARGV_DEREF:[a-z0-9.]+]] = load ptr, ptr %[[ARGV]]{{.*}}
-// IR: %[[LEN_DEREF:[a-z0-9.]+]] = load i32, ptr %{{.*}}, !dbg ![[LOC_11_20:[0-9]+]]
-// IR: %[[LEN_EXT:[a-z0-9.]+]] = sext i32 %[[LEN_DEREF]] to i64, !dbg ![[LOC_11_20]]
+// IR: %[[LEN_DEREF:[a-z0-9.]+]] = load i32, ptr %{{.*}}, !dbg ![[LOC_11_33:[0-9]+]]
+// IR: %[[LEN_EXT:[a-z0-9.]+]] = sext i32 %[[LEN_DEREF]] to i64, !dbg ![[LOC_11_33]]
 // IR: icmp ule ptr %[[ARGV_DEREF]], {{.*}}, !dbg ![[LOC_11_37:[0-9]+]]
 // IR: br i1 {{.*}}, label %[[LABEL_CONT:[a-z0-9.]+]], label %[[LABEL_TRAP_RES:[a-z0-9.]+]], !dbg ![[LOC_11_37]]
 // ...
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
 // IR-DAG: ![[TRAP_LOC_11_44]] = !DILocation(line: 0, scope: ![[TRAP_INFO_11_44:[0-9]+]], inlinedAt: ![[LOC_11_44]])
 // IR-DAG: ![[TRAP_INFO_11_44]] = distinct !DISubprogram(name: "__clang_trap_msg$Bounds check failed$"
 //
-// IR-DAG: ![[LOC_11_20]] = !DILocation(line: 11, column: 20
+// IR-DAG: ![[LOC_11_33]] = !DILocation(line: 11, column: 33
 
 // IR-DAG: ![[TRAP_LOC_MISSING]] = !DILocation(line: 0, scope: ![[MAIN_SCOPE:[0-9]+]])
 // IR-DAG: ![[MAIN_SCOPE]] = distinct !DISubprogram(name: "main", {{.*}} line: 9, {{.*}} scopeLine: 9

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-argc-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-argc-O0.c
@@ -105,7 +105,7 @@ int main(int argc, char **argv) {
 // OPT-REM-NEXT: Pass:            annotation-remarks
 // OPT-REM-NEXT: Name:            BoundsSafetyCheck
 // OPT-REM-NEXT: DebugLoc:        { File: '{{.*}}ptr-count-assignment-argc-O0.c', 
-// OPT-REM-NEXT:                    Line: 11, Column: 11 }
+// OPT-REM-NEXT:                    Line: 11, Column: 24 }
 // OPT-REM-NEXT: Function:        main
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Inserted '

--- a/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-const-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/opt-remarks/ptr-count-assignment-const-O0.c
@@ -94,7 +94,7 @@ int main(void) {
 // OPT-REM-NEXT: Pass:            annotation-remarks
 // OPT-REM-NEXT: Name:            BoundsSafetyCheck
 // OPT-REM-NEXT: DebugLoc:        { File: '{{.*}}ptr-count-assignment-const-O0.c', 
-// OPT-REM-NEXT:                    Line: 11, Column: 11 }
+// OPT-REM-NEXT:                    Line: 11, Column: 24 }
 // OPT-REM-NEXT: Function:        main
 // OPT-REM-NEXT: Args:
 // OPT-REM-NEXT:   - String:          'Inserted '

--- a/clang/test/BoundsSafety/CodeGen/trap-reasons/ptr_ge_upper_bound-deref-array_subscript-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/trap-reasons/ptr_ge_upper_bound-deref-array_subscript-O0.c
@@ -61,7 +61,7 @@ int operation(int index) {
 
 // CHECK-DAG: [[TRAP_LOC:![0-9]+]] = !DILocation(line: 0, scope: [[TRAP_SCOPE]], inlinedAt: [[SRC_LOC:![0-9]+]])
 // PLAIN-DAG: [[SRC_LOC]] = !DILocation(line: 49, column: 10, scope: {{![0-9]+}})
-// MACRO-DAG: [[SRC_LOC]] = !DILocation(line: 51, column: 10, scope: {{![0-9]+}})
+// MACRO-DAG: [[SRC_LOC]] = !DILocation(line: 51, column: 16, scope: {{![0-9]+}})
 
 // In the detailed mode the address space overflow gets its own trap reason.
 // FIXME: Basic mode should probably be making this distinction too.

--- a/clang/test/BoundsSafety/CodeGen/trap-reasons/ptr_lt_lower_bound-deref-array_subscript-O0.c
+++ b/clang/test/BoundsSafety/CodeGen/trap-reasons/ptr_lt_lower_bound-deref-array_subscript-O0.c
@@ -49,4 +49,4 @@ int operation(int index) {
 // DETAILED-DAG: [[TRAP_SCOPE]] = distinct !DISubprogram(name: "__clang_trap_msg$Bounds check failed$indexing below lower bound in 'array[index]'", scope: [[FILE_SCOPE:![0-9]+]], file: [[FILE_SCOPE]], type: {{.+}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, unit: {{![0-9]+}}
 
 // PLAIN-DAG: [[LOC]] = !DILocation(line: 32, column: 10, scope: {{![0-9]+}})
-// MACRO-DAG: [[LOC]] = !DILocation(line: 34, column: 10, scope: {{![0-9]+}})
+// MACRO-DAG: [[LOC]] = !DILocation(line: 34, column: 16, scope: {{![0-9]+}})


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/160667 change changed how debug info for macros were handled.

```
commit beadb9eacb0103efcc8bc440fce4dca7deb6d051
Author: SKill <skill@google.com>
Date:   Thu Oct 30 14:39:15 2025 +0100

    [clang] Use File Location for debug info resolution. (#163982)

    To improve debuggability, the macro arguments should be resolved to
    their original location rather than macro expansion location.
```

This broke a bunch of the BoundsSafety tests because they were testing the debug info used by some macros. In particular

* The `opt-remarks` test use debug info and the location of the `<count>` in `__counted_by(<count>)` changed to point at the macro argument instead the beginning of the macro
* The `trap-reasons` tests explicitly tested the debug location of access that happened through a macro. The debug location previously pointed at the beginning of the `ARRAY` macro and now it points at the `array` argument to the macro.

rdar://163727761&163727775&163727819&163727893&163727903