### PR TITLE
[lldb][android] Cherry-pick fixes from branch "next"

### DIFF
--- a/lldb/source/Plugins/Platform/Android/AdbClient.h
+++ b/lldb/source/Plugins/Platform/Android/AdbClient.h
@@ -10,6 +10,7 @@
 #define LLDB_SOURCE_PLUGINS_PLATFORM_ANDROID_ADBCLIENT_H
 
 #include "lldb/Utility/Status.h"
+#include "llvm/Support/Error.h"
 #include <chrono>
 #include <functional>
 #include <list>
@@ -32,59 +33,21 @@ public:
 
   using DeviceIDList = std::list<std::string>;
 
-  class SyncService {
-    friend class AdbClient;
-
-  public:
-    virtual ~SyncService();
-
-    virtual Status PullFile(const FileSpec &remote_file,
-                            const FileSpec &local_file);
-
-    Status PushFile(const FileSpec &local_file, const FileSpec &remote_file);
-
-    virtual Status Stat(const FileSpec &remote_file, uint32_t &mode,
-                        uint32_t &size, uint32_t &mtime);
-
-    bool IsConnected() const;
-
-  protected:
-    explicit SyncService(std::unique_ptr<Connection> &&conn);
-
-  private:
-    Status SendSyncRequest(const char *request_id, const uint32_t data_len,
-                           const void *data);
-
-    Status ReadSyncHeader(std::string &response_id, uint32_t &data_len);
-
-    Status PullFileChunk(std::vector<char> &buffer, bool &eof);
-
-    Status ReadAllBytes(void *buffer, size_t size);
-
-    Status internalPullFile(const FileSpec &remote_file,
-                            const FileSpec &local_file);
-
-    Status internalPushFile(const FileSpec &local_file,
-                            const FileSpec &remote_file);
-
-    Status internalStat(const FileSpec &remote_file, uint32_t &mode,
-                        uint32_t &size, uint32_t &mtime);
-
-    Status executeCommand(const std::function<Status()> &cmd);
-
-    std::unique_ptr<Connection> m_conn;
-  };
-
-  static Status CreateByDeviceID(const std::string &device_id, AdbClient &adb);
+  /// Resolves a device identifier to its canonical form.
+  ///
+  /// \param device_id the device identifier to resolve (may be empty).
+  ///
+  /// \returns Expected<std::string> containing the resolved device ID on
+  ///          success, or an Error if the device ID cannot be resolved or
+  ///          is ambiguous.
+  static llvm::Expected<std::string> ResolveDeviceID(llvm::StringRef device_id);
 
   AdbClient();
-  explicit AdbClient(const std::string &device_id);
+  explicit AdbClient(llvm::StringRef device_id);
 
   virtual ~AdbClient();
 
-  const std::string &GetDeviceID() const;
-
-  Status GetDevices(DeviceIDList &device_list);
+  llvm::StringRef GetDeviceID() const;
 
   Status SetPortForwarding(const uint16_t local_port,
                            const uint16_t remote_port);
@@ -102,39 +65,50 @@ public:
                              std::chrono::milliseconds timeout,
                              const FileSpec &output_file_spec);
 
-  virtual std::unique_ptr<SyncService> GetSyncService(Status &error);
-
-  Status SwitchDeviceTransport();
-
-private:
   Status Connect();
 
-  void SetDeviceID(const std::string &device_id);
-
-  Status SendMessage(const std::string &packet, const bool reconnect = true);
-
-  Status SendDeviceMessage(const std::string &packet);
-
-  Status ReadMessage(std::vector<char> &message);
+private:
+  Status SendDeviceMessage(llvm::StringRef packet);
 
   Status ReadMessageStream(std::vector<char> &message,
                            std::chrono::milliseconds timeout);
 
-  Status GetResponseError(const char *response_id);
-
-  Status ReadResponseStatus();
-
-  Status Sync();
-
-  Status StartSync();
-
   Status internalShell(const char *command, std::chrono::milliseconds timeout,
                        std::vector<char> &output_buf);
 
-  Status ReadAllBytes(void *buffer, size_t size);
-
   std::string m_device_id;
   std::unique_ptr<Connection> m_conn;
+};
+
+class AdbSyncService {
+public:
+  explicit AdbSyncService(const std::string device_id);
+  virtual ~AdbSyncService();
+  Status SetupSyncConnection();
+
+  virtual Status PullFile(const FileSpec &remote_file,
+                          const FileSpec &local_file);
+  virtual Status PushFile(const FileSpec &local_file,
+                          const FileSpec &remote_file);
+  virtual Status Stat(const FileSpec &remote_file, uint32_t &mode,
+                      uint32_t &size, uint32_t &mtime);
+  virtual bool IsConnected() const;
+
+  llvm::StringRef GetDeviceId() const { return m_device_id; }
+
+private:
+  Status SendSyncRequest(const char *request_id, const uint32_t data_len,
+                         const void *data);
+  Status ReadSyncHeader(std::string &response_id, uint32_t &data_len);
+  Status PullFileChunk(std::vector<char> &buffer, bool &eof);
+  Status PullFileImpl(const FileSpec &remote_file, const FileSpec &local_file);
+  Status PushFileImpl(const FileSpec &local_file, const FileSpec &remote_file);
+  Status StatImpl(const FileSpec &remote_file, uint32_t &mode, uint32_t &size,
+                  uint32_t &mtime);
+  Status ExecuteCommand(const std::function<Status()> &cmd);
+
+  std::unique_ptr<Connection> m_conn;
+  std::string m_device_id;
 };
 
 } // namespace platform_android

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -477,6 +477,249 @@ std::string PlatformAndroid::GetRunAs() {
   }
   return run_as.str();
 }
