### PR TITLE
[lldb][API] Make SB-API functions const if possible. (#172687)

### DIFF
--- a/lldb/include/lldb/API/SBThread.h
+++ b/lldb/include/lldb/API/SBThread.h
@@ -182,7 +182,7 @@ public:
 
   lldb::SBFrame GetFrameAtIndex(uint32_t idx);
 
-  lldb::SBFrameList GetFrames();
+  lldb::SBFrameList GetFrames() const;
 
   lldb::SBFrame GetSelectedFrame();
 

--- a/lldb/source/API/SBThread.cpp
+++ b/lldb/source/API/SBThread.cpp
@@ -1120,7 +1120,7 @@ SBFrame SBThread::GetFrameAtIndex(uint32_t idx) {
   return sb_frame;
 }
 
-lldb::SBFrameList SBThread::GetFrames() {
+lldb::SBFrameList SBThread::GetFrames() const {
   LLDB_INSTRUMENT_VA(this);
 
   SBFrameList sb_frame_list;


### PR DESCRIPTION
Only applied to functions that were added after 22.x tag.

(cherry picked from commit 556eb902ce50fcbc4c41b42358af97cfef160f57)
