### PR TITLE
[LLDB] Improve testcoverage for typealiases in the expression evaluator

### DIFF
--- a/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
+++ b/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftExpressionTypeAlias(lldbtest.TestBase):
+
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect('expr -d run -- local', substrs=['Pair<Int>'])
+        process.Continue()
+        # FIXME!
+        self.expect('expr -d run -- local', substrs=['(Int, Int)'])
+        process.Continue()
+        self.expect("frame var associated", substrs=['A'])
+        # FIXME!
+        self.expect("expr associated", error=True,
+                    substrs=['type for typename "$s1a1BV7MyAliasaD" was not found'])

--- a/lldb/test/API/lang/swift/expression/typealias/TestTypealiasExpressionParser.py
+++ b/lldb/test/API/lang/swift/expression/typealias/TestTypealiasExpressionParser.py
@@ -1,5 +1,0 @@
-import lldbsuite.test.lldbinline as lldbinline
-from lldbsuite.test.decorators import *
-
-# FIXME! The Swift driver insists on passing -experimental-skip-non-inlinable-function-bodies-without-types to -emit-module.
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest,expectedFailureAll(bugnumber="rdar://120928396")])

--- a/lldb/test/API/lang/swift/expression/typealias/main.swift
+++ b/lldb/test/API/lang/swift/expression/typealias/main.swift
@@ -1,7 +1,35 @@
-func main() {
-  typealias Pair<T> = (T, T)
-  let patatino : Pair<Int> = (1, 2)
-  print(patatino) //%self.expect('expr -d run -- patatino', substrs=['Pair<Int>'])
+struct A {}
+
+private protocol MyProtocolBase<T> {
+    typealias MyAlias = A
+    associatedtype T
 }
 
-main()
+private protocol MyProtocol : MyProtocolBase<Int> {
+}
+
+extension MyProtocol {
+    func f1() {
+        typealias Pair<T> = (T, T)
+        let local : Pair<Int> = (1, 2)
+        print("break here")
+    }
+
+    func f2(_ associated : MyAlias) {
+        print("break here")
+    }
+}
+
+struct B : MyProtocol {
+}
+
+func f() {
+    typealias Pair<T> = (T, T)
+    let local : Pair<Int> = (1, 2)
+    print("break here")
+}
+
+f()
+let b = B()
+b.f1()
+b.f2(A())


### PR DESCRIPTION
and document several cases that aren't working correctly.

(cherry picked from commit b067de0d4920adf777553d52bd6b47dfa13230f9)