### PR TITLE
[6.3][ScanDaemon] unlock pid file first before unlink socket

### DIFF
--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -659,6 +659,9 @@ struct ScanServer {
   /// jobs to finish.
   void shutdown() {
     ShutDown.store(true);
+    // Unlock pidfile first so another daemon can spin up when it can't find
+    // the socket.
+    ::flock(PidFD, LOCK_UN);
     cc1depscand::unlinkBoundSocket(BasePath);
     // Clean up the pidfile when we're done.
     if (PidFD != -1)


### PR DESCRIPTION
- **Explanation**: Fix a potential issue that can cause new clang scan daemon failed to start when the previous daemon timed out at the same time. It is possible for the timed out daemon still hold pid file when being shutdown, when the new clang daemon is starting up and failed to lock the pid file. To the new clang daemon, this is indistinguishable from losing the race to start a new daemon with another clang invocation, thus the new starting request will be dropped and no daemon will be started.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Affects clang cache build that uses daemon to integrate with legacy build systems.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**:
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/llvm-project/pull/11817
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. caching build with daemon only and fixes a race condition.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: N/A
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @benlangmuir 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
