### PR TITLE
🍒 Add missing `LLVM_ABI` annotations (llvm#167718)

### DIFF
--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -34,7 +34,7 @@ public:
   // which then `getOrCompute` method can be used to avoid multiple calls to
   // has function.
   CacheKey(const CASID &ID);
-  CacheKey(const ObjectProxy &Proxy);
+  LLVM_ABI_FOR_TEST CacheKey(const ObjectProxy &Proxy);
   CacheKey(const ObjectStore &CAS, const ObjectRef &Ref);
 
 private:
@@ -142,14 +142,16 @@ private:
 };
 
 /// Create an action cache in memory.
-std::unique_ptr<ActionCache> createInMemoryActionCache();
+LLVM_ABI std::unique_ptr<ActionCache> createInMemoryActionCache();
 
 /// Get a reasonable default on-disk path for a persistent ActionCache for the
 /// current user.
 std::string getDefaultOnDiskActionCachePath();
 
 /// Create an action cache on disk.
-Expected<std::unique_ptr<ActionCache>> createOnDiskActionCache(StringRef Path);
+LLVM_ABI Expected<std::unique_ptr<ActionCache>>
+createOnDiskActionCache(StringRef Path);
+
 } // end namespace llvm::cas
 
 #endif // LLVM_CAS_CASACTIONCACHE_H

--- a/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
+++ b/llvm/include/llvm/CAS/BuiltinUnifiedCASDatabases.h
@@ -18,6 +18,7 @@ class ObjectStore;
 
 /// Create on-disk \c ObjectStore and \c ActionCache instances based on
 /// \c ondisk::UnifiedOnDiskCache, with built-in hashing.
+LLVM_ABI
 Expected<std::pair<std::unique_ptr<ObjectStore>, std::unique_ptr<ActionCache>>>
 createOnDiskUnifiedCASDatabases(StringRef Path);
 

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -67,7 +67,7 @@ public:
     ID.print(OS);
     return OS;
   }
-  std::string toString() const;
+  LLVM_ABI std::string toString() const;
 
   ArrayRef<uint8_t> getHash() const {
     return arrayRefFromStringRef<uint8_t>(Hash);

--- a/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
+++ b/llvm/include/llvm/CAS/MappedFileRegionBumpPtr.h
@@ -50,7 +50,7 @@ public:
   /// \param BumpPtrOffset the offset at which to store the bump pointer.
   /// \param NewFileConstructor is for constructing new files. It has exclusive
   /// access to the file. Must call \c initializeBumpPtr.
-  static Expected<MappedFileRegionBumpPtr>
+  LLVM_ABI_FOR_TEST static Expected<MappedFileRegionBumpPtr>
   create(const Twine &Path, uint64_t Capacity, int64_t BumpPtrOffset,
          std::shared_ptr<ondisk::OnDiskCASLogger> Logger,
          function_ref<Error(MappedFileRegionBumpPtr &)> NewFileConstructor);
@@ -75,7 +75,7 @@ public:
     return data() + *Offset;
   }
   /// Allocate, returning the offset from \a data() instead of a pointer.
-  Expected<int64_t> allocateOffset(uint64_t AllocSize);
+  LLVM_ABI_FOR_TEST Expected<int64_t> allocateOffset(uint64_t AllocSize);
 
   char *data() const { return Region.data(); }
   uint64_t size() const { return H->BumpPtr; }
@@ -97,7 +97,7 @@ public:
   MappedFileRegionBumpPtr &operator=(const MappedFileRegionBumpPtr &) = delete;
 
 private:
-  void destroyImpl();
+  LLVM_ABI_FOR_TEST void destroyImpl();
   void moveImpl(MappedFileRegionBumpPtr &RHS) {
     std::swap(Region, RHS.Region);
     std::swap(H, RHS.H);

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -225,7 +225,8 @@ protected:
 
 public:
   /// Helper functions to store object and returns a ObjectProxy.
-  Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs, StringRef Data);
+  LLVM_ABI_FOR_TEST Expected<ObjectProxy> createProxy(ArrayRef<ObjectRef> Refs,
+                                                      StringRef Data);
 
   /// Store object from StringRef.
   Expected<ObjectRef> storeFromString(ArrayRef<ObjectRef> Refs,
@@ -251,10 +252,10 @@ public:
   static Error createUnknownObjectError(const CASID &ID);
 
   /// Create ObjectProxy from CASID. If the object doesn't exist, get an error.
-  Expected<ObjectProxy> getProxy(const CASID &ID);
+  LLVM_ABI Expected<ObjectProxy> getProxy(const CASID &ID);
   /// Create ObjectProxy from ObjectRef. If the object can't be loaded, get an
   /// error.
-  Expected<ObjectProxy> getProxy(ObjectRef Ref);
+  LLVM_ABI Expected<ObjectProxy> getProxy(ObjectRef Ref);
 
   /// \returns \c std::nullopt if the object is missing from the CAS.
   Expected<std::optional<ObjectProxy>> getProxyIfExists(ObjectRef Ref);
@@ -394,7 +395,8 @@ private:
   ObjectHandle H;
 };
 
