### PR TITLE
[libclang][reproducers] Redirect writing .d dependencies to the reproducer cache directory.

### DIFF
--- a/clang/test/Modules/reproducer-with-module-dependencies.c
+++ b/clang/test/Modules/reproducer-with-module-dependencies.c
@@ -20,7 +20,8 @@
 // RUN:   -- clang-executable -c %t/reproducer.c -o %t/reproducer.o \
 // RUN:      -fmodules -fmodules-cache-path=%t \
 // RUN:      -DMACRO="\$foo" \
-// RUN:      -ivfsoverlay %t/existing.yaml -I /virtual
+// RUN:      -ivfsoverlay %t/existing.yaml -I /virtual \
+// RUN:      -MMD -MT dependencies -MF %t/deps.d
 // RUN: FileCheck %t/script-expectations.txt --input-file %t/repro-content/reproducer.sh
 
 //--- include/modular-header.h
@@ -67,9 +68,11 @@ void test(void) {
 
 //--- script-expectations.txt
 CHECK: CLANG:-clang-executable
+CHECK: "-dependency-file" "reproducer.cache/explicitly-built-modules/Test-{{.*}}.d"
 CHECK: "-o" "reproducer.cache/reproducer.o"
 CHECK: -fmodule-file=Test=reproducer.cache/explicitly-built-modules/Test-{{.*}}.pcm
 Verify the reproducer VFS overlay is added before the existing overlay provided on a command line.
 CHECK: -ivfsoverlay "reproducer.cache/vfs/vfs.yaml"
 CHECK: "-ivfsoverlay" "{{.*}}/existing.yaml"
 CHECK: MACRO=\$foo
+CHECK: "-dependency-file" "reproducer.cache/deps.d"

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -806,10 +806,20 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
   std::string FileCacheName = llvm::sys::path::filename(FileCachePath).str();
   auto LookupOutput = [&FileCacheName](const ModuleDeps &MD,
                                        ModuleOutputKind MOK) -> std::string {
-    if (MOK != ModuleOutputKind::ModuleFile)
+    if (MOK == ModuleOutputKind::DependencyTargets)
+      return "reproducerdependencytargets";
+    std::string CommonPrefix = FileCacheName + "/explicitly-built-modules/" +
+                               MD.ID.ModuleName + "-" + MD.ID.ContextHash;
+    switch (MOK) {
+    case ModuleOutputKind::ModuleFile:
+      return CommonPrefix + ".pcm";
+    case ModuleOutputKind::DependencyFile:
+      return CommonPrefix + ".d";
+    case ModuleOutputKind::DiagnosticSerializationFile:
+      return CommonPrefix + ".dia";
+    default:
       return "";
-    return FileCacheName + "/explicitly-built-modules/" +
-           MD.ID.ModuleName + "-" + MD.ID.ContextHash + ".pcm";
+    }
   };
 
   llvm::DenseSet<ModuleID> AlreadySeen;
@@ -849,13 +859,15 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
     bool DidAddVFSOverlay = false;
     OS << ReproExecutable;
     for (const llvm::opt::Arg *Arg : ParsedArgs) {
-      if (Arg->getOption().matches(options::OPT_ivfsoverlay)) {
+      const llvm::opt::Option &Opt = Arg->getOption();
+      if (Opt.matches(options::OPT_ivfsoverlay)) {
         if (!DidAddVFSOverlay) {
           OS << " -ivfsoverlay \"" << FileCacheName << "/vfs/vfs.yaml\"";
           DidAddVFSOverlay = true;
         }
       }
-      bool IsOutputArg = Arg->getOption().matches(options::OPT_o);
+      bool IsOutputArg = Opt.matches(options::OPT_o) ||
+                         Opt.matches(options::OPT_dependency_file);
       llvm::opt::ArgStringList OutArgs;
       Arg->render(ParsedArgs, OutArgs);
       bool IsArgValue = false;


### PR DESCRIPTION
It allows to achieve the same behavior in a reproducer as in an original compilation regarding .d dependencies. And it will be required to support CAS-based builds.