### PR TITLE
[dsymutil] Remove spurious exit when falling back to fat64 header

### DIFF
--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -897,7 +897,6 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
                 "-fat64 flag to force a 64-bit header and silence this "
                 "warning.",
                 FileOffset);
-            return EXIT_FAILURE;
           }
           FileOffset += stat->getSize();
         }


### PR DESCRIPTION
In #118898 I changed dsymutil to emit a warning instead of an error when exceeding the 4GB limit for a slice and automatically fall back to using the fat64 header. However, while doing so, I forgot to remove the return which defeats the whole purpose.

rdar://140998416
(cherry picked from commit 83fd2c994a82119edf249ac3c169250c26f0b21c)