-std::unique_ptr<ObjectStore> createInMemoryCAS();
+/// Create an in memory CAS.
+LLVM_ABI std::unique_ptr<ObjectStore> createInMemoryCAS();
 
 /// \returns true if \c LLVM_ENABLE_ONDISK_CAS configuration was enabled.
 bool isOnDiskCASEnabled();
@@ -406,7 +408,8 @@ bool isOnDiskCASEnabled();
 ///
 /// FIXME: Remove the special behaviour for getDefaultOnDiskCASStableID(). The
 /// client should handle this logic, if/when desired.
-Expected<std::unique_ptr<ObjectStore>> createOnDiskCAS(const Twine &Path);
+LLVM_ABI Expected<std::unique_ptr<ObjectStore>>
+createOnDiskCAS(const Twine &Path);
 
 /// Set \p Path to a reasonable default on-disk path for a persistent CAS for
 /// the current user.

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -259,10 +259,11 @@ public:
   /// already a record for this object the operation is a no-op. \param ID the
   /// object ID to associate the data & references with. \param Refs references
   /// \param Data data buffer.
-  Error store(ObjectID ID, ArrayRef<ObjectID> Refs, ArrayRef<char> Data);
+  LLVM_ABI_FOR_TEST Error store(ObjectID ID, ArrayRef<ObjectID> Refs,
+                                ArrayRef<char> Data);
 
   /// \returns \p nullopt if the object associated with \p Ref does not exist.
-  Expected<std::optional<ObjectHandle>> load(ObjectID Ref);
+  LLVM_ABI_FOR_TEST Expected<std::optional<ObjectHandle>> load(ObjectID Ref);
 
   /// \returns the hash bytes digest for the object reference.
   ArrayRef<uint8_t> getDigest(ObjectID Ref) const {
@@ -271,12 +272,13 @@ public:
 
   /// Form a reference for the provided hash. The reference can be used as part
   /// of a CAS object even if it's not associated with an object yet.
-  Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
+  LLVM_ABI_FOR_TEST Expected<ObjectID> getReference(ArrayRef<uint8_t> Hash);
 
   /// Get an existing reference to the object \p Digest.
   ///
   /// Returns \p nullopt if the object is not stored in this CAS.
-  std::optional<ObjectID> getExistingReference(ArrayRef<uint8_t> Digest);
+  LLVM_ABI_FOR_TEST std::optional<ObjectID>
+  getExistingReference(ArrayRef<uint8_t> Digest);
 
   /// Check whether the object associated with \p Ref is stored in the CAS.
   /// Note that this function will fault-in according to the policy.
@@ -289,7 +291,7 @@ public:
   }
 
   /// \returns the data part of the provided object handle.
-  ArrayRef<char> getObjectData(ObjectHandle Node) const;
+  LLVM_ABI_FOR_TEST ArrayRef<char> getObjectData(ObjectHandle Node) const;
 
   object_refs_range getObjectRefs(ObjectHandle Node) const {
     InternalRefArrayRef Refs = getInternalRefs(Node);
@@ -300,7 +302,7 @@ public:
   ///
   /// NOTE: There's a possibility that the returned size is not including a
   /// large object if the process crashed right at the point of inserting it.
-  size_t getStorageSize() const;
+  LLVM_ABI_FOR_TEST size_t getStorageSize() const;
 
   /// \returns The precentage of space utilization of hard space limits.
   ///
@@ -335,13 +337,13 @@ public:
   /// \param Policy If \p UpstreamDB is provided, controls how nodes are copied
   /// to primary store. This is recorded at creation time and subsequent opens
   /// need to pass the same policy otherwise the \p open will fail.
-  static Expected<std::unique_ptr<OnDiskGraphDB>>
+  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<OnDiskGraphDB>>
   open(StringRef Path, StringRef HashName, unsigned HashByteSize,
        std::unique_ptr<OnDiskGraphDB> UpstreamDB = nullptr,
        std::shared_ptr<OnDiskCASLogger> Logger = nullptr,
        FaultInPolicy Policy = FaultInPolicy::FullTree);
 
-  ~OnDiskGraphDB();
+  LLVM_ABI_FOR_TEST ~OnDiskGraphDB();
 
 private:
   struct IndexProxy;
@@ -354,7 +356,9 @@ private:
     OnlyInUpstreamDB,
   };
 
