### PR TITLE
[lldb][windows] set -sdk flag when invoking swiftc in tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -46,8 +46,9 @@ ifeq "$(OS)" "Windows_NT"
 	RM_F = del /f /q $(subst /,\,$(1))
 	RM_RF = rd /s /q $(subst /,\,$(1))
 	LN_SF = mklink /D "$(subst /,\,$(2))" "$(subst /,\,$(1))"
-	ECHO = echo $(1)
-	ECHO_TO_FILE = echo $(1) > $(subst /,\,$(2))
+	ECHO = echo $(1);
+	ECHO_TO_FILE = printf "%s\n" $(1) > "$(subst /,\,$(2))"
+	ECHO_APPEND_FILE = printf "%s\n" $(1) >> "$(subst /,\,$(2))"
 else
 	MKDIR_P = mkdir -p $(1)
 	CP = cp $(1) $(2)
@@ -56,8 +57,9 @@ else
 	RM_F = rm -f $(1)
 	RM_RF = rm -rf $(1)
 	LN_SF = ln -sf $(1) $(2)
-	ECHO = echo "$(1)"
-	ECHO_TO_FILE = echo $(1) > $(2)
+	ECHO = echo $(1);
+	ECHO_TO_FILE = printf '%s\n' $(1) > "$(2)"
+	ECHO_APPEND_FILE = printf '%s\n' $(1) >> "$(2)"
 endif
 
 # Suppress built-in suffix rules. We explicitly define rules for %.o.

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -15,15 +15,22 @@
 #   o cxx_compiler
 #   o cxx_linker
 #----------------------------------------------------------------------
-SWIFTC ?= $(shell $(VPATH)/$(LEVEL)/find-swift.py)
+PYTHON ?= python3
+
+SWIFTC ?= $(shell $(PYTHON) "$(VPATH)/$(LEVEL)/find-swift.py")
 ifeq "$(SDKROOT)" ""
-	SWIFTSDKROOT = $(shell $(VPATH)/$(LEVEL)/find-swift.py -s)
+	SWIFTSDKROOT = $(shell $(PYTHON) "$(VPATH)/$(LEVEL)/find-swift.py" -s)
 else
 	SWIFTSDKROOT = $(SDKROOT)
 endif
-PYTHON ?= python3
 
-SWIFTFLAGS ?= $(DEBUG_INFO_FLAG) -Onone -Xfrontend -serialize-debugging-options
+ifeq "$(OS)" "Windows_NT"
+	SWIFT_DEBUG_INFO_FLAG ?= -g
+else
+	SWIFT_DEBUG_INFO_FLAG ?= $(DEBUG_INFO_FLAG)
+endif
+
+SWIFTFLAGS ?= $(SWIFT_DEBUG_INFO_FLAG) -Onone -Xfrontend -serialize-debugging-options
 
 SWIFTFLAGS += $(SWIFTFLAGS_EXTRAS)
 SWIFTFLAGS += $(FRAMEWORK_INCLUDES)
@@ -77,7 +84,10 @@ endif
 # If C++ interop is enabled, the generated header file will try to include 
 # SWIFT_LIBS_DIR/swiftToCxx/_SwiftCxxInteroperability.h
 ifneq "$(SWIFT_CXX_INTEROP)" ""
-  CFLAGS += -I$(SWIFT_LIBS_DIR)
+	CFLAGS += -I$(SWIFT_LIBS_DIR)
+	ifeq "$(OS)" "Windows_NT"
+		CXXFLAGS += -D_MT -D_DLL
+	endif
 endif
 
 
@@ -101,7 +111,7 @@ endif
 
 ifeq "$(USESWIFTDRIVER)" "1"
 	LDFLAGS +=-L"$(SWIFTLIBS)"
-	ifeq "$(OS)" "Darwin"
+	ifeq ($(filter $(OS),Darwin Windows_NT),$(OS))
 		SWIFTFLAGS += -sdk "$(SWIFTSDKROOT)"
 	endif
 	SWIFTFLAGS += -tools-directory "$(shell dirname $(CC))"
@@ -251,20 +261,20 @@ endif # Darwin
 $(DYLIB_FILENAME) : $(DYLIB_OBJECTS) $(MODULE_INTERFACE)
 	@echo "### Linking dynamic library $(DYLIB_NAME)"
 ifneq "$(FRAMEWORK)" ""
-	mkdir -p $(FRAMEWORK).framework/Versions/A/Headers
-	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules
-	mkdir -p $(FRAMEWORK).framework/Versions/A/Resources
+	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Headers)
+	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Modules)
+	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Resources)
 ifeq "$(DYLIB_HIDE_SWIFTMODULE)" ""
 ifneq "$(MODULENAME)" ""
-	mkdir -p $(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule
-	cp -r $(MODULENAME).swiftmodule $(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule/$(ARCH).swiftmodule
+	$(call MKDIR_P,$(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule)
+	$(call CP_R,$(MODULENAME).swiftmodule,$(FRAMEWORK).framework/Versions/A/Modules/$(MODULENAME).swiftmodule/$(ARCH).swiftmodule)
 endif
 endif
-	(cd $(FRAMEWORK).framework/Versions; ln -sf A Current)
-	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Headers Headers)
-	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Modules Modules)
-	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/Resources Resources)
-	(cd $(FRAMEWORK).framework/; ln -sf Versions/A/$(FRAMEWORK) $(FRAMEWORK))
+	cd $(FRAMEWORK).framework/Versions && $(call LN_SF,A,Current)
+	cd $(FRAMEWORK).framework && $(call LN_SF,Versions/A/Headers,Headers)
+	cd $(FRAMEWORK).framework && $(call LN_SF,Versions/A/Modules,Modules)
+	cd $(FRAMEWORK).framework && $(call LN_SF,Versions/A/Resources,Resources)
+	cd $(FRAMEWORK).framework && $(call LN_SF,Versions/A/$(FRAMEWORK),$(FRAMEWORK))
 endif
 	$(SWIFTC) $(patsubst -g,,$(SWIFTFLAGS)) \
             -emit-library $(DYLIB_SWIFT_FLAGS) -o $@ $(DYLIB_OBJECTS)

