### PR TITLE
🍒 [-Wunsafe-buffer-usage] Check safe assignment patterns

### DIFF
--- a/clang/include/clang/Analysis/Analyses/UnsafeBufferUsage.h
+++ b/clang/include/clang/Analysis/Analyses/UnsafeBufferUsage.h
@@ -186,6 +186,11 @@ public:
                                      bool IsRelatedToDecl, ASTContext &Ctx) {
     handleUnsafeOperation(Assign, IsRelatedToDecl, Ctx);
   }
+
+  virtual void handleUnsafeCountAttributedPointerAssignment(
+      const BinaryOperator *Assign, bool IsRelatedToDecl, ASTContext &Ctx) {
+    handleUnsafeOperation(Assign, IsRelatedToDecl, Ctx);
+  }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   /// Invoked when a fix is suggested against a variable. This function groups

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -14130,6 +14130,9 @@ def warn_duplicated_assignment_in_bounds_attributed_group : Warning<
 def warn_assigned_and_used_in_bounds_attributed_group : Warning<
   "%select{variable|parameter|member}0 %1 is assigned and used in the same "
   "bounds-attributed group">, InGroup<UnsafeBufferUsage>, DefaultIgnore;
+def warn_unsafe_count_attributed_pointer_assignment : Warning<
+  "unsafe assignment to count-attributed pointer">,
+  InGroup<UnsafeBufferUsage>, DefaultIgnore;
 #ifndef NDEBUG
 // Not a user-facing diagnostic. Useful for debugging false negatives in
 // -fsafe-buffer-usage-suggestions (i.e. lack of -Wunsafe-buffer-usage fixits).

--- a/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2685,6 +2685,13 @@ public:
         << getBoundsAttributedObjectKind(VD) << VD;
     S.Diag(Use->getBeginLoc(), diag::note_used_here);
   }
