### PR TITLE
[MCCAS] Improve MCCAS callbacks and error handling

### DIFF
--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -93,16 +93,12 @@ public:
 
   // BEGIN MCCAS
   /// Create a CAS object writer for the assembler backend.
-  std::unique_ptr<MCObjectWriter> createCASObjectWriter(
-      raw_pwrite_stream &OS, const Triple &TT, cas::ObjectStore &CAS,
-      const MCTargetOptions &MCOpts, CASBackendMode Mode,
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                           llvm::MCAssembler &,
-                                           cas::ObjectStore &, raw_ostream *)>
-          CreateFromMcAssembler,
-      std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-          SerializeObjectFile,
-      raw_pwrite_stream *CasIDOS = nullptr) const;
+  std::unique_ptr<MCObjectWriter>
+  createCASObjectWriter(raw_pwrite_stream &OS, const Triple &TT,
+                        cas::ObjectStore &CAS, const MCTargetOptions &MCOpts,
+                        CASBackendMode Mode,
+                        std::unique_ptr<mccasformats::MCCASSchema> Schema,
+                        raw_pwrite_stream *CasIDOS = nullptr) const;
   // END MCCAS
 
 

--- a/llvm/include/llvm/MC/MCCASFormatSchemaBase.h
+++ b/llvm/include/llvm/MC/MCCASFormatSchemaBase.h
@@ -1,0 +1,54 @@
+//===- llvm/MC/MCCASFormatSchemaBase.h --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_MC_MCCASFORMATSCHEMABASE_H
+#define LLVM_MC_MCCASFORMATSCHEMABASE_H
+
+#include "llvm/CAS/CASNodeSchema.h"
+#include "llvm/CAS/ObjectStore.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace llvm {
+
+class MachOCASWriter;
+class MCAssembler;
+
+namespace mccasformats {
+
+class MCFormatSchemaBase
+    : public RTTIExtends<MCFormatSchemaBase, cas::NodeSchema> {
+  void anchor() override;
+
+public:
+  static char ID;
+
+  Expected<cas::ObjectProxy>
+  createFromMCAssembler(llvm::MachOCASWriter &ObjectWriter,
+                        llvm::MCAssembler &Asm,
+                        raw_ostream *DebugOS = nullptr) const {
+    return createFromMCAssemblerImpl(ObjectWriter, Asm, DebugOS);
+  }
+
+  virtual Error serializeObjectFile(cas::ObjectProxy RootNode,
+                                    llvm::raw_ostream &OS) const = 0;
+
+protected:
+  virtual Expected<cas::ObjectProxy>
+  createFromMCAssemblerImpl(llvm::MachOCASWriter &ObjectWriter,
+                            llvm::MCAssembler &Asm,
+                            raw_ostream *DebugOS) const = 0;
+
+  MCFormatSchemaBase(cas::ObjectStore &CAS)
+      : MCFormatSchemaBase::RTTIExtends(CAS) {}
+};
+
+using MCCASSchema = MCFormatSchemaBase;
+} // namespace mccasformats
+} // namespace llvm
+
+#endif // LLVM_MC_MCCASFORMATSCHEMABASE_H

--- a/llvm/include/llvm/MC/MCMachOCASWriter.h
+++ b/llvm/include/llvm/MC/MCMachOCASWriter.h
@@ -9,30 +9,20 @@
 #ifndef LLVM_MC_MCMACHOCASWRITER_H
 #define LLVM_MC_MCMACHOCASWRITER_H
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/CAS/ObjectStore.h"
+#include "llvm/MC/MCCASFormatSchemaBase.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCMachObjectWriter.h"
 #include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCSection.h"
 #include "llvm/MC/MCTargetOptions.h"
-#include "llvm/MC/MCValue.h"
-#include "llvm/MC/StringTableBuilder.h"
-#include "llvm/Support/EndianStream.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cstdint>
 #include <memory>
