### PR TITLE
[CXX BoundsSafety] upstream some CXX bounds safety interop tests (#12054)

### DIFF
--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -14,9 +14,13 @@
 // RUN:            -verify -fexperimental-bounds-safety-attributes %t/interop_test.cpp
 // RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call -Wno-gcc-compat\
 // RUN:            -verify -fexperimental-bounds-safety-attributes %t/test.cpp -DTEST_STD_NS
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wunsafe-buffer-usage-in-format-attr-call -Wno-gcc-compat\
+// RUN:            -verify %t/format_attr_test.cpp
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wunsafe-buffer-usage-in-format-attr-call -Wno-gcc-compat\
+// RUN:            -verify -fexperimental-bounds-safety-attributes %t/format_attr_test.cpp
 
 
-//--- test.cpp
+//--- test.h
 typedef struct {} FILE;
 typedef unsigned int size_t;
 
@@ -88,6 +92,10 @@ namespace std {
   typedef basic_string_view<char> string_view;
   typedef basic_string_view<wchar_t> wstring_view;
 }
+
+//--- test.cpp
+
+#include "test.h"
 
 void f(char * p, char * q, std::span<char> s, std::span<char> s2) {
   typedef FILE * _Nullable aligned_file_ptr_t __attribute__((align_value(64)));
@@ -271,7 +279,9 @@ void dontCrashForInvalidFormatString() {
   snprintf(nullptr, 0, "\0");
 }
 
+//--- format_attr_test.cpp
 
+#include "test.h"
 // Also warn about unsafe printf/scanf-like functions:
 void myprintf(const char *, ...) __attribute__((__format__ (__printf__, 1, 2)));
 void myprintf_2(const char *, int, const char *) __attribute__((__format__ (__printf__, 1, 3)));
@@ -382,6 +392,7 @@ void test_format_attr_invalid_arg_idx(char * Str, std::string StdStr) {
   myprintf(Str); // expected-warning{{formatting function 'myprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
   myprintf(StdStr.c_str());
 }
+
 //--- interop_test.cpp
 
 #include <ptrcheck.h>

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -1,14 +1,22 @@
-// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wno-gcc-compat\
-// RUN:            -verify %s
-// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wno-gcc-compat\
-// RUN:            -verify %s -x objective-c++
-// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call \
-// RUN:            -Wunsafe-buffer-usage-in-format-attr-call -Wno-gcc-compat \
-// RUN:            -verify %s
-// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call \
-// RUN:            -Wunsafe-buffer-usage-in-format-attr-call -Wno-gcc-compat \
-// RUN:            -verify %s -DTEST_STD_NS
+// RUN: rm -rf %t
+// RUN: mkdir %t
+// RUN: split-file %s %t
 
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wno-gcc-compat \
+// RUN:            -verify %t/test.cpp
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wno-gcc-compat\
+// RUN:            -verify %t/test.cpp -x objective-c++
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call -Wno-gcc-compat\
+// RUN:            -verify %t/test.cpp
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call -Wno-gcc-compat\
+// RUN:            -verify -fexperimental-bounds-safety-attributes %t/test.cpp
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage -Wno-gcc-compat\
+// RUN:            -verify -fexperimental-bounds-safety-attributes %t/interop_test.cpp
+// RUN: %clang_cc1 -std=c++20 -Wno-all -Wunsafe-buffer-usage-in-libc-call -Wno-gcc-compat\
+// RUN:            -verify -fexperimental-bounds-safety-attributes %t/test.cpp -DTEST_STD_NS
+
+
+//--- test.cpp
 typedef struct {} FILE;
 typedef unsigned int size_t;
 
@@ -216,8 +224,6 @@ void ff(char * p, char * q, std::span<char> s, std::span<char> s2) {
 #pragma clang diagnostic pop
 }
 
-
-
 // functions not in global scope or std:: namespace are not libc
 // functions regardless of their names:
 struct StrBuff
@@ -375,4 +381,45 @@ void test_format_attr_invalid_arg_idx(char * Str, std::string StdStr) {
   myprintf("hello");
   myprintf(Str); // expected-warning{{formatting function 'myprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
   myprintf(StdStr.c_str());
+}
+//--- interop_test.cpp
+
+#include <ptrcheck.h>
+typedef unsigned size_t;
+
+// expected-note@+2{{consider using a safe container and passing '.data()' to the parameter 'dst' and '.size()' to its dependent parameter 'size' or 'std::span' and passing '.first(...).data()' to the parameter 'dst'}}
+// expected-note@+1{{consider using a safe container and passing '.data()' to the parameter 'src' and '.size()' to its dependent parameter 'size' or 'std::span' and passing '.first(...).data()' to the parameter 'src'}}
+void memcpy(void * __sized_by(size) dst, const void * __sized_by(size) src, unsigned size);
+unsigned strlen( const char* __null_terminated str );
+// expected-note@+1{{consider using a safe container and passing '.data()' to the parameter 'buffer' and '.size()' to its dependent parameter 'buf_size' or 'std::span' and passing '.first(...).data()' to the parameter 'buffer'}}
+int snprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
+int snwprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
+int vsnprintf( char* __counted_by(buf_size) buffer, unsigned buf_size, const char* format, ... );
+int sprintf( char* __counted_by(10) buffer, const char* format, ... );
+
+void test(char * p, char * q, const char * str,
+	  const char * __null_terminated safe_str,
+	  char * __counted_by(n) safe_p,
+	  size_t n,
+	  char * __counted_by(10) safe_ten) {
+  memcpy(p, q, 10);                  // expected-warning2{{unsafe assignment to function parameter of count-attributed type}}
+  snprintf(p, 10, "%s", "hlo");      // expected-warning{{unsafe assignment to function parameter of count-attributed type}}
+
+  // We still warn about unsafe string pointer arguments to printfs:
+
+  snprintf(safe_p, n, "%s", str);  // expected-warning{{function 'snprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
+  snwprintf(safe_p, n, "%s", str); // expected-warning{{function 'snwprintf' is unsafe}} expected-note{{string argument is not guaranteed to be null-terminated}}
+
+  memcpy(safe_p, safe_p, n);               // no warn
+  strlen(safe_str);                        // no warn
+  snprintf(safe_p, n, "%s", "hlo");        // no warn
+  snprintf(safe_p, n, "%s", safe_str);     // no warn
+  snwprintf(safe_p, n, "%s", safe_str);    // no warn
+
+  // v-printf functions and sprintf are still warned about because
+  // they cannot be fully safe:
+
+  vsnprintf(safe_p, n, "%s", safe_str); // expected-warning{{function 'vsnprintf' is unsafe}} expected-note{{'va_list' is unsafe}}
+  sprintf(safe_ten, "%s", safe_str);    // expected-warning{{function 'sprintf' is unsafe}} expected-note{{change to 'snprintf' for explicit bounds checking}}
+
 }


### PR DESCRIPTION
Upstream the tests for the interop in
clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp

(cherry picked from commit d01209c414b27d1de1607dc2c4cf6940a956a6d3)

 Conflicts:
	clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp