### PR TITLE
[lldb] Implement DW_CFA_val_offset and DW_CFA_val_offset_sf (#150732)

### DIFF
--- a/lldb/include/lldb/Target/UnwindLLDB.h
+++ b/lldb/include/lldb/Target/UnwindLLDB.h
@@ -51,6 +51,9 @@ protected:
                                       // target mem (target_memory_location)
       eRegisterInRegister, // register is available in a (possible other)
                            // register (register_number)
+      eRegisterIsRegisterPlusOffset, // register is available in a (possible
+                                     // other) register (register_number) with
+                                     // an offset applied
       eRegisterSavedAtHostMemoryLocation, // register is saved at a word in
                                           // lldb's address space
       eRegisterValueInferred,        // register val was computed (and is in
@@ -66,6 +69,11 @@ protected:
       void *host_memory_location;
       uint64_t inferred_value; // eRegisterValueInferred - e.g. stack pointer ==
                                // cfa + offset
+      struct {
+        uint32_t
+            register_number; // in eRegisterKindLLDB register numbering system
+        uint64_t offset;
+      } reg_plus_offset;
     } location;
   };
 

--- a/lldb/source/Target/RegisterContextUnwind.cpp
+++ b/lldb/source/Target/RegisterContextUnwind.cpp
@@ -1121,6 +1121,27 @@ bool RegisterContextUnwind::ReadRegisterValueFromRegisterLocation(
       success = GetNextFrame()->ReadRegister(other_reg_info, value);
     }
   } break;
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterIsRegisterPlusOffset: {
+    auto regnum = regloc.location.reg_plus_offset.register_number;
+    const RegisterInfo *other_reg_info =
+        GetRegisterInfoAtIndex(regloc.location.reg_plus_offset.register_number);
+
+    if (!other_reg_info)
+      return false;
+
+    if (IsFrameZero()) {
+      success =
+          m_thread.GetRegisterContext()->ReadRegister(other_reg_info, value);
+    } else {
+      success = GetNextFrame()->ReadRegister(other_reg_info, value);
+    }
+    if (success) {
+      UnwindLogMsg("read (%d)'s location", regnum);
+      value = value.GetAsUInt64(~0ull, &success) +
+              regloc.location.reg_plus_offset.offset;
+      UnwindLogMsg("success %s", success ? "yes" : "no");
+    }
+  } break;
   case UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred:
     success =
         value.SetUInt(regloc.location.inferred_value, reg_info->byte_size);
@@ -1167,6 +1188,7 @@ bool RegisterContextUnwind::WriteRegisterValueToRegisterLocation(
       success = GetNextFrame()->WriteRegister(other_reg_info, value);
     }
   } break;
+  case UnwindLLDB::ConcreteRegisterLocation::eRegisterIsRegisterPlusOffset:
   case UnwindLLDB::ConcreteRegisterLocation::eRegisterValueInferred:
   case UnwindLLDB::ConcreteRegisterLocation::eRegisterNotSaved:
     break;
