### PR TITLE
[libclang][reproducers] Redirect writing output to the reproducer cache directory.

### DIFF
--- a/clang/test/Modules/reproducer-with-module-dependencies.c
+++ b/clang/test/Modules/reproducer-with-module-dependencies.c
@@ -67,6 +67,7 @@ void test(void) {
 
 //--- script-expectations.txt
 CHECK: CLANG:-clang-executable
+CHECK: "-o" "reproducer.cache/reproducer.o"
 CHECK: -fmodule-file=Test=reproducer.cache/explicitly-built-modules/Test-{{.*}}.pcm
 Verify the reproducer VFS overlay is added before the existing overlay provided on a command line.
 CHECK: -ivfsoverlay "reproducer.cache/vfs/vfs.yaml"

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -835,7 +835,8 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
   std::string ReproExecutable = "\"${CLANG:-" + Opts.BuildArgs.front() + "}\"";
   auto PrintArguments = [&ReproExecutable, &FileCacheName,
                          &ClangOpts](llvm::raw_fd_ostream &OS,
-                                     ArrayRef<std::string> Arguments) {
+                                     ArrayRef<std::string> Arguments,
+                                     bool RedirectOutput) {
     std::vector<const char *> CharArgs(Arguments.size());
     for (const std::string &Arg : Arguments)
       CharArgs.push_back(Arg.c_str());
@@ -853,11 +854,19 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
           DidAddVFSOverlay = true;
         }
       }
+      bool IsOutputArg = Arg->getOption().matches(options::OPT_o);
       llvm::opt::ArgStringList OutArgs;
       Arg->render(ParsedArgs, OutArgs);
+      bool IsArgValue = false;
       for (const auto &OutArg : OutArgs) {
         OS << ' ';
-        llvm::sys::printArg(OS, OutArg, /*Quote=*/true);
+        if (RedirectOutput && IsOutputArg && IsArgValue) {
+          StringRef OutputFileName = llvm::sys::path::filename(OutArg);
+          OS << " \"" << FileCacheName << '/' << OutputFileName << '"';
+        } else {
+          llvm::sys::printArg(OS, OutArg, /*Quote=*/true);
+        }
+        IsArgValue = true;
       }
     }
     if (!DidAddVFSOverlay) {
@@ -866,11 +875,13 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
     }
     OS << '\n';
   };
+  // Redirect the output to keep reproducers relocatable. But don't redirect
+  // modules as they are already in the appropriate place (see `LookupOutput`).
   for (ModuleDeps &Dep : TU.ModuleGraph)
-    PrintArguments(ScriptOS, Dep.getBuildArguments());
+    PrintArguments(ScriptOS, Dep.getBuildArguments(), /*RedirectOutput=*/false);
   ScriptOS << "\n# Translation unit:\n";
   for (const Command &BuildCommand : TU.Commands)
-    PrintArguments(ScriptOS, BuildCommand.Arguments);
+    PrintArguments(ScriptOS, BuildCommand.Arguments, /*RedirectOutput=*/true);
 
   auto RealFS = llvm::vfs::getRealFileSystem();
   RealFS->setCurrentWorkingDirectory(*Opts.WorkingDirectory);


### PR DESCRIPTION
The intention is to keep reproducers relocatable. Without redirection we are trying to write output to "/some/path/existing/only/where/reproducer/generated.o" and failing to do so. Instead we redirect the output to the reproducer cache directory which is a relative path that is guaranteed to exist.

.pcm files are the output too but we don't redirect them because they should be written and read from a specific place which is controlled by `LookupOutput` callback.