### PR TITLE
🍒[lldb][DWARFASTParserClang] RequireCompleteType for ObjC types

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserClang.cpp
@@ -1728,6 +1728,12 @@ void DWARFASTParserClang::ParseInheritance(
 
   CompilerType base_class_clang_type = base_class_type->GetFullCompilerType();
   assert(base_class_clang_type);
+
+  // Make sure all base classes refer to complete types and not forward
+  // declarations. If we don't do this, clang will crash with an
+  // assertion in the call to clang_type.TransferBaseClasses()
+  TypeSystemClang::RequireCompleteType(base_class_clang_type);
+
   if (TypeSystemClang::IsObjCObjectOrInterfaceType(class_clang_type)) {
     ast->SetObjCSuperClass(class_clang_type, base_class_clang_type);
     return;
@@ -2370,19 +2376,8 @@ bool DWARFASTParserClang::CompleteRecordType(const DWARFDIE &die,
     return {};
   }
 
-  if (!bases.empty()) {
-    // Make sure all base classes refer to complete types and not forward
-    // declarations. If we don't do this, clang will crash with an
-    // assertion in the call to clang_type.TransferBaseClasses()
-    for (const auto &base_class : bases) {
-      clang::TypeSourceInfo *type_source_info = base_class->getTypeSourceInfo();
-      if (type_source_info)
-        TypeSystemClang::RequireCompleteType(
-            m_ast.GetType(type_source_info->getType()));
-    }
-
+  if (!bases.empty())
     m_ast.TransferBaseClasses(clang_type.GetOpaqueQualType(), std::move(bases));
-  }
 
   m_ast.AddMethodOverridesForCXXRecordType(clang_type.GetOpaqueQualType());
   TypeSystemClang::BuildIndirectFields(clang_type);

--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -9698,7 +9698,8 @@ TypeSystemClang::DeclContextGetTypeSystemClang(const CompilerDeclContext &dc) {
 void TypeSystemClang::RequireCompleteType(CompilerType type) {
   // Technically, enums can be incomplete too, but we don't handle those as they
   // are emitted even under -flimit-debug-info.
-  if (!TypeSystemClang::IsCXXClassType(type))
+  if (!TypeSystemClang::IsCXXClassType(type) &&
+      !TypeSystemClang::IsObjCObjectOrInterfaceType(type))
     return;
 
   if (type.GetCompleteType())

--- a/lldb/test/Shell/Expr/TestObjCIncompleteSuperclass.test
+++ b/lldb/test/Shell/Expr/TestObjCIncompleteSuperclass.test
@@ -3,7 +3,6 @@
 # it will fail to do so. LLDB should handle this situation gracefully.
 # A super-class definition is required when laying out Obj-C types.
 #
-# XFAIL: *
 # REQUIRES: system-darwin
 #
 # RUN: split-file %s %t

--- a/lldb/test/Shell/Expr/TestObjCIncompleteSuperclass.test
+++ b/lldb/test/Shell/Expr/TestObjCIncompleteSuperclass.test
@@ -1,0 +1,60 @@
+# In this test we compile with -gmodules but delete the ModuleCache.
+# When LLDB tries to find a definition for NSObject (the Foo's super-class)
+# it will fail to do so. LLDB should handle this situation gracefully.
+# A super-class definition is required when laying out Obj-C types.
+#
+# XFAIL: *
+# REQUIRES: system-darwin
+#
+# RUN: split-file %s %t
+#
+# RUN: %clang_host %t/main.m -c -g -gmodules -fmodules -fcxx-modules \
+# RUN:             -fmodule-map-file=%t/module.modulemap \
+# RUN:             -fmodules-cache-path=%t/ModuleCache -o %t/main.o
+#
+# RUN: %clang_host %t/module.m -c -g -gmodules -fmodules -fcxx-modules \
+# RUN:             -fmodule-map-file=%t/module.modulemap \
+# RUN:             -fmodules-cache-path=%t/ModuleCache -o %t/module.o
+#
+# RUN: %clang_host %t/*.o -framework Foundation -o %t.out
+#
+# RUN: rm -r %t/ModuleCache
+#
+# RUN: %lldb -x -o "settings set interpreter.stop-command-source-on-error false" \
+# RUN:       -s %t/commands.input %t.out -o exit 2>&1 | FileCheck %s
+
+#--- main.m
+@import foo;
+
+int main() {
+    Foo *f = [Foo new];
+
+    __builtin_debugtrap();
+}
+
+#--- module.m
+
+#import "module.h"
+
+@implementation Foo
+@end
+
+#--- module.h
+
+#import <Foundation/Foundation.h>
+
+@interface Foo : NSObject
+@end
+
+#--- module.modulemap
+module foo {
+  header "module.h"
+  export *
+}
+
+#--- commands.input
+
+run
+expression *f
+
+# CHECK: (lldb) expression *f


### PR DESCRIPTION
Currently we forcefully complete C++ types if we can't find their
definition for layout purposes. This ensures that we at least don't
crash in Clang when laying out the type. The definition is required for
types of members/array elements/base classes for the purposes of
calculating their layout. This is also true for Obj-C types, but we
haven't been forcefully completing those.

The test-case that's being un-XFAILed in this patch demonstrates a case
where not completing the super-class forcefully causes a clang crash.

rdar://168440264
(cherry picked from commit https://github.com/swiftlang/llvm-project/commit/3aea01b271ae5908e99cb4b12263ca450ab91afc)