### PR TITLE
[stable/21.x][llvm/CAS] Add file-based APIs to `OnDiskGraphDB`

### DIFF
--- a/llvm/include/llvm/CAS/BuiltinObjectHasher.h
+++ b/llvm/include/llvm/CAS/BuiltinObjectHasher.h
@@ -40,6 +40,8 @@ public:
     return H.finish();
   }
 
+  static Expected<HashT> hashFile(StringRef FilePath);
+
 private:
   HashT finish() { return Hasher.final(); }
 

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -262,6 +262,19 @@ public:
   LLVM_ABI_FOR_TEST Error store(ObjectID ID, ArrayRef<ObjectID> Refs,
                                 ArrayRef<char> Data);
 
+  /// Associates the data of a file with a particular object ID. If there is
+  /// already a record for this object the operation is a no-op.
+  ///
+  /// This is more than a convenience variant of \c store(), \c storeFile() can
+  /// perform optimizations that reduce I/O and disk space consumption.
+  ///
+  /// If there are any concurrent modifications to the file, the contents in the
+  /// CAS may be corrupt.
+  ///
+  /// \param ID the object ID to associate the data with.
+  /// \param FilePath the path of the file data.
+  LLVM_ABI_FOR_TEST Error storeFile(ObjectID ID, StringRef FilePath);
+
   /// \returns \p nullopt if the object associated with \p Ref does not exist.
   LLVM_ABI_FOR_TEST Expected<std::optional<ObjectHandle>> load(ObjectID Ref);
 
@@ -304,6 +317,31 @@ public:
     InternalRefArrayRef Refs = getInternalRefs(Node);
     return make_range(Refs.begin(), Refs.end());
   }
+
+  /// Encapsulates file info for an underlying object node.
+  struct FileBackedData {
+    /// The data of the object node.
+    ArrayRef<char> Data;
+
+    struct FileInfoTy {
+      /// The file path of the object node.
+      std::string FilePath;
+      /// Whether the file of the object leaf node has an extra nul appended at
+      /// the end. If the file is copied the extra nul needs to be removed.
+      bool IsFileNulTerminated;
+    };
+    /// File information for the object, if available.
+    std::optional<FileInfoTy> FileInfo;
+  };
+
+  /// Provides access to the underlying file path, that represents an object
+  /// leaf node, when available.
+  ///
+  /// This enables reducing I/O and disk space consumption, i.e. instead of
+  /// loading the data in memory and then writing it to a file, the client could
+  /// clone the underlying file directly. The client *must not* write to or
+  /// delete the underlying file, the path is provided only for reading/copying.
+  FileBackedData getInternalFileBackedObjectData(ObjectHandle Node) const;
 
   /// \returns Total size of stored objects.
   ///
@@ -376,14 +414,23 @@ private:
   Expected<std::optional<ObjectHandle>> faultInFromUpstream(ObjectID PrimaryID);
   Error importFullTree(ObjectID PrimaryID, ObjectHandle UpstreamNode);
   Error importSingleNode(ObjectID PrimaryID, ObjectHandle UpstreamNode);
+  Error importUpstreamData(ObjectID PrimaryID, ArrayRef<ObjectID> PrimaryRefs,
+                           ObjectHandle UpstreamNode);
+
+  enum class InternalUpstreamImportKind { Leaf, Leaf0 };
+  /// Private \c storeFile than optimizes internal upstream database imports.
+  Error storeFile(ObjectID ID, StringRef FilePath,
+                  std::optional<InternalUpstreamImportKind> ImportKind);
 
   Expected<IndexProxy> indexHash(ArrayRef<uint8_t> Hash);
 
+  /// Get path for creating standalone data file.
+  void getStandalonePath(StringRef FileSuffix, FileOffset IndexOffset,
+                         SmallVectorImpl<char> &Path) const;
+  /// Create a standalone leaf file.
   Error createStandaloneLeaf(IndexProxy &I, ArrayRef<char> Data);
 
   Expected<MappedTempFile> createTempFile(StringRef FinalPath, uint64_t Size);
-
-  OnDiskContent getContentFromHandle(ObjectHandle H) const;
 
   static InternalRef getInternalRef(ObjectID Ref) {
     return InternalRef::getFromRawData(Ref.getOpaqueData());
@@ -393,9 +440,6 @@ private:
   }
 
   static ObjectID getExternalReference(const IndexProxy &I);
-
-  void getStandalonePath(StringRef FileSuffix, const IndexProxy &I,
-                         SmallVectorImpl<char> &Path) const;
 
   LLVM_ABI_FOR_TEST ArrayRef<uint8_t>
   getDigest(InternalRef Ref) const;

