### PR TITLE
[lldb] Add summary formatter for System.FilePath

### DIFF
--- a/lldb/source/Plugins/Language/Swift/CMakeLists.txt
+++ b/lldb/source/Plugins/Language/Swift/CMakeLists.txt
@@ -24,6 +24,7 @@ add_lldb_library(lldbPluginSwiftLanguage PLUGIN
   SwiftFrameRecognizers.cpp
   SwiftSet.cpp
   SwiftUnsafeTypes.cpp
+  SystemValueTypes.cpp
 
   LINK_LIBS
     lldbCore

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.h
@@ -30,6 +30,7 @@
 #include "SwiftOptional.h"
 #include "SwiftSet.h"
 #include "SwiftUnsafeTypes.h"
+#include "SystemValueTypes.h"
 
 namespace lldb_private {
 namespace formatters {

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -755,6 +755,33 @@ LoadFoundationValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
           .SetNonCacheable(false));
 }
 
+static void
+LoadSystemValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
+  if (!swift_category_sp)
+    return;
+
+  TypeSummaryImpl::Flags summary_flags;
+  summary_flags.SetCascades(true)
+      .SetDontShowChildren(false)
+      .SetSkipPointers(true)
+      .SetSkipReferences(false)
+      .SetHideItemNames(false)
+      .SetShowMembersOneLiner(false);
+
+  lldb_private::formatters::AddCXXSummary(
+      swift_category_sp,
+      lldb_private::formatters::swift::FilePath_SummaryProvider,
+      "FilePath summary provider", ConstString("^System(Package)?\\.FilePath$"),
+      summary_flags, true);
+
+  lldb_private::formatters::AddCXXSummary(
+      swift_category_sp,
+      lldb_private::formatters::swift::SystemChar_SummaryProvider,
+      "SystemChar summary provider",
+      ConstString("^System(Package)?\\.SystemChar$"),
+      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
+}
+
 lldb::TypeCategoryImplSP SwiftLanguage::GetFormatters() {
   static std::once_flag g_initialize;
   static TypeCategoryImplSP g_category;
@@ -765,6 +792,7 @@ lldb::TypeCategoryImplSP SwiftLanguage::GetFormatters() {
     if (g_category) {
       LoadSwiftFormatters(g_category);
       LoadFoundationValueTypesFormatters(g_category);
+      LoadSystemValueTypesFormatters(g_category);
     }
   });
   return g_category;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -772,13 +772,6 @@ LoadSystemValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::FilePath_SummaryProvider,
       "FilePath summary provider", ConstString("^System(Package)?\\.FilePath$"),
-      summary_flags, true);
-
-  lldb_private::formatters::AddCXXSummary(
-      swift_category_sp,
-      lldb_private::formatters::swift::SystemChar_SummaryProvider,
-      "SystemChar summary provider",
-      ConstString("^System(Package)?\\.SystemChar$"),
       TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
 }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -772,6 +772,13 @@ LoadSystemValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
       swift_category_sp,
       lldb_private::formatters::swift::FilePath_SummaryProvider,
       "FilePath summary provider", ConstString("^System(Package)?\\.FilePath$"),
+      summary_flags, true);
+
+  lldb_private::formatters::AddCXXSummary(
+      swift_category_sp,
+      lldb_private::formatters::swift::SystemString_SummaryProvider,
+      "SystemString summary provider",
+      ConstString("^System(Package)?\\.SystemString$"),
       TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
 }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -762,24 +762,25 @@ LoadSystemValueTypesFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
 
   TypeSummaryImpl::Flags summary_flags;
   summary_flags.SetCascades(true)
-      .SetDontShowChildren(false)
+      .SetDontShowChildren(true) // overridden at runtime by DoesPrintChildren
       .SetSkipPointers(true)
       .SetSkipReferences(false)
       .SetHideItemNames(false)
       .SetShowMembersOneLiner(false);
 
