### PR TITLE
[lldb] Ignore trailing spaces on quit confirmation (#162263)

### DIFF
--- a/lldb/source/Core/IOHandler.cpp
+++ b/lldb/source/Core/IOHandler.cpp
@@ -152,15 +152,16 @@ void IOHandlerConfirm::IOHandlerComplete(IOHandler &io_handler,
 
 void IOHandlerConfirm::IOHandlerInputComplete(IOHandler &io_handler,
                                               std::string &line) {
-  if (line.empty()) {
+  const llvm::StringRef input = llvm::StringRef(line).rtrim();
+  if (input.empty()) {
     // User just hit enter, set the response to the default
     m_user_response = m_default_response;
     io_handler.SetIsDone(true);
     return;
   }
 
-  if (line.size() == 1) {
-    switch (line[0]) {
+  if (input.size() == 1) {
+    switch (input[0]) {
     case 'y':
     case 'Y':
       m_user_response = true;
@@ -176,10 +177,10 @@ void IOHandlerConfirm::IOHandlerInputComplete(IOHandler &io_handler,
     }
   }
 
-  if (line == "yes" || line == "YES" || line == "Yes") {
+  if (input.equals_insensitive("yes")) {
     m_user_response = true;
     io_handler.SetIsDone(true);
-  } else if (line == "no" || line == "NO" || line == "No") {
+  } else if (input.equals_insensitive("no")) {
     m_user_response = false;
     io_handler.SetIsDone(true);
   }

--- a/lldb/test/API/driver/quit_speed/TestQuitWithProcess.py
+++ b/lldb/test/API/driver/quit_speed/TestQuitWithProcess.py
@@ -33,3 +33,28 @@ class DriverQuitSpeedTest(PExpectTest):
         child.sendline("quit")
         print("sent quit")
         child.expect(pexpect.EOF, timeout=15)
+
+    @skipIfAsan
+    def test_run_quit_with_prompt(self):
+        """Test that the lldb driver's batch mode works correctly with trailing space in confimation."""
+        import pexpect
+
+        self.build()
+
+        exe = self.getBuildArtifact("a.out")
+
+        self.launch(executable=exe)
+        child = self.child
+
+        # Launch the process without a TTY so we don't have to interrupt:
+        child.sendline("process launch -n")
+        print("launched process")
+        child.expect(r"Process ([\d]*) launched:")
+        print("Got launch message")
+        child.sendline("quit")
+        print("sent quit")
+
+        child.expect(r".*LLDB will kill one or more processes.*")
+        # add trailing space to the confirmation.
+        child.sendline("yEs ")
+        child.expect(pexpect.EOF, timeout=15)


### PR DESCRIPTION
(cherry picked from commit 8e62acec9e0228118e2a5a982ca2eaa7b213a049)