### PR TITLE
🍒 [APINotes] Avoid duplicate attributes when fields instantiate class templates

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -21041,7 +21041,8 @@ void Sema::ActOnFields(Scope *S, SourceLocation RecLoc, Decl *EnclosingDecl,
       CDecl->setIvarRBraceLoc(RBrac);
     }
   }
-  ProcessAPINotes(Record);
+  if (Record && !isa<ClassTemplateSpecializationDecl>(Record))
+    ProcessAPINotes(Record);
 }
 
 // Given an integral type, return the next larger integral type

--- a/clang/test/APINotes/Inputs/Headers/Templates.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/Templates.apinotes
@@ -3,3 +3,5 @@ Name: Templates
 Tags:
 - Name: Box
   SwiftImportAs: owned
+- Name: MoveOnly
+  SwiftCopyable: false

--- a/clang/test/APINotes/Inputs/Headers/Templates.h
+++ b/clang/test/APINotes/Inputs/Headers/Templates.h
@@ -8,3 +8,18 @@ struct Box {
 
 using FloatBox = Box<float>;
 using IntBox = Box<int>;
+
+template <typename T>
+struct MoveOnly {
+  T value;
+};
+
+template <>
+struct MoveOnly<float> {
+  double value;
+};
+
+struct MoveOnlyBox {
+  MoveOnly<int> value1;
+  MoveOnly<float> value2;
+};

--- a/clang/test/APINotes/templates.cpp
+++ b/clang/test/APINotes/templates.cpp
@@ -1,6 +1,7 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Tmpl -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -x c++
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Tmpl -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter Box -x c++ | FileCheck -check-prefix=CHECK-BOX %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Tmpl -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter MoveOnly -x c++ | FileCheck -check-prefix=CHECK-MOVEONLY %s
 
 #include "Templates.h"
 
@@ -10,3 +11,24 @@
 
 // Make sure the attributes aren't duplicated.
 // CHECK-BOX-NOT: SwiftAttrAttr {{.+}} <<invalid sloc>> "import_owned"
+
+// CHECK-MOVEONLY: Dumping MoveOnly:
+// CHECK-MOVEONLY-NEXT: ClassTemplateDecl {{.+}} imported in Templates MoveOnly
+// CHECK-MOVEONLY: SwiftAttrAttr {{.+}} <<invalid sloc>> "~Copyable"
+
+// Make sure the attributes aren't duplicated.
+// CHECK-MOVEONLY-NOT: SwiftAttrAttr {{.+}} <<invalid sloc>> "~Copyable"
+
+// CHECK-MOVEONLY: ClassTemplateSpecializationDecl {{.+}} imported in Templates {{.+}} MoveOnly
+// CHECK-MOVEONLY: TemplateArgument type 'int'
+// CHECK-MOVEONLY: SwiftAttrAttr {{.+}} <<invalid sloc>> "~Copyable"
+
+// Make sure the attributes aren't duplicated.
+// CHECK-MOVEONLY-NOT: SwiftAttrAttr {{.+}} <<invalid sloc>> "~Copyable"
+
+// CHECK-MOVEONLY: ClassTemplateSpecializationDecl {{.+}} imported in Templates {{.+}} MoveOnly
+// CHECK-MOVEONLY: TemplateArgument type 'float'
+// CHECK-MOVEONLY: SwiftAttrAttr {{.+}} <<invalid sloc>> "~Copyable"
+
+// Make sure the attributes aren't duplicated.
+// CHECK-MOVEONLY-NOT: SwiftAttrAttr {{.+}} <<invalid sloc>> "~Copyable"


### PR DESCRIPTION
If a C++ class template `A` is annotated via API Notes and another class `B` has a field of type `A`, we would apply the attributes from the API Notes twice. This happened during `ActOnFields`, so this change makes sure we stop processing API Notes for class template instantiations in this function.

rdar://166179307
(cherry-picked from 1ab98893f73f5389a9dae50e5634d1d4b6ea851a)