### PR TITLE
[lldb] fix incorrect return value in lambda

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -715,7 +715,7 @@ Module::LookupInfo::MakeLookupInfos(ConstString name,
       auto lang_type = lang->GetLanguageType();
       if (!llvm::is_contained(lang_types, lang_type))
         lang_types.push_back(lang_type);
-      return true;
+      return IterationAction::Continue;
     });
 
     if (lang_types.empty())


### PR DESCRIPTION
This patch fixes an incorrect return value in a lambda, by changing from a `bool` to an `lldb_private::IterationAction`.