### PR TITLE
[gmodule][CAS] Don't generate bogus DW_AT_LLVM_include_path

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -3533,7 +3533,9 @@ llvm::DIModule *CGDebugInfo::getOrCreateModuleRef(ASTSourceDescriptor Mod,
       IsRootModule ? nullptr
                    : getOrCreateModuleRef(ASTSourceDescriptor(*M->Parent),
                                           CreateSkeletonCU);
-  std::string IncludePath = Mod.getPath().str();
+
+  // If Module is from CAS, there is not a valid include path for that module.
+  std::string IncludePath = Mod.getCASID().empty() ? Mod.getPath().str() : "";
   llvm::DIModule *DIMod =
       DBuilder.createModule(Parent, Mod.getModuleName(), ConfigMacros,
                             RemapPath(IncludePath), M ? M->APINotesFile : "");

--- a/clang/test/ClangScanDeps/gmodules.c
+++ b/clang/test/ClangScanDeps/gmodules.c
@@ -39,6 +39,7 @@
 // OBJECT-DWARF: DW_TAG_compile_unit
 // OBJECT-DWARF: DW_AT_name        ("Left")
 // OBJECT-DWARF: DW_AT_dwo_name    ("llvmcas://
+// OBJECT-DWARF-NOT: DW_AT_LLVM_include_path
 
 /// Check debug info is correct.
 // RUN: %clang %t/tu.o -o %t/a.out


### PR DESCRIPTION
When using gmodules with prefix header, the precompiled prefix header is loaded from CAS thus there should not be an include path for the precompiled header as it might cause confusion for debug info consumers.

rdar://169032197