### PR TITLE
[clang][cas] Only use mccas by default on mach-o platforms in clang-cache

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -151,6 +151,8 @@ def err_feature_availability_flag_invalid_value : Error<
 
 def err_fe_incompatible_option_with_remote_cache : Error<
   "'%0' is incompatible with remote caching backend">;
+def err_fe_mccas_incompatible_target : Error<
+  "-fcas-backend is incompatible with target '%0'; requires mach-o object format">;
 def err_fe_unable_to_load_include_tree : Error<
   "unable to load the CAS include-tree '%0': '%1'">;
 def err_unable_to_load_include_tree_node : Error<

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5521,6 +5521,8 @@ bool CompilerInvocation::CreateFromArgsImpl(
       Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
           << "-fcasid-output";
   }
+  if (Res.getCodeGenOpts().UseCASBackend && !T.isOSBinFormatMachO())
+    Diags.Report(diag::err_fe_mccas_incompatible_target) << T.str();
   // END MCCAS
 
   // FIXME: Override value name discarding when asan or msan is used because the

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -42,31 +42,43 @@
 // PLUGIN: "-fcas-plugin-option" "opt2=val2"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS -DPREFIX=%t
 // ENABLE-MCCAS: "-fcas-path" "[[PREFIX]]/cas"
 // ENABLE-MCCAS: "-fcas-backend"
 // ENABLE-MCCAS: "-mllvm"
 // ENABLE-MCCAS: "-cas-friendly-debug-info"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_VERIFY_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS-VERIFY -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS-VERIFY -DPREFIX=%t
 // ENABLE-MCCAS-VERIFY: "-fcas-path" "[[PREFIX]]/cas"
 // ENABLE-MCCAS-VERIFY: "-fcas-backend"
 // ENABLE-MCCAS-VERIFY: "-fcas-backend-mode=verify"
 // ENABLE-MCCAS-VERIFY: "-mllvm"
 // ENABLE-MCCAS-VERIFY: "-cas-friendly-debug-info"
 
+// ELF/COFF platforms do not support mccas.
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
+// RUN: %clang-cache %clang -target x86_64-unknown-linux-gnu -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
+// RUN: %clang-cache %clang -target x86_64-unknown-windows-msvc -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// Forcing mccas gives an error on ELF/COFF.
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
+// RUN: not %clang -target x86_64-unknown-linux-gnu -Xclang -fcas-backend -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=MCCAS_NOT_ALLOWED
+// MCCAS_NOT_ALLOWED: error: -fcas-backend is incompatible with target 'x86_64-unknown-linux-gnu'; requires mach-o object format
+
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote CLANG_CACHE_DISABLE_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote CLANG_CACHE_DISABLE_MCCAS=1 CLANG_CACHE_VERIFY_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // DISABLE-MCCAS-NOT: "-fcas-backend"
 // DISABLE-MCCAS-NOT: "-fcas-backend-mode=verify"

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -36,7 +36,8 @@ static bool isSameProgram(StringRef clangCachePath, StringRef compilerPath) {
 }
 
 static bool shouldCacheInvocation(ArrayRef<const char *> Args,
-                                  IntrusiveRefCntPtr<DiagnosticsEngine> Diags) {
+                                  IntrusiveRefCntPtr<DiagnosticsEngine> Diags,
+                                  bool &SupportsMCCAS) {
   SmallVector<const char *, 128> CheckArgs(Args.begin(), Args.end());
   // Make sure "-###" is not present otherwise we won't get an object back.
   CheckArgs.erase(
@@ -70,6 +71,10 @@ static bool shouldCacheInvocation(ArrayRef<const char *> Args,
         << "AS_SECURE_LOG_FILE is set";
     return false;
   }
+
+  llvm::Triple T(CInvok->getTargetOpts().Triple);
+  SupportsMCCAS = T.isOSBinFormatMachO();
+
   return true;
 }
 
@@ -123,7 +128,7 @@ static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
 
 /// Arguments specific to \p clang-cache compiler launcher functionality.
 static void addLauncherArgs(SmallVectorImpl<const char *> &Args,
-                            llvm::StringSaver &Saver) {
+                            llvm::StringSaver &Saver, bool SupportsMCCAS) {
 
   if (const char *DaemonPath =
           ::getenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH")) {
@@ -171,8 +176,8 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &Args,
   }
   Args.append({"-greproducible"});
 
-  if (!llvm::sys::Process::GetEnv("CLANG_CACHE_DISABLE_MCCAS") &&
-      !ServicePath) {
+  if (SupportsMCCAS && !ServicePath &&
+      !llvm::sys::Process::GetEnv("CLANG_CACHE_DISABLE_MCCAS")) {
     Args.push_back("-Xclang");
     Args.push_back("-fcas-backend");
     if (llvm::sys::Process::GetEnv("CLANG_CACHE_VERIFY_MCCAS")) {
@@ -253,12 +258,13 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
     Args[0] = Saver.save(compilerPath).data();
 
   if (isSameProgram(clangCachePath, compilerPath)) {
-    if (!shouldCacheInvocation(Args, DiagsPtr)) {
+    bool SupportsMCCAS = false;
+    if (!shouldCacheInvocation(Args, DiagsPtr, SupportsMCCAS)) {
       if (Diags.hasErrorOccurred())
         return 1;
       return std::nullopt;
     }
-    addLauncherArgs(Args, Saver);
+    addLauncherArgs(Args, Saver, SupportsMCCAS);
     return std::nullopt;
   }
 


### PR DESCRIPTION
This was causing the clang-cache launcher to fail when targeting Linux/Windows. Only enable mccas on mach-o platforms. Incidentally, add a proper diagnostic if someone attempts to force mccas since it was previously hitting an llvm_unreachable.