### PR TITLE
[stable/21.x][Triple] Make a target triple "os" for firmware

### DIFF
--- a/clang/include/clang/Basic/TargetOSMacros.def
+++ b/clang/include/clang/Basic/TargetOSMacros.def
@@ -56,4 +56,7 @@ TARGET_OS(TARGET_OS_UIKITFORMAC, Triple.isMacCatalystEnvironment())
 // UEFI target.
 TARGET_OS(TARGET_OS_UEFI, Triple.isUEFI())
 
+// General targets.
+TARGET_OS(TARGET_OS_FIRMWARE, Triple.isOSFirmware())
+
 #undef TARGET_OS

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7017,6 +7017,8 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
           TC = std::make_unique<toolchains::BareMetal>(*this, Target, Args);
         else if (Target.isOSBinFormatELF())
           TC = std::make_unique<toolchains::Generic_ELF>(*this, Target, Args);
+        else if (Target.isAppleFirmware())
+          TC = std::make_unique<toolchains::DarwinClang>(*this, Target, Args);
         else if (Target.isAppleMachO())
           TC = std::make_unique<toolchains::AppleMachO>(*this, Target, Args);
         else if (Target.isOSBinFormatMachO())

--- a/clang/lib/Driver/ToolChains/Arch/ARM.cpp
+++ b/clang/lib/Driver/ToolChains/Arch/ARM.cpp
@@ -512,7 +512,8 @@ arm::FloatABI arm::getARMFloatABI(const Driver &D, const llvm::Triple &Triple,
     else
       ABI = FloatABI::Soft;
 
-    if (Triple.getOS() != llvm::Triple::UnknownOS ||
+    if (((Triple.getOS() != llvm::Triple::UnknownOS) &&
+         !Triple.isOSFirmware()) ||
         !Triple.isOSBinFormatMachO())
       D.Diag(diag::warn_drv_assuming_mfloat_abi_is) << "soft";
   }

--- a/clang/lib/Driver/ToolChains/Darwin.h
+++ b/clang/lib/Driver/ToolChains/Darwin.h
@@ -363,7 +363,7 @@ public:
     WatchOS,
     DriverKit,
     XROS,
-    LastDarwinPlatform = XROS
+    Firmware,
   };
   enum DarwinEnvironmentKind {
     NativeEnvironment,
@@ -519,6 +519,8 @@ public:
     assert(TargetInitialized && "Target not initialized!");
     return TargetPlatform == DriverKit;
   }
