### PR TITLE
[ValueTracking] Allow dereferenceable(0) to be applied to a null poin…

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -2967,7 +2967,8 @@ the behavior is undefined, unless one of the following exceptions applies:
 
 * ``dereferenceable(<n>)`` operand bundles only guarantee the pointer is
   dereferenceable at the point of the assumption. The pointer may not be
-  dereferenceable at later pointers, e.g. because it could have been freed.
+  dereferenceable at later pointers, e.g., because it could have been freed.
+  Only ``n > 0`` implies that the pointer is dereferenceable.
 
 In addition to allowing operand bundles encoding function and parameter
 attributes, an assume operand bundle my also encode a ``separate_storage``

--- a/llvm/lib/Analysis/ValueTracking.cpp
+++ b/llvm/lib/Analysis/ValueTracking.cpp
@@ -668,12 +668,26 @@ static bool isKnownNonZeroFromAssume(const Value *V, const SimplifyQuery &Q) {
         continue;
       if (RetainedKnowledge RK = getKnowledgeFromBundle(
               *I, I->bundle_op_info_begin()[Elem.Index])) {
-        if (RK.WasOn == V &&
-            (RK.AttrKind == Attribute::NonNull ||
-             (RK.AttrKind == Attribute::Dereferenceable &&
-              !NullPointerIsDefined(Q.CxtI->getFunction(),
-                                    V->getType()->getPointerAddressSpace()))) &&
-            isValidAssumeForContext(I, Q.CxtI, Q.DT))
+        if (RK.WasOn != V)
+          continue;
+        bool AssumeImpliesNonNull = [&]() {
+          if (RK.AttrKind == Attribute::NonNull)
+            return true;
+
+          if (RK.AttrKind == Attribute::Dereferenceable) {
+            if (NullPointerIsDefined(Q.CxtI->getFunction(),
+                                     V->getType()->getPointerAddressSpace()))
+              return false;
+            assert(RK.IRArgValue &&
+                   "Dereferenceable attribute without IR argument?");
+
+            auto *CI = dyn_cast<ConstantInt>(RK.IRArgValue);
+            return CI && !CI->isZero();
+          }
+
+          return false;
+        }();
+        if (AssumeImpliesNonNull && isValidAssumeForContext(I, Q.CxtI, Q.DT))
           return true;
       }
       continue;

--- a/llvm/test/Analysis/ValueTracking/assume.ll
+++ b/llvm/test/Analysis/ValueTracking/assume.ll
@@ -159,3 +159,35 @@ A:
   %6 = phi i32 [ %4, %3 ], [ 0, %A ]
   ret i32 %6
 }
+
+define i1 @test_dereferenceable_unknown_size_not_nonnull(ptr %ptr, i32 %bytes) {
+; CHECK-LABEL: @test_dereferenceable_unknown_size_not_nonnull(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 [[BYTES:%.*]]) ]
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %ptr, i32 %bytes)]
+  %2 = icmp eq ptr %ptr, null
+  ret i1 %2
+}
+
+define i1 @test_dereferenceable_zero_size_not_nonnull(ptr %ptr) {
+; CHECK-LABEL: @test_dereferenceable_zero_size_not_nonnull(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 0) ]
+; CHECK-NEXT:    [[TMP2:%.*]] = icmp eq ptr [[TMP0]], null
+; CHECK-NEXT:    ret i1 [[TMP2]]
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %ptr, i32 0)]
+  %2 = icmp eq ptr %ptr, null
+  ret i1 %2
+}
+
+define i1 @test_dereferenceable_non_zero_size_is_nonnull(ptr %ptr) {
+; CHECK-LABEL: @test_dereferenceable_non_zero_size_is_nonnull(
+; CHECK-NEXT:    call void @llvm.assume(i1 true) [ "dereferenceable"(ptr [[TMP0:%.*]], i32 1) ]
+; CHECK-NEXT:    ret i1 false
+;
+  call void @llvm.assume(i1 true) ["dereferenceable"(ptr %ptr, i32 1)]
+  %2 = icmp eq ptr %ptr, null
+  ret i1 %2
+}


### PR DESCRIPTION
…ter (#175913)

`dereferenceable(<n>)` with n being potentially zero can come up when using an operand bundle with a variable size. Currently this implies that the pointer is non-null, even though `[nullptr, nullptr)` is a valid range in any programming language I'm aware of. This patch removes this implication and updates the language reference to reflect that `dereferenceable` with a zero argument is valid.

(cherry picked from commit d2afc3e84b1aeac446e94cb67d41f94c315901ab)