### PR TITLE
[AArch64] Add DEBUG_TYPE and wrap dump() in LLVM_DEBUG()

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -62,6 +62,8 @@
 
 using namespace llvm;
 
+#define DEBUG_TYPE "aarch64-instr-info"
+
 #define GET_INSTRINFO_CTOR_DTOR
 #include "AArch64GenInstrInfo.inc"
 
@@ -7499,7 +7501,7 @@ static bool mayAlias(const MachineInstr &MIa,
                      AliasAnalysis *AA) {
   for (const MachineInstr *MIb : MemInstrs) {
     if (MIa.mayAlias(AA, *MIb, /*UseTBAA*/ false)) {
-      MIb->dump();
+      LLVM_DEBUG(MIb->dump());
       return true;
     }
   }


### PR DESCRIPTION
mayAlias in AArch64InstrInfo.cpp calls dump() which is only enabled with NDEBUG or LLVM_ENABLE_DUMP.

rdar://165133928