### PR TITLE
[BoundsSafety] fix counted_by on ObjC methods in ObjC++ mode

### DIFF
--- a/clang/include/clang/Sema/SemaObjC.h
+++ b/clang/include/clang/Sema/SemaObjC.h
@@ -396,6 +396,13 @@ public:
   void AddAnyMethodToGlobalPool(Decl *D);
 
   void ActOnStartOfObjCMethodDef(Scope *S, Decl *D);
+
+  /// Set CurContext to @c D, to prevent semantic errors when late parsing
+  /// expressions in attributes. This does not setup the context needed for
+  /// parsing a method body.
+  void ActOnEnterObjCMethodContextForLateParsedAttrs(Scope *S,
+                                                     ObjCMethodDecl *D);
+
   bool isObjCMethodDecl(Decl *D) { return isa_and_nonnull<ObjCMethodDecl>(D); }
 
   /// CheckImplementationIvars - This routine checks if the instance variables

--- a/clang/lib/Parse/ParseObjc.cpp
+++ b/clang/lib/Parse/ParseObjc.cpp
@@ -1405,8 +1405,14 @@ Decl *Parser::ParseObjCMethodDecl(SourceLocation mLoc,
       LateAttr->addDecl(Result);
     }
     LateParsedAttrs.append(LateParsedReturnAttrs);
+    // The parsing of ObjC methods differs enough from C functions and C++
+    // methods that it's easier to enter the context here rather than in
+    // ParseLexedCAttribute.
+    Actions.ObjC().ActOnEnterObjCMethodContextForLateParsedAttrs(
+        getCurScope(), cast<ObjCMethodDecl>(Result));
     ParseLexedCAttributeList(LateParsedAttrs,
                              /*we already have parameters in scope*/ false);
+    Actions.ActOnExitFunctionContext();
   }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 

--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -382,6 +382,11 @@ static void copyDomainAvailabilityAttr(ObjCMethodDecl *MD, Sema &SemaRef) {
     SemaRef.copyFeatureAvailabilityCheck(MD, IDecl, true);
 }
 
+void SemaObjC::ActOnEnterObjCMethodContextForLateParsedAttrs(Scope *S, ObjCMethodDecl *D) {
+  SemaRef.PushDeclContext(S, D);
+  // parameters are already added to scope
+}
+
 /// ActOnStartOfObjCMethodDef - This routine sets up parameters; invisible
 /// and user declared, in the method definition's AST.
 void SemaObjC::ActOnStartOfObjCMethodDef(Scope *FnBodyScope, Decl *D) {

--- a/clang/test/BoundsSafety/AST/objc.m
+++ b/clang/test/BoundsSafety/AST/objc.m
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -Wno-deprecated-declarations -Wno-return-type -Wno-objc-root-class -ast-dump %s 2>&1 | FileCheck --check-prefixes=COMMON-CHECK,BOUNDS-CHECK %s
 // RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c -Wno-deprecated-declarations -Wno-return-type -Wno-objc-root-class -ast-dump %s 2>&1 | FileCheck --check-prefixes=COMMON-CHECK,ATTR-CHECK %s
 
+// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c++ -Wno-deprecated-declarations -Wno-return-type -Wno-objc-root-class -ast-dump %s 2>&1 | FileCheck --check-prefixes=COMMON-CHECK,ATTR-CHECK %s
+
 #include <ptrcheck.h>
 
 @protocol CountedByProtocol


### PR DESCRIPTION
ObjC method parsing diverges significantly from normal C function parsing. This results in decl contexts for both parameters, as well as the methods/functions themselves differing between the two. When parsing a C function, the decl context of the parameters is the same as that of the function, until parsing of the function body starts. This means that they will be equal when late parsing bounds attributes. For ObjC methods, the decl context for parameters is always the ObjCMethodDecl. This deviation means that tryCaptureVariable() will do its full analysis when parsing count expressions on ObjC methods. In ObjC mode this doesn't pose an issue, but in ObjC++ mode this results in emitting the following diagnostic for every referenced parameter:
```
error: reference to local variable 'len' declared in enclosing context
```

By temporarily entering the context of the ObjCMethodDecl while parsing the bounds attributes, the `VarDC == CurContext` check passes and tryCaptureVariable() does an early exit. Normally ParseLexedCAttribute() will enter the function context for C/C++ functions and methods, but those LateParsedAttributes are attached to the function/method, whereas they are attached to the parameters for ObjC methods. The current scope also already contains the ObjC parameters, so we don't need to do a normal full method scope entering; instead we only set CurContext. For this reason the context is entered before calling
ParseLexedCAttributeList.

rdar://168702220