### PR TITLE
[lldb] Retrieve the mangled type name from the static type, when performing the new Swift po

### DIFF
--- a/lldb/test/API/lang/swift/po/private_subclass/Makefile
+++ b/lldb/test/API/lang/swift/po/private_subclass/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+HIDE_SWIFTMODULE := YES
+include Makefile.rules

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -1,0 +1,33 @@
+import os
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        log = self.getBuildArtifact("expr.log")
+        self.runCmd(f"log enable lldb expr -f {log}")
+
+        self.expect("frame variable -O x", substrs=["Easy as pie"])
+        self.filecheck(f"platform shell cat {log}", __file__)
+
+        # Clear the log.
+        self.runCmd(f"log disable lldb expr")
+        os.unlink(log)
+        self.runCmd(f"log enable lldb expr -f {log}")
+
+        self.expect("dwim-print -O -- x", substrs=["Easy as pie"])
+        self.filecheck(f"platform shell cat {log}", __file__)
+
+        # Verify po used the mangled name of the static type - which is public,
+        # and not the private dynamic type.
+        #
+        # CHECK: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a10PublicBaseCD")
+        # CHECK: stringForPrintObject(_:mangledTypeName:) succeeded

--- a/lldb/test/API/lang/swift/po/private_subclass/main.swift
+++ b/lldb/test/API/lang/swift/po/private_subclass/main.swift
@@ -1,0 +1,16 @@
+public class PublicBase {}
+
+private class PrivateSubclass: PublicBase, CustomStringConvertible {
+  var description = "Easy as pie"
+}
+
+func makeIt() -> PublicBase {
+  return PrivateSubclass()
+}
+
+func main() {
+  let x = makeIt()
+  print("break here \(x)")
+}
+
+main()


### PR DESCRIPTION
Improves the new Swift `po`'s handling of private types.

Mangled names for private types contain a discriminator to make them unique. Debug info gets mangled names from the AST (swiftmodules). The AST uses discriminators that are a hash based on the source file. The Swift runtime, however, does not have source info and uses an internal pointer as the discriminator (anonymous context). When querying the Swift runtime for a type using a mangled name, AST-based private discriminators are not supported.

The fix in many (but not all) cases is to prefer the mangled name of the static type, not the dynamic type. Consider this example:

```swift
public class Thing {
  // ...
}

private class Gizmo: Thing {
  // ...
}

public func makeThing() -> Thing {
    return Gizmo()
}
```

The static return type of `makeThing()` is the public class `Thing`. The dynamic return type is the private class `Gizmo`.

This change updates the new Swift `po` to get the mangled name of the static type, which in this case would be something like `$s4main5ThingCN` (no private discriminator). Without this change, the mangled name would contain a private discriminator: `$s4main5Gizmo029_12232F587A4C5CD8B1EEDF696793D2FCLLCN`.

This change increases the likelihood of the new Swift `po` receiving a mangled name that does not contain a private discriminator. It's still possible that the static type is private, but that will require more investigation for a solution.

See https://github.com/swiftlang/swift/pull/84742 for the details of the new Swift `po`.

rdar://166643254