### PR TITLE
[lldb] Fix data buffer regression in ObjectFile (#177724)

### DIFF
--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -374,8 +374,7 @@ ObjectFile *ObjectFileELF::CreateInstance(const lldb::ModuleSP &module_sp,
     DataBufferSP buffer_sp = MapFileDataWritable(*file, length, file_offset);
     if (!buffer_sp)
       return nullptr;
-    extractor_sp = std::make_shared<DataExtractor>();
-    extractor_sp->SetData(buffer_sp, data_offset, buffer_sp->GetByteSize());
+    extractor_sp = std::make_shared<DataExtractor>(buffer_sp);
     data_offset = 0;
     mapped_writable = true;
   }

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -88,8 +88,7 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
       // not 0 size, but we can't make a data buffer for it.
       if (DataBufferSP buffer_sp = FileSystem::Instance().CreateDataBuffer(
               file->GetPath(), g_initial_bytes_to_read, file_offset)) {
-        extractor_sp = std::make_shared<DataExtractor>();
-        extractor_sp->SetData(buffer_sp, data_offset, buffer_sp->GetByteSize());
+        extractor_sp = std::make_shared<DataExtractor>(buffer_sp);
         data_offset = 0;
       }
     }


### PR DESCRIPTION
This fixes a regression in `ObjectFile` and `ObjectFileELF` introduced by #171574.

The original code created a `DataBuffer` using `MapFileDataWritable`.

```
  data_sp = MapFileDataWritable(*file, length, file_offset);
  if (!data_sp)
    return nullptr;
  data_offset = 0;
```

The new code requires converting the `DataBuffer` to a `DataExtractor`:

```
  DataBufferSP buffer_sp = MapFileDataWritable(*file, length, file_offset);
  if (!buffer_sp)
    return nullptr;
  extractor_sp = std::make_shared<DataExtractor>();
  extractor_sp->SetData(buffer_sp, data_offset, buffer_sp->GetByteSize());
  data_offset = 0;
```

The issue is that once we get a data buffer back from MapFileDataWritable, we don't have to adjust for the `data_offset` again when calling `SetData` as the `DataBuffer` is already normalized to have a zero start offset. A similar issue exists in `ObjectFile`.

rdar://168317174
(cherry picked from commit d6652c189db4811e4b56fe4164f9c5f7a6627372)