### PR TITLE
[lldb] Fix GetParentIfClosure for async closures inside non-async functions

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftDemangle.h
@@ -41,9 +41,10 @@ inline NodePointer GetFirstChildOfKind(NodePointer node,
 inline void ReplaceChildWith(Node &parent, Node &to_replace, Node &new_child) {
   for (unsigned idx = 0; idx < parent.getNumChildren(); idx++) {
     auto *child = parent.getChild(idx);
-    if (child == &to_replace)
+    if (child == &to_replace) {
       parent.replaceChild(idx, &new_child);
-    return;
+      return;
+    }
   }
   llvm_unreachable("invalid child passed to replaceChildWith");
 }

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -107,6 +107,18 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
+    # Async variable inspection on Linux/Windows are still problematic.
+    @skipIf(oslist=["windows", "linux"])
+    def test_task_inside_non_async_func(self):
+        self.build()
+        (target, process, thread) = self.get_to_bkpt(
+            "break_task_inside_non_async_function"
+        )
+        check_not_captured_error(
+            self, thread.frames[0], "x", "task_inside_non_async_function()"
+        )
+
+    @swiftTest
     def test_ctor_class_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_class")

--- a/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/main.swift
@@ -212,6 +212,18 @@ enum MY_ENUM {
   }
 }
 
+func async_foo() async {}
+
+func task_inside_non_async_function() -> Task<Void, Never> {
+  var x = 10;
+  var task = Task {
+    await async_foo()
+    print("break_task_inside_non_async_function")
+  }
+
+  return task
+}
+
 func_1(arg: 42)
 func_2(arg: 42)
 await func_3(arg: 42)
@@ -227,3 +239,4 @@ my_struct.struct_computed_property = 10
 my_struct.struct_computed_property_didset = 10
 let _ = MY_ENUM(input: [1,2])
 MY_ENUM.static_func(input_static: [42])
+await task_inside_non_async_function().getResult()


### PR DESCRIPTION
When computing the name of the parent function of a closure, LLDB takes the demangled parent function Node and replaces it on the top level "Global" demangle node. However, this logic was faulty in two ways:

1. A misplaced return made the "replace logic" only look at the fist child of the Global node.
2. The new Global node was inheriting _all_ children from the original Global node, which is wrong.

For example, an async closure inside a non-async function would have this demangle tree:

```
Global
    <Async Attributes>
    <Explicit Closure>
        <Parent Function>
```

By replacing the `Explicit Closure` with `Parent Function`, we were creating another async function. The solution is to just create the Global node from scratch, dropping most other nodes it may have had. This begs the question of which other nodes could be there as a sibling of the closure in the tree; given how none of the existing tests failed with this patch, it seems safe to assume any such nodes are not too important (until proven otherwise).

rdar://162788289