### PR TITLE
🍒 [lldb][test] Remove a Windows xfail from TestThreadStates

### DIFF
--- a/lldb/test/API/functionalities/thread/state/TestThreadStates.py
+++ b/lldb/test/API/functionalities/thread/state/TestThreadStates.py
@@ -30,7 +30,6 @@ class ThreadStateTestCase(TestBase):
     @expectedFailureAll(
         oslist=lldbplatformutil.getDarwinOSTriples(), bugnumber="llvm.org/pr23669"
     )
-    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24660")
     def test_state_after_continue(self):
         """Test thread state after continue."""
         self.build()


### PR DESCRIPTION
This case is passing since https://github.com/llvm/llvm-project/pull/152020.

(cherry picked from commit 52f7cfb5ef0a21173f0c7ae2305c76e1662831c5)

rdar://160015182