### PR TITLE
[lldb][windows] early return if Python can not be loaded

### DIFF
--- a/lldb/include/lldb/Host/windows/PythonPathSetup/PythonPathSetup.h
+++ b/lldb/include/lldb/Host/windows/PythonPathSetup/PythonPathSetup.h
@@ -44,4 +44,8 @@ bool AddPythonDLLToSearchPath();
 ///   again if python3xx.dll can be loaded.
 llvm::Error SetupPythonRuntimeLibrary();
 
+// BEGIN SWIFT
+extern const std::string g_python_installation_note;
+// END SWIFT
+
 #endif // LLDB_SOURCE_HOST_PYTHONPATHSETUP_H

--- a/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
+++ b/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
@@ -8,3 +8,9 @@ endif()
 if(DEFINED LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME)
   target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME="${LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME}")
 endif()
+# BEGIN SWIFT
+find_package(Python ${Python3_VERSION} EXACT COMPONENTS Interpreter Development)
+if((DEFINED Python3_VERSION_MAJOR) AND (DEFINED Python3_VERSION_MINOR))
+  target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_VERSION="${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+endif()
+# END SWIFT

--- a/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
+++ b/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
@@ -93,3 +93,21 @@ llvm::Error SetupPythonRuntimeLibrary() {
 #endif
   return Error::success();
 }
+
+// BEGIN SWIFT
+const std::string g_python_installation_note =
+    "Ensure Python " LLDB_PYTHON_VERSION " "
+#if defined(_M_ARM64)
+    "(arm64)"
+#elif defined(_M_AMD64)
+    "(x64)"
+#endif
+    " is installed and available in your Path.\n"
+    "Pre-built binaries are available at "
+#if defined(_M_ARM64)
+    "https://nuget.org (search 'python')\n";
+#elif defined(_M_AMD64)
+    "https://python.org\n";
+#endif
+;
+// END SWIFT

--- a/lldb/tools/driver/Driver.cpp
+++ b/lldb/tools/driver/Driver.cpp
@@ -746,8 +746,13 @@ int main(int argc, char const *argv[]) {
 #endif
 
 #ifdef _WIN32
-  if (llvm::Error error = SetupPythonRuntimeLibrary())
+  if (llvm::Error error = SetupPythonRuntimeLibrary()) {
     llvm::WithColor::error() << llvm::toString(std::move(error)) << '\n';
+    // BEGIN SWIFT
+    llvm::WithColor::note() << g_python_installation_note;
+    return 1;
+    // END SWIFT
+  }
 #endif
 
   // Parse arguments.

--- a/lldb/tools/lldb-dap/tool/lldb-dap.cpp
+++ b/lldb/tools/lldb-dap/tool/lldb-dap.cpp
@@ -379,8 +379,13 @@ int main(int argc, char *argv[]) {
 #endif
 
 #ifdef _WIN32
-  if (llvm::Error error = SetupPythonRuntimeLibrary())
+  if (llvm::Error error = SetupPythonRuntimeLibrary()) {
     llvm::WithColor::error() << llvm::toString(std::move(error)) << '\n';
+    // BEGIN SWIFT
+    llvm::WithColor::note() << g_python_installation_note;
+    return 1;
+    // END SWIFT
+  }
 #endif
 
   llvm::SmallString<256> program_path(argv[0]);


### PR DESCRIPTION
Add an error message explaining where to install Python and which version to install, and return (1) right after. upstream, if Python is not found, we still try to run lldb, in case our Python check failed due to a false positive. In Swiftlang, we control the build environment better and we can exit with an error instead.

This allows for a clearer error message by gracefully exiting lldb rather than crashing.

<img width="1074" height="177" alt="Screenshot 2026-03-11 at 16 56 53" src="https://github.com/user-attachments/assets/e09ea378-7692-4a84-b7de-dd3b73c1702e" />

This should be merged after:
- https://github.com/swiftlang/llvm-project/pull/12343