### PR TITLE
[CoroSplit] Tag the remaining async funclets 

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -898,8 +898,8 @@ static void eraseIntrinsicRetPoplessBefore(ReturnInst *Return) {
 }
 
 // BEGIN SWIFT
-/// Identify which async funclets push or pop async frames, updating `NewAttrs`
-/// accordingly.
+/// Identify which async funclets push or pop async frames, and those that are
+/// continuation funclets, updating `NewAttrs` accordingly.
 static void
 appendSwiftAsyncAttributes(AttributeList &NewAttrs, Function &OrigF,
                            CoroSuspendAsyncInst &ActiveAsyncSuspend) {
@@ -911,8 +911,8 @@ appendSwiftAsyncAttributes(AttributeList &NewAttrs, Function &OrigF,
   if (HasAsyncEntryAttribute) {
     auto &Ctx = OrigF.getContext();
     NewAttrs = NewAttrs.removeFnAttribute(Ctx, "async_entry");
-    if (IsAsyncFramePop)
-      NewAttrs = NewAttrs.addFnAttribute(Ctx, "async_ret");
+    NewAttrs = NewAttrs.addFnAttribute(
+        Ctx, IsAsyncFramePop ? "async_ret" : "async_continuation");
   }
 }
 // END SWIFT

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -897,6 +897,26 @@ static void eraseIntrinsicRetPoplessBefore(ReturnInst *Return) {
   Intr->eraseFromParent();
 }
 
+// BEGIN SWIFT
+/// Identify which async funclets push or pop async frames, updating `NewAttrs`
+/// accordingly.
+static void
+appendSwiftAsyncAttributes(AttributeList &NewAttrs, Function &OrigF,
+                           CoroSuspendAsyncInst &ActiveAsyncSuspend) {
+  const bool HasAsyncEntryAttribute = OrigF.hasFnAttribute("async_entry");
+  const StringRef ProjectionFunctionName =
+      ActiveAsyncSuspend.getAsyncContextProjectionFunction()->getName();
+  const bool IsAsyncFramePop =
+      ProjectionFunctionName == "__swift_async_resume_project_context";
+  if (HasAsyncEntryAttribute) {
+    auto &Ctx = OrigF.getContext();
+    NewAttrs = NewAttrs.removeFnAttribute(Ctx, "async_entry");
+    if (IsAsyncFramePop)
+      NewAttrs = NewAttrs.addFnAttribute(Ctx, "async_ret");
+  }
+}
+// END SWIFT
+
 /// Clone the body of the original function into a resume function of
 /// some sort.
 void coro::BaseCloner::create() {
@@ -991,21 +1011,9 @@ void coro::BaseCloner::create() {
     // Transfer the original function's attributes.
     auto FnAttrs = OrigF.getAttributes().getFnAttrs();
     NewAttrs = NewAttrs.addFnAttributes(Context, AttrBuilder(Context, FnAttrs));
-
-    // Mark async funclets that "pop the frame" if the async function is marked
-    // with the `async_entry` function attribute. Remove the `async_entry`
-    // attribute from clones.
-    bool HasAsyncEntryAttribute = OrigF.hasFnAttribute("async_entry");
-    auto ProjectionFunctionName =
-        ActiveAsyncSuspend->getAsyncContextProjectionFunction()->getName();
-    bool IsAsyncFramePop =
-      ProjectionFunctionName == "__swift_async_resume_project_context";
-    if (HasAsyncEntryAttribute) {
-      NewAttrs = NewAttrs.removeFnAttribute(Context, "async_entry");
-      if (IsAsyncFramePop) {
-        NewAttrs = NewAttrs.addFnAttribute(Context, "async_ret");
-      }
-    }
+    // BEGIN SWIFT
+    appendSwiftAsyncAttributes(NewAttrs, OrigF, *ActiveAsyncSuspend);
+    // END SWIFT
     break;
   }
   case coro::ABI::Retcon:

--- a/llvm/test/Transforms/Coroutines/coro-async.ll
+++ b/llvm/test/Transforms/Coroutines/coro-async.ll
@@ -145,7 +145,9 @@ define void @my_async_function_pa(ptr %ctxt, ptr %task, ptr %actor) {
 
 ; CHECK-LABEL: define internal swiftcc void @my_async_functionTQ0_(ptr readonly swiftasync captures(none) %0, ptr %1, ptr readnone captures(none) %2)
 ; CHECK-O0-LABEL: define internal swiftcc void @my_async_functionTQ0_(ptr swiftasync %0, ptr %1, ptr %2)
+; BEGIN SWIFT
 ; CHECK-SAME: #[[ATTRS:[0-9]+]]
+; END SWIFT
 ; CHECK-SAME: !dbg ![[SP2:[0-9]+]] {
 ; CHECK: entryresume.0:
 ; CHECK:   [[CALLER_CONTEXT:%.*]] = load ptr, ptr %0
@@ -544,7 +546,9 @@ declare ptr @hide(ptr)
 !llvm.dbg.cu = !{!2}
 !llvm.module.flags = !{!0}
 
+; BEGIN SWIFT
 ; CHECK: #[[ATTRS]] = {{.*}}async_ret
+; END SWIFT
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 ; CHECK: ![[SP1]] = distinct !DISubprogram(name: "my_async_function",

--- a/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
+++ b/llvm/test/Transforms/Coroutines/swift-async-dbg.ll
@@ -14,7 +14,7 @@ target datalayout = "e-m:o-i64:64-i128:128-n32:64-S128"
 ;                          with it at the coroutine entry.
 ; We check that, for each funclet, the debug intrinsics are propagated properly AND that
 ; an `entry_value` operation is created.
-define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
+define swifttailcc void @coroutineA(ptr swiftasync %arg) "async_entry" !dbg !48 {
   %var_with_dbg_value = alloca ptr, align 8
   %var_with_dbg_declare = alloca ptr, align 8
   call void @llvm.dbg.declare(metadata ptr %var_with_dbg_declare, metadata !500, metadata !DIExpression()), !dbg !54
@@ -23,6 +23,7 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
   %i3 = call ptr @llvm.coro.begin(token %i2, ptr null)
 ; CHECK-LABEL: define {{.*}} @coroutineA(
 ; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]])
+; CHECK-SAME: #[[ATTR_ENTRY:[0-9]+]]
 ; CHECK:      %[[frame_ptr_alloca:.*]] = alloca ptr
 ; CHECK:      #dbg_declare(ptr %[[frame_ptr_alloca]], {{.*}} !DIExpression(
 ; CHECK-SAME:                   DW_OP_deref, DW_OP_plus_uconst, 24)
@@ -43,7 +44,7 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
   %i19 = call swiftcc ptr @swift_task_alloc(i64 %i18), !dbg !54
 ; CHECK-NOT: define
 ; CHECK-LABEL: define {{.*}} @coroutineATY0_(
-; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]]) !dbg ![[ATY0:[0-9]*]]
+; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]]) #[[ATTR_CONTINUATION:[0-9]+]] !dbg ![[ATY0:[0-9]*]]
 ; CHECK:      #dbg_declare(ptr %[[frame_ptr]], {{.*}} !DIExpression(
 ; CHECK-SAME:                   DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24)
 ; CHECK:      #dbg_value(ptr %[[frame_ptr]], {{.*}} !DIExpression(
