### PR TITLE
[LLDB] Support importing modules from llvmcas:// URLs 

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -24,6 +24,10 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/RWMutex.h"
 
+// BEGIN CAS
+#include "llvm/CAS/CASConfiguration.h"
+// END CAS
+
 #include <functional>
 #include <list>
 #include <mutex>
@@ -547,7 +551,7 @@ public:
   // START CAS
 
   struct CAS {
-    std::shared_ptr<llvm::cas::CASConfiguration> configuration;
+    llvm::cas::CASConfiguration configuration;
     std::shared_ptr<llvm::cas::ObjectStore> object_store;
     std::shared_ptr<llvm::cas::ActionCache> action_cache;
   };

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -17,6 +17,7 @@
 #include "lldb/Interpreter/Property.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Symbol/SymbolContext.h"
+#include "lldb/Symbol/SymbolFile.h"
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/VariableList.h"
 #include "lldb/Utility/ArchSpec.h"
@@ -27,7 +28,9 @@
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-defines.h"
+#include "lldb/lldb-private-enumerations.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileUtilities.h"
 
 #if defined(_WIN32)
@@ -302,6 +305,11 @@ bool ModuleListProperties::GetSwiftEnableASTContext() const {
 FileSpec ModuleListProperties::GetCASOnDiskPath() const {
   const uint32_t idx = ePropertyCASOnDiskPath;
   return GetPropertyAtIndexAs<FileSpec>(idx, {});
+}
+
+bool ModuleListProperties::SetCASOnDiskPath(const FileSpec &path) {
+  const uint32_t idx = ePropertyCASOnDiskPath;
+  return SetPropertyAtIndex(idx, path);
 }
 
 FileSpec ModuleListProperties::GetCASPluginPath() const {
@@ -1278,6 +1286,16 @@ private:
           continue;
         ModuleList to_remove = RemoveOrphansFromVector(vec);
         remove_count += to_remove.GetSize();
+        // BEGIN CAS
+        to_remove.ForEach([&](auto &m) {
+          auto it = m_module_configs.find(m.get());
+          if (it != m_module_configs.end()) {
+            m_cas_cache.erase(it->second.get());
+            m_module_configs.erase(it);
+          }
+          return IterationAction::Continue;
+        });
+        // END CAS
         m_list.Remove(to_remove);
       }
       // Break when fixed-point is reached.
@@ -1292,6 +1310,24 @@ private:
   /// filename, for fast module lookups by name.
   llvm::DenseMap<ConstString, llvm::SmallVector<ModuleSP, 1>> m_name_to_modules;
 
+  // BEGIN CAS
+public:
+  /// Each module may have a CAS config associated with it.
+  /// Often many modules share the same CAS.
+  llvm::DenseMap<const Module *, std::shared_ptr<llvm::cas::CASConfiguration>>
+      m_module_configs;
+
+  llvm::StringMap<std::weak_ptr<llvm::cas::CASConfiguration>> m_cas_configs;
+
+  /// Each CAS config has a CAS associated with it.
+  llvm::DenseMap<const llvm::cas::CASConfiguration *,
+                 std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+                           std::shared_ptr<llvm::cas::ActionCache>>>
+      m_cas_cache;
+
+private:
+  // END CAS
+
   /// The use count of a module held only by m_list and m_name_to_modules.
   static constexpr long kUseCountSharedModuleListOrphaned = 2;
 };
@@ -1299,7 +1335,6 @@ private:
 struct SharedModuleListInfo {
   SharedModuleList module_list;
   ModuleListProperties module_list_properties;
-  std::shared_ptr<llvm::cas::ObjectStore> cas_object_store;
   std::mutex shared_lock;
 };
 }
@@ -1322,45 +1357,24 @@ static SharedModuleList &GetSharedModuleList() {
   return GetSharedModuleListInfo().module_list;
 }
 