+
+// Helper function to populate process status information from
+// /proc/[pid]/status
+void PlatformAndroid::PopulateProcessStatusInfo(
+    lldb::pid_t pid, ProcessInstanceInfo &process_info) {
+  // Read /proc/[pid]/status to get parent PID, UIDs, and GIDs
+  Status error;
+  AdbClientUP status_adb = GetAdbClient(error);
+  if (error.Fail())
+    return;
+
+  std::string status_output;
+  StreamString status_cmd;
+  status_cmd.Printf(
+      "cat /proc/%llu/status 2>/dev/null | grep -E '^(PPid|Uid|Gid):'",
+      static_cast<unsigned long long>(pid));
+  Status status_error =
+      status_adb->Shell(status_cmd.GetData(), seconds(5), &status_output);
+
+  if (status_error.Fail() || status_output.empty())
+    return;
+
+  llvm::SmallVector<llvm::StringRef, 16> lines;
+  llvm::StringRef(status_output).split(lines, '\n');
+
+  for (llvm::StringRef line : lines) {
+    line = line.trim();
+    if (line.starts_with("PPid:")) {
+      llvm::StringRef ppid_str = line.substr(5).trim();
+      lldb::pid_t ppid;
+      if (llvm::to_integer(ppid_str, ppid))
+        process_info.SetParentProcessID(ppid);
+    } else if (line.starts_with("Uid:")) {
+      llvm::SmallVector<llvm::StringRef, 4> uid_parts;
+      line.substr(4).trim().split(uid_parts, '\t', -1, false);
+      if (uid_parts.size() >= 2) {
+        uint32_t uid, euid;
+        if (llvm::to_integer(uid_parts[0].trim(), uid))
+          process_info.SetUserID(uid);
+        if (llvm::to_integer(uid_parts[1].trim(), euid))
+          process_info.SetEffectiveUserID(euid);
+      }
+    } else if (line.starts_with("Gid:")) {
+      llvm::SmallVector<llvm::StringRef, 4> gid_parts;
+      line.substr(4).trim().split(gid_parts, '\t', -1, false);
+      if (gid_parts.size() >= 2) {
+        uint32_t gid, egid;
+        if (llvm::to_integer(gid_parts[0].trim(), gid))
+          process_info.SetGroupID(gid);
+        if (llvm::to_integer(gid_parts[1].trim(), egid))
+          process_info.SetEffectiveGroupID(egid);
+      }
+    }
+  }
+}
+
+// Helper function to populate command line arguments from /proc/[pid]/cmdline
+void PlatformAndroid::PopulateProcessCommandLine(
+    lldb::pid_t pid, ProcessInstanceInfo &process_info) {
+  // Read /proc/[pid]/cmdline to get command line arguments
+  Status error;
+  AdbClientUP cmdline_adb = GetAdbClient(error);
+  if (error.Fail())
+    return;
+
+  std::string cmdline_output;
+  StreamString cmdline_cmd;
+  cmdline_cmd.Printf("cat /proc/%llu/cmdline 2>/dev/null | tr '\\000' ' '",
+                     static_cast<unsigned long long>(pid));
+  Status cmdline_error =
+      cmdline_adb->Shell(cmdline_cmd.GetData(), seconds(5), &cmdline_output);
+
+  if (cmdline_error.Fail() || cmdline_output.empty())
+    return;
+
+  cmdline_output = llvm::StringRef(cmdline_output).trim().str();
+  if (cmdline_output.empty())
+    return;
+
+  llvm::SmallVector<llvm::StringRef, 16> args;
+  llvm::StringRef(cmdline_output).split(args, ' ', -1, false);
+  if (args.empty())
+    return;
+
+  process_info.SetArg0(args[0]);
+  Args process_args;
+  for (size_t i = 1; i < args.size(); i++) {
+    if (!args[i].empty())
+      process_args.AppendArgument(args[i]);
+  }
+  process_info.SetArguments(process_args, false);
+}
+
+// Helper function to populate architecture from /proc/[pid]/exe
+void PlatformAndroid::PopulateProcessArchitecture(
+    lldb::pid_t pid, ProcessInstanceInfo &process_info) {
+  // Read /proc/[pid]/exe to get executable path for architecture detection
+  Status error;
+  AdbClientUP exe_adb = GetAdbClient(error);
+  if (error.Fail())
+    return;
+
+  std::string exe_output;
+  StreamString exe_cmd;
+  exe_cmd.Printf("readlink /proc/%llu/exe 2>/dev/null",
+                 static_cast<unsigned long long>(pid));
+  Status exe_error = exe_adb->Shell(exe_cmd.GetData(), seconds(5), &exe_output);
+
+  if (exe_error.Fail() || exe_output.empty())
+    return;
+
+  exe_output = llvm::StringRef(exe_output).trim().str();
+
+  // Determine architecture from exe path
+  ArchSpec arch;
+  if (exe_output.find("64") != std::string::npos ||
+      exe_output.find("arm64") != std::string::npos ||
+      exe_output.find("aarch64") != std::string::npos) {
+    arch.SetTriple("aarch64-unknown-linux-android");
+  } else if (exe_output.find("x86_64") != std::string::npos) {
+    arch.SetTriple("x86_64-unknown-linux-android");
+  } else if (exe_output.find("x86") != std::string::npos ||
+             exe_output.find("i686") != std::string::npos) {
+    arch.SetTriple("i686-unknown-linux-android");
+  } else {
+    // Default to armv7 for 32-bit ARM (most common on Android)
+    arch.SetTriple("armv7-unknown-linux-android");
+  }
+
+  if (arch.IsValid())
+    process_info.SetArchitecture(arch);
+}
+
+uint32_t
+PlatformAndroid::FindProcesses(const ProcessInstanceInfoMatch &match_info,
+                               ProcessInstanceInfoList &proc_infos) {
+  proc_infos.clear();
+
+  // When LLDB is running natively on an Android device (IsHost() == true),
+  // use the parent class's standard Linux /proc enumeration. IsHost() is only
+  // true when compiled for Android (#if defined(__ANDROID__)), so calling
+  // PlatformLinux methods is safe (Android is Linux-based).
+  if (IsHost())
+    return PlatformLinux::FindProcesses(match_info, proc_infos);
+
+  // Remote Android platform: implement process name lookup using 'pidof' over
+  // adb.
+
+  // LLDB stores the search name in GetExecutableFile() (even though it's
+  // actually a process name like "com.android.chrome" rather than an
+  // executable path). If no search name is provided, we can't use
+  // 'pidof', so return early with no results.
+  const ProcessInstanceInfo &match_process_info = match_info.GetProcessInfo();
+  if (!match_process_info.GetExecutableFile() ||
+      match_info.GetNameMatchType() == NameMatch::Ignore) {
+    return 0;
+  }
+
+  // Extract the process name to search for (typically an Android package name
+  // like "com.example.app" or binary name like "app_process64")
+  std::string process_name = match_process_info.GetExecutableFile().GetPath();
+  if (process_name.empty())
+    return 0;
+
+  // Use adb to find the process by name
+  Status error;
+  AdbClientUP adb(GetAdbClient(error));
+  if (error.Fail()) {
+    Log *log = GetLog(LLDBLog::Platform);
+    LLDB_LOGF(log, "PlatformAndroid::%s failed to get ADB client: %s",
+              __FUNCTION__, error.AsCString());
+    return 0;
+  }
+
+  // Use 'pidof' command to get PIDs for the process name.
+  // Quote the process name to handle special characters (spaces, etc.)
+  std::string pidof_output;
+  StreamString command;
+  command.Printf("pidof '%s'", process_name.c_str());
+  error = adb->Shell(command.GetData(), seconds(5), &pidof_output);
+
+  if (error.Fail()) {
+    Log *log = GetLog(LLDBLog::Platform);
+    LLDB_LOG(log, "PlatformAndroid::{} 'pidof {}' failed: {}", __FUNCTION__,
+             process_name.c_str(), error.AsCString());
+    return 0;
+  }
+
+  // Parse PIDs from pidof output.
+  // Note: pidof can return multiple PIDs (space-separated) if multiple
+  // instances of the same executable are running.
+  pidof_output = llvm::StringRef(pidof_output).trim().str();
+  if (pidof_output.empty()) {
+    Log *log = GetLog(LLDBLog::Platform);
+    LLDB_LOGF(log, "PlatformAndroid::%s no process found with name '%s'",
+              __FUNCTION__, process_name.c_str());
+    return 0;
+  }
+
+  // Split the output by whitespace to handle multiple PIDs
+  llvm::SmallVector<llvm::StringRef, 8> pid_strings;
+  llvm::StringRef(pidof_output).split(pid_strings, ' ', -1, false);
+
+  Log *log = GetLog(LLDBLog::Platform);
+
+  // Process each PID and gather information
+  uint32_t num_matches = 0;
+  for (llvm::StringRef pid_str : pid_strings) {
+    pid_str = pid_str.trim();
+    if (pid_str.empty())
+      continue;
+
+    lldb::pid_t pid;
+    if (!llvm::to_integer(pid_str, pid)) {
+      LLDB_LOGF(log, "PlatformAndroid::%s failed to parse PID from: '%s'",
+                __FUNCTION__, pid_str.str().c_str());
+      continue;
+    }
+
+    ProcessInstanceInfo process_info;
+    process_info.SetProcessID(pid);
+    process_info.GetExecutableFile().SetFile(process_name,
+                                             FileSpec::Style::posix);
+
+    // Populate additional process information
+    PopulateProcessStatusInfo(pid, process_info);
+    PopulateProcessCommandLine(pid, process_info);
+    PopulateProcessArchitecture(pid, process_info);
+
+    // Check if this process matches the criteria
+    if (match_info.Matches(process_info)) {
+      proc_infos.push_back(process_info);
+      num_matches++;
+
+      LLDB_LOGF(log, "PlatformAndroid::%s found process '%s' with PID %llu",
+                __FUNCTION__, process_name.c_str(),
+                static_cast<unsigned long long>(pid));
+    }
+  }
+
+  return num_matches;
+}
+
 std::unique_ptr<AdbSyncService> PlatformAndroid::GetSyncService(Status &error) {
   auto sync_service = std::make_unique<AdbSyncService>(m_device_id);
   error = sync_service->SetupSyncConnection();

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.cpp
@@ -9,6 +9,7 @@
 #include "lldb/Core/Module.h"
 #include "lldb/Core/PluginManager.h"
 #include "lldb/Core/Section.h"
+#include "lldb/Host/HostInfo.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/UriParser.h"

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.h
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.h
@@ -59,6 +59,9 @@ public:
 
   uint32_t GetDefaultMemoryCacheLineSize() override;
 
+  uint32_t FindProcesses(const ProcessInstanceInfoMatch &match_info,
+                         ProcessInstanceInfoList &proc_infos) override;
+
 protected:
   const char *GetCacheHostname() override;
 
@@ -86,6 +89,14 @@ protected:
 private:
   std::string m_device_id;
   uint32_t m_sdk_version;
+
+  // Helper functions for process information gathering
+  void PopulateProcessStatusInfo(lldb::pid_t pid,
+                                 ProcessInstanceInfo &process_info);
+  void PopulateProcessCommandLine(lldb::pid_t pid,
+                                  ProcessInstanceInfo &process_info);
+  void PopulateProcessArchitecture(lldb::pid_t pid,
+                                   ProcessInstanceInfo &process_info);
 };
 
 } // namespace platform_android

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.h
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.h
@@ -75,14 +75,15 @@ protected:
   typedef std::unique_ptr<AdbClient> AdbClientUP;
   virtual AdbClientUP GetAdbClient(Status &error);
 
