### PR TITLE
[CoroFrame] Save frame ptr in entry funclets

### DIFF
--- a/lldb/test/API/lang/swift/async/variables/Makefile
+++ b/lldb/test/API/lang/swift/async/variables/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
+SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -enable-upcoming-feature -Xfrontend NonisolatedNonsendingByDefault
 include Makefile.rules

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -1939,21 +1939,25 @@ salvageDebugInfoImpl(SmallDenseMap<Argument *, AllocaInst *, 4> &ArgToAllocaMap,
     return std::nullopt;
 
   auto *StorageAsArg = dyn_cast<Argument>(Storage);
-  const bool IsSwiftAsyncArg =
-      StorageAsArg && StorageAsArg->hasAttribute(Attribute::SwiftAsync);
 
-  // Swift async arguments are described by an entry value of the ABI-defined
-  // register containing the coroutine context.
+  const bool IsSingleLocationExpression = Expr->isSingleLocationExpression();
+  // Use an EntryValue when requested (UseEntryValue) for swift async Arguments.
   // Entry values in variadic expressions are not supported.
-  if (IsSwiftAsyncArg && UseEntryValue && !Expr->isEntryValue() &&
-      Expr->isSingleLocationExpression())
+  const bool WillUseEntryValue =
+      UseEntryValue && StorageAsArg &&
+      StorageAsArg->hasAttribute(Attribute::SwiftAsync) &&
+      !Expr->isEntryValue() && IsSingleLocationExpression;
+
+  if (WillUseEntryValue)
     Expr = DIExpression::prepend(Expr, DIExpression::EntryValue);
 
   // If the coroutine frame is an Argument, store it in an alloca to improve
   // its availability (e.g. registers may be clobbered).
   // Avoid this if the value is guaranteed to be available through other means
   // (e.g. swift ABI guarantees).
-  if (StorageAsArg && !IsSwiftAsyncArg) {
+  // Avoid this if multiple location expressions are involved, as LLVM does not
+  // know how to prepend a deref in this scenario.
+  if (StorageAsArg && !WillUseEntryValue && IsSingleLocationExpression) {
     auto &Cached = ArgToAllocaMap[StorageAsArg];
     if (!Cached) {
       Cached = Builder.CreateAlloca(Storage->getType(), 0, nullptr,

--- a/llvm/test/Transforms/Coroutines/declare-value.ll
+++ b/llvm/test/Transforms/Coroutines/declare-value.ll
@@ -1,9 +1,13 @@
 ;RUN: opt -mtriple='arm64-' %s -S -passes='module(coro-early),cgscc(coro-split,simplifycfg)' -o - | FileCheck %s
 
+; CHECK-LABEL: define swifttailcc void @coroutineA
+; CHECK-SAME:    (ptr swiftasync %[[frame_ptr:.*]],
 ; CHECK:  %.debug = alloca double, align 8
 ; CHECK-NEXT:    #dbg_declare(ptr %{{.*}}, !{{[0-9]+}}, !DIExpression(DW_OP_deref), !{{[0-9]+}})
 ; CHECK-NEXT:  store double %{{[0-9]+}}, ptr %{{.*}}, align 8
-; CHECK-NEXT:    #dbg_declare(ptr %arg, !{{[0-9]+}}, !DIExpression(DW_OP_plus_uconst, 24), !{{[0-9]+}})
+; CHECK:       %[[frame_ptr_alloca:.*]] = alloca ptr,
+; CHECK-NEXT:  #dbg_declare(ptr %[[frame_ptr_alloca]], !{{[0-9]+}}, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 24), !{{[0-9]+}})
+; CHECK-NEXT:  store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
 
 ; ModuleID = '/Users/srastogi/Development/llvm-project-2/llvm/test/Transforms/Coroutines/declare-value.ll'
 source_filename = "/Users/srastogi/Development/llvm-project-2/llvm/test/Transforms/Coroutines/declare-value.ll"

--- a/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
+++ b/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
@@ -23,10 +23,12 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
   %i3 = call ptr @llvm.coro.begin(token %i2, ptr null)
 ; CHECK-LABEL: define {{.*}} @coroutineA(
 ; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]])
-; CHECK:      #dbg_declare(ptr %[[frame_ptr]], {{.*}} !DIExpression(
-; CHECK-SAME:                   DW_OP_plus_uconst, 24)
-; CHECK:      #dbg_value(ptr %[[frame_ptr]], {{.*}} !DIExpression(
-; CHECK-SAME:                 DW_OP_plus_uconst, 16, DW_OP_deref)
+; CHECK:      %[[frame_ptr_alloca:.*]] = alloca ptr
+; CHECK:      #dbg_declare(ptr %[[frame_ptr_alloca]], {{.*}} !DIExpression(
+; CHECK-SAME:                   DW_OP_deref, DW_OP_plus_uconst, 24)
+; CHECK:      store ptr %[[frame_ptr]], ptr %[[frame_ptr_alloca]]
+; CHECK:      #dbg_value(ptr %[[frame_ptr_alloca]], {{.*}} !DIExpression(
+; CHECK-SAME:                 DW_OP_deref, DW_OP_plus_uconst, 16, DW_OP_deref)
 ; CHECK:      call {{.*}} @swift_task_switch
 
   %i7 = call ptr @llvm.coro.async.resume(), !dbg !54


### PR DESCRIPTION
The logic deciding whether to save the frame pointer using an Alloca was flawed: it must be the opposite of deciding whether to use EntryValue, since those are the only methods allowing debuggers to find the frame pointer (and therefore variables) reliably. This commit fixes the logic.

This is a cherry-pick of https://github.com/llvm/llvm-project/pull/176766

rdar://166248165