### PR TITLE
Add LLVM_ABI annotations for the Swift toolchain

### DIFF
--- a/llvm/include/llvm/ADT/Hashing.h
+++ b/llvm/include/llvm/ADT/Hashing.h
@@ -329,7 +329,7 @@ struct hash_state {
 /// This variable can be set using the \see llvm::set_fixed_execution_seed
 /// function. See that function for details. Do not, under any circumstances,
 /// set or read this variable.
-extern uint64_t fixed_seed_override;
+LLVM_ABI extern uint64_t fixed_seed_override;
 
 inline uint64_t get_execution_seed() {
   // FIXME: This needs to be a per-execution seed. This is just a placeholder

--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -27,15 +27,15 @@ class ObjectProxy;
 /// for CAS types.
 class CacheKey {
 public:
-  StringRef getKey() const { return Key; }
+  LLVM_ABI StringRef getKey() const { return Key; }
 
   // TODO: Support CacheKey other than a CASID but rather any array of bytes.
   // To do that, ActionCache need to be able to rehash the key into the index,
   // which then `getOrCompute` method can be used to avoid multiple calls to
   // has function.
   LLVM_ABI CacheKey(const CASID &ID);
-  LLVM_ABI_FOR_TEST CacheKey(const ObjectProxy &Proxy);
-  CacheKey(const ObjectStore &CAS, const ObjectRef &Ref);
+  LLVM_ABI CacheKey(const ObjectProxy &Proxy);
+  LLVM_ABI CacheKey(const ObjectStore &CAS, const ObjectRef &Ref);
 
 private:
   std::string Key;
@@ -146,7 +146,7 @@ LLVM_ABI std::unique_ptr<ActionCache> createInMemoryActionCache();
 
 /// Get a reasonable default on-disk path for a persistent ActionCache for the
 /// current user.
-std::string getDefaultOnDiskActionCachePath();
+LLVM_ABI std::string getDefaultOnDiskActionCachePath();
 
 /// Create an action cache on disk.
 LLVM_ABI Expected<std::unique_ptr<ActionCache>>

--- a/llvm/include/llvm/CAS/CASConfiguration.h
+++ b/llvm/include/llvm/CAS/CASConfiguration.h
@@ -55,6 +55,7 @@ public:
   void getResolvedCASPath(llvm::SmallVectorImpl<char> &Result) const;
 
   // Create CASDatabase from the CASConfiguration.
+  LLVM_ABI
   llvm::Expected<std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
                            std::shared_ptr<llvm::cas::ActionCache>>>
   createDatabases() const;
@@ -70,6 +71,7 @@ public:
   ///
   /// Returns the path to configuration file and its corresponding
   /// CASConfiguration.
+  LLVM_ABI
   static std::optional<std::pair<std::string, CASConfiguration>>
   createFromSearchConfigFile(
       StringRef Path,

--- a/llvm/include/llvm/CAS/CASFileSystem.h
+++ b/llvm/include/llvm/CAS/CASFileSystem.h
@@ -20,7 +20,7 @@ class CASID;
 /// Abstract class represents an open file backed by a CAS.
 class CASBackedFile : public RTTIExtends<CASBackedFile, vfs::File> {
 public:
-  static const char ID;
+  LLVM_ABI static const char ID;
   /// Get the CAS reference for the contents of the file.
   virtual cas::ObjectRef getObjectRefForContent() = 0;
 };
@@ -29,7 +29,7 @@ public:
 class CASBackedFileSystem
     : public llvm::RTTIExtends<CASBackedFileSystem, vfs::FileSystem> {
 public:
-  static const char ID;
+  LLVM_ABI static const char ID;
 
   /// This is a convenience method that opens a file, gets its content and then
   /// closes the file. It returns MemoryBuffer and ObjectRef in one call to avoid
@@ -42,7 +42,8 @@ public:
                                bool IsVolatile = false, bool IsText = true);
 
   /// Get ObjectRef of a file from its path.
-  llvm::Expected<cas::ObjectRef> getObjectRefForFileContent(const Twine &Name);
+  LLVM_ABI llvm::Expected<cas::ObjectRef>
+  getObjectRefForFileContent(const Twine &Name);
 
   /// Implementation for openFileForRead using CASBackedFile.
   ErrorOr<std::unique_ptr<vfs::File>>
@@ -62,11 +63,11 @@ public:
   createThreadSafeProxyFS() = 0;
 };
 
-Expected<std::unique_ptr<vfs::FileSystem>>
+LLVM_ABI Expected<std::unique_ptr<vfs::FileSystem>>
 createCASFileSystem(std::shared_ptr<ObjectStore> DB, const CASID &RootID,
                     sys::path::Style PathStyle = sys::path::Style::native);
 
-Expected<std::unique_ptr<vfs::FileSystem>>
+LLVM_ABI Expected<std::unique_ptr<vfs::FileSystem>>
 createCASFileSystem(ObjectStore &DB, const CASID &RootID,
                     sys::path::Style PathStyle = sys::path::Style::native);
 

--- a/llvm/include/llvm/CAS/CASID.h
+++ b/llvm/include/llvm/CAS/CASID.h
@@ -137,7 +137,7 @@ private:
 };
 
 class Cancellable {
-  virtual void anchor();
+  LLVM_ABI virtual void anchor();
 
 public:
   virtual ~Cancellable() {}

--- a/llvm/include/llvm/CAS/CASNodeSchema.h
+++ b/llvm/include/llvm/CAS/CASNodeSchema.h
@@ -22,10 +22,10 @@ class ObjectProxy;
 /// TODO: Build a FilesystemSchema on top of this for reimplementing Trees on
 /// top of the CAS.
 class NodeSchema : public RTTIExtends<NodeSchema, RTTIRoot> {
-  void anchor() override;
+  LLVM_ABI void anchor() override;
 
 public:
-  static char ID;
+  LLVM_ABI static char ID;
 
   /// Check if \a Node is a root (entry node) for the schema. This is a strong
   /// check, since it requires that the first reference matches a complete

--- a/llvm/include/llvm/CAS/CASOutputBackend.h
+++ b/llvm/include/llvm/CAS/CASOutputBackend.h
@@ -33,7 +33,7 @@ public:
   SmallVector<OutputFile> takeOutputs() { return std::move(Outputs); }
 
   /// Add a CAS object to the path in the output backend.
-  void addObject(StringRef Path, ObjectRef Object);
+  LLVM_ABI void addObject(StringRef Path, ObjectRef Object);
 
 private:
   Expected<std::unique_ptr<vfs::OutputFileImpl>>
@@ -47,8 +47,8 @@ private:
   }
 
 public:
-  CASOutputBackend(std::shared_ptr<ObjectStore> CAS);
-  CASOutputBackend(ObjectStore &CAS);
+  LLVM_ABI CASOutputBackend(std::shared_ptr<ObjectStore> CAS);
+  LLVM_ABI CASOutputBackend(ObjectStore &CAS);
   ~CASOutputBackend();
 
 private:

--- a/llvm/include/llvm/CAS/CASProvidingFileSystem.h
+++ b/llvm/include/llvm/CAS/CASProvidingFileSystem.h
@@ -23,7 +23,7 @@ class ObjectStore;
 /// Implements \p vfs::File::getObjectRefForContent() by ingesting the file
 /// buffer into the \p DB, unless the \p UnderlyingFS already supports \p
 /// vfs::File::getObjectRefForContent().
-std::unique_ptr<llvm::vfs::FileSystem> createCASProvidingFileSystem(
+LLVM_ABI std::unique_ptr<llvm::vfs::FileSystem> createCASProvidingFileSystem(
     std::shared_ptr<ObjectStore> DB,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS);
 

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -145,10 +145,10 @@ protected:
   std::shared_ptr<ObjectStore> OwnedDB;
 };
 
-Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
+LLVM_ABI Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
 createCachingOnDiskFileSystem(std::shared_ptr<ObjectStore> DB);
 
-Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
+LLVM_ABI Expected<IntrusiveRefCntPtr<CachingOnDiskFileSystem>>
 createCachingOnDiskFileSystem(ObjectStore &DB);
 
 } // namespace cas

--- a/llvm/include/llvm/CAS/HierarchicalTreeBuilder.h
+++ b/llvm/include/llvm/CAS/HierarchicalTreeBuilder.h
@@ -50,8 +50,8 @@ class HierarchicalTreeBuilder {
   SmallVector<HierarchicalEntry, 8> Entries;
   SmallVector<HierarchicalEntry, 0> TreeContents;
 
-  void pushImpl(std::optional<ObjectRef> Ref, TreeEntry::EntryKind Kind,
-                const Twine &Path);
+  LLVM_ABI void pushImpl(std::optional<ObjectRef> Ref,
+                         TreeEntry::EntryKind Kind, const Twine &Path);
 
 public:
   HierarchicalTreeBuilder(sys::path::Style PathStyle = sys::path::Style::native)
@@ -85,7 +85,7 @@ public:
 
   /// Recursively create the trees implied by calls to \a push(), return the
   /// top-level \a CASID.
-  Expected<ObjectProxy> create(ObjectStore &CAS);
+  LLVM_ABI Expected<ObjectProxy> create(ObjectStore &CAS);
 };
 
 } // namespace cas

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -249,7 +249,7 @@ public:
     return storeFromOpenFileImpl(FD, Status);
   }
 
