### PR TITLE
[lldb] Increment max-children-depth to 5

### DIFF
--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -143,7 +143,7 @@ let Definition = "target" in {
     DefaultUnsignedValue<24>,
     Desc<"Maximum number of children to expand in any level of depth.">;
   def MaxChildrenDepth: Property<"max-children-depth", "UInt64">,
-    DefaultUnsignedValue<4>,
+    DefaultUnsignedValue<5>,
     Desc<"Maximum depth to expand children.">;
   def MaxSummaryLength: Property<"max-string-summary-length", "UInt64">,
     DefaultUnsignedValue<1024>,

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
@@ -359,13 +359,13 @@ class AdvDataFormatterTestCase(TestBase):
         self.runCmd("type format delete int")
 
         # First, check the following:
-        #   1. Verify the default max-children-depth (4) is applied
+        #   1. Verify the default max-children-depth (5) is applied
         #   2. Ensure the one-time warning is printed
         warning = "*** Some of the displayed variables have a greater depth"
         self.expect(
             "frame variable quite_nested",
             matching=True,
-            substrs=["four ={...}", warning],
+            substrs=["five ={...}", warning],
         )
         self.expect(
             "frame variable quite_nested",

--- a/lldb/test/Shell/Settings/TestChildDepthTruncation.test
+++ b/lldb/test/Shell/Settings/TestChildDepthTruncation.test
@@ -18,15 +18,18 @@
 #--- main.cpp
 
 struct L1 {
-    int w;
+    int a;
     struct L2 {
-        int x;
+        int b;
         struct L3 {
-            int y;
+            int c;
             struct L4 {
-              int z;
+                int d;
                 struct L5 {
-                  int a;
+                    int e;
+                    struct L6 {
+                      int f;
+                    } l6;
                 } l5;
             } l4;
         } l3;


### PR DESCRIPTION
`max-children-depth` was [originally 6](https://github.com/swiftlang/llvm-project/pull/4280/changes/ee0782bf6b2e9705e261c5a82147ce0e45a8d753), which produced too large of output. It was then [reduced to 4](https://github.com/swiftlang/llvm-project/pull/10683), which for some people is too low. This change is to try 5 as the default.