### PR TITLE
[lldb] Re-enable tests that were failing due to LookupInfo changes

### DIFF
--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -18,7 +18,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-@skipIf(bugnumber = "rdar://159531198")
 class SwiftPartialBreakTest(TestBase):
     @swiftTest
     def test_swift_partial_break(self):

--- a/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
+++ b/lldb/test/API/lang/swift/expression/equality_operators/TestEqualityOperators.py
@@ -30,7 +30,6 @@ def execute_command(command):
     (exit_status, output) = subprocess.getstatusoutput(command)
     return exit_status
 
-@skipIf(bugnumber = "rdar://159531216")
 class TestUnitTests(TestBase):
     @swiftTest
     @skipIf(debug_info=no_match(["dsym"]), bugnumber="This test is building a dSYM")


### PR DESCRIPTION
7901f38d96 fixed the issues with lookup up functions by name using. This re-enables the tests that were disabled due to the LooupInfo issues, and which is not fixed.

rdar://159531216