@@ -64,6 +65,7 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
 ; CHECK-NOT: define
 ; CHECK-LABEL: define {{.*}} @coroutineATQ1_(
 ; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]])
+; CHECK-SAME: #[[ATTR_RET:[0-9]+]]
 ; Note the extra level of indirection that shows up here!
 ; CHECK:      #dbg_declare(ptr %[[frame_ptr]], {{.*}} !DIExpression(
 ; CHECK-SAME:                   DW_OP_LLVM_entry_value, 1, DW_OP_deref, DW_OP_plus_uconst, 24)
@@ -80,10 +82,14 @@ define swifttailcc void @coroutineA(ptr swiftasync %arg) !dbg !48 {
 ; CHECK-NOT: define
 ; CHECK-LABEL: define {{.*}} @coroutineATY2_(
 ; CHECK-SAME:    ptr swiftasync %[[frame_ptr:.*]])
+; CHECK-SAME: #[[ATTR_CONTINUATION]]
 ; CHECK:      #dbg_declare(ptr %[[frame_ptr]], {{.*}} !DIExpression(
 ; CHECK-SAME:                   DW_OP_LLVM_entry_value, 1, DW_OP_plus_uconst, 24)
 }
 
+; CHECK: #[[ATTR_ENTRY]] = {{.*}}async_entry
+; CHECK: #[[ATTR_CONTINUATION]] = {{.*}}async_continuation
+; CHECK: #[[ATTR_RET]] = {{.*}}async_ret
 ; CHECK: ![[ATY0]] = {{.*}}DISubprogram(linkageName: "coroutineATY0_", {{.*}} scopeLine: 42
 
 ; Everything from here on is just support code for the coroutines.


### PR DESCRIPTION
This PR contains a commit with some NFC refactoring to isolate downstream-only code, and another commit tagging the remaining swift async funclets. Please see each commit in isolation.