### PR TITLE
[NFC][BoundsSafety] Unbreak `BoundsSafety/Sema/check-format-arguments.c`

### DIFF
--- a/clang/test/BoundsSafety/Sema/check-format-arguments.c
+++ b/clang/test/BoundsSafety/Sema/check-format-arguments.c
@@ -9,6 +9,7 @@
 
 void __printflike(1, 0) foo(const char *__null_terminated, va_list);
 
+// expected-note@+1{{'bar' declared here}}
 void __printflike(2, 3) bar(const char *__unsafe_indexable p1, const char *__unsafe_indexable p2, ...) {
     va_list variadicArgs;
     va_start(variadicArgs, p2);
@@ -18,7 +19,7 @@ void __printflike(2, 3) bar(const char *__unsafe_indexable p1, const char *__uns
     foo(__unsafe_forge_null_terminated(const char *, "Hello, %s!\n"), variadicArgs);
 
     foo(__unsafe_forge_null_terminated(const char *, 2), variadicArgs); // expected-warning{{format string is not a string literal}}
-    foo(__unsafe_forge_null_terminated(const char *, p1), variadicArgs); // expected-warning{{format string is not a string literal}}
+    foo(__unsafe_forge_null_terminated(const char *, p1), variadicArgs); // expected-warning{{diagnostic behavior may be improved by adding the 'format(printf, 1, 3)' attribute to the declaration of 'bar'}}
 
     va_end(variadicArgs);
 }


### PR DESCRIPTION
This test was broken by https://github.com/llvm/llvm-project/pull/166738

```
commit 1df7b512bde79a2580e1599b9e5a01b3505f7659
Author: Vladimir Vuksanovic <109677816+vvuksanovic@users.noreply.github.com>
Date:   Fri Dec 5 15:04:12 2025 +0100

    [Sema] Suggest missing format attributes (#166738)
```

It seems a different warning (`-Wmissing-format-attribute`) is emitted for the case where a non-format string argument is passed to `foo`. This new behavior seems a little confusing

* There's no longer a warning about the call to `foo` not taking a string literal.
* The suggested attribute conflicts with the `format` attribute that's already on bar.

Dealing with this odd behavior is out-of-scope though for fixing this test case though.

rdar://166071403