### PR TITLE
[LLDB] Poison SwiftASTContext if stdlib fails to import

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4136,6 +4136,12 @@ SwiftASTContext::GetModule(const SourceModule &module, bool *cached) {
     std::string diagnostic = diagnostic_manager.GetString();
     LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- %s",
                module.path.front().GetCString(), diagnostic.c_str());
+
+    // Poison this context if it was the stdlib. Continuing will not
+    // work and risks crashes.
+    if (module_name == swift::STDLIB_NAME)
+      RaiseFatalError(diagnostic);
+
     return llvm::createStringError(
         llvm::formatv("failed to get module \"{0}\" from AST context:\n{1}",
                       module_name, diagnostic));


### PR DESCRIPTION
In the catastrophic case where LLDB fails to import Swift stdlib, raise a fatal error in SwiftASTContext. No operation will succeed anyway afterwards and this will make it easier to diagnose the root cause of problems.

rdar://167711620