### PR TITLE
🍒 [clang][modules] Read PCM validation timestamp earlier

### DIFF
--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -117,7 +117,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
 
   uint64_t InputFilesValidationTimestamp = 0;
   if (Type == MK_ImplicitModule)
-    InputFilesValidationTimestamp = ModCache.getModuleTimestamp(FileName);
+    InputFilesValidationTimestamp = ModCache->getModuleTimestamp(FileName);
 
   // Look for the file entry. This only fails if the expected size or
   // modification time differ.

--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -115,6 +115,10 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
                          std::string &ErrorStr) {
   Module = nullptr;
 
+  uint64_t InputFilesValidationTimestamp = 0;
+  if (Type == MK_ImplicitModule)
+    InputFilesValidationTimestamp = ModCache.getModuleTimestamp(FileName);
+
   // Look for the file entry. This only fails if the expected size or
   // modification time differ.
   OptionalFileEntryRef Entry;
@@ -182,11 +186,7 @@ ModuleManager::addModule(StringRef FileName, ModuleKind Type,
   NewModule->Index = Chain.size();
   NewModule->FileName = FileName.str();
   NewModule->ImportLoc = ImportLoc;
-  NewModule->InputFilesValidationTimestamp = 0;
-
-  if (NewModule->Kind == MK_ImplicitModule)
-    NewModule->InputFilesValidationTimestamp =
-        ModCache->getModuleTimestamp(NewModule->FileName);
+  NewModule->InputFilesValidationTimestamp = InputFilesValidationTimestamp;
 
   // Load the contents of the module
   if (std::unique_ptr<llvm::MemoryBuffer> Buffer = lookupBuffer(FileName)) {


### PR DESCRIPTION
When building a module, the PCM file is always written first and then the validation timestamp gets created. Clang needs to first read the validation timestamp and only then read the PCM file. Otherwise, it could read an out-of-date PCM file and then read the validation timestamp for its new up-to-date version. This would erroneously skip validation with `-fmodules-validate-once-per-build-session`. I'm not concerned about multiple Clang instances seeing different filesystem contents from each other within a single build session, since that would break the assumption `-fmodules-validate-once-per-build-session` relies on.

(cherry picked from commit ada79f4c2691ab6546d379a144377162fd4f5191)

rdar://168674197