### PR TITLE
[clang][DependencyScanning] Check for the Existence of `CIWithContext` before Finalizing

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScanningWorker.cpp
@@ -245,8 +245,17 @@ DependencyScanningWorker::computeDependenciesByNameWithContextOrError(
 
 llvm::Error
 DependencyScanningWorker::finalizeCompilerInstanceWithContextOrError() {
-  bool Success = finalizeCompilerInstance();
-  return CIWithContext->handleReturnStatus(Success);
+  // TODO: this finalization interface is not ideal. Finalizing the
+  // CIWithContext should happen automatically for successful scans, and
+  // when errors occur.
+  if (CIWithContext) {
+    bool Success = finalizeCompilerInstance();
+    return CIWithContext->handleReturnStatus(Success);
+  }
+
+  // There is nothing to finalize, so the finalization should not report an
+  // error.
+  return llvm::Error::success();
 }
 
 bool DependencyScanningWorker::initializeCompilerInstanceWithContext(
@@ -265,5 +274,6 @@ bool DependencyScanningWorker::computeDependenciesByNameWithContext(
 }
 
 bool DependencyScanningWorker::finalizeCompilerInstance() {
+  assert(CIWithContext && "Should not finalize without a CIWithContext");
   return CIWithContext->finalize();
 }


### PR DESCRIPTION
The by-name lookup APIs are intended for Swift. https://github.com/swiftlang/swift/pull/85555 teaches Swift to use it. The original intention was to invoke the `finalization` API explicitly. https://github.com/swiftlang/swift/pull/85555 folds the finalization step into the module dependency scanner's destructor. This leads to a case where if an initialization error occurs, the `CIWithContext` may not be setup for some workers, and calling the finalization API is incorrect. 

This PR checks against the existence of the `CIWithContext` and then performs the finalization. 