+
+  bool isTargetFirmware() const { return TargetPlatform == Firmware; }
 
   bool isTargetMacCatalyst() const {
     return TargetPlatform == IPhoneOS && TargetEnvironment == MacCatalyst;

--- a/clang/test/Driver/darwin-fapple-link-rtlib.c
+++ b/clang/test/Driver/darwin-fapple-link-rtlib.c
@@ -1,6 +1,9 @@
 // RUN: %clang -target arm64-apple-ios12.0 %s -nostdlib -fapple-link-rtlib -resource-dir=%S/Inputs/resource_dir -### 2>&1 | FileCheck %s
 // RUN: %clang -target arm64-apple-ios12.0 %s -static -fapple-link-rtlib -resource-dir=%S/Inputs/resource_dir -### 2>&1 | FileCheck %s
 // RUN: %clang -target arm64-apple-ios12.0 %s -fapple-link-rtlib -resource-dir=%S/Inputs/resource_dir -### 2>&1 | FileCheck %s --check-prefix=DEFAULT
+// RUN: %clang -target arm64-apple-firmware %s -static -fapple-link-rtlib -resource-dir=%S/Inputs/resource_dir -### 2>&1 | FileCheck %s --check-prefix=FIRMWARE
 // CHECK-NOT: "-lSystem"
 // DEFAULT: "-lSystem"
 // CHECK: libclang_rt.ios.a
+// FIRMWARE-NOT: "-lSystem"
+// FIRMWARE: libclang_rt.soft_static.a

--- a/clang/test/Driver/darwin-ld.c
+++ b/clang/test/Driver/darwin-ld.c
@@ -204,6 +204,16 @@
 // LINK_DRIVERKIT-NOT: lSystem
 // LINK_DRIVERKIT: libclang_rt.driverkit.a
 
+// RUN: %clang -target arm64-apple-firmware1.0 -fuse-ld= -mlinker-version=400 -resource-dir=%S/Inputs/resource_dir -### %t.o 2> %t.log
+// RUN: FileCheck -check-prefix=LINK_FIRMWARE %s < %t.log
+// RUN: %clang -target arm64-apple-firmware1.0 -static -fuse-ld= -mlinker-version=400 -resource-dir=%S/Inputs/resource_dir -### %t.o 2> %t.log
+// RUN: FileCheck -check-prefix=LINK_FIRMWARE %s < %t.log
+// LINK_FIRMWARE: {{ld(.exe)?"}}
+// LINK_FIRMWARE-NOT: crt
+// LINK_FIRMWARE-NOT: lgcc_s.1
+// LINK_FIRMWARE-NOT: lSystem
+// LINK_FIRMWARE: libclang_rt.soft_static.a
+
 // RUN: %clang -target armv7k-apple-watchos2.0 -fuse-ld= -mlinker-version=400 -mwatchos-version-min=2.0 -resource-dir=%S/Inputs/resource_dir -### %t.o 2> %t.log
 // RUN: FileCheck -check-prefix=LINK_WATCHOS_ARM %s < %t.log
 // LINK_WATCHOS_ARM: {{ld(.exe)?"}}

--- a/clang/test/Driver/fdefine-target-os-macros.c
+++ b/clang/test/Driver/fdefine-target-os-macros.c
@@ -20,7 +20,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-ios \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -37,7 +38,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-ios-macabi \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -54,7 +56,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-ios-simulator \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -71,7 +74,8 @@
 // RUN:                -DSIMULATOR=1   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-tvos \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -88,7 +92,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-tvos-simulator \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -105,7 +110,8 @@
 // RUN:                -DSIMULATOR=1   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-watchos \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -122,7 +128,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-watchos-simulator \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -139,7 +146,8 @@
 // RUN:                -DSIMULATOR=1   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-xros \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -156,7 +164,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-xros-simulator \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -173,7 +182,8 @@
 // RUN:                -DSIMULATOR=1   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=arm64-apple-driverkit \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -190,7 +200,25 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
+
+// RUN: %clang -dM -E --target=arm64-apple-firmware %s 2>&1 \
+// RUN: | FileCheck %s -DMAC=1         \
+// RUN:                -DOSX=0         \
+// RUN:                -DIPHONE=0      \
+// RUN:                -DIOS=0         \
+// RUN:                -DTV=0          \
+// RUN:                -DWATCH=0       \
+// RUN:                -DVISION=0      \
+// RUN:                -DDRIVERKIT=0   \
+// RUN:                -DMACCATALYST=0 \
+// RUN:                -DEMBEDDED=0    \
+// RUN:                -DSIMULATOR=0   \
+// RUN:                -DWINDOWS=0     \
+// RUN:                -DLINUX=0       \
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=1
 
 // RUN: %clang -dM -E --target=x86_64-pc-linux-gnu \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -207,7 +235,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=1       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=x86_64-pc-win32 \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -224,7 +253,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=1     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=x86_64-pc-windows-gnu \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -241,7 +271,8 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=1     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=0
+// RUN:                -DUNIX=0        \
+// RUN:                -DFIRMWARE=0
 
 // RUN: %clang -dM -E --target=sparc-none-solaris \
 // RUN:        -fdefine-target-os-macros %s 2>&1 \
@@ -258,7 +289,11 @@
 // RUN:                -DSIMULATOR=0   \
 // RUN:                -DWINDOWS=0     \
 // RUN:                -DLINUX=0       \
-// RUN:                -DUNIX=1
+// RUN:                -DUNIX=1        \
+// RUN:                -DFIRMWARE=0
+
+// If the firmware OS was valid for a non-Apple vendor,
+// it would be TARGET_OS_MAC=0, TARGET_OS_FIRMWARE=1.
 
 // RUN: %clang -dM -E --target=arm64-apple-macos \
 // RUN:        -fno-define-target-os-macros %s 2>&1 \
@@ -296,3 +331,4 @@
 // CHECK-DAG: #define TARGET_OS_WINDOWS [[WINDOWS]]
 // CHECK-DAG: #define TARGET_OS_LINUX [[LINUX]]
 // CHECK-DAG: #define TARGET_OS_UNIX [[UNIX]]
+// CHECK-DAG: #define TARGET_OS_FIRMWARE [[FIRMWARE]]

--- a/clang/test/Driver/unsupported-target-vendor.c
+++ b/clang/test/Driver/unsupported-target-vendor.c
@@ -1,0 +1,60 @@
+// Tests that clang does not crash with invalid vendors in target triples.
+//
+// RUN: %clang --target=arm-apple-firmware -### %s 2>&1 | FileCheck -check-prefix CHECK_APPLE %s
+// RUN: %clang_cl --target=arm-apple-firmware -### %s 2>&1 | FileCheck -check-prefix CHECK_APPLE %s
+
+// CHECK_APPLE-NOT: LLVM ERROR: the firmware target os is only supported for the apple vendor
+
+
+// RUN: not %clang --target=arm-none-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-none-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-unknown-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-unknown-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-pc-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-pc-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-scei-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-scei-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-sie-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-sie-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-fsl-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-fsl-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-ibm-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-ibm-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-img-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-img-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-mti-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-mti-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-nvidia-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-nvidia-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-csr-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-csr-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-amd-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-amd-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-mesa-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-mesa-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-suse-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-suse-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-oe-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-oe-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-intel-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-intel-firmware -### %s 2>&1 | FileCheck %s
+
+// RUN: not %clang --target=arm-meta-firmware -### %s 2>&1 | FileCheck %s
+// RUN: not %clang_cl --target=arm-meta-firmware -### %s 2>&1 | FileCheck %s
+
+// CHECK: LLVM ERROR: the firmware target os is only supported for the apple vendor

--- a/llvm/include/llvm/TargetParser/Triple.h
+++ b/llvm/include/llvm/TargetParser/Triple.h
@@ -244,7 +244,8 @@ public:
     LiteOS,
     Serenity,
     Vulkan, // Vulkan SPIR-V
-    LastOSType = Vulkan
+    Firmware,
+    LastOSType = Firmware
   };
   enum EnvironmentType {
     UnknownEnvironment,
@@ -602,11 +603,18 @@ public:
     return (getVendor() == Triple::Apple) && isOSBinFormatMachO();
   }
 