-  lldb_private::formatters::AddCXXSummary(
-      swift_category_sp,
-      lldb_private::formatters::swift::FilePath_SummaryProvider,
-      "FilePath summary provider", ConstString("^System(Package)?\\.FilePath$"),
-      summary_flags, true);
+  TypeSummaryImplSP filepath_summary_sp(
+      new lldb_private::formatters::swift::FilePathSummaryProvider(
+          summary_flags));
+  lldb_private::formatters::AddSummary(
+      swift_category_sp, filepath_summary_sp,
+      ConstString("^System(Package)?\\.FilePath$"), true);
 
   lldb_private::formatters::AddCXXSummary(
       swift_category_sp,
       lldb_private::formatters::swift::SystemString_SummaryProvider,
       "SystemString summary provider",
       ConstString("^System(Package)?\\.SystemString$"),
-      TypeSummaryImpl::Flags(summary_flags).SetDontShowChildren(true), true);
+      summary_flags, true);
 }
 
 lldb::TypeCategoryImplSP SwiftLanguage::GetFormatters() {

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
@@ -12,6 +12,7 @@
 
 #include "SystemValueTypes.h"
 
+#include "lldb/Target/Target.h"
 #include "lldb/Utility/Stream.h"
 #include "lldb/ValueObject/ValueObject.h"
 
@@ -63,8 +64,12 @@ static bool ExtractSystemChars(ValueObjectSP storage_sp,
     }
   }
 
-  // Guard against overly long paths.
-  const uint32_t max_length = 4096;
+  // Use the target's max-children-count, or 4096 (~PATH_MAX) by default
+  uint32_t max_length = 4096;
+  if (auto target_sp = storage_sp->GetTargetSP())
+    max_length = target_sp->GetMaximumNumberOfChildrenToDisplay();
+  if (max_length == 0)
+    max_length = 4096;
   uint32_t length = std::min(num_children, max_length);
 
   values.clear();

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
@@ -1,0 +1,126 @@
+//===-- SystemValueTypes.cpp ------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SystemValueTypes.h"
+
+#include "lldb/Utility/Stream.h"
+#include "lldb/ValueObject/ValueObject.h"
+
+#include <algorithm>
+#include <string>
+
+using namespace lldb;
+using namespace lldb_private;
+using namespace lldb_private::formatters;
+using namespace lldb_private::formatters::swift;
+
+bool lldb_private::formatters::swift::FilePath_SummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+
+  // public struct FilePath {
+  //   internal var _storage: SystemString
+  // }
+  // internal struct SystemString {
+  //   internal var nullTerminatedStorage: [SystemChar]
+  // }
+  // internal struct SystemChar {
+  //   internal var rawValue: CInterop.PlatformChar  // Int8 on Unix, UInt16 on Windows
+  // }
+
+  static constexpr llvm::StringLiteral g__storage("_storage");
+  static constexpr llvm::StringLiteral g_nullTerminatedStorage(
+      "nullTerminatedStorage");
+  static constexpr llvm::StringLiteral g_rawValue("rawValue");
+
+  ValueObjectSP storage_sp =
+      valobj.GetChildAtNamePath({g__storage, g_nullTerminatedStorage});
+  if (!storage_sp)
+    return false;
+
+  storage_sp = storage_sp->GetSyntheticValue();
+  if (!storage_sp)
+    return false;
+
+  uint32_t num_children = storage_sp->GetNumChildrenIgnoringErrors();
+  if (num_children == 0)
+    return false;
+
+  // The storage array is null-terminated, so read num_children - 1 elements.
+  // Also guard against overly long paths.
+  const uint32_t max_path_length = 4096;
+  uint32_t path_length = std::min(num_children - 1, max_path_length);
+
+  std::string path;
+  path.reserve(path_length);
+
+  for (uint32_t i = 0; i < path_length; ++i) {
+    ValueObjectSP char_sp = storage_sp->GetChildAtIndex(i);
+    if (!char_sp)
+      return false;
+
+    // Get the rawValue from SystemChar
+    ValueObjectSP raw_value_sp = char_sp->GetChildAtNamePath({g_rawValue});
+    if (!raw_value_sp)
+      return false;
+
+    raw_value_sp = raw_value_sp->GetQualifiedRepresentationIfAvailable(
+        lldb::eDynamicDontRunTarget, true);
+    if (!raw_value_sp)
+      return false;
+
+    int64_t byte_value = raw_value_sp->GetValueAsSigned(0);
+
+    // Stop if we reach an early null-terminator
+    if (byte_value == 0)
+      break;
+
+    // On Windows, SystemChar is UInt16 (UTF-16). This truncates non-ASCII.
+    path.push_back(static_cast<char>(byte_value));
+  }
+
+  stream << '"' << path << '"';
+  return true;
+}
+
+bool lldb_private::formatters::swift::SystemChar_SummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+
+  // internal struct SystemChar {
+  //   internal var rawValue: CInterop.PlatformChar // Int8 on Unix, UInt16 on Windows
+  // }
+
+  static constexpr llvm::StringLiteral g_rawValue("rawValue");
+
+  ValueObjectSP raw_value_sp = valobj.GetChildAtNamePath({g_rawValue});
+  if (!raw_value_sp)
+    return false;
+
+  raw_value_sp = raw_value_sp->GetQualifiedRepresentationIfAvailable(
+      lldb::eDynamicDontRunTarget, true);
+  if (!raw_value_sp)
+    return false;
+
+  int64_t byte_value = raw_value_sp->GetValueAsSigned(0);
+
+  // For printable ASCII characters (0x20-0x7E), show the character.
+  // For other values, just show the numeric value.
+  if (byte_value >= 0x20 && byte_value <= 0x7E) {
+    stream.Printf("'%c' (%d)", static_cast<char>(byte_value),
+                  static_cast<int>(byte_value));
+  } else if (byte_value == 0) {
+    stream.Printf("'\\0' (0)");
+  } else {
+    stream.Printf("%d", static_cast<int>(byte_value));
+  }
+
+  return true;
+}

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
@@ -1,4 +1,4 @@
-//===-- SystemValueTypes.cpp ------------------------------------*- C++ -*-===//
+//===-- SystemValueTypes.cpp ----------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -88,39 +88,5 @@ bool lldb_private::formatters::swift::FilePath_SummaryProvider(
   }
 
   stream << '"' << path << '"';
