### PR TITLE
[stable/21.x][clang][driver][darwin] Base the platform prefix on the SDK, not the target

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -11,11 +11,15 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/TargetParser/Triple.h"
 #include <optional>
+#include <string>
 
 namespace llvm {
 namespace json {
@@ -28,6 +32,39 @@ namespace clang {
 /// The information about the darwin SDK that was used during this compilation.
 class DarwinSDKInfo {
 public:
+  /// Information about the supported platforms, derived from the target triple
+  /// definitions, in the SDK.
+  struct SDKPlatformInfo {
+  public:
+    SDKPlatformInfo(llvm::Triple::VendorType Vendor, llvm::Triple::OSType OS,
+                    llvm::Triple::EnvironmentType Environment,
+                    llvm::Triple::ObjectFormatType ObjectFormat,
+                    StringRef PlatformPrefix)
+        : Vendor(Vendor), OS(OS), Environment(Environment),
+          ObjectFormat(ObjectFormat), PlatformPrefix(PlatformPrefix) {}
+
+    llvm::Triple::VendorType getVendor() const { return Vendor; }
+    llvm::Triple::OSType getOS() const { return OS; }
+    llvm::Triple::EnvironmentType getEnvironment() const { return Environment; }
+    llvm::Triple::ObjectFormatType getObjectFormat() const {
+      return ObjectFormat;
+    }
+    StringRef getPlatformPrefix() const { return PlatformPrefix; }
+
+    bool operator==(const llvm::Triple &RHS) const {
+      return (Vendor == RHS.getVendor()) && (OS == RHS.getOS()) &&
+             (Environment == RHS.getEnvironment()) &&
+             (ObjectFormat == RHS.getObjectFormat());
+    }
+
+  private:
+    llvm::Triple::VendorType Vendor;
+    llvm::Triple::OSType OS;
+    llvm::Triple::EnvironmentType Environment;
+    llvm::Triple::ObjectFormatType ObjectFormat;
+    std::string PlatformPrefix;
+  };
+
   /// A value that describes two os-environment pairs that can be used as a key
   /// to the version map in the SDK.
   struct OSEnvPair {
@@ -141,20 +178,32 @@ public:
     llvm::DenseMap<VersionTuple, VersionTuple> Mapping;
   };
 
+  using PlatformInfoStorageType = SmallVector<SDKPlatformInfo, 2>;
+
   DarwinSDKInfo(
       VersionTuple Version, VersionTuple MaximumDeploymentTarget,
-      llvm::Triple::OSType OS,
+      PlatformInfoStorageType PlatformInfos,
       llvm::DenseMap<OSEnvPair::StorageType,
                      std::optional<RelatedTargetVersionMapping>>
           VersionMappings =
               llvm::DenseMap<OSEnvPair::StorageType,
                              std::optional<RelatedTargetVersionMapping>>())
       : Version(Version), MaximumDeploymentTarget(MaximumDeploymentTarget),
-        OS(OS), VersionMappings(std::move(VersionMappings)) {}
+        PlatformInfos(std::move(PlatformInfos)),
+        VersionMappings(std::move(VersionMappings)) {}
 
   const llvm::VersionTuple &getVersion() const { return Version; }
 
-  const llvm::Triple::OSType &getOS() const { return OS; }
+  const SDKPlatformInfo &getCanonicalPlatformInfo() const {
+    return PlatformInfos[0];
+  }
+
+  const StringRef getPlatformPrefix(llvm::Triple Triple) const {
+    auto PlatformInfoIt = llvm::find(PlatformInfos, Triple);
+    if (PlatformInfoIt == PlatformInfos.end())
+      return StringRef();
+    return PlatformInfoIt->getPlatformPrefix();
+  }
 
   // Returns the optional, target-specific version mapping that maps from one
   // target to another target.
@@ -180,7 +229,7 @@ public:
 private:
   VersionTuple Version;
   VersionTuple MaximumDeploymentTarget;
-  llvm::Triple::OSType OS;
+  PlatformInfoStorageType PlatformInfos;
   // Need to wrap the value in an optional here as the value has to be default
   // constructible, and std::unique_ptr doesn't like DarwinSDKInfo being
   // Optional as Optional is trying to copy it in emplace.

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -63,26 +63,105 @@ DarwinSDKInfo::RelatedTargetVersionMapping::parseJSON(
       Min, Max, MinValue, MaximumDeploymentTarget, std::move(Mapping));
 }
 
-static llvm::Triple::OSType parseOS(const llvm::json::Object &Obj) {
+static DarwinSDKInfo::PlatformInfoStorageType
+parsePlatformInfos(const llvm::json::Object &Obj, VersionTuple Version) {
   // The CanonicalName is the Xcode platform followed by a version, e.g.
-  // macosx16.0.
-  auto CanonicalName = Obj.getString("CanonicalName");
-  if (!CanonicalName)
-    return llvm::Triple::UnknownOS;
-  size_t VersionStart = CanonicalName->find_first_of("0123456789");
-  StringRef XcodePlatform = CanonicalName->slice(0, VersionStart);
-  return llvm::StringSwitch<llvm::Triple::OSType>(XcodePlatform)
-      .Case("macosx", llvm::Triple::MacOSX)
-      .Case("iphoneos", llvm::Triple::IOS)
-      .Case("iphonesimulator", llvm::Triple::IOS)
-      .Case("appletvos", llvm::Triple::TvOS)
-      .Case("appletvsimulator", llvm::Triple::TvOS)
-      .Case("watchos", llvm::Triple::WatchOS)
-      .Case("watchsimulator", llvm::Triple::WatchOS)
-      .Case("xros", llvm::Triple::XROS)
-      .Case("xrsimulator", llvm::Triple::XROS)
-      .Case("driverkit", llvm::Triple::DriverKit)
-      .Default(llvm::Triple::UnknownOS);
+  // macosx15.0. The associated SDKPlatformInfo must be the first entry  in the
+  // returned PlatformInfoStorageType.
+  StringRef XcodePlatform;
+  if (auto CanonicalName = Obj.getString("CanonicalName")) {
+    size_t VersionStart = CanonicalName->find_first_of("0123456789");
+    XcodePlatform = CanonicalName->slice(0, VersionStart);
+  }
+
+  DarwinSDKInfo::PlatformInfoStorageType PlatformInfos;
+  auto SupportedTargets = Obj.getObject("SupportedTargets");
+  if (!SupportedTargets) {
+    // For older SDKs that don't have SupportedTargets, infer one from the Xcode
+    // platform.
+    if (XcodePlatform == "macosx") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::MacOSX,
+                               llvm::Triple::UnknownEnvironment,
+                               llvm::Triple::MachO, ""});
+    } else if (XcodePlatform == "iphoneos") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::IOS,
+                               llvm::Triple::UnknownEnvironment,
+                               llvm::Triple::MachO, ""});
+    } else if (XcodePlatform == "iphonesimulator") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::IOS,
+                               llvm::Triple::Simulator, llvm::Triple::MachO,
+                               ""});
+    } else if (XcodePlatform == "appletvos") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::TvOS,
+                               llvm::Triple::UnknownEnvironment,
+                               llvm::Triple::MachO, ""});
+    } else if (XcodePlatform == "appletvsimulator") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::TvOS,
+                               llvm::Triple::Simulator, llvm::Triple::MachO,
+                               ""});
+    } else if (XcodePlatform == "watchos") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::WatchOS,
+                               llvm::Triple::UnknownEnvironment,
+                               llvm::Triple::MachO, ""});
+    } else if (XcodePlatform == "watchsimulator") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::WatchOS,
+                               llvm::Triple::Simulator, llvm::Triple::MachO,
+                               ""});
+    } else if (XcodePlatform == "driverkit") {
+      PlatformInfos.push_back({llvm::Triple::Apple, llvm::Triple::DriverKit,
+                               llvm::Triple::UnknownEnvironment,
+                               llvm::Triple::MachO, "/System/DriverKit"});
+    } else {
+      llvm::reportFatalUsageError(
+          "Unrecognized CanonicalName in SDKSettings.json. SupportedTargets is "
+          "expected, or a recognized CanonicalName.");
+    }
+    return PlatformInfos;
+  }
+
+  for (auto SupportedTargetPair : *SupportedTargets) {
+    llvm::json::Object *SupportedTarget =
+        SupportedTargetPair.getSecond().getAsObject();
+    auto Vendor = SupportedTarget->getString("LLVMTargetTripleVendor");
+    auto OS = SupportedTarget->getString("LLVMTargetTripleSys");
+    if (!Vendor || !OS)
+      continue;
+
+    StringRef Arch = llvm::Triple::getArchName(llvm::Triple::UnknownArch);
+    auto Environment =
+        SupportedTarget->getString("LLVMTargetTripleEnvironment");
+    llvm::Triple Triple;
+    if (Environment)
+      Triple = llvm::Triple(Arch, *Vendor, *OS, *Environment);
+    else
+      Triple = llvm::Triple(Arch, *Vendor, *OS);
+
+    StringRef PlatformOrVariant = SupportedTargetPair.getFirst();
+
+    StringRef EffectivePlatformPrefix;
+    // Ignore iosmac value if it exists.
+    if ((PlatformOrVariant != "iosmac") || (Version >= VersionTuple(99))) {
+      auto PlatformPrefix = SupportedTarget->getString("SystemPrefix");
+      if (PlatformPrefix) {
+        EffectivePlatformPrefix = *PlatformPrefix;
+      } else {
+        // Older SDKs don't have SystemPrefix in SupportedTargets, manually add
+        // their prefixes.
+        if ((Triple.getOS() == llvm::Triple::DriverKit) &&
+            (Version < VersionTuple(22, 1)))
+          EffectivePlatformPrefix = "/System/DriverKit";
+      }
+    }
+
+    DarwinSDKInfo::SDKPlatformInfo PlatformInfo(
+        Triple.getVendor(), Triple.getOS(), Triple.getEnvironment(),
+        Triple.getObjectFormat(), EffectivePlatformPrefix);
+    if (PlatformOrVariant == XcodePlatform)
+      PlatformInfos.insert(PlatformInfos.begin(), PlatformInfo);
+    else
+      PlatformInfos.push_back(PlatformInfo);
+  }
+  return PlatformInfos;
 }
 
 static std::optional<VersionTuple> getVersionKey(const llvm::json::Object &Obj,
@@ -105,7 +184,7 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(const llvm::json::Object *Obj) {
       getVersionKey(*Obj, "MaximumDeploymentTarget");
   if (!MaximumDeploymentVersion)
     return std::nullopt;
-  llvm::Triple::OSType OS = parseOS(*Obj);
+  PlatformInfoStorageType PlatformInfos = parsePlatformInfos(*Obj, *Version);
   llvm::DenseMap<OSEnvPair::StorageType,
                  std::optional<RelatedTargetVersionMapping>>
       VersionMappings;
@@ -148,8 +227,8 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(const llvm::json::Object *Obj) {
   }
 
   return DarwinSDKInfo(std::move(*Version),
-                       std::move(*MaximumDeploymentVersion), OS,
-                       std::move(VersionMappings));
+                       std::move(*MaximumDeploymentVersion),
+                       std::move(PlatformInfos), std::move(VersionMappings));
 }
 
 Expected<std::optional<DarwinSDKInfo>>

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -664,8 +664,6 @@ void VirtualEnvironment::set(
   Environment->push_back(nullptr);
 }
 
