### PR TITLE
Support: allow `llvm::sys::fs::rename` to rename a directory on Windo…

### DIFF
--- a/llvm/lib/Support/Windows/Path.inc
+++ b/llvm/lib/Support/Windows/Path.inc
@@ -597,10 +597,12 @@ std::error_code rename(const Twine &From, const Twine &To) {
   for (unsigned Retry = 0; Retry != 200; ++Retry) {
     if (Retry != 0)
       ::Sleep(10);
+    // `FILE_FLAG_BACKUP_SEMANTICS` must be used to create a handle to a
+    // directory.
     FromHandle =
         ::CreateFileW(WideFrom.begin(), GENERIC_READ | DELETE,
                       FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                      NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+                      NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
     if (FromHandle)
       break;
 


### PR DESCRIPTION
…ws (#179739)

`CreateFileW` must be passed `FILE_FLAG_BACKUP_SEMANTICS` to allow a handle to a directory to be acquired. Without this, we would previously fail with permission denied if a directory was attempted to be renamed.

(cherry picked from commit ecd0e7df8c8207589a675203d163d8709d8a6e82)