### PR TITLE
🍒[lldb][Format] Unwrap references to C-strings when printing C-string summaries

### DIFF
--- a/lldb/source/DataFormatters/FormatManager.cpp
+++ b/lldb/source/DataFormatters/FormatManager.cpp
@@ -747,7 +747,7 @@ void FormatManager::LoadSystemFormatters() {
   TypeSummaryImpl::Flags string_flags;
   string_flags.SetCascades(true)
       .SetSkipPointers(true)
-      .SetSkipReferences(false)
+      .SetSkipReferences(true)
       .SetDontShowChildren(true)
       .SetDontShowValue(false)
       .SetShowMembersOneLiner(false)

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/Makefile
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp
+CXXFLAGS_EXTRAS := -std=c++20
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
@@ -51,15 +51,17 @@ class TestStringPrinter(TestBase):
 
         # FIXME: make "b.data" and "c.data" work sanely
 
+        self.expect("frame variable ref", substrs=['(&ref = "Hello")'])
         self.expect_var_path(
             "ref",
-            summary="<no value available>",
+            summary=None,
             children=[ValueCheck(name="&ref", summary='"Hello"')],
         )
 
         # FIXME: should LLDB use "&&refref" for the name here?
+        self.expect("frame variable refref", substrs=['(&refref = "Hi")'])
         self.expect_var_path(
             "refref",
-            summary="<no value available>",
+            summary=None,
             children=[ValueCheck(name="&refref", summary='"Hi"')],
         )

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
@@ -1,7 +1,52 @@
-from lldbsuite.test import lldbinline
-from lldbsuite.test import decorators
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
 
-lldbinline.MakeInlineTest(
-    __file__,
-    globals(),
-)
+
+class TestStringPrinter(TestBase):
+    def test(self):
+        self.build()
+
+        self.addTearDownHook(
+            lambda x: x.runCmd("setting set escape-non-printables true")
+        )
+
+        lldbutil.run_to_source_breakpoint(
+            self, "Break here", lldb.SBFileSpec("main.cpp", False)
+        )
+
+        self.expect_var_path(
+            "charwithtabs",
+            summary='"Hello\\t\\tWorld\\nI am here\\t\\tto say hello\\n"',
+        )
+        self.expect_var_path("a.data", summary='"FOOB"')
+        self.expect_var_path("b.data", summary=r'"FO\0B"')
+        self.expect_var_path("c.data", summary=r'"F\0O"')
+        self.expect_var_path("manytrailingnuls", summary=r'"F\0OO\0BA\0R"')
+
+        for c in ["", "const"]:
+            for v in ["", "volatile"]:
+                for s in ["", "unsigned"]:
+                    summary = '"' + c + v + s + 'char"'
+                    self.expect_var_path(c + v + s + "chararray", summary=summary)
+                    # These should be printed normally
+                    self.expect_var_path(c + v + s + "charstar", summary=summary)
+
+        Schar5 = self.expect_var_path(
+            "Schar5", children=[ValueCheck(name="x", value="0")]
+        )
+        self.assertIsNone(Schar5.GetSummary())
+        Scharstar = self.expect_var_path(
+            "Scharstar", children=[ValueCheck(name="x", value="0")]
+        )
+        self.assertIsNone(Scharstar.GetSummary())
+
+        self.runCmd("setting set escape-non-printables false")
+        self.expect_var_path(
+            "charwithtabs", summary='"Hello\t\tWorld\nI am here\t\tto say hello\n"'
+        )
+        self.assertTrue(
+            self.frame().FindVariable("longconstcharstar").GetSummary().endswith('"...')
+        )
+
+        # FIXME: make "b.data" and "c.data" work sanely

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/TestStringPrinter.py
@@ -50,3 +50,16 @@ class TestStringPrinter(TestBase):
         )
 
         # FIXME: make "b.data" and "c.data" work sanely