-  ObjectPresence getObjectPresence(ObjectID Ref, bool CheckUpstream) const;
+  /// Check if object exists and if it is on upstream only.
+  LLVM_ABI_FOR_TEST ObjectPresence
+  getObjectPresence(ObjectID Ref, bool CheckUpstream) const;
 
   bool containsObject(ObjectID Ref, bool CheckUpstream) const {
     switch (getObjectPresence(Ref, CheckUpstream)) {
@@ -393,7 +397,9 @@ private:
   void getStandalonePath(StringRef FileSuffix, const IndexProxy &I,
                          SmallVectorImpl<char> &Path) const;
 
-  ArrayRef<uint8_t> getDigest(InternalRef Ref) const;
+  LLVM_ABI_FOR_TEST ArrayRef<uint8_t>
+  getDigest(InternalRef Ref) const;
+
   ArrayRef<uint8_t> getDigest(const IndexProxy &I) const;
 
   IndexProxy getIndexProxyFromRef(InternalRef Ref) const;
@@ -403,7 +409,8 @@ private:
   IndexProxy
   getIndexProxyFromPointer(OnDiskHashMappedTrie::const_pointer P) const;
 
-  InternalRefArrayRef getInternalRefs(ObjectHandle Node) const;
+  LLVM_ABI_FOR_TEST InternalRefArrayRef
+  getInternalRefs(ObjectHandle Node) const;
 
   void recordStandaloneSizeIncrease(size_t SizeIncrease);
 

--- a/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
+++ b/llvm/include/llvm/CAS/OnDiskKeyValueDB.h
@@ -28,11 +28,13 @@ public:
   ///
   /// \returns the value associated with the \p Key. It may be different than
   /// \p Value if another value is already associated with this key.
-  Expected<ArrayRef<char>> put(ArrayRef<uint8_t> Key, ArrayRef<char> Value);
+  LLVM_ABI_FOR_TEST Expected<ArrayRef<char>> put(ArrayRef<uint8_t> Key,
+                                                 ArrayRef<char> Value);
 
   /// \returns the value associated with the \p Key, or \p std::nullopt if the
   /// key does not exist.
-  Expected<std::optional<ArrayRef<char>>> get(ArrayRef<uint8_t> Key);
+  LLVM_ABI_FOR_TEST Expected<std::optional<ArrayRef<char>>>
+  get(ArrayRef<uint8_t> Key);
 
   /// \returns Total size of stored data.
   size_t getStorageSize() const {
@@ -55,13 +57,13 @@ public:
   /// \param KeySize Size for the key hash bytes.
   /// \param ValueName Identifier name for the values.
   /// \param ValueSize Size for the value bytes.
-  static Expected<std::unique_ptr<OnDiskKeyValueDB>>
+  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<OnDiskKeyValueDB>>
   open(StringRef Path, StringRef HashName, unsigned KeySize,
        StringRef ValueName, size_t ValueSize,
        std::shared_ptr<OnDiskCASLogger> Logger = nullptr);
 
   using CheckValueT = function_ref<Error(FileOffset Offset, ArrayRef<char>)>;
-  Error validate(CheckValueT CheckValue) const;
+  LLVM_ABI_FOR_TEST Error validate(CheckValueT CheckValue) const;
 
 private:
   OnDiskKeyValueDB(size_t ValueSize, OnDiskHashMappedTrie Cache)

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -77,7 +77,7 @@ public:
   /// \param FaultInPolicy Controls how nodes are copied to primary store. This
   /// is recorded at creation time and subsequent opens need to pass the same
   /// policy otherwise the \p open will fail.
-  static Expected<std::unique_ptr<UnifiedOnDiskCache>>
+  LLVM_ABI_FOR_TEST static Expected<std::unique_ptr<UnifiedOnDiskCache>>
   open(StringRef Path, std::optional<uint64_t> SizeLimit, StringRef HashName,
        unsigned HashByteSize,
        OnDiskGraphDB::FaultInPolicy FaultInPolicy =
@@ -118,20 +118,20 @@ public:
   /// \param CheckSizeLimit if true it will check whether the primary store has
   /// exceeded its intended size limit. If false the check is skipped even if a
   /// \p SizeLimit was passed to the \p open call.
-  Error close(bool CheckSizeLimit = true);
+  LLVM_ABI_FOR_TEST Error close(bool CheckSizeLimit = true);
 
   /// Set the size for limiting growth. This has an effect for when the instance
   /// is closed.
-  void setSizeLimit(std::optional<uint64_t> SizeLimit);
+  LLVM_ABI_FOR_TEST void setSizeLimit(std::optional<uint64_t> SizeLimit);
 
   /// \returns the storage size of the cache data.
-  uint64_t getStorageSize() const;
+  LLVM_ABI_FOR_TEST uint64_t getStorageSize() const;
 
   /// \returns whether the primary store has exceeded the intended size limit.
   /// This can return false even if the overall size of the opened directory is
   /// over the \p SizeLimit passed to \p open. To know whether garbage
   /// collection needs to be triggered or not, call \p needsGarbaseCollection.
-  bool hasExceededSizeLimit() const;
+  LLVM_ABI_FOR_TEST bool hasExceededSizeLimit() const;
 
   /// \returns whether there are unused data that can be deleted using a
   /// \p collectGarbage call.
@@ -146,12 +146,12 @@ public:
   ///
   /// It is recommended that garbage-collection is triggered concurrently in the
   /// background, so that it has minimal effect on the workload of the process.
-  static Error collectGarbage(StringRef Path,
-                              ondisk::OnDiskCASLogger *Logger = nullptr);
+  LLVM_ABI_FOR_TEST static Error
+  collectGarbage(StringRef Path, ondisk::OnDiskCASLogger *Logger = nullptr);
 
   Error collectGarbage();
 
-  ~UnifiedOnDiskCache();
+  LLVM_ABI_FOR_TEST ~UnifiedOnDiskCache();
 
   Error validateActionCache();
 

--- a/llvm/include/llvm/IR/BasicBlock.h
+++ b/llvm/include/llvm/IR/BasicBlock.h
@@ -750,7 +750,7 @@ public:
   /// instructions, so the order should be validated no more than once after
   /// each ordering to ensure that transforms have the same algorithmic
   /// complexity when asserts are enabled as when they are disabled.
-  void validateInstrOrdering() const;
+  LLVM_ABI_FOR_TEST void validateInstrOrdering() const;
 };
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).

--- a/llvm/include/llvm/SandboxIR/Argument.h
+++ b/llvm/include/llvm/SandboxIR/Argument.h
@@ -29,7 +29,7 @@ public:
     assert(isa<llvm::Argument>(Val) && "Expected Argument!");
   }
   void printAsOperand(raw_ostream &OS) const;
-  void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/BasicBlock.h
+++ b/llvm/include/llvm/SandboxIR/BasicBlock.h
@@ -104,7 +104,7 @@ public:
 
 #ifndef NDEBUG
   void verify() const final;
-  void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/Function.h
+++ b/llvm/include/llvm/SandboxIR/Function.h
@@ -73,8 +73,8 @@ public:
   void verify() const final {
     assert(isa<llvm::Function>(Val) && "Expected Function!");
   }
-  void dumpNameAndArgs(raw_ostream &OS) const;
-  void dumpOS(raw_ostream &OS) const final;
+  LLVM_ABI_FOR_TEST void dumpNameAndArgs(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const final;
 #endif
 };
 

--- a/llvm/include/llvm/SandboxIR/Pass.h
+++ b/llvm/include/llvm/SandboxIR/Pass.h
@@ -65,7 +65,7 @@ public:
     return OS;
   }
   virtual void print(raw_ostream &OS) const { OS << Name; }