-static void AppendPlatformPrefix(SmallString<128> &Path, const llvm::Triple &T);
-
 void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                   const InputInfo &Output,
                                   const InputInfoList &Inputs,
@@ -899,13 +897,15 @@ void darwin::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       NonStandardSearchPath =
           Version.getMajor() < 605 ||
           (Version.getMajor() == 605 && Version.getMinor().value_or(0) < 1);
+    } else {
+      NonStandardSearchPath = getMachOToolChain().HasPlatformPrefix(Triple);
     }
 
     if (NonStandardSearchPath) {
       if (auto *Sysroot = Args.getLastArg(options::OPT_isysroot)) {
         auto AddSearchPath = [&](StringRef Flag, StringRef SearchPath) {
           SmallString<128> P(Sysroot->getValue());
-          AppendPlatformPrefix(P, Triple);
+          getMachOToolChain().AppendPlatformPrefix(P, Triple);
           llvm::sys::path::append(P, SearchPath);
           if (getToolChain().getVFS().exists(P)) {
             CmdArgs.push_back(Args.MakeArgString(Flag + P));
@@ -2051,10 +2051,15 @@ struct DarwinPlatform {
   /// the platform from the SDKPath.
   DarwinSDKInfo inferSDKInfo() {
     assert(Kind == InferredFromSDK && "can infer SDK info only");
-    return DarwinSDKInfo(getOSVersion(),
-                         /*MaximumDeploymentTarget=*/
-                         VersionTuple(getOSVersion().getMajor(), 0, 99),
-                         getOSFromPlatform(Platform));
+    llvm::Triple::OSType OS = getOSFromPlatform(Platform);
+    StringRef PlatformPrefix =
+        (Platform == DarwinPlatformKind::DriverKit) ? "/System/DriverKit" : "";
+    return DarwinSDKInfo(
+        getOSVersion(), /*MaximumDeploymentTarget=*/
+        VersionTuple(getOSVersion().getMajor(), 0, 99),
+        {DarwinSDKInfo::SDKPlatformInfo(llvm::Triple::Apple, OS,
+                                        llvm::Triple::UnknownEnvironment,
+                                        llvm::Triple::MachO, PlatformPrefix)});
   }
 
 private:
@@ -2744,12 +2749,25 @@ void Darwin::AddDeploymentTarget(DerivedArgList &Args) const {
   }
 }
 
+bool DarwinClang::HasPlatformPrefix(const llvm::Triple &T) const {
+  if (SDKInfo)
+    return !SDKInfo->getPlatformPrefix(T).empty();
+  else
+    return Darwin::HasPlatformPrefix(T);
+}
+
 // For certain platforms/environments almost all resources (e.g., headers) are
 // located in sub-directories, e.g., for DriverKit they live in
 // <SYSROOT>/System/DriverKit/usr/include (instead of <SYSROOT>/usr/include).
-static void AppendPlatformPrefix(SmallString<128> &Path,
-                                 const llvm::Triple &T) {
-  if (T.isDriverKit()) {
+void DarwinClang::AppendPlatformPrefix(SmallString<128> &Path,
+                                       const llvm::Triple &T) const {
+  if (SDKInfo) {
+    const StringRef PlatformPrefix = SDKInfo->getPlatformPrefix(T);
+    if (!PlatformPrefix.empty())
+      llvm::sys::path::append(Path, PlatformPrefix);
+  } else if (T.isDriverKit()) {
+    // The first version of DriverKit didn't have SDKSettings.json, manually add
+    // its prefix.
     llvm::sys::path::append(Path, "System", "DriverKit");
   }
 }
@@ -3258,8 +3276,22 @@ sdkSupportsBuiltinModules(const std::optional<DarwinSDKInfo> &SDKInfo) {
     // the old behavior which is to not use builtin modules.
     return false;
 
+  DarwinSDKInfo::SDKPlatformInfo PlatformInfo =
+      SDKInfo->getCanonicalPlatformInfo();
+  switch (PlatformInfo.getEnvironment()) {
+  case llvm::Triple::UnknownEnvironment:
+  case llvm::Triple::Simulator:
+  case llvm::Triple::MacABI:
+    // Standard xnu/Mach/Darwin based environments depend on the SDK version.
+    break;
+
+  default:
+    // All other environments support builtin modules from the start.
+    return true;
+  }
+
   VersionTuple SDKVersion = SDKInfo->getVersion();
-  switch (SDKInfo->getOS()) {
+  switch (PlatformInfo.getOS()) {
   // Existing SDKs added support for builtin modules in the fall
   // 2024 major releases.
   case llvm::Triple::MacOSX:

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -197,6 +197,11 @@ public:
                                       llvm::opt::ArgStringList &CmdArgs) const {
   }
 
+  virtual bool HasPlatformPrefix(const llvm::Triple &T) const { return false; }
+
+  virtual void AppendPlatformPrefix(SmallString<128> &Path,
+                                    const llvm::Triple &T) const {}
+
   /// On some iOS platforms, kernel and kernel modules were built statically. Is
   /// this such a target?
   virtual bool isKernelStatic() const { return false; }
@@ -669,6 +674,11 @@ public:
 
   void AddLinkARCArgs(const llvm::opt::ArgList &Args,
                       llvm::opt::ArgStringList &CmdArgs) const override;
+
+  bool HasPlatformPrefix(const llvm::Triple &T) const override;
+
+  void AppendPlatformPrefix(SmallString<128> &Path,
+                            const llvm::Triple &T) const override;
 
   unsigned GetDefaultDwarfVersion() const override;
   // Until dtrace (via CTF) and LLDB can deal with distributed debug info,

--- a/clang/test/CAS/Inputs/MacOSX11.0.sdk/SDKSettings.json
+++ b/clang/test/CAS/Inputs/MacOSX11.0.sdk/SDKSettings.json
@@ -1,8 +1,24 @@
 {
   "DefaultVariant": "macos", "DisplayName": "macOS 11",
   "Version": "11.0",
+  "CanonicalName": "macosx11.0",
   "MaximumDeploymentTarget": "11.0.99",
-  "PropertyConditionFallbackNames": [], "VersionMap": {
+  "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "macosx",
+      "LLVMTargetTripleEnvironment": ""
+    },
+    "iosmac": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "ios",
+      "LLVMTargetTripleEnvironment": "macabi"
+    }
+  },
+  "VersionMap": {
     "iOSMac_macOS": {
       "13.2": "10.15.1",
       "13.4": "10.15.4",

--- a/clang/test/ClangScanDeps/modules-availability-check.c
+++ b/clang/test/ClangScanDeps/modules-availability-check.c
@@ -26,8 +26,22 @@
 //--- MacOSX11.0.sdk/SDKSettings.json
 {
   "DefaultVariant": "macos", "DisplayName": "macOS 11",
-  "Version": "11.0",
-  "MaximumDeploymentTarget": "11.0.99"
+  "CanonicalName": "macosx11.0", "Version": "11.0",
+  "MaximumDeploymentTarget": "11.0.99",
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "macosx",
+      "LLVMTargetTripleEnvironment": ""
+    },
+    "iosmac": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "ios",
+      "LLVMTargetTripleEnvironment": "macabi"
+    }
+  }
 }
 
 //--- module.modulemap

--- a/clang/test/ClangScanDeps/modules-include-tree-sdk-settings.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-sdk-settings.c
@@ -10,7 +10,22 @@
 //--- sdk/SDKSettings.json
 {
   "Version": "11.0",
-  "MaximumDeploymentTarget": "11.0.99"
+  "CanonicalName": "macosx11.0", 
+  "MaximumDeploymentTarget": "11.0.99",
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "macosx",
+      "LLVMTargetTripleEnvironment": ""
+    },
+    "iosmac": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "ios",
+      "LLVMTargetTripleEnvironment": "macabi"
+    }
+  }
 }
 
 //--- module.modulemap

--- a/clang/test/Driver/Inputs/DriverKit21.0.1.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/DriverKit21.0.1.sdk/SDKSettings.json
@@ -1,0 +1,4 @@
+{"Version": "21.0.1", "CanonicalName": "driverkit21.0.1", "MaximumDeploymentTarget": "21.0.1.99",
+ "SupportedTargets": {
+   "driverkit": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "driverkit", "LLVMTargetTripleEnvironment": ""}
+}}

--- a/clang/test/Driver/Inputs/DriverKit23.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/DriverKit23.0.sdk/SDKSettings.json
@@ -1,1 +1,4 @@
-{"Version":"23.0", "CanonicalName": "driverkit23.0", "MaximumDeploymentTarget": "23.0.99"}
+{"Version":"23.0", "CanonicalName": "driverkit23.0", "MaximumDeploymentTarget": "23.0.99",
+ "SupportedTargets": {
+   "driverkit": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "driverkit", "LLVMTargetTripleEnvironment": "", "SystemPrefix": "\/System\/DriverKit"}
+}}

--- a/clang/test/Driver/Inputs/MacOSX10.14.versioned.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX10.14.versioned.sdk/SDKSettings.json
@@ -1,5 +1,7 @@
 {
   "Version":"10.14",
+  "CanonicalName": "macosx10.14",
+  "MaximumDeploymentTarget": "10.14.99",
   "VersionMap" : {
       "macOS_iOSMac" : {
           "10.14.4" : "12.4",

--- a/clang/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX10.15.versioned.sdk/SDKSettings.json
@@ -2,6 +2,20 @@
   "Version":"10.15",
   "CanonicalName": "macosx10.15",
   "MaximumDeploymentTarget": "10.15.99",
+  "SupportedTargets": {
+      "macosx": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "macosx",
+          "LLVMTargetTripleEnvironment": ""
+      },
+      "iosmac": {
+          "Archs": ["x86_64"],
+          "LLVMTargetTripleVendor": "apple",
+          "LLVMTargetTripleSys": "ios",
+          "LLVMTargetTripleEnvironment": "macabi"
+      }
+  },
   "VersionMap" : {
       "macOS_iOSMac" : {
           "10.15" : "13.1",

--- a/clang/test/Driver/Inputs/MacOSX15.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX15.0.sdk/SDKSettings.json
@@ -1,1 +1,5 @@
-{"Version":"15.0", "CanonicalName": "macosx15.0", "MaximumDeploymentTarget": "15.0.99"}
+{"Version":"15.0", "CanonicalName": "macosx15.0", "MaximumDeploymentTarget": "15.0.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}

--- a/clang/test/Driver/Inputs/MacOSX15.1.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/MacOSX15.1.sdk/SDKSettings.json
@@ -1,1 +1,5 @@
-{"Version":"15.1", "CanonicalName": "macosx15.1", "MaximumDeploymentTarget": "15.1.99"}
+{"Version":"15.1", "CanonicalName": "macosx15.1", "MaximumDeploymentTarget": "15.1.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}

--- a/clang/test/Driver/Inputs/WatchOS6.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/WatchOS6.0.sdk/SDKSettings.json
@@ -1,1 +1,4 @@
-{"Version":"6.0", "CanonicalName": "watchos6.0", "MaximumDeploymentTarget": "6.0.99"}
+{"Version":"6.0", "CanonicalName": "watchos6.0", "MaximumDeploymentTarget": "6.0.99",
+ "SupportedTargets": {
+   "watchos": {"Archs": ["armv7k", "arm64_32"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "watchos", "LLVMTargetTripleEnvironment": ""}
+}}

--- a/clang/test/Driver/Inputs/iPhoneOS13.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/iPhoneOS13.0.sdk/SDKSettings.json
@@ -1,1 +1,4 @@
-{"Version":"13.0", "CanonicalName": "iphoneos13.0", "MaximumDeploymentTarget": "13.0.99"}
+{"Version":"13.0", "CanonicalName": "iphoneos13.0", "MaximumDeploymentTarget": "13.0.99",
+ "SupportedTargets": {
+   "iphoneos": {"Archs": ["armv7", "armv7s", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": ""}
+}}

--- a/clang/test/Driver/darwin-invalid-version-range.c
+++ b/clang/test/Driver/darwin-invalid-version-range.c
@@ -26,4 +26,7 @@
 // DEPLOY_VAR: error: invalid version number in 'IPHONEOS_DEPLOYMENT_TARGET=21.0'
 
 //--- iPhoneOS21.0.sdk/SDKSettings.json
-{"Version":"21.0", "MaximumDeploymentTarget": "21.0.99"}
+{"Version":"21.0", "CanonicalName":"iphoneos21.0", "MaximumDeploymentTarget": "21.0.99",
+ "SupportedTargets": {
+   "iphoneos": {"Archs": ["arm64e", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "","SystemPrefix": ""}
+}}

--- a/clang/test/Driver/driverkit-path.c
+++ b/clang/test/Driver/driverkit-path.c
@@ -26,6 +26,10 @@ int main() { return 0; }
 
 // RUN: %clang %s -target x86_64-apple-driverkit19.0 -isysroot %S/Inputs/DriverKit19.0.sdk -x c++ -### 2>&1 \
 // RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit19.0.sdk --check-prefix=INC
+// RUN: %clang %s -target x86_64-apple-driverkit21.0.1 -isysroot %S/Inputs/DriverKit21.0.1.sdk -x c++ -### 2>&1 \
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit21.0.1.sdk --check-prefix=INC
+// RUN: %clang %s -target x86_64-apple-driverkit23.0 -isysroot %S/Inputs/DriverKit23.0.sdk -x c++ -### 2>&1 \
+// RUN: | FileCheck %s -DSDKROOT=%S/Inputs/DriverKit23.0.sdk --check-prefix=INC
 //
 // INC: "-isysroot" "[[SDKROOT]]"
 // INC: "-internal-isystem" "[[SDKROOT]]/System/DriverKit/usr/local/include"

--- a/clang/test/Driver/modulemap-allow-subdirectory-search.c
+++ b/clang/test/Driver/modulemap-allow-subdirectory-search.c
@@ -21,7 +21,15 @@
 // SEARCH-SUBDIRECTORIES-NOT: "-fno-modulemap-allow-subdirectory-search"
 
 //--- MacOSX15.0.sdk/SDKSettings.json
-{"Version":"15.0", "MaximumDeploymentTarget": "15.0.99"}
+{"Version":"15.0", "CanonicalName": "macosx15.0", "MaximumDeploymentTarget": "15.0.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}
 
 //--- MacOSX14.0.sdk/SDKSettings.json
-{"Version":"14.0", "MaximumDeploymentTarget": "14.0.99"}
+{"Version":"14.0", "CanonicalName": "macosx14.0", "MaximumDeploymentTarget": "14.0.99",
+ "SupportedTargets": {
+   "macosx": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "macos", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""},
+   "iosmac": {"Archs": ["x86_64", "x86_64h", "arm64", "arm64e"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "ios", "LLVMTargetTripleEnvironment": "macabi", "SystemPrefix": "\/System\/iOSSupport"}
+}}

--- a/clang/test/InstallAPI/Inputs/MacOSX13.0.sdk/SDKSettings.json
+++ b/clang/test/InstallAPI/Inputs/MacOSX13.0.sdk/SDKSettings.json
@@ -3,7 +3,24 @@
   "Version": "13.0",
   "CanonicalName": "macosx13.0",
   "MaximumDeploymentTarget": "13.0.99",
-  "PropertyConditionFallbackNames": [], "VersionMap": {
+  "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "macos",
+      "LLVMTargetTripleEnvironment": "",
+      "SystemPrefix": ""
+    },
+    "iosmac": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "ios",
+      "LLVMTargetTripleEnvironment": "macabi",
+      "SystemPrefix": "\/System\/iOSSupport"
+    }
+  },
+  "VersionMap": {
     "iOSMac_macOS": {
       "16.1": "13.0",
       "15.0": "12.0",

--- a/clang/test/Modules/sdk-settings-json-dep.m
+++ b/clang/test/Modules/sdk-settings-json-dep.m
@@ -9,7 +9,15 @@
   "Version": "15.0",
   "CanonicalName": "appletvos15.0",
   "MaximumDeploymentTarget": "15.0.99",
-  "PropertyConditionFallbackNames": []
+  "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "appletvos": {
+      "Archs": ["arm64e", "arm64"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "tvos",
+      "LLVMTargetTripleEnvironment": ""
+    }
+  },
 }
 //--- AppleTVOS15.0.sdk/SDKSettings-new.json
 {
@@ -18,6 +26,14 @@
   "CanonicalName": "appletvos15.0",
   "MaximumDeploymentTarget": "15.0.99",
   "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "appletvos": {
+      "Archs": ["arm64e", "arm64"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "tvos",
+      "LLVMTargetTripleEnvironment": ""
+    }
+  },
   "VersionMap": {
     "iOS_tvOS": {
       "13.2": "13.1"

--- a/clang/test/Sema/Inputs/AppleTVOS15.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/AppleTVOS15.0.sdk/SDKSettings.json
@@ -4,6 +4,14 @@
   "CanonicalName": "appletvos15.0",
   "MaximumDeploymentTarget": "15.0.99",
   "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "appletvos": {
+      "Archs": ["arm64e", "arm64"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "tvos",
+      "LLVMTargetTripleEnvironment": ""
+    }
+  },
   "VersionMap": {
     "iOS_tvOS": {
       "10.0": "10.0",

--- a/clang/test/Sema/Inputs/MacOSX11.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/MacOSX11.0.sdk/SDKSettings.json
@@ -3,7 +3,22 @@
   "Version": "11.0",
   "CanonicalName": "macosx11.0",
   "MaximumDeploymentTarget": "11.0.99",
-  "PropertyConditionFallbackNames": [], "VersionMap": {
+  "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "macosx": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "macosx",
+      "LLVMTargetTripleEnvironment": ""
+    },
+    "iosmac": {
+      "Archs": ["x86_64", "x86_64h", "arm64", "arm64e"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "ios",
+      "LLVMTargetTripleEnvironment": "macabi"
+    }
+  },
+  "VersionMap": {
     "iOSMac_macOS": {
       "13.2": "10.15.1",
       "13.4": "10.15.4",

--- a/clang/test/Sema/Inputs/WatchOS7.0.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/WatchOS7.0.sdk/SDKSettings.json
@@ -4,6 +4,14 @@
   "CanonicalName": "watchos7.0",
   "MaximumDeploymentTarget": "7.0.99",
   "PropertyConditionFallbackNames": [],
+  "SupportedTargets": {
+    "watchos": {
+      "Archs": ["arm64_32", "armv7k"],
+      "LLVMTargetTripleVendor": "apple",
+      "LLVMTargetTripleSys": "watchos",
+      "LLVMTargetTripleEnvironment": ""
+    }
+  },
   "VersionMap": {
     "iOS_watchOS": {
       "10.0": "3.0",

--- a/clang/test/Sema/Inputs/XROS.sdk/SDKSettings.json
+++ b/clang/test/Sema/Inputs/XROS.sdk/SDKSettings.json
@@ -3,6 +3,9 @@
   "Version": "26.0",
   "CanonicalName": "xros26.0",
   "MaximumDeploymentTarget": "26.0.99",
+  "SupportedTargets": {
+    "xros": {"Archs": ["arm64e", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "xros", "LLVMTargetTripleEnvironment": "", "SystemPrefix": ""}
+  },
   "VersionMap": {
     "iOS_xrOS":{"15.0":"1.0", "16.0":"2.0", "19.0":"26.0", "26.0":"26.0"}
   }

--- a/clang/unittests/Basic/CMakeLists.txt
+++ b/clang/unittests/Basic/CMakeLists.txt
@@ -16,6 +16,7 @@ add_distinct_clang_unittest(BasicTests
   clangLex
   LINK_LIBS
   LLVMCAS
+  LLVMTargetParser
   LLVMTestingSupport
   LLVM_COMPONENTS
   Support


### PR DESCRIPTION
The search path prefix is really a property of the SDK, and not the target triple. The target is just being used as a proxy for the SDK. That's problematic when the SDK being used doesn't match the target assumption, and the prefix should be taken from the SDK rather than hard coded.

Parse the SupportedTargets, which is what holds the platform prefix, in DarwinSDKInfo. SupportedTargets contains an entry for the SDK's canonical name, and that entry holds a valid OS value so use that instead of the hard coded map. Include the environment which is also relevant in some situations, and the vendor and object format in case they're useful later. Skip architectures because they typically aren't used for doing platform matching.

rdar://165414248