-std::optional<llvm::cas::CASConfiguration>
-ModuleList::GetCASConfiguration(FileSpec CandidateConfigSearchPath) {
+static std::shared_ptr<llvm::cas::CASConfiguration>
+GetCASConfiguration(FileSpec CandidateConfigSearchPath) {
   // Config CAS from properties.
-  llvm::cas::CASConfiguration cas_config;
-  cas_config.CASPath =
-      ModuleList::GetGlobalModuleListProperties().GetCASOnDiskPath().GetPath();
-  cas_config.PluginPath =
-      ModuleList::GetGlobalModuleListProperties().GetCASPluginPath().GetPath();
-  cas_config.PluginOptions =
-      ModuleList::GetGlobalModuleListProperties().GetCASPluginOptions();
-
-  if (!cas_config.CASPath.empty())
-    return cas_config;
-
+  auto &props = ModuleList::GetGlobalModuleListProperties();
+  auto path = props.GetCASOnDiskPath().GetPath();
+  if (!path.empty()) {
+    auto config = std::make_shared<llvm::cas::CASConfiguration>();
+    config->CASPath = props.GetCASOnDiskPath().GetPath();
+    config->PluginPath = props.GetCASPluginPath().GetPath();
+    config->PluginOptions = props.GetCASPluginOptions();
+    return config;
+  }
   auto search_config = llvm::cas::CASConfiguration::createFromSearchConfigFile(
       CandidateConfigSearchPath.GetPath());
   if (search_config)
-    return search_config->second;
+    return std::make_shared<llvm::cas::CASConfiguration>(search_config->second);
 
-  return std::nullopt;
-}
-
-static llvm::Expected<std::shared_ptr<llvm::cas::ObjectStore>>
-GetOrCreateCASStorage(FileSpec CandidateConfigSearchPath) {
-  auto &shared_module_list = GetSharedModuleListInfo();
-  if (shared_module_list.cas_object_store)
-    return shared_module_list.cas_object_store;
-
-  auto config = ModuleList::GetCASConfiguration(CandidateConfigSearchPath);
-  if (!config)
-    return nullptr;
-
-  auto cas = config->createDatabases();
-  if (!cas)
-    return cas.takeError();
-
-  std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
-  shared_module_list.cas_object_store = std::move(cas->first);
-  return shared_module_list.cas_object_store;
+  return {};
 }
 
 ModuleListProperties &ModuleList::GetGlobalModuleListProperties() {
@@ -1634,19 +1648,18 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
   return error;
 }
 
-static llvm::Expected<bool> loadModuleFromCAS(ConstString module_name,
-                                              llvm::StringRef cas_id,
-                                              FileSpec cu_path,
-                                              ModuleSpec &module_spec) {
-  auto maybe_cas = GetOrCreateCASStorage(cu_path);
+static llvm::Expected<bool> loadModuleFromCASImpl(llvm::StringRef cas_id,
+                                                  const lldb::ModuleSP &nearby,
+                                                  ModuleSpec &module_spec) {
+  auto maybe_cas = ModuleList::GetOrCreateCAS(nearby);
   if (!maybe_cas)
     return maybe_cas.takeError();
 
-  auto cas = std::move(*maybe_cas);
+  auto cas = std::move(maybe_cas->object_store);
   if (!cas) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
              "skip loading module '{0}' from CAS: CAS is not available",
-             module_name);
+             cas_id);
     return false;
   }
 
@@ -1665,20 +1678,152 @@ static llvm::Expected<bool> loadModuleFromCAS(ConstString module_name,
       std::make_shared<DataBufferLLVM>(module_proxy->getMemoryBuffer());
 
   // Swap out the module_spec with the one loaded via CAS.
-  ModuleSpec loaded(module_spec.GetFileSpec(), module_spec.GetUUID(),
-                    std::move(file_buffer));
+  FileSpec cas_spec;
+  cas_spec.SetDirectory(ConstString(maybe_cas->configuration->CASPath));
+  cas_spec.SetFilename(ConstString(cas_id));
+  ModuleSpec loaded(cas_spec, module_spec.GetUUID(), std::move(file_buffer));
   loaded.GetArchitecture() = module_spec.GetArchitecture();
   module_spec = loaded;
 
-  LLDB_LOG(GetLog(LLDBLog::Modules), "loading module '{0}' using CASID '{1}'",
-           module_name, cas_id);
+  LLDB_LOG(GetLog(LLDBLog::Modules), "loading module using CASID '{0}'",
+           cas_id);
   return true;
 }
 
