### PR TITLE
[lldb] Fix a bug when disabling the statusline. (#169127)

### DIFF
--- a/lldb/source/Core/Statusline.cpp
+++ b/lldb/source/Core/Statusline.cpp
@@ -91,7 +91,7 @@ void Statusline::UpdateScrollWindow(ScrollWindowMode mode) {
   if (!stream_sp)
     return;
 
-  const unsigned reduced_scroll_window = m_terminal_height - 1;
+  const unsigned reduced_scroll_rows = m_terminal_height - 1;
   LockedStreamFile locked_stream = stream_sp->Lock();
 
   switch (mode) {
@@ -101,13 +101,14 @@ void Statusline::UpdateScrollWindow(ScrollWindowMode mode) {
     locked_stream.Printf(ANSI_UP_ROWS, 1);
     // Reduce the scroll window.
     locked_stream << ANSI_SAVE_CURSOR;
-    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, reduced_scroll_window);
+    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, reduced_scroll_rows);
     locked_stream << ANSI_RESTORE_CURSOR;
     break;
   case DisableStatusline:
     // Reset the scroll window.
     locked_stream << ANSI_SAVE_CURSOR;
-    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, 0);
+    locked_stream.Printf(ANSI_SET_SCROLL_ROWS,
+                         static_cast<unsigned>(m_terminal_height));
     locked_stream << ANSI_RESTORE_CURSOR;
     // Clear the screen below to hide the old statusline.
     locked_stream << ANSI_CLEAR_BELOW;
@@ -116,7 +117,7 @@ void Statusline::UpdateScrollWindow(ScrollWindowMode mode) {
     // Clear the screen and update the scroll window.
     // FIXME: Find a better solution (#146919).
     locked_stream << ANSI_CLEAR_SCREEN;
-    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, reduced_scroll_window);
+    locked_stream.Printf(ANSI_SET_SCROLL_ROWS, reduced_scroll_rows);
     break;
   }
 

--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -66,8 +66,10 @@ class TestStatusline(PExpectTest):
         )
         self.expect('set set separator "| "')
 
-        # Hide the statusline and check or the control character.
-        self.expect("set set show-statusline false", ["\x1b[1;0r"])
+        # Hide the statusline and check for the control character.
+        self.expect(
+            "set set show-statusline false", ["\x1b[1;{}r".format(self.TERMINAL_HEIGHT)]
+        )
 
     def test_no_color(self):
         """Basic test for the statusline with colors disabled."""


### PR DESCRIPTION
Currently, disabling the statusline with `settings set show-statusline false` leaves LLDB in a broken state. The same is true when trying to toggle the setting again.

The issue was that setting the scroll window to 0 is apparently not identical to setting it to the correct number of rows, even though some documentation online incorrectly claims so.

Fixes #166608

(cherry picked from commit c103d61758e61a9fe4c1963b29d602ffe2c22427)