### PR TITLE
[lldb] Add a new way of loading files from a shared cache (#179881)

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -130,6 +130,8 @@ public:
   bool SetClangModulesCachePath(const FileSpec &path);
   bool GetEnableExternalLookup() const;
   bool SetEnableExternalLookup(bool new_value);
+  bool GetSharedCacheBinaryLoading() const;
+  bool SetSharedCacheBinaryLoading(bool new_value);
   bool GetEnableLLDBIndexCache() const;
   bool SetEnableLLDBIndexCache(bool new_value);
   uint64_t GetLLDBIndexCacheMaxByteSize();

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -14,6 +14,10 @@ let Definition = "modulelist" in {
     DefaultEnumValue<"eSymbolDownloadOff">,
     EnumValues<"OptionEnumValues(g_auto_download_enum_values)">,
     Desc<"On macOS, automatically download symbols with dsymForUUID (or an equivalent script/binary) for relevant images in the debug session.">;
+  def SharedCacheBinaryLoading: Property<"shared-cache-binary-loading", "Boolean">,
+    Global,
+    DefaultTrue,
+    Desc<"On macOS, load the binaries from a shared cache blob directly, instead of loading them from lldb's own in-process shared cache.">;
   def ClangModulesCachePath: Property<"clang-modules-cache-path", "FileSpec">,
     Global,
     DefaultStringValue<"">,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -175,6 +175,16 @@ SymbolDownload ModuleListProperties::GetSymbolAutoDownload() const {
                g_modulelist_properties[idx].default_uint_value));
 }
 