+/// Load the module referenced by \c cas_id from a CAS located
+/// near \c nearby.
+static llvm::Expected<bool> loadModuleFromCAS(llvm::StringRef cas_id,
+                                              const lldb::ModuleSP &nearby,
+                                              ModuleSpec &module_spec) {
+  static llvm::StringMap<bool> g_cache;
+  static std::recursive_mutex g_cache_lock;
+  std::scoped_lock<std::recursive_mutex> lock(g_cache_lock);
+  auto cached = g_cache.find(cas_id);
+  if (cached != g_cache.end())
+    return cached->second;
+  auto result = loadModuleFromCASImpl(cas_id, nearby, module_spec);
+  // Errors are only returned the first time.
+  g_cache.insert({cas_id, result ? *result : false});
+  return result;
+}
+
+static std::shared_ptr<llvm::cas::CASConfiguration>
+FindCASConfiguration(const ModuleSP &module_sp) {
+  auto get_dir = [](FileSpec path) {
+    path.ClearFilename();
+    return path;
+  };
+
+  // Look near the binary / dSYM.
+  std::set<FileSpec> unique_paths;
+  std::shared_ptr<llvm::cas::CASConfiguration> cas_config =
+      GetCASConfiguration(module_sp->GetFileSpec());
+
+  if (!cas_config) {
+    // Look near the object files.
+    if (SymbolFile *sf = module_sp->GetSymbolFile()) {
+      sf->GetDebugInfoModules().ForEach([&](const ModuleSP &m) {
+        if (m)
+          unique_paths.insert(get_dir(m->GetFileSpec()));
+        return IterationAction::Continue;
+      });
+      for (auto &path : unique_paths)
+        if ((cas_config = GetCASConfiguration(path)))
+          break;
+    }
+  }
+  // TODO: Remove this block once the build system consistently
+  // generates .cas-config files.
+  if (!cas_config) {
+    unique_paths.insert(get_dir(module_sp->GetFileSpec()));
+    for (auto &path : unique_paths) {
+      llvm::StringRef parent = path.GetDirectory().GetStringRef();
+      while (!parent.empty() &&
+             llvm::sys::path::filename(parent) != "DerivedData")
+        parent = llvm::sys::path::parent_path(parent);
+      if (parent.empty())
+        continue;
+      llvm::SmallString<256> cas_path(parent);
+      llvm::sys::path::append(cas_path, "CompilationCache.noindex", "builtin");
+      FileSpec fs = FileSpec(cas_path);
+      ModuleList::GetGlobalModuleListProperties().SetCASOnDiskPath(fs);
+      cas_config = GetCASConfiguration(fs);
+      if (cas_config)
+        break;
+    }
+  }    
+  return cas_config;
+}
+
+llvm::Expected<ModuleList::CAS>
+ModuleList::GetOrCreateCAS(const ModuleSP &module_sp) {
+  if (!module_sp)
+    return llvm::createStringError("no lldb::Module available");
+
+  // Look in cache first.
+  auto &shared_module_list = GetSharedModuleListInfo();
+  std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
+  auto &module_configs = shared_module_list.module_list.m_module_configs;
+  auto &cas_configs = shared_module_list.module_list.m_cas_configs;
+  auto &cas_cache = shared_module_list.module_list.m_cas_cache;
+
+  std::shared_ptr<llvm::cas::CASConfiguration> cas_config;
+  {
+    auto cached_config = module_configs.find(module_sp.get());
+    if (cached_config != module_configs.end()) {
+      cas_config = cached_config->second;
+      if (!cas_config)
+        return llvm::createStringError("no CAS available (cached)");
+    }
+  }
+
+  if (!cas_config) {
+    cas_config = FindCASConfiguration(module_sp);
+    if (cas_config) {
+      // Unique the configuration. This assumes that no two configs
+      // with different plugins share the same path.
+      auto it = cas_configs.find(cas_config->CASPath);
+      if (it != cas_configs.end())
+        if (auto unique_config = it->second.lock())
+          cas_config = unique_config;
+      cas_configs.insert({cas_config->CASPath, cas_config});
+    }
+    // Cache the config or lack thereof.
+    module_configs.insert({module_sp.get(), cas_config});
+  }
+
+  if (!cas_config)
+    return llvm::createStringError("no CAS available");
+
+  // Look in the cache.
+  {
+    auto cached = cas_cache.find(cas_config.get());
+    if (cached != cas_cache.end()) {
+      if (!cached->second.first)
+        return llvm::createStringError(
+            "CAS config created, but CAS not available (cached)");
+      return ModuleList::CAS{cas_config, cached->second.first,
+                             cached->second.second};
+    }
+  }
+
+  // Create the CAS.
+  auto cas = cas_config->createDatabases();
+  if (!cas) {
+    cas_cache.insert({cas_config.get(), {}});
+    return cas.takeError();
+  }
+
+  LLDB_LOG(GetLog(LLDBLog::Modules | LLDBLog::Symbols),
+           "Initialized CAS at {0}", cas_config->CASPath);
+  cas_cache.insert({cas_config.get(), {cas->first, cas->second}});
+  return ModuleList::CAS{cas_config, cas->first, cas->second};
+}
+
 llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