+  /// Is this an Apple firmware triple.
+  bool isAppleFirmware() const {
+    return (getVendor() == Triple::Apple) && isOSFirmware();
+  }
+
   /// Is this a "Darwin" OS (macOS, iOS, tvOS, watchOS, DriverKit, XROS, or
   /// bridgeOS).
   bool isOSDarwin() const {
     return isMacOSX() || isiOS() || isWatchOS() || isDriverKit() || isXROS() ||
-           isBridgeOS();
+           isBridgeOS() || isAppleFirmware();
+    // Apple firmware isn't necessarily a Darwin based OS, but for most intents
+    // and purposes it can be treated like a Darwin OS in the compiler.
   }
 
   bool isSimulatorEnvironment() const {
@@ -864,6 +872,8 @@ public:
   bool isVulkanOS() const { return getOS() == Triple::Vulkan; }
 
   bool isOSManagarm() const { return getOS() == Triple::Managarm; }
+
+  bool isOSFirmware() const { return getOS() == Triple::Firmware; }
 
   bool isShaderStageEnvironment() const {
     EnvironmentType Env = getEnvironment();

--- a/llvm/lib/TargetParser/Triple.cpp
+++ b/llvm/lib/TargetParser/Triple.cpp
@@ -323,6 +323,8 @@ StringRef Triple::getOSTypeName(OSType Kind) {
   case LiteOS: return "liteos";
   case XROS: return "xros";
   case Vulkan: return "vulkan";
+  case Firmware:
+    return "firmware";
   }
 
   llvm_unreachable("Invalid OSType");
@@ -719,6 +721,7 @@ static Triple::OSType parseOS(StringRef OSName) {
     .StartsWith("liteos", Triple::LiteOS)
     .StartsWith("serenity", Triple::Serenity)
     .StartsWith("vulkan", Triple::Vulkan)
+    .StartsWith("firmware", Triple::Firmware)
     .Default(Triple::UnknownOS);
 }
 
@@ -1344,6 +1347,12 @@ std::string Triple::normalize(StringRef Str, CanonicalForm Form) {
     }
   }
 
+  // Currently the firmware OS is an Apple specific concept.
+  if ((Components.size() > 2) && (Components[2] == "firmware") &&
+      (Components[1] != "apple"))
+    llvm::reportFatalUsageError(
+        "the firmware target os is only supported for the apple vendor");
+
   // Canonicalize the components if necessary.
   switch (Form) {
   case CanonicalForm::ANY:
@@ -1477,6 +1486,8 @@ bool Triple::getMacOSXVersion(VersionTuple &Version) const {
     llvm_unreachable("OSX version isn't relevant for xrOS");
   case DriverKit:
     llvm_unreachable("OSX version isn't relevant for DriverKit");
+  case Firmware:
+    llvm_unreachable("OSX version isn't relevant for Firmware");
   }
   return true;
 }
@@ -1527,6 +1538,8 @@ VersionTuple Triple::getiOSVersion() const {
     llvm_unreachable("conflicting triple info");
   case DriverKit:
     llvm_unreachable("DriverKit doesn't have an iOS version");
+  case Firmware:
+    llvm_unreachable("iOS version isn't relevant for Firmware");
   }
 }
 
