### PR TITLE
🍒 llvm: Export IndexedCodeGenDataLazyLoading (llvm#169563)

### DIFF
--- a/llvm/include/llvm/CGData/CodeGenDataReader.h
+++ b/llvm/include/llvm/CGData/CodeGenDataReader.h
@@ -16,6 +16,7 @@
 #include "llvm/CGData/CodeGenData.h"
 #include "llvm/CGData/OutlinedHashTreeRecord.h"
 #include "llvm/CGData/StableFunctionMapRecord.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/VirtualFileSystem.h"
@@ -98,6 +99,8 @@ protected:
   /// Clear the current error and return a successful one.
   Error success() { return error(cgdata_error::success); }
 };
+
+LLVM_ABI extern cl::opt<bool> IndexedCodeGenDataLazyLoading;
 
 class LLVM_ABI IndexedCodeGenDataReader : public CodeGenDataReader {
   /// The codegen data file contents.


### PR DESCRIPTION
This is needed so the llvm-cgdata tool properly builds with `LLVM_BUILD_LLVM_DYLIB` so LLVM can be built as a DLL on Windows.

This effort is tracked in swiftlang/swift#85241.