### PR TITLE
[lldb] fix `get_python_module_path` indentation (#11649)

### DIFF
--- a/lldb/bindings/python/prepare_binding_python.py
+++ b/lldb/bindings/python/prepare_binding_python.py
@@ -382,7 +382,8 @@ def get_python_module_path(options):
                 module_path = get_python_lib(True, False, options.prefix)
             else:
                 module_path = get_python_lib(True, False)
-            return os.path.normcase(os.path.join(module_path, "lldb"))
+
+        return os.path.normcase(os.path.join(module_path, "lldb"))
 
 
 def main(options):


### PR DESCRIPTION
(cherry picked from commit 2759f736c531a6f307a464178eb2ab1f66d7d956)