### PR TITLE
[lldb] Fix expression evaluation in static functions in actors

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -430,9 +430,6 @@ do {
   if (needs_object_ptr || static_method) {
     const char *func_decorator = "";
     if (static_method) {
-      if (is_class)
-        func_decorator = "final class";
-      else
         func_decorator = "static";
     } else if (is_class && !weak_self) {
       func_decorator = "final";

--- a/lldb/test/API/lang/swift/expression/actor/Makefile
+++ b/lldb/test/API/lang/swift/expression/actor/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
+++ b/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+import os
+
+
+class TestSwiftExpressionActor(TestBase):
+    @swiftTest
+    def test_static_func(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here for static", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("expr self", substrs=["A.Type"])
+
+    @swiftTest
+    def test_func(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here for func", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("expr self", substrs=["(a.A)", "i = 42", 's = "Hello"'])

--- a/lldb/test/API/lang/swift/expression/actor/main.swift
+++ b/lldb/test/API/lang/swift/expression/actor/main.swift
@@ -1,0 +1,14 @@
+actor A {
+    let i = 42
+    let s = "Hello"
+    static func foo() {
+        print("break here for static")
+    }
+
+    func bar() {
+        print("break here for func")
+    }
+}
+
+A.foo()
+await A().bar()

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -49,6 +49,8 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
 
             self.assertTrue(len(threads) == 1)
             lldbutil.check_expression(self, self.frame(), "i", str(i), False)
+            if i == 4:
+                self.expect('e self', substrs=['F<Int>.Type'])
             if i == 6:
               lldbutil.check_expression(self, self.frame(), "self", "a.H<Int>")
               frame = threads[0].GetFrameAtIndex(0)


### PR DESCRIPTION
Instead of trying to discern if lldb is stopped in a static or class function, always generate the function as static in either of those cases, since static works for classes/actors/structs/enums and for expression evaluation purposes a static or class function will work exactly the same.

rdar://152446035
(cherry picked from commit 5fb35b20b598096c2a679ea11d6ddccec2af053f)