### PR TITLE
[Cherry-pick into next] [LLDB] Downgrade fallback warning to a HEALTH log

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -20,6 +20,7 @@
 #include "Plugins/ExpressionParser/Swift/SwiftPersistentExpressionState.h"
 #include "Plugins/ExpressionParser/Swift/SwiftUserExpression.h"
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
+#include "Plugins/Language/Swift/LogChannelSwift.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "TypeSystemSwiftTypeRef.h"
@@ -3194,9 +3195,9 @@ void TypeSystemSwiftTypeRef::DiagnoseSwiftASTContextFallback(
   llvm::raw_string_ostream(msg)
       << "TypeSystemSwiftTypeRef::" << func_name
       << ": had to engage SwiftASTContext fallback for type " << type_name;
-  Debugger::ReportWarning(msg, debugger_id, &m_fallback_warning);
 
   LLDB_LOGF(GetLog(LLDBLog::Types), "%s", msg.c_str());
+  LLDB_LOGF(lldb_private::GetSwiftHealthLog(), "%s", msg.c_str());
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -614,7 +614,6 @@ protected:
     unsigned char retry_count = 0;
   };
 
-  std::once_flag m_fallback_warning;
   mutable std::mutex m_swift_ast_context_lock;
   /// The "precise" SwiftASTContexts managed by this scratch context. There
   /// exists one per Swift module. The keys in this map are module names.


### PR DESCRIPTION
```
commit 846d8cd9bac7bb3e152b7394ce5b243bb758deb5
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Jan 30 17:18:49 2026 -0800

    [LLDB] Downgrade fallback warning to a HEALTH log
    
    This message existed to encourage bugreports but it's not a
    particularly actionable message itself. Moving it into
    swift-healthcheck is more appropriate.
    
    Part of rdar://169199844
```
