### PR TITLE
[BoundsSafety][LLDB] Implement instrumentation plugin for -fbounds-safety soft traps

### DIFF
--- a/lldb/include/lldb/Utility/LLDBLog.h
+++ b/lldb/include/lldb/Utility/LLDBLog.h
@@ -50,7 +50,8 @@ enum class LLDBLog : Log::MaskType {
   OnDemand = Log::ChannelFlag<31>,
   Source = Log::ChannelFlag<32>,
   Disassembler = Log::ChannelFlag<33>,
-  LLVM_MARK_AS_BITMASK_ENUM(Disassembler),
+  InstrumentationRuntime = Log::ChannelFlag<34>,
+  LLVM_MARK_AS_BITMASK_ENUM(InstrumentationRuntime),
 };
 
 LLVM_ENABLE_BITMASK_ENUMS_IN_NAMESPACE();

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -538,6 +538,7 @@ enum InstrumentationRuntimeType {
   eInstrumentationRuntimeTypeMainThreadChecker = 0x0003,
   eInstrumentationRuntimeTypeSwiftRuntimeReporting = 0x0004,
   eInstrumentationRuntimeTypeLibsanitizersAsan = 0x0005,
+  eInstrumentationRuntimeTypeBoundsSafety = 0x0006,
   eNumInstrumentationRuntimeTypes
 };
 

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/CMakeLists.txt
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_lldb_library(lldbPluginInstrumentationRuntimeBoundsSafety PLUGIN
+  InstrumentationRuntimeBoundsSafety.cpp
+
+  LINK_LIBS
+    lldbBreakpoint
+    lldbCore
+    lldbSymbol
+    lldbTarget
+    lldbPluginInstrumentationRuntimeUtility
+
+  CLANG_LIBS
+    clangCodeGen
+  )

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.cpp
@@ -1,0 +1,491 @@
+//===-- InstrumentationRuntimeBoundsSafety.cpp -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "InstrumentationRuntimeBoundsSafety.h"
+
+#include "Plugins/Process/Utility/HistoryThread.h"
+#include "lldb/Breakpoint/StoppointCallbackContext.h"
+#include "lldb/Core/Debugger.h"
+#include "lldb/Core/Module.h"
+#include "lldb/Core/PluginManager.h"
+#include "lldb/Symbol/Block.h"
+#include "lldb/Symbol/Symbol.h"
+#include "lldb/Symbol/SymbolContext.h"
+#include "lldb/Symbol/Variable.h"
+#include "lldb/Symbol/VariableList.h"
+#include "lldb/Target/InstrumentationRuntimeStopInfo.h"
+#include "lldb/Target/RegisterContext.h"
+#include "lldb/Target/SectionLoadList.h"
+#include "lldb/Target/StopInfo.h"
+#include "lldb/Target/Target.h"
+#include "lldb/Target/Thread.h"
+#include "lldb/Utility/RegisterValue.h"
+#include "lldb/Utility/RegularExpression.h"
+#include "clang/CodeGen/ModuleBuilder.h"
+
+#include <memory>
+
+using namespace lldb;
+using namespace lldb_private;
+
+LLDB_PLUGIN_DEFINE(InstrumentationRuntimeBoundsSafety)
+
+#define BOUNDS_SAFETY_SOFT_TRAP_MINIMAL "__bounds_safety_soft_trap"
+#define BOUNDS_SAFETY_SOFT_TRAP_S "__bounds_safety_soft_trap_s"
+
+const std::vector<std::string> &getBoundsSafetySoftTrapRuntimeFuncs() {
+  static std::vector<std::string> Funcs = {BOUNDS_SAFETY_SOFT_TRAP_MINIMAL,
+                                           BOUNDS_SAFETY_SOFT_TRAP_S};
+
+  return Funcs;
+}
+
+#define SOFT_TRAP_CATEGORY_PREFIX "Soft "
+#define SOFT_TRAP_FALLBACK_CATEGORY                                            \
+  SOFT_TRAP_CATEGORY_PREFIX "Bounds check failed"
+
+class InstrumentationBoundsSafetyStopInfo : public StopInfo {
+public:
+  ~InstrumentationBoundsSafetyStopInfo() override = default;
+
+  lldb::StopReason GetStopReason() const override {
+    return lldb::eStopReasonInstrumentation;
+  }
+
+  std::optional<uint32_t>
+  GetSuggestedStackFrameIndex(bool inlined_stack) override {
+    return m_value;
+  }
+
+  const char *GetDescription() override { return m_description.c_str(); }
+
+  bool DoShouldNotify(Event *event_ptr) override { return true; }
+
+  static lldb::StopInfoSP
+  CreateInstrumentationBoundsSafetyStopInfo(Thread &thread) {
+    return StopInfoSP(new InstrumentationBoundsSafetyStopInfo(thread));
+  }
+
+private:
+  InstrumentationBoundsSafetyStopInfo(Thread &thread);
+
+  std::pair<std::optional<std::string>, std::optional<uint32_t>>
+  ComputeStopReasonAndSuggestedStackFrame(bool &warning_emitted_for_failure);
+
+  std::pair<std::string, std::optional<uint32_t>>
+  ComputeStopReasonAndSuggestedStackFrameWithDebugInfo(
+      lldb::StackFrameSP parent_sf, lldb::user_id_t debugger_id,
+      bool &warning_emitted_for_failure);
+
+  std::pair<std::optional<std::string>, std::optional<uint32_t>>
+  ComputeStopReasonAndSuggestedStackFrameWithoutDebugInfo(
+      ThreadSP thread_sp, lldb::user_id_t debugger_id,
+      bool &warning_emitted_for_failure);
+};
+
+InstrumentationBoundsSafetyStopInfo::InstrumentationBoundsSafetyStopInfo(
+    Thread &thread)
+    : StopInfo(thread, 0) {
+  // No additional data describing the reason for stopping
+  m_extended_info = nullptr;
+  m_description = SOFT_TRAP_FALLBACK_CATEGORY;
+
+  bool warning_emitted_for_failure = false;
+  auto [Description, MaybeSuggestedStackIndex] =
+      ComputeStopReasonAndSuggestedStackFrame(warning_emitted_for_failure);
+  if (Description)
+    m_description = Description.value();
+  if (MaybeSuggestedStackIndex)
+    m_value = MaybeSuggestedStackIndex.value();
+
+  // Emit warning about the failure to compute the stop info if one wasn't
+  // already emitted
+  if ((!Description.has_value()) && !warning_emitted_for_failure) {
+    if (auto thread_sp = GetThread()) {
+      lldb::user_id_t debugger_id =
+          thread_sp->GetProcess()->GetTarget().GetDebugger().GetID();
+      Debugger::ReportWarning(
+          "specific BoundsSafety trap reason could not be computed",
+          debugger_id);
+    }
+  }
+}
+
+std::pair<std::optional<std::string>, std::optional<uint32_t>>
+InstrumentationBoundsSafetyStopInfo::ComputeStopReasonAndSuggestedStackFrame(
+    bool &warning_emitted_for_failure) {
+  auto *log_category = GetLog(LLDBLog::InstrumentationRuntime);
+  ThreadSP thread_sp = GetThread();
+  if (!thread_sp) {
+    LLDB_LOGF(log_category, "failed to get thread while stopped");
+    return {};
+  }
+
+  lldb::user_id_t debugger_id =
+      thread_sp->GetProcess()->GetTarget().GetDebugger().GetID();
+
+  auto parent_sf = thread_sp->GetStackFrameAtIndex(1);
+  if (!parent_sf) {
+    LLDB_LOGF(log_category, "got nullptr when fetching stackframe at index 1");
+    return {};
+  }
+
+  if (parent_sf->HasDebugInformation()) {
+    return ComputeStopReasonAndSuggestedStackFrameWithDebugInfo(
+        parent_sf, debugger_id, warning_emitted_for_failure);
+  }
+
+  // If the debug info is missing we can still get some information
+  // from the parameter in the soft trap runtime call.
+  return ComputeStopReasonAndSuggestedStackFrameWithoutDebugInfo(
+      thread_sp, debugger_id, warning_emitted_for_failure);
+}
+
+std::pair<std::string, std::optional<uint32_t>>
+InstrumentationBoundsSafetyStopInfo::
+    ComputeStopReasonAndSuggestedStackFrameWithDebugInfo(
+        lldb::StackFrameSP parent_sf, lldb::user_id_t debugger_id,
+        bool &warning_emitted_for_failure) {
+  // First try to use debug info to understand the reason for trapping. The
+  // call stack will look something like this:
+  //
+  // ```
+  // frame #0: `__bounds_safety_soft_trap_s(reason="")
+  // frame #1: `__clang_trap_msg$Bounds check failed$<reason>'
+  // frame #2: `bad_read(index=10)
+  // ```
+  // ....
+  const auto *TrapReasonFuncName = parent_sf->GetFunctionName();
+
+  auto MaybeTrapReason =
+      clang::CodeGen::DemangleTrapReasonInDebugInfo(TrapReasonFuncName);
+  if (!MaybeTrapReason.has_value()) {
+    LLDB_LOGF(
+        GetLog(LLDBLog::InstrumentationRuntime),
+        "clang::CodeGen::DemangleTrapReasonInDebugInfo(\"%s\") call failed",
+        TrapReasonFuncName);
+    return {};
+  }
+  auto category = MaybeTrapReason.value().first;
+  auto message = MaybeTrapReason.value().second;
+
+  // TODO: Clang should probably be changed to emit the "Soft " prefix itself
+  std::string stop_reason;
+  llvm::raw_string_ostream ss(stop_reason);
+  ss << SOFT_TRAP_CATEGORY_PREFIX;
+  if (category.empty())
+    ss << "<empty category>";
+  else
+    ss << category;
+  if (message.empty()) {
+    // This is not a failure so leave `warning_emitted_for_failure` untouched.
+    Debugger::ReportWarning(
+        "specific BoundsSafety trap reason is not "
+        "available because the compiler omitted it from the debug info",
+        debugger_id);
+  } else {
+    ss << ": " << message;
+  }
+  // Use computed stop-reason and assume the parent of `parent_sf` is the
+  // the place in the user's code where the call to the soft trap runtime
+  // originated.
+  return std::make_pair(stop_reason, parent_sf->GetFrameIndex() + 1);
+}
+
+std::pair<std::optional<std::string>, std::optional<uint32_t>>
+InstrumentationBoundsSafetyStopInfo::
+    ComputeStopReasonAndSuggestedStackFrameWithoutDebugInfo(
+        ThreadSP thread_sp, lldb::user_id_t debugger_id,
+        bool &warning_emitted_for_failure) {
+
+  auto *log_category = GetLog(LLDBLog::InstrumentationRuntime);
+  auto softtrap_sf = thread_sp->GetStackFrameAtIndex(0);
+  if (!softtrap_sf) {
+    LLDB_LOGF(log_category, "got nullptr when fetching stackframe at index 0");
+    return {};
+  }
+  llvm::StringRef trap_reason_func_name = softtrap_sf->GetFunctionName();
+
+  if (trap_reason_func_name == BOUNDS_SAFETY_SOFT_TRAP_MINIMAL) {
+    // This function has no arguments so there's no additional information
+    // that would allow us to identify the trap reason.
+    //
+    // Use the fallback stop reason and the current frame.
+    // While we "could" set the suggested frame to our parent (where the
+    // bounds check failed), doing this leads to very misleading output in
+    // LLDB. E.g.:
+    //
+    // ```
+    //     0x100003b40 <+104>: bl  0x100003d64    ; __bounds_safety_soft_trap
+    // ->  0x100003b44 <+108>: b   0x100003b48    ; <+112>
+    // ```
+    //
+    // This makes it look we stopped after finishing the call to
+    // `__bounds_safety_soft_trap` but actually we are in the middle of the
+    // call. To avoid this confusion just use the current frame.
+    Debugger::ReportWarning(
+        "specific BoundsSafety trap reason is not available because debug "
+        "info is missing on the caller of '" BOUNDS_SAFETY_SOFT_TRAP_MINIMAL
+        "'",
+        debugger_id);
+    warning_emitted_for_failure = true;
+    return {};
+  }
+
+  // BOUNDS_SAFETY_SOFT_TRAP_S has one argument which is a pointer to a string
+  // describing the trap or a nullptr.
+  if (trap_reason_func_name != BOUNDS_SAFETY_SOFT_TRAP_S) {
+    LLDB_LOGF(log_category,
+              "unexpected function name. Expected \"%s\" but got \"%s\"",
+              BOUNDS_SAFETY_SOFT_TRAP_S, trap_reason_func_name.data());
+    assert(0 && "hit breakpoint for unexpected function name");
+    return {};
+  }
+
+  auto rc = thread_sp->GetRegisterContext();
+  if (!rc) {
+    LLDB_LOGF(log_category, "failed to get register context");
+    return {};
+  }
+
+  // FIXME: LLDB should have an API that tells us for the current target if
+  // `LLDB_REGNUM_GENERIC_ARG1` can be used.
+  // https://github.com/llvm/llvm-project/issues/168602
+  // Don't try for architectures where examining the first register won't
+  // work.
+  auto process = thread_sp->GetProcess();
+  if (!process) {
+    LLDB_LOGF(log_category, "failed to get process");
+    return {};
+  }
+  switch (process->GetTarget().GetArchitecture().GetCore()) {
+  case ArchSpec::eCore_x86_32_i386:
+  case ArchSpec::eCore_x86_32_i486:
+  case ArchSpec::eCore_x86_32_i486sx:
+  case ArchSpec::eCore_x86_32_i686:
+    // Technically some x86 calling conventions do use a register for
+    // passing the first argument but let's ignore that for now.
+    Debugger::ReportWarning(
+        "specific BoundsSafety trap reason cannot be inferred on x86 when "
+        "the caller of '" BOUNDS_SAFETY_SOFT_TRAP_S "' is missing debug info",
+        debugger_id);
+    warning_emitted_for_failure = true;
+    return {};
+  default: {
+  }
+  };
+
+  // Examine the register for the first argument
+  auto *arg0_info = rc->GetRegisterInfo(
+      lldb::RegisterKind::eRegisterKindGeneric, LLDB_REGNUM_GENERIC_ARG1);
+  if (!arg0_info) {
+    LLDB_LOGF(log_category,
+              "failed to get register info for LLDB_REGNUM_GENERIC_ARG1");
+    return {};
+  }
+  RegisterValue reg_value;
+  if (!rc->ReadRegister(arg0_info, reg_value)) {
+    LLDB_LOGF(log_category, "failed to read register %s", arg0_info->name);
+    return {};
+  }
+  uint64_t reg_value_as_int = reg_value.GetAsUInt64(UINT64_MAX);
+  if (reg_value_as_int == UINT64_MAX) {
+    LLDB_LOGF(log_category, "failed to read register %s as a UInt64",
+              arg0_info->name);
+    return {};
+  }
+
+  if (reg_value_as_int == 0) {
+    // nullptr arg. The compiler will pass that if no trap reason string was
+    // available.
+    Debugger::ReportWarning(
+        "specific BoundsSafety trap reason cannot be inferred because the "
+        "compiler omitted the reason",
+        debugger_id);
+    warning_emitted_for_failure = true;
+    return {};
+  }
+
+  // The first argument to the call is a pointer to a global C string
+  // containing the trap reason.
+  std::string out_string;
+  Status error_status;
+  thread_sp->GetProcess()->ReadCStringFromMemory(reg_value_as_int, out_string,
+                                                 error_status);
+  if (error_status.Fail()) {
+    LLDB_LOGF(log_category, "failed to read C string from address %p",
+              (void *)reg_value_as_int);
+    return {};
+  }
+  LLDB_LOGF(log_category, "read C string from %p found in register %s: \"%s\"",
+            (void *)reg_value_as_int, arg0_info->name, out_string.c_str());
+  std::string stop_reason;
+  llvm::raw_string_ostream SS(stop_reason);
+  SS << SOFT_TRAP_FALLBACK_CATEGORY;
+  if (!stop_reason.empty()) {
+    SS << ": " << out_string;
+  }
+  // Use the current frame as the suggested frame for the same reason as for
+  // `BOUNDS_SAFETY_SOFT_TRAP_MINIMAL`.
+  return {stop_reason, 0};
+}
+
+InstrumentationRuntimeBoundsSafety::~InstrumentationRuntimeBoundsSafety() {
+  Deactivate();
+}
+
+lldb::InstrumentationRuntimeSP
+InstrumentationRuntimeBoundsSafety::CreateInstance(
+    const lldb::ProcessSP &process_sp) {
+  return InstrumentationRuntimeSP(
+      new InstrumentationRuntimeBoundsSafety(process_sp));
+}
+
+void InstrumentationRuntimeBoundsSafety::Initialize() {
+  PluginManager::RegisterPlugin(GetPluginNameStatic(),
+                                "BoundsSafety instrumentation runtime plugin.",
+                                CreateInstance, GetTypeStatic);
+}
+
+void InstrumentationRuntimeBoundsSafety::Terminate() {
+  PluginManager::UnregisterPlugin(CreateInstance);
+}
+
+lldb::InstrumentationRuntimeType
+InstrumentationRuntimeBoundsSafety::GetTypeStatic() {
+  return lldb::eInstrumentationRuntimeTypeBoundsSafety;
+}
+
+const RegularExpression &
+InstrumentationRuntimeBoundsSafety::GetPatternForRuntimeLibrary() {
+  static RegularExpression regex;
+  return regex;
+}
+
+bool InstrumentationRuntimeBoundsSafety::CheckIfRuntimeIsValid(
+    const lldb::ModuleSP module_sp) {
+  auto *log_category = GetLog(LLDBLog::InstrumentationRuntime);
+  for (const auto &SoftTrapFunc : getBoundsSafetySoftTrapRuntimeFuncs()) {
+    ConstString test_sym(SoftTrapFunc);
+
+    if (module_sp->FindFirstSymbolWithNameAndType(test_sym,
+                                                  lldb::eSymbolTypeAny)) {
+      LLDB_LOGF(log_category, "found \"%s\" in %s", SoftTrapFunc.c_str(),
+                module_sp->GetObjectName().AsCString("<unknown>"));
+      return true;
+    }
+  }
+  LLDB_LOGF(log_category,
+            "did not findFound BoundsSafety soft trap functions in %s",
+            module_sp->GetObjectName().AsCString("<unknown>"));
+  return false;
+}
+
+bool InstrumentationRuntimeBoundsSafety::NotifyBreakpointHit(
+    void *baton, StoppointCallbackContext *context, user_id_t break_id,
+    user_id_t break_loc_id) {
+  assert(baton && "null baton");
+  if (!baton)
+    return false; ///< false => resume execution.
+
+  InstrumentationRuntimeBoundsSafety *const instance =
+      static_cast<InstrumentationRuntimeBoundsSafety *>(baton);
+
+  auto *log_category = GetLog(LLDBLog::InstrumentationRuntime);
+  ProcessSP process_sp = instance->GetProcessSP();
+  if (!process_sp) {
+    LLDB_LOGF(log_category, "failed to get process from baton");
+    return false;
+  }
+  ThreadSP thread_sp = context->exe_ctx_ref.GetThreadSP();
+  if (!thread_sp) {
+    LLDB_LOGF(log_category,
+              "failed to get thread from StoppointCallbackContext");
+    return false;
+  }
+  if (process_sp != context->exe_ctx_ref.GetProcessSP()) {
+    LLDB_LOGF(log_category,
+              "process from baton (%p) and StoppointCallbackContext (%p) do "
+              "not match",
+              (void *)process_sp.get(),
+              (void *)context->exe_ctx_ref.GetProcessSP().get());
+    return false;
+  }
+
+  if (process_sp->GetModIDRef().IsLastResumeForUserExpression()) {
+    LLDB_LOGF(log_category, "IsLastResumeForUserExpression is true");
+    return false;
+  }
+
+  // Maybe the stop reason and stackframe selection should be done by
+  // a stackframe recognizer instead (rdar://165066642)?
+  thread_sp->SetStopInfo(
+      InstrumentationBoundsSafetyStopInfo::
+          CreateInstrumentationBoundsSafetyStopInfo(*thread_sp));
+  return true;
+}
+
+void InstrumentationRuntimeBoundsSafety::Activate() {
+  if (IsActive())
+    return;
+
+  auto *log_category = GetLog(LLDBLog::InstrumentationRuntime);
+  ProcessSP process_sp = GetProcessSP();
+  if (!process_sp) {
+    LLDB_LOGF(log_category, "could not get process during Activate()");
+    return;
+  }
+
+  auto breakpoint = process_sp->GetTarget().CreateBreakpoint(
+      /*containingModules=*/nullptr,
+      /*containingSourceFiles=*/nullptr, getBoundsSafetySoftTrapRuntimeFuncs(),
+      eFunctionNameTypeFull, eLanguageTypeUnknown,
+      /*m_offset=*/0,
+      /*skip_prologue*/ eLazyBoolNo,
+      /*internal=*/true,
+      /*request_hardware*/ false);
+
+  if (!breakpoint)
+    return;
+  if (!breakpoint->HasResolvedLocations()) {
+    LLDB_LOGF(log_category,
+              "breakpoint %d for BoundsSafety soft traps did not resolve to "
+              "any locations",
+              breakpoint->GetID());
+    assert(0 && "breakpoint has no resolved locations");
+    process_sp->GetTarget().RemoveBreakpointByID(breakpoint->GetID());
+    return;
+  }
+
+  // Note: When `sync=true` the suggested stackframe is completely ignored. So
+  // we use `sync=false`. Is that a bug?
+  breakpoint->SetCallback(
+      InstrumentationRuntimeBoundsSafety::NotifyBreakpointHit, this,
+      /*sync=*/false);
+  breakpoint->SetBreakpointKind("bounds-safety-soft-trap");
+  SetBreakpointID(breakpoint->GetID());
+  LLDB_LOGF(log_category, "created breakpoint %d for BoundsSafety soft traps",
+            breakpoint->GetID());
+  SetActive(true);
+}
+
+void InstrumentationRuntimeBoundsSafety::Deactivate() {
+  SetActive(false);
+  auto *log_category = GetLog(LLDBLog::InstrumentationRuntime);
+  if (ProcessSP process_sp = GetProcessSP()) {
+    bool success =
+        process_sp->GetTarget().RemoveBreakpointByID(GetBreakpointID());
+    LLDB_LOGF(log_category,
+              "%sremoved breakpoint %llu for BoundsSafety soft traps",
+              success ? "" : "failed to ", GetBreakpointID());
+  } else {
+    LLDB_LOGF(log_category, "no process available during Deactivate()");
+  }
+
+  SetBreakpointID(LLDB_INVALID_BREAK_ID);
+}

