### PR TITLE
🍒 [clang] Canonicalizing `-include-pch` input in the Frontend (#180065)

### DIFF
--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1058,20 +1058,29 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     return true;
   }
 
-  // If the implicit PCH include is actually a directory, rather than
-  // a single file, search for a suitable PCH file in that directory.
   if (!CI.getPreprocessorOpts().ImplicitPCHInclude.empty()) {
     FileManager &FileMgr = CI.getFileManager();
     PreprocessorOptions &PPOpts = CI.getPreprocessorOpts();
-    StringRef PCHInclude = PPOpts.ImplicitPCHInclude;
     CI.getLangOpts().NeededByPCHOrCompilationUsesPCH = true;
-    std::string SpecificModuleCachePath = CI.getSpecificModuleCachePath();
+
+    // Canonicalize ImplicitPCHInclude. This way, all the downstream code,
+    // including the ASTWriter, will receive the absolute path to the included
+    // PCH.
+    SmallString<128> PCHIncludePath(PPOpts.ImplicitPCHInclude);
+    FileMgr.makeAbsolutePath(PCHIncludePath);
+    llvm::sys::path::remove_dots(PCHIncludePath, true);
+    PPOpts.ImplicitPCHInclude = PCHIncludePath.str();
+    StringRef PCHInclude = PPOpts.ImplicitPCHInclude;
+
+    // If the implicit PCH include is actually a directory, rather than
+    // a single file, search for a suitable PCH file in that directory.
     if (auto PCHDir = FileMgr.getOptionalDirectoryRef(PCHInclude)) {
       std::error_code EC;
       SmallString<128> DirNative;
       llvm::sys::path::native(PCHDir->getName(), DirNative);
       bool Found = false;
       llvm::vfs::FileSystem &FS = FileMgr.getVirtualFileSystem();
+      std::string SpecificModuleCachePath = CI.getSpecificModuleCachePath();
       for (llvm::vfs::directory_iterator Dir = FS.dir_begin(DirNative, EC),
                                          DirEnd;
            Dir != DirEnd && !EC; Dir.increment(EC)) {

--- a/clang/lib/Serialization/ASTWriter.cpp
+++ b/clang/lib/Serialization/ASTWriter.cpp
@@ -1786,6 +1786,11 @@ void ASTWriter::WriteControlBlock(Preprocessor &PP, StringRef isysroot) {
   Record.push_back(PPOpts.UsePredefines);
   // Detailed record is important since it is used for the module cache hash.
   Record.push_back(PPOpts.DetailedRecord);
+
+  // FIXME: Using `AddString` to record `ImplicitPCHInclude` does not handle
+  // relocatable files. We probably should call
+  // `AddPath(PPOpts.ImplicitPCHInclude, Record)` to properly support chained
+  // relocatable PCHs.
   AddString(PPOpts.ImplicitPCHInclude, Record);
   Record.push_back(static_cast<unsigned>(PPOpts.ObjCXXARCStandardLibrary));
   Stream.EmitRecord(PREPROCESSOR_OPTIONS, Record);
@@ -6166,6 +6171,10 @@ ASTFileSignature ASTWriter::WriteASTCore(Sema *SemaPtr, StringRef isysroot,
 
         endian::Writer LE(Out, llvm::endianness::little);
         LE.write<uint8_t>(static_cast<uint8_t>(M.Kind));
+        // FIXME: Storing a PCH's name (M.FileName) as a string does not handle
+        // relocatable files. We probably should call
+        // `PreparePathForOutput(M.FileName)` to properly support relocatable
+        // PCHs.
         StringRef Name = M.isModule() ? M.ModuleName : M.FileName;
         LE.write<uint16_t>(Name.size());
         Out.write(Name.data(), Name.size());

--- a/clang/test/Modules/validate-file-content.m
+++ b/clang/test/Modules/validate-file-content.m
@@ -26,7 +26,7 @@
 // RUN: not %clang_cc1 -fsyntax-only -fmodules-cache-path=%t/cache -fmodules -fimplicit-module-maps -I %t -include-pch %t/a.pch %s -fvalidate-ast-input-files-content 2> %t/stderr
 // RUN: FileCheck %s < %t/stderr
 //
-// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*/a\.pch]]' was built: content changed
+// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*[/\\]a\.pch]]' was built: content changed
 // CHECK: '[[M_H]]' required by '[[M_PCM:.*[/\\]m.*\.pcm]]'
 // CHECK: '[[M_PCM]]' required by '[[A_PCH]]'
 // CHECK: please rebuild precompiled file '[[A_PCH]]'

--- a/clang/test/PCH/debug-info-pch-path.c
+++ b/clang/test/PCH/debug-info-pch-path.c
@@ -17,6 +17,7 @@
 // RUN: %clang_cc1 -debug-info-kind=standalone                  \
 // RUN:     -dwarf-ext-refs -fmodule-format=obj                 \
 // RUN:     -triple %itanium_abi_triple                         \
+// RUN:     -fdebug-compilation-dir=%t                          \
 // RUN:     -include-pch prefix.pch %s -emit-llvm -o %t.nodir.ll %s
 // RUN: cat %t.nodir.ll | FileCheck %s --check-prefix=CHECK-REL-NODIR
 //
@@ -42,6 +43,7 @@
 // RUN: %clang_cc1 -debug-info-kind=standalone                  \
 // RUN:     -dwarf-ext-refs -fmodule-format=obj                 \
 // RUN:     -triple %itanium_abi_triple                         \
+// RUN:     -fdebug-compilation-dir=%t                          \
 // RUN:     -include-pch pchdir/prefix.pch %s -emit-llvm -o %t.rel.ll %s
 // RUN: cat %t.rel.ll | FileCheck %s --check-prefix=CHECK-REL
 

--- a/clang/test/PCH/modified-module-dependency.m
+++ b/clang/test/PCH/modified-module-dependency.m
@@ -14,7 +14,7 @@
 // RUN: not %clang_cc1 -x objective-c -I %t-dir -include-pch %t-dir/prefix.pch -fmodules -fimplicit-module-maps -fmodules-cache-path=%t-dir/cache -fdisable-module-hash -fsyntax-only %s 2> %t-dir/log
 // RUN: FileCheck %s < %t-dir/log
 
-// CHECK: file '[[TEST_H:.*[/\\]test\.h]]' has been modified since the precompiled header '[[PREFIX_PCH:.*/prefix\.pch]]' was built
+// CHECK: file '[[TEST_H:.*[/\\]test\.h]]' has been modified since the precompiled header '[[PREFIX_PCH:.*[/\\]prefix\.pch]]' was built
 // CHECK: '[[TEST_H]]' required by '[[TEST_PCM:.*[/\\]test\.pcm]]'
 // CHECK: '[[TEST_PCM]]' required by '[[PREFIX_PCH]]'
 // CHECK: please rebuild precompiled file '[[PREFIX_PCH]]'

--- a/clang/test/PCH/pch-input-path-independent.c
+++ b/clang/test/PCH/pch-input-path-independent.c
@@ -1,0 +1,29 @@
+// Testing `-include-pch` canonicalization.
+// When PCHs are chained, the dependent PCHs produced are identical
+// whether the included PCH is specified through a relative path or an absolute
+// path (bridging1.h.pch vs bridging2.h.pch).
+// The dependent PCHs are also identical regardless of the working
+// directory where clang is invoked (bridging1.h.pch vs bridging3.h.pch).
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: cd %t
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -emit-pch h1.h -o %t/h1.h.pch
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -emit-pch %t/bridging.h \
+// RUN:  -o %t/bridging1.h.pch -include-pch %t/h1.h.pch
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -emit-pch %t/bridging.h \
+// RUN:  -o %t/bridging2.h.pch -include-pch ./h1.h.pch
+// RUN: mkdir %t/wd/
+// RUN: cd %t/wd/
+// RUN: %clang_cc1 -triple x86_64-apple-macos11 -emit-pch %t/bridging.h \
+// RUN:  -o %t/bridging3.h.pch -include-pch ../h1.h.pch
+
+// RUN: diff %t/bridging1.h.pch %t/bridging2.h.pch
+// RUN: diff %t/bridging1.h.pch %t/bridging3.h.pch
+
+//--- h1.h
+int bar1() { return 42; }
+
+//--- bridging.h
+int bar() { return bar1(); }
+

--- a/clang/test/PCH/validate-file-content.m
+++ b/clang/test/PCH/validate-file-content.m
@@ -24,6 +24,6 @@
 // RUN: not %clang_cc1 -fsyntax-only -I %t -include-pch %t/a.pch %s -fvalidate-ast-input-files-content 2> %t/stderr
 // RUN: FileCheck %s < %t/stderr
 //
-// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*/a\.pch]]' was built: content changed
+// CHECK: file '[[M_H:.*[/\\]m\.h]]' has been modified since the precompiled header '[[A_PCH:.*[/\\]a\.pch]]' was built: content changed
 // CHECK: please rebuild precompiled file '[[A_PCH]]'
 // expected-no-diagnostics


### PR DESCRIPTION
This patch adds logic to canonicalize `-include-pch`'s input in the frontend. This way, the `ASTWriter` always serializes the canonicalized path to the included pch file whether the input is an absolute path or a relative path.

Fixes rdar://168596546.

(cherry picked from commit f7aa1cdc9b91493c56425505faa0cec3dfac5441)