### PR TITLE
[🍒][-Wunsafe-buffer-usage] Check isValueDependent before EvaluateAsBooleanCondition 

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1658,8 +1658,10 @@ static const Expr *tryConstantFoldConditionalExpr(const Expr *E,
   // FIXME: more places can use this function
   if (const auto *CE = dyn_cast<ConditionalOperator>(E)) {
     bool CondEval;
+    const auto *Cond = CE->getCond();
 
-    if (CE->getCond()->EvaluateAsBooleanCondition(CondEval, Ctx))
+    if (!Cond->isValueDependent() &&
+        Cond->EvaluateAsBooleanCondition(CondEval, Ctx))
       return CondEval ? CE->getLHS() : CE->getRHS();
   }
   return E;

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-fold-conditional.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-fold-conditional.cpp
@@ -29,3 +29,16 @@ void f(int x, int y) {
   return;
 }
 
+// Test that the analysis will not crash when a conditional expression
+// appears in dependent context:
+#ifdef __cplusplus
+struct Foo {
+  static void static_method(int);
+};
+void conditional_inside_dependent_context(void) {
+  auto lambda = [](auto result) { // opens a dependent context
+    Foo::static_method(result ? 1 : 2); // no-crash
+  };
+  (void)lambda;
+}
+#endif // __cplusplus

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -135,6 +135,8 @@ void safe_examples(std::string s1, int *p) {
   snprintf(a, 10, "%s%d%s%p%s", __PRETTY_FUNCTION__, *p, "hello", s1.c_str());                // no warn
   snprintf(&c, 1, "%s%d%s%p%s", __PRETTY_FUNCTION__, *p, "hello", s1.c_str());                // no warn
   snprintf(nullptr, 0, "%s%d%s%p%s", __PRETTY_FUNCTION__, *p, "hello", s1.c_str());           // no warn
+
+  strlen(s1.c_str());
 }
 
 


### PR DESCRIPTION
Conflicts:
      clang/lib/Analysis/UnsafeBufferUsage.cpp

rdar://166521282
(cherry picked from commit d060dacf2435fb11871cc030176414a9cf07524c)

Message of the merged commit 'a630642585cc':
[-Wunsafe-buffer-usage] Check isValueDependent before EvaluateAsBooleanCondition (#172091)

The function `EvaluateAsBooleanCondition` assumes (asserts) that the input `Expr` is not in a dependent context. So it is caller's responsibility to check the condition before the call. This commit fixes the issue in `UnsafeBufferUsage.cpp`.

The issue was first found downstream because of some code not upstreamed. This commit also includes those un-upstreamed code.

rdar://166217941