### PR TITLE
[lldb] Canonicalize field types when building field descriptors from …

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -309,21 +309,27 @@ public:
       auto tag = child_die.Tag();
       if (tag != llvm::dwarf::DW_TAG_member)
         continue;
-      const auto *member_field_name =
+      const char *member_field_name =
           child_die.GetAttributeValueAsString(llvm::dwarf::DW_AT_name, "");
       auto *member_type = dwarf_parser->GetTypeForDIE(child_die);
       if (!member_type)
         continue;
-      auto member_mangled_typename =
-          member_type->GetForwardCompilerType().GetMangledTypeName();
+      auto member_compiler_type = member_type->GetForwardCompilerType();
 
+      // TypeRefBuilder expects types to be canonical.
+      CompilerType canonical = m_type_system.Canonicalize(member_compiler_type);
+      if (!canonical) {
+        LLDB_LOG(GetLog(LLDBLog::Types), "Could not build canonical type: {0}",
+                 member_compiler_type.GetMangledTypeName());
+        canonical = member_compiler_type;
+      }
       // Only matters for enums, so set to false for structs.
       bool is_indirect_case = false;
       // Unused by type info construction.
       bool is_var = false;
       fields.emplace_back(std::make_unique<DWARFFieldRecordImpl>(
           is_indirect_case, is_var, ConstString(member_field_name),
-          member_mangled_typename));
+          canonical.GetMangledTypeName()));
     }
     return fields;
   }

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1651,6 +1651,22 @@ TypeSystemSwiftTypeRef::Canonicalize(swift::Demangle::Demangler &dem,
   return node;
 }
 
+CompilerType TypeSystemSwiftTypeRef::Canonicalize(CompilerType type) {
+  using namespace swift::Demangle;
+  auto mangled_name = type.GetMangledTypeName();
+  if (!mangled_name)
+    return {};
+  Demangler dem;
+  NodePointer node = GetDemangledType(dem, mangled_name.GetStringRef());
+  if (!node)
+    return {};
+  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
+  NodePointer canonical = GetCanonicalNode(dem, node, flavor);
+  NodePointer type_node = dem.createNode(Node::Kind::Type);
+  type_node->addChild(canonical, dem);
+  return RemangleAsType(dem, type_node, flavor);
+}
+
 swift::Demangle::NodePointer
 TypeSystemSwiftTypeRef::GetCanonicalNode(swift::Demangle::Demangler &dem,
                                          swift::Demangle::NodePointer node,

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -488,6 +488,10 @@ public:
   /// Lookup a type in the debug info.
   lldb::TypeSP FindTypeInModule(lldb::opaque_compiler_type_t type);
 
+  /// Desugar a CompilerType and resolve type aliases by looking up
+  /// their types in the debug info.
+  CompilerType Canonicalize(CompilerType type);
+
   /// Returns the mangling flavor associated with the ASTContext corresponding
   /// with this TypeSystem.
   swift::Mangle::ManglingFlavor

--- a/lldb/test/API/lang/swift/embedded/typealias/Makefile
+++ b/lldb/test/API/lang/swift/embedded/typealias/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/typealias/TestSwiftEmbeddedTypealias.py
+++ b/lldb/test/API/lang/swift/embedded/typealias/TestSwiftEmbeddedTypealias.py
@@ -1,0 +1,34 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedTypealias(TestBase):
+
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect("frame variable simple", substrs=["x = 42"])
+
+        self.expect("frame variable multi", substrs=["i = 1", "d = 2.5", "b = true"])
+
+        self.expect("frame variable optionalNil", substrs=["maybeInt = nil"])
+        self.expect("frame variable optionalSome", substrs=["maybeInt = 99"])
+
+        self.expect("frame variable tupleStruct.pair", substrs=["0 = 10", "1 = 20"])
+
+        self.expect("frame variable nestedAlias", substrs=["nested = 123"])
+
+        self.expect("frame variable genericAlias", substrs=["value = 314", "aliased = 100"])
+
+        self.expect("frame variable classAlias", substrs=["x = 500"])
+
+        self.expect("frame variable outer", substrs=["x = 777"])

--- a/lldb/test/API/lang/swift/embedded/typealias/main.swift
+++ b/lldb/test/API/lang/swift/embedded/typealias/main.swift
@@ -1,0 +1,72 @@
+typealias MyInt = Int
+typealias MyDouble = Double
+typealias MyBool = Bool
+
+typealias IntPair = (Int, Int)
+typealias MixedTuple = (Int, Double, Bool)
+
+typealias AliasOfMyInt = MyInt
+
+struct SimpleStruct {
+    var x: MyInt
+}
+
+struct MultiFieldStruct {
+    var i: MyInt
+    var d: MyDouble
+    var b: MyBool
+}
+
+struct OptionalStruct {
+    var maybeInt: MyInt?
+}
+
+struct TupleStruct {
+    var pair: IntPair
+    var mixed: MixedTuple
+}
+
+struct NestedAliasStruct {
+    var nested: AliasOfMyInt
+}
+
+struct GenericWithAlias<T> {
+    var value: T
+    var aliased: MyInt
+}
+
+final class ClassWithAlias {
+    var x: MyInt
+    init(x: MyInt) { self.x = x }
+}
+
+struct Outer {
+    typealias InnerInt = Int
+    struct Inner {
+        var x: InnerInt
+    }
+    var inner: Inner
+}
+
+func test() {
+    let simple = SimpleStruct(x: 42)
+
+    let multi = MultiFieldStruct(i: 1, d: 2.5, b: true)
+
+    let optionalNil = OptionalStruct(maybeInt: nil)
+    let optionalSome = OptionalStruct(maybeInt: 99)
+
+    let tupleStruct = TupleStruct(pair: (10, 20), mixed: (1, 2.5, false))
+
+    let nestedAlias = NestedAliasStruct(nested: 123)
+
+    let genericAlias = GenericWithAlias<Int>(value: 314, aliased: 100)
+
+    let classAlias = ClassWithAlias(x: 500)
+
+    let outer = Outer(inner: Outer.Inner(x: 777))
+
+    print("break here") // break here
+}
+
+test()


### PR DESCRIPTION
…DWARF

When building field descriptors from DWARF for embedded Swift, TypeRef builder expect the types to be canonical (no sugar or typealiases).

rdar://169814158