@@ -1997,8 +2019,9 @@ bool RegisterContextUnwind::ReadFrameAddress(
 
   switch (fa.GetValueType()) {
   case UnwindPlan::Row::FAValue::isRegisterDereferenced: {
+    UnwindLogMsg("CFA value via dereferencing reg");
     RegisterNumber regnum_to_deref(m_thread, row_register_kind,
-                                   fa.GetRegisterNumber());
+                           fa.GetRegisterNumber());
     addr_t reg_to_deref_contents;
     if (ReadGPRValue(regnum_to_deref, reg_to_deref_contents)) {
       const RegisterInfo *reg_info =
@@ -2028,6 +2051,7 @@ bool RegisterContextUnwind::ReadFrameAddress(
     break;
   }
   case UnwindPlan::Row::FAValue::isRegisterPlusOffset: {
+    UnwindLogMsg("CFA value via register plus offset");
     RegisterNumber cfa_reg(m_thread, row_register_kind,
                            fa.GetRegisterNumber());
     if (ReadGPRValue(cfa_reg, cfa_reg_contents)) {
@@ -2047,10 +2071,13 @@ bool RegisterContextUnwind::ReadFrameAddress(
           address, cfa_reg.GetName(), cfa_reg.GetAsKind(eRegisterKindLLDB),
           cfa_reg_contents, fa.GetOffset());
       return true;
-    }
+    } else
+      UnwindLogMsg("unable to read CFA register %s (%d)", cfa_reg.GetName(),
+                   cfa_reg.GetAsKind(eRegisterKindLLDB));
     break;
   }
   case UnwindPlan::Row::FAValue::isDWARFExpression: {
+    UnwindLogMsg("CFA value via DWARF expression");
     ExecutionContext exe_ctx(m_thread.shared_from_this());
     Process *process = exe_ctx.GetProcessPtr();
     DataExtractor dwarfdata(fa.GetDWARFExpressionBytes(),
@@ -2074,6 +2101,7 @@ bool RegisterContextUnwind::ReadFrameAddress(
     break;
   }
   case UnwindPlan::Row::FAValue::isRaSearch: {
+    UnwindLogMsg("CFA value via heuristic search");
     Process &process = *m_thread.GetProcess();
     lldb::addr_t return_address_hint = GetReturnAddressHint(fa.GetOffset());
     if (return_address_hint == LLDB_INVALID_ADDRESS)

--- a/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind-val-offset.s
+++ b/lldb/test/Shell/Unwind/Inputs/eh-frame-dwarf-unwind-val-offset.s
@@ -1,0 +1,50 @@
+        .text
+        .globl  bar
+bar:
+        .cfi_startproc
+        leal    (%edi, %edi), %eax
+        ret
+        .cfi_endproc
+
+        .globl  foo
+        # This function uses a non-standard calling convention (return address
+        # needs to be adjusted) to force lldb to use eh_frame/debug_frame
+        # instead of reading the code directly.
+foo:
+        .cfi_startproc
+        .cfi_escape 0x16, 0x10, 0x06, 0x38, 0x1c, 0x06, 0x08, 0x47, 0x1c
+        # Clobber r12 and record that it's reconstructable from CFA
+        .cfi_val_offset %r12, 32
+        movq    $0x456, %r12
+        call    bar
+        addl    $1, %eax
+        # Reconstruct %r12
+        movq    %rsp, %r12
+        addq    %r12, 8
+        popq    %rdi
+        subq    $0x47, %rdi
+        jmp     *%rdi # Return
+        .cfi_endproc
+
+        .globl  asm_main
+asm_main:
+        .cfi_startproc
+        pushq   %rbp
+        .cfi_def_cfa_offset 16
+        .cfi_offset %rbp, -16
+        movq    %rsp, %rbp
+        movq    %rsp, %r12
+        addq    $32, %r12
+        .cfi_def_cfa_register %rbp
+        movl    $47, %edi
+
+        # Non-standard calling convention. The real return address must be
+        # decremented by 0x47.
+        leaq    0x47+1f(%rip), %rax
+        pushq   %rax
+        jmp     foo # call
+1:
+        popq    %rbp
+        .cfi_def_cfa %rsp, 8
+        ret
+        .cfi_endproc

--- a/lldb/test/Shell/Unwind/eh-frame-dwarf-unwind-val-offset.test
+++ b/lldb/test/Shell/Unwind/eh-frame-dwarf-unwind-val-offset.test
@@ -1,0 +1,58 @@
+# Test handing of the dwarf val_offset() rule which can be used to reconstruct
+# the value of a register that is neither in a live register or saved on the
+# stack but is computable with CFA + offset.
+
+# UNSUPPORTED: system-windows, ld_new-bug
+# REQUIRES: target-x86_64, native
+
+# RUN: %clang_host %p/Inputs/call-asm.c %p/Inputs/eh-frame-dwarf-unwind-val-offset.s -o %t
+# RUN: %lldb %t -s %s -o exit | FileCheck %s
+
+breakpoint set -n asm_main
+# CHECK: Breakpoint 1: where = {{.*}}`asm_main
+
+breakpoint set -n bar
+# CHECK: Breakpoint 2: where = {{.*}}`bar
+
+process launch
+# CHECK: stop reason = breakpoint 1.1
+
+stepi
+stepi
+stepi
+register read -G x r12
+# CHECK: r12 = 0x[[#%.16x,R12:]]{{$}}
+
+continue
+# CHECK: stop reason = breakpoint 2.1
+
+thread backtrace
+# CHECK: frame #0: {{.*}}`bar
+# CHECK: frame #1: {{.*}}`foo + 12
+# CHECK: frame #2: {{.*}}`asm_main + 29
+
+target modules show-unwind -n bar
+# CHECK: eh_frame UnwindPlan:
+# CHECK: row[0]:  0: CFA=rsp +8 => rip=[CFA-8]
+
+target modules show-unwind -n foo
+# CHECK: eh_frame UnwindPlan:
+# CHECK: row[0]: 0: CFA=rsp +8 => r12=CFA+32 rip=DW_OP_lit8, DW_OP_minus, DW_OP_deref, DW_OP_const1u 0x47, DW_OP_minus
+
+target modules show-unwind -n asm_main
+# CHECK: eh_frame UnwindPlan:
+# CHECK: row[0]:  0: CFA=rsp +8 => rip=[CFA-8]
+# CHECK: row[1]:  1: CFA=rsp+16 => rbp=[CFA-16] rip=[CFA-8]
+# CHECK: row[2]: 11: CFA=rbp+16 => rbp=[CFA-16] rip=[CFA-8]
+# CHECK: row[3]: 30: CFA=rsp +8 => rbp=[CFA-16] rip=[CFA-8]
+
+register read -G x r12
+# CHECK: r12 = 0x0000000000000456
+
+frame select 1
+register read -G x r12
+# CHECK: r12 = 0x0000000000000456
+
+frame select 2
+register read -G x r12
+# CHECK: r12 = 0x[[#R12 + 32]]


### PR DESCRIPTION
The test for this is artificial as I'm not aware of any upstream targets that use DW_CFA_val_offset

RegisterContextUnwind::ReadFrameAddress now reports how it's attempting to obtain the CFA unless all success/failure cases emit logs that clearly identify the method it was attempting. Previously several of the existing failure paths emit no message or a message that's indistinguishable from those on other paths.

(cherry picked from commit c455c4e2d7f78d5992369457066b249699fe2084)