-  LLVM_DUMP_METHOD virtual void dump() const;
+  LLVM_ABI_FOR_TEST LLVM_DUMP_METHOD virtual void dump() const;
 #endif
   /// Similar to print() but adds a newline. Used for testing.
   virtual void printPipeline(raw_ostream &OS) const { OS << Name << "\n"; }

--- a/llvm/include/llvm/SandboxIR/Region.h
+++ b/llvm/include/llvm/SandboxIR/Region.h
@@ -169,10 +169,10 @@ public:
 
 #ifndef NDEBUG
   /// This is an expensive check, meant for testing.
-  bool operator==(const Region &Other) const;
+  LLVM_ABI_FOR_TEST bool operator==(const Region &Other) const;
   bool operator!=(const Region &other) const { return !(*this == other); }
 
-  void dump(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void dump(raw_ostream &OS) const;
   void dump() const;
   friend raw_ostream &operator<<(raw_ostream &OS, const Region &Rgn) {
     Rgn.dump(OS);

--- a/llvm/include/llvm/SandboxIR/Tracker.h
+++ b/llvm/include/llvm/SandboxIR/Tracker.h
@@ -107,10 +107,10 @@ public:
 
   /// Saves a snapshot of the current state. If there was any previous snapshot,
   /// it will be replaced with the new one.
-  void save();
+  LLVM_ABI_FOR_TEST void save();
 
   /// Checks current state against saved state, crashes if different.
-  void expectNoDiff();
+  LLVM_ABI_FOR_TEST void expectNoDiff();
 };
 
 #endif // NDEBUG

--- a/llvm/include/llvm/SandboxIR/Use.h
+++ b/llvm/include/llvm/SandboxIR/Use.h
@@ -62,7 +62,7 @@ public:
   }
   bool operator!=(const Use &Other) const { return !(*this == Other); }
 #ifndef NDEBUG
-  void dumpOS(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void dumpOS(raw_ostream &OS) const;
   void dump() const;
 #endif // NDEBUG
 };

