### PR TITLE
[Cherry-pick into next] normalize vendor name when vendor is unknown

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3037,7 +3037,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
           {
             llvm::raw_svector_ostream os(buffer);
             os << preferred_triple.getArchName() << '-';
-            os << preferred_triple.getVendorName() << '-';
+            os << llvm::Triple::getVendorTypeName(preferred_triple.getVendor()) << '-';
             os << llvm::Triple::getOSTypeName(preferred_triple.getOS());
             os << platform_version.getAsString();
           }


### PR DESCRIPTION
```
commit 931d73a76254907c6b4dc90be615e745d2359b4a
Author: Michael Chiu <m_chiu@apple.com>
Date:   Mon Nov 10 15:09:12 2025 -0800

    normalize vendor name when vendor is unknown
```
