### PR TITLE
Drop ObjectFile changes from the 6.3 release

### DIFF
--- a/lldb/include/lldb/Expression/ObjectFileJIT.h
+++ b/lldb/include/lldb/Expression/ObjectFileJIT.h
@@ -49,10 +49,9 @@ public:
   }
 
   static lldb_private::ObjectFile *
-  CreateInstance(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const lldb_private::FileSpec *file, lldb::offset_t file_offset,
-                 lldb::offset_t length);
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static lldb_private::ObjectFile *CreateMemoryInstance(
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,

--- a/lldb/include/lldb/Symbol/ObjectContainer.h
+++ b/lldb/include/lldb/Symbol/ObjectContainer.h
@@ -97,10 +97,10 @@ public:
   /// Attempts to parse the object header.
   ///
   /// This function is used as a test to see if a given plug-in instance can
-  /// parse the header data already contained in
-  /// ObjectContainer::m_extractor_sp. If an object file parser does not
-  /// recognize that magic bytes in a header, false should be returned and the
-  /// next plug-in can attempt to parse an object file.
+  /// parse the header data already contained in ObjectContainer::m_data. If
+  /// an object file parser does not recognize that magic bytes in a header,
+  /// false should be returned and the next plug-in can attempt to parse an
+  /// object file.
   ///
   /// \return
   ///     Returns \b true if the header was parsed successfully, \b
@@ -140,7 +140,7 @@ protected:
   lldb::addr_t m_length;
 
   /// The data for this object file so things can be parsed lazily.
-  lldb::DataExtractorSP m_extractor_sp;
+  DataExtractor m_data;
 
 private:
   ObjectContainer(const ObjectContainer &) = delete;

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -105,10 +105,10 @@ public:
   /// more than one architecture or object.
   ObjectFile(const lldb::ModuleSP &module_sp, const FileSpec *file_spec_ptr,
              lldb::offset_t file_offset, lldb::offset_t length,
-             lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset);
+             lldb::DataBufferSP data_sp, lldb::offset_t data_offset);
 
   ObjectFile(const lldb::ModuleSP &module_sp, const lldb::ProcessSP &process_sp,
-             lldb::addr_t header_addr, lldb::DataExtractorSP extractor_sp);
+             lldb::addr_t header_addr, lldb::DataBufferSP data_sp);
 
   /// Destructor.
   ///
@@ -152,7 +152,7 @@ public:
   static lldb::ObjectFileSP
   FindPlugin(const lldb::ModuleSP &module_sp, const FileSpec *file_spec,
              lldb::offset_t file_offset, lldb::offset_t file_size,
-             lldb::DataExtractorSP extractor_sp, lldb::offset_t &data_offset);
+             lldb::DataBufferSP &data_sp, lldb::offset_t &data_offset);
 
   /// Find a ObjectFile plug-in that can parse a file in memory.
   ///

--- a/lldb/include/lldb/Symbol/ObjectFile.h
+++ b/lldb/include/lldb/Symbol/ObjectFile.h
@@ -18,7 +18,6 @@
 #include "lldb/Utility/Endian.h"
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/FileSpecList.h"
-#include "lldb/Utility/NonNullSharedPtr.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/UUID.h"
 #include "lldb/lldb-private.h"
@@ -419,7 +418,7 @@ public:
   /// Attempts to parse the object header.
   ///
   /// This function is used as a test to see if a given plug-in instance can
-  /// parse the header data already contained in ObjectFile::m_data_nsp. If an
+  /// parse the header data already contained in ObjectFile::m_data. If an
   /// object file parser does not recognize that magic bytes in a header,
   /// false should be returned and the next plug-in can attempt to parse an
   /// object file.
@@ -781,8 +780,6 @@ public:
   std::string GetObjectName() const;
 
 protected:
-  typedef NonNullSharedPtr<lldb_private::DataExtractor> DataExtractorNSP;
-
   // Member variables.
   FileSpec m_file;
   Type m_type;
@@ -792,10 +789,8 @@ protected:
   lldb::addr_t m_length; ///< The length of this object file if it is known (can
                          ///be zero if length is unknown or can't be
                          ///determined).
-  DataExtractorNSP m_data_nsp; ///< The data for this object file so things
-                               ///< can be parsed lazily.  This shared pointer
-                               ///< will always have a DataExtractor object,
-                               ///< although it may only be default-constructed.
+  DataExtractor
+      m_data; ///< The data for this object file so things can be parsed lazily.
   lldb::ProcessWP m_process_wp;
   /// Set if the object file only exists in memory.
   const lldb::addr_t m_memory_addr;

--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -9,7 +9,6 @@
 #ifndef LLDB_UTILITY_DATAEXTRACTOR_H
 #define LLDB_UTILITY_DATAEXTRACTOR_H
 
-#include "lldb/Utility/DataBuffer.h"
 #include "lldb/Utility/Endian.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
@@ -91,10 +90,10 @@ public:
 
   /// Construct with shared data.
   ///
-  /// Copies the data shared pointer which adds a reference to the data
-  /// contained in \a data_sp. The shared data reference is reference counted to
-  /// ensure the data lives as long as anyone still has a valid shared pointer
-  /// to the data in \a data_sp.
+  /// Copies the data shared pointer which adds a reference to the contained
+  /// in \a data_sp. The shared data reference is reference counted to ensure
+  /// the data lives as long as anyone still has a valid shared pointer to the
+  /// data in \a data_sp.
   ///
   /// \param[in] data_sp
   ///     A shared pointer to data.
@@ -109,18 +108,6 @@ public:
   ///     A size of a target byte in 8-bit host bytes
   DataExtractor(const lldb::DataBufferSP &data_sp, lldb::ByteOrder byte_order,
                 uint32_t addr_size, uint32_t target_byte_size = 1);
-
-  /// Construct with shared data, but byte-order & addr-size are unspecified.
-  ///
-  /// Copies the data shared pointer which adds a reference to the data
-  /// contained in \a data_sp. The shared data reference is reference counted to
-  /// ensure the data lives as long as anyone still has a valid shared pointer
-  /// to the data in \a data_sp.
-  ///
-  /// \param[in] data_sp
-  ///     A shared pointer to data.
-  DataExtractor(const lldb::DataBufferSP &data_sp,
-                uint32_t target_byte_size = 1);
 
   /// Construct with a subset of \a data.
   ///
@@ -819,8 +806,6 @@ public:
   uint64_t GetULEB128(lldb::offset_t *offset_ptr) const;
 
   lldb::DataBufferSP &GetSharedDataBuffer() { return m_data_sp; }
-
-  bool HasData() { return m_start && m_end && m_end - m_start > 0; }
 
   /// Peek at a C string at \a offset.
   ///

--- a/lldb/include/lldb/lldb-forward.h
+++ b/lldb/include/lldb/lldb-forward.h
@@ -342,7 +342,6 @@ typedef std::shared_ptr<lldb_private::CompileUnit> CompUnitSP;
 typedef std::shared_ptr<lldb_private::DataBuffer> DataBufferSP;
 typedef std::shared_ptr<lldb_private::WritableDataBuffer> WritableDataBufferSP;
 typedef std::shared_ptr<lldb_private::DataExtractor> DataExtractorSP;
-typedef std::unique_ptr<lldb_private::DataExtractor> DataExtractorUP;
 typedef std::shared_ptr<lldb_private::Debugger> DebuggerSP;
 typedef std::weak_ptr<lldb_private::Debugger> DebuggerWP;
 typedef std::shared_ptr<lldb_private::Disassembler> DisassemblerSP;

--- a/lldb/include/lldb/lldb-private-interfaces.h
+++ b/lldb/include/lldb/lldb-private-interfaces.h
@@ -48,10 +48,12 @@ typedef size_t (*ObjectFileGetModuleSpecifications)(
     const FileSpec &file, lldb::DataBufferSP &data_sp,
     lldb::offset_t data_offset, lldb::offset_t file_offset,
     lldb::offset_t length, ModuleSpecList &module_specs);
