### PR TITLE
[Cherry-pick into next] [lldb] Retrieve the mangled type name from the static type, when performing the new Swift po

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -131,6 +131,11 @@ public:
         "Swift values do not have an object description");
   }
 
+private:
+  llvm::Error PrintObjectViaPointer(Stream &strm, ValueObject &object,
+                                    Process &process) const;
+
+public:
   lldb::LanguageType GetLanguageType() const override {
     return lldb::eLanguageTypeSwift;
   }
@@ -706,7 +711,7 @@ protected:
 
   bool GetTargetOfPartialApply(SymbolContext &curr_sc, ConstString &apply_name,
                                SymbolContext &sc);
-  AppleObjCRuntimeV2 *GetObjCRuntime();
+  AppleObjCRuntimeV2 *GetObjCRuntime() const;
 
   /// Creates an UnwindPlan for following the AsyncContext chain up the stack,
   /// from a current AsyncContext frame.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2871,7 +2871,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
     }
     swift_ast_sp.reset(new SwiftASTContextForExpressions(
         m_description, module_sp,
-        typeref_typesystem.GetTypeSystemSwiftTypeRef()));
+        typeref_typesystem.GetTypeSystemSwiftTypeRef(), playground));
     // This is a scratch AST context, mark it as such.
     swift_ast_sp->m_is_scratch_context = true;
     auto &lang_opts = swift_ast_sp->GetLanguageOptions();
