### PR TITLE
[LLDB] Avoid diagnosing CAS warnings for regular files

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -564,8 +564,10 @@ public:
   ///    in the CAS, error if there are any errors happened during the loading
   ///    process.
   static llvm::Expected<bool>
-  GetSharedModuleFromCAS(llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
-                         ModuleSpec &module_spec, lldb::ModuleSP &module_sp);
+  GetSharedModuleFromCAS(llvm::StringRef cas_id,
+                         llvm::StringRef name_for_diagnostics,
+                         const lldb::ModuleSP &nearby, ModuleSpec &module_spec,
+                         lldb::ModuleSP &module_sp);
   // END CAS
 
   static bool RemoveSharedModule(lldb::ModuleSP &module_sp);

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2012,7 +2012,8 @@ void SymbolFileDWARF::UpdateExternalModuleListIfNeeded() {
       LLDB_LOG(GetLog(LLDBLog::Symbols | LLDBLog::Modules),
                "Loading module '{0}' from CAS at {1}...", const_name, dwo_path);
       auto loaded = ModuleList::GetSharedModuleFromCAS(
-          dwo_path, GetObjectFile()->GetModule(), dwo_module_spec, module_sp);
+          dwo_path, const_name, GetObjectFile()->GetModule(), dwo_module_spec,
+          module_sp);
       if (!loaded)
         GetObjectFile()->GetModule()->ReportWarning(
             "Failed to load module '{0}' from CAS: {1}", const_name,

--- a/lldb/test/Shell/SymbolFile/DWARF/clang-gmodules-type-lookup.c
+++ b/lldb/test/Shell/SymbolFile/DWARF/clang-gmodules-type-lookup.c
@@ -10,6 +10,15 @@
 // RUN:   --language=C99 -compiler-context 'ClassOrStruct:TypeFromPCH' \
 // RUN:   %t.exe | FileCheck %s
 
+// BEGIN CAS
+// RUN: rm %t.pch
+// RUN: lldb-test symbols -dump-clang-ast -find type --find-in-any-module \
+// RUN:   --language=C99 -compiler-context 'ClassOrStruct:TypeFromPCH' \
+// RUN:   %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-CAS
+// CHECK-CAS-NOT: Failed to load module {{.*}} from CAS
+// CHECK-CAS: pch{{.*}}does not exist
+// END CAS
+
 anchor_t anchor;
 
 int main(int argc, char **argv) { return 0; }

--- a/lldb/test/Shell/SymbolFile/cas-gmodule.test
+++ b/lldb/test/Shell/SymbolFile/cas-gmodule.test
@@ -8,7 +8,7 @@
 # RUN: sed "s|DIR|%/t|g" %t/cas-config.template > %t/.cas-config
 # RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s
 
-# FAIL: Failed to load module 'Bottom' from CAS: no CAS available
+# FAIL: Failed to load module 'Bottom' at '{{.*}}' from CAS: no CAS available
 # FAIL: Unable to locate module needed for external types.
 # CHECK: Loading module 'Bottom' from CAS at
 # CHECK: Loading module 'Top' from CAS at


### PR DESCRIPTION
Only the CAS plugin can determine what is a CAS URL so we log the errors instead of printing them to users. The normal file not found warning is being diagnosed right after.

rdar://169010767