### PR TITLE
[BoundsSafety] Set the default bounds check mode for driver tests

### DIFF
--- a/clang/test/BoundsSafety/Driver/bounds-safety-attributes.c
+++ b/clang/test/BoundsSafety/Driver/bounds-safety-attributes.c
@@ -4,7 +4,7 @@
 
 // RUN: %clang -c %s -### 2>&1 | not grep fexperimental-bounds-safety-attributes
 
-// RUN: %clang -fexperimental-bounds-safety-attributes -c %s -### 2>&1 | not grep fbounds-safety
+// RUN: %clang_no_bounds_check_mode_specified -fexperimental-bounds-safety-attributes -c %s -### 2>&1 | not grep fbounds-safety
 
 // RUN: %clang -fexperimental-bounds-safety-attributes -c %s -### 2>&1 | FileCheck -check-prefixes ALL,T0 %s
 // T0: -fexperimental-bounds-safety-attributes

--- a/clang/test/BoundsSafety/Driver/driver.c
+++ b/clang/test/BoundsSafety/Driver/driver.c
@@ -1,13 +1,13 @@
 // ALL-NOT: unknown argument
 
 // Warning: careful to not grep some directory in the buid
-// RUN: %clang -c %s -### 2>&1 | not grep fbounds-safety
+// RUN: %clang_no_bounds_check_mode_specified -c %s -### 2>&1 | not grep fbounds-safety
 
 // RUN: %clang -fbounds-safety -### %s 2>&1 | FileCheck -check-prefixes ALL,T0 %s
 // T0: -fbounds-safety
 // T0: -enable-constraint-elimination
 
-// RUN: %clang -fbounds-safety -fno-bounds-safety -c %s -### 2>&1 | not grep -e fbounds-safety -e enable-constraint-elimination
+// RUN: %clang_no_bounds_check_mode_specified -fbounds-safety -fno-bounds-safety -c %s -### 2>&1 | not grep -e fbounds-safety -e enable-constraint-elimination
 
 // RUN: %clang -fno-bounds-safety -fbounds-safety -c %s -### 2>&1 | FileCheck -check-prefixes ALL,T4 %s
 // T4: -fbounds-safety

--- a/clang/test/BoundsSafety/Frontend/cmdl_opts.c
+++ b/clang/test/BoundsSafety/Frontend/cmdl_opts.c
@@ -2,8 +2,8 @@
 
 // Making sure the Frontend accepts the -fbounds-safety flags - it would otherwise produce error: unknown argument '...'
 
-// RUN: %clang -cc1 -fbounds-safety -fsyntax-only %s
+// RUN: %clang_cc1 -fbounds-safety -fsyntax-only %s
 
-// RUN: %clang -cc1 -fbounds-safety -fexperimental-bounds-safety-cxx -fsyntax-only %s
+// RUN: %clang_cc1 -fbounds-safety -fexperimental-bounds-safety-cxx -fsyntax-only %s
 
-// RUN: %clang -cc1 -fbounds-safety -fexperimental-bounds-safety-objc -fsyntax-only %s
+// RUN: %clang_cc1 -fbounds-safety -fexperimental-bounds-safety-objc -fsyntax-only %s

--- a/clang/test/BoundsSafety/Frontend/objc_experimental_is_supported.m
+++ b/clang/test/BoundsSafety/Frontend/objc_experimental_is_supported.m
@@ -1,2 +1,2 @@
 
-// RUN: %clang -cc1 -fbounds-safety -fexperimental-bounds-safety-objc -fsyntax-only %s
+// RUN: %clang_cc1 -fbounds-safety -fexperimental-bounds-safety-objc -fsyntax-only %s

--- a/clang/test/BoundsSafety/Frontend/objc_experimental_without_bounds_safety_ignored.cpp
+++ b/clang/test/BoundsSafety/Frontend/objc_experimental_without_bounds_safety_ignored.cpp
@@ -1,5 +1,5 @@
 
 
-// RUN: %clang -cc1 -fexperimental-bounds-safety-objc -fsyntax-only %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fexperimental-bounds-safety-objc -fsyntax-only %s 2>&1 | FileCheck %s
 
 // CHECK: warning: -fexperimental-bounds-safety-objc without -fbounds-safety is ignored

