### PR TITLE
[lldb] Add support for existential containers in embedded Swift

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -385,6 +385,15 @@ public:
     return ptr;
   }
 
+  std::optional<swift::remote::RemoteExistential>
+  ReadMetadataAndValueOpaqueExistential(
+      lldb::addr_t existential_address) override {
+    return m_reflection_ctx.readMetadataAndValueOpaqueExistential(
+        swift::remote::RemoteAddress(
+            existential_address,
+            swift::remote::RemoteAddress::DefaultAddressSpace));
+  }
+
   std::optional<bool> IsValueInlinedInExistentialContainer(
       swift::remote::RemoteAddress existential_address) override {
     return m_reflection_ctx.isValueInlinedInExistentialContainer(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -156,6 +156,8 @@ public:
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
+  virtual std::optional<swift::remote::RemoteExistential>
+  ReadMetadataAndValueOpaqueExistential(lldb::addr_t existential_address) = 0;
   struct AsyncTaskInfo {
     bool isChildTask = false;
     bool isFuture = false;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -672,6 +672,23 @@ protected:
   CompilerType GetDynamicTypeAndAddress_EmbeddedClass(uint64_t instance_ptr,
                                                       CompilerType class_type);
 
+  /// Resolves the dynamic type of a class-constrained embedded Swift
+  /// existential.
+  std::optional<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type);
+
+  /// Resolves the dynamic type of an embedded Swift existential container.
+  std::optional<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type);
+
+  /// Resolves the dynamic type of an embedded Swift existential.
+  /// Tries class-constrained first, then falls back to existential container.
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ExistentialEmbedded(lldb::addr_t existential_address,
+                                               CompilerType existential_type);
+
   /// Dynamic type resolution tends to want to generate scalar data -
   /// but there are caveats Per original comment here "Our address is
   /// the location of the dynamic type stored in memory.  It isn't a

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -405,6 +405,19 @@ CompilerType TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
   return RemangleAsType(dem, type, flavor);
 }
 
+CompilerType TypeSystemSwiftTypeRef::GetTypeFromValueWitnessTable(
+    llvm::StringRef mangled_name) {
+  Demangler dem;
+  NodePointer node = dem.demangleSymbol(mangled_name);
+  NodePointer type = swift_demangle::NodeAtPath(
+      node,
+      {Node::Kind::Global, Node::Kind::ValueWitnessTable, Node::Kind::Type});
+  if (!type)
+    return {};
+  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
+  return RemangleAsType(dem, type, flavor);
+}
+
 TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name_ref,
                                                SymbolContext sc) {
   llvm::SmallVector<CompilerContext, 2> decl_context;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -446,6 +446,10 @@ public:
   /// CompilerType with that Type.
   CompilerType GetTypeFromTypeMetadataNode(llvm::StringRef mangled_name);
 
+  /// Given a mangled name that mangles a "value witness table for Type",
+  /// return a CompilerType with that Type.
+  CompilerType GetTypeFromValueWitnessTable(llvm::StringRef mangled_name);
+
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;

--- a/lldb/test/API/lang/swift/embedded/existential_type_resolution/Makefile
+++ b/lldb/test/API/lang/swift/embedded/existential_type_resolution/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/existential_type_resolution/TestSwiftEmbeddedExistentialTypeResolution.py
+++ b/lldb/test/API/lang/swift/embedded/existential_type_resolution/TestSwiftEmbeddedExistentialTypeResolution.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedExistentialTypeResolution(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect('frame variable pStruct', substrs=['a.S', 'structField = 111'])
+        self.expect('frame variable pClass', substrs=['a.C', 'classField = 222'])
+        self.expect('frame variable pSubclass', substrs=['a.Sub', 'a.C', 'classField = 222', 'subField = 333'])
+        self.expect('frame variable pEnumFirst', substrs=['a.E', 'first'])
+        self.expect('frame variable pEnumSecond', substrs=['a.E', 'second'])

--- a/lldb/test/API/lang/swift/embedded/existential_type_resolution/main.swift
+++ b/lldb/test/API/lang/swift/embedded/existential_type_resolution/main.swift
@@ -1,0 +1,32 @@
+protocol P {
+}
+
+struct S: P {
+    let structField = 111
+}
+
+class C: P {
+    let classField = 222
+}
+
+class Sub: C {
+    let subField = 333
+}
+
+enum E: P {
+    case first
+    case second(Int)
+}
+
+func f() {
+    let pStruct: any P = S()
+    let pClass: any P = C()
+    let pSubclass: any P = Sub()
+    // FIXME: rdar://168697959 (Debug info for enums is not generated, if there are no variables/parameter with the enum type in embedded swift)
+    let bug = E.first
+    let pEnumFirst: any P = E.first
+    let pEnumSecond: any P = E.second(444)
+    print("break here")
+}
+
+f()


### PR DESCRIPTION
Embedded Swift now supports existential containers for non-class-constrained protocols. This change adds support for resolving the dynamic type of these existentials.