### PR TITLE
normalize vendor name when vendor is unknown

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3037,7 +3037,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
           {
             llvm::raw_svector_ostream os(buffer);
             os << preferred_triple.getArchName() << '-';
-            os << preferred_triple.getVendorName() << '-';
+            os << llvm::Triple::getVendorTypeName(preferred_triple.getVendor()) << '-';
             os << llvm::Triple::getOSTypeName(preferred_triple.getOS());
             os << platform_version.getAsString();
           }


### PR DESCRIPTION
Currently on FreeBSD, the triple is set to `x86_64--freebsd` instead of `x86_64-unknown-freebsd`. normalize the triple when the vendor type is unknown.