### PR TITLE
[6.2][ScanDaemon] Increase the timeouts in daemon

### DIFF
--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -117,8 +117,8 @@ Expected<ScanDaemon> ScanDaemon::connectToDaemon(StringRef BasePath,
   if (!Socket)
     return reportError(Socket.takeError());
 
-  // Wait up to 30 seconds.
-  constexpr int MaxWait = 30 * 1000 * 1000;
+  // Wait up to 60 seconds.
+  constexpr int MaxWait = 60 * 1000 * 1000;
   int NextBackoff = 0;
   int TotalBackoff = 0;
   while (TotalBackoff < MaxWait) {
@@ -139,8 +139,9 @@ Expected<ScanDaemon> ScanDaemon::connectToDaemon(StringRef BasePath,
           std::error_code(errno, std::generic_category())));
   }
 
-  return reportError(
-      llvm::errorCodeToError(std::error_code(ENOENT, std::generic_category())));
+  return llvm::createStringError(
+      std::make_error_code(std::errc::timed_out),
+      "timeout when connecting to scan daemon on path: '" + BasePath + "'");
 }
 
 Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -768,7 +768,7 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
     reportError("unknown command '" + Command + "'");
   }
 
-  Server.TimeoutSeconds = LongRunning ? 45 : 15;
+  Server.TimeoutSeconds = LongRunning ? 120 : 15;
 
   // Daemonize.
   if (::signal(SIGHUP, SIG_IGN) == SIG_ERR)


### PR DESCRIPTION
Increase the timeout in clang scan daemon for both connecting to a just launched daemon (due to possibility of hitting validation and pruning) and daemon lifetime timeout (due to possibility of large gaps between tasks in the same session).

Also adjust the error message for connection timeout to make it more obvious.

rdar://164491940