-  return true;
-}
-
-bool lldb_private::formatters::swift::SystemChar_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-
-  // internal struct SystemChar {
-  //   internal var rawValue: CInterop.PlatformChar // Int8 on Unix, UInt16 on Windows
-  // }
-
-  static constexpr llvm::StringLiteral g_rawValue("rawValue");
-
-  ValueObjectSP raw_value_sp = valobj.GetChildAtNamePath({g_rawValue});
-  if (!raw_value_sp)
-    return false;
-
-  raw_value_sp = raw_value_sp->GetQualifiedRepresentationIfAvailable(
-      lldb::eDynamicDontRunTarget, true);
-  if (!raw_value_sp)
-    return false;
-
-  int64_t byte_value = raw_value_sp->GetValueAsSigned(0);
-
-  // For printable ASCII characters (0x20-0x7E), show the character.
-  // For other values, just show the numeric value.
-  if (byte_value >= 0x20 && byte_value <= 0x7E) {
-    stream.Printf("'%c' (%d)", static_cast<char>(byte_value),
-                  static_cast<int>(byte_value));
-  } else if (byte_value == 0) {
-    stream.Printf("'\\0' (0)");
-  } else {
-    stream.Printf("%d", static_cast<int>(byte_value));
-  }
-
   return true;
 }

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
@@ -17,49 +17,77 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <string>
 
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::formatters;
 using namespace lldb_private::formatters::swift;
 
