### PR TITLE
🍒[lldb][InstrumentationRuntime] Run sanitizer utility expressions as C

### DIFF
--- a/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/TSan/InstrumentationRuntimeTSan.cpp
@@ -325,7 +325,7 @@ StructuredData::ObjectSP InstrumentationRuntimeTSan::RetrieveReportData(
   options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetPrefix(thread_sanitizer_retrieve_report_data_prefix);
   options.SetAutoApplyFixIts(false);
-  options.SetLanguage(eLanguageTypeObjC_plus_plus);
+  options.SetLanguage(eLanguageTypeC);
 
   ValueObjectSP main_value;
   ExecutionContext exe_ctx;

--- a/lldb/source/Plugins/InstrumentationRuntime/UBSan/InstrumentationRuntimeUBSan.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/UBSan/InstrumentationRuntimeUBSan.cpp
@@ -124,7 +124,7 @@ StructuredData::ObjectSP InstrumentationRuntimeUBSan::RetrieveReportData(
   options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetPrefix(ub_sanitizer_retrieve_report_data_prefix);
   options.SetAutoApplyFixIts(false);
-  options.SetLanguage(eLanguageTypeObjC_plus_plus);
+  options.SetLanguage(eLanguageTypeC);
 
   ValueObjectSP main_value;
   ExecutionContext exe_ctx;

--- a/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
+++ b/lldb/source/Plugins/InstrumentationRuntime/Utility/ReportRetriever.cpp
@@ -81,7 +81,7 @@ ReportRetriever::RetrieveReportData(const ProcessSP process_sp) {
   options.SetTimeout(process_sp->GetUtilityExpressionTimeout());
   options.SetPrefix(address_sanitizer_retrieve_report_data_prefix);
   options.SetAutoApplyFixIts(false);
-  options.SetLanguage(eLanguageTypeObjC_plus_plus);
+  options.SetLanguage(eLanguageTypeC);
 
   if (auto m = GetPreferredAsanModule(process_sp->GetTarget())) {
     SymbolContextList sc_list;


### PR DESCRIPTION
The utility expressions in the `InstrumentationRuntime` plugins are just plain C code, but we run them as `ObjC++`. That meant we were doing redundant work (like looking up decls in the Objective-C runtime). The sanitizer tests sporadically time out while looking up function symbols in the Objective-C runtime. This patch switches the expression language to `C`.

Didn't find a great way of testing this other than looking at the expression log.

rdar://165656320
(cherry picked from commit d7cbc7f9e465344dd326eaf6e5a6cfa90285ce8e)