-#include <string>
-#include <vector>
 
 namespace llvm {
-
-namespace cas {
-class ObjectStore;
-class CASID;
-} // namespace cas
 
 class MachOCASWriter : public MachObjectWriter {
 public:
@@ -42,18 +32,12 @@ public:
   CASBackendMode Mode;
   std::optional<MCTargetOptions::ResultCallBackTy> ResultCallBack;
 
-  MachOCASWriter(
-      std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
-      cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
-      bool IsLittleEndian,
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                           llvm::MCAssembler &,
-                                           cas::ObjectStore &, raw_ostream *)>
-          CreateFromMcAssembler,
-      std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-          SerializeObjectFile,
-      std::optional<MCTargetOptions::ResultCallBackTy> CallBack,
-      raw_pwrite_stream *CasIDOS = nullptr);
+  MachOCASWriter(std::unique_ptr<MCMachObjectTargetWriter> MOTW,
+                 const Triple &TT, cas::ObjectStore &CAS, CASBackendMode Mode,
+                 raw_pwrite_stream &OS, bool IsLittleEndian,
+                 std::unique_ptr<mccasformats::MCCASSchema> Schema,
+                 std::optional<MCTargetOptions::ResultCallBackTy> CallBack,
+                 raw_pwrite_stream *CasIDOS = nullptr);
 
   uint8_t getAddressSize() { return Target.isArch32Bit() ? 4 : 8; }
 
@@ -72,12 +56,7 @@ private:
 
   uint64_t OSOffset = 0;
 
-  std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                       llvm::MCAssembler &, cas::ObjectStore &,
-                                       raw_ostream *)>
-      CreateFromMcAssembler;
-  std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-      SerializeObjectFile;
+  std::unique_ptr<mccasformats::MCCASSchema> Schema;
 };
 
 /// Construct a new Mach-O CAS writer instance.
@@ -88,17 +67,13 @@ private:
 /// \param TT - The target triple.
 /// \param CAS - The ObjectStore instance.
 /// \param OS - The stream to write to.
+/// \param Schema - The MCCAS schema to use.
+/// \param CallBack - The callback to return the result CASID.
 /// \returns The constructed object writer.
 std::unique_ptr<MCObjectWriter> createMachOCASWriter(
     std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
     cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
-    bool IsLittleEndian,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                         llvm::MCAssembler &,
-                                         cas::ObjectStore &, raw_ostream *)>
-        CreateFromMcAssembler,
-    std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-        SerializeObjectFile,
+    bool IsLittleEndian, std::unique_ptr<mccasformats::MCCASSchema> Schema,
     std::optional<MCTargetOptions::ResultCallBackTy> CallBack = std::nullopt,
     raw_pwrite_stream *CasIDOS = nullptr);
 

--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.h
@@ -176,7 +176,7 @@
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/CAS/CASID.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/MCCAS/MCCASFormatSchemaBase.h"
+#include "llvm/MC/MCCASFormatSchemaBase.h"
 #include "llvm/MCCAS/MCCASReader.h"
 #include "llvm/Support/BinaryStreamReader.h"
 #include "llvm/Support/DataExtractor.h"

--- a/llvm/include/llvm/MCCAS/MCCASSchemaPool.h
+++ b/llvm/include/llvm/MCCAS/MCCASSchemaPool.h
@@ -1,4 +1,4 @@
-//===- llvm/MC/CAS/MCCASFormatSchemaBase.h ----------------------*- C++ -*-===//
+//===- llvm/MCCAS/MCCASFormatSchemaBase.h -----------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,45 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_MC_CAS_MCCASFORMATSCHEMABASE_H
-#define LLVM_MC_CAS_MCCASFORMATSCHEMABASE_H
+#ifndef LLVM_MCCAS_MCCASFORMATSCHEMABASE_H
+#define LLVM_MCCAS_MCCASFORMATSCHEMABASE_H
 
-#include "llvm/CAS/CASNodeSchema.h"
 #include "llvm/CAS/ObjectStore.h"
