### PR TITLE
[debugserver] Remove unnecessary sleep in MachProcess::AttachForDebug

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -2853,12 +2853,6 @@ pid_t MachProcess::AttachForDebug(
 
     if (err.Success()) {
       m_flags |= eMachProcessFlagsAttached;
-      // Sleep a bit to let the exception get received and set our process
-      // status
-      // to stopped.
-      ::usleep(250000);
-      DNBLog("[LaunchAttach] (%d) Done napping after ptrace(PT_ATTACHEXC)'ing",
-             getpid());
       DNBLogThreadedIf(LOG_PROCESS, "successfully attached to pid %d", pid);
       return m_pid;
     } else {


### PR DESCRIPTION
Remove the unnecessary sleep in MachProcess::AttachForDebug. The preceding comment makes it seem like it's necessary for synchronization, though I don't believe that's the case (see below), and even if it were, sleeping is not a reliable way to achieve that.

The reason I don't believe it's necessary is because after we return, we synchronize with the exception thread on a state change. The latter will call and update the process state, which is exactly what we synchronize on. I was able to verify that this is the first time we change the process state: i.e., `GetState` doesn't return a different value before and after the sleep.

On top of that, there are 3 more places where we call ptrace attach (`PosixSpawnChildForPTraceDebugging`, `SBLaunchForDebug`, and `BoardServiceLaunchForDebug`) where we don't sleep.

rdar://163952037
(cherry picked from commit fa83723bbe55f2aee857438f8087c4fc0f52449e)