### PR TITLE
[LLDB] Disable implicit modules when importting current CU dependencies 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -52,6 +52,7 @@ class SourceFile;
 class CASOptions;
 struct PrintOptions;
 class MemoryBufferSerializedModuleLoader;
+class ModuleInterfaceLoader;
 namespace Demangle {
 class Demangler;
 class Node;
@@ -976,6 +977,7 @@ protected:
   swift::MemoryBufferSerializedModuleLoader *m_memory_buffer_module_loader =
       nullptr;
   swift::ModuleLoader *m_explicit_swift_module_loader = nullptr;
+  swift::ModuleInterfaceLoader *m_module_interface_loader = nullptr;
   swift::ClangImporter *m_clangimporter = nullptr;
   /// Wraps the clang::ASTContext owned by ClangImporter.
   std::shared_ptr<TypeSystemClang> m_clangimporter_typesystem;


### PR DESCRIPTION
when in an EBM-enabled project. This avoids discovering additional modules, such as unused Swift overlays durign the intial contextual import. Afterwards implicit modules are enabled again, so expressions that import additional modules still work.

rdar://166574409