### PR TITLE
[lldb] Allow LLDBMemoryReader to provide symbols outside refl. sections

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -180,6 +180,14 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
   if (!target.GetSwiftUseReflectionSymbols())
     return {};
 
+  auto &triple = m_process.GetTarget().GetArchitecture().GetTriple();
+  // On Linux, there seems to be a bug where we can't reliably look for symbols by address,
+  // since these symbols have an actual size and can overlap.
+  // This could be an LLDB bug or a compiler bug.
+  // rdar://166344740
+  if (triple.isOSLinux())
+    return {};
+
   std::optional<Address> maybeAddr = remoteAddressToLLDBAddress(address);
   // This is not an assert, but should never happen.
   if (!maybeAddr)

--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -195,19 +195,6 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
       return {};
   }
 
-  if (auto section_sp = addr.GetSection()) {
-    if (auto *obj_file = section_sp->GetObjectFile()) {
-      auto obj_file_format_type =
-          obj_file->GetArchitecture().GetTriple().getObjectFormat();
-      if (auto swift_obj_file_format =
-              GetSwiftObjectFileFormat(obj_file_format_type)) {
-        if (!swift_obj_file_format->sectionContainsReflectionData(
-                section_sp->GetName().GetStringRef()))
-          return {};
-      }
-    }
-  }
-
   if (auto *symbol = addr.CalculateSymbolContextSymbol()) {
     auto mangledName = symbol->GetMangled().GetMangledName().GetStringRef();
     // MemoryReader requires this to be a Swift symbol. LLDB can also be


### PR DESCRIPTION
There are swift metadata symbols outside the "__swift_" sections. For example, swift context descriptors live in the "const" sections. Allow LLDBMemoryReader::resolvePointerAsSymbol to return any symbol that it finds.

rdar://165950673