### PR TITLE
[lldb][windows] add NSDate and FoundationEssentials.Date dataformatters

### DIFF
--- a/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
+++ b/lldb/source/Plugins/Language/ObjC/Cocoa.cpp
@@ -1256,9 +1256,11 @@ bool lldb_private::formatters::ObjCSELSummaryProvider(
 // this call gives the POSIX equivalent of the Cocoa epoch
 time_t lldb_private::formatters::GetOSXEpoch() {
   static time_t epoch = 0;
+#ifndef _AIX
   if (!epoch) {
-#if !defined(_WIN32) && !defined(_AIX)
+#ifndef _WIN32
     tzset();
+#endif
     tm tm_epoch;
     tm_epoch.tm_sec = 0;
     tm_epoch.tm_hour = 0;
@@ -1267,11 +1269,15 @@ time_t lldb_private::formatters::GetOSXEpoch() {
     tm_epoch.tm_mday = 1;
     tm_epoch.tm_year = 2001 - 1900;
     tm_epoch.tm_isdst = -1;
+#ifdef _WIN32
+    epoch = _mkgmtime(&tm_epoch);
+#else
     tm_epoch.tm_gmtoff = 0;
     tm_epoch.tm_zone = nullptr;
     epoch = timegm(&tm_epoch);
 #endif
   }
+#endif
   return epoch;
 }
 

--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -34,8 +34,14 @@ using namespace lldb_private::formatters::swift;
 bool lldb_private::formatters::swift::Date_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
   static ConstString g__time("_time");
+  static ConstString g__timeIntervalSinceReferenceDate(
+      "_timeIntervalSinceReferenceDate");
 
   ValueObjectSP time_sp(valobj.GetChildAtNamePath({g__time}));
+
+  if (!time_sp)
+    time_sp = valobj.GetChildAtNamePath(
+        {g__timeIntervalSinceReferenceDate, "_value"});
 
   if (!time_sp)
     return false;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -670,8 +670,9 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp, lldb_private::formatters::swift::Date_SummaryProvider,
-      "Foundation.Date summary provider", ConstString("Foundation.Date"),
-      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true));
+      "Foundation.Date summary provider",
+      ConstString("Foundation(Essentials)?\\.(NS)?Date"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp,

--- a/lldb/test/API/functionalities/data-formatter/swift/date/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/swift/date/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/date/TestSwiftDateFormatters.py
@@ -1,0 +1,35 @@
+"""
+Test Foundation.Date summary strings.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+import sys
+
+
+class TestCase(TestBase):
+    @skipUnlessFoundation
+    @swiftTest
+    def test_swift_date_formatters(self):
+        """Test Date summary strings."""
+        self.build()
+
+        _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "v date",
+            startstr="(Foundation.Date) date = 2001-01-15 13:12:00 UTC",
+        )
+
+        if sys.platform != "win32":
+            return
+
+        self.expect(
+            "v nsdate",
+            startstr="(Foundation.NSDate) date = 2001-01-15 13:12:00 UTC",
+        )

--- a/lldb/test/API/functionalities/data-formatter/swift/date/main.swift
+++ b/lldb/test/API/functionalities/data-formatter/swift/date/main.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+let paris = TimeZone(identifier: "Europe/Paris")!
+
+var comps = DateComponents()
+comps.year = 2001
+comps.month = 1
+comps.day = 15
+comps.hour = 14
+comps.minute = 12
+comps.timeZone = paris
+
+let date = Calendar(identifier: .gregorian).date(from: comps)!
+let nsdate = date as NSDate
+
+print("break here")


### PR DESCRIPTION
This patch adds a dataformatter for FoundationEssentials.Date and NSDate on Windows.

# Before
```
1> Date.now
$R1: FoundationEssentials.Date = {
  _time = 786641176.638381
}
2> NSDate()
$R2: Foundation.NSDate = {
  Foundation.NSObject = {}
  _base = {
    info = 10880
    pad = 0
  }
  _timeIntervalSinceReferenceDate = 786641176.638381
}
```

# After
```
1> Date.now
$R1: Foundation.Date = 2025-12-05 15:26:16 UTC
2> NSDate()
$R2: NSDate = 2025-12-05 15:26:16 UTC
```

rdar://155901731