### PR TITLE
[clang] Handle null dtor decl during consumed analysis

### DIFF
--- a/clang/lib/Analysis/Consumed.cpp
+++ b/clang/lib/Analysis/Consumed.cpp
@@ -1354,12 +1354,13 @@ void ConsumedAnalyzer::run(AnalysisDeclContext &AC) {
 
       case CFGElement::AutomaticObjectDtor: {
         const CFGAutomaticObjDtor &DTor = B.castAs<CFGAutomaticObjDtor>();
+        const auto *DD = DTor.getDestructorDecl(AC.getASTContext());
+        if (!DD)
+          break;
+
         SourceLocation Loc = DTor.getTriggerStmt()->getEndLoc();
         const VarDecl *Var = DTor.getVarDecl();
-
-        Visitor.checkCallability(PropagationInfo(Var),
-                                 DTor.getDestructorDecl(AC.getASTContext()),
-                                 Loc);
+        Visitor.checkCallability(PropagationInfo(Var), DD, Loc);
         break;
       }
 

--- a/clang/test/SemaCXX/no-warn-consumed-analysis.cpp
+++ b/clang/test/SemaCXX/no-warn-consumed-analysis.cpp
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fsyntax-only -verify -Wconsumed -fcxx-exceptions -std=c++11 %s
+// expected-no-diagnostics
+
+struct foo {
+  ~foo();
+};
+struct bar : foo {};
+struct baz : bar {};
+baz foobar(baz a) { return a; }


### PR DESCRIPTION
This is another case where null was not handled when returned from `getDestructorDecl`.

Cherry-picked from: https://github.com/llvm/llvm-project/pull/170180