--- a/lldb/test/API/lang/cpp/incomplete-types/Makefile
+++ b/lldb/test/API/lang/cpp/incomplete-types/Makefile
@@ -15,7 +15,7 @@ main.o: NO_LIMIT_DEBUG_INFO_FLAGS = ""
 main.o: CFLAGS_EXTRAS = -flimit-debug-info
 
 limit: a.o main.o
-	mkdir -p build_limit
+	$(call MKDIR_P,build_limit)
 	"$(MAKE)" -C $(BUILDDIR)/build_limit -f $(MAKEFILE_RULES) \
 		EXE=../limit CXX_SOURCES="length.cpp ../a.o ../main.o" \
 		CFLAGS_EXTRAS=-flimit-debug-info NO_LIMIT_DEBUG_INFO_FLAGS=""

--- a/lldb/test/API/lang/objc/conflicting-definition/Makefile
+++ b/lldb/test/API/lang/objc/conflicting-definition/Makefile
@@ -8,14 +8,14 @@ a.out: libTest.dylib libTestExt.dylib
 include Makefile.rules
 
 libTest.dylib:	Test/Test.m
-	mkdir -p Test
+	$(call MKDIR_P,Test)
 	"$(MAKE)" MAKE_DSYM=YES -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES DYLIB_NAME=Test DYLIB_OBJC_SOURCES=Test/Test.m \
 		LD_EXTRAS="-lobjc -framework Foundation" \
 		CFLAGS_EXTRAS=-I$(SRCDIR)
 
 libTestExt.dylib: TestExt/TestExt.m
-	mkdir -p TestExt
+	$(call MKDIR_P,TestExt)
 	"$(MAKE)" MAKE_DSYM=YES -f $(MAKEFILE_RULES) \
 		DYLIB_ONLY=YES DYLIB_NAME=TestExt DYLIB_OBJC_SOURCES=TestExt/TestExt.m \
 		LD_EXTRAS="-lobjc -framework Foundation -lTest -L." \

--- a/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/Makefile
@@ -11,5 +11,5 @@ libDylib.dylib: dylib.swift
 		-f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)
 

--- a/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/bridging_header_headermap/Makefile
@@ -24,5 +24,5 @@ libdylib.dylib: dylib.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)
 

--- a/lldb/test/API/lang/swift/clangimporter/caching/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/caching/Makefile
@@ -6,5 +6,7 @@ all: a.out cas-config
 
 include Makefile.rules
 
+CAS_CONFIG_CONTENT := {"CASPath": "$(BUILDDIR)/cas"}
+
 cas-config:
-	echo "{\"CASPath\": \"$(BUILDDIR)/cas\"}" > .cas-config
+	$(call ECHO_TO_FILE,'$(CAS_CONFIG_CONTENT)',.cas-config)

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/Makefile
@@ -11,5 +11,4 @@ libDylib.dylib: dylib.swift
 		-f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
-
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/dynamic_type_resolution_import_conflict/Makefile
@@ -29,4 +29,4 @@ libConflict.dylib: Conflict.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
@@ -9,7 +9,7 @@ include Makefile.rules
 
 # Note that this is being built with implicit modules!
 libDylib: Dylib.swift
-	mkdir -p $(BUILDDIR)/$(shell basename $< .swift)
+	$(call MKDIR_P,$(BUILDDIR)/$(shell basename $< .swift))
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_NAME=Dylib DYLIB_SWIFT_SOURCES=Dylib.swift \

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
@@ -19,5 +19,5 @@ Framework.framework: Framework.swift
 		SWIFT_OBJC_INTEROP=1 \
 		SWIFTFLAGS_EXTRAS="$(FOO_FLAGS)" \
 		FRAMEWORK=Framework
-	rm -f $(BUILDDIR)/Framework.swiftmodule
-	ln -s $(BUILDDIR)/Framework.framework/Framework $(BUILDDIR)/Framework # FIXME
+	$(call RM_F,$(BUILDDIR)/Framework.swiftmodule)
+	$(call LN_SF,$(BUILDDIR)/Framework.framework/Framework,$(BUILDDIR)/Framework) #FIXME

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/Makefile
@@ -20,4 +20,4 @@ libdylib.dylib: dylib.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/include_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/include_conflict/Makefile
@@ -20,4 +20,4 @@ libdylib.dylib: dylib.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/macro_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/macro_conflict/Makefile
@@ -20,4 +20,4 @@ lib%.dylib: %.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/missing_pch/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/missing_pch/Makefile
@@ -9,15 +9,15 @@ include Makefile.rules
 
 OVERLAY := $(BUILDDIR)/overlay.yaml
 lib%.dylib: %.swift
-	echo "struct S {};">$(BUILDDIR)/header.h
+	$(call ECHO_TO_FILE,'struct S {};',$(BUILDDIR)/header.h)
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \
 	        DISABLE_SWIFT_INTERFACE=YES \
 		SWIFTFLAGS_EXTRAS="-import-objc-header header.h -enable-bridging-pch -pch-output-dir $(BUILDDIR)" \
                 VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
-	rm -f $(OVERLAY)
-	rm header*.pch
+	$(call RM_F,$(OVERLAY))
+	$(call RM_F,header*.pch)
 
 clean::
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/missing_vfsoverlay/Makefile
@@ -7,16 +7,18 @@ all: libFoo.dylib $(EXE)
 
 include Makefile.rules
 
+OVERLAY_CONTENT := { "version": 0, "roots": [] }
 OVERLAY := $(BUILDDIR)/overlay.yaml
+
 lib%.dylib: %.swift
