### PR TITLE
🍒 [lldb][test] Add CMake option for extra Swift driver flags in shell tests (#11785)

### DIFF
--- a/lldb/test/CMakeLists.txt
+++ b/lldb/test/CMakeLists.txt
@@ -279,6 +279,9 @@ llvm_canonicalize_cmake_booleans(
 llvm_canonicalize_cmake_booleans(
   LLDB_ENABLE_SWIFT_SUPPORT
 )
+
+set(LLDB_SWIFT_DRIVER_EXTRA_FLAGS "" CACHE STRING
+    "Additional swift driver arguments for LLDB shell tests")
 # END SWIFT
 
 # Configure the individual test suites.

--- a/lldb/test/Shell/helper/toolchain.py
+++ b/lldb/test/Shell/helper/toolchain.py
@@ -260,6 +260,9 @@ def use_support_substitutions(config):
     swift_driver_args = []
     if platform.system() in ["Darwin"]:
         swift_args += ["-sdk", sdk_path]
+    swift_driver_extra_args = getattr(config, "swift_driver_extra_args", [])
+    if swift_driver_extra_args:
+        swift_args += swift_driver_extra_args
     tools = [
         ToolSubst(
             "%target-swiftc",

--- a/lldb/test/Shell/lit.site.cfg.py.in
+++ b/lldb/test/Shell/lit.site.cfg.py.in
@@ -24,6 +24,10 @@ config.python_executable = "@Python3_EXECUTABLE@"
 config.python_root_dir = "@Python3_ROOT_DIR@"
 config.swiftc = "@LLDB_SWIFTC@"
 config.swift_libs_dir = '@LLDB_SWIFT_LIBS@'
+# BEGIN SWIFT
+_swift_driver_flags = lit_config.substitute("@LLDB_SWIFT_DRIVER_EXTRA_FLAGS@")
+config.swift_driver_extra_args = [flag.strip() for flag in _swift_driver_flags.split(";") if flag.strip()]
+# END SWIFT
 config.lldb_enable_swift = @LLDB_ENABLE_SWIFT_SUPPORT@
 config.have_zlib = @LLVM_ENABLE_ZLIB@
 config.objc_gnustep_dir = "@LLDB_TEST_OBJC_GNUSTEP_DIR@"


### PR DESCRIPTION
Tests that invoke swift currently fail on Windows because we're not passing -sdk. Unlike Darwin, there's no way to figure out a good value for this at runtime.

This change adds a CMake variable LLDB_SWIFT_DRIVER_EXTRA_FLAGS which takes a semicolon-separated list of arguments for the Swift driver which we pipe into the lit config.

(cherry picked from commit cdf39759ae0ddd5571a5e9f4e4cf6c4099025272)