-  static Error createUnknownObjectError(const CASID &ID);
+  LLVM_ABI static Error createUnknownObjectError(const CASID &ID);
 
   /// Create ObjectProxy from CASID. If the object doesn't exist, get an error.
   LLVM_ABI Expected<ObjectProxy> getProxy(const CASID &ID);
@@ -258,10 +258,10 @@ public:
   LLVM_ABI Expected<ObjectProxy> getProxy(ObjectRef Ref);
 
   /// \returns \c std::nullopt if the object is missing from the CAS.
-  Expected<std::optional<ObjectProxy>> getProxyIfExists(ObjectRef Ref);
+  LLVM_ABI Expected<std::optional<ObjectProxy>> getProxyIfExists(ObjectRef Ref);
 
   /// Asynchronous version of \c getProxyIfExists.
-  std::future<AsyncProxyValue> getProxyFuture(ObjectRef Ref);
+  LLVM_ABI std::future<AsyncProxyValue> getProxyFuture(ObjectRef Ref);
 
   /// Asynchronous version of \c getProxyIfExists using a callback.
   /// \param[out] CancelObj Optional pointer to receive a cancellation object.
@@ -270,7 +270,7 @@ public:
       unique_function<void(Expected<std::optional<ObjectProxy>>)> Callback,
       std::unique_ptr<Cancellable> *CancelObj = nullptr);
   /// Asynchronous version of \c getProxyIfExists using a callback.
