### PR TITLE
[NFC][LLDB] Make it possible to detect if the compiler used in tests supports -fbounds-safety

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -1058,6 +1058,15 @@ def skipUnlessAddressSanitizer(func):
 
     return skipTestIfFn(is_compiler_with_address_sanitizer)(func)
 
+def skipUnlessBoundsSafety(func):
+    """Decorate the item to skip test unless Clang -fbounds-safety is supported."""
+
+    def is_compiler_with_bounds_safety():
+        if not _compiler_supports(lldbplatformutil.getCompiler(), "-fbounds-safety"):
+            return "Compiler cannot compile with -fbounds-safety"
+        return None
+
+    return skipTestIfFn(is_compiler_with_bounds_safety)(func)
 
 def skipIfAsan(func):
     """Skip this test if the environment is set up to run LLDB *itself* under ASAN."""

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -277,6 +277,9 @@ def use_support_substitutions(config):
         required=True,
         use_installed=True,
     )
+    if llvm_config.clang_has_bounds_safety():
+        llvm_config.lit_config.note("clang has -fbounds-safety support")
+        config.available_features.add("clang-bounds-safety")
 
     if sys.platform == "win32":
         _use_msvc_substitutions(config)

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -293,6 +293,15 @@ class LLVMConfig(object):
         except OSError:
             self.lit_config.fatal("Could not run process %s" % command)
 
+    def check_process_success(self, command):
+        cp = subprocess.run(command,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            env=self.config.environment)
+        if cp.returncode == 0:
+            return True
+        return False
+
     def feature_config(self, features):
         # Ask llvm-config about the specified feature.
         arguments = [x for (x, _) in features]
@@ -333,6 +342,25 @@ class LLVMConfig(object):
             clang_dir = clang_dir.replace("\\", "/")
         # Ensure the result is an ascii string, across Python2.5+ - Python3.
         return clang_dir
+
+    def clang_has_bounds_safety(self, additional_flags=None):
+        """
+        Return True iff `self.config.clang` supports -fbounds-safety
+        """
+        if not self.config.clang:
+            return False
+        if not os.path.exists(self.config.clang):
+            return False
+        if additional_flags is None:
+            additional_flags = []
+        # Invoke the clang driver to see if it supports the `-fbounds-safety`
+        # flag. Only the downstream implementation has this flag so this is
+        # a simple way to check if the full implementation is available or not.
+        cmd = [ self.config.clang ] + additional_flags
+        cmd += ['-fbounds-safety', '-###']
+        if self.check_process_success(cmd):
+            return True
+        return False
 
     # On macOS, LSan is only supported on clang versions 5 and higher
     def get_clang_has_lsan(self, clang, triple):


### PR DESCRIPTION
This patch makes it possible to detect in LLDB shell and API tests if `-fbounds-safety` is supported by the compiler used for testing. The motivation behind this is to allow upstreaming https://github.com/swiftlang/llvm-project/pull/11835 but with the tests disabled in upstream because the full implementation of -fbounds-safety isn't available in Clang yet.

For shell tests when -fbounds-safety is available the `clang-bounds-safety` feature is available which means tests can be annotated with `# REQUIRES: clang-bounds-safety`.

API tests that need -fbounds-safety support in the compiler can use the new `@skipUnlessBoundsSafety` decorator.

rdar://165225507