--- a/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.h
+++ b/lldb/source/Plugins/InstrumentationRuntime/BoundsSafety/InstrumentationRuntimeBoundsSafety.h
@@ -1,0 +1,61 @@
+//===-- InstrumentationRuntimeBoundsSafetySoftTrap.h-------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_INSTRUMENTATIONRUNTIME_BOUNDS_SAFETY_SOFT_TRAP_H
+#define LLDB_SOURCE_PLUGINS_INSTRUMENTATIONRUNTIME_BOUNDS_SAFETY_SOFT_TRAP_H
+
+#include "lldb/Target/ABI.h"
+#include "lldb/Target/InstrumentationRuntime.h"
+#include "lldb/Utility/StructuredData.h"
+#include "lldb/lldb-private.h"
+
+namespace lldb_private {
+
+class InstrumentationRuntimeBoundsSafety
+    : public lldb_private::InstrumentationRuntime {
+public:
+  ~InstrumentationRuntimeBoundsSafety() override;
+
+  static lldb::InstrumentationRuntimeSP
+  CreateInstance(const lldb::ProcessSP &process_sp);
+
+  static void Initialize();
+
+  static void Terminate();
+
+  static llvm::StringRef GetPluginNameStatic() { return "BoundsSafety"; }
+
+  static lldb::InstrumentationRuntimeType GetTypeStatic();
+
+  llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
+
+  virtual lldb::InstrumentationRuntimeType GetType() { return GetTypeStatic(); }
+
+private:
+  InstrumentationRuntimeBoundsSafety(const lldb::ProcessSP &process_sp)
+      : lldb_private::InstrumentationRuntime(process_sp) {}
+
+  const RegularExpression &GetPatternForRuntimeLibrary() override;
+
+  bool CheckIfRuntimeIsValid(const lldb::ModuleSP module_sp) override;
+
+  void Activate() override;
+
+  void Deactivate();
+
+  static bool NotifyBreakpointHit(void *baton,
+                                  StoppointCallbackContext *context,
+                                  lldb::user_id_t break_id,
+                                  lldb::user_id_t break_loc_id);
+
+  bool MatchAllModules() override { return true; }
+};
+
+} // namespace lldb_private
+
+#endif

