### PR TITLE
[lldb][test] Update test to match the error in Sema

### DIFF
--- a/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -39,4 +39,4 @@ class TestClosureShortcuts(TestBase):
         )
         self.expect("expr tinky.map({$0 * 2})", substrs=["[0] = 4", "[1] = 8"])
         self.expect("expr [2,4].map({$0 * 2})", substrs=["[0] = 4", "[1] = 8"])
-        self.expect("expr $0", substrs=["cannot find '$0' in scope"], error=True)
+        self.expect("expr $0", substrs=["anonymous closure argument not contained in a closure"], error=True)


### PR DESCRIPTION
The anonymous closure argument was moved from Parser to Sema in https://github.com/swiftlang/swift/pull/86163. Update LLDB test accordingly.