### PR TITLE
[clang][tests] XFAIL GH170084 on non-darwin platforms

### DIFF
--- a/clang/test/Modules/GH170084.cpp
+++ b/clang/test/Modules/GH170084.cpp
@@ -1,3 +1,7 @@
+/// Due to module bypass workaround for non-darwin platforms, relative and absolute path do not match after bypass.
+/// See: https://github.com/llvm/llvm-project/issues/130795
+// XFAIL: !system-darwin
+
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file %s %t


### PR DESCRIPTION
XFAIL tests that are affected by the downstream workaround for file system inode reuses.