-	rm -f $(OVERLAY)
-	echo "{ 'version': 0, 'roots': [] }" >$(OVERLAY)
+	$(call RM_F,$(OVERLAY))
+	$(call ECHO_TO_FILE,'$(OVERLAY_CONTENT)',$(OVERLAY))
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \
 		SWIFTFLAGS_EXTRAS="-Xcc -ivfsoverlay -Xcc $(OVERLAY)" \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
-	rm -f $(OVERLAY)
+	$(call RM_F,$(OVERLAY))
 
 clean::
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_bridging_headers/Makefile
@@ -12,11 +12,11 @@ ifneq "$(CODESIGN)" ""
 endif
 
 lib%.dylib: %.swift
-	mkdir -p $(BUILDDIR)/$(shell basename $< .swift)
+	$(call MKDIR_P,$(BUILDDIR)/$(shell basename $< .swift))
 	"$(MAKE)" MAKE_DSYM=YES X=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		DYLIB_NAME=$(shell basename $< .swift) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/Makefile
@@ -16,4 +16,4 @@ lib%.dylib: %.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/Makefile
@@ -6,24 +6,24 @@ include Makefile.rules
 BUILD_SDK := $(BUILDDIR)/LocalSDK/$(shell basename $(SDKROOT))
 
 $(EXE): $(SWIFT_SOURCES)
-	rm -rf $(BUILDDIR)/LocalSDK
-	echo "Symlinking iOS SDK into build directory as a fake macOS SDK"
-	mkdir $(BUILDDIR)/LocalSDK
-	ln -s $(SDKROOT) $(BUILD_SDK)
-	echo "Building using SDK in build directory"
+	$(call RM_RF,$(BUILDDIR)/LocalSDK)
+	$(call ECHO,"Symlinking iOS SDK into build directory as a fake macOS SDK")
+	$(call MKDIR_P,$(BUILDDIR)/LocalSDK)
+	$(call LN_SF,$(SDKROOT),$(BUILD_SDK))
+	$(call ECHO,"Building using SDK in build directory")
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \
 		SDKROOT=$(BUILD_SDK) \
 		SWIFTFLAGS_EXTRAS="$(SWIFTFLAGS_EXTRAS)" \
 		-f $(SRCDIR)/helper.mk clean main.swift.o a.swiftmodule
-	echo "Sanity check that our SDK shenanigns worked"
+	$(call ECHO,"Sanity check that our SDK shenanigns worked")
 	dwarfdump -r 0 $(BUILDDIR)/main.swift.o | egrep 'DW_AT_LLVM_i?sysroot' | grep -q LocalSDK
-	echo "Linking with regular SDK (otherwise the linker complains)"
+	$(call ECHO,"Linking with regular SDK (otherwise the linker complains)")
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) \
 		SDKROOT=$(SDKROOT) \
 		-f $(SRCDIR)/helper.mk all
-	echo "Deleting build SDK"
-	rm -rf $(BUILDDIR)/LocalSDK
+	$(call ECHO,"Deleting build SDK")
+	$(call RM_RF,$(BUILDDIR)/LocalSDK)

--- a/lldb/test/API/lang/swift/clangimporter/remoteast_import/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/remoteast_import/Makefile
@@ -16,4 +16,4 @@ libLibrary:
 	"$(MAKE)" -f $(SRCDIR)/Library.mk VPATH=$(SRCDIR) -I $(SRCDIR)
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/Makefile
@@ -14,30 +14,30 @@ endif
 	mv $(BOTDIR) $(USERDIR)
 
 libFoo.dylib: Foo.swift
-	mkdir -p $(BOTDIR)
-	cp -r $(SRCDIR)/Foo $(BOTDIR)/
+	$(call MKDIR_P,$(BOTDIR))
+	$(call CP_R,$(SRCDIR)/Foo,$(BOTDIR)/)
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		BASENAME=$(shell basename $< .swift) \
 		BOTDIR=$(BOTDIR) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 	UUID=$$(dwarfdump --uuid "$@.dSYM" | awk '{ print $$2 }') ; \
-	echo "UUID = $$UUID" ; \
+	$(call ECHO,"UUID = $$UUID") \
 	PLIST="$@.dSYM/Contents/Resources/$$UUID.plist" ; \
-	echo "Generating $$PLIST ..."; \
-	echo '<?xml version="1.0" encoding="UTF-8"?>'>$$PLIST; \
-	echo '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'>>$$PLIST; \
-	echo '<plist version="1.0">'>>$$PLIST; \
-	echo '<dict>'>>$$PLIST; \
-	echo '  <key>DBGSourcePathRemapping</key>'>>$$PLIST; \
-	echo '  <dict>'>>$$PLIST; \
-	echo "    <key>$(BOTDIR)</key>">>$$PLIST; \
-	echo "    <string>$(USERDIR)</string>">>$$PLIST; \
-	echo "    <key>/nonexisting-rootdir</key>">>$$PLIST; \
-	echo "    <string>$(USERDIR)</string>">>$$PLIST; \
-	echo '  </dict>'>>$$PLIST; \
-	echo '</dict>'>>$$PLIST; \
-	echo '</plist>'>>$$PLIST
+	$(call ECHO,"Generating $$PLIST ...") \
+	$(call ECHO_TO_FILE,'<?xml version="1.0" encoding="UTF-8"?>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'<plist version="1.0">',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'<dict>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'  <key>DBGSourcePathRemapping</key>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'  <dict>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'    <key>$(BOTDIR)</key>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'    <string>$(USERDIR)</string>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'    <key>/nonexisting-rootdir</key>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'    <string>$(USERDIR)</string>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'  </dict>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'</dict>',$$PLIST) \
+	$(call ECHO_APPEND_FILE,'</plist>',$$PLIST) \
 
 clean::
-	rm -rf $(USERDIR) rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,$(USERDIR) $(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o))

--- a/lldb/test/API/lang/swift/clangimporter/static_archive/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/static_archive/Makefile
@@ -41,4 +41,4 @@ lib%.a: lib%.o
 	$(AR) $(ARFLAGS) $@ -L$(shell pwd) $<
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.a a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.a a.out *.o)

