### PR TITLE
[Cherry-pick into next] [LLDB] Add missing argument to log function call

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -747,7 +747,7 @@ static void ResolveSpecialNames(
 
     resolved_names.insert(name_cs);
 
-    LLDB_LOG(log, "Resolving special name {0}");
+    LLDB_LOG(log, "Resolving special name {0}", name_cs);
 
     lldb::ExpressionVariableSP expr_var_sp =
         persistent_state->GetVariable(name_cs);


### PR DESCRIPTION
```
commit e66bffa77b8dd8013e7adaee0b32dfdc7aac81f8
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Jan 8 15:57:00 2026 -0800

    [LLDB] Add missing argument to log function call
```
