### PR TITLE
[lldb][NFC] Add some override methods to VirtualDataExtractor (#179858)

### DIFF
--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -281,7 +281,7 @@ public:
   ///
   /// \return
   ///     The total number of bytes of data this object refers to.
-  uint64_t GetByteSize() const { return m_end - m_start; }
+  virtual uint64_t GetByteSize() const { return m_end - m_start; }
 
   /// Extract a C string from \a *offset_ptr.
   ///
@@ -858,7 +858,7 @@ public:
     return GetSubsetExtractorSP(0);
   }
 
-  lldb::DataBufferSP &GetSharedDataBuffer() { return m_data_sp; }
+  lldb::DataBufferSP GetSharedDataBuffer() const { return m_data_sp; }
 
   bool HasData() { return m_start && m_end && m_end - m_start > 0; }
 
@@ -922,8 +922,8 @@ public:
   ///
   /// \return
   ///     The number of bytes that this object now contains.
-  lldb::offset_t SetData(const void *bytes, lldb::offset_t length,
-                         lldb::ByteOrder byte_order);
+  virtual lldb::offset_t SetData(const void *bytes, lldb::offset_t length,
+                                 lldb::ByteOrder byte_order);
 
   /// Adopt a subset of \a data.
   ///
@@ -947,8 +947,8 @@ public:
   ///
   /// \return
   ///     The number of bytes that this object now contains.
-  lldb::offset_t SetData(const DataExtractor &data, lldb::offset_t offset,
-                         lldb::offset_t length);
+  virtual lldb::offset_t SetData(const DataExtractor &data,
+                                 lldb::offset_t offset, lldb::offset_t length);
 
   /// Adopt a subset of shared data in \a data_sp.
   ///
@@ -972,9 +972,9 @@ public:
   ///
   /// \return
   ///     The number of bytes that this object now contains.
-  lldb::offset_t SetData(const lldb::DataBufferSP &data_sp,
-                         lldb::offset_t offset = 0,
-                         lldb::offset_t length = LLDB_INVALID_OFFSET);
+  virtual lldb::offset_t SetData(const lldb::DataBufferSP &data_sp,
+                                 lldb::offset_t offset = 0,
+                                 lldb::offset_t length = LLDB_INVALID_OFFSET);
 
   /// Set the byte_order value.
   ///
@@ -1028,7 +1028,7 @@ public:
 
   bool Append(void *bytes, lldb::offset_t length);
 
