### PR TITLE
Disable test for Regex in SwiftREPL until new toolchain

### DIFF
--- a/lldb/test/Shell/SwiftREPL/Regex.test
+++ b/lldb/test/Shell/SwiftREPL/Regex.test
@@ -2,7 +2,7 @@
 // REQUIRES: swift
 
 // Disabling until we can test with an updated toolchain
-// XFAIL: *
+// REQUIRES: rdar168153424
 
 // RUN: %lldb --repl < %s | FileCheck %s
 

--- a/lldb/test/Shell/SwiftREPL/Regex.test
+++ b/lldb/test/Shell/SwiftREPL/Regex.test
@@ -1,6 +1,9 @@
 // Test that we can use Swift's regex functionalities on the REPL.
 // REQUIRES: swift
 
+// Disabling until we can test with an updated toolchain
+// XFAIL: *
+
 // RUN: %lldb --repl < %s | FileCheck %s
 
 // Make sure we can use an extended literal without enabling anything.


### PR DESCRIPTION
The change in https://github.com/swiftlang/swift-experimental-string-processing/pull/849 seems to be modifying the REPL output for regexes in a way that breaks this test, but the log output doesn't include enough lines for me to see what's going wrong, and I haven't been able to reproduce the failure locally. Disabling so that we can land the change and generate a toolchain with an LLDB that understands the new Regex.