### PR TITLE
[Cherry-pick into next] [LLDB] Avoid diagnosing CAS warnings for regular files

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -563,8 +563,10 @@ public:
   ///    in the CAS, error if there are any errors happened during the loading
   ///    process.
   static llvm::Expected<bool>
-  GetSharedModuleFromCAS(llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
-                         ModuleSpec &module_spec, lldb::ModuleSP &module_sp);
+  GetSharedModuleFromCAS(llvm::StringRef cas_id,
+                         llvm::StringRef name_for_diagnostics,
+                         const lldb::ModuleSP &nearby, ModuleSpec &module_spec,
+                         lldb::ModuleSP &module_sp);
   // END CAS
 
   static bool RemoveSharedModule(lldb::ModuleSP &module_sp);

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -1679,18 +1679,23 @@ ModuleList::GetSharedModule(const ModuleSpec &module_spec, ModuleSP &module_sp,
   return error;
 }
 
-static llvm::Expected<ModuleSpec>
-loadModuleFromCASImpl(llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
-                      const UUID &uuid, const ArchSpec &arch) {
-  auto maybe_cas = ModuleList::GetOrCreateCAS(nearby);
-  if (!maybe_cas)
-    return maybe_cas.takeError();
+static llvm::Expected<ModuleSpec> loadModuleFromCASImpl(
+    llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
+    const lldb::ModuleSP &nearby, const UUID &uuid, const ArchSpec &arch) {
+  llvm::Expected<ModuleList::CAS> maybe_cas =
+      ModuleList::GetOrCreateCAS(nearby);
+  if (!maybe_cas) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Modules), maybe_cas.takeError(),
+                   "Failed to load module '{1}' at '{2}' from CAS: {0}",
+                   name_for_diagnostics, cas_id);
+    return ModuleSpec();
+  }
 
   auto cas = std::move(maybe_cas->object_store);
   if (!cas) {
     LLDB_LOG(GetLog(LLDBLog::Modules),
-             "skip loading module '{0}' from CAS: CAS is not available",
-             cas_id);
+             "Failed to load '{0}' at '{1}' from CAS: CAS is not available",
+             name_for_diagnostics, cas_id);
     return ModuleSpec();
   }
 
@@ -1723,8 +1728,9 @@ loadModuleFromCASImpl(llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
 /// Load the module referenced by \c cas_id from a CAS located
 /// near \c nearby.
 static llvm::Expected<ModuleSpec>
-loadModuleFromCAS(llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
-                  const UUID &uuid, const ArchSpec &arch) {
+loadModuleFromCAS(llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
+                  const lldb::ModuleSP &nearby, const UUID &uuid,
+                  const ArchSpec &arch) {
   static llvm::StringMap<ModuleSpec> g_cache;
   static std::recursive_mutex g_cache_lock;
   std::scoped_lock<std::recursive_mutex> lock(g_cache_lock);
@@ -1732,7 +1738,8 @@ loadModuleFromCAS(llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
   if (cached != g_cache.end())
     return cached->second;
 
-  auto spec_or_err = loadModuleFromCASImpl(cas_id, nearby, uuid, arch);
+  auto spec_or_err =
+      loadModuleFromCASImpl(cas_id, name_for_diagnostics, nearby, uuid, arch);
   g_cache.try_emplace(cas_id, spec_or_err ? *spec_or_err : ModuleSpec());
 
   return spec_or_err;
@@ -1842,10 +1849,12 @@ ModuleList::GetOrCreateCAS(const ModuleSP &module_sp) {
 }
 
 llvm::Expected<bool> ModuleList::GetSharedModuleFromCAS(
-    llvm::StringRef cas_id, const lldb::ModuleSP &nearby,
-    ModuleSpec &module_spec, lldb::ModuleSP &module_sp) {
-  auto loaded = loadModuleFromCAS(cas_id, nearby, module_spec.GetUUID(),
-                                  module_spec.GetArchitecture());
+    llvm::StringRef cas_id, llvm::StringRef name_for_diagnostics,
+    const lldb::ModuleSP &nearby, ModuleSpec &module_spec,
+    lldb::ModuleSP &module_sp) {
+  auto loaded =
+      loadModuleFromCAS(cas_id, name_for_diagnostics, nearby,
+                        module_spec.GetUUID(), module_spec.GetArchitecture());
   if (!loaded)
     return loaded.takeError();
 

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARF.cpp
@@ -2013,7 +2013,8 @@ void SymbolFileDWARF::UpdateExternalModuleListIfNeeded() {
       LLDB_LOG(GetLog(LLDBLog::Symbols | LLDBLog::Modules),
                "Loading module '{0}' from CAS at {1}...", const_name, dwo_path);
       auto loaded = ModuleList::GetSharedModuleFromCAS(
-          dwo_path, GetObjectFile()->GetModule(), dwo_module_spec, module_sp);
+          dwo_path, const_name, GetObjectFile()->GetModule(), dwo_module_spec,
+          module_sp);
       if (!loaded)
         GetObjectFile()->GetModule()->ReportWarning(
             "Failed to load module '{0}' from CAS: {1}", const_name,

--- a/lldb/test/Shell/SymbolFile/DWARF/clang-gmodules-type-lookup.c
+++ b/lldb/test/Shell/SymbolFile/DWARF/clang-gmodules-type-lookup.c
@@ -10,6 +10,15 @@
 // RUN:   --language=C99 -compiler-context 'ClassOrStruct:TypeFromPCH' \
 // RUN:   %t.exe | FileCheck %s
 
+// BEGIN CAS
+// RUN: rm %t.pch
+// RUN: lldb-test symbols -dump-clang-ast -find type --find-in-any-module \
+// RUN:   --language=C99 -compiler-context 'ClassOrStruct:TypeFromPCH' \
+// RUN:   %t.exe 2>&1 | FileCheck %s --check-prefix=CHECK-CAS
+// CHECK-CAS-NOT: Failed to load module {{.*}} from CAS
+// CHECK-CAS: pch{{.*}}does not exist
+// END CAS
+
 anchor_t anchor;
 
 int main(int argc, char **argv) { return 0; }

--- a/lldb/test/Shell/SymbolFile/cas-gmodule.test
+++ b/lldb/test/Shell/SymbolFile/cas-gmodule.test
@@ -8,7 +8,7 @@
 # RUN: sed "s|DIR|%/t|g" %t/cas-config.template > %t/.cas-config
 # RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s
 
-# FAIL: Failed to load module 'Bottom' from CAS: no CAS available
+# FAIL: Failed to load module 'Bottom' at '{{.*}}' from CAS: no CAS available
 # FAIL: Unable to locate module needed for external types.
 # CHECK: Loading module 'Bottom' from CAS at
 # CHECK: Loading module 'Top' from CAS at


### PR DESCRIPTION
```
commit 4c61dea74b05854dfd6fec39b9c0d49a793aec49
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Jan 27 10:57:54 2026 -0800

    [LLDB] Avoid diagnosing CAS warnings for regular files
    
    Only the CAS plugin can determine what is a CAS URL so we log the
    errors instead of printing them to users. The normal file not found
    warning is being diagnosed right after.
    
    rdar://169010767
```