-  lldb::offset_t BytesLeft(lldb::offset_t offset) const {
+  virtual lldb::offset_t BytesLeft(lldb::offset_t offset) const {
     const lldb::offset_t size = GetByteSize();
     if (size > offset)
       return size - offset;

--- a/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
+++ b/lldb/source/Plugins/ObjectContainer/BSD-Archive/ObjectContainerBSDArchive.cpp
@@ -441,9 +441,8 @@ size_t ObjectContainerBSDArchive::GetModuleSpecifications(
   if (!file || !extractor_sp)
     return 0;
 
-  DataExtractorSP data_extractor_sp = extractor_sp->GetSubsetExtractorSP(
-      data_offset,
-      extractor_sp->GetSharedDataBuffer()->GetByteSize() - data_offset);
+  DataExtractorSP data_extractor_sp =
+      extractor_sp->GetSubsetExtractorSP(data_offset);
   // We have data, which means this is the first 512 bytes of the file Check to
   // see if the magic bytes match and if they do, read the entire table of
   // contents for the archive and cache it

--- a/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Mach-O-Fileset/ObjectContainerMachOFileset.cpp
@@ -227,8 +227,8 @@ size_t ObjectContainerMachOFileset::GetModuleSpecifications(
   if (!extractor_sp)
     return initial_count;
 
-  DataExtractorSP data_extractor_sp = extractor_sp->GetSubsetExtractorSP(
-      data_offset, extractor_sp->GetByteSize());
+  DataExtractorSP data_extractor_sp =
+      extractor_sp->GetSubsetExtractorSP(data_offset);
   if (!data_extractor_sp)
     return initial_count;
   if (MagicBytesMatch(*data_extractor_sp)) {

--- a/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
+++ b/lldb/source/Plugins/ObjectContainer/Universal-Mach-O/ObjectContainerUniversalMachO.cpp
@@ -195,8 +195,8 @@ size_t ObjectContainerUniversalMachO::GetModuleSpecifications(
   if (!extractor_sp)
     return initial_count;
 
-  DataExtractorSP data_extractor_sp = extractor_sp->GetSubsetExtractorSP(
-      data_offset, extractor_sp->GetByteSize());
+  DataExtractorSP data_extractor_sp =
+      extractor_sp->GetSubsetExtractorSP(data_offset);
   if (ObjectContainerUniversalMachO::MagicBytesMatch(*data_extractor_sp)) {
     llvm::MachO::fat_header header;
     std::vector<FatArch> fat_archs;

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.cpp
@@ -459,7 +459,7 @@ ObjectFile *ObjectFileELF::CreateMemoryInstance(
   return nullptr;
 }
 
-bool ObjectFileELF::MagicBytesMatch(DataBufferSP &data_sp,
+bool ObjectFileELF::MagicBytesMatch(DataBufferSP data_sp,
                                     lldb::addr_t data_offset,
                                     lldb::addr_t data_length) {
   if (data_sp &&
@@ -2688,7 +2688,7 @@ static void ApplyELF64ABS64Relocation(Symtab *symtab, ELFRelocation &rel,
   Symbol *symbol = symtab->FindSymbolByID(ELFRelocation::RelocSymbol64(rel));
   if (symbol) {
     addr_t value = symbol->GetAddressRef().GetFileAddress();
-    DataBufferSP &data_buffer_sp = debug_data.GetSharedDataBuffer();
+    DataBufferSP data_buffer_sp = debug_data.GetSharedDataBuffer();
     // ObjectFileELF creates a WritableDataBuffer in CreateInstance.
     WritableDataBuffer *data_buffer =
         llvm::cast<WritableDataBuffer>(data_buffer_sp.get());
@@ -2715,7 +2715,7 @@ static void ApplyELF64ABS32Relocation(Symtab *symtab, ELFRelocation &rel,
       return;
     }
     uint32_t truncated_addr = (value & 0xFFFFFFFF);
-    DataBufferSP &data_buffer_sp = debug_data.GetSharedDataBuffer();
+    DataBufferSP data_buffer_sp = debug_data.GetSharedDataBuffer();
     // ObjectFileELF creates a WritableDataBuffer in CreateInstance.
     WritableDataBuffer *data_buffer =
         llvm::cast<WritableDataBuffer>(data_buffer_sp.get());
@@ -2739,7 +2739,7 @@ static void ApplyELF32ABS32RelRelocation(Symtab *symtab, ELFRelocation &rel,
       return;
     }
     assert(llvm::isUInt<32>(value) && "Valid addresses are 32-bit");
-    DataBufferSP &data_buffer_sp = debug_data.GetSharedDataBuffer();
+    DataBufferSP data_buffer_sp = debug_data.GetSharedDataBuffer();
     // ObjectFileELF creates a WritableDataBuffer in CreateInstance.
     WritableDataBuffer *data_buffer =
         llvm::cast<WritableDataBuffer>(data_buffer_sp.get());
@@ -2816,7 +2816,7 @@ unsigned ObjectFileELF::ApplyRelocations(
           if (symbol) {
             addr_t f_offset =
                 rel_section->GetFileOffset() + ELFRelocation::RelocOffset32(rel);
-            DataBufferSP &data_buffer_sp = debug_data.GetSharedDataBuffer();
+            DataBufferSP data_buffer_sp = debug_data.GetSharedDataBuffer();
             // ObjectFileELF creates a WritableDataBuffer in CreateInstance.
             WritableDataBuffer *data_buffer =
                 llvm::cast<WritableDataBuffer>(data_buffer_sp.get());

--- a/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
+++ b/lldb/source/Plugins/ObjectFile/ELF/ObjectFileELF.h
@@ -85,7 +85,7 @@ public:
                                         lldb::offset_t length,
                                         lldb_private::ModuleSpecList &specs);
 
-  static bool MagicBytesMatch(lldb::DataBufferSP &data_sp, lldb::addr_t offset,
+  static bool MagicBytesMatch(lldb::DataBufferSP data_sp, lldb::addr_t offset,
                               lldb::addr_t length);
 
   // PluginInterface protocol

--- a/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
+++ b/lldb/source/Plugins/ObjectFile/XCOFF/ObjectFileXCOFF.cpp
@@ -167,7 +167,7 @@ bool ObjectFileXCOFF::MagicBytesMatch(DataExtractorSP &extractor_sp,
                                       lldb::addr_t data_offset,
                                       lldb::addr_t data_length) {
   DataExtractorSP magic_extractor_sp =
-      extractor_sp->GetSubsetExtractorSP(data_offset, data_length);
+      extractor_sp->GetSubsetExtractorSP(data_offset);
   // Need to set this as XCOFF is only compatible with Big Endian
   magic_extractor_sp->SetByteOrder(eByteOrderBig);
   lldb::offset_t offset = 0;

--- a/lldb/unittests/Utility/VirtualDataExtractorTest.cpp
+++ b/lldb/unittests/Utility/VirtualDataExtractorTest.cpp
@@ -652,4 +652,12 @@ TEST(VirtualDataExtractorTest, SubsetExtractorGetU32) {
   lldb::DataExtractorSP middle_contiguous_subset =
       extractor->GetSubsetExtractorSP(4 * sizeof(uint32_t));
   EXPECT_EQ(middle_contiguous_subset->GetByteSize(), 4 * sizeof(uint32_t));
+
+  // Set the data source of extractor to its current data source
+  // with offset 0 and same size -- this should be a no-op.
+  extractor->SetData(extractor->GetSharedDataBuffer(), 0,
+                     extractor->GetByteSize());
+  virtual_offset = 0;
+  // Entry(0x0, 4*sizeof(uint32_t), 12*sizeof(uint32_t))
+  EXPECT_EQ(extractor->GetU32(&virtual_offset), 0xccccccccU);
 }


### PR DESCRIPTION
This changes VirtualDataExtractor's GetByteSize to return the virtual byte size of the buffer (external users only understand the data contents in terms of the virtual sizes & offsets). There are check methods in DataExtractor that check they are not going off the end of a buffer, they usually use the BytesLeft() method. There are a couple of callers of BytesLeft() externally, but it is predominantly an internal use API. I have BytesLeft() use the physical size of the buffer, not the virtual size, for the benefit of the DataExtractor methods. (and to avoid duplicating all of them down in VirtualDataExtractor)

Another problem is the we call SetData on DataExtractorSP's (e.g. see the ObjectFile ctor) with the DataBuffer it already has, an offset of 0, and the GetByteSize. A no-op for a DataExtractor that is already using that DataBuffer. But SetData would try to use that length as a physical size, and truncate the buffer that the DataExtractor would accept.

I added VirtualDataExtractor subclass methods for the SetData's, detect (1) data being added to an uninitialized DataExtractor, (2) the same data / offset / length as currently being used is added to the DataExtractor (a no-op), or (3) we're genuinely changing the data source or setting an offset / length that is different. This final case we're not ready to handle today, I added asserts for them so we can catch it in debug builds, and then I clear the LookupTable and add a no-op entry so this extractor will behave like a plain DataExtractor -- because I don't know better to do. If we genuinely need to handle this case, and I'm pretty sure we don't need to, I'd have to assume that we're taking a subset of the original data source (an offset & length), so we'd need to update all of the LookupTable entries to reflect the new offsets, and remove entries that are no longer referring to the subsetted range. I'll leave that until there's any evidence it's actually needed.

rdar://148939795
(cherry picked from commit af3cc148c39e4e7d91250962019745c4bc1d37b3)