### PR TITLE
Revert "[stable/21.x][lldb][swift] Update Swift ASTContextCreation to…

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3761,10 +3761,6 @@ void SwiftASTContext::InitializeSearchPathOptions(
   invocation.computeCXXStdlibOptions();
 }
 
-std::optional<clang::DarwinSDKInfo> &SwiftASTContext::GetSDKInfo() {
-  return GetCompilerInvocation().getSDKInfo();
-}
-
 ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   assert(m_initialized_search_path_options &&
          m_initialized_clang_importer_options &&
@@ -3779,8 +3775,7 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
       GetLanguageOptions(), GetTypeCheckerOptions(), GetSILOptions(),
       GetSearchPathOptions(), GetClangImporterOptions(),
       GetSymbolGraphOptions(), GetCASOptions(), GetSerializationOptions(),
-      GetSourceManager(), GetDiagnosticEngine(), GetSDKInfo(),
-      /*OutputBackend=*/nullptr));
+      GetSourceManager(), GetDiagnosticEngine(), /*OutputBackend=*/nullptr));
 
   if (getenv("LLDB_SWIFT_DUMP_DIAGS")) {
     // NOTE: leaking a swift::PrintingDiagnosticConsumer() here, but

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -31,13 +31,11 @@
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 
-#include "clang/Basic/DarwinSDKInfo.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Target/TargetOptions.h"
 
 #include <memory>
-#include <optional>
 
 namespace swift {
 enum class IRGenDebugInfoLevel : unsigned;
@@ -255,8 +253,6 @@ public:
   swift::DiagnosticEngine &GetDiagnosticEngine();
 
   swift::SearchPathOptions &GetSearchPathOptions();
-
-  std::optional<clang::DarwinSDKInfo> &GetSDKInfo();
 
   swift::SerializationOptions &GetSerializationOptions();
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -85,8 +85,8 @@ public:
         m_compiler_invocation.getClangImporterOptions(),
         m_compiler_invocation.getSymbolGraphOptions(),
         m_compiler_invocation.getCASOptions(),
-        m_compiler_invocation.getSerializationOptions(), m_source_manager,
-        m_diagnostic_engine, m_compiler_invocation.getSDKInfo()));
+        m_compiler_invocation.getSerializationOptions(),
+        m_source_manager, m_diagnostic_engine));
     m_clang_importer = swift::ClangImporter::create(*m_ast_context,
         nullptr, "", {}, {});
   }


### PR DESCRIPTION
… account for the new argument"

This reverts commit b9639fc139687fd15ff30aca9e687748e74d71fa.

The change is no longer needed after a partial revert of the change in swift repo that restores the original function signiture.