### PR TITLE
[lldb] Change po fallback messaging (#175847)

### DIFF
--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -12,6 +12,7 @@
 #include "lldb/Interpreter/CommandInterpreter.h"
 #include "lldb/Target/Language.h"
 #include "lldb/Target/Target.h"
+#include "lldb/Utility/Log.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/ValueObject/ValueObject.h"
 #include "llvm/Support/Error.h"
@@ -100,8 +101,10 @@ llvm::Error ValueObjectPrinter::PrintValueObject() {
     llvm::Expected<std::string> object_desc_or_err =
         GetMostSpecializedValue().GetObjectDescription();
     if (!object_desc_or_err) {
-      auto error_msg = toString(object_desc_or_err.takeError());
-      *m_stream << "error: " << error_msg << maybeNewline(error_msg);
+      *m_stream << "warning: `po` was unsuccessful, running `p` instead\n";
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions),
+                     object_desc_or_err.takeError(),
+                     "Object description fallback due to error: {0}");
 
       // Print the value object directly.
       m_options.DisableObjectDescription();

--- a/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
+++ b/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
@@ -8,10 +8,24 @@ class TestCase(TestBase):
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+
+        log = self.getBuildArtifact("expr.log")
+        self.runCmd(f"log enable lldb expr -f {log}")
+
         self.expect(
-            "expr -O -- bad", substrs=["error:", "expression interrupted", "(Bad *) 0x"]
+            "expr -O -- bad",
+            substrs=["`po` was unsuccessful, running `p` instead\n", "(Bad *) 0x"],
         )
+        self.filecheck(
+            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
+        )
+        # CHECK-EXPR: Object description fallback due to error: could not evaluate print object function: expression interrupted
+
         self.expect(
             "dwim-print -O -- bad",
-            substrs=["error:", "expression interrupted", "_lookHere = NO"],
+            substrs=["`po` was unsuccessful, running `p` instead\n", "_lookHere = NO"],
         )
+        self.filecheck(
+            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-DWIM-PRINT"
+        )
+        # CHECK-DWIM-PRINT: Object description fallback due to error: could not evaluate print object function: expression interrupted

--- a/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
+++ b/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
@@ -8,11 +8,28 @@ class TestCase(TestBase):
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.m"))
+
+        log = self.getBuildArtifact("expr.log")
+        self.runCmd(f"log enable lldb expr -f {log}")
+
         self.expect(
             "vo pair",
-            substrs=["error:", "not a pointer type", "(Pair) pair = (f = 2, e = 3)"],
+            substrs=[
+                "warning: `po` was unsuccessful, running `p` instead\n",
+                "(Pair) pair = (f = 2, e = 3)",
+            ],
         )
+        self.filecheck(f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-VO")
+        # CHECK-VO: Object description fallback due to error: not a pointer type
+
         self.expect(
             "expr -O -- pair",
-            substrs=["error:", "not a pointer type", "(Pair)  (f = 2, e = 3)"],
+            substrs=[
+                "warning: `po` was unsuccessful, running `p` instead\n",
+                "(Pair)  (f = 2, e = 3)",
+            ],
         )
+        self.filecheck(
+            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
+        )
+        # CHECK-EXPR: Object description fallback due to error: not a pointer type


### PR DESCRIPTION
When an object description expression fails, instead of emitting an error, mark it as a
warning instead. Additionally, send the more low level details of the failure to the
`expr` log, and show a more user friendly message:

> `po` was unsuccessful, running `p` instead

rdar://165190497
(cherry picked from commit fb0653c36b84d5d53180e2374f52e72035944c41)