--- a/llvm/include/llvm/Support/VirtualOutputBackends.h
+++ b/llvm/include/llvm/Support/VirtualOutputBackends.h
@@ -17,25 +17,25 @@ namespace llvm {
 namespace vfs {
 
 /// Create a backend that ignores all output.
-IntrusiveRefCntPtr<OutputBackend> makeNullOutputBackend();
+LLVM_ABI IntrusiveRefCntPtr<OutputBackend> makeNullOutputBackend();
 
 /// Make a backend where \a OutputBackend::createFile() forwards to
 /// \p UnderlyingBackend when \p Filter is true, and otherwise returns a
 /// \a NullOutput.
-IntrusiveRefCntPtr<OutputBackend> makeFilteringOutputBackend(
+LLVM_ABI IntrusiveRefCntPtr<OutputBackend> makeFilteringOutputBackend(
     IntrusiveRefCntPtr<OutputBackend> UnderlyingBackend,
     std::function<bool(StringRef, std::optional<OutputConfig>)> Filter);
 
 /// Create a backend that forwards \a OutputBackend::createFile() to both \p
 /// Backend1 and \p Backend2 and sends content to both places.
-IntrusiveRefCntPtr<OutputBackend>
+LLVM_ABI IntrusiveRefCntPtr<OutputBackend>
 makeMirroringOutputBackend(IntrusiveRefCntPtr<OutputBackend> Backend1,
                            IntrusiveRefCntPtr<OutputBackend> Backend2);
 
 /// A helper class for proxying another backend, with the default
 /// implementation to forward to the underlying backend.
 class ProxyOutputBackend : public OutputBackend {
-  void anchor() override;
+  LLVM_ABI void anchor() override;
 
 protected:
   // Require subclass to implement cloneImpl().

--- a/llvm/include/llvm/Support/VirtualOutputConfig.h
+++ b/llvm/include/llvm/Support/VirtualOutputConfig.h
@@ -34,7 +34,7 @@ struct EmptyBaseClass {};
 /// configuration flag is either \c true or \c false.
 struct OutputConfig : detail::EmptyBaseClass {
 public:
-  void print(raw_ostream &OS) const;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &OS) const;
   void dump() const;
 
 #define HANDLE_OUTPUT_CONFIG_FLAG(NAME, DEFAULT)                               \
@@ -59,7 +59,7 @@ public:
   /// Updates Text and CRLF flags based on \a sys::fs::OF_Text and \a
   /// sys::fs::OF_CRLF in \p Flags. Rejects CRLF without Text (calling
   /// \a setBinary()).
-  OutputConfig &setOpenFlags(const sys::fs::OpenFlags &Flags);
+  LLVM_ABI_FOR_TEST OutputConfig &setOpenFlags(const sys::fs::OpenFlags &Flags);
 
   constexpr OutputConfig()
       : EmptyBaseClass()
@@ -84,7 +84,8 @@ private:
 
 } // namespace vfs
 
-raw_ostream &operator<<(raw_ostream &OS, vfs::OutputConfig Config);
+LLVM_ABI_FOR_TEST raw_ostream &operator<<(raw_ostream &OS,
+                                          vfs::OutputConfig Config);
 
 } // namespace llvm
 

--- a/llvm/include/llvm/Support/VirtualOutputFile.h
+++ b/llvm/include/llvm/Support/VirtualOutputFile.h
@@ -21,10 +21,10 @@ namespace llvm {
 namespace vfs {
 
 class OutputFileImpl : public RTTIExtends<OutputFileImpl, RTTIRoot> {
-  void anchor() override;
+  LLVM_ABI void anchor() override;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   virtual ~OutputFileImpl() = default;
 
   virtual Error keep() = 0;
@@ -34,10 +34,10 @@ public:
 
 class NullOutputFileImpl final
     : public RTTIExtends<NullOutputFileImpl, OutputFileImpl> {
-  void anchor() override;
+  LLVM_ABI void anchor() override;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
   Error keep() final { return Error::success(); }
   Error discard() final { return Error::success(); }
   raw_pwrite_stream &getOS() final { return OS; }

--- a/llvm/include/llvm/Support/raw_ostream_proxy.h
+++ b/llvm/include/llvm/Support/raw_ostream_proxy.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_SUPPORT_RAW_OSTREAM_PROXY_H
 #define LLVM_SUPPORT_RAW_OSTREAM_PROXY_H
 
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -137,7 +138,7 @@ protected:
 /// Non-owning proxy for a \a raw_ostream. Enables passing a stream into of an
 /// API that takes ownership.
 class raw_ostream_proxy : public raw_ostream_proxy_adaptor<> {
-  void anchor() override;
+  LLVM_ABI_FOR_TEST void anchor() override;
 
 public:
   raw_ostream_proxy(raw_ostream &OS) : raw_ostream_proxy_adaptor<>(OS) {}
@@ -146,7 +147,7 @@ public:
 /// Non-owning proxy for a \a raw_pwrite_stream. Enables passing a stream
 /// into of an API that takes ownership.
 class raw_pwrite_stream_proxy : public raw_pwrite_stream_proxy_adaptor<> {
-  void anchor() override;
+  LLVM_ABI_FOR_TEST void anchor() override;
 
 public:
   raw_pwrite_stream_proxy(raw_pwrite_stream &OS)

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -24,7 +24,7 @@ Expected<std::optional<uint64_t>> getOverriddenMaxMappingSize();
 /// Set MaxMappingSize for ondisk CAS. This function is not thread-safe and
 /// should be set before creaing any ondisk CAS and does not affect CAS already
 /// created. Set value 0 to use default size.
-void setMaxMappingSize(uint64_t Size);
+LLVM_ABI_FOR_TEST void setMaxMappingSize(uint64_t Size);
 
 /// Thread-safe alternative to \c sys::fs::lockFile. This does not support all
 /// the platforms that \c sys::fs::lockFile does, so keep it in the CAS library

--- a/llvm/lib/Transforms/Vectorize/VPlan.h
+++ b/llvm/lib/Transforms/Vectorize/VPlan.h
@@ -588,7 +588,7 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print this VPSingleDefRecipe to dbgs() (for debugging).
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI_FOR_TEST LLVM_DUMP_METHOD void dump() const;
 #endif
 };
 
@@ -3239,8 +3239,8 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
-  void print(raw_ostream &O, const Twine &Indent,
-             VPSlotTracker &SlotTracker) const override;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &O, const Twine &Indent,
+                               VPSlotTracker &SlotTracker) const override;
 #endif
 
   /// Returns the scalar type of the induction.
@@ -3339,8 +3339,8 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Print the recipe.
-  void print(raw_ostream &O, const Twine &Indent,
-             VPSlotTracker &SlotTracker) const override;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &O, const Twine &Indent,
+                               VPSlotTracker &SlotTracker) const override;
 #endif
 };
 
@@ -4134,10 +4134,10 @@ public:
   void printLiveIns(raw_ostream &O) const;
 
   /// Print this VPlan to \p O.
-  void print(raw_ostream &O) const;
+  LLVM_ABI_FOR_TEST void print(raw_ostream &O) const;
 
   /// Print this VPlan in DOT format to \p O.
-  void printDOT(raw_ostream &O) const;
+  LLVM_ABI_FOR_TEST void printDOT(raw_ostream &O) const;
 
   /// Dump the plan to stderr (for debugging).
   LLVM_DUMP_METHOD void dump() const;
@@ -4164,7 +4164,7 @@ public:
 
   /// Clone the current VPlan, update all VPValues of the new VPlan and cloned
   /// recipes to refer to the clones, and return it.
-  VPlan *duplicate();
+  LLVM_ABI_FOR_TEST VPlan *duplicate();
 
   /// Create a new VPBasicBlock with \p Name and containing \p Recipe if
   /// present. The returned block is owned by the VPlan and deleted once the

--- a/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanHelpers.h
@@ -394,7 +394,7 @@ class VPSlotTracker {
   std::unique_ptr<ModuleSlotTracker> MST;
 
   void assignName(const VPValue *V);
-  void assignNames(const VPlan &Plan);
+  LLVM_ABI_FOR_TEST void assignNames(const VPlan &Plan);
   void assignNames(const VPBasicBlock *VPBB);
   std::string getName(const Value *V);
 

--- a/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanTransforms.h
@@ -31,7 +31,7 @@ class VPBuilder;
 class VPRecipeBuilder;
 struct VFRange;
 
-extern cl::opt<bool> VerifyEachVPlan;
+LLVM_ABI_FOR_TEST extern cl::opt<bool> VerifyEachVPlan;
 
 struct VPlanTransforms {
   /// Helper to run a VPlan transform \p Transform on \p VPlan, forwarding extra
@@ -126,7 +126,7 @@ struct VPlanTransforms {
   /// Apply VPlan-to-VPlan optimizations to \p Plan, including induction recipe
   /// optimizations, dead recipe removal, replicate region optimizations and
   /// block merging.
-  static void optimize(VPlan &Plan);
+  LLVM_ABI_FOR_TEST static void optimize(VPlan &Plan);
 
   /// Wrap predicated VPReplicateRecipes with a mask operand in an if-then
   /// region block and remove the mask operand. Optimize the created regions by

--- a/llvm/lib/Transforms/Vectorize/VPlanValue.h
+++ b/llvm/lib/Transforms/Vectorize/VPlanValue.h
@@ -190,7 +190,8 @@ public:
 typedef DenseMap<Value *, VPValue *> Value2VPValueTy;
 typedef DenseMap<VPValue *, Value *> VPValue2ValueTy;
 
-raw_ostream &operator<<(raw_ostream &OS, const VPRecipeBase &R);
+LLVM_ABI_FOR_TEST raw_ostream &operator<<(raw_ostream &OS,
+                                          const VPRecipeBase &R);
 
 /// This class augments VPValue with operands which provide the inverse def-use
 /// edges from VPValue's users to their defs.
@@ -427,7 +428,7 @@ public:
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// Dump the VPDef to stderr (for debugging).
-  void dump() const;
+  LLVM_ABI_FOR_TEST void dump() const;
 
   /// Each concrete VPDef prints itself.
   virtual void print(raw_ostream &O, const Twine &Indent,

--- a/mlir/include/mlir/Tools/lsp-server-support/Logging.h
+++ b/mlir/include/mlir/Tools/lsp-server-support/Logging.h
@@ -26,7 +26,7 @@ public:
   enum class Level { Debug, Info, Error };
 
   /// Set the severity level of the logger.
-  static void setLogLevel(Level logLevel);
+  LLVM_ABI_FOR_TEST static void setLogLevel(Level logLevel);
 
   /// Initiate a log message at various severity levels. These should be called
   /// after a call to `initialize`.
@@ -50,8 +50,8 @@ private:
   static Logger &get();
 
   /// Start a log message with the given severity level.
-  static void log(Level logLevel, const char *fmt,
-                  const llvm::formatv_object_base &message);
+  LLVM_ABI_FOR_TEST static void log(Level logLevel, const char *fmt,
+                                    const llvm::formatv_object_base &message);
 
   /// The minimum logging level. Messages with lower level are ignored.
   Level logLevel = Level::Error;

--- a/mlir/include/mlir/Tools/lsp-server-support/Protocol.h
+++ b/mlir/include/mlir/Tools/lsp-server-support/Protocol.h
@@ -24,6 +24,7 @@
 #define MLIR_TOOLS_LSPSERVERSUPPORT_PROTOCOL_H
 
 #include "mlir/Support/LLVM.h"
+#include "llvm/Support/Compiler.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
@@ -76,7 +77,7 @@ class LSPError : public llvm::ErrorInfo<LSPError> {
 public:
   std::string message;
   ErrorCode code;
-  static char ID;
+  LLVM_ABI_FOR_TEST static char ID;
 
   LSPError(std::string message, ErrorCode code)
       : message(std::move(message)), code(code) {}
@@ -141,9 +142,9 @@ private:
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const URIForFile &value);
-bool fromJSON(const llvm::json::Value &value, URIForFile &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const URIForFile &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                URIForFile &result, llvm::json::Path path);
 raw_ostream &operator<<(raw_ostream &os, const URIForFile &value);
 
 //===----------------------------------------------------------------------===//
@@ -167,8 +168,9 @@ struct ClientCapabilities {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ClientCapabilities &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ClientCapabilities &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ClientInfo
@@ -183,8 +185,8 @@ struct ClientInfo {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ClientInfo &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ClientInfo &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InitializeParams
@@ -197,8 +199,8 @@ enum class TraceLevel {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, TraceLevel &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TraceLevel &result, llvm::json::Path path);
 
 struct InitializeParams {
   /// The capabilities provided by the client (editor or tool).
@@ -212,8 +214,9 @@ struct InitializeParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, InitializeParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                InitializeParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InitializedParams
@@ -244,8 +247,9 @@ struct TextDocumentItem {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, TextDocumentItem &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentItem &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // TextDocumentIdentifier
@@ -257,9 +261,10 @@ struct TextDocumentIdentifier {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const TextDocumentIdentifier &value);
-bool fromJSON(const llvm::json::Value &value, TextDocumentIdentifier &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const TextDocumentIdentifier &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentIdentifier &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // VersionedTextDocumentIdentifier
@@ -273,9 +278,11 @@ struct VersionedTextDocumentIdentifier {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const VersionedTextDocumentIdentifier &value);
-bool fromJSON(const llvm::json::Value &value,
-              VersionedTextDocumentIdentifier &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value
+toJSON(const VersionedTextDocumentIdentifier &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                VersionedTextDocumentIdentifier &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // Position
@@ -323,9 +330,9 @@ struct Position {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, Position &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const Position &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                Position &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Position &value);
 raw_ostream &operator<<(raw_ostream &os, const Position &value);
 
 //===----------------------------------------------------------------------===//
@@ -376,9 +383,9 @@ struct Range {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, Range &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const Range &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value, Range &result,
+                                llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Range &value);
 raw_ostream &operator<<(raw_ostream &os, const Range &value);
 
 //===----------------------------------------------------------------------===//
@@ -411,9 +418,9 @@ struct Location {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, Location &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const Location &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                Location &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Location &value);
 raw_ostream &operator<<(raw_ostream &os, const Location &value);
 
 //===----------------------------------------------------------------------===//
@@ -429,8 +436,9 @@ struct TextDocumentPositionParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              TextDocumentPositionParams &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentPositionParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ReferenceParams
@@ -442,16 +450,17 @@ struct ReferenceContext {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ReferenceContext &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ReferenceContext &result,
+                                llvm::json::Path path);
 
 struct ReferenceParams : public TextDocumentPositionParams {
   ReferenceContext context;
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, ReferenceParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                ReferenceParams &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidOpenTextDocumentParams
@@ -463,8 +472,9 @@ struct DidOpenTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, DidOpenTextDocumentParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DidOpenTextDocumentParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidCloseTextDocumentParams
@@ -476,8 +486,9 @@ struct DidCloseTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              DidCloseTextDocumentParams &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DidCloseTextDocumentParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DidChangeTextDocumentParams
@@ -501,8 +512,9 @@ struct TextDocumentContentChangeEvent {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              TextDocumentContentChangeEvent &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextDocumentContentChangeEvent &result,
+                                llvm::json::Path path);
 
 struct DidChangeTextDocumentParams {
   /// The document that changed.
@@ -513,8 +525,9 @@ struct DidChangeTextDocumentParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              DidChangeTextDocumentParams &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DidChangeTextDocumentParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // MarkupContent
@@ -534,7 +547,7 @@ struct MarkupContent {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const MarkupContent &mc);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const MarkupContent &mc);
 
 //===----------------------------------------------------------------------===//
 // Hover
@@ -553,7 +566,7 @@ struct Hover {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const Hover &hover);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Hover &hover);
 
 //===----------------------------------------------------------------------===//
 // SymbolKind
@@ -628,7 +641,7 @@ struct DocumentSymbol {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const DocumentSymbol &symbol);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const DocumentSymbol &symbol);
 
 //===----------------------------------------------------------------------===//
 // DocumentSymbolParams
@@ -640,8 +653,9 @@ struct DocumentSymbolParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, DocumentSymbolParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DocumentSymbolParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DiagnosticRelatedInformation
@@ -662,9 +676,11 @@ struct DiagnosticRelatedInformation {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value,
-              DiagnosticRelatedInformation &result, llvm::json::Path path);
-llvm::json::Value toJSON(const DiagnosticRelatedInformation &info);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DiagnosticRelatedInformation &result,
+                                llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value
+toJSON(const DiagnosticRelatedInformation &info);
 
 //===----------------------------------------------------------------------===//
 // Diagnostic
@@ -686,9 +702,9 @@ enum class DiagnosticTag {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(DiagnosticTag tag);
-bool fromJSON(const llvm::json::Value &value, DiagnosticTag &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(DiagnosticTag tag);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DiagnosticTag &result, llvm::json::Path path);
 
 struct Diagnostic {
   /// The source range where the message applies.
@@ -720,9 +736,9 @@ struct Diagnostic {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const Diagnostic &diag);
-bool fromJSON(const llvm::json::Value &value, Diagnostic &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const Diagnostic &diag);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                Diagnostic &result, llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // PublishDiagnosticsParams
@@ -741,7 +757,8 @@ struct PublishDiagnosticsParams {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const PublishDiagnosticsParams &params);
+LLVM_ABI_FOR_TEST llvm::json::Value
+toJSON(const PublishDiagnosticsParams &params);
 
 //===----------------------------------------------------------------------===//
 // TextEdit
@@ -761,9 +778,9 @@ inline bool operator==(const TextEdit &lhs, const TextEdit &rhs) {
   return std::tie(lhs.newText, lhs.range) == std::tie(rhs.newText, rhs.range);
 }
 
-bool fromJSON(const llvm::json::Value &value, TextEdit &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const TextEdit &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                TextEdit &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const TextEdit &value);
 raw_ostream &operator<<(raw_ostream &os, const TextEdit &value);
 
 //===----------------------------------------------------------------------===//
@@ -799,16 +816,18 @@ enum class CompletionItemKind {
   Operator = 24,
   TypeParameter = 25,
 };
-bool fromJSON(const llvm::json::Value &value, CompletionItemKind &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionItemKind &result,
+                                llvm::json::Path path);
 
 constexpr auto kCompletionItemKindMin =
     static_cast<size_t>(CompletionItemKind::Text);
 constexpr auto kCompletionItemKindMax =
     static_cast<size_t>(CompletionItemKind::TypeParameter);
 using CompletionItemKindBitset = std::bitset<kCompletionItemKindMax + 1>;
-bool fromJSON(const llvm::json::Value &value, CompletionItemKindBitset &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionItemKindBitset &result,
+                                llvm::json::Path path);
 
 CompletionItemKind
 adjustKindToCapability(CompletionItemKind kind,
@@ -891,7 +910,7 @@ struct CompletionItem {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const CompletionItem &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CompletionItem &value);
 raw_ostream &operator<<(raw_ostream &os, const CompletionItem &value);
 bool operator<(const CompletionItem &lhs, const CompletionItem &rhs);
 
@@ -910,7 +929,7 @@ struct CompletionList {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const CompletionList &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CompletionList &value);
 
 //===----------------------------------------------------------------------===//
 // CompletionContext
@@ -939,8 +958,9 @@ struct CompletionContext {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CompletionContext &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionContext &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // CompletionParams
@@ -951,8 +971,9 @@ struct CompletionParams : TextDocumentPositionParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CompletionParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CompletionParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // ParameterInformation
@@ -972,7 +993,7 @@ struct ParameterInformation {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const ParameterInformation &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const ParameterInformation &value);
 
 //===----------------------------------------------------------------------===//
 // SignatureInformation
@@ -991,7 +1012,7 @@ struct SignatureInformation {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const SignatureInformation &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const SignatureInformation &value);
 raw_ostream &operator<<(raw_ostream &os, const SignatureInformation &value);
 
 //===----------------------------------------------------------------------===//
@@ -1011,7 +1032,7 @@ struct SignatureHelp {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const SignatureHelp &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const SignatureHelp &value);
 
 //===----------------------------------------------------------------------===//
 // DocumentLinkParams
@@ -1024,8 +1045,9 @@ struct DocumentLinkParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, DocumentLinkParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                DocumentLinkParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // DocumentLink
@@ -1061,7 +1083,7 @@ struct DocumentLink {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const DocumentLink &value);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const DocumentLink &value);
 
 //===----------------------------------------------------------------------===//
 // InlayHintsParams
@@ -1077,8 +1099,9 @@ struct InlayHintsParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, InlayHintsParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                InlayHintsParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // InlayHintKind
@@ -1138,7 +1161,7 @@ struct InlayHint {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const InlayHint &);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const InlayHint &);
 bool operator==(const InlayHint &lhs, const InlayHint &rhs);
 bool operator<(const InlayHint &lhs, const InlayHint &rhs);
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, InlayHintKind value);
@@ -1164,8 +1187,9 @@ struct CodeActionContext {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CodeActionContext &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CodeActionContext &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // CodeActionParams
@@ -1183,8 +1207,9 @@ struct CodeActionParams {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, CodeActionParams &result,
-              llvm::json::Path path);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                CodeActionParams &result,
+                                llvm::json::Path path);
 
 //===----------------------------------------------------------------------===//
 // WorkspaceEdit
@@ -1199,9 +1224,9 @@ struct WorkspaceEdit {
 };
 
 /// Add support for JSON serialization.
-bool fromJSON(const llvm::json::Value &value, WorkspaceEdit &result,
-              llvm::json::Path path);
-llvm::json::Value toJSON(const WorkspaceEdit &value);
+LLVM_ABI_FOR_TEST bool fromJSON(const llvm::json::Value &value,
+                                WorkspaceEdit &result, llvm::json::Path path);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const WorkspaceEdit &value);
 
 //===----------------------------------------------------------------------===//
 // CodeAction
@@ -1238,7 +1263,7 @@ struct CodeAction {
 };
 
 /// Add support for JSON serialization.
-llvm::json::Value toJSON(const CodeAction &);
+LLVM_ABI_FOR_TEST llvm::json::Value toJSON(const CodeAction &);
 
 } // namespace lsp
 } // namespace mlir


### PR DESCRIPTION
This patch updates various LLVM headers to properly add the `LLVM_ABI` and `LLVM_ABI_FOR_TEST` annotations to build LLVM as a DLL on Windows.

This effort is tracked in swiftlang/swift#85241.