### PR TITLE
[lldb][CAS] Cache the ModuleSpec when loading from CAS

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1819,9 +1819,9 @@ llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
 
   module_spec = std::move(*loaded);
 
-  auto status =
-      GetSharedModule(module_spec, module_sp, nullptr, nullptr, nullptr,
-                      /*always_create=*/true);
+  auto status = GetSharedModule(module_spec, module_sp, nullptr, nullptr,
+                                nullptr, /*always_create=*/false);
+
   if (status.Success()) {
     if (module_sp) {
       // Enter the new module into the config cache.


### PR DESCRIPTION
`GetSharedModuleFromCAS` calls `loadModuleFromCAS` to get the
`ModuleSpec` for a module from CAS. And then call `GetSharedModule`
using said `ModuleSpec` to locate the `ModuleSP`.

However, after calling `loadModuleFromCASImpl`, LLDB would cache the
fact that it loaded from a given CAS ID, but it wouldn't cache the
`ModuleSpec`. So if one `SymbolFile` successfully called
`loadModuleFromCAS` and then a different `SymbolFile` tried to do the
same for the same CAS ID, the second invocation wouldn't fill the
`ModuleSpec` correctly and it wouldn't find the `ModuleSP` for that CAS
ID. This leads to failures in the expression evaluator later down the
line when it tries to read decls from Clang modules imported by a CU.

This patch makes `loadModuleFromCASImpl` cache the `ModuleSpec` for each
CAS ID. It then returns it (instead of passing it via an output
parameter).

rdar://167701655