### PR TITLE
MC: adjust signature to use `MCObjectWriter`

### DIFF
--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -96,12 +96,12 @@ public:
   // BEGIN MCCAS
   /// Create a CAS object writer for the assembler backend.
   std::unique_ptr<MCObjectWriter> createCASObjectWriter(
-      raw_pwrite_stream &OS, const Triple &TT, cas::ObjectStore &CAS,
+      raw_pwrite_stream &OS, const Triple &Triple, cas::ObjectStore &CAS,
       const MCTargetOptions &MCOpts, CASBackendMode Mode,
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+      std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                            llvm::MCAssembler &,
                                            cas::ObjectStore &, raw_ostream *)>
-          CreateFromMcAssembler,
+          CreateFromMCAssembler,
       std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
           SerializeObjectFile,
       raw_pwrite_stream *CasIDOS = nullptr) const;

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -46,7 +46,7 @@ public:
       std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
       cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
       bool IsLittleEndian,
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+      std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                            llvm::MCAssembler &,
                                            cas::ObjectStore &, raw_ostream *)>
           CreateFromMcAssembler,
@@ -72,7 +72,7 @@ private:
 
   uint64_t OSOffset = 0;
 
-  std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+  std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                        llvm::MCAssembler &, cas::ObjectStore &,
                                        raw_ostream *)>
       CreateFromMcAssembler;
@@ -93,7 +93,7 @@ std::unique_ptr<MCObjectWriter> createMachOCASWriter(
     std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
     cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
     bool IsLittleEndian,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+    std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                          llvm::MCAssembler &,
                                          cas::ObjectStore &, raw_ostream *)>
         CreateFromMcAssembler,

--- a/llvm/include/llvm/MC/MCWinCOFFCASWriter.h
+++ b/llvm/include/llvm/MC/MCWinCOFFCASWriter.h
@@ -1,0 +1,82 @@
+//===- llvm/MC/MCWinCOFFCASWriter.h - Mach CAS Object Writer ----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_MC_MCWINCOFFCASWRITER_H
+#define LLVM_MC_MCWINCOFFCASWRITER_H
+
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/MC/MCTargetOptions.h"
+#include "llvm/MC/MCWinCOFFObjectWriter.h"
+#include <functional>
+#include <memory>
+
+namespace llvm {
+
+namespace cas {
+class ObjectStore;
+class CASID;
+} // namespace cas
+
+class COFFCASWriter : public WinCOFFObjectWriter {
+  const Triple Target;
+  cas::ObjectStore &CAS;
+  CASBackendMode Mode;
+  std::function<const cas::ObjectProxy(MCObjectWriter &, MCAssembler &,
+                                       cas::ObjectStore &, raw_ostream *)>
+      CreateFromMCAssembler;
+  std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
+      SerializeObjectFile;
+  std::optional<MCTargetOptions::ResultCallBackTy> ResultCallBack;
+
+  raw_pwrite_stream &OS;
+  raw_pwrite_stream *CASIDOS;
+
+  // Buffer
+  SmallString<512> InternalBuffer;
+  raw_svector_ostream InternalOS;
+
+  Error VerifyObject(cas::ObjectProxy CASObject);
+
+public:
+  COFFCASWriter(
+      std::unique_ptr<MCWinCOFFObjectTargetWriter>, const Triple &Target,
+      cas::ObjectStore &CAS, CASBackendMode CBM, raw_pwrite_stream &OS,
+      std::function<const cas::ObjectProxy(MCObjectWriter &, MCAssembler &,
+                                           cas::ObjectStore &, raw_ostream *)>
+          CreateFromMCAssembler,
+      std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
+          SerializeObjectFile,
+      std::optional<MCTargetOptions::ResultCallBackTy> CallBack,
+      raw_pwrite_stream *CASIDOS = nullptr);
+
+  uint64_t writeObject() override;
+};
+
+/// Construct a new COFF CAS Writer instance.
+///
+/// This routine takes ownership of the target writer subclass.
+///
+/// \param TW - The target specific (WinCOFF) writer subclass.
+/// \param Target - The target triple.
+/// \param CAS - The ObjectStore instance.
+/// \param OS - The stream to write to.
+/// \returns The constructed object writer.
+std::unique_ptr<MCObjectWriter> createCOFFCASWriter(
+    std::unique_ptr<MCWinCOFFObjectTargetWriter> TW, const Triple &Triple,
+    cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
+    std::function<const cas::ObjectProxy(MCObjectWriter &, MCAssembler &,
+                                         cas::ObjectStore &, raw_ostream *)>
+        CreateFromMCAssembler,
+    std::function<llvm::Error(cas::ObjectProxy, cas::ObjectStore &,
+                              raw_ostream &)>
+        SerializeObjectFile,
+    std::optional<MCTargetOptions::ResultCallBackTy> Callback = std::nullopt,
+    raw_pwrite_stream *CasIDOS = nullptr);
+} // namespace llvm
+
+#endif

