### PR TITLE
[lldb] Fix handling of AsyncStream.Continuation in embedded Swift

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -132,14 +132,33 @@ ifeq "$(SWIFT_CXX_INTEROP)" "1"
 endif
 
 #----------------------------------------------------------------------
+# SWIFT_EMBEDDED_CONCURRENCY implies SWIFT_EMBEDDED_MODE
+#----------------------------------------------------------------------
+ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
+	SWIFT_EMBEDDED_MODE = 1
+endif
+
+#----------------------------------------------------------------------
 # Check if we should compile in Swift embedded mode
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
 	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -enable-experimental-feature ValueGenerics -Xfrontend -disable-objc-interop -runtime-compatibility-version none
 	ifeq "$(OS)" "Darwin"
 		SWIFTFLAGS += -target $(ARCH)-apple-macos14
+		SWIFT_EMBEDDED_TRIPLE = $(ARCH)-apple-macos
 	endif
 	SWIFT_WMO = 1
+endif
+
+#----------------------------------------------------------------------
+# Check if we need embedded Swift concurrency support
+#----------------------------------------------------------------------
+ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
+	SWIFT_EMBEDDED_LIB_DIR = $(shell dirname $(SWIFTC))/../lib/swift/embedded/$(SWIFT_EMBEDDED_TRIPLE)
+	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_Concurrency.a
+	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_ConcurrencyDefaultExecutor.a
+	LD_EXTRAS += -lc++
+	LD_EXTRAS += -Xlinker -dead_strip
 endif
 
 #----------------------------------------------------------------------

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -501,6 +501,9 @@ protected:
   void DiagnoseSwiftASTContextFallback(const char *func_name,
                                        lldb::opaque_compiler_type_t type);
 
+  /// Looks for the type using the provided compiler context.
+  lldb::TypeSP FindTypeInModule(std::vector<CompilerContext> context);
+
   /// Helper that creates an AST type from \p type.
   ///
   /// FIXME: This API is dangerous, it would be better to return a

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
@@ -1,0 +1,5 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_CONCURRENCY := 1
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/TestSwiftEmbeddedAsyncStreamContinuation.py
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/TestSwiftEmbeddedAsyncStreamContinuation.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedAsyncStreamContinuation(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test frame variable on an AsyncStream continuation in embedded Swift."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame variable continuation",
+            substrs=[
+                "AsyncStream<a.DataItem>.Continuation",
+            ],
+        )

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/main.swift
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/main.swift
@@ -1,0 +1,20 @@
+import _Concurrency
+
+struct DataItem {
+    let id: Int
+    let value: Int
+}
+
+@main struct Main {
+    static func main() async {
+        let stream = AsyncStream<DataItem> { continuation in
+            print("break here") // break here
+            continuation.yield(DataItem(id: 1, value: 100))
+            continuation.finish()
+        }
+
+        for await item in stream {
+            print("Received item: \(item.id)")
+        }
+    }
+}


### PR DESCRIPTION
There were two issues to fix:

- The mangled name of types in the "_Concurrency" module state they belong to the "Swift" module, so the search in DWARF for those types would fail.
- We were relying on the fact that the first word of a class instance was a pointer to the it's "type metadata", however, it can be either the "type metadata" or "full type metadata".

This patch also adds support for compiling async embedded swift tests.

rdar://164268372