### PR TITLE
[compiler-rt] [Darwin] Add darwin-remote feature for remote darwin test targets

### DIFF
--- a/compiler-rt/test/asan/TestCases/Darwin/asan-symbolize-partial-report-no-external-symbolizer.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/asan-symbolize-partial-report-no-external-symbolizer.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 // When `external_symbolizer_path` is empty on Darwin we fallback on using
 // dladdr as the symbolizer which means we get the symbol name
 // but no source location. The current implementation also doesn't try to

--- a/compiler-rt/test/asan/TestCases/Darwin/asan-symbolize-partial-report-with-module-map.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/asan-symbolize-partial-report-with-module-map.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 // FIXME(dliew): We currently have to use module map for this test due to the atos
 // symbolizer changing the module name from an absolute path to just the file name.
 // rdar://problem/49784442

--- a/compiler-rt/test/asan/TestCases/Darwin/asan-symbolize-with-module-map.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/asan-symbolize-with-module-map.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 // RUN: %clangxx_asan -O0 -g %s -o %t.executable
 
 // Deliberately don't produce the module map and then check that offline symbolization fails

--- a/compiler-rt/test/asan/TestCases/Darwin/atos-symbolizer-dyld-root-path.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/atos-symbolizer-dyld-root-path.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: asan-64-bits
 
 // Path returned by `which atos` is invalid on iOS.
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 #include <stdlib.h>
 #include <string.h>

--- a/compiler-rt/test/asan/TestCases/Darwin/atos-symbolizer.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/atos-symbolizer.cpp
@@ -4,8 +4,8 @@
 // RUN: which atos | tr -d '\n' > %t.symbolizer_path
 // RUN: %env_asan_opts=verbosity=2 ASAN_SYMBOLIZER_PATH=%{readfile:%t.symbolizer_path} not %run %t 2>&1 | FileCheck %s
 
-// Path returned by `which atos` is invalid on iOS.
-// UNSUPPORTED: ios, i386-darwin
+// Path returned by `which atos` is invalid on non-host
+// UNSUPPORTED: darwin-remote, i386-darwin
 
 #include <stdlib.h>
 #include <string.h>

--- a/compiler-rt/test/asan/TestCases/Darwin/duplicate_os_log_reports.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/duplicate_os_log_reports.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 // REQUIRES: darwin_log_cmd
 // RUN: %clangxx_asan -fsanitize-recover=address %s -o %t
 // RUN: bash -c '{ %env_asan_opts=halt_on_error=0,log_to_syslog=1 %run %t > %t.process_output.txt 2>&1 & } \

--- a/compiler-rt/test/asan/TestCases/Darwin/dyld_insert_libraries_reexec.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/dyld_insert_libraries_reexec.cpp
@@ -1,7 +1,7 @@
 // When DYLD-inserting the ASan dylib from a different location than the
 // original, make sure we don't try to reexec.
 
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_asan -print-file-name=lib | tr -d '\n' > %t.lib_name

--- a/compiler-rt/test/asan/TestCases/Darwin/dyld_insert_libraries_remove.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/dyld_insert_libraries_remove.cpp
@@ -2,7 +2,7 @@
 // the ASan dylib from the environment variable (both when using an absolute
 // or relative path) and also that the other dylibs are left untouched.
 
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_asan -print-file-name=lib | tr -d '\n' > %t.lib_name

--- a/compiler-rt/test/asan/TestCases/Darwin/interface_symbols_darwin.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/interface_symbols_darwin.cpp
@@ -51,6 +51,6 @@
 // RUN: echo "=== NOTE === If you see a mismatch below, please update sanitizer_interface.inc files."
 // RUN: diff %t.imports-sorted %t.exports-sorted
 
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 int main() { return 0; }

--- a/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/suppressions-sandbox.cpp
@@ -9,8 +9,8 @@
 // Check that suppressing a function name works within a no-fork sandbox
 // RUN: echo "interceptor_via_fun:createCFString" > %t.supp
 // RUN: %env_asan_opts=suppressions='"%t.supp"' \
-// RUN:   sandbox-exec -p '(version 1)(allow default)(deny process-fork)' \
-// RUN:   %run %t 2>&1 | FileCheck --check-prefix=CHECK-IGNORE %s
+// RUN:   %run sandbox-exec -p '(version 1)(allow default)(deny process-fork)' \
+// RUN:   %t 2>&1 | FileCheck --check-prefix=CHECK-IGNORE %s
 
 // sandbox-exec isn't available on iOS
 // UNSUPPORTED: ios

--- a/compiler-rt/test/asan/TestCases/Darwin/uuid.cpp
+++ b/compiler-rt/test/asan/TestCases/Darwin/uuid.cpp
@@ -5,7 +5,7 @@
 // RUN: %env_asan_opts=print_module_map=2:halt_on_error=0     %run %t 2>&1 | FileCheck %s
 
 // We can't run system("otool") in the simulator.
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/asan/TestCases/Posix/asan-symbolize-sanity-test.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/asan-symbolize-sanity-test.cpp
@@ -9,7 +9,7 @@
 // RUN: %env_asan_opts=symbolize=0 not %run %t 2>&1 | %asan_symbolize | FileCheck %s
 // REQUIRES: stable-runtime
 
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 #if !defined(SHARED_LIB)
 #include <dlfcn.h>