-    ConstString module_name, llvm::StringRef cas_id, FileSpec cu_path,
+    llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
     ModuleSpec &module_spec, lldb::ModuleSP &module_sp) {
-  auto loaded = loadModuleFromCAS(module_name, cas_id, cu_path, module_spec);
+  auto loaded = loadModuleFromCAS(cas_id, nearby, module_spec);
   if (!loaded)
     return loaded.takeError();
 
@@ -1688,8 +1833,17 @@ llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
   auto status =
       GetSharedModule(module_spec, module_sp, nullptr, nullptr, nullptr,
                       /*always_create=*/true);
-  if (status.Success())
+  if (status.Success()) {
+    if (module_sp) {
+      // Enter the new module into the config cache.
+      auto &shared_module_list = GetSharedModuleListInfo();
+      std::scoped_lock<std::mutex> lock(shared_module_list.shared_lock);
+      auto &module_configs = shared_module_list.module_list.m_module_configs;
+      auto config = module_configs.lookup(nearby.get());
+      module_configs.insert({module_sp.get(), config});
+    }
     return true;
+  }
   return status.takeError();
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
+  LLDBExplicitModuleLoader.cpp
   SwiftDWARFImporterForClangTypes.cpp
   TypeSystemSwift.cpp
   TypeSystemSwiftTypeRef.cpp

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
@@ -1,0 +1,134 @@
+//===--LLDBExplicitModuleLoader.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===---------------------------------------------------------------------===//
+
+#include "LLDBExplicitModuleLoader.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
+#include <swift/Frontend/ModuleInterfaceLoader.h>
+namespace lldb_private {
+
+LLDBExplicitSwiftModuleLoader::LLDBExplicitSwiftModuleLoader(
+    swift::ASTContext &ctx, llvm::cas::ObjectStore *CAS,
+    swift::DependencyTracker *tracker, swift::ModuleLoadingMode loadMode,
+    bool IgnoreSwiftSourceInfoFile,
+    std::unique_ptr<swift::ExplicitCASModuleLoader> casml,
+    std::unique_ptr<swift::ExplicitSwiftModuleLoader> esml)
+    : swift::SerializedModuleLoaderBase(ctx, tracker, loadMode,
+                                        IgnoreSwiftSourceInfoFile),
+      m_cas(CAS), m_casml(std::move(casml)), m_esml(std::move(esml)) {}
+
+std::unique_ptr<LLDBExplicitSwiftModuleLoader>
+LLDBExplicitSwiftModuleLoader::create(
+    swift::ASTContext &ctx, llvm::cas::ObjectStore *CAS,
+    llvm::cas::ActionCache *cache, swift::DependencyTracker *tracker,
+    swift::ModuleLoadingMode loadMode, llvm::StringRef ExplicitSwiftModuleMap,
+    const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
+    bool IgnoreSwiftSourceInfoFile) {
+  auto esml = swift::ExplicitSwiftModuleLoader::create(
+      ctx, tracker, loadMode, ExplicitSwiftModuleMap, ExplicitSwiftModuleInputs,
+      IgnoreSwiftSourceInfoFile);
+  std::unique_ptr<swift::ExplicitCASModuleLoader> casml;
+  if (CAS && cache) {
+    casml = swift::ExplicitCASModuleLoader::create(
+        ctx, *CAS, *cache, tracker, loadMode, ExplicitSwiftModuleMap,
+        ExplicitSwiftModuleInputs, IgnoreSwiftSourceInfoFile);
+  }
+  return std::make_unique<LLDBExplicitSwiftModuleLoader>(
+      ctx, CAS, tracker, loadMode, IgnoreSwiftSourceInfoFile, std::move(casml),
+      std::move(esml));
+}
+
+void LLDBExplicitSwiftModuleLoader::collectVisibleTopLevelModuleNames(
+    llvm::SmallVectorImpl<swift::Identifier> &names) const {
+  if (m_casml)
+    m_casml->collectVisibleTopLevelModuleNames(names);
+  m_esml->collectVisibleTopLevelModuleNames(names);
+}
+
+std::error_code LLDBExplicitSwiftModuleLoader::findModuleFilesInDirectory(
+    swift::ImportPath::Element ModuleID,
+    const swift::SerializedModuleBaseName &BaseName,
+    llvm::SmallVectorImpl<char> *ModuleInterfacePath,
+    llvm::SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsCanImportLookup, bool IsFramework, bool IsTestableDependencyLookup) {
+  // This is a protected member and probably also not useful.
+  return {};
+}
+bool LLDBExplicitSwiftModuleLoader::canImportModule(
+    swift::ImportPath::Module named, swift::SourceLoc loc,
+    ModuleVersionInfo *versionInfo, bool isTestableImport) {
+  if (m_casml &&
+      llvm::cast<swift::SerializedModuleLoaderBase>(m_casml.get())
+          ->canImportModule(named, loc, versionInfo, isTestableImport))
+    return true;
+  return llvm::cast<swift::SerializedModuleLoaderBase>(m_esml.get())
+      ->canImportModule(named, loc, versionInfo, isTestableImport);
+}
+
+swift::ModuleDecl *
+LLDBExplicitSwiftModuleLoader::loadModule(swift::SourceLoc importLoc,
+                                          swift::ImportPath::Module path,
+                                          bool AllowMemoryCache) {
+  if (m_casml)
+    if (auto *decl = m_casml->loadModule(importLoc, path, AllowMemoryCache))
+      return decl;
+  return m_esml->loadModule(importLoc, path, AllowMemoryCache);
+}
+
+void LLDBExplicitSwiftModuleLoader::loadExtensions(
+    swift::NominalTypeDecl *nominal, unsigned previousGeneration) {
+  if (m_casml)
+    m_casml->loadExtensions(nominal, previousGeneration);
+  m_esml->loadExtensions(nominal, previousGeneration);
+}
+
+void LLDBExplicitSwiftModuleLoader::loadObjCMethods(
+    swift::NominalTypeDecl *typeDecl, swift::ObjCSelector selector,
+    bool isInstanceMethod, unsigned previousGeneration,
+    llvm::TinyPtrVector<swift::AbstractFunctionDecl *> &methods) {
+  if (m_casml)
+    m_casml->loadObjCMethods(typeDecl, selector, isInstanceMethod,
+                             previousGeneration, methods);
+  m_esml->loadObjCMethods(typeDecl, selector, isInstanceMethod,
+                          previousGeneration, methods);
+}
+
+void LLDBExplicitSwiftModuleLoader::loadDerivativeFunctionConfigurations(
+    swift::AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
+    llvm::SetVector<swift::AutoDiffConfig> &results) {
+  if (m_casml)
+    m_casml->loadDerivativeFunctionConfigurations(originalAFD,
+                                                  previousGeneration, results);
+  m_esml->loadDerivativeFunctionConfigurations(originalAFD, previousGeneration,
+                                               results);
+}
+
+void LLDBExplicitSwiftModuleLoader::verifyAllModules() {
+  if (m_casml)
+    m_casml->verifyAllModules();
+  m_esml->verifyAllModules();
+}
+
+void LLDBExplicitSwiftModuleLoader::addExplicitModulePath(llvm::StringRef name,
+                                                          std::string path) {
+  if (m_cas && m_casml) {
+    auto parsed_id = m_cas->parseID(path);
+    if (parsed_id)
+      return m_casml->addExplicitModulePath(name, path);
+    llvm::consumeError(parsed_id.takeError());
+  }
+  m_esml->addExplicitModulePath(name, path);
+}
+
+} // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
@@ -1,0 +1,85 @@
+//===--LLDBExplicitModuleLoader.h -------------------------------*- C++-*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_LLDBExplicitModuleLoader_h_
+#define liblldb_LLDBExplicitModuleLoader_h_
+
+#include <swift/Serialization/SerializedModuleLoader.h>
+namespace swift {
+class ExplicitSwiftModuleLoader;
+class ExplicitCASModuleLoader;
+} // namespace swift
+
+namespace lldb_private {
+/// This Swift module loader implementation wraps a CAS module loader
+/// and an ESML and forwards calls to addExplicitModulePath to both of
+/// them.
+class LLDBExplicitSwiftModuleLoader : public swift::SerializedModuleLoaderBase {
+public:
+  LLDBExplicitSwiftModuleLoader(
+      swift::ASTContext &ctx, llvm::cas::ObjectStore *CAS,
+      swift::DependencyTracker *tracker, swift::ModuleLoadingMode LoadMode,
+      bool IgnoreSwiftSourceInfoFile,
+      std::unique_ptr<swift::ExplicitCASModuleLoader> casml,
+      std::unique_ptr<swift::ExplicitSwiftModuleLoader> esml);
+
+  static std::unique_ptr<LLDBExplicitSwiftModuleLoader>
+  create(swift::ASTContext &ctx, llvm::cas::ObjectStore *CAS,
+         llvm::cas::ActionCache *cache, swift::DependencyTracker *tracker,
+         swift::ModuleLoadingMode loadMode,
+         llvm::StringRef ExplicitSwiftModuleMap,
+         const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
+         bool IgnoreSwiftSourceInfoFile);
+
+  void collectVisibleTopLevelModuleNames(
+      llvm::SmallVectorImpl<swift::Identifier> &names) const override;
+  std::error_code findModuleFilesInDirectory(
+      swift::ImportPath::Element ModuleID,
+      const swift::SerializedModuleBaseName &BaseName,
+      llvm::SmallVectorImpl<char> *ModuleInterfacePath,
+      llvm::SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool IsCanImportLookup, bool IsFramework,
+      bool IsTestableDependencyLookup = false) override;
+
+  bool canImportModule(swift::ImportPath::Module named, swift::SourceLoc loc,
+                       ModuleVersionInfo *versionInfo,
+                       bool isTestableImport = false) override;
+
+  swift::ModuleDecl *loadModule(swift::SourceLoc importLoc,
+                                swift::ImportPath::Module path,
+                                bool AllowMemoryCache = true) override;
+  void loadExtensions(swift::NominalTypeDecl *nominal,
+                      unsigned previousGeneration) override;
+  void loadObjCMethods(
+      swift::NominalTypeDecl *typeDecl, swift::ObjCSelector selector,
+      bool isInstanceMethod, unsigned previousGeneration,
+      llvm::TinyPtrVector<swift::AbstractFunctionDecl *> &methods) override;
+
+  void loadDerivativeFunctionConfigurations(
+      swift::AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
+      llvm::SetVector<swift::AutoDiffConfig> &results) override;
+
+  void verifyAllModules() override;
+  void addExplicitModulePath(llvm::StringRef name, std::string path) override;
+
+protected:
+  llvm::cas::ObjectStore *m_cas;
+  /// The CAS Swift module loader.
+  std::unique_ptr<swift::ExplicitCASModuleLoader> m_casml;
+  /// The explicit Swift module loader (ESML).
+  std::unique_ptr<swift::ExplicitSwiftModuleLoader> m_esml;
+};
+} // namespace lldb_private
+#endif

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -926,14 +926,14 @@ static void ConfigureCASStorage(const std::string &m_description,
   }
   m_ast_context->SetCASStorage(std::move(cas->object_store),
                                std::move(cas->action_cache));
-  m_ast_context->GetCASOptions().CASOpts.CASPath = cas->configuration->CASPath;
+  m_ast_context->GetCASOptions().CASOpts.CASPath = cas->configuration.CASPath;
   m_ast_context->GetCASOptions().CASOpts.PluginPath =
-      cas->configuration->PluginPath;
+      cas->configuration.PluginPath;
   m_ast_context->GetCASOptions().CASOpts.PluginOptions =
-      cas->configuration->PluginOptions;
+      cas->configuration.PluginOptions;
   LOG_PRINTF(GetLog(LLDBLog::Types),
              "Setup CAS from module list properties with cas path: %s",
-             cas->configuration->CASPath.c_str());
+             cas->configuration.CASPath.c_str());
 }
 
 SwiftASTContext::ScopedDiagnostics::ScopedDiagnostics(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -14,6 +14,7 @@
 #define liblldb_SwiftASTContext_h_
 
 #include "Plugins/LanguageRuntime/Swift/LockGuarded.h"
+#include "Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwift.h"
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 
@@ -976,8 +977,8 @@ protected:
   /// Owned by the AST.
   swift::MemoryBufferSerializedModuleLoader *m_memory_buffer_module_loader =
       nullptr;
-  swift::ModuleLoader *m_explicit_swift_module_loader = nullptr;
   swift::ModuleInterfaceLoader *m_module_interface_loader = nullptr;
+  LLDBExplicitSwiftModuleLoader *m_explicit_swift_module_loader = nullptr;
   swift::ClangImporter *m_clangimporter = nullptr;
   /// Wraps the clang::ASTContext owned by ClangImporter.
   std::shared_ptr<TypeSystemClang> m_clangimporter_typesystem;

--- a/lldb/test/API/lang/swift/clangimporter/caching/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/caching/Makefile
@@ -2,4 +2,9 @@ SWIFT_SOURCES := main.swift
 SWIFT_ENABLE_EXPLICIT_MODULES := YES
 SWIFTFLAGS_EXTRAS = -I$(SRCDIR) -I/TEST_DIR -F/FRAMEWORK_DIR -cache-compile-job -cas-path $(BUILDDIR)/cas
 
+all: a.out cas-config
+
 include Makefile.rules
+
+cas-config:
+	echo "{\"CASPath\": \"$(BUILDDIR)/cas\"}" > .cas-config

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -5,27 +5,23 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClangImporterCaching(TestBase):
 
-    NO_DEBUG_INFO_TESTCASE = True
-
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))
     @skipUnlessDarwin
     @swiftTest
     def test(self):