+bool ModuleListProperties::GetSharedCacheBinaryLoading() const {
+  const uint32_t idx = ePropertySharedCacheBinaryLoading;
+  return GetPropertyAtIndexAs<bool>(
+      idx, g_modulelist_properties[idx].default_uint_value != 0);
+}
+
+bool ModuleListProperties::SetSharedCacheBinaryLoading(bool new_value) {
+  return SetPropertyAtIndex(ePropertySharedCacheBinaryLoading, new_value);
+}
+
 FileSpec ModuleListProperties::GetClangModulesCachePath() const {
   const uint32_t idx = ePropertyClangModulesCachePath;
   return GetPropertyAtIndexAs<FileSpec>(idx, {});

--- a/lldb/source/Host/macosx/objcxx/CMakeLists.txt
+++ b/lldb/source/Host/macosx/objcxx/CMakeLists.txt
@@ -20,6 +20,7 @@ add_lldb_library(lldbHostMacOSXObjCXX NO_PLUGIN_DEPENDENCIES
     Support
     TargetParser
   LINK_LIBS
+    lldbCore
     lldbUtility
     ${EXTRA_LIBS}
   )

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -124,7 +124,12 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
   if (module_sp || !can_create)
     return module_sp;
 
-  if (HostInfo::GetArchitecture().IsCompatibleMatch(target.GetArchitecture())) {
+  // See if we have this binary in the Target or the global Module
+  // cache already.
+  module_sp = target.GetOrCreateModule(module_spec, /*notify=*/false);
+
+  if (!module_sp &&
+      HostInfo::GetArchitecture().IsCompatibleMatch(target.GetArchitecture())) {
     // When debugging on the host, we are most likely using the same shared
     // cache as our inferior. The dylibs from the shared cache might not
     // exist on the filesystem, so let's use the images in our own memory
@@ -135,18 +140,18 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.
-    if (image_info.uuid &&
-        (!module_spec.GetUUID() || module_spec.GetUUID() == image_info.uuid)) {
-      ModuleSpec shared_cache_spec(module_spec.GetFileSpec(), image_info.uuid,
-                                   image_info.extractor_sp);
+    if (image_info.GetUUID() &&
+        (!module_spec.GetUUID() ||
+         module_spec.GetUUID() == image_info.GetUUID())) {
+      ModuleSpec shared_cache_spec(module_spec.GetFileSpec(),
+                                   image_info.GetUUID(),
+                                   image_info.GetExtractor());
       module_sp =
           target.GetOrCreateModule(shared_cache_spec, false /* notify */);
     }
   }
   // We'll call Target::ModulesDidLoad after all the modules have been
   // added to the target, don't let it be called for every one.
-  if (!module_sp)
-    module_sp = target.GetOrCreateModule(module_spec, false /* notify */);
   if (!module_sp || module_sp->GetObjectFile() == nullptr)
     module_sp = m_process->ReadModuleFromMemory(image_info.file_spec,
                                                 image_info.address);

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -324,10 +324,12 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.
-    if (image_info.uuid &&
-        (!module_spec.GetUUID() || module_spec.GetUUID() == image_info.uuid)) {
-      ModuleSpec shared_cache_spec(module_spec.GetFileSpec(), image_info.uuid,
-                                   image_info.extractor_sp);
+    if (image_info.GetUUID() &&
+        (!module_spec.GetUUID() ||
+         module_spec.GetUUID() == image_info.GetUUID())) {
+      ModuleSpec shared_cache_spec(module_spec.GetFileSpec(),
+                                   image_info.GetUUID(),
+                                   image_info.GetExtractor());
       err = ModuleList::GetSharedModule(shared_cache_spec, module_sp,
                                         module_search_paths_ptr, old_modules,
                                         did_create_ptr);

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -207,8 +207,9 @@ std::optional<ModuleSpec> SymbolLocatorDebugSymbols::LocateExecutableObjectFile(
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.
-            if (image_info.uuid && (!module_spec.GetUUID() ||
-                                    module_spec.GetUUID() == image_info.uuid)) {
+            if (image_info.GetUUID() &&
+                (!module_spec.GetUUID() ||
+                 module_spec.GetUUID() == image_info.GetUUID())) {
               success = true;
               return_module_spec.GetFileSpec() = module_spec.GetFileSpec();
               LLDB_LOGF(log,
@@ -649,8 +650,9 @@ static int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.
-            if (image_info.uuid && (!module_spec.GetUUID() ||
-                                    module_spec.GetUUID() == image_info.uuid)) {
+            if (image_info.GetUUID() &&
+                (!module_spec.GetUUID() ||
+                 module_spec.GetUUID() == image_info.GetUUID())) {
               success = true;
               return_module_spec.GetFileSpec() = module_spec.GetFileSpec();
               LLDB_LOGF(log,

--- a/lldb/unittests/ObjectFile/MachO/CMakeLists.txt
+++ b/lldb/unittests/ObjectFile/MachO/CMakeLists.txt
@@ -6,5 +6,6 @@ add_lldb_unittest(ObjectFileMachOTests
     lldbPluginSymbolFileSymtab
     lldbCore
     lldbUtilityHelpers
+    lldbPluginPlatformMacOSX
     LLVMTestingSupport
   )


### PR DESCRIPTION
Taking advantage of a few new SPI in macOS 26.4 libdyld, it is possible for lldb to load binaries out of a shared cache binary blob, instead of needing discrete files on disk. lldb has had one special case where it has done this for years -- if the debugee process and lldb itself are using the same shared cache, it could create ObjectFiles based on its own memory contents. This new method requires only the shared cache on disk, not depending on it being mapped into lldb's address space already.

In HostInfoMacOSX.mm, we create an array of binaries in lldb's shared cache, by one of two methods depending on the availability of SPI/SDKs. This PR adds a new third method for loading lldb's shared cache off disk as a proof of concept. It will prefer this new method when the needed SPI are available at runtime. There is also a user setting to disable this new method in case we uncover a problem as it is deployed.

I did change the internal store of the shared cache files from a single array, to being organized by shared cache UUIDs, so we can have multiple shared caches indexed in the future.

In HostInfoBase.h's SharedCacheImageInfo class, you can now create an ImageInfo with a DataExtractorSP or a void* baton. I added GetUUID and GetExtractor methods, and the latter will use the libdyld SPI to map the segments for a specific binary into lldb's memory and return a DataExtractorSP.

The setting is currently called symbols.shared-cache-binary-loading.

In DynamicLoaderDarwin::FindTargetModuleForImageInfo there was an ordering mistake where we would always consult the HostInfoMacOSX.mm shared cache provider, instead of checking lldb's own global module cache first when looking for a binary, resulting in creating a new Module repeatedly for shared cache binaries with the new method, parsing the symbol table repeatedly. I fixed the ordering so we look at existing Modules before we check the shared cache for one.

In ObjectFileMachOTest, it tests a TEXT and a DATA symbol, checking that the contents of the function/data object match the bytes we got from the shared cache. The test was using a DATA_DIRTY symbol, which was fine when using lldb's own shared cache memory, but when we worked on the shared cache binary on-disk directly, we were seeing different values for the bytes because of relocations in there. I changed this to a constant DATA symbol.

rdar://148939795

---------



(cherry picked from commit e3c72cf008a31a8896f6058f99a208d4c877bd96)