### PR TITLE
[lldb] Add try_lock to SBMutex (#164109)

### DIFF
--- a/lldb/include/lldb/API/SBMutex.h
+++ b/lldb/include/lldb/API/SBMutex.h
@@ -31,6 +31,10 @@ public:
   /// Releases ownership of this lock.
   void unlock() const;
 
+  /// Tries to lock the mutex. Returns immediately. On successful lock
+  /// acquisition returns true, otherwise returns false.
+  bool try_lock() const;
+
 private:
   // Private constructor used by SBTarget to create the Target API mutex.
   // Requires a friend declaration.

--- a/lldb/source/API/SBMutex.cpp
+++ b/lldb/source/API/SBMutex.cpp
@@ -58,3 +58,12 @@ void SBMutex::unlock() const {
   if (m_opaque_sp)
     m_opaque_sp->unlock();
 }
+
+bool SBMutex::try_lock() const {
+  LLDB_INSTRUMENT_VA(this);
+
+  if (m_opaque_sp)
+    return m_opaque_sp->try_lock();
+
+  return false;
+}

--- a/lldb/unittests/API/SBMutexTest.cpp
+++ b/lldb/unittests/API/SBMutexTest.cpp
@@ -36,11 +36,16 @@ TEST_F(SBMutexTest, LockTest) {
   std::future<void> f;
   {
     lldb::SBMutex lock = target.GetAPIMutex();
+
+    ASSERT_TRUE(lock.try_lock());
+    lock.unlock();
+
     std::lock_guard<lldb::SBMutex> lock_guard(lock);
     ASSERT_FALSE(locked.exchange(true));
 
     f = std::async(std::launch::async, [&]() {
       ASSERT_TRUE(locked);
+      EXPECT_FALSE(lock.try_lock());
       target.BreakpointCreateByName("foo", "bar");
       ASSERT_FALSE(locked);
     });


### PR DESCRIPTION
Add `try_lock` to confirm to Lockable, which is necessary to use it with `std::scoped_lock`.

(cherry picked from commit c01a22363034b98a21affde44b1b45ba5d022c71)