### PR TITLE
[clang][cas] Build clang-cas-test even when CLANG_INCLUDE_TESTS=0

### DIFF
--- a/clang/tools/CMakeLists.txt
+++ b/clang/tools/CMakeLists.txt
@@ -25,9 +25,11 @@ endif()
 if(CLANG_INCLUDE_TESTS)
   add_clang_subdirectory(c-index-test)
   add_clang_subdirectory(apinotes-test)
-  add_clang_subdirectory(clang-cas-test)
   add_clang_subdirectory(clang-refactor-test)
 endif()
+
+# Add clang-cas-test unconditionally, as it is not only used by tests.
+add_clang_subdirectory(clang-cas-test)
 
 add_clang_subdirectory(IndexStore)
 


### PR DESCRIPTION
This utility is perhaps misnamed, as we also install it even when tests are disabled in some toolchains. For now, simply remove it from the CLANG_INCLUDE_TESTS check.

rdar://165789721