--- a/llvm/lib/CAS/BuiltinObjectHasher.cpp
+++ b/llvm/lib/CAS/BuiltinObjectHasher.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/BuiltinObjectHasher.h"
+#include "llvm/Support/BLAKE3.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+template <class HasherT>
+Expected<typename BuiltinObjectHasher<HasherT>::HashT>
+BuiltinObjectHasher<HasherT>::hashFile(StringRef FilePath) {
+  BuiltinObjectHasher H;
+  H.updateSize(0); // 0 refs
+
+  sys::fs::file_t FD;
+  if (Error E = sys::fs::openNativeFileForRead(FilePath).moveInto(FD))
+    return E;
+
+  sys::fs::file_status Status;
+  std::error_code EC = sys::fs::status(FD, Status);
+  if (EC)
+    return createFileError(FilePath, EC);
+  // FIXME: Do we need to add a hash of the data size? If we remove that we can
+  // avoid needing to read the file size before reading the file contents.
+  H.updateSize(Status.getSize());
+
+  size_t ChunkSize = sys::fs::DefaultReadChunkSize;
+  SmallVector<char, 0> Buffer;
+  Buffer.resize_for_overwrite(ChunkSize);
+  for (;;) {
+    Expected<size_t> ReadBytes =
+        sys::fs::readNativeFile(FD, MutableArrayRef(Buffer.begin(), ChunkSize));
+    if (!ReadBytes)
+      return ReadBytes.takeError();
+    if (*ReadBytes == 0)
+      break;
+    H.Hasher.update(toStringRef(ArrayRef(Buffer).take_front(*ReadBytes)));
+  }
+
+  return H.finish();
+}
+
+// Provide the definition for when using the BLAKE3 hasher.
+template Expected<BuiltinObjectHasher<BLAKE3>::HashT>
+BuiltinObjectHasher<BLAKE3>::hashFile(StringRef FilePath);

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_component_library(LLVMCAS
   ActionCache.cpp
   ActionCaches.cpp
   BuiltinCAS.cpp
+  BuiltinObjectHasher.cpp
   BuiltinUnifiedCASDatabases.cpp
   CASConfiguration.cpp
   CASFileSystem.cpp

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -50,6 +50,7 @@
 #include "llvm/CAS/OnDiskGraphDB.h"
 #include "OnDiskCommon.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/CAS/OnDiskHashMappedTrie.h"
@@ -64,6 +65,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include <optional>
+#include <variant>
 
 #if __has_include(<sys/mount.h>)
 #include <sys/mount.h> // statfs
@@ -347,13 +349,17 @@ class StandaloneDataInMemory {
 public:
   OnDiskContent getContent() const;
 
+  OnDiskGraphDB::FileBackedData
+  getInternalFileBackedObjectData(StringRef RootPath) const;
+
   /// FIXME: Should be mapped_file_region instead of MemoryBuffer to drop a
   /// layer of indirection.
   std::unique_ptr<MemoryBuffer> Region;
   TrieRecord::StorageKind SK;
+  FileOffset IndexOffset;
   StandaloneDataInMemory(std::unique_ptr<MemoryBuffer> Region,
-                         TrieRecord::StorageKind SK)
-      : Region(std::move(Region)), SK(SK) {
+                         TrieRecord::StorageKind SK, FileOffset IndexOffset)
+      : Region(std::move(Region)), SK(SK), IndexOffset(IndexOffset) {
 #ifndef NDEBUG
     bool IsStandalone = false;
     switch (SK) {
@@ -377,7 +383,8 @@ template <size_t NumShards> class StandaloneDataMap {
 public:
   const StandaloneDataInMemory &insert(ArrayRef<uint8_t> Hash,
                                        TrieRecord::StorageKind SK,
-                                       std::unique_ptr<MemoryBuffer> Buffer);
+                                       std::unique_ptr<MemoryBuffer> Buffer,
+                                       FileOffset IndexOffset);
 
   const StandaloneDataInMemory *lookup(ArrayRef<uint8_t> Hash) const;
   bool count(ArrayRef<uint8_t> Hash) const { return bool(lookup(Hash)); }
@@ -457,6 +464,13 @@ private:
 struct ondisk::OnDiskContent {
   std::optional<DataRecordHandle> Record;
   std::optional<ArrayRef<char>> Bytes;
+
+  ArrayRef<char> getData() const {
+    if (Bytes)
+      return *Bytes;
+    assert(Record && "Expected record or bytes");
+    return Record->getData();
+  }
 };
 
 Expected<DataRecordHandle> DataRecordHandle::createWithError(
@@ -485,12 +499,14 @@ struct OnDiskGraphDB::IndexProxy {
 template <size_t N>
 const StandaloneDataInMemory &
 StandaloneDataMap<N>::insert(ArrayRef<uint8_t> Hash, TrieRecord::StorageKind SK,
-                             std::unique_ptr<MemoryBuffer> Buffer) {
+                             std::unique_ptr<MemoryBuffer> Buffer,
+                             FileOffset IndexOffset) {
   auto &S = getShard(Hash);
   std::lock_guard<std::mutex> Lock(S.Mutex);
   auto &V = S.Map[Hash.data()];
   if (!V)
-    V = std::make_unique<StandaloneDataInMemory>(std::move(Buffer), SK);
+    V = std::make_unique<StandaloneDataInMemory>(std::move(Buffer), SK,
+                                                 IndexOffset);
   return *V;
 }
 
@@ -936,7 +952,8 @@ Error OnDiskGraphDB::validate(bool Deep, HashingFuncT Hasher) const {
     case TrieRecord::StorageKind::StandaloneLeaf:
     case TrieRecord::StorageKind::StandaloneLeaf0:
       SmallString<256> Path;
-      getStandalonePath(TrieRecord::getStandaloneFileSuffix(D.SK), I, Path);
+      getStandalonePath(TrieRecord::getStandaloneFileSuffix(D.SK), I.Offset,
+                        Path);
       // If need to validate the content of the file later, just load the
       // buffer here. Otherwise, just check the existance of the file.
       if (Deep) {
@@ -1187,19 +1204,60 @@ ArrayRef<uint8_t> OnDiskGraphDB::getDigest(const IndexProxy &I) const {
   return I.Hash;
 }
 
+static std::variant<const StandaloneDataInMemory *, DataRecordHandle>
+getStandaloneDataOrDataRecord(const OnDiskDataAllocator &DataPool,
+                              ObjectHandle OH) {
+  auto getInternalHandle = [](ObjectHandle Handle) -> InternalHandle {
+    uint64_t Data = Handle.getOpaqueData();
+    if (Data & 1)
+      return InternalHandle(*reinterpret_cast<const StandaloneDataInMemory *>(
+          Data & (-1ULL << 1)));
+    return InternalHandle(Data);
+  };
+
+  InternalHandle Handle = getInternalHandle(OH);
+  if (Handle.SDIM)
+    return Handle.SDIM;
+
+  auto DataHandle =
+      DataRecordHandle::get(DataPool.beginData(Handle.getAsFileOffset()));
+  assert(DataHandle.getData().end()[0] == 0 && "Null termination");
+  return DataHandle;
+}
+
+static OnDiskContent getContentFromHandle(const OnDiskDataAllocator &DataPool,
+                                          ObjectHandle OH) {
+  auto SDIMOrRecord = getStandaloneDataOrDataRecord(DataPool, OH);
+  if (std::holds_alternative<const StandaloneDataInMemory *>(SDIMOrRecord)) {
+    return std::get<const StandaloneDataInMemory *>(SDIMOrRecord)->getContent();
+  } else {
+    auto DataHandle = std::get<DataRecordHandle>(std::move(SDIMOrRecord));
+    return OnDiskContent{std::move(DataHandle), std::nullopt};
+  }
+}
+
 ArrayRef<char> OnDiskGraphDB::getObjectData(ObjectHandle Node) const {
-  OnDiskContent Content = getContentFromHandle(Node);
-  if (Content.Bytes)
-    return *Content.Bytes;
-  assert(Content.Record && "Expected record or bytes");
-  return Content.Record->getData();
+  OnDiskContent Content = getContentFromHandle(DataPool, Node);
+  return Content.getData();
 }
 
 InternalRefArrayRef OnDiskGraphDB::getInternalRefs(ObjectHandle Node) const {
   if (std::optional<DataRecordHandle> Record =
-          getContentFromHandle(Node).Record)
+          getContentFromHandle(DataPool, Node).Record)
     return Record->getRefs();
   return std::nullopt;
+}
+
+OnDiskGraphDB::FileBackedData
+OnDiskGraphDB::getInternalFileBackedObjectData(ObjectHandle Node) const {
+  auto SDIMOrRecord = getStandaloneDataOrDataRecord(DataPool, Node);
+  if (std::holds_alternative<const StandaloneDataInMemory *>(SDIMOrRecord)) {
+    auto *SDIM = std::get<const StandaloneDataInMemory *>(SDIMOrRecord);
+    return SDIM->getInternalFileBackedObjectData(RootPath);
+  } else {
+    auto DataHandle = std::get<DataRecordHandle>(std::move(SDIMOrRecord));
+    return FileBackedData{DataHandle.getData(), /*FileInfo=*/std::nullopt};
+  }
 }
 
 Expected<std::optional<ObjectHandle>>
@@ -1244,15 +1302,16 @@ OnDiskGraphDB::load(ObjectID ExternalRef) {
   // suitably 0-padded. Requiring null-termination here would be too expensive
   // for extremely large objects that happen to be page-aligned.
   SmallString<256> Path;
-  getStandalonePath(TrieRecord::getStandaloneFileSuffix(Object.SK), I, Path);
+  getStandalonePath(TrieRecord::getStandaloneFileSuffix(Object.SK), I.Offset,
+                    Path);
   ErrorOr<std::unique_ptr<MemoryBuffer>> OwnedBuffer = MemoryBuffer::getFile(
       Path, /*IsText=*/false, /*RequiresNullTerminator=*/false);
   if (!OwnedBuffer)
     return createCorruptObjectError(getDigest(I));
 
-  return toObjectHandle(
-      InternalHandle(static_cast<StandaloneDataMapTy *>(StandaloneData)
-                         ->insert(I.Hash, Object.SK, std::move(*OwnedBuffer))));
+  return toObjectHandle(InternalHandle(
+      static_cast<StandaloneDataMapTy *>(StandaloneData)
+          ->insert(I.Hash, Object.SK, std::move(*OwnedBuffer), I.Offset)));
 }
 
 Expected<bool> OnDiskGraphDB::isMaterialized(ObjectID Ref) {
@@ -1293,29 +1352,16 @@ InternalRef OnDiskGraphDB::makeInternalRef(FileOffset IndexOffset) {
   return InternalRef::getFromOffset(IndexOffset);
 }
 
-void OnDiskGraphDB::getStandalonePath(StringRef Suffix, const IndexProxy &I,
-                                      SmallVectorImpl<char> &Path) const {
+static void getStandalonePath(StringRef RootPath, StringRef Suffix,
+                              FileOffset IndexOffset,
+                              SmallVectorImpl<char> &Path) {
   Path.assign(RootPath.begin(), RootPath.end());
-  sys::path::append(Path, FilePrefix + Twine(I.Offset.get()) + Suffix);
+  sys::path::append(Path, FilePrefix + Twine(IndexOffset.get()) + Suffix);
 }
 
-OnDiskContent OnDiskGraphDB::getContentFromHandle(ObjectHandle OH) const {
-  auto getInternalHandle = [](ObjectHandle Handle) -> InternalHandle {
-    uint64_t Data = Handle.getOpaqueData();
-    if (Data & 1)
-      return InternalHandle(*reinterpret_cast<const StandaloneDataInMemory *>(
-          Data & (-1ULL << 1)));
-    return InternalHandle(Data);
-  };
-
-  InternalHandle Handle = getInternalHandle(OH);
-  if (Handle.SDIM)
-    return Handle.SDIM->getContent();
-
-  auto DataHandle =
-      DataRecordHandle::get(DataPool.beginData(Handle.getAsFileOffset()));
-  assert(DataHandle.getData().end()[0] == 0 && "Null termination");
-  return OnDiskContent{DataHandle, std::nullopt};
+void OnDiskGraphDB::getStandalonePath(StringRef Suffix, FileOffset IndexOffset,
+                                      SmallVectorImpl<char> &Path) const {
+  return ::getStandalonePath(RootPath, Suffix, IndexOffset, Path);
 }
 
 OnDiskContent StandaloneDataInMemory::getContent() const {
@@ -1346,6 +1392,28 @@ OnDiskContent StandaloneDataInMemory::getContent() const {
   assert(Record.getData().end()[0] == 0 &&
          "Standalone object record missing null termination for data");
   return OnDiskContent{Record, std::nullopt};
+}
+
+OnDiskGraphDB::FileBackedData
+StandaloneDataInMemory::getInternalFileBackedObjectData(
+    StringRef RootPath) const {
+  switch (SK) {
+  case TrieRecord::StorageKind::Unknown:
+  case TrieRecord::StorageKind::DataPool:
+    llvm_unreachable("unexpected storage kind");
+  case TrieRecord::StorageKind::Standalone:
+    return OnDiskGraphDB::FileBackedData{getContent().getData(),
+                                         /*FileInfo=*/std::nullopt};
+  case TrieRecord::StorageKind::StandaloneLeaf0:
+  case TrieRecord::StorageKind::StandaloneLeaf:
+    bool IsFileNulTerminated = SK == TrieRecord::StorageKind::StandaloneLeaf0;
+    SmallString<256> Path;
+    ::getStandalonePath(RootPath, TrieRecord::getStandaloneFileSuffix(SK),
+                        IndexOffset, Path);
+    return OnDiskGraphDB::FileBackedData{
+        getContent().getData(), OnDiskGraphDB::FileBackedData::FileInfoTy{
+                                    std::string(Path), IsFileNulTerminated}};
+  }
 }
 
 Expected<OnDiskGraphDB::MappedTempFile>
@@ -1386,7 +1454,7 @@ Error OnDiskGraphDB::createStandaloneLeaf(IndexProxy &I, ArrayRef<char> Data) {
 
   SmallString<256> Path;
   int64_t FileSize = Data.size() + Leaf0;
-  getStandalonePath(TrieRecord::getStandaloneFileSuffix(SK), I, Path);
+  getStandalonePath(TrieRecord::getStandaloneFileSuffix(SK), I.Offset, Path);
 
   // Write the file. Don't reuse this mapped_file_region, which is read/write.
   // Let load() pull up one that's read-only.
@@ -1453,7 +1521,7 @@ Error OnDiskGraphDB::store(ObjectID ID, ArrayRef<ObjectID> Refs,
   auto AllocStandaloneFile = [&](size_t Size) -> Expected<char *> {
     getStandalonePath(TrieRecord::getStandaloneFileSuffix(
                           TrieRecord::StorageKind::Standalone),
-                      I, Path);
+                      I.Offset, Path);
     if (Error E = createTempFile(Path, Size).moveInto(File))
       return std::move(E);
     assert(File->size() == Size);
@@ -1533,6 +1601,115 @@ Error OnDiskGraphDB::store(ObjectID ID, ArrayRef<ObjectID> Refs,
     return createCorruptObjectError(getDigest(I));
 
   // Load existing object.
+  return Error::success();
+}
+
+Error OnDiskGraphDB::storeFile(ObjectID ID, StringRef FilePath) {
+  return storeFile(ID, FilePath, /*ImportKind=*/std::nullopt);
+}
+
+Error OnDiskGraphDB::storeFile(
+    ObjectID ID, StringRef FilePath,
+    std::optional<InternalUpstreamImportKind> ImportKind) {
+  auto I = getIndexProxyFromRefChecked(getInternalRef(ID));
+  if (LLVM_UNLIKELY(!I))
+    return I.takeError();
+
+  // Early return in case the node exists.
+  {
+    TrieRecord::Data Existing = I->Ref.load();
+    if (Existing.SK != TrieRecord::StorageKind::Unknown)
+      return Error::success();
+  }
+
+  uint64_t FileSize;
+  if (std::error_code EC = sys::fs::file_size(FilePath, FileSize))
+    return createFileError(FilePath, EC);
+
+  if (FileSize <= TrieRecord::MaxEmbeddedSize) {
+    auto Buf = MemoryBuffer::getFile(FilePath);
+    if (!Buf)
+      return createFileError(FilePath, Buf.getError());
+    return store(ID, {}, arrayRefFromStringRef<char>((*Buf)->getBuffer()));
+  }
+
+  StringRef FromPath;
+  SmallString<256> TmpPath;
+
+  auto RemoveTmpFile = scope_exit([&TmpPath] {
+    if (!TmpPath.empty())
+      sys::fs::remove(TmpPath);
+  });
+
+  // \c clonefile requires that the destination path doesn't exist. We create
+  // a "placeholder" temporary file, then modify its path a bit and use that
+  // for \c clonefile to write to.
+  // FIXME: Instead of creating a dummy file, add a new file system API for
+  // copying to a unique path that can loop while checking EEXIST.
+  SmallString<256> UniqueTmpPath;
+  if (std::error_code EC =
+          sys::fs::createUniqueFile(RootPath + "/tmp.%%%%%%%", UniqueTmpPath))
+    return createFileError(RootPath + "/tmp.%%%%%%%", EC);
+  auto RemoveUniqueFile =
+      scope_exit([&UniqueTmpPath] { sys::fs::remove(UniqueTmpPath); });
+  TmpPath = UniqueTmpPath;
+  TmpPath += 'c'; // modify so that there's no file at that path.
+  // \c copy_file will use \c clonefile when applicable.
+  if (std::error_code EC = sys::fs::copy_file(FilePath, TmpPath))
+    return createFileError(FilePath, EC);
+  FromPath = TmpPath;
+
+  TrieRecord::StorageKind SK;
+  if (ImportKind.has_value()) {
+    // Importing the file from upstream, the nul is already added if necessary.
+    switch (*ImportKind) {
+    case InternalUpstreamImportKind::Leaf:
+      SK = TrieRecord::StorageKind::StandaloneLeaf;
+      break;
+    case InternalUpstreamImportKind::Leaf0:
+      SK = TrieRecord::StorageKind::StandaloneLeaf0;
+      break;
+    }
+  } else {
+    bool Leaf0 = isAligned(Align(getPageSize()), FileSize);
+    SK = Leaf0 ? TrieRecord::StorageKind::StandaloneLeaf0
+               : TrieRecord::StorageKind::StandaloneLeaf;
+
+    if (Leaf0) {
+      // Add a nul byte at the end.
+      std::error_code EC;
+      raw_fd_ostream OS(FromPath, EC, sys::fs::CD_OpenExisting,
+                        sys::fs::FA_Write, sys::fs::OF_Append);
+      if (EC)
+        return createFileError(FromPath, EC);
+      OS.write(0);
+      OS.close();
+      if (OS.has_error())
+        return createFileError(FromPath, OS.error());
+    }
+  }
+
+  SmallString<256> StandalonePath;
+  getStandalonePath(TrieRecord::getStandaloneFileSuffix(SK), I->Offset,
+                    StandalonePath);
+  if (std::error_code EC = sys::fs::rename(FromPath, StandalonePath))
+    return createFileError(FromPath, EC);
+  TmpPath.clear();
+
+  // Store the object reference.
+  TrieRecord::Data Existing;
+  {
+    TrieRecord::Data Leaf{SK, FileOffset()};
+    if (I->Ref.compare_exchange_strong(Existing, Leaf)) {
+      recordStandaloneSizeIncrease(FileSize);
+      return Error::success();
+    }
+  }
+
+  // If there was a race, confirm that the new value has valid storage.
+  if (Existing.SK == TrieRecord::StorageKind::Unknown)
+    return createCorruptObjectError(getDigest(*I));
+
   return Error::success();
 }
 
@@ -1700,8 +1877,6 @@ Error OnDiskGraphDB::importFullTree(ObjectID PrimaryID,
     UpstreamCursor &Cur = CursorStack.back();
     if (Cur.RefI == Cur.RefE) {
       // Copy the node data into the primary store.
-      // FIXME: Use hard-link or cloning if the file-system supports it and data
-      // is stored into a separate file.
 
       // The bottom of \p PrimaryNodesStack contains the primary ID for the
       // current node plus the list of imported referenced IDs.
@@ -1709,8 +1884,7 @@ Error OnDiskGraphDB::importFullTree(ObjectID PrimaryID,
       ObjectID PrimaryID = *(PrimaryNodesStack.end() - Cur.RefsCount - 1);
       auto PrimaryRefs = ArrayRef(PrimaryNodesStack)
                              .slice(PrimaryNodesStack.size() - Cur.RefsCount);
-      auto Data = UpstreamDB->getObjectData(Cur.Node);
-      if (Error E = store(PrimaryID, PrimaryRefs, Data))
+      if (Error E = importUpstreamData(PrimaryID, PrimaryRefs, Cur.Node))
         return E;
       // Remove the current node and its IDs from the stack.
       PrimaryNodesStack.truncate(PrimaryNodesStack.size() - Cur.RefsCount);
@@ -1745,11 +1919,6 @@ Error OnDiskGraphDB::importSingleNode(ObjectID PrimaryID,
                                       ObjectHandle UpstreamNode) {
   // Copies only a single node, it doesn't copy the referenced nodes.
 
-  // Copy the node data into the primary store.
-  // FIXME: Use hard-link or cloning if the file-system supports it and data is
-  // stored into a separate file.
-
-  auto Data = UpstreamDB->getObjectData(UpstreamNode);
   auto UpstreamRefs = UpstreamDB->getObjectRefs(UpstreamNode);
   SmallVector<ObjectID, 64> Refs;
   Refs.reserve(std::distance(UpstreamRefs.begin(), UpstreamRefs.end()));
@@ -1760,7 +1929,29 @@ Error OnDiskGraphDB::importSingleNode(ObjectID PrimaryID,
     Refs.push_back(*Ref);
   }
 
-  return store(PrimaryID, Refs, Data);
+  return importUpstreamData(PrimaryID, Refs, UpstreamNode);
+}
+
+Error OnDiskGraphDB::importUpstreamData(ObjectID PrimaryID,
+                                        ArrayRef<ObjectID> PrimaryRefs,
+                                        ObjectHandle UpstreamNode) {
+  // If there are references we can't copy an upstream's standalone file because
+  // we need to re-resolve the reference offsets it contains.
+  if (PrimaryRefs.empty()) {
+    auto FBData = UpstreamDB->getInternalFileBackedObjectData(UpstreamNode);
+    if (FBData.FileInfo.has_value()) {
+      // Disk-space optimization, import the file directly since it is a
+      // standalone leaf.
+      return storeFile(
+          PrimaryID, FBData.FileInfo->FilePath,
+          /*InternalUpstreamImport=*/FBData.FileInfo->IsFileNulTerminated
+              ? InternalUpstreamImportKind::Leaf0
+              : InternalUpstreamImportKind::Leaf);
+    }
+  }
+
+  auto Data = UpstreamDB->getObjectData(UpstreamNode);
+  return store(PrimaryID, PrimaryRefs, Data);
 }
 
 Expected<std::optional<ObjectHandle>>

--- a/llvm/unittests/CAS/BuiltinObjectHasherTest.cpp
+++ b/llvm/unittests/CAS/BuiltinObjectHasherTest.cpp
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/BuiltinObjectHasher.h"
+#include "llvm/Support/BLAKE3.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+using HasherT = BLAKE3;
+using HashType = BuiltinObjectHasher<HasherT>::HashT;
+
+TEST(BuiltinObjectHasherTest, Basic) {
+  unittest::TempFile TmpFile("somefile.o", /*Suffix=*/"", /*Contents=*/"",
+                             /*Unique=*/true);
+  {
+    std::error_code EC;
+    raw_fd_stream Out(TmpFile.path(), EC);
+    ASSERT_FALSE(EC);
+    SmallVector<char, 200> Data;
+    for (unsigned i = 1; i != 201; ++i) {
+      Data.push_back(i);
+    }
+    for (unsigned i = 0; i != 1000; ++i) {
+      Out.write(Data.data(), Data.size());
+    }
+  }
+
+  ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+      MemoryBuffer::getFile(TmpFile.path());
+  ASSERT_TRUE(!!MB);
+  ASSERT_NE(*MB, nullptr);
+
+  HashType Hash1 =
+      BuiltinObjectHasher<HasherT>::hashObject({}, (*MB)->getBuffer());
+  std::optional<HashType> Hash2;
+  ASSERT_THAT_ERROR(
+      BuiltinObjectHasher<HasherT>::hashFile(TmpFile.path()).moveInto(Hash2),
+      Succeeded());
+  EXPECT_EQ(Hash1, *Hash2);
+}

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_unittest(CASTests
   ActionCacheTest.cpp
+  BuiltinObjectHasherTest.cpp
   BuiltinUnifiedCASDatabasesTest.cpp
   CASConfigurationTest.cpp
   CASFileSystemTest.cpp

--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -40,6 +40,21 @@ inline HashType digest(StringRef Data) {
   return HasherT::hash(arrayRefFromStringRef(Data));
 }
 
+inline HashType digestFile(StringRef FilePath) {
+  std::optional<HashType> Digest;
+  EXPECT_THAT_ERROR(
+      BuiltinObjectHasher<HasherT>::hashFile(FilePath).moveInto(Digest),
+      Succeeded());
+  return *Digest;
+}
+
+inline ObjectID digestFile(OnDiskGraphDB &DB, StringRef FilePath) {
+  HashType Digest = digestFile(FilePath);
+  std::optional<ObjectID> ID;
+  EXPECT_THAT_ERROR(DB.getReference(Digest).moveInto(ID), Succeeded());
+  return *ID;
+}
+
 inline ValueType valueFromString(StringRef S) {
   ValueType Val;
   llvm::copy(S.substr(0, sizeof(Val)), Val.data());

--- a/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
@@ -8,6 +8,9 @@
 
 #include "CASTestConfig.h"
 #include "OnDiskCommonUtils.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Process.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
@@ -293,6 +296,211 @@ TEST(OnDiskGraphDBTest, FaultInPolicyConflict) {
   // Open as 'full', then as 'single'.
   tryFaultInPolicyConflict(OnDiskGraphDB::FaultInPolicy::FullTree,
                            OnDiskGraphDB::FaultInPolicy::SingleNode);
+}
+
+static std::unique_ptr<unittest::TempFile> createLargeFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largefile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<200> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != 200; ++i) {
+    Data += i;
+  }
+  for (unsigned i = 0; i != 1000; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  return TmpFile;
+}
+
+static std::unique_ptr<unittest::TempFile>
+createLargePageAlignedFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largepagealignedfile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<256> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != sys::Process::getPageSizeEstimate(); ++i) {
+    Data += char(i);
+  }
+  for (unsigned i = 0; i != 64; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  Out.close();
+  uint64_t FileSize;
+  EC = sys::fs::file_size(Path, FileSize);
+  EXPECT_FALSE(EC);
+  assert(isAligned(Align(sys::Process::getPageSizeEstimate()), FileSize));
+  return TmpFile;
+}
+
+TEST(OnDiskGraphDBTest, OnDiskGraphDBFaultInLargeFile) {
+  auto runCommonTests =
+      [](function_ref<std::unique_ptr<unittest::TempFile>(char)> createFileFn) {
+        unittest::TempDir TempUpstream("ondiskcas-upstream", /*Unique=*/true);
+        std::unique_ptr<OnDiskGraphDB> UpstreamDB;
+        ASSERT_THAT_ERROR(
+            OnDiskGraphDB::open(TempUpstream.path(), "blake3", sizeof(HashType))
+                .moveInto(UpstreamDB),
+            Succeeded());
+
+        auto TmpFile = createFileFn('a');
+        auto Path = TmpFile->path();
+        HashType FileDigest = digestFile(Path);
+        std::optional<ObjectID> UpstrID;
+        ASSERT_THAT_ERROR(
+            UpstreamDB->getReference(FileDigest).moveInto(UpstrID),
+            Succeeded());
+        ASSERT_THAT_ERROR(UpstreamDB->storeFile(*UpstrID, Path), Succeeded());
+
+        unittest::TempDir Temp("ondiskcas", /*Unique=*/true);
+        std::unique_ptr<OnDiskGraphDB> DB;
+        ASSERT_THAT_ERROR(
+            OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType),
+                                std::move(UpstreamDB), /*Logger=*/nullptr,
+                                OnDiskGraphDB::FaultInPolicy::SingleNode)
+                .moveInto(DB),
+            Succeeded());
+
+        std::optional<ObjectID> ID1;
+        ASSERT_THAT_ERROR(DB->getReference(FileDigest).moveInto(ID1),
+                          Succeeded());
+        std::optional<ondisk::ObjectHandle> Obj;
+        ASSERT_THAT_ERROR(DB->load(*ID1).moveInto(Obj), Succeeded());
+        ASSERT_TRUE(Obj.has_value());
+
+        std::optional<ObjectID> ID2;
+        ASSERT_THAT_ERROR(
+            store(*DB, toStringRef(DB->getObjectData(*Obj)), {}).moveInto(ID2),
+            Succeeded());
+        ASSERT_TRUE(ID2.has_value());
+        EXPECT_EQ(*ID1, *ID2);
+      };
+
+  runCommonTests(createLargeFile);
+  runCommonTests(createLargePageAlignedFile);
+}
+
+TEST(OnDiskGraphDBTest, OnDiskGraphDBFileAPIs) {
+  unittest::TempDir Temp("ondiskcas", /*Unique=*/true);
+  std::unique_ptr<OnDiskGraphDB> DB;
+  ASSERT_THAT_ERROR(
+      OnDiskGraphDB::open(Temp.path(), "blake3", sizeof(HashType)).moveInto(DB),
+      Succeeded());
+
+  SmallVector<std::unique_ptr<unittest::TempFile>, 4> TempFiles;
+
+  // Create a file with small size and and controlling the initial byte so
+  // caller can create different contents.
+  auto createSmallFile = [&TempFiles](char initChar) -> StringRef {
+    TempFiles.push_back(std::make_unique<unittest::TempFile>(
+        "smallfile.o", /*Suffix=*/"", /*Contents=*/"",
+        /*Unique=*/true));
+    StringRef Path = TempFiles.back()->path();
+    std::error_code EC;
+    raw_fd_stream Out(Path, EC);
+    EXPECT_FALSE(EC);
+    SmallString<200> Data;
+    Data += initChar;
+    for (unsigned i = 1; i != 200; ++i) {
+      Data += i;
+    }
+    Out.write(Data.data(), Data.size());
+    return Path;
+  };
+
+  auto createLargeFile = [&TempFiles](char initChar) -> StringRef {
+    TempFiles.push_back(::createLargeFile(initChar));
+    return TempFiles.back()->path();
+  };
+
+  auto createLargePageAlignedFile = [&TempFiles](char initChar) -> StringRef {
+    TempFiles.push_back(::createLargePageAlignedFile(initChar));
+    return TempFiles.back()->path();
+  };
+
+  auto runCommonTests =
+      [&DB](function_ref<StringRef(char)> createFileFn,
+            function_ref<void(const OnDiskGraphDB::FileBackedData &FBD)>
+                additionalChecks) {
+        {
+          auto FilePath = createFileFn('a');
+          ObjectID ID1 = digestFile(*DB, FilePath);
+          ASSERT_THAT_ERROR(DB->storeFile(ID1, FilePath), Succeeded());
+          EXPECT_TRUE(sys::fs::exists(FilePath));
+
+          std::optional<ondisk::ObjectHandle> Obj;
+          ASSERT_THAT_ERROR(DB->load(ID1).moveInto(Obj), Succeeded());
+          EXPECT_TRUE(DB->getObjectRefs(*Obj).empty());
+          ArrayRef<char> Contents = DB->getObjectData(*Obj);
+          EXPECT_EQ(Contents.data()[Contents.size()], '\0');
+          ObjectID ID2 = digest(*DB, toStringRef(Contents), {});
+          EXPECT_EQ(ID1, ID2);
+
+          auto FBD = DB->getInternalFileBackedObjectData(*Obj);
+          EXPECT_EQ(FBD.Data, Contents);
+          additionalChecks(FBD);
+        }
+      };
+
+  auto checkSmallFile = [](const OnDiskGraphDB::FileBackedData &FBD) {
+    EXPECT_FALSE(FBD.FileInfo.has_value());
+  };
+
+  auto checkLargeFile = [](const OnDiskGraphDB::FileBackedData &FBD) {
+    ASSERT_TRUE(FBD.FileInfo.has_value());
+    EXPECT_FALSE(FBD.FileInfo->IsFileNulTerminated);
+    ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+        MemoryBuffer::getFile(FBD.FileInfo->FilePath);
+    ASSERT_TRUE(!!MB);
+    ASSERT_NE(*MB, nullptr);
+    EXPECT_EQ((*MB)->getBuffer(), toStringRef(FBD.Data));
+  };
+
+  auto checkLargePageAlignedFile =
+      [](const OnDiskGraphDB::FileBackedData &FBD) {
+        ASSERT_TRUE(FBD.FileInfo.has_value());
+        EXPECT_TRUE(FBD.FileInfo->IsFileNulTerminated);
+        ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+            MemoryBuffer::getFile(FBD.FileInfo->FilePath);
+        ASSERT_TRUE(!!MB);
+        ASSERT_NE(*MB, nullptr);
+        EXPECT_EQ((*MB)->getBuffer().back(), '\0');
+        EXPECT_EQ((*MB)->getBuffer().drop_back(1), toStringRef(FBD.Data));
+      };
+
+  runCommonTests(createSmallFile, checkSmallFile);
+  runCommonTests(createLargeFile, checkLargeFile);
+  runCommonTests(createLargePageAlignedFile, checkLargePageAlignedFile);
+
+  // Check non-leaf node.
+  {
+    std::optional<ObjectID> ID1;
+    ASSERT_THAT_ERROR(store(*DB, "hello", {}).moveInto(ID1), Succeeded());
+
+    auto Path = createLargeFile('r');
+    ErrorOr<std::unique_ptr<MemoryBuffer>> MB = MemoryBuffer::getFile(Path);
+    ASSERT_TRUE(!!MB);
+    ASSERT_NE(*MB, nullptr);
+    std::optional<ObjectID> ID2;
+    ASSERT_THAT_ERROR(store(*DB, (*MB)->getBuffer(), *ID1).moveInto(ID2),
+                      Succeeded());
+
+    std::optional<ondisk::ObjectHandle> Obj;
+    ASSERT_THAT_ERROR(DB->load(*ID2).moveInto(Obj), Succeeded());
+    ArrayRef<char> Contents = DB->getObjectData(*Obj);
+    auto FBD = DB->getInternalFileBackedObjectData(*Obj);
+    EXPECT_EQ(FBD.Data, Contents);
+    EXPECT_FALSE(FBD.FileInfo.has_value());
+  }
 }
 
 #if defined(EXPENSIVE_CHECKS)


### PR DESCRIPTION
These allow performing optimizations that reduce I/O and disk space consumption. For example, when applicable, a file can be cloned directly into the database directory, instead of needing to load it in memory and then copy its contents into a new file.

These APIs are then used to optimize importing data from an upstream DB by using file cloning where applicable.

(cherry picked from commit 60ecb378960662a6579a66d2bbda98d681606868)