-#include "llvm/MC/MCAssembler.h"
-#include "llvm/MC/MCMachOCASWriter.h"
+#include "llvm/MC/MCCASFormatSchemaBase.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
 namespace mccasformats {
-
-class MCFormatSchemaBase
-    : public RTTIExtends<MCFormatSchemaBase, cas::NodeSchema> {
-  void anchor() override;
-
-public:
-  static char ID;
-
-  Expected<cas::ObjectProxy>
-  createFromMCAssembler(llvm::MachOCASWriter &ObjectWriter,
-                        llvm::MCAssembler &Asm,
-                        raw_ostream *DebugOS = nullptr) const {
-    return createFromMCAssemblerImpl(ObjectWriter, Asm, DebugOS);
-  }
-
-  virtual Error serializeObjectFile(cas::ObjectProxy RootNode,
-                                    llvm::raw_ostream &OS) const = 0;
-
-protected:
-  virtual Expected<cas::ObjectProxy>
-  createFromMCAssemblerImpl(llvm::MachOCASWriter &ObjectWriter,
-                            llvm::MCAssembler &Asm,
-                            raw_ostream *DebugOS) const = 0;
-
-  MCFormatSchemaBase(cas::ObjectStore &CAS)
-      : MCFormatSchemaBase::RTTIExtends(CAS) {}
-};
 
 /// Creates all the schemas and can be used to retrieve a particular schema
 /// based on a CAS root node. A client should aim to create and maximize re-use
@@ -66,8 +36,7 @@ public:
   ///
   /// Thread-safe.
   MCFormatSchemaBase *getSchemaForRoot(cas::ObjectProxy Node) const {
-    return dyn_cast_or_null<MCFormatSchemaBase>(
-        Pool.getSchemaForRoot(Node));
+    return dyn_cast_or_null<MCFormatSchemaBase>(Pool.getSchemaForRoot(Node));
   }
 
   cas::SchemaPool &getPool() { return Pool; }
@@ -80,4 +49,4 @@ private:
 } // namespace mccasformats
 } // namespace llvm
 
-#endif // LLVM_MC_CAS_MCCASFORMATSCHEMABASE_H
+#endif // LLVM_MCCAS_MCCASFORMATSCHEMABASE_H

