### PR TITLE
[swift/release/6.3][lldb] Swift: Fix `swift::Type` casts for https://github.com/swiftlang/swift/pull/85487

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -687,8 +687,8 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
     swift::Type first_arg_type = optional_type->getGenericArgs()[0];
 
     // In Swift only class types can be weakly captured.
-    if (!llvm::isa<swift::ClassType>(first_arg_type) &&
-        !llvm::isa<swift::BoundGenericClassType>(first_arg_type))
+    if (!first_arg_type->is<swift::ClassType>() &&
+        !first_arg_type->is<swift::BoundGenericClassType>())
       return llvm::createStringError(
           "Unable to add the aliases the expression needs because "
           "weakly captured type is not a class type.");

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5450,7 +5450,7 @@ bool SwiftASTContext::IsTupleType(lldb::opaque_compiler_type_t type) {
   VALID_OR_RETURN(false);
 
   auto swift_type = GetSwiftType(type);
-  return llvm::isa<::swift::TupleType>(swift_type);
+  return swift_type->is<swift::TupleType>();
 }
 
 std::optional<TypeSystemSwift::NonTriviallyManagedReferenceKind>
@@ -6060,8 +6060,7 @@ SwiftASTContext::GetStaticSelfType(lldb::opaque_compiler_type_t type) {
   VALID_OR_RETURN_CHECK_TYPE(type, CompilerType());
 
   swift::Type swift_type = GetSwiftType(type);
-  if (auto *dyn_self =
-          llvm::dyn_cast_or_null<swift::DynamicSelfType>(swift_type))
+  if (auto *dyn_self = swift_type->getAs<swift::DynamicSelfType>())
     return ToCompilerType({dyn_self->getSelfType().getPointer()});
   return {weak_from_this(), type};
 }


### PR DESCRIPTION
Cherry-picks https://github.com/swiftlang/llvm-project/pull/11823 to unblock https://github.com/swiftlang/swift/pull/85561 — I was wrong to assume that `stable/21.x` gets automerged into this release branch.