### PR TITLE
[🍒 ][CodeGen][InstCombine][Sanitizers] Emit lifetimes when compiling with memtag-stack 

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -888,6 +888,7 @@ EmitMaterializeTemporaryExpr(const MaterializeTemporaryExpr *M) {
       if (isInConditionalBranch() && !E->getType().isDestructedType() &&
           ((!SanOpts.has(SanitizerKind::HWAddress) &&
             !SanOpts.has(SanitizerKind::Memory) &&
+            !SanOpts.has(SanitizerKind::MemtagStack) &&
             !CGM.getCodeGenOpts().SanitizeAddressUseAfterScope) ||
            inSuspendBlock())) {
         OldConditional = OutermostConditional;

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -68,7 +68,8 @@ static bool shouldEmitLifetimeMarkers(const CodeGenOptions &CGOpts,
   // Sanitizers may use markers.
   if (CGOpts.SanitizeAddressUseAfterScope ||
       LangOpts.Sanitize.has(SanitizerKind::HWAddress) ||
-      LangOpts.Sanitize.has(SanitizerKind::Memory))
+      LangOpts.Sanitize.has(SanitizerKind::Memory) ||
+      LangOpts.Sanitize.has(SanitizerKind::MemtagStack))
     return true;
 
   // For now, only in optimized builds.

--- a/clang/test/CodeGen/lifetime-sanitizer.c
+++ b/clang/test/CodeGen/lifetime-sanitizer.c
@@ -12,6 +12,9 @@
 // RUN: %clang -target aarch64-linux-gnu -S -emit-llvm -o - -O0 \
 // RUN:     -fsanitize=hwaddress -Xclang -disable-llvm-passes %s | \
 // RUN:     FileCheck %s -check-prefix=LIFETIME
+// RUN: %clang -target aarch64-linux-gnu -S -emit-llvm -o - -O0 \
+// RUN:     -fsanitize=memtag-stack -march=armv8a+memtag -Xclang -disable-llvm-passes %s | \
+// RUN:     FileCheck %s -check-prefix=LIFETIME
 
 extern int bar(char *A, int n);
 

--- a/clang/test/CodeGenCXX/lifetime-sanitizer.cpp
+++ b/clang/test/CodeGenCXX/lifetime-sanitizer.cpp
@@ -13,6 +13,9 @@
 // RUN: %clang -w -target aarch64-linux-gnu -S -emit-llvm -o - -fno-exceptions -O0 \
 // RUN:     -fsanitize=hwaddress -Xclang -disable-llvm-passes %s | \
 // RUN:     FileCheck %s -check-prefixes=CHECK,LIFETIME
+// RUN: %clang -w -target aarch64-linux-gnu -S -emit-llvm -o - -fno-exceptions -O0 \
+// RUN:     -fsanitize=memtag-stack -march=armv8a+memtag -Xclang -disable-llvm-passes %s | \
+// RUN:     FileCheck %s -check-prefixes=CHECK,LIFETIME
 
 extern int bar(char *A, int n);
 

--- a/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -3272,7 +3272,8 @@ Instruction *InstCombinerImpl::visitCallInst(CallInst &CI) {
     // even for empty lifetime range.
     if (II->getFunction()->hasFnAttribute(Attribute::SanitizeAddress) ||
         II->getFunction()->hasFnAttribute(Attribute::SanitizeMemory) ||
-        II->getFunction()->hasFnAttribute(Attribute::SanitizeHWAddress))
+        II->getFunction()->hasFnAttribute(Attribute::SanitizeHWAddress) ||
+        II->getFunction()->hasFnAttribute(Attribute::SanitizeMemTag))
       break;
 
     if (removeTriviallyEmptyRange(*II, *this, [](const IntrinsicInst &I) {

--- a/llvm/test/Transforms/InstCombine/lifetime-sanitizer.ll
+++ b/llvm/test/Transforms/InstCombine/lifetime-sanitizer.ll
@@ -34,6 +34,21 @@ entry:
   ret void
 }
 
+define void @memtag() sanitize_memtag {
+entry:
+  ; CHECK-LABEL: @memtag(
+  %text = alloca i8, align 1
+
+  call void @llvm.lifetime.start.p0(ptr %text)
+  call void @llvm.lifetime.end.p0(ptr %text)
+  ; CHECK: call void @llvm.lifetime.start
+  ; CHECK-NEXT: call void @llvm.lifetime.end
+
+  call void @foo(ptr %text) ; Keep alloca alive
+
+  ret void
+}
+
 define void @msan() sanitize_memory {
 entry:
   ; CHECK-LABEL: @msan(

--- a/llvm/test/Transforms/InstCombine/lifetime-sanitizer.ll
+++ b/llvm/test/Transforms/InstCombine/lifetime-sanitizer.ll
@@ -39,8 +39,8 @@ entry:
   ; CHECK-LABEL: @memtag(
   %text = alloca i8, align 1
 
-  call void @llvm.lifetime.start.p0(ptr %text)
-  call void @llvm.lifetime.end.p0(ptr %text)
+  call void @llvm.lifetime.start.p0(i64 1, ptr %text)
+  call void @llvm.lifetime.end.p0(i64 1, ptr %text)
   ; CHECK: call void @llvm.lifetime.start
   ; CHECK-NEXT: call void @llvm.lifetime.end
 


### PR DESCRIPTION
Currently we do not emit lifetimes by default when compiling with memtag-stack - which means we don't catch use-after-scope (when compiling without optimization).

This patch fixes that by mirroring ASan, HWASan and MSan, and always emitting lifetime markers. The patch is based on the changes made in aeca569.

rdar://163713381
(cherry picked from commit c63a744f3fbc91f0f544d79a50ae91e860d092b7)