### PR TITLE
[cherry-pick] [lldb] Fix handling of AsyncStream.Continuation in embedded Swift

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -132,14 +132,33 @@ ifeq "$(SWIFT_CXX_INTEROP)" "1"
 endif
 
 #----------------------------------------------------------------------
+# SWIFT_EMBEDDED_CONCURRENCY implies SWIFT_EMBEDDED_MODE
+#----------------------------------------------------------------------
+ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
+	SWIFT_EMBEDDED_MODE = 1
+endif
+
+#----------------------------------------------------------------------
 # Check if we should compile in Swift embedded mode
 #----------------------------------------------------------------------
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
 	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -enable-experimental-feature ValueGenerics -Xfrontend -disable-objc-interop -runtime-compatibility-version none
 	ifeq "$(OS)" "Darwin"
 		SWIFTFLAGS += -target $(ARCH)-apple-macos14
+		SWIFT_EMBEDDED_TRIPLE = $(ARCH)-apple-macos
 	endif
 	SWIFT_WMO = 1
+endif
+
+#----------------------------------------------------------------------
+# Check if we need embedded Swift concurrency support
+#----------------------------------------------------------------------
+ifeq "$(SWIFT_EMBEDDED_CONCURRENCY)" "1"
+	SWIFT_EMBEDDED_LIB_DIR = $(shell dirname $(SWIFTC))/../lib/swift/embedded/$(SWIFT_EMBEDDED_TRIPLE)
+	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_Concurrency.a
+	LD_EXTRAS +=  -Xlinker $(SWIFT_EMBEDDED_LIB_DIR)/libswift_ConcurrencyDefaultExecutor.a
+	LD_EXTRAS += -lc++
+	LD_EXTRAS += -Xlinker -dead_strip
 endif
 
 #----------------------------------------------------------------------

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -400,6 +400,10 @@ CompilerType TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
   NodePointer type = swift_demangle::NodeAtPath(
       node, {Node::Kind::Global, Node::Kind::TypeMetadata, Node::Kind::Type});
   if (!type)
+    type = swift_demangle::NodeAtPath(
+        node,
+        {Node::Kind::Global, Node::Kind::FullTypeMetadata, Node::Kind::Type});
+  if (!type)
     return {};
   auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
   return RemangleAsType(dem, type, flavor);
@@ -2722,29 +2726,22 @@ plugin::dwarf::DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {
 }
 
 TypeSP
-TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
+TypeSystemSwiftTypeRef::FindTypeInModule(std::vector<CompilerContext> context) {
   auto *M = GetModule();
   if (!M)
-    return {};
-
-  swift::Demangle::Demangler dem;
-  auto context = BuildDeclContext(AsMangledName(opaque_type), dem);
-  if (!context)
     return {};
   // DW_AT_linkage_name is not part of the accelerator table, so
   // we need to search by decl context.
   auto options =
       TypeQueryOptions::e_find_one | TypeQueryOptions::e_module_search;
-
   // FIXME: It would be nice to not need this.
-  if (context->size() == 2 &&
-      context->front().kind == CompilerContextKind::Module &&
-      context->front().name == "Builtin") {
+  if (context.size() == 2 && context[0].kind == CompilerContextKind::Module &&
+      context[0].name == "Builtin") {
     // LLVM cannot nest basic types inside a module.
-    context->erase(context->begin());
+    context.erase(context.begin());
     options = TypeQueryOptions::e_find_one;
   }
-  TypeQuery query(*context, options);
+  TypeQuery query(context, options);
   query.SetLanguages(TypeSystemSwift::GetSupportedLanguagesForTypes());
 
   TypeResults results;
@@ -2752,6 +2749,27 @@ TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
   if (results.Done(query))
     return results.GetFirstType();
   return {};
+}
+
+TypeSP
+TypeSystemSwiftTypeRef::FindTypeInModule(opaque_compiler_type_t opaque_type) {
+
+  swift::Demangle::Demangler dem;
+  auto maybe_context = BuildDeclContext(AsMangledName(opaque_type), dem);
+  if (!maybe_context || maybe_context->empty())
+    return {};
+
+  auto context = *maybe_context;
+  if (auto result = FindTypeInModule(context))
+    return result;
+
+  // Types with "Swift" as their module might actually belong to the
+  // _Concurrency module, so look there too.
+  if (context[0].name != "Swift" ||
+      context[0].kind != CompilerContextKind::Module)
+    return {};
+  context[0].name = ConstString("_Concurrency");
+  return FindTypeInModule(context);
 }
 
 // Tests

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -493,6 +493,9 @@ protected:
   void DiagnoseSwiftASTContextFallback(const char *func_name,
                                        lldb::opaque_compiler_type_t type);
 
+  /// Looks for the type using the provided compiler context.
+  lldb::TypeSP FindTypeInModule(std::vector<CompilerContext> context);
+
   /// Helper that creates an AST type from \p type.
   ///
   /// FIXME: This API is dangerous, it would be better to return a

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/Makefile
@@ -1,0 +1,5 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_CONCURRENCY := 1
+SWIFTFLAGS_EXTRAS := -parse-as-library
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/TestSwiftEmbeddedAsyncStreamContinuation.py
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/TestSwiftEmbeddedAsyncStreamContinuation.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedAsyncStreamContinuation(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test frame variable on an AsyncStream continuation in embedded Swift."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect(
+            "frame variable continuation",
+            substrs=[
+                "AsyncStream<a.DataItem>.Continuation",
+            ],
+        )

--- a/lldb/test/API/lang/swift/embedded/asyncstream_continuation/main.swift
+++ b/lldb/test/API/lang/swift/embedded/asyncstream_continuation/main.swift
@@ -1,0 +1,20 @@
+import _Concurrency
+
+struct DataItem {
+    let id: Int
+    let value: Int
+}
+
+@main struct Main {
+    static func main() async {
+        let stream = AsyncStream<DataItem> { continuation in
+            print("break here") // break here
+            continuation.yield(DataItem(id: 1, value: 100))
+            continuation.finish()
+        }
+
+        for await item in stream {
+            print("Received item: \(item.id)")
+        }
+    }
+}


### PR DESCRIPTION
There were two issues to fix:

- The mangled name of types in the "_Concurrency" module state they belong
  to the "Swift" module, so the search in DWARF for those types would
  fail.
- We were relying on the fact that the first word of a class instance
  was a pointer to the it's "type metadata", however, it can be either
  the "type metadata" or "full type metadata".

This patch also adds support for compiling async embedded swift tests.

rdar://164268372