### PR TITLE
[clang][deps] Add missing initialization of `Command::CacheKey`

### DIFF
--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -95,7 +95,7 @@ bool DependencyScanningWorker::computeDependencies(
     if (StringRef(Cmd[1]) != "-cc1") {
       // Non-clang command. Just pass through to the dependency consumer.
       DepConsumer.handleBuildCommand(
-          {Cmd.front(), {Cmd.begin() + 1, Cmd.end()}});
+          {Cmd.front(), {Cmd.begin() + 1, Cmd.end()}, std::nullopt});
       return true;
     }
 


### PR DESCRIPTION
This PR fixes a warning about missing initialization of `Command::CacheKey` in recently-refactored code that has downstream differences.