### PR TITLE
[lldb][swift] Update Swift ASTContextCreation to account for the new argument

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3728,6 +3728,10 @@ void SwiftASTContext::InitializeSearchPathOptions(
   invocation.computeCXXStdlibOptions();
 }
 
+std::optional<clang::DarwinSDKInfo> &SwiftASTContext::GetSDKInfo() {
+  return GetCompilerInvocation().getSDKInfo();
+}
+
 ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   assert(m_initialized_search_path_options &&
          m_initialized_clang_importer_options &&
@@ -3742,7 +3746,8 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
       GetLanguageOptions(), GetTypeCheckerOptions(), GetSILOptions(),
       GetSearchPathOptions(), GetClangImporterOptions(),
       GetSymbolGraphOptions(), GetCASOptions(), GetSerializationOptions(),
-      GetSourceManager(), GetDiagnosticEngine(), /*OutputBackend=*/nullptr));
+      GetSourceManager(), GetDiagnosticEngine(), GetSDKInfo(),
+      /*OutputBackend=*/nullptr));
 
   if (getenv("LLDB_SWIFT_DUMP_DIAGS")) {
     // NOTE: leaking a swift::PrintingDiagnosticConsumer() here, but

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -31,11 +31,13 @@
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
+#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Target/TargetOptions.h"
 
 #include <memory>
+#include <optional>
 
 namespace swift {
 enum class IRGenDebugInfoLevel : unsigned;
@@ -252,6 +254,8 @@ public:
   swift::DiagnosticEngine &GetDiagnosticEngine();
 
   swift::SearchPathOptions &GetSearchPathOptions();
+
+  std::optional<clang::DarwinSDKInfo> &GetSDKInfo();
 
   swift::SerializationOptions &GetSerializationOptions();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -83,8 +83,8 @@ public:
         m_compiler_invocation.getClangImporterOptions(),
         m_compiler_invocation.getSymbolGraphOptions(),
         m_compiler_invocation.getCASOptions(),
-        m_compiler_invocation.getSerializationOptions(),
-        m_source_manager, m_diagnostic_engine));
+        m_compiler_invocation.getSerializationOptions(), m_source_manager,
+        m_diagnostic_engine, m_compiler_invocation.getSDKInfo()));
     m_clang_importer = swift::ClangImporter::create(*m_ast_context, "", {}, {});
   }
   std::string ImportName(const clang::NamedDecl *decl) {


### PR DESCRIPTION
Pipe the SDKInfo from the Swift CompilerInvocation to the Swift ASTContext.

rdar://167721226