### PR TITLE
CAS: adjust test expectations (NFC)

### DIFF
--- a/llvm/unittests/CAS/CASConfigurationTest.cpp
+++ b/llvm/unittests/CAS/CASConfigurationTest.cpp
@@ -23,7 +23,7 @@ TEST(CASConfigurationTest, roundTrips) {
     ASSERT_THAT_ERROR(
         CASConfiguration::createFromConfig(Serialized).moveInto(NewConfig),
         Succeeded());
-    ASSERT_TRUE(Config == *NewConfig);
+    EXPECT_EQ(Config, *NewConfig);
   };
 
   CASConfiguration Config;
@@ -83,6 +83,6 @@ TEST(CASConfigurationTest, configFileSearch) {
   auto NewConfig =
       CASConfiguration::createFromSearchConfigFile(PathToE.str(), VFS);
   ASSERT_TRUE(NewConfig);
-  ASSERT_TRUE(NewConfig->first == PathToDConfig.str());
-  ASSERT_TRUE(Config == NewConfig->second);
+  EXPECT_EQ(NewConfig->first, PathToDConfig.str());
+  EXPECT_EQ(Config, NewConfig->second);
 }


### PR DESCRIPTION
Use `EXPECT_EQ` instead of `ASSERT_TRUE` for equality tests to print out both values and make them non-fatal allowing other conditions to be tested.