### PR TITLE
[LLDB] Add a setting to simulate variables with missing locations

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -88,12 +88,10 @@ public:
   uint64_t GetLLDBIndexCacheExpirationDays();
   FileSpec GetLLDBIndexCachePath() const;
   bool SetLLDBIndexCachePath(const FileSpec &path);
-
-  bool GetLoadSymbolOnDemand();
-
+  bool GetLoadSymbolOnDemand() const;
   lldb::SymbolDownload GetSymbolAutoDownload() const;
-
   PathMappingList GetSymlinkMappings() const;
+  bool GetInjectVarLocListError() const;
 };
 
 /// \class ModuleList ModuleList.h "lldb/Core/ModuleList.h"

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -46,6 +46,10 @@ let Definition = "modulelist" in {
     Global,
     DefaultFalse,
     Desc<"Enable on demand symbol loading in LLDB. LLDB will load debug info on demand for each module based on various conditions (e.g. matched breakpoint, resolved stack frame addresses and matched global variables/function symbols in symbol table) to improve performance. Please refer to docs/use/ondemand.rst for details.">;
+  def InjectVarLocListError: Property<"inject-variable-location-error", "Boolean">,
+    Global,
+    DefaultFalse,
+    Desc<"Used for testing LLDB only. Hide locations of local variables.">;
 }
 
 let Definition = "debugger" in {

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -186,8 +186,14 @@ PathMappingList ModuleListProperties::GetSymlinkMappings() const {
   return m_symlink_paths;
 }
 
-bool ModuleListProperties::GetLoadSymbolOnDemand() {
+bool ModuleListProperties::GetLoadSymbolOnDemand() const {
   const uint32_t idx = ePropertyLoadSymbolOnDemand;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
+bool ModuleListProperties::GetInjectVarLocListError() const {
+  const uint32_t idx = ePropertyInjectVarLocListError;
   return GetPropertyAtIndexAs<bool>(
       idx, g_modulelist_properties[idx].default_uint_value != 0);
 }

--- a/lldb/source/Symbol/Variable.cpp
+++ b/lldb/source/Symbol/Variable.cpp
@@ -47,9 +47,13 @@ Variable::Variable(lldb::user_id_t uid, const char *name, const char *mangled,
     : UserID(uid), m_name(name), m_mangled(ConstString(mangled)),
       m_symfile_type_sp(symfile_type_sp), m_scope(scope),
       m_owner_scope(context), m_scope_range(scope_range),
-      m_declaration(decl_ptr), m_location_list(location_list), m_external(external),
-      m_artificial(artificial), m_loc_is_const_data(location_is_constant_data),
-      m_static_member(static_member) {}
+      m_declaration(decl_ptr), m_location_list(location_list),
+      m_external(external), m_artificial(artificial),
+      m_loc_is_const_data(location_is_constant_data),
+      m_static_member(static_member) {
+  if (ModuleList::GetGlobalModuleListProperties().GetInjectVarLocListError())
+    m_location_list.Clear();
+}
 
 Variable::~Variable() = default;
 

--- a/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
+++ b/lldb/test/API/commands/expression/diagnostics/TestExprDiagnostics.py
@@ -272,3 +272,17 @@ note: candidate function not viable: requires single argument 'x', but 2 argumen
         self.assertEqual(err_ty.GetIntegerValue(), lldb.eErrorTypeExpression)
         diags = data.GetValueForKey("errors").GetItemAtIndex(0)
         check_error(diags)
+
+    def test_no_location(self):
+        """Test the error reporting for missing locations"""
+        self.build()
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "// Break here", self.main_source_spec
+        )
+        self.expect('settings set symbols.inject-variable-location-error true')
+        frame = thread.GetFrameAtIndex(0)
+        value = frame.EvaluateExpression('f')
+        error = value.GetError()
+        self.assertIn('variable not available', str(error))
+


### PR DESCRIPTION
Writing testcases for error handling that depends on specific DWARF is very difficult and the resulting tests tend not to be very protable. This patch adds a new setting to inject an error into variable materialization, thus making it possible to write very simple source code based tests for error handling instead.

This is primarily motivated by the Swift language plugin, but functionality is generic and should be useful for other languages as well.