--- a/lldb/test/API/lang/swift/cross_module_extension/Makefile
+++ b/lldb/test/API/lang/swift/cross_module_extension/Makefile
@@ -23,5 +23,5 @@ libmodb.dylib: modb.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf a.out.dSYM a.out libmoda.dylib libmoda.dylib.dSYM libmodb.dylib libmodb.dylib.dSYM moda.swiftdoc moda.swiftmodule modb.swiftmodule modb.swiftdoc
+	$(call RM_RF,a.out.dSYM a.out libmoda.dylib libmoda.dylib.dSYM libmodb.dylib libmodb.dylib.dSYM moda.swiftdoc moda.swiftmodule modb.swiftmodule modb.swiftdoc)
 

--- a/lldb/test/API/lang/swift/deployment_target/Makefile
+++ b/lldb/test/API/lang/swift/deployment_target/Makefile
@@ -26,4 +26,4 @@ lib%.dylib: %.swift
 		SWIFTFLAGS_EXTRAS="-target $(ARCH)-apple-macosx11.1"
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out dlopen_module *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out dlopen_module *.o)

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/Makefile
@@ -10,5 +10,5 @@ include Makefile.rules
 .PHONY: secret.h
 
 secret.h:
-	mkdir -p $(BUILDDIR)/secret
-	echo "struct S { int i; };" > $(BUILDDIR)/secret/secret.h
+	$(call MKDIR_P,$(BUILDDIR)/secret)
+	$(call ECHO_TO_FILE,'struct S { int i; };',$(BUILDDIR)/secret/secret.h)

--- a/lldb/test/API/lang/swift/expression/empty_self/Makefile
+++ b/lldb/test/API/lang/swift/expression/empty_self/Makefile
@@ -2,5 +2,5 @@ SWIFT_SOURCES := main.swift
 include Makefile.rules
 
 cleanup:
-	rm -f Makefile *.d
+	$(call RM_F,Makefile *.d)
 

--- a/lldb/test/API/lang/swift/expression/error_missing_type/Makefile
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/Makefile
@@ -9,6 +9,6 @@ lib%.dylib: %.swift
 		DYLIB_NAME=$(shell basename $< .swift) \
 		DYLIB_SWIFT_SOURCES=$(shell basename $<) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(MAKEFILE_RULES) all
-	rm -f Library.private.swiftinterface
+	$(call RM_F,Library.private.swiftinterface)
 
 include Makefile.rules

--- a/lldb/test/API/lang/swift/expression/generic_protocol_extension/Makefile
+++ b/lldb/test/API/lang/swift/expression/generic_protocol_extension/Makefile
@@ -2,5 +2,5 @@ SWIFT_SOURCES := main.swift
 include Makefile.rules
 
 cleanup:
-	rm -f Makefile *.d
+	$(call RM_F,Makefile *.d)
 

--- a/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/Makefile
@@ -8,7 +8,7 @@ all: libDirect $(EXE)
 include Makefile.rules
 
 libHidden: $(SRCDIR)/hidden/Indirect.swift
-	mkdir -p $(BUILDDIR)/hidden
+	$(call MKDIR_P,$(BUILDDIR)/hidden)
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		-C $(BUILDDIR)/hidden VPATH=$(SRCDIR)/hidden \
 		DYLIB_ONLY=YES \

--- a/lldb/test/API/lang/swift/expression/mutating_struct_extension/Makefile
+++ b/lldb/test/API/lang/swift/expression/mutating_struct_extension/Makefile
@@ -2,5 +2,5 @@ SWIFT_SOURCES := main.swift
 include Makefile.rules
 
 cleanup:
-	rm -f Makefile *.d
+	$(call RM_F,Makefile *.d)
 

--- a/lldb/test/API/lang/swift/expression/objc_context/Makefile
+++ b/lldb/test/API/lang/swift/expression/objc_context/Makefile
@@ -16,4 +16,4 @@ lib%.dylib: %.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf *.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o
+	$(call RM_RF,*.swiftmodule *.swiftdoc *.dSYM *~ lib*.dylib a.out *.o)

--- a/lldb/test/API/lang/swift/expression/weak_self/Makefile
+++ b/lldb/test/API/lang/swift/expression/weak_self/Makefile
@@ -2,5 +2,5 @@ SWIFT_SOURCES := main.swift
 include Makefile.rules
 
 cleanup:
-	rm -f Makefile *.d
+	$(call RM_F,Makefile *.d)
 

--- a/lldb/test/API/lang/swift/framework_paths/Makefile
+++ b/lldb/test/API/lang/swift/framework_paths/Makefile
@@ -16,8 +16,8 @@ Discovered.framework: Discovered.h
 		FRAMEWORK=Discovered
 
 Direct.framework: $(SRCDIR)/Direct.swift.in Discovered.framework
-	mkdir -p $(BUILDDIR)/secret_path
-	cp $< $(BUILDDIR)/Direct.swift
+	$(call MKDIR_P,$(BUILDDIR)/secret_path)
+	$(call CP,$<,$(BUILDDIR)/Direct.swift)
 	mv Discovered.framework $(BUILDDIR)/secret_path
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=Direct \
@@ -25,4 +25,4 @@ Direct.framework: $(SRCDIR)/Direct.swift.in Discovered.framework
 		DYLIB_MODULENAME=Direct \
 		FRAMEWORK=Direct \
 		SWIFTFLAGS_EXTRAS="-F$(BUILDDIR)/secret_path"
-	rm -f $(BUILDDIR)/Direct.swiftmodule $(BUILDDIR)/Direct.swiftinterface $(BUILDDIR)/Direct.swift
+	$(call RM_F,$(BUILDDIR)/Direct.swiftmodule $(BUILDDIR)/Direct.swiftinterface $(BUILDDIR)/Direct.swift)

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/Makefile
@@ -15,5 +15,5 @@ SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
 		VPATH=$(SRCDIR) LD_EXTRAS="-L$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)" -f $(SRCDIR)/../dylib.mk all
 
 clean::
