### PR TITLE
[AArch64] Make StackTagging pass use alloca getAllocationSize rather than lifetime size

### DIFF
--- a/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
+++ b/llvm/lib/Target/AArch64/AArch64StackTagging.cpp
@@ -586,8 +586,7 @@ bool AArch64StackTagging::runOnFunction(Function &Fn) {
                                    ClMaxLifetimes);
     if (StandardLifetime) {
       IntrinsicInst *Start = Info.LifetimeStart[0];
-      uint64_t Size =
-          cast<ConstantInt>(Start->getArgOperand(0))->getZExtValue();
+      uint64_t Size = *Info.AI->getAllocationSize(*DL);
       Size = alignTo(Size, kTagGranuleSize);
       tagAlloca(AI, Start->getNextNode(), TagPCall, Size);
 


### PR DESCRIPTION
This was causing zero sized setTags to be emitted when compiling Swift class initializers with memtag-stack sanitization; this caused an assert in the backend 'N->getOpcode() != ISD::EntryToken && "EntryToken in CSEMap!"'.

This patch does as the title says and replaces the use of the lifetime size argument with AllocaInst.getAllocationSize.

rdar://164400893