+
+  void handleUnsafeCountAttributedPointerAssignment(
+      const BinaryOperator *Assign, [[maybe_unused]] bool IsRelatedToDecl,
+      [[maybe_unused]] ASTContext &Ctx) override {
+    S.Diag(Assign->getOperatorLoc(),
+           diag::warn_unsafe_count_attributed_pointer_assignment);
+  }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
   void handleUnsafeVariableGroup(const VarDecl *Variable,

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-assignment.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-count-attributed-pointer-assignment.cpp
@@ -20,6 +20,12 @@ struct cb {
   size_t count;
 };
 
+struct cb_multi {
+  int *__counted_by(m * n) p;
+  size_t m;
+  size_t n;
+};
+
 // Simple pointer and count
 
 void good_null(int *__counted_by(count) p, int count) {
@@ -27,10 +33,57 @@ void good_null(int *__counted_by(count) p, int count) {
   count = 0;
 }
 
+void good_simple_self(int *__counted_by(count) p, int count) {
+  p = p;
+  count = count;
+}
+
+void good_simple_other(int *__counted_by(count) p, int count, int *__counted_by(len) q, int len) {
+  p = q;
+  count = len;
+}
+
+void good_simple_span(int *__counted_by(count) p, size_t count, std::span<int> sp) {
+  p = sp.data();
+  count = sp.size();
+}
+
+void bad_simple_span(int *__counted_by(count) p, size_t count, std::span<int> sp) {
+  p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  count = 42;
+}
+
+void good_simple_subspan_const(int *__counted_by(count) p, int count, std::span<int> sp) {
+  p = sp.first(42).data();
+  count = 42;
+}
+
+void bad_simple_subspan_const(int *__counted_by(count) p, int count, std::span<int> sp) {
+  p = sp.first(42).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  count = 43;
+}
+
+void good_simple_subspan_var(int *__counted_by(count) p, int count, std::span<int> sp, int new_count) {
+  p = sp.first(new_count).data();
+  count = new_count;
+}
+
+void bad_simple_subspan_var(int *__counted_by(count) p, int count, std::span<int> sp, int new_count, int new_count2) {
+  p = sp.first(new_count).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  count = new_count2;
+}
+
 void good_null_loop(int *__counted_by(count) p, int count) {
   for (int i = 0; i < 2; i++) {
     p = nullptr;
     count = 0;
+  }
+}
+
+void good_simple_loop(int *__counted_by(count) p, int count, std::span<int> sp) {
+  for (int i = 0; i < 2; i++) {
+    p = sp.data();
+    count = sp.size();
   }
 }
 
@@ -41,6 +94,16 @@ void good_null_ifelse(int *__counted_by(count) p, int count) {
   } else {
     count = 0;
     p = nullptr;
+  }
+}
+
+void good_simple_ifelse(int *__counted_by(count) p, size_t count, std::span<int> a, std::span<int> b) {
+  if (count % 2 == 0) {
+    p = a.data();
+    count = a.size();
+  } else {
+    count = b.size();
+    p = b.data();
   }
 }
 
@@ -62,11 +125,198 @@ void good_struct_self(cb *c) {
   c->count = c->count;
 }
 
+void good_struct_other_struct(cb *c, cb *d) {
+  c->p = d->p;
+  c->count = d->count;
+}
+
+void good_struct_other_param(cb *c, int *__counted_by(count) p, int count) {
+  c->p = p;
+  c->count = count;
+}
+
+void good_struct_span(cb *c, std::span<int> sp) {
+  c->p = sp.data();
+  c->count = sp.size();
+}
+
+void bad_struct_span(cb *c, std::span<int> sp) {
+  c->p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  c->count = 42;
+}
+
+void good_struct_subspan(cb *c, std::span<int> sp) {
+  c->p = sp.first(42).data();
+  c->count = 42;
+}
+
+void bad_struct_subspan(cb *c, std::span<int> sp) {
+  c->p = sp.first(42).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  c->count = 43;
+}
+
+void bad_struct_unrelated_structs(cb *c, cb *d, cb *e) {
+  c->p = d->p; // expected-warning{{unsafe assignment to count-attributed pointer}}
+  c->count = e->count;
+}
+
 void good_struct_self_loop(cb *c) {
   for (int i = 0; i < 2; i++) {
     c->p = c->p;
     c->count = c->count;
   }
+}
+
+// Pointer with multiple counts
+
+void bad_multicounts_span(int *__counted_by(a + b) p, size_t a, size_t b, std::span<int> sp) {
+  p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  a = sp.size();
+  b = sp.size();
+}
+
+void good_multicounts_subspan_const(int *__counted_by(a + b) p, int a, int b, std::span<int> sp) {
+  p = sp.first(42 + 100).data();
+  a = 42;
+  b = 100;
+}
+
+void bad_multicounts_subspan_const(int *__counted_by(a + b) p, int a, int b, std::span<int> sp) {
+  p = sp.first(42 + 100).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  a = 42;
+  b = 99;
+}
+
+// TODO: Currently, we only do pattern matching against count expr. With some
+// const-eval, we could support the following pattern.
+void todo_multicounts_subspan_const(int *__counted_by(a + b) p, int a, int b, std::span<int> sp) {
+  p = sp.first(142).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  a = 42;
+  b = 100;
+}
+
+void good_multicounts_subspan_var(int *__counted_by(a + b) p, int a, int b, std::span<int> sp, int n, int m) {
+  p = sp.first(n + m).data();
+  a = n;
+  b = m;
+}
+
+void bad_multicounts_subspan_var(int *__counted_by(a + b) p, int a, int b, std::span<int> sp, int n, int m) {
+  p = sp.first(n + m).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  a = n;
+  b = n;
+}
+
+// Pointer with multiple counts in struct
+
+void bad_multicount_struct_span(cb_multi *cbm, std::span<int> sp) {
+  cbm->p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  cbm->m = sp.size();
+  cbm->n = sp.size();
+}
+
+void good_multicount_struct_subspan_const(cb_multi *cbm, std::span<int> sp) {
+  cbm->p = sp.first(42 * 100).data();
+  cbm->m = 42;
+  cbm->n = 100;
+}
+
+void bad_multicount_struct_subspan_const(cb_multi *cbm, std::span<int> sp) {
+  cbm->p = sp.first(42 * 100).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  cbm->m = 43;
+  cbm->n = 100;
+}
+
+void good_multicount_struct_subspan_var(cb_multi *cbm, std::span<int> sp, size_t a, size_t b) {
+  cbm->p = sp.first(a * b).data();
+  cbm->m = a;
+  cbm->n = b;
+}
+
+void bad_multicount_struct_subspan_var(cb_multi *cbm, std::span<int> sp, size_t a, size_t b) {
+  cbm->p = sp.first(a * b).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  cbm->m = a;
+  cbm->n = a;
+}
+
+bool good_multicount_struct_realistic(cb_multi *cbm, std::span<int> sp, size_t stride) {
+  if (sp.size() % stride != 0)
+    return false;
+  size_t length = sp.size() / stride;
+  cbm->p = sp.first(length * stride).data();
+  cbm->m = length;
+  cbm->n = stride;
+  return true;
+}
+
+// Multiple pointers
+
+void good_multiptr_span(int *__counted_by(count) p, int *__counted_by(count) q, size_t count, std::span<int> sp) {
+  p = sp.data();
+  q = sp.data();
+  count = sp.size();
+}
+
+void bad_multiptr_span(int *__counted_by(count) p, int *__counted_by(count) q, size_t count, std::span<int> sp) {
+  p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  q = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  count = 42;
+}
+
+void bad_multiptr_span_subspan(int *__counted_by(count) p, int *__counted_by(count) q, size_t count, std::span<int> sp) {
+  p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  q = sp.first(42).data();
+  count = 42;
+}
+
+void bad_multiptr_span_subspan2(int *__counted_by(count) p, int *__counted_by(count) q, size_t count, std::span<int> sp) {
+  p = sp.data();
+  q = sp.first(42).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  count = sp.size();
+}
+
+void good_multiptr_subspan(int *__counted_by(count) p, int *__counted_by(count) q, size_t count, std::span<int> sp) {
+  p = sp.first(42).data();
+  q = sp.last(42).data();
+  count = 42;
+}
+
+// Multiple pointers with multiple counts
+
+void good_multimix_subspan_complex(int *__counted_by(a * b) p, int *__counted_by((a + b) * c) q, size_t a, size_t b, size_t c,
+                                   std::span<int> sp, size_t i, size_t j, size_t k) {
+  p = sp.first(i * j).data();
+  q = sp.last((i + j) * k).data();
+  a = i;
+  b = j;
+  c = k;
+}
+
+void bad_multimix_subspan_complex(int *__counted_by(a * b) p, int *__counted_by((a + b) * c) q, size_t a, size_t b, size_t c,
+                                  std::span<int> sp, size_t i, size_t j, size_t k) {
+  p = sp.first(i * j).data();      // expected-warning{{unsafe assignment to count-attributed pointer}}
+  q = sp.last((i + j) * k).data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
+  a = k;
+  b = j;
+  c = i;
+}
+
+void good_multimix_subspan_complex2(int *__counted_by(a * b) p, int *__counted_by((a + b) * c) q, size_t a, size_t b, size_t c,
+                                    std::span<int> sp, size_t i, size_t j, size_t k) {
+  a = i * 2;
+  b = j;
+  c = j + k;
+  p = sp.first((i * 2) * j).data();
+  q = sp.last(((i * 2) + j) * (j + k)).data();
+}
+
+void good_multimix_subspan_complex_multispan(int *__counted_by(a * b) p, int *__counted_by((a + b) * c) q, size_t a, size_t b, size_t c,
+                                   std::span<int> sp, std::span<int> sp2, size_t i, size_t j, size_t k) {
+  a = i;
+  b = j;
+  c = k;
+  p = sp.first(i * j).data();
+  q = sp2.first((i + j) * k).data();
 }
 
 // Inout pointer and count
@@ -77,7 +327,7 @@ void good_inout_span(int *__counted_by(*count) *p, size_t *count, std::span<int>
 }
 
 void bad_inout_span(int *__counted_by(*count) *p, size_t *count, std::span<int> sp) {
-  *p = sp.data(); // TODO-expected-warning{{unsafe assignment to count-attributed pointer}}
+  *p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
   *count = 42;
 }
 
@@ -105,7 +355,7 @@ void good_inout_span_if(int *__counted_by(*count) *p, size_t *count, std::span<i
 
 void bad_inout_span_if(int *__counted_by(*count) *p, size_t *count, std::span<int> sp, size_t size) {
   if (p && count) {
-    *p = sp.data(); // TODO-expected-warning{{unsafe assignment to count-attributed pointer}}
+    *p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
     *count = size;
   }
 }
@@ -117,7 +367,7 @@ class inout_class {
   }
 
   void bad_inout_span(int *__counted_by(*count) *p, size_t *count, std::span<int> sp) {
-    *p = sp.data(); // TODO-expected-warning{{unsafe assignment to count-attributed pointer}}
+    *p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
     *count = 42;
   }
 
@@ -130,7 +380,7 @@ class inout_class {
 // Inout pointer
 
 void bad_inout_ptr_span(int *__counted_by(count) *p, int count, std::span<int> sp) {
-  *p = sp.data(); // TODO-expected-warning{{unsafe assignment to count-attributed pointer}}
+  *p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
 }
 
 void good_inout_ptr_subspan(int *__counted_by(count) *p, size_t count, std::span<int> sp) {
@@ -147,7 +397,7 @@ void good_inout_ptr_multi_subspan(int *__counted_by(a + b) *p, size_t a, size_t 
 
 class inout_ptr_class {
   void bad_inout_ptr_span(int *__counted_by(count) *p, int count, std::span<int> sp) {
-    *p = sp.data(); // TODO-expected-warning{{unsafe assignment to count-attributed pointer}}
+    *p = sp.data(); // expected-warning{{unsafe assignment to count-attributed pointer}}
   }
 
   void good_inout_ptr_subspan(int *__counted_by(count) *p, size_t count, std::span<int> sp) {


### PR DESCRIPTION
Check safe assignment patterns. This uses the infrastructure that is already available for count-attributed arguments, and checks for each assigned pointer in the group that the RHS has enough elements.

rdar://161608493

(cherry picked from commit cb7dcc9cd230ba2bad413f8c7043ae8f4cd758ff)