-	rm -rf *.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+	$(call RM_RF,*.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface)
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/Makefile
@@ -17,4 +17,4 @@ SomeLibrary.swiftmodule: SomeLibrary.swift SomeLibraryCore.swiftmodule
 		VPATH=$(SRCDIR) LD_EXTRAS="-L$(BUILDDIR) -Xlinker -rpath -Xlinker $(BUILDDIR)" -f $(SRCDIR)/../dylib.mk all
 
 clean::
-	rm -rf *.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+	$(call RM_RF,*.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface)

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/Makefile
@@ -13,5 +13,5 @@ SomeLibrary.swiftmodule: SomeLibrary.swift
 		VPATH=$(SRCDIR) -f $(SRCDIR)/../dylib.mk all
 
 clean::
-	rm -rf *.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface
+	$(call RM_RF,*.o *.dylib *.so *.dll *.dSYM *.swiftdoc *.swiftmodule *.swiftinterface)
 

--- a/lldb/test/API/lang/swift/lazy_framework/Makefile
+++ b/lldb/test/API/lang/swift/lazy_framework/Makefile
@@ -12,4 +12,4 @@ Lazy.framework: $(SRCDIR)/Lazy.swift
 		DYLIB_SWIFT_SOURCES=Lazy.swift \
 		DYLIB_MODULENAME=Lazy \
 		FRAMEWORK=Lazy
-	rm -f $(BUILDDIR)/Lazy.swiftmodule $(BUILDDIR)/Lazy.swiftinterface
+	$(call RM_F,$(BUILDDIR)/Lazy.swiftmodule $(BUILDDIR)/Lazy.swiftinterface)

--- a/lldb/test/API/lang/swift/missing_sdk/Makefile
+++ b/lldb/test/API/lang/swift/missing_sdk/Makefile
@@ -5,9 +5,9 @@ all: fakesdk a.out
 include Makefile.rules
 
 fakesdk:
-	ln -s $(SDKROOT) $@
+	$(call LN_SF,$(SDKROOT),$@)
 
 SWIFTFLAGS := $(subst $(SDKROOT),$(shell pwd)/fakesdk,$(SWIFTFLAGS))
 
 clean::
-	rm -f fakesdk a.out *.dSYM
+	$(call RM_F,fakesdk a.out *.dSYM)

--- a/lldb/test/API/lang/swift/nonmodular-include/Makefile
+++ b/lldb/test/API/lang/swift/nonmodular-include/Makefile
@@ -8,10 +8,10 @@ SWIFTFLAGS += -Xcc -F$(SRCDIR) -I$(SRCDIR) -I$(BUILDDIR)
 
 # Create a nonmodular include by removing the modulemap after building.
 all:
-	rm module.modulemap
+	$(call RM,module.modulemap)
 
 conflict.h: conflict.h.in
-	cp $< $@
+	$(call CP,$<,$@)
 
 module.modulemap:
-	echo 'module Baz { header "conflict.h" }' >$@
+	$(call ECHO_TO_FILE,'module Baz { header "conflict.h" }',$@)

--- a/lldb/test/API/lang/swift/other_arch_dylib/Makefile
+++ b/lldb/test/API/lang/swift/other_arch_dylib/Makefile
@@ -16,5 +16,5 @@ OtherArch.framework/Versions/A/OtherArch: $(SRCDIR)/OtherArch.swift
 		FRAMEWORK_MODULES=OtherArch.swiftinterface \
 		FRAMEWORK_HEADERS=OtherArch.h \
 		SWIFTFLAGS_EXTRAS="-target arm64e-apple-macos15"
-	rm -f $(BUILDDIR)/OtherArch.swiftmodule $(BUILDDIR)/OtherArch.swiftinterface
-	rm -f OtherArch.o OtherArch.h OtherArch.partial.swiftmodule
+	$(call RM_F,$(BUILDDIR)/OtherArch.swiftmodule $(BUILDDIR)/OtherArch.swiftinterface)
+	$(call RM_F,OtherArch.o OtherArch.h OtherArch.partial.swiftmodule)

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/Makefile
@@ -13,8 +13,8 @@ include Makefile.rules
 setup:
 	# copy the source files into the build directory because we delete them
 	# to be really sure we only have/use the .dylibs and .swiftinterfaces
