### PR TITLE
[stable/21.x][clang][driver][darwin] Prefer DarwinSDKInfo for platform identification and compatibility over the -isysroot path

### DIFF
--- a/clang/include/clang/Basic/DarwinSDKInfo.h
+++ b/clang/include/clang/Basic/DarwinSDKInfo.h
@@ -183,7 +183,7 @@ public:
   DarwinSDKInfo(
       std::string FilePath, llvm::Triple::OSType OS,
       llvm::Triple::EnvironmentType Environment, VersionTuple Version,
-      VersionTuple MaximumDeploymentTarget,
+      StringRef DisplayName, VersionTuple MaximumDeploymentTarget,
       PlatformInfoStorageType PlatformInfos,
       llvm::DenseMap<OSEnvPair::StorageType,
                      std::optional<RelatedTargetVersionMapping>>
@@ -191,6 +191,7 @@ public:
               llvm::DenseMap<OSEnvPair::StorageType,
                              std::optional<RelatedTargetVersionMapping>>())
       : FilePath(FilePath), OS(OS), Environment(Environment), Version(Version),
+        DisplayName(DisplayName),
         MaximumDeploymentTarget(MaximumDeploymentTarget),
         PlatformInfos(std::move(PlatformInfos)),
         VersionMappings(std::move(VersionMappings)) {}
@@ -203,8 +204,14 @@ public:
 
   const llvm::VersionTuple &getVersion() const { return Version; }
 
