### PR TITLE
🍒 [21.x][BoundsSafety] fix counted_by on ObjC methods in ObjC++ mode

### DIFF
--- a/clang/include/clang/Sema/SemaObjC.h
+++ b/clang/include/clang/Sema/SemaObjC.h
@@ -396,6 +396,13 @@ public:
   void AddAnyMethodToGlobalPool(Decl *D);
 
   void ActOnStartOfObjCMethodDef(Scope *S, Decl *D);
+
+  /// Set CurContext to @c D, to prevent semantic errors when late parsing
+  /// expressions in attributes. This does not setup the context needed for
+  /// parsing a method body.
+  void ActOnEnterObjCMethodContextForLateParsedAttrs(Scope *S,
+                                                     ObjCMethodDecl *D);
+
   bool isObjCMethodDecl(Decl *D) { return isa_and_nonnull<ObjCMethodDecl>(D); }
 
   /// CheckImplementationIvars - This routine checks if the instance variables

--- a/clang/lib/Parse/ParseObjc.cpp
+++ b/clang/lib/Parse/ParseObjc.cpp
@@ -1405,8 +1405,14 @@ Decl *Parser::ParseObjCMethodDecl(SourceLocation mLoc,
       LateAttr->addDecl(Result);
     }
     LateParsedAttrs.append(LateParsedReturnAttrs);
+    // The parsing of ObjC methods differs enough from C functions and C++
+    // methods that it's easier to enter the context here rather than in
+    // ParseLexedCAttribute.
+    Actions.ObjC().ActOnEnterObjCMethodContextForLateParsedAttrs(
+        getCurScope(), cast<ObjCMethodDecl>(Result));
     ParseLexedCAttributeList(LateParsedAttrs,
                              /*we already have parameters in scope*/ false);
+    Actions.ActOnExitFunctionContext();
   }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 

--- a/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/clang/lib/Sema/SemaDeclObjC.cpp
@@ -382,6 +382,11 @@ static void copyDomainAvailabilityAttr(ObjCMethodDecl *MD, Sema &SemaRef) {
     SemaRef.copyFeatureAvailabilityCheck(MD, IDecl, true);
 }
 
+void SemaObjC::ActOnEnterObjCMethodContextForLateParsedAttrs(Scope *S, ObjCMethodDecl *D) {
+  SemaRef.PushDeclContext(S, D);
+  // parameters are already added to scope
+}
+
 /// ActOnStartOfObjCMethodDef - This routine sets up parameters; invisible
 /// and user declared, in the method definition's AST.
 void SemaObjC::ActOnStartOfObjCMethodDef(Scope *FnBodyScope, Decl *D) {

--- a/clang/test/BoundsSafety/AST/objc.m
+++ b/clang/test/BoundsSafety/AST/objc.m
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -Wno-deprecated-declarations -Wno-return-type -Wno-objc-root-class -ast-dump %s 2>&1 | FileCheck --check-prefixes=COMMON-CHECK,BOUNDS-CHECK %s
 // RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c -Wno-deprecated-declarations -Wno-return-type -Wno-objc-root-class -ast-dump %s 2>&1 | FileCheck --check-prefixes=COMMON-CHECK,ATTR-CHECK %s
 
+// RUN: %clang_cc1 -fexperimental-bounds-safety-attributes -x objective-c++ -Wno-deprecated-declarations -Wno-return-type -Wno-objc-root-class -ast-dump %s 2>&1 | FileCheck --check-prefixes=COMMON-CHECK,ATTR-CHECK %s
+
 #include <ptrcheck.h>
 
 @protocol CountedByProtocol


### PR DESCRIPTION
[BoundsSafety] fix counted_by on ObjC methods in ObjC++ mode

(cherry picked from commit ef1fb95ef264c14da281b5245dd439746a168bd3)