### PR TITLE
[Cherry-pick into next] [LLDB] Add an opt-out setting for the explicit-only import mode

### DIFF
--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -208,6 +208,12 @@ public:
 
   bool GetSwiftAllowImplicitModules() const;
 
+  void SetSwiftAllowImplicitModules(bool) const;
+
+  bool GetSwiftAllowImplicitModuleLoader() const;
+
+  void SetSwiftAllowImplicitModuleLoader(bool) const;
+
   AutoBool GetSwiftPCMValidation() const;
 
   bool GetSwiftUseTasksPlugin() const;

--- a/lldb/include/lldb/Target/Target.h
+++ b/lldb/include/lldb/Target/Target.h
@@ -206,6 +206,8 @@ public:
 
   bool GetSwiftAllowExplicitModules() const;
 
+  bool GetSwiftAllowImplicitModules() const;
+
   AutoBool GetSwiftPCMValidation() const;
 
   bool GetSwiftUseTasksPlugin() const;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1319,13 +1319,13 @@ SwiftExpressionParser::ParseAndImport(
     process_sp = this_frame_sp->CalculateProcess();
   if (!m_swift_ast_ctx.GetASTContext()->LangOpts.hasFeature(
           swift::Feature::Embedded))
-    if (auto error =
+    if (llvm::Error error =
             m_swift_ast_ctx.LoadImplicitModules(process_sp, *m_exe_scope))
       return make_error<ModuleImportError>(llvm::toString(std::move(error)));
 
   if (!m_options.GetUseContextFreeSwiftPrintObject())
-    if (auto error = m_swift_ast_ctx.GetImplicitImports(m_sc, process_sp,
-                                                        additional_imports))
+    if (llvm::Error error = m_swift_ast_ctx.GetImplicitImports(
+            m_sc, process_sp, additional_imports))
       return make_error<ModuleImportError>(llvm::toString(std::move(error)));
 
   swift::ImplicitImportInfo importInfo;
@@ -1493,7 +1493,8 @@ SwiftExpressionParser::ParseAndImport(
         IRExecutionUnit::GetLLVMGlobalContextMutex());
 
     Status auto_import_error;
-    if (auto error = m_swift_ast_ctx.CacheUserImports(process_sp, *source_file))
+    if (llvm::Error error =
+            m_swift_ast_ctx.CacheUserImports(process_sp, *source_file))
       return make_error<ModuleImportError>(llvm::toString(std::move(error)),
                                            /*is_new_dylib=*/true);
     if (m_swift_ast_ctx.HasFatalErrors()) {

--- a/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/TypeSystem/Swift/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_lldb_library(lldbPluginTypeSystemSwift PLUGIN
   LLDBExplicitModuleLoader.cpp
+  LLDBImplicitModuleLoader.cpp
   SwiftDWARFImporterForClangTypes.cpp
   TypeSystemSwift.cpp
   TypeSystemSwiftTypeRef.cpp

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.cpp
@@ -1,0 +1,111 @@
+//===--LLDBImplicitModuleLoader.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===---------------------------------------------------------------------===//
+
+#include "LLDBImplicitModuleLoader.h"
+#include "SwiftASTContext.h"
+#include "lldb/Target/Target.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
+
+namespace lldb_private {
+
+LLDBImplicitSwiftModuleLoader::LLDBImplicitSwiftModuleLoader(
+    swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+    swift::ModuleLoadingMode loadMode,
+    std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp,
+    std::unique_ptr<swift::ImplicitSerializedModuleLoader> isml)
+    : swift::SerializedModuleLoaderBase(ctx, tracker, loadMode, true),
+      m_swift_ast_ctx_wp(swift_ast_ctx_wp), m_isml(std::move(isml)) {}
+
+std::unique_ptr<LLDBImplicitSwiftModuleLoader>
+LLDBImplicitSwiftModuleLoader::create(
+    swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+    swift::ModuleLoadingMode loadMode,
+    std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp) {
+  auto isml =
+      swift::ImplicitSerializedModuleLoader::create(ctx, tracker, loadMode);
+  return std::make_unique<LLDBImplicitSwiftModuleLoader>(
+      ctx, tracker, loadMode, swift_ast_ctx_wp, std::move(isml));
+}
+
+bool LLDBImplicitSwiftModuleLoader::enabled() const {
+  if (Target::GetGlobalProperties().GetSwiftAllowImplicitModuleLoader())
+    return true;
+  if (auto swift_ast_ctx_sp = m_swift_ast_ctx_wp.lock())
+    return !swift_ast_ctx_sp->ImplicitModulesDisabled();
+  return false;
+}
+
+void LLDBImplicitSwiftModuleLoader::collectVisibleTopLevelModuleNames(
+    llvm::SmallVectorImpl<swift::Identifier> &names) const {
+  if (enabled())
+    m_isml->collectVisibleTopLevelModuleNames(names);
+}
+
+std::error_code LLDBImplicitSwiftModuleLoader::findModuleFilesInDirectory(
+    swift::ImportPath::Element ModuleID,
+    const swift::SerializedModuleBaseName &BaseName,
+    llvm::SmallVectorImpl<char> *ModuleInterfacePath,
+    llvm::SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool IsCanImportLookup, bool IsFramework, bool IsTestableDependencyLookup) {
+  // This is a protected member and probably also not useful.
+  return {};
+}
+bool LLDBImplicitSwiftModuleLoader::canImportModule(
+    swift::ImportPath::Module named, swift::SourceLoc loc,
+    ModuleVersionInfo *versionInfo, bool isTestableImport) {
+  if (enabled())
+    return llvm::cast<swift::SerializedModuleLoaderBase>(m_isml.get())
+        ->canImportModule(named, loc, versionInfo, isTestableImport);
+  return false;
+}
+
+swift::ModuleDecl *
+LLDBImplicitSwiftModuleLoader::loadModule(swift::SourceLoc importLoc,
+                                          swift::ImportPath::Module path,
+                                          bool AllowMemoryCache) {
+  if (enabled())
+    return m_isml->loadModule(importLoc, path, AllowMemoryCache);
+  return nullptr;
+}
+
+void LLDBImplicitSwiftModuleLoader::loadExtensions(
+    swift::NominalTypeDecl *nominal, unsigned previousGeneration) {
+  if (enabled())
+    m_isml->loadExtensions(nominal, previousGeneration);
+}
+
+void LLDBImplicitSwiftModuleLoader::loadObjCMethods(
+    swift::NominalTypeDecl *typeDecl, swift::ObjCSelector selector,
+    bool isInstanceMethod, unsigned previousGeneration,
+    llvm::TinyPtrVector<swift::AbstractFunctionDecl *> &methods) {
+  if (enabled())
+    m_isml->loadObjCMethods(typeDecl, selector, isInstanceMethod,
+                            previousGeneration, methods);
+}
+
+void LLDBImplicitSwiftModuleLoader::loadDerivativeFunctionConfigurations(
+    swift::AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
+    llvm::SetVector<swift::AutoDiffConfig> &results) {
+  if (enabled())
+    m_isml->loadDerivativeFunctionConfigurations(originalAFD,
+                                                 previousGeneration, results);
+}
+
+void LLDBImplicitSwiftModuleLoader::verifyAllModules() {
+  if (enabled())
+    m_isml->verifyAllModules();
+}
+
+} // namespace lldb_private

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBImplicitModuleLoader.h
@@ -1,0 +1,78 @@
+//===--LLDBImplicitModuleLoader.h -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_LLDBImplicitModuleLoader_h_
+#define liblldb_LLDBImplicitModuleLoader_h_
+
+#include "SwiftASTContext.h"
+#include <swift/Serialization/SerializedModuleLoader.h>
+namespace swift {
+class ImplicitSerializedModuleLoader;
+} // namespace swift
+
+namespace lldb_private {
+/// This is a wrapper around the ImplicitSwiftSerializedModuleLoader
+/// that can be selectively disabled.
+class LLDBImplicitSwiftModuleLoader : public swift::SerializedModuleLoaderBase {
+public:
+  LLDBImplicitSwiftModuleLoader(
+      swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+      swift::ModuleLoadingMode LoadMode,
+      std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp,
+      std::unique_ptr<swift::ImplicitSerializedModuleLoader> isml);
+
+  static std::unique_ptr<LLDBImplicitSwiftModuleLoader>
+  create(swift::ASTContext &ctx, swift::DependencyTracker *tracker,
+         swift::ModuleLoadingMode loadMode,
+         std::weak_ptr<SwiftASTContext> swift_ast_ctx_wp);
+
+  void collectVisibleTopLevelModuleNames(
+      llvm::SmallVectorImpl<swift::Identifier> &names) const override;
+  std::error_code findModuleFilesInDirectory(
+      swift::ImportPath::Element ModuleID,
+      const swift::SerializedModuleBaseName &BaseName,
+      llvm::SmallVectorImpl<char> *ModuleInterfacePath,
+      llvm::SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool IsCanImportLookup, bool IsFramework,
+      bool IsTestableDependencyLookup = false) override;
+
+  bool canImportModule(swift::ImportPath::Module named, swift::SourceLoc loc,
+                       ModuleVersionInfo *versionInfo,
+                       bool isTestableImport = false) override;
+
+  swift::ModuleDecl *loadModule(swift::SourceLoc importLoc,
+                                swift::ImportPath::Module path,
+                                bool AllowMemoryCache = true) override;
+  void loadExtensions(swift::NominalTypeDecl *nominal,
+                      unsigned previousGeneration) override;
+  void loadObjCMethods(
+      swift::NominalTypeDecl *typeDecl, swift::ObjCSelector selector,
+      bool isInstanceMethod, unsigned previousGeneration,
+      llvm::TinyPtrVector<swift::AbstractFunctionDecl *> &methods) override;
+
+  void loadDerivativeFunctionConfigurations(
+      swift::AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
+      llvm::SetVector<swift::AutoDiffConfig> &results) override;
+
+  void verifyAllModules() override;
+
+protected:
+  bool enabled() const;
+  std::weak_ptr<SwiftASTContext> m_swift_ast_ctx_wp;
+  /// The implicit Swift module loader.
+  std::unique_ptr<swift::ImplicitSerializedModuleLoader> m_isml;
+};
+} // namespace lldb_private
+#endif

--- a/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h
@@ -172,16 +172,16 @@ public:
       // user code, but doing this here could interfere with
       // ExprOptions.PoundLineLine mechanism used Swift
       // Playgrounds. So instead we find the markers from both ends.
-      StringRef buffer_data = buffer->getBuffer();
+      llvm::StringRef buffer_data = buffer->getBuffer();
       size_t pos = buffer_data.find("__LLDB_USER_START__");
-      if (pos == StringRef::npos)
+      if (pos == llvm::StringRef::npos)
         return;
       auto start_loc =
           llvm::SMLoc::getFromPointer(buffer->getBufferStart() + pos);
       unsigned start_line = src_mgr.FindLineNumber(start_loc, buffer_id);
 
       pos = buffer_data.rfind("__LLDB_USER_END__");
-      if (pos == StringRef::npos)
+      if (pos == llvm::StringRef::npos)
         return;
       auto end_loc =
           llvm::SMLoc::getFromPointer(buffer->getBufferStart() + pos);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -10,15 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Plugins/TypeSystem/Swift/SwiftASTContext.h"
-#include "Plugins/TypeSystem/Swift/SwiftDWARFImporterForClangTypes.h"
-#include "Plugins/TypeSystem/Swift/StoringDiagnosticConsumer.h"
-#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
-
 #include "SwiftASTContext.h"
+#include "LLDBExplicitModuleLoader.h"
+#include "LLDBImplicitModuleLoader.h"
+#include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
+#include "StoringDiagnosticConsumer.h"
+#include "SwiftDWARFImporterForClangTypes.h"
 #include "SwiftDemangle.h"
 #include "TypeSystemSwift.h"
 #include "TypeSystemSwiftTypeRef.h"
+
 #include "lldb/Utility/Log.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTContext.h"
@@ -917,7 +918,8 @@ static std::string GetClangModulesCacheProperty() {
 }
 
 void SwiftASTContext::ConfigureCASStorage(const SymbolContext &sc) {
-  auto cas = ModuleList::GetOrCreateCAS(sc.module_sp);
+  llvm::Expected<ModuleList::CAS> cas =
+      ModuleList::GetOrCreateCAS(sc.module_sp);
   if (!cas) {
     HEALTH_LOG_PRINTF("Did not create CAS: %s",
                       toString(cas.takeError()).c_str());
@@ -3935,9 +3937,10 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   }
 
   // 4. Create and install the serialized module loader.
-  std::unique_ptr<swift::ModuleLoader> serialized_module_loader_up(
-      swift::ImplicitSerializedModuleLoader::create(
-          *m_ast_context_up, m_dependency_tracker.get(), loading_mode));
+  std::unique_ptr<swift::ModuleLoader> serialized_module_loader_up =
+      LLDBImplicitSwiftModuleLoader::create(
+          *m_ast_context_up, m_dependency_tracker.get(), loading_mode,
+          std::static_pointer_cast<SwiftASTContext>(shared_from_this()));
   if (serialized_module_loader_up)
     m_ast_context_up->addModuleLoader(std::move(serialized_module_loader_up));
 
@@ -9253,8 +9256,16 @@ LoadOneModule(const SourceModule &module, SwiftASTContext &swift_ast_context,
               "-module-wrap and linked.");
 
     if (toplevel.GetStringRef() == swift::STDLIB_NAME) {
-      swift_ast_context.RaiseFatalError(
-          "Could not import Swift standard library");
+      if (swift_ast_context.HasExplicitModules()) {
+        swift_ast_context.RaiseFatalError(
+            "Could not import Swift standard library using only explicit "
+            "modules.\n"
+            "Enabling implicit modules now; this operation may succeed on "
+            "retry.");
+        Target::GetGlobalProperties().SetSwiftAllowImplicitModules(true);
+      } else
+        swift_ast_context.RaiseFatalError(
+            "Could not import Swift standard library");
       return llvm::createStringError("Could not import Swift standard library");
     }
   }
@@ -9434,26 +9445,27 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     llvm::SmallVectorImpl<swift::AttributedImport<swift::ImportedModule>>
         *modules) {
   // If EBM is enabled, disable implicit modules during contextual imports.
-  bool turn_off_implicit = m_has_explicit_modules;
-  if (Target::GetGlobalProperties().GetSwiftAllowImplicitModules())
-    turn_off_implicit = false;
-  
+  m_implicit_modules_disabled =
+      m_has_explicit_modules &&
+      !Target::GetGlobalProperties().GetSwiftAllowImplicitModules();
+
   auto reset = llvm::make_scope_exit([&] {
-    if (turn_off_implicit) {
-      LOG_PRINTF(GetLog(LLDBLog::Types), "Turning on implicit modules");
-      if (m_module_interface_loader) {
-        auto &opts = m_module_interface_loader->getOptions();
-        opts.disableImplicitSwiftModule = false;
-        opts.disableBuildingInterface = false;
-      }
-      if (m_clangimporter) {
-        auto &clang_instance = const_cast<clang::CompilerInstance &>(
-            m_clangimporter->getClangInstance());
-        clang_instance.getLangOpts().ImplicitModules = true;
-      }
+    if (!m_implicit_modules_disabled)
+      return;
+    m_implicit_modules_disabled = false;
+    LOG_PRINTF(GetLog(LLDBLog::Types), "Turning on implicit modules");
+    if (m_module_interface_loader) {
+      auto &opts = m_module_interface_loader->getOptions();
+      opts.disableImplicitSwiftModule = false;
+      opts.disableBuildingInterface = false;
+    }
+    if (m_clangimporter) {
+      auto &clang_instance = const_cast<clang::CompilerInstance &>(
+          m_clangimporter->getClangInstance());
+      clang_instance.getLangOpts().ImplicitModules = true;
     }
   });
-  if (turn_off_implicit) {
+  if (m_implicit_modules_disabled) {
     LOG_PRINTF(GetLog(LLDBLog::Types), "Turning off implicit modules");
     // Swift.
     if (m_module_interface_loader) {
@@ -9469,9 +9481,6 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     if (m_clangimporter) {
       auto &clang_instance = const_cast<clang::CompilerInstance &>(
           m_clangimporter->getClangInstance());
-      // AddExtraArgs is supposed to always turn implicit modules on.
-      assert(clang_instance.getLangOpts().ImplicitModules &&
-             "ClangImporter implicit module support is off");
       clang_instance.getLangOpts().ImplicitModules = false;
     }
   }
@@ -9528,6 +9537,7 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
   // If we haven't already loaded an explicitly tracked one, import the Swift
   // standard library and its dependencies.
   if (!loaded_stdlib) {
+    m_implicit_modules_disabled = false;
     SourceModule swift_module;
     swift_module.path.emplace_back(swift::STDLIB_NAME);
     auto stdlib = LoadOneModule(swift_module, *this, process_sp,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -9435,6 +9435,9 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
         *modules) {
   // If EBM is enabled, disable implicit modules during contextual imports.
   bool turn_off_implicit = m_has_explicit_modules;
+  if (Target::GetGlobalProperties().GetSwiftAllowImplicitModules())
+    turn_off_implicit = false;
+  
   auto reset = llvm::make_scope_exit([&] {
     if (turn_off_implicit) {
       LOG_PRINTF(GetLog(LLDBLog::Types), "Turning on implicit modules");

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -88,6 +88,7 @@ class LLVMContext;
 class SwiftEnumDescriptor;
 
 namespace lldb_private {
+class LLDBExplicitSwiftModuleLoader;
 
 namespace plugin {
 namespace dwarf {
@@ -574,6 +575,7 @@ public:
   void LogConfiguration(bool repl = false, bool playground = false);
   bool HasTarget();
   bool HasExplicitModules() const { return m_has_explicit_modules; }
+  bool ImplicitModulesDisabled() const { return m_implicit_modules_disabled; }
   bool HasCAS() const { return m_cas_initialized; }
   bool CheckProcessChanged();
 
@@ -1024,6 +1026,7 @@ protected:
   bool m_initialized_search_path_options = false;
   bool m_initialized_clang_importer_options = false;
   bool m_has_explicit_modules = false;
+  bool m_implicit_modules_disabled = false;
   bool m_cas_initialized = false;
   mutable bool m_reported_fatal_error = false;
   mutable bool m_logged_fatal_error = false;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2542,7 +2542,7 @@ SwiftASTContextSP TypeSystemSwiftTypeRefForExpressions::GetSwiftASTContext(
     TargetSP target_sp = GetTargetWP().lock();
     if (target_sp)
       process_sp = target_sp->GetProcessSP();
-    if (auto error =
+    if (llvm::Error error =
             swift_ast_context->PerformCompileUnitImports(sc, process_sp)) {
       if (target_sp) {
         if (StreamSP errs_sp = target_sp->GetDebugger().GetAsyncErrorStream())

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4754,6 +4754,37 @@ bool TargetProperties::GetSwiftAllowImplicitModules() const {
   return false;
 }
 
+void TargetProperties::SetSwiftAllowImplicitModules(bool b) const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    exp_values->SetPropertyAtIndex(ePropertySwiftAllowImplicitModules, b);
+}
+
+bool TargetProperties::GetSwiftAllowImplicitModuleLoader() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftAllowImplicitModuleLoader)
+        .value_or(true);
+
+  return false;
+}
+
+void TargetProperties::SetSwiftAllowImplicitModuleLoader(bool b) const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    exp_values->SetPropertyAtIndex(ePropertySwiftAllowImplicitModuleLoader, b);
+}
+
 AutoBool TargetProperties::GetSwiftPCMValidation() const {
   const Property *exp_property =
       m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);

--- a/lldb/source/Target/Target.cpp
+++ b/lldb/source/Target/Target.cpp
@@ -4741,6 +4741,19 @@ bool TargetProperties::GetSwiftAllowExplicitModules() const {
   return true;
 }
 
+bool TargetProperties::GetSwiftAllowImplicitModules() const {
+  const Property *exp_property =
+      m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);
+  OptionValueProperties *exp_values =
+      exp_property->GetValue()->GetAsProperties();
+  if (exp_values)
+    return exp_values
+        ->GetPropertyAtIndexAs<bool>(ePropertySwiftAllowImplicitModules)
+        .value_or(false);
+
+  return false;
+}
+
 AutoBool TargetProperties::GetSwiftPCMValidation() const {
   const Property *exp_property =
       m_collection_sp->GetPropertyAtIndex(ePropertyExperimental);

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -29,6 +29,11 @@ let Definition = "target_experimental" in {
   def SwiftAllowImplicitModules: Property<"swift-allow-implicit-modules", "Boolean">,
     DefaultFalse,
     Desc<"Allows implicit module imports in an explicitly-built target.">;
+  def SwiftAllowImplicitModuleLoader
+      : Property<"swift-allow-implicit-module-loader", "Boolean">,
+        DefaultTrue,
+        Desc<
+            "Enable the implicit module loader in an explicitly-built target.">;
   def SwiftPCMValidation: Property<"swift-pcm-validation", "Enum">,
     Global,
     DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -26,6 +26,9 @@ let Definition = "target_experimental" in {
   def SwiftAllowExplicitModules: Property<"swift-allow-explicit-modules", "Boolean">,
     DefaultTrue,
     Desc<"Allows explicit module flags to be passed through to ClangImporter.">;
+  def SwiftAllowImplicitModules: Property<"swift-allow-implicit-modules", "Boolean">,
+    DefaultFalse,
+    Desc<"Allows implicit module imports in an explicitly-built target.">;
   def SwiftPCMValidation: Property<"swift-pcm-validation", "Enum">,
     Global,
     DefaultEnumValue<"llvm::to_underlying(AutoBool::Auto)">,

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/Makefile
@@ -7,6 +7,7 @@ all: libDylib a.out
 
 include Makefile.rules
 
+# Note that this is being built with implicit modules!
 libDylib: Dylib.swift
 	mkdir -p $(BUILDDIR)/$(shell basename $< .swift)
 	"$(MAKE)" MAKE_DSYM=YES CC=$(CC) SWIFTC=$(SWIFTC) \

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -23,8 +23,13 @@ class TestSwiftClangImporterExplicitNoImplicit(TestBase):
                                           extra_images=['Dylib'])
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
+        self.expect('settings set target.experimental.swift-allow-implicit-module-loader false')
+        # This is expected to fail because the dependencies of Dylib
+        # (including the stdlib) are implicit modules.
+        self.expect("expression obj", error=True)
+        self.expect('settings set target.experimental.swift-allow-implicit-module-loader true')
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["hidden"])
         self.filecheck('platform shell cat "%s"' % log, __file__)
-#       CHECK-NOT: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/SwiftShims-{{.*}}.pcm
-#       CHECK: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/Hidden-{{.*}}.pcm
+        # CHECK-NOT: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/SwiftShims-{{.*}}.pcm
+        # CHECK: IMPLICIT-CLANG-MODULE-CACHE/{{.*}}/Hidden-{{.*}}.pcm

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
     def test_missing_explicit_modules(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
@@ -56,3 +57,23 @@ class TestCase(lldbtest.TestBase):
         # CHECK-SANITY: Explicit modules : true
         # CHECK-SANITY: Turning off implicit modules
         # CHECK-SANITY: Turning on implicit modules
+
+    @swiftTest
+    def test_setting(self):
+        """Check the normal behavior."""
+        self.build()
+
+        lldbutil.run_to_source_breakpoint(
+            self, "Set breakpoint here", lldb.SBFileSpec("main.swift")
+        )
+
+        log = self.getBuildArtifact("types.log")
+        self.runCmd(f"log enable lldb types -f '{log}'")
+        self.expect("settings set target.experimental.swift-allow-implicit-modules true")
+
+        self.expect("expression c")
+
+        self.filecheck(f"platform shell cat {log}", __file__,
+                       '--check-prefix=CHECK-SETTING')
+        # CHECK-SETTING: Explicit modules : true
+        # CHECK-SETTING-NOT: Turning {{.*}} implicit modules


### PR DESCRIPTION
```
commit ef6827158b8a66676d4ca4f70da2610416bc5a0b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Dec 19 16:00:58 2025 -0800

    [LLDB] Add an opt-out setting for the explicit-only import mode
    
    rdar://166747831

commit 6d8211fd4ea4b6322ba1066b61b4e2b3e430a6b0
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Jan 16 15:35:54 2026 -0800

    [LLDB] Allow control over implicit module loading in EBM projects
    
    This is an NFC change unless the
    target.experimental.swift-allow-implicit-module-loader setting is
    modified. The goal is to eventually flip the default. This disables
    the implicit module loader while doing contextual imports in an EBM
    project. ClangImporter will eagerly try to discover Swift overlays for
    Clang modules. In EBM build, if they are not found, this is a
    recoverable and silent failure, however if the implicit module loader
    is active,. it will perform an implicit build of this module. To
    replicate the compiler's behavior and performance the implicit module
    loader should be turned off.
```