@@ -1552,6 +1565,8 @@ VersionTuple Triple::getWatchOSVersion() const {
     llvm_unreachable("watchOS version isn't relevant for xrOS");
   case DriverKit:
     llvm_unreachable("DriverKit doesn't have a WatchOS version");
+  case Firmware:
+    llvm_unreachable("watchOS version isn't relevant for Firmware");
   }
 }
 

--- a/llvm/unittests/TargetParser/TripleTest.cpp
+++ b/llvm/unittests/TargetParser/TripleTest.cpp
@@ -1654,6 +1654,26 @@ TEST(TripleTest, Normalization) {
             Triple::normalize("wasm32-wasi")); // wasm32-unknown-wasi
   EXPECT_EQ("wasm64-unknown-wasi",
             Triple::normalize("wasm64-wasi")); // wasm64-unknown-wasi
+
+  // Firmware should only be allowed for the Apple vendor
+  EXPECT_DEATH(Triple::normalize("arm-none-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-unknown-firmware"), "");
+  EXPECT_EQ("arm-apple-firmware", Triple::normalize("arm-apple-firmware"));
+  EXPECT_DEATH(Triple::normalize("arm-pc-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-scei-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-sie-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-fsl-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-ibm-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-img-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-mti-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-nvidia-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-csr-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-amd-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-mesa-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-suse-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-oe-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-intel-firmware"), "");
+  EXPECT_DEATH(Triple::normalize("arm-meta-firmware"), "");
 }
 
 TEST(TripleTest, MutateName) {


### PR DESCRIPTION
Make a Triple::OSType to represent a generic Apple firmware platform that isn't bare metal, but isn't tied to a specific hardware platform like macOS or iOS. Hook up support for the new OSType in the Darwin toolchain.