### PR TITLE
🍒 sanitizers: cherry-pick test stability improvements

### DIFF
--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -14,7 +14,7 @@ RUN: echo ....U. > %tmp/T2/2
 RUN: echo ...Z.. > %tmp/T2/3
 RUN: echo ...Z.. > %tmp/T2/4
 RUN: echo ....E. > %tmp/T2/5
-RUN: echo .....R > %tmp/T2/6
+RUN: %python -c "print('.....R' + 'X' * 1024, end='')" > %tmp/T2/6
 
 # Check that we can report an error if file size exceeded
 RUN: (ulimit -f 1; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)

--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -14,10 +14,10 @@ RUN: echo ....U. > %tmp/T2/2
 RUN: echo ...Z.. > %tmp/T2/3
 RUN: echo ...Z.. > %tmp/T2/4
 RUN: echo ....E. > %tmp/T2/5
-RUN: %python -c "print('.....R' + 'X' * 1024, end='')" > %tmp/T2/6
+RUN: %python -c "print('.....R' + 'X' * 4096, end='')" > %tmp/T2/6
 
 # Check that we can report an error if file size exceeded
-RUN: (ulimit -f 1; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)
+RUN: (ulimit -f 4; not %run %t-FullCoverageSetTest -merge=1 %tmp/T1 %tmp/T2 2>&1 | FileCheck %s --check-prefix=SIGXFSZ)
 SIGXFSZ: ERROR: libFuzzer: file size exceeded
 
 # Check that we honor TMPDIR

--- a/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/Posix/posix_spawn.c
@@ -6,7 +6,11 @@
 #include <assert.h>
 #include <spawn.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/wait.h>
+
+extern char **environ;
 
 int main(int argc, char **argv) {
   if (argc > 1) {
@@ -23,10 +27,21 @@ int main(int argc, char **argv) {
       argv[0], "2", "3", "4", "2", "3", "4", "2", "3", "4",
       "2",     "3", "4", "2", "3", "4", "2", "3", "4", NULL,
   };
-  char *const env[] = {
+  char *env[] = {
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B",
       "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", "A=B", NULL,
   };
+
+  // When this test runs with a runtime (e.g. ASAN), the spawned process needs
+  // to use the same runtime search path as the parent. Otherwise, it might
+  // try to load a runtime that doesn't work and crash before hitting main(),
+  // failing the test. We technically should forward the variable for the
+  // current platform, but some platforms have multiple such variables and
+  // it's quite difficult to plumb this through the lit config.
+  for (char **e = environ; *e; e++)
+    if (strncmp(*e, "DYLD_LIBRARY_PATH=", sizeof("DYLD_LIBRARY_PATH=") - 1) ==
+        0)
+      env[0] = *e;
 
   pid_t pid;
   int s = posix_spawn(&pid, argv[0], &file_actions, &attr, args, env);

--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -1124,6 +1124,8 @@ def executeScriptInternal(
     results = []
     timeoutInfo = None
     shenv = ShellEnvironment(cwd, test.config.environment)
+    shenv.env["LIT_CURRENT_TESTCASE"] = test.getFullName()
+
     exitCode, timeoutInfo = executeShCmd(
         cmd, shenv, results, timeout=litConfig.maxIndividualTestTime
     )
@@ -1323,11 +1325,13 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
             # run on clang with no real loss.
             command = litConfig.valgrindArgs + command
 
+    env = dict(test.config.environment)
+    env["LIT_CURRENT_TESTCASE"] = test.getFullName()
     try:
         out, err, exitCode = lit.util.executeCommand(
             command,
             cwd=cwd,
-            env=test.config.environment,
+            env=env,
             timeout=litConfig.maxIndividualTestTime,
         )
         return (out, err, exitCode, None)

--- a/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-current-testcase.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-current-testcase.txt
@@ -1,0 +1,6 @@
+## Tests that the LIT_CURRENT_TESTCASE variable is set to the name of the currently executing testcase
+
+## Check default environment.
+# RUN: bash -c 'echo $LIT_CURRENT_TESTCASE' | FileCheck --match-full-lines %s
+#
+# CHECK: shtest-env :: env-current-testcase.txt

--- a/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-no-subcommand.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-env-positive/env-no-subcommand.txt
@@ -1,4 +1,5 @@
 ## Tests the env command in various scenarios: without arguments, setting, unsetting, and mixing envrionment variables.
+# FIXME: All of these tests are broken and will not even call FileCheck.
 
 ## Check default environment.
 # RUN: env | FileCheck -check-prefix=NO-ARGS %s

--- a/llvm/utils/lit/tests/shtest-env-positive.py
+++ b/llvm/utils/lit/tests/shtest-env-positive.py
@@ -7,7 +7,7 @@
 
 ## Test the env command's successful executions.
 
-# CHECK: -- Testing: 9 tests{{.*}}
+# CHECK: -- Testing: 10 tests{{.*}}
 
 # CHECK: PASS: shtest-env :: env-args-last-is-assign.txt ({{[^)]*}})
 # CHECK: env FOO=1
@@ -39,6 +39,11 @@
 # CHECK-NOT: # error:
 # CHECK: --
 
+# CHECK: PASS: shtest-env :: env-current-testcase.txt ({{[^)]*}})
+# CHECK: # executed command: bash -c 'echo $LIT_CURRENT_TESTCASE'
+# CHECK-NOT: # error:
+# CHECK: --
+
 # CHECK: PASS: shtest-env :: env-no-subcommand.txt ({{[^)]*}})
 # CHECK: env | {{.*}}
 # CHECK: # executed command: env
@@ -65,6 +70,6 @@
 # CHECK-NOT: # error:
 # CHECK: --
 
-# CHECK: Total Discovered Tests: 9
-# CHECK: Passed: 9 {{\([0-9]*\.[0-9]*%\)}}
+# CHECK: Total Discovered Tests: 10
+# CHECK: Passed: 10 {{\([0-9]*\.[0-9]*%\)}}
 # CHECK-NOT: {{.}}


### PR DESCRIPTION
[sanitizer_common] posix_spawn test should forward DYLD_LIBRARY_PATH (llvm#168795)
[lit] Add LIT_CURRENT_TESTCASE environment variable when running tests (llvm#168762)
[compiler-rt] [libFuzzer] Fix merge-posix test (again) (llvm#168639)
[compiler-rt] [libFuzzer] Fix merge-posix.test file size test (llvm#168137)