### PR TITLE
[lldb] Adopt new pointer and mangled typename based stringForPrintObject

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -215,7 +215,7 @@ public:
 
   bool GetSwiftAutoImportFrameworks() const;
 
-  bool GetSwiftUseNewPrintObject() const;
+  bool GetSwiftUseContextFreePrintObject() const;
 
   bool GetEnableAutoImportClangModules() const;
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -568,7 +568,9 @@ public:
 
   bool GetPreparePlaygroundStubFunctions() const { return m_prepare_playground_stub_functions; }
 
-  void SetDisableAvailability() { m_disable_availability = true; }
+  void SetDisableAvailability(bool disable = true) {
+    m_disable_availability = disable;
+  }
 
   bool GetDisableAvailability() const { return m_disable_availability; }
 

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -568,11 +568,13 @@ public:
 
   bool GetPreparePlaygroundStubFunctions() const { return m_prepare_playground_stub_functions; }
 
-  void SetDisableAvailability(bool disable = true) {
-    m_disable_availability = disable;
+  void SetUseContextFreeSwiftPrintObject(bool enable = true) {
+    m_use_context_free_swift_print_object = enable;
   }
 
-  bool GetDisableAvailability() const { return m_disable_availability; }
+  bool GetUseContextFreeSwiftPrintObject() const {
+    return m_use_context_free_swift_print_object;
+  }
 
 private:
   ExecutionPolicy m_execution_policy = default_execution_policy;
@@ -615,8 +617,10 @@ private:
   mutable uint32_t m_pound_line_line = 0;
   bool m_prepare_playground_stub_functions = true;
 
-  /// Disable compiler availability checking.
-  bool m_disable_availability = false;
+  /// An evaluation mode that for swift. Has the following effects:
+  ///   1. Disables implicit module loading
+  ///   2. Disables compiler availability checking
+  bool m_use_context_free_swift_print_object = false;
 
   /// During expression evaluation, any SymbolContext in this list will be
   /// used for symbol/function lookup before any other context (except for

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -566,6 +566,10 @@ public:
 
   bool GetPreparePlaygroundStubFunctions() const { return m_prepare_playground_stub_functions; }
 
+  void SetDisableAvailability() { m_disable_availability = true; }
+
+  bool GetDisableAvailability() const { return m_disable_availability; }
+
 private:
   ExecutionPolicy m_execution_policy = default_execution_policy;
   SourceLanguage m_language;
@@ -606,6 +610,9 @@ private:
   mutable std::string m_pound_line_file;
   mutable uint32_t m_pound_line_line = 0;
   bool m_prepare_playground_stub_functions = true;
+
+  /// Disable compiler availability checking.
+  bool m_disable_availability = false;
 
   /// During expression evaluation, any SymbolContext in this list will be
   /// used for symbol/function lookup before any other context (except for

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -215,6 +215,8 @@ public:
 
   bool GetSwiftAutoImportFrameworks() const;
 
+  bool GetSwiftUseNewPrintObject() const;
+
   bool GetEnableAutoImportClangModules() const;
 
   bool GetUseAllCompilerFlags() const;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1317,13 +1317,14 @@ SwiftExpressionParser::ParseAndImport(
   if (lldb::StackFrameSP this_frame_sp = m_stack_frame_wp.lock())
     process_sp = this_frame_sp->CalculateProcess();
   m_swift_ast_ctx.LoadImplicitModules(m_sc.target_sp, process_sp, *m_exe_scope);
-  if (!m_swift_ast_ctx.GetImplicitImports(m_sc, process_sp, additional_imports,
-                                          implicit_import_error)) {
-    const char *msg = implicit_import_error.AsCString();
-    if (!msg)
-      msg = "error status positive, but import still failed";
-    return make_error<ModuleImportError>(msg);
-  }
+  if (!m_options.GetUseContextFreeSwiftPrintObject())
+    if (!m_swift_ast_ctx.GetImplicitImports(
+            m_sc, process_sp, additional_imports, implicit_import_error)) {
+      const char *msg = implicit_import_error.AsCString();
+      if (!msg)
+        msg = "error status positive, but import still failed";
+      return make_error<ModuleImportError>(msg);
+    }
 
   swift::ImplicitImportInfo importInfo;
   importInfo.StdlibKind = swift::ImplicitStdlibKind::Stdlib;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -640,7 +640,7 @@ Status SwiftExpressionSourceCode::GetText(
     if (triple.isOSDarwin()) {
       if (auto process_sp = exe_ctx.GetProcessSP()) {
         os_vers << getAvailabilityName(triple) << " ";
-        if (options.GetDisableAvailability()) {
+        if (options.GetUseContextFreeSwiftPrintObject()) {
           // Disable availability by setting the OS version to 9999. This
           // placeholder OS version used for future OS versions when building
           // the Swift standard library locally.

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -641,8 +641,9 @@ Status SwiftExpressionSourceCode::GetText(
       if (auto process_sp = exe_ctx.GetProcessSP()) {
         os_vers << getAvailabilityName(triple) << " ";
         if (options.GetDisableAvailability()) {
-          // Disable availability by setting the OS version to 9999, the
-          // placeholder number used for future OS versions.
+          // Disable availability by setting the OS version to 9999. This
+          // placeholder OS version used for future OS versions when building
+          // the Swift standard library locally.
           os_vers << "9999";
         } else {
           auto platform = target->GetPlatform();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -650,7 +650,7 @@ Status SwiftExpressionSourceCode::GetText(
           bool is_simulator = platform->GetPluginName().ends_with("-simulator");
           if (is_simulator) {
             // The simulators look like the host OS to Process, but Platform
-            // can the version out of an environment variable.
+            // can get the version out of an environment variable.
             os_vers << platform->GetOSVersion(process_sp.get()).getAsString();
           } else {
             llvm::VersionTuple version = process_sp->GetHostOSVersion();

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionSourceCode.cpp
@@ -640,15 +640,21 @@ Status SwiftExpressionSourceCode::GetText(
     if (triple.isOSDarwin()) {
       if (auto process_sp = exe_ctx.GetProcessSP()) {
         os_vers << getAvailabilityName(triple) << " ";
-        auto platform = target->GetPlatform();
-        bool is_simulator = platform->GetPluginName().ends_with("-simulator");
-        if (is_simulator) {
-          // The simulators look like the host OS to Process, but Platform
-          // can the version out of an environment variable.
-          os_vers << platform->GetOSVersion(process_sp.get()).getAsString();
+        if (options.GetDisableAvailability()) {
+          // Disable availability by setting the OS version to 9999, the
+          // placeholder number used for future OS versions.
+          os_vers << "9999";
         } else {
-          llvm::VersionTuple version = process_sp->GetHostOSVersion();
-          os_vers << version.getAsString();
+          auto platform = target->GetPlatform();
+          bool is_simulator = platform->GetPluginName().ends_with("-simulator");
+          if (is_simulator) {
+            // The simulators look like the host OS to Process, but Platform
+            // can the version out of an environment variable.
+            os_vers << platform->GetOSVersion(process_sp.get()).getAsString();
+          } else {
+            llvm::VersionTuple version = process_sp->GetHostOSVersion();
+            os_vers << version.getAsString();
+          }
         }
       }
     }

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -914,7 +914,7 @@ std::string SwiftLanguageRuntime::GetObjectDescriptionExpr_Copy(
 
 static llvm::Expected<ValueObjectSP>
 RunObjectDescription(ValueObject &object, std::string &expr_string,
-                     Process &process, bool disable_availability = false) {
+                     Process &process, bool context_free = false) {
   Log *log(GetLog(LLDBLog::DataFormatters | LLDBLog::Expressions));
   ValueObjectSP result_sp;
   EvaluateExpressionOptions eval_options;
@@ -923,8 +923,8 @@ RunObjectDescription(ValueObject &object, std::string &expr_string,
   eval_options.SetSuppressPersistentResult(true);
   eval_options.SetIgnoreBreakpoints(true);
   eval_options.SetTimeout(process.GetUtilityExpressionTimeout());
-  if (disable_availability)
-    eval_options.SetDisableAvailability();
+  if (context_free)
+    eval_options.SetUseContextFreeSwiftPrintObject();
 
   StackFrameSP frame_sp = object.GetFrameSP();
   if (!frame_sp)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1026,6 +1026,7 @@ static llvm::Error PrintObjectViaPointer(Stream &strm, ValueObject &object,
   if (flags.Test(eTypeInstanceIsPointer)) {
     // Objects are pointers.
     addr = object.GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+    addr = process.FixDataAddress(addr);
   } else {
     // Get the address of non-object values (structs, enums).
     auto addr_and_type = object.GetAddressOf(false);

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1043,8 +1043,9 @@ static bool PrintObjectViaPointer(Stream &strm, ValueObject &object,
     return false;
 
   StringRef mangled_type_name = object.GetMangledTypeName();
-  // Swift's APIs that accept mangled names require the "$s" prefix removed.
+  // Swift APIs that receive mangled names require the prefix removed.
   mangled_type_name.consume_front("$s");
+  mangled_type_name.consume_front("$e"); // Embedded Swift prefix
 
   std::string expr_string =
       llvm::formatv(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1094,8 +1094,9 @@ llvm::Error SwiftLanguageRuntime::GetObjectDescription(Stream &str,
   if (object.IsUninitializedReference())
     return llvm::createStringError("<uninitialized>");
 
-  if (printObjectViaPointer(str, object, GetProcess()))
-    return llvm::Error::success();
+  if (GetProcess().GetTarget().GetSwiftUseNewPrintObject())
+    if (printObjectViaPointer(str, object, GetProcess()))
+      return llvm::Error::success();
 
   std::string expr_string;
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1094,7 +1094,7 @@ llvm::Error SwiftLanguageRuntime::GetObjectDescription(Stream &str,
   if (object.IsUninitializedReference())
     return llvm::createStringError("<uninitialized>");
 
-  if (tryPointerPrintObject(str, object, GetProcess()))
+  if (printObjectViaPointer(str, object, GetProcess()))
     return llvm::Error::success();
 
   std::string expr_string;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -48,6 +48,7 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/OptionParsing.h"
 #include "lldb/Utility/Status.h"
+#include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/Timer.h"
 #include "lldb/ValueObject/ValueObject.h"
@@ -835,7 +836,7 @@ SwiftLanguageRuntime::GetObjectDescriptionExpr_Ref(ValueObject &object) {
                       object.GetValueAsUnsigned(0)).str();
 
   if (log)
-    log->Printf("[GetObjectDescriptionExpr_Result] expression: %s",
+    log->Printf("[GetObjectDescriptionExpr_Ref] expression: %s",
                 expr_string.GetData());
   return expr_str;
 }
@@ -911,8 +912,9 @@ std::string SwiftLanguageRuntime::GetObjectDescriptionExpr_Copy(
   return expr_string;
 }
 
-llvm::Error SwiftLanguageRuntime::RunObjectDescriptionExpr(
-    ValueObject &object, std::string &expr_string, Stream &result) {
+static llvm::Expected<ValueObjectSP>
+runObjectDescription(ValueObject &object, std::string &expr_string,
+                     Process &process, bool disable_availability = false) {
   Log *log(GetLog(LLDBLog::DataFormatters | LLDBLog::Expressions));
   ValueObjectSP result_sp;
   EvaluateExpressionOptions eval_options;
@@ -920,16 +922,17 @@ llvm::Error SwiftLanguageRuntime::RunObjectDescriptionExpr(
   eval_options.SetLanguage(lldb::eLanguageTypeSwift);
   eval_options.SetSuppressPersistentResult(true);
   eval_options.SetIgnoreBreakpoints(true);
-  eval_options.SetTimeout(GetProcess().GetUtilityExpressionTimeout());
+  eval_options.SetTimeout(process.GetUtilityExpressionTimeout());
+  if (disable_availability)
+    eval_options.SetDisableAvailability();
 
   StackFrameSP frame_sp = object.GetFrameSP();
   if (!frame_sp)
-    frame_sp =
-        GetProcess().GetThreadList().GetSelectedThread()->GetSelectedFrame(
-            DoNoSelectMostRelevantFrame);
+    frame_sp = process.GetThreadList().GetSelectedThread()->GetSelectedFrame(
+        DoNoSelectMostRelevantFrame);
   if (!frame_sp)
     return llvm::createStringError("no execution context to run expression in");
-  auto eval_result = GetProcess().GetTarget().EvaluateExpression(
+  auto eval_result = process.GetTarget().EvaluateExpression(
       expr_string, frame_sp.get(), result_sp, eval_options);
 
   LLDB_LOG(log, "[RunObjectDescriptionExpr] {0}", toString(eval_result));
@@ -952,12 +955,28 @@ llvm::Error SwiftLanguageRuntime::RunObjectDescriptionExpr(
     return llvm::createStringError("expression produced invalid result type");
   }
 
+  return result_sp;
+}
+
+static llvm::Error dumpString(ValueObjectSP result_sp, Stream &strm);
+
+llvm::Error SwiftLanguageRuntime::RunObjectDescriptionExpr(
+    ValueObject &object, std::string &expr_string, Stream &strm) {
+  auto result_or_err = runObjectDescription(object, expr_string, GetProcess());
+  if (!result_or_err)
+    return result_or_err.takeError();
+
+  return dumpString(*result_or_err, strm);
+}
+
+static llvm::Error dumpString(ValueObjectSP result_sp, Stream &strm) {
+  Log *log(GetLog(LLDBLog::DataFormatters | LLDBLog::Expressions));
   formatters::StringPrinter::ReadStringAndDumpToStreamOptions dump_options;
   dump_options.SetEscapeNonPrintables(false);
   dump_options.SetQuote('\0');
   dump_options.SetPrefixToken(nullptr);
   if (formatters::swift::String_SummaryProvider(
-          *result_sp.get(), result,
+          *result_sp, strm,
           TypeSummaryOptions()
               .SetLanguage(lldb::eLanguageTypeSwift)
               .SetCapping(eTypeSummaryUncapped),
@@ -1002,10 +1021,81 @@ static bool IsSwiftReferenceType(ValueObject &object) {
   return false;
 }
 
+static bool printObjectViaPointer(Stream &strm, ValueObject &object,
+                                  Process &process) {
+  Log *log = GetLog(LLDBLog::DataFormatters | LLDBLog::Expressions);
+
+  Flags flags(object.GetCompilerType().GetTypeInfo());
+  addr_t addr = LLDB_INVALID_ADDRESS;
+  if (flags.Test(eTypeInstanceIsPointer)) {
+    // Objects are pointers.
+    addr = object.GetValueAsUnsigned(LLDB_INVALID_ADDRESS);
+  } else {
+    // Get the address of non-object values (structs, enums).
+    auto addr_and_type = object.GetAddressOf(false);
+    if (addr_and_type.type != eAddressTypeLoad) {
+      LLDB_LOG(log, "address-of value object failed, preventing use of "
+                    "stringForPrintObject(_:mangledTypeName:)");
+      return false;
+    }
+    addr = addr_and_type.address;
+  }
+
+  if (addr == 0 || addr == LLDB_INVALID_ADDRESS)
+    return false;
+
+  StringRef mangled_type_name = object.GetMangledTypeName();
+  // Swift's APIs that accept mangled names require the "$s" prefix removed.
+  mangled_type_name.consume_front("$s");
+
+  std::string expr_string =
+      llvm::formatv(
+          "Swift._DebuggerSupport.stringForPrintObject(UnsafeRawPointer("
+          "bitPattern: {0}), mangledTypeName: \"{1}\")",
+          addr, mangled_type_name)
+          .str();
+
+  auto result_or_err = runObjectDescription(object, expr_string, process, true);
+  if (!result_or_err) {
+    LLDB_LOG_ERROR(log, result_or_err.takeError(),
+                   "stringForPrintObject(_:mangledTypeName:) failed: {0}");
+    return false;
+  }
+
+  // A `(Bool, String)` tuple, where the bool indicates success/failure.
+  auto result_sp = *result_or_err;
+  auto success_sp = result_sp->GetChildAtIndex(0);
+  auto description_sp = result_sp->GetChildAtIndex(1);
+
+  StreamString dump_stream;
+  auto err = dumpString(description_sp, dump_stream);
+  if (err) {
+    LLDB_LOG_ERROR(log, std::move(err),
+                   "decoding result of "
+                   "stringForPrintObject(_:mangledTypeName:) failed: {0}");
+    return false;
+  }
+
+  Status status;
+  if (!success_sp->IsLogicalTrue(status)) {
+    LLDB_LOGF(log,
+              "stringForPrintObject(_:mangledTypeName:) produced error: %s",
+              dump_stream.GetData());
+    return false;
+  }
+
+  LLDB_LOG(log, "stringForPrintObject(_:mangledTypeName:) succeeded");
+  strm.PutCString(dump_stream.GetString());
+  return true;
+}
+
 llvm::Error SwiftLanguageRuntime::GetObjectDescription(Stream &str,
                                                        ValueObject &object) {
   if (object.IsUninitializedReference())
     return llvm::createStringError("<uninitialized>");
+
+  if (tryPointerPrintObject(str, object, GetProcess()))
+    return llvm::Error::success();
 
   std::string expr_string;
 

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4705,14 +4705,14 @@ bool TargetProperties::GetSwiftAutoImportFrameworks() const {
       idx, g_target_properties[idx].default_uint_value != 0);
 }
 
-bool TargetProperties::GetSwiftUseNewPrintObject() const {
+bool TargetProperties::GetSwiftUseContextFreePrintObject() const {
   const Property *exp_property =
       m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
   OptionValueProperties *exp_values =
       exp_property->GetValue()->GetAsProperties();
   if (exp_values)
     return exp_values
-        ->GetPropertyAtIndexAs<bool>(ePropertySwiftUseNewPrintObject)
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftUseContextFreePrintObject)
         .value_or(false);
   return false;
 }

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4705,6 +4705,18 @@ bool TargetProperties::GetSwiftAutoImportFrameworks() const {
       idx, g_target_properties[idx].default_uint_value != 0);
 }
 
+bool TargetProperties::GetSwiftUseNewPrintObject() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftUseNewPrintObject)
+        .value_or(false);
+  return false;
+}
+
 void TargetProperties::SetUseDIL(ExecutionContext *exe_ctx, bool b) {
   const Property *exp_property =
       m_collection_sp->GetPropertyAtIndex(ePropertyExperimental, exe_ctx);

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -37,9 +37,9 @@ let Definition = "target_experimental" in {
   def SwiftCacheTaskPointerLocation: Property<"swift-cache-task-pointer-location", "Boolean">,
     DefaultTrue,
     Desc<"Enables caching of task pointers inside the swift tasks plugin">;
-  def SwiftUseNewPrintObject: Property<"swift-use-new-po", "Boolean">,
+  def SwiftUseContextFreePrintObject: Property<"swift-use-context-free-po", "Boolean">,
     DefaultFalse,
-    Desc<"If true, use the new Swift po implementation.">;
+    Desc<"If true, use the context-free po implementation for Swift.">;
   def UseDIL : Property<"use-DIL", "Boolean">,
     Global, DefaultTrue,
     Desc<"If true, use the DIL implementation for frame variable evaluation.">;

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -37,6 +37,9 @@ let Definition = "target_experimental" in {
   def SwiftCacheTaskPointerLocation: Property<"swift-cache-task-pointer-location", "Boolean">,
     DefaultTrue,
     Desc<"Enables caching of task pointers inside the swift tasks plugin">;
+  def SwiftUseNewPrintObject: Property<"swift-use-new-po", "Boolean">,
+    DefaultFalse,
+    Desc<"If true, use the new Swift po implementation.">;
   def UseDIL : Property<"use-DIL", "Boolean">,
     Global, DefaultTrue,
     Desc<"If true, use the DIL implementation for frame variable evaluation.">;

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -68,7 +68,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
-        self.runCmd("settings set target.experimental.swift-use-new-po true")
+        self.runCmd("settings set target.experimental.swift-use-context-free-po true")
 
         options = lldb.SBExpressionOptions()
         value = self.frame().EvaluateExpression("strct", options)

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -68,6 +68,8 @@ class TestSwiftExpressionErrorReporting(TestBase):
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
+        self.runCmd("settings set target.experimental.swift-use-new-po true")
+
         options = lldb.SBExpressionOptions()
         value = self.frame().EvaluateExpression("strct", options)
         def check(value):
@@ -84,7 +86,6 @@ class TestSwiftExpressionErrorReporting(TestBase):
         # This succeeds using stringForPrintObject(_:mangledTypeName:), which
         # doesn't require the type to be available.
         # Note: (?s)^(?!.*<pattern>) checks that the pattern is not found.
-        # self.runCmd("log enable lldb formatters")
         self.expect(
             "dwim-print -O -- strct",
             patterns=["(?s)^(?!.*error: Missing type)", "properties : true"],
@@ -93,4 +94,3 @@ class TestSwiftExpressionErrorReporting(TestBase):
         process.Continue()
         self.expect('expression -O -- number', error=True,
                     substrs=['self', 'not', 'found'])
-

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -81,9 +81,13 @@ class TestSwiftExpressionErrorReporting(TestBase):
 
         check(value)
 
+        # This succeeds using stringForPrintObject(_:mangledTypeName:), which
+        # doesn't require the type to be available.
+        # Note: (?s)^(?!.*<pattern>) checks that the pattern is not found.
+        # self.runCmd("log enable lldb formatters")
         self.expect(
             "dwim-print -O -- strct",
-            substrs=["error: Missing type", "properties = true"],
+            patterns=["(?s)^(?!.*error: Missing type)", "properties : true"],
         )
 
         process.Continue()

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/Makefile
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -8,7 +8,6 @@ class TestCase(TestBase):
 
     def setUp(self):
         TestBase.setUp(self)
-        self.build()
         self.runCmd("settings set target.experimental.swift-use-context-free-po true")
 
         self.log = self.getBuildArtifact("expr.log")
@@ -19,6 +18,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_int(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break int", lldb.SBFileSpec("main.swift")
         )
@@ -28,6 +28,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_string(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break string", lldb.SBFileSpec("main.swift")
         )
@@ -37,6 +38,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_struct(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break struct", lldb.SBFileSpec("main.swift")
         )
@@ -46,6 +48,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_class(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break class", lldb.SBFileSpec("main.swift")
         )
@@ -55,6 +58,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_enum(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break enum", lldb.SBFileSpec("main.swift")
         )
@@ -64,6 +68,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_generic_struct(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break generic struct", lldb.SBFileSpec("main.swift")
         )
@@ -73,6 +78,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_generic_class(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break generic class", lldb.SBFileSpec("main.swift")
         )
@@ -82,6 +88,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_generic_enum(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break generic enum", lldb.SBFileSpec("main.swift")
         )
@@ -91,6 +98,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_described_struct(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break described struct", lldb.SBFileSpec("main.swift")
         )
@@ -100,6 +108,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_described_class(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break described class", lldb.SBFileSpec("main.swift")
         )
@@ -109,6 +118,7 @@ class TestCase(TestBase):
 
     @swiftTest
     def test_described_enum(self):
+        self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break described enum", lldb.SBFileSpec("main.swift")
         )

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -9,7 +9,7 @@ class TestCase(TestBase):
     def setUp(self):
         TestBase.setUp(self)
         self.build()
-        self.runCmd("settings set target.experimental.swift-use-new-po true")
+        self.runCmd("settings set target.experimental.swift-use-context-free-po true")
 
         self.log = self.getBuildArtifact("expr.log")
         self.runCmd(f"log enable lldb expr -f {self.log}")

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -1,0 +1,117 @@
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestCase(TestBase):
+
+    def setUp(self):
+        TestBase.setUp(self)
+        self.build()
+        self.runCmd("settings set target.experimental.swift-use-new-po true")
+
+        self.log = self.getBuildArtifact("expr.log")
+        self.runCmd(f"log enable lldb expr -f {self.log}")
+
+    def _filecheck(self, key):
+        self.filecheck(f"platform shell cat {self.log}", __file__, f"-check-prefix=CHECK-{key}")
+
+    @swiftTest
+    def test_int(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break int", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["2025"])
+        self._filecheck("INT")
+        # CHECK-INT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SiD")
+
+    @swiftTest
+    def test_string(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break string", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["Po"])
+        self._filecheck("STRING")
+        # CHECK-STRING: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SSD")
+
+    @swiftTest
+    def test_struct(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break struct", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["▿ Struct"])
+        self._filecheck("STRUCT")
+        # CHECK-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a6StructVD")
+
+    @swiftTest
+    def test_class(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break class", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["<Class: 0x"])
+        self._filecheck("CLASS")
+        # CHECK-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a5ClassCD")
+
+    @swiftTest
+    def test_enum(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break enum", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["▿ Enum"])
+        self._filecheck("ENUM")
+        # CHECK-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a4EnumOD")
+
+    @swiftTest
+    def test_generic_struct(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break generic struct", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["▿ GenericStruct<String>"])
+        self._filecheck("GEN-STRUCT")
+        # CHECK-GEN-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a13GenericStructVySSGD")
+
+    @swiftTest
+    def test_generic_class(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break generic class", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["<GenericClass<String>: 0x"])
+        self._filecheck("GEN-CLASS")
+        # CHECK-GEN-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a12GenericClassCySSGD")
+
+    @swiftTest
+    def test_generic_enum(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break generic enum", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["▿ GenericEnum<String>"])
+        self._filecheck("GEN-ENUM")
+        # CHECK-GEN-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a11GenericEnumOySSGD")
+
+    @swiftTest
+    def test_described_struct(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break described struct", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["DescribedStruct"])
+        self._filecheck("DESC-STRUCT")
+        # CHECK-DESC-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a15DescribedStructVD")
+
+    @swiftTest
+    def test_described_class(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break described class", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["DescribedClass"])
+        self._filecheck("DESC-CLASS")
+        # CHECK-DESC-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a14DescribedClassCD")
+
+    @swiftTest
+    def test_described_enum(self):
+        lldbutil.run_to_source_breakpoint(
+            self, "break described enum", lldb.SBFileSpec("main.swift")
+        )
+        self.expect("po value", substrs=["DescribedEnum"])
+        self._filecheck("DESC-ENUM")
+        # CHECK-DESC-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a13DescribedEnumOD")

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/main.swift
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/main.swift
@@ -1,0 +1,97 @@
+struct Struct {
+    var s = "Po"
+    var n = 2025
+}
+
+class Class {
+    var s = "Po"
+    var n = 2025
+}
+
+enum Enum {
+    case zero
+    case pair(String, Int)
+}
+
+struct GenericStruct<T> {
+    var s: T
+    var n = 2025
+}
+
+class GenericClass<T> {
+    var s: T
+    var n = 2025
+    init(s: T) { self.s = s }
+}
+
+enum GenericEnum<T> {
+    case zero
+    case pair(T, Int)
+}
+
+struct DescribedStruct: CustomStringConvertible {
+    var s = "Po"
+    var n = 2025
+    var description: String { "DescribedStruct" }
+}
+
+class DescribedClass: CustomStringConvertible {
+    var s = "Po"
+    var n = 2025
+    var description: String { "DescribedClass" }
+}
+
+enum DescribedEnum: CustomStringConvertible {
+    case zero
+    case pair(String, Int)
+    var description: String { "DescribedEnum" }
+}
+
+@main struct Entry {
+    static func main() {
+        do {
+            var value = 2025
+            print("break int")
+        }
+        do {
+            var value = "Po"
+            print("break string")
+        }
+        do {
+            let value = Struct()
+            print("break struct")
+        }
+        do {
+            let value = Class()
+            print("break class")
+        }
+        do {
+            let value = Enum.pair("Po", 50)
+            print("break enum")
+        }
+        do {
+            let value = GenericStruct(s: "Po")
+            print("break generic struct")
+        }
+        do {
+            let value = GenericClass(s: "Po")
+            print("break generic class")
+        }
+        do {
+            let value = GenericEnum.pair("Po", 50)
+            print("break generic enum")
+        }
+        do {
+            let value = DescribedStruct()
+            print("break described struct")
+        }
+        do {
+            let value = DescribedClass()
+            print("break described class")
+        }
+        do {
+            let value = DescribedEnum.pair("Po", 50)
+            print("break described enum")
+        }
+    }
+}


### PR DESCRIPTION
Adopt `stringForPrintObject(_:mangledTypeName:)`, an overload added in https://github.com/swiftlang/swift/pull/84742.

This new overload allows lldb to call `stringForPrintObject` using only a pointer referencing the value, and the mangled typename corresponding to the value. The resulting expression does not reference the concrete type.

By not referencing a value's type, `po` can be performed on variables (and their nested stored properties) without loading the modules corresponding to the value's type. This will improve performance and reliability of `po`.

rdar://158968103