### PR TITLE
[windows] enable Swift tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -812,9 +812,9 @@ def swiftTest(func):
 
         if "i386" == self.getArchitecture():
             return "skipping Swift test because i386 is not a supported architecture"
-        elif not (any(x in sys.platform for x in ["darwin", "linux"])):
+        elif not (any(x in sys.platform for x in ["darwin", "linux", "win32"])):
             return (
-                "skipping Swift test because only Darwin and Linux are supported OSes"
+                "skipping Swift test because only Darwin, Linux and Windows are supported OSes"
             )
         else:
             # This configuration is Swift-compatible

--- a/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
@@ -9,6 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_po_address(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
@@ -21,6 +22,7 @@ class TestCase(TestBase):
         self.expect(f"dwim-print -O -- {addr}", patterns=[f"Object@0x0*{hex_addr}"])
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_po_non_address_hex(self):
         """No special handling of non-memory integer values."""
         self.build()
@@ -30,6 +32,7 @@ class TestCase(TestBase):
         self.expect(f"dwim-print -O -- 0x1000", substrs=["4096"])
 
     @swiftTest
+    @expectedFailureWindows
     def test_print_swift_object_does_not_show_name(self):
         """Ensure that objects are printed without a name, and without the '='
         that would follow the name."""

--- a/lldb/test/API/commands/expression/persistent_result/swift/TestSwiftPersistentResult.py
+++ b/lldb/test/API/commands/expression/persistent_result/swift/TestSwiftPersistentResult.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_enable_persistent_result(self):
         """Test explicitly enabling result variables persistence."""
         self.build()
@@ -21,6 +22,7 @@ class TestCase(TestBase):
         self.expect("expression $R0", startstr="(Int) $R1 = 30")
 
     @swiftTest
+    @expectedFailureWindows
     def test_disable_persistent_result(self):
         """Test explicitly disabling persistent result variables."""
         self.build()
@@ -32,6 +34,7 @@ class TestCase(TestBase):
         self.expect("expression $R0", error=True)
 
     @swiftTest
+    @expectedFailureWindows
     def test_expression_persists_result(self):
         """Test `expression`'s default behavior is to persist a result variable."""
         self.build()
@@ -42,6 +45,7 @@ class TestCase(TestBase):
         self.expect("expression $R0", startstr="(Int) $R1 = 30")
 
     @swiftTest
+    @expectedFailureWindows
     def test_p_does_not_persist_results(self):
         """Test `p` does not persist a result variable."""
         self.build()

--- a/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
+++ b/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftAddressExpressionTest(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that you can use register names in image lookup in a swift frame."""
         self.build()

--- a/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
+++ b/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
@@ -26,6 +26,7 @@ class AsanSwiftTestCase(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfWindows
     @skipIfLinux
     @skipUnlessSwiftAddressSanitizer
     def test_asan_swift(self):

--- a/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
@@ -22,18 +22,21 @@ import os
 class TestSwiftErrorBreakpoint(TestBase):
     @decorators.skipIfLinux  # <rdar://problem/30909618>
     @swiftTest
+    @expectedFailureWindows
     def test_swift_error_no_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests(None)
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_error_matching_base_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests("EnumError")
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_error_matching_full_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
@@ -46,6 +49,7 @@ class TestSwiftErrorBreakpoint(TestBase):
         self.do_tests_in_mode("NoSuchErrorHere", mode="untyped", should_stop=False)
 
     @swiftTest
+    @expectedFailureWindows
     @expectedFailureAll(bugnumber="rdar://148033473")
     def test_swift_typed_error_bogus_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
@@ -5,6 +5,7 @@ from lldbsuite.test.decorators import *
 
 class TestCase(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that a breakpoint on a property accessor can be set by name."""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftTypeAliasFormatters(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_type_alias_formatters(self):
         """Test that Swift typealiases get formatted properly"""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
@@ -1,7 +1,10 @@
 """
 Test that Swift unsafe types get formatted properly
 """
+
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
@@ -9,6 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_array_slice_formatters(self):
         """Test ArraySlice synthetic types."""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -10,6 +10,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_substring_formatters(self):
         """Test Subtring summary strings."""
         self.build()

--- a/lldb/test/API/functionalities/swift-runtime-reporting/abi-v2/TestABIv2.py
+++ b/lldb/test/API/functionalities/swift-runtime-reporting/abi-v2/TestABIv2.py
@@ -25,6 +25,7 @@ class SwiftRuntimeReportingABIv2TestCase(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.skipIfWindows
     @decorators.skipIfLinux
     def test_swift_runtime_reporting(self):
         self.build()

--- a/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
+++ b/lldb/test/API/functionalities/swift-runtime-reporting/exclusivity-violation/TestExclusivityViolation.py
@@ -26,6 +26,7 @@ class SwiftRuntimeReportingExclusivityViolationTestCase(lldbtest.TestBase):
 
     @decorators.swiftTest
     @decorators.skipIfLinux
+    @decorators.expectedFailureWindows
     def test_swift_runtime_reporting(self):
         self.build()
         self.do_test()

--- a/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
+++ b/lldb/test/API/functionalities/tsan/swift-access-race/TestSwiftTsanAccessRace.py
@@ -26,6 +26,7 @@ class TsanSwiftAccessRaceTestCase(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfWindows
     @skipIfLinux
     @skipUnlessSwiftThreadSanitizer
     @skipIfAsan  # This test does not behave reliable with an ASANified LLDB.

--- a/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
+++ b/lldb/test/API/functionalities/tsan/swift/TestSwiftTsan.py
@@ -25,6 +25,7 @@ class TsanSwiftTestCase(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfWindows
     @skipIfLinux
     @skipUnlessSwiftThreadSanitizer
     @skipIfAsan # This test does not behave reliable with an ASANified LLDB.

--- a/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
+++ b/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
@@ -48,6 +48,7 @@ class TestSwiftAddressOf(lldbtest.TestBase):
 
         
     @swiftTest
+    @expectedFailureWindows
     def test_any_type(self):
         """Test the Any type"""
         self.build()

--- a/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
+++ b/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
@@ -24,6 +24,7 @@ class TestSwiftAnyType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_any_type(self):
         """Test the Any type"""
         self.build()

--- a/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftAnyObjectType(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_any_object_type(self):
         """Test the AnyObject type"""
         self.build()

--- a/lldb/test/API/lang/swift/anytype_array/TestAnyTypeArray.py
+++ b/lldb/test/API/lang/swift/anytype_array/TestAnyTypeArray.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/archetype_in_cond_breakpoint/TestArchetypeInConditionalBreakpoint.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestArchetypeInConditionalBreakpoint(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_stops_free_function(self):
         self.stops("break here for free function")
 
@@ -14,6 +15,7 @@ class TestArchetypeInConditionalBreakpoint(TestBase):
         self.doesnt_stop("break here for free function")
 
     @swiftTest
+    @expectedFailureWindows
     def test_stops_class(self):
         self.stops("break here for class")
 

--- a/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
+++ b/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestArchetypeInExpression(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that a user can refer to the archetypes in their expressions"""         
         self.build()

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftArchetypeResolution(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_archetype_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""
         self.build()

--- a/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
+++ b/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
+++ b/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
+++ b/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
+++ b/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftArrayUninitialized(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test unitialized global arrays"""
         self.build()

--- a/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
+++ b/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftArchetypeResolution(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_associated_type_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""
         self.build()

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""
         self.build()

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test_unsafe_continuation_printing(self):
         """Print an UnsafeContinuation and verify its children."""
         self.build()
@@ -34,6 +35,7 @@ class TestCase(TestBase):
         )
 
     @swiftTest
+    @expectedFailureWindows
     def test_checked_continuation_printing(self):
         """Print an CheckedContinuation and verify its children."""
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test_top_level_task(self):
         """Test Task synthetic child provider for top-level Task."""
         self.build()
@@ -34,6 +35,7 @@ class TestCase(TestBase):
         )
 
     @swiftTest
+    @expectedFailureWindows
     @skipIfLinux
     def test_current_task(self):
         """Test Task synthetic child for UnsafeCurrentTask (from an async let)."""

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test_summary_contains_name(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -16,6 +17,7 @@ class TestCase(TestBase):
         self.expect("v task", patterns=[r'"Chore" id:[1-9]'])
 
     @swiftTest
+    @expectedFailureWindows
     @skipIfLinux  # rdar://151471067
     def test_thread_contains_name(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test summary formatter for TaskPriority."""
         self.build()

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test_print_task_group(self):
         """Print a TaskGroup and verify its children."""
         self.build()
@@ -17,6 +18,7 @@ class TestCase(TestBase):
         self.do_test_print()
 
     @swiftTest
+    @expectedFailureWindows
     def test_print_throwing_task_group(self):
         """Print a ThrowingTaskGroup and verify its children."""
         self.build()
@@ -60,6 +62,7 @@ class TestCase(TestBase):
         )
 
     @swiftTest
+    @expectedFailureWindows
     def test_api_task_group(self):
         """Verify a TaskGroup contains its expected children."""
         self.build()
@@ -69,6 +72,7 @@ class TestCase(TestBase):
         self.do_test_api(process)
 
     @swiftTest
+    @expectedFailureWindows
     def test_api_throwing_task_group(self):
         """Verify a ThrowingTaskGroup contains its expected children."""
         self.build()

--- a/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
+++ b/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     @skipIfLinux
     def test(self):
         """Test async that async breakpoints are not filtered when the same

--- a/lldb/test/API/lang/swift/big_multi_payload_enum/TestSwiftBigMultiPayloadEnum.py
+++ b/lldb/test/API/lang/swift/big_multi_payload_enum/TestSwiftBigMultiPayloadEnum.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftBigMultiPayloadEnum(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftPartialBreakTest(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_partial_break(self):
         """Tests that we can break on a partial name of a Swift function"""
         self.build()

--- a/lldb/test/API/lang/swift/breakpoint_perf/TestSwiftBreakpointPerf.py
+++ b/lldb/test/API/lang/swift/breakpoint_perf/TestSwiftBreakpointPerf.py
@@ -7,6 +7,7 @@ class TestSwiftReflectionLoading(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that no SwiftASTContext is initialized just to stop at a breakpoint"""
         self.build()

--- a/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -20,6 +20,7 @@ import os
 
 class TestSwiftBacktracePrinting(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_backtrace_printing(self):
         """Test printing Swift backtrace"""
         self.build()

--- a/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
+++ b/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftCTypeIvar(TestBase):
     @swiftTest
+    @expectedFailureWindows
     @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     def test(self):
         """Test that the extra inhabitants are correctly computed for various

--- a/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
+++ b/lldb/test/API/lang/swift/clangimporter/anonymous-clang-types/TestSwiftAnonymousClangTypes.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftAnonymousClangTypes(lldbtest.TestBase):
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
@@ -21,6 +21,7 @@ class TestSwiftClangImporterCustomAlignment(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -7,6 +7,7 @@ class TestSwiftExprImport(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test error handling if the expression evaluator
            encounters a Clang import failure.

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -8,6 +8,7 @@ class TestSwiftFModuleFlags(TestBase):
     @skipIf(macos_version=["<", "14.0"])
     @skipIfDarwinEmbedded
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test that -fmodule flags get stripped out"""
         self.build()

--- a/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftSubmoduleImport(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test imports of Clang submodules"""
         self.build()

--- a/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
+++ b/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
@@ -7,6 +7,7 @@ class TestSwiftClassBaseClass(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here",

--- a/lldb/test/API/lang/swift/class_empty/TestSwiftClassEmpty.py
+++ b/lldb/test/API/lang/swift/class_empty/TestSwiftClassEmpty.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/class_error/TestClassError.py
+++ b/lldb/test/API/lang/swift/class_error/TestClassError.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
+++ b/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -16,6 +16,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestClosureShortcuts(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -52,6 +52,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         return (target, process, thread)
 
     @swiftTest
+    @expectedFailureWindows
     def test_simple_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_simple_closure")
@@ -60,6 +61,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
+    @expectedFailureWindows
     def test_nested_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_double_closure_1")
@@ -84,6 +86,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
+    @expectedFailureWindows
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
     def test_async_closure(self):
@@ -107,6 +110,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
+    @expectedFailureWindows
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
     def test_task_inside_non_async_func(self):
@@ -119,6 +123,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
 
     @swiftTest
+    @expectedFailureWindows
     def test_ctor_class_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_class")
@@ -176,6 +181,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
+    @expectedFailureWindows
     def test_ctor_struct_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_struct")
@@ -233,6 +239,7 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
+    @expectedFailureWindows
     def test_ctor_enum_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_enum")

--- a/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
+++ b/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
@@ -19,6 +19,7 @@ class TestSwiftCommandMemoryFind(TestBase):
                     substrs=["data found at location"])
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         target, _, _, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
+++ b/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_scalar_types(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
@@ -35,6 +36,7 @@ class TestCase(TestBase):
             )
 
     @swiftTest
+    @expectedFailureWindows
     @expectedFailureAll
     def test_generic_types(self):
         self.build()

--- a/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
+++ b/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConstrainedExistential(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test constrained existential types"""
 

--- a/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/expressions/TestSwiftBackwardInteropExpressions.py
@@ -9,6 +9,7 @@ class TestSwiftBackwardInteropExpressions(TestBase):
 
     @skipIfLinux
     @swiftTest
+    @skipIfWindows
     def test_func_step_in(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropStepping.py
@@ -33,122 +33,146 @@ class TestSwiftBackwardInteropStepping(TestBase):
         self.assertIn(func, name)
 
     @swiftTest
+    @skipIfWindows
     def test_func_step_in(self):
         thread = self.setup('Break here for func')
         self.check_step_in(thread, 'testFunc', 'swiftFunc')
         
     @swiftTest
+    @skipIfWindows
     def test_func_step_over(self):
         thread = self.setup('Break here for func')
         self.check_step_over(thread, 'testFunc')
 
     @swiftTest
+    @skipIfWindows
     def test_method_step_in_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_in(thread, 'testMethod', 'SwiftClass.swiftMethod')
         
     @swiftTest
+    @skipIfWindows
     def test_method_step_over_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_over(thread, 'testMethod')
 
     @swiftTest
+    @skipIfWindows
     def test_init_step_in_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_in(thread, 'testConstructor', 'SwiftClass.init')
         
     @swiftTest
+    @skipIfWindows
     def test_init_step_over_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_over(thread, 'testConstructor')
 
     @swiftTest
+    @skipIfWindows
     def test_static_method_step_in_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_in(thread, 'testStaticMethod', 'SwiftClass.swiftStaticMethod')
         
     @swiftTest
+    @skipIfWindows
     def test_static_method_step_over_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_over(thread, 'testStaticMethod')
 
     @swiftTest
+    @skipIfWindows
     def test_getter_step_in_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_in(thread, 'testGetter', 'SwiftClass.swiftProperty.getter')
         
     @swiftTest
+    @skipIfWindows
     def test_getter_step_over_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_over(thread, 'testGetter')
 
     @swiftTest
+    @skipIfWindows
     def test_setter_step_in_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_in(thread, 'testSetter', 'SwiftClass.swiftProperty.setter')
         
     @swiftTest
+    @skipIfWindows
     def test_setter_step_over_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_over(thread, 'testSetter')
 
 
     @swiftTest
+    @skipIfWindows
     def test_overriden_step_in_class(self):
         thread = self.setup('Break here for overridden - class')
         self.check_step_in(thread, 'testOverridenMethod', 'SwiftSubclass.overrideableMethod')
         
     @swiftTest
+    @skipIfWindows
     def test_overriden_step_over_class(self):
         thread = self.setup('Break here for overridden')
         self.check_step_over(thread, 'testOverridenMethod')
 
     @swiftTest
+    @skipIfWindows
     def test_method_step_in_struct_class(self):
         thread = self.setup('Break here for method - struct')
         self.check_step_in(thread, 'testMethod', 'SwiftStruct.swiftMethod')
         
     @swiftTest
+    @skipIfWindows
     def test_method_step_over_struct_class(self):
         thread = self.setup('Break here for method - struct')
         self.check_step_over(thread, 'testMethod')
 
     @swiftTest
+    @skipIfWindows
     def test_init_step_in_struct_class(self):
         thread = self.setup('Break here for constructor - struct')
         self.check_step_in(thread, 'testConstructor', 'SwiftStruct.init')
         
     @swiftTest
+    @skipIfWindows
     def test_init_step_over_struct_class(self):
         thread = self.setup('Break here for constructor - struct')
         self.check_step_over(thread, 'testConstructor')
 
     @swiftTest
+    @skipIfWindows
     def test_static_method_step_in_struct(self):
         thread = self.setup('Break here for static method - struct')
         self.check_step_in(thread, 'testStaticMethod', 'SwiftStruct.swiftStaticMethod')
         
     @swiftTest
+    @skipIfWindows
     def test_static_method_step_over_struct(self):
         thread = self.setup('Break here for static method - struct')
         self.check_step_over(thread, 'testStaticMethod')
 
     @swiftTest
+    @skipIfWindows
     def test_getter_step_in_struct(self):
         thread = self.setup('Break here for getter - struct')
         self.check_step_in(thread, 'testGetter', 'SwiftStruct.swiftProperty.getter')
         
     @swiftTest
+    @skipIfWindows
     def test_getter_step_over_struct(self):
         thread = self.setup('Break here for getter - struct')
         self.check_step_over(thread, 'testGetter')
 
     @swiftTest
+    @skipIfWindows
     def test_setter_step_in_struct(self):
         thread = self.setup('Break here for setter - struct')
         self.check_step_in(thread, 'testSetter', 'SwiftStruct.swiftProperty.setter')
         
     @swiftTest
+    @skipIfWindows
     def test_setter_step_over_struct(self):
         thread = self.setup('Break here for setter - struct')
         self.check_step_over(thread, 'testSetter')

--- a/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/class-in-namespace/TestSwiftForwardInteropClassInNamespace.py
@@ -10,6 +10,7 @@ class TestSwiftForwardInteropClassInNamespace(TestBase):
 
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
+    @skipIfWindows
     def test_class(self):
         self.build()
         _, _, _, _= lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class-as-existential/TestSwiftForwardInteropCxxClassAsExistential.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropCxxClassAsExistential(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/cxx-class/TestSwiftForwardInteropCxxClass.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropCxxClass(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test_class(self):
         self.build()
         _, _, _, _= lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropCxxLangOpt(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test_class(self):
         """
         Test that C++ interoperability is enabled on a per-CU basis.

--- a/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
@@ -10,6 +10,7 @@ class TestCxxForwardInteropNestedClasses(TestBase):
 
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop/TestSwiftForwardInteropStepping.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropStepping(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_function(self):
         """ Test that stepping into a simple C++ function works"""
         self.build()
@@ -26,6 +27,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testFunction', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_function(self):
         """ Test that stepping over a simple C++ function works"""
         self.build()
@@ -41,6 +43,7 @@ class TestSwiftForwardInteropStepping(TestBase):
 
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_method(self):
         """ Test that stepping into a C++ method works"""
         self.build()
@@ -58,6 +61,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testMethod', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_method(self):
         """ Test that stepping over a C++ method works"""
         self.build()
@@ -72,6 +76,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testMethod', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_constructor(self):
         """ Test that stepping into a simple C++ constructor works"""
         self.build()
@@ -92,6 +97,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testContructor', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_constructor(self):
         """ Test that stepping over a simple C++ constructor works"""
         self.build()
@@ -109,6 +115,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testContructor', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_extension(self):
         """ Test that stepping into a C++ function defined in an extension works"""
         self.build()
@@ -126,6 +133,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testClassWithExtension', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_extension(self):
         """ Test that stepping over a C++ function defined in an extension works"""
         self.build()
@@ -140,6 +148,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testClassWithExtension', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_call_operator(self):
         """ Test that stepping into a C++ call operator works"""
         self.build()
@@ -157,6 +166,7 @@ class TestSwiftForwardInteropStepping(TestBase):
         self.assertIn('testCallOperator', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_call_operator(self):
         """ Test that stepping over a C++ call operator works"""
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stepping-forward-interop_header_only/TestSwiftForwardInteropSteppingHeaderOnly.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_function(self):
         """ Test that stepping into a simple C++ function works"""
         self.build()
@@ -26,6 +27,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testFunction', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_function(self):
         """ Test that stepping over a simple C++ function works"""
         self.build()
@@ -41,6 +43,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
 
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_method(self):
         """ Test that stepping into a C++ method works"""
         self.build()
@@ -58,6 +61,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testMethod', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_method(self):
         """ Test that stepping over a C++ method works"""
         self.build()
@@ -72,6 +76,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testMethod', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_constructor(self):
         """ Test that stepping into a simple C++ constructor works"""
         self.build()
@@ -92,6 +97,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testContructor', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_constructor(self):
         """ Test that stepping over a simple C++ constructor works"""
         self.build()
@@ -109,6 +115,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testContructor', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_extension(self):
         """ Test that stepping into a C++ function defined in an extension works"""
         self.build()
@@ -126,6 +133,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testClassWithExtension', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_extension(self):
         """ Test that stepping over a C++ function defined in an extension works"""
         self.build()
@@ -140,6 +148,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testClassWithExtension', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_into_call_operator(self):
         """ Test that stepping into a C++ call operator works"""
         self.build()
@@ -157,6 +166,7 @@ class TestSwiftForwardInteropSteppingHeaderOnly(TestBase):
         self.assertIn('testCallOperator', name)
 
     @swiftTest
+    @skipIfWindows
     def test_step_over_call_operator(self):
         """ Test that stepping over a C++ call operator works"""
         self.build()

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -11,6 +11,7 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
     @skipIfLinux # rdar://106532498
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false')) # rdar://106438227 (TestSTLTypes fails when clang importer is disabled)
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
         log = self.getBuildArtifact("types.log")

--- a/lldb/test/API/lang/swift/cxx_interop/forward/swift-class-with-cxx-ivars/TestSwiftForwardInteropClassWithCxxIvars.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/swift-class-with-cxx-ivars/TestSwiftForwardInteropClassWithCxxIvars.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropClassWithCxxIvars(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/swift-generic-with-cxx-type/TestSwiftForwardInteropGenericWithCxxType.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/swift-generic-with-cxx-type/TestSwiftForwardInteropGenericWithCxxType.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropGenericWithCxxType(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/template-types/TestSwiftForwardInteropTemplateTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/template-types/TestSwiftForwardInteropTemplateTypes.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropTemplateTypes(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/typedefed-type/TestSwiftForwardInteropTypedefType.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/typedefed-type/TestSwiftForwardInteropTypedefType.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropTypedefType(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test_class(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/variadic-template-types/TestSwiftForwardInteropVariadicTemplateTypes.py
@@ -9,6 +9,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropVariadicTemplateTypes(TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         self.build()
         

--- a/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
+++ b/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
@@ -23,6 +23,7 @@ import shutil
 
 class TestSwiftDebugPrefixMap(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_debug_prefix_map(self):
         self.do_test()
 

--- a/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
+++ b/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
+++ b/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
+++ b/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftDifferentABIName(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -36,6 +36,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
+    @skipIfWindows
     # This test needs a working Remote Mirrors implementation.
     @skipIf(oslist=['windows'])
     def test_dwarf_importer(self):
@@ -70,6 +71,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
+    @skipIfWindows
     # This test needs a working Remote Mirrors implementation.
     @skipIf(oslist=['windows'])
     def test_dwarf_importer_exprs(self):
@@ -97,6 +99,7 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
     @swiftTest
+    @skipIfWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test_negative(self):
         lldb.SBDebugger.MemoryPressureDetected()

--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test looking up a Clang typedef type that isn't directly
         referenced by debug info in the Swift object file.

--- a/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
+++ b/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
@@ -30,6 +30,7 @@ class TestSwiftDynamicSelf(lldbtest.TestBase):
         lldbutil.check_variable(self, member_v, False, value=v_val)
 
     @swiftTest
+    @expectedFailureWindows
     def test_dynamic_self(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
+++ b/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftDynamicValueTest(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_dynamic_value(self):
         """Tests that dynamic values work correctly for Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
+++ b/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
@@ -9,6 +9,7 @@ class TestSwiftAnyType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_any_type(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
+++ b/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
+++ b/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     @expectedFailureAll(oslist=["linux"], bugnumber="rdar://83444822")
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
+++ b/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/enums/extension/TestSwiftEnumExtension.py
+++ b/lldb/test/API/lang/swift/enums/extension/TestSwiftEnumExtension.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test indirect enums"""
         self.build()

--- a/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
+++ b/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test indirect enums"""
         self.build()

--- a/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
@@ -7,6 +7,7 @@ class TestSwiftErrorHandlingMissingTypes(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'true'))
     def test(self):
         """Test that errors are surfaced"""

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExplicitModules(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @skipIfWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'), bugnumber='rdar://157258485')
     def test(self):
         """Test explicit Swift modules with bridging headers"""

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -8,6 +8,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @skipIfWindows
     def test_missing_explicit_modules(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""
         self.build()
@@ -31,6 +32,7 @@ class TestCase(lldbtest.TestBase):
         # CHECK: Explicit modules : false
 
     @swiftTest
+    @skipIfWindows
     def test_sanity(self):
         """Check the normal behavior."""
         mod_cache = self.getBuildArtifact("my-clang-modules-cache")
@@ -59,6 +61,7 @@ class TestCase(lldbtest.TestBase):
         # CHECK-SANITY: Turning on implicit modules
 
     @swiftTest
+    @skipIfWindows
     def test_setting(self):
         """Check the normal behavior."""
         self.build()

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test explicit Swift modules"""
         self.build()
@@ -21,6 +22,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Module import remark: loaded module 'a'; source: '{{.*}}a.swiftmodule', loaded: '{{.*}}a.swiftmodule'
 
     @swiftTest
+    @skipIfWindows
     def test_disable_esml(self):
         """Test disabling the explicit Swift module loader"""
         self.build()
@@ -38,6 +40,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
         
     @swiftTest
+    @skipIfWindows
     @skipUnlessDarwin
     def test_import(self):
         """Test an implicit import inside an explicit build"""

--- a/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
+++ b/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
@@ -8,6 +8,7 @@ import os
 class TestSwiftExpressionAccessControl(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_expression_access_control(self):
         """Make sure expressions ignore access control"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
+++ b/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
@@ -7,6 +7,7 @@ import os
 
 class TestSwiftExpressionActor(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_static_func(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -16,6 +17,7 @@ class TestSwiftExpressionActor(TestBase):
         self.expect("expr self", substrs=["A.Type"])
 
     @swiftTest
+    @expectedFailureWindows
     def test_func(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
+++ b/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
@@ -10,6 +10,7 @@ class TestSwiftExprAllocator(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_allocator_self(self):
         """Test expressions involving self in a allocating constructor. In an
         allocator, self is just a local variable, not being passed in, but

--- a/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
+++ b/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -15,24 +15,28 @@ from lldbsuite.test.decorators import *
 
 class TestClassConstrainedProtocol(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_extension_weak_self(self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for weak self", needs_dynamic=False)
 
     @swiftTest
+    @expectedFailureWindows
     def test_extension_self (self):
         """Test that we can reconstruct self in method of a class constrained protocol."""
         self.build()
         self.do_self_test("Break here in class protocol", needs_dynamic=False)
 
     @swiftTest
+    @expectedFailureWindows
     def test_method_weak_self(self):
         """Test that we can reconstruct weak self capture in method of a class conforming to a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for method weak self", needs_dynamic=False)
 
     @swiftTest
+    @expectedFailureWindows
     def test_method_self(self):
         """Test that we can reconstruct self in method of a class conforming to a class constrained protocol."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestExpressionOpenClass(TestBase):
     NO_DEBUG_INFO_TEST = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests calling an open function"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open_resilient/TestSwiftExpressionOpenResilientClass.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestExpressionOpenResilientClass(TestBase):
     NO_DEBUG_INFO_TEST = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests calling an open resilient function"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -21,6 +21,7 @@ import os
 
 class TestExpressionsInSwiftMethodsPureSwift(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/empty_self/TestEmptySelf.py
+++ b/lldb/test/API/lang/swift/expression/empty_self/TestEmptySelf.py
@@ -13,4 +13,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
+++ b/lldb/test/API/lang/swift/expression/error_missing_type/TestSwiftExpressionErrorMissingType.py
@@ -7,6 +7,7 @@ class TestSwiftExpressionErrorMissingType(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test an extra hint inserted by LLDB for missing module imports"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -7,6 +7,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test_missing_location(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -34,6 +35,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         )
 
     @swiftTest
+    @expectedFailureWindows
     def test_missing_var(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""
@@ -88,6 +90,7 @@ class TestSwiftExpressionErrorReporting(TestBase):
         check(value)
 
     @swiftTest
+    @expectedFailureWindows
     def test_missing_type(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -32,6 +32,7 @@ class TestExclusivitySuppression(TestBase):
     # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
     # a failure due to exclusivity
     @swiftTest
+    @expectedFailureWindows
     def test_basic_exclusivity_suppression(self):
         """Test that exclusively owned values can still be accessed"""
 
@@ -52,6 +53,7 @@ class TestExclusivitySuppression(TestBase):
     # (5) Evaluating w.s.i again to check that finishing the nested expression
     #     did not prematurely re-enable exclusivity checks.
     @swiftTest
+    @expectedFailureWindows
     def test_exclusivity_suppression_for_concurrent_expressions(self):
         """Test that exclusivity suppression works with concurrent expressions"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/function_definition/TestSwiftFunctionDefinition.py
+++ b/lldb/test/API/lang/swift/expression/function_definition/TestSwiftFunctionDefinition.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftFunctionDefinition(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that persistent variables are mutable."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -29,12 +29,14 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
+    @expectedFailureWindows
     def test_generic_expressions(self):
         """Test expressions in generic contexts"""
         self.build()
         self.do_test()
 
     @swiftTest
+    @expectedFailureWindows
     def test_ivars_in_generic_expressions(self):
         """Test ivar access through expressions in generic contexts"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -9,10 +9,12 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfWindows
     def test_positive(self):
         self.do_test('true')
 
     @swiftTest
+    @skipIfWindows
     def test_negative(self):
         self.do_test('false')
         

--- a/lldb/test/API/lang/swift/expression/language_version/TestSwiftExpressionLanguageVersion.py
+++ b/lldb/test/API/lang/swift/expression/language_version/TestSwiftExpressionLanguageVersion.py
@@ -7,6 +7,7 @@ class TestSwiftExpressionLanguageVersion(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test changing the Swift language version"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
+++ b/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExprMissingType(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
+++ b/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftMutablePersistentVar(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that persistent variables are mutable."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/mutating_struct_extension/TestMutatingStructExtension.py
+++ b/lldb/test/API/lang/swift/expression/mutating_struct_extension/TestMutatingStructExtension.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -16,6 +16,7 @@ from lldbsuite.test.lldbtest import *
 
 class TestOptionalAmbiguity(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_sample_rename_this(self):
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.swift")

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -21,6 +21,7 @@ import os
 
 class TestDefiningOverloadedFunctions(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_simple_overload_expressions(self):
         """Test defining overloaded functions"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -32,6 +32,7 @@ class TestSwiftExprInProtocolExtension(TestBase):
         self.target.BreakpointDelete(bkpt.GetID())
 
     @swiftTest
+    @expectedFailureWindows
     def test_protocol_extension(self):
         """Tests that swift expressions in protocol extension functions behave correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -5,6 +5,7 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftProtocolExtensionSelf(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that the generic self in a protocol extension works in the expression evaluator.
         """

--- a/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftExpressionScopes(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_expression_scopes(self):
         """Tests that swift expressions resolve scoped variables correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/self/TestSwiftSelf.py
+++ b/lldb/test/API/lang/swift/expression/self/TestSwiftSelf.py
@@ -13,4 +13,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
@@ -22,6 +22,7 @@ import sys
 
 class TestSwiftSimpleExpressions(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftExpressionsInClassFunctions(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_expressions_in_class_functions(self):
         """Test expressions in class func contexts"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
+++ b/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExpressionTypeAlias(lldbtest.TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftWeakGenericSelf(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Confirms that expression evaluation works with a generic class
         type within a closure that weakly captures it"""

--- a/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
@@ -19,6 +19,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGenericExtension(TestBase):
      @swiftTest
+     @expectedFailureWindows
      def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
+++ b/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
@@ -30,6 +30,7 @@ class TestFilePrivate(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that we find the right file-local private decls using the discriminator"""
         self.build()

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFixIts(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_fixits(self):
         """Test applying fixits to expressions"""
         self.build()

--- a/lldb/test/API/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
+++ b/lldb/test/API/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
+++ b/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
+++ b/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftGenericClassTest(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that a generic class type can be resolved from the instance metadata alone"""
         self.build()

--- a/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
+++ b/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
+++ b/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftGenericClassNestedInFunctionTest(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that a generic class type nested inside a function can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
+++ b/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
@@ -18,6 +18,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGenericExtension(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
+++ b/lldb/test/API/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
+++ b/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGenericFunction(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test display of generic function names"""
         self.build()

--- a/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
+++ b/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
+++ b/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
+++ b/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftDynamicTypeGenericsTest(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_genericresolution_commands(self):
         """Check that we can correctly figure out the dynamic type of generic things"""
         self.build()

--- a/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftGetValueAsUnsignedAPITest(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_get_value_as_unsigned_sbapi(self):
         """Tests that the SBValue::GetValueAsUnsigned() API works for Swift types"""
         self.build()

--- a/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
+++ b/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftGenericClassInHashedContainerTest(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that the type of hashed container whose value type is a non-generic class declared inside a generic class can be read from instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -12,6 +12,7 @@ import os
 
 class TestSwiftHashedContainerEnum(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_any_object_type(self):
         """Test combinations of hashed swift containers with enums"""
         self.build()

--- a/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftHideRuntimeSupport(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_hide_runtime_support(self):
         """Test that we hide runtime support values"""
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_indirect/TestLibraryIndirect.py
@@ -37,6 +37,7 @@ class TestLibraryIndirect(TestBase):
         return info
 
     @swiftTest
+    @skipIfWindows
     def test_implementation_only_import_library(self):
         """Test `@_implementationOnly import` behind some indirection in a library used by the main executable
 
@@ -70,6 +71,7 @@ class TestLibraryIndirect(TestBase):
         self.expect("expr container.wrapped.value", substrs=["(SomeLibraryCore.TwoInts)", "(first = 2, second = 3)"])
 
     @swiftTest
+    @skipIfWindows
     def test_implementation_only_import_library_no_library_module(self):
         """Test `@_implementationOnly import` behind some indirection in a library used by the main executable, after removing the implementation-only library's swiftmodule
 

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -40,6 +40,7 @@ class TestMainExecutable(TestBase):
     @skipIf(bugnumber="rdar://problem/54322424", # This test is unreliable.
             setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
+    @skipIfWindows
     def test_implementation_only_import_main_executable(self):
         """Test `@_implementationOnly import` in the main executable
 
@@ -62,6 +63,7 @@ class TestMainExecutable(TestBase):
     @skipIf(bugnumber="rdar://problem/54322424", # This test is unreliable.
             setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
+    @skipIfWindows
     @skipIfLinux # rdar://problem/67348391
     def test_implementation_only_import_main_executable_no_library_module(self):
         """Test `@_implementationOnly import` in the main executable, after removing the library's swiftmodule
@@ -93,6 +95,7 @@ class TestMainExecutable(TestBase):
         self.runCmd("settings set symbols.use-swift-dwarfimporter true")
 
     @swiftTest
+    @skipIfWindows
     @expectedFailureAll(oslist=["windows"])
     def test_implementation_only_import_main_executable_resilient(self):
         """Test `@_implementationOnly import` in the main executable with a resilient library
@@ -114,6 +117,7 @@ class TestMainExecutable(TestBase):
         self.expect("expr TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
 
     @swiftTest
+    @skipIfWindows
     @expectedFailureOS(no_match(["macosx"])) # Requires Remote Mirrors support
     def test_implementation_only_import_main_executable_resilient_no_library_module(self):
         """Test `@_implementationOnly import` in the main executable with a resilient library, after removing the library's swiftmodule

--- a/lldb/test/API/lang/swift/import_spi/TestSwiftImportSPI.py
+++ b/lldb/test/API/lang/swift/import_spi/TestSwiftImportSPI.py
@@ -7,6 +7,7 @@ import os
 
 class TestSwiftImportSPI(lldbtest.TestBase):
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test SPI imports"""
         self.build()

--- a/lldb/test/API/lang/swift/inline_array/TestSwiftInlineArray.py
+++ b/lldb/test/API/lang/swift/inline_array/TestSwiftInlineArray.py
@@ -8,6 +8,7 @@ class TestSwiftInlineArray(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test the inline array synthetic child provider and summary"""
         self.build()

--- a/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
+++ b/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
@@ -24,6 +24,7 @@ class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_instancepointerset_sp(self):
         """Test that we correctly track instance pointers in ValueObjectPrinter"""
         self.build()

--- a/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
+++ b/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftLetIntSupport(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_let_int(self):
         """Test that a 'let' Int is formatted properly"""
         self.build()

--- a/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
+++ b/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
@@ -15,5 +15,5 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[swiftTest,
+    decorators=[swiftTest, expectedFailureWindows,
                 skipIf(oslist=["macosx"],bugnumber="rdar://26051759")])

--- a/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
+++ b/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -28,6 +28,7 @@ class TestSwiftMacro(lldbtest.TestBase):
 
 
     @swiftTest
+    @skipIfWindows
     # At the time of writing swift/test/Macros/macro_expand.swift is also disabled.
     @expectedFailureAll(oslist=["linux"])
     def testDebugging(self):
@@ -91,6 +92,7 @@ class TestSwiftMacro(lldbtest.TestBase):
         self.assertGreaterEqual(b.GetNumLocations(), 1)
 
     @swiftTest
+    @skipIfWindows
     # At the time of writing swift/test/Macros/macro_expand.swift is also disabled.
     @expectedFailureAll(oslist=["linux"])
     def testInteractive(self):

--- a/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
+++ b/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -41,6 +41,7 @@ class TestSwiftMetadataCache(TestBase):
             
         
     @swiftTest
+    @expectedFailureWindows
     def test_swift_metadata_cache(self):
         """Test the swift metadata cache."""
         

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftMetatype(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_metatype(self):
         """Test the formatting of Swift metatypes"""
         self.build()

--- a/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
+++ b/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
@@ -9,6 +9,7 @@ class TestSwiftModuleImport(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -26,6 +26,7 @@ class TestSwiftModuleSearchPaths(TestBase):
 
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_module_search_paths(self):
         """
         Tests that we can import modules located using

--- a/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
+++ b/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/multibases/TestSwiftMultipleBases.py
+++ b/lldb/test/API/lang/swift/multibases/TestSwiftMultipleBases.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftMultipayloadEnum(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_multipayload_enum(self):
         """Test that LLDB understands generic enums with more than one payload type"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
+++ b/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
@@ -38,6 +38,7 @@ class TestSwiftNestedArray(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_nested_array(self):
         """Test Arrays of Arrays in Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
+++ b/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
+++ b/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftNestedGeneric(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test the inline array synthetic child provider and summary"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftNestedGenericClass(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that a generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
+++ b/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
@@ -7,6 +7,7 @@ class TestSwiftNoRuntime(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test running a Swift expression in a C program"""
         self.build()

--- a/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
+++ b/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
@@ -8,6 +8,7 @@ class TestSwiftObservation(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that types with private discriminators read from the file cache work"""
         self.build()

--- a/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftOneCaseEnum(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_one_case_enum(self):
         """Test that an enum with only one case does not crash LLDB"""
         self.build()

--- a/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
+++ b/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
+++ b/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestBoundOpaqueArchetype(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         
         self.build()

--- a/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
+++ b/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftGlobalOpaque(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         
         self.build()

--- a/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
+++ b/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
@@ -1,4 +1,12 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest, skipIf(macos_version=["<", "10.15"])])
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    decorators=[
+        swiftTest,
+        expectedFailureWindows,
+        skipIf(macos_version=["<", "10.15"]),
+    ],
+)

--- a/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
+++ b/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftOpaque(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test opaque types in parameter positions"""         
         self.build()

--- a/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
+++ b/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
@@ -10,6 +10,7 @@ class TestSwiftOptimizedBoundGenericEnum(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test the bound generic enum types in "optimized" code."""
         self.build()

--- a/lldb/test/API/lang/swift/optional_error_handling/TestSwiftOptionalErrorHandling.py
+++ b/lldb/test/API/lang/swift/optional_error_handling/TestSwiftOptionalErrorHandling.py
@@ -7,6 +7,7 @@ class TestSwiftOptionalErrorHandling(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that errors are surfaced"""
         self.build()

--- a/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
+++ b/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
@@ -7,6 +7,7 @@ import os
 
 class TestSwiftOriginallyDefinedInPayload(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
+++ b/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 
@@ -37,6 +38,7 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
         )
     
     @swiftTest
+    @expectedFailureWindows
     def test_expr(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
     
@@ -65,6 +67,7 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
         )
     
     @swiftTest
+    @expectedFailureWindows
     def test_expr_from_generic(self):
          """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -27,12 +27,14 @@ import os.path
 
 class TestSwiftInterfaceNoDebugInfo(TestBase):
     @swiftTest
+    @skipIfWindows
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""
         self.build()
         self.do_test()
 
     @swiftTest
+    @skipIfWindows
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
         self.build()
@@ -44,6 +46,7 @@ class TestSwiftInterfaceNoDebugInfo(TestBase):
         self.do_test()
 
     @swiftTest
+    @skipIfWindows
     @skipUnlessPlatform(["macosx"])
     def test_prebuilt_cache_location(self):
         """Verify the prebuilt cache path is correct"""

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -27,12 +27,14 @@ import os.path
 
 class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
     @swiftTest
+    @skipIfWindows
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""
         self.build()
         self.do_test()
 
     @swiftTest
+    @skipIfWindows
     def test_swift_interface_fallback(self):
         """Test that we fall back to load from the .swiftinterface file if the .swiftmodule is invalid"""
         self.build()

--- a/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
@@ -12,6 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[
-    swiftTest
-    ])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
+++ b/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -16,6 +16,7 @@ class TestCase(TestBase):
         self.filecheck(f"platform shell cat {self.log}", __file__, f"-check-prefix=CHECK-{key}")
 
     @swiftTest
+    @expectedFailureWindows
     def test_int(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -26,6 +27,7 @@ class TestCase(TestBase):
         # CHECK-INT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SiD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_string(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -36,6 +38,7 @@ class TestCase(TestBase):
         # CHECK-STRING: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SSD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -46,6 +49,7 @@ class TestCase(TestBase):
         # CHECK-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a6StructVD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -56,6 +60,7 @@ class TestCase(TestBase):
         # CHECK-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a5ClassCD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -66,6 +71,7 @@ class TestCase(TestBase):
         # CHECK-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a4EnumOD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_generic_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -76,6 +82,7 @@ class TestCase(TestBase):
         # CHECK-GEN-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a13GenericStructVySSGD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_generic_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -86,6 +93,7 @@ class TestCase(TestBase):
         # CHECK-GEN-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a12GenericClassCySSGD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_generic_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -96,6 +104,7 @@ class TestCase(TestBase):
         # CHECK-GEN-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a11GenericEnumOySSGD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_described_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -106,6 +115,7 @@ class TestCase(TestBase):
         # CHECK-DESC-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a15DescribedStructVD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_described_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -116,6 +126,7 @@ class TestCase(TestBase):
         # CHECK-DESC-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a14DescribedClassCD")
 
     @swiftTest
+    @expectedFailureWindows
     def test_described_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
+++ b/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
+++ b/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
+++ b/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
@@ -18,6 +18,7 @@ from lldbsuite.test.decorators import *
 class TestSwiftPOValueTypes(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test_value_types(self):
         """Test 'po' on a variety of value types with and without custom descriptions."""
         self.build()
@@ -35,6 +36,7 @@ class TestSwiftPOValueTypes(TestBase):
         self.expect("po patatino", substrs=['foo'])
 
     @swiftTest
+    @expectedFailureWindows
     def test_ignore_bkpts_in_po(self):
         """Run a po expression with a breakpoint in the debugDescription, make sure we don't hit it."""
 

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftTypeLookup(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""
         self.build()

--- a/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
+++ b/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
@@ -28,6 +28,7 @@ class TestSwiftPrivateDeclName(TestBase):
         self.b_source_spec = lldb.SBFileSpec(self.b_source)
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_private_decl_name(self):
         """Test that we correctly find private decls"""
         self.build()

--- a/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
+++ b/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftPrivateNestedGenericClassTest(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Tests that a private generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
+++ b/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
+++ b/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftPrivateTypeAlias(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_private_typealias(self):
         """Test that we can correctly print variables whose types are private type aliases"""
         self.build()

--- a/lldb/test/API/lang/swift/private_var/TestSwiftPrivateVar.py
+++ b/lldb/test/API/lang/swift/private_var/TestSwiftPrivateVar.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
+++ b/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftProtocolCompositionExpr(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that expression evaluation can call functions in protocol composition existentials"""
 

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
@@ -8,6 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestDefaultProtocolExtensionNoSelfReference(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_protocol_default_extension_no_self_reference(self):
         """
         Test that we can resolve "self" even if there are no references to it in a dynamic context

--- a/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
+++ b/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
+++ b/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftRangeType(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_range_type(self):
         """Test the Swift.Range<T> type"""
         self.build()

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -22,6 +22,7 @@ import os
 class TestSwiftReferenceStorageTypes(TestBase):
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
+    @expectedFailureWindows
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()

--- a/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
+++ b/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
@@ -10,6 +10,7 @@ class TestSwiftReflectionLoading(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test that reflection metadata is imported"""
         self.build()

--- a/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
+++ b/lldb/test/API/lang/swift/reflection_only/TestSwiftReflectionOnly.py
@@ -10,6 +10,7 @@ class TestSwiftReflectionOnly(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @skipIfWindows
     def test(self):
         """Test debugging a program without swiftmodules is functional"""
         self.build()

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -25,6 +25,7 @@ class TestSwiftRegex(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_frame_var(self):
         """Test frame variable support for Swift regexes."""
@@ -37,6 +38,7 @@ class TestSwiftRegex(TestBase):
                     substrs=['(_StringProcessing.Regex<Substring>) dslRegex = {'])
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_expr_desc(self):
         """Test expression object description support for Swift regexes."""
@@ -49,6 +51,7 @@ class TestSwiftRegex(TestBase):
                     substrs=['Regex<Substring>'])
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_frame_var_desc(self):
         """Test frame variable object description support for Swift regexes."""
@@ -61,6 +64,7 @@ class TestSwiftRegex(TestBase):
                     substrs=['Regex<Substring>'])
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_expr(self):
         """Test expression support for Swift regexes."""
@@ -73,6 +77,7 @@ class TestSwiftRegex(TestBase):
                     substrs=['(_StringProcessing.Regex<Substring>) $R1 = {'])
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_in_exp(self):
         """Test Swift's regex support"""

--- a/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
+++ b/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
@@ -9,6 +9,7 @@ class TestSwiftResiliencePrivateField(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/runtime_failure_recognizer/TestSwiftRuntimeFailureRecognizer.py
+++ b/lldb/test/API/lang/swift/runtime_failure_recognizer/TestSwiftRuntimeFailureRecognizer.py
@@ -23,6 +23,7 @@ class TestSwiftRuntimeRecognizer(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_runtime_recognizer(self):
         """Test Swift Runtime Failure Recognizer"""
         self.build()

--- a/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
+++ b/lldb/test/API/lang/swift/runtime_instrumentation_recognizer/TestSwiftRuntimeInstrumentationRecognizer.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftRuntimeInstrumentationRecognizer(lldbtest.TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test Swift Runtime Instrumentation Recognizer"""
         self.build()

--- a/lldb/test/API/lang/swift/span/TestSwiftSpan.py
+++ b/lldb/test/API/lang/swift/span/TestSwiftSpan.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -24,6 +24,7 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_split_debug_info(self):
         """Test split debug info"""
         self.build()

--- a/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
+++ b/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
@@ -13,6 +13,7 @@ class TestContiguousArray(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_frame_contiguous_array(self):
         """Test that contiguous array prints correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
+++ b/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
@@ -9,6 +9,7 @@ class TestStepIntoOverride(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_stepping(self):
         self.build()
         self.do_test()

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -9,12 +9,14 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_stepping_api(self):
         """Test that step in using the Python API steps through thunk."""
         self.build()
         self.do_test(True)
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_stepping_cli(self):
         """Same test with the cli - it goes a slightly different path than
            the API."""

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -24,6 +24,7 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     @skipIf(oslist=["linux"], archs=no_match("x86_64"))
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""

--- a/lldb/test/API/lang/swift/string/TestSwiftString.py
+++ b/lldb/test/API/lang/swift/string/TestSwiftString.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftTuple(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test the String formatter under adverse conditions"""
         self.build()

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -22,6 +22,7 @@ import shutil
 
 class TestSwiftStructChangeRerun(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_struct_change_rerun(self):
         """Test that we display self correctly for an inline-initialized struct"""
         copied_main_swift = self.getBuildArtifact("main.swift")

--- a/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
+++ b/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
+++ b/lldb/test/API/lang/swift/swift-healthcheck/TestSwiftHealthCheck.py
@@ -9,6 +9,7 @@ class TestSwiftHealthCheck(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     @skipIfDarwinEmbedded
     def test_run_healthcheck(self):
         """Test that an underspecified triple is upgraded with a version number.

--- a/lldb/test/API/lang/swift/swift_callback/TestSwiftCallback.py
+++ b/lldb/test/API/lang/swift/swift_callback/TestSwiftCallback.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
+++ b/lldb/test/API/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
+++ b/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
@@ -7,6 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftSymbolicExtendedExistential(lldbtest.TestBase):
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test symbolic extended existentials"""
         self.build()

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftTuple(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftTypeMetadataTest(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_type_metadata(self):
         """Test that LLDB can effectively use the type metadata to reconstruct dynamic types for Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
+++ b/lldb/test/API/lang/swift/typealias/TestSwiftTypeAlias.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTypeAlias(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test type aliases are only searched in the debug info once"""
         self.build()

--- a/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
+++ b/lldb/test/API/lang/swift/typealias_othermodule/TestSwiftTypeAliasOthermodule.py
@@ -7,6 +7,7 @@ class TestSwiftTypeAliasOtherModule(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test_frame_variable(self):
         """Test that type aliases can be imported from reflection metadata"""
         self.build()
@@ -18,6 +19,7 @@ class TestSwiftTypeAliasOtherModule(TestBase):
         self.expect("frame variable -- payload", substrs=["Bool", "true"])
 
     @swiftTest
+    @expectedFailureWindows
     def test_expression(self):
         """Test that type aliases can be imported into expressions from reflection metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
+++ b/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
@@ -4,6 +4,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTypeAliasRecurtsive(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test that type aliases of type aliases can be resolved"""
         self.build()

--- a/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
+++ b/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
@@ -10,6 +10,7 @@ class TestSwiftCUnion(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_c_unions(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
+++ b/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
@@ -10,6 +10,7 @@ import os
 
 class TestSwiftActorTypes(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_class_types(self):
         """Test swift Actor types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
+++ b/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
@@ -24,6 +24,7 @@ class TestSwiftArrayType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
+    @expectedFailureWindows
     def test_array(self):
         """Check formatting for Swift.Array<T>"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
+++ b/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
@@ -21,6 +21,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftBool(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_bool(self):
         """Test that we can inspect various Swift bools"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -21,6 +21,7 @@ import os
 
 class TestBulkyEnumVariables(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_bulky_enum_variables(self):
         """Tests that large-size Enum variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftClassTypes(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_class_types(self):
         """Test swift Class types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
@@ -27,6 +27,7 @@ class TestSwiftConsumeOperatorType(TestBase):
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=['aarch64'], oslist=['linux'])
     @swiftTest
+    @expectedFailureWindows
     def test_swift_consume_operator(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -25,6 +25,7 @@ def stderr_print(line):
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.

--- a/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -84,6 +84,7 @@ class TestSwiftStdlibDictionary(TestBase):
                         (key_str, value_str)))
 
     @swiftTest
+    @expectedFailureWindows
     # @skipIfLinux  # bugs.swift.org/SR-844
     def test_swift_stdlib_dictionary(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary"""

--- a/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
@@ -21,6 +21,7 @@ import os
 
 class TestEnumVariables(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_enum_variables(self):
         """Tests that Enum variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
+++ b/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
@@ -16,6 +16,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftErrorType(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test handling of Swift Error types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
+++ b/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestFunctionVariables(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_function_variables(self):
         """Tests that function type variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -27,6 +27,7 @@ class TestSwiftGenericEnumTypes(TestBase):
         return var
 
     @swiftTest
+    @expectedFailureWindows
     def test_swift_generic_enum_types(self):
         """Test that we handle reasonably generically-typed enums"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
+++ b/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
@@ -27,6 +27,7 @@ class TestSwiftGenericTupleLabels(lldbtest.TestBase):
         lldbtest.TestBase.setUp(self)
 
     @swiftTest
+    @expectedFailureWindows
     def test_generic_tuple_labels(self):
         """Test that LLDB can reconstruct tuple labels from metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
+++ b/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftGenericTypes(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_generic_types(self):
         """Test support for generic types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftGlobals(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_globals(self):
         """Check that we can examine module globals in the expression parser"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -21,12 +21,14 @@ import os
 
 class TestIndirectEnumVariables(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_indirect_cases_variables(self):
         """Tests that indirect Enum variables display correctly when cases are indirect"""
         self.build()
         self.do_test("indirect case break here")
 
     @swiftTest
+    @expectedFailureWindows
     def test_indirect_enum_variables(self):
         """Tests that indirect Enum variables display correctly when enum is indirect"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -19,6 +19,7 @@ import os
 
 class TestInOutVariables(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_in_out_variables(self):
         """Test that @inout variables display reasonably"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
+++ b/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
@@ -6,6 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLetConstants(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_let_constants(self):
         """Test that let constants aren't writeable"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftOptionalType(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_optional_type(self):
         """Check formatting for T? and T!"""
         self.do_check_consistency()

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftProtocolTypes(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_protocol_types(self):
         """Test support for protocol types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftStdlibSet(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_stdlib_set(self):
         """Tests that we properly vend synthetic children for Swift.Set"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -24,6 +24,7 @@ import os
 
 class TestSwiftStaticStringVariables(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_static_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -24,6 +24,7 @@ import os
 
 class TestSwiftStringVariables(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
+++ b/lldb/test/API/lang/swift/variables/swift/TestSwiftTypes.py
@@ -21,6 +21,7 @@ import platform
 
 class TestSwiftTypes(TestBase):
     @swiftTest
+    @skipIfWindows
     def test_swift_types(self):
         """Test that we can inspect basic Swift types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -20,6 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTupleTypes(TestBase):
     @swiftTest
+    @expectedFailureWindows
     def test_swift_tuple_types(self):
         """Test support for tuple types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -1,4 +1,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
+++ b/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
@@ -15,6 +15,7 @@ class TestSwiftUnsafeTypes(TestBase):
         self.assertEqual(child.GetSummary(), 'nil')
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """Test formatters for unsafe types"""
         self.build()

--- a/lldb/test/API/lang/swift/zero_size_generic_self/TestSwiftZeroSizeGenericSelf.py
+++ b/lldb/test/API/lang/swift/zero_size_generic_self/TestSwiftZeroSizeGenericSelf.py
@@ -12,4 +12,6 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])
+lldbinline.MakeInlineTest(
+    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+)

--- a/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
+++ b/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
@@ -12,6 +12,7 @@ class TestSBValueUpdates(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
+    @decorators.expectedFailureWindows
     def test_update_and_format_with_type_change(self):
         """Test that an SBValue can update and format itself as its type
         changes"""


### PR DESCRIPTION
Enable Swift specific lldb tests on Windows and mark the failing tests as expected failures.

This depends on:
- https://github.com/swiftlang/llvm-project/pull/12127
- https://github.com/swiftlang/swift/pull/86580

With the above PRs, the results on Windows are as follow:
```
Total Discovered Tests: 2543
  Excluded         : 2010 (79.04%)
  Unsupported      :  223 (8.77%)
  Passed           :    7 (0.28%)
  Expectedly Failed:   48 (1.89%)
  Unresolved       :   36 (1.42%)
  Failed           :  219 (8.61%)
```

This patch marks the failed tests as expected failures and the unresolved ones as skipped on Windows. They will be gradually fixed in followup patches.