### PR TITLE
[lldb-dap] Report any errors during attach request (#165270)

### DIFF
--- a/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
+++ b/lldb/test/API/tools/lldb-dap/coreFile/TestDAP_coreFile.py
@@ -61,6 +61,21 @@ class TestDAP_coreFile(lldbdap_testcase.DAPTestCaseBase):
         self.dap_server.request_next(threadId=32259)
         self.assertEqual(self.get_stackFrames(), expected_frames)
 
+    def test_wrong_core_file(self):
+        exe_file = self.getSourcePath("linux-x86_64.out")
+        wrong_core_file = self.getSourcePath("main.c")
+
+        self.create_debug_adapter()
+        resp = self.attach(
+            program=exe_file, coreFile=wrong_core_file, expectFailure=True
+        )
+        self.assertIsNotNone(resp)
+        self.assertFalse(resp["success"], "Expected failure in response {resp!r}")
+        error_msg = resp["body"]["error"]["format"]
+
+        # attach may fail for mutilple reasons.
+        self.assertEqual(error_msg, "Failed to create the process")
+
     @skipIfLLVMTargetMissing("X86")
     def test_core_file_source_mapping_array(self):
         """Test that sourceMap property is correctly applied when loading a core"""

--- a/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
+++ b/lldb/tools/lldb-dap/Handler/AttachRequestHandler.cpp
@@ -124,6 +124,8 @@ Error AttachRequestHandler::Run(const AttachRequestArguments &args) const {
       attach_info.SetWaitForLaunch(args.waitFor, /*async=*/false);
       dap.target.Attach(attach_info, error);
     }
+    if (error.Fail())
+      return ToError(error);
   }
 
   // Make sure the process is attached and stopped.


### PR DESCRIPTION
Attaching using `core`, `gdbremote` or `attachInfo` may have an error. fail early if it does.

(cherry picked from commit b17f1fd6766a5b36b06df734ee577f7dae9cb964)