### PR TITLE
[BoundsSafety][LLDB] Try to Fix `bounds_safety_soft_trap*_missing_reason` tests on Linux

### DIFF
--- a/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c
+++ b/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ptrcheck.h>
 
 int bad_call(int *__counted_by(count) ptr, int count) {}
 

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_minimal_missing_reason.test
@@ -20,7 +20,7 @@ run
 bt
 # CHECK: frame #{{.*}}`__bounds_safety_soft_trap{{$}}
 # CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$
-# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:16
+# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:17
 
 # Resume execution
 c

--- a/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
+++ b/lldb/test/Shell/BoundsSafety/boundssafety_soft_trap_call_with_str_missing_reason.test
@@ -20,7 +20,7 @@ run
 bt
 # CHECK: frame #{{.*}}`__bounds_safety_soft_trap_s{{$}}
 # CHECK-NEXT: frame #{{.*}}`__clang_trap_msg$Bounds check failed$
-# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:16
+# CHECK-NEXT: * frame #{{.*}}`main({{.+}}) at boundsSafetySoftTrapsMissingReason.c:17
 
 # Resume execution
 c


### PR DESCRIPTION
The tests were failing with:

```
/home/build-user/llvm-project/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c:5:32: error: a parameter list without types is only allowed in a function definition
    5 | int bad_call(int *__counted_by(count) ptr, int count) {}
      |                                ^
/home/build-user/llvm-project/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c:5:39: error: expected ')'
    5 | int bad_call(int *__counted_by(count) ptr, int count) {}
      |                                       ^
/home/build-user/llvm-project/lldb/test/Shell/BoundsSafety/Inputs/boundsSafetySoftTrapsMissingReason.c:5:13: note: to match this '('
    5 | int bad_call(int *__counted_by(count) ptr, int count) {}
      |             ^
2 errors generated.
```

This is happening because `__counted_by` is a macro but the `ptrcheck.h`
header that defines it is not included. This wasn't caught on macOS
because the Libc headers on that platform automatically include that
header.

I don't have a Linux VM to hand so this is a speculative fix that should
fix the include issue.

rdar://165202129