-  virtual llvm::StringRef GetPropertyPackageName();
-
   std::string GetRunAs();
 
-private:
-  AdbClient::SyncService *GetSyncService(Status &error);
+public:
+  virtual llvm::StringRef GetPropertyPackageName();
 
-  std::unique_ptr<AdbClient::SyncService> m_adb_sync_svc;
+protected:
+  virtual std::unique_ptr<AdbSyncService> GetSyncService(Status &error);
+
+private:
   std::string m_device_id;
   uint32_t m_sdk_version;
 };

--- a/lldb/source/Plugins/Platform/Android/PlatformAndroid.h
+++ b/lldb/source/Plugins/Platform/Android/PlatformAndroid.h
@@ -60,7 +60,7 @@ public:
   uint32_t GetDefaultMemoryCacheLineSize() override;
 
   uint32_t FindProcesses(const ProcessInstanceInfoMatch &match_info,
-                         ProcessInstanceInfoList &proc_infos) override;
+                         ProcessInstanceInfoList &process_infos) override;
 
 protected:
   const char *GetCacheHostname() override;
@@ -86,17 +86,8 @@ public:
 protected:
   virtual std::unique_ptr<AdbSyncService> GetSyncService(Status &error);
 
-private:
   std::string m_device_id;
   uint32_t m_sdk_version;
