### PR TITLE
[lldb] Fix swift mangling flavor in SwiftRuntimeTypeVisitor

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -738,9 +738,9 @@ class SwiftRuntimeTypeVisitor {
   bool m_visit_superclass = false;
 
   void SetFlavor() {
-    if (auto ts_sp =
-            m_type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwiftTypeRef>())
-      m_flavor = ts_sp->GetManglingFlavor(&m_exe_ctx);
+    auto mangled_name = m_type.GetMangledTypeName();
+    m_flavor =
+        SwiftLanguageRuntime::GetManglingFlavor(mangled_name.GetStringRef());
   }
 
 public:

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -5776,11 +5776,30 @@ TypeSystemSwiftTypeRef::GetDependentGenericParamListForType(
 
 swift::Mangle::ManglingFlavor
 TypeSystemSwiftTypeRef::GetManglingFlavor(const ExecutionContext *exe_ctx) {
+  if (!exe_ctx)
+    return swift::Mangle::ManglingFlavor::Default;
   auto sc = GetSymbolContext(exe_ctx);
-  auto *cu = sc.comp_unit;
+  CompileUnit *cu = sc.comp_unit;
+  // If we didn't find a compile unit, try to go up the stack until we find one.
+  // Limit the search to avoid iterating through a very large stack if
+  // interrupted during infinite recursion.
+  if (!cu) {
+    if (auto *thread = exe_ctx->GetThreadPtr()) {
+      constexpr uint32_t max_frames = 128;
+      for (uint32_t i = 0; i < max_frames; ++i) {
+        auto stack_frame = thread->GetStackFrameAtIndex(i);
+        if (!stack_frame)
+          break;
+        cu = stack_frame->GetSymbolContext(lldb::eSymbolContextCompUnit)
+                 .comp_unit;
+        if (cu)
+          break;
+      }
+    }
+  }
   // Cache the result for the last recently used CU.
   if (cu != m_lru_is_embedded.first)
-    m_lru_is_embedded = {cu, ShouldEnableEmbeddedSwift(sc.comp_unit)
+    m_lru_is_embedded = {cu, ShouldEnableEmbeddedSwift(cu)
                                  ? swift::Mangle::ManglingFlavor::Embedded
                                  : swift::Mangle::ManglingFlavor::Default};
   return m_lru_is_embedded.second;

--- a/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/Makefile
+++ b/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/TestSwiftEmbeddedGenericClassProtocolConstraint.py
+++ b/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/TestSwiftEmbeddedGenericClassProtocolConstraint.py
@@ -1,0 +1,89 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedGenericClassProtocolConstraint(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame variable b",
+            substrs=[
+                "a.SubConcreteB",
+                "a.ConcreteB",
+                'name = "ConcreteB"',
+                "value = 42",
+                "extra = 100",
+            ],
+        )
+        self.expect(
+            "frame variable a",
+            substrs=["a.A<a.SubConcreteB>", "member", "extra = 100", "id = 1"],
+        )
+        self.expect(
+            "frame variable aWithProtocol",
+            substrs=["a.A<a.ConcreteB>", "member", "extra = 100", "id = 1"],
+        )
+        self.expect(
+            "frame variable arrayOfB",
+            substrs=["[a.B]", "[0] = ", 'name = "ConcreteB"', "value = 42", "[1] = "],
+        )
+        self.expect(
+            "frame variable arrayOfA",
+            substrs=[
+                "[a.A<a.SubConcreteB>]",
+                "[0] = ",
+                "[1] = ",
+                "member",
+                "a.ConcreteB",
+                'name = "ConcreteB"',
+                "value = 42",
+                "extra = 100",
+                "id = 1",
+            ],
+        )
+
+        self.expect(
+            "target variable globalB",
+            substrs=[
+                "a.SubConcreteB",
+                "a.ConcreteB",
+                'name = "ConcreteB"',
+                "value = 42",
+                "extra = 100",
+            ],
+        )
+        self.expect(
+            "target variable globalA",
+            substrs=["a.A<a.SubConcreteB>", "member", "extra = 100", "id = 1"],
+        )
+        self.expect(
+            "target variable globalAWithProtocol",
+            substrs=["a.A<a.ConcreteB>", "member", "extra = 100", "id = 1"],
+        )
+        self.expect(
+            "target variable globalArrayOfB",
+            substrs=["[a.B]", "[0] = ", 'name = "ConcreteB"', "value = 42", "[1] = "],
+        )
+        self.expect(
+            "target variable globalArrayOfA",
+            substrs=[
+                "[a.A<a.SubConcreteB>]",
+                "[0] = ",
+                "[1] = ",
+                "member",
+                "a.ConcreteB",
+                'name = "ConcreteB"',
+                "value = 42",
+                "extra = 100",
+                "id = 1",
+            ],
+        )

--- a/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/main.swift
+++ b/lldb/test/API/lang/swift/embedded/generic_class_protocol_constraint/main.swift
@@ -1,0 +1,45 @@
+protocol B: AnyObject {
+    var name: String { get }
+}
+
+class ConcreteB: B {
+    let name = "ConcreteB"
+    let value = 42
+}
+
+class SubConcreteB: ConcreteB {
+    let extra = 100
+}
+
+class A<SomeB: B> {
+    let member: SomeB
+    let id = 1
+
+    init(member: SomeB) {
+        self.member = member
+    }
+}
+
+struct Statics {
+    static let globalB: B = SubConcreteB()
+    static let globalA = A(member: SubConcreteB())
+    static let globalAWithProtocol: A<ConcreteB> = A(member: SubConcreteB())
+    static let globalArrayOfB: [B] = [ConcreteB(), SubConcreteB()]
+    static let globalArrayOfA = [A(member: SubConcreteB()), A(member: SubConcreteB())]
+}
+
+func f() {
+    let b: B = SubConcreteB()
+    let a = A(member: SubConcreteB())
+    let aWithProtocol: A<ConcreteB> = A(member: SubConcreteB())
+    let arrayOfB: [B] = [ConcreteB(), SubConcreteB()]
+    let arrayOfA = [A(member: SubConcreteB()), A(member: SubConcreteB())]
+    let _ = Statics.globalB
+    let _ = Statics.globalA
+    let _ = Statics.globalAWithProtocol
+    let _ = Statics.globalArrayOfB
+    let _ = Statics.globalArrayOfA
+    print("break here")
+}
+
+f()


### PR DESCRIPTION
SwiftRuntimeTypeVisitor would get the mangling flavor incorrectly if the frame lldb is stopped at does not have debug information.

This fixes the issue in two ways:
1 - get the mangling flavor from the type instead, this should be faster and simpler.
2 - for other callers of TypeSystemSwift::GetManglingFlavor(), go up the stack until we find a compile unit.

rdar://164282261