### PR TITLE
[BoundsSafety][NFC] Fix Sema/attr-counted-by-void-ptr-gnu.c

### DIFF
--- a/clang/test/Sema/attr-counted-by-void-ptr-gnu.c
+++ b/clang/test/Sema/attr-counted-by-void-ptr-gnu.c
@@ -3,7 +3,9 @@
 // RUN: %clang_cc1 -fexperimental-bounds-safety -fsyntax-only -verify=expected-bounds %s
 
 // expected-nowarn-no-diagnostics
-// expected-bounds-no-diagnostics
+
+// FIXME: We don't allow `counted_by` on `void *` yet, unlike upstream.
+// See: https://github.com/swiftlang/llvm-project/issues/11807
 
 #define NULL (void*)0
 #define __counted_by(f)  __attribute__((counted_by(f)))
@@ -16,6 +18,7 @@
 
 struct test_void_ptr_gnu {
   int count;
+  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   void* buf __counted_by(count);
@@ -23,6 +26,7 @@ struct test_void_ptr_gnu {
 
 struct test_const_void_ptr_gnu {
   int count;
+  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'const void *' because 'const void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   const void* buf __counted_by(count);
@@ -30,6 +34,7 @@ struct test_const_void_ptr_gnu {
 
 struct test_volatile_void_ptr_gnu {
   int count;
+  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'volatile void *' because 'volatile void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   volatile void* buf __counted_by(count);
@@ -37,6 +42,7 @@ struct test_volatile_void_ptr_gnu {
 
 struct test_const_volatile_void_ptr_gnu {
   int count;
+  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'const volatile void *' because 'const volatile void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   const volatile void* buf __counted_by(count);
@@ -54,6 +60,7 @@ struct test_sized_by_void_ptr {
 
 struct test_void_ptr_or_null_gnu {
   int count;
+  // expected-bounds-error@+3{{cannot apply '__counted_by_or_null' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
   // expected-warn-warning@+2{{'counted_by_or_null' on a pointer to void is a GNU extension, treated as 'sized_by_or_null'}}
   // expected-warn-note@+1{{use '__sized_by_or_null' to suppress this warning}}
   void* buf __counted_by_or_null(count);
@@ -61,6 +68,7 @@ struct test_void_ptr_or_null_gnu {
 
 struct test_const_void_ptr_or_null_gnu {
   int count;
+  // expected-bounds-error@+3{{cannot apply '__counted_by_or_null' attribute to 'const void *' because 'const void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
   // expected-warn-warning@+2{{'counted_by_or_null' on a pointer to void is a GNU extension, treated as 'sized_by_or_null'}}
   // expected-warn-note@+1{{use '__sized_by_or_null' to suppress this warning}}
   const void* buf __counted_by_or_null(count);
@@ -85,6 +93,7 @@ void assign_to_pointer(struct test_void_ptr_gnu* t) {
 extern void* my_allocator(unsigned long);
 
 void assign_from_allocator(struct test_void_ptr_gnu* t) {
+  // expected-bounds-error@+1{{assigning to 'void *__single __sized_by(count)' (aka 'void *__single') with size value of 100 from 'void *__single' with pointee of size 0 always fails}}
   t->buf = my_allocator(100);
   t->count = 100;
 }


### PR DESCRIPTION
Upstream now allows 'counted_by' on 'void *', but we still don't with -fbounds-safety. Fixing this divergence is tracked separately in https://github.com/swiftlang/llvm-project/issues/11807.

rdar://164360900