### PR TITLE
[LLDB] Fix regression when po'ing a Swift value from ObjC

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -131,6 +131,11 @@ public:
         "Swift values do not have an object description");
   }
 
+private:
+  llvm::Error PrintObjectViaPointer(Stream &strm, ValueObject &object,
+                                    Process &process) const;
+
+public:
   lldb::LanguageType GetLanguageType() const override {
     return lldb::eLanguageTypeSwift;
   }
@@ -690,7 +695,7 @@ protected:
 
   bool GetTargetOfPartialApply(SymbolContext &curr_sc, ConstString &apply_name,
                                SymbolContext &sc);
-  AppleObjCRuntimeV2 *GetObjCRuntime();
+  AppleObjCRuntimeV2 *GetObjCRuntime() const;
 
   /// Creates an UnwindPlan for following the AsyncContext chain up the stack,
   /// from a current AsyncContext frame.

--- a/lldb/test/API/lang/swift/expression/objc_context/Foo.swift
+++ b/lldb/test/API/lang/swift/expression/objc_context/Foo.swift
@@ -1,2 +1,7 @@
 import Foundation
+
 @objc public class Foo : NSObject {}
+
+extension Foo {
+  public override var debugDescription: String { return "Foo from Swift!" }
+}

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -35,3 +35,7 @@ class TestSwiftExpressionObjCContext(TestBase):
                     "context-less swift expression works",
                     substrs=["(Int, Int, Int)"])
 
+        self.expect("po foo",
+                    "po of Swift object in Objective-C works",
+                    substrs=["Foo from Swift"])
+

--- a/lldb/test/API/lang/swift/expression/objc_context/main.m
+++ b/lldb/test/API/lang/swift/expression/objc_context/main.m
@@ -7,6 +7,6 @@
 
 int main(int argc, char **argv) {
   [[Bar alloc] init];
-  [[Foo alloc] init];
+  id foo = [[Foo alloc] init];
   return 0; // break here
 }


### PR DESCRIPTION
This code was recently changed to prefer the static value of the
ValueObject, but if the static value is in a different type system, we
need to perform the print operation in the other LanguageRuntime.

rdar://168933024