### PR TITLE
clang-cache fixes for Windows

### DIFF
--- a/clang/test/CAS/clang-cache-mode.c
+++ b/clang/test/CAS/clang-cache-mode.c
@@ -1,0 +1,3 @@
+// RUN: %clang-cache %clang -v -fsyntax-only -x c %s 2>&1 | FileCheck %s
+
+// CHECK: -fdepscan

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -21,17 +21,25 @@
 using namespace clang;
 
 static bool isSameProgram(StringRef clangCachePath, StringRef compilerPath) {
+  using namespace llvm::sys;
+
   // Fast path check, see if they have the same parent path.
-  if (llvm::sys::path::parent_path(clangCachePath) ==
-      llvm::sys::path::parent_path(compilerPath))
+  if (path::parent_path(clangCachePath) == path::parent_path(compilerPath))
     return true;
+
+#if LLVM_ON_WIN32
+  // executables are normally copies on Windows, so we cannot do much more of a
+  // check.
+  return true;
+#else
   // Check the file status IDs;
-  llvm::sys::fs::file_status CacheStat, CompilerStat;
-  if (llvm::sys::fs::status(clangCachePath, CacheStat))
+  fs::file_status CacheStat, CompilerStat;
+  if (fs::status(clangCachePath, CacheStat))
     return false;
-  if (llvm::sys::fs::status(compilerPath, CompilerStat))
+  if (fs::status(compilerPath, CompilerStat))
     return false;
   return CacheStat.getUniqueID() == CompilerStat.getUniqueID();
+#endif
 }
 
 static bool shouldCacheInvocation(ArrayRef<const char *> Args,

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -216,7 +216,11 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
           llvm::sys::Process::GetEnv("LLVM_CACHE_WARNINGS")) {
     SmallVector<const char *, 8> WarnOpts;
     WarnOpts.push_back(Args.front());
+#if LLVM_ON_WIN32
+    llvm::cl::TokenizeWindowsCommandLine(*WarnOptsValue, Saver, WarnOpts);
+#else
     llvm::cl::TokenizeGNUCommandLine(*WarnOptsValue, Saver, WarnOpts);
+#endif
     DiagOpts = CreateAndPopulateDiagOpts(WarnOpts);
   } else {
     DiagOpts = std::make_unique<DiagnosticOptions>();

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -27,7 +27,7 @@ static bool isSameProgram(StringRef clangCachePath, StringRef compilerPath) {
   if (path::parent_path(clangCachePath) == path::parent_path(compilerPath))
     return true;
 
-#if LLVM_ON_WIN32
+#if defined(_WIN32)
   // executables are normally copies on Windows, so we cannot do much more of a
   // check.
   return true;
@@ -216,7 +216,7 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
           llvm::sys::Process::GetEnv("LLVM_CACHE_WARNINGS")) {
     SmallVector<const char *, 8> WarnOpts;
     WarnOpts.push_back(Args.front());
-#if LLVM_ON_WIN32
+#if defined(_WIN32)
     llvm::cl::TokenizeWindowsCommandLine(*WarnOptsValue, Saver, WarnOpts);
 #else
     llvm::cl::TokenizeGNUCommandLine(*WarnOptsValue, Saver, WarnOpts);

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -352,6 +352,13 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   }
 
   std::string Path = GetExecutablePath(ToolContext.Path, CanonicalPrefixes);
+  // We might be in in-process execution mode, where `ToolContext.Path` is
+  // pointing to `clang-cache`. This is then used subsequently in the
+  // constructor for `Driver` which uses this same value in `BuildCompilation`.
+  // That path results in the wrong mode being selected. Explicitly adjust the
+  // `Path` to point to the wrapped tool invocation.
+  if (isClangCache(getDriverMode(ToolContext.Path, {})))
+    Path = Args[0];
 
   // Whether the cc1 tool should be called inside the current process, or if we
   // should spawn a new clang subprocess (old behavior).


### PR DESCRIPTION
Loosen the same program restriction and correct tokenisation.