### PR TITLE
[next][clang] Driver: Re-add accidentally removed public specifier

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -828,6 +828,7 @@ private:
   llvm::ErrorOr<bool>
   ScanInputsForCXX20ModulesUsage(const InputList &Inputs) const;
 
+public: // for Swift.
   /// Retrieves a ToolChain for a particular \p Target triple.
   ///
   /// Will cache ToolChains for the life of the driver object, and create them


### PR DESCRIPTION
Faulty merge: 3975083ab542a84fc69bd0ed0dcc59c9fde6c4cd.