### PR TITLE
[lldb][CAS] Don't try loading a module using an invalid ModuleSpec

### DIFF
--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1843,6 +1843,10 @@ llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
   if (!loaded)
     return loaded.takeError();
 
+  // Don't try searching with an invalid ModuleSpec.
+  if (!*loaded)
+    return false;
+
   module_spec = std::move(*loaded);
 
   auto status = GetSharedModule(module_spec, module_sp, nullptr, nullptr,


### PR DESCRIPTION
This fixes a regression introduced in
https://github.com/swiftlang/llvm-project/pull/12124 where we removed the check for thre turn value of `loadModuleFromCAS`. This meant we would try to call `GetSharedModule` even if the `ModuleSpec` we found in CAS is invalid. `GetSharedModule` module doesn't return an `Error` in such cases, so we would incorrectly succeed and callers of `GetSharedModuleFromCAS` would think we successfully loaded a `ModuleSP` from CAS, which isn't true.

This caused some PCH tests to fail. E.g,:
```
 lldb-api :: lang/cpp/gmodules/alignment/TestPchAlignment.py
 lldb-api :: lang/cpp/gmodules/pch-chain/TestPchChain.py
```

We should probably change `GetSharedModuleFromCAS` to return a `ModuleSP` instead of a boolean, so callers can decide to search further for `ModuleSP`s even if no hard error occurred. But for now lets put back the `ModuleSpec` check back in the lower layer.