### PR TITLE
🍒 [lldb][test] Skip tail_call_frames tests on older Clang versions

### DIFF
--- a/lldb/test/API/functionalities/tail_call_frames/cross_dso/TestCrossDSOTailCalls.py
+++ b/lldb/test/API/functionalities/tail_call_frames/cross_dso/TestCrossDSOTailCalls.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCrossDSOTailCalls(TestBase):
-    @skipIf(compiler="clang", compiler_version=["<", "10.0"])
+    @skipIf(compiler="clang", compiler_version=["<", "22.0"])
     @skipIf(dwarf_version=["<", "4"])
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr26265")
     def test_cross_dso_tail_calls(self):

--- a/lldb/test/API/functionalities/tail_call_frames/cross_object/TestCrossObjectTailCalls.py
+++ b/lldb/test/API/functionalities/tail_call_frames/cross_object/TestCrossObjectTailCalls.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestCrossObjectTailCalls(TestBase):
-    @skipIf(compiler="clang", compiler_version=["<", "10.0"])
+    @skipIf(compiler="clang", compiler_version=["<", "22.0"])
     @skipIf(dwarf_version=["<", "4"])
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr26265")
     def test_cross_object_tail_calls(self):


### PR DESCRIPTION
These have been un-XFAILed in
`ebe6eba62580592af7065a36b22d929c15291e9a`, but require following Clang fix: https://github.com/llvm/llvm-project/pull/150022. So skip older compilers.

(cherry picked from commit 779868de6975f6fd0ea17bb9a8e929037d3752d7)