### PR TITLE
[clang][cas] Work around `-cc1` sandbox violations

### DIFF
--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -21,6 +21,7 @@
 #include "llvm/MCCAS/MCCASObjectV1.h"
 #include "llvm/RemoteCachingService/Client.h"
 #include "llvm/Support/FileOutputBuffer.h"
+#include "llvm/Support/IOSandbox.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
@@ -601,7 +602,11 @@ Expected<bool> CompileJobCache::maybeIngestNonVirtualOutputFromFileSystem(
     StringRef OutputPath = FrontendOpts.OutputFile;
     if (OutputPath.empty())
       return false;
-    if (llvm::sys::fs::is_directory(OutputPath)) {
+    bool IsDirectory = [&] {
+      auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+      return llvm::sys::fs::is_directory(OutputPath);
+    }();
+    if (IsDirectory) {
       // FIXME: A directory is produced for the 'html' output of the analyzer,
       // support it for caching purposes.
       Clang.getDiagnostics().Report(diag::warn_clang_cache_disabled_caching)
@@ -713,6 +718,8 @@ Expected<llvm::cas::ObjectRef> ObjectStoreCachingOutputs::writeOutputs(
 }
 
 Error ObjectStoreCachingOutputs::addNonVirtualOutputFile(StringRef FilePath) {
+  auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+
   auto F = llvm::sys::fs::openNativeFileForRead(FilePath);
   if (!F)
     return F.takeError();

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -926,6 +926,8 @@ void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
   CompilerInvocation::ParseCASArgs(CASOpts, ParsedCASArgs, Diags);
   CASOpts.ensurePersistentCAS();
 
+  auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+
   static std::once_flag ValidateOnce;
   std::call_once(ValidateOnce, [&] {
     if (getenv("LLVM_CAS_DISABLE_VALIDATION"))
@@ -1255,10 +1257,13 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainA
     }
   }
 
-  // Create the base directory if necessary.
-  StringRef BaseDir = llvm::sys::path::parent_path(Server.BasePath);
-  if (std::error_code EC = llvm::sys::fs::create_directories(BaseDir))
-    reportError(Twine("cannot create basedir: ") + EC.message());
+  {
+    // Create the base directory if necessary.
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
+    StringRef BaseDir = llvm::sys::path::parent_path(Server.BasePath);
+    if (std::error_code EC = llvm::sys::fs::create_directories(BaseDir))
+      reportError(Twine("cannot create basedir: ") + EC.message());
+  }
 
   if (Command == "-serve") {
     Server.start(/*Exclusive*/ true, CASArgs);
@@ -1333,6 +1338,7 @@ int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainA
 
   // Redirect stdout and stderr using dup2.
   auto openAndReplaceFD = [&](int ReplacedFD, StringRef Path) {
+    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
     int FD;
     if (std::error_code EC = llvm::sys::fs::openFile(
             Path, FD, llvm::sys::fs::CD_CreateAlways, llvm::sys::fs::FA_Write,


### PR DESCRIPTION
After https://github.com/llvm/llvm-project/pull/174653, some CAS tests started failing with sandbox violations. This PR works around these.

The `CompileJobCache::maybeIngestNonVirtualOutputFromFileSystem()` function already contains this FIXME:
> All consumers should adopt \c llvm::vfs::OutputBackend and this unction should go away.

So adding another FIXME for the sandbox disablement itself felt redundant.

The sandbox disablements around the dependency scanner server/daemon infrastructure are obviously not formal inputs/outputs of the compiler, so I didn't feel the need to mark those with FIXMEs or other comments.

However, the many sandbox disablements in `cc1depscan_main.cpp` make me question whether we should just disable sandbox once at the start of `cc1depscan_main()` and only re-enable it when entering into the scanner.