-// Writes a character value to the stream with appropriate escaping.
-// Printable ASCII characters (0x20-0x7E) are written directly, except for
-// backslash and double-quote which are escaped. Non-printable characters
-// use "\x{XX}" format (or "\x{XXXX}" on 16-bit wide char platforms).
-static void WriteChar(Stream &stream, uint64_t value, bool is_wide_char) {
-  // Handle special escape characters
-  switch (value) {
-  case '\n':
-    stream << "\\n";
-    return;
-  case '\r':
-    stream << "\\r";
-    return;
-  case '\t':
-    stream << "\\t";
-    return;
-  case '\\':
-    stream << "\\\\";
-    return;
-  case '"':
-    stream << "\\\"";
-    return;
-  default:
-    break;
+// public struct FilePath {
+//   internal var _storage: SystemString
+// }
+// internal struct SystemString {
+//   internal var nullTerminatedStorage: [SystemChar]
+// }
+// internal struct SystemChar {
+//   internal var rawValue: CInterop.PlatformChar // Int8 on Unix, UInt16 on Windows
+// }
+
+static constexpr llvm::StringLiteral g__storage("_storage");
+static constexpr llvm::StringLiteral g_nullTerminatedStorage("nullTerminatedStorage");
+static constexpr llvm::StringLiteral g_rawValue("rawValue");
+
+// Given a synthetic array of `SystemChar` elements, extract each `rawValue`
+// into a vector `values` and detect whether the elements are wide (16-bit).
+// Returns false on failure.
+static bool ExtractSystemChars(ValueObjectSP storage_sp,
+                               std::vector<uint64_t> &values,
+                               bool &is_wide_char) {
+  storage_sp = storage_sp->GetSyntheticValue();
+  if (!storage_sp)
+    return false;
+
+  uint32_t num_children = storage_sp->GetNumChildrenIgnoringErrors();
+  if (num_children == 0)
+    return false;
+
+  // Detect if we're dealing with 16-bit characters (Windows) by
+  // checking the byte size of the first character's rawValue.
+  is_wide_char = false;
+  if (ValueObjectSP first_char_sp = storage_sp->GetChildAtIndex(0)) {
+    if (ValueObjectSP first_raw_sp =
+            first_char_sp->GetChildAtNamePath({g_rawValue})) {
+      if (auto byte_size = first_raw_sp->GetByteSize())
+        is_wide_char = *byte_size > 1;
+    }
   }
 
-  // Printable ASCII (0x20 space through 0x7E tilde)
-  if (value >= 0x20 && value <= 0x7E) {
-    stream << static_cast<char>(value);
-    return;
+  // Guard against overly long paths.
+  const uint32_t max_length = 4096;
+  uint32_t length = std::min(num_children, max_length);
+
+  values.clear();
+  values.reserve(length);
+
+  for (uint32_t i = 0; i < length; ++i) {
+    ValueObjectSP char_sp = storage_sp->GetChildAtIndex(i);
+    if (!char_sp)
+      return false;
+
+    ValueObjectSP raw_value_sp = char_sp->GetChildAtNamePath({g_rawValue});
+    if (!raw_value_sp)
+      return false;
+
+    raw_value_sp = raw_value_sp->GetQualifiedRepresentationIfAvailable(
+        lldb::eDynamicDontRunTarget, true);
+    if (!raw_value_sp)
+      return false;
+
+    values.push_back(raw_value_sp->GetValueAsUnsigned(0));
   }
 
-  // Non-printable: use "\x{XX}" format (or "\x{XXXX}" for 16-bit wide char)
-  if (is_wide_char)
-    stream.Printf("\\x{%04" PRIX64 "}", value & 0xFFFF);
-  else
-    stream.Printf("\\x{%02" PRIX64 "}", value & 0xFF);
+  return true;
 }
 
 bool lldb_private::formatters::swift::FilePath_SummaryProvider(
@@ -71,72 +99,69 @@ bool lldb_private::formatters::swift::FilePath_SummaryProvider(
   // internal struct SystemString {
   //   internal var nullTerminatedStorage: [SystemChar]
   // }
-  // internal struct SystemChar {
-  //   internal var rawValue: CInterop.PlatformChar  // Int8 on Unix, UInt16 on Windows
-  // }
-
-  static constexpr llvm::StringLiteral g__storage("_storage");
-  static constexpr llvm::StringLiteral g_nullTerminatedStorage(
-      "nullTerminatedStorage");
-  static constexpr llvm::StringLiteral g_rawValue("rawValue");
 
   ValueObjectSP storage_sp =
       valobj.GetChildAtNamePath({g__storage, g_nullTerminatedStorage});
   if (!storage_sp)
     return false;
 
-  storage_sp = storage_sp->GetSyntheticValue();
+  std::vector<uint64_t> values;
+  bool is_wide_char = false;
+  if (!ExtractSystemChars(storage_sp, values, is_wide_char))
+    return false;
+
+  std::string path;
+  path.reserve(values.size());
+
+  for (uint64_t value : values) {
+    // Stop at null-terminator.
+    if (value == 0)
+      break;
+    // On Windows, SystemChar is UInt16 (UTF-16). This truncates non-ASCII.
+    path.push_back(static_cast<char>(value));
+  }
+
+  stream << '"' << path << '"';
+  return true;
+}
+
+bool lldb_private::formatters::swift::SystemString_SummaryProvider(
+    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
+
+  // internal struct SystemString {
+  //   internal var nullTerminatedStorage: [SystemChar]
+  // }
+
+  ValueObjectSP storage_sp =
+      valobj.GetChildAtNamePath({g_nullTerminatedStorage});
   if (!storage_sp)
     return false;
 
-  uint32_t num_children = storage_sp->GetNumChildrenIgnoringErrors();
-  if (num_children == 0)
+  std::vector<uint64_t> values;
+  bool is_wide_char = false;
+  if (!ExtractSystemChars(storage_sp, values, is_wide_char))
     return false;
 
-  // The storage array is null-terminated, so read num_children - 1 elements.
-  // Also guard against overly long paths.
-  const uint32_t max_path_length = 4096;
-  uint32_t path_length = std::min(num_children - 1, max_path_length);
+  // Display as an array of bytes, e.g: ['/', 'b', 'i', 'n', 0x00]
+  // Printable ASCII (0x20-0x7E) are shown as characters, others as hex.
 
-  // Detect if we're dealing with 16-bit characters (Windows) by
-  // checking the byte size of the first character's rawValue.
-  bool is_wide_char = false;
-  if (path_length > 0) {
-    if (ValueObjectSP first_char_sp = storage_sp->GetChildAtIndex(0)) {
-      if (ValueObjectSP first_raw_sp =
-              first_char_sp->GetChildAtNamePath({g_rawValue})) {
-        if (auto byte_size = first_raw_sp->GetByteSize())
-          is_wide_char = *byte_size > 1;
-      }
+  stream << '[';
+
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i > 0)
+      stream << ", ";
+
+    uint64_t value = values[i];
+
+    if (value >= 0x20 && value <= 0x7E) {
+      stream.Printf("'%c'", static_cast<char>(value));
+    } else if (is_wide_char) {
+      stream.Printf("0x%04" PRIX64, value & 0xFFFF);
+    } else {
+      stream.Printf("0x%02" PRIX64, value & 0xFF);
     }
   }
 
-  stream << '"';
-
-  for (uint32_t i = 0; i < path_length; ++i) {
-    ValueObjectSP char_sp = storage_sp->GetChildAtIndex(i);
-    if (!char_sp)
-      return false;
-
-    // Get the rawValue from SystemChar
-    ValueObjectSP raw_value_sp = char_sp->GetChildAtNamePath({g_rawValue});
-    if (!raw_value_sp)
-      return false;
-
-    raw_value_sp = raw_value_sp->GetQualifiedRepresentationIfAvailable(
-        lldb::eDynamicDontRunTarget, true);
-    if (!raw_value_sp)
-      return false;
-
-    uint64_t value = raw_value_sp->GetValueAsUnsigned(0);
-
-    // Stop if we reach an early null-terminator
-    if (value == 0)
-      break;
-
-    WriteChar(stream, value, is_wide_char);
-  }
-
-  stream << '"';
+  stream << ']';
   return true;
 }

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
@@ -16,12 +16,51 @@
 #include "lldb/ValueObject/ValueObject.h"
 
 #include <algorithm>
-#include <string>
+#include <cinttypes>
 
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::formatters;
 using namespace lldb_private::formatters::swift;
+
+// Writes a character value to the stream with appropriate escaping.
+// Printable ASCII characters (0x20-0x7E) are written directly, except for
+// backslash and double-quote which are escaped. Non-printable characters
+// use "\x{XX}" format (or "\x{XXXX}" on 16-bit wide char platforms).
+static void WriteChar(Stream &stream, uint64_t value, bool is_wide_char) {
+  // Handle special escape characters
+  switch (value) {
+  case '\n':
+    stream << "\\n";
+    return;
+  case '\r':
+    stream << "\\r";
+    return;
+  case '\t':
+    stream << "\\t";
+    return;
+  case '\\':
+    stream << "\\\\";
+    return;
+  case '"':
+    stream << "\\\"";
+    return;
+  default:
+    break;
+  }
+
+  // Printable ASCII (0x20 space through 0x7E tilde)
+  if (value >= 0x20 && value <= 0x7E) {
+    stream << static_cast<char>(value);
+    return;
+  }
+
+  // Non-printable: use "\x{XX}" format (or "\x{XXXX}" for 16-bit wide char)
+  if (is_wide_char)
+    stream.Printf("\\x{%04" PRIX64 "}", value & 0xFFFF);
+  else
+    stream.Printf("\\x{%02" PRIX64 "}", value & 0xFF);
+}
 
 bool lldb_private::formatters::swift::FilePath_SummaryProvider(
     ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
@@ -59,8 +98,20 @@ bool lldb_private::formatters::swift::FilePath_SummaryProvider(
   const uint32_t max_path_length = 4096;
   uint32_t path_length = std::min(num_children - 1, max_path_length);
 
-  std::string path;
-  path.reserve(path_length);
+  // Detect if we're dealing with 16-bit characters (Windows) by
+  // checking the byte size of the first character's rawValue.
+  bool is_wide_char = false;
+  if (path_length > 0) {
+    if (ValueObjectSP first_char_sp = storage_sp->GetChildAtIndex(0)) {
+      if (ValueObjectSP first_raw_sp =
+              first_char_sp->GetChildAtNamePath({g_rawValue})) {
+        if (auto byte_size = first_raw_sp->GetByteSize())
+          is_wide_char = *byte_size > 1;
+      }
+    }
+  }
+
+  stream << '"';
 
   for (uint32_t i = 0; i < path_length; ++i) {
     ValueObjectSP char_sp = storage_sp->GetChildAtIndex(i);
@@ -77,16 +128,15 @@ bool lldb_private::formatters::swift::FilePath_SummaryProvider(
     if (!raw_value_sp)
       return false;
 
-    int64_t byte_value = raw_value_sp->GetValueAsSigned(0);
+    uint64_t value = raw_value_sp->GetValueAsUnsigned(0);
 
     // Stop if we reach an early null-terminator
-    if (byte_value == 0)
+    if (value == 0)
       break;
 
-    // On Windows, SystemChar is UInt16 (UTF-16). This truncates non-ASCII.
-    path.push_back(static_cast<char>(byte_value));
+    WriteChar(stream, value, is_wide_char);
   }
 
-  stream << '"' << path << '"';
+  stream << '"';
   return true;
 }

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.cpp
@@ -90,24 +90,37 @@ static bool ExtractSystemChars(ValueObjectSP storage_sp,
   return true;
 }
 
-bool lldb_private::formatters::swift::FilePath_SummaryProvider(
-    ValueObject &valobj, Stream &stream, const TypeSummaryOptions &options) {
-
-  // public struct FilePath {
-  //   internal var _storage: SystemString
-  // }
-  // internal struct SystemString {
-  //   internal var nullTerminatedStorage: [SystemChar]
-  // }
-
+// Extract SystemChar values from a FilePath's _storage.nullTerminatedStorage.
+static bool ExtractFilePathChars(ValueObject &valobj,
+                                 std::vector<uint64_t> &values,
+                                 bool &is_wide_char) {
   ValueObjectSP storage_sp =
       valobj.GetChildAtNamePath({g__storage, g_nullTerminatedStorage});
   if (!storage_sp)
     return false;
+  return ExtractSystemChars(storage_sp, values, is_wide_char);
+}
+
+// Check if all characters before the null-terminator are printable ASCII.
+static bool IsAllPrintableASCII(const std::vector<uint64_t> &values) {
+  for (uint64_t value : values) {
+    if (value == 0)
+      break;
+    if (value < 0x20 || value > 0x7E)
+      return false;
+  }
+  return true;
+}
+
+bool lldb_private::formatters::swift::FilePathSummaryProvider::FormatObject(
+    ValueObject *valobj, std::string &dest,
+    const TypeSummaryOptions &options) {
+  if (!valobj)
+    return false;
 
   std::vector<uint64_t> values;
   bool is_wide_char = false;
-  if (!ExtractSystemChars(storage_sp, values, is_wide_char))
+  if (!ExtractFilePathChars(*valobj, values, is_wide_char))
     return false;
 
   std::string path;
@@ -121,8 +134,31 @@ bool lldb_private::formatters::swift::FilePath_SummaryProvider(
     path.push_back(static_cast<char>(value));
   }
 
-  stream << '"' << path << '"';
+  dest = "\"" + path + "\"";
   return true;
+}
+
+bool lldb_private::formatters::swift::FilePathSummaryProvider::
+    DoesPrintChildren(ValueObject *valobj) const {
+  if (!valobj)
+    return false;
+
+  std::vector<uint64_t> values;
+  bool is_wide_char = false;
+  if (!ExtractFilePathChars(*valobj, values, is_wide_char))
+    return false;
+
+  return !IsAllPrintableASCII(values);
+}
+
+std::string
+lldb_private::formatters::swift::FilePathSummaryProvider::GetDescription() {
+  return "FilePath summary provider";
+}
+
+std::string
+lldb_private::formatters::swift::FilePathSummaryProvider::GetName() {
+  return "FilePathSummaryProvider";
 }
 
 bool lldb_private::formatters::swift::SystemString_SummaryProvider(

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
@@ -1,0 +1,32 @@
+//===-- SystemValueTypes.h --------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef liblldb_SystemValueTypes_h_
+#define liblldb_SystemValueTypes_h_
+
+#include "lldb/lldb-forward.h"
+
+#include "lldb/DataFormatters/TypeSummary.h"
+
+namespace lldb_private {
+namespace formatters {
+namespace swift {
+bool FilePath_SummaryProvider(ValueObject &valobj, Stream &stream,
+                              const TypeSummaryOptions &options);
+
+bool SystemChar_SummaryProvider(ValueObject &valobj, Stream &stream,
+                                const TypeSummaryOptions &options);
+}
+}
+}
+
+#endif // liblldb_SystemValueTypes_h_

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
@@ -21,6 +21,9 @@ namespace formatters {
 namespace swift {
 bool FilePath_SummaryProvider(ValueObject &valobj, Stream &stream,
                               const TypeSummaryOptions &options);
+
+bool SystemString_SummaryProvider(ValueObject &valobj, Stream &stream,
+                                  const TypeSummaryOptions &options);
 }
 }
 }

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
@@ -1,4 +1,4 @@
-//===-- SystemValueTypes.h --------------------------------------*- C++ -*-===//
+//===-- SystemValueTypes.h ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -14,7 +14,6 @@
 #define liblldb_SystemValueTypes_h_
 
 #include "lldb/lldb-forward.h"
-
 #include "lldb/DataFormatters/TypeSummary.h"
 
 namespace lldb_private {
@@ -22,9 +21,6 @@ namespace formatters {
 namespace swift {
 bool FilePath_SummaryProvider(ValueObject &valobj, Stream &stream,
                               const TypeSummaryOptions &options);
-
-bool SystemChar_SummaryProvider(ValueObject &valobj, Stream &stream,
-                                const TypeSummaryOptions &options);
 }
 }
 }

--- a/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
+++ b/lldb/source/Plugins/Language/Swift/SystemValueTypes.h
@@ -19,8 +19,22 @@
 namespace lldb_private {
 namespace formatters {
 namespace swift {
-bool FilePath_SummaryProvider(ValueObject &valobj, Stream &stream,
-                              const TypeSummaryOptions &options);
+
+struct FilePathSummaryProvider : public TypeSummaryImpl {
+  FilePathSummaryProvider(const TypeSummaryImpl::Flags &flags)
+      : TypeSummaryImpl(TypeSummaryImpl::Kind::eInternal, flags) {}
+
+  bool FormatObject(ValueObject *valobj, std::string &dest,
+                    const TypeSummaryOptions &options) override;
+  std::string GetDescription() override;
+  std::string GetName() override;
+  bool DoesPrintChildren(ValueObject *valobj) const override;
+
+private:
+  FilePathSummaryProvider(const FilePathSummaryProvider &) = delete;
+  const FilePathSummaryProvider &
+  operator=(const FilePathSummaryProvider &) = delete;
+};
 
 bool SystemString_SummaryProvider(ValueObject &valobj, Stream &stream,
                                   const TypeSummaryOptions &options);

--- a/lldb/test/API/lang/swift/system/Makefile
+++ b/lldb/test/API/lang/swift/system/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
+++ b/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
@@ -1,0 +1,31 @@
+"""
+Test System.FilePath summary strings.
+"""
+
+import lldb
+
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+from lldbsuite.test import lldbutil
+
+class TestSwiftSystemFilePath(TestBase):
+    @swiftTest
+    @skipUnlessDarwin
+    def test(self):
+        """Test that System.FilePath is formatted correctly."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame var path",
+            startstr='(System.FilePath) path = "/usr/local/bin"',
+        )
+        self.expect(
+            "frame var empty",
+            startstr='(System.FilePath) empty = ""',
+        )
+        self.expect(
+            "frame var root",
+            startstr='(System.FilePath) root = "/"',
+        )

--- a/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
+++ b/lldb/test/API/lang/swift/system/TestSwiftSystemFilePath.py
@@ -1,5 +1,5 @@
 """
-Test System.FilePath summary strings.
+Test System.FilePath and SystemString summary strings.
 """
 
 import lldb
@@ -12,20 +12,53 @@ class TestSwiftSystemFilePath(TestBase):
     @swiftTest
     @skipUnlessDarwin
     def test(self):
-        """Test that System.FilePath is formatted correctly."""
+        """Test that System.FilePath and SystemString are formatted correctly."""
         self.build()
         lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.swift")
         )
-        self.expect(
-            "frame var path",
-            startstr='(System.FilePath) path = "/usr/local/bin"',
-        )
-        self.expect(
-            "frame var empty",
-            startstr='(System.FilePath) empty = ""',
-        )
-        self.expect(
-            "frame var root",
-            startstr='(System.FilePath) root = "/"',
-        )
+
+        # Test FilePath summaries.
+        path = self.frame().FindVariable("path")
+        self.assertEqual(path.GetSummary(), '"/usr/local/bin"')
+
+        empty = self.frame().FindVariable("empty")
+        self.assertEqual(empty.GetSummary(), '""')
+
+        root = self.frame().FindVariable("root")
+        self.assertEqual(root.GetSummary(), '"/"')
+
+        nonASCII = self.frame().FindVariable("nonASCII")
+        self.assertEqual(nonASCII.GetSummary(), '"/hëllo/wôrld"')
+
+        # Test SystemString summary via the _storage child of a FilePath.
+        # These checks are guarded because _storage is an internal
+        # implementation detail that may change in future Swift versions.
+        storage = path.GetChildMemberWithName("_storage")
+        if storage.IsValid():
+            self.assertEqual(
+                storage.GetSummary(),
+                "['/', 'u', 's', 'r', '/', 'l', 'o', 'c', 'a', 'l', '/', 'b', 'i', 'n', 0x00]",
+            )
+
+            # For an ASCII-only path, children should not be printed.
+            self.expect(
+                "frame variable path",
+                matching=False,
+                substrs=["_storage ="],
+            )
+
+            # Test SystemString summary for a non-ASCII path.
+            nonASCII_storage = nonASCII.GetChildMemberWithName("_storage")
+            self.assertTrue(nonASCII_storage.IsValid())
+            self.assertEqual(
+                nonASCII_storage.GetSummary(),
+                "['/', 'h', 0xC3, 0xAB, 'l', 'l', 'o', '/', 'w', 0xC3, 0xB4, 'r', 'l', 'd', 0x00]",
+            )
+
+            # For a non-ASCII path, children (the _storage byte array)
+            # should be printed alongside the summary.
+            self.expect(
+                "frame variable nonASCII",
+                substrs=["_storage ="],
+            )

--- a/lldb/test/API/lang/swift/system/main.swift
+++ b/lldb/test/API/lang/swift/system/main.swift
@@ -1,0 +1,10 @@
+import System
+
+@main enum Entry {
+    static func main() {
+        let path = FilePath("/usr/local/bin")
+        let empty = FilePath("")
+        let root = FilePath("/")
+        print("break here", path, empty, root)
+    }
+}

--- a/lldb/test/API/lang/swift/system/main.swift
+++ b/lldb/test/API/lang/swift/system/main.swift
@@ -5,6 +5,7 @@ import System
         let path = FilePath("/usr/local/bin")
         let empty = FilePath("")
         let root = FilePath("/")
-        print("break here", path, empty, root)
+        let nonASCII = FilePath("/hëllo/wôrld")
+        print("break here", path, empty, root, nonASCII)
     }
 }


### PR DESCRIPTION
Added formatters for `System.FilePath` (and `SystemPackage.FilePath` when System is used as a package).

With these formatters, we should see while debugging:

Collapsed:

```
  ▶ path = "/usr/local/bin": System.FilePath
```

Expanded:

```
  ▼ path = "/usr/local/bin": System.FilePath
      ▼ _storage System.SystemString
          ▼ nullTerminatedStorage = 15 values: [System.SystemChar]
              [0] = '/' (47)
              [1] = 'u' (117)
              [2] = 's' (115)
              [3] = 'r' (114)
              [4] = '/' (47)
              [5] = 'l' (108)
              [6] = 'o' (111)
              [7] = 'c' (99)
              [8] = 'a' (97)
              [9] = 'l' (108)
              [10] = '/' (47)
              [11] = 'b' (98)
              [12] = 'i' (105)
              [13] = 'n' (110)
              [14] = '\0' (0)
```

Whereas before it was difficult to parse unless you know ASCII values by heart:

```
  ▼ path System.FilePath
      ▼ _storage System.SystemString
          ▼ nullTerminatedStorage = 15 values: [System.SystemChar]
              ▼ [0] System.SystemChar
                  rawValue = 47: Int8
              ▼ [1] System.SystemChar
                  rawValue = 117: Int8
              ...
```

Will verify the debug output works as expected once a toolchain is built. Added a unit test for the summary, too.

Please let me know if `stable/21.x` is not the correct branch to target, thanks! Resolves rdar://139749211