### PR TITLE
[lldb][windows] reenable TestDAP_commands.test_command_directive_quiet_on_success

### DIFF
--- a/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
+++ b/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
@@ -7,7 +7,6 @@ from lldbsuite.test.decorators import *
 
 
 class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
-    @skipIfWindows	# rdar://163316257
     def test_command_directive_quiet_on_success(self):
         program = self.getBuildArtifact("a.out")
         command_quiet = (


### PR DESCRIPTION
This patch reenables `TestDAP_commands.test_command_directive_quiet_on_success` which was deactivated in https://github.com/swiftlang/llvm-project/pull/11708.

rdar://163316257