### PR TITLE
[clang][NFC] Migrate from getOriginalDecl() to getDecl()

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -5223,7 +5223,7 @@ bool RecordDecl::isParentStructOf(const Decl *Inner) const {
     return true;
   for (auto FD : fields()) {
     if (auto InnerStructTy = FD->getType()->getAs<RecordType>()) {
-      if (cast<RecordDecl>(InnerStructTy->getOriginalDecl())->isParentStructOf(Inner))
+      if (cast<RecordDecl>(InnerStructTy->getDecl())->isParentStructOf(Inner))
         return true;
     }
   }

--- a/clang/lib/AST/Type.cpp
+++ b/clang/lib/AST/Type.cpp
@@ -2739,7 +2739,7 @@ bool Type::isSizeMeaningless() const {
   if (isFunctionType())
     return true;
   if (auto *RT = getAs<RecordType>())
-    if (RT->getOriginalDecl()->hasFlexibleArrayMember())
+    if (RT->getDecl()->hasFlexibleArrayMember())
       return true;
   return false;
 }

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1985,7 +1985,7 @@ static void boundsSafetyRecursiveInit(CodeGenFunction &CGF, const Decl *D,
   } else if (ShouldInitializeType(Ty)) {
     boundsSafetyZeroInit(CGF, BaseAddrGen(), IsVolatileQualified);
   } else if (auto RTy = Ty->getAs<RecordType>()) {
-    auto RD = RTy->getOriginalDecl();
+    auto RD = RTy->getDecl();
     assert(RD);
     if (RD->isUnion()) {
       for (auto F : RD->fields()) {

--- a/clang/lib/Index/IndexRecordHasher.cpp
+++ b/clang/lib/Index/IndexRecordHasher.cpp
@@ -270,7 +270,7 @@ void IndexRecordHasher::hashCanonicalType(CanQualType CT) {
     }
     if (const TagType *tag = dyn_cast<TagType>(T)) {
       HashBuilder.add('$');
-      hashDecl(tag->getOriginalDecl()->getCanonicalDecl());
+      hashDecl(tag->getDecl()->getCanonicalDecl());
       return;
     }
     if (const ObjCInterfaceType *interface = dyn_cast<ObjCInterfaceType>(T)) {

--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
@@ -3515,7 +3515,7 @@ RecordDecl *FlexibleArrayMemberUtils::GetFlexibleRecord(QualType QT) {
   if (!RT)
     return nullptr;
 
-  auto *RD = RT->getOriginalDecl();
+  auto *RD = RT->getDecl();
   if (!RD->hasFlexibleArrayMember())
     return nullptr;
 
@@ -3531,7 +3531,7 @@ RecordDecl *FlexibleArrayMemberUtils::GetFlexibleRecord(QualType QT) {
     assert(FlexibleField);
     QualType FieldType = FlexibleField->getType();
     if (auto *RT = FieldType->getAs<RecordType>()) {
-      FlexibleRecord = RT->getOriginalDecl();
+      FlexibleRecord = RT->getDecl();
     } else {
       DCPTy = FieldType->isIncompleteArrayType() ? FieldType->getAs<CountAttributedType>() : nullptr;
       FlexibleRecord = nullptr;
@@ -3563,7 +3563,7 @@ bool FlexibleArrayMemberUtils::Find(
     PathToFlex.push_back(FlexibleField);
     QualType FieldType = FlexibleField->getType();
     if (auto *RT = FieldType->getAs<RecordType>()) {
-      FlexibleRecord = RT->getOriginalDecl();
+      FlexibleRecord = RT->getDecl();
     } else {
       DCPTy = FieldType->isIncompleteArrayType() ? FieldType->getAs<CountAttributedType>() : nullptr;
       FlexibleRecord = nullptr;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -15085,7 +15085,7 @@ void Sema::AddInitializerToDecl(Decl *RealDecl, Expr *Init, bool DirectInit) {
   // initializer lists (and no initializers), but that's it.
   if (Init && getLangOpts().BoundsSafety && VDecl->hasLocalStorage()) {
     auto *RecordT = VDecl->getType()->getAs<RecordType>();
-    if (RecordT && RecordT->getOriginalDecl()->hasFlexibleArrayMember()) {
+    if (RecordT && RecordT->getDecl()->hasFlexibleArrayMember()) {
       if (!isa<InitListExpr>(Init->IgnoreParenImpCasts())) {
         Diag(
             Init->getBeginLoc(), diag::err_flexible_array_member_passed_by_copy)
@@ -16806,7 +16806,7 @@ ParmVarDecl *Sema::CheckParameter(DeclContext *DC, SourceLocation StartLoc,
     }
 
     auto *RecordT = T->getAs<RecordType>();
-    if (RecordT && RecordT->getOriginalDecl()->hasFlexibleArrayMember()) {
+    if (RecordT && RecordT->getDecl()->hasFlexibleArrayMember()) {
       // BoundsSafety prevents passing flexible array members by copy.
       Diag(TSInfo->getTypeLoc().getBeginLoc(),
            diag::err_flexible_array_member_passed_by_copy) << TSInfo->getType();

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6976,7 +6976,7 @@ unsigned TransitiveFieldCopyCount(const RecordDecl *RD,
   for (auto FD : RD->fields()) {
     if (auto InnerStructTy = FD->getType()->getAs<RecordType>()) {
       Count += TransitiveFieldCopyCount(
-          cast<RecordDecl>(InnerStructTy->getOriginalDecl()), Inner);
+          cast<RecordDecl>(InnerStructTy->getDecl()), Inner);
     }
   }
   return Count;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -712,7 +712,7 @@ PromoteBoundsSafetyFlexibleArrayMember(Sema &S, MemberExpr *M, Expr *ArrayBase) 
   if (auto *PT = BasePtr->getType()->getAs<PointerType>()) {
     if (!PT->getPointerAttributes().hasUpperBound()) {
       auto *RecordPointee = PT->getPointeeType()->getAs<RecordType>();
-      auto *RD = RecordPointee->getOriginalDecl();
+      auto *RD = RecordPointee->getDecl();
       assert(RD->hasFlexibleArrayMember() &&
              RD->getTagKind() != TagTypeKind::Union);
       // Skipping the null check for the struct base because it must have been
@@ -909,7 +909,7 @@ static RecordDecl *getImmediateDeclForFlexibleArrayPromotion(QualType T) {
   if (T->isSinglePointerType() && !T->isBoundsAttributedType()) {
     auto *PT = T->getAs<PointerType>();
     if (auto *RecordPointee = PT->getPointeeType()->getAs<RecordType>()) {
-      auto *RD = RecordPointee->getOriginalDecl();
+      auto *RD = RecordPointee->getDecl();
       if (RD->hasFlexibleArrayMember() &&
           RD->getTagKind() != TagTypeKind::Union) {
         return RD;
@@ -8041,7 +8041,7 @@ bool Sema::CheckDynamicCountSizeForAssignment(
   if (UnboundedRHS)
     // It might still have a flexible array member
     if (auto *RT = RHSTy->getPointeeType()->getAs<RecordType>())
-      UnboundedRHS = !RT->getOriginalDecl()->hasFlexibleArrayMember();
+      UnboundedRHS = !RT->getDecl()->hasFlexibleArrayMember();
 
   ReplaceDeclRefWithRHS Transform(*this, DependentValues);
   if (!DependentValues.empty()) {
@@ -13914,7 +13914,7 @@ static bool checkArithmeticUnaryOpBoundsSafetyPointer(Sema &S, Expr *Operand, bo
   }
 
   if (auto *RD = ResType->getPointeeType()->getAs<RecordType>()) {
-    if (RD->getOriginalDecl()->hasFlexibleArrayMember()) {
+    if (RD->getDecl()->hasFlexibleArrayMember()) {
       S.Diag(Operand->getExprLoc(),
         diag::err_bounds_safety_flexible_array_member_record_pointer_arithmetic);
       return false;
@@ -13982,7 +13982,7 @@ static bool checkArithmeticBinOpBoundsSafetyPointer(Sema &S, Expr *Base,
   }
 
   if (auto *RD = PT->getPointeeType()->getAs<RecordType>()) {
-    if (RD->getOriginalDecl()->hasFlexibleArrayMember()) {
+    if (RD->getDecl()->hasFlexibleArrayMember()) {
       S.Diag(Base->getExprLoc(),
         diag::err_bounds_safety_flexible_array_member_record_pointer_arithmetic);
       return false;
@@ -17090,7 +17090,7 @@ QualType Sema::CheckAssignmentOperands(Expr *LHSExpr, ExprResult &RHS,
   /* TO_UPSTREAM(BoundsSafety) ON*/
   if (getLangOpts().BoundsSafety) {
     auto *RecordTy = RHSType->getAs<RecordType>();
-    if (RecordTy && RecordTy->getOriginalDecl()->hasFlexibleArrayMember()) {
+    if (RecordTy && RecordTy->getDecl()->hasFlexibleArrayMember()) {
       // BoundsSafety prevents passing flexible array members by copy.
       QualType DisplayType = CompoundType.isNull()
           ? RHS.get()->IgnoreParenImpCasts()->getType() : CompoundType;
@@ -26560,7 +26560,7 @@ ExprResult BoundsCheckBuilder::CheckFlexibleArrayMemberSizeImpl(
   SmallVector<FieldDecl *, 1> PathToFlex;
   ArrayRef<TypeCoupledDeclRefInfo> CountDecls;
   auto *RT = FAMPtr->getType()->getPointeeType()->getAs<RecordType>();
-  bool Found = FlexUtils.Find(RT->getOriginalDecl(), PathToFlex, CountDecls);
+  bool Found = FlexUtils.Find(RT->getDecl(), PathToFlex, CountDecls);
   assert(Found); (void)Found;
 
   Expr *FlexibleObj = FlexUtils.SelectFlexibleObject(PathToFlex, OpaqueRoot);

--- a/clang/lib/Sema/SemaFeatureAvailability.cpp
+++ b/clang/lib/Sema/SemaFeatureAvailability.cpp
@@ -333,7 +333,7 @@ bool DiagnoseUnguardedFeatureAvailability::VisitTypeLoc(TypeLoc Ty) {
     return true;
 
   if (const auto *TT = dyn_cast<TagType>(TyPtr)) {
-    TagDecl *TD = TT->getOriginalDecl();
+    TagDecl *TD = TT->getDecl();
     diagnoseDeclFeatureAvailability(TD, Ty.getSourceRange());
   } else if (const auto *TD = dyn_cast<TypedefType>(TyPtr)) {
     TypedefNameDecl *D = TD->getDecl();

--- a/clang/lib/Sema/SemaInit.cpp
+++ b/clang/lib/Sema/SemaInit.cpp
@@ -105,7 +105,7 @@ static void checkValueTerminatedInit(Sema &S, SourceLocation Loc,
   // Recursively check each field.
   if (const auto *RT = T->getAs<RecordType>()) {
     unsigned Index = 0;
-    for (const FieldDecl *FD : RT->getOriginalDecl()->fields()) {
+    for (const FieldDecl *FD : RT->getDecl()->fields()) {
       Expr *I;
       bool ZI;
       std::tie(I, ZI) = getInitAt(Index);

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -2636,7 +2636,7 @@ bool Sema::CheckFunctionReturnType(QualType T, SourceLocation Loc) {
   // by value.
   if (getLangOpts().BoundsSafety) {
     auto *RecordTy = T->getAs<RecordType>();
-    if (RecordTy && RecordTy->getOriginalDecl()->hasFlexibleArrayMember()) {
+    if (RecordTy && RecordTy->getDecl()->hasFlexibleArrayMember()) {
       Diag(Loc, diag::err_flexible_array_member_passed_by_copy) << T;
       return true;
     }
@@ -5137,7 +5137,7 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
       if (S.getLangOpts().BoundsSafety) {
         SourceLocation DiagLoc;
         auto *RecordTy = T->getAs<RecordType>();
-        if (RecordTy && RecordTy->getOriginalDecl()->hasFlexibleArrayMember()) {
+        if (RecordTy && RecordTy->getDecl()->hasFlexibleArrayMember()) {
           if (TInfo) {
             DiagLoc = TInfo->getTypeLoc().getBeginLoc();
           } else {

--- a/clang/lib/Tooling/Refactor/FillInEnumSwitchCases.cpp
+++ b/clang/lib/Tooling/Refactor/FillInEnumSwitchCases.cpp
@@ -69,7 +69,7 @@ clang::tooling::initiateFillInEnumSwitchCasesOperation(
   const Expr *Cond = Switch->getCond()->IgnoreImpCasts();
   const EnumDecl *ED = nullptr;
   if (const auto *ET = Cond->getType()->getAs<EnumType>())
-    ED = ET->getOriginalDecl();
+    ED = ET->getDecl();
   else {
     // Enum literals are 'int' in C.
     if (const auto *DRE = dyn_cast<DeclRefExpr>(Cond)) {


### PR DESCRIPTION
This addresses the use of the now deprecated getOriginalDecl() method by migrating to getDecl(). The bulk of these uses are in BoundsSafety paths, but there are a couple of other uses.