### PR TITLE
🍒 [lit] Make not still fail if the called process returns a signal

### DIFF
--- a/llvm/utils/lit/lit/TestRunner.py
+++ b/llvm/utils/lit/lit/TestRunner.py
@@ -743,6 +743,7 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
     procs = []
     proc_not_counts = []
+    proc_not_fail_if_crash = []
     default_stdin = subprocess.PIPE
     stderrTempFiles = []
     opened_files = []
@@ -866,10 +867,14 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
 
         # For plain negations, either 'not' without '--crash', or the shell
         # operator '!', leave them out from the command to execute and
-        # invert the result code afterwards.
+        # invert the result code afterwards. If we have a plain not, pass the
+        # args along so we can recognize it later and still fail if the
+        # executed command returns a signal.
         if not_crash:
             args = not_args + args
             not_count = 0
+        elif not_args == ["not"]:
+            pass
         else:
             not_args = []
 
@@ -944,6 +949,10 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
                 )
             )
             proc_not_counts.append(not_count)
+            if not not_crash and not_args == ["not"]:
+                proc_not_fail_if_crash.append(True)
+            else:
+                proc_not_fail_if_crash.append(False)
             # Let the helper know about this process
             timeoutHelper.addProcess(procs[-1])
         except OSError as e:
@@ -999,7 +1008,10 @@ def _executeShCmd(cmd, shenv, results, timeoutHelper):
         if res == -signal.SIGINT:
             raise KeyboardInterrupt
         if proc_not_counts[i] % 2:
-            res = 1 if res == 0 else 0
+            if proc_not_fail_if_crash[i]:
+                res = int(res <= 0)
+            else:
+                res = 1 if res == 0 else 0
         elif proc_not_counts[i] > 1:
             res = 1 if res != 0 else 0
 

--- a/llvm/utils/lit/tests/Inputs/shtest-not-posix/fail-signal.py
+++ b/llvm/utils/lit/tests/Inputs/shtest-not-posix/fail-signal.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import os
+import signal
+
+os.kill(os.getpid(), signal.SIGABRT)

--- a/llvm/utils/lit/tests/Inputs/shtest-not-posix/lit.cfg
+++ b/llvm/utils/lit/tests/Inputs/shtest-not-posix/lit.cfg
@@ -1,0 +1,8 @@
+import lit.formats
+
+config.name = "shtest-not-posix"
+config.suffixes = [".txt"]
+config.test_format = lit.formats.ShTest()
+config.test_source_root = None
+config.test_exec_root = None
+config.substitutions.append(("%{python}", '"%s"' % (sys.executable)))

--- a/llvm/utils/lit/tests/Inputs/shtest-not-posix/not-signal-crash.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-not-posix/not-signal-crash.txt
@@ -1,0 +1,3 @@
+# Check that the builtin not passes when we fail with a signal with --crash
+
+# RUN: not --crash %{python} fail-signal.py

--- a/llvm/utils/lit/tests/Inputs/shtest-not-posix/not-signal.txt
+++ b/llvm/utils/lit/tests/Inputs/shtest-not-posix/not-signal.txt
@@ -1,0 +1,3 @@
+# Check that the builtin not still fails when we fail with a signal.
+
+# RUN: not %{python} fail-signal.py

--- a/llvm/utils/lit/tests/shtest-not-posix.py
+++ b/llvm/utils/lit/tests/shtest-not-posix.py
@@ -1,0 +1,13 @@
+# Check the not command correctly handles POSIX signals
+
+# UNSUPPORTED: system-windows
+
+# RUN: not %{lit} -a %{inputs}/shtest-not-posix \
+# RUN: | FileCheck -match-full-lines %s
+
+# CHECK: -- Testing: 2 tests{{.*}}
+
+# CHECK PASS: shtest-not-posix :: not-signal-crash.txt (1 of 2)
+
+# CHECK: FAIL: shtest-not-posix :: not-signal.txt (2 of 2)
+# CHECK: # error: command failed with exit status: 1


### PR DESCRIPTION
This cherry-picks the following commit to enable us to proceed with enabling the internal shell in Swift:
```
This is the behavior of the main not binary that was not preserved in the internal shell. Make it so that the builtin not command does actually fail if we end up with a signal rather than just a non-zero exit code.

Reviewers: petrhosek, ilovepi, jdenny-ornl, arichardson

Pull Request: https://github.com/llvm/llvm-project/pull/174298

(cherry picked from commit 65dbee00898417b09d6bd40d67c129ee7b0de2fc)
```