-	mkdir -p libs
-	cp $(SRCDIR)/libs/A.swift libs/AA.swift
+	$(call MKDIR_P,libs)
+	$(call CP,$(SRCDIR)/libs/A.swift,libs/AA.swift)
 
 sharedA:
 	"$(MAKE)" MAKE_DSYM=$(DYLIB_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
@@ -26,11 +26,11 @@ sharedA:
 clear_modules:
 	# make sure we only have .swiftinterface files for the generated modules:
 	# remove the copied sources and the swiftmodules from the build directory
-	rm -f *.swiftmodule
-	rm -rf libs
-	rm -rf cache
+	$(call RM_F,*.swiftmodule)
+	$(call RM_RF,libs)
+	$(call RM_RF,cache)
 
 clean::
 	"$(MAKE)" VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=AA -f $(SRCDIR)/libs/Makefile clean
-	rm -rf libs
-	rm -rf cache
+	$(call RM_RF,libs)
+	$(call RM_RF,cache)

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/libs/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/libs/Makefile
@@ -16,5 +16,5 @@ endif
 include Makefile.rules
 
 clean::
-	rm -f $(BASENAME).swiftinterface
-	rm -f $(CLANG_MODULE_CACHE_DIR)/$(BASENAME)-*.swiftmodule
+	$(call RM_F,$(BASENAME).swiftinterface)
+	$(call RM_F,$(CLANG_MODULE_CACHE_DIR)/$(BASENAME)-*.swiftmodule)

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/Makefile
@@ -12,15 +12,11 @@ all: setup sharedA sharedB sharedC clear_modules
 include Makefile.rules
 
 setup:
-	# copy the source files into the build directory because we delete them
-	# to be really sure we only have/use the .dylibs and .swiftinterfaces
-	mkdir -p libs
-	cp $(SRCDIR)/libs/A.swift libs/AA.swift
-	cp $(SRCDIR)/libs/B.swift libs/BB.swift
-	cp $(SRCDIR)/libs/C.swift libs/CC.swift
-
-	# record the used SDKROOT, to use from the python test file
-	echo $(SWIFTSDKROOT) > $(BUILDDIR)/sdk-root.txt
+	$(call MKDIR_P,libs)
+	$(call CP,$(SRCDIR)/libs/A.swift,libs/AA.swift)
+	$(call CP,$(SRCDIR)/libs/B.swift,libs/BB.swift)
+	$(call CP,$(SRCDIR)/libs/C.swift,libs/CC.swift)
+	$(call ECHO_TO_FILE,'$(SWIFTSDKROOT)',$(BUILDDIR)/sdk-root.txt)
 
 sharedA:
 	"$(MAKE)" MAKE_DSYM=NO CC=$(CC) SWIFTC=$(SWIFTC) \
@@ -41,16 +37,14 @@ sharedC:
 		BASENAME=CC -f $(SRCDIR)/libs/Makefile
 
 clear_modules:
-	# make sure we only have .swiftinterface files for the generated modules:
-	# remove the copied sources and the swiftmodules from the build directory
-	rm -f *.swiftmodule
-	rm -rf libs
-	rm -rf MCP
+	$(call RM_F,*.swiftmodule)
+	$(call RM_RF,libs)
+	$(call RM_RF,MCP)
 
 clean::
 	"$(MAKE)" VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=AA -f $(SRCDIR)/libs/Makefile clean
 	"$(MAKE)" VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=BB -f $(SRCDIR)/libs/Makefile clean
 	"$(MAKE)" VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=CC -f $(SRCDIR)/libs/Makefile clean
-	rm -rf libs
-	rm -rf MCP
-	rm -f sdk-root.txt
+	$(call RM_RF,libs)
+	$(call RM_RF,MCP)
+	$(call RM_F,sdk-root.txt)

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/libs/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/libs/Makefile
@@ -14,5 +14,5 @@ DYLIB_HIDE_SWIFTMODULE=1
 include Makefile.rules
 
 clean::
-	rm -f $(BASENAME).swiftinterface
-	rm -f $(CLANG_MODULE_CACHE_DIR)/$(BASENAME)-*.swiftmodule
+	$(call RM_F,$(BASENAME).swiftinterface)
+	$(call RM_F,$(CLANG_MODULE_CACHE_DIR)/$(BASENAME)-*.swiftmodule)

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/Makefile
@@ -12,10 +12,10 @@ include Makefile.rules
 setup:
 	# copy the source files into the build directory because we delete them
 	# to be really sure we only have/use the .dylibs and .swiftinterfaces
-	mkdir -p libs
-	cp $(SRCDIR)/libs/A.swift libs/AA.swift
-	cp $(SRCDIR)/libs/B.swift libs/BB.swift
-	cp $(SRCDIR)/libs/C.swift libs/CC.swift
+	$(call MKDIR_P,libs)
+	$(call CP,$(SRCDIR)/libs/A.swift,libs/AA.swift)
+	$(call CP,$(SRCDIR)/libs/B.swift,libs/BB.swift)
+	$(call CP,$(SRCDIR)/libs/C.swift,libs/CC.swift)
 
 staticA:
 	# Because we override VPATH to point to the build directory, we need to pass
@@ -44,13 +44,13 @@ staticC:
 clear_modules:
 	# make sure we only have .swiftinterface files for the generated modules:
 	# remove the copied sources and the swiftmodules from the build directory
-	rm -f *.swiftmodule
-	rm -rf libs
-	rm -rf MCP
+	$(call RM_F,*.swiftmodule)
+	$(call RM_RF,libs)
+	$(call RM_RF,MCP)
 
 clean::
 	"$(MAKE)" VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=AA -f $(SRCDIR)/libs/Makefile clean
 	"$(MAKE)" VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=BB -f $(SRCDIR)/libs/Makefile clean
 	"$(MAKE)" VPATH=$(BUILDDIR) SWIFTC=$(SWIFTC) BASENAME=CC -f $(SRCDIR)/libs/Makefile clean
-	rm -rf libs
-	rm -rf MCP
+	$(call RM_RF,libs)
+	$(call RM_RF,MCP)

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/libs/Makefile
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/libs/Makefile
@@ -24,4 +24,4 @@ $(ARCHIVE_NAME): $(ARCHIVE_OBJECTS) $(BASENAME).swiftmodule
 static_only: $(ARCHIVE_NAME)
 
 clean::
-	rm -f $(BASENAME).swiftinterface
+	$(call RM_F,$(BASENAME).swiftinterface)

--- a/lldb/test/API/lang/swift/private_discriminator/Makefile
+++ b/lldb/test/API/lang/swift/private_discriminator/Makefile
@@ -24,4 +24,4 @@ libBuilder.dylib: $(SRCDIR)/Builder.swift libGeneric.dylib
 		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR)" \
 		LD_EXTRAS="-L$(BUILDDIR) -lGeneric" \
 		MAKE_DSYM=NO
-	rm -f $(BUILDDIR)/Builder.swiftmodule
+	$(call RM_F,$(BUILDDIR)/Builder.swiftmodule)

--- a/lldb/test/API/lang/swift/resilience/Makefile
+++ b/lldb/test/API/lang/swift/resilience/Makefile
@@ -4,7 +4,7 @@ all: libmod.a.dylib libmod.b.dylib main.a main.b
 include Makefile.rules
 
 libmod.%.dylib: mod.%.swift