--- a/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
+++ b/llvm/include/llvm/MC/MCWinCOFFObjectWriter.h
@@ -45,7 +45,7 @@ public:
 
 class WinCOFFWriter;
 
-class WinCOFFObjectWriter final : public MCObjectWriter {
+class WinCOFFObjectWriter : public MCObjectWriter {
   friend class WinCOFFWriter;
 
   std::unique_ptr<MCWinCOFFObjectTargetWriter> TargetObjectWriter;
@@ -57,6 +57,7 @@ public:
                       raw_pwrite_stream &OS);
   WinCOFFObjectWriter(std::unique_ptr<MCWinCOFFObjectTargetWriter> MOTW,
                       raw_pwrite_stream &OS, raw_pwrite_stream &DwoOS);
+  ~WinCOFFObjectWriter();
 
   // MCObjectWriter interface implementation.
   void reset() override;

--- a/llvm/include/llvm/MCCAS/MCCASFormatSchemaBase.h
+++ b/llvm/include/llvm/MCCAS/MCCASFormatSchemaBase.h
@@ -27,7 +27,7 @@ public:
   static char ID;
 
   Expected<cas::ObjectProxy>
-  createFromMCAssembler(llvm::MachOCASWriter &ObjectWriter,
+  createFromMCAssembler(llvm::MCObjectWriter &ObjectWriter,
                         llvm::MCAssembler &Asm,
                         raw_ostream *DebugOS = nullptr) const {
     return createFromMCAssemblerImpl(ObjectWriter, Asm, DebugOS);
@@ -38,7 +38,7 @@ public:
 
 protected:
   virtual Expected<cas::ObjectProxy>
-  createFromMCAssemblerImpl(llvm::MachOCASWriter &ObjectWriter,
+  createFromMCAssemblerImpl(llvm::MCObjectWriter &ObjectWriter,
                             llvm::MCAssembler &Asm,
                             raw_ostream *DebugOS) const = 0;
 

--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.h
@@ -267,7 +267,7 @@ public:
   bool isNode(const cas::ObjectProxy &Node) const override;
 
   Expected<cas::ObjectProxy>
-  createFromMCAssemblerImpl(llvm::MachOCASWriter &ObjectWriter,
+  createFromMCAssemblerImpl(llvm::MCObjectWriter &ObjectWriter,
                             llvm::MCAssembler &Asm,
                             raw_ostream *DebugOS) const override;
 
@@ -458,7 +458,7 @@ public:
   }
 
   static Expected<MCAssemblerRef> create(const MCSchema &Schema,
-                                         MachOCASWriter &ObjectWriter,
+                                         MCObjectWriter &ObjectWriter,
                                          MCAssembler &Asm,
                                          raw_ostream *DebugOS = nullptr);
 
@@ -505,12 +505,12 @@ Expected<size_t> getSizeFromDwarfHeaderAndSkip(BinaryStreamReader &Reader);
 class MCCASBuilder {
 public:
   cas::ObjectStore &CAS;
-  MachOCASWriter &ObjectWriter;
+  MCObjectWriter &ObjectWriter;
   const MCSchema &Schema;
   MCAssembler &Asm;
   raw_ostream *DebugOS;
 
-  MCCASBuilder(const MCSchema &Schema, MachOCASWriter &ObjectWriter,
+  MCCASBuilder(const MCSchema &Schema, MCObjectWriter &ObjectWriter,
                MCAssembler &Asm, raw_ostream *DebugOS)
       : CAS(Schema.CAS), ObjectWriter(ObjectWriter), Schema(Schema), Asm(Asm),
         DebugOS(DebugOS), FragmentOS(FragmentData), CurrentContext(&Sections),

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -211,11 +211,11 @@ CodeGenTargetMachineImpl::createMCStreamer(raw_pwrite_stream &Out,
     // BEGIN MCCAS
     std::unique_ptr<MCObjectWriter> CASBackendWriter;
     if (Options.UseCASBackend) {
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+      std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                            llvm::MCAssembler &,
                                            cas::ObjectStore &, raw_ostream *)>
           CreateFromMcAssembler =
-              [](llvm::MachOCASWriter &Writer, llvm::MCAssembler &Asm,
+              [](llvm::MCObjectWriter &Writer, llvm::MCAssembler &Asm,
                  cas::ObjectStore &CAS,
                  raw_ostream *DebugOS = nullptr) -> const cas::ObjectProxy {
         auto Schema = std::make_unique<mccasformats::v1::MCSchema>(CAS);

--- a/llvm/lib/MC/CMakeLists.txt
+++ b/llvm/lib/MC/CMakeLists.txt
@@ -36,6 +36,7 @@ add_llvm_component_library(LLVMMC
   MCMachOStreamer.cpp
   MCMachObjectTargetWriter.cpp
   MachOCASWriter.cpp
+  COFFCASWriter.cpp
   MCNullStreamer.cpp
   MCObjectFileInfo.cpp
   MCObjectStreamer.cpp

--- a/llvm/lib/MC/COFFCASWriter.cpp
+++ b/llvm/lib/MC/COFFCASWriter.cpp
@@ -1,0 +1,81 @@
+//===- lib/MC/COFFCASWriter.cpp - COFF CAS File Writer --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/Utils.h"
+#include "llvm/MC/MCWinCOFFCASWriter.h"
+
+namespace llvm {
+COFFCASWriter::COFFCASWriter(
+    std::unique_ptr<MCWinCOFFObjectTargetWriter> TW, const Triple &Target,
+    cas::ObjectStore &CAS, CASBackendMode CBM, raw_pwrite_stream &OS,
+    std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
+                                         llvm::MCAssembler &,
+                                         cas::ObjectStore &, raw_ostream *)>
+        Create,
+    std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
+        Serialize,
+    std::optional<MCTargetOptions::ResultCallBackTy> CallBack,
+    raw_pwrite_stream *CASIDOS)
+    : WinCOFFObjectWriter(std::move(TW), InternalOS), Target(Target), CAS(CAS),
+      Mode(CBM), CreateFromMCAssembler(Create), SerializeObjectFile(Serialize),
+      ResultCallBack(CallBack), OS(OS), CASIDOS(CASIDOS),
+      InternalOS(InternalBuffer) {}
+
+Error COFFCASWriter::VerifyObject(cas::ObjectProxy CASObject) {
+  SmallString<512> ObjectBuffer;
+  raw_svector_ostream ObjectOS(ObjectBuffer);
+  if (auto E = SerializeObjectFile(CASObject, CAS, ObjectOS))
+    return E;
+  if (!ObjectBuffer.equals(InternalBuffer))
+    return createStringError(inconvertibleErrorCode(),
+                             "CASBackend output round-trip verification error");
+  OS << ObjectBuffer;
+  return Error::success();
+}
+
+uint64_t COFFCASWriter::writeObject() {
+  uint64_t StartOffset = OS.tell();
+
+  auto CASObject = CreateFromMCAssembler(*this, *this->Asm, CAS, nullptr);
+  if (CASIDOS)
+    cas::writeCASIDBuffer(CASObject.getID(), *CASIDOS);
+  if (ResultCallBack)
+    cantFail((*ResultCallBack)(CASObject.getID()));
+
+  switch (Mode) {
+  case CASBackendMode::CASID:
+    cas::writeCASIDBuffer(CASObject.getID(), OS);
+    break;
+  case CASBackendMode::Native:
+    if (auto E = SerializeObjectFile(CASObject, CAS, OS))
+      report_fatal_error(std::move(E));
+    break;
+  case CASBackendMode::Verify:
+    if (auto E = VerifyObject(CASObject))
+      report_fatal_error(std::move(E));
+  }
+
+  return OS.tell() - StartOffset;
+}
+
+std::unique_ptr<llvm::MCObjectWriter> createCOFFCASWriter(
+    std::unique_ptr<MCWinCOFFObjectTargetWriter> W, const Triple &Triple,
+    cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
+    std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
+                                         llvm::MCAssembler &,
+                                         cas::ObjectStore &, raw_ostream *)>
+        CreateFromMCAssembler,
+    std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
+        SerializeObjectFile,
+    std::optional<MCTargetOptions::ResultCallBackTy> ResultCallBack,
+    raw_pwrite_stream *CasIDOS) {
+  return std::make_unique<COFFCASWriter>(
+      std::move(W), Triple, CAS, Mode, OS, CreateFromMCAssembler,
+      SerializeObjectFile, ResultCallBack, CasIDOS);
+}
+} // namespace llvm

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -68,7 +68,7 @@ MCAsmBackend::createObjectWriter(raw_pwrite_stream &OS) const {
 std::unique_ptr<MCObjectWriter> MCAsmBackend::createCASObjectWriter(
     raw_pwrite_stream &OS, const Triple &TT, cas::ObjectStore &CAS,
     const MCTargetOptions &MCOpts, CASBackendMode Mode,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+    std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                          llvm::MCAssembler &,
                                          cas::ObjectStore &, raw_ostream *)>
         CreateFromMcAssembler,

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -11,12 +11,13 @@
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCDXContainerWriter.h"
 #include "llvm/MC/MCELFObjectWriter.h"
-#include "llvm/MC/MCMachOCASWriter.h"
 #include "llvm/MC/MCGOFFObjectWriter.h"
+#include "llvm/MC/MCMachOCASWriter.h"
 #include "llvm/MC/MCMachObjectWriter.h"
 #include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCSPIRVObjectWriter.h"
 #include "llvm/MC/MCWasmObjectWriter.h"
+#include "llvm/MC/MCWinCOFFCASWriter.h"
 #include "llvm/MC/MCWinCOFFObjectWriter.h"
 #include "llvm/MC/MCXCOFFObjectWriter.h"
 #include <cassert>
@@ -82,6 +83,11 @@ std::unique_ptr<MCObjectWriter> MCAsmBackend::createCASObjectWriter(
                                 TT, CAS, Mode, OS, Endian == endianness::little,
                                 CreateFromMcAssembler, SerializeObjectFile,
                                 MCOpts.ResultCallBack, CasIDOS);
+  case Triple::COFF:
+    return createCOFFCASWriter(cast<MCWinCOFFObjectTargetWriter>(std::move(TW)),
+                               TT, CAS, Mode, OS, CreateFromMcAssembler,
+                               SerializeObjectFile, MCOpts.ResultCallBack,
+                               CasIDOS);
   default:
     llvm_unreachable("unexpected object format");
   }

--- a/llvm/lib/MC/MachOCASWriter.cpp
+++ b/llvm/lib/MC/MachOCASWriter.cpp
@@ -43,7 +43,7 @@ MachOCASWriter::MachOCASWriter(
     std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
     cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
     bool IsLittleEndian,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+    std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                          llvm::MCAssembler &,
                                          cas::ObjectStore &, raw_ostream *)>
         CreateFromMcAssembler,
@@ -110,7 +110,7 @@ std::unique_ptr<MCObjectWriter> llvm::createMachOCASWriter(
     std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
     cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
     bool IsLittleEndian,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+    std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                          llvm::MCAssembler &,
                                          cas::ObjectStore &, raw_ostream *)>
         CreateFromMcAssembler,

--- a/llvm/lib/MC/WinCOFFObjectWriter.cpp
+++ b/llvm/lib/MC/WinCOFFObjectWriter.cpp
@@ -210,6 +210,8 @@ WinCOFFObjectWriter::WinCOFFObjectWriter(
       DwoWriter(std::make_unique<WinCOFFWriter>(*this, DwoOS,
                                                 WinCOFFWriter::DwoOnly)) {}
 
+WinCOFFObjectWriter::~WinCOFFObjectWriter() = default;
+
 static bool isDwoSection(const MCSection &Sec) {
   return Sec.getName().ends_with(".dwo");
 }

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -126,8 +126,9 @@ struct CUInfo {
 static Expected<CUInfo> getAndSetDebugAbbrevOffsetAndSkip(
     MutableArrayRef<char> CUData, endianness Endian,
     std::optional<uint32_t> NewOffset, uint8_t AddressSize);
+
 Expected<cas::ObjectProxy>
-MCSchema::createFromMCAssemblerImpl(MachOCASWriter &ObjectWriter,
+MCSchema::createFromMCAssemblerImpl(MCObjectWriter &ObjectWriter,
                                     MCAssembler &Asm,
                                     raw_ostream *DebugOS) const {
   return MCAssemblerRef::create(*this, ObjectWriter, Asm, DebugOS);
@@ -3309,7 +3310,7 @@ void MCCASBuilder::addNode(cas::ObjectProxy Node) {
 }
 
 Expected<MCAssemblerRef> MCAssemblerRef::create(const MCSchema &Schema,
-                                                MachOCASWriter &ObjectWriter,
+                                                MCObjectWriter &ObjectWriter,
                                                 MCAssembler &Asm,
                                                 raw_ostream *DebugOS) {
   MCCASBuilder Builder(Schema, ObjectWriter, Asm, DebugOS);

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -83,15 +83,14 @@ class InMemoryCASDWARFObject : public DWARFObject {
   ArrayRef<char> DebugAbbrevSection;
   DWARFSection DebugStringOffsetsSection;
   bool IsLittleEndian;
-  uint8_t AddressSize;
 
 public:
   InMemoryCASDWARFObject(ArrayRef<char> AbbrevContents,
                          ArrayRef<char> StringOffsetsContents,
-                         bool IsLittleEndian, uint8_t AddressSize)
+                         bool IsLittleEndian)
       : DebugAbbrevSection(AbbrevContents),
         DebugStringOffsetsSection({toStringRef(StringOffsetsContents)}),
-        IsLittleEndian(IsLittleEndian), AddressSize(AddressSize) {}
+        IsLittleEndian(IsLittleEndian) {}
   bool isLittleEndian() const override { return IsLittleEndian; }
 
   StringRef getAbbrevSection() const override {
@@ -1827,17 +1826,20 @@ DwarfSectionsCache mccasformats::v1::getDwarfSections(MCAssembler &Asm) {
 }
 
 Error MCCASBuilder::prepare() {
-  ObjectWriter.resetBuffer();
-  ObjectWriter.prepareObject(Asm);
-  assert(ObjectWriter.getContent().empty() &&
-         "prepare stage writes no content");
+  // FIXME: this needs a mixin
+  MachOCASWriter &Writer = static_cast<MachOCASWriter &>(ObjectWriter);
+  Writer.resetBuffer();
+  Writer.prepareObject(Asm);
+  assert(Writer.getContent().empty() && "prepare stage writes no content");
   return Error::success();
 }
 
 Error MCCASBuilder::buildMachOHeader() {
-  ObjectWriter.resetBuffer();
-  ObjectWriter.writeMachOHeader(Asm);
-  auto Header = HeaderRef::create(*this, ObjectWriter.getContent());
+  MachOCASWriter &Writer = static_cast<MachOCASWriter &>(ObjectWriter);
+
+  Writer.resetBuffer();
+  Writer.writeMachOHeader(Asm);
+  auto Header = HeaderRef::create(*this, Writer.getContent());
   if (!Header)
     return Header.takeError();
 
@@ -1933,8 +1935,9 @@ static Error writeAlignFragment(MCCASBuilder &Builder,
                                    Twine(Count) + " bytes");
     return Error::success();
   }
-  auto Endian = Builder.ObjectWriter.Target.isLittleEndian() ? endianness::little
-                                                             : endianness::big;
+
+  const Triple &Target = Builder.ObjectWriter.getContext().getTargetTriple();
+  auto Endian = Target.isLittleEndian() ? endianness::little : endianness::big;
   for (uint64_t I = 0; I != Count; ++I) {
     switch (AF.getFillLen()) {
     default:
@@ -2026,7 +2029,8 @@ void MCDataFragmentMerger::reset() {
 }
 
 Error MCCASBuilder::createPaddingRef(const MCSection *Sec) {
-  uint64_t Pad = ObjectWriter.getPaddingSize(Asm, Sec);
+  MachObjectWriter &Writer = static_cast<MachObjectWriter &>(ObjectWriter);
+  uint64_t Pad = Writer.getPaddingSize(Asm, Sec);
   auto Fill = PaddingRef::create(*this, Pad);
   if (!Fill)
     return Fill.takeError();
@@ -2186,12 +2190,15 @@ MCCASBuilder::mergeMCFragmentContents(const MCSection *Section,
 
 Expected<MCCASBuilder::CUSplit>
 MCCASBuilder::splitDebugInfoSectionData(MutableArrayRef<char> DebugInfoData) {
+  const Triple &Target = ObjectWriter.getContext().getTargetTriple();
+  const uint8_t AddressSize = Target.isArch32Bit() ? 4 : 8;
+
   CUSplit Split;
   // CU splitting loop.
   while (!DebugInfoData.empty()) {
     Expected<CUInfo> Info = getAndSetDebugAbbrevOffsetAndSkip(
         DebugInfoData, Asm.getBackend().Endian, /*NewOffset*/ 0,
-        ObjectWriter.getAddressSize());
+        AddressSize);
     if (!Info)
       return Info.takeError();
     Split.SplitCUData.push_back(DebugInfoData.take_front(Info->CUSize));
@@ -2361,18 +2368,19 @@ Error InMemoryCASDWARFObject::partitionCUData(ArrayRef<char> DebugInfoData,
                                               MCCASBuilder &Builder,
                                               AbbrevSetWriter &AbbrevWriter,
                                               uint16_t DwarfVersion) {
+  const Triple &Target = Builder.ObjectWriter.getContext().getTargetTriple();
+  uint8_t AddressSize = Target.isArch32Bit() ? 4 : 8;
+
   StringRef AbbrevSectionContribution =
       getAbbrevSection().drop_front(AbbrevOffset);
-  DataExtractor Data(AbbrevSectionContribution, isLittleEndian(),
-                     Builder.ObjectWriter.getAddressSize());
+  DataExtractor Data(AbbrevSectionContribution, isLittleEndian(), AddressSize);
   DWARFDebugAbbrev Abbrev(Data);
   uint64_t OffsetPtr = 0;
   DWARFUnitHeader Header;
   DWARFSection Section = {toStringRef(DebugInfoData), 0 /*Address*/};
   if (Error E = Header.extract(
           *Ctx,
-          DWARFDataExtractor(*this, Section, isLittleEndian(),
-                             Builder.ObjectWriter.getAddressSize()),
+          DWARFDataExtractor(*this, Section, isLittleEndian(), AddressSize),
           &OffsetPtr, DWARFSectionKind::DW_SECT_INFO))
     return E;
 
@@ -2441,9 +2449,9 @@ Error MCCASBuilder::splitDebugInfoAndAbbrevSections() {
   if (!FullStringOffsetsData)
     return FullStringOffsetsData.takeError();
 
+  const Triple &Target = ObjectWriter.getContext().getTargetTriple();
   InMemoryCASDWARFObject CASObj(*FullAbbrevData, *FullStringOffsetsData,
-                                Asm.getBackend().Endian == endianness::little,
-                                ObjectWriter.getAddressSize());
+                                Target.isLittleEndian());
   auto DWARFObj = std::make_unique<InMemoryCASDWARFObject>(CASObj);
   auto DWARFContextHolder = std::make_unique<DWARFContext>(std::move(DWARFObj));
   auto *DWARFCtx = DWARFContextHolder.get();
@@ -2471,9 +2479,11 @@ MCCASBuilder::createOptimizedLineSection(StringRef DebugLineStrRef) {
   auto Endian = Asm.getBackend().Endian;
   assert((Endian == endianness::big || Endian == endianness::little) &&
          "Endian must be either big or little");
+  const Triple &Target = ObjectWriter.getContext().getTargetTriple();
+  uint8_t AddressSize = Target.isArch32Bit() ? 4 : 8;
   DWARFDataExtractor LineTableDataReader(DebugLineStrRef,
                                          Endian == endianness::little,
-                                         ObjectWriter.getAddressSize());
+                                         AddressSize);
   auto Prologue = parseLineTableHeaderAndSkip(LineTableDataReader);
   if (!Prologue)
     return Prologue.takeError();
@@ -3128,18 +3138,19 @@ Error MCCASBuilder::buildFragments() {
         continue;
 
       SmallVector<char, 0> FinalFragmentContents;
+      const Triple &Target = ObjectWriter.getContext().getTargetTriple();
+      uint8_t AddressSize = Target.isArch32Bit() ? 4 : 8;
       // Set the RelocationBuffer to be an empty ArrayRef, and the
       // RelocationBufferIndex to zero if the architecture is 32-bit, because we
       // do not support relocation partitioning on 32-bit platforms. With this,
       // partitionFragment will put all the fragment contents in the
       // FinalFragmentContents, and the Addends buffer will be empty.
-      if (ObjectWriter.getAddressSize() == 4) {
+      if (AddressSize == 4) {
         RelocationBuffer = ArrayRef<MachO::any_relocation_info>();
         RelocationBufferIndex = 0;
       }
       partitionFragment(Asm, Addends, FinalFragmentContents, RelocationBuffer,
-                        F, RelocationBufferIndex,
-                        ObjectWriter.Target.isLittleEndian());
+                        F, RelocationBufferIndex, Target.isLittleEndian());
 
       if (auto E = Merger.tryMerge(F, Size, FinalFragmentContents))
         return E;
@@ -3169,13 +3180,14 @@ Error MCCASBuilder::buildFragments() {
 }
 
 Error MCCASBuilder::buildRelocations() {
-  ObjectWriter.resetBuffer();
-  if (ObjectWriter.Mode == CASBackendMode::Verify ||
-      RelocLocation == CompileUnit)
-    ObjectWriter.writeRelocations(Asm);
+  MachOCASWriter &Writer = static_cast<MachOCASWriter &>(ObjectWriter);
+
+  Writer.resetBuffer();
+  if (Writer.Mode == CASBackendMode::Verify || RelocLocation == CompileUnit)
+    Writer.writeRelocations(Asm);
 
   if (RelocLocation == CompileUnit) {
-    auto Relocs = RelocationsRef::create(*this, ObjectWriter.getContent());
+    auto Relocs = RelocationsRef::create(*this, Writer.getContent());
     if (!Relocs)
       return Relocs.takeError();
 
@@ -3186,9 +3198,11 @@ Error MCCASBuilder::buildRelocations() {
 }
 
 Error MCCASBuilder::buildDataInCodeRegion() {
-  ObjectWriter.resetBuffer();
-  ObjectWriter.writeDataInCodeRegion(Asm);
-  auto Data = DataInCodeRef::create(*this, ObjectWriter.getContent());
+  MachOCASWriter &Writer = static_cast<MachOCASWriter &>(ObjectWriter);
+
+  Writer.resetBuffer();
+  Writer.writeDataInCodeRegion(Asm);
+  auto Data = DataInCodeRef::create(*this, Writer.getContent());
   if (!Data)
     return Data.takeError();
 
@@ -3197,9 +3211,11 @@ Error MCCASBuilder::buildDataInCodeRegion() {
 }
 
 Error MCCASBuilder::buildSymbolTable() {
-  ObjectWriter.resetBuffer();
-  ObjectWriter.writeSymbolTable(Asm);
-  StringRef S = ObjectWriter.getContent();
+  MachOCASWriter &Writer = static_cast<MachOCASWriter &>(ObjectWriter);
+
+  Writer.resetBuffer();
+  Writer.writeSymbolTable(Asm);
+  StringRef S = Writer.getContent();
   std::vector<cas::ObjectRef> CStrings;
   if (auto E = createStringSection(S, [&](StringRef S) -> Error {
         auto Sym = CStringRef::create(*this, S);
@@ -3239,10 +3255,11 @@ void MCCASBuilder::startSection(const MCSection *Sec) {
 
   CurrentSection = Sec;
   CurrentContext = &SectionContext;
+  MachObjectWriter &Writer = static_cast<MachObjectWriter &>(ObjectWriter);
 
   if (RelocLocation == Atom) {
     // Build a map for lookup.
-    for (auto R : ObjectWriter.getRelocations()[Sec]) {
+    for (auto R : Writer.getRelocations()[Sec]) {
       // For the Dwarf Sections, just append the relocations to the
       // SectionRelocs. No Atoms are considered for this section.
       if (R.F && Sec != DwarfSections.Line && Sec != DwarfSections.DebugInfo &&
@@ -3262,7 +3279,7 @@ void MCCASBuilder::startSection(const MCSection *Sec) {
   }
 
   if (RelocLocation == Section) {
-    for (auto R : ObjectWriter.getRelocations()[Sec])
+    for (auto R : Writer.getRelocations()[Sec])
       SectionRelocs.push_back(R.MRE);
   }
 }
@@ -3314,6 +3331,7 @@ Expected<MCAssemblerRef> MCAssemblerRef::create(const MCSchema &Schema,
                                                 MCAssembler &Asm,
                                                 raw_ostream *DebugOS) {
   MCCASBuilder Builder(Schema, ObjectWriter, Asm, DebugOS);
+  MachOCASWriter &Writer = static_cast<MachOCASWriter &>(ObjectWriter);
 
   if (auto E = Builder.prepare())
     return std::move(E);
@@ -3326,8 +3344,8 @@ Expected<MCAssemblerRef> MCAssemblerRef::create(const MCSchema &Schema,
 
   // Only need to do this for verify mode so we compare the output byte by
   // byte.
-  if (ObjectWriter.Mode == CASBackendMode::Verify) {
-    ObjectWriter.writeSectionData(Asm);
+  if (Writer.Mode == CASBackendMode::Verify) {
+    Writer.writeSectionData(Asm);
   }
 
   if (auto E = Builder.buildRelocations())
@@ -3346,7 +3364,8 @@ Expected<MCAssemblerRef> MCAssemblerRef::create(const MCSchema &Schema,
   // Put Header, Relocations, SymbolTable, etc. in the front.
   B->Refs.append(Builder.Sections.begin(), Builder.Sections.end());
 
-  std::string NormalizedTriple = ObjectWriter.Target.normalize();
+  const Triple &Target = ObjectWriter.getContext().getTargetTriple();
+  std::string NormalizedTriple = Target.normalize();
   writeVBR8(uint32_t(NormalizedTriple.size()), B->Data);
   B->Data.append(NormalizedTriple);
 

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -655,11 +655,11 @@ int main(int argc, char **argv) {
                           llvm::sys::Process::GetEnv("LLVM_TEST_CAS_BACKEND"));
 
     if (UseCASBackend) {
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
+      std::function<const cas::ObjectProxy(llvm::MCObjectWriter &,
                                            llvm::MCAssembler &,
                                            cas::ObjectStore &, raw_ostream *)>
           CreateFromMcAssembler =
-              [](llvm::MachOCASWriter &Writer, llvm::MCAssembler &Asm,
+              [](llvm::MCObjectWriter &Writer, llvm::MCAssembler &Asm,
                  cas::ObjectStore &CAS,
                  raw_ostream *DebugOS = nullptr) -> const cas::ObjectProxy {
         auto Schema = std::make_unique<mccasformats::v1::MCSchema>(CAS);


### PR DESCRIPTION
Rather than using the explicit `MCMachOCASWriter` type, use the abstract `MCObjectWriter` type. This flexibility allows enabling new object writers, e.g. COFF.