### PR TITLE
Clean up MachTask.mm's handling of m_exception_thread.

### DIFF
--- a/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
+++ b/lldb/tools/debugserver/source/MacOSX/MachProcess.mm
@@ -1739,7 +1739,7 @@ bool MachProcess::Detach() {
     ReplyToAllExceptions();
   }
 
-  m_task.ShutDownExcecptionThread();
+  m_task.ShutDownExceptionThread();
 
   // Detach from our process
   errno = 0;

--- a/lldb/tools/debugserver/source/MacOSX/MachTask.h
+++ b/lldb/tools/debugserver/source/MacOSX/MachTask.h
@@ -68,7 +68,7 @@ public:
   bool ExceptionPortIsValid() const;
   kern_return_t SaveExceptionPortInfo();
   kern_return_t RestoreExceptionPortInfo();
-  kern_return_t ShutDownExcecptionThread();
+  void ShutDownExceptionThread();
 
   bool StartExceptionThread(
       const RNBContext::IgnoredExceptions &ignored_exceptions, DNBError &err);


### PR DESCRIPTION
This was getting joined in ShutDownExcecptionThread (sic) but not cleared.  So this function was not safe to call twice, since you aren't supposed to join a thread twice.  Sadly, this was called in MachTask::Clear and MachProcess::Destroy, which are both called when you tell debugserver to detach.

This didn't seem to cause problems IRL, but the most recent ASAN detects this as an error and calls ASAN::Die, which was causing all the tests that ran detach to fail.

I fixed that by moving the clear & test for m_exception_thread to ShutDownExceptionThread.  I also fixed the spelling of that routine. And that routine was claiming to return a kern_return_t which no one was checking.  It actually returns a kern_return_t if there was a Mach failure and a Posix error if there was a join failure.  Since there's really nothing you can do but exit if this fails, which is always what you are in the process of doing when you call this, and since we have already done all the useful logging in ShutDownExceptionThread, I just removed the return value.