+
+        self.expect_var_path(
+            "ref",
+            summary="<no value available>",
+            children=[ValueCheck(name="&ref", summary='"Hello"')],
+        )
+
+        # FIXME: should LLDB use "&&refref" for the name here?
+        self.expect_var_path(
+            "refref",
+            summary="<no value available>",
+            children=[ValueCheck(name="&refref", summary='"Hi"')],
+        )

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/main.cpp
@@ -76,6 +76,10 @@ int main(int argc, char const *argv[]) {
       "this a few times, you know.."
       " for science, or something";
 
+  const char *basic = "Hello";
+  const char *&ref = basic;
+  const char *&&refref = "Hi";
+
   puts("Break here");
 
   return 0;

--- a/lldb/test/API/functionalities/data-formatter/stringprinter/main.cpp
+++ b/lldb/test/API/functionalities/data-formatter/stringprinter/main.cpp
@@ -1,4 +1,4 @@
-#include <string>
+#include <cstdio>
 #include <cstring>
 
 struct A {
@@ -20,67 +20,63 @@ struct A {
 MAKE_VARS();
 MAKE_VARS(const);
 
-template<typename T>
-struct S {
+template <typename T> struct S {
   int x = 0;
 };
 S<char[5]> Schar5;
 S<char *> Scharstar;
 
-int main (int argc, char const *argv[])
-{
-    const char manytrailingnuls[] = "F\0OO\0BA\0R\0\0\0\0";
-    A a, b, c;
-    // Deliberately write past the end of data to test that the formatter stops
-    // at the end of array.
-    memcpy(a.data, "FOOBAR", 7);
-    memcpy(b.data, "FO\0BAR", 7);
-    memcpy(c.data, "F\0O\0AR", 7);
-    std::string stdstring("Hello\t\tWorld\nI am here\t\tto say hello\n"); //%self.addTearDownHook(lambda x: x.runCmd("setting set escape-non-printables true"))
-    const char *charwithtabs = stdstring.c_str();
-    std::string longstring(
-"I am a very long string; in fact I am longer than any reasonable length that a string should be; quite long indeed; oh my, so many words; so many letters; this is kind of like writing a poem; except in real life all that is happening"
-" is just me producing a very very long set of words; there is text here, text there, text everywhere; it fills me with glee to see so much text; all around me it's just letters, and symbols, and other pleasant drawings that cause me"
-" a large amount of joy upon visually seeing them with my eyes; well, this is now a lot of letters, but it is still not enough for the purpose of the test I want to test, so maybe I should copy and paste this a few times, you know.."
-" for science, or something"
-      "I am a very long string; in fact I am longer than any reasonable length that a string should be; quite long indeed; oh my, so many words; so many letters; this is kind of like writing a poem; except in real life all that is happening"
-      " is just me producing a very very long set of words; there is text here, text there, text everywhere; it fills me with glee to see so much text; all around me it's just letters, and symbols, and other pleasant drawings that cause me"
-      " a large amount of joy upon visually seeing them with my eyes; well, this is now a lot of letters, but it is still not enough for the purpose of the test I want to test, so maybe I should copy and paste this a few times, you know.."
+int main(int argc, char const *argv[]) {
+  const char manytrailingnuls[] = "F\0OO\0BA\0R\0\0\0\0";
+  A a, b, c;
+  // Deliberately write past the end of data to test that the formatter stops
+  // at the end of array.
+  memcpy(a.data, "FOOBAR", 7);
+  memcpy(b.data, "FO\0BAR", 7);
+  memcpy(c.data, "F\0O\0AR", 7);
+  const char *charwithtabs = "Hello\t\tWorld\nI am here\t\tto say hello\n";
+  const char *longconstcharstar =
+      "I am a very long string; in fact I am longer than any reasonable length "
+      "that a string should be; quite long indeed; oh my, so many words; so "
+      "many letters; this is kind of like writing a poem; except in real life "
+      "all that is happening"
+      " is just me producing a very very long set of words; there is text "
+      "here, text there, text everywhere; it fills me with glee to see so much "
+      "text; all around me it's just letters, and symbols, and other pleasant "
+      "drawings that cause me"
+      " a large amount of joy upon visually seeing them with my eyes; well, "
+      "this is now a lot of letters, but it is still not enough for the "
+      "purpose of the test I want to test, so maybe I should copy and paste "
+      "this a few times, you know.."
       " for science, or something"
-            "I am a very long string; in fact I am longer than any reasonable length that a string should be; quite long indeed; oh my, so many words; so many letters; this is kind of like writing a poem; except in real life all that is happening"
-            " is just me producing a very very long set of words; there is text here, text there, text everywhere; it fills me with glee to see so much text; all around me it's just letters, and symbols, and other pleasant drawings that cause me"
-            " a large amount of joy upon visually seeing them with my eyes; well, this is now a lot of letters, but it is still not enough for the purpose of the test I want to test, so maybe I should copy and paste this a few times, you know.."
-            " for science, or something"
-      );
-    const char* longconstcharstar = longstring.c_str();
-    return 0;     //% if self.TraceOn(): self.runCmd('frame variable')
-    //%
-    //% self.expect_var_path('stdstring', summary='"Hello\\t\\tWorld\\nI am here\\t\\tto say hello\\n"')
-    //% self.expect_var_path('charwithtabs', summary='"Hello\\t\\tWorld\\nI am here\\t\\tto say hello\\n"')
-    //% self.expect_var_path("a.data", summary='"FOOB"')
-    //% self.expect_var_path("b.data", summary=r'"FO\0B"')
-    //% self.expect_var_path("c.data", summary=r'"F\0O"')
-    //% self.expect_var_path("manytrailingnuls", summary=r'"F\0OO\0BA\0R"')
-    //%
-    //% for c in ["", "const"]:
-    //%   for v in ["", "volatile"]:
-    //%     for s in ["", "unsigned"]:
-    //%       summary = '"'+c+v+s+'char"'
-    //%       self.expect_var_path(c+v+s+"chararray", summary=summary)
-    //% # These should be printed normally
-    //%       self.expect_var_path(c+v+s+"charstar", summary=summary)
-    //% Schar5 = self.expect_var_path("Schar5",
-    //%     children=[ValueCheck(name="x", value="0")])
-    //% self.assertIsNone(Schar5.GetSummary())
-    //% Scharstar = self.expect_var_path("Scharstar",
-    //%     children=[ValueCheck(name="x", value="0")])
-    //% self.assertIsNone(Scharstar.GetSummary())
-    //%
-    //% self.runCmd("setting set escape-non-printables false")
-    //% self.expect_var_path('stdstring', summary='"Hello\t\tWorld\nI am here\t\tto say hello\n"')
-    //% self.expect_var_path('charwithtabs', summary='"Hello\t\tWorld\nI am here\t\tto say hello\n"')
-    //% self.assertTrue(self.frame().FindVariable('longstring').GetSummary().endswith('"...'))
-    //% self.assertTrue(self.frame().FindVariable('longconstcharstar').GetSummary().endswith('"...'))
-    // FIXME: make "b.data" and "c.data" work sanely
-}
+      "I am a very long string; in fact I am longer than any reasonable length "
+      "that a string should be; quite long indeed; oh my, so many words; so "
+      "many letters; this is kind of like writing a poem; except in real life "
+      "all that is happening"
+      " is just me producing a very very long set of words; there is text "
+      "here, text there, text everywhere; it fills me with glee to see so much "
+      "text; all around me it's just letters, and symbols, and other pleasant "
+      "drawings that cause me"
+      " a large amount of joy upon visually seeing them with my eyes; well, "
+      "this is now a lot of letters, but it is still not enough for the "
+      "purpose of the test I want to test, so maybe I should copy and paste "
+      "this a few times, you know.."
+      " for science, or something"
+      "I am a very long string; in fact I am longer than any reasonable length "
+      "that a string should be; quite long indeed; oh my, so many words; so "
+      "many letters; this is kind of like writing a poem; except in real life "
+      "all that is happening"
+      " is just me producing a very very long set of words; there is text "
+      "here, text there, text everywhere; it fills me with glee to see so much "
+      "text; all around me it's just letters, and symbols, and other pleasant "
+      "drawings that cause me"
+      " a large amount of joy upon visually seeing them with my eyes; well, "
+      "this is now a lot of letters, but it is still not enough for the "
+      "purpose of the test I want to test, so maybe I should copy and paste "
+      "this a few times, you know.."
+      " for science, or something";
 
+  puts("Break here");
+
+  return 0;
+}


### PR DESCRIPTION
The `${var%s}` format isn't capable of formatting references to
C-strings. So the summary for those becomes `<no value available>`. This
patch prevents the system C-string formatter from applying to
references, which means the summary for such types will be empty. This
prompts LLDB to instead print the child, which is the referenced
C-string.

Before:
```
(lldb) v ref
(const char *&) ref = 0x000000016fdfe960 <no value available>
```

After:
```
(lldb) v ref
(const char *&) ref = 0x000000016fdfec40 (&ref = "hi")
```

An alternative would be to support references in the `ValueObject` dump
methods. We assume C-string are pointers/arrays in a lot of places, so
such a fix would be a more intrusive undertaking, and I'm not sure we
would want to support references there in the first place. So for now I
went with the fallback logic in this PR.

(cherry picked from commit https://github.com/swiftlang/llvm-project/commit/dca088023e2b126e67989070d8d47aeea44b414f)