--- a/clang/test/BoundsSafety/Frontend/only_c_is_supported.c
+++ b/clang/test/BoundsSafety/Frontend/only_c_is_supported.c
@@ -1,10 +1,10 @@
 
-// RUN: not %clang -cc1 -fbounds-safety -x c++ %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fbounds-safety -x c++ %s 2>&1 | FileCheck %s
 
-// RUN: not %clang -cc1 -fbounds-safety -x objective-c %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fbounds-safety -x objective-c %s 2>&1 | FileCheck %s
 
-// RUN: not %clang -cc1 -fbounds-safety -x objective-c++ %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fbounds-safety -x objective-c++ %s 2>&1 | FileCheck %s
 
-// RUN: not %clang -cc1 -fbounds-safety -x objective-c++ %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -fbounds-safety -x objective-c++ %s 2>&1 | FileCheck %s
 
 // CHECK: error: -fbounds-safety is supported only for C language

--- a/clang/test/BoundsSafety/lit.local.cfg.py
+++ b/clang/test/BoundsSafety/lit.local.cfg.py
@@ -1,4 +1,4 @@
-import lit
+import lit.formats
 import os
 
 # clang/test uses external shell by default, but all tests in clang/test/BoundsSafety
@@ -7,7 +7,7 @@ config.test_format = lit.formats.ShTest(False)
 
 cc1_substituted = [ False ]
 clang_substituted = [ False ]
-extra_flags = '-fno-bounds-safety-bringup-missing-checks=all'
+extra_flags = '-fbounds-safety-bringup-missing-checks=all'
 
 def get_subst(subst_name):
     subst_re = r'%\b{}\b'.format(subst_name)
@@ -45,18 +45,25 @@ def patch_clang_subst(sub_tuple):
     return (subst_name, subst)
 
 
+force_new_bounds_checks_on = False
+
 # Provide an un-patched substitution
 default_clang_subst = get_subst('clang')
 config.substitutions.append(
     (r'%\bclang_no_bounds_check_mode_specified\b', default_clang_subst)
 )
 
-config.substitutions = list(map(patch_cc1_subst, config.substitutions))
-config.substitutions = list(map(patch_clang_subst, config.substitutions))
+if False:
+    force_new_bounds_checks_on = True
 
-dir_with_patched_sub = os.path.dirname(__file__)
-for subst, patched in [('%clang_cc1', cc1_substituted[0]), ('%clang', clang_substituted[0])]:
-    if not patched:
-        lit_config.fatal(f'Failed to add `{extra_flags}` to {subst} invocations under {dir_with_patched_sub}')
-    else:
-        lit_config.note(f'Implicitly passing `{extra_flags}` to {subst} invocations under {dir_with_patched_sub}')
+if force_new_bounds_checks_on:
+    config.substitutions = list(map(patch_cc1_subst, config.substitutions))
+    config.substitutions = list(map(patch_clang_subst, config.substitutions))
+
+    dir_with_patched_sub = os.path.dirname(__file__)
+    for subst, patched in [('%clang_cc1', cc1_substituted[0]), ('%clang', clang_substituted[0])]:
+        if not patched:
+            lit_config.fatal(f'Failed to add `{extra_flags}` to {subst} invocations under {dir_with_patched_sub}')
+        else:
+            lit_config.note(f'Implicitly passing `{extra_flags}` to {subst} invocations under {dir_with_patched_sub}')
+


### PR DESCRIPTION
Previously the `%clang` substitution was using the default bounds check mode rather than the default of the diretory (i.e. new checks for `test/BoundsSafety` and legacy checks for `BoundsSafety-legacy-checks`).

This patch

1. Adds the relevant flag bounds check flag to the `%clang` substitution.
2. Adds a new `%clang_no_bounds_check_mode_specified` substitution. This is the same as `%clang` but it does not have the bounds check flag present (e.g. `-fbounds-safety-bringup-missing-checks=all`). This is needed for some test cases.

Note some tests in `BoundsSafety/Frontend` needed fixing because they were trying to invoke cc1 using `%clang` instead of `%clang_cc1`.

rdar://164123351