--- a/compiler-rt/test/asan/TestCases/Posix/asan_symbolize_script/plugin_wrong_frame_number_bug.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/asan_symbolize_script/plugin_wrong_frame_number_bug.cpp
@@ -1,7 +1,7 @@
 // This test case checks for an old bug when using plug-ins that caused
 // the stack numbering to be incorrect.
 // UNSUPPORTED: android
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 // RUN: %clangxx_asan -O0 -g %s -o %t
 // RUN: %env_asan_opts=symbolize=0 not %run %t DUMMY_ARG > %t.asan_report 2>&1

--- a/compiler-rt/test/asan/TestCases/Posix/coverage.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/coverage.cpp
@@ -17,7 +17,7 @@
 //
 // https://code.google.com/p/address-sanitizer/issues/detail?id=263
 // XFAIL: android
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 #include <assert.h>
 #include <stdio.h>

--- a/compiler-rt/test/asan/TestCases/Posix/new_array_cookie_with_new_from_class.cpp
+++ b/compiler-rt/test/asan/TestCases/Posix/new_array_cookie_with_new_from_class.cpp
@@ -4,7 +4,7 @@
 //
 // XFAIL: target=arm{{.*}}
 
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 #include <new>
 #include <stdlib.h>

--- a/compiler-rt/test/asan/TestCases/default_ignorelist.cpp
+++ b/compiler-rt/test/asan/TestCases/default_ignorelist.cpp
@@ -1,6 +1,6 @@
 // FIXME: https://code.google.com/p/address-sanitizer/issues/detail?id=316
 // XFAIL: android, msvc
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 //
 // Test that ASan uses the default ignorelist from resource directory.
 // RUN: %clangxx_asan -### %s 2>&1 | FileCheck %s

--- a/compiler-rt/test/asan/TestCases/log-path_test.cpp
+++ b/compiler-rt/test/asan/TestCases/log-path_test.cpp
@@ -1,5 +1,5 @@
 // FIXME: https://code.google.com/p/address-sanitizer/issues/detail?id=316
-// UNSUPPORTED: ios, android
+// UNSUPPORTED: darwin-remote, android
 //
 // RUN: %clangxx_asan  %s -o %t
 

--- a/compiler-rt/test/asan/TestCases/suppressions-exec-relative-location.cpp
+++ b/compiler-rt/test/asan/TestCases/suppressions-exec-relative-location.cpp
@@ -25,7 +25,7 @@
 
 // FIXME: Upload suppressions to device.
 // XFAIL: android
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/compiler-rt/test/fuzzer/afl-driver-stderr.test
+++ b/compiler-rt/test/fuzzer/afl-driver-stderr.test
@@ -1,6 +1,6 @@
 # AFL doesn't work on Windows. No reason to test the driver.
 UNSUPPORTED: target={{.*(freebsd|windows).*}}
-XFAIL: ios
+XFAIL: darwin-remote
 RUN: %no_fuzzer_cpp_compiler %S/AFLDriverTest.cpp %libfuzzer_src/afl/afl_driver.cpp -o %t-AFLDriverTest
 
 ; Test that not specifying a stderr file isn't broken.

--- a/compiler-rt/test/fuzzer/big-file-copy.test
+++ b/compiler-rt/test/fuzzer/big-file-copy.test
@@ -1,5 +1,5 @@
 REQUIRES: darwin
-UNSUPPORTED: ios
+UNSUPPORTED: darwin-remote
 RUN: %cpp_compiler %S/BigFileCopy.cpp -o %t
 RUN: bash -c '%run %t -runs=1 -rss_limit_mb=4096 2>big-file-out.txt; result=$? \
 RUN:   %run rm -f big-file.txt big-file-out.txt && exit $result'

--- a/compiler-rt/test/fuzzer/cross_over.test
+++ b/compiler-rt/test/fuzzer/cross_over.test
@@ -1,5 +1,5 @@
 # For IOS, we fail to permute the run lines properly (rdar://99889376)
-XFAIL: ios && !iossim
+XFAIL: darwin-remote && !iossim
 # Tests CrossOverTest.
 # We want to make sure that the test can find the input
 # ABCDEFGHIJ when given two other inputs in the seed corpus:

--- a/compiler-rt/test/fuzzer/merge-control-file.test
+++ b/compiler-rt/test/fuzzer/merge-control-file.test
@@ -1,5 +1,5 @@
 # For IOS, we fail to permute the run lines properly (rdar://99889376)
-XFAIL: ios && !iossim
+XFAIL: darwin-remote && !iossim
 RUN: mkdir -p %t
 # Use a ".exe" extension because it is needed on Windows to call system()
 # to execute itself again.

