### PR TITLE
[llvm][clang] Fix IO sandbox violations

### DIFF
--- a/clang/lib/Index/IndexRecordWriter.cpp
+++ b/clang/lib/Index/IndexRecordWriter.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -258,6 +259,7 @@ IndexRecordWriter::beginRecord(StringRef Filename, uint64_t RecordHash,
   if (OutRecordFile)
     *OutRecordFile = RecordName;
 
+  auto BypassSandbox = sandbox::scopedDisable();
   if (std::error_code EC =
           fs::access(RecordPath.c_str(), fs::AccessMode::Exist)) {
     if (EC != errc::no_such_file_or_directory) {
@@ -300,6 +302,8 @@ IndexRecordWriter::endRecord(std::string &Error,
   if (!State.Decls.empty()) {
     writeDecls(State.Stream, State.Decls, State.Occurrences, GetSymbolForDecl);
   }
+
+  auto BypassSandbox = sys::sandbox::scopedDisable();
 
   if (std::error_code EC = sys::fs::create_directory(sys::path::parent_path(State.RecordPath))) {
     llvm::raw_string_ostream Err(Error);

--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Compression.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/xxhash.h"
@@ -242,8 +243,11 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
   SmallString<256> UnitPath;
   getUnitPathForOutputFile(FilePath, UnitPath);
 
-  llvm::sys::fs::file_status UnitStat;
-  if (std::error_code EC = llvm::sys::fs::status(UnitPath.c_str(), UnitStat)) {
+  auto &VFS = FileMgr.getVirtualFileSystem();
+
+  auto UnitStatOrErr = VFS.status(UnitPath);
+  if (!UnitStatOrErr) {
+    std::error_code EC = UnitStatOrErr.getError();
     if (EC != llvm::errc::no_such_file_or_directory && EC != llvm::errc::delete_pending) {
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << UnitPath
@@ -256,8 +260,9 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
   if (!TimeCompareFilePath)
     return true;
 
-  llvm::sys::fs::file_status CompareStat;
-  if (std::error_code EC = llvm::sys::fs::status(*TimeCompareFilePath, CompareStat)) {
+  auto CompareStatOrErr = VFS.status(*TimeCompareFilePath);
+  if (!CompareStatOrErr) {
+    std::error_code EC = CompareStatOrErr.getError();
     if (EC != llvm::errc::no_such_file_or_directory && EC != llvm::errc::delete_pending) {
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << *TimeCompareFilePath
@@ -269,7 +274,8 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
 
   // Return true (unit is up-to-date) if the file to compare is older than the
   // unit file.
-  return CompareStat.getLastModificationTime() <= UnitStat.getLastModificationTime();
+  return CompareStatOrErr->getLastModificationTime() <=
+         UnitStatOrErr->getLastModificationTime();
 }
 
 void IndexUnitWriter::getUnitNameForAbsoluteOutputFile(StringRef FilePath,
@@ -337,21 +343,11 @@ static void writeVersionInfo(BitstreamWriter &Stream) {
 bool IndexUnitWriter::write(std::string &Error) {
   using namespace llvm::sys;
 
+  auto BypassSandbox = sandbox::scopedDisable();
+
   // Determine the working directory.
   SmallString<128> CWDPath;
-  if (!FileMgr.getFileSystemOpts().WorkingDir.empty()) {
-    CWDPath = FileMgr.getFileSystemOpts().WorkingDir;
-    if (!path::is_absolute(CWDPath)) {
-      fs::make_absolute(CWDPath);
-    }
-  } else {
-    std::error_code EC = sys::fs::current_path(CWDPath);
-    if (EC) {
-      llvm::raw_string_ostream Err(Error);
-      Err << "failed to determine current working directory: " << EC.message();
-      return true;
-    }
-  }
+  FileMgr.makeAbsolutePath(CWDPath);
   WorkDir = std::string(CWDPath.str());
 
   SmallString<512> Buffer;

--- a/clang/lib/Index/IndexUnitWriter.cpp
+++ b/clang/lib/Index/IndexUnitWriter.cpp
@@ -243,11 +243,10 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
   SmallString<256> UnitPath;
   getUnitPathForOutputFile(FilePath, UnitPath);
 
-  auto &VFS = FileMgr.getVirtualFileSystem();
+  auto BypassSandbox = sys::sandbox::scopedDisable();
 
-  auto UnitStatOrErr = VFS.status(UnitPath);
-  if (!UnitStatOrErr) {
-    std::error_code EC = UnitStatOrErr.getError();
+  llvm::sys::fs::file_status UnitStat;
+  if (std::error_code EC = llvm::sys::fs::status(UnitPath.c_str(), UnitStat)) {
     if (EC != llvm::errc::no_such_file_or_directory && EC != llvm::errc::delete_pending) {
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << UnitPath
@@ -260,9 +259,8 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
   if (!TimeCompareFilePath)
     return true;
 
-  auto CompareStatOrErr = VFS.status(*TimeCompareFilePath);
-  if (!CompareStatOrErr) {
-    std::error_code EC = CompareStatOrErr.getError();
+  llvm::sys::fs::file_status CompareStat;
+  if (std::error_code EC = llvm::sys::fs::status(*TimeCompareFilePath, CompareStat)) {
     if (EC != llvm::errc::no_such_file_or_directory && EC != llvm::errc::delete_pending) {
       llvm::raw_string_ostream Err(Error);
       Err << "could not access path '" << *TimeCompareFilePath
@@ -274,8 +272,7 @@ std::optional<bool> IndexUnitWriter::isUnitUpToDateForOutputFile(
 
   // Return true (unit is up-to-date) if the file to compare is older than the
   // unit file.
-  return CompareStatOrErr->getLastModificationTime() <=
-         UnitStatOrErr->getLastModificationTime();
+  return CompareStat.getLastModificationTime() <= UnitStat.getLastModificationTime();
 }
 
 void IndexUnitWriter::getUnitNameForAbsoluteOutputFile(StringRef FilePath,

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -41,6 +41,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
@@ -459,6 +460,7 @@ static void writeResponseFile(raw_ostream &OS,
 
 static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
                             SmallVectorImpl<const char *> &NewArgs,
+                            llvm::vfs::FileSystem &VFS,
                             DiagnosticsEngine &Diag,
                             const llvm::opt::ArgList &Args,
                             const CASOptions &CASOpts,
@@ -469,16 +471,17 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
   });
 
   StringRef WorkingDirectory;
-  SmallString<128> WorkingDirectoryBuf;
+  std::string WorkingDirectoryBuf;
   if (auto *Arg =
           Args.getLastArg(clang::options::OPT_working_directory)) {
     WorkingDirectory = Arg->getValue();
   } else {
-    if (llvm::Error E = llvm::errorCodeToError(
-            llvm::sys::fs::current_path(WorkingDirectoryBuf))) {
+    auto CWD = VFS.getCurrentWorkingDirectory();
+    if (Error E = llvm::errorCodeToError(CWD.getError())) {
       Diag.Report(diag::err_cas_depscan_failed) << std::move(E);
       return 1;
     }
+    WorkingDirectoryBuf = std::move(*CWD);
     WorkingDirectory = WorkingDirectoryBuf;
   }
 
@@ -555,7 +558,10 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
       std::make_unique<TextDiagnosticPrinter>(llvm::errs(), *DiagOpts, false);
   DiagnosticsEngine Diags(new DiagnosticIDs(), *DiagOpts);
   Diags.setClient(DiagsConsumer.get(), /*ShouldOwnClient=*/false);
-  auto VFS = llvm::vfs::getRealFileSystem();
+  auto VFS = [] {
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+    return llvm::vfs::getRealFileSystem();
+  }();
   ProcessWarningOptions(Diags, *DiagOpts, *VFS);
   if (Diags.hasErrorOccurred())
     return 1;
@@ -593,8 +599,8 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
   CompilerInvocation::ParseCASArgs(CASOpts, ParsedCC1Args, Diags);
   CASOpts.ensurePersistentCAS();
 
-  if (int Ret = scanAndUpdateCC1(Argv0, CC1Args->getValues(), NewArgs, Diags,
-                                 Args, CASOpts, RootID))
+  if (int Ret = scanAndUpdateCC1(Argv0, CC1Args->getValues(), NewArgs, *VFS,
+                                 Diags, Args, CASOpts, RootID))
     return Ret;
 
   // FIXME: Use OutputBackend to OnDisk only now.
@@ -981,8 +987,10 @@ int ScanServer::listen() {
       // Is this safe to reuse? Or does DependendencyScanningWorkerFileSystem
       // make some bad assumptions about relative paths?
       if (!Tool) {
-        llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS =
-            llvm::vfs::createPhysicalFileSystem();
+        auto UnderlyingFS = [] {
+          auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+          return llvm::vfs::createPhysicalFileSystem();
+        }();
         UnderlyingFS = llvm::cas::createCASProvidingFileSystem(
             CAS, std::move(UnderlyingFS));
         Tool.emplace(Service, std::move(UnderlyingFS));
@@ -1118,8 +1126,10 @@ scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
   dependencies::DependencyScanningService Service(
       dependencies::ScanningMode::DependencyDirectivesScan,
       dependencies::ScanningOutputFormat::IncludeTree, CASOpts, DB, Cache);
-  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS =
-      llvm::vfs::createPhysicalFileSystem();
+  auto UnderlyingFS = [] {
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+    return llvm::vfs::createPhysicalFileSystem();
+  }();
   UnderlyingFS =
       llvm::cas::createCASProvidingFileSystem(DB, std::move(UnderlyingFS));
   tooling::DependencyScanningTool Tool(Service, std::move(UnderlyingFS));

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -15,6 +15,8 @@
 #include "llvm/CAS/TreePath.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/IOSandbox.h"
+
 #include <mutex>
 
 using namespace llvm;
@@ -254,6 +256,7 @@ void CachingOnDiskFileSystemImpl::initializeWorkingDirectory() {
   WorkingDirectory.Entry = &Cache->getRoot(RootPath);
   WorkingDirectory.Path = WorkingDirectory.Entry->getTreePath().str();
 
+  auto BypassSandbox = sys::sandbox::scopedDisable();
   SmallString<128> CWD;
   if (std::error_code EC = llvm::sys::fs::current_path(CWD)) {
     (void)EC;
@@ -540,6 +543,8 @@ CachingOnDiskFileSystemImpl::getDirectoryIterator(const Twine &Path) {
 Expected<FileSystemCache::DirectoryEntry *>
 CachingOnDiskFileSystemImpl::preloadRealPath(DirectoryEntry &From,
                                              StringRef Remaining) {
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
   PathStorage RemainingStorage(Remaining);
   SmallString<256> ExpectedRealTreePath;
   ExpectedRealTreePath = From.getTreePath();

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -58,6 +58,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
@@ -1240,6 +1241,8 @@ OnDiskGraphDB::load(ObjectID ExternalRef) {
   SmallString<256> Path;
   getStandalonePath(TrieRecord::getStandaloneFilePrefix(Object.SK), *I, Path);
 
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
   auto File = sys::fs::openNativeFileForRead(Path);
   if (!File)
     return createFileError(Path, File.takeError());
@@ -1343,6 +1346,8 @@ OnDiskContent StandaloneDataInMemory::getContent() const {
 
 static Expected<MappedTempFile>
 createTempFile(StringRef FinalPath, uint64_t Size, OnDiskCASLogger *Logger) {
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
   assert(Size && "Unexpected request for an empty temp file");
   Expected<TempFile> File = TempFile::create(FinalPath + ".%%%%%%", Logger);
   if (!File)
@@ -1379,6 +1384,8 @@ Error OnDiskGraphDB::createStandaloneLeaf(IndexProxy &I, ArrayRef<char> Data) {
   SmallString<256> Path;
   int64_t FileSize = Data.size() + Leaf0;
   getStandalonePath(TrieRecord::getStandaloneFilePrefix(SK), I, Path);
+
+  auto BypassSandbox = sys::sandbox::scopedDisable();
 
   // Write the file. Don't reuse this mapped_file_region, which is read/write.
   // Let load() pull up one that's read-only.

--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -83,6 +83,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FileUtilities.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Program.h"
@@ -414,6 +415,8 @@ Expected<std::unique_ptr<UnifiedOnDiskCache>>
 UnifiedOnDiskCache::open(StringRef RootPath, std::optional<uint64_t> SizeLimit,
                          StringRef HashName, unsigned HashByteSize,
                          OnDiskGraphDB::FaultInPolicy FaultInPolicy) {
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
   if (std::error_code EC = sys::fs::create_directories(RootPath))
     return createFileError(RootPath, EC);
 
@@ -543,6 +546,8 @@ bool UnifiedOnDiskCache::hasExceededSizeLimit() const {
 }
 
 Error UnifiedOnDiskCache::close(bool CheckSizeLimit) {
+  auto BypassSandbox = sys::sandbox::scopedDisable();
+
   if (LockFD == -1)
     return Error::success(); // already closed.
   auto CloseLock = make_scope_exit([&]() {


### PR DESCRIPTION
This fixes downstream violations of the IO sandbox introduced in https://github.com/llvm/llvm-project/pull/165350 and enabled in https://github.com/llvm/llvm-project/pull/171935.