### PR TITLE
[clang][modules] Diagnose config mismatches more generally from precompiled files (#174260)

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -226,11 +226,8 @@ def note_incompatible_analyzer_plugin_api : Note<
 
 def err_module_build_requires_fmodules : Error<
   "module compilation requires '-fmodules'">;
-def err_module_interface_requires_cpp_modules : Error<
-  "module interface compilation requires '-std=c++20'">;
-def warn_module_config_mismatch : Warning<
-  "module file '%0' cannot be loaded due to a configuration mismatch with the current "
-  "compilation">, InGroup<DiagGroup<"module-file-config-mismatch">>, DefaultError;
+def err_module_interface_requires_cpp_modules
+    : Error<"module interface compilation requires '-std=c++20'">;
 def err_module_map_not_found : Error<"module map file '%0' not found">,
   DefaultFatal;
 def err_missing_module_name : Error<

--- a/clang/include/clang/Basic/DiagnosticSerializationKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSerializationKinds.td
@@ -39,6 +39,12 @@ def err_ast_file_targetopt_feature_mismatch : Error<
     "not">;
 def err_ast_file_langopt_mismatch : Error<"%0 was %select{disabled|enabled}1 in "
     "precompiled file '%3' but is currently %select{disabled|enabled}2">;
+def warn_ast_file_config_mismatch
+    : Warning<"precompiled file '%0' cannot be loaded due to a configuration "
+              "mismatch with the current "
+              "compilation">,
+      InGroup<DiagGroup<"module-file-config-mismatch">>,
+      DefaultError;
 def err_ast_file_langopt_value_mismatch : Error<
   "%0 differs in precompiled file '%1' vs. current file">;
 def err_ast_file_diagopt_mismatch : Error<"%0 is currently enabled, but was not in "

--- a/clang/include/clang/Serialization/ASTReader.h
+++ b/clang/include/clang/Serialization/ASTReader.h
@@ -2020,14 +2020,12 @@ public:
 
   /// Determine whether the given AST file is acceptable to load into a
   /// translation unit with the given language and target options.
-  static bool isAcceptableASTFile(StringRef Filename, FileManager &FileMgr,
-                                  const ModuleCache &ModCache,
-                                  const PCHContainerReader &PCHContainerRdr,
-                                  const LangOptions &LangOpts,
-                                  const TargetOptions &TargetOpts,
-                                  const PreprocessorOptions &PPOpts,
-                                  StringRef ExistingModuleCachePath,
-                                  bool RequireStrictOptionMatches = false);
+  static bool isAcceptableASTFile(
+      StringRef Filename, FileManager &FileMgr, const ModuleCache &ModCache,
+      const PCHContainerReader &PCHContainerRdr, const LangOptions &LangOpts,
+      const TargetOptions &TargetOpts, const PreprocessorOptions &PPOpts,
+      const HeaderSearchOptions &HSOpts, StringRef ExistingModuleCachePath,
+      bool RequireStrictOptionMatches = false);
 
   /// Returns the suggested contents of the predefines buffer,
   /// which contains a (typically-empty) subset of the predefines

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -48,6 +48,7 @@
 #include "clang/Serialization/GlobalModuleIndex.h"
 #include "clang/Serialization/InMemoryModuleCache.h"
 #include "clang/Serialization/ModuleCache.h"
+#include "clang/Serialization/SerializationDiagnostic.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
@@ -1920,9 +1921,9 @@ bool CompilerInstance::loadModuleFile(
   // If -Wmodule-file-config-mismatch is mapped as an error or worse, allow the
   // ASTReader to diagnose it, since it can produce better errors that we can.
   bool ConfigMismatchIsRecoverable =
-      getDiagnostics().getDiagnosticLevel(diag::warn_module_config_mismatch,
-                                          SourceLocation())
-        <= DiagnosticsEngine::Warning;
+      getDiagnostics().getDiagnosticLevel(diag::warn_ast_file_config_mismatch,
+                                          SourceLocation()) <=
+      DiagnosticsEngine::Warning;
 
   auto Listener = std::make_unique<ReadModuleNames>(*PP);
   auto &ListenerRef = *Listener;
@@ -1942,7 +1943,8 @@ bool CompilerInstance::loadModuleFile(
 
   case ASTReader::ConfigurationMismatch:
     // Ignore unusable module files.
-    getDiagnostics().Report(SourceLocation(), diag::warn_module_config_mismatch)
+    getDiagnostics().Report(SourceLocation(),
+                            diag::warn_ast_file_config_mismatch)
         << FileName;
     // All modules provided by any files we tried and failed to load are now
     // unavailable; includes of those modules should now be handled textually.
@@ -2101,7 +2103,7 @@ ModuleLoadResult CompilerInstance::findOrCompileModuleAndReadAST(
       // FIXME: We shouldn't be setting HadFatalFailure below if we only
       // produce a warning here!
       getDiagnostics().Report(SourceLocation(),
-                              diag::warn_module_config_mismatch)
+                              diag::warn_ast_file_config_mismatch)
           << ModuleFilename;
     // Fall through to error out.
     [[fallthrough]];

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1080,7 +1080,8 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
                 Dir->path(), FileMgr, CI.getModuleCache(),
                 CI.getPCHContainerReader(), CI.getLangOpts(),
                 CI.getTargetOpts(), CI.getPreprocessorOpts(),
-                SpecificModuleCachePath, /*RequireStrictOptionMatches=*/true)) {
+                CI.getHeaderSearchOpts(), SpecificModuleCachePath,
+                /*RequireStrictOptionMatches=*/true)) {
           PPOpts.ImplicitPCHInclude = std::string(Dir->path());
           Found = true;
           break;

--- a/clang/test/Modules/explicit-build.cpp
+++ b/clang/test/Modules/explicit-build.cpp
@@ -153,7 +153,7 @@
 // RUN:            -fmodule-file=%t/a.pch \
 // RUN:            %s 2>&1 | FileCheck --check-prefix=CHECK-A-AS-PCH %s
 //
-// CHECK-A-AS-PCH: error: module file '{{.*}}a.pch' cannot be loaded due to a configuration mismatch with the current compilation
+// CHECK-A-AS-PCH: error: precompiled file '{{.*}}a.pch' cannot be loaded due to a configuration mismatch with the current compilation
 
 // -------------------------------
 // Try to import a non-AST file with -fmodule-file=

--- a/clang/test/Modules/ignored_macros.m
+++ b/clang/test/Modules/ignored_macros.m
@@ -10,7 +10,7 @@
 // RUN: %clang_cc1 -fmodules-cache-path=%t.modules -fmodules -fimplicit-module-maps -I %S/Inputs -emit-pch -o %t.pch -x objective-c-header %s -verify
 // RUN: not %clang_cc1 -fmodules-cache-path=%t.modules -DIGNORED=1 -fmodules -fimplicit-module-maps -I %S/Inputs -include-pch %t.pch %s > %t.err 2>&1
 // RUN: FileCheck -check-prefix=CHECK-CONFLICT %s < %t.err
-// CHECK-CONFLICT: precompiled file '{{.*}}' was compiled with module cache path
+// CHECK-CONFLICT: precompiled file '{{.*}}' cannot be loaded due to a configuration mismatch
 
 // Third trial: pass -DIGNORED=1 only to the second invocation, but
 // make it ignored. There should be no failure, IGNORED is defined in

--- a/clang/test/Modules/mismatch-diagnostics.cpp
+++ b/clang/test/Modules/mismatch-diagnostics.cpp
@@ -30,4 +30,4 @@ export module mismatching_module;
 //--- use.cpp
 import mismatching_module;
 // CHECK: error: POSIX thread support was enabled in precompiled file '{{.*[/|\\\\]}}mismatching_module.pcm' but is currently disabled
-// CHECK-NEXT: module file '{{.*[/|\\\\]}}mismatching_module.pcm' cannot be loaded due to a configuration mismatch with the current compilation
+// CHECK-NEXT: precompiled file '{{.*[/|\\\\]}}mismatching_module.pcm' cannot be loaded due to a configuration mismatch with the current compilation

--- a/clang/test/Modules/precompiled-config-mismatch-diagnostics.c
+++ b/clang/test/Modules/precompiled-config-mismatch-diagnostics.c
@@ -1,0 +1,49 @@
+// Validate configuration mismatches from precompiled files are reported.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %clang_cc1 -I%t/BuildDir -fimplicit-module-maps -fmodules \
+// RUN:   -fmodules-cache-path=%t/cache %t/h1.h -emit-pch -o %t/BuildDir/h1.h.pch
+
+// Check command line diff that is reported uniquely.
+// RUN: not %clang_cc1 -I%t/BuildDir -fimplicit-module-maps -fmodules \
+// RUN:   -O3 \
+// RUN:   -fmodules-cache-path=%t/cache -fsyntax-only -include-pch %t/BuildDir/h1.h.pch \
+// RUN:   %t/client.c 2>&1 | FileCheck %s  --check-prefixes=OPTMODE,CONFIG
+
+// Check command line difference that end up in the module hash, but is not 
+// uniquely reported as a mismatch.
+// RUN: not %clang_cc1 -I%t/BuildDir -fimplicit-module-maps -fmodules \
+// RUN:   -dwarf-ext-refs -fmodule-format=obj \
+// RUN:   -debug-info-kind=standalone -dwarf-version=5 \
+// RUN:   -fmodules-cache-path=%t/cache -fsyntax-only -include-pch %t/BuildDir/h1.h.pch \
+// RUN:   %t/client.c 2>&1 | FileCheck %s --check-prefix=CONFIG
+
+// Check that module cache path is uniquely reported.
+// RUN: not %clang_cc1 -I%t/BuildDir -fimplicit-module-maps -fmodules \
+// RUN:   -fmodules-cache-path=%t/wrong/cache -fsyntax-only \
+// RUN:   -include-pch %t/BuildDir/h1.h.pch \
+// RUN:   %t/client.c 2>&1 | FileCheck %s --check-prefix=CACHEPATH
+
+// OPTMODE: OptimizationLevel differs in precompiled file
+// CONFIG: h1.h.pch' cannot be loaded due to a configuration mismatch
+// CACHEPATH: h1.h.pch' was compiled with module cache path '{{.*}}', but the path is currently '{{.*}}'
+
+//--- BuildDir/A/module.modulemap
+module A [system] {
+  umbrella "."
+}
+
+//--- BuildDir/A/A.h
+typedef int A_t;
+
+//--- h1.h
+#include <A/A.h>
+#if __OPTIMIZE__
+A_t foo(void);
+#endif 
+
+//--- client.c
+typedef int foo_t;
+

--- a/clang/test/Modules/precompiled-config-mismatch-diagnostics.c
+++ b/clang/test/Modules/precompiled-config-mismatch-diagnostics.c
@@ -26,7 +26,7 @@
 // RUN:   -include-pch %t/BuildDir/h1.h.pch \
 // RUN:   %t/client.c 2>&1 | FileCheck %s --check-prefix=CACHEPATH
 
-// OPTMODE: OptimizationLevel differs in precompiled file
+// OPTMODE: __OPTIMIZE__ predefined macro was disabled in precompiled file '{{.*}}' but is currently enabled
 // CONFIG: h1.h.pch' cannot be loaded due to a configuration mismatch
 // CACHEPATH: h1.h.pch' was compiled with module cache path '{{.*}}', but the path is currently '{{.*}}'
 

--- a/clang/test/PCH/module-hash-difference.m
+++ b/clang/test/PCH/module-hash-difference.m
@@ -4,5 +4,5 @@
 // RUN: not %clang_cc1 -fsyntax-only -include-pch %t.pch %s -I %S/Inputs/modules -fmodules -fimplicit-module-maps -fmodules-cache-path=%t.mcp -fdisable-module-hash 2> %t.err
 // RUN: FileCheck -input-file=%t.err %s
 
-// CHECK: error: precompiled file '{{.*}}' was compiled with module cache path {{.*}}, but the path is currently {{.*}}
+// CHECK: error: precompiled file '{{.*}}' cannot be loaded due to a configuration mismatch with the current compilation
 @import Foo;


### PR DESCRIPTION
PCHs (but also modules generated from several implicit invocations like swiftc) previously reported a confusing diagnostic about module caches being mismatched by subdir. This is an implementation detail of the module machinery, and not very useful to the end user. Instead, report this case as a configuration mismatch when the compiler can confirm the module cache was passed the same between the current TU & previously compiled products.

Ideally, each argument that could result in this error would be uniquely reported (e.g., O3), but as a starting point, providing something more general is strictly better than pointing the user to the module cache.

This patch also includes NFCs for renaming variable names from Module to AST and formatting cleanup in related areas.

resolves: rdar://167453135
(cherry picked from commit 5089f634609aab7bec747c731ecdb572ac4d9d40)