### PR TITLE
[lldb] Honor the process plugin name in the attach/launch info (#175195)

### DIFF
--- a/lldb/test/API/functionalities/gdb_remote_client/TestPlatformAttach.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPlatformAttach.py
@@ -49,10 +49,12 @@ class TestPlatformAttach(GDBRemoteTestBase):
 
         attach_info = lldb.SBAttachInfo()
         attach_info.SetExecutable("foo")
+        attach_info.SetProcessPluginName("wasm")
 
         target = lldb.SBTarget()
         process = platform.Attach(attach_info, self.dbg, target, error)
         self.assertSuccess(error)
         self.assertEqual(process.GetProcessID(), 95117)
+        self.assertEqual(process.GetPluginName(), "wasm")
 
         platform.DisconnectRemote()


### PR DESCRIPTION
When connected to a GDB remote platform, we always use "gdb-remote" as the process plugin when attaching. This means that the `--plugin` argument to `process attach` is effectively ignored. This patch makes it so that "gdb-remote" remains the default, while still honoring the process plugin name specified in the attach info. The same thing applies to launching a process.

rdar://167845923
(cherry picked from commit 5c3f02cbb344ffcd6766c1959e7851d1afec118f)