### PR TITLE
[lldb] Split TestSwiftTypeAliasOtherModule in "fr v" and "expr" tests

### DIFF
--- a/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
+++ b/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
@@ -7,20 +7,26 @@ class TestSwiftTypeAliasOtherModule(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    def test(self):
+    def test_frame_variable(self):
         """Test that type aliases can be imported from reflection metadata"""
-        arch = self.getArchitecture()
         self.build()
-        self.expect('settings set symbols.swift-load-conformances true')
-        log = self.getBuildArtifact("types.log")
-        self.runCmd('log enable lldb expr types -f "%s"' % log)
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift"), extra_images=["Dylib"]
         )
         self.expect("frame variable -- payload", substrs=["Bool", "true"])
-        self.expect("expr -- payload", substrs=["Dylib.Impl.Payload", "true"])
         self.expect("continue")
         self.expect("frame variable -- payload", substrs=["Bool", "true"])
+
+    @swiftTest
+    def test_expression(self):
+        """Test that type aliases can be imported into expressions from reflection metadata"""
+        self.build()
+        self.expect('settings set symbols.swift-load-conformances true')
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"), extra_images=["Dylib"]
+        )
+        self.expect("expr -- payload", substrs=["Dylib.Impl.Payload", "true"])
+        self.expect("continue")
         self.expect(
             "expr -- payload", substrs=["Dylib.GenericImpl<Bool>.Payload", "true"]
         )


### PR DESCRIPTION
Frame variable is actually able to resolve all of the type aliases without needing to conformances from reflection metadata. Split the test so the frame variable part can run without turning the swift-load-conformances setting on.

rdar://143718920