### PR TITLE
🍒 [CoroSplit][DebugInfo] Fix scope of continuation funclets

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1881,3 +1881,17 @@ def launch_exe_in_apple_simulator(
             break
 
     return exe_path, matched_strings
+
+def ignore_swift_stdlib_when_stepping(platform, tester):
+        system = platform.system()
+        if system == "Darwin":
+            lib_name = "libswiftCore.dylib"
+        elif system == "Windows":
+            lib_name = "swiftCore.dll"
+        else:
+            lib_name = "libswiftCore.so"
+
+        tester.dbg.HandleCommand(
+            "settings set "
+            "target.process.thread.step-avoid-libraries {}".format(lib_name)
+        )

--- a/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
+++ b/lldb/test/API/lang/swift/step_into_objc_interop_init/TestStepIntoObjCInteropInit.py
@@ -4,17 +4,6 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftObjcProtocol(TestBase):
-    def skip_debug_info_libraries(self):
-        if platform.system() == "Darwin":
-            lib_name = "libswiftCore.dylib"
-        else:
-            lib_name = "libswiftCore.so"
-
-        self.dbg.HandleCommand(
-            "settings set "
-            "target.process.thread.step-avoid-libraries {}".format(lib_name)
-        )
-
     @skipUnlessDarwin
     @swiftTest
     def test(self):
@@ -23,7 +12,7 @@ class TestSwiftObjcProtocol(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
 
-        self.skip_debug_info_libraries()
+        lldbutil.ignore_swift_stdlib_when_stepping(platform, self)
         # Go to the first constructor, assert we can step into it.
         thread.StepInto()
         self.assertEqual(thread.stop_reason, lldb.eStopReasonPlanComplete)

--- a/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
+++ b/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
@@ -17,18 +17,7 @@ class TestStepIntoOverride(lldbtest.TestBase):
         lldbtest.TestBase.setUp(self)
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
-        # If you are running against a debug swift you are going to
-        # end up stepping into the stdlib and that will make stepping
-        # tests impossible to write.  So avoid that.
-
-        if platform.system() == 'Darwin':
-            lib_name = "libswiftCore.dylib"
-        else:
-            lib_name = "libswiftCore.so"
-
-        self.dbg.HandleCommand(
-            "settings set "
-            "target.process.thread.step-avoid-libraries {}".format(lib_name))
+        lldbutil.ignore_swift_stdlib_when_stepping(platform, self)
 
     def do_test(self):
         """Tests that we can step reliably in swift code."""

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -34,18 +34,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         lldbtest.TestBase.setUp(self)
         self.main_source = "main.swift"
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
-        # If you are running against a debug swift you are going to
-        # end up stepping into the stdlib and that will make stepping
-        # tests impossible to write.  So avoid that.
-
-        if platform.system() == 'Darwin':
-            lib_name = "libswiftCore.dylib"
-        else:
-            lib_name = "libswiftCore.so"
-
-        self.dbg.HandleCommand(
-            "settings set "
-            "target.process.thread.step-avoid-libraries {}".format(lib_name))
+        lldbutil.ignore_swift_stdlib_when_stepping(platform, self)
 
     def correct_stop_reason(self, thread):
         # We are always just stepping, so that should be the thread stop reason:

--- a/lldb/test/API/lang/swift/yielding_accessors/Makefile
+++ b/lldb/test/API/lang/swift/yielding_accessors/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -enable-experimental-feature CoroutineAccessors
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
+++ b/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
@@ -1,0 +1,91 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftStepping(lldbtest.TestBase):
+    def setUp(self):
+        lldbtest.TestBase.setUp(self)
+        self.main_source = "main.swift"
+        self.main_source_spec = lldb.SBFileSpec(self.main_source)
+        lldbutil.ignore_swift_stdlib_when_stepping(platform, self)
+
+    def check_stop_reason_plan_complete(self, thread):
+        self.assertEqual(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
+
+    def check_self_available(self, thread):
+        frame0 = thread.frames[0]
+        self_var = frame0.FindVariable("self")
+        self.assertSuccess(self_var.GetError(), "Failed to fetch self")
+        member_int = self_var.GetChildAtIndex(0)
+        self.assertSuccess(member_int.GetError(), "Failed to fetch self.member_int")
+        self.assertEqual(member_int.GetValueAsSigned(), 42)
+
+    def hit_correct_line(self, thread, pattern):
+        self.check_stop_reason_plan_complete(thread)
+        target_line = lldbtest.line_number(self.main_source, pattern)
+        self.assertNotEqual(target_line, 0, "Could not find source pattern " + pattern)
+        cur_line = thread.frames[0].GetLineEntry().GetLine()
+        hit_line = cur_line == target_line
+        self.assertTrue(
+            hit_line,
+            "Stepped to line %d instead of expected %d "
+            "with pattern '%s'\nBacktrace = \n%s."
+            % (
+                cur_line,
+                target_line,
+                pattern,
+                "\n".join(str(frame) for frame in thread.frames),
+            ),
+        )
+        return hit_line
+
+    @swiftTest
+    def test_correct_number_of_breakpoints(self):
+        self.build()
+        exe = self.getBuildArtifact("a.out")
+        target = self.dbg.CreateTarget(exe)
+        breakpoint = target.BreakpointCreateBySourceRegex(
+            "yield line", self.main_source_spec
+        )
+        self.assertEqual(breakpoint.GetNumLocations(), 1, breakpoint)
+
+    @swiftTest
+    def test_step_over_starting_inside_coroutine(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "first coroutine line", self.main_source_spec
+        )
+        self.check_self_available(thread)
+        thread.StepOver()
+        self.hit_correct_line(thread, "yield line")
+        self.check_self_available(thread)
+        thread.StepOver()
+        self.hit_correct_line(thread, "coroutine call site")
+        thread.StepOver()
+        self.hit_correct_line(thread, "last main line")
+
+    @swiftTest
+    def test_step_in_and_out_callsite(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "coroutine call site", self.main_source_spec
+        )
+        thread.StepInto()
+        self.hit_correct_line(thread, "first coroutine line")
+        self.check_self_available(thread)
+        thread.StepOut()
+        self.hit_correct_line(thread, "coroutine call site")
+        thread.StepInto()
+        self.hit_correct_line(thread, "USE line")
+        thread.StepOut()
+        self.hit_correct_line(thread, "coroutine call site")
+        thread.StepInto()
+        self.hit_correct_line(thread, "last coroutine line")
+        self.check_self_available(thread)
+        thread.StepOut()
+        # FIXME: this last line behaves differently in CI, where it instead
+        # returns to the last line of main. This is likely a result of the
+        # debug symbols in the standard library.
+        # self.hit_correct_line(thread, "coroutine call site")

--- a/lldb/test/API/lang/swift/yielding_accessors/main.swift
+++ b/lldb/test/API/lang/swift/yielding_accessors/main.swift
@@ -1,0 +1,19 @@
+func USE(_ int: inout Int) {} // USE line
+func FINISH() {}
+
+struct S {
+  private var member_int: Int = 42
+
+  var COMPUTED_PROPERTY: Int {
+    get { return member_int }
+    yielding mutate {
+      FINISH() // first coroutine line
+      yield &member_int //yield line
+      FINISH() // last coroutine line
+    }
+  }
+}
+
+var state = S()
+USE(&state.COMPUTED_PROPERTY) // coroutine call site
+FINISH() // last main line

--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -827,9 +827,11 @@ static void updateScopeLine(Instruction *ActiveSuspend,
       ActiveSuspend->getNextNonDebugInstruction()->getIterator();
   // Corosplit splits the BB around ActiveSuspend, so the meaningful
   // instructions are not in the same BB.
-  if (auto *Branch = dyn_cast_or_null<BranchInst>(Successor);
-      Branch && Branch->isUnconditional())
+  while (auto *Branch = dyn_cast_or_null<BranchInst>(Successor)) {
+    if (!Branch->isUnconditional())
+      break;
     Successor = Branch->getSuccessor(0)->getFirstNonPHIOrDbg();
+  }
 
   // Find the first successor of ActiveSuspend with a non-zero line location.
   // If that matches the file of ActiveSuspend, use it.

--- a/llvm/test/Transforms/Coroutines/coro-retcon-continuation-scope.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-continuation-scope.ll
@@ -1,0 +1,69 @@
+; RUN: opt < %s -passes='cgscc(coro-split),simplifycfg,early-cse' -S | FileCheck %s
+
+@"coroutineTwc" = global <{ i32, i32, i64 }> <{ i32 trunc (i64 sub (i64 ptrtoint (ptr @"coroutine" to i64), i64 ptrtoint (ptr @"coroutineTwc" to i64)) to i32), i32 0, i64 51979 }>, align 8
+
+define swiftcc { ptr, ptr } @"coroutine"(ptr noalias %0, ptr %1, ptr swiftself %2) #0 !dbg !39 {
+entry:
+  %3 = call token @llvm.coro.id.retcon.once(i32 -1, i32 16, ptr %0, ptr @"$s4test1SVSiIetMIlYl_TC", ptr @_swift_coro_alloc, ptr @_swift_coro_dealloc), !dbg !48
+  %4 = call ptr @llvm.coro.begin(token %3, ptr null), !dbg !48
+  call swiftcc void @"$s4test6FINISHyyF"(), !dbg !50
+  %.member_int = getelementptr inbounds nuw <{ <{ i64 }> }>, ptr %2, i32 0, i32 0, !dbg !51
+; Test that the scope of the continuation is NOT on the same line as the split
+; point.
+; In this case the split point is on line 11, and the scope of the continuation
+; should be line 12.
+  %5 = call ptr (...) @llvm.coro.suspend.retcon.p0(ptr %.member_int), !dbg !52 ; [debug line = 11:7]
+; CHECK-LABEL: define {{.*}} @coroutine.resume
+; CHECK-SAME: !dbg ![[CONTINUATION_SP:[0-9]+]]
+; CHECK: ![[CONTINUATION_SP]] = {{.*}} scopeLine: 12
+  br i1 false, label %7, label %6, !dbg !52       ; [debug line = 11:7]
+
+6:
+  call swiftcc void @"$s4test6FINISHyyF"(), !dbg !53 ; [debug line = 12:7]
+  br label %coro.end, !dbg !54
+
+7:
+  br label %coro.end, !dbg !54
+
+coro.end:
+  call void @llvm.coro.end(ptr %4, i1 false, token none), !dbg !54
+  unreachable, !dbg !54
+}
+
+declare swiftcc void @"$s4test6FINISHyyF"()
+declare swiftcc ptr @_swift_coro_alloc(i64) #3
+declare swiftcc void @_swift_coro_dealloc(ptr) #3
+declare swiftcc ptr @_swift_coro_alloc_frame(ptr, ptr, i64, i64) #3
+declare swiftcc void @_swift_coro_dealloc_frame(ptr, ptr, ptr) #3
+declare swiftcc void @"$s4test1SVSiIetMIlYl_TC"(ptr noalias, ptr)
+
+attributes #0 = { noinline presplitcoroutine }
+attributes #3 = { noinline nounwind }
+
+!llvm.module.flags = !{!7, !8, !9, !10, !11}
+!llvm.dbg.cu = !{!17}
+
+!7 = !{i32 7, !"Dwarf Version", i32 5}
+!8 = !{i32 2, !"Debug Info Version", i32 3}
+!9 = !{i32 1, !"wchar_size", i32 4}
+!10 = !{i32 8, !"PIC Level", i32 2}
+!11 = !{i32 7, !"uwtable", i32 1}
+!17 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !18, producer: "Swift", isOptimized: false, emissionKind: FullDebug)
+!18 = !DIFile(filename: "test.ll", directory: "/")
+!39 = distinct !DISubprogram(name: "COMPUTED_PROPERTY.yielding_mutate", linkageName: "coroutine", scope: !40, file: !18, line: 9, type: !41, scopeLine: 9, spFlags: DISPFlagDefinition, unit: !17, declaration: !44, retainedNodes: !45)
+!40 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !18, size: 64, runtimeLang: DW_LANG_Swift, identifier: "$s4test1SVD")
+!41 = !DISubroutineType(types: !42)
+!42 = !{!43, !40}
+!43 = !DICompositeType(tag: DW_TAG_structure_type, name: "$sytD", flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift, identifier: "$sytD")
+!44 = !DISubprogram(name: "COMPUTED_PROPERTY.yielding_mutate", linkageName: "coroutine", scope: !40, file: !18, line: 9, type: !41, scopeLine: 9, spFlags: 0)
+!45 = !{!46}
+!46 = !DILocalVariable(name: "self", arg: 1, scope: !39, file: !18, line: 9, type: !40, flags: DIFlagArtificial)
+!47 = !DILocation(line: 9, column: 14, scope: !39)
+!48 = !DILocation(line: 0, scope: !39)
+!50 = !DILocation(line: 10, column: 7, scope: !39)
+!51 = !DILocation(line: 11, column: 13, scope: !39)
+!52 = !DILocation(line: 11, column: 7, scope: !39)
+!53 = !DILocation(line: 12, column: 7, scope: !39)
+!54 = !DILocation(line: 0, scope: !55)
+!55 = !DILexicalBlockFile(scope: !39, file: !56, discriminator: 0)
+!56 = !DIFile(filename: "<compiler-generated>", directory: "/")

--- a/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic-continuation-scope.ll
+++ b/llvm/test/Transforms/Coroutines/coro-retcon-once-dynamic-continuation-scope.ll
@@ -1,0 +1,76 @@
+; RUN: opt < %s -passes='cgscc(coro-split),simplifycfg,early-cse' -S | FileCheck %s
+
+@"coroutineTwc" = global <{ i32, i32, i64 }> <{ i32 trunc (i64 sub (i64 ptrtoint (ptr @"coroutine" to i64), i64 ptrtoint (ptr @"coroutineTwc" to i64)) to i32), i32 0, i64 51979 }>, align 8
+
+define swiftcc { ptr, ptr } @"coroutine"(ptr noalias %0, ptr swiftcoro %1, ptr swiftself captures(none) dereferenceable(8) %2) #0 !dbg !39 {
+entry:
+  %3 = call token @llvm.coro.id.retcon.once.dynamic(i32 -1, i32 16, ptr @"coroutineTwc", ptr %1, ptr %0, ptr @"$s4test1SVSiIetMIlYl_TC", ptr @_swift_coro_alloc, ptr @_swift_coro_dealloc, ptr @_swift_coro_alloc_frame, ptr @_swift_coro_dealloc_frame, i64 51979), !dbg !48
+  %4 = call ptr @llvm.coro.begin(token %3, ptr null), !dbg !48
+  call swiftcc void @"$s4test6FINISHyyF"(), !dbg !50
+  %.member_int = getelementptr inbounds nuw <{ <{ i64 }> }>, ptr %2, i32 0, i32 0, !dbg !51
+; Test that the scope of the continuation is NOT on the same line as the split
+; point.
+; In this case the split point is on line 11, and the scope of the continuation
+; should be line 12.
+  %5 = call ptr (...) @llvm.coro.suspend.retcon.p0(ptr %.member_int), !dbg !52 ; [debug line = 11:7]
+; CHECK-LABEL: define {{.*}} @coroutine.resume
+; CHECK-SAME: !dbg ![[CONTINUATION_SP:[0-9]+]]
+; CHECK: ![[CONTINUATION_SP]] =
+  br i1 false, label %7, label %6, !dbg !52       ; [debug line = 11:7]
+
+6:
+  call swiftcc void @"$s4test6FINISHyyF"(), !dbg !53 ; [debug line = 12:7]
+  br label %coro.end, !dbg !54
+
+7:
+  br label %coro.end, !dbg !54
+
+coro.end:
+  %8 = call ptr @llvm.coro.end(ptr %4, i1 false, token none) #5, !dbg !54
+  unreachable, !dbg !54
+}
+
+declare swiftcc void @"$s4test6FINISHyyF"()
+declare void @llvm.memset.p0.i64(ptr writeonly captures(none), i8, i64, i1 immarg)
+declare swiftcc ptr @_swift_coro_alloc(ptr, ptr swiftcoro, i64, i64) #3
+declare swiftcc void @_swift_coro_dealloc(ptr, ptr swiftcoro, ptr) #3
+declare swiftcc ptr @_swift_coro_alloc_frame(ptr, ptr swiftcoro, i64, i64) #3
+declare swiftcc void @_swift_coro_dealloc_frame(ptr, ptr swiftcoro, ptr) #3
+declare swiftcc void @"$s4test1SVSiIetMIlYl_TC"(ptr noalias, ptr swiftcoro)
+declare token @llvm.coro.id.retcon.once.dynamic(i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, i64) #4
+declare ptr @llvm.coro.begin(token, ptr writeonly) #4
+declare ptr @llvm.coro.suspend.retcon.p0(...) #4
+declare ptr @llvm.coro.end(ptr, i1, token) #4
+
+attributes #0 = { noinline presplitcoroutine }
+attributes #3 = { noinline nounwind }
+attributes #4 = { nounwind }
+attributes #5 = { noduplicate }
+
+!llvm.module.flags = !{!7, !8, !9, !10, !11}
+!llvm.dbg.cu = !{!17}
+
+!7 = !{i32 7, !"Dwarf Version", i32 5}
+!8 = !{i32 2, !"Debug Info Version", i32 3}
+!9 = !{i32 1, !"wchar_size", i32 4}
+!10 = !{i32 8, !"PIC Level", i32 2}
+!11 = !{i32 7, !"uwtable", i32 1}
+!17 = distinct !DICompileUnit(language: DW_LANG_Swift, file: !18, producer: "Swift", isOptimized: false, emissionKind: FullDebug)
+!18 = !DIFile(filename: "test.ll", directory: "/")
+!39 = distinct !DISubprogram(name: "COMPUTED_PROPERTY.yielding_mutate", linkageName: "coroutine", scope: !40, file: !18, line: 9, type: !41, scopeLine: 9, spFlags: DISPFlagDefinition, unit: !17, declaration: !44, retainedNodes: !45)
+!40 = !DICompositeType(tag: DW_TAG_structure_type, name: "S", file: !18, size: 64, runtimeLang: DW_LANG_Swift, identifier: "$s4test1SVD")
+!41 = !DISubroutineType(types: !42)
+!42 = !{!43, !40}
+!43 = !DICompositeType(tag: DW_TAG_structure_type, name: "$sytD", flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift, identifier: "$sytD")
+!44 = !DISubprogram(name: "COMPUTED_PROPERTY.yielding_mutate", linkageName: "coroutine", scope: !40, file: !18, line: 9, type: !41, scopeLine: 9, spFlags: 0)
+!45 = !{!46}
+!46 = !DILocalVariable(name: "self", arg: 1, scope: !39, file: !18, line: 9, type: !40, flags: DIFlagArtificial)
+!47 = !DILocation(line: 9, column: 14, scope: !39)
+!48 = !DILocation(line: 0, scope: !39)
+!50 = !DILocation(line: 10, column: 7, scope: !39)
+!51 = !DILocation(line: 11, column: 13, scope: !39)
+!52 = !DILocation(line: 11, column: 7, scope: !39)
+!53 = !DILocation(line: 12, column: 7, scope: !39)
+!54 = !DILocation(line: 0, scope: !55)
+!55 = !DILexicalBlockFile(scope: !39, file: !56, discriminator: 0)
+!56 = !DIFile(filename: "<compiler-generated>", directory: "/")


### PR DESCRIPTION
This PR contains 3 commits:
1. cherry-pick a of the commit mentioned in the title
2. (new) a downstream-only LLVM test for the downstream-only corosplit ABI ("retcon-once-dynamic")
3. (new) a downstream-only LLDB test for the yielding accessors feature of swift