### PR TITLE
[lldb] Fix format string in FindPrologueSize

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -415,7 +415,7 @@ void SwiftLanguageRuntime::SetupReflection() {
     return;
 
   LLDB_SCOPED_TIMER();
-  
+
   // The global ABI bit is read by the Swift runtime library.
   SetupABIBit();
   SetupExclusivity();
@@ -3287,7 +3287,7 @@ llvm::Expected<uint64_t> FindPrologueSize(Process &process,
                                                     eSymbolContextSymbol);
   if (!sc_ok || (!sc.symbol && !sc.function))
     return llvm::createStringError(llvm::formatv(
-        "Failed to find a symbol context for address {1:x}", load_address));
+        "Failed to find a symbol context for address {0:x}", load_address));
 
   uint64_t prologue_size = sc.symbol ? sc.symbol->GetPrologueByteSize()
                                      : sc.function->GetPrologueByteSize();


### PR DESCRIPTION
The format string was using an incorrect index (1 instead of 0) which was caught by an asserts build.

rdar://166562512