### PR TITLE
[lldb] Fix builtin type name format for embedded Swift type lowering

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -207,11 +207,29 @@ getFieldDescriptorKindForDie(CompilerType type) {
 }
 
 namespace {
+
+/// Given a mangled name in the format $snameD, return "name". The type info
+/// builder machinery expects builtins to have their mangled names stored in
+/// this format.
+/// This is the inverse operation of LLDBTypeInfoProvider::getTypeInfo, which
+/// consumes the name from TypeRefBuilder.
+static llvm::StringRef ExtractTypeName(llvm::StringRef name) {
+  if ((name.starts_with("$s") || name.starts_with("$e")) &&
+      name.ends_with("D") && name.size() > 3) {
+    return name.drop_front(2).drop_back(1);
+  }
+  return name;
+}
+
 // Class that implements the same layout as a builtin type descriptor, only it's
 // built from DWARF instead.
 class DWARFBuiltinTypeDescriptorImpl
     : public swift::reflection::BuiltinTypeDescriptorBase {
-  ConstString m_type_name;
+  // We store the typename as a StringRef, this is safe to do because the
+  // backing variable which is passed in the constructor is a ConstString. If we
+  // ever change the constructor to receive something else, we'd need to update
+  // the type of this variable to own the data.
+  llvm::StringRef m_type_name;
 
 public:
   DWARFBuiltinTypeDescriptorImpl(uint32_t size, uint32_t alignment,
@@ -220,7 +238,7 @@ public:
                                  bool is_bitwise_takable, ConstString type_name)
       : swift::reflection::BuiltinTypeDescriptorBase(
             size, alignment, stride, num_extra_inhabitants, is_bitwise_takable),
-        m_type_name(type_name) {}
+        m_type_name(ExtractTypeName(type_name.GetStringRef())) {}
   ~DWARFBuiltinTypeDescriptorImpl() override = default;
 
   llvm::StringRef getMangledTypeName() override { return m_type_name; }

--- a/lldb/test/API/lang/swift/embedded/multi_payload_enum/Makefile
+++ b/lldb/test/API/lang/swift/embedded/multi_payload_enum/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/multi_payload_enum/TestSwiftEmbeddedMultiPayloadEnum.py
+++ b/lldb/test/API/lang/swift/embedded/multi_payload_enum/TestSwiftEmbeddedMultiPayloadEnum.py
@@ -1,0 +1,114 @@
+"""
+Test that multi-payload enums are properly resolved in embedded Swift.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedMultiPayloadEnum(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test_multi_payload_enum(self):
+        """Test that multi-payload enums display the correct case."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable multiSingle",
+            substrs=["MultiPayloadEnum", "single", "42"],
+        )
+
+        self.expect(
+            "frame variable multiPair",
+            substrs=["MultiPayloadEnum", "pair", "1", "2.5"],
+        )
+
+        self.expect(
+            "frame variable multiTriple",
+            substrs=["MultiPayloadEnum", "triple", "1", "2.5", "true"],
+        )
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_same_size_payloads(self):
+        """Test enums where cases have same-sized payloads."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable intPair",
+            substrs=["SameSizePayloads", "intPair", "10", "20"],
+        )
+
+        self.expect(
+            "frame variable doublePair",
+            substrs=["SameSizePayloads", "doublePair", "1.5", "2.5"],
+        )
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_mixed_payload_enum(self):
+        """Test enums mixing no-payload and various payload cases."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable mixedEmpty",
+            substrs=["MixedPayloadEnum", "empty"],
+        )
+
+        self.expect(
+            "frame variable mixedOne",
+            substrs=["MixedPayloadEnum", "oneArg", "100"],
+        )
+
+        self.expect(
+            "frame variable mixedTwo",
+            substrs=["MixedPayloadEnum", "twoArgs", "100", "200.5"],
+        )
+
+        self.expect(
+            "frame variable mixedThree",
+            substrs=["MixedPayloadEnum", "threeArgs", "100", "200.5", "false"],
+        )
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test_struct_payload_enum(self):
+        """Test enums with struct payloads of different sizes."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable structSmall",
+            substrs=["StructPayloadEnum", "small", "x = 1"],
+        )
+
+        self.expect(
+            "frame variable structMedium",
+            substrs=["StructPayloadEnum", "medium", "x = 1", "y = 2"],
+        )
+
+        self.expect(
+            "frame variable structLarge",
+            substrs=["StructPayloadEnum", "large", "x = 1", "y = 2", "z = 3"],
+        )

--- a/lldb/test/API/lang/swift/embedded/multi_payload_enum/main.swift
+++ b/lldb/test/API/lang/swift/embedded/multi_payload_enum/main.swift
@@ -1,0 +1,54 @@
+enum MultiPayloadEnum {
+    case single(Int)
+    case pair(Int, Double)
+    case triple(Int, Double, Bool)
+}
+
+enum SameSizePayloads {
+    case intPair(Int, Int)
+    case doublePair(Double, Double)
+}
+
+enum MixedPayloadEnum {
+    case empty
+    case oneArg(Int)
+    case twoArgs(Int, Double)
+    case threeArgs(Int, Double, Bool)
+}
+
+struct Small { let x: Int = 1 }
+struct Medium { let x: Int = 1; let y: Int = 2 }
+struct Large { let x: Int = 1; let y: Int = 2; let z: Int = 3 }
+
+enum StructPayloadEnum {
+    case small(Small)
+    case medium(Medium)
+    case large(Large)
+}
+
+func f() {
+    // MultiPayloadEnum cases
+    let multiSingle = MultiPayloadEnum.single(42)
+    let multiPair = MultiPayloadEnum.pair(1, 2.5)
+    let multiTriple = MultiPayloadEnum.triple(1, 2.5, true)
+
+    // SameSizePayloads cases
+    let intPair = SameSizePayloads.intPair(10, 20)
+    let doublePair = SameSizePayloads.doublePair(1.5, 2.5)
+
+    // MixedPayloadEnum cases
+    let mixedEmpty = MixedPayloadEnum.empty
+    let mixedOne = MixedPayloadEnum.oneArg(100)
+    let mixedTwo = MixedPayloadEnum.twoArgs(100, 200.5)
+    let mixedThree = MixedPayloadEnum.threeArgs(100, 200.5, false)
+
+    // StructPayloadEnum cases
+    let structSmall = StructPayloadEnum.small(Small())
+    let structMedium = StructPayloadEnum.medium(Medium())
+    let structLarge = StructPayloadEnum.large(Large())
+
+    let string = StaticString("break here")
+    print(string) // break here
+}
+
+f()


### PR DESCRIPTION
The type info builder expects builtin type names in a reduced format (e.g., "Int" instead of "$sIntD"). This adds MakeReducedName to strip the mangling prefix and suffix when constructing builtin type descriptors.

rdar://169747618