### PR TITLE
[🍒][lldb-dap] Do not expose internal breakpoints to DAP clients

### DIFF
--- a/lldb/tools/lldb-dap/LLDBUtils.cpp
+++ b/lldb/tools/lldb-dap/LLDBUtils.cpp
@@ -15,6 +15,7 @@
 #include "lldb/API/SBStringList.h"
 #include "lldb/API/SBStructuredData.h"
 #include "lldb/API/SBThread.h"
+#include "lldb/lldb-defines.h"
 #include "lldb/lldb-enumerations.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/JSON.h"
@@ -126,7 +127,6 @@ bool ThreadHasStopReason(lldb::SBThread &thread) {
   switch (thread.GetStopReason()) {
   case lldb::eStopReasonTrace:
   case lldb::eStopReasonPlanComplete:
-  case lldb::eStopReasonBreakpoint:
   case lldb::eStopReasonWatchpoint:
   case lldb::eStopReasonInstrumentation:
   case lldb::eStopReasonSignal:
@@ -139,6 +139,20 @@ bool ThreadHasStopReason(lldb::SBThread &thread) {
   case lldb::eStopReasonInterrupt:
   case lldb::eStopReasonHistoryBoundary:
     return true;
+  case lldb::eStopReasonBreakpoint: {
+    // Stop reason data for breakpoints consists of breakpoint ID and location
+    // ID pairs. Internal breakpoints (identified by their ID) are not
+    // considered valid stop reasons.
+    const uint64_t data_count = thread.GetStopReasonDataCount();
+    if (data_count == 0)
+      return true;
+    for (uint64_t i = 0; i < data_count; i += 2) {
+      const lldb::break_id_t bp_id = thread.GetStopReasonDataAtIndex(i);
+      if (!LLDB_BREAK_ID_IS_INTERNAL(bp_id))
+        return true;
+    }
+    return false;
+  }
   case lldb::eStopReasonThreadExiting:
   case lldb::eStopReasonInvalid:
   case lldb::eStopReasonNone:


### PR DESCRIPTION
Scope:
This is a cherry-pick from branch `next`.
It’s part on an effort to get lldb working for debugging Swift on Android: https://github.com/swiftlang/llvm-project/issues/10831

Issue:
When debugging an APK running on Android, and the Android process stops due to a user breakpoint, sometimes a second breakpoint is hit at the same time, and the corresponding thread is marked as stopped for reason jit-debug-register.
This second breakpoint is used by lldb internally, to track code generated by the JIT compiler (JVM).
Instead of displaying the code corresponding to the user breakpoint, the debugger displays the disassembled code corresponding to this internal breakpoint.

Original PR:
https://github.com/llvm/llvm-project/pull/173848

Risk:
Only affects lldb-dap, already approved in llvm
