### PR TITLE
[next] Fix test failures in `Index/annotate-parameterized-classes.m`

### DIFF
--- a/clang/test/Index/annotate-parameterized-classes.m
+++ b/clang/test/Index/annotate-parameterized-classes.m
@@ -34,5 +34,5 @@ typedef A<id<NSObject>, NSObject *> ASpecialization1;
 
 // RUN: c-index-test -test-annotate-tokens=%s:15:1:16:1 %s -target x86_64-apple-macosx10.7.0 | FileCheck -check-prefix=CHECK-SUPER %s
 // CHECK-SUPER: Identifier: "A" [15:40 - 15:41] ObjCSuperClassRef=A:7:12
-// CHECK-SUPER: Identifier: "T" [15:42 - 15:43] TypeRef=T:15:14
-// CHECK-SUPER: Identifier: "U" [15:45 - 15:46] TypeRef=U:15:22
+// CHECK-SUPER: Identifier: "T" [15:42 - 15:43] TypeRef=B::T:15:14
+// CHECK-SUPER: Identifier: "U" [15:45 - 15:46] TypeRef=B::U:15:22


### PR DESCRIPTION
Adjust test to account for apparently updated printing behavior in upstream clang.

Noticed this while investigating the test failure in https://github.com/swiftlang/llvm-project/pull/11892.