-typedef ObjectFile *(*ObjectFileCreateInstance)(
-    const lldb::ModuleSP &module_sp, lldb::DataExtractorSP extractor_sp,
-    lldb::offset_t data_offset, const FileSpec *file,
-    lldb::offset_t file_offset, lldb::offset_t length);
+typedef ObjectFile *(*ObjectFileCreateInstance)(const lldb::ModuleSP &module_sp,
+                                                lldb::DataBufferSP data_sp,
+                                                lldb::offset_t data_offset,
+                                                const FileSpec *file,
+                                                lldb::offset_t file_offset,
+                                                lldb::offset_t length);
 typedef ObjectFile *(*ObjectFileCreateMemoryInstance)(
     const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
     const lldb::ProcessSP &process_sp, lldb::addr_t offset);

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1332,12 +1332,10 @@ ObjectFile *Module::GetObjectFile() {
         m_did_load_objfile = true;
         // FindPlugin will modify its data_sp argument. Do not let it
         // modify our m_data_sp member.
-        DataExtractorSP extractor_sp;
-        if (m_data_sp)
-          extractor_sp = std::make_shared<DataExtractor>(m_data_sp);
+        auto data_sp = m_data_sp;
         m_objfile_sp = ObjectFile::FindPlugin(
             shared_from_this(), &m_file, m_object_offset,
-            file_size - m_object_offset, extractor_sp, data_offset);
+            file_size - m_object_offset, data_sp, data_offset);
         if (m_objfile_sp) {
           // Once we get the object file, update our module with the object
           // file's architecture since it might differ in vendor/os if some

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -73,8 +73,8 @@ ObjectFileJIT::ObjectFileJIT(const lldb::ModuleSP &module_sp,
     : ObjectFile(module_sp, nullptr, 0, 0, DataBufferSP(), 0), m_delegate_wp() {
   if (delegate_sp) {
     m_delegate_wp = delegate_sp;
-    m_data_nsp->SetByteOrder(delegate_sp->GetByteOrder());
-    m_data_nsp->SetAddressByteSize(delegate_sp->GetAddressByteSize());
+    m_data.SetByteOrder(delegate_sp->GetByteOrder());
+    m_data.SetAddressByteSize(delegate_sp->GetAddressByteSize());
   }
 }
 
@@ -85,14 +85,12 @@ bool ObjectFileJIT::ParseHeader() {
   return false;
 }
 
-ByteOrder ObjectFileJIT::GetByteOrder() const {
-  return m_data_nsp->GetByteOrder();
-}
+ByteOrder ObjectFileJIT::GetByteOrder() const { return m_data.GetByteOrder(); }
 
 bool ObjectFileJIT::IsExecutable() const { return false; }
 
 uint32_t ObjectFileJIT::GetAddressByteSize() const {
-  return m_data_nsp->GetAddressByteSize();
+  return m_data.GetAddressByteSize();
 }
 
 void ObjectFileJIT::ParseSymtab(Symtab &symtab) {

--- a/lldb/source/Expression/ObjectFileJIT.cpp
+++ b/lldb/source/Expression/ObjectFileJIT.cpp
@@ -41,7 +41,7 @@ void ObjectFileJIT::Terminate() {
 }
 
 ObjectFile *ObjectFileJIT::CreateInstance(const lldb::ModuleSP &module_sp,
-                                          DataExtractorSP extractor_sp,
+                                          DataBufferSP data_sp,
                                           lldb::offset_t data_offset,
                                           const FileSpec *file,
                                           lldb::offset_t file_offset,
@@ -70,8 +70,7 @@ size_t ObjectFileJIT::GetModuleSpecifications(
 
 ObjectFileJIT::ObjectFileJIT(const lldb::ModuleSP &module_sp,
                              const ObjectFileJITDelegateSP &delegate_sp)
-    : ObjectFile(module_sp, nullptr, 0, 0, DataExtractorSP(), 0),
-      m_delegate_wp() {
+    : ObjectFile(module_sp, nullptr, 0, 0, DataBufferSP(), 0), m_delegate_wp() {
   if (delegate_sp) {
     m_delegate_wp = delegate_sp;
     m_data_nsp->SetByteOrder(delegate_sp->GetByteOrder());

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -68,19 +68,21 @@ void ObjectContainerBSDArchive::Object::Dump() const {
 ObjectContainerBSDArchive::Archive::Archive(const lldb_private::ArchSpec &arch,
                                             const llvm::sys::TimePoint<> &time,
                                             lldb::offset_t file_offset,
-                                            lldb::DataExtractorSP extractor_sp,
+                                            lldb_private::DataExtractor &data,
                                             ArchiveType archive_type)
     : m_arch(arch), m_modification_time(time), m_file_offset(file_offset),
-      m_objects(), m_extractor_sp(extractor_sp), m_archive_type(archive_type) {}
+      m_objects(), m_data(data), m_archive_type(archive_type) {}
 
 Log *l = GetLog(LLDBLog::Object);
 ObjectContainerBSDArchive::Archive::~Archive() = default;
 
 size_t ObjectContainerBSDArchive::Archive::ParseObjects() {
+  DataExtractor &data = m_data;
+
   std::unique_ptr<llvm::MemoryBuffer> mem_buffer =
       llvm::MemoryBuffer::getMemBuffer(
-          llvm::StringRef((const char *)m_extractor_sp->GetDataStart(),
-                          m_extractor_sp->GetByteSize()),
+          llvm::StringRef((const char *)data.GetDataStart(),
+                          data.GetByteSize()),
           llvm::StringRef(),
           /*RequiresNullTerminator=*/false);
 
@@ -219,9 +221,9 @@ ObjectContainerBSDArchive::Archive::shared_ptr
 ObjectContainerBSDArchive::Archive::ParseAndCacheArchiveForFile(
     const FileSpec &file, const ArchSpec &arch,
     const llvm::sys::TimePoint<> &time, lldb::offset_t file_offset,
-    DataExtractorSP extractor_sp, ArchiveType archive_type) {
+    DataExtractor &data, ArchiveType archive_type) {
   shared_ptr archive_sp(
-      new Archive(arch, time, file_offset, extractor_sp, archive_type));
+      new Archive(arch, time, file_offset, data, archive_type));
   if (archive_sp) {
     const size_t num_objects = archive_sp->ParseObjects();
     if (num_objects > 0) {
@@ -366,17 +368,16 @@ ObjectContainerBSDArchive::~ObjectContainerBSDArchive() = default;
 
 bool ObjectContainerBSDArchive::ParseHeader() {
   if (m_archive_sp.get() == nullptr) {
-    if (m_extractor_sp->GetByteSize() > 0) {
+    if (m_data.GetByteSize() > 0) {
       ModuleSP module_sp(GetModule());
       if (module_sp) {
         m_archive_sp = Archive::ParseAndCacheArchiveForFile(
             m_file, module_sp->GetArchitecture(),
-            module_sp->GetModificationTime(), m_offset, m_extractor_sp,
-            m_archive_type);
+            module_sp->GetModificationTime(), m_offset, m_data, m_archive_type);
       }
-      // Clear the m_extractor_sp that contains the entire archive data and let
-      // our m_archive_sp hold onto the data.
-      m_extractor_sp = std::make_shared<DataExtractor>();
+      // Clear the m_data that contains the entire archive data and let our
+      // m_archive_sp hold onto the data.
+      m_data.Clear();
     }
   }
   return m_archive_sp.get() != nullptr;
@@ -415,18 +416,14 @@ ObjectFileSP ObjectContainerBSDArchive::GetObjectFile(const FileSpec *file) {
               child_data_sp->GetByteSize() != object->file_size)
             return ObjectFileSP();
           lldb::offset_t data_offset = 0;
-          DataExtractorSP extractor_sp =
-              std::make_shared<DataExtractor>(child_data_sp);
           return ObjectFile::FindPlugin(
               module_sp, &child, m_offset + object->file_offset,
-              object->file_size, extractor_sp, data_offset);
+              object->file_size, child_data_sp, data_offset);
         }
         lldb::offset_t data_offset = object->file_offset;
-        DataExtractorSP extractor_sp =
-            std::make_shared<DataExtractor>(m_archive_sp->GetData());
         return ObjectFile::FindPlugin(
             module_sp, file, m_offset + object->file_offset, object->file_size,
-            extractor_sp, data_offset);
+            m_archive_sp->GetData().GetSharedDataBuffer(), data_offset);
       }
     }
   }
@@ -441,10 +438,9 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
   // We have data, which means this is the first 512 bytes of the file Check to
   // see if the magic bytes match and if they do, read the entire table of
   // contents for the archive and cache it
-  DataExtractorSP extractor_sp = std::make_shared<DataExtractor>();
-  extractor_sp->SetData(data_sp, data_offset, data_sp->GetByteSize());
-  ArchiveType archive_type =
-      ObjectContainerBSDArchive::MagicBytesMatch(*extractor_sp.get());
+  DataExtractor data;
+  data.SetData(data_sp, data_offset, data_sp->GetByteSize());
+  ArchiveType archive_type = ObjectContainerBSDArchive::MagicBytesMatch(data);
   if (!file || !data_sp || archive_type == ArchiveType::Invalid)
     return 0;
 
@@ -459,10 +455,9 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
     data_sp =
         FileSystem::Instance().CreateDataBuffer(file, file_size, file_offset);
     if (data_sp) {
-      extractor_sp->SetData(data_sp);
+      data.SetData(data_sp, 0, data_sp->GetByteSize());
       archive_sp = Archive::ParseAndCacheArchiveForFile(
-          file, ArchSpec(), file_mod_time, file_offset, extractor_sp,
-          archive_type);
+          file, ArchSpec(), file_mod_time, file_offset, data, archive_type);
     }
   }
 

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.h
@@ -13,9 +13,7 @@
 #include "lldb/Symbol/ObjectContainer.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/ConstString.h"
-#include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/FileSpec.h"
-#include "lldb/Utility/NonNullSharedPtr.h"
 
 #include "llvm/Object/Archive.h"
 #include "llvm/Support/Chrono.h"
@@ -61,8 +59,7 @@ public:
                                         lldb::offset_t length,
                                         lldb_private::ModuleSpecList &specs);
 
-  static ArchiveType
-  MagicBytesMatch(const lldb_private::DataExtractor &extractor);
+  static ArchiveType MagicBytesMatch(const lldb_private::DataExtractor &data);
 
   // Member Functions
   bool ParseHeader() override;
@@ -84,11 +81,11 @@ protected:
 
     void Clear();
 
-    lldb::offset_t ExtractFromThin(const lldb_private::DataExtractor &extractor,
+    lldb::offset_t ExtractFromThin(const lldb_private::DataExtractor &data,
                                    lldb::offset_t offset,
                                    llvm::StringRef stringTable);
 
-    lldb::offset_t Extract(const lldb_private::DataExtractor &extractor,
+    lldb::offset_t Extract(const lldb_private::DataExtractor &data,
                            lldb::offset_t offset);
     /// Object name in the archive.
     lldb_private::ConstString ar_name;
@@ -115,7 +112,7 @@ protected:
 
     Archive(const lldb_private::ArchSpec &arch,
             const llvm::sys::TimePoint<> &mod_time, lldb::offset_t file_offset,
-            lldb::DataExtractorSP extractor_sp, ArchiveType archive_type);
+            lldb_private::DataExtractor &data, ArchiveType archive_type);
 
     ~Archive();
 
@@ -130,7 +127,7 @@ protected:
     static Archive::shared_ptr ParseAndCacheArchiveForFile(
         const lldb_private::FileSpec &file, const lldb_private::ArchSpec &arch,
         const llvm::sys::TimePoint<> &mod_time, lldb::offset_t file_offset,
-        lldb::DataExtractorSP extractor_sp, ArchiveType archive_type);
+        lldb_private::DataExtractor &data, ArchiveType archive_type);
 
     size_t GetNumObjects() const { return m_objects.size(); }
 
@@ -157,8 +154,7 @@ protected:
 
     bool HasNoExternalReferences() const;
 
-    lldb_private::DataExtractor &GetData() { return *m_extractor_sp.get(); }
-    lldb::DataExtractorSP &GetDataSP() { return m_extractor_sp; }
+    lldb_private::DataExtractor &GetData() { return m_data; }
 
     ArchiveType GetArchiveType() { return m_archive_type; }
 
@@ -170,9 +166,9 @@ protected:
     lldb::offset_t m_file_offset;
     std::vector<Object> m_objects;
     ObjectNameToIndexMap m_object_name_to_index_map;
-    /// The data for this object container so we don't lose data if the .a files
-    /// gets modified.
-    lldb::DataExtractorSP m_extractor_sp;
+    lldb_private::DataExtractor m_data; ///< The data for this object container
+                                        ///so we don't lose data if the .a files
+                                        ///gets modified
     ArchiveType m_archive_type;
   };
 

--- a/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
@@ -54,9 +54,9 @@ ObjectContainer *ObjectContainerMachOFileset::CreateInstance(
   if (!data_sp)
     return {};
 
-  DataExtractor extractor;
-  extractor.SetData(data_sp, data_offset, length);
-  if (!MagicBytesMatch(extractor))
+  DataExtractor data;
+  data.SetData(data_sp, data_offset, length);
+  if (!MagicBytesMatch(data))
     return {};
 
   auto container_up = std::make_unique<ObjectContainerMachOFileset>(
@@ -96,45 +96,45 @@ static uint32_t MachHeaderSizeFromMagic(uint32_t magic) {
   }
 }
 
-static std::optional<mach_header> ParseMachOHeader(DataExtractor &extractor) {
+static std::optional<mach_header> ParseMachOHeader(DataExtractor &data) {
   lldb::offset_t offset = 0;
   mach_header header;
-  header.magic = extractor.GetU32(&offset);
+  header.magic = data.GetU32(&offset);
   switch (header.magic) {
   case MH_MAGIC:
-    extractor.SetByteOrder(endian::InlHostByteOrder());
-    extractor.SetAddressByteSize(4);
+    data.SetByteOrder(endian::InlHostByteOrder());
+    data.SetAddressByteSize(4);
     break;
   case MH_MAGIC_64:
-    extractor.SetByteOrder(endian::InlHostByteOrder());
-    extractor.SetAddressByteSize(8);
+    data.SetByteOrder(endian::InlHostByteOrder());
+    data.SetAddressByteSize(8);
     break;
   case MH_CIGAM:
-    extractor.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                               ? eByteOrderLittle
-                               : eByteOrderBig);
-    extractor.SetAddressByteSize(4);
+    data.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                          ? eByteOrderLittle
+                          : eByteOrderBig);
+    data.SetAddressByteSize(4);
     break;
   case MH_CIGAM_64:
-    extractor.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                               ? eByteOrderLittle
-                               : eByteOrderBig);
-    extractor.SetAddressByteSize(8);
+    data.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                          ? eByteOrderLittle
+                          : eByteOrderBig);
+    data.SetAddressByteSize(8);
     break;
   default:
     return {};
   }
 
-  header.cputype = extractor.GetU32(&offset);
-  header.cpusubtype = extractor.GetU32(&offset);
-  header.filetype = extractor.GetU32(&offset);
-  header.ncmds = extractor.GetU32(&offset);
-  header.sizeofcmds = extractor.GetU32(&offset);
+  header.cputype = data.GetU32(&offset);
+  header.cpusubtype = data.GetU32(&offset);
+  header.filetype = data.GetU32(&offset);
+  header.ncmds = data.GetU32(&offset);
+  header.sizeofcmds = data.GetU32(&offset);
   return header;
 }
 
 static bool
-ParseFileset(DataExtractor &extractor, mach_header header,
+ParseFileset(DataExtractor &data, mach_header header,
              std::vector<ObjectContainerMachOFileset::Entry> &entries,
              std::optional<lldb::addr_t> load_addr = std::nullopt) {
   lldb::offset_t offset = MachHeaderSizeFromMagic(header.magic);
@@ -142,15 +142,14 @@ ParseFileset(DataExtractor &extractor, mach_header header,
   for (uint32_t i = 0; i < header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
     load_command lc = {};
-    if (extractor.GetU32(&offset, &lc.cmd, 2) == nullptr)
+    if (data.GetU32(&offset, &lc.cmd, 2) == nullptr)
       break;
 
     // If we know the load address we can compute the slide.
     if (load_addr) {
       if (lc.cmd == llvm::MachO::LC_SEGMENT_64) {
         segment_command_64 segment;
-        extractor.CopyData(load_cmd_offset, sizeof(segment_command_64),
-                           &segment);
+        data.CopyData(load_cmd_offset, sizeof(segment_command_64), &segment);
         if (llvm::StringRef(segment.segname) == "__TEXT")
           slide = *load_addr - segment.vmaddr;
       }
@@ -158,10 +157,9 @@ ParseFileset(DataExtractor &extractor, mach_header header,
 
     if (lc.cmd == LC_FILESET_ENTRY) {
       fileset_entry_command entry;
-      extractor.CopyData(load_cmd_offset, sizeof(fileset_entry_command),
-                         &entry);
+      data.CopyData(load_cmd_offset, sizeof(fileset_entry_command), &entry);
       lldb::offset_t entry_id_offset = load_cmd_offset + entry.entry_id.offset;
-      if (const char *id = extractor.GetCStr(&entry_id_offset))
+      if (const char *id = data.GetCStr(&entry_id_offset))
         entries.emplace_back(entry.vmaddr + slide, entry.fileoff,
                              std::string(id));
     }
@@ -173,9 +171,9 @@ ParseFileset(DataExtractor &extractor, mach_header header,
 }
 
 bool ObjectContainerMachOFileset::ParseHeader(
-    DataExtractor &extractor, const lldb_private::FileSpec &file,
+    DataExtractor &data, const lldb_private::FileSpec &file,
     lldb::offset_t file_offset, std::vector<Entry> &entries) {
-  std::optional<mach_header> header = ParseMachOHeader(extractor);
+  std::optional<mach_header> header = ParseMachOHeader(data);
 
   if (!header)
     return false;
@@ -183,13 +181,13 @@ bool ObjectContainerMachOFileset::ParseHeader(
   const size_t header_size = MachHeaderSizeFromMagic(header->magic);
   const size_t header_and_lc_size = header_size + header->sizeofcmds;
 
-  if (extractor.GetByteSize() < header_and_lc_size) {
+  if (data.GetByteSize() < header_and_lc_size) {
     DataBufferSP data_sp =
         ObjectFile::MapFileData(file, header_and_lc_size, file_offset);
-    extractor.SetData(data_sp);
+    data.SetData(data_sp);
   }
 
-  return ParseFileset(extractor, *header, entries);
+  return ParseFileset(data, *header, entries);
 }
 
 bool ObjectContainerMachOFileset::ParseHeader() {
@@ -199,24 +197,24 @@ bool ObjectContainerMachOFileset::ParseHeader() {
 
   std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
 
-  std::optional<mach_header> header = ParseMachOHeader(*m_extractor_sp.get());
+  std::optional<mach_header> header = ParseMachOHeader(m_data);
   if (!header)
     return false;
 
   const size_t header_size = MachHeaderSizeFromMagic(header->magic);
   const size_t header_and_lc_size = header_size + header->sizeofcmds;
 
-  if (m_extractor_sp->GetByteSize() < header_and_lc_size) {
+  if (m_data.GetByteSize() < header_and_lc_size) {
     ProcessSP process_sp(m_process_wp.lock());
     DataBufferSP data_sp =
         process_sp
             ? ObjectFile::ReadMemory(process_sp, m_memory_addr,
                                      header_and_lc_size)
             : ObjectFile::MapFileData(m_file, header_and_lc_size, m_offset);
-    m_extractor_sp->SetData(data_sp);
+    m_data.SetData(data_sp);
   }
 
-  return ParseFileset(*m_extractor_sp.get(), *header, m_entries, m_memory_addr);
+  return ParseFileset(m_data, *header, m_entries, m_memory_addr);
 }
 
 size_t ObjectContainerMachOFileset::GetModuleSpecifications(
@@ -225,12 +223,12 @@ size_t ObjectContainerMachOFileset::GetModuleSpecifications(
     lldb::offset_t file_size, lldb_private::ModuleSpecList &specs) {
   const size_t initial_count = specs.GetSize();
 
-  DataExtractor extractor;
-  extractor.SetData(data_sp, data_offset, data_sp->GetByteSize());
+  DataExtractor data;
+  data.SetData(data_sp, data_offset, data_sp->GetByteSize());
 
-  if (MagicBytesMatch(extractor)) {
+  if (MagicBytesMatch(data)) {
     std::vector<Entry> entries;
-    if (ParseHeader(extractor, file, file_offset, entries)) {
+    if (ParseHeader(data, file, file_offset, entries)) {
       for (const Entry &entry : entries) {
         const lldb::offset_t entry_offset = entry.fileoff + file_offset;
         if (ObjectFile::GetModuleSpecifications(
@@ -247,15 +245,14 @@ size_t ObjectContainerMachOFileset::GetModuleSpecifications(
 bool ObjectContainerMachOFileset::MagicBytesMatch(DataBufferSP data_sp,
                                                   lldb::addr_t data_offset,
                                                   lldb::addr_t data_length) {
-  DataExtractor extractor;
-  extractor.SetData(data_sp, data_offset, data_length);
-  return MagicBytesMatch(extractor);
+  DataExtractor data;
+  data.SetData(data_sp, data_offset, data_length);
+  return MagicBytesMatch(data);
 }
 
-bool ObjectContainerMachOFileset::MagicBytesMatch(
-    const DataExtractor &extractor) {
+bool ObjectContainerMachOFileset::MagicBytesMatch(const DataExtractor &data) {
   lldb::offset_t offset = 0;
-  uint32_t magic = extractor.GetU32(&offset);
+  uint32_t magic = data.GetU32(&offset);
   switch (magic) {
   case MH_MAGIC:
   case MH_CIGAM:
@@ -267,7 +264,7 @@ bool ObjectContainerMachOFileset::MagicBytesMatch(
   }
   offset += 4; // cputype
   offset += 4; // cpusubtype
-  uint32_t filetype = extractor.GetU32(&offset);
+  uint32_t filetype = data.GetU32(&offset);
   return filetype == MH_FILESET;
 }
 
@@ -285,11 +282,11 @@ ObjectContainerMachOFileset::GetObjectFile(const lldb_private::FileSpec *file) {
   if (!entry)
     return {};
 
-  DataExtractorSP extractor_sp;
+  DataBufferSP data_sp;
   lldb::offset_t data_offset = 0;
   return ObjectFile::FindPlugin(module_sp, file, m_offset + entry->fileoff,
-                                m_extractor_sp->GetByteSize() - entry->fileoff,
-                                extractor_sp, data_offset);
+                                m_data.GetByteSize() - entry->fileoff, data_sp,
+                                data_offset);
 }
 
 ObjectContainerMachOFileset::Entry *

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
@@ -74,51 +74,51 @@ ObjectContainerUniversalMachO::ObjectContainerUniversalMachO(
 ObjectContainerUniversalMachO::~ObjectContainerUniversalMachO() = default;
 
 bool ObjectContainerUniversalMachO::ParseHeader() {
-  bool success = ParseHeader(*m_extractor_sp.get(), m_header, m_fat_archs);
+  bool success = ParseHeader(m_data, m_header, m_fat_archs);
   // We no longer need any data, we parsed all we needed to parse and cached it
   // in m_header and m_fat_archs
-  m_extractor_sp = std::make_shared<DataExtractor>();
+  m_data.Clear();
   return success;
 }
 
 bool ObjectContainerUniversalMachO::ParseHeader(
-    lldb_private::DataExtractor &extractor, llvm::MachO::fat_header &header,
+    lldb_private::DataExtractor &data, llvm::MachO::fat_header &header,
     std::vector<FatArch> &fat_archs) {
   // Store the file offset for this universal file as we could have a universal
   // .o file in a BSD archive, or be contained in another kind of object.
   lldb::offset_t offset = 0;
-  extractor.SetByteOrder(eByteOrderBig);
-  header.magic = extractor.GetU32(&offset);
+  data.SetByteOrder(eByteOrderBig);
+  header.magic = data.GetU32(&offset);
   fat_archs.clear();
 
   // Universal mach-o files always have their headers in big endian.
   if (header.magic == FAT_MAGIC || header.magic == FAT_MAGIC_64) {
     const bool is_fat64 = header.magic == FAT_MAGIC_64;
-    extractor.SetAddressByteSize(is_fat64 ? 8 : 4);
+    data.SetAddressByteSize(is_fat64 ? 8 : 4);
 
-    header.nfat_arch = extractor.GetU32(&offset);
+    header.nfat_arch = data.GetU32(&offset);
 
     // Now we should have enough data for all of the fat headers, so lets index
     // them so we know how many architectures that this universal binary
     // contains.
     for (uint32_t arch_idx = 0; arch_idx < header.nfat_arch; ++arch_idx) {
-      if (extractor.ValidOffsetForDataOfSize(offset, sizeof(fat_arch))) {
+      if (data.ValidOffsetForDataOfSize(offset, sizeof(fat_arch))) {
         if (is_fat64) {
           fat_arch_64 arch;
-          arch.cputype = extractor.GetU32(&offset);
-          arch.cpusubtype = extractor.GetU32(&offset);
-          arch.offset = extractor.GetU64(&offset);
-          arch.size = extractor.GetU64(&offset);
-          arch.align = extractor.GetU32(&offset);
-          arch.reserved = extractor.GetU32(&offset);
+          arch.cputype = data.GetU32(&offset);
+          arch.cpusubtype = data.GetU32(&offset);
+          arch.offset = data.GetU64(&offset);
+          arch.size = data.GetU64(&offset);
+          arch.align = data.GetU32(&offset);
+          arch.reserved = data.GetU32(&offset);
           fat_archs.emplace_back(arch);
         } else {
           fat_arch arch;
-          arch.cputype = extractor.GetU32(&offset);
-          arch.cpusubtype = extractor.GetU32(&offset);
-          arch.offset = extractor.GetU32(&offset);
-          arch.size = extractor.GetU32(&offset);
-          arch.align = extractor.GetU32(&offset);
+          arch.cputype = data.GetU32(&offset);
+          arch.cpusubtype = data.GetU32(&offset);
+          arch.offset = data.GetU32(&offset);
+          arch.size = data.GetU32(&offset);
+          arch.align = data.GetU32(&offset);
           fat_archs.emplace_back(arch);
         }
       }
@@ -177,11 +177,11 @@ ObjectContainerUniversalMachO::GetObjectFile(const FileSpec *file) {
     }
 
     if (arch_idx < m_header.nfat_arch) {
-      DataExtractorSP extractor_sp;
+      DataBufferSP data_sp;
       lldb::offset_t data_offset = 0;
       return ObjectFile::FindPlugin(
           module_sp, file, m_offset + m_fat_archs[arch_idx].GetOffset(),
-          m_fat_archs[arch_idx].GetSize(), extractor_sp, data_offset);
+          m_fat_archs[arch_idx].GetSize(), data_sp, data_offset);
     }
   }
   return ObjectFileSP();
@@ -193,13 +193,13 @@ size_t ObjectContainerUniversalMachO::GetModuleSpecifications(
     lldb::offset_t file_size, lldb_private::ModuleSpecList &specs) {
   const size_t initial_count = specs.GetSize();
 
-  DataExtractor extractor;
-  extractor.SetData(data_sp, data_offset, data_sp->GetByteSize());
+  DataExtractor data;
+  data.SetData(data_sp, data_offset, data_sp->GetByteSize());
 
-  if (ObjectContainerUniversalMachO::MagicBytesMatch(extractor)) {
+  if (ObjectContainerUniversalMachO::MagicBytesMatch(data)) {
     llvm::MachO::fat_header header;
     std::vector<FatArch> fat_archs;
-    if (ParseHeader(extractor, header, fat_archs)) {
+    if (ParseHeader(data, header, fat_archs)) {
       for (const FatArch &fat_arch : fat_archs) {
         const lldb::offset_t slice_file_offset =
             fat_arch.GetOffset() + file_offset;

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.cpp
@@ -130,13 +130,13 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
 
   std::optional<Record::Kind> current_section;
   offset_t section_start;
-  llvm::StringRef text = toStringRef(m_data_nsp->GetData());
+  llvm::StringRef text = toStringRef(m_data.GetData());
   uint32_t next_section_id = 1;
   auto maybe_add_section = [&](const uint8_t *end_ptr) {
     if (!current_section)
       return; // We have been called before parsing the first line.
 
-    offset_t end_offset = end_ptr - m_data_nsp->GetDataStart();
+    offset_t end_offset = end_ptr - m_data.GetDataStart();
     auto section_sp = std::make_shared<Section>(
         GetModule(), this, next_section_id++,
         ConstString(toString(*current_section)), eSectionTypeOther,
@@ -162,8 +162,8 @@ void ObjectFileBreakpad::CreateSections(SectionList &unified_section_list) {
     maybe_add_section(line.bytes_begin());
     // And start a new one.
     current_section = next_section;
-    section_start = line.bytes_begin() - m_data_nsp->GetDataStart();
+    section_start = line.bytes_begin() - m_data.GetDataStart();
   }
   // Finally, add the last section.
-  maybe_add_section(m_data_nsp->GetDataEnd());
+  maybe_add_section(m_data.GetDataEnd());
 }

--- a/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.h
+++ b/lldb/source/Plugins/ObjectFile/Breakpad/ObjectFileBreakpad.h
@@ -26,12 +26,10 @@ public:
     return "Breakpad object file reader.";
   }
 
-  static ObjectFile *CreateInstance(const lldb::ModuleSP &module_sp,
-                                    lldb::DataExtractorSP extractor_sp,
-                                    lldb::offset_t data_offset,
-                                    const FileSpec *file,
-                                    lldb::offset_t file_offset,
-                                    lldb::offset_t length);
+  static ObjectFile *
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static ObjectFile *CreateMemoryInstance(const lldb::ModuleSP &module_sp,
                                           lldb::WritableDataBufferSP data_sp,
@@ -96,10 +94,9 @@ private:
   UUID m_uuid;
 
   ObjectFileBreakpad(const lldb::ModuleSP &module_sp,
-                     lldb::DataExtractorSP extractor_sp,
-                     lldb::offset_t data_offset, const FileSpec *file,
-                     lldb::offset_t offset, lldb::offset_t length,
-                     ArchSpec arch, UUID uuid);
+                     lldb::DataBufferSP &data_sp, lldb::offset_t data_offset,
+                     const FileSpec *file, lldb::offset_t offset,
+                     lldb::offset_t length, ArchSpec arch, UUID uuid);
 };
 
 } // namespace breakpad

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.cpp
@@ -300,8 +300,8 @@ bool ObjectFileCOFF::ParseHeader() {
 
   std::lock_guard<std::recursive_mutex> guard(module->GetMutex());
 
-  m_data_nsp->SetByteOrder(eByteOrderLittle);
-  m_data_nsp->SetAddressByteSize(GetAddressByteSize());
+  m_data.SetByteOrder(eByteOrderLittle);
+  m_data.SetAddressByteSize(GetAddressByteSize());
 
   return true;
 }

--- a/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/COFF/ObjectFileCOFF.h
@@ -24,13 +24,11 @@ class ObjectFileCOFF : public lldb_private::ObjectFile {
   lldb_private::UUID m_uuid;
 
   ObjectFileCOFF(std::unique_ptr<llvm::object::COFFObjectFile> object,
-                 const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const lldb_private::FileSpec *file, lldb::offset_t file_offset,
-                 lldb::offset_t length)
-      : ObjectFile(module_sp, file, file_offset, length, extractor_sp,
-                   data_offset),
-        m_object(std::move(object)) {}
+                 const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length)
+    : ObjectFile(module_sp, file, file_offset, length, data_sp, data_offset),
+      m_object(std::move(object)) {}
 
 public:
   ~ObjectFileCOFF() override;
@@ -44,10 +42,9 @@ public:
   }
 
   static lldb_private::ObjectFile *
-  CreateInstance(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const lldb_private::FileSpec *file, lldb::offset_t file_offset,
-                 lldb::offset_t length);
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static lldb_private::ObjectFile *
   CreateMemoryInstance(const lldb::ModuleSP &module_sp,

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -781,7 +781,7 @@ ByteOrder ObjectFileELF::GetByteOrder() const {
 }
 
 uint32_t ObjectFileELF::GetAddressByteSize() const {
-  return m_data_nsp->GetAddressByteSize();
+  return m_data.GetAddressByteSize();
 }
 
 AddressClass ObjectFileELF::GetAddressClass(addr_t file_addr) {
@@ -822,7 +822,7 @@ size_t ObjectFileELF::SectionIndex(const SectionHeaderCollConstIter &I) const {
 
 bool ObjectFileELF::ParseHeader() {
   lldb::offset_t offset = 0;
-  return m_header.Parse(*m_data_nsp.get(), &offset);
+  return m_header.Parse(m_data, &offset);
 }
 
 UUID ObjectFileELF::GetUUID() {
@@ -840,7 +840,7 @@ UUID ObjectFileELF::GetUUID() {
         return UUID();
 
       core_notes_crc =
-          CalculateELFNotesSegmentsCRC32(m_program_headers, *m_data_nsp.get());
+          CalculateELFNotesSegmentsCRC32(m_program_headers, m_data);
 
       if (core_notes_crc) {
         // Use 8 bytes - first 4 bytes for *magic* prefix, mainly to make it
@@ -851,7 +851,7 @@ UUID ObjectFileELF::GetUUID() {
       }
     } else {
       if (!m_gnu_debuglink_crc)
-        m_gnu_debuglink_crc = calc_crc32(0, *m_data_nsp.get());
+        m_gnu_debuglink_crc = calc_crc32(0, m_data);
       if (m_gnu_debuglink_crc) {
         // Use 4 bytes of crc from the .gnu_debuglink section.
         u32le data(m_gnu_debuglink_crc);
@@ -1037,8 +1037,7 @@ size_t ObjectFileELF::GetProgramHeaderInfo(ProgramHeaderColl &program_headers,
 
 // ParseProgramHeaders
 bool ObjectFileELF::ParseProgramHeaders() {
-  return GetProgramHeaderInfo(m_program_headers, *m_data_nsp.get(), m_header) !=
-         0;
+  return GetProgramHeaderInfo(m_program_headers, m_data, m_header) != 0;
 }
 
 lldb_private::Status
@@ -1628,8 +1627,8 @@ ObjectFileELF::StripLinkerSymbolAnnotations(llvm::StringRef symbol_name) const {
 
 // ParseSectionHeaders
 size_t ObjectFileELF::ParseSectionHeaders() {
-  return GetSectionHeaderInfo(m_section_headers, *m_data_nsp.get(), m_header,
-                              m_uuid, m_gnu_debuglink_file, m_gnu_debuglink_crc,
+  return GetSectionHeaderInfo(m_section_headers, m_data, m_header, m_uuid,
+                              m_gnu_debuglink_file, m_gnu_debuglink_crc,
                               m_arch_spec);
 }
 
@@ -3601,8 +3600,7 @@ ArchSpec ObjectFileELF::GetArchitecture() {
       if (H.p_type != PT_NOTE || H.p_offset == 0 || H.p_filesz == 0)
         continue;
       DataExtractor data;
-      if (data.SetData(*m_data_nsp.get(), H.p_offset, H.p_filesz) ==
-          H.p_filesz) {
+      if (data.SetData(m_data, H.p_offset, H.p_filesz) == H.p_filesz) {
         UUID uuid;
         RefineModuleDetailsFromNote(data, m_arch_spec, uuid);
       }
@@ -3757,10 +3755,10 @@ llvm::ArrayRef<ELFProgramHeader> ObjectFileELF::ProgramHeaders() {
 }
 
 DataExtractor ObjectFileELF::GetSegmentData(const ELFProgramHeader &H) {
-  // Try and read the program header from our cached m_data_nsp which can come
-  // from the file on disk being mmap'ed or from the initial part of the ELF
-  // file we read from memory and cached.
-  DataExtractor data = DataExtractor(*m_data_nsp.get(), H.p_offset, H.p_filesz);
+  // Try and read the program header from our cached m_data which can come from
+  // the file on disk being mmap'ed or from the initial part of the ELF file we
+  // read from memory and cached.
+  DataExtractor data = DataExtractor(m_data, H.p_offset, H.p_filesz);
   if (data.GetByteSize() == H.p_filesz)
     return data;
   if (IsInMemory()) {

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -364,25 +364,21 @@ void ObjectFileELF::Terminate() {
 }
 
 ObjectFile *ObjectFileELF::CreateInstance(const lldb::ModuleSP &module_sp,
-                                          DataExtractorSP extractor_sp,
+                                          DataBufferSP data_sp,
                                           lldb::offset_t data_offset,
                                           const lldb_private::FileSpec *file,
                                           lldb::offset_t file_offset,
                                           lldb::offset_t length) {
   bool mapped_writable = false;
-  if (!extractor_sp || !extractor_sp->HasData()) {
-    DataBufferSP buffer_sp = MapFileDataWritable(*file, length, file_offset);
-    if (!buffer_sp)
+  if (!data_sp) {
+    data_sp = MapFileDataWritable(*file, length, file_offset);
+    if (!data_sp)
       return nullptr;
-    extractor_sp = std::make_shared<DataExtractor>();
-    extractor_sp->SetData(buffer_sp, data_offset, buffer_sp->GetByteSize());
     data_offset = 0;
     mapped_writable = true;
   }
 
-  assert(extractor_sp && extractor_sp->HasData());
-
-  DataBufferSP data_sp = extractor_sp->GetSharedDataBuffer();
+  assert(data_sp);
 
   if (data_sp->GetByteSize() <= (llvm::ELF::EI_NIDENT + data_offset))
     return nullptr;
@@ -399,7 +395,6 @@ ObjectFile *ObjectFileELF::CreateInstance(const lldb::ModuleSP &module_sp,
     data_offset = 0;
     mapped_writable = true;
     magic = data_sp->GetBytes();
-    extractor_sp->SetData(data_sp);
   }
 
   // If we didn't map the data as writable take ownership of the buffer.
@@ -408,14 +403,12 @@ ObjectFile *ObjectFileELF::CreateInstance(const lldb::ModuleSP &module_sp,
                                                data_sp->GetByteSize());
     data_offset = 0;
     magic = data_sp->GetBytes();
-    extractor_sp->SetData(data_sp);
   }
 
   unsigned address_size = ELFHeader::AddressSizeInBytes(magic);
   if (address_size == 4 || address_size == 8) {
-    extractor_sp->SetAddressByteSize(address_size);
     std::unique_ptr<ObjectFileELF> objfile_up(new ObjectFileELF(
-        module_sp, extractor_sp, data_offset, file, file_offset, length));
+        module_sp, data_sp, data_offset, file, file_offset, length));
     ArchSpec spec = objfile_up->GetArchitecture();
     if (spec && objfile_up->SetModulesArchitecture(spec))
       return objfile_up.release();
@@ -702,11 +695,10 @@ size_t ObjectFileELF::GetModuleSpecifications(
 // ObjectFile protocol
 
 ObjectFileELF::ObjectFileELF(const lldb::ModuleSP &module_sp,
-                             DataExtractorSP extractor_sp,
-                             lldb::offset_t data_offset, const FileSpec *file,
-                             lldb::offset_t file_offset, lldb::offset_t length)
-    : ObjectFile(module_sp, file, file_offset, length, extractor_sp,
-                 data_offset) {
+                             DataBufferSP data_sp, lldb::offset_t data_offset,
+                             const FileSpec *file, lldb::offset_t file_offset,
+                             lldb::offset_t length)
+    : ObjectFile(module_sp, file, file_offset, length, data_sp, data_offset) {
   if (file)
     m_file = *file;
 }
@@ -715,8 +707,7 @@ ObjectFileELF::ObjectFileELF(const lldb::ModuleSP &module_sp,
                              DataBufferSP header_data_sp,
                              const lldb::ProcessSP &process_sp,
                              addr_t header_addr)
-    : ObjectFile(module_sp, process_sp, header_addr,
-                 std::make_shared<DataExtractor>(header_data_sp)) {}
+    : ObjectFile(module_sp, process_sp, header_addr, header_data_sp) {}
 
 bool ObjectFileELF::IsExecutable() const {
   return ((m_header.e_type & ET_EXEC) != 0) || (m_header.e_entry != 0);
@@ -2014,11 +2005,10 @@ std::shared_ptr<ObjectFileELF> ObjectFileELF::GetGnuDebugDataObjectFile() {
   // Construct ObjectFileELF object from decompressed buffer
   DataBufferSP gdd_data_buf(
       new DataBufferHeap(uncompressedData.data(), uncompressedData.size()));
-  DataExtractorSP extractor_sp = std::make_shared<DataExtractor>(gdd_data_buf);
   auto fspec = GetFileSpec().CopyByAppendingPathComponent(
       llvm::StringRef("gnu_debugdata"));
   m_gnu_debug_data_object_file.reset(new ObjectFileELF(
-      GetModule(), extractor_sp, 0, &fspec, 0, gdd_data_buf->GetByteSize()));
+      GetModule(), gdd_data_buf, 0, &fspec, 0, gdd_data_buf->GetByteSize()));
 
   // This line is essential; otherwise a breakpoint can be set but not hit.
   m_gnu_debug_data_object_file->SetType(ObjectFile::eTypeDebugInfo);

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -69,10 +69,9 @@ public:
   }
 
   static lldb_private::ObjectFile *
-  CreateInstance(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const lldb_private::FileSpec *file, lldb::offset_t file_offset,
-                 lldb::offset_t length);
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static lldb_private::ObjectFile *CreateMemoryInstance(
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
@@ -166,10 +165,9 @@ protected:
                       uint64_t Offset);
 
 private:
-  ObjectFileELF(const lldb::ModuleSP &module_sp,
-                lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                const lldb_private::FileSpec *file, lldb::offset_t offset,
-                lldb::offset_t length);
+  ObjectFileELF(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                lldb::offset_t offset, lldb::offset_t length);
 
   ObjectFileELF(const lldb::ModuleSP &module_sp,
                 lldb::DataBufferSP header_data_sp,

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.cpp
@@ -36,37 +36,32 @@ void ObjectFileJSON::Terminate() {
   PluginManager::UnregisterPlugin(CreateInstance);
 }
 
-ObjectFile *ObjectFileJSON::CreateInstance(const ModuleSP &module_sp,
-                                           DataExtractorSP extractor_sp,
-                                           offset_t data_offset,
-                                           const FileSpec *file,
-                                           offset_t file_offset,
-                                           offset_t length) {
-  if (!extractor_sp || !extractor_sp->HasData()) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+ObjectFile *
+ObjectFileJSON::CreateInstance(const ModuleSP &module_sp, DataBufferSP data_sp,
+                               offset_t data_offset, const FileSpec *file,
+                               offset_t file_offset, offset_t length) {
+  if (!data_sp) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp)
       return nullptr;
-    extractor_sp = std::make_shared<DataExtractor>(data_sp);
     data_offset = 0;
   }
 
-  if (!MagicBytesMatch(extractor_sp->GetSharedDataBuffer(), 0,
-                       extractor_sp->GetByteSize()))
+  if (!MagicBytesMatch(data_sp, 0, data_sp->GetByteSize()))
     return nullptr;
 
   // Update the data to contain the entire file if it doesn't already.
-  if (extractor_sp->GetByteSize() < length) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+  if (data_sp->GetByteSize() < length) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp)
       return nullptr;
-    extractor_sp->SetData(data_sp);
     data_offset = 0;
   }
 
   Log *log = GetLog(LLDBLog::Symbols);
 
-  auto text = llvm::StringRef(reinterpret_cast<const char *>(
-      extractor_sp->GetSharedDataBuffer()->GetBytes()));
+  auto text =
+      llvm::StringRef(reinterpret_cast<const char *>(data_sp->GetBytes()));
 
   Expected<json::Value> json = json::parse(text);
   if (!json) {
@@ -95,10 +90,9 @@ ObjectFile *ObjectFileJSON::CreateInstance(const ModuleSP &module_sp,
     return nullptr;
   }
 
-  return new ObjectFileJSON(module_sp, extractor_sp, data_offset, file,
-                            file_offset, length, std::move(arch),
-                            std::move(uuid), type, std::move(body.symbols),
-                            std::move(body.sections));
+  return new ObjectFileJSON(module_sp, data_sp, data_offset, file, file_offset,
+                            length, std::move(arch), std::move(uuid), type,
+                            std::move(body.symbols), std::move(body.sections));
 }
 
 ObjectFile *ObjectFileJSON::CreateMemoryInstance(const ModuleSP &module_sp,
@@ -152,14 +146,13 @@ size_t ObjectFileJSON::GetModuleSpecifications(
   return 1;
 }
 
-ObjectFileJSON::ObjectFileJSON(const ModuleSP &module_sp,
-                               DataExtractorSP extractor_sp,
+ObjectFileJSON::ObjectFileJSON(const ModuleSP &module_sp, DataBufferSP &data_sp,
                                offset_t data_offset, const FileSpec *file,
                                offset_t offset, offset_t length, ArchSpec arch,
                                UUID uuid, Type type,
                                std::vector<JSONSymbol> symbols,
                                std::vector<JSONSection> sections)
-    : ObjectFile(module_sp, file, offset, length, extractor_sp, data_offset),
+    : ObjectFile(module_sp, file, offset, length, data_sp, data_offset),
       m_arch(std::move(arch)), m_uuid(std::move(uuid)), m_type(type),
       m_symbols(std::move(symbols)), m_sections(std::move(sections)) {}
 

--- a/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.h
+++ b/lldb/source/Plugins/ObjectFile/JSON/ObjectFileJSON.h
@@ -26,12 +26,10 @@ public:
     return "JSON object file reader.";
   }
 
-  static ObjectFile *CreateInstance(const lldb::ModuleSP &module_sp,
-                                    lldb::DataExtractorSP extractor_sp,
-                                    lldb::offset_t data_offset,
-                                    const FileSpec *file,
-                                    lldb::offset_t file_offset,
-                                    lldb::offset_t length);
+  static ObjectFile *
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static ObjectFile *CreateMemoryInstance(const lldb::ModuleSP &module_sp,
                                           lldb::WritableDataBufferSP data_sp,
@@ -113,11 +111,10 @@ private:
   std::vector<JSONSymbol> m_symbols;
   std::vector<JSONSection> m_sections;
 
-  ObjectFileJSON(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const FileSpec *file, lldb::offset_t offset,
-                 lldb::offset_t length, ArchSpec arch, UUID uuid, Type type,
-                 std::vector<JSONSymbol> symbols,
+  ObjectFileJSON(const lldb::ModuleSP &module_sp, lldb::DataBufferSP &data_sp,
+                 lldb::offset_t data_offset, const FileSpec *file,
+                 lldb::offset_t offset, lldb::offset_t length, ArchSpec arch,
+                 UUID uuid, Type type, std::vector<JSONSymbol> symbols,
                  std::vector<JSONSection> sections);
 };
 

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -784,33 +784,30 @@ void ObjectFileMachO::Terminate() {
 }
 
 ObjectFile *ObjectFileMachO::CreateInstance(const lldb::ModuleSP &module_sp,
-                                            DataExtractorSP extractor_sp,
+                                            DataBufferSP data_sp,
                                             lldb::offset_t data_offset,
                                             const FileSpec *file,
                                             lldb::offset_t file_offset,
                                             lldb::offset_t length) {
-  if (!extractor_sp || !extractor_sp->HasData()) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+  if (!data_sp) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp)
       return nullptr;
     data_offset = 0;
-    extractor_sp = std::make_shared<DataExtractor>(data_sp);
   }
 
-  if (!ObjectFileMachO::MagicBytesMatch(extractor_sp->GetSharedDataBuffer(),
-                                        data_offset, length))
+  if (!ObjectFileMachO::MagicBytesMatch(data_sp, data_offset, length))
     return nullptr;
 
   // Update the data to contain the entire file if it doesn't already
-  if (extractor_sp->GetByteSize() < length) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+  if (data_sp->GetByteSize() < length) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp)
       return nullptr;
     data_offset = 0;
-    extractor_sp = std::make_shared<DataExtractor>(data_sp);
   }
   auto objfile_up = std::make_unique<ObjectFileMachO>(
-      module_sp, extractor_sp, data_offset, file, file_offset, length);
+      module_sp, data_sp, data_offset, file, file_offset, length);
   if (!objfile_up || !objfile_up->ParseHeader())
     return nullptr;
 
@@ -931,13 +928,12 @@ bool ObjectFileMachO::MagicBytesMatch(DataBufferSP data_sp,
 }
 
 ObjectFileMachO::ObjectFileMachO(const lldb::ModuleSP &module_sp,
-                                 DataExtractorSP extractor_sp,
+                                 DataBufferSP data_sp,
                                  lldb::offset_t data_offset,
                                  const FileSpec *file,
                                  lldb::offset_t file_offset,
                                  lldb::offset_t length)
-    : ObjectFile(module_sp, file, file_offset, length, extractor_sp,
-                 data_offset),
+    : ObjectFile(module_sp, file, file_offset, length, data_sp, data_offset),
       m_mach_sections(), m_entry_point_address(), m_thread_context_offsets(),
       m_thread_context_offsets_valid(false), m_reexported_dylibs(),
       m_allow_assembly_emulation_unwind_plans(true) {
@@ -949,8 +945,7 @@ ObjectFileMachO::ObjectFileMachO(const lldb::ModuleSP &module_sp,
                                  lldb::WritableDataBufferSP header_data_sp,
                                  const lldb::ProcessSP &process_sp,
                                  lldb::addr_t header_addr)
-    : ObjectFile(module_sp, process_sp, header_addr,
-                 std::make_shared<DataExtractor>(header_data_sp)),
+    : ObjectFile(module_sp, process_sp, header_addr, header_data_sp),
       m_mach_sections(), m_entry_point_address(), m_thread_context_offsets(),
       m_thread_context_offsets_valid(false), m_reexported_dylibs(),
       m_allow_assembly_emulation_unwind_plans(true) {

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.cpp
@@ -1015,35 +1015,35 @@ bool ObjectFileMachO::ParseHeader() {
   std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
   bool can_parse = false;
   lldb::offset_t offset = 0;
-  m_data_nsp->SetByteOrder(endian::InlHostByteOrder());
+  m_data.SetByteOrder(endian::InlHostByteOrder());
   // Leave magic in the original byte order
-  m_header.magic = m_data_nsp->GetU32(&offset);
+  m_header.magic = m_data.GetU32(&offset);
   switch (m_header.magic) {
   case MH_MAGIC:
-    m_data_nsp->SetByteOrder(endian::InlHostByteOrder());
-    m_data_nsp->SetAddressByteSize(4);
+    m_data.SetByteOrder(endian::InlHostByteOrder());
+    m_data.SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_MAGIC_64:
-    m_data_nsp->SetByteOrder(endian::InlHostByteOrder());
-    m_data_nsp->SetAddressByteSize(8);
+    m_data.SetByteOrder(endian::InlHostByteOrder());
+    m_data.SetAddressByteSize(8);
     can_parse = true;
     break;
 
   case MH_CIGAM:
-    m_data_nsp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                                 ? eByteOrderLittle
-                                 : eByteOrderBig);
-    m_data_nsp->SetAddressByteSize(4);
+    m_data.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                            ? eByteOrderLittle
+                            : eByteOrderBig);
+    m_data.SetAddressByteSize(4);
     can_parse = true;
     break;
 
   case MH_CIGAM_64:
-    m_data_nsp->SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
-                                 ? eByteOrderLittle
-                                 : eByteOrderBig);
-    m_data_nsp->SetAddressByteSize(8);
+    m_data.SetByteOrder(endian::InlHostByteOrder() == eByteOrderBig
+                            ? eByteOrderLittle
+                            : eByteOrderBig);
+    m_data.SetAddressByteSize(8);
     can_parse = true;
     break;
 
@@ -1052,13 +1052,12 @@ bool ObjectFileMachO::ParseHeader() {
   }
 
   if (can_parse) {
-    m_data_nsp->GetU32(&offset, &m_header.cputype, 6);
+    m_data.GetU32(&offset, &m_header.cputype, 6);
 
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_nsp.get(),
-                    MachHeaderSizeFromMagic(m_header.magic), base_spec,
-                    all_specs);
+    GetAllArchSpecs(m_header, m_data, MachHeaderSizeFromMagic(m_header.magic),
+                    base_spec, all_specs);
 
     for (unsigned i = 0, e = all_specs.GetSize(); i != e; ++i) {
       ArchSpec mach_arch =
@@ -1072,7 +1071,7 @@ bool ObjectFileMachO::ParseHeader() {
       if (SetModulesArchitecture(mach_arch)) {
         const size_t header_and_lc_size =
             m_header.sizeofcmds + MachHeaderSizeFromMagic(m_header.magic);
-        if (m_data_nsp->GetByteSize() < header_and_lc_size) {
+        if (m_data.GetByteSize() < header_and_lc_size) {
           DataBufferSP data_sp;
           ProcessSP process_sp(m_process_wp.lock());
           if (process_sp) {
@@ -1084,7 +1083,7 @@ bool ObjectFileMachO::ParseHeader() {
               continue;
           }
           if (data_sp)
-            m_data_nsp->SetData(data_sp);
+            m_data.SetData(data_sp);
         }
       }
       return true;
@@ -1098,7 +1097,7 @@ bool ObjectFileMachO::ParseHeader() {
 }
 
 ByteOrder ObjectFileMachO::GetByteOrder() const {
-  return m_data_nsp->GetByteOrder();
+  return m_data.GetByteOrder();
 }
 
 bool ObjectFileMachO::IsExecutable() const {
@@ -1118,7 +1117,7 @@ bool ObjectFileMachO::IsKext() const {
 }
 
 uint32_t ObjectFileMachO::GetAddressByteSize() const {
-  return m_data_nsp->GetAddressByteSize();
+  return m_data.GetAddressByteSize();
 }
 
 AddressClass ObjectFileMachO::GetAddressClass(lldb::addr_t file_addr) {
@@ -1303,13 +1302,13 @@ bool ObjectFileMachO::IsStripped() {
         const lldb::offset_t load_cmd_offset = offset;
 
         llvm::MachO::load_command lc = {};
-        if (m_data_nsp->GetU32(&offset, &lc.cmd, 2) == nullptr)
+        if (m_data.GetU32(&offset, &lc.cmd, 2) == nullptr)
           break;
         if (lc.cmd == LC_DYSYMTAB) {
           m_dysymtab.cmd = lc.cmd;
           m_dysymtab.cmdsize = lc.cmdsize;
-          if (m_data_nsp->GetU32(&offset, &m_dysymtab.ilocalsym,
-                                 (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2) ==
+          if (m_data.GetU32(&offset, &m_dysymtab.ilocalsym,
+                            (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2) ==
               nullptr) {
             // Clear m_dysymtab if we were unable to read all items from the
             // load command
@@ -1332,14 +1331,14 @@ ObjectFileMachO::EncryptedFileRanges ObjectFileMachO::GetEncryptedFileRanges() {
   llvm::MachO::encryption_info_command encryption_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data_nsp->GetU32(&offset, &encryption_cmd, 2) == nullptr)
+    if (m_data.GetU32(&offset, &encryption_cmd, 2) == nullptr)
       break;
 
     // LC_ENCRYPTION_INFO and LC_ENCRYPTION_INFO_64 have the same sizes for the
     // 3 fields we care about, so treat them the same.
     if (encryption_cmd.cmd == LC_ENCRYPTION_INFO ||
         encryption_cmd.cmd == LC_ENCRYPTION_INFO_64) {
-      if (m_data_nsp->GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
+      if (m_data.GetU32(&offset, &encryption_cmd.cryptoff, 3)) {
         if (encryption_cmd.cryptid != 0) {
           EncryptedFileRanges::Entry entry;
           entry.SetRangeBase(encryption_cmd.cryptoff);
@@ -1568,7 +1567,7 @@ void ObjectFileMachO::ProcessSegmentCommand(
   llvm::MachO::segment_command_64 load_cmd;
   memcpy(&load_cmd, &load_cmd_, sizeof(load_cmd_));
 
-  if (!m_data_nsp->GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
+  if (!m_data.GetU8(&offset, (uint8_t *)load_cmd.segname, 16))
     return;
 
   ModuleSP module_sp = GetModule();
@@ -1592,11 +1591,11 @@ void ObjectFileMachO::ProcessSegmentCommand(
       add_section = false;
     }
   }
-  load_cmd.vmaddr = m_data_nsp->GetAddress(&offset);
-  load_cmd.vmsize = m_data_nsp->GetAddress(&offset);
-  load_cmd.fileoff = m_data_nsp->GetAddress(&offset);
-  load_cmd.filesize = m_data_nsp->GetAddress(&offset);
-  if (!m_data_nsp->GetU32(&offset, &load_cmd.maxprot, 4))
+  load_cmd.vmaddr = m_data.GetAddress(&offset);
+  load_cmd.vmsize = m_data.GetAddress(&offset);
+  load_cmd.fileoff = m_data.GetAddress(&offset);
+  load_cmd.filesize = m_data.GetAddress(&offset);
+  if (!m_data.GetU32(&offset, &load_cmd.maxprot, 4))
     return;
 
   SanitizeSegmentCommand(load_cmd, cmd_idx);
@@ -1683,16 +1682,16 @@ void ObjectFileMachO::ProcessSegmentCommand(
   const uint32_t num_u32s = load_cmd.cmd == LC_SEGMENT ? 7 : 8;
   for (segment_sect_idx = 0; segment_sect_idx < load_cmd.nsects;
        ++segment_sect_idx) {
-    if (m_data_nsp->GetU8(&offset, (uint8_t *)sect64.sectname,
-                          sizeof(sect64.sectname)) == nullptr)
+    if (m_data.GetU8(&offset, (uint8_t *)sect64.sectname,
+                     sizeof(sect64.sectname)) == nullptr)
       break;
-    if (m_data_nsp->GetU8(&offset, (uint8_t *)sect64.segname,
-                          sizeof(sect64.segname)) == nullptr)
+    if (m_data.GetU8(&offset, (uint8_t *)sect64.segname,
+                     sizeof(sect64.segname)) == nullptr)
       break;
-    sect64.addr = m_data_nsp->GetAddress(&offset);
-    sect64.size = m_data_nsp->GetAddress(&offset);
+    sect64.addr = m_data.GetAddress(&offset);
+    sect64.size = m_data.GetAddress(&offset);
 
-    if (m_data_nsp->GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
+    if (m_data.GetU32(&offset, &sect64.offset, num_u32s) == nullptr)
       break;
 
     if (IsSharedCacheBinary() && !IsInMemory()) {
@@ -1847,8 +1846,8 @@ void ObjectFileMachO::ProcessDysymtabCommand(
     const llvm::MachO::load_command &load_cmd, lldb::offset_t offset) {
   m_dysymtab.cmd = load_cmd.cmd;
   m_dysymtab.cmdsize = load_cmd.cmdsize;
-  m_data_nsp->GetU32(&offset, &m_dysymtab.ilocalsym,
-                     (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2);
+  m_data.GetU32(&offset, &m_dysymtab.ilocalsym,
+                (sizeof(m_dysymtab) / sizeof(uint32_t)) - 2);
 }
 
 void ObjectFileMachO::CreateSections(SectionList &unified_section_list) {
@@ -1867,7 +1866,7 @@ void ObjectFileMachO::CreateSections(SectionList &unified_section_list) {
   llvm::MachO::load_command load_cmd;
   for (uint32_t i = 0; i < m_header.ncmds; ++i) {
     const lldb::offset_t load_cmd_offset = offset;
-    if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     if (load_cmd.cmd == LC_SEGMENT || load_cmd.cmd == LC_SEGMENT_64)
@@ -2232,13 +2231,13 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     const lldb::offset_t cmd_offset = offset;
     // Read in the load command and load command size
     llvm::MachO::load_command lc;
-    if (m_data_nsp->GetU32(&offset, &lc, 2) == nullptr)
+    if (m_data.GetU32(&offset, &lc, 2) == nullptr)
       break;
     // Watch for the symbol table load command
     switch (lc.cmd) {
     case LC_SYMTAB: {
       llvm::MachO::symtab_command lc_obj;
-      if (m_data_nsp->GetU32(&offset, &lc_obj.symoff, 4)) {
+      if (m_data.GetU32(&offset, &lc_obj.symoff, 4)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         symtab_load_command = lc_obj;
@@ -2248,7 +2247,7 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_DYLD_INFO:
     case LC_DYLD_INFO_ONLY: {
       llvm::MachO::dyld_info_command lc_obj;
-      if (m_data_nsp->GetU32(&offset, &lc_obj.rebase_off, 10)) {
+      if (m_data.GetU32(&offset, &lc_obj.rebase_off, 10)) {
         lc_obj.cmd = lc.cmd;
         lc_obj.cmdsize = lc.cmdsize;
         dyld_info = lc_obj;
@@ -2260,8 +2259,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     case LC_REEXPORT_DYLIB:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data_nsp->GetU32(&offset);
-      const char *path = m_data_nsp->PeekCStr(name_offset);
+      uint32_t name_offset = cmd_offset + m_data.GetU32(&offset);
+      const char *path = m_data.PeekCStr(name_offset);
       if (path) {
         FileSpec file_spec(path);
         // Strip the path if there is @rpath, @executable, etc so we just use
@@ -2281,19 +2280,19 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data_nsp->GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data.GetU32(&offset, &lc_obj.dataoff, 2))
         exports_trie_load_command = lc_obj;
     } break;
     case LC_FUNCTION_STARTS: {
       llvm::MachO::linkedit_data_command lc_obj;
       lc_obj.cmd = lc.cmd;
       lc_obj.cmdsize = lc.cmdsize;
-      if (m_data_nsp->GetU32(&offset, &lc_obj.dataoff, 2))
+      if (m_data.GetU32(&offset, &lc_obj.dataoff, 2))
         function_starts_load_command = lc_obj;
     } break;
 
     case LC_UUID: {
-      const uint8_t *uuid_bytes = m_data_nsp->PeekData(offset, 16);
+      const uint8_t *uuid_bytes = m_data.PeekData(offset, 16);
 
       if (uuid_bytes)
         image_uuid = UUID(uuid_bytes, 16);
@@ -2313,8 +2312,8 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
   if (section_list == nullptr)
     return;
 
-  const uint32_t addr_byte_size = m_data_nsp->GetAddressByteSize();
-  const ByteOrder byte_order = m_data_nsp->GetByteOrder();
+  const uint32_t addr_byte_size = m_data.GetAddressByteSize();
+  const ByteOrder byte_order = m_data.GetByteOrder();
   bool bit_width_32 = addr_byte_size == 4;
   const size_t nlist_byte_size =
       bit_width_32 ? sizeof(struct nlist) : sizeof(struct nlist_64);
@@ -2479,9 +2478,9 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
       exports_trie_load_command.dataoff += linkedit_slide;
     }
 
-    nlist_data.SetData(*m_data_nsp.get(), symtab_load_command.symoff,
+    nlist_data.SetData(m_data, symtab_load_command.symoff,
                        nlist_data_byte_size);
-    strtab_data.SetData(*m_data_nsp.get(), symtab_load_command.stroff,
+    strtab_data.SetData(m_data, symtab_load_command.stroff,
                         strtab_data_byte_size);
 
     // We shouldn't have exports data from both the LC_DYLD_INFO command
@@ -2489,22 +2488,19 @@ void ObjectFileMachO::ParseSymtab(Symtab &symtab) {
     lldbassert(!((dyld_info.export_size > 0)
                  && (exports_trie_load_command.datasize > 0)));
     if (dyld_info.export_size > 0) {
-      dyld_trie_data.SetData(*m_data_nsp.get(), dyld_info.export_off,
+      dyld_trie_data.SetData(m_data, dyld_info.export_off,
                              dyld_info.export_size);
     } else if (exports_trie_load_command.datasize > 0) {
-      dyld_trie_data.SetData(*m_data_nsp.get(),
-                             exports_trie_load_command.dataoff,
+      dyld_trie_data.SetData(m_data, exports_trie_load_command.dataoff,
                              exports_trie_load_command.datasize);
     }
 
     if (dysymtab.nindirectsyms != 0) {
-      indirect_symbol_index_data.SetData(*m_data_nsp.get(),
-                                         dysymtab.indirectsymoff,
+      indirect_symbol_index_data.SetData(m_data, dysymtab.indirectsymoff,
                                          dysymtab.nindirectsyms * 4);
     }
     if (function_starts_load_command.cmd) {
-      function_starts_data.SetData(*m_data_nsp.get(),
-                                   function_starts_load_command.dataoff,
+      function_starts_data.SetData(m_data, function_starts_load_command.dataoff,
                                    function_starts_load_command.datasize);
     }
   }
@@ -4698,9 +4694,8 @@ void ObjectFileMachO::Dump(Stream *s) {
     *s << ", file = '" << m_file;
     ModuleSpecList all_specs;
     ModuleSpec base_spec;
-    GetAllArchSpecs(m_header, *m_data_nsp.get(),
-                    MachHeaderSizeFromMagic(m_header.magic), base_spec,
-                    all_specs);
+    GetAllArchSpecs(m_header, m_data, MachHeaderSizeFromMagic(m_header.magic),
+                    base_spec, all_specs);
     for (unsigned i = 0, e = all_specs.GetSize(); i != e; ++i) {
       *s << "', triple";
       if (e)
@@ -5006,7 +5001,7 @@ UUID ObjectFileMachO::GetUUID() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     lldb::offset_t offset = MachHeaderSizeFromMagic(m_header.magic);
-    return GetUUID(m_header, *m_data_nsp.get(), offset);
+    return GetUUID(m_header, m_data, offset);
   }
   return UUID();
 }
@@ -5026,7 +5021,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
   uint32_t i;
   for (i = 0; i < m_header.ncmds; ++i) {
     const uint32_t cmd_offset = offset;
-    if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
+    if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
       break;
 
     switch (load_cmd.cmd) {
@@ -5037,17 +5032,17 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
     case LC_LOAD_DYLINKER:
     case LC_LOADFVMLIB:
     case LC_LOAD_UPWARD_DYLIB: {
-      uint32_t name_offset = cmd_offset + m_data_nsp->GetU32(&offset);
+      uint32_t name_offset = cmd_offset + m_data.GetU32(&offset);
       // For LC_LOAD_DYLIB there is an alternate encoding
       // which adds a uint32_t `flags` field for `DYLD_USE_*`
       // flags.  This can be detected by a timestamp field with
       // the `DYLIB_USE_MARKER` constant value.
       bool is_delayed_init = false;
-      uint32_t use_command_marker = m_data_nsp->GetU32(&offset);
+      uint32_t use_command_marker = m_data.GetU32(&offset);
       if (use_command_marker == 0x1a741800 /* DYLIB_USE_MARKER */) {
         offset += 4; /* uint32_t current_version */
         offset += 4; /* uint32_t compat_version */
-        uint32_t flags = m_data_nsp->GetU32(&offset);
+        uint32_t flags = m_data.GetU32(&offset);
         // If this LC_LOAD_DYLIB is marked delay-init,
         // don't report it as a dependent library -- it
         // may be loaded in the process at some point,
@@ -5055,7 +5050,7 @@ uint32_t ObjectFileMachO::GetDependentModules(FileSpecList &files) {
         if (flags & 0x08 /* DYLIB_USE_DELAYED_INIT */)
           is_delayed_init = true;
       }
-      const char *path = m_data_nsp->PeekCStr(name_offset);
+      const char *path = m_data.PeekCStr(name_offset);
       if (path && !is_delayed_init) {
         if (load_cmd.cmd == LC_RPATH)
           rpath_paths.push_back(path);
@@ -5175,15 +5170,15 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
 
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       switch (load_cmd.cmd) {
       case LC_UNIXTHREAD:
       case LC_THREAD: {
         while (offset < cmd_offset + load_cmd.cmdsize) {
-          uint32_t flavor = m_data_nsp->GetU32(&offset);
-          uint32_t count = m_data_nsp->GetU32(&offset);
+          uint32_t flavor = m_data.GetU32(&offset);
+          uint32_t count = m_data.GetU32(&offset);
           if (count == 0) {
             // We've gotten off somehow, log and exit;
             return m_entry_point_address;
@@ -5197,7 +5192,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 60; // This is the offset of pc in the GPR thread state
                             // data structure.
-              start_address = m_data_nsp->GetU32(&offset);
+              start_address = m_data.GetU32(&offset);
               done = true;
             }
             break;
@@ -5207,7 +5202,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 256; // This is the offset of pc in the GPR thread state
                              // data structure.
-              start_address = m_data_nsp->GetU64(&offset);
+              start_address = m_data.GetU64(&offset);
               done = true;
             }
             break;
@@ -5217,7 +5212,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
             {
               offset += 16 * 8; // This is the offset of rip in the GPR thread
                                 // state data structure.
-              start_address = m_data_nsp->GetU64(&offset);
+              start_address = m_data.GetU64(&offset);
               done = true;
             }
             break;
@@ -5232,7 +5227,7 @@ lldb_private::Address ObjectFileMachO::GetEntryPointAddress() {
         }
       } break;
       case LC_MAIN: {
-        uint64_t entryoffset = m_data_nsp->GetU64(&offset);
+        uint64_t entryoffset = m_data.GetU64(&offset);
         SectionSP text_segment_sp =
             GetSectionList()->FindSectionByName(GetSegmentNameTEXT());
         if (text_segment_sp) {
@@ -5316,7 +5311,7 @@ uint32_t ObjectFileMachO::GetNumThreadContexts() {
       llvm::MachO::thread_command thread_cmd;
       for (uint32_t i = 0; i < m_header.ncmds; ++i) {
         const uint32_t cmd_offset = offset;
-        if (m_data_nsp->GetU32(&offset, &thread_cmd, 2) == nullptr)
+        if (m_data.GetU32(&offset, &thread_cmd, 2) == nullptr)
           break;
 
         if (thread_cmd.cmd == LC_THREAD) {
@@ -5342,17 +5337,17 @@ ObjectFileMachO::FindLC_NOTEByName(std::string name) {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::load_command lc = {};
-      if (m_data_nsp->GetU32(&offset, &lc.cmd, 2) == nullptr)
+      if (m_data.GetU32(&offset, &lc.cmd, 2) == nullptr)
         break;
       if (lc.cmd == LC_NOTE) {
         char data_owner[17];
-        m_data_nsp->CopyData(offset, 16, data_owner);
+        m_data.CopyData(offset, 16, data_owner);
         data_owner[16] = '\0';
         offset += 16;
 
         if (name == data_owner) {
-          offset_t payload_offset = m_data_nsp->GetU64_unchecked(&offset);
-          offset_t payload_size = m_data_nsp->GetU64_unchecked(&offset);
+          offset_t payload_offset = m_data.GetU64_unchecked(&offset);
+          offset_t payload_size = m_data.GetU64_unchecked(&offset);
           results.push_back({payload_offset, payload_size});
         }
       }
@@ -5374,11 +5369,11 @@ std::string ObjectFileMachO::GetIdentifierString() {
       offset_t payload_offset = std::get<0>(lc_note);
       offset_t payload_size = std::get<1>(lc_note);
       uint32_t version;
-      if (m_data_nsp->GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data.GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 1) {
           uint32_t strsize = payload_size - sizeof(uint32_t);
           std::string result(strsize, '\0');
-          m_data_nsp->CopyData(payload_offset, strsize, result.data());
+          m_data.CopyData(payload_offset, strsize, result.data());
           LLDB_LOGF(log, "LC_NOTE 'kern ver str' found with text '%s'",
                     result.c_str());
           return result;
@@ -5392,12 +5387,12 @@ std::string ObjectFileMachO::GetIdentifierString() {
     for (uint32_t i = 0; i < m_header.ncmds; ++i) {
       const uint32_t cmd_offset = offset;
       llvm::MachO::ident_command ident_command;
-      if (m_data_nsp->GetU32(&offset, &ident_command, 2) == nullptr)
+      if (m_data.GetU32(&offset, &ident_command, 2) == nullptr)
         break;
       if (ident_command.cmd == LC_IDENT && ident_command.cmdsize != 0) {
         std::string result(ident_command.cmdsize, '\0');
-        if (m_data_nsp->CopyData(offset, ident_command.cmdsize,
-                                 result.data()) == ident_command.cmdsize) {
+        if (m_data.CopyData(offset, ident_command.cmdsize, result.data()) ==
+            ident_command.cmdsize) {
           LLDB_LOGF(log, "LC_IDENT found with text '%s'", result.c_str());
           return result;
         }
@@ -5419,10 +5414,9 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
     for (auto lc_note : lc_notes) {
       offset_t payload_offset = std::get<0>(lc_note);
       uint32_t version;
-      if (m_data_nsp->GetU32(&payload_offset, &version, 1) != nullptr) {
+      if (m_data.GetU32(&payload_offset, &version, 1) != nullptr) {
         if (version == 3) {
-          uint32_t num_addr_bits =
-              m_data_nsp->GetU32_unchecked(&payload_offset);
+          uint32_t num_addr_bits = m_data.GetU32_unchecked(&payload_offset);
           addressable_bits.SetAddressableBits(num_addr_bits);
           LLDB_LOGF(log,
                     "LC_NOTE 'addrable bits' v3 found, value %d "
@@ -5430,8 +5424,8 @@ AddressableBits ObjectFileMachO::GetAddressableBits() {
                     num_addr_bits);
         }
         if (version == 4) {
-          uint32_t lo_addr_bits = m_data_nsp->GetU32_unchecked(&payload_offset);
-          uint32_t hi_addr_bits = m_data_nsp->GetU32_unchecked(&payload_offset);
+          uint32_t lo_addr_bits = m_data.GetU32_unchecked(&payload_offset);
+          uint32_t hi_addr_bits = m_data.GetU32_unchecked(&payload_offset);
 
           if (lo_addr_bits == hi_addr_bits)
             addressable_bits.SetAddressableBits(lo_addr_bits);
@@ -5502,26 +5496,25 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
       //    uint32_t unused        [ for alignment ]
 
       uint32_t version;
-      if (m_data_nsp->GetU32(&payload_offset, &version, 1) != nullptr &&
+      if (m_data.GetU32(&payload_offset, &version, 1) != nullptr &&
           version <= 2) {
         uint32_t binspec_type = 0;
         uuid_t raw_uuid;
         memset(raw_uuid, 0, sizeof(uuid_t));
 
-        if (!m_data_nsp->GetU32(&payload_offset, &binspec_type, 1))
+        if (!m_data.GetU32(&payload_offset, &binspec_type, 1))
           return false;
-        if (!m_data_nsp->GetU64(&payload_offset, &value, 1))
+        if (!m_data.GetU64(&payload_offset, &value, 1))
           return false;
         uint64_t slide = LLDB_INVALID_ADDRESS;
-        if (version > 1 && !m_data_nsp->GetU64(&payload_offset, &slide, 1))
+        if (version > 1 && !m_data.GetU64(&payload_offset, &slide, 1))
           return false;
         if (value == LLDB_INVALID_ADDRESS && slide != LLDB_INVALID_ADDRESS) {
           value = slide;
           value_is_offset = true;
         }
 
-        if (m_data_nsp->CopyData(payload_offset, sizeof(uuid_t), raw_uuid) !=
-            0) {
+        if (m_data.CopyData(payload_offset, sizeof(uuid_t), raw_uuid) != 0) {
           uuid = UUID(raw_uuid, sizeof(uuid_t));
           // convert the "main bin spec" type into our
           // ObjectFile::BinaryType enum
@@ -5555,9 +5548,9 @@ bool ObjectFileMachO::GetCorefileMainBinaryInfo(addr_t &value,
                     version, type, typestr, value,
                     value_is_offset ? "true" : "false",
                     uuid.GetAsString().c_str());
-          if (!m_data_nsp->GetU32(&payload_offset, &log2_pagesize, 1))
+          if (!m_data.GetU32(&payload_offset, &log2_pagesize, 1))
             return false;
-          if (version > 1 && !m_data_nsp->GetU32(&payload_offset, &platform, 1))
+          if (version > 1 && !m_data.GetU32(&payload_offset, &platform, 1))
             return false;
           return true;
         }
@@ -5637,7 +5630,7 @@ StructuredData::ObjectSP ObjectFileMachO::GetCorefileProcessMetadata() {
 
   auto [payload_offset, strsize] = lc_notes[0];
   std::string buf(strsize, '\0');
-  if (m_data_nsp->CopyData(payload_offset, strsize, buf.data()) != strsize) {
+  if (m_data.CopyData(payload_offset, strsize, buf.data()) != strsize) {
     LLDB_LOGF(log,
               "Unable to read %" PRIu64
               " bytes of 'process metadata' LC_NOTE JSON contents",
@@ -5677,8 +5670,7 @@ ObjectFileMachO::GetThreadContextAtIndex(uint32_t idx,
         m_thread_context_offsets.GetEntryAtIndex(idx);
     if (thread_context_file_range) {
 
-      DataExtractor data(*m_data_nsp.get(),
-                         thread_context_file_range->GetRangeBase(),
+      DataExtractor data(m_data, thread_context_file_range->GetRangeBase(),
                          thread_context_file_range->GetByteSize());
 
       switch (m_header.cputype) {
@@ -5818,13 +5810,13 @@ llvm::VersionTuple ObjectFileMachO::GetVersion() {
     uint32_t i;
     for (i = 0; i < m_header.ncmds; ++i) {
       const lldb::offset_t cmd_offset = offset;
-      if (m_data_nsp->GetU32(&offset, &load_cmd, 2) == nullptr)
+      if (m_data.GetU32(&offset, &load_cmd, 2) == nullptr)
         break;
 
       if (load_cmd.cmd == LC_ID_DYLIB) {
         if (version_cmd == 0) {
           version_cmd = load_cmd.cmd;
-          if (m_data_nsp->GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
+          if (m_data.GetU32(&offset, &load_cmd.dylib, 4) == nullptr)
             break;
           version = load_cmd.dylib.current_version;
         }
@@ -5850,7 +5842,7 @@ ArchSpec ObjectFileMachO::GetArchitecture() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
 
-    return GetArchitecture(module_sp, m_header, *m_data_nsp.get(),
+    return GetArchitecture(module_sp, m_header, m_data,
                            MachHeaderSizeFromMagic(m_header.magic));
   }
   return arch;
@@ -6021,16 +6013,14 @@ static llvm::VersionTuple FindMinimumVersionInfo(DataExtractor &data,
 llvm::VersionTuple ObjectFileMachO::GetMinimumOSVersion() {
   if (!m_min_os_version)
     m_min_os_version = FindMinimumVersionInfo(
-        *m_data_nsp.get(), MachHeaderSizeFromMagic(m_header.magic),
-        m_header.ncmds);
+        m_data, MachHeaderSizeFromMagic(m_header.magic), m_header.ncmds);
   return *m_min_os_version;
 }
 
 llvm::VersionTuple ObjectFileMachO::GetSDKVersion() {
   if (!m_sdk_versions)
     m_sdk_versions = FindMinimumVersionInfo(
-        *m_data_nsp.get(), MachHeaderSizeFromMagic(m_header.magic),
-        m_header.ncmds);
+        m_data, MachHeaderSizeFromMagic(m_header.magic), m_header.ncmds);
   return *m_sdk_versions;
 }
 
@@ -6845,12 +6835,12 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
     // Read the struct all_image_infos_header.
-    uint32_t version = m_data_nsp->GetU32(&payload_offset);
+    uint32_t version = m_data.GetU32(&payload_offset);
     if (version != 1) {
       return image_infos;
     }
-    uint32_t imgcount = m_data_nsp->GetU32(&payload_offset);
-    uint64_t entries_fileoff = m_data_nsp->GetU64(&payload_offset);
+    uint32_t imgcount = m_data.GetU32(&payload_offset);
+    uint64_t entries_fileoff = m_data.GetU64(&payload_offset);
     // 'entries_size' is not used, nor is the 'unused' entry.
     //  offset += 4; // uint32_t entries_size;
     //  offset += 4; // uint32_t unused;
@@ -6860,18 +6850,17 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
     payload_offset = entries_fileoff;
     for (uint32_t i = 0; i < imgcount; i++) {
       // Read the struct image_entry.
-      offset_t filepath_offset = m_data_nsp->GetU64(&payload_offset);
+      offset_t filepath_offset = m_data.GetU64(&payload_offset);
       uuid_t uuid;
-      memcpy(&uuid, m_data_nsp->GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data.GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data_nsp->GetU64(&payload_offset);
-      offset_t seg_addrs_offset = m_data_nsp->GetU64(&payload_offset);
-      uint32_t segment_count = m_data_nsp->GetU32(&payload_offset);
-      uint32_t currently_executing = m_data_nsp->GetU32(&payload_offset);
+      uint64_t load_address = m_data.GetU64(&payload_offset);
+      offset_t seg_addrs_offset = m_data.GetU64(&payload_offset);
+      uint32_t segment_count = m_data.GetU32(&payload_offset);
+      uint32_t currently_executing = m_data.GetU32(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
-      image_entry.filename =
-          (const char *)m_data_nsp->GetCStr(&filepath_offset);
+      image_entry.filename = (const char *)m_data.GetCStr(&filepath_offset);
       image_entry.uuid = UUID(uuid, sizeof(uuid_t));
       image_entry.load_address = load_address;
       image_entry.currently_executing = currently_executing;
@@ -6879,10 +6868,10 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
       offset_t seg_vmaddrs_offset = seg_addrs_offset;
       for (uint32_t j = 0; j < segment_count; j++) {
         char segname[17];
-        m_data_nsp->CopyData(seg_vmaddrs_offset, 16, segname);
+        m_data.CopyData(seg_vmaddrs_offset, 16, segname);
         segname[16] = '\0';
         seg_vmaddrs_offset += 16;
-        uint64_t vmaddr = m_data_nsp->GetU64(&seg_vmaddrs_offset);
+        uint64_t vmaddr = m_data.GetU64(&seg_vmaddrs_offset);
         seg_vmaddrs_offset += 8; /* unused */
 
         std::tuple<ConstString, addr_t> new_seg{ConstString(segname), vmaddr};
@@ -6901,14 +6890,14 @@ ObjectFileMachO::GetCorefileAllImageInfos() {
   lc_notes = FindLC_NOTEByName("load binary");
   for (auto lc_note : lc_notes) {
     offset_t payload_offset = std::get<0>(lc_note);
-    uint32_t version = m_data_nsp->GetU32(&payload_offset);
+    uint32_t version = m_data.GetU32(&payload_offset);
     if (version == 1) {
       uuid_t uuid;
-      memcpy(&uuid, m_data_nsp->GetData(&payload_offset, sizeof(uuid_t)),
+      memcpy(&uuid, m_data.GetData(&payload_offset, sizeof(uuid_t)),
              sizeof(uuid_t));
-      uint64_t load_address = m_data_nsp->GetU64(&payload_offset);
-      uint64_t slide = m_data_nsp->GetU64(&payload_offset);
-      std::string filename = m_data_nsp->GetCStr(&payload_offset);
+      uint64_t load_address = m_data.GetU64(&payload_offset);
+      uint64_t slide = m_data.GetU64(&payload_offset);
+      std::string filename = m_data.GetCStr(&payload_offset);
 
       MachOCorefileImageEntry image_entry;
       image_entry.filename = filename;

--- a/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
+++ b/lldb/source/Plugins/ObjectFile/Mach-O/ObjectFileMachO.h
@@ -24,8 +24,7 @@
 // will export the ObjectFile protocol
 class ObjectFileMachO : public lldb_private::ObjectFile {
 public:
-  ObjectFileMachO(const lldb::ModuleSP &module_sp,
-                  lldb::DataExtractorSP extractor_sp,
+  ObjectFileMachO(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
                   lldb::offset_t data_offset,
                   const lldb_private::FileSpec *file, lldb::offset_t offset,
                   lldb::offset_t length);
@@ -48,10 +47,9 @@ public:
   }
 
   static lldb_private::ObjectFile *
-  CreateInstance(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const lldb_private::FileSpec *file, lldb::offset_t file_offset,
-                 lldb::offset_t length);
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static lldb_private::ObjectFile *CreateMemoryInstance(
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,

--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.cpp
@@ -35,7 +35,7 @@ void ObjectFileMinidump::Terminate() {
 }
 
 ObjectFile *ObjectFileMinidump::CreateInstance(
-    const lldb::ModuleSP &module_sp, lldb::DataExtractorSP extractor_sp,
+    const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
     lldb::offset_t data_offset, const lldb_private::FileSpec *file,
     lldb::offset_t offset, lldb::offset_t length) {
   return nullptr;

--- a/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.h
+++ b/lldb/source/Plugins/ObjectFile/Minidump/ObjectFileMinidump.h
@@ -39,10 +39,9 @@ public:
   llvm::StringRef GetPluginName() override { return GetPluginNameStatic(); }
 
   static lldb_private::ObjectFile *
-  CreateInstance(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const lldb_private::FileSpec *file, lldb::offset_t offset,
-                 lldb::offset_t length);
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t offset, lldb::offset_t length);
 
   static lldb_private::ObjectFile *CreateMemoryInstance(
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,

--- a/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
+++ b/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.cpp
@@ -91,14 +91,12 @@ bool ObjectFilePDB::initPDBFile() {
   return true;
 }
 
-ObjectFile *ObjectFilePDB::CreateInstance(const ModuleSP &module_sp,
-                                          DataExtractorSP extractor_sp,
-                                          offset_t data_offset,
-                                          const FileSpec *file,
-                                          offset_t file_offset,
-                                          offset_t length) {
+ObjectFile *
+ObjectFilePDB::CreateInstance(const ModuleSP &module_sp, DataBufferSP data_sp,
+                              offset_t data_offset, const FileSpec *file,
+                              offset_t file_offset, offset_t length) {
   auto objfile_up = std::make_unique<ObjectFilePDB>(
-      module_sp, extractor_sp, data_offset, file, file_offset, length);
+      module_sp, data_sp, data_offset, file, file_offset, length);
   if (!objfile_up->initPDBFile())
     return nullptr;
   return objfile_up.release();
@@ -160,11 +158,10 @@ size_t ObjectFilePDB::GetModuleSpecifications(
   return specs.GetSize() - initial_count;
 }
 
-ObjectFilePDB::ObjectFilePDB(const ModuleSP &module_sp,
-                             DataExtractorSP &extractor_sp,
+ObjectFilePDB::ObjectFilePDB(const ModuleSP &module_sp, DataBufferSP &data_sp,
                              offset_t data_offset, const FileSpec *file,
                              offset_t offset, offset_t length)
-    : ObjectFile(module_sp, file, offset, length, extractor_sp, data_offset) {}
+    : ObjectFile(module_sp, file, offset, length, data_sp, data_offset) {}
 
 std::unique_ptr<PDBFile>
 ObjectFilePDB::loadPDBFile(std::string PdbPath,

--- a/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.h
+++ b/lldb/source/Plugins/ObjectFile/PDB/ObjectFilePDB.h
@@ -30,12 +30,10 @@ public:
   static std::unique_ptr<llvm::pdb::PDBFile>
   loadPDBFile(std::string PdbPath, llvm::BumpPtrAllocator &Allocator);
 
-  static ObjectFile *CreateInstance(const lldb::ModuleSP &module_sp,
-                                    lldb::DataExtractorSP extractor_sp,
-                                    lldb::offset_t data_offset,
-                                    const FileSpec *file,
-                                    lldb::offset_t file_offset,
-                                    lldb::offset_t length);
+  static ObjectFile *
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static ObjectFile *CreateMemoryInstance(const lldb::ModuleSP &module_sp,
                                           lldb::WritableDataBufferSP data_sp,
@@ -91,10 +89,9 @@ public:
 
   llvm::pdb::PDBFile &GetPDBFile() { return *m_file_up; }
 
-  ObjectFilePDB(const lldb::ModuleSP &module_sp,
-                lldb::DataExtractorSP &extractor_sp, lldb::offset_t data_offset,
-                const FileSpec *file, lldb::offset_t offset,
-                lldb::offset_t length);
+  ObjectFilePDB(const lldb::ModuleSP &module_sp, lldb::DataBufferSP &data_sp,
+                lldb::offset_t data_offset, const FileSpec *file,
+                lldb::offset_t offset, lldb::offset_t length);
 
 private:
   UUID m_uuid;

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -396,7 +396,7 @@ bool ObjectFilePECOFF::CreateBinary() {
   Log *log = GetLog(LLDBLog::Object);
 
   auto binary = llvm::object::createBinary(llvm::MemoryBufferRef(
-      toStringRef(m_data_nsp->GetData()), m_file.GetFilename().GetStringRef()));
+      toStringRef(m_data.GetData()), m_file.GetFilename().GetStringRef()));
   if (!binary) {
     LLDB_LOG_ERROR(log, binary.takeError(),
                    "Failed to create binary for file ({1}): {0}", m_file);
@@ -442,20 +442,20 @@ bool ObjectFilePECOFF::ParseHeader() {
   if (module_sp) {
     std::lock_guard<std::recursive_mutex> guard(module_sp->GetMutex());
     m_sect_headers.clear();
-    m_data_nsp->SetByteOrder(eByteOrderLittle);
+    m_data.SetByteOrder(eByteOrderLittle);
     lldb::offset_t offset = 0;
 
-    if (ParseDOSHeader(*m_data_nsp.get(), m_dos_header)) {
+    if (ParseDOSHeader(m_data, m_dos_header)) {
       offset = m_dos_header.e_lfanew;
-      uint32_t pe_signature = m_data_nsp->GetU32(&offset);
+      uint32_t pe_signature = m_data.GetU32(&offset);
       if (pe_signature != IMAGE_NT_SIGNATURE)
         return false;
-      if (ParseCOFFHeader(*m_data_nsp.get(), &offset, m_coff_header)) {
+      if (ParseCOFFHeader(m_data, &offset, m_coff_header)) {
         if (m_coff_header.hdrsize > 0)
           ParseCOFFOptionalHeader(&offset);
         ParseSectionHeaders(offset);
       }
-      m_data_nsp->SetAddressByteSize(GetAddressByteSize());
+      m_data.SetAddressByteSize(GetAddressByteSize());
       return true;
     }
   }
@@ -602,63 +602,57 @@ bool ObjectFilePECOFF::ParseCOFFOptionalHeader(lldb::offset_t *offset_ptr) {
   const lldb::offset_t end_offset = *offset_ptr + m_coff_header.hdrsize;
   if (*offset_ptr < end_offset) {
     success = true;
-    m_coff_header_opt.magic = m_data_nsp->GetU16(offset_ptr);
-    m_coff_header_opt.major_linker_version = m_data_nsp->GetU8(offset_ptr);
-    m_coff_header_opt.minor_linker_version = m_data_nsp->GetU8(offset_ptr);
-    m_coff_header_opt.code_size = m_data_nsp->GetU32(offset_ptr);
-    m_coff_header_opt.data_size = m_data_nsp->GetU32(offset_ptr);
-    m_coff_header_opt.bss_size = m_data_nsp->GetU32(offset_ptr);
-    m_coff_header_opt.entry = m_data_nsp->GetU32(offset_ptr);
-    m_coff_header_opt.code_offset = m_data_nsp->GetU32(offset_ptr);
+    m_coff_header_opt.magic = m_data.GetU16(offset_ptr);
+    m_coff_header_opt.major_linker_version = m_data.GetU8(offset_ptr);
+    m_coff_header_opt.minor_linker_version = m_data.GetU8(offset_ptr);
+    m_coff_header_opt.code_size = m_data.GetU32(offset_ptr);
+    m_coff_header_opt.data_size = m_data.GetU32(offset_ptr);
+    m_coff_header_opt.bss_size = m_data.GetU32(offset_ptr);
+    m_coff_header_opt.entry = m_data.GetU32(offset_ptr);
+    m_coff_header_opt.code_offset = m_data.GetU32(offset_ptr);
 
     const uint32_t addr_byte_size = GetAddressByteSize();
 
     if (*offset_ptr < end_offset) {
       if (m_coff_header_opt.magic == OPT_HEADER_MAGIC_PE32) {
         // PE32 only
-        m_coff_header_opt.data_offset = m_data_nsp->GetU32(offset_ptr);
+        m_coff_header_opt.data_offset = m_data.GetU32(offset_ptr);
       } else
         m_coff_header_opt.data_offset = 0;
 
       if (*offset_ptr < end_offset) {
         m_coff_header_opt.image_base =
-            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.sect_alignment = m_data_nsp->GetU32(offset_ptr);
-        m_coff_header_opt.file_alignment = m_data_nsp->GetU32(offset_ptr);
-        m_coff_header_opt.major_os_system_version =
-            m_data_nsp->GetU16(offset_ptr);
-        m_coff_header_opt.minor_os_system_version =
-            m_data_nsp->GetU16(offset_ptr);
-        m_coff_header_opt.major_image_version = m_data_nsp->GetU16(offset_ptr);
-        m_coff_header_opt.minor_image_version = m_data_nsp->GetU16(offset_ptr);
-        m_coff_header_opt.major_subsystem_version =
-            m_data_nsp->GetU16(offset_ptr);
-        m_coff_header_opt.minor_subsystem_version =
-            m_data_nsp->GetU16(offset_ptr);
-        m_coff_header_opt.reserved1 = m_data_nsp->GetU32(offset_ptr);
-        m_coff_header_opt.image_size = m_data_nsp->GetU32(offset_ptr);
-        m_coff_header_opt.header_size = m_data_nsp->GetU32(offset_ptr);
-        m_coff_header_opt.checksum = m_data_nsp->GetU32(offset_ptr);
-        m_coff_header_opt.subsystem = m_data_nsp->GetU16(offset_ptr);
-        m_coff_header_opt.dll_flags = m_data_nsp->GetU16(offset_ptr);
+            m_data.GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.sect_alignment = m_data.GetU32(offset_ptr);
+        m_coff_header_opt.file_alignment = m_data.GetU32(offset_ptr);
+        m_coff_header_opt.major_os_system_version = m_data.GetU16(offset_ptr);
+        m_coff_header_opt.minor_os_system_version = m_data.GetU16(offset_ptr);
+        m_coff_header_opt.major_image_version = m_data.GetU16(offset_ptr);
+        m_coff_header_opt.minor_image_version = m_data.GetU16(offset_ptr);
+        m_coff_header_opt.major_subsystem_version = m_data.GetU16(offset_ptr);
+        m_coff_header_opt.minor_subsystem_version = m_data.GetU16(offset_ptr);
+        m_coff_header_opt.reserved1 = m_data.GetU32(offset_ptr);
+        m_coff_header_opt.image_size = m_data.GetU32(offset_ptr);
+        m_coff_header_opt.header_size = m_data.GetU32(offset_ptr);
+        m_coff_header_opt.checksum = m_data.GetU32(offset_ptr);
+        m_coff_header_opt.subsystem = m_data.GetU16(offset_ptr);
+        m_coff_header_opt.dll_flags = m_data.GetU16(offset_ptr);
         m_coff_header_opt.stack_reserve_size =
-            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data.GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.stack_commit_size =
-            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data.GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_reserve_size =
-            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
+            m_data.GetMaxU64(offset_ptr, addr_byte_size);
         m_coff_header_opt.heap_commit_size =
-            m_data_nsp->GetMaxU64(offset_ptr, addr_byte_size);
-        m_coff_header_opt.loader_flags = m_data_nsp->GetU32(offset_ptr);
-        uint32_t num_data_dir_entries = m_data_nsp->GetU32(offset_ptr);
+            m_data.GetMaxU64(offset_ptr, addr_byte_size);
+        m_coff_header_opt.loader_flags = m_data.GetU32(offset_ptr);
+        uint32_t num_data_dir_entries = m_data.GetU32(offset_ptr);
         m_coff_header_opt.data_dirs.clear();
         m_coff_header_opt.data_dirs.resize(num_data_dir_entries);
         uint32_t i;
         for (i = 0; i < num_data_dir_entries; i++) {
-          m_coff_header_opt.data_dirs[i].vmaddr =
-              m_data_nsp->GetU32(offset_ptr);
-          m_coff_header_opt.data_dirs[i].vmsize =
-              m_data_nsp->GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmaddr = m_data.GetU32(offset_ptr);
+          m_coff_header_opt.data_dirs[i].vmsize = m_data.GetU32(offset_ptr);
         }
 
         m_image_base = m_coff_header_opt.image_base;
@@ -690,8 +684,8 @@ DataExtractor ObjectFilePECOFF::ReadImageData(uint32_t offset, size_t size) {
   if (!size)
     return {};
 
-  if (m_data_nsp->ValidOffsetForDataOfSize(offset, size))
-    return DataExtractor(*m_data_nsp.get(), offset, size);
+  if (m_data.ValidOffsetForDataOfSize(offset, size))
+    return DataExtractor(m_data, offset, size);
 
   ProcessSP process_sp(m_process_wp.lock());
   DataExtractor data;
@@ -765,7 +759,7 @@ llvm::StringRef ObjectFilePECOFF::GetSectionName(const section_header_t &sect) {
       return "";
     lldb::offset_t string_file_offset =
         m_coff_header.symoff + (m_coff_header.nsyms * 18) + stroff;
-    if (const char *name = m_data_nsp->GetCStr(&string_file_offset))
+    if (const char *name = m_data.GetCStr(&string_file_offset))
       return name;
     return "";
   }

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.cpp
@@ -203,31 +203,29 @@ llvm::StringRef ObjectFilePECOFF::GetPluginDescriptionStatic() {
 }
 
 ObjectFile *ObjectFilePECOFF::CreateInstance(
-    const lldb::ModuleSP &module_sp, DataExtractorSP extractor_sp,
+    const lldb::ModuleSP &module_sp, DataBufferSP data_sp,
     lldb::offset_t data_offset, const lldb_private::FileSpec *file_p,
     lldb::offset_t file_offset, lldb::offset_t length) {
   FileSpec file = file_p ? *file_p : FileSpec();
-  if (!extractor_sp || !extractor_sp->HasData()) {
-    DataBufferSP data_sp = MapFileData(file, length, file_offset);
+  if (!data_sp) {
+    data_sp = MapFileData(file, length, file_offset);
     if (!data_sp)
       return nullptr;
     data_offset = 0;
-    extractor_sp = std::make_shared<DataExtractor>(data_sp);
   }
 
-  if (!ObjectFilePECOFF::MagicBytesMatch(extractor_sp->GetSharedDataBuffer()))
+  if (!ObjectFilePECOFF::MagicBytesMatch(data_sp))
     return nullptr;
 
   // Update the data to contain the entire file if it doesn't already
-  if (extractor_sp->GetByteSize() < length) {
-    DataBufferSP data_sp = MapFileData(file, length, file_offset);
+  if (data_sp->GetByteSize() < length) {
+    data_sp = MapFileData(file, length, file_offset);
     if (!data_sp)
       return nullptr;
-    extractor_sp = std::make_shared<DataExtractor>(data_sp);
   }
 
   auto objfile_up = std::make_unique<ObjectFilePECOFF>(
-      module_sp, extractor_sp, data_offset, file_p, file_offset, length);
+      module_sp, data_sp, data_offset, file_p, file_offset, length);
   if (!objfile_up || !objfile_up->ParseHeader())
     return nullptr;
 
@@ -418,13 +416,12 @@ bool ObjectFilePECOFF::CreateBinary() {
 }
 
 ObjectFilePECOFF::ObjectFilePECOFF(const lldb::ModuleSP &module_sp,
-                                   DataExtractorSP extractor_sp,
+                                   DataBufferSP data_sp,
                                    lldb::offset_t data_offset,
                                    const FileSpec *file,
                                    lldb::offset_t file_offset,
                                    lldb::offset_t length)
-    : ObjectFile(module_sp, file, file_offset, length, extractor_sp,
-                 data_offset),
+    : ObjectFile(module_sp, file, file_offset, length, data_sp, data_offset),
       m_dos_header(), m_coff_header(), m_coff_header_opt(), m_sect_headers(),
       m_image_base(LLDB_INVALID_ADDRESS), m_entry_point_address(),
       m_deps_filespec() {}
@@ -433,8 +430,7 @@ ObjectFilePECOFF::ObjectFilePECOFF(const lldb::ModuleSP &module_sp,
                                    WritableDataBufferSP header_data_sp,
                                    const lldb::ProcessSP &process_sp,
                                    addr_t header_addr)
-    : ObjectFile(module_sp, process_sp, header_addr,
-                 std::make_shared<DataExtractor>(header_data_sp)),
+    : ObjectFile(module_sp, process_sp, header_addr, header_data_sp),
       m_dos_header(), m_coff_header(), m_coff_header_opt(), m_sect_headers(),
       m_image_base(LLDB_INVALID_ADDRESS), m_entry_point_address(),
       m_deps_filespec() {}

--- a/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
+++ b/lldb/source/Plugins/ObjectFile/PECOFF/ObjectFilePECOFF.h
@@ -44,8 +44,7 @@ public:
     MachineWcemIpsv2 = 0x169
   };
 
-  ObjectFilePECOFF(const lldb::ModuleSP &module_sp,
-                   lldb::DataExtractorSP extractor_sp,
+  ObjectFilePECOFF(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
                    lldb::offset_t data_offset,
                    const lldb_private::FileSpec *file,
                    lldb::offset_t file_offset, lldb::offset_t length);
@@ -67,12 +66,10 @@ public:
 
   static llvm::StringRef GetPluginDescriptionStatic();
 
-  static ObjectFile *CreateInstance(const lldb::ModuleSP &module_sp,
-                                    lldb::DataExtractorSP extractor_sp,
-                                    lldb::offset_t data_offset,
-                                    const lldb_private::FileSpec *file,
-                                    lldb::offset_t offset,
-                                    lldb::offset_t length);
+  static ObjectFile *
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t offset, lldb::offset_t length);
 
   static lldb_private::ObjectFile *CreateMemoryInstance(
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -94,7 +94,7 @@ bool ObjectFileXCOFF::CreateBinary() {
 
   Log *log = GetLog(LLDBLog::Object);
 
-  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data_nsp->GetData()),
+  auto memory_ref = llvm::MemoryBufferRef(toStringRef(m_data.GetData()),
                                           m_file.GetFilename().GetStringRef());
   llvm::file_magic magic = llvm::identify_magic(memory_ref.getBuffer());
 

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -19,7 +19,6 @@
 #include "lldb/Target/Target.h"
 #include "lldb/Utility/ArchSpec.h"
 #include "lldb/Utility/DataBufferHeap.h"
-#include "lldb/Utility/DataExtractor.h"
 #include "lldb/Utility/FileSpecList.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
@@ -54,31 +53,28 @@ void ObjectFileXCOFF::Terminate() {
 }
 
 ObjectFile *ObjectFileXCOFF::CreateInstance(const lldb::ModuleSP &module_sp,
-                                            DataExtractorSP extractor_sp,
+                                            DataBufferSP data_sp,
                                             lldb::offset_t data_offset,
                                             const lldb_private::FileSpec *file,
                                             lldb::offset_t file_offset,
                                             lldb::offset_t length) {
-  if (!extractor_sp || !extractor_sp->HasData()) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+  if (!data_sp) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp)
       return nullptr;
     data_offset = 0;
-    extractor_sp = std::make_shared<lldb_private::DataExtractor>(data_sp);
   }
-  if (!ObjectFileXCOFF::MagicBytesMatch(extractor_sp->GetSharedDataBuffer(),
-                                        data_offset, length))
+  if (!ObjectFileXCOFF::MagicBytesMatch(data_sp, data_offset, length))
     return nullptr;
   // Update the data to contain the entire file if it doesn't already
-  if (extractor_sp->GetByteSize() < length) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+  if (data_sp->GetByteSize() < length) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp)
       return nullptr;
     data_offset = 0;
-    extractor_sp = std::make_shared<lldb_private::DataExtractor>(data_sp);
   }
   auto objfile_up = std::make_unique<ObjectFileXCOFF>(
-      module_sp, extractor_sp, data_offset, file, file_offset, length);
+      module_sp, data_sp, data_offset, file, file_offset, length);
   if (!objfile_up)
     return nullptr;
 
@@ -163,12 +159,12 @@ static uint32_t XCOFFHeaderSizeFromMagic(uint32_t magic) {
 bool ObjectFileXCOFF::MagicBytesMatch(DataBufferSP &data_sp,
                                       lldb::addr_t data_offset,
                                       lldb::addr_t data_length) {
-  lldb_private::DataExtractor extractor;
-  extractor.SetData(data_sp, data_offset, data_length);
+  lldb_private::DataExtractor data;
+  data.SetData(data_sp, data_offset, data_length);
   // Need to set this as XCOFF is only compatible with Big Endian
-  extractor.SetByteOrder(eByteOrderBig);
+  data.SetByteOrder(eByteOrderBig);
   lldb::offset_t offset = 0;
-  uint16_t magic = extractor.GetU16(&offset);
+  uint16_t magic = data.GetU16(&offset);
   return XCOFFHeaderSizeFromMagic(magic) != 0;
 }
 
@@ -398,13 +394,12 @@ ObjectFileXCOFF::MapFileDataWritable(const FileSpec &file, uint64_t Size,
 }
 
 ObjectFileXCOFF::ObjectFileXCOFF(const lldb::ModuleSP &module_sp,
-                                 DataExtractorSP extractor_sp,
+                                 DataBufferSP data_sp,
                                  lldb::offset_t data_offset,
                                  const FileSpec *file,
                                  lldb::offset_t file_offset,
                                  lldb::offset_t length)
-    : ObjectFile(module_sp, file, file_offset, length, extractor_sp,
-                 data_offset) {
+    : ObjectFile(module_sp, file, file_offset, length, data_sp, data_offset) {
   if (file)
     m_file = *file;
 }
@@ -413,6 +408,4 @@ ObjectFileXCOFF::ObjectFileXCOFF(const lldb::ModuleSP &module_sp,
                                  DataBufferSP header_data_sp,
                                  const lldb::ProcessSP &process_sp,
                                  addr_t header_addr)
-    : ObjectFile(
-          module_sp, process_sp, header_addr,
-          std::make_shared<lldb_private::DataExtractor>(header_data_sp)) {}
+    : ObjectFile(module_sp, process_sp, header_addr, header_data_sp) {}

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.h
@@ -38,10 +38,9 @@ public:
   }
 
   static lldb_private::ObjectFile *
-  CreateInstance(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const lldb_private::FileSpec *file, lldb::offset_t file_offset,
-                 lldb::offset_t length);
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const lldb_private::FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static lldb_private::ObjectFile *CreateMemoryInstance(
       const lldb::ModuleSP &module_sp, lldb::WritableDataBufferSP data_sp,
@@ -89,8 +88,7 @@ public:
 
   ObjectFile::Strata CalculateStrata() override;
 
-  ObjectFileXCOFF(const lldb::ModuleSP &module_sp,
-                  lldb::DataExtractorSP extractor_sp,
+  ObjectFileXCOFF(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
                   lldb::offset_t data_offset,
                   const lldb_private::FileSpec *file, lldb::offset_t offset,
                   lldb::offset_t length);

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -287,7 +287,7 @@ ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp, DataBufferSP data_sp,
                                offset_t offset, offset_t length)
     : ObjectFile(module_sp, file, offset, length, data_sp, data_offset),
       m_arch("wasm32-unknown-unknown-wasm") {
-  m_data_nsp->SetAddressByteSize(4);
+  m_data.SetAddressByteSize(4);
 }
 
 ObjectFileWasm::ObjectFileWasm(const lldb::ModuleSP &module_sp,
@@ -783,11 +783,11 @@ DataExtractor ObjectFileWasm::ReadImageData(offset_t offset, uint32_t size) {
         DataBufferSP buffer_sp(data_up.release());
         data.SetData(buffer_sp, 0, buffer_sp->GetByteSize());
       }
-    } else if (offset < m_data_nsp->GetByteSize()) {
-      size = std::min(static_cast<uint64_t>(size),
-                      m_data_nsp->GetByteSize() - offset);
-      return DataExtractor(m_data_nsp->GetDataStart() + offset, size,
-                           GetByteOrder(), GetAddressByteSize());
+    } else if (offset < m_data.GetByteSize()) {
+      size =
+          std::min(static_cast<uint64_t>(size), m_data.GetByteSize() - offset);
+      return DataExtractor(m_data.GetDataStart() + offset, size, GetByteOrder(),
+                           GetAddressByteSize());
     }
   }
   data.SetByteOrder(GetByteOrder());

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.cpp
@@ -139,27 +139,24 @@ void ObjectFileWasm::Terminate() {
   PluginManager::UnregisterPlugin(CreateInstance);
 }
 
-ObjectFile *ObjectFileWasm::CreateInstance(const ModuleSP &module_sp,
-                                           DataExtractorSP extractor_sp,
-                                           offset_t data_offset,
-                                           const FileSpec *file,
-                                           offset_t file_offset,
-                                           offset_t length) {
+ObjectFile *
+ObjectFileWasm::CreateInstance(const ModuleSP &module_sp, DataBufferSP data_sp,
+                               offset_t data_offset, const FileSpec *file,
+                               offset_t file_offset, offset_t length) {
   Log *log = GetLog(LLDBLog::Object);
 
-  if (!extractor_sp || !extractor_sp->HasData()) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+  if (!data_sp) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp) {
       LLDB_LOGF(log, "Failed to create ObjectFileWasm instance for file %s",
                 file->GetPath().c_str());
       return nullptr;
     }
-    extractor_sp = std::make_shared<DataExtractor>(data_sp);
     data_offset = 0;
   }
 
-  assert(extractor_sp);
-  if (!ValidateModuleHeader(extractor_sp->GetSharedDataBuffer())) {
+  assert(data_sp);
+  if (!ValidateModuleHeader(data_sp)) {
     LLDB_LOGF(log,
               "Failed to create ObjectFileWasm instance: invalid Wasm header");
     return nullptr;
@@ -167,20 +164,19 @@ ObjectFile *ObjectFileWasm::CreateInstance(const ModuleSP &module_sp,
 
   // Update the data to contain the entire file if it doesn't contain it
   // already.
-  if (extractor_sp->GetByteSize() < length) {
-    DataBufferSP data_sp = MapFileData(*file, length, file_offset);
+  if (data_sp->GetByteSize() < length) {
+    data_sp = MapFileData(*file, length, file_offset);
     if (!data_sp) {
       LLDB_LOGF(log,
                 "Failed to create ObjectFileWasm instance: cannot read file %s",
                 file->GetPath().c_str());
       return nullptr;
     }
-    extractor_sp = std::make_shared<DataExtractor>(data_sp);
     data_offset = 0;
   }
 
   std::unique_ptr<ObjectFileWasm> objfile_up(new ObjectFileWasm(
-      module_sp, extractor_sp, data_offset, file, file_offset, length));
+      module_sp, data_sp, data_offset, file, file_offset, length));
   ArchSpec spec = objfile_up->GetArchitecture();
   if (spec && objfile_up->SetModulesArchitecture(spec)) {
     LLDB_LOGF(log,
@@ -286,11 +282,10 @@ size_t ObjectFileWasm::GetModuleSpecifications(
   return 1;
 }
 
-ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp,
-                               DataExtractorSP extractor_sp,
+ObjectFileWasm::ObjectFileWasm(const ModuleSP &module_sp, DataBufferSP data_sp,
                                offset_t data_offset, const FileSpec *file,
                                offset_t offset, offset_t length)
-    : ObjectFile(module_sp, file, offset, length, extractor_sp, data_offset),
+    : ObjectFile(module_sp, file, offset, length, data_sp, data_offset),
       m_arch("wasm32-unknown-unknown-wasm") {
   m_data_nsp->SetAddressByteSize(4);
 }
@@ -299,8 +294,7 @@ ObjectFileWasm::ObjectFileWasm(const lldb::ModuleSP &module_sp,
                                lldb::WritableDataBufferSP header_data_sp,
                                const lldb::ProcessSP &process_sp,
                                lldb::addr_t header_addr)
-    : ObjectFile(module_sp, process_sp, header_addr,
-                 std::make_shared<DataExtractor>(header_data_sp)),
+    : ObjectFile(module_sp, process_sp, header_addr, header_data_sp),
       m_arch("wasm32-unknown-unknown-wasm") {}
 
 bool ObjectFileWasm::ParseHeader() {
@@ -787,7 +781,7 @@ DataExtractor ObjectFileWasm::ReadImageData(offset_t offset, uint32_t size) {
           offset, data_up->GetBytes(), data_up->GetByteSize(), readmem_error);
       if (bytes_read > 0) {
         DataBufferSP buffer_sp(data_up.release());
-        data.SetData(buffer_sp);
+        data.SetData(buffer_sp, 0, buffer_sp->GetByteSize());
       }
     } else if (offset < m_data_nsp->GetByteSize()) {
       size = std::min(static_cast<uint64_t>(size),

--- a/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.h
+++ b/lldb/source/Plugins/ObjectFile/wasm/ObjectFileWasm.h
@@ -30,12 +30,10 @@ public:
     return "WebAssembly object file reader.";
   }
 
-  static ObjectFile *CreateInstance(const lldb::ModuleSP &module_sp,
-                                    lldb::DataExtractorSP extractor_sp,
-                                    lldb::offset_t data_offset,
-                                    const FileSpec *file,
-                                    lldb::offset_t file_offset,
-                                    lldb::offset_t length);
+  static ObjectFile *
+  CreateInstance(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const FileSpec *file,
+                 lldb::offset_t file_offset, lldb::offset_t length);
 
   static ObjectFile *CreateMemoryInstance(const lldb::ModuleSP &module_sp,
                                           lldb::WritableDataBufferSP data_sp,
@@ -114,10 +112,9 @@ public:
   std::optional<FileSpec> GetExternalDebugInfoFileSpec();
 
 private:
-  ObjectFileWasm(const lldb::ModuleSP &module_sp,
-                 lldb::DataExtractorSP extractor_sp, lldb::offset_t data_offset,
-                 const FileSpec *file, lldb::offset_t offset,
-                 lldb::offset_t length);
+  ObjectFileWasm(const lldb::ModuleSP &module_sp, lldb::DataBufferSP data_sp,
+                 lldb::offset_t data_offset, const FileSpec *file,
+                 lldb::offset_t offset, lldb::offset_t length);
   ObjectFileWasm(const lldb::ModuleSP &module_sp,
                  lldb::WritableDataBufferSP header_data_sp,
                  const lldb::ProcessSP &process_sp, lldb::addr_t header_addr);

--- a/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/GDBRemoteRegisterContext.cpp
@@ -162,8 +162,7 @@ bool GDBRemoteRegisterContext::PrivateSetRegisterValue(uint32_t reg,
   InvalidateIfNeeded(false);
 
   DataBufferSP buffer_sp(new DataBufferHeap(&new_reg_val, sizeof(new_reg_val)));
-  DataExtractor extractor;
-  extractor.SetData(buffer_sp, 0, buffer_sp->GetByteSize());
+  DataExtractor data(buffer_sp, endian::InlHostByteOrder(), sizeof(void *));
 
   // If our register context and our register info disagree, which should never
   // happen, don't overwrite past the end of the buffer.
@@ -177,12 +176,11 @@ bool GDBRemoteRegisterContext::PrivateSetRegisterValue(uint32_t reg,
   if (dst == nullptr)
     return false;
 
-  if (extractor.CopyByteOrderedData(
-          0,                          // src offset
-          reg_info->byte_size,        // src length
-          dst,                        // dst
-          reg_info->byte_size,        // dst length
-          m_reg_data.GetByteOrder())) // dst byte order
+  if (data.CopyByteOrderedData(0,                          // src offset
+                               reg_info->byte_size,        // src length
+                               dst,                        // dst
+                               reg_info->byte_size,        // dst length
+                               m_reg_data.GetByteOrder())) // dst byte order
   {
     SetRegisterIsValid(reg, true);
     return true;

--- a/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
+++ b/lldb/source/Plugins/Process/scripted/ScriptedProcess.cpp
@@ -231,7 +231,7 @@ size_t ScriptedProcess::DoReadMemory(lldb::addr_t addr, void *buf, size_t size,
   lldb::DataExtractorSP data_extractor_sp =
       GetInterface().ReadMemoryAtAddress(addr, size, error);
 
-  if (!data_extractor_sp || !data_extractor_sp->HasData() || error.Fail())
+  if (!data_extractor_sp || !data_extractor_sp->GetByteSize() || error.Fail())
     return 0;
 
   offset_t bytes_copied = data_extractor_sp->CopyByteOrderedData(
@@ -252,7 +252,7 @@ size_t ScriptedProcess::DoWriteMemory(lldb::addr_t vm_addr, const void *buf,
   lldb::DataExtractorSP data_extractor_sp = std::make_shared<DataExtractor>(
       buf, size, GetByteOrder(), GetAddressByteSize());
 
-  if (!data_extractor_sp || !data_extractor_sp->HasData())
+  if (!data_extractor_sp || !data_extractor_sp->GetByteSize())
     return 0;
 
   lldb::offset_t bytes_written =

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -1953,11 +1953,11 @@ SymbolFileDWARF::GetDwoSymbolFileForCompileUnit(
   }
 
   const lldb::offset_t file_offset = 0;
-  DataExtractorSP dwo_file_extractor_sp;
+  DataBufferSP dwo_file_data_sp;
   lldb::offset_t dwo_file_data_offset = 0;
   ObjectFileSP dwo_obj_file = ObjectFile::FindPlugin(
       GetObjectFile()->GetModule(), &dwo_file, file_offset,
-      FileSystem::Instance().GetByteSize(dwo_file), dwo_file_extractor_sp,
+      FileSystem::Instance().GetByteSize(dwo_file), dwo_file_data_sp,
       dwo_file_data_offset);
   if (dwo_obj_file == nullptr) {
     unit.SetDwoError(Status::FromErrorStringWithFormatv(
@@ -4598,12 +4598,12 @@ const std::shared_ptr<SymbolFileDWARFDwo> &SymbolFileDWARF::GetDwpSymbolFile() {
     }
     if (FileSystem::Instance().Exists(dwp_filespec)) {
       LLDB_LOG(log, "Found DWP file: \"{0}\"", dwp_filespec);
-      DataExtractorSP dwp_file_extractor_sp;
+      DataBufferSP dwp_file_data_sp;
       lldb::offset_t dwp_file_data_offset = 0;
       ObjectFileSP dwp_obj_file = ObjectFile::FindPlugin(
           GetObjectFile()->GetModule(), &dwp_filespec, 0,
-          FileSystem::Instance().GetByteSize(dwp_filespec),
-          dwp_file_extractor_sp, dwp_file_data_offset);
+          FileSystem::Instance().GetByteSize(dwp_filespec), dwp_file_data_sp,
+          dwp_file_data_offset);
       if (dwp_obj_file) {
         m_dwp_symfile = std::make_shared<SymbolFileDWARFDwo>(
             *this, dwp_obj_file, DIERef::k_file_index_mask);

--- a/lldb/source/Plugins/SymbolVendor/ELF/SymbolVendorELF.cpp
+++ b/lldb/source/Plugins/SymbolVendor/ELF/SymbolVendorELF.cpp
@@ -47,12 +47,12 @@ llvm::StringRef SymbolVendorELF::GetPluginDescriptionStatic() {
 // If this is needed elsewhere, it can be exported/moved.
 static bool IsDwpSymbolFile(const lldb::ModuleSP &module_sp,
                             const FileSpec &file_spec) {
-  DataExtractorSP dwp_file_extractor_sp;
+  DataBufferSP dwp_file_data_sp;
   lldb::offset_t dwp_file_data_offset = 0;
   // Try to create an ObjectFile from the file_spec.
   ObjectFileSP dwp_obj_file = ObjectFile::FindPlugin(
       module_sp, &file_spec, 0, FileSystem::Instance().GetByteSize(file_spec),
-      dwp_file_extractor_sp, dwp_file_data_offset);
+      dwp_file_data_sp, dwp_file_data_offset);
   // The presence of a debug_cu_index section is the key identifying feature of
   // a DWP file. Make sure we don't fill in the section list on dwp_obj_file
   // (by calling GetSectionList(false)) as this function could be called before
@@ -120,11 +120,11 @@ SymbolVendorELF::CreateInstance(const lldb::ModuleSP &module_sp,
     dsym_fspec = unstripped_spec.GetFileSpec();
   }
 
-  DataExtractorSP dsym_file_extractor_sp;
+  DataBufferSP dsym_file_data_sp;
   lldb::offset_t dsym_file_data_offset = 0;
   ObjectFileSP dsym_objfile_sp = ObjectFile::FindPlugin(
       module_sp, &dsym_fspec, 0, FileSystem::Instance().GetByteSize(dsym_fspec),
-      dsym_file_extractor_sp, dsym_file_data_offset);
+      dsym_file_data_sp, dsym_file_data_offset);
   if (!dsym_objfile_sp)
     return nullptr;
   // This objfile is for debugging purposes. Sadly, ObjectFileELF won't

--- a/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
+++ b/lldb/source/Plugins/SymbolVendor/MacOSX/SymbolVendorMacOSX.cpp
@@ -148,12 +148,12 @@ SymbolVendorMacOSX::CreateInstance(const lldb::ModuleSP &module_sp,
       const size_t pos = dsym_root.find("/Contents/Resources/");
       dsym_root = pos != std::string::npos ? dsym_root.substr(0, pos) : "";
 
-      DataExtractorSP dsym_file_extractor_sp;
+      DataBufferSP dsym_file_data_sp;
       lldb::offset_t dsym_file_data_offset = 0;
       dsym_objfile_sp =
           ObjectFile::FindPlugin(module_sp, &dsym_fspec, 0,
                                  FileSystem::Instance().GetByteSize(dsym_fspec),
-                                 dsym_file_extractor_sp, dsym_file_data_offset);
+                                 dsym_file_data_sp, dsym_file_data_offset);
       // Important to save the dSYM FileSpec so we don't call
       // PluginManager::LocateExecutableSymbolFile a second time while trying to
       // add the symbol ObjectFile to this Module.

--- a/lldb/source/Plugins/SymbolVendor/PECOFF/SymbolVendorPECOFF.cpp
+++ b/lldb/source/Plugins/SymbolVendor/PECOFF/SymbolVendorPECOFF.cpp
@@ -90,11 +90,11 @@ SymbolVendorPECOFF::CreateInstance(const lldb::ModuleSP &module_sp,
   if (!dsym_fspec)
     return nullptr;
 
-  DataExtractorSP dsym_file_extractor_sp;
+  DataBufferSP dsym_file_data_sp;
   lldb::offset_t dsym_file_data_offset = 0;
   ObjectFileSP dsym_objfile_sp = ObjectFile::FindPlugin(
       module_sp, &dsym_fspec, 0, FileSystem::Instance().GetByteSize(dsym_fspec),
-      dsym_file_extractor_sp, dsym_file_data_offset);
+      dsym_file_data_sp, dsym_file_data_offset);
   if (!dsym_objfile_sp)
     return nullptr;
 

--- a/lldb/source/Plugins/SymbolVendor/wasm/SymbolVendorWasm.cpp
+++ b/lldb/source/Plugins/SymbolVendor/wasm/SymbolVendorWasm.cpp
@@ -90,11 +90,11 @@ SymbolVendorWasm::CreateInstance(const lldb::ModuleSP &module_sp,
   if (!sym_fspec)
     return nullptr;
 
-  DataExtractorSP sym_file_extractor_sp;
+  DataBufferSP sym_file_data_sp;
   lldb::offset_t sym_file_data_offset = 0;
   ObjectFileSP sym_objfile_sp = ObjectFile::FindPlugin(
       module_sp, &sym_fspec, 0, FileSystem::Instance().GetByteSize(sym_fspec),
-      sym_file_extractor_sp, sym_file_data_offset);
+      sym_file_data_sp, sym_file_data_offset);
   if (!sym_objfile_sp)
     return nullptr;
 

--- a/lldb/source/Symbol/ObjectContainer.cpp
+++ b/lldb/source/Symbol/ObjectContainer.cpp
@@ -23,13 +23,11 @@ ObjectContainer::ObjectContainer(const lldb::ModuleSP &module_sp,
                                  lldb::offset_t data_offset)
     : ModuleChild(module_sp),
       m_file(), // This file can be different than the module's file spec
-      m_offset(file_offset), m_length(length),
-      m_extractor_sp(std::make_shared<DataExtractor>()) {
+      m_offset(file_offset), m_length(length) {
   if (file)
     m_file = *file;
-  if (data_sp) {
-    m_extractor_sp->SetData(data_sp, data_offset, length);
-  }
+  if (data_sp)
+    m_data.SetData(data_sp, data_offset, length);
 }
 
 ObjectContainerSP ObjectContainer::FindPlugin(const lldb::ModuleSP &module_sp,

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -49,12 +49,10 @@ CreateObjectFromContainer(const lldb::ModuleSP &module_sp, const FileSpec *file,
   return {};
 }
 
-ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
-                                    const FileSpec *file,
-                                    lldb::offset_t file_offset,
-                                    lldb::offset_t file_size,
-                                    DataExtractorSP extractor_sp,
-                                    lldb::offset_t &data_offset) {
+ObjectFileSP
+ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp, const FileSpec *file,
+                       lldb::offset_t file_offset, lldb::offset_t file_size,
+                       DataBufferSP &data_sp, lldb::offset_t &data_offset) {
   LLDB_SCOPED_TIMERF(
       "ObjectFile::FindPlugin (module = %s, file = %p, file_offset = "
       "0x%8.8" PRIx64 ", file_size = 0x%8.8" PRIx64 ")",
@@ -68,14 +66,14 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
   if (!file)
     return {};
 
-  if (!extractor_sp || !extractor_sp->HasData()) {
+  if (!data_sp) {
     const bool file_exists = FileSystem::Instance().Exists(*file);
     // We have an object name which most likely means we have a .o file in
     // a static archive (.a file). Try and see if we have a cached archive
     // first without reading any data first
     if (file_exists && module_sp->GetObjectName()) {
       ObjectFileSP object_file_sp = CreateObjectFromContainer(
-          module_sp, file, file_offset, file_size, DataBufferSP(), data_offset);
+          module_sp, file, file_offset, file_size, data_sp, data_offset);
       if (object_file_sp)
         return object_file_sp;
     }
@@ -84,18 +82,13 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
     // container plug-ins can use these bytes to see if they can parse this
     // file.
     if (file_size > 0) {
-      // Check that we made a data buffer. For instance, a directory node is
-      // not 0 size, but we can't make a data buffer for it.
-      if (DataBufferSP buffer_sp = FileSystem::Instance().CreateDataBuffer(
-              file->GetPath(), g_initial_bytes_to_read, file_offset)) {
-        extractor_sp = std::make_shared<DataExtractor>();
-        extractor_sp->SetData(buffer_sp, data_offset, buffer_sp->GetByteSize());
-        data_offset = 0;
-      }
+      data_sp = FileSystem::Instance().CreateDataBuffer(
+          file->GetPath(), g_initial_bytes_to_read, file_offset);
+      data_offset = 0;
     }
   }
 
-  if (!extractor_sp || !extractor_sp->HasData()) {
+  if (!data_sp || data_sp->GetByteSize() == 0) {
     // Check for archive file with format "/path/to/archive.a(object.o)"
     llvm::SmallString<256> path_with_object;
     module_sp->GetFileSpec().GetPath(path_with_object);
@@ -117,20 +110,18 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
         // (like BSD archives caching the contained objects within an
         // file).
         ObjectFileSP object_file_sp = CreateObjectFromContainer(
-            module_sp, file, file_offset, file_size,
-            extractor_sp->GetSharedDataBuffer(), data_offset);
+            module_sp, file, file_offset, file_size, data_sp, data_offset);
         if (object_file_sp)
           return object_file_sp;
         // We failed to find any cached object files in the container plug-
         // ins, so lets read the first 512 bytes and try again below...
-        DataBufferSP buffer_sp = FileSystem::Instance().CreateDataBuffer(
+        data_sp = FileSystem::Instance().CreateDataBuffer(
             archive_file.GetPath(), g_initial_bytes_to_read, file_offset);
-        extractor_sp = std::make_shared<DataExtractor>(buffer_sp);
       }
     }
   }
 
-  if (extractor_sp && extractor_sp->HasData()) {
+  if (data_sp && data_sp->GetByteSize() > 0) {
     // Check if this is a normal object file by iterating through all
     // object file plugin instances.
     ObjectFileCreateInstance callback;
@@ -138,7 +129,7 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
          (callback = PluginManager::GetObjectFileCreateCallbackAtIndex(idx)) !=
          nullptr;
          ++idx) {
-      ObjectFileSP object_file_sp(callback(module_sp, extractor_sp, data_offset,
+      ObjectFileSP object_file_sp(callback(module_sp, data_sp, data_offset,
                                            file, file_offset, file_size));
       if (object_file_sp.get())
         return object_file_sp;
@@ -147,9 +138,8 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
     // Check if this is a object container by iterating through all object
     // container plugin instances and then trying to get an object file
     // from the container.
-    DataBufferSP buffer_sp = extractor_sp->GetSharedDataBuffer();
     ObjectFileSP object_file_sp = CreateObjectFromContainer(
-        module_sp, file, file_offset, file_size, buffer_sp, data_offset);
+        module_sp, file, file_offset, file_size, data_sp, data_offset);
     if (object_file_sp)
       return object_file_sp;
   }
@@ -195,12 +185,12 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
 }
 
 bool ObjectFile::IsObjectFile(lldb_private::FileSpec file_spec) {
-  DataExtractorSP extractor_sp;
+  DataBufferSP data_sp;
   offset_t data_offset = 0;
   ModuleSP module_sp = std::make_shared<Module>(file_spec);
   return static_cast<bool>(ObjectFile::FindPlugin(
       module_sp, &file_spec, 0, FileSystem::Instance().GetByteSize(file_spec),
-      extractor_sp, data_offset));
+      data_sp, data_offset));
 }
 
 size_t ObjectFile::GetModuleSpecifications(const FileSpec &file,
@@ -260,8 +250,7 @@ size_t ObjectFile::GetModuleSpecifications(
 ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
                        const FileSpec *file_spec_ptr,
                        lldb::offset_t file_offset, lldb::offset_t length,
-                       lldb::DataExtractorSP extractor_sp,
-                       lldb::offset_t data_offset)
+                       lldb::DataBufferSP data_sp, lldb::offset_t data_offset)
     : ModuleChild(module_sp),
       m_file(), // This file could be different from the original module's file
       m_type(eTypeInvalid), m_strata(eStrataInvalid),
@@ -271,13 +260,8 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
       m_symtab_once_up(new llvm::once_flag()) {
   if (file_spec_ptr)
     m_file = *file_spec_ptr;
-  if (extractor_sp && extractor_sp->HasData()) {
-    m_data_nsp = extractor_sp;
-    // The offset & length fields may be specifying a subset of the
-    // total data buffer.
-    m_data_nsp->SetData(extractor_sp->GetSharedDataBuffer(), data_offset,
-                        length);
-  }
+  if (data_sp)
+    m_data_nsp->SetData(data_sp, data_offset, length);
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), file = %s, "
@@ -290,14 +274,14 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
 
 ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
                        const ProcessSP &process_sp, lldb::addr_t header_addr,
-                       DataExtractorSP header_extractor_sp)
+                       DataBufferSP header_data_sp)
     : ModuleChild(module_sp), m_file(), m_type(eTypeInvalid),
       m_strata(eStrataInvalid), m_file_offset(0), m_length(0),
       m_data_nsp(std::make_shared<DataExtractor>()), m_process_wp(process_sp),
       m_memory_addr(header_addr), m_sections_up(), m_symtab_up(),
       m_symtab_once_up(new llvm::once_flag()) {
-  if (header_extractor_sp && header_extractor_sp->HasData())
-    m_data_nsp = header_extractor_sp;
+  if (header_data_sp)
+    m_data_nsp->SetData(header_data_sp, 0, header_data_sp->GetByteSize());
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), process = %p, "

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -254,14 +254,13 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
     : ModuleChild(module_sp),
       m_file(), // This file could be different from the original module's file
       m_type(eTypeInvalid), m_strata(eStrataInvalid),
-      m_file_offset(file_offset), m_length(length),
-      m_data_nsp(std::make_shared<DataExtractor>()), m_process_wp(),
+      m_file_offset(file_offset), m_length(length), m_data(), m_process_wp(),
       m_memory_addr(LLDB_INVALID_ADDRESS), m_sections_up(), m_symtab_up(),
       m_symtab_once_up(new llvm::once_flag()) {
   if (file_spec_ptr)
     m_file = *file_spec_ptr;
   if (data_sp)
-    m_data_nsp->SetData(data_sp, data_offset, length);
+    m_data.SetData(data_sp, data_offset, length);
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), file = %s, "
@@ -276,12 +275,11 @@ ObjectFile::ObjectFile(const lldb::ModuleSP &module_sp,
                        const ProcessSP &process_sp, lldb::addr_t header_addr,
                        DataBufferSP header_data_sp)
     : ModuleChild(module_sp), m_file(), m_type(eTypeInvalid),
-      m_strata(eStrataInvalid), m_file_offset(0), m_length(0),
-      m_data_nsp(std::make_shared<DataExtractor>()), m_process_wp(process_sp),
-      m_memory_addr(header_addr), m_sections_up(), m_symtab_up(),
-      m_symtab_once_up(new llvm::once_flag()) {
+      m_strata(eStrataInvalid), m_file_offset(0), m_length(0), m_data(),
+      m_process_wp(process_sp), m_memory_addr(header_addr), m_sections_up(),
+      m_symtab_up(), m_symtab_once_up(new llvm::once_flag()) {
   if (header_data_sp)
-    m_data_nsp->SetData(header_data_sp, 0, header_data_sp->GetByteSize());
+    m_data.SetData(header_data_sp, 0, header_data_sp->GetByteSize());
   Log *log = GetLog(LLDBLog::Object);
   LLDB_LOGF(log,
             "%p ObjectFile::ObjectFile() module = %p (%s), process = %p, "
@@ -478,16 +476,16 @@ WritableDataBufferSP ObjectFile::ReadMemory(const ProcessSP &process_sp,
 
 size_t ObjectFile::GetData(lldb::offset_t offset, size_t length,
                            DataExtractor &data) const {
-  // The entire file has already been mmap'ed into m_data_nsp, so just copy from
+  // The entire file has already been mmap'ed into m_data, so just copy from
   // there as the back mmap buffer will be shared with shared pointers.
-  return data.SetData(*m_data_nsp.get(), offset, length);
+  return data.SetData(m_data, offset, length);
 }
 
 size_t ObjectFile::CopyData(lldb::offset_t offset, size_t length,
                             void *dst) const {
-  // The entire file has already been mmap'ed into m_data_nsp, so just copy from
+  // The entire file has already been mmap'ed into m_data, so just copy from
   // there Note that the data remains in target byte order.
-  return m_data_nsp->CopyData(offset, length, dst);
+  return m_data.CopyData(offset, length, dst);
 }
 
 size_t ObjectFile::ReadSectionData(Section *section,

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -576,7 +576,7 @@ const char *
 ObjectFile::GetCStrFromSection(Section *section,
                                lldb::offset_t section_offset) const {
   offset_t offset = section->GetOffset() + section_offset;
-  return m_data_nsp->GetCStr(&offset);
+  return m_data.GetCStr(&offset);
 }
 
 bool ObjectFile::SplitArchivePathWithObject(llvm::StringRef path_with_object,

--- a/lldb/source/Symbol/SymbolVendor.cpp
+++ b/lldb/source/Symbol/SymbolVendor.cpp
@@ -45,11 +45,11 @@ SymbolVendor *SymbolVendor::FindPlugin(const lldb::ModuleSP &module_sp,
   ObjectFileSP sym_objfile_sp;
   FileSpec sym_spec = module_sp->GetSymbolFileFileSpec();
   if (sym_spec && sym_spec != module_sp->GetObjectFile()->GetFileSpec()) {
-    DataExtractorSP extractor_sp;
+    DataBufferSP data_sp;
     offset_t data_offset = 0;
     sym_objfile_sp = ObjectFile::FindPlugin(
         module_sp, &sym_spec, 0, FileSystem::Instance().GetByteSize(sym_spec),
-        extractor_sp, data_offset);
+        data_sp, data_offset);
   }
   if (!sym_objfile_sp)
     sym_objfile_sp = module_sp->GetObjectFile()->shared_from_this();

--- a/lldb/source/Utility/DataExtractor.cpp
+++ b/lldb/source/Utility/DataExtractor.cpp
@@ -149,15 +149,6 @@ DataExtractor::DataExtractor(const DataBufferSP &data_sp, ByteOrder endian,
   SetData(data_sp);
 }
 
-// Make a shared pointer reference to the shared data in "data_sp".
-DataExtractor::DataExtractor(const DataBufferSP &data_sp,
-                             uint32_t target_byte_size)
-    : m_byte_order(endian::InlHostByteOrder()), m_addr_size(sizeof(void *)),
-      m_data_sp(data_sp), m_target_byte_size(target_byte_size) {
-  if (data_sp)
-    SetData(data_sp);
-}
-
 // Initialize this object with a subset of the data bytes in "data". If "data"
 // contains shared data, then a reference to this shared data will added and
 // the shared data will stay around as long as any object contains a reference


### PR DESCRIPTION
The changes to the ObjectFile interfaces were found to have caused some regressions. Out of an abundance of caution we have decided to pull it out of the 6.3 release while addressing the fallout on main.

rdar://168955398