### PR TITLE
[stable/21.x][clang][driver][darwin] Fix use after scope in darwin driver

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2181,7 +2181,7 @@ private:
   static std::string getDisplayName(DarwinPlatformKind TargetPlatform,
                                     DarwinEnvironmentKind TargetEnvironment,
                                     VersionTuple Version) {
-    SmallVector<StringRef, 3> Components;
+    SmallVector<std::string, 3> Components;
     switch (TargetPlatform) {
     case DarwinPlatformKind::MacOS:
       Components.push_back("macOS");


### PR DESCRIPTION
`Version.getAsString()` returns an `std::string`, and thus the `StringRef` points to an invalid location when pushed into the Components vector. Change the Components vector to hold a std::string instead, to fix the ASAN failure after #176541

rdar://167891541