-        """
-        Test flipping on/off implicit modules.
-        """
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here",
                                           lldb.SBFileSpec('main.swift'))
         log = self.getBuildArtifact("types.log")
         self.runCmd("settings set target.swift-clang-override-options +-DADDED=1")
         self.runCmd("settings set target.swift-extra-clang-flags -- -DEXTRA=1")
-        self.expect('log enable lldb types -f "%s"' % log)
+        self.expect('log enable lldb types symbols -f "%s"' % log)
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["b ="])
         self.filecheck('platform shell cat "%s"' % log, __file__)
+#       CHECK Loading module ClangB from CAS at llvmcas://
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -triple
 ### Check include paths in the module are forwards. The first argument is the source directory.
@@ -39,5 +35,4 @@ class TestSwiftClangImporterCaching(TestBase):
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DEXTRA=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'ClangA'
 #       CHECK-NOT: -cc1
-#       CHECK-NOT: -fmodule-file-cache-key
-#       CHECK-NOT: Clang error:
+#       CHECK-NOT: Clang error

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -41,6 +41,13 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
     @skipUnlessDarwin
     def test_import(self):
         """Test an implicit import inside an explicit build"""
+        mod_cache = self.getBuildArtifact("my-clang-modules-cache")
+        if os.path.isdir(mod_cache):
+          shutil.rmtree(mod_cache)
+
+        self.runCmd('settings set symbols.clang-modules-cache-path "%s"'
+                    % mod_cache)
+
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))

