### PR TITLE
[-Wunsafe-buffer-usage] Fix false positive when assigning in C++ class

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -5608,8 +5608,10 @@ static bool isSameMemberBase(const Expr *Self, const Expr *Other) {
 
     const auto *SelfICE = dyn_cast<ImplicitCastExpr>(Self);
     const auto *OtherICE = dyn_cast<ImplicitCastExpr>(Other);
-    if (SelfICE && OtherICE && SelfICE->getCastKind() == CK_LValueToRValue &&
-        OtherICE->getCastKind() == CK_LValueToRValue) {
+    if (SelfICE && OtherICE &&
+        SelfICE->getCastKind() == OtherICE->getCastKind() &&
+        (SelfICE->getCastKind() == CK_LValueToRValue ||
+         SelfICE->getCastKind() == CK_UncheckedDerivedToBase)) {
       Self = SelfICE->getSubExpr();
       Other = OtherICE->getSubExpr();
     }
@@ -5618,6 +5620,12 @@ static bool isSameMemberBase(const Expr *Self, const Expr *Other) {
     const auto *OtherDRE = dyn_cast<DeclRefExpr>(Other);
     if (SelfDRE && OtherDRE)
       return SelfDRE->getDecl() == OtherDRE->getDecl();
+
+    if (isa<CXXThisExpr>(Self) && isa<CXXThisExpr>(Other)) {
+      // `Self` and `Other` should be evaluated at the same state so `this` must
+      // mean the same thing for both:
+      return true;
+    }
 
     const auto *SelfME = dyn_cast<MemberExpr>(Self);
     const auto *OtherME = dyn_cast<MemberExpr>(Other);


### PR DESCRIPTION
Fix false positive when assigning to `__counted_by()` that is a class member. The analysis fails to see through `CXXThisExpr` and thinks we are assigning 2 different groups. This is caused by me, failing to copy/paste the updated version of `isSameMemberBase()`.

Example before this patch:
```cxx
struct cb {
  int *__counted_by(count) p;
  size_t count;
};

class struct_test {
  cb cb_;

  void set_cb(std::span<int> sp) {
    cb_.p = sp.data();     // warning: missing assignment to count
    cb_.count = sp.size(); // warning: missing assignment to p
  }
};
```

rdar://164535516