### PR TITLE
[Cherry-pick into next] [LLDB] Downgrade cc1/driver mix&match warning to a HEALTH log

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1905,8 +1905,7 @@ void SwiftASTContext::AddExtraClangArgs(
   // If it is not a fresh invocation, make sure the cc1 option matches.
   if (!fresh_invocation &&
       (importer_options.DirectClangCC1ModuleBuild != invocation_direct_cc1))
-    AddDiagnostic(
-        eSeverityWarning,
+    HEALTH_LOG_PRINTF(
         "Mixing and matching of driver and cc1 Clang options detected");
 
   importer_options.DirectClangCC1ModuleBuild = invocation_direct_cc1;


### PR DESCRIPTION
```
commit dd31c006695dd9cc97fac7967568db1b2d131941
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Jan 23 10:32:19 2026 -0800

    [LLDB] Downgrade cc1/driver mix&match warning to a HEALTH log
    
    This is outside of the control of the user and indicative of either a
    build system or LLDB bug, where LLDB is processing the flags of more
    than just the top-level EBM (rdar://167868997)
```
