### PR TITLE
[lldb] Fix crash when passing a folder in as the executable (#175181)

### DIFF
--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -84,11 +84,14 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
     // container plug-ins can use these bytes to see if they can parse this
     // file.
     if (file_size > 0) {
-      DataBufferSP buffer_sp = FileSystem::Instance().CreateDataBuffer(
-          file->GetPath(), g_initial_bytes_to_read, file_offset);
-      extractor_sp = std::make_shared<DataExtractor>();
-      extractor_sp->SetData(buffer_sp, data_offset, buffer_sp->GetByteSize());
-      data_offset = 0;
+      // Check that we made a data buffer. For instance, a directory node is
+      // not 0 size, but we can't make a data buffer for it.
+      if (DataBufferSP buffer_sp = FileSystem::Instance().CreateDataBuffer(
+              file->GetPath(), g_initial_bytes_to_read, file_offset)) {
+        extractor_sp = std::make_shared<DataExtractor>();
+        extractor_sp->SetData(buffer_sp, data_offset, buffer_sp->GetByteSize());
+        data_offset = 0;
+      }
     }
   }
 

--- a/lldb/test/Shell/ObjectFile/invalid.test
+++ b/lldb/test/Shell/ObjectFile/invalid.test
@@ -1,0 +1,4 @@
+RUN: mkdir -p %t.dir
+RUN: %lldb %t.dir 2>&1| FileCheck %s
+
+CHECK: error: '{{.*}}.dir' is not a valid executable


### PR DESCRIPTION
This is another instance where we weren't checking that the result of FileSystem::CreateDataBuffer and unconditionally accessing it, similar to the bug in SourceManager last week. In this particular case, ObjectFile was assuming that we can read the contents non-zero, which isn't true for directory nodes.

Jim figured this one out yesterday. I'm just putting up the patch and adding a test.

rdar://167796036
(cherry picked from commit 17e226f71e1c4704ba028adbd799c3932b8c5862)