### PR TITLE
🍒 [lldb] Add missing locks in SBThread methods (#174791)

### DIFF
--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -322,6 +322,13 @@ void SBThread::SetThread(const ThreadSP &lldb_object_sp) {
 lldb::tid_t SBThread::GetThreadID() const {
   LLDB_INSTRUMENT_VA(this);
 
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return LLDB_INVALID_THREAD_ID;
+  }
+
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
     return thread_sp->GetID();
@@ -330,6 +337,13 @@ lldb::tid_t SBThread::GetThreadID() const {
 
 uint32_t SBThread::GetIndexID() const {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return LLDB_INVALID_INDEX32;
+  }
 
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
@@ -1318,6 +1332,13 @@ SBThread SBThread::GetExtendedBacktraceThread(const char *type) {
 uint32_t SBThread::GetExtendedBacktraceOriginatingIndexID() {
   LLDB_INSTRUMENT_VA(this);
 
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return LLDB_INVALID_INDEX32;
+  }
+
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
     return thread_sp->GetExtendedBacktraceOriginatingIndexID();
@@ -1326,6 +1347,13 @@ uint32_t SBThread::GetExtendedBacktraceOriginatingIndexID() {
 
 SBValue SBThread::GetCurrentException() {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return SBValue();
+  }
 
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (!thread_sp)
@@ -1337,6 +1365,13 @@ SBValue SBThread::GetCurrentException() {
 SBThread SBThread::GetCurrentExceptionBacktrace() {
   LLDB_INSTRUMENT_VA(this);
 
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return SBThread();
+  }
+
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (!thread_sp)
     return SBThread();
@@ -1346,6 +1381,13 @@ SBThread SBThread::GetCurrentExceptionBacktrace() {
 
 bool SBThread::SafeToCallFunctions() {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return false;
+  }
 
   ThreadSP thread_sp(m_opaque_sp->GetThreadSP());
   if (thread_sp)
@@ -1365,6 +1407,13 @@ lldb_private::Thread *SBThread::get() {
 
 SBValue SBThread::GetSiginfo() {
   LLDB_INSTRUMENT_VA(this);
+
+  llvm::Expected<StoppedExecutionContext> exe_ctx =
+      GetStoppedExecutionContext(m_opaque_sp);
+  if (!exe_ctx) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::API), exe_ctx.takeError(), "{0}");
+    return SBValue();
+  }
 
   ThreadSP thread_sp = m_opaque_sp->GetThreadSP();
   if (!thread_sp)


### PR DESCRIPTION
Some of these methods are not acquiring the run lock prior to executing.

(cherry picked from commit 13829dfaac414775fb932282b0cc92192aec08d6)