### PR TITLE
[lldb][android] Fix management of Android specific pointer tagging in LLDB

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -72,6 +72,7 @@ MaskMaybeBridgedPointer(Process &process, lldb::addr_t addr,
                         lldb::addr_t *masked_bits = nullptr) {
   const ArchSpec &arch_spec(process.GetTarget().GetArchitecture());
   const llvm::Triple &triple = arch_spec.GetTriple();
+  bool is_android = triple.isAndroid();
   bool is_arm = false;
   bool is_intel = false;
   bool is_s390x = false;
@@ -100,7 +101,9 @@ MaskMaybeBridgedPointer(Process &process, lldb::addr_t addr,
 
   lldb::addr_t mask = 0;
 
-  if (is_arm && is_64)
+  if (is_arm && is_64 && is_android)
+    mask = SWIFT_ABI_ANDROID_ARM64_SWIFT_SPARE_BITS_MASK;
+  else if (is_arm && is_64)
     mask = SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK;
   else if (is_arm && is_32)
     mask = SWIFT_ABI_ARM_SWIFT_SPARE_BITS_MASK;
@@ -3423,6 +3426,8 @@ SwiftLanguageRuntime::FixupPointerValue(lldb::addr_t addr, CompilerType type) {
   llvm::Triple triple = target.GetArchitecture().GetTriple();
   switch (triple.getArch()) {
   case llvm::Triple::ArchType::aarch64:
+    if (triple.isAndroid())
+      return {addr & ~SWIFT_ABI_ANDROID_ARM64_SWIFT_SPARE_BITS_MASK, false};
     return {addr & ~SWIFT_ABI_ARM64_SWIFT_SPARE_BITS_MASK, false};
   case llvm::Triple::ArchType::arm:
     return {addr & ~SWIFT_ABI_ARM_SWIFT_SPARE_BITS_MASK, false};


### PR DESCRIPTION
- **Explanation**:
Swift uses pointer tagging. On Android, the OS uses pointer tagging as well and Swift cannot use the same bits as on other platforms. On Swift stdlib, there are Android specific implementations for everything related to pointer tagging, mainly in Strings and Arrays. However, LLDB is not aware of these platform specific things and, when debugging Android apps, is not able to handle these types correctly. This PR addresses this gap.

- **Scope**:
These changes only affect debugging on Android. Swift debugging on Android is in an early stage and this is one of the fundamental things to be fixed.

- **Issues**:
LLDB, when used to debug Android APKs, is not able to display Short Strings and Array items. 

- **Original PRs**:
This is part on an effort to get lldb working for debugging Swift on Android: #10831

- **Risk**:
Changes are small and gated behind `if android`–type conditions.

- **Testing**:
I don’t know if there are automated tests for lldb when used for remote debugging an Android apps

- **Reviewers**:
No sure who should be
