### PR TITLE
[ScanDaemon] unlock pid file first before unlink socket

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -659,6 +659,9 @@ struct ScanServer {
   /// jobs to finish.
   void shutdown() {
     ShutDown.store(true);
+    // Unlock pidfile first so another daemon can spin up when it can't find
+    // the socket.
+    ::flock(PidFD, LOCK_UN);
     cc1depscand::unlinkBoundSocket(BasePath);
     // Clean up the pidfile when we're done.
     if (PidFD != -1)


### PR DESCRIPTION
Fix a potential issue that can cause new clang scan daemon failed to start when the previous daemon timed out at the same time. It is possible for the timed out daemon still hold pid file when being shutdown, when the new clang daemon is starting up and failed to lock the pid file. To the new clang daemon, this is indistinguishable from losing the race to start a new daemon with another clang invocation, thus the new starting request will be dropped and no daemon will be started.