### PR TITLE
[StackProtector] Add metadata to opt-out (#170229)

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2838,6 +2838,13 @@ def NoStackProtector : InheritableAttr {
   let SimpleHandler = 1;
 }
 
+def StackProtectorIgnore : InheritableAttr {
+  let Spellings = [Clang<"stack_protector_ignore">];
+  let Subjects = SubjectList<[LocalVar]>;
+  let Documentation = [StackProtectorIgnoreDocs];
+  let SimpleHandler = 1;
+}
+
 def StrictGuardStackCheck : InheritableAttr {
   let Spellings = [Declspec<"strict_gs_check">];
   let Subjects = SubjectList<[Function]>;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -5554,6 +5554,20 @@ option.
     }];
 }
 
+def StackProtectorIgnoreDocs : Documentation {
+  let Category = DocCatFunction;
+  let Content = [{
+The ``stack_protector_ignore`` attribute skips analysis of the given local
+variable when determining if a function should use a stack protector.
+
+The ``-fstack-protector`` option uses a heuristic to only add stack protectors
+to functions which contain variables or buffers over some size threshold.  This
+attribute overrides that heuristic for the attached variable, opting
+them out.  If this results in no variables or buffers remaining over the stack
+protector threshold, then the function will no longer use a stack protector.
+  }];
+}
+
 def StrictGuardStackCheckDocs : Documentation {
   let Category = DocCatFunction;
   let Content = [{

--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -1645,6 +1645,14 @@ CodeGenFunction::EmitAutoVarAlloca(const VarDecl &D) {
         assert(!emission.useLifetimeMarkers());
       }
     }
+
+    if (D.hasAttr<StackProtectorIgnoreAttr>()) {
+      if (auto *AI = dyn_cast<llvm::AllocaInst>(address.getBasePointer())) {
+        llvm::LLVMContext &Ctx = Builder.getContext();
+        auto *Operand = llvm::ConstantAsMetadata::get(Builder.getInt32(0));
+        AI->setMetadata("stack-protector", llvm::MDNode::get(Ctx, {Operand}));
+      }
+    }
   } else {
     EnsureInsertPoint();
 

--- a/clang/test/CodeGen/stack-protector-vars.cpp
+++ b/clang/test/CodeGen/stack-protector-vars.cpp
@@ -1,0 +1,70 @@
+// RUN: %clang -target x86_64-apple-darwin -emit-llvm -S -o - %s | FileCheck %s
+// RUN: %clang -target x86_64-apple-darwin -emit-llvm -S -o - %s -fstack-protector | FileCheck %s
+// RUN: %clang -target x86_64-apple-darwin -emit-llvm -S -o - %s -fstack-protector-all | FileCheck %s
+
+typedef __SIZE_TYPE__ size_t;
+
+int printf(const char * _Format, ...);
+char *strcpy(char *s1, const char *s2);
+
+struct S {
+  S();
+  int a[4];
+};
+
+// CHECK: define {{.*}} @_Z5test1PKc
+// CHECK: %{{.*}} = alloca [1000 x i8], align {{.*}}, !stack-protector ![[A:.*]]
+void test1(const char *msg) {
+  __attribute__((stack_protector_ignore))
+  char a[1000];
+  strcpy(a, msg);
+  printf("%s\n", a);
+}
+
+// CHECK: define {{.*}} @_Z5test2
+// CHECK-NOT: %{{.*}} = alloca [1000 x i8], align {{.*}}, !stack-protector
+void test2(const char *msg) {
+  char b[1000];
+  strcpy(b, msg);
+  printf("%s\n", b);
+}
+
+// CHECK: define {{.*}} @_Z5test3v
+// CHECK: %{{.*}} = alloca %struct.S, align {{.*}}, !stack-protector ![[A:.*]]
+S test3() {
+  __attribute__((stack_protector_ignore))
+  S s;
+  return s;
+}
+
+// CHECK: define {{.*}} @_Z5test4b
+// CHECK: %{{.*}} = alloca %struct.S, align {{.*}}, !stack-protector ![[A:.*]]
+// CHECK: call void @_ZN1SC1Ev
+S test4(bool b) {
+  __attribute__((stack_protector_ignore))
+  S s;
+  if ( b )
+    return s;
+  else
+    return s;
+}
+
+// CHECK: define {{.*}} @_Z5test5b
+// CHECK: %{{.*}} = alloca %struct.S, align {{.*}}
+// CHECK-NOT: stack-protector
+// CHECK: %{{.*}} = alloca %struct.S, align {{.*}}, !stack-protector ![[A:.*]]
+// CHECK: %{{.*}} = alloca %struct.S, align {{.*}}
+// CHECK-NOT: stack-protector
+// CHECK: call void @_ZN1SC1Ev
+// CHECK: call void @_ZN1SC1Ev
+S test5(bool b) {
+  __attribute__((stack_protector_ignore))
+  S s1;
+  S s2;
+  if ( b )
+    return s1;
+  else
+    return s2;
+}
+
+// CHECK: ![[A]] = !{i32 0}

--- a/clang/test/Misc/pragma-attribute-supported-attributes-list.test
+++ b/clang/test/Misc/pragma-attribute-supported-attributes-list.test
@@ -189,6 +189,7 @@
 // CHECK-NEXT: Section (SubjectMatchRule_function, SubjectMatchRule_variable_is_global, SubjectMatchRule_objc_method, SubjectMatchRule_objc_property)
 // CHECK-NEXT: SetTypestate (SubjectMatchRule_function_is_member)
 // CHECK-NEXT: SpeculativeLoadHardening (SubjectMatchRule_function, SubjectMatchRule_objc_method)
+// CHECK-NEXT: StackProtectorIgnore (SubjectMatchRule_variable_is_local)
 // CHECK-NEXT: StandaloneDebug (SubjectMatchRule_record)
 // CHECK-NEXT: SwiftAsync (SubjectMatchRule_function, SubjectMatchRule_objc_method)
 // CHECK-NEXT: SwiftAsyncContext (SubjectMatchRule_variable_is_parameter)

--- a/clang/test/Sema/stack_protector_ignore.c
+++ b/clang/test/Sema/stack_protector_ignore.c
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+int __attribute__((stack_protector_ignore)) global_var; // expected-warning {{'stack_protector_ignore' attribute only applies to local variables}}
+
+void __attribute__((stack_protector_ignore)) func(void) {} // expected-warning {{'stack_protector_ignore' attribute only applies to local variables}}
+
+void func2(void) {
+	__attribute__((stack_protector_ignore)) int var;
+	__attribute__((stack_protector_ignore)) static int var2; // expected-warning {{'stack_protector_ignore' attribute only applies to local variables}}
+	__attribute__((stack_protector_ignore(2))) int var3; // expected-error {{'stack_protector_ignore' attribute takes no arguments}}
+}

--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -8446,6 +8446,23 @@ specific. The behavior is undefined if the runtime memory address does
 resolve to an object defined in one of the indicated address spaces.
 
 
+'``stack-protector``' Metadata
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``stack-protector`` metadata may be attached to alloca instructions.  An
+alloca instruction with this metadata and value `i32 0` will be skipped when
+deciding whether a given function requires a stack protector.  The function
+may still use a stack protector, if other criteria determine it needs one.
+
+The metadata contains an integer, where a 0 value opts the given alloca out
+of requiring a stack protector.
+
+.. code-block:: none
+
+   %a = alloca [1000 x i8], align 1, !stack-protector !0
+
+  !0 = !{i32 0}
+
 Module Flags Metadata
 =====================
 

--- a/llvm/lib/CodeGen/StackProtector.cpp
+++ b/llvm/lib/CodeGen/StackProtector.cpp
@@ -432,6 +432,11 @@ bool SSPLayoutAnalysis::requiresStackProtector(Function *F,
   for (const BasicBlock &BB : *F) {
     for (const Instruction &I : BB) {
       if (const AllocaInst *AI = dyn_cast<AllocaInst>(&I)) {
+        if (const MDNode *MD = AI->getMetadata("stack-protector")) {
+          const auto *CI = mdconst::dyn_extract<ConstantInt>(MD->getOperand(0));
+          if (CI->isZero())
+            continue;
+        }
         if (AI->isArrayAllocation()) {
           auto RemarkBuilder = [&]() {
             return OptimizationRemark(DEBUG_TYPE, "StackProtectorAllocaOrArray",

--- a/llvm/test/CodeGen/AArch64/stack-protector-metadata.ll
+++ b/llvm/test/CodeGen/AArch64/stack-protector-metadata.ll
@@ -1,0 +1,55 @@
+; RUN: llc -mtriple=aarch64-apple-darwin < %s -o - | FileCheck %s
+
+@.str = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
+
+; CHECK-LABEL: test1:
+; CHECK-NOT: ___stack_chk_guard
+
+; Function Attrs: noinline nounwind optnone
+define void @test1(ptr noundef %msg) #0 {
+entry:
+  %msg.addr = alloca ptr, align 8
+  %a = alloca [1000 x i8], align 1, !stack-protector !2
+  store ptr %msg, ptr %msg.addr, align 8
+  %arraydecay = getelementptr inbounds [1000 x i8], ptr %a, i64 0, i64 0
+  %0 = load ptr, ptr %msg.addr, align 8
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %0) #3
+  %arraydecay1 = getelementptr inbounds [1000 x i8], ptr %a, i64 0, i64 0
+  %call2 = call i32 (ptr, ...) @printf(ptr noundef @.str, ptr noundef %arraydecay1)
+  ret void
+}
+
+
+; CHECK-LABEL: test2:
+; CHECK: ___stack_chk_guard
+
+; Function Attrs: noinline nounwind optnone
+define void @test2(ptr noundef %msg) #0 {
+entry:
+  %msg.addr = alloca ptr, align 8
+  %b = alloca [1000 x i8], align 1
+  store ptr %msg, ptr %msg.addr, align 8
+  %arraydecay = getelementptr inbounds [1000 x i8], ptr %b, i64 0, i64 0
+  %0 = load ptr, ptr %msg.addr, align 8
+  %call = call ptr @strcpy(ptr noundef %arraydecay, ptr noundef %0) #3
+  %arraydecay1 = getelementptr inbounds [1000 x i8], ptr %b, i64 0, i64 0
+  %call2 = call i32 (ptr, ...) @printf(ptr noundef @.str, ptr noundef %arraydecay1)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare ptr @strcpy(ptr noundef, ptr noundef) #1
+
+declare i32 @printf(ptr noundef, ...) #2
+
+attributes #0 = { noinline nounwind optnone "no-trapping-math"="true" "stack-protector-buffer-size"="8" ssp }
+attributes #1 = { nounwind "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 22.0.0"}
+!2 = !{i32 0}

--- a/llvm/test/CodeGen/AArch64/stack-protector-metadata.ll
+++ b/llvm/test/CodeGen/AArch64/stack-protector-metadata.ll
@@ -1,9 +1,13 @@
 ; RUN: llc -mtriple=aarch64-apple-darwin < %s -o - | FileCheck %s
+; RUN: llc -mtriple=x86_64-windows < %s -o - | FileCheck %s --check-prefix=WINDOWS
 
 @.str = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
 
 ; CHECK-LABEL: test1:
 ; CHECK-NOT: ___stack_chk_guard
+
+; WINDOWS-LABEL: test1:
+; WINDOWS-NOT: __security_cookie
 
 ; Function Attrs: noinline nounwind optnone
 define void @test1(ptr noundef %msg) #0 {
@@ -22,6 +26,9 @@ entry:
 
 ; CHECK-LABEL: test2:
 ; CHECK: ___stack_chk_guard
+
+; WINDOWS-LABEL: test2:
+; WINDOWS: __security_cookie
 
 ; Function Attrs: noinline nounwind optnone
 define void @test2(ptr noundef %msg) #0 {


### PR DESCRIPTION
This is the LLVM piece of this work. There is also a clang piece, which adds this metadata to AllocaInst when the source does `__attribute__((no_stack_protector))` on a variable.

We already have `__attribute__((no_stack_protector))` on functions, but opting out the whole function might be too heavy a hammer. Instead this allows us to opt out of stack protectors on specific allocations we might have audited an know to be safe, but still allow the function to generate a stack protector if other allocations necessitate it.