### PR TITLE
[🍒][sanitizer_common] Disable sanitizer_redefine_builtins on Apple platforms

### DIFF
--- a/compiler-rt/lib/sanitizer_common/sanitizer_redefine_builtins.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_redefine_builtins.h
@@ -15,7 +15,7 @@
 #    define SANITIZER_REDEFINE_BUILTINS_H
 
 // The asm hack only works with GCC and Clang.
-#    if !defined(_WIN32) && !defined(_AIX)
+#    if !defined(_WIN32) && !defined(_AIX) && !defined(__APPLE__)
 
 asm(R"(
     .set memcpy, __sanitizer_internal_memcpy


### PR DESCRIPTION
This currently generates many linker warnings of this form, due to defining mem(cpy|move|set) in every object file:
```
ld: warning: '.../build/projects/compiler-rt/lib/interception/CMakeFiles/RTInterception.ios.dir/interception_linux.cpp.o' has malformed LC_DYSYMTAB, expected 6 undefined symbols to start at index 1, found 3 undefined symbols starting at index 1
```

In order for this to actually replace these symbols on mach-o, they would need a leading underscore, e.g. `.set _memcpy, ___sanitizer_internal_memcpy`. However doing so does not fix the warnings, and furthermore it ends up replacing `REAL(memcpy)` calls with `__sanitizer_internal_memcpy` in places such as
`__asan::Allocator::Reallocate`. There is no way on Apple platforms to recreate the intended behaviour, so let's just disable this on them to reduce warning noise.

rdar://123771479
(cherry picked from commit cfdbbb8fcc62f75dcf0b251dfab63353f3921227)