### PR TITLE
[clang][cas] Only use mccas by default on mach-o platforms in clang-cache

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -146,6 +146,8 @@ def err_feature_availability_flag_invalid_value : Error<
 
 def err_fe_incompatible_option_with_remote_cache : Error<
   "'%0' is incompatible with remote caching backend">;
+def err_fe_mccas_incompatible_target : Error<
+  "-fcas-backend is incompatible with target '%0'; requires mach-o object format">;
 def err_fe_unable_to_load_include_tree : Error<
   "unable to load the CAS include-tree '%0': '%1'">;
 def err_unable_to_load_include_tree_node : Error<

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5587,6 +5587,8 @@ bool CompilerInvocation::CreateFromArgsImpl(
       Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
           << "-fcasid-output";
   }
+  if (Res.getCodeGenOpts().UseCASBackend && !T.isOSBinFormatMachO())
+    Diags.Report(diag::err_fe_mccas_incompatible_target) << T.str();
   // END MCCAS
 
   // FIXME: Override value name discarding when asan or msan is used because the

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -46,31 +46,43 @@
 // PLUGIN: "-fcas-plugin-option" "opt2=val2"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS -DPREFIX=%t
 // ENABLE-MCCAS: "-fcas-path" "[[PREFIX]]/cas"
 // ENABLE-MCCAS: "-fcas-backend"
 // ENABLE-MCCAS: "-mllvm"
 // ENABLE-MCCAS: "-cas-friendly-debug-info"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_VERIFY_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS-VERIFY -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=ENABLE-MCCAS-VERIFY -DPREFIX=%t
 // ENABLE-MCCAS-VERIFY: "-fcas-path" "[[PREFIX]]/cas"
 // ENABLE-MCCAS-VERIFY: "-fcas-backend"
 // ENABLE-MCCAS-VERIFY: "-fcas-backend-mode=verify"
 // ENABLE-MCCAS-VERIFY: "-mllvm"
 // ENABLE-MCCAS-VERIFY: "-cas-friendly-debug-info"
 
+// ELF/COFF platforms do not support mccas.
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
+// RUN: %clang-cache %clang -target x86_64-unknown-linux-gnu -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
+// RUN: %clang-cache %clang -target x86_64-unknown-windows-msvc -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+
+// Forcing mccas gives an error on ELF/COFF.
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas \
+// RUN: not %clang -target x86_64-unknown-linux-gnu -Xclang -fcas-backend -c %s -o %t.o 2>&1 | FileCheck %s -check-prefix=MCCAS_NOT_ALLOWED
+// MCCAS_NOT_ALLOWED: error: -fcas-backend is incompatible with target 'x86_64-unknown-linux-gnu'; requires mach-o object format
+
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote CLANG_CACHE_DISABLE_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH=%t/ccremote CLANG_CACHE_DISABLE_MCCAS=1 CLANG_CACHE_VERIFY_MCCAS=1 \
-// RUN: %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
+// RUN: %clang-cache %clang -target x86_64-apple-darwin10 -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=DISABLE-MCCAS -DPREFIX=%t
 
 // DISABLE-MCCAS-NOT: "-fcas-backend"
 // DISABLE-MCCAS-NOT: "-fcas-backend-mode=verify"


### PR DESCRIPTION
This was causing the clang-cache launcher to fail when targeting Linux/Windows. Only enable mccas on mach-o platforms. Incidentally, add a proper diagnostic if someone attempts to force mccas since it was previously hitting an llvm_unreachable.