### PR TITLE
🍒 llvm: Export `ilist_node_base` template specialization (llvm#168094)

### DIFF
--- a/llvm/include/llvm/ADT/ilist_node_base.h
+++ b/llvm/include/llvm/ADT/ilist_node_base.h
@@ -67,6 +67,9 @@ class ilist_node_base : public ilist_detail::node_base_prevnext<
                             EnableSentinelTracking>,
                         public ilist_detail::node_base_parent<ParentTy> {};
 
+// Specialization implemented in the core LLVM library.
+template class LLVM_ABI ilist_node_base<true, void>;
+
 } // end namespace llvm
 
 #endif // LLVM_ADT_ILIST_NODE_BASE_H


### PR DESCRIPTION
The core LLVM library implements a specialization for `ilist_node_base<true, void>`, which is used by other components. This is needed to link properly when building LLVM as a library on Windows.

This effort is tracked in swiftlang/swift#85241.