### PR TITLE
[lldb][test] stop checking forwarded include path from swift

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -31,13 +31,6 @@ class TestSwiftClangImporterCaching(TestBase):
 #       CHECK Loading module ClangB from CAS at llvmcas://
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -triple
-### Check include paths in the module are forwards. The first argument is the source directory.
-#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -I
-#       CHECK-NEXT:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --
-#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -I
-#       CHECK-NEXT:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /TEST_DIR
-#       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -F
-#       CHECK-NEXT:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /FRAMEWORK_DIR
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DADDED=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DEXTRA=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'ClangA'


### PR DESCRIPTION
Swift caching build do not have include path forwarded from compiler. Stop checking for them in preparation for removing them.