### PR TITLE
[next] Add pretty stack trace entry during indexing

### DIFF
--- a/clang/lib/Index/IndexingAction.cpp
+++ b/clang/lib/Index/IndexingAction.cpp
@@ -604,6 +604,7 @@ protected:
   }
 
   bool HandleTopLevelDecl(DeclGroupRef DG) override {
+    llvm::PrettyStackTraceFormat trace("indexing");
     return IndexCtx->indexDeclGroupRef(DG);
   }
 
@@ -612,6 +613,7 @@ protected:
   }
 
   void HandleTopLevelDeclInObjCContainer(DeclGroupRef DG) override {
+    llvm::PrettyStackTraceFormat trace("indexing");
     IndexCtx->indexDeclGroupRef(DG);
   }
 


### PR DESCRIPTION
In case we hit a crash during indexing, this will make it easier to identify the crash as coming from indexing vs from compilation.