--- a/compiler-rt/test/fuzzer/merge-posix.test
+++ b/compiler-rt/test/fuzzer/merge-posix.test
@@ -1,4 +1,4 @@
-XFAIL: ios
+XFAIL: darwin-remote
 # Uses ulimit
 # UNSUPPORTED: system-windows
 RUN: %cpp_compiler %S/FullCoverageSetTest.cpp -o %t-FullCoverageSetTest

--- a/compiler-rt/test/fuzzer/seed_inputs.test
+++ b/compiler-rt/test/fuzzer/seed_inputs.test
@@ -1,5 +1,5 @@
 # Uses echo in a way that is not supported by the iOS "run-on-device" script.
-UNSUPPORTED: ios
+UNSUPPORTED: darwin-remote
 
 RUN: %cpp_compiler %S/SimpleTest.cpp -o %t-SimpleTest
 

--- a/compiler-rt/test/lit.common.cfg.py
+++ b/compiler-rt/test/lit.common.cfg.py
@@ -419,14 +419,18 @@ elif config.target_os == "Darwin" and not config.apple_target_is_host:
     # =========================================================================
     # Target             | Feature set
     # =========================================================================
-    # macOS              | darwin
-    # iOS device         | darwin, ios
-    # iOS simulator      | darwin, ios, iossim
-    # tvOS device        | darwin, ios, tvos
-    # tvOS simulator     | darwin, ios, iossim, tvos, tvossim
-    # watchOS device     | darwin, ios, watchos
-    # watchOS simulator  | darwin, ios, iossim, watchos, watchossim
+    # macOS host         | darwin
+    # macOS device       | darwin, darwin-remote
+    # iOS device         | darwin, darwin-remote, ios
+    # iOS simulator      | darwin, darwin-remote, ios, iossim
+    # tvOS device        | darwin, darwin-remote, ios, tvos
+    # tvOS simulator     | darwin, darwin-remote, ios, iossim, tvos, tvossim
+    # watchOS device     | darwin, darwin-remote, ios, watchos
+    # watchOS simulator  | darwin, darwin-remote, ios, iossim, watchos, watchossim
     # =========================================================================
+
+    # All suites that aren't running on the host get the darwin-remote feature.
+    config.available_features.add("darwin-remote")
 
     # All non-OSX targets have the ios feature (see the above table)
     if config.apple_platform != "osx":

--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_trace_pc_guard.cpp
@@ -6,7 +6,7 @@
 // UNSUPPORTED: x86_64h-darwin && lsan
 // XFAIL: tsan
 // XFAIL: android && asan
-// XFAIL: ios
+// XFAIL: darwin-remote
 
 // RUN: rm -rf %t_workdir
 // RUN: mkdir -p %t_workdir

--- a/compiler-rt/test/sanitizer_common/TestCases/suffix-log-path_test.c
+++ b/compiler-rt/test/sanitizer_common/TestCases/suffix-log-path_test.c
@@ -6,7 +6,7 @@
 // RUN: %env_tool_opts=log_path=%t.dir/sanitizer.log:log_exe_name=1:log_suffix=.txt %run %t.dir/suffix-log-path_test-binary 2> %t.out
 // RUN: FileCheck %s < %t.dir/sanitizer.log.suffix-log-path_test-binary.*.txt
 
-// UNSUPPORTED: ios, android
+// UNSUPPORTED: darwin-remote, android
 
 #include <stdlib.h>
 #include <string.h>

--- a/compiler-rt/test/tsan/Darwin/dlopen.cpp
+++ b/compiler-rt/test/tsan/Darwin/dlopen.cpp
@@ -4,7 +4,7 @@
 
 // REQUIRES: osx-autointerception
 
-// XFAIL: ios
+// XFAIL: darwin-remote
 
 // RUN: %clangxx_tsan %s -o %t.so -shared -DSHARED_LIB
 // RUN: %clangxx_tsan -fno-sanitize=thread %s -o %t

--- a/compiler-rt/test/tsan/Darwin/dyld-insert-libraries.c
+++ b/compiler-rt/test/tsan/Darwin/dyld-insert-libraries.c
@@ -9,7 +9,7 @@
 //
 // RUN: env DYLD_INSERT_LIBRARIES=%t.dylib %run %t 2>&1 | FileCheck %s --implicit-check-not='ThreadSanitizer'
 //
-// XFAIL: ios
+// XFAIL: darwin-remote
 
 #include <assert.h>
 #include <pthread.h>

--- a/compiler-rt/test/tsan/Darwin/write-interpose.c
+++ b/compiler-rt/test/tsan/Darwin/write-interpose.c
@@ -8,7 +8,7 @@
 // deadlock (self-lock)
 // RUN: env DYLD_INSERT_LIBRARIES=%t.dylib TSAN_OPTIONS=verbosity=2:lock_during_write=disable_for_current_process %run %t 2>&1 | FileCheck %s
 //
-// UNSUPPORTED: ios
+// UNSUPPORTED: darwin-remote
 
 #include <stdio.h>
 


### PR DESCRIPTION
Some tests are already supported on Darwin "remote" devices and simulators. However, there is currently no way to distinguish a remote macOS host from a local one.

This adds the darwin-remote feature which is common to all test targets which use a wrapper script (e.g. iossim_run.py).

rdar://167735355