### PR TITLE
Replace "REQUIRES: shell" with "UNSUPPORTED: system-windows" per upstream change

### DIFF
--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -1,4 +1,4 @@
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t && mkdir %t
 // RUN: echo "#!/bin/sh"              > %t/clang

--- a/clang/test/CAS/libclang-replay-job.c
+++ b/clang/test/CAS/libclang-replay-job.c
@@ -1,4 +1,4 @@
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: split-file %s %t

--- a/clang/test/CAS/output-path-error.c
+++ b/clang/test/CAS/output-path-error.c
@@ -1,6 +1,6 @@
 // Check that fatal errors from cache-related output paths show up.
 
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t && mkdir -p %t
 

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -1,4 +1,4 @@
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t && mkdir -p %t
 

--- a/clang/test/CAS/zero-ar-date.c
+++ b/clang/test/CAS/zero-ar-date.c
@@ -6,7 +6,6 @@
 
 // Needs 'shell' for touch and 'system-darwin' for calling through to the
 // linker.
-// REQUIRES: shell
 // REQUIRES: system-darwin
 
 // RUN: rm -rf %t

--- a/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
@@ -1,7 +1,8 @@
 // Check that the path of an "affecting" modulemap file matches what is captured
 // in the cas fs.
 
-// REQUIRES: shell, ondisk_cas
+// REQUIRES: ondisk_cas
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t

--- a/clang/test/ClangScanDeps/stable-dirs-c-api.c
+++ b/clang/test/ClangScanDeps/stable-dirs-c-api.c
@@ -1,4 +1,4 @@
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 

--- a/clang/test/Index/Store/json-with-module.m
+++ b/clang/test/Index/Store/json-with-module.m
@@ -1,6 +1,6 @@
 @import ModDep;
 
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t
 // RUN: mkdir %t

--- a/clang/test/Index/Store/json-with-pch.c
+++ b/clang/test/Index/Store/json-with-pch.c
@@ -2,7 +2,7 @@ int main() {
   test1_func();
 }
 
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t
 // RUN: mkdir %t

--- a/clang/test/Index/Store/json.c
+++ b/clang/test/Index/Store/json.c
@@ -7,4 +7,4 @@
 // RUN: sed -e "s:%S::g" -e "s:%t.o::g" %t.json > %t.final.json
 // RUN: diff -u %S/Inputs/json.c.json %t.final.json
 
-// REQUIRES: shell
+// UNSUPPORTED: system-windows

--- a/clang/test/Index/Store/relative-out-path.c
+++ b/clang/test/Index/Store/relative-out-path.c
@@ -1,5 +1,5 @@
 // Needs 'find'.
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t

--- a/clang/test/Index/Store/unit-with-vfs.c
+++ b/clang/test/Index/Store/unit-with-vfs.c
@@ -1,5 +1,5 @@
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs:g" -e "s:OUT_DIR:%t:g" %S/Inputs/overlay.yaml > %t.yaml
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 #include "using-overlay.h"
 

--- a/clang/test/Modules/crash-index-store-path.m
+++ b/clang/test/Modules/crash-index-store-path.m
@@ -1,4 +1,4 @@
-// REQUIRES: crash-recovery, shell, system-darwin
+// REQUIRES: crash-recovery, system-darwin
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t/m

--- a/clang/test/Modules/infer_swift_name.m
+++ b/clang/test/Modules/infer_swift_name.m
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: %clang_cc1 -fmodules-cache-path=%t -fmodules -fimplicit-module-maps -I %S/Inputs/swift_name %s -verify
-// REQUIRES: shell
+// UNSUPPORTED: system-windows
 
 @import SwiftNameInferred; // ok
 @import SwiftName; // expected-error{{module 'SwiftName' not found}}

--- a/llvm/test/CAS/databasefile-concurrent-creation.c
+++ b/llvm/test/CAS/databasefile-concurrent-creation.c
@@ -1,4 +1,5 @@
-// REQUIRES: ondisk_cas, shell
+// REQUIRES: ondisk_cas
+// UNSUPPORTED: system-windows
 
 // RUN: rm -rf %t
 // RUN: mkdir -p %t


### PR DESCRIPTION
In 9553f119b the "shell" lit feature was removed. Update our downstream tests to instead check for !windows. Note: this is being done mechanically, so it's possible some of these tests work on Windows and should be enabled in a future change.