### PR TITLE
[LLDB] Allow control over implicit module loading in EBM projects

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -208,6 +208,12 @@ public:
 
   bool GetSwiftAllowImplicitModules() const;
 
+  void SetSwiftAllowImplicitModules(bool) const;
+
+  bool GetSwiftAllowImplicitModuleLoader() const;
+
+  void SetSwiftAllowImplicitModuleLoader(bool) const;
+
   AutoBool GetSwiftPCMValidation() const;
 
   bool GetSwiftUseTasksPlugin() const;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1319,13 +1319,13 @@ SwiftExpressionParser::ParseAndImport(
     process_sp = this_frame_sp->CalculateProcess();
   if (!m_swift_ast_ctx.GetASTContext()->LangOpts.hasFeature(
           swift::Feature::Embedded))
-    if (auto error =
+    if (llvm::Error error =
             m_swift_ast_ctx.LoadImplicitModules(process_sp, *m_exe_scope))
       return make_error<ModuleImportError>(llvm::toString(std::move(error)));
 
   if (!m_options.GetUseContextFreeSwiftPrintObject())
-    if (auto error = m_swift_ast_ctx.GetImplicitImports(m_sc, process_sp,
-                                                        additional_imports))
+    if (llvm::Error error = m_swift_ast_ctx.GetImplicitImports(
+            m_sc, process_sp, additional_imports))
       return make_error<ModuleImportError>(llvm::toString(std::move(error)));
 
   swift::ImplicitImportInfo importInfo;
@@ -1493,7 +1493,8 @@ SwiftExpressionParser::ParseAndImport(
         IRExecutionUnit::GetLLVMGlobalContextMutex());
 
     Status auto_import_error;
-    if (auto error = m_swift_ast_ctx.CacheUserImports(process_sp, *source_file))
+    if (llvm::Error error =
+            m_swift_ast_ctx.CacheUserImports(process_sp, *source_file))
       return make_error<ModuleImportError>(llvm::toString(std::move(error)),
                                            /*is_new_dylib=*/true);
     if (m_swift_ast_ctx.HasFatalErrors()) {

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -803,7 +803,8 @@ SwiftExpressionParser::GetASTContext(DiagnosticManager &diagnostic_manager) {
 
     if (m_swift_ast_ctx.HasFatalErrors()) {
       diagnostic_manager.PutString(
-          eSeverityError, "The AST context is in a fatal error state.");
+          eSeverityError,
+          llvm::toString(m_swift_ast_ctx.GetFatalErrors().takeError()));
       return;
     }
 
@@ -817,7 +818,8 @@ SwiftExpressionParser::GetASTContext(DiagnosticManager &diagnostic_manager) {
 
     if (m_swift_ast_ctx.HasFatalErrors()) {
       diagnostic_manager.PutString(
-          eSeverityError, "The AST context is in a fatal error state.");
+          eSeverityError,
+          llvm::toString(m_swift_ast_ctx.GetFatalErrors().takeError()));
       return;
     }
 
@@ -1310,21 +1312,21 @@ SwiftExpressionParser::ParseAndImport(
   // Gather the modules that need to be implicitly imported.
   // The Swift stdlib needs to be imported before the SwiftLanguageRuntime can
   // be used.
-  Status implicit_import_error;
   llvm::SmallVector<swift::AttributedImport<swift::ImportedModule>, 16>
       additional_imports;
   lldb::ProcessSP process_sp;
   if (lldb::StackFrameSP this_frame_sp = m_stack_frame_wp.lock())
     process_sp = this_frame_sp->CalculateProcess();
-  m_swift_ast_ctx.LoadImplicitModules(m_sc.target_sp, process_sp, *m_exe_scope);
+  if (!m_swift_ast_ctx.GetASTContext()->LangOpts.hasFeature(
+          swift::Feature::Embedded))
+    if (auto error =
+            m_swift_ast_ctx.LoadImplicitModules(process_sp, *m_exe_scope))
+      return make_error<ModuleImportError>(llvm::toString(std::move(error)));
+
   if (!m_options.GetUseContextFreeSwiftPrintObject())
-    if (!m_swift_ast_ctx.GetImplicitImports(
-            m_sc, process_sp, additional_imports, implicit_import_error)) {
-      const char *msg = implicit_import_error.AsCString();
-      if (!msg)
-        msg = "error status positive, but import still failed";
-      return make_error<ModuleImportError>(msg);
-    }
+    if (auto error = m_swift_ast_ctx.GetImplicitImports(m_sc, process_sp,
+                                                        additional_imports))
+      return make_error<ModuleImportError>(llvm::toString(std::move(error)));
 
   swift::ImplicitImportInfo importInfo;
   importInfo.StdlibKind = swift::ImplicitStdlibKind::Stdlib;
@@ -1491,18 +1493,18 @@ SwiftExpressionParser::ParseAndImport(
         IRExecutionUnit::GetLLVMGlobalContextMutex());
 
     Status auto_import_error;
-    if (!m_swift_ast_ctx.CacheUserImports(process_sp, *source_file,
-                                          auto_import_error)) {
-      const char *msg = auto_import_error.AsCString();
-      if (!msg) {
-        // The import itself succeeded, but the AST context is in a
-        // fatal error state. One way this can happen is if the import
-        // triggered a dylib import, in which case the context is
-        // purposefully poisoned.
-        msg = "import may have triggered a dylib import, "
-              "resetting compiler state";
-      }
-      return make_error<ModuleImportError>(msg, /*is_new_dylib=*/true);
+    if (auto error = m_swift_ast_ctx.CacheUserImports(process_sp, *source_file))
+      return make_error<ModuleImportError>(llvm::toString(std::move(error)),
+                                           /*is_new_dylib=*/true);
+    if (m_swift_ast_ctx.HasFatalErrors()) {
+      // The import itself succeeded, but the AST context is in a
+      // fatal error state. One way this can happen is if the import
+      // triggered a dylib import, in which case the context is
+      // purposefully poisoned.
+      return make_error<ModuleImportError>(
+          "import may have triggered a dylib import, "
+          "resetting compiler state",
+          /*is_new_dylib=*/true);
     }
   }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
   LLDBExplicitModuleLoader.cpp
+  LLDBImplicitModuleLoader.cpp
   SwiftDWARFImporterForClangTypes.cpp
   TypeSystemSwift.cpp
   TypeSystemSwiftTypeRef.cpp

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.cpp
@@ -1,0 +1,111 @@
+//===--LLDBImplicitModuleLoader.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===---------------------------------------------------------------------===//
+
+#include "LLDBImplicitModuleLoader.h"
+#include "SwiftASTContext.h"
+#include "lldb/Target/Target.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
+
+namespace lldb_private {
+
+LLDBImplicitSwiftModuleLoader::LLDBImplicitSwiftModuleLoader(
+    swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+    swift::ModuleLoadingMode loadMode,
+    std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp,
+    std::unique_ptr<swift::ImplicitSerializedModuleLoader> isml)
+    : swift::SerializedModuleLoaderBase(ctx, tracker, loadMode, true),
+      m_swift_ast_ctx_wp(swift_ast_ctx_wp), m_isml(std::move(isml)) {}
+
+std::unique_ptr<LLDBImplicitSwiftModuleLoader>
+LLDBImplicitSwiftModuleLoader::create(
+    swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+    swift::ModuleLoadingMode loadMode,
+    std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp) {
+  auto isml =
+      swift::ImplicitSerializedModuleLoader::create(ctx, tracker, loadMode);
+  return std::make_unique<LLDBImplicitSwiftModuleLoader>(
+      ctx, tracker, loadMode, swift_ast_ctx_wp, std::move(isml));
+}
+
+bool LLDBImplicitSwiftModuleLoader::enabled() const {
+  if (Target::GetGlobalProperties().GetSwiftAllowImplicitModuleLoader())
+    return true;
+  if (auto swift_ast_ctx_sp = m_swift_ast_ctx_wp.lock())
+    return !swift_ast_ctx_sp->ImplicitModulesDisabled();
+  return false;
+}
+
+void LLDBImplicitSwiftModuleLoader::collectVisibleTopLevelModuleNames(
+    llvm::SmallVectorImpl<swift::Identifier> &names) const {
+  if (enabled())
+    m_isml->collectVisibleTopLevelModuleNames(names);
+}
+
+std::error_code LLDBImplicitSwiftModuleLoader::findModuleFilesInDirectory(
+    swift::ImportPath::Element ModuleID,
+    const swift::SerializedModuleBaseName &BaseName,
+    llvm::SmallVectorImpl<char> *ModuleInterfacePath,
+    llvm::SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsCanImportLookup, bool IsFramework, bool IsTestableDependencyLookup) {
+  // This is a protected member and probably also not useful.
+  return {};
+}
+bool LLDBImplicitSwiftModuleLoader::canImportModule(
+    swift::ImportPath::Module named, swift::SourceLoc loc,
+    ModuleVersionInfo *versionInfo, bool isTestableImport) {
+  if (enabled())
+    return llvm::cast<swift::SerializedModuleLoaderBase>(m_isml.get())
+        ->canImportModule(named, loc, versionInfo, isTestableImport);
+  return false;
+}
+
+swift::ModuleDecl *
+LLDBImplicitSwiftModuleLoader::loadModule(swift::SourceLoc importLoc,
+                                          swift::ImportPath::Module path,
+                                          bool AllowMemoryCache) {
+  if (enabled())
+    return m_isml->loadModule(importLoc, path, AllowMemoryCache);
+  return nullptr;
+}
+
+void LLDBImplicitSwiftModuleLoader::loadExtensions(
+    swift::NominalTypeDecl *nominal, unsigned previousGeneration) {
+  if (enabled())
+    m_isml->loadExtensions(nominal, previousGeneration);
+}
+
+void LLDBImplicitSwiftModuleLoader::loadObjCMethods(
+    swift::NominalTypeDecl *typeDecl, swift::ObjCSelector selector,
+    bool isInstanceMethod, unsigned previousGeneration,
+    llvm::TinyPtrVector<swift::AbstractFunctionDecl *> &methods) {
+  if (enabled())
+    m_isml->loadObjCMethods(typeDecl, selector, isInstanceMethod,
+                            previousGeneration, methods);
+}
+
+void LLDBImplicitSwiftModuleLoader::loadDerivativeFunctionConfigurations(
+    swift::AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
+    llvm::SetVector<swift::AutoDiffConfig> &results) {
+  if (enabled())
+    m_isml->loadDerivativeFunctionConfigurations(originalAFD,
+                                                 previousGeneration, results);
+}
+
+void LLDBImplicitSwiftModuleLoader::verifyAllModules() {
+  if (enabled())
+    m_isml->verifyAllModules();
+}
+
+} // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.h
@@ -1,0 +1,78 @@
+//===--LLDBImplicitModuleLoader.h -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_LLDBImplicitModuleLoader_h_
+#define liblldb_LLDBImplicitModuleLoader_h_
+
+#include "SwiftASTContext.h"
+#include <swift/Serialization/SerializedModuleLoader.h>
+namespace swift {
+class ImplicitSerializedModuleLoader;
+} // namespace swift
+
+namespace lldb_private {
+/// This is a wrapper around the ImplicitSwiftSerializedModuleLoader
+/// that can be selectively disabled.
+class LLDBImplicitSwiftModuleLoader : public swift::SerializedModuleLoaderBase {
+public:
+  LLDBImplicitSwiftModuleLoader(
+      swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+      swift::ModuleLoadingMode LoadMode,
+      std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp,
+      std::unique_ptr<swift::ImplicitSerializedModuleLoader> isml);
+
+  static std::unique_ptr<LLDBImplicitSwiftModuleLoader>
+  create(swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+         swift::ModuleLoadingMode loadMode,
+         std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp);
+
+  void collectVisibleTopLevelModuleNames(
+      llvm::SmallVectorImpl<swift::Identifier> &names) const override;
+  std::error_code findModuleFilesInDirectory(
+      swift::ImportPath::Element ModuleID,
+      const swift::SerializedModuleBaseName &BaseName,
+      llvm::SmallVectorImpl<char> *ModuleInterfacePath,
+      llvm::SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool IsCanImportLookup, bool IsFramework,
+      bool IsTestableDependencyLookup = false) override;
+
+  bool canImportModule(swift::ImportPath::Module named, swift::SourceLoc loc,
+                       ModuleVersionInfo *versionInfo,
+                       bool isTestableImport = false) override;
+
+  swift::ModuleDecl *loadModule(swift::SourceLoc importLoc,
+                                swift::ImportPath::Module path,
+                                bool AllowMemoryCache = true) override;
+  void loadExtensions(swift::NominalTypeDecl *nominal,
+                      unsigned previousGeneration) override;
+  void loadObjCMethods(
+      swift::NominalTypeDecl *typeDecl, swift::ObjCSelector selector,
+      bool isInstanceMethod, unsigned previousGeneration,
+      llvm::TinyPtrVector<swift::AbstractFunctionDecl *> &methods) override;
+
+  void loadDerivativeFunctionConfigurations(
+      swift::AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
+      llvm::SetVector<swift::AutoDiffConfig> &results) override;
+
+  void verifyAllModules() override;
+
+protected:
+  bool enabled() const;
+  std::weak_ptr<SwiftASTContext> m_swift_ast_ctx_wp;
+  /// The implicit Swift module loader.
+  std::unique_ptr<swift::ImplicitSerializedModuleLoader> m_isml;
+};
+} // namespace lldb_private
+#endif

--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -172,16 +172,16 @@ public:
       // user code, but doing this here could interfere with
       // ExprOptions.PoundLineLine mechanism used Swift
       // Playgrounds. So instead we find the markers from both ends.
-      StringRef buffer_data = buffer->getBuffer();
+      llvm::StringRef buffer_data = buffer->getBuffer();
       size_t pos = buffer_data.find("__LLDB_USER_START__");
-      if (pos == StringRef::npos)
+      if (pos == llvm::StringRef::npos)
         return;
       auto start_loc =
           llvm::SMLoc::getFromPointer(buffer->getBufferStart() + pos);
       unsigned start_line = src_mgr.FindLineNumber(start_loc, buffer_id);
 
       pos = buffer_data.rfind("__LLDB_USER_END__");
-      if (pos == StringRef::npos)
+      if (pos == llvm::StringRef::npos)
         return;
       auto end_loc =
           llvm::SMLoc::getFromPointer(buffer->getBufferStart() + pos);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -10,15 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
-#include "Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.h"
-#include "Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h"
-#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
-
 #include "SwiftASTContext.h"
+#include "LLDBExplicitModuleLoader.h"
+#include "LLDBImplicitModuleLoader.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
+#include "StoringDiagnosticConsumer.h"
+#include "SwiftDWARFImporterForClangTypes.h"
 #include "SwiftDemangle.h"
 #include "TypeSystemSwift.h"
 #include "TypeSystemSwiftTypeRef.h"
+
 #include "lldb/Utility/Log.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTContext.h"
@@ -917,7 +918,8 @@ static std::string GetClangModulesCacheProperty() {
 }
 
 void SwiftASTContext::ConfigureCASStorage(const SymbolContext &sc) {
-  auto cas = ModuleList::GetOrCreateCAS(sc.module_sp);
+  llvm::Expected<ModuleList::CAS> cas =
+      ModuleList::GetOrCreateCAS(sc.module_sp);
   if (!cas) {
     HEALTH_LOG_PRINTF("Did not create CAS: %s",
                       toString(cas.takeError()).c_str());
@@ -3930,9 +3932,10 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   }
 
   // 4. Create and install the serialized module loader.
-  std::unique_ptr<swift::ModuleLoader> serialized_module_loader_up(
-      swift::ImplicitSerializedModuleLoader::create(
-          *m_ast_context_up, m_dependency_tracker.get(), loading_mode));
+  std::unique_ptr<swift::ModuleLoader> serialized_module_loader_up =
+      LLDBImplicitSwiftModuleLoader::create(
+          *m_ast_context_up, m_dependency_tracker.get(), loading_mode,
+          std::static_pointer_cast<SwiftASTContext>(shared_from_this()));
   if (serialized_module_loader_up)
     m_ast_context_up->addModuleLoader(std::move(serialized_module_loader_up));
 
@@ -9255,8 +9258,16 @@ LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
               "-module-wrap and linked.");
 
     if (toplevel.GetStringRef() == swift::STDLIB_NAME) {
-      swift_ast_context.RaiseFatalError(
-          "Could not import Swift standard library");
+      if (swift_ast_context.HasExplicitModules()) {
+        swift_ast_context.RaiseFatalError(
+            "Could not import Swift standard library using only explicit "
+            "modules.\n"
+            "Enabling implicit modules now; this operation may succeed on "
+            "retry.");
+        Target::GetGlobalProperties().SetSwiftAllowImplicitModules(true);
+      } else
+        swift_ast_context.RaiseFatalError(
+            "Could not import Swift standard library");
       return llvm::createStringError("Could not import Swift standard library");
     }
   }
@@ -9436,26 +9447,27 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         *modules) {
   // If EBM is enabled, disable implicit modules during contextual imports.
-  bool turn_off_implicit = m_has_explicit_modules;
-  if (Target::GetGlobalProperties().GetSwiftAllowImplicitModules())
-    turn_off_implicit = false;
-  
+  m_implicit_modules_disabled =
+      m_has_explicit_modules &&
+      !Target::GetGlobalProperties().GetSwiftAllowImplicitModules();
+
   auto reset = llvm::make_scope_exit([&] {
-    if (turn_off_implicit) {
-      LOG_PRINTF(GetLog(LLDBLog::Types), "Turning on implicit modules");
-      if (m_module_interface_loader) {
-        auto &opts = m_module_interface_loader->getOptions();
-        opts.disableImplicitSwiftModule = false;
-        opts.disableBuildingInterface = false;
-      }
-      if (m_clangimporter) {
-        auto &clang_instance = const_cast<clang::CompilerInstance &>(
-            m_clangimporter->getClangInstance());
-        clang_instance.getLangOpts().ImplicitModules = true;
-      }
+    if (!m_implicit_modules_disabled)
+      return;
+    m_implicit_modules_disabled = false;
+    LOG_PRINTF(GetLog(LLDBLog::Types), "Turning on implicit modules");
+    if (m_module_interface_loader) {
+      auto &opts = m_module_interface_loader->getOptions();
+      opts.disableImplicitSwiftModule = false;
+      opts.disableBuildingInterface = false;
+    }
+    if (m_clangimporter) {
+      auto &clang_instance = const_cast<clang::CompilerInstance &>(
+          m_clangimporter->getClangInstance());
+      clang_instance.getLangOpts().ImplicitModules = true;
     }
   });
-  if (turn_off_implicit) {
+  if (m_implicit_modules_disabled) {
     LOG_PRINTF(GetLog(LLDBLog::Types), "Turning off implicit modules");
     // Swift.
     if (m_module_interface_loader) {
@@ -9471,9 +9483,6 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     if (m_clangimporter) {
       auto &clang_instance = const_cast<clang::CompilerInstance &>(
           m_clangimporter->getClangInstance());
-      // AddExtraArgs is supposed to always turn implicit modules on.
-      assert(clang_instance.getLangOpts().ImplicitModules &&
-             "ClangImporter implicit module support is off");
       clang_instance.getLangOpts().ImplicitModules = false;
     }
   }
@@ -9530,6 +9539,7 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
   // If we haven't already loaded an explicitly tracked one, import the Swift
   // standard library and its dependencies.
   if (!loaded_stdlib) {
+    m_implicit_modules_disabled = false;
     SourceModule swift_module;
     swift_module.path.emplace_back(swift::STDLIB_NAME);
     auto stdlib = LoadOneModule(swift_module, *this, process_sp,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -20,6 +20,7 @@
 #include "TypeSystemSwift.h"
 #include "TypeSystemSwiftTypeRef.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
 #include "swift/AST/ASTMangler.h"
@@ -77,6 +78,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
@@ -135,6 +137,7 @@
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserClang.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -4265,21 +4268,18 @@ SwiftASTContext::GetModule(const FileSpec &module_spec) {
       "failed to get module \"{0}\" from AST context", module_spec.GetPath()));
 }
 
-template<typename ModuleT> swift::ModuleDecl *
+template <typename ModuleT>
+llvm::Expected<swift::ModuleDecl &>
 SwiftASTContext::FindAndLoadModule(const ModuleT &module, Process &process,
-                                   bool import_dylib, Status &error) {
-  VALID_OR_RETURN(nullptr);
+                                   bool import_dylib) {
+  VALID_OR_RETURN(llvm::createStringError("no context"));
 
   bool cached = false;
   auto swift_module_or_err = GetModule(module, &cached);
-  if (!swift_module_or_err) {
-    error = Status::FromError(swift_module_or_err.takeError());
-    return nullptr;
-  }
-  swift::ModuleDecl *swift_module = &*swift_module_or_err;
+  if (!swift_module_or_err)
+    return swift_module_or_err.takeError();
 
-  if (!swift_module)
-    return nullptr;
+  swift::ModuleDecl &swift_module = *swift_module_or_err;
 
   // If import_dylib is true, this is an explicit "import Module"
   // declaration in a user expression, and we should load the dylib
@@ -4295,7 +4295,8 @@ SwiftASTContext::FindAndLoadModule(const ModuleT &module, Process &process,
     return swift_module;
 
   if (import_dylib)
-    LoadModule(swift_module, process, error);
+    if (llvm::Error error = LoadModule(swift_module, process))
+      return error;
 
   return swift_module;
 }
@@ -4310,8 +4311,7 @@ bool SwiftASTContext::LoadOneImage(Process &process, FileSpec &link_lib_spec,
   if (platform_sp)
     return platform_sp->LoadImage(&process, FileSpec(), link_lib_spec, error) !=
            LLDB_INVALID_IMAGE_TOKEN;
-  else
-    return false;
+  return false;
 }
 
 static std::vector<std::string>
@@ -4332,9 +4332,9 @@ GetLibrarySearchPaths(const swift::SearchPathOptions &search_path_opts) {
   return paths;
 }
 
-void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
-                                 Process &process, Status &error) {
-  VALID_OR_RETURN();
+llvm::Error SwiftASTContext::LoadModule(swift::ModuleDecl &swift_module,
+                                        Process &process) {
+  VALID_OR_RETURN(llvm::createStringError("invalid context"));
 
   Status current_error;
   auto addLinkLibrary = [&](swift::LinkLibrary link_lib) {
@@ -4343,7 +4343,7 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
     std::string library_name = link_lib.getName().str();
 
     if (library_name.empty()) {
-      error = Status::FromErrorString(
+      current_error = Status::FromErrorString(
           "Empty library name passed to addLinkLibrary");
       return;
     }
@@ -4446,7 +4446,7 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
       std::vector<std::string> uniqued_paths;
 
       for (const auto &framework_search_dir :
-           swift_module->getASTContext()
+           swift_module.getASTContext()
                .SearchPathOpts.getFrameworkSearchPaths()) {
         // The framework search dir as it comes from the AST context
         // often has duplicate entries, don't try to load along the
@@ -4506,7 +4506,7 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
     } break;
     case swift::LibraryKind::Library: {
       std::vector<std::string> search_paths =
-          GetLibrarySearchPaths(swift_module->getASTContext().SearchPathOpts);
+          GetLibrarySearchPaths(swift_module.getASTContext().SearchPathOpts);
 
       if (LoadLibraryUsingPaths(process, library_name, search_paths, true,
                                 all_dlopen_errors))
@@ -4521,14 +4521,14 @@ void SwiftASTContext::LoadModule(swift::ModuleDecl *swift_module,
 
     current_error = Status::FromErrorStringWithFormatv(
         "Failed to load linked library {0} of module {1} - errors:\n{2}\n",
-        library_name, swift_module->getName().str().str(),
+        library_name, swift_module.getName().str().str(),
         all_dlopen_errors.GetData());
   };
 
-  for (auto import : swift::namelookup::getAllImports(swift_module)) {
+  for (auto import : swift::namelookup::getAllImports(&swift_module)) {
     import.importedModule->collectLinkLibraries(addLinkLibrary);
   }
-  error = current_error.Clone();
+  return current_error.takeError();
 }
 
 bool SwiftASTContext::LoadLibraryUsingPaths(
@@ -5615,11 +5615,6 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
     DiagnosticManager fatal_diagnostics;
     diags.PrintDiagnostics(fatal_diagnostics, {}, bufferID, first_line,
                            last_line);
-    if (fatal_diagnostics.Diagnostics().size())
-      RaiseFatalError(fatal_diagnostics.GetString());
-    else
-      RaiseFatalError("Unknown fatal error occurred.");
-
     m_reported_fatal_error = true;
 
     for (const DiagnosticList::value_type &fatal_diagnostic :
@@ -5633,6 +5628,10 @@ void SwiftASTContext::PrintDiagnostics(DiagnosticManager &diagnostic_manager,
   } else {
     diags.PrintDiagnostics(diagnostic_manager, {}, bufferID, first_line,
                            last_line);
+    if (m_fatal_errors.Fail())
+      diagnostic_manager.AddDiagnostic(
+          llvm::toString(m_fatal_errors.Clone().takeError()),
+          lldb::eSeverityError, eDiagnosticOriginLLDB);
   }
 }
 
@@ -9213,37 +9212,33 @@ static void GetNameFromModule(swift::ModuleDecl *module, std::string &result) {
   }
 }
 
-static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
-                                        SwiftASTContext &swift_ast_context,
-                                        lldb::ProcessSP process_sp,
-                                        bool import_dylibs,
-                                        Status &error) {
+static llvm::Expected<swift::ModuleDecl &>
+LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
+              lldb::ProcessSP process_sp, bool import_dylibs) {
   if (!module.path.size())
-    return nullptr;
+    return llvm::createStringError("empty module name");
 
-  error.Clear();
   ConstString toplevel = module.path.front();
   const std::string &m_description = swift_ast_context.GetDescription();
   LOG_PRINTF(GetLog(LLDBLog::Types | LLDBLog::Expressions),
              "Importing module %s", toplevel.AsCString());
-  swift::ModuleDecl *swift_module = nullptr;
-  auto *clangimporter = swift_ast_context.GetClangImporter();
-  swift::ModuleDecl *imported_header_module =
-      clangimporter ? clangimporter->getImportedHeaderModule() : nullptr;
-  if (imported_header_module &&
-      toplevel.GetStringRef() == imported_header_module->getName().str())
-    swift_module = imported_header_module;
-  else if (process_sp)
-    swift_module = swift_ast_context.FindAndLoadModule(
-        module, *process_sp.get(), import_dylibs, error);
-  else {
-    auto swift_module_or_err = swift_ast_context.GetModule(module);
-    if (!swift_module_or_err)
-      llvm::consumeError(swift_module_or_err.takeError());
-    else
-      swift_module = &*swift_module_or_err;
-  }
 
+  auto load_impl =
+      [&](ConstString path) -> llvm::Expected<swift::ModuleDecl &> {
+    auto *clangimporter = swift_ast_context.GetClangImporter();
+    swift::ModuleDecl *imported_header_module =
+        clangimporter ? clangimporter->getImportedHeaderModule() : nullptr;
+    if (imported_header_module &&
+        toplevel.GetStringRef() == imported_header_module->getName().str())
+      return *imported_header_module;
+    else if (process_sp) {
+      return swift_ast_context.FindAndLoadModule(module, *process_sp.get(),
+                                                 import_dylibs);
+    } else
+      return swift_ast_context.GetModule(module);
+  };
+
+  auto swift_module = load_impl(toplevel);
   if (swift_module && IsDWARFImported(*swift_module)) {
     // This module was "imported" from DWARF. This basically means the
     // import as a Swift or Clang module failed. We have not yet
@@ -9259,18 +9254,17 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
             : "Swift modules can be wrapped in object containers using "
               "-module-wrap and linked.");
 
-    if (toplevel.GetStringRef() == swift::STDLIB_NAME)
-      swift_module = nullptr;
+    if (toplevel.GetStringRef() == swift::STDLIB_NAME) {
+      swift_ast_context.RaiseFatalError(
+          "Could not import Swift standard library");
+      return llvm::createStringError("Could not import Swift standard library");
+    }
   }
 
-  if (!swift_module || !error.Success() || swift_ast_context.HasFatalErrors()) {
+  if (!swift_module) {
     LOG_PRINTF(GetLog(LLDBLog::Types | LLDBLog::Expressions),
-               "Couldn't import module %s: %s", toplevel.AsCString(),
-               error.AsCString());
-
-    if (!swift_module || swift_ast_context.HasFatalErrors()) {
-      return nullptr;
-    }
+               "Couldn't import module %s", toplevel.AsCString());
+    return swift_module;
   }
 
   if (GetLog(LLDBLog::Types | LLDBLog::Expressions)) {
@@ -9284,13 +9278,12 @@ static swift::ModuleDecl *LoadOneModule(const SourceModule &module,
   return swift_module;
 }
 
-bool SwiftASTContextForExpressions::GetImplicitImports(
+llvm::Error SwiftASTContextForExpressions::GetImplicitImports(
     SymbolContext &sc, lldb::ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-        &modules,
-    Status &error) {
-  if (!GetCompileUnitImports(sc, process_sp, modules, error))
-    return false;
+        &modules) {
+  if (auto error = GetCompileUnitImports(sc, process_sp, modules))
+    return error;
 
   // Get the hand-loaded modules from the SwiftPersistentExpressionState.
   for (auto &module_pair : m_hand_loaded_modules) {
@@ -9306,51 +9299,44 @@ bool SwiftASTContextForExpressions::GetImplicitImports(
     // Otherwise, try reloading the ModuleDecl using the module name.
     SourceModule module_info;
     module_info.path.emplace_back(module_pair.first());
-    auto *module = LoadOneModule(module_info, *this, process_sp,
-                                 /*import_dylibs=*/false, error);
+    auto module = LoadOneModule(module_info, *this, process_sp,
+                                /*import_dylibs=*/false);
     if (!module)
-      return false;
+      return module.takeError();
 
-    attributed_import.module = swift::ImportedModule(module);
+    attributed_import.module = swift::ImportedModule(&*module);
     modules.emplace_back(attributed_import);
   }
-  return true;
+  return llvm::Error::success();
 }
 
-void SwiftASTContextForExpressions::LoadImplicitModules(
-    TargetSP target, ProcessSP process, ExecutionContextScope &exe_scope) {
-  auto load_module = [&](ConstString module_name) {
+llvm::Error SwiftASTContextForExpressions::LoadImplicitModules(
+    ProcessSP process, ExecutionContextScope &exe_scope) {
+  auto load_module = [&](ConstString module_name) -> llvm::Error {
     SourceModule module_info;
     module_info.path.push_back(module_name);
-    Status err;
-    LoadOneModule(module_info, *this, process, true, err);
-    if (err.Fail()) {
-      LOG_PRINTF(GetLog(LLDBLog::Types),
-                 "Could not load module %s implicitly, error: %s",
-                 module_name.GetCString(), err.AsCString());
-      return;
+    {
+      auto module_or_err = LoadOneModule(module_info, *this, process, true);
+      if (!module_or_err)
+        return module_or_err.takeError();
     }
-
-    auto module_or_err = GetModule(module_info);
-    if (!module_or_err) {
-      std::string error = llvm::toString(module_or_err.takeError());
-      LOG_PRINTF(
-          GetLog(LLDBLog::Types),
-          "Could not add hand loaded module %s to persistent state, error: %s",
-          module_name.GetCString(), error.c_str());
-      return;
+    {
+      auto module_or_err = GetModule(module_info);
+      if (!module_or_err)
+        return module_or_err.takeError();
+      swift::ModuleDecl *module = &*module_or_err;
+      AddHandLoadedModule(module_name, swift::ImportedModule(module));
     }
-    swift::ModuleDecl *module = &*module_or_err;
-
-    AddHandLoadedModule(module_name, swift::ImportedModule(module));
+    return llvm::Error::success();
   };
 
-  load_module(ConstString(swift::SWIFT_STRING_PROCESSING_NAME));
-  load_module(ConstString(swift::SWIFT_CONCURRENCY_NAME));
+  return llvm::joinErrors(
+      load_module(ConstString(swift::SWIFT_STRING_PROCESSING_NAME)),
+      load_module(ConstString(swift::SWIFT_CONCURRENCY_NAME)));
 }
 
-bool SwiftASTContextForExpressions::CacheUserImports(
-    lldb::ProcessSP process_sp, swift::SourceFile &source_file, Status &error) {
+llvm::Error SwiftASTContextForExpressions::CacheUserImports(
+    lldb::ProcessSP process_sp, swift::SourceFile &source_file) {
   llvm::SmallString<1> m_description;
 
   auto src_file_imports = source_file.getImports();
@@ -9381,10 +9367,10 @@ bool SwiftASTContextForExpressions::CacheUserImports(
         LOG_PRINTF(GetLog(LLDBLog::Types | LLDBLog::Expressions),
                    "Performing auto import on found module: %s.\n",
                    module_name.c_str());
-        auto *module_decl = LoadOneModule(module_info, *this, process_sp,
-                                          /*import_dylibs=*/true, error);
+        auto module_decl = LoadOneModule(module_info, *this, process_sp,
+                                         /*import_dylibs=*/true);
         if (!module_decl)
-          return false;
+          return module_decl.takeError();
         if (IsSerializedAST(*module_decl)) {
           // Parse additional search paths from the module.
           StringRef ast_file = module_decl->getModuleLoadedFilename();
@@ -9424,21 +9410,20 @@ bool SwiftASTContextForExpressions::CacheUserImports(
       }
     }
   }
-  return true;
+  return llvm::Error::success();
 }
 
-bool SwiftASTContext::GetCompileUnitImports(
+llvm::Error SwiftASTContext::GetCompileUnitImports(
     const SymbolContext &sc, ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-        &modules,
-    Status &error) {
-  return GetCompileUnitImportsImpl(sc, process_sp, &modules, error);
+        &modules) {
+  return GetCompileUnitImportsImpl(sc, process_sp, &modules);
 }
 
-void SwiftASTContext::PerformCompileUnitImports(const SymbolContext &sc,
-                                                lldb::ProcessSP process_sp,
-                                                Status &error) {
-  GetCompileUnitImportsImpl(sc, process_sp, nullptr, error);
+llvm::Error
+SwiftASTContext::PerformCompileUnitImports(const SymbolContext &sc,
+                                           lldb::ProcessSP process_sp) {
+  return GetCompileUnitImportsImpl(sc, process_sp, nullptr);
 }
 
 static std::pair<Module *, lldb::user_id_t>
@@ -9446,11 +9431,10 @@ GetCUSignature(CompileUnit &compile_unit) {
   return {compile_unit.GetModule().get(), compile_unit.GetID()};
 }
 
-bool SwiftASTContext::GetCompileUnitImportsImpl(
+llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     const SymbolContext &sc, lldb::ProcessSP process_sp,
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-        *modules,
-    Status &error) {
+        *modules) {
   // If EBM is enabled, disable implicit modules during contextual imports.
   bool turn_off_implicit = m_has_explicit_modules;
   if (Target::GetGlobalProperties().GetSwiftAllowImplicitModules())
@@ -9507,52 +9491,57 @@ bool SwiftASTContext::GetCompileUnitImportsImpl(
     if (!m_cu_imports.insert(GetCUSignature(*compile_unit)).second)
       // List of imports isn't requested and we already processed this CU?
       if (!modules)
-        return true;
+        return llvm::Error::success();
 
-  // Import the Swift standard library and its dependencies.
-  SourceModule swift_module;
-  swift_module.path.emplace_back(swift::STDLIB_NAME);
-  auto *stdlib = LoadOneModule(swift_module, *this, process_sp,
-                               /*import_dylibs=*/true, error);
-  if (!stdlib)
-    return false;
+  bool loaded_stdlib = false;
+  if (compile_unit && compile_unit->GetLanguage() == lldb::eLanguageTypeSwift) {
+    std::vector<SourceModule> cu_imports = compile_unit->GetImportedModules();
+    LOG_PRINTF(GetLog(LLDBLog::Types), "Importing dependencies of current CU");
+    std::string category = "Importing dependencies for ";
+    category += compile_unit->GetPrimaryFile().GetFilename().GetString();
+    auto module_import_progress_raii = GetModuleImportProgressRAII(category);
 
-  if (modules)
-    modules->emplace_back(swift::ImportedModule(stdlib));
+    for (const SourceModule &module : cu_imports) {
+      // When building the Swift stdlib with debug info these will
+      // show up in "Swift.o", but we already imported them and
+      // manually importing them will fail.
+      // Also skip the "std" module, as the C++ standard library will be
+      // imported as "CxxStdlib", which should also be imported.
+      if (module.path.size() &&
+          llvm::StringSwitch<bool>(module.path.front().GetStringRef())
+              .Cases("SwiftShims", "Builtin", "std", true)
+              .Default(false))
+        continue;
 
-  if (!compile_unit || compile_unit->GetLanguage() != lldb::eLanguageTypeSwift)
-    return true;
+      auto loaded_module = LoadOneModule(module, *this, process_sp,
+                                         /*import_dylibs=*/false);
+      if (!loaded_module)
+        return loaded_module.takeError();
 
-  auto cu_imports = compile_unit->GetImportedModules();
-  if (cu_imports.size() == 0)
-    return true;
+      if (module.path.size() &&
+          module.path.front().GetStringRef() == swift::STDLIB_NAME)
+        loaded_stdlib = true;
 
-  LOG_PRINTF(GetLog(LLDBLog::Types), "Importing dependencies of current CU");
-  std::string category = "Importing dependencies for ";
-  category += compile_unit->GetPrimaryFile().GetFilename().GetString();
-  auto module_import_progress_raii = GetModuleImportProgressRAII(category);
- 
-  for (const SourceModule &module : cu_imports) {
-    // When building the Swift stdlib with debug info these will
-    // show up in "Swift.o", but we already imported them and
-    // manually importing them will fail.
-    // Also skip the "std" module, as the C++ standard library will be
-    // imported as "CxxStdlib", which should also be imported.
-    if (module.path.size() &&
-        llvm::StringSwitch<bool>(module.path.front().GetStringRef())
-            .Cases("Swift", "SwiftShims", "Builtin", "std", true)
-            .Default(false))
-      continue;
+      if (modules)
+        modules->emplace_back(swift::ImportedModule(&*loaded_module));
+    }
+  }
 
-    auto *loaded_module = LoadOneModule(module, *this, process_sp,
-                                        /*import_dylibs=*/false, error);
-    if (!loaded_module)
-      return false;
+  // If we haven't already loaded an explicitly tracked one, import the Swift
+  // standard library and its dependencies.
+  if (!loaded_stdlib) {
+    SourceModule swift_module;
+    swift_module.path.emplace_back(swift::STDLIB_NAME);
+    auto stdlib = LoadOneModule(swift_module, *this, process_sp,
+                                /*import_dylibs=*/true);
+    if (!stdlib)
+      return stdlib.takeError();
 
     if (modules)
-      modules->emplace_back(swift::ImportedModule(loaded_module));
+      modules->emplace_back(swift::ImportedModule(&*stdlib));
   }
-  return true;
+
+  return llvm::Error::success();
 }
 
 swift::Mangle::ManglingFlavor SwiftASTContext::GetManglingFlavor() {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -86,6 +86,7 @@ class LLVMContext;
 class SwiftEnumDescriptor;
 
 namespace lldb_private {
+class LLDBExplicitSwiftModuleLoader;
 
 namespace plugin {
 namespace dwarf {
@@ -570,6 +571,7 @@ public:
   void LogConfiguration(bool repl = false, bool playground = false);
   bool HasTarget();
   bool HasExplicitModules() const { return m_has_explicit_modules; }
+  bool ImplicitModulesDisabled() const { return m_implicit_modules_disabled; }
   bool HasCAS() const { return m_cas_initialized; }
   bool CheckProcessChanged();
 
@@ -1019,6 +1021,7 @@ protected:
   bool m_initialized_search_path_options = false;
   bool m_initialized_clang_importer_options = false;
   bool m_has_explicit_modules = false;
+  bool m_implicit_modules_disabled = false;
   bool m_cas_initialized = false;
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -368,11 +368,10 @@ public:
   /// by module, load the module into the AST context, and (if import_dylib is
   /// set) also load any "LinkLibraries" that the module requires.
   template <typename ModuleT>
-  swift::ModuleDecl *FindAndLoadModule(const ModuleT &module, Process &process,
-                                       bool import_dylib, Status &error);
+  llvm::Expected<swift::ModuleDecl &>
+  FindAndLoadModule(const ModuleT &module, Process &process, bool import_dylib);
 
-  void LoadModule(swift::ModuleDecl *swift_module, Process &process,
-                  Status &error);
+  llvm::Error LoadModule(swift::ModuleDecl &swift_module, Process &process);
 
   /// Collect Swift modules in the .swift_ast section of \p module.
   void RegisterSectionModules(Module &module,
@@ -878,15 +877,14 @@ public:
 
   /// Retrieve/import the modules imported by the compilation
   /// unit. Early-exists with false if there was an import failure.
-  bool GetCompileUnitImports(
+  llvm::Error GetCompileUnitImports(
       const SymbolContext &sc, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-          &modules,
-      Status &error);
+          &modules);
 
   /// Perform all the implicit imports for the current frame.
-  void PerformCompileUnitImports(const SymbolContext &sc, lldb::ProcessSP process_sp,
-                                 Status &error);
+  llvm::Error PerformCompileUnitImports(const SymbolContext &sc,
+                                        lldb::ProcessSP process_sp);
 
   /// Returns the mangling flavor associated with this ASTContext.
   swift::Mangle::ManglingFlavor GetManglingFlavor();
@@ -896,11 +894,10 @@ protected:
   /// configuration file.
   void ConfigureCASStorage(const SymbolContext &sc);
 
-  bool GetCompileUnitImportsImpl(
+  llvm::Error GetCompileUnitImportsImpl(
       const SymbolContext &sc, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-          *modules,
-      Status &error);
+          *modules);
 
   /// This map uses the string value of ConstStrings as the key, and the
   /// TypeBase
@@ -1115,22 +1112,21 @@ public:
   /// Retrieves the modules that need to be implicitly imported in a given
   /// execution scope. This includes the modules imported by both the compile
   /// unit as well as any imports from previous expression evaluations.
-  bool GetImplicitImports(
+  llvm::Error GetImplicitImports(
       SymbolContext &sc, lldb::ProcessSP process_sp,
       llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
-          &modules,
-      Status &error);
+          &modules);
 
   // FIXME: the correct thing to do would be to get the modules by calling
   // CompilerInstance::getImplicitImportInfo, instead of loading these
   // modules manually. However, we currently don't have  access to a
   // CompilerInstance, which is why this function is needed.
-  void LoadImplicitModules(lldb::TargetSP target, lldb::ProcessSP process,
-                           ExecutionContextScope &exe_scope);
+  llvm::Error LoadImplicitModules(lldb::ProcessSP process,
+                                  ExecutionContextScope &exe_scope);
   /// Cache the user's imports from a SourceFile in a given execution scope such
   /// that they are carried over into future expression evaluations.
-  bool CacheUserImports(lldb::ProcessSP process_sp,
-                        swift::SourceFile &source_file, Status &error);
+  llvm::Error CacheUserImports(lldb::ProcessSP process_sp,
+                               swift::SourceFile &source_file);
 
 protected:
   /// These are the names of modules that we have loaded by hand into

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2545,7 +2545,7 @@ SwiftASTContextSP TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
     TargetSP target_sp = GetTargetWP().lock();
     if (target_sp)
       process_sp = target_sp->GetProcessSP();
-    if (auto error =
+    if (llvm::Error error =
             swift_ast_context->PerformCompileUnitImports(sc, process_sp)) {
       if (target_sp) {
         if (StreamSP errs_sp = target_sp->GetDebugger().GetAsyncErrorStream())

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2374,16 +2374,15 @@ void TypeSystemSwiftTypeRefForExpressions::ModulesDidLoad(
   });
 }
 
-Status TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
+llvm::Error TypeSystemSwiftTypeRefForExpressions::PerformCompileUnitImports(
     const SymbolContext &sc) {
-  Status status;
   lldb::ProcessSP process_sp;
   if (auto target_sp = sc.target_sp)
     process_sp = target_sp->GetProcessSP();
 
   if (auto swift_ast_ctx = GetSwiftASTContextOrNull(sc))
-    swift_ast_ctx->PerformCompileUnitImports(sc, process_sp, status);
-  return status;
+    return swift_ast_ctx->PerformCompileUnitImports(sc, process_sp);
+  return llvm::Error::success();
 }
 
 UserExpression *TypeSystemSwiftTypeRefForExpressions::GetUserExpression(
@@ -2542,17 +2541,20 @@ SwiftASTContextSP TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
   assert(llvm::isa<SwiftASTContextForExpressions>(swift_ast_context.get()));
 
   auto perform_initial_import = [&](const SymbolContext &sc) {
-    Status error;
     lldb::ProcessSP process_sp;
     TargetSP target_sp = GetTargetWP().lock();
     if (target_sp)
       process_sp = target_sp->GetProcessSP();
-    swift_ast_context->PerformCompileUnitImports(sc, process_sp, error);
-    if (error.Fail() && target_sp)
-      if (StreamSP errs_sp = target_sp->GetDebugger().GetAsyncErrorStream())
-        errs_sp->Printf(
-            "Could not import Swift modules for translation unit: %s",
-            error.AsCString());
+    if (auto error =
+            swift_ast_context->PerformCompileUnitImports(sc, process_sp)) {
+      if (target_sp) {
+        if (StreamSP errs_sp = target_sp->GetDebugger().GetAsyncErrorStream())
+          errs_sp->Printf(
+              "Could not import Swift modules for translation unit: %s",
+              llvm::toString(std::move(error)).c_str());
+      } else
+        llvm::consumeError(std::move(error));
+    }
   };
 
   perform_initial_import(sc);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -695,7 +695,7 @@ public:
 
   /// Forwards to SwiftASTContext.
   PersistentExpressionState *GetPersistentExpressionState() override;
-  Status PerformCompileUnitImports(const SymbolContext &sc);
+  llvm::Error PerformCompileUnitImports(const SymbolContext &sc);
   /// Returns how often ModulesDidLoad was called.
   unsigned GetGeneration() const { return m_generation; }
   /// Performs a target-wide search.

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4721,6 +4721,37 @@ bool TargetProperties::GetSwiftAllowImplicitModules() const {
   return false;
 }
 
+void TargetProperties::SetSwiftAllowImplicitModules(bool b) const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    exp_values->SetPropertyAtIndex(ePropertySwiftAllowImplicitModules, b);
+}
+
+bool TargetProperties::GetSwiftAllowImplicitModuleLoader() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftAllowImplicitModuleLoader)
+        .value_or(true);
+
+  return false;
+}
+
+void TargetProperties::SetSwiftAllowImplicitModuleLoader(bool b) const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    exp_values->SetPropertyAtIndex(ePropertySwiftAllowImplicitModuleLoader, b);
+}
+
 AutoBool TargetProperties::GetSwiftPCMValidation() const {
   const Property *exp_property =
       m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -29,6 +29,11 @@ let Definition = "target_experimental" in {
   def SwiftAllowImplicitModules: Property<"swift-allow-implicit-modules", "Boolean">,
     DefaultFalse,
     Desc<"Allows implicit module imports in an explicitly-built target.">;
+  def SwiftAllowImplicitModuleLoader
+      : Property<"swift-allow-implicit-module-loader", "Boolean">,
+        DefaultTrue,
+        Desc<
+            "Enable the implicit module loader in an explicitly-built target.">;
   def SwiftPCMValidation: Property<"swift-pcm-validation", "Enum">,
     Global,
     DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
@@ -7,6 +7,7 @@ all: libDylib a.out
 
 include Makefile.rules
 
+# Note that this is being built with implicit modules!
 libDylib: Dylib.swift
 	mkdir -p $(BUILDDIR)/$(shell basename $< .swift)
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -23,8 +23,13 @@ class TestSwiftClangImporterExplicitNoImplicit(TestBase):
                                           extra_images=['Dylib'])
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
+        self.expect('settings set target.experimental.swift-allow-implicit-module-loader false')
+        # This is expected to fail because the dependencies of Dylib
+        # (including the stdlib) are implicit modules.
+        self.expect("expression obj", error=True)
+        self.expect('settings set target.experimental.swift-allow-implicit-module-loader true')
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["hidden"])
         self.filecheck('platform shell cat "%s"' % log, __file__)
-#       CHECK-NOT: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/SwiftShims-{{.*}}.pcm
-#       CHECK: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/Hidden-{{.*}}.pcm
+        # CHECK-NOT: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/SwiftShims-{{.*}}.pcm
+        # CHECK: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/Hidden-{{.*}}.pcm


### PR DESCRIPTION
This is an NFC change unless the
target.experimental.swift-allow-implicit-module-loader setting is
modified. The goal is to eventually flip the default. This disables
the implicit module loader while doing contextual imports in an EBM
project. ClangImporter will eagerly try to discover Swift overlays for
Clang modules. In EBM build, if they are not found, this is a
recoverable and silent failure, however if the implicit module loader
is active,. it will perform an implicit build of this module. To
replicate the compiler's behavior and performance the implicit module
loader should be turned off.