-  void getProxyAsync(
+  LLVM_ABI void getProxyAsync(
       ObjectRef Ref,
       unique_function<void(Expected<std::optional<ObjectProxy>>)> Callback,
       std::unique_ptr<Cancellable> *CancelObj = nullptr);
@@ -360,7 +360,7 @@ public:
     return CAS->forEachRef(H, Callback);
   }
 
-  std::unique_ptr<MemoryBuffer>
+  LLVM_ABI std::unique_ptr<MemoryBuffer>
   getMemoryBuffer(StringRef Name = "",
                   bool RequiresNullTerminator = true) const;
 
@@ -414,11 +414,11 @@ createOnDiskCAS(const Twine &Path);
 
 /// Set \p Path to a reasonable default on-disk path for a persistent CAS for
 /// the current user.
-void getDefaultOnDiskCASPath(SmallVectorImpl<char> &Path);
+LLVM_ABI void getDefaultOnDiskCASPath(SmallVectorImpl<char> &Path);
 
 /// Get a reasonable default on-disk path for a persistent CAS for the current
 /// user.
-std::string getDefaultOnDiskCASPath();
+LLVM_ABI std::string getDefaultOnDiskCASPath();
 
 /// FIXME: Remove.
 void getDefaultOnDiskCASStableID(SmallVectorImpl<char> &Path);
