### PR TITLE
[lldb][NativePDB] Introduce PdbAstBuilderSwift

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
@@ -1,3 +1,9 @@
+set(SWIFT_SOURCES PdbAstBuilderSwift.cpp)
+set(LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
+if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
+  unset(SWIFT_SOURCES)
+endif()
+
 add_lldb_library(lldbPluginSymbolFileNativePDB
   CodeViewRegisterMapping.cpp
   CompileUnitIndex.cpp
@@ -9,6 +15,9 @@ add_lldb_library(lldbPluginSymbolFileNativePDB
   PdbUtil.cpp
   SymbolFileNativePDB.cpp
   UdtRecordCompleter.cpp
+  ## BEGIN SWIFT
+  ${SWIFT_SOURCES}
+  ##END SWIFT
 
   LINK_COMPONENTS
     DebugInfoCodeView

--- a/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/CMakeLists.txt
@@ -1,8 +1,10 @@
+## BEGIN SWIFT
 set(SWIFT_SOURCES PdbAstBuilderSwift.cpp)
 set(LLVM_OPTIONAL_SOURCES ${SWIFT_SOURCES})
 if (NOT LLDB_ENABLE_SWIFT_SUPPORT)
   unset(SWIFT_SOURCES)
 endif()
+## END SWIFT
 
 add_lldb_library(lldbPluginSymbolFileNativePDB
   CodeViewRegisterMapping.cpp

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -14,10 +14,12 @@
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "lldb/Symbol/ObjectFile.h"
 #include "lldb/Utility/LLDBAssert.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 
 #include "llvm/DebugInfo/CodeView/TypeDeserializer.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/DebugInfo/PDB/Native/TpiStream.h"
+#include "llvm/Support/ErrorHandling.h"
 
 #include "swift/Demangling/Demangle.h"
 
@@ -41,7 +43,11 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
   case LF_STRUCTURE:
   case LF_CLASS: {
     ClassRecord cr;
-    llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
+    if (auto err = TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ClassRecord: {0}");
+      return {};
+    }
     if (!cr.hasUniqueName())
       return {};
     decorated = cr.UniqueName;
@@ -49,7 +55,11 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
   }
   case LF_ENUM: {
     EnumRecord er;
-    llvm::cantFail(TypeDeserializer::deserializeAs<EnumRecord>(cvt, er));
+    if (auto err = TypeDeserializer::deserializeAs<EnumRecord>(cvt, er)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize EnumRecord: {0}");
+      return {};
+    }
     if (!er.hasUniqueName())
       return {};
     decorated = er.UniqueName;
@@ -57,8 +67,11 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
   }
   case LF_MODIFIER: {
     ModifierRecord mfr;
-    llvm::cantFail(
-        TypeDeserializer::deserializeAs<ModifierRecord>(cvt, mfr));
+    if (auto err = TypeDeserializer::deserializeAs<ModifierRecord>(cvt, mfr)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ModifierRecord: {0}");
+      return {};
+    }
     return GetOrCreateType(PdbTypeSymId(mfr.ModifiedType, false));
   }
   default:

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -1,0 +1,90 @@
+#include "PdbAstBuilderSwift.h"
+
+#include "PdbUtil.h"
+#include "SymbolFileNativePDB.h"
+
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
+#include "lldb/Symbol/ObjectFile.h"
+#include "lldb/Utility/LLDBAssert.h"
+
+#include "llvm/DebugInfo/CodeView/TypeDeserializer.h"
+#include "llvm/DebugInfo/PDB/Native/TpiStream.h"
+
+using namespace lldb_private;
+using namespace lldb_private::npdb;
+using namespace llvm::codeview;
+using namespace llvm::pdb;
+
+PdbAstBuilderSwift::PdbAstBuilderSwift(TypeSystemSwiftTypeRef &swift_ts)
+    : m_swift_ts(swift_ts) {}
+
+CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
+                                            TpiStream &tpi) {
+  if (type.index.isSimple())
+    return {};
+
+  CVType cvt = tpi.getType(type.index);
+
+  llvm::StringRef mangled_name;
+  switch (cvt.kind()) {
+  case LF_STRUCTURE:
+  case LF_CLASS: {
+    ClassRecord cr;
+    llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
+    if (!cr.hasUniqueName())
+      return {};
+    mangled_name = cr.UniqueName;
+    break;
+  }
+  case LF_ENUM: {
+    EnumRecord er;
+    llvm::cantFail(TypeDeserializer::deserializeAs<EnumRecord>(cvt, er));
+    if (!er.hasUniqueName())
+      return {};
+    mangled_name = er.UniqueName;
+    break;
+  }
+  case LF_MODIFIER: {
+    ModifierRecord mfr;
+    llvm::cantFail(
+        TypeDeserializer::deserializeAs<ModifierRecord>(cvt, mfr));
+    return GetOrCreateType(PdbTypeSymId(mfr.ModifiedType, false));
+  }
+  default:
+    return {};
+  }
+
+  if (!mangled_name.starts_with("$s"))
+    return {};
+
+  return m_swift_ts.GetTypeFromMangledTypename(ConstString(mangled_name));
+}
+
+CompilerType PdbAstBuilderSwift::GetOrCreateType(PdbTypeSymId type) {
+  if (type.index.isNoneType())
+    return {};
+
+  lldb::user_id_t uid = toOpaqueUid(type);
+  auto iter = m_uid_to_type.find(uid);
+  if (iter != m_uid_to_type.end())
+    return iter->second;
+
+  auto *pdb = llvm::cast<SymbolFileNativePDB>(
+      m_swift_ts.GetSymbolFile()->GetBackingSymbolFile());
+  PdbIndex &index = pdb->GetIndex();
+  PdbTypeSymId best_type = GetBestPossibleDecl(type, index.tpi());
+
+  CompilerType ct;
+  if (best_type.index != type.index)
+    ct = GetOrCreateType(best_type);
+  else
+    ct = CreateType(type, index.tpi());
+
+  if (ct)
+    m_uid_to_type[uid] = ct;
+  return ct;
+}
+
+void PdbAstBuilderSwift::Dump(Stream &stream, llvm::StringRef filter) {
+  m_swift_ts.Dump(stream.AsRawOstream(), filter);
+}

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -94,8 +94,10 @@ CompilerType PdbAstBuilderSwift::GetOrCreateType(PdbTypeSymId type) {
 
   auto *pdb = llvm::dyn_cast<SymbolFileNativePDB>(
       m_swift_ts.GetSymbolFile()->GetBackingSymbolFile());
-  if (!pdb)
-    llvm::report_fatal_error("PdbAstBuilderSwift called from outside NativePDB context.");
+  if (!pdb) {
+    lldbassert(false && "PdbAstBuilderSwift called from outside NativePDB context.");
+    return {};
+  }
   PdbIndex &index = pdb->GetIndex();
   PdbTypeSymId best_type = GetBestPossibleDecl(type, index.tpi());
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -1,3 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include "PdbAstBuilderSwift.h"
 
 #include "PdbUtil.h"
@@ -74,12 +82,9 @@ CompilerType PdbAstBuilderSwift::GetOrCreateType(PdbTypeSymId type) {
   PdbIndex &index = pdb->GetIndex();
   PdbTypeSymId best_type = GetBestPossibleDecl(type, index.tpi());
 
-  CompilerType ct;
-  if (best_type.index != type.index)
-    ct = GetOrCreateType(best_type);
-  else
-    ct = CreateType(type, index.tpi());
-
+  CompilerType ct = best_type.index == type.index
+                        ? CreateType(type, index.tpi())
+                        : GetOrCreateType(best_type);
   if (ct)
     m_uid_to_type[uid] = ct;
   return ct;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -16,6 +16,7 @@
 #include "lldb/Utility/LLDBAssert.h"
 
 #include "llvm/DebugInfo/CodeView/TypeDeserializer.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/DebugInfo/PDB/Native/TpiStream.h"
 
 #include "swift/Demangling/Demangle.h"
@@ -78,8 +79,10 @@ CompilerType PdbAstBuilderSwift::GetOrCreateType(PdbTypeSymId type) {
   if (auto iter = m_uid_to_type.find(uid); iter != m_uid_to_type.end())
     return iter->second;
 
-  auto *pdb = llvm::cast<SymbolFileNativePDB>(
+  auto *pdb = llvm::dyn_cast<SymbolFileNativePDB>(
       m_swift_ts.GetSymbolFile()->GetBackingSymbolFile());
+  if (!pdb)
+    llvm::report_fatal_error("PdbAstBuilderSwift called from outside NativePDB context.");
   PdbIndex &index = pdb->GetIndex();
   PdbTypeSymId best_type = GetBestPossibleDecl(type, index.tpi());
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -18,6 +18,8 @@
 #include "llvm/DebugInfo/CodeView/TypeDeserializer.h"
 #include "llvm/DebugInfo/PDB/Native/TpiStream.h"
 
+#include "swift/Demangling/Demangle.h"
+
 using namespace lldb_private;
 using namespace lldb_private::npdb;
 using namespace llvm::codeview;
@@ -33,7 +35,7 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
 
   CVType cvt = tpi.getType(type.index);
 
-  llvm::StringRef mangled_name;
+  llvm::StringRef decorated;
   switch (cvt.kind()) {
   case LF_STRUCTURE:
   case LF_CLASS: {
@@ -41,7 +43,7 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
     llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
     if (!cr.hasUniqueName())
       return {};
-    mangled_name = cr.UniqueName;
+    decorated = cr.UniqueName;
     break;
   }
   case LF_ENUM: {
@@ -49,7 +51,7 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
     llvm::cantFail(TypeDeserializer::deserializeAs<EnumRecord>(cvt, er));
     if (!er.hasUniqueName())
       return {};
-    mangled_name = er.UniqueName;
+    decorated = er.UniqueName;
     break;
   }
   case LF_MODIFIER: {
@@ -62,10 +64,10 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
     return {};
   }
 
-  if (!mangled_name.starts_with("$s"))
+  if (!swift::Demangle::isSwiftSymbol(decorated))
     return {};
 
-  return m_swift_ts.GetTypeFromMangledTypename(ConstString(mangled_name));
+  return m_swift_ts.GetTypeFromMangledTypename(ConstString(decorated));
 }
 
 CompilerType PdbAstBuilderSwift::GetOrCreateType(PdbTypeSymId type) {
@@ -73,8 +75,7 @@ CompilerType PdbAstBuilderSwift::GetOrCreateType(PdbTypeSymId type) {
     return {};
 
   lldb::user_id_t uid = toOpaqueUid(type);
-  auto iter = m_uid_to_type.find(uid);
-  if (iter != m_uid_to_type.end())
+  if (auto iter = m_uid_to_type.find(uid); iter != m_uid_to_type.end())
     return iter->second;
 
   auto *pdb = llvm::cast<SymbolFileNativePDB>(

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
@@ -1,4 +1,4 @@
-//===------------------------------------------------------------*- C++ -*-===//
+//===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
@@ -1,0 +1,65 @@
+//===------------------------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDERSWIFT_H
+#define LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDERSWIFT_H
+
+#include "PdbAstBuilder.h"
+
+#include "llvm/ADT/DenseMap.h"
+
+namespace llvm::pdb {
+class TpiStream;
+}
+
+namespace lldb_private {
+
+class TypeSystemSwiftTypeRef;
+
+namespace npdb {
+
+class PdbAstBuilderSwift : public PdbAstBuilder {
+public:
+  PdbAstBuilderSwift(TypeSystemSwiftTypeRef &swift_ts);
+
+  CompilerDecl GetOrCreateDeclForUid(PdbSymUid uid) override { return {}; }
+  CompilerDeclContext GetOrCreateDeclContextForUid(PdbSymUid uid) override {
+    return {};
+  }
+  CompilerDeclContext GetParentDeclContext(PdbSymUid uid) override {
+    return {};
+  }
+
+  void EnsureFunction(PdbCompilandSymId func_id) override {}
+  void EnsureInlinedFunction(PdbCompilandSymId inlinesite_id) override {}
+  void EnsureBlock(PdbCompilandSymId block_id) override {}
+  void EnsureVariable(PdbCompilandSymId scope_id,
+                      PdbCompilandSymId var_id) override {}
+  void EnsureVariable(PdbGlobalSymId var_id) override {}
+
+  CompilerType GetOrCreateType(PdbTypeSymId type) override;
+  CompilerType GetOrCreateTypedefType(PdbGlobalSymId id) override {
+    return {};
+  }
+  bool CompleteType(CompilerType ct) override { return true; }
+
+  void ParseDeclsForContext(CompilerDeclContext context) override {}
+
+  void Dump(Stream &stream, llvm::StringRef filter) override;
+
+private:
+  CompilerType CreateType(PdbTypeSymId type, llvm::pdb::TpiStream &tpi);
+
+  TypeSystemSwiftTypeRef &m_swift_ts;
+  llvm::DenseMap<lldb::user_id_t, CompilerType> m_uid_to_type;
+};
+
+} // namespace npdb
+} // namespace lldb_private
+
+#endif // LLDB_SOURCE_PLUGINS_SYMBOLFILE_NATIVEPDB_PDBASTBUILDERSWIFT_H

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -57,6 +57,10 @@
 #include <optional>
 #include <string_view>
 
+// BEGIN SWIFT
+#include "swift/Demangling/Demangle.h"
+// END SWIFT
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace npdb;
@@ -282,7 +286,7 @@ GetNestedTagDefinition(const NestedTypeRecord &Record,
 }
 
 // BEGIN SWIFT
-// Uses a heuristic (mangled name starts with `$s`) to identify
+// Uses a heuristic based on the mangled name to identify
 // Swift types. Needed since types are commingled in the type stream. 
 static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
   TypeIndex ti = type_id.index;
@@ -300,7 +304,7 @@ static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
     return false;
   ClassRecord cr;
   llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
-  return cr.hasUniqueName() && cr.UniqueName.starts_with("$s");
+  return cr.hasUniqueName() && swift::Demangle::isSwiftSymbol(cr.UniqueName);
 }
 // END SWIFT
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -281,6 +281,30 @@ GetNestedTagDefinition(const NestedTypeRecord &Record,
   return std::move(child);
 }
 
+// BEGIN SWIFT
+// Uses a heuristic (mangled name starts with `$s`) to identify
+// Swift types. Needed since types are commingled in the type stream. 
+static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
+  TypeIndex ti = type_id.index;
+  if (ti.isSimple())
+    return false;
+  CVType cvt = index.tpi().getType(ti);
+  // Follow LF_MODIFIER to the underlying type.
+  if (cvt.kind() == LF_MODIFIER) {
+    ModifierRecord mfr;
+    llvm::cantFail(
+        TypeDeserializer::deserializeAs<ModifierRecord>(cvt, mfr));
+    return IsSwiftType(PdbTypeSymId(mfr.ModifiedType, false), index);
+  }
+  if (cvt.kind() != LF_STRUCTURE && cvt.kind() != LF_CLASS)
+    return false;
+  ClassRecord cr;
+  llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
+  return cr.hasUniqueName() && cr.UniqueName.starts_with("$s");
+}
+// END SWIFT
+
+
 void SymbolFileNativePDB::Initialize() {
   PluginManager::RegisterPlugin(GetPluginNameStatic(),
                                 GetPluginDescriptionStatic(), CreateInstance,
@@ -799,7 +823,9 @@ TypeSP SymbolFileNativePDB::CreateAndCacheType(PdbTypeSymId type_id) {
   }
 
   PdbTypeSymId best_decl_id = full_decl_uid ? *full_decl_uid : type_id;
-  auto ts_or_err = GetTypeSystemForLanguage(lldb::eLanguageTypeC_plus_plus);
+  // BEGIN SWIFT
+  auto ts_or_err = GetTypeSystemForLanguage(IsSwiftType(best_decl_id, *m_index) ? lldb::eLanguageTypeSwift : lldb::eLanguageTypeC_plus_plus);
+  // END SWIFT
   if (auto err = ts_or_err.takeError())
     return nullptr;
   auto ts = *ts_or_err;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -287,7 +287,7 @@ GetNestedTagDefinition(const NestedTypeRecord &Record,
 
 // BEGIN SWIFT
 // Uses a heuristic based on the mangled name to identify
-// Swift types. Needed since types are commingled in the type stream. 
+// Swift types. Needed since types are commingled in the type stream.
 static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
   TypeIndex ti = type_id.index;
   if (ti.isSimple())
@@ -300,7 +300,7 @@ static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
         TypeDeserializer::deserializeAs<ModifierRecord>(cvt, mfr));
     return IsSwiftType(PdbTypeSymId(mfr.ModifiedType, false), index);
   }
-  if (cvt.kind() != LF_STRUCTURE && cvt.kind() != LF_CLASS)
+  if (!llvm::is_contained({LF_STRUCTURE, LF_CLASS}, cvt.kind()))
     return false;
   ClassRecord cr;
   llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -22,6 +22,7 @@
 #include "Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h"
 #include "Plugins/Language/Swift/LogChannelSwift.h"
 #include "Plugins/SymbolFile/DWARF/DWARFASTParserSwift.h"
+#include "Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h"
 #include "Plugins/TypeSystem/Clang/TypeSystemClang.h"
 #include "TypeSystemSwiftTypeRef.h"
 #include "lldb/Core/Debugger.h"
@@ -2780,6 +2781,13 @@ plugin::dwarf::DWARFASTParser *TypeSystemSwiftTypeRef::GetDWARFParser() {
   if (!m_dwarf_ast_parser_up)
     m_dwarf_ast_parser_up.reset(new DWARFASTParserSwift(*this));
   return m_dwarf_ast_parser_up.get();
+}
+
+npdb::PdbAstBuilder *TypeSystemSwiftTypeRef::GetNativePDBParser() {
+  if (!m_pdb_ast_parser_up)
+    m_pdb_ast_parser_up =
+        std::make_unique<npdb::PdbAstBuilderSwift>(*this);
+  return m_pdb_ast_parser_up.get();
 }
 
 TypeSP

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -119,6 +119,8 @@ public:
   Status IsCompatible() override;
 
   plugin::dwarf::DWARFASTParser *GetDWARFParser() override;
+  npdb::PdbAstBuilder *GetNativePDBParser() override;
+
   // CompilerDecl functions
   ConstString DeclGetName(void *opaque_decl) override {
     return ConstString("");
@@ -642,6 +644,7 @@ protected:
       m_dwarf_importer_for_clang_types_up;
   mutable std::unique_ptr<ClangNameImporter> m_name_importer_up;
   std::unique_ptr<plugin::dwarf::DWARFASTParser> m_dwarf_ast_parser_up;
+  std::unique_ptr<npdb::PdbAstBuilder> m_pdb_ast_parser_up;
 
   /// The APINotesManager responsible for each Clang module.
   llvm::DenseMap<clang::Module *,

--- a/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
@@ -1,0 +1,49 @@
+# Test that frame variable works for Swift types with NativePDB debug info.
+
+# REQUIRES: swift, system-windows
+
+# RUN: split-file %s %t
+# RUN: %target-swiftc -v -g -debug-info-format=codeview %t/main.swift -o %t.exe -Xlinker -debug -use-ld=lld
+# RUN: %lldb -x -b -s %t/commands.input %t.exe -o exit 2>&1 | FileCheck %s
+
+#--- main.swift
+struct Point {
+    var x: Int32
+    var y: Int32
+}
+
+enum Direction {
+    case north
+    case south
+}
+
+func main() {
+    var myInt32: Int32 = 42
+    var myBool: Bool = true
+    var myUInt64: UInt64 = 123456789
+    var myFloat: Float = 3.14
+    var myDouble: Double = 2.718
+    var myString: String = "hello"
+    var myPoint: Point = Point(x: 10, y: 20)
+    var myDirection: Direction = .north
+    print(myInt32, myBool, myUInt64, myFloat, myDouble,
+          myString, myPoint, myDirection)
+}
+
+main()
+
+#--- commands.input
+b main.swift:20
+run
+frame variable
+
+# Basic scalar types
+# CHECK: (Int32) myInt32 = 42
+# CHECK: (Bool) myBool = true
+# CHECK: (UInt64) myUInt64 = 123456789
+# CHECK: (Float) myFloat = 3.1400001
+# CHECK: (Double) myDouble = 2.718
+# Compound types
+# CHECK: (String) myString = "hello"
+# CHECK: (main.Point) myPoint = (x = 10, y = 20)
+# CHECK: (main.Direction) myDirection = north

--- a/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
@@ -1,5 +1,7 @@
 # Test that frame variable works for Swift types with NativePDB debug info.
 
+# Won't pass until https://github.com/swiftlang/llvm-project/issues/12289 is resolved.
+# XFAIL: system-windows
 # REQUIRES: swift, system-windows
 
 # RUN: split-file %s %t

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -98,11 +98,6 @@ xfail lldb-api :: python_api/address_range/TestAddressRange.py
 # https://github.com/swiftlang/llvm-project/issues/9643
 xfail lldb-shell :: Commands/command-process-launch-user-entry.test
 
-# Pre-emptively skipping since it won't pass until the following
-# is fixed:
-# https://github.com/swiftlang/llvm-project/issues/12289
-skip lldb-shell :: SymbolFile/NativePDB/swift-frame-var.test
-
 # Skip SymbolTests because we cannot xfail unittests by name. We would need to
 # specify their indexes, but these are subject to change. Right now, failures
 # are:

--- a/lldb/test/windows-swift-llvm-lit-test-overrides.txt
+++ b/lldb/test/windows-swift-llvm-lit-test-overrides.txt
@@ -98,6 +98,11 @@ xfail lldb-api :: python_api/address_range/TestAddressRange.py
 # https://github.com/swiftlang/llvm-project/issues/9643
 xfail lldb-shell :: Commands/command-process-launch-user-entry.test
 
+# Pre-emptively skipping since it won't pass until the following
+# is fixed:
+# https://github.com/swiftlang/llvm-project/issues/12289
+skip lldb-shell :: SymbolFile/NativePDB/swift-frame-var.test
+
 # Skip SymbolTests because we cannot xfail unittests by name. We would need to
 # specify their indexes, but these are subject to change. Right now, failures
 # are:


### PR DESCRIPTION
Introduces a Swift-specific `PdbAstBuilder`, `PdbAstBuilderSwift` and wires it up to `TypeSystemSwift`.

This brings support for printing locals when using the NativePDB backend. See the tests for some known-working types.

Generics are blocked by https://github.com/swiftlang/swift/issues/87093 and let constants are forthcoming.