@@ -3164,8 +3164,8 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   if (target_sp) {
     discover_implicit_search_paths =
         target_sp->GetSwiftDiscoverImplicitSearchPaths();
-    use_all_compiler_flags =
-        !got_serialized_options || target_sp->GetUseAllCompilerFlags();
+    use_all_compiler_flags = !got_serialized_options ||
+                             target_sp->GetUseAllCompilerFlags() || playground;
 
     const bool is_system = false;
 
@@ -3178,22 +3178,29 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   if (module_sp) {
     std::string error;
     StringRef module_filter = TypeSystemSwiftTypeRef::GetSwiftModuleFor(sc);
-    std::vector<std::string> extra_clang_args;
-    // In a per-module fallback context, the module the "main" module of that
-    // context.
-    bool is_main_executable =
-        target_sp ? (target_sp->GetExecutableModulePointer() == module_sp.get())
-                  : true;
-    ProcessModule(*module_sp, m_description, discover_implicit_search_paths,
-                  use_all_compiler_flags, is_main_executable, module_filter,
-                  triple, plugin_search_options, module_search_paths,
-                  framework_search_paths, extra_clang_args, error);
-    if (!error.empty())
-      swift_ast_sp->AddDiagnostic(eSeverityError, error);
-    StringRef override_opts =
-        target_sp ? target_sp->GetSwiftClangOverrideOptions() : "";
-    swift_ast_sp->AddExtraClangArgs(extra_clang_args, module_search_paths,
-                                    framework_search_paths, override_opts);
+    // An empty module filter means we're in a non-Swift "*" context.
+    // Only scan all modules if user opts in.
+    bool scan_module = !module_filter.empty() || use_all_compiler_flags;
+    if (scan_module) {
+      std::vector<std::string> extra_clang_args;
+      // In a per-module fallback context, the module the "main" module of that
+      // context.
+      bool is_main_executable =
+          target_sp
+              ? (target_sp->GetExecutableModulePointer() == module_sp.get())
+              : true;
+      ProcessModule(*module_sp, m_description, discover_implicit_search_paths,
+                    /*use_all_compiler_flags*/ true, is_main_executable,
+                    module_filter, triple, plugin_search_options,
+                    module_search_paths, framework_search_paths,
+                    extra_clang_args, error);
+      if (!error.empty())
+        swift_ast_sp->AddDiagnostic(eSeverityError, error);
+      StringRef override_opts =
+          target_sp ? target_sp->GetSwiftClangOverrideOptions() : "";
+      swift_ast_sp->AddExtraClangArgs(extra_clang_args, module_search_paths,
+                                      framework_search_paths, override_opts);
+    }
   }
 
   // Now fold any extra options we were passed. This has to be done
@@ -5653,7 +5660,8 @@ void SwiftASTContextForExpressions::ModulesDidLoad(ModuleList &module_list) {
 
   bool discover_implicit_search_paths =
       target_sp->GetSwiftDiscoverImplicitSearchPaths();
-  bool use_all_compiler_flags = target_sp->GetUseAllCompilerFlags();
+  bool use_all_compiler_flags =
+      target_sp->GetUseAllCompilerFlags() || m_playground;
   unsigned num_images = module_list.GetSize();
   for (size_t mi = 0; mi != num_images; ++mi) {
     std::vector<swift::PluginSearchOption> plugin_search_options;
@@ -9101,8 +9109,9 @@ SwiftASTContext::GetASTVectorForModule(const Module *module) {
 
 SwiftASTContextForExpressions::SwiftASTContextForExpressions(
     std::string description, ModuleSP module_sp,
-    TypeSystemSwiftTypeRefSP typeref_typesystem)
-    : SwiftASTContext(std::move(description), module_sp, typeref_typesystem) {
+    TypeSystemSwiftTypeRefSP typeref_typesystem, bool playground)
+    : SwiftASTContext(std::move(description), module_sp, typeref_typesystem),
+      m_playground(playground) {
   assert(llvm::isa<TypeSystemSwiftTypeRefForExpressions>(
       m_typeref_typesystem.lock().get()));
 }

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -1087,7 +1087,8 @@ public:
 
   SwiftASTContextForExpressions(std::string description,
                                 lldb::ModuleSP module_sp,
-                                TypeSystemSwiftTypeRefSP typeref_typesystem);
+                                TypeSystemSwiftTypeRefSP typeref_typesystem,
+                                bool playground);
   virtual ~SwiftASTContextForExpressions();
 
   UserExpression *GetUserExpression(llvm::StringRef expr,
@@ -1140,6 +1141,7 @@ protected:
   /// These are the names of modules that we have loaded by hand into
   /// the Contexts we make for parsing.
   HandLoadedModuleSet m_hand_loaded_modules;
+  bool m_playground = false;
 };
 
 } // namespace lldb_private

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -266,9 +266,11 @@ let Definition = "target" in {
   def SwiftAutoImportFrameworks : Property<"swift-auto-import-frameworks", "Boolean">,
      DefaultFalse,
      Desc<"Automatically import all frameworks and dynamic libraries that are autolinked by Swift modules in the target.">;
-  def UseAllCompilerFlags: Property<"use-all-compiler-flags", "Boolean">,
-    DefaultTrue,
-    Desc<"Try to use compiler flags for all modules when setting up the Swift expression parser, not just the main executable.">;
+  def UseAllCompilerFlags
+      : Property<"use-all-compiler-flags", "Boolean">,
+        DefaultFalse,
+        Desc<"Try to use compiler flags for all modules when setting up the "
+             "Swift expression parser, not just the main executable.">;
   def SDKPath: Property<"sdk-path", "FileSpec">,
     DefaultStringValue<"">,
     Desc<"The path to the SDK used to build the current target.">;

--- a/lldb/test/API/lang/swift/expression/objc_context/Foo.swift
+++ b/lldb/test/API/lang/swift/expression/objc_context/Foo.swift
@@ -1,2 +1,7 @@
 import Foundation
+
 @objc public class Foo : NSObject {}
+
+extension Foo {
+  public override var debugDescription: String { return "Foo from Swift!" }
+}

--- a/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
+++ b/lldb/test/API/lang/swift/expression/objc_context/TestSwiftExpressionObjCContext.py
@@ -35,3 +35,7 @@ class TestSwiftExpressionObjCContext(TestBase):
                     "context-less swift expression works",
                     substrs=["(Int, Int, Int)"])
 
+        self.expect("po foo",
+                    "po of Swift object in Objective-C works",
+                    substrs=["Foo from Swift"])
+

--- a/lldb/test/API/lang/swift/expression/objc_context/main.m
+++ b/lldb/test/API/lang/swift/expression/objc_context/main.m
@@ -7,6 +7,6 @@
 
 int main(int argc, char **argv) {
   [[Bar alloc] init];
-  [[Foo alloc] init];
+  id foo = [[Foo alloc] init];
   return 0; // break here
 }

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -12,12 +12,13 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
-    def test_system_framework(self):
+    def test(self):
         """Test that a framework that is registered as autolinked in a Swift
            module used in the target, but not linked against the target is
            automatically loaded by LLDB."""
         self.build()
         self.expect("settings set target.swift-auto-import-frameworks true")
+        self.expect("settings set target.use-all-compiler-flags true")
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
@@ -32,3 +33,14 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
 
         # Verify that lazy has been dynamically loaded.
         self.expect("image list", substrs=["Lazy.framework/Versions/A/Lazy"])
+
+    @swiftTest
+    @skipIf(oslist=no_match(["macosx"]))
+    def test_precise_compiler_invocation(self):
+        """In modern LLDB, with precise compiler invocations the expression
+           is evaluated in the local context by default."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, 'break here', lldb.SBFileSpec('main.swift'))
+
+        self.expect("expression -- 1", error=False)

--- a/lldb/test/API/lang/swift/po/private_subclass/Makefile
+++ b/lldb/test/API/lang/swift/po/private_subclass/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+HIDE_SWIFTMODULE := YES
+include Makefile.rules

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -1,0 +1,33 @@
+import os
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        log = self.getBuildArtifact("expr.log")
+        self.runCmd(f"log enable lldb expr -f {log}")
+
+        self.expect("frame variable -O x", substrs=["Easy as pie"])
+        self.filecheck(f"platform shell cat {log}", __file__)
+
+        # Clear the log.
+        self.runCmd(f"log disable lldb expr")
+        os.unlink(log)
+        self.runCmd(f"log enable lldb expr -f {log}")
+
+        self.expect("dwim-print -O -- x", substrs=["Easy as pie"])
+        self.filecheck(f"platform shell cat {log}", __file__)
+
+        # Verify po used the mangled name of the static type - which is public,
+        # and not the private dynamic type.
+        #
+        # CHECK: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a10PublicBaseCD")
+        # CHECK: stringForPrintObject(_:mangledTypeName:) succeeded

--- a/lldb/test/API/lang/swift/po/private_subclass/main.swift
+++ b/lldb/test/API/lang/swift/po/private_subclass/main.swift
@@ -1,0 +1,16 @@
+public class PublicBase {}
+
+private class PrivateSubclass: PublicBase, CustomStringConvertible {
+  var description = "Easy as pie"
+}
+
+func makeIt() -> PublicBase {
+  return PrivateSubclass()
+}
+
+func main() {
+  let x = makeIt()
+  print("break here \(x)")
+}
+
+main()


### PR DESCRIPTION
```
commit b78b5f7d552089b606b8fadfb99a9f67fe4ed50a
Author: Dave Lee <davelee.com@gmail.com>
Date:   Tue Jan 20 16:20:50 2026 -0800

    [lldb] Retrieve the mangled type name from the static type, when performing the new Swift po

commit f73c88c963f27d9efdc83d65162103893b3d970d
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jan 27 15:33:50 2026 -0800

    [LLDB] Fix regression when po'ing a Swift value from ObjC
    
    This code was recently changed to prefer the static value of the
    ValueObject, but if the static value is in a different type system, we
    need to perform the print operation in the other LanguageRuntime.
    
    rdar://168933024

commit bde67663cb7ee8b8f691da0ae13937d1db40f27c
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jan 27 17:16:54 2026 -0800

    [LLDB] Avoid scanning all for Swift modules in a non-Swift context
    
    This is primarily a performance boost; on top of that it can also
    eliminate spurious warning when running Swift expressions in non-Swift
    frames. In the explicit modules world, scanning an entire dylib and
    combining its compiler flags is not expected to produce a meaningful
    result, so this work is largely unnecessary. To ease the transition,
    users can get the old behavior back by setting the
    target.use-all-compiler-flags setting.
    
    rdar://168933024
```