@@ -452,6 +452,7 @@ class ActionCache;
 
 /// Create \c ObjectStore and \c ActionCache instances using the plugin
 /// interface.
+LLVM_ABI
 Expected<std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
 createPluginCASDatabases(
     StringRef PluginPath, StringRef OnDiskPath,

--- a/llvm/include/llvm/CAS/TreeEntry.h
+++ b/llvm/include/llvm/CAS/TreeEntry.h
@@ -61,7 +61,7 @@ public:
   NamedTreeEntry(ObjectRef Ref, EntryKind Kind, StringRef Name)
       : TreeEntry(Ref, Kind), Name(Name) {}
 
-  void print(raw_ostream &OS, ObjectStore &CAS) const;
+  LLVM_ABI void print(raw_ostream &OS, ObjectStore &CAS) const;
 
 private:
   StringRef Name;

--- a/llvm/include/llvm/CAS/TreeSchema.h
+++ b/llvm/include/llvm/CAS/TreeSchema.h
@@ -26,13 +26,13 @@ public:
   bool isRootNode(const ObjectProxy &Node) const final {
     return false; // TreeSchema doesn't have a root node.
   }
-  bool isNode(const ObjectProxy &Node) const final;
+  LLVM_ABI bool isNode(const ObjectProxy &Node) const final;
 
-  TreeSchema(ObjectStore &CAS);
+  LLVM_ABI TreeSchema(ObjectStore &CAS);
 
-  size_t getNumTreeEntries(TreeProxy Tree) const;
+  LLVM_ABI size_t getNumTreeEntries(TreeProxy Tree) const;
 
-  Error
+  LLVM_ABI Error
   forEachTreeEntry(TreeProxy Tree,
                    function_ref<Error(const NamedTreeEntry &)> Callback) const;
 
@@ -44,18 +44,19 @@ public:
   ///
   /// Passes the \p TreeNodeProxy if the entry is a \p TreeEntry::Tree,
   /// otherwise passes \p None.
-  Error walkFileTreeRecursively(
+  LLVM_ABI Error walkFileTreeRecursively(
       ObjectStore &CAS, ObjectRef Root,
       function_ref<Error(const NamedTreeEntry &, std::optional<TreeProxy>)>
           Callback);
 
-  std::optional<size_t> lookupTreeEntry(TreeProxy Tree, StringRef Name) const;
-  NamedTreeEntry loadTreeEntry(TreeProxy Tree, size_t I) const;
+  LLVM_ABI std::optional<size_t> lookupTreeEntry(TreeProxy Tree,
+                                                 StringRef Name) const;
+  LLVM_ABI NamedTreeEntry loadTreeEntry(TreeProxy Tree, size_t I) const;
 
-  Expected<TreeProxy> load(ObjectRef Object) const;
-  Expected<TreeProxy> load(ObjectProxy Object) const;
+  LLVM_ABI Expected<TreeProxy> load(ObjectRef Object) const;
+  LLVM_ABI Expected<TreeProxy> load(ObjectProxy Object) const;
 
-  Expected<TreeProxy> create(ArrayRef<NamedTreeEntry> Entries = {});
+  LLVM_ABI Expected<TreeProxy> create(ArrayRef<NamedTreeEntry> Entries = {});
 
 private:
   static constexpr StringLiteral SchemaName = "llvm::cas::schema::tree::v1";

--- a/llvm/include/llvm/CASUtil/Utils.h
+++ b/llvm/include/llvm/CASUtil/Utils.h
@@ -23,7 +23,7 @@ class CASID;
 Expected<CASID> readCASIDBuffer(cas::ObjectStore &CAS,
                                 llvm::MemoryBufferRef Buffer);
 
-void writeCASIDBuffer(const CASID &ID, llvm::raw_ostream &OS);
+LLVM_ABI void writeCASIDBuffer(const CASID &ID, llvm::raw_ostream &OS);
 
 } // namespace cas
 

--- a/llvm/include/llvm/IR/GlobalPtrAuthInfo.h
+++ b/llvm/include/llvm/IR/GlobalPtrAuthInfo.h
@@ -47,7 +47,7 @@ public:
 
   /// Try to analyze \p V as an authenticated global reference, and return its
   /// information if successful.
-  static std::optional<GlobalPtrAuthInfo> analyze(const Value *V);
+  LLVM_ABI static std::optional<GlobalPtrAuthInfo> analyze(const Value *V);
 
   /// Try to analyze \p V as an authenticated global reference, and return its
   /// information if successful, or an error explaining the failure if not.
@@ -108,9 +108,10 @@ public:
 
   /// Produce a "llvm.ptrauth" global that signs a value using the given
   /// schema.  The result will be casted to have the same type as the value.
-  static llvm::Constant *create(Module &M, Constant *Pointer, ConstantInt *Key,
-                                Constant *AddrDiscriminator,
-                                ConstantInt *Discriminator);
+  LLVM_ABI static llvm::Constant *create(Module &M, Constant *Pointer,
+                                         ConstantInt *Key,
+                                         Constant *AddrDiscriminator,
+                                         ConstantInt *Discriminator);
 
   /// Produce a new "llvm.ptrauth" global for signing the given value using
   /// the same schema as is stored in this info.

--- a/llvm/include/llvm/IR/GlobalValue.h
+++ b/llvm/include/llvm/IR/GlobalValue.h
@@ -510,27 +510,43 @@ public:
   LLVM_ABI bool isInterposable() const;
   LLVM_ABI bool canBenefitFromLocalAlias() const;
 
-  bool hasExternalLinkage() const { return isExternalLinkage(getLinkage()); }
-  bool hasAvailableExternallyLinkage() const {
+  LLVM_ABI bool hasExternalLinkage() const {
+    return isExternalLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasAvailableExternallyLinkage() const {
     return isAvailableExternallyLinkage(getLinkage());
   }
-  bool hasLinkOnceLinkage() const { return isLinkOnceLinkage(getLinkage()); }
-  bool hasLinkOnceAnyLinkage() const {
+  LLVM_ABI bool hasLinkOnceLinkage() const {
+    return isLinkOnceLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasLinkOnceAnyLinkage() const {
     return isLinkOnceAnyLinkage(getLinkage());
   }
-  bool hasLinkOnceODRLinkage() const {
+  LLVM_ABI bool hasLinkOnceODRLinkage() const {
     return isLinkOnceODRLinkage(getLinkage());
   }
-  bool hasWeakLinkage() const { return isWeakLinkage(getLinkage()); }
-  bool hasWeakAnyLinkage() const { return isWeakAnyLinkage(getLinkage()); }
-  bool hasWeakODRLinkage() const { return isWeakODRLinkage(getLinkage()); }
-  bool hasAppendingLinkage() const { return isAppendingLinkage(getLinkage()); }
-  bool hasInternalLinkage() const { return isInternalLinkage(getLinkage()); }
-  bool hasPrivateLinkage() const { return isPrivateLinkage(getLinkage()); }
-  bool hasLocalLinkage() const { return isLocalLinkage(getLinkage()); }
-  bool hasExternalWeakLinkage() const;
-  bool hasCommonLinkage() const { return isCommonLinkage(getLinkage()); }
-  bool hasValidDeclarationLinkage() const {
+  LLVM_ABI bool hasWeakLinkage() const { return isWeakLinkage(getLinkage()); }
+  LLVM_ABI bool hasWeakAnyLinkage() const {
+    return isWeakAnyLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasWeakODRLinkage() const {
+    return isWeakODRLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasAppendingLinkage() const {
+    return isAppendingLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasInternalLinkage() const {
+    return isInternalLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasPrivateLinkage() const {
+    return isPrivateLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasLocalLinkage() const { return isLocalLinkage(getLinkage()); }
+  LLVM_ABI bool hasExternalWeakLinkage() const;
+  LLVM_ABI bool hasCommonLinkage() const {
+    return isCommonLinkage(getLinkage());
+  }
+  LLVM_ABI bool hasValidDeclarationLinkage() const {
     return isValidDeclarationLinkage(getLinkage());
   }
 

--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -175,7 +175,7 @@ public:
 
   /// Provide a path to a directory where to store the cached files for
   /// incremental build.
-  Error setCacheDir(std::string Path);
+  LLVM_ABI Error setCacheDir(std::string Path);
 
   /// Create a cache entry for the module
   std::unique_ptr<ModuleCacheEntry> createModuleCacheEntry(

--- a/llvm/include/llvm/MCA/SourceMgr.h
+++ b/llvm/include/llvm/MCA/SourceMgr.h
@@ -29,6 +29,8 @@ typedef std::pair<unsigned, const Instruction &> SourceRef;
 struct SourceMgr {
   using UniqueInst = std::unique_ptr<Instruction>;
 
+  LLVM_ABI SourceMgr() = default;
+
   /// Provides a fixed range of \a UniqueInst to iterate.
   virtual ArrayRef<UniqueInst> getInstructions() const = 0;
 
@@ -50,7 +52,7 @@ struct SourceMgr {
   /// Advance to the next \a SourceRef.
   virtual void updateNext() = 0;
 
-  virtual ~SourceMgr() {}
+  LLVM_ABI virtual ~SourceMgr() {}
 };
 
 /// The default implementation of \a SourceMgr. It always takes a fixed number

--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.h
@@ -271,10 +271,10 @@ public:
                             llvm::MCAssembler &Asm,
                             raw_ostream *DebugOS) const override;
 
-  Error serializeObjectFile(cas::ObjectProxy RootNode,
-                            raw_ostream &OS) const override;
+  LLVM_ABI Error serializeObjectFile(cas::ObjectProxy RootNode,
+                                     raw_ostream &OS) const override;
 
-  MCSchema(cas::ObjectStore &CAS);
+  LLVM_ABI MCSchema(cas::ObjectStore &CAS);
 
   Expected<MCObjectProxy> create(ArrayRef<cas::ObjectRef> Refs,
                                  StringRef Data) const {

--- a/llvm/include/llvm/Passes/PassBuilder.h
+++ b/llvm/include/llvm/Passes/PassBuilder.h
@@ -625,7 +625,7 @@ public:
 
   /// Enable or disable the hot/cold splitting optimization. By default, it is
   /// disabled.
-  void setEnableHotColdSplitting(bool Enabled);
+  LLVM_ABI void setEnableHotColdSplitting(bool Enabled);
 
   /// Add PGOInstrumenation passes for O0 only.
   LLVM_ABI void addPGOInstrPassesForO0(ModulePassManager &MPM,

--- a/llvm/include/llvm/Remarks/RemarkStreamer.h
+++ b/llvm/include/llvm/Remarks/RemarkStreamer.h
@@ -50,6 +50,7 @@ class RemarkStreamer final {
   const std::optional<std::string> Filename;
 
 public:
+  LLVM_ABI
   RemarkStreamer(std::unique_ptr<remarks::RemarkSerializer> RemarkSerializer,
                  std::optional<StringRef> Filename = std::nullopt);
 
@@ -63,9 +64,9 @@ public:
   remarks::RemarkSerializer &getSerializer() { return *RemarkSerializer; }
   /// Set a pass filter based on a regex \p Filter.
   /// Returns an error if the regex is invalid.
-  Error setFilter(StringRef Filter);
+  LLVM_ABI Error setFilter(StringRef Filter);
   /// Check wether the string matches the filter.
-  bool matchesFilter(StringRef Str);
+  LLVM_ABI bool matchesFilter(StringRef Str);
   /// Check if the remarks also need to have associated metadata in a section.
   bool needsSection() const;
 };

--- a/llvm/include/llvm/RemoteCachingService/Client.h
+++ b/llvm/include/llvm/RemoteCachingService/Client.h
@@ -26,7 +26,7 @@ namespace llvm::cas::remote {
 
 /// Used to optionally associate additional context with a particular request.
 class AsyncCallerContext {
-  virtual void anchor();
+  LLVM_ABI virtual void anchor();
 
 public:
   virtual ~AsyncCallerContext() = default;
@@ -427,7 +427,7 @@ createRemoteCASDBClient(StringRef SocketPath);
 Expected<std::unique_ptr<KeyValueDBClient>>
 createRemoteKeyValueClient(StringRef SocketPath);
 
-Expected<ClientServices>
+LLVM_ABI Expected<ClientServices>
 createCompilationCachingRemoteClient(StringRef SocketPath);
 
 } // namespace llvm::cas::remote

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -39,7 +39,8 @@ struct MappedPrefix {
   }
   bool operator!=(const MappedPrefix &RHS) const { return !(*this == RHS); }
 
-  static std::optional<MappedPrefix> getFromJoined(StringRef JoinedMapping);
+  LLVM_ABI static std::optional<MappedPrefix>
+  getFromJoined(StringRef JoinedMapping);
 
   static Error transformJoined(ArrayRef<StringRef> Joined,
                                SmallVectorImpl<MappedPrefix> &Split);
@@ -49,8 +50,9 @@ struct MappedPrefix {
                                      SmallVectorImpl<MappedPrefix> &Split);
   static void transformJoinedIfValid(ArrayRef<std::string> Joined,
                                      SmallVectorImpl<MappedPrefix> &Split);
-  static void transformPairs(ArrayRef<std::pair<std::string, std::string>> Pairs,
-                             SmallVectorImpl<MappedPrefix> & Split);
+  LLVM_ABI static void
+  transformPairs(ArrayRef<std::pair<std::string, std::string>> Pairs,
+                 SmallVectorImpl<MappedPrefix> &Split);
 };
 
 /// Remap path prefixes.
@@ -65,31 +67,31 @@ public:
   ///
   /// \pre \p Path is not a reference into \p NewPath.
   /// \returns true if \c NewPath was mapped.
-  bool map(StringRef Path, SmallVectorImpl<char> &NewPath);
+  LLVM_ABI bool map(StringRef Path, SmallVectorImpl<char> &NewPath);
   /// Map \p Path, and saving the new (or existing) path in \p NewPath.
   ///
   /// \pre \p Path is not a reference into \p NewPath.
   /// \returns true if \c NewPath was mapped.
-  bool map(StringRef Path, std::string &NewPath);
+  LLVM_ABI bool map(StringRef Path, std::string &NewPath);
 
   /// Map \p Path, returning \a std::string.
-  std::string mapToString(StringRef Path);
+  LLVM_ABI std::string mapToString(StringRef Path);
 
   /// Map \p Path in place.
   /// \returns true if the path was modified.
-  bool mapInPlace(SmallVectorImpl<char> &Path);
+  LLVM_ABI bool mapInPlace(SmallVectorImpl<char> &Path);
 
   /// Map \p Path in place.
   /// \returns true if the path was modified.
-  bool mapInPlace(std::string &Path);
+  LLVM_ABI bool mapInPlace(std::string &Path);
 
 protected:
   /// Map (or unmap) \p Path. On a match, fills \p Storage with the mapped path
   /// unless it's an exact match.
   ///
   /// \pre \p Path is not a reference into \p Storage.
-  virtual std::optional<StringRef> mapImpl(StringRef Path,
-                                      SmallVectorImpl<char> &Storage);
+  LLVM_ABI virtual std::optional<StringRef>
+  mapImpl(StringRef Path, SmallVectorImpl<char> &Storage);
 
 public:
   virtual void add(const MappedPrefix &MP) { Mappings.push_back(MP); }
@@ -106,7 +108,7 @@ public:
   /// or std::map.
   ///
   /// TODO: Test.
-  void sort();
+  LLVM_ABI void sort();
 
   template <class RangeT> void addRange(const RangeT &Mappings) {
     for (const MappedPrefix &M : Mappings)
@@ -176,12 +178,13 @@ private:
 public:
   void add(const MappedPrefix &Mapping) override;
 
-  StringRef mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
-                        SmallVectorImpl<char> &Storage);
+  LLVM_ABI StringRef mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
+                                 SmallVectorImpl<char> &Storage);
 
+  LLVM_ABI
   TreePathPrefixMapper(IntrusiveRefCntPtr<vfs::FileSystem> FS,
                        sys::path::Style PathStyle = sys::path::Style::native);
-  ~TreePathPrefixMapper();
+  LLVM_ABI ~TreePathPrefixMapper();
 
 private:
   IntrusiveRefCntPtr<vfs::FileSystem> FS;

--- a/llvm/include/llvm/Support/PrefixMappingFileSystem.h
+++ b/llvm/include/llvm/Support/PrefixMappingFileSystem.h
@@ -10,6 +10,7 @@
 #define LLVM_SUPPORT_PREFIXMAPPINGFILESYSTEM_H
 
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Compiler.h"
 
 namespace llvm {
 class PrefixMapper;
@@ -19,7 +20,7 @@ class FileSystem;
 
 /// Creates a VFS that remaps paths using the given \p Mapper, before looking
 /// them up.
-std::unique_ptr<FileSystem>
+LLVM_ABI std::unique_ptr<FileSystem>
 createPrefixMappingFileSystem(PrefixMapper Mapper,
                               IntrusiveRefCntPtr<FileSystem> UnderlyingFS);
 

--- a/llvm/include/llvm/Support/SMTAPI.h
+++ b/llvm/include/llvm/Support/SMTAPI.h
@@ -159,7 +159,7 @@ public:
   virtual ~SMTSolver() = default;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
-  LLVM_DUMP_METHOD void dump() const;
+  LLVM_ABI LLVM_DUMP_METHOD void dump() const;
 #endif
 
   // Returns an appropriate floating-point sort for the given bitwidth.

--- a/llvm/include/llvm/Support/SourceMgr.h
+++ b/llvm/include/llvm/Support/SourceMgr.h
@@ -109,8 +109,8 @@ public:
   explicit SourceMgr(IntrusiveRefCntPtr<vfs::FileSystem> FS);
   SourceMgr(const SourceMgr &) = delete;
   SourceMgr &operator=(const SourceMgr &) = delete;
-  SourceMgr(SourceMgr &&);
-  SourceMgr &operator=(SourceMgr &&);
+  LLVM_ABI SourceMgr(SourceMgr &&);
+  LLVM_ABI SourceMgr &operator=(SourceMgr &&);
   LLVM_ABI ~SourceMgr();
 
   IntrusiveRefCntPtr<vfs::FileSystem> getVirtualFileSystem() const;

--- a/llvm/include/llvm/Transforms/Instrumentation/SoftPointerAuth.h
+++ b/llvm/include/llvm/Transforms/Instrumentation/SoftPointerAuth.h
@@ -14,7 +14,7 @@
 namespace llvm {
 
 struct SoftPointerAuthPass : public PassInfoMixin<SoftPointerAuthPass> {
-  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
 };
 
 } // end namespace llvm

--- a/llvm/include/llvm/Transforms/Scalar/DCE.h
+++ b/llvm/include/llvm/Transforms/Scalar/DCE.h
@@ -22,7 +22,7 @@ class Function;
 /// Basic Dead Code Elimination pass.
 class DCEPass : public PassInfoMixin<DCEPass> {
 public:
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
+  LLVM_ABI PreservedAnalyses run(Function &F, FunctionAnalysisManager &AM);
 };
 
 class RedundantDbgInstEliminationPass


### PR DESCRIPTION
This is needed to build LLVM as a DLL on Windows.

This effort is tracked in swiftlang/swift#85241.