### PR TITLE
[cas] FileSystem::printImpl for CAS-related filesystems

### DIFF
--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -1039,6 +1039,26 @@ public:
   createThreadSafeProxyFS() override {
     llvm::report_fatal_error("not implemented");
   }
+
+  void printImpl(raw_ostream &OS, PrintType Type,
+                 unsigned IndentLevel) const final {
+    printIndent(OS, IndentLevel);
+    IndentLevel += 1;
+    OS << "IncludeTreeFileSystem\n";
+    if (Type == PrintType::Summary)
+      return;
+
+    // Files is unordered, so sort by name to get a deterministic order.
+    std::vector<std::pair<StringRef, ObjectRef>> FileRefs;
+    for (auto &[Name, F] : Files)
+      FileRefs.emplace_back(Name, F.ContentsRef);
+    llvm::sort(FileRefs, [](auto &&A, auto &&B) { return A.first < B.first; });
+
+    for (auto &[Name, ContentsRef] : FileRefs) {
+      printIndent(OS, IndentLevel);
+      OS << Name << ' ' << CAS.getID(ContentsRef) << '\n';
+    }
+  }
 };
 } // namespace
 

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -296,27 +296,29 @@ TEST(IncludeTree, IncludeTreeFileListDuplicates) {
   EXPECT_EQ(I, Files.size());
 }
 