--- a/lldb/source/Plugins/InstrumentationRuntime/CMakeLists.txt
+++ b/lldb/source/Plugins/InstrumentationRuntime/CMakeLists.txt
@@ -2,6 +2,9 @@ set_property(DIRECTORY PROPERTY LLDB_PLUGIN_KIND InstrumentationRuntime)
 
 add_subdirectory(ASan)
 add_subdirectory(ASanLibsanitizers)
+# TO_UPSTREAM(BoundsSafety) ON
+add_subdirectory(BoundsSafety)
+# TO_UPSTREAM(BoundsSafety) OFF
 add_subdirectory(MainThreadChecker)
 add_subdirectory(TSan)
 add_subdirectory(UBSan)

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
@@ -207,8 +207,11 @@ bool ReportRetriever::NotifyBreakpointHit(ProcessSP process_sp,
     return false;
 
   StructuredData::ObjectSP report = RetrieveReportData(process_sp);
-  if (!report || report->GetType() != lldb::eStructuredDataTypeDictionary)
+  if (!report || report->GetType() != lldb::eStructuredDataTypeDictionary) {
+    LLDB_LOGF(GetLog(LLDBLog::InstrumentationRuntime),
+              "ReportRetriever::RetrieveReportData() failed");
     return false;
+  }
 
   std::string description = FormatDescription(report);
 

--- a/lldb/source/Utility/LLDBLog.cpp
+++ b/lldb/source/Utility/LLDBLog.cpp
@@ -67,6 +67,9 @@ static constexpr Log::Category g_categories[] = {
     {{"disassembler"},
      {"log disassembler related activities"},
      LLDBLog::Disassembler},
+    {{"instrumentation-runtime"},
+     {"log instrumentation runtime plugin related activities"},
+     LLDBLog::InstrumentationRuntime},
 };
 
 static Log::Channel g_log_channel(g_categories,

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/Makefile
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/Makefile
@@ -1,0 +1,10 @@
+# FIXME: mockSoftTrapRuntime.c shouldn't really be built with -fbounds-safety
+C_SOURCES := main.c mockSoftTrapRuntime.c
+
+soft-trap-test-minimal: CFLAGS_EXTRAS := -fbounds-safety -fbounds-safety-soft-traps=call-minimal
+soft-trap-test-minimal: all
+
+soft-trap-test-with-str: CFLAGS_EXTRAS := -fbounds-safety -fbounds-safety-soft-traps=call-with-str
+soft-trap-test-with-str: all
+
+include Makefile.rules

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
@@ -1,0 +1,146 @@
+"""
+Test the BoundsSafety instrumentation plugin
+"""
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+STOP_REASON_MAX_LEN = 100
+SOFT_TRAP_FUNC_MINIMAL = '__bounds_safety_soft_trap'
+SOFT_TRAP_FUNC_WITH_STR = '__bounds_safety_soft_trap_s'
+
+
+class BoundsSafetyTestSoftTrapPlugin(TestBase):
+    def _check_stop_reason_impl(self,
+                                expected_soft_trap_func:str,
+                                expected_stop_reason:str,
+                                expected_func_name:str,
+                                expected_file_name:str,
+                                expected_line_num:int):
+        process = self.test_target.process
+        thread =  process.GetSelectedThread()
+        self.assertEqual(
+            thread.GetStopReason(),
+            lldb.eStopReasonInstrumentation,
+        )
+        stop_reason = thread.GetStopDescription(STOP_REASON_MAX_LEN)
+        self.assertEqual(
+            stop_reason,
+            expected_stop_reason
+        )
+        stop_frame = thread.GetSelectedFrame()
+        self.assertEqual(
+            stop_frame.name,
+            expected_func_name
+        )
+        # The stop frame isn't frame 1 because that frame is the artificial
+        # frame containing the trap reason.
+        self.assertEqual(
+            stop_frame.idx,
+            2
+        )
+        soft_trap_func_frame = thread.GetFrameAtIndex(0)
+        self.assertEqual(
+            soft_trap_func_frame.name,
+            expected_soft_trap_func
+        )
+        file_name = stop_frame.GetLineEntry().GetFileSpec().basename
+        self.assertEqual(
+            file_name,
+            expected_file_name
+        )
+        line = stop_frame.GetLineEntry().line
+        self.assertEqual(
+            line,
+            expected_line_num
+        )
+
+    def check_state_soft_trap_minimal(self,
+                                  stop_reason:str,
+                                  func_name:str,
+                                  file_name:str,
+                                  line_num:int):
+        """
+        Check the program state is as expected when hitting
+        a soft trap from -fbounds-safety-soft-traps=call-minimal
+        """
+        self._check_stop_reason_impl(SOFT_TRAP_FUNC_MINIMAL,
+            expected_stop_reason=stop_reason,
+            expected_func_name=func_name,
+            expected_file_name=file_name,
+            expected_line_num=line_num)
+        
+    def check_state_soft_trap_with_str(self,
+                                  stop_reason:str,
+                                  func_name:str,
+                                  file_name:str,
+                                  line_num:int):
+        """
+        Check the program state is as expected when hitting
+        a soft trap from -fbounds-safety-soft-traps=call-with_str
+        """
+        self._check_stop_reason_impl(SOFT_TRAP_FUNC_WITH_STR,
+            expected_stop_reason=stop_reason,
+            expected_func_name=func_name,
+            expected_file_name=file_name,
+            expected_line_num=line_num)
+
+    # Skip the tests on Windows because they fail due to the stop reason
+    # being `eStopReasonNon` instead of the expected
+    # `eStopReasonInstrumentation`.
+    @skipIfWindows
+    def test_call_minimal(self):
+        """
+        Test the plugin on code built with 
+        -fbounds-safety-soft-traps=call-minimal
+        """
+        self.build(make_targets=['soft-trap-test-minimal'])
+        self.test_target = self.createTestTarget()
+        self.runCmd("run")
+
+        process = self.test_target.process
+
+        # First soft trap hit
+        self.check_state_soft_trap_minimal(
+            "Soft Bounds check failed: indexing above upper bound in 'buffer[2]'",
+            "main", "main.c", 7)
+
+        process.Continue()
+
+        # Second soft trap hit
+        self.check_state_soft_trap_minimal(
+            "Soft Bounds check failed: indexing below lower bound in 'buffer[-1]'",
+            "main", "main.c", 8)
+
+        process.Continue()
+        self.assertEqual(process.GetState(), lldb.eStateExited)
+        self.assertEqual(process.GetExitStatus(), 0)
+
+    @skipIfWindows
+    def test_call_with_str(self):
+        """
+        Test the plugin on code built with 
+        -fbounds-safety-soft-traps=call-with-str
+        """
+        self.build(make_targets=['soft-trap-test-with-str'])
+        self.test_target = self.createTestTarget()
+        self.runCmd("run")
+
+        process = self.test_target.process
+
+        # First soft trap hit
+        self.check_state_soft_trap_with_str(
+            "Soft Bounds check failed: indexing above upper bound in 'buffer[2]'",
+            "main", "main.c", 7)
+
+        process.Continue()
+
+        # Second soft trap hit
+        self.check_state_soft_trap_with_str(
+            "Soft Bounds check failed: indexing below lower bound in 'buffer[-1]'",
+            "main", "main.c", 8)
+
+        process.Continue()
+        self.assertEqual(process.GetState(), lldb.eStateExited)
+        self.assertEqual(process.GetExitStatus(), 0)

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/main.c
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/main.c
@@ -1,0 +1,10 @@
+#include <ptrcheck.h>
+
+int main(void) {
+  int pad;
+  int buffer[] = {0, 1};
+  int pad2;
+  int tmp = buffer[2]; // access past upper bound
+  tmp = buffer[-1];    // access below lower bound
+  return 0;
+}

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/mockSoftTrapRuntime.c
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/mockSoftTrapRuntime.c
@@ -1,0 +1,17 @@
+#include <bounds_safety_soft_traps.h>
+#include <ptrcheck.h>
+#include <stdio.h>
+
+#if __CLANG_BOUNDS_SAFETY_SOFT_TRAP_API_VERSION > 0
+#error API version changed
+#endif
+
+// FIXME: The runtimes really shouldn't be built with `-fbounds-safety` in
+// soft trap mode because of the risk of infinite recursion. However,
+// there's currently no way to have source files built with different flags
+
+void __bounds_safety_soft_trap_s(const char *reason) {
+  printf("BoundsSafety check FAILED: message:\"%s\"\n", reason ? reason : "");
+}
+
+void __bounds_safety_soft_trap(void) { printf("BoundsSafety check FAILED\n"); }

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockCallSoftTrapRuntime.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockCallSoftTrapRuntime.c
@@ -1,0 +1,8 @@
+#include <bounds_safety_soft_traps.h>
+#include <stdio.h>
+
+int main(void) {
+  __bounds_safety_soft_trap_s(0);
+  printf("Execution continued\n");
+  return 0;
+}

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockSoftTrapRuntime.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetyMockSoftTrapRuntime.c
@@ -1,0 +1,21 @@
+#include <bounds_safety_soft_traps.h>
+#include <ptrcheck.h>
+#include <stdio.h>
+
+#if __CLANG_BOUNDS_SAFETY_SOFT_TRAP_API_VERSION > 0
+#error API version changed
+#endif
+
+#if __has_ptrcheck
+#error Do not compile the runtime with -fbounds-safety enabled due to potential for infinite recursion
+#endif
+
+
+
+void __bounds_safety_soft_trap_s(const char *reason) {
+    printf("BoundsSafety check FAILED: message:\"%s\"\n", reason? reason: "");
+}
+
+void __bounds_safety_soft_trap(void) {
+    printf("BoundsSafety check FAILED\n");
+}

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTraps.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTraps.c
@@ -1,17 +1,4 @@
 #include <stdio.h>
-#include <bounds_safety_soft_traps.h>
-
-#if __CLANG_BOUNDS_SAFETY_SOFT_TRAP_API_VERSION > 0
-#error API version changed
-#endif
-
-void __bounds_safety_soft_trap_s(const char *reason) {
-    printf("BoundsSafety check FAILED: message:\"%s\"\n", reason? reason: "");
-}
-
-void __bounds_safety_soft_trap(void) {
-    printf("BoundsSafety check FAILED\n");
-}
 
 int bad_read(int index) {
   int array[] = {0, 1, 2};

--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int bad_call(int *__counted_by(count) ptr, int count) {}
+
+int main(int argc, char **argv) {
+  const int num_bytes = sizeof(int) * 2;
+  int *array = (int *)malloc(num_bytes);
+  memset(array, 0, num_bytes);
+
+  // The count argument is too large and will cause a trap.
+  // This code pattern is currently missing a trap reason (rdar://100346924) and
+  // so we can use it to test how `InstrumentationRuntimeBoundsSafety` handles
+  // this.
+  bad_call(array, 3);
+  printf("Execution continued\n");
+  return 0;
+}

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal.test
@@ -1,5 +1,7 @@
 # UNSUPPORTED: system-windows
-# RUN: %clang_host -fbounds-safety -fbounds-safety-soft-traps=call-minimal -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.out
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 b __bounds_safety_soft_trap
 run
@@ -10,9 +12,9 @@ run
 
 # Check that reason for bounds check failing can be seen in the stacktrace
 bt
-# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap{{[ ]+}}
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap{{$}}
 # CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
-# CHECK-NEXT: frame #2{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:18
+# CHECK-NEXT: frame #2{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
 
 # Resume execution
 c

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
@@ -1,0 +1,30 @@
+# UNSUPPORTED: system-windows
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -g -O0 %S/Inputs/boundsSafetySoftTrapsMissingReason.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason is not available because the compiler omitted it from the debug info
+
+# Check that the `bad_read` frame is selected
+bt
+# CHECK: frame #{{.*}}`__bounds_safety_soft_trap{{$}}
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$
+# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:16
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_dbg_info.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_dbg_info.test
@@ -1,0 +1,29 @@
+# UNSUPPORTED: system-windows
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason is not available because debug info is missing on the caller of '__bounds_safety_soft_trap'
+
+# Check that the `__bounds_safety_soft_trap` frame is selected
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap{{$}}
+# CHECK-NEXT: frame #{{.*}}`bad_read
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_plugin.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_no_plugin.test
@@ -5,19 +5,21 @@
 # RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 
-# This test relies on this plugin being enabled
-plugin list instrumentation-runtime.BoundsSafety
-# CHECK: [+] BoundsSafety
+# Run without the plugin. A user might want to do this so they can set their
+# own custom breakpoint with custom stopping behavior (e.g. stop after n hits).
+plugin disable instrumentation-runtime.BoundsSafety
+# CHECK: [-] BoundsSafety
 
+b __bounds_safety_soft_trap
 run
 
-# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}
+# CHECK: * thread #{{.*}} stop reason = breakpoint 1.1
 
-# Check that the `bad_read` frame is selected
+# Check that reason for bounds check failing can be seen in the stacktrace
 bt
-# CHECK: frame #{{.*}}`__bounds_safety_soft_trap{{$}}
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap{{$}}
 # CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
-# CHECK-NEXT: * frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+# CHECK-NEXT: frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
 
 # Resume execution
 c

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_str.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_str.test
@@ -4,22 +4,24 @@
 # RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
 # RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
-b __bounds_safety_soft_trap_s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
 run
 
-# TODO: We should probably teach LLDB to recognize soft traps, set the stop
-# reason appropriately and set a breakpoint automatically (rdar://163230807).
-# CHECK: * thread #{{.*}} stop reason = breakpoint 1.1
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}
 
-# Check that reason for bounds check failing can be seen in the stacktrace
+# Check that the `bad_read` frame is selected
 bt
-# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s
+# CHECK: frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
 # CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
-# CHECK-NEXT: frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+# CHECK-NEXT: * frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
 
 # Resume execution
 c
-# CHECK: BoundsSafety check FAILED: message:"indexing above upper bound in 'array[index]'"
+# CHECK: BoundsSafety check FAILED
 # CHECK-NEXT: Execution continued
 # CHECK: Process {{[0-9]+}} exited with status = 0
 q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str.test
@@ -1,5 +1,8 @@
 # UNSUPPORTED: system-windows
-# RUN: %clang_host -fbounds-safety -fbounds-safety-soft-traps=call-with-str -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.out
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
 # RUN: %lldb -b -s %s %t.out | FileCheck %s
 b __bounds_safety_soft_trap_s
 run
@@ -10,9 +13,9 @@ run
 
 # Check that reason for bounds check failing can be seen in the stacktrace
 bt
-# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s(reason="indexing above upper bound in 'array[index]'")
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s
 # CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
-# CHECK-NEXT: frame #2{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:18
+# CHECK-NEXT: frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
 
 # Resume execution
 c

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
@@ -1,0 +1,30 @@
+# UNSUPPORTED: system-windows
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -g -O0 %S/Inputs/boundsSafetySoftTrapsMissingReason.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason is not available because the compiler omitted it from the debug info
+
+# Check that the `bad_read` frame is selected
+bt
+# CHECK: frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$
+# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:16
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info.test
@@ -1,5 +1,5 @@
 # UNSUPPORTED: system-windows
-# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-minimal -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
 # Note: Building the runtime without debug info is intentional because this is the common case
 # RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
 # RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
@@ -13,11 +13,10 @@ run
 
 # CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed: indexing above upper bound in 'array[index]'{{$}}
 
-# Check that the `bad_read` frame is selected
+# Check that the `__bounds_safety_soft_trap_s` frame is selected
 bt
-# CHECK: frame #{{.*}}`__bounds_safety_soft_trap{{$}}
-# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
-# CHECK-NEXT: * frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
+# CHECK-NEXT: frame #{{.*}}`bad_read
 
 # Resume execution
 c

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info_null_str.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_dbg_info_null_str.test
@@ -1,0 +1,32 @@
+# UNSUPPORTED: system-windows
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockCallSoftTrapRuntime.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out 2> %t.warnings | FileCheck %s
+# Warnings are checked separately because their order in the output is not guaranteed.
+# RUN: FileCheck --input-file=%t.warnings --check-prefix=WARN %s
+
+# This test relies on this plugin being enabled
+plugin list instrumentation-runtime.BoundsSafety
+# CHECK: [+] BoundsSafety
+
+run
+
+# This exists to check that the instrumentation correctly handles
+# `__bounds_safety_soft_trap_s()` being called with a nullptr argument.
+
+# CHECK: * thread #{{.*}} stop reason = Soft Bounds check failed{{$}}
+# WARN: warning: specific BoundsSafety trap reason cannot be inferred because the compiler omitted the reason
+
+# Check that the `__bounds_safety_soft_trap_s` frame is selected
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
+# CHECK-NEXT: frame #{{.*}}`main
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_plugin.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_no_plugin.test
@@ -1,0 +1,29 @@
+# UNSUPPORTED: system-windows
+# RUN: %clang_host -c -fbounds-safety -fbounds-safety-soft-traps=call-with-str -g -O0 %S/Inputs/boundsSafetySoftTraps.c -o %t.o
+# Note: Building the runtime without debug info is intentional because this is the common case
+# RUN: %clang_host -c -O0 %S/Inputs/boundsSafetyMockSoftTrapRuntime.c -o %t.softtrap_runtime.o
+# RUN: %clang_host %t.o %t.softtrap_runtime.o -o %t.out
+# RUN: %lldb -b -s %s %t.out | FileCheck %s
+
+# Run without the plugin. A user might want to do this so they can set their
+# own custom breakpoint with custom stopping behavior (e.g. stop after n hits).
+plugin disable instrumentation-runtime.BoundsSafety
+# CHECK: [-] BoundsSafety
+
+b __bounds_safety_soft_trap_s
+run
+
+# CHECK: * thread #{{.*}} stop reason = breakpoint 1.1
+
+# Check that reason for bounds check failing can be seen in the stacktrace
+bt
+# CHECK: * frame #{{.*}}`__bounds_safety_soft_trap_s
+# CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$indexing above upper bound in 'array[index]'
+# CHECK-NEXT: frame #{{.*}}`bad_read(index=10) at boundsSafetySoftTraps.c:5
+
+# Resume execution
+c
+# CHECK: BoundsSafety check FAILED: message:"indexing above upper bound in 'array[index]'"
+# CHECK-NEXT: Execution continued
+# CHECK: Process {{[0-9]+}} exited with status = 0
+q


### PR DESCRIPTION
This patch implements an instrumentation plugin for the
`-fbounds-safety` soft trap mode first implemented in
https://github.com/swiftlang/llvm-project/pull/11645 (rdar://158088757).

The current implementation of -fbounds-safety traps works by emitting
calls to runtime functions intended to log the occurrence of a soft trap.
While the user could just set a breakpoint of these functions the
instrumentation plugin sets it automatically and provides several
additional features:

When debug info is available:

* It adjusts the stop reason to be the reason for trapping. This is
  extracted from the artificial frame in the debug info (similar to
  -fbounds-safety hard traps).
* It adjusts the selected frame to be the frame where the soft trap
  occurred.

When debug info is not available:

* For the `call-with-str` soft trap mode the soft trap reason is
  read from the first argument register.
* For the `call-minimal` soft trap mode the stop reason is adjusted
  to note its a bounds check failure but does not give further
  information because none is available.
* In this situation the selected frame is not adjusted because in
  this mode the user will be looking at assembly and adjusting the
  frame makes things confusing.

This patch includes shell and api tests. The shell tests seemed like the
best way to test behavior when debug info is missing because those tests
make it easy to disable building with debug info completely.

rdar://163230807