### PR TITLE
test: adjust plugin file prefix

### DIFF
--- a/clang/test/CAS/libclang-replay-job.c
+++ b/clang/test/CAS/libclang-replay-job.c
@@ -6,7 +6,7 @@
 
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
 // RUN:   -format experimental-include-tree-full \
-// RUN:   -cas-path %t/cas -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -cas-path %t/cas -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option no-logging \
 // RUN:   > %t/deps.json
 
@@ -25,7 +25,7 @@
 // RUN:   -e "s/' .*$//" > %t/cache-key
 
 // RUN: c-index-test core -upload-cached-job -cas-path %t/cas @%t/cache-key -test-cas-cancellation \
-// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option upstream-path=%t/cas-upstream \
 // RUN:   2>&1 | FileCheck %s --check-prefix=UPLOAD-CANCEL
 // UPLOAD-CANCEL: actioncache_put_for_digest_async cancelled
@@ -36,21 +36,21 @@
 // Re-run the scan to populate the include-tree in the cas
 // RUN: clang-scan-deps -compilation-database %t/cdb.json \
 // RUN:   -format experimental-include-tree-full \
-// RUN:   -cas-path %t/cas -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -cas-path %t/cas -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option no-logging \
 // RUN:   > %t/deps2.json
 // RUN: diff -u %t/deps.json %t/deps2.json
 
 
 // RUN: c-index-test core -materialize-cached-job -cas-path %t/cas @%t/cache-key -test-cas-cancellation \
-// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option upstream-path=%t/cas-upstream \
 // RUN:   2>&1 | FileCheck %s --check-prefix=MATERIALIZE-CANCEL
 // MATERIALIZE-CANCEL: actioncache_get_for_digest_async cancelled
 // MATERIALIZE-CANCEL: load_object_async cancelled
 
 // RUN: c-index-test core -replay-cached-job -cas-path %t/cas @%t/cache-key \
-// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option no-logging \
 // RUN:   -working-dir %t \
 // RUN: -- @%t/cc1.rsp \
@@ -66,7 +66,7 @@
 // RUN: mkdir -p %t/a/b
 // RUN: cd %t/a
 // RUN: c-index-test core -replay-cached-job -cas-path %t/cas @%t/cache-key \
-// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option no-logging \
 // RUN:   -working-dir %t/a/b \
 // RUN: -- @%t/cc1.rsp \
@@ -80,7 +80,7 @@
 // Check with -fdiagnostics-absolute-path
 // RUN: cd %t
 // RUN: c-index-test core -replay-cached-job -cas-path %t/cas @%t/cache-key \
-// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext \
+// RUN:   -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext \
 // RUN:   -fcas-plugin-option no-logging \
 // RUN:   -working-dir %t \
 // RUN: -- @%t/cc1.rsp \

--- a/clang/test/CAS/print-compile-job-cache-key.c
+++ b/clang/test/CAS/print-compile-job-cache-key.c
@@ -27,10 +27,10 @@
 
 // Print key from plugin CAS.
 // RUN: %clang -cc1depscan -fdepscan=inline -o %t/inc-plugin.rsp -cc1-args -cc1 -triple x86_64-apple-macos11 -emit-obj \
-// RUN:   %s -o %t/output-plugin.o -fcas-path %t/cas-plugin -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext
+// RUN:   %s -o %t/output-plugin.o -fcas-path %t/cas-plugin -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext
 // RUN: %clang @%t/inc-plugin.rsp -Rcompile-job-cache-miss 2> %t/output-plugin.txt
 // RUN: cat %t/output-plugin.txt | sed \
 // RUN:   -e "s/^.*miss for '//" \
 // RUN:   -e "s/' .*$//" > %t/cache-key-plugin
 // RUN: clang-cas-test -print-compile-job-cache-key -cas %t/cas-plugin @%t/cache-key-plugin \
-// RUN:   -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext | FileCheck %s -check-prefix=INCLUDE_TREE_KEY -check-prefix=INCLUDE_TREE -DSRC_FILE=%s
+// RUN:   -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext | FileCheck %s -check-prefix=INCLUDE_TREE_KEY -check-prefix=INCLUDE_TREE -DSRC_FILE=%s

--- a/llvm/test/tools/llvm-cas/ingest.test
+++ b/llvm/test/tools/llvm-cas/ingest.test
@@ -7,9 +7,9 @@ RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
 RUN: llvm-cas --cas %t/cas --ls-tree-recursive @%t/cas.id | FileCheck %s
 
 // Using the plugin.
-RUN: llvm-cas --cas plugin://%llvmshlibdir/libCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ingest %S/Inputs > %t/cas-plugin.id
-RUN: llvm-cas --cas plugin://%llvmshlibdir/libCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ls-tree-recursive @%t/cas-plugin.id | FileCheck %s
-RUN: llvm-cas --cas %t/cas-plugin -fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext --ls-tree-recursive @%t/cas-plugin.id | FileCheck %s
+RUN: llvm-cas --cas plugin://%llvmshlibdir/%pluginpreCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ingest %S/Inputs > %t/cas-plugin.id
+RUN: llvm-cas --cas plugin://%llvmshlibdir/%pluginpreCASPluginTest%pluginext?ondisk-path=%t/cas-plugin --ls-tree-recursive @%t/cas-plugin.id | FileCheck %s
+RUN: llvm-cas --cas %t/cas-plugin -fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext --ls-tree-recursive @%t/cas-plugin.id | FileCheck %s
 
 CHECK: syml
 CHECK-SAME: broken_symlink -> missing
@@ -40,5 +40,5 @@ CHECK-NODE-REFS: llvmcas://
 CHECK-NODE-REFS: llvmcas://
 
 // Test exporting the entire tree.
-RUN: llvm-cas --cas %t/new-cas --fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext --upstream-cas %t/cas --import @%t/cas.id > %t/plugin.id
-RUN: llvm-cas --cas %t/new-cas --fcas-plugin-path %llvmshlibdir/libCASPluginTest%pluginext --ls-tree-recursive @%t/plugin.id | FileCheck %s
+RUN: llvm-cas --cas %t/new-cas --fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext --upstream-cas %t/cas --import @%t/cas.id > %t/plugin.id
+RUN: llvm-cas --cas %t/new-cas --fcas-plugin-path %llvmshlibdir/%pluginpreCASPluginTest%pluginext --ls-tree-recursive @%t/plugin.id | FileCheck %s


### PR DESCRIPTION
`%pluginpre` is a substitution that expands according to the platform. This allows us to expand the library name properly on Windows.