+  const StringRef getDisplayName() const { return DisplayName; }
+
   const SDKPlatformInfo &getCanonicalPlatformInfo() const {
     return PlatformInfos[0];
+  }
+
+  bool supportsTriple(llvm::Triple Triple) const {
+    return llvm::find(PlatformInfos, Triple) != PlatformInfos.end();
   }
 
   const StringRef getPlatformPrefix(llvm::Triple Triple) const {
@@ -241,6 +248,7 @@ private:
   llvm::Triple::OSType OS;
   llvm::Triple::EnvironmentType Environment;
   VersionTuple Version;
+  std::string DisplayName;
   VersionTuple MaximumDeploymentTarget;
   PlatformInfoStorageType PlatformInfos;
   // Need to wrap the value in an optional here as the value has to be default

--- a/clang/lib/Basic/DarwinSDKInfo.cpp
+++ b/clang/lib/Basic/DarwinSDKInfo.cpp
@@ -188,6 +188,10 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(std::string FilePath,
   std::optional<StringRef> XcodePlatform = parseXcodePlatform(*Obj);
   std::pair<llvm::Triple::OSType, llvm::Triple::EnvironmentType>
       OSAndEnvironment = parseOSAndEnvironment(XcodePlatform);
+  // DisplayName should always be present, but don't require it.
+  StringRef DisplayName =
+      Obj->getString("DisplayName")
+          .value_or(Obj->getString("CanonicalName").value_or("<unknown>"));
   PlatformInfoStorageType PlatformInfos =
       parsePlatformInfos(*Obj, XcodePlatform, OSAndEnvironment.first,
                          OSAndEnvironment.second, *Version);
@@ -234,7 +238,7 @@ DarwinSDKInfo::parseDarwinSDKSettingsJSON(std::string FilePath,
 
   return DarwinSDKInfo(std::move(FilePath), OSAndEnvironment.first,
                        OSAndEnvironment.second, std::move(*Version),
-                       std::move(*MaximumDeploymentVersion),
+                       DisplayName, std::move(*MaximumDeploymentVersion),
                        std::move(PlatformInfos), std::move(VersionMappings));
 }
 

--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1240,6 +1240,40 @@ AppleMachO::~AppleMachO() {}
 
 MachO::~MachO() {}
 
+void Darwin::VerifyTripleForSDK(const llvm::opt::ArgList &Args,
+                                const llvm::Triple Triple) const {
+  if (SDKInfo) {
+    if (!SDKInfo->supportsTriple(Triple))
+      getDriver().Diag(diag::warn_incompatible_sysroot)
+          << SDKInfo->getDisplayName() << Triple.getTriple();
+  } else if (const Arg *A = Args.getLastArg(options::OPT_isysroot)) {
+    const char *isysroot = A->getValue();
+    StringRef SDK = getSDKName(isysroot);
+    if (!SDK.empty()) {
+      size_t StartVer = SDK.find_first_of("0123456789");
+      StringRef SDKName = SDK.slice(0, StartVer);
+      bool supported = true;
+      if (Triple.isWatchOS())
+        supported = SDKName.starts_with("Watch");
+      else if (Triple.isTvOS())
+        supported = SDKName.starts_with("AppleTV");
+      else if (Triple.isDriverKit())
+        supported = SDKName.starts_with("DriverKit");
+      else if (Triple.isiOS())
+        supported = SDKName.starts_with("iPhone");
+      else if (Triple.isMacOSX())
+        supported = SDKName.starts_with("MacOSX");
+      else
+        llvm::reportFatalUsageError(Twine("SDK at '") + isysroot +
+                                    "' missing SDKSettings.json.");
+
+      if (!supported)
+        getDriver().Diag(diag::warn_incompatible_sysroot)
+            << SDKName << Triple.getTriple();
+    }
+  }
+}
+
 std::string Darwin::ComputeEffectiveClangTriple(const ArgList &Args,
                                                 types::ID InputType) const {
   llvm::Triple Triple(ComputeLLVMTriple(Args, InputType));
@@ -1264,6 +1298,8 @@ std::string Darwin::ComputeEffectiveClangTriple(const ArgList &Args,
     Str += "macosx";
   Str += getTripleTargetVersion().getAsString();
   Triple.setOSName(Str);
+
+  VerifyTripleForSDK(Args, Triple);
 
   return Triple.getTriple();
 }
@@ -1523,26 +1559,6 @@ std::string Darwin::getCompilerRT(const ArgList &Args, StringRef Component,
   SmallString<128> FullPath(getDriver().ResourceDir);
   llvm::sys::path::append(FullPath, "lib", "darwin", DarwinLibName);
   return std::string(FullPath);
-}
-
-StringRef Darwin::getPlatformFamily() const {
-  switch (TargetPlatform) {
-    case DarwinPlatformKind::MacOS:
-      return "MacOSX";
-    case DarwinPlatformKind::IPhoneOS:
-      if (TargetEnvironment == MacCatalyst)
-        return "MacOSX";
-      return "iPhone";
-    case DarwinPlatformKind::TvOS:
-      return "AppleTV";
-    case DarwinPlatformKind::WatchOS:
-      return "Watch";
-    case DarwinPlatformKind::DriverKit:
-      return "DriverKit";
-    case DarwinPlatformKind::XROS:
-      return "XR";
-  }
-  llvm_unreachable("Unsupported platform");
 }
 
 StringRef Darwin::getSDKName(StringRef isysroot) {
@@ -2026,6 +2042,18 @@ struct DarwinPlatform {
     Result.EnvVarName = EnvVarName;
     return Result;
   }
+  static DarwinPlatform createFromSDKInfo(StringRef SDKRoot,
+                                          const DarwinSDKInfo &SDKInfo) {
+    const DarwinSDKInfo::SDKPlatformInfo PlatformInfo =
+        SDKInfo.getCanonicalPlatformInfo();
+    DarwinPlatform Result(InferredFromSDK,
+                          getPlatformFromOS(PlatformInfo.getOS()),
+                          SDKInfo.getVersion());
+    Result.Environment = getEnvKindFromEnvType(PlatformInfo.getEnvironment());
+    Result.InferSimulatorFromArch = false;
+    Result.InferredSource = SDKRoot;
+    return Result;
+  }
   static DarwinPlatform createFromSDK(StringRef SDKRoot,
                                       DarwinPlatformKind Platform,
                                       StringRef Value,
@@ -2056,12 +2084,13 @@ struct DarwinPlatform {
         getEnvTypeFromEnvKind(Environment);
     StringRef PlatformPrefix =
         (Platform == DarwinPlatformKind::DriverKit) ? "/System/DriverKit" : "";
-    return DarwinSDKInfo(
-        "", OS, EnvironmentType, getOSVersion(), /*MaximumDeploymentTarget=*/
-        VersionTuple(getOSVersion().getMajor(), 0, 99),
-        {DarwinSDKInfo::SDKPlatformInfo(llvm::Triple::Apple, OS,
-                                        EnvironmentType, llvm::Triple::MachO,
-                                        PlatformPrefix)});
+    return DarwinSDKInfo("", OS, EnvironmentType, getOSVersion(),
+                         getDisplayName(Platform, Environment, getOSVersion()),
+                         /*MaximumDeploymentTarget=*/
+                         VersionTuple(getOSVersion().getMajor(), 0, 99),
+                         {DarwinSDKInfo::SDKPlatformInfo(
+                             llvm::Triple::Apple, OS, EnvironmentType,
+                             llvm::Triple::MachO, PlatformPrefix)});
   }
 
 private:
@@ -2122,6 +2151,20 @@ private:
     llvm_unreachable("Unknown DarwinPlatformKind enum");
   }
 
+  static DarwinEnvironmentKind
+  getEnvKindFromEnvType(llvm::Triple::EnvironmentType EnvironmentType) {
+    switch (EnvironmentType) {
+    case llvm::Triple::UnknownEnvironment:
+      return DarwinEnvironmentKind::NativeEnvironment;
+    case llvm::Triple::Simulator:
+      return DarwinEnvironmentKind::Simulator;
+    case llvm::Triple::MacABI:
+      return DarwinEnvironmentKind::MacCatalyst;
+    default:
+      llvm_unreachable("Unable to infer Darwin environment");
+    }
+  }
+
   static llvm::Triple::EnvironmentType
   getEnvTypeFromEnvKind(DarwinEnvironmentKind EnvironmentKind) {
     switch (EnvironmentKind) {
@@ -2133,6 +2176,46 @@ private:
       return llvm::Triple::MacABI;
     }
     llvm_unreachable("Unknown DarwinEnvironmentKind enum");
+  }
+
+  static std::string getDisplayName(DarwinPlatformKind TargetPlatform,
+                                    DarwinEnvironmentKind TargetEnvironment,
+                                    VersionTuple Version) {
+    SmallVector<StringRef, 3> Components;
+    switch (TargetPlatform) {
+    case DarwinPlatformKind::MacOS:
+      Components.push_back("macOS");
+      break;
+    case DarwinPlatformKind::IPhoneOS:
+      Components.push_back("iOS");
+      break;
+    case DarwinPlatformKind::TvOS:
+      Components.push_back("tvOS");
+      break;
+    case DarwinPlatformKind::WatchOS:
+      Components.push_back("watchOS");
+      break;
+    case DarwinPlatformKind::DriverKit:
+      Components.push_back("DriverKit");
+      break;
+    default:
+      llvm::reportFatalUsageError(Twine("Platform: '") +
+                                  std::to_string(TargetPlatform) +
+                                  "' is unsupported when inferring SDK Info.");
+    }
+    switch (TargetEnvironment) {
+    case DarwinEnvironmentKind::NativeEnvironment:
+      break;
+    case DarwinEnvironmentKind::Simulator:
+      Components.push_back("Simulator");
+      break;
+    default:
+      llvm::reportFatalUsageError(Twine("Environment: '") +
+                                  std::to_string(TargetEnvironment) +
+                                  "' is unsupported when inferring SDK Info.");
+    }
+    Components.push_back(Version.getAsString());
+    return join(Components, " ");
   }
 
   SourceKind Kind;
@@ -2279,15 +2362,6 @@ getDeploymentTargetFromEnvironmentVariables(const Driver &TheDriver,
   return std::nullopt;
 }
 
-/// Returns the SDK name without the optional prefix that ends with a '.' or an
-/// empty string otherwise.
-static StringRef dropSDKNamePrefix(StringRef SDKName) {
-  size_t PrefixPos = SDKName.find('.');
-  if (PrefixPos == StringRef::npos)
-    return "";
-  return SDKName.substr(PrefixPos + 1);
-}
-
 /// Tries to infer the deployment target from the SDK specified by -isysroot
 /// (or SDKROOT). Uses the version specified in the SDKSettings.json file if
 /// it's available.
@@ -2298,57 +2372,43 @@ inferDeploymentTargetFromSDK(DerivedArgList &Args,
   if (!A)
     return std::nullopt;
   StringRef isysroot = A->getValue();
+  if (SDKInfo)
+    return DarwinPlatform::createFromSDKInfo(isysroot, *SDKInfo);
+
   StringRef SDK = Darwin::getSDKName(isysroot);
   if (!SDK.size())
     return std::nullopt;
 
   std::string Version;
-  if (SDKInfo) {
-    // Get the version from the SDKSettings.json if it's available.
-    Version = SDKInfo->getVersion().getAsString();
-  } else {
-    // Slice the version number out.
-    // Version number is between the first and the last number.
-    size_t StartVer = SDK.find_first_of("0123456789");
-    size_t EndVer = SDK.find_last_of("0123456789");
-    if (StartVer != StringRef::npos && EndVer > StartVer)
-      Version = std::string(SDK.slice(StartVer, EndVer + 1));
-  }
+  // Slice the version number out.
+  // Version number is between the first and the last number.
+  size_t StartVer = SDK.find_first_of("0123456789");
+  size_t EndVer = SDK.find_last_of("0123456789");
+  if (StartVer != StringRef::npos && EndVer > StartVer)
+    Version = std::string(SDK.slice(StartVer, EndVer + 1));
   if (Version.empty())
     return std::nullopt;
 
-  auto CreatePlatformFromSDKName =
-      [&](StringRef SDK) -> std::optional<DarwinPlatform> {
-    if (SDK.starts_with("iPhoneOS") || SDK.starts_with("iPhoneSimulator"))
-      return DarwinPlatform::createFromSDK(
-          isysroot, Darwin::IPhoneOS, Version,
-          /*IsSimulator=*/SDK.starts_with("iPhoneSimulator"));
-    else if (SDK.starts_with("MacOSX"))
-      return DarwinPlatform::createFromSDK(isysroot, Darwin::MacOS,
-                                           getSystemOrSDKMacOSVersion(Version));
-    else if (SDK.starts_with("WatchOS") || SDK.starts_with("WatchSimulator"))
-      return DarwinPlatform::createFromSDK(
-          isysroot, Darwin::WatchOS, Version,
-          /*IsSimulator=*/SDK.starts_with("WatchSimulator"));
-    else if (SDK.starts_with("AppleTVOS") ||
-             SDK.starts_with("AppleTVSimulator"))
-      return DarwinPlatform::createFromSDK(
-          isysroot, Darwin::TvOS, Version,
-          /*IsSimulator=*/SDK.starts_with("AppleTVSimulator"));
-    else if (SDK.starts_with("XR"))
-      return DarwinPlatform::createFromSDK(
-          isysroot, Darwin::XROS, Version,
-          /*IsSimulator=*/SDK.contains("Simulator"));
-    else if (SDK.starts_with("DriverKit"))
-      return DarwinPlatform::createFromSDK(isysroot, Darwin::DriverKit,
-                                           Version);
-    return std::nullopt;
-  };
-  if (auto Result = CreatePlatformFromSDKName(SDK))
-    return Result;
-  // The SDK can be an SDK variant with a name like `<prefix>.<platform>`.
-  return CreatePlatformFromSDKName(dropSDKNamePrefix(SDK));
+  if (SDK.starts_with("iPhoneOS") || SDK.starts_with("iPhoneSimulator"))
+    return DarwinPlatform::createFromSDK(
+        isysroot, Darwin::IPhoneOS, Version,
+        /*IsSimulator=*/SDK.starts_with("iPhoneSimulator"));
+  else if (SDK.starts_with("MacOSX"))
+    return DarwinPlatform::createFromSDK(isysroot, Darwin::MacOS,
+                                         getSystemOrSDKMacOSVersion(Version));
+  else if (SDK.starts_with("WatchOS") || SDK.starts_with("WatchSimulator"))
+    return DarwinPlatform::createFromSDK(
+        isysroot, Darwin::WatchOS, Version,
+        /*IsSimulator=*/SDK.starts_with("WatchSimulator"));
+  else if (SDK.starts_with("AppleTVOS") || SDK.starts_with("AppleTVSimulator"))
+    return DarwinPlatform::createFromSDK(
+        isysroot, Darwin::TvOS, Version,
+        /*IsSimulator=*/SDK.starts_with("AppleTVSimulator"));
+  else if (SDK.starts_with("DriverKit"))
+    return DarwinPlatform::createFromSDK(isysroot, Darwin::DriverKit, Version);
+  return std::nullopt;
 }
+
 // Compute & get the OS Version when the target triple omitted one.
 VersionTuple getInferredOSVersion(llvm::Triple::OSType OS,
                                   const llvm::Triple &Triple,
@@ -2749,18 +2809,6 @@ void Darwin::AddDeploymentTarget(DerivedArgList &Args) const {
                                          TargetVariantTriple->getOSVersion())) {
     getDriver().Diag(diag::err_drv_invalid_version_number)
         << TargetVariantTriple->str();
-  }
-
-  if (const Arg *A = Args.getLastArg(options::OPT_isysroot)) {
-    StringRef SDK = getSDKName(A->getValue());
-    if (SDK.size() > 0) {
-      size_t StartVer = SDK.find_first_of("0123456789");
-      StringRef SDKName = SDK.slice(0, StartVer);
-      if (!SDKName.starts_with(getPlatformFamily()) &&
-          !dropSDKNamePrefix(SDKName).starts_with(getPlatformFamily()))
-        getDriver().Diag(diag::warn_incompatible_sysroot)
-            << SDKName << getPlatformFamily();
-    }
   }
 }
 
@@ -3283,12 +3331,8 @@ bool Darwin::isAlignedAllocationUnavailable() const {
 static bool
 sdkSupportsBuiltinModules(const std::optional<DarwinSDKInfo> &SDKInfo) {
   if (!SDKInfo)
-    // If there is no SDK info, assume this is building against a
-    // pre-SDK version of macOS (i.e. before Mac OS X 10.4). Those
-    // don't support modules anyway, but the headers definitely
-    // don't support builtin modules either. It might also be some
-    // kind of degenerate build environment, err on the side of
-    // the old behavior which is to not use builtin modules.
+    // If there is no SDK info, assume this is building against an SDK that
+    // predates SDKSettings.json. None of those support builtin modules.
     return false;
 
   switch (SDKInfo->getEnvironment()) {

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -388,6 +388,9 @@ public:
 private:
   void AddDeploymentTarget(llvm::opt::DerivedArgList &Args) const;
 
+  void VerifyTripleForSDK(const llvm::opt::ArgList &Args,
+                          const llvm::Triple Triple) const;
+
 public:
   Darwin(const Driver &D, const llvm::Triple &Triple,
          const llvm::opt::ArgList &Args);
@@ -589,7 +592,6 @@ protected:
       const llvm::opt::ArgList &Args,
       llvm::opt::ArgStringList &CC1ASArgs) const override;
 
-  StringRef getPlatformFamily() const;
   StringRef getOSLibraryNameSuffix(bool IgnoreSim = false) const override;
 
 public:

--- a/clang/test/Driver/Inputs/XROS1.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/XROS1.0.sdk/SDKSettings.json
@@ -1,0 +1,29 @@
+{
+  "CanonicalName": "xros1.0",
+  "Version": "1.0",
+  "IsBaseSDK": "YES",
+  "DisplayName": "visionOS 1.0",
+  "MinimalDisplayName": "1.0",
+  "SupportedTargets": {
+    "xros": {
+      "PlatformFamilyName": "xrOS",
+      "PlatformFamilyDisplayName": "visionOS",
+      "Archs": ["arm64e", "arm64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "xros", "LLVMTargetTripleEnvironment": "",
+      "BuildVersionPlatformID": "11",
+      "ClangRuntimeLibraryPlatformName": "xros",
+      "SystemPrefix": "",
+      "DefaultDeploymentTarget": "1.0",
+      "RecommendedDeploymentTarget": "1.0",
+      "MinimumDeploymentTarget": "1.0", "MaximumDeploymentTarget": "1.0.99",
+      "ValidDeploymentTargets": ["1.0"]
+    }
+  },
+  "VersionMap": {
+    "visionOS_iOS": {"1.0": "17.1"},
+    "iOS_visionOS": {"17.1": "1.0"},
+    "xrOS_iOS": {"1.0": "17.1"},
+    "iOS_xrOS": {"17.1": "1.0"}
+  },
+  "DefaultDeploymentTarget": "1.0",
+  "MaximumDeploymentTarget": "1.0.99"
+}

--- a/clang/test/Driver/Inputs/XRSimulator1.0.sdk/SDKSettings.json
+++ b/clang/test/Driver/Inputs/XRSimulator1.0.sdk/SDKSettings.json
@@ -1,0 +1,29 @@
+{
+  "CanonicalName": "xrsimulator1.0",
+  "Version": "1.0",
+  "IsBaseSDK": "YES",
+  "DisplayName": "Simulator - visionOS 1.0",
+  "MinimalDisplayName": "Simulator - 1.0",
+  "SupportedTargets": {
+    "xrsimulator": {
+      "PlatformFamilyName": "xrOS",
+      "PlatformFamilyDisplayName": "visionOS",
+      "Archs": ["arm64", "x86_64"], "LLVMTargetTripleVendor": "apple", "LLVMTargetTripleSys": "xros", "LLVMTargetTripleEnvironment": "simulator",
+      "BuildVersionPlatformID": "12",
+      "ClangRuntimeLibraryPlatformName": "xrossim",
+      "SystemPrefix": "",
+      "DefaultDeploymentTarget": "1.0",
+      "RecommendedDeploymentTarget": "1.0",
+      "MinimumDeploymentTarget": "1.0", "MaximumDeploymentTarget": "1.0.99",
+      "ValidDeploymentTargets": ["1.0"]
+    }
+  },
+  "VersionMap": {
+    "visionOS_iOS": {"1.0": "17.1"},
+    "iOS_visionOS": {"17.1": "1.0"},
+    "xrOS_iOS": {"1.0": "17.1"},
+    "iOS_xrOS": {"17.1": "1.0"}
+  },
+  "DefaultDeploymentTarget": "1.0",
+  "MaximumDeploymentTarget": "1.0.99"
+}

--- a/clang/test/Driver/darwin-sdk-with-prefix.c
+++ b/clang/test/Driver/darwin-sdk-with-prefix.c
@@ -1,10 +1,18 @@
 // RUN: rm -rf %t.dir
 // RUN: mkdir -p %t.dir
 
-// RUN: rm -rf %t.dir/prefix.iPhoneOS12.0.0.sdk
-// RUN: mkdir -p %t.dir/prefix.iPhoneOS12.0.0.sdk
-// RUN: %clang -c -isysroot %t.dir/prefix.iPhoneOS12.0.0.sdk -target arm64-apple-darwin %s -### 2>&1 | FileCheck %s
-// RUN: env SDKROOT=%t.dir/prefix.iPhoneOS12.0.0.sdk %clang -c -target arm64-apple-darwin %s -### 2>&1 | FileCheck %s
+// The name of the SDK directory doesn't matter, the supported triples come from the SDKSettings file.
+
+// RUN: rm -rf %t.dir/prefix.MacOSX13.0.sdk
+// RUN: cp -R %S/Inputs/iPhoneOS13.0.sdk %t.dir/prefix.MacOSX13.0.sdk
+// RUN: %clang -c -isysroot %t.dir/prefix.MacOSX13.0.sdk -target arm64-apple-darwin %s -### 2>&1 | FileCheck %s
+// RUN: env SDKROOT=%t.dir/prefix.MacOSX13.0.sdk %clang -c -target arm64-apple-darwin %s -### 2>&1 | FileCheck %s
 //
 // CHECK-NOT: warning: using sysroot for
-// CHECK: "-triple" "arm64-apple-ios12.0.0"
+// CHECK: "-triple" "arm64-apple-ios13.0.0"
+
+// RUN: %clang -c -isysroot %t.dir/prefix.MacOSX13.0.sdk -target arm64-apple-macos %s -### 2>&1 | FileCheck %s --check-prefix=INCOMPATIBLE
+// RUN: env SDKROOT=%t.dir/prefix.MacOSX13.0.sdk %clang -c -target arm64-apple-macos %s -### 2>&1 | FileCheck %s --check-prefix=INCOMPATIBLE
+//
+// INCOMPATIBLE: warning: using sysroot for
+// INCOMPATIBLE: "-triple" "arm64-apple-macos{{[\d.]*}}

--- a/clang/test/Driver/incompatible_sysroot.c
+++ b/clang/test/Driver/incompatible_sysroot.c
@@ -9,11 +9,19 @@
 // RUN: %clang -target x86_64-apple-darwin -Wincompatible-sysroot -isysroot SDKs/iPhoneSimulator9.2.sdk -mios-version-min=9.0 -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-IOS-IOSSIM %s
 // RUN: %clang -target x86_64-apple-darwin -Wno-incompatible-sysroot -isysroot SDKs/MacOSX10.9.sdk -mios-version-min=9.0 -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-OSX-IOS-DISABLED %s
 
+// RUN: %clang -target arm64-apple-visionos1.0-simulator -Wincompatible-sysroot -isysroot %S/Inputs/XRSimulator1.0.sdk -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-VISIONOSSIM %s
+// RUN: %clang -target arm64-apple-xros1.0 -Wincompatible-sysroot -isysroot %S/Inputs/XRSimulator1.0.sdk -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-VISIONOSSIM-VISIONOS %s
+// RUN: %clang -target arm64-apple-ios17.1 -Wincompatible-sysroot -isysroot %S/Inputs/XRSimulator1.0.sdk -S -o - %s 2>&1 | FileCheck -check-prefix CHECK-VISIONOSSIM-IOS %s
+
 int main() { return 0; }
-// CHECK-OSX-IOS: warning: using sysroot for 'MacOSX' but targeting 'iPhone'
-// CHECK-IOS-WATCHOS: warning: using sysroot for 'iPhoneOS' but targeting 'Watch'
-// CHECK-IOS-TVOS: warning: using sysroot for 'iPhoneOS' but targeting 'AppleTV'
-// CHECK-OSX-DRIVERKIT: warning: using sysroot for 'MacOSX' but targeting 'DriverKit'
-// CHECK-IOS-DRIVERKIT: warning: using sysroot for 'iPhoneOS' but targeting 'DriverKit'
+// CHECK-OSX-IOS: warning: using sysroot for 'MacOSX' but targeting 'x86_64-apple-ios9.0.0-simulator'
+// CHECK-IOS-WATCHOS: warning: using sysroot for 'iPhoneOS' but targeting 'arm64-apple-watchos2.0.0'
+// CHECK-IOS-TVOS: warning: using sysroot for 'iPhoneOS' but targeting 'arm64-apple-tvos9.0.0'
+// CHECK-OSX-DRIVERKIT: warning: using sysroot for 'MacOSX' but targeting 'x86_64-apple-driverkit19.0.0'
+// CHECK-IOS-DRIVERKIT: warning: using sysroot for 'iPhoneOS' but targeting 'x86_64-apple-driverkit19.0.0'
 // CHECK-IOS-IOSSIM-NOT: warning: using sysroot for '{{.*}}' but targeting '{{.*}}'
 // CHECK-OSX-IOS-DISABLED-NOT: warning: using sysroot for '{{.*}}' but targeting '{{.*}}'
+
+// CHECK-VISIONOSSIM-NOT: warning: using sysroot for '{{.*}}' but targeting '{{.*}}'
+// CHECK-VISIONOSSIM-VISIONOS: warning: using sysroot for 'Simulator - visionOS 1.0' but targeting 'arm64-apple-xros1.0.0'
+// CHECK-VISIONOSSIM-IOS: warning: using sysroot for 'Simulator - visionOS 1.0' but targeting 'arm64-apple-ios17.1.0'

--- a/clang/test/Driver/xros-driver-requires-darwin-host.c
+++ b/clang/test/Driver/xros-driver-requires-darwin-host.c
@@ -2,11 +2,8 @@
 
 // RUN: env XROS_DEPLOYMENT_TARGET=1.0 %clang -arch arm64 -c -### %s 2>&1 | FileCheck %s
 
-// RUN: rm -rf %t.dir
-// RUN: mkdir -p %t.dir/XROS1.0.sdk
-// RUN: %clang -arch arm64 -isysroot %t.dir/XROS1.0.sdk -c -### %s 2>&1 | FileCheck %s
-// RUN: mkdir -p %t.dir/XRSimulator1.0.sdk
-// RUN: %clang -arch arm64 -isysroot %t.dir/XRSimulator1.0.sdk -c -### %s 2>&1 | FileCheck --check-prefix=CHECK_SIM %s
+// RUN: %clang -arch arm64 -isysroot %S/Inputs/XROS1.0.sdk -c -### %s 2>&1 | FileCheck %s
+// RUN: %clang -arch arm64 -isysroot %S/Inputs/XRSimulator1.0.sdk -c -### %s 2>&1 | FileCheck --check-prefix=CHECK_SIM %s
 
 
 // CHECK: "-cc1"{{.*}} "-triple" "arm64-apple-xros1.0.0"


### PR DESCRIPTION
Using the file system path to identify the SDK platform, and determine which platforms the SDK supports, is unreliable. In particular, the SDK's file name prefix is usually significant, and dropping it usually gives incorrect results. Instead, use information from SDKinfo to positively identify its platform/environment, and to identify which triples are compatible.

rdar://167891541