### PR TITLE
[stable/21.x][clang][test][NFC] Fix more dependency test failures

### DIFF
--- a/clang/test/ClangScanDeps/modules.cpp
+++ b/clang/test/ClangScanDeps/modules.cpp
@@ -14,9 +14,9 @@
 // RUN: sed -e "s|DIR|%/t.dir|g" %S/Inputs/modules_cdb_clangcl.json > %t_clangcl.cdb
 //
 // RUN: clang-scan-deps -compilation-database %t.cdb -j 1 -mode preprocess-dependency-directives | \
-// RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO%if system-darwin %{,CHECK-DARWIN1,CHECK-DARWIN2 %} %s
+// RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO%if system-darwin %{,CHECK1-DARWIN,CHECK2-DARWIN %} %else %{,CHECK2-NON-DARWIN %} %s
 // RUN: clang-scan-deps -compilation-database %t_clangcl.cdb -j 1 -mode preprocess-dependency-directives | \
-// RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO %s
+// RUN:   FileCheck --check-prefixes=CHECK1,CHECK2,CHECK2NO,CHECK2-NON-DARWIN %s
 //
 // The output order is non-deterministic when using more than one thread,
 // so check the output using two runs. Note that the 'NOT' check is not used
@@ -24,33 +24,33 @@
 // `modules_cdb_input2.cpp`.
 //
 // RUN: clang-scan-deps -compilation-database %t.cdb -j 2 -mode preprocess-dependency-directives | \
-// RUN:   FileCheck --check-prefixes=CHECK1%if system-darwin %{,CHECK-DARWIN1 %} %s
+// RUN:   FileCheck --check-prefixes=CHECK1%if system-darwin %{,CHECK1-DARWIN %} %s
 // RUN: clang-scan-deps -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-dependency-directives | \
 // RUN:   FileCheck --check-prefix=CHECK1 %s
 // RUN: clang-scan-deps -compilation-database %t.cdb -j 2 -mode preprocess | \
-// RUN:   FileCheck --check-prefixes=CHECK1%if system-darwin %{,CHECK-DARWIN1 %} %s
+// RUN:   FileCheck --check-prefixes=CHECK1%if system-darwin %{,CHECK1-DARWIN %} %s
 // RUN: clang-scan-deps -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
 // RUN:   FileCheck --check-prefix=CHECK1 %s
 // RUN: clang-scan-deps -compilation-database %t.cdb -j 2 -mode preprocess-dependency-directives | \
-// RUN:   FileCheck --check-prefixes=CHECK2%if system-darwin %{,CHECK-DARWIN2 %} %s
+// RUN:   FileCheck --check-prefixes=CHECK2%if system-darwin %{,CHECK2-DARWIN %} %else %{,CHECK2-NON-DARWIN %} %s
 // RUN: clang-scan-deps -compilation-database %t_clangcl.cdb -j 2 -mode preprocess-dependency-directives | \
-// RUN:   FileCheck --check-prefix=CHECK2 %s
+// RUN:   FileCheck --check-prefixes=CHECK2,CHECK2-NON-DARWIN %s
 // RUN: clang-scan-deps -compilation-database %t.cdb -j 2 -mode preprocess | \
-// RUN:   FileCheck --check-prefixes=CHECK2%if system-darwin %{,CHECK-DARWIN2 %} %s
+// RUN:   FileCheck --check-prefixes=CHECK2%if system-darwin %{,CHECK2-DARWIN %} %else %{,CHECK2-NON-DARWIN %} %s
 // RUN: clang-scan-deps -compilation-database %t_clangcl.cdb -j 2 -mode preprocess | \
-// RUN:   FileCheck --check-prefix=CHECK2 %s
+// RUN:   FileCheck --check-prefixes=CHECK2,CHECK2-NON-DARWIN %s
 
 #include "header.h"
 
 // CHECK1: modules_cdb_input2.o:
-// CHECK-DARWIN1-NEXT: SDKSettings.json
+// CHECK1-DARWIN-NEXT: SDKSettings.json
 // CHECK1-NEXT: modules_cdb_input2.cpp
 // CHECK1-NEXT: Inputs{{/|\\}}module.modulemap
 // CHECK1-NEXT: Inputs{{/|\\}}header2.h
 // CHECK1: Inputs{{/|\\}}header.h
 
-// CHECK2: {{(modules_cdb_input)|(a)|(b)}}.o:
-// CHECK-DARWIN2-NEXT: SDKSettings.json
+// CHECK2-NON-DARWIN: {{(modules_cdb_input)|(a)|(b)}}.o:
+// CHECK2-DARWIN: {{(modules_cdb_input)|(a)|(b)}}.o:{{.*[[:space:]].*}}SDKSettings.json
 // CHECK2-NEXT: modules_cdb_input.cpp
 // CHECK2-NEXT: Inputs{{/|\\}}module.modulemap
 // CHECK2-NEXT: Inputs{{/|\\}}header.h


### PR DESCRIPTION
The bots found another spot where the path to SDKSettings.json is short enough to go on the same line as the file in the output.