### PR TITLE
[lldb-dap] Fix crash when a module doesn't have a UUID string

### DIFF
--- a/lldb/tools/lldb-dap/JSONUtils.cpp
+++ b/lldb/tools/lldb-dap/JSONUtils.cpp
@@ -552,7 +552,7 @@ llvm::json::Value CreateStackFrame(DAP &dap, lldb::SBFrame &frame,
 
   lldb::SBModule module = frame.GetModule();
   if (module.IsValid()) {
-    std::string uuid = module.GetUUIDString();
+    llvm::StringRef uuid = module.GetUUIDString();
     if (!uuid.empty())
       object.try_emplace("moduleId", uuid);
   }


### PR DESCRIPTION
GetUUIDString returns NULL if the UUID/string is empty (as is the case for Wasm modules). We should check the pointer before creating a std::string out of it, or use llvm::StringRef which does that on our behalf.

This code has been refactored upstream, where it's also using llvm::StringRef.

rdar://167700045