### PR TITLE
[lldb][swift] Fix default search paths for modules

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1922,8 +1922,8 @@ void SwiftASTContext::AddExtraClangCC1Args(
     const std::vector<std::pair<std::string, bool>> framework_search_paths,
     std::vector<std::string> &dest) {
   clang::CompilerInvocation invocation;
-  std::vector<std::string> default_paths = {"/usr/include",
-                                            "/user/local/include"};
+  std::vector<std::string> default_paths = {
+      "/usr/include", "/usr/local/include", "/usr/lib/swift/shims"};
   llvm::SmallVector<const char *> clangArgs;
   clangArgs.reserve(source.size() + module_search_paths.size() * 2 +
                     framework_search_paths.size() * 2 +
@@ -1978,6 +1978,11 @@ void SwiftASTContext::AddExtraClangCC1Args(
   invocation.getHeaderSearchOpts().ImplicitModuleMaps = true;
   invocation.getHeaderSearchOpts().ModuleCachePath =
       GetCompilerInvocation().getClangModuleCachePath().str();
+
+  // Since explicit module build, do not check relocated modules and update
+  // module base directories. Clang modules loaded from swift are loaded
+  // by name and there is no need to update and validate module maps.
+  invocation.getPreprocessorOpts().ModulesCheckRelocated = false;
 
   bool use_cas_module = m_cas && m_action_cache;
   if (use_cas_module) {


### PR DESCRIPTION
Fix a typo in the default module search path which are added to help implicit import when using explicit module build. Also added a default path that usually can find Darwin swift shim modules.

Note when turning on implicit clang module in swift requires disable relocatable PCM checks since the search path for implicit modules can pick up an incompatible module map that defines a module with the same name that was built explicitly. Make sure we don't apply base directory relocation for explicitly loaded modules.