### PR TITLE
🍒 [lldb] Recognize MTE fault Mach exceptions (#159117)

### DIFF
--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -77,6 +77,35 @@ static void DescribeAddressBriefly(Stream &strm, const Address &addr,
   strm.Printf(".\n");
 }
 
+static constexpr uint8_t g_mte_tag_shift = 64 - 8;
+static constexpr uintptr_t g_mte_tag_mask = (uintptr_t)0x0f << g_mte_tag_shift;
+
+bool StopInfoMachException::DetermineTagMismatch(ExecutionContext &exe_ctx) {
+  const bool IsBadAccess = m_value == 1;            // EXC_BAD_ACCESS
+  const bool IsMTETagFault = (m_exc_code == 0x106); // EXC_ARM_MTE_TAG_FAULT
+  if (!IsBadAccess || !IsMTETagFault)
+    return false;
+
+  if (m_exc_data_count < 2)
+    return false;
+
+  const uint64_t bad_address = m_exc_subcode;
+
+  StreamString strm;
+  strm.Printf("EXC_ARM_MTE_TAG_FAULT (code=%" PRIu64 ", address=0x%" PRIx64
+              ")\n",
+              m_exc_code, bad_address);
+
+  const uint8_t tag = (bad_address & g_mte_tag_mask) >> g_mte_tag_shift;
+  const uint64_t canonical_addr = bad_address & ~g_mte_tag_mask;
+  strm.Printf(
+      "Note: MTE tag mismatch detected: pointer tag=%d, address=0x%" PRIx64,
+      tag, canonical_addr);
+  m_description = std::string(strm.GetString());
+
+  return true;
+}
+
 bool StopInfoMachException::DeterminePtrauthFailure(ExecutionContext &exe_ctx) {
   bool IsBreakpoint = m_value == 6; // EXC_BREAKPOINT
   bool IsBadAccess = m_value == 1;  // EXC_BAD_ACCESS
@@ -265,6 +294,8 @@ const char *StopInfoMachException::GetDescription() {
 
     case llvm::Triple::aarch64:
       if (DeterminePtrauthFailure(exe_ctx))
+        return m_description.c_str();
+      if (DetermineTagMismatch(exe_ctx))
         return m_description.c_str();
       break;
 

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.cpp
@@ -78,7 +78,7 @@ static void DescribeAddressBriefly(Stream &strm, const Address &addr,
 }
 
 static constexpr uint8_t g_mte_tag_shift = 64 - 8;
-static constexpr uintptr_t g_mte_tag_mask = (uintptr_t)0x0f << g_mte_tag_shift;
+static constexpr addr_t g_mte_tag_mask = (addr_t)0x0f << g_mte_tag_shift;
 
 bool StopInfoMachException::DetermineTagMismatch(ExecutionContext &exe_ctx) {
   const bool IsBadAccess = m_value == 1;            // EXC_BAD_ACCESS
@@ -97,7 +97,7 @@ bool StopInfoMachException::DetermineTagMismatch(ExecutionContext &exe_ctx) {
               m_exc_code, bad_address);
 
   const uint8_t tag = (bad_address & g_mte_tag_mask) >> g_mte_tag_shift;
-  const uint64_t canonical_addr = bad_address & ~g_mte_tag_mask;
+  const addr_t canonical_addr = bad_address & ~g_mte_tag_mask;
   strm.Printf(
       "Note: MTE tag mismatch detected: pointer tag=%d, address=0x%" PRIx64,
       tag, canonical_addr);

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
@@ -27,6 +27,8 @@ class StopInfoMachException : public StopInfo {
   /// is auth-related failure, and returns false otherwise.
   bool DeterminePtrauthFailure(ExecutionContext &exe_ctx);
 
+  bool DetermineTagMismatch(ExecutionContext &exe_ctx);
+
 public:
   // Constructors and Destructors
   StopInfoMachException(Thread &thread, uint32_t exc_type,

--- a/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
+++ b/lldb/source/Plugins/Process/Utility/StopInfoMachException.h
@@ -27,7 +27,7 @@ class StopInfoMachException : public StopInfo {
   /// is auth-related failure, and returns false otherwise.
   bool DeterminePtrauthFailure(ExecutionContext &exe_ctx);
 
-  bool DetermineTagMismatch(ExecutionContext &exe_ctx);
+  bool DetermineTagMismatch();
 
 public:
   // Constructors and Destructors
@@ -47,6 +47,9 @@ public:
   }
 
   const char *GetDescription() override;
+
+  // Returns the fault address, iff this is a EXC_ARM_MTE_TAG_FAULT.
+  std::optional<lldb::addr_t> GetTagFaultAddress() const;
 
 #if defined(__APPLE__)
   struct MachException {


### PR DESCRIPTION
Cherry-picks of:
* [lldb] Recognize MTE fault Mach exceptions (def202048586dad7029c9458a39dcb0e3cdb6c33)
* [lldb] Correct 32-bit build failure in StopInfoMachException.cpp (88b5c7435e70702d54772c1ec3864013099edc6c)
* [lldb] Recognize MTE faults with EXC_GUARD exception type (2d1bc9f5a212dc4c8fa14a5741af2a7a5e60ff36)