### PR TITLE
[lldb] Add support for raw value enums in embedded Swift

### DIFF
--- a/lldb/test/API/lang/swift/embedded/raw_value_enum/Makefile
+++ b/lldb/test/API/lang/swift/embedded/raw_value_enum/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/raw_value_enum/TestSwiftEmbeddedRawValueEnum.py
+++ b/lldb/test/API/lang/swift/embedded/raw_value_enum/TestSwiftEmbeddedRawValueEnum.py
@@ -1,0 +1,79 @@
+"""
+Test that raw value enums are properly resolved in embedded Swift.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedRawValueEnum(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test that raw value enums display correctly in embedded Swift."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        # Test Int raw value enum
+        self.expect(
+            "frame variable intZero",
+            substrs=["IntRawEnum", "zero"],
+        )
+        self.expect(
+            "frame variable intOne",
+            substrs=["IntRawEnum", "one"],
+        )
+        self.expect(
+            "frame variable intHundred",
+            substrs=["IntRawEnum", "hundred"],
+        )
+
+        # Test Int8 raw value enum
+        self.expect(
+            "frame variable int8A",
+            substrs=["Int8RawEnum", "a"],
+        )
+        self.expect(
+            "frame variable int8B",
+            substrs=["Int8RawEnum", "b"],
+        )
+
+        # Test UInt raw value enum
+        self.expect(
+            "frame variable uintX",
+            substrs=["UIntRawEnum", "x"],
+        )
+        self.expect(
+            "frame variable uintY",
+            substrs=["UIntRawEnum", "y"],
+        )
+
+        # Test UInt8 raw value enum (C-style)
+        self.expect(
+            "frame variable uint8First",
+            substrs=["UInt8RawEnum", "first"],
+        )
+        self.expect(
+            "frame variable uint8Second",
+            substrs=["UInt8RawEnum", "second"],
+        )
+
+        # Test Int16 raw value enum with negative values
+        self.expect(
+            "frame variable int16Neg",
+            substrs=["Int16RawEnum", "neg"],
+        )
+        self.expect(
+            "frame variable int16Zero",
+            substrs=["Int16RawEnum", "zero"],
+        )
+        self.expect(
+            "frame variable int16Pos",
+            substrs=["Int16RawEnum", "pos"],
+        )

--- a/lldb/test/API/lang/swift/embedded/raw_value_enum/main.swift
+++ b/lldb/test/API/lang/swift/embedded/raw_value_enum/main.swift
@@ -1,0 +1,57 @@
+// Test for raw value enum type resolution in embedded Swift
+// Bug: Raw value enums fail with "unimplemented enum kind"
+
+enum IntRawEnum: Int {
+    case zero = 0
+    case one = 1
+    case two = 2
+    case hundred = 100
+}
+
+enum Int8RawEnum: Int8 {
+    case a = 1
+    case b = 2
+    case c = 3
+}
+
+enum UIntRawEnum: UInt {
+    case x = 100
+    case y = 200
+    case z = 300
+}
+
+enum UInt8RawEnum: UInt8 {
+    case first = 0
+    case second = 1
+    case third = 2
+}
+
+enum Int16RawEnum: Int16 {
+    case neg = -100
+    case zero = 0
+    case pos = 100
+}
+
+func f() {
+    let intZero = IntRawEnum.zero
+    let intOne = IntRawEnum.one
+    let intHundred = IntRawEnum.hundred
+
+    let int8A = Int8RawEnum.a
+    let int8B = Int8RawEnum.b
+
+    let uintX = UIntRawEnum.x
+    let uintY = UIntRawEnum.y
+
+    let uint8First = UInt8RawEnum.first
+    let uint8Second = UInt8RawEnum.second
+
+    let int16Neg = Int16RawEnum.neg
+    let int16Zero = Int16RawEnum.zero
+    let int16Pos = Int16RawEnum.pos
+
+    let string = StaticString("break here")
+    print(string) // break here
+}
+
+f()


### PR DESCRIPTION
Raw value enums (enums with explicit integer raw values) use DW_TAG_enumeration_type with DW_TAG_enumerator children in DWARF, unlike payload enums which use DW_TAG_structure_type with DW_TAG_variant_part. This change adds handling for this DWARF representation in the descriptor finder.

rdar://169743789