### PR TITLE
[lldb] Detect not-captured variables in DIL's impl of GetValueForVariableExpressionPath

### DIFF
--- a/lldb/include/lldb/Target/StackFrame.h
+++ b/lldb/include/lldb/Target/StackFrame.h
@@ -533,6 +533,17 @@ public:
 
   lldb::RecognizedStackFrameSP GetRecognizedFrame();
 
+  // BEGIN SWIFT
+  // Implement LanguageCPlusPlus::GetParentNameIfClosure and upstream this.
+  // rdar://152321823
+  /// If `sc` represents a "closure-like" function according to `lang`, and
+  /// `missing_var_name` can be found in a parent context, create a diagnostic
+  /// explaining that this variable is available but not captured by the
+  /// closure.
+  std::string
+  GetVariableNotCapturedDiagnostic(llvm::StringRef missing_var_name);
+  // END SWIFT
+
 protected:
   friend class StackFrameList;
 

--- a/lldb/source/ValueObject/DILEval.cpp
+++ b/lldb/source/ValueObject/DILEval.cpp
@@ -161,6 +161,15 @@ Interpreter::Visit(const IdentifierNode *node) {
     identifier = LookupGlobalIdentifier(node->GetName(), m_exe_ctx_scope,
                                         m_target, use_dynamic);
   if (!identifier) {
+    // BEGIN SWIFT
+    // Implement LanguageCPlusPlus::GetParentNameIfClosure and upstream this.
+    // rdar://152321823
+    if (std::string message =
+            m_exe_ctx_scope->GetVariableNotCapturedDiagnostic(node->GetName());
+        !message.empty())
+      return llvm::make_error<DILDiagnosticError>(
+          m_expr, message, node->GetLocation(), node->GetName().size());
+    // END SWIFT
     std::string errMsg =
         llvm::formatv("use of undeclared identifier '{0}'", node->GetName());
     return llvm::make_error<DILDiagnosticError>(

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -54,8 +54,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @swiftTest
     def test_simple_closure(self):
         self.build()
-        # rdar://158447239
-        self.runCmd('settings set target.experimental.use-DIL false')
         (target, process, thread) = self.get_to_bkpt("break_simple_closure")
         check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_1(arg:)")
         check_not_captured_error(self, thread.frames[0], "arg", "func_1(arg:)")
@@ -64,8 +62,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @swiftTest
     def test_nested_closure(self):
         self.build()
-        # rdar://158447239
-        self.runCmd('settings set target.experimental.use-DIL false')
         (target, process, thread) = self.get_to_bkpt("break_double_closure_1")
         check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_2(arg:)")
         check_not_captured_error(self, thread.frames[0], "arg", "func_2(arg:)")
@@ -92,8 +88,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @skipIf(oslist=["windows", "linux"])
     def test_async_closure(self):
         self.build()
-        # rdar://158447239
-        self.runCmd('settings set target.experimental.use-DIL false')
         (target, process, thread) = self.get_to_bkpt("break_async_closure_1")
         check_not_captured_error(self, thread.frames[0], "var_in_foo", "func_3(arg:)")
         check_not_captured_error(self, thread.frames[0], "arg", "func_3(arg:)")
@@ -115,8 +109,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @swiftTest
     def test_ctor_class_closure(self):
         self.build()
-        # rdar://158447239
-        self.runCmd('settings set target.experimental.use-DIL false')
         (target, process, thread) = self.get_to_bkpt("break_ctor_class")
         check_not_captured_error(
             self, thread.frames[0], "input", "MY_CLASS.init(input:)"
@@ -174,8 +166,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @swiftTest
     def test_ctor_struct_closure(self):
         self.build()
-        # rdar://158447239
-        self.runCmd('settings set target.experimental.use-DIL false')
         (target, process, thread) = self.get_to_bkpt("break_ctor_struct")
         check_not_captured_error(
             self, thread.frames[0], "input", "MY_STRUCT.init(input:)"
@@ -233,8 +223,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
     @swiftTest
     def test_ctor_enum_closure(self):
         self.build()
-        # rdar://158447239
-        self.runCmd('settings set target.experimental.use-DIL false')
         (target, process, thread) = self.get_to_bkpt("break_ctor_enum")
         check_not_captured_error(
             self, thread.frames[0], "input", "MY_ENUM.init(input:)"


### PR DESCRIPTION
This PR contains two commits:

1. An NFC refactor that moves a function into a header for re-use.
2. A fix for detecting not-captured variables in DIL's impl of GetValueForVariableExpressionPath

rdar://158447239