### PR TITLE
[lldb] Implement GetTemplateArgumentType for Swift type systems

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -20,6 +20,7 @@
 #include "TypeSystemSwift.h"
 #include "TypeSystemSwiftTypeRef.h"
 
+#include "lldb/Symbol/CompilerType.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTContext.h"
@@ -8413,6 +8414,26 @@ size_t SwiftASTContext::GetNumTemplateArguments(opaque_compiler_type_t type,
   }
 
   return 0;
+}
+
+lldb::TemplateArgumentKind
+SwiftASTContext::GetTemplateArgumentKind(lldb::opaque_compiler_type_t type,
+                                         size_t idx, bool expand_pack) {
+  switch (GetGenericArgumentKind(type, idx)) {
+  case eBoundGenericKindType:
+    return eTemplateArgumentKindType;
+  case eUnboundGenericKindType:
+    return eTemplateArgumentKindDeclaration;
+  default:
+    break;
+  }
+  return eTemplateArgumentKindNull;
+}
+
+CompilerType
+SwiftASTContext::GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+                                         size_t idx, bool expand_pack) {
+  return GetGenericArgumentType(type, idx);
 }
 
 bool SwiftASTContext::GetSelectedEnumCase(const CompilerType &type,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -779,6 +779,11 @@ public:
 
   size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
                                  bool expand_pack) override;
+  lldb::TemplateArgumentKind
+  GetTemplateArgumentKind(lldb::opaque_compiler_type_t type, size_t idx,
+                          bool expand_pack) override;
+  CompilerType GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+                                       size_t idx, bool expand_pack) override;
 
   lldb::GenericKind GetGenericArgumentKind(lldb::opaque_compiler_type_t type,
                                            size_t idx);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -4526,6 +4526,31 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
   return {};
 }
 
+static NodePointer GetTemplateTypeListNode(NodePointer type) {
+  if (!type)
+    return nullptr;
+
+  switch (type->getKind()) {
+  case Node::Kind::BoundGenericClass:
+  case Node::Kind::BoundGenericEnum:
+  case Node::Kind::BoundGenericStructure:
+  case Node::Kind::BoundGenericProtocol:
+  case Node::Kind::BoundGenericOtherNominalType:
+  case Node::Kind::BoundGenericTypeAlias:
+  case Node::Kind::BoundGenericFunction: {
+    if (type->getNumChildren() > 1)
+      if (auto *child = type->getChild(1))
+        if (child->getKind() == Node::Kind::TypeList)
+          return child;
+    break;
+  }
+  default:
+    break;
+  }
+
+  return nullptr;
+}
+
 size_t
 TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type,
                                                 bool expand_pack) {
@@ -4533,31 +4558,40 @@ TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type,
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = DemangleCanonicalOutermostType(dem, type);
+    if (auto *type_list = GetTemplateTypeListNode(node))
+      return type_list->getNumChildren();
 
-    if (!node)
-      return 0;
-
-    switch (node->getKind()) {
-    case Node::Kind::BoundGenericClass:
-    case Node::Kind::BoundGenericEnum:
-    case Node::Kind::BoundGenericStructure:
-    case Node::Kind::BoundGenericProtocol:
-    case Node::Kind::BoundGenericOtherNominalType:
-    case Node::Kind::BoundGenericTypeAlias:
-    case Node::Kind::BoundGenericFunction: {
-      if (node->getNumChildren() > 1) {
-        NodePointer child = node->getChild(1);
-        if (child && child->getKind() == Node::Kind::TypeList)
-          return child->getNumChildren();
-      }
-    } break;
-    default:
-      break;
-    }
     return 0;
   };
   VALIDATE_AND_RETURN(impl, GetNumTemplateArguments, type, g_no_exe_ctx,
                       (ReconstructType(type), expand_pack));
+}
+
+lldb::TemplateArgumentKind TypeSystemSwiftTypeRef::GetTemplateArgumentKind(
+    lldb::opaque_compiler_type_t type, size_t idx, bool expand_pack) {
+  Demangler dem;
+  NodePointer node = DemangleCanonicalOutermostType(dem, type);
+  if (auto *type_list = GetTemplateTypeListNode(node))
+    if (idx < type_list->getNumChildren())
+      return lldb::eTemplateArgumentKindType;
+
+  return lldb::eTemplateArgumentKindNull;
+}
+
+CompilerType TypeSystemSwiftTypeRef::GetTypeTemplateArgument(
+    lldb::opaque_compiler_type_t type, size_t idx, bool expand_pack) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodePointer node = DemangleCanonicalOutermostType(dem, type);
+  if (auto *type_list = GetTemplateTypeListNode(node))
+    if (idx < type_list->getNumChildren()) {
+      const auto *mangled_name = AsMangledName(type);
+      auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
+      auto *template_type = type_list->getChild(idx);
+      return RemangleAsType(dem, template_type, flavor);
+    }
+
+  return {};
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -249,6 +249,11 @@ public:
                                 std::vector<uint32_t> &child_indexes) override;
   size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
                                  bool expand_pack) override;
+  lldb::TemplateArgumentKind
+  GetTemplateArgumentKind(lldb::opaque_compiler_type_t type, size_t idx,
+                          bool expand_pack) override;
+  CompilerType GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+                                       size_t idx, bool expand_pack) override;
   CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;
   LazyBool ShouldPrintAsOneLiner(lldb::opaque_compiler_type_t type,
                                  ValueObject *valobj) override;

--- a/lldb/test/API/lang/swift/generic_arguments/Makefile
+++ b/lldb/test/API/lang/swift/generic_arguments/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.selected_frame
+        array_type = frame.var("array").type
+        generic_type = array_type.GetTemplateArgumentType(0)
+        self.assertTrue(generic_type.IsValid())
+        self.assertEqual(generic_type.name, "Swift.Int")
+        self.assertEqual(generic_type.GetDisplayTypeName(), "Int")

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -5,6 +5,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestCase(TestBase):
+
+    @swiftTest
     def test(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/generic_arguments/main.swift
+++ b/lldb/test/API/lang/swift/generic_arguments/main.swift
@@ -1,0 +1,6 @@
+@main enum Entry {
+    static func main() {
+        let array = [1, 2, 4]
+        print("break here", array)
+    }
+}


### PR DESCRIPTION
Currently, `GetNumTemplateArguments` is implemented by both Swift system implementations (`TypeSystemSwiftTypeRef` and `SwiftASTContext`), but the associated function `GetTypeTemplateArgument` is not supported. From SBAPI (and `CompilerType`), this means code cannot easily introspect on a type's generic arguments. This implements the relevant methods on both Swift type systems.

rdar://169239996