-TEST(IncludeTree, IncludeTreeFileSystemOverlay) {
-  StringRef PathSep = llvm::sys::path::get_separator();
-  std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
+static Expected<IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
+createTestInclueTreeFS(ObjectStore &DB, unsigned NumFiles = 10) {
   SmallVector<IncludeTree::FileList::FileEntry> Files;
-  for (unsigned I = 0; I < 10; ++I) {
+  for (unsigned I = 0; I < NumFiles; ++I) {
     std::optional<IncludeTree::File> File;
     std::string Path = "/file" + std::to_string(I);
     static constexpr StringRef Bytes = "123456789";
     std::optional<ObjectRef> Content;
-    ASSERT_THAT_ERROR(
-        DB->storeFromString({}, Bytes.substr(0, I)).moveInto(Content),
-        llvm::Succeeded());
-    ASSERT_THAT_ERROR(
-        IncludeTree::File::create(*DB, Path, *Content).moveInto(File),
-        llvm::Succeeded());
+    if (auto E = DB.storeFromString({}, Bytes.substr(0, I)).moveInto(Content))
+      return std::move(E);
+    if (auto E = IncludeTree::File::create(DB, Path, *Content).moveInto(File))
+      return std::move(E);
     Files.push_back({File->getRef(), I});
   }
+  return createIncludeTreeFileSystem(DB, Files);
+}
+
+TEST(IncludeTree, IncludeTreeFileSystemOverlay) {
+  StringRef PathSep = llvm::sys::path::get_separator();
+  std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> IncludeTreeFS;
-  ASSERT_THAT_ERROR(
-      createIncludeTreeFileSystem(*DB, Files).moveInto(IncludeTreeFS),
-      llvm::Succeeded());
+  ASSERT_THAT_ERROR(createTestInclueTreeFS(*DB).moveInto(IncludeTreeFS),
+                    llvm::Succeeded());
 
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   FS->setCurrentWorkingDirectory("/dir");
@@ -337,4 +339,33 @@ TEST(IncludeTree, IncludeTreeFileSystemOverlay) {
     ASSERT_EQ(I->path(), Path);
   }
   ASSERT_EQ(NumFile, 2);
+}
+
+TEST(IncludeTree, IncludeTreeFileSystemPrint) {
+  std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
+  IntrusiveRefCntPtr<llvm::vfs::FileSystem> IncludeTreeFS;
+  ASSERT_THAT_ERROR(
+      createTestInclueTreeFS(*DB, /*NumFiles=*/3).moveInto(IncludeTreeFS),
+      llvm::Succeeded());
+
+  {
+    std::string FSStr;
+    llvm::raw_string_ostream OS(FSStr);
+    IncludeTreeFS->print(OS, llvm::vfs::FileSystem::PrintType::Summary);
+    EXPECT_EQ(FSStr, "IncludeTreeFileSystem\n");
+  }
+  {
+    std::string FSStr;
+    llvm::raw_string_ostream OS(FSStr);
+    IncludeTreeFS->print(OS, llvm::vfs::FileSystem::PrintType::Contents);
+    StringRef Printed(FSStr);
+    EXPECT_TRUE(Printed.consume_front("IncludeTreeFileSystem")) << Printed;
+    EXPECT_TRUE(Printed.consume_front("\n  /file0 llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_TRUE(Printed.consume_front("\n  /file1 llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_TRUE(Printed.consume_front("\n  /file2 llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_EQ(Printed, "\n");         // Final newline.
+  }
 }

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -96,6 +96,9 @@ public:
     return WorkingDirectory.Path;
   }
 
+  void printImpl(raw_ostream &OS, PrintType Type,
+                 unsigned IndentLevel) const final;
+
   Error initialize(ObjectRef Root);
 
   CASFileSystem(std::shared_ptr<ObjectStore> DB, sys::path::Style PathStyle)
@@ -182,6 +185,45 @@ std::error_code CASFileSystem::setCurrentWorkingDirectory(const Twine &Path) {
   WorkingDirectory.Path = CanonicalPath.str();
   WorkingDirectory.Entry = *ExpectedEntry;
   return std::error_code();
+}
+
+void CASFileSystem::printImpl(raw_ostream &OS, PrintType Type,
+                              unsigned IndentLevel) const {
+  printIndent(OS, IndentLevel);
+  OS << "CASFileSystem\n";
+  if (Type == PrintType::Summary)
+    return;
+
+  IndentLevel += 1;
+  printIndent(OS, IndentLevel);
+  StringRef path_separator = get_separator(PathStyle);
+  auto &Root = Cache->getRoot(path_separator);
+  OS << "root: " << Root.getTreePath();
+  assert(Root.getRef() && "missing ID for primary CASFileSystem root");
+  if (Root.getRef())
+    OS << ' ' << DB.getID(*Root.getRef()) << '\n';
+
+  if (Type == PrintType::Contents)
+    return;
+
+  IndentLevel += 1;
+  TreeSchema Schema(DB);
+  auto TreeN = DB.getProxy(*Root.getRef());
+  if (!TreeN) {
+    OS << toString(TreeN.takeError()) << '\n';
+    return;
+  }
+  Error E = Schema.walkFileTreeRecursively(
+      DB, TreeN->getRef(),
+      [&](const NamedTreeEntry &Entry, std::optional<TreeProxy> Tree) -> Error {
+        if (Entry.getKind() != TreeEntry::Tree) {
+          printIndent(OS, IndentLevel);
+          Entry.print(OS, DB);
+        }
+        return Error::success();
+      });
+  if (E)
+    OS << toString(std::move(E)) << '\n';
 }
 
 Error CASFileSystem::loadDirectory(DirectoryEntry &Parent) {

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -121,6 +121,9 @@ public:
     return makeIntrusiveRefCnt<CachingOnDiskFileSystemImpl>(*this);
   }
 
+  void printImpl(raw_ostream &OS, PrintType Type,
+                 unsigned IndentLevel) const final;
+
   CachingOnDiskFileSystemImpl(std::shared_ptr<ObjectStore> DB)
       : CachingOnDiskFileSystem(std::move(DB)) {
     initializeWorkingDirectory();
@@ -892,6 +895,13 @@ public:
 std::unique_ptr<CachingOnDiskFileSystem::TreeBuilder>
 CachingOnDiskFileSystemImpl::createTreeBuilder() {
   return std::make_unique<TreeBuilder>(*this);
+}
+
+void CachingOnDiskFileSystemImpl::printImpl(raw_ostream &OS, PrintType Type,
+                                            unsigned IndentLevel) const {
+  printIndent(OS, IndentLevel);
+  OS << "CachingOnDiskFileSystem\n";
+  // FIXME: print contents
 }
 
 void CachingOnDiskFileSystemImpl::TreeBuilder::pushSymlink(

--- a/llvm/unittests/CAS/CASFileSystemTest.cpp
+++ b/llvm/unittests/CAS/CASFileSystemTest.cpp
@@ -516,3 +516,46 @@ TEST(CASFileSystemTest, recursiveDirectoryIteratorNested) {
                                             sys::fs::file_type::regular_file));
   ASSERT_TRUE(isEnd(D, EC));
 }
+
+TEST(CASFileSystemTest, print) {
+  std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
+  ASSERT_TRUE(CAS);
+  std::optional<ObjectProxy> Tree;
+  ASSERT_THAT_ERROR(createNestedTree(*CAS).moveInto(Tree), Succeeded());
+  std::unique_ptr<vfs::FileSystem> CASFS;
+  ASSERT_THAT_ERROR(createFS(*CAS, *Tree).moveInto(CASFS), Succeeded());
+
+  {
+    std::string FSStr;
+    llvm::raw_string_ostream OS(FSStr);
+    CASFS->print(OS, vfs::FileSystem::PrintType::Summary);
+    EXPECT_EQ(FSStr, "CASFileSystem\n");
+  }
+  {
+    std::string FSStr;
+    llvm::raw_string_ostream OS(FSStr);
+    CASFS->print(OS, vfs::FileSystem::PrintType::Contents);
+    std::string Expected = "CASFileSystem\n";
+    Expected += "  root: / " + Tree->getID().toString() + "\n";
+    EXPECT_EQ(FSStr, Expected);
+  }
+  {
+    std::string FSStr;
+    llvm::raw_string_ostream OS(FSStr);
+    CASFS->print(OS, vfs::FileSystem::PrintType::RecursiveContents);
+    std::string Expected = "CASFileSystem\n";
+    Expected += "  root: / " + Tree->getID().toString() + "\n";
+    StringRef Printed(FSStr);
+    EXPECT_TRUE(Printed.consume_front("CASFileSystem")) << Printed;
+    EXPECT_TRUE(Printed.consume_front("\n  root: / llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_TRUE(Printed.consume_front("\n    file llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_TRUE(Printed.consume_front(" /d2")) << Printed;
+    EXPECT_TRUE(Printed.consume_front("\n    file llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_TRUE(Printed.consume_front(" /t1/d1\n")) << Printed;
+    // ...
+    EXPECT_TRUE(Printed.consume_back("/t3/t2/d2\n")) << Printed;
+  }
+}


### PR DESCRIPTION
For IncludeTreeFileSystem, contents (and recursive contents, since there is no distinction) prints the list of files in sorted order along with the casid of their contents.

For CASFileSystem, contents prints the root casid, while recursive contents additionally walks the full recursive contents printing each entry.

For CachingOnDiskFileSystem this is currently a stub that just prints the name of the filesystem with no contents. This is still helpful to know what kind of filesystem is in use for debugging.