--- a/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
+++ b/llvm/lib/CodeGen/CodeGenTargetMachineImpl.cpp
@@ -221,27 +221,11 @@ CodeGenTargetMachineImpl::createMCStreamer(raw_pwrite_stream &Out,
     // BEGIN MCCAS
     std::unique_ptr<MCObjectWriter> CASBackendWriter;
     if (Options.UseCASBackend) {
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                           llvm::MCAssembler &,
-                                           cas::ObjectStore &, raw_ostream *)>
-          CreateFromMcAssembler =
-              [](llvm::MachOCASWriter &Writer, llvm::MCAssembler &Asm,
-                 cas::ObjectStore &CAS,
-                 raw_ostream *DebugOS = nullptr) -> const cas::ObjectProxy {
-        auto Schema = std::make_unique<mccasformats::v1::MCSchema>(CAS);
-        return cantFail(Schema->createFromMCAssembler(Writer, Asm, DebugOS));
-      };
-      std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-          SerializeObjectFile = [](cas::ObjectProxy RootNode,
-                                   cas::ObjectStore &CAS,
-                                   raw_ostream &OS) -> Error {
-        auto Schema = std::make_unique<mccasformats::v1::MCSchema>(CAS);
-        return Schema->serializeObjectFile(RootNode, OS);
-      };
       CASBackendWriter = MAB->createCASObjectWriter(
           Out, getTargetTriple(), *Options.MCOptions.CAS, Options.MCOptions,
-          Options.MCOptions.CASObjMode, CreateFromMcAssembler,
-          SerializeObjectFile, CasIDOS);
+          Options.MCOptions.CASObjMode,
+          std::make_unique<mccasformats::v1::MCSchema>(*Options.MCOptions.CAS),
+          CasIDOS);
     }
     // END MCCAS
     AsmStreamer.reset(getTarget().createMCObjectStreamer(

--- a/llvm/lib/MC/CMakeLists.txt
+++ b/llvm/lib/MC/CMakeLists.txt
@@ -15,6 +15,7 @@ add_llvm_component_library(LLVMMC
   MCAsmMacro.cpp
   MCAsmStreamer.cpp
   MCAssembler.cpp
+  MCCASFormatSchemaBase.cpp
   MCCodeEmitter.cpp
   MCCodeView.cpp
   MCContext.cpp

--- a/llvm/lib/MC/MCAsmBackend.cpp
+++ b/llvm/lib/MC/MCAsmBackend.cpp
@@ -69,20 +69,15 @@ MCAsmBackend::createObjectWriter(raw_pwrite_stream &OS) const {
 std::unique_ptr<MCObjectWriter> MCAsmBackend::createCASObjectWriter(
     raw_pwrite_stream &OS, const Triple &TT, cas::ObjectStore &CAS,
     const MCTargetOptions &MCOpts, CASBackendMode Mode,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                         llvm::MCAssembler &,
-                                         cas::ObjectStore &, raw_ostream *)>
-        CreateFromMcAssembler,
-    std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-        SerializeObjectFile,
+    std::unique_ptr<mccasformats::MCCASSchema> Schema,
     raw_pwrite_stream *CasIDOS) const {
   auto TW = createObjectTargetWriter();
   switch (TW->getFormat()) {
   case Triple::MachO:
     return createMachOCASWriter(cast<MCMachObjectTargetWriter>(std::move(TW)),
                                 TT, CAS, Mode, OS, Endian == endianness::little,
-                                CreateFromMcAssembler, SerializeObjectFile,
-                                MCOpts.ResultCallBack, CasIDOS);
+                                std::move(Schema), MCOpts.ResultCallBack,
+                                CasIDOS);
   default:
     llvm_unreachable("unexpected object format");
   }

--- a/llvm/lib/MC/MCCASFormatSchemaBase.cpp
+++ b/llvm/lib/MC/MCCASFormatSchemaBase.cpp
@@ -1,0 +1,14 @@
+//===- MCCASFormatSchemaBase.cpp ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/MC/MCCASFormatSchemaBase.h"
+
+using namespace llvm::mccasformats;
+
+char MCFormatSchemaBase::ID = 0;
+void MCFormatSchemaBase::anchor() {}

--- a/llvm/lib/MC/MachOCASWriter.cpp
+++ b/llvm/lib/MC/MachOCASWriter.cpp
@@ -6,68 +6,50 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/iterator_range.h"
 #include "llvm/BinaryFormat/MachO.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/CASUtil/Utils.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCContext.h"
-#include "llvm/MC/MCDirectives.h"
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCMachOCASWriter.h"
 #include "llvm/MC/MCObjectWriter.h"
 #include "llvm/MC/MCSection.h"
-#include "llvm/MC/MCSectionMachO.h"
 #include "llvm/MC/MCSymbol.h"
-#include "llvm/MC/MCSymbolMachO.h"
 #include "llvm/MC/MCValue.h"
-#include "llvm/MCCAS/MCCASFormatSchemaBase.h"
-#include "llvm/MCCAS/MCCASObjectV1.h"
-#include "llvm/Support/Alignment.h"
-#include "llvm/Support/Allocator.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
 
 using namespace llvm;
 using namespace llvm::cas;
-using namespace llvm::mccasformats;
 
 #define DEBUG_TYPE "mc"
 
 MachOCASWriter::MachOCASWriter(
     std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
     cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
-    bool IsLittleEndian,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                         llvm::MCAssembler &,
-                                         cas::ObjectStore &, raw_ostream *)>
-        CreateFromMcAssembler,
-    std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-        SerializeObjectFile,
+    bool IsLittleEndian, std::unique_ptr<mccasformats::MCCASSchema> Schema,
     std::optional<MCTargetOptions::ResultCallBackTy> ResultCallBack,
     raw_pwrite_stream *CasIDOS)
     : MachObjectWriter(std::move(MOTW), InternalOS, IsLittleEndian), Target(TT),
       CAS(CAS), Mode(Mode), ResultCallBack(ResultCallBack), OS(OS),
-      CasIDOS(CasIDOS), InternalOS(InternalBuffer),
-      CreateFromMcAssembler(CreateFromMcAssembler),
-      SerializeObjectFile(SerializeObjectFile) {
+      CasIDOS(CasIDOS), InternalOS(InternalBuffer), Schema(std::move(Schema)) {
   assert(TT.isLittleEndian() == IsLittleEndian && "Endianess should match");
 }
 
 uint64_t MachOCASWriter::writeObject() {
   auto &Asm = *this->Asm;
   uint64_t StartOffset = OS.tell();
-  auto CASObj = CreateFromMcAssembler(*this, Asm, CAS, nullptr);
+  auto CASObj = Schema->createFromMCAssembler(*this, Asm, nullptr);
+  if (!CASObj)
+    getContext().reportError(SMLoc(), toString(CASObj.takeError()));
 
   auto VerifyObject = [&]() -> Error {
     SmallString<512> ObjectBuffer;
     raw_svector_ostream ObjectOS(ObjectBuffer);
-    if (auto E = SerializeObjectFile(CASObj, CAS, ObjectOS))
+    if (auto E = Schema->serializeObjectFile(*CASObj, ObjectOS))
       return E;
 
     if (!ObjectBuffer.equals(InternalBuffer))
@@ -80,28 +62,29 @@ uint64_t MachOCASWriter::writeObject() {
   };
 
   if (CasIDOS)
-    writeCASIDBuffer(CASObj.getID(), *CasIDOS);
+    writeCASIDBuffer(CASObj->getID(), *CasIDOS);
 
   // If there is a callback, then just hand off the result through callback.
   if (ResultCallBack) {
-    cantFail((*ResultCallBack)(CASObj.getID()));
+    if (auto E = (*ResultCallBack)(CASObj->getID()))
+      getContext().reportError(SMLoc(), toString(std::move(E)));
   }
 
   switch (Mode) {
   case CASBackendMode::CASID:
-    writeCASIDBuffer(CASObj.getID(), OS);
+    writeCASIDBuffer(CASObj->getID(), OS);
     break;
   case CASBackendMode::Native: {
-    auto E = SerializeObjectFile(CASObj, CAS, OS);
+    auto E = Schema->serializeObjectFile(*CASObj, OS);
     if (E)
-      report_fatal_error(std::move(E));
+      getContext().reportError(SMLoc(), toString(std::move(E)));
     break;
   }
   case CASBackendMode::Verify: {
     if (!getContext().hadError()) {
       // Verify only when there is no error.
       if (auto E = VerifyObject())
-        report_fatal_error(std::move(E));
+        getContext().reportError(SMLoc(), toString(std::move(E)));
     }
   }
   }
@@ -112,16 +95,10 @@ uint64_t MachOCASWriter::writeObject() {
 std::unique_ptr<MCObjectWriter> llvm::createMachOCASWriter(
     std::unique_ptr<MCMachObjectTargetWriter> MOTW, const Triple &TT,
     cas::ObjectStore &CAS, CASBackendMode Mode, raw_pwrite_stream &OS,
-    bool IsLittleEndian,
-    std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                         llvm::MCAssembler &,
-                                         cas::ObjectStore &, raw_ostream *)>
-        CreateFromMcAssembler,
-    std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-        SerializeObjectFile,
+    bool IsLittleEndian, std::unique_ptr<mccasformats::MCCASSchema> Schema,
     std::optional<MCTargetOptions::ResultCallBackTy> ResultCallBack,
     raw_pwrite_stream *CasIDOS) {
-  return std::make_unique<MachOCASWriter>(
-      std::move(MOTW), TT, CAS, Mode, OS, IsLittleEndian, CreateFromMcAssembler,
-      SerializeObjectFile, ResultCallBack, CasIDOS);
+  return std::make_unique<MachOCASWriter>(std::move(MOTW), TT, CAS, Mode, OS,
+                                          IsLittleEndian, std::move(Schema),
+                                          ResultCallBack, CasIDOS);
 }

--- a/llvm/lib/MCCAS/CMakeLists.txt
+++ b/llvm/lib/MCCAS/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_llvm_component_library(LLVMMCCAS
   MCCASDebugV1.cpp
   MCCASObjectV1.cpp
-  MCCASFormatSchemaBase.cpp
+  MCCASSchemaPool.cpp
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/MCCAS
 

--- a/llvm/lib/MCCAS/MCCASObjectV1.cpp
+++ b/llvm/lib/MCCAS/MCCASObjectV1.cpp
@@ -17,14 +17,13 @@
 #include "llvm/DebugInfo/DWARF/DWARFDebugAbbrev.h"
 #include "llvm/DebugInfo/DWARF/DWARFDebugLine.h"
 #include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCObjectFileInfo.h"
 #include "llvm/MCCAS/MCCASDebugV1.h"
 #include "llvm/Support/BinaryStreamWriter.h"
 #include "llvm/Support/Compression.h"
-#include "llvm/Support/Endian.h"
 #include "llvm/Support/EndianStream.h"
-#include <memory>
 #include <stack>
 
 // FIXME: Fix dependency here.

--- a/llvm/lib/MCCAS/MCCASSchemaPool.cpp
+++ b/llvm/lib/MCCAS/MCCASSchemaPool.cpp
@@ -6,17 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/MCCAS/MCCASFormatSchemaBase.h"
+#include "llvm/MCCAS/MCCASSchemaPool.h"
 #include "llvm/MCCAS/MCCASObjectV1.h"
 
 using namespace llvm;
-using namespace llvm::mccasformats;
-
-char MCFormatSchemaBase::ID = 0;
-void MCFormatSchemaBase::anchor() {}
 
 void mccasformats::addMCFormatSchemas(cas::SchemaPool &Pool) {
   auto &CAS = Pool.getCAS();
   Pool.addSchema(std::make_unique<v1::MCSchema>(CAS));
 }
-

--- a/llvm/tools/llvm-cas-dump/StatsCollector.h
+++ b/llvm/tools/llvm-cas-dump/StatsCollector.h
@@ -9,7 +9,9 @@
 #ifndef LLVM_TOOLS_LLVM_CAS_DUMP_STATSCOLLECTOR_H
 #define LLVM_TOOLS_LLVM_CAS_DUMP_STATSCOLLECTOR_H
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/CASNodeSchema.h"
 #include "llvm/CAS/CASReference.h"
 #include "llvm/MCCAS/MCCASObjectV1.h"

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -700,26 +700,9 @@ int main(int argc, char **argv) {
                           llvm::sys::Process::GetEnv("LLVM_TEST_CAS_BACKEND"));
 
     if (UseCASBackend) {
-      std::function<const cas::ObjectProxy(llvm::MachOCASWriter &,
-                                           llvm::MCAssembler &,
-                                           cas::ObjectStore &, raw_ostream *)>
-          CreateFromMcAssembler =
-              [](llvm::MachOCASWriter &Writer, llvm::MCAssembler &Asm,
-                 cas::ObjectStore &CAS,
-                 raw_ostream *DebugOS = nullptr) -> const cas::ObjectProxy {
-        auto Schema = std::make_unique<mccasformats::v1::MCSchema>(CAS);
-        return cantFail(Schema->createFromMCAssembler(Writer, Asm, DebugOS));
-      };
-      std::function<Error(cas::ObjectProxy, cas::ObjectStore &, raw_ostream &)>
-          SerializeObjectFile = [](cas::ObjectProxy RootNode,
-                                   cas::ObjectStore &CAS,
-                                   raw_ostream &OS) -> Error {
-        auto Schema = std::make_unique<mccasformats::v1::MCSchema>(CAS);
-        return Schema->serializeObjectFile(RootNode, OS);
-      };
       CASBackendWriter = MAB->createCASObjectWriter(
           *OS, TheTriple, *CAS, MCOptions, MCCASBackendMode,
-          CreateFromMcAssembler, SerializeObjectFile,
+          std::make_unique<mccasformats::v1::MCSchema>(*CAS),
           CasIDOS ? &CasIDOS->os() : nullptr);
     }
     // END MCCAS


### PR DESCRIPTION
To make MCCAS more manageable, make few improvements:
* Relayer MCSchema so it can be used directly in MCCASWriter to avoid callbacks.
* Improve error handling in MCCASWriter.