--- a/lldb/test/Shell/Swift/caching.test
+++ b/lldb/test/Shell/Swift/caching.test
@@ -8,18 +8,14 @@
 # RUN:          -cache-compile-job -cas-path %t/cas -explicit-module-build \
 # RUN:          -module-name main -o %t/main
 
-# RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s
+# RUN: sed "s|DIR|%/t|g" %t/lldb.script.template > %t/lldb.script
+# RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s --check-prefix=CAS-LOAD --check-prefix=CHECK
 
-## Setup CAS and try loading from CAS
-# RUN: sed "s|DIR|%/t|g" %t/lldb.script.template > %t/lldb_2.script
-# RUN: %lldb %t/main -s %t/lldb_2.script 2>&1 | FileCheck %s --check-prefix=CAS-LOAD --check-prefix=CHECK
-
-## Check fallback to file system.
+## Check warning message
 # RUN: rm -rf %t/cas
-# RUN: %lldb %t/main -s %t/lldb_2.script 2>&1 | FileCheck %s --check-prefix=CAS-FALLBACK --check-prefix=CHECK
+# RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s --check-prefix=CAS-FALLBACK --check-prefix=CHECK
 
-# CAS-FALLBACK:  operator()() -- module '{{.*}}' cannot be load from CAS using key
-# CAS-FALLBACK-SAME: fallback to load from file system
+# CAS-FALLBACK:  cannot be loaded from CAS using key:
 # CAS-LOAD:      ConfigureCASStorage() -- Setup CAS from module list properties with cas path
 # CHECK:         LogConfiguration() --   Extra clang arguments
 # CHECK-COUNT-1: LogConfiguration() --     -triple
