### PR TITLE
[clang][cas] Fix use of clang-cache for -E on Linux

### DIFF
--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -152,6 +152,7 @@ bool types::isAcceptedByClang(ID Id) {
   case TY_AST: case TY_ModuleFile: case TY_PCH:
   case TY_LLVM_IR: case TY_LLVM_BC:
   case TY_API_INFO:
+  case TY_ResponseFile: // TO_UPSTREAM(CAS)
     return true;
   }
 }

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -169,3 +169,13 @@
 // UNUSED_OPT-NOT: warning:
 // UNUSED_OPT: warning: -Wl,-ObjC: 'linker' input unused
 // UNUSED_OPT-NOT: warning:
+
+// -E with caching
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target x86_64-apple-darwin10 -E %s -### 2>&1 | FileCheck %s -check-prefix=CLANG_E -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target x86_64-unknown-linux-gnu -E %s -### 2>&1 | FileCheck %s -check-prefix=CLANG_E -DPREFIX=%t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target 86_64-unknown-windows-msvc -E %s -### 2>&1 | FileCheck %s -check-prefix=CLANG_E -DPREFIX=%t
+
+// CLANG_E: "-cc1depscan" "-fdepscan=auto"
+// CLANG_E: "-fcas-path" "[[PREFIX]]/cas"
+// CLANG_E: "-greproducible"
+// CLANG_E: "{{.*}}clang{{.*}}" "-cc1" "@{{.*}}.rsp" "-o" "-"


### PR DESCRIPTION
The GCC/Linux toolchain checks whether a given filetype is supported by clang and falls back to gcc if not, so we need it to know that clang can support the response-file type that is output by the dependency scan. Previously we would try to execute the cached -E rsp file using gcc.