-	ln -sf $< mod.swift
+	$(call LN_SF,$<,mod.swift)
 	$(SWIFTC) $(SWIFTFLAGS) -emit-module -module-name mod mod.swift -emit-library -o $@ -Xlinker -install_name -Xlinker @executable_path/libmod.$*.dylib -###
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
@@ -12,25 +12,25 @@ libmod.%.dylib: mod.%.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 	mv libmod.dylib $@
 	mv libmod.dylib.dSYM $@.dSYM || true
-	rm mod.swiftmodule
+	$(call RM,mod.swiftmodule)
 	mv mod.swiftinterface mod.$*.swiftinterface
 	mv mod.swift.o mod.$*.swift.o
-	rm mod.swift
+	$(call RM,mod.swift)
 
 main.%: main.swift
-	ln -sf libmod.$*.dylib libmod.dylib
-	ln -sf libmod.$*.dylib.dSYM libmod.dylib.dSYM
-	ln -sf mod.$*.swiftdoc mod.swiftdoc
-	ln -sf mod.$*.swiftinterface mod.swiftinterface
+	$(call LN_SF,libmod.$*.dylib,libmod.dylib)
+	$(call LN_SF,libmod.$*.dylib.dSYM,libmod.dylib.dSYM)
+	$(call LN_SF,mod.$*.swiftdoc,mod.swiftdoc)
+	$(call LN_SF,mod.$*.swiftinterface,mod.swiftinterface)
 	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/exe.mk all
 	mv main main.$*
 	mv main.dSYM main.$*.dSYM || true
-	rm -rf libmod.dylib libmod.dylib.dSYM mod.swiftdoc mod.swiftmodule
+	$(call RM_RF,libmod.dylib libmod.dylib.dSYM mod.swiftdoc mod.swiftmodule)
 
 $(DSYM):
-	echo "Already built by exe.mk"
+	$(call ECHO,"Already built by exe.mk")
 
 clean::
-	rm -rf main main.a main.b *.dylib *.dSYM *.swiftdoc *.swiftmodule mod.swift *.o
+	$(call RM_RF,main main.a main.b *.dylib *.dSYM *.swiftdoc *.swiftmodule mod.swift *.o)

--- a/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
+++ b/lldb/test/API/lang/swift/resilience_swiftinterface/Makefile
@@ -8,7 +8,7 @@ LD_EXTRAS = -lImpl -L$(BUILDDIR) -Xlinker -add_ast_path -Xlinker Impl.swiftmodul
 SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
 
 ImplB: ImplB.swift
-	echo "Building an out-of-date swift interface"
+	$(call ECHO,"Building an out-of-date swift interface")
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
 		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
 		SWIFTFLAGS_EXTRAS="-I$(BUILDDIR) -enable-library-evolution" \
@@ -17,7 +17,7 @@ ImplB: ImplB.swift
 		DYLIB_SWIFT_SOURCES:=ImplB.swift \
 		-f $(MAKEFILE_RULES)
 	mv Impl.swiftinterface ImplB.swiftinterface
-	rm Impl.swiftmodule Impl.private.swiftinterface libImpl.dylib 
+	$(call RM,Impl.swiftmodule Impl.private.swiftinterface libImpl.dylib )
 
 ImplA: ImplB ImplA.swift
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \
@@ -27,14 +27,14 @@ ImplA: ImplB ImplA.swift
 		DYLIB_ONLY:=YES DYLIB_NAME=Impl \
 		DYLIB_SWIFT_SOURCES:=ImplA.swift \
 		-f $(MAKEFILE_RULES)
-	echo "Moving out-of-date-swiftinterface into place"
-	rm -rf libImpl.dylib.dSYM Impl.swiftmodule Impl.private.swiftinterface
-	rm ImplA.swift.o ImplB.swift.o
+	$(call ECHO,"Moving out-of-date-swiftinterface into place")
+	$(call RM_RF,libImpl.dylib.dSYM Impl.swiftmodule Impl.private.swiftinterface)
+	$(call RM,ImplA.swift.o ImplB.swift.o)
 	mv ImplB.swiftinterface Impl.swiftinterface
 
 Postprocess:
-	echo "Compiling Impl.swiftinterfact to Impl.swiftmodule"
-	echo "import Impl" >trigger.swift
+	$(call ECHO,"Compiling Impl.swiftinterfact to Impl.swiftmodule")
+	$(call ECHO_TO_FILE,'import Impl',trigger.swift)
 	$(SWIFT_FE) -module-cache-path cache -c trigger.swift -o trigger -I.
 	mv cache/Impl*.swiftmodule Impl.swiftmodule
-	rm Impl.swiftinterface
+	$(call RM,Impl.swiftinterface)

--- a/lldb/test/API/lang/swift/static_framework/Makefile
+++ b/lldb/test/API/lang/swift/static_framework/Makefile
@@ -19,11 +19,11 @@ lib%.a: %.swift
 	ar -r $@ $(BUILDDIR)/$(patsubst lib%.a,%.swift.o,$@)
 
 %.framework: lib%.a
-	mkdir -p $(BUILDDIR)/$@/Headers
-	mkdir -p $(BUILDDIR)/$@/Modules
-	mkdir -p $(BUILDDIR)/$@/Resources
+	$(call MKDIR_P,$(BUILDDIR)/$@/Headers)
+	$(call MKDIR_P,$(BUILDDIR)/$@/Modules)
+	$(call MKDIR_P,$(BUILDDIR)/$@/Resources)
 	mv $< $(BUILDDIR)/$@/$(patsubst lib%.a,%,$<)
-	mkdir -p $(BUILDDIR)/$@/Modules/$(patsubst lib%.a,%.swiftmodule,$<)
+	$(call MKDIR_P,$(BUILDDIR)/$@/Modules/$(patsubst lib%.a,%.swiftmodule,$<))
 	mv $(BUILDDIR)/$(patsubst lib%.a,%.swiftmodule,$<) $(BUILDDIR)/$@/Modules/$(patsubst lib%.a,%.swiftmodule,$<)/$(ARCH)-apple-macos.swiftmodule
 	mv $(BUILDDIR)/$(patsubst lib%.a,%.swiftinterface,$<) $(BUILDDIR)/$@/Modules/
 