@@ -31,16 +27,6 @@ func test() {
   print("break here")
 }
 test()
-
-//--- lldb.script
-# Force loading from interface to simulate no binary module available.
-settings set symbols.swift-module-loading-mode prefer-interface
-log enable lldb types
-b test
-run
-# Create a SwiftASTContext
-expr 1
-quit
 
 //--- lldb.script.template
 # Force loading from interface to simulate no binary module available.

--- a/lldb/test/Shell/SymbolFile/cas-gmodule.test
+++ b/lldb/test/Shell/SymbolFile/cas-gmodule.test
@@ -8,10 +8,10 @@
 # RUN: sed "s|DIR|%/t|g" %t/cas-config.template > %t/.cas-config
 # RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s
 
-# FAIL: skip loading module 'Bottom' from CAS: CAS is not available
+# FAIL: Failed to load module 'Bottom' from CAS: no CAS available
 # FAIL: Unable to locate module needed for external types.
-# CHECK: loading module 'Bottom' using CASID
-# CHECK: loading module 'Top' using CASID
+# CHECK: Loading module 'Bottom' from CAS at
+# CHECK: Loading module 'Top' from CAS at
 # CHECK: top = (x = 1)
 
 //--- module.modulemap


### PR DESCRIPTION
This patch creates a wrapper LLDB Swft module loader that owns both an ESML (explicit Swift module loader) and a CAS explicit module loader, dispatches module discovery calls to both, and tries to find each module in the CAS first, before trying the ESML.

rdar://166576110