-
-  // Helper functions for process information gathering
-  void PopulateProcessStatusInfo(lldb::pid_t pid,
-                                 ProcessInstanceInfo &process_info);
-  void PopulateProcessCommandLine(lldb::pid_t pid,
-                                  ProcessInstanceInfo &process_info);
-  void PopulateProcessArchitecture(lldb::pid_t pid,
-                                   ProcessInstanceInfo &process_info);
 };
 
 } // namespace platform_android

--- a/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
+++ b/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
@@ -65,6 +65,7 @@ class TestPlatformProcessLaunchGDBServer(TestBase):
 
     @skipIfRemote
     @skipIfDarwin  # Uses debugserver for debugging
+    @skipIfWindows
     @add_test_categories(["lldb-server"])
     def test_launch_with_unusual_process_name(self):
         """

--- a/lldb/unittests/Platform/Android/AdbClientTest.cpp
+++ b/lldb/unittests/Platform/Android/AdbClientTest.cpp
@@ -6,8 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
 #include "Plugins/Platform/Android/AdbClient.h"
+#include "lldb/Host/Socket.h"
+#include "lldb/Host/common/TCPSocket.h"
+#include "gtest/gtest.h"
+#include <chrono>
 #include <cstdlib>
 
 static void set_env(const char *var, const char *value) {
@@ -20,32 +23,117 @@ static void set_env(const char *var, const char *value) {
 
 using namespace lldb;
 using namespace lldb_private;
-
-namespace lldb_private {
-namespace platform_android {
+using namespace lldb_private::platform_android;
 
 class AdbClientTest : public ::testing::Test {
 public:
-  void SetUp() override { set_env("ANDROID_SERIAL", ""); }
+  void SetUp() override {
+    set_env("ANDROID_SERIAL", "");
+    set_env("ANDROID_ADB_SERVER_PORT", "");
+  }
 
-  void TearDown() override { set_env("ANDROID_SERIAL", ""); }
+  void TearDown() override {
+    set_env("ANDROID_SERIAL", "");
+    set_env("ANDROID_ADB_SERVER_PORT", "");
+  }
 };
 
-TEST(AdbClientTest, CreateByDeviceId) {
-  AdbClient adb;
-  Status error = AdbClient::CreateByDeviceID("device1", adb);
-  EXPECT_TRUE(error.Success());
-  EXPECT_EQ("device1", adb.GetDeviceID());
+TEST_F(AdbClientTest, ResolveDeviceId_ExplicitDeviceId) {
+  auto result = AdbClient::ResolveDeviceID("device1");
+  EXPECT_TRUE(static_cast<bool>(result));
+  EXPECT_EQ("device1", *result);
 }
 
-TEST(AdbClientTest, CreateByDeviceId_ByEnvVar) {
+TEST_F(AdbClientTest, ResolveDeviceId_ByEnvVar) {
   set_env("ANDROID_SERIAL", "device2");
 
-  AdbClient adb;
-  Status error = AdbClient::CreateByDeviceID("", adb);
-  EXPECT_TRUE(error.Success());
-  EXPECT_EQ("device2", adb.GetDeviceID());
+  auto result = AdbClient::ResolveDeviceID("");
+  EXPECT_TRUE(static_cast<bool>(result));
+  EXPECT_EQ("device2", *result);
 }
 
-} // end namespace platform_android
-} // end namespace lldb_private
+TEST_F(AdbClientTest, ResolveDeviceId_PrefersExplicitOverEnvVar) {
+  set_env("ANDROID_SERIAL", "env_device");
+
+  // Explicit device ID should take precedence over environment variable
+  auto result = AdbClient::ResolveDeviceID("explicit_device");
+  EXPECT_TRUE(static_cast<bool>(result));
+  EXPECT_EQ("explicit_device", *result);
+}
+
+TEST_F(AdbClientTest, AdbClient_Constructor_StoresDeviceId) {
+  AdbClient client("test_device_123");
+  EXPECT_EQ(client.GetDeviceID(), "test_device_123");
+}
+
+TEST_F(AdbClientTest, AdbClient_DefaultConstructor) {
+  AdbClient client;
+  EXPECT_EQ(client.GetDeviceID(), "");
+}
+
+TEST_F(AdbClientTest, AdbSyncService_Constructor_StoresDeviceId) {
+  AdbSyncService sync("device123");
+  EXPECT_EQ(sync.GetDeviceId(), "device123");
+}
+
+TEST_F(AdbClientTest, AdbSyncService_OperationsFailWhenNotConnected) {
+  AdbSyncService sync_service("test_device");
+
+  // Verify service is not connected initially
+  EXPECT_FALSE(sync_service.IsConnected());
+
+  // File operations should fail when not connected
+  FileSpec remote_file("/data/test.txt");
+  FileSpec local_file("/tmp/test.txt");
+  uint32_t mode, size, mtime;
+
+  Status stat_result = sync_service.Stat(remote_file, mode, size, mtime);
+  EXPECT_TRUE(stat_result.Fail());
+
+  Status pull_result = sync_service.PullFile(remote_file, local_file);
+  EXPECT_TRUE(pull_result.Fail());
+
+  Status push_result = sync_service.PushFile(local_file, remote_file);
+  EXPECT_TRUE(push_result.Fail());
+}
+
+static uint16_t FindUnusedPort() {
+  auto temp_socket = std::make_unique<TCPSocket>(true);
+  Status error = temp_socket->Listen("localhost:0", 1);
+  if (error.Fail()) {
+    return 0; // fallback
+  }
+  uint16_t port = temp_socket->GetLocalPortNumber();
+  temp_socket.reset(); // Close the socket to free the port
+  return port;
+}
+
+TEST_F(AdbClientTest, RealTcpConnection) {
+  uint16_t unused_port = FindUnusedPort();
+  ASSERT_NE(unused_port, 0) << "Failed to find an unused port";
+
+  std::string port_str = std::to_string(unused_port);
+  set_env("ANDROID_ADB_SERVER_PORT", port_str.c_str());
+
+  AdbClient client;
+  const auto status1 = client.Connect();
+  EXPECT_FALSE(status1.Success())
+      << "Connection should fail when no server is listening on port "
+      << unused_port;
+
+  // now start a server on the port and try again
+  auto listen_socket = std::make_unique<TCPSocket>(true);
+  std::string listen_address = "localhost:" + port_str;
+  Status error = listen_socket->Listen(listen_address.c_str(), 5);
+  ASSERT_TRUE(error.Success()) << "Failed to create listening socket on port "
+                               << unused_port << ": " << error.AsCString();
+
+  // Verify the socket is listening on the expected port
+  ASSERT_EQ(listen_socket->GetLocalPortNumber(), unused_port)
+      << "Socket is not listening on the expected port";
+
+  const auto status2 = client.Connect();
+  EXPECT_TRUE(status2.Success())
+      << "Connection should succeed when server is listening on port "
+      << unused_port;
+}

--- a/lldb/unittests/Platform/Android/AdbClientTest.cpp
+++ b/lldb/unittests/Platform/Android/AdbClientTest.cpp
@@ -108,6 +108,9 @@ static uint16_t FindUnusedPort() {
   return port;
 }
 
+#ifndef _WIN32
+// This test is disabled on Windows due to platform-specific socket behavior
+// that causes assertion failures in TCPSocket::Listen()
 TEST_F(AdbClientTest, RealTcpConnection) {
   uint16_t unused_port = FindUnusedPort();
   ASSERT_NE(unused_port, 0) << "Failed to find an unused port";
@@ -137,3 +140,4 @@ TEST_F(AdbClientTest, RealTcpConnection) {
       << "Connection should succeed when server is listening on port "
       << unused_port;
 }
+#endif // _WIN32

--- a/lldb/unittests/Platform/Android/PlatformAndroidTest.cpp
+++ b/lldb/unittests/Platform/Android/PlatformAndroidTest.cpp
@@ -8,8 +8,6 @@
 
 #include "Plugins/Platform/Android/PlatformAndroid.h"
 #include "Plugins/Platform/Android/PlatformAndroidRemoteGDBServer.h"
-#include "TestingSupport/SubsystemRAII.h"
-#include "TestingSupport/TestUtilities.h"
 #include "lldb/Utility/Connection.h"
 #include "gmock/gmock.h"
 
@@ -20,212 +18,281 @@ using namespace testing;
 
 namespace {
 
-class MockSyncService : public AdbClient::SyncService {
-public:
-  MockSyncService() : SyncService(std::unique_ptr<Connection>()) {}
-
-  MOCK_METHOD2(PullFile,
-               Status(const FileSpec &remote_file, const FileSpec &local_file));
-  MOCK_METHOD4(Stat, Status(const FileSpec &remote_file, uint32_t &mode,
-                            uint32_t &size, uint32_t &mtime));
-};
-
-typedef std::unique_ptr<AdbClient::SyncService> SyncServiceUP;
-
 class MockAdbClient : public AdbClient {
 public:
-  explicit MockAdbClient() : AdbClient("mock") {}
+  explicit MockAdbClient() : AdbClient() {}
 
   MOCK_METHOD3(ShellToFile,
                Status(const char *command, std::chrono::milliseconds timeout,
                       const FileSpec &output_file_spec));
-  MOCK_METHOD1(GetSyncService, SyncServiceUP(Status &error));
 };
 
 class PlatformAndroidTest : public PlatformAndroid, public ::testing::Test {
 public:
   PlatformAndroidTest() : PlatformAndroid(false) {
     m_remote_platform_sp = PlatformSP(new PlatformAndroidRemoteGDBServer());
+
+    // Set up default mock behavior to avoid uninteresting call warnings
+    ON_CALL(*this, GetSyncService(_))
+        .WillByDefault([](Status &error) -> std::unique_ptr<AdbSyncService> {
+          error = Status::FromErrorString("Sync service unavailable");
+          return nullptr;
+        });
   }
 
   MOCK_METHOD1(GetAdbClient, AdbClientUP(Status &error));
   MOCK_METHOD0(GetPropertyPackageName, llvm::StringRef());
+  MOCK_METHOD1(GetSyncService, std::unique_ptr<AdbSyncService>(Status &error));
+
+  // Make GetSyncService public for testing
+  using PlatformAndroid::GetSyncService;
 };
 
 } // namespace
 
-TEST_F(PlatformAndroidTest, DownloadModuleSliceWithAdbClientError) {
+TEST_F(PlatformAndroidTest,
+       DownloadModuleSlice_AdbClientError_FailsGracefully) {
   EXPECT_CALL(*this, GetAdbClient(_))
-      .Times(1)
       .WillOnce(DoAll(WithArg<0>([](auto &arg) {
                         arg = Status::FromErrorString(
                             "Failed to create AdbClient");
                       }),
                       Return(ByMove(AdbClientUP()))));
 
-  EXPECT_TRUE(
-      DownloadModuleSlice(
-          FileSpec("/system/app/Test/Test.apk!/lib/arm64-v8a/libtest.so"), 4096,
-          3600, FileSpec())
-          .Fail());
+  Status result = DownloadModuleSlice(
+      FileSpec("/system/app/Test/Test.apk!/lib/arm64-v8a/libtest.so"), 4096,
+      3600, FileSpec("/tmp/libtest.so"));
+
+  EXPECT_TRUE(result.Fail());
+  EXPECT_THAT(result.AsCString(), HasSubstr("Failed to create AdbClient"));
 }
 
-TEST_F(PlatformAndroidTest, DownloadModuleSliceWithNormalFile) {
-  auto sync_service = new MockSyncService();
-  EXPECT_CALL(*sync_service, Stat(FileSpec("/system/lib64/libc.so"), _, _, _))
-      .Times(1)
-      .WillOnce(DoAll(SetArgReferee<1>(1), Return(Status())));
-  EXPECT_CALL(*sync_service, PullFile(FileSpec("/system/lib64/libc.so"), _))
-      .Times(1)
-      .WillOnce(Return(Status()));
-
-  auto adb_client = new MockAdbClient();
-  EXPECT_CALL(*adb_client, GetSyncService(_))
-      .Times(1)
-      .WillOnce(Return(ByMove(SyncServiceUP(sync_service))));
-
-  EXPECT_CALL(*this, GetAdbClient(_))
-      .Times(1)
-      .WillOnce(Return(ByMove(AdbClientUP(adb_client))));
-
-  EXPECT_TRUE(
-      DownloadModuleSlice(FileSpec("/system/lib64/libc.so"), 0, 0, FileSpec())
-          .Success());
-}
-
-TEST_F(PlatformAndroidTest, DownloadModuleSliceWithZipFile) {
-  auto adb_client = new MockAdbClient();
+TEST_F(PlatformAndroidTest, DownloadModuleSlice_ZipFile_UsesCorrectDdCommand) {
+  auto *adb_client = new MockAdbClient();
   EXPECT_CALL(*adb_client,
               ShellToFile(StrEq("dd if='/system/app/Test/Test.apk' "
                                 "iflag=skip_bytes,count_bytes "
                                 "skip=4096 count=3600 status=none"),
                           _, _))
-      .Times(1)
       .WillOnce(Return(Status()));
 
+  EXPECT_CALL(*this, GetPropertyPackageName())
+      .WillOnce(Return(llvm::StringRef("")));
+
   EXPECT_CALL(*this, GetAdbClient(_))
-      .Times(1)
       .WillOnce(Return(ByMove(AdbClientUP(adb_client))));
 
-  EXPECT_TRUE(
-      DownloadModuleSlice(
-          FileSpec("/system/app/Test/Test.apk!/lib/arm64-v8a/libtest.so"), 4096,
-          3600, FileSpec())
-          .Success());
+  Status result = DownloadModuleSlice(
+      FileSpec("/system/app/Test/Test.apk!/lib/arm64-v8a/libtest.so"), 4096,
+      3600, FileSpec("/tmp/libtest.so"));
+
+  EXPECT_TRUE(result.Success());
 }
 
-TEST_F(PlatformAndroidTest, DownloadModuleSliceWithZipFileAndRunAs) {
-  auto adb_client = new MockAdbClient();
+TEST_F(PlatformAndroidTest,
+       DownloadModuleSlice_ZipFileWithRunAs_UsesRunAsCommand) {
+  auto *adb_client = new MockAdbClient();
   EXPECT_CALL(*adb_client,
               ShellToFile(StrEq("run-as 'com.example.test' "
                                 "dd if='/system/app/Test/Test.apk' "
                                 "iflag=skip_bytes,count_bytes "
                                 "skip=4096 count=3600 status=none"),
                           _, _))
-      .Times(1)
       .WillOnce(Return(Status()));
 
   EXPECT_CALL(*this, GetPropertyPackageName())
-      .Times(1)
       .WillOnce(Return(llvm::StringRef("com.example.test")));
 
   EXPECT_CALL(*this, GetAdbClient(_))
-      .Times(1)
       .WillOnce(Return(ByMove(AdbClientUP(adb_client))));
 
-  EXPECT_TRUE(
-      DownloadModuleSlice(
-          FileSpec("/system/app/Test/Test.apk!/lib/arm64-v8a/libtest.so"), 4096,
-          3600, FileSpec())
-          .Success());
+  Status result = DownloadModuleSlice(
+      FileSpec("/system/app/Test/Test.apk!/lib/arm64-v8a/libtest.so"), 4096,
+      3600, FileSpec("/tmp/libtest.so"));
+
+  EXPECT_TRUE(result.Success());
 }
 
-TEST_F(PlatformAndroidTest, GetFileWithNormalFile) {
-  auto sync_service = new MockSyncService();
-  EXPECT_CALL(*sync_service, Stat(FileSpec("/data/local/tmp/test"), _, _, _))
-      .Times(1)
-      .WillOnce(DoAll(SetArgReferee<1>(1), Return(Status())));
-  EXPECT_CALL(*sync_service, PullFile(FileSpec("/data/local/tmp/test"), _))
-      .Times(1)
-      .WillOnce(Return(Status()));
+TEST_F(PlatformAndroidTest,
+       DownloadModuleSlice_LargeFile_CalculatesParametersCorrectly) {
+  const uint64_t large_offset = 100 * 1024 * 1024; // 100MB offset
+  const uint64_t large_size = 50 * 1024 * 1024;    // 50MB size
 
-  auto adb_client = new MockAdbClient();
-  EXPECT_CALL(*adb_client, GetSyncService(_))
-      .Times(1)
-      .WillOnce(Return(ByMove(SyncServiceUP(sync_service))));
-
-  EXPECT_CALL(*this, GetAdbClient(_))
-      .Times(1)
-      .WillOnce(Return(ByMove(AdbClientUP(adb_client))));
-
-  EXPECT_TRUE(GetFile(FileSpec("/data/local/tmp/test"), FileSpec()).Success());
-}
-
-TEST_F(PlatformAndroidTest, GetFileWithCatFallback) {
-  auto sync_service = new MockSyncService();
-  EXPECT_CALL(
-      *sync_service,
-      Stat(FileSpec("/data/data/com.example.app/lib-main/libtest.so"), _, _, _))
-      .Times(1)
-      .WillOnce(DoAll(SetArgReferee<1>(0), Return(Status())));
-
-  auto adb_client0 = new MockAdbClient();
-  EXPECT_CALL(*adb_client0, GetSyncService(_))
-      .Times(1)
-      .WillOnce(Return(ByMove(SyncServiceUP(sync_service))));
-
-  auto adb_client1 = new MockAdbClient();
-  EXPECT_CALL(
-      *adb_client1,
-      ShellToFile(StrEq("cat '/data/data/com.example.app/lib-main/libtest.so'"),
-                  _, _))
-      .Times(1)
-      .WillOnce(Return(Status()));
-
-  EXPECT_CALL(*this, GetAdbClient(_))
-      .Times(2)
-      .WillOnce(Return(ByMove(AdbClientUP(adb_client0))))
-      .WillOnce(Return(ByMove(AdbClientUP(adb_client1))));
-
-  EXPECT_TRUE(
-      GetFile(FileSpec("/data/data/com.example.app/lib-main/libtest.so"),
-              FileSpec())
-          .Success());
-}
-
-TEST_F(PlatformAndroidTest, GetFileWithCatFallbackAndRunAs) {
-  auto sync_service = new MockSyncService();
-  EXPECT_CALL(
-      *sync_service,
-      Stat(FileSpec("/data/data/com.example.app/lib-main/libtest.so"), _, _, _))
-      .Times(1)
-      .WillOnce(DoAll(SetArgReferee<1>(0), Return(Status())));
-
-  auto adb_client0 = new MockAdbClient();
-  EXPECT_CALL(*adb_client0, GetSyncService(_))
-      .Times(1)
-      .WillOnce(Return(ByMove(SyncServiceUP(sync_service))));
-
-  auto adb_client1 = new MockAdbClient();
-  EXPECT_CALL(
-      *adb_client1,
-      ShellToFile(StrEq("run-as 'com.example.app' "
-                        "cat '/data/data/com.example.app/lib-main/libtest.so'"),
-                  _, _))
-      .Times(1)
+  auto *adb_client = new MockAdbClient();
+  EXPECT_CALL(*adb_client,
+              ShellToFile(StrEq("dd if='/system/app/Large.apk' "
+                                "iflag=skip_bytes,count_bytes "
+                                "skip=104857600 count=52428800 status=none"),
+                          _, _))
       .WillOnce(Return(Status()));
 
   EXPECT_CALL(*this, GetPropertyPackageName())
-      .Times(1)
+      .WillOnce(Return(llvm::StringRef("")));
+
+  EXPECT_CALL(*this, GetAdbClient(_))
+      .WillOnce(Return(ByMove(AdbClientUP(adb_client))));
+
+  Status result = DownloadModuleSlice(
+      FileSpec("/system/app/Large.apk!/lib/arm64-v8a/large.so"), large_offset,
+      large_size, FileSpec("/tmp/large.so"));
+
+  EXPECT_TRUE(result.Success());
+}
+
+TEST_F(PlatformAndroidTest,
+       GetFile_SyncServiceUnavailable_FallsBackToShellCat) {
+  auto *adb_client = new MockAdbClient();
+  EXPECT_CALL(*adb_client,
+              ShellToFile(StrEq("cat '/data/local/tmp/test'"), _, _))
+      .WillOnce(Return(Status()));
+
+  EXPECT_CALL(*this, GetPropertyPackageName())
+      .WillOnce(Return(llvm::StringRef("")));
+
+  EXPECT_CALL(*this, GetAdbClient(_))
+      .WillOnce(DoAll(WithArg<0>([](auto &arg) { arg.Clear(); }),
+                      Return(ByMove(AdbClientUP(adb_client)))));
+
+  EXPECT_CALL(*this, GetSyncService(_))
+      .WillOnce([](Status &error) -> std::unique_ptr<AdbSyncService> {
+        error = Status::FromErrorString("Sync service unavailable");
+        return nullptr;
+      });
+
+  Status result =
+      GetFile(FileSpec("/data/local/tmp/test"), FileSpec("/tmp/test"));
+  EXPECT_TRUE(result.Success());
+}
+
+TEST_F(PlatformAndroidTest, GetFile_WithRunAs_UsesRunAsInShellCommand) {
+  auto *adb_client = new MockAdbClient();
+  EXPECT_CALL(
+      *adb_client,
+      ShellToFile(StrEq("run-as 'com.example.app' "
+                        "cat '/data/data/com.example.app/lib-main/libtest.so'"),
+                  _, _))
+      .WillOnce(Return(Status()));
+
+  EXPECT_CALL(*this, GetPropertyPackageName())
       .WillOnce(Return(llvm::StringRef("com.example.app")));
 
   EXPECT_CALL(*this, GetAdbClient(_))
-      .Times(2)
-      .WillOnce(Return(ByMove(AdbClientUP(adb_client0))))
-      .WillOnce(Return(ByMove(AdbClientUP(adb_client1))));
+      .WillOnce(DoAll(WithArg<0>([](auto &arg) { arg.Clear(); }),
+                      Return(ByMove(AdbClientUP(adb_client)))));
 
-  EXPECT_TRUE(
+  EXPECT_CALL(*this, GetSyncService(_))
+      .WillOnce([](Status &error) -> std::unique_ptr<AdbSyncService> {
+        error = Status::FromErrorString("Sync service unavailable");
+        return nullptr;
+      });
+
+  Status result =
       GetFile(FileSpec("/data/data/com.example.app/lib-main/libtest.so"),
-              FileSpec())
-          .Success());
+              FileSpec("/tmp/libtest.so"));
+  EXPECT_TRUE(result.Success());
+}
+
+TEST_F(PlatformAndroidTest, GetFile_FilenameWithSingleQuotes_Rejected) {
+  EXPECT_CALL(*this, GetSyncService(_))
+      .WillOnce([](Status &error) -> std::unique_ptr<AdbSyncService> {
+        error = Status::FromErrorString("Sync service unavailable");
+        return nullptr;
+      });
+
+  Status result =
+      GetFile(FileSpec("/test/file'with'quotes"), FileSpec("/tmp/output"));
+
+  EXPECT_TRUE(result.Fail());
+  EXPECT_THAT(result.AsCString(), HasSubstr("single-quotes"));
+}
+
+TEST_F(PlatformAndroidTest,
+       DownloadModuleSlice_FilenameWithSingleQuotes_Rejected) {
+  Status result = DownloadModuleSlice(FileSpec("/test/file'with'quotes"), 100,
+                                      200, FileSpec("/tmp/output"));
+
+  EXPECT_TRUE(result.Fail());
+  EXPECT_THAT(result.AsCString(), HasSubstr("single-quotes"));
+}
+
+TEST_F(PlatformAndroidTest, GetFile_NetworkTimeout_PropagatesErrorCorrectly) {
+  auto *adb_client = new MockAdbClient();
+  EXPECT_CALL(*adb_client, ShellToFile(_, _, _))
+      .WillOnce(Return(Status::FromErrorString("Network timeout")));
+
+  EXPECT_CALL(*this, GetPropertyPackageName())
+      .WillOnce(Return(llvm::StringRef("")));
+
+  EXPECT_CALL(*this, GetAdbClient(_))
+      .WillOnce(DoAll(WithArg<0>([](auto &arg) { arg.Clear(); }),
+                      Return(ByMove(AdbClientUP(adb_client)))));
+
+  EXPECT_CALL(*this, GetSyncService(_))
+      .WillOnce([](Status &error) -> std::unique_ptr<AdbSyncService> {
+        error = Status::FromErrorString("Sync service unavailable");
+        return nullptr;
+      });
+
+  Status result =
+      GetFile(FileSpec("/data/large/file.so"), FileSpec("/tmp/large.so"));
+  EXPECT_TRUE(result.Fail());
+  EXPECT_THAT(result.AsCString(), HasSubstr("Network timeout"));
+}
+
+TEST_F(PlatformAndroidTest, SyncService_ConnectionFailsGracefully) {
+  // Constructor should succeed even with a failing connection
+  AdbSyncService sync_service("test-device");
+
+  // The service should report as not connected initially
+  EXPECT_FALSE(sync_service.IsConnected());
+  EXPECT_EQ(sync_service.GetDeviceId(), "test-device");
+
+  // Operations should fail gracefully when connection setup fails
+  FileSpec remote_file("/data/test.txt");
+  FileSpec local_file("/tmp/test.txt");
+  uint32_t mode, size, mtime;
+
+  Status result = sync_service.Stat(remote_file, mode, size, mtime);
+  EXPECT_TRUE(result.Fail());
+}
+
+TEST_F(PlatformAndroidTest, GetRunAs_FormatsPackageNameCorrectly) {
+  // Empty package name
+  EXPECT_CALL(*this, GetPropertyPackageName())
+      .WillOnce(Return(llvm::StringRef("")));
+  EXPECT_EQ(this->GetRunAs(), "");
+
+  // Valid package name
+  EXPECT_CALL(*this, GetPropertyPackageName())
+      .WillOnce(Return(llvm::StringRef("com.example.test")));
+  EXPECT_EQ(this->GetRunAs(), "run-as 'com.example.test' ");
+}
+
+TEST_F(PlatformAndroidTest,
+       DownloadModuleSlice_ZeroOffset_CallsGetFileInsteadOfDd) {
+  // When offset=0, DownloadModuleSlice calls GetFile which uses 'cat', not 'dd'
+  // We need to ensure the sync service fails so GetFile falls back to shell cat
+  auto *adb_client = new MockAdbClient();
+  EXPECT_CALL(*adb_client,
+              ShellToFile(StrEq("cat '/system/lib64/libc.so'"), _, _))
+      .WillOnce(Return(Status()));
+
+  EXPECT_CALL(*this, GetPropertyPackageName())
+      .WillOnce(Return(llvm::StringRef("")));
+
+  EXPECT_CALL(*this, GetAdbClient(_))
+      .WillOnce(DoAll(WithArg<0>([](auto &arg) { arg.Clear(); }),
+                      Return(ByMove(AdbClientUP(adb_client)))));
+
+  // Mock GetSyncService to fail, forcing GetFile to use shell cat fallback
+  EXPECT_CALL(*this, GetSyncService(_))
+      .WillOnce(DoAll(WithArg<0>([](auto &arg) {
+                        arg =
+                            Status::FromErrorString("Sync service unavailable");
+                      }),
+                      Return(ByMove(std::unique_ptr<AdbSyncService>()))));
+
+  Status result = DownloadModuleSlice(FileSpec("/system/lib64/libc.so"), 0, 0,
+                                      FileSpec("/tmp/libc.so"));
+  EXPECT_TRUE(result.Success());
 }


### PR DESCRIPTION
- **Explanation**: In order to allow Swift debugging on Android, we need to cherry-pick a few fixes made on the llvm project, on Android platform support in lldb. This PR only contains code already on branch `next`.
- **Scope**: Changes only affect modules related to Android. They have no impact on any other platform.
- **Issues**: These fixes are related to #10831 and concern:
  - concurrent requests to pull modules from the android device via ADB
  - ability to attach to a process by name on Android
- **Original PRs**: Each cherry-picked commit has a link to the original commit (I used git cherry-pick -x). 
- **Risk**: Being changes already merged in the llvm main branch and concerning Android only, the risk is very low.
- **Testing**: Honestly, I don't know if something is in place on llvm side, where these changes come from.
- **Reviewers**: I don't know who should be.
