### PR TITLE
[lldb] Don't trim expression in progress event (#174609)

### DIFF
--- a/lldb/source/Expression/UserExpression.cpp
+++ b/lldb/source/Expression/UserExpression.cpp
@@ -434,15 +434,10 @@ UserExpression::Execute(DiagnosticManager &diagnostic_manager,
                         lldb::ExpressionVariableSP &result_var) {
   Debugger *debugger =
       exe_ctx.GetTargetPtr() ? &exe_ctx.GetTargetPtr()->GetDebugger() : nullptr;
-  std::string details;
-  if (m_options.IsForUtilityExpr())
-    details = "LLDB utility";
-  else if (m_expr_text.size() > 15)
-    details = m_expr_text.substr(0, 14) + "…";
-  else
-    details = m_expr_text;
 
-  Progress progress("Running expression", details, {}, debugger);
+  Progress progress("Running expression",
+                    m_options.IsForUtilityExpr() ? "LLDB utility" : m_expr_text,
+                    {}, debugger);
 
   lldb::ExpressionResults expr_result = DoExecute(
       diagnostic_manager, exe_ctx, options, shared_ptr_to_me, result_var);

--- a/lldb/test/Shell/Expr/TestExecProgress.test
+++ b/lldb/test/Shell/Expr/TestExecProgress.test
@@ -5,4 +5,4 @@ expr 1 // And a very long comment.
 quit
 
 # CHECK: {{title = "Running expression", details = "1"}}
-# CHECK: {{title = "Running expression", details = "1 // And a ver…"}}
+# CHECK: {{title = "Running expression", details = "1 // And a very long comment."}}


### PR DESCRIPTION
Trimming the content of the progress event is the responsibility of the consumer, not the producer. For example, when using the statusline, there's plenty of space to show longer expressions.

rdar://166879951
(cherry picked from commit 1f5126dae135364b0df4127cf5cc62605b349ced)