@@ -33,4 +33,4 @@ dylib: Dylib.swift
 		DYLIB_SWIFT_SOURCES=Dylib.swift \
 		DYLIB_MODULENAME=Dylib \
 		FRAMEWORK=Dylib
-	rm -f $(BUILDDIR)/Dylib.swiftmodule $(BUILDDIR)/Dylib.swiftinterface
+	$(call RM_F,$(BUILDDIR)/Dylib.swiftmodule $(BUILDDIR)/Dylib.swiftinterface)

--- a/lldb/test/API/lang/swift/step_into_override/Makefile
+++ b/lldb/test/API/lang/swift/step_into_override/Makefile
@@ -2,5 +2,5 @@ SWIFT_SOURCES := main.swift
 include Makefile.rules
 
 cleanup:
-	rm -f Makefile *.d
+	$(call RM_F,Makefile *.d)
 

--- a/lldb/test/API/lang/swift/step_through_allocating_init/Makefile
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/Makefile
@@ -2,5 +2,5 @@ SWIFT_SOURCES := main.swift
 include Makefile.rules
 
 cleanup:
-	rm -f Makefile *.d
+	$(call RM_F,Makefile *.d)
 

--- a/lldb/test/API/lang/swift/swift_version/Makefile
+++ b/lldb/test/API/lang/swift/swift_version/Makefile
@@ -18,5 +18,5 @@ libmod%.dylib: mod%.swift
 		VPATH=$(SRCDIR) -I $(SRCDIR) -f $(SRCDIR)/dylib.mk all
 
 clean::
-	rm -rf main main.a main.b *.dylib *.dSYM *.swiftdoc *.swiftmodule mod.swift
+	$(call RM_RF,main main.a main.b *.dylib *.dSYM *.swiftdoc *.swiftmodule mod.swift)
 

--- a/lldb/test/API/macosx/duplicate-archive-members/Makefile
+++ b/lldb/test/API/macosx/duplicate-archive-members/Makefile
@@ -5,7 +5,7 @@ C_SOURCES := main.c
 # can be controlled without confusing Make.
 libfoo.a: a.c sub1/a.c
 	$(CC) $(CFLAGS) -c $(<D)/a.c -o a.o
-	mkdir -p sub1
+	$(call MKDIR_P,sub1)
 	$(CC) $(CFLAGS) -c $(<D)/sub1/a.c -o sub1/a.o
 	touch -t '198001010000.00' a.o
 	touch -t '198001010000.01' sub1/a.o

--- a/lldb/test/API/macosx/find-dsym/bundle-with-dot-in-filename/Makefile
+++ b/lldb/test/API/macosx/find-dsym/bundle-with-dot-in-filename/Makefile
@@ -8,7 +8,7 @@ $(EXE):
 	$(CC) $(CFLAGS) -dynamiclib -o com.apple.sbd $(SRCDIR)/bundle.c
 	mkdir com.apple.sbd.xpc
 	mv com.apple.sbd com.apple.sbd.xpc/
-	mkdir -p com.apple.sbd.xpc.dSYM/Contents/Resources/DWARF
+	$(call MKDIR_P,com.apple.sbd.xpc.dSYM/Contents/Resources/DWARF)
 	mv com.apple.sbd.dSYM/Contents/Resources/DWARF/com.apple.sbd com.apple.sbd.xpc.dSYM/Contents/Resources/DWARF/
 	rm -rf com.apple.sbd.dSYM
 	mkdir hide.app

--- a/lldb/test/API/macosx/find-dsym/deep-bundle/Makefile
+++ b/lldb/test/API/macosx/find-dsym/deep-bundle/Makefile
@@ -5,8 +5,8 @@ include Makefile.rules
 
 $(EXE):
 	$(CC) $(CFLAGS) -install_name $(shell pwd)/MyFramework.framework/Versions/A/MyFramework -dynamiclib -o MyFramework $(SRCDIR)/myframework.c
-	mkdir -p MyFramework.framework/Versions/A/Headers
-	mkdir -p MyFramework.framework/Versions/A/Resources
+	$(call MKDIR_P,MyFramework.framework/Versions/A/Headers)
+	$(call MKDIR_P,MyFramework.framework/Versions/A/Resources)
 	cp MyFramework MyFramework.framework/Versions/A
 	cp $(SRCDIR)/MyFramework.h MyFramework.framework/Versions/A/Headers
 	cp $(SRCDIR)/Info.plist MyFramework.framework/Versions/A/Resources

--- a/lldb/test/API/repl/cpp_exceptions/Makefile
+++ b/lldb/test/API/repl/cpp_exceptions/Makefile
@@ -7,7 +7,7 @@ all: sdkroot.txt libWrapper.dylib a.out
 include Makefile.rules
 
 libCppLib.dylib: CppLib/CppLib.cpp
-	mkdir -p CppLib
+	$(call MKDIR_P,CppLib)
 	"$(MAKE)" -f $(MAKEFILE_RULES) \
 		DYLIB_NAME=CppLib DYLIB_ONLY=YES CXXFLAGS_EXTRAS=-fPIC \
 		DYLIB_CXX_SOURCES="CppLib/CppLib.cpp CppLib/CppLibWrapper.cpp"


### PR DESCRIPTION
This patch ensures we pass the `-sdk` flag to `swiftc` when building debug targets in lldb's test suite on Windows.

This patch also introduces cross platform alternatives to `mkdir -p` and `cp -r`, which are used in swift tests Makefiles.

This patch depends on:
- https://github.com/swiftlang/llvm-project/pull/11785
- https://github.com/swiftlang/llvm-project/pull/12131
- https://github.com/swiftlang/llvm-project/pull/12301
- https://github.com/llvm/llvm-project/pull/183090