### PR TITLE
[lldb][test] check if CoreDumping is supported at runtime  (#161385)

### DIFF
--- a/lldb/unittests/Host/posix/HostTest.cpp
+++ b/lldb/unittests/Host/posix/HostTest.cpp
@@ -15,10 +15,6 @@
 #include <cerrno>
 #include <sys/resource.h>
 
-#ifdef __linux__
-#include <linux/version.h>
-#endif // __linux__
-
 using namespace lldb_private;
 
 namespace {
@@ -120,12 +116,13 @@ TEST_F(HostTest, GetProcessInfoSetsPriority) {
   ASSERT_TRUE(Info.IsZombie().has_value());
   ASSERT_FALSE(Info.IsZombie().value());
 
-  // CoreDumping was added in kernel version 4.15.
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-  ASSERT_TRUE(Info.IsCoreDumping().has_value());
-  ASSERT_FALSE(Info.IsCoreDumping().value());
-#else
-  ASSERT_FALSE(Info.IsCoreDumping().has_value());
-#endif
+  const llvm::VersionTuple host_version = HostInfo::GetOSVersion();
+  ASSERT_FALSE(host_version.empty());
+  if (host_version >= llvm::VersionTuple(4, 15, 0)) {
+    ASSERT_TRUE(Info.IsCoreDumping().has_value());
+    ASSERT_FALSE(Info.IsCoreDumping().value());
+  } else {
+    ASSERT_FALSE(Info.IsCoreDumping().has_value());
+  }
 }
 #endif


### PR DESCRIPTION
#160333 reimplementation but at runtime instead because of broken CI.

---------



(cherry picked from commit c488dca6564d11ae84fb482599996a9d310f370d)