### PR TITLE
[dsymutil] Reduce noise from CAS loading

### DIFF
--- a/llvm/tools/dsymutil/BinaryHolder.cpp
+++ b/llvm/tools/dsymutil/BinaryHolder.cpp
@@ -282,8 +282,9 @@ BinaryHolder::searchAndCreateCAS(StringRef Path) {
   if (!DB)
     return DB.takeError();
 
-  WithColor::note() << "create CAS using configuration: " << Config->first
-                    << "'\n";
+  if (Opts.Verbose)
+    WithColor::note() << "create CAS using configuration: " << Config->first
+                      << "'\n";
   return LocalCAS.try_emplace(Path, std::move(DB->first)).first->second;
 }
 
@@ -338,8 +339,9 @@ BinaryHolder::getObjectEntryFromCAS(StringRef MaybeCASID, StringRef Filename) {
 
   auto DB = GlobalCAS;
   if (!DB) {
-    // If no global CAS, infer from Filename.
-    auto MaybeCAS = searchAndCreateCAS(Filename);
+    // If no global CAS, infer from Filename and search from the parent path of
+    // the binary file.
+    auto MaybeCAS = searchAndCreateCAS(sys::path::parent_path(Filename));
     if (!MaybeCAS)
       return MaybeCAS.takeError();
     DB = std::move(*MaybeCAS);


### PR DESCRIPTION
When createing CAS from a `.cas-config` file, dsymtil can emit notes once per object file. Reduce the noise by:
* Notes should only be emitted when `-verbose` is used.
* The `.cas-config` file should be cached from the directory the object file is in, not the path of the object file, which can reduce the number of CAS created.

rdar://168789005