### PR TITLE
🍒 llvm: Disable copy for SingleThreadExecutor (llvm#168782)

### DIFF
--- a/llvm/include/llvm/Support/ThreadPool.h
+++ b/llvm/include/llvm/Support/ThreadPool.h
@@ -224,6 +224,12 @@ public:
   /// Blocking destructor: the pool will first execute the pending tasks.
   ~SingleThreadExecutor() override;
 
+  // Excplicitly disable copy. This is necessary for the MSVC LLVM_DYLIB build
+  // because MSVC tries to generate copy constructor and assignment operator
+  // for classes marked with `__declspec(dllexport)`.
+  SingleThreadExecutor(const SingleThreadExecutor &) = delete;
+  SingleThreadExecutor &operator=(const SingleThreadExecutor &) = delete;
+
   /// Blocking wait for all the tasks to execute first
   void wait() override;
 


### PR DESCRIPTION
This is a workaround for the MSVC compiler, which attempts to generate a copy assignment operator implementation for classes marked as `__declspec(dllexport)`. Explicitly marking the copy assignment operator as deleted works around the problem.

DevCom ticket:
https://developercommunity.microsoft.com/t/Classes-marked-with-__declspecdllexport/11003192