### PR TITLE
[APINotes] Apply APINotes to non-global decls in a LinkageSpecDecl

### DIFF
--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -1066,8 +1066,8 @@ void Sema::ProcessAPINotes(Decl *D) {
 
   auto *DC = D->getDeclContext();
   // Globals.
-  if (DC->isFileContext() || DC->isNamespace() || DC->isExternCContext() ||
-      DC->isExternCXXContext()) {
+  if (DC->isFileContext() || DC->isNamespace() ||
+      DC->getDeclKind() == Decl::LinkageSpec) {
     std::optional<api_notes::Context> APINotesContext =
         UnwindNamespaceContext(DC, APINotes);
     // Global variables.

--- a/clang/test/APINotes/Inputs/Headers/Methods.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/Methods.apinotes
@@ -9,6 +9,16 @@ Tags:
   - Name: getDecremented
     Availability: none
     AvailabilityMsg: "this should have no effect"
+- Name: IntWrapper2
+  Methods:
+  - Name: getIncremented
+    Availability: none
+    AvailabilityMsg: "oh no"
+- Name: IntWrapper3
+  Methods:
+  - Name: getIncremented
+    Availability: none
+    AvailabilityMsg: "oh no"
 - Name: Outer
   Tags:
   - Name: Inner

--- a/clang/test/APINotes/Inputs/Headers/Methods.h
+++ b/clang/test/APINotes/Inputs/Headers/Methods.h
@@ -6,6 +6,22 @@ struct IntWrapper {
   IntWrapper operator+(const IntWrapper& RHS) const { return {value + RHS.value}; }
 };
 
+extern "C++" {
+struct IntWrapper2 {
+  int value;
+
+  IntWrapper2 getIncremented() const { return {value + 1}; }
+};
+}
+
+extern "C++" {
+extern "C" {
+  struct IntWrapper3 {
+    static IntWrapper3 getIncremented(IntWrapper3 val) { return val; }
+  };
+}
+}
+
 struct Outer {
   struct Inner {
     int value;

--- a/clang/test/APINotes/methods.cpp
+++ b/clang/test/APINotes/methods.cpp
@@ -1,6 +1,8 @@
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -fsyntax-only -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -x c++
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper::getIncremented -x c++ | FileCheck --check-prefix=CHECK-METHOD %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper2::getIncremented -x c++ | FileCheck --check-prefix=CHECK-METHOD-2 %s
+// RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter IntWrapper3::getIncremented -x c++ | FileCheck --check-prefix=CHECK-METHOD-3 %s
 // RUN: %clang_cc1 -fmodules -fblocks -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache/Methods -fdisable-module-hash -fapinotes-modules -I %S/Inputs/Headers -F %S/Inputs/Frameworks %s -ast-dump -ast-dump-filter Outer::Inner::getDecremented -x c++ | FileCheck --check-prefix=CHECK-DEEP-METHOD %s
 
 #include "Methods.h"
@@ -8,6 +10,14 @@
 // CHECK-METHOD: Dumping IntWrapper::getIncremented:
 // CHECK-METHOD-NEXT: CXXMethodDecl {{.+}} getIncremented
 // CHECK-METHOD: UnavailableAttr {{.+}} <<invalid sloc>> "oh no"
+
+// CHECK-METHOD-2: Dumping IntWrapper2::getIncremented:
+// CHECK-METHOD-2-NEXT: CXXMethodDecl {{.+}} getIncremented
+// CHECK-METHOD-2: UnavailableAttr {{.+}} <<invalid sloc>> "oh no"
+
+// CHECK-METHOD-3: Dumping IntWrapper3::getIncremented:
+// CHECK-METHOD-3-NEXT: CXXMethodDecl {{.+}} getIncremented
+// CHECK-METHOD-3: UnavailableAttr {{.+}} <<invalid sloc>> "oh no"
 
 // CHECK-DEEP-METHOD: Dumping Outer::Inner::getDecremented:
 // CHECK-DEEP-METHOD-NEXT: CXXMethodDecl {{.+}} getDecremented


### PR DESCRIPTION
We checked if a declaration has a LinkageSpecDecl ancestor and assumed that it would be a declaration in global/namespace scope. This prevented us from applying APINotes to methods or fields of a class that was declared in a LinkageSpecDecl. This PR changes the logic to only check whether the parent DeclContext is a LinkageSpecDecl instead of checking for all the ancestors.