### PR TITLE
[lldb] Adjust expected type of `value` variable in `TestSwiftGenericE…

### DIFF
--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -58,5 +58,5 @@ class TestSwiftGenericEnumTypes(TestBase):
             value,
             use_dynamic=True,
             summary='"Now with Content"',
-            typename='Swift.Optional<Swift.String>')
+            typename='Swift.String')
 


### PR DESCRIPTION
…nums` test-case

`let _: String? = log("")`  where `log` is `<T>(_: T) -> T` should should have `T` bound to `String` and result injected into an optional instead of injecting the literal argument.

This is paired with https://github.com/swiftlang/swift/pull/86096 which changes the inference behavior here.