### PR TITLE
[NFC][BoundsSafety] Fix BoundsSafety/CodeGen/unique-traps-O2.c test

### DIFF
--- a/clang/test/BoundsSafety/CodeGen/unique-traps-O2.c
+++ b/clang/test/BoundsSafety/CodeGen/unique-traps-O2.c
@@ -117,9 +117,9 @@ int consume(int* __bidi_indexable ptr, int* __bidi_indexable ptr2, int idx) {
 //
 //
 //.
-// CHECK: attributes #[[ATTR0]] = { alwaysinline nounwind memory(read, inaccessiblemem: write) "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+// CHECK: attributes #[[ATTR0]] = { alwaysinline nounwind memory(read, inaccessiblemem: write, target_mem0: none, target_mem1: none) "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 // CHECK: attributes #[[ATTR1:[0-9]+]] = { cold noreturn nounwind memory(inaccessiblemem: write) }
-// CHECK: attributes #[[ATTR2]] = { nounwind memory(read, inaccessiblemem: write) "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+// CHECK: attributes #[[ATTR2]] = { nounwind memory(read, inaccessiblemem: write, target_mem0: none, target_mem1: none) "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 // CHECK: attributes #[[ATTR3]] = { nomerge noreturn nounwind }
 //.
 // CHECK: [[META0:![0-9]+]] = !{i32 1, !"wchar_size", i32 4}


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/148650 caused new arguments to be passed to the `memory` attribute. This patch re-generates the FileCheck lines to account for this.

rdar://164964481