### PR TITLE
[Cherry-pick into next] [LLDB] Remove overly strict assertions (NFC)

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -91,13 +91,6 @@ lldb::addr_t SwiftUnsafeType::GetAddress(llvm::StringRef child_name) {
   ValueObjectSP unsafe_ptr_value_sp = synth_optional_sp;
   // Work around a bug in GetSyntheticValue(), which doesn't return
   // the result of SyntheticFrontend::GetSyntheticValue().
-  if (type.GetTypeName().GetStringRef().starts_with("Swift.Optional")) {
-    // type = TypeSystemSwiftTypeRef::GetOptionalType(type);
-
-    // if (auto v = synth_optional_sp->GetChildAtIndex(0))
-    //   unsafe_ptr_value_sp = v->GetSP();
-    // type = unsafe_ptr_value_sp->GetCompilerType();
-  }
   assert(type.GetTypeName().GetStringRef().starts_with("Swift.Unsafe"));
   if (!type.IsValid()) {
     LLDB_LOG(GetLog(LLDBLog::DataFormatters),
@@ -120,10 +113,6 @@ lldb::addr_t SwiftUnsafeType::GetAddress(llvm::StringRef child_name) {
 
   if (argument_type.IsValid())
     m_elem_type = argument_type;
-
-  assert(
-      !m_elem_type.GetTypeName().GetStringRef().starts_with("Swift.Optional"));
-  assert(!m_elem_type.GetTypeName().GetStringRef().starts_with("Swift.Unsafe"));
 
   ValueObjectSP pointer_value_sp =
       unsafe_ptr_value_sp->GetChildAtIndex(0, true);
@@ -368,9 +357,6 @@ lldb::ChildCacheState SwiftUnsafePointer::Update() {
   CompilerType argument_type = GetArgumentType();
   if (argument_type.IsValid())
     m_elem_type = argument_type;
-
-  assert(
-      !m_elem_type.GetTypeName().GetStringRef().starts_with("Swift.Optional"));
 
   ValueObjectSP pointer_value_sp(m_valobj.GetChildAtIndex(0, true));
   if (!pointer_value_sp) {

--- a/lldb/test/API/lang/swift/variables/unsafe/Makefile
+++ b/lldb/test/API/lang/swift/variables/unsafe/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
+++ b/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
@@ -1,0 +1,25 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftUnsafeTypes(TestBase):
+
+    def check_ptr(self):
+        ptr = self.frame().FindVariable("ptr")
+        self.assertEqual(ptr.GetSummary()[:2], '0x')
+        self.assertEqual(ptr.GetNumChildren(), 1)
+        child = ptr.GetChildAtIndex(0)
+        self.assertEqual(child.GetName(), 'pointee')
+        self.assertEqual(child.GetSummary(), 'nil')
+
+    @swiftTest
+    def test(self):
+        """Test formatters for unsafe types"""
+        self.build()
+        _, process, _, _ = lldbutil.run_to_source_breakpoint(self, 'break here',
+                                          lldb.SBFileSpec('main.swift'))
+        self.check_ptr()
+        process.Continue()
+        self.check_ptr()

--- a/lldb/test/API/lang/swift/variables/unsafe/main.swift
+++ b/lldb/test/API/lang/swift/variables/unsafe/main.swift
@@ -1,0 +1,12 @@
+func f1(_ ptr: UnsafePointer<UnsafePointer<Int>?>) {
+    print("pointer: \(ptr)") // break here
+}
+
+func f2(_ ptr: UnsafePointer<Int?>) {
+    print("pointer: \(ptr)") // break here
+}
+
+var ptr: UnsafePointer<Int>? = nil
+f1(&ptr)
+var n: Int? = nil
+f2(&n)


### PR DESCRIPTION
```
commit 32b9501f639c4377522374cde5a416449c278dd9
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Feb 6 12:37:47 2026 -0800

    [LLDB] Remove overly strict assertions (NFC)
    
    The original intention of these assertions was to guard against the
    child type being the parent type, but the way they are written they
    also trigger when the child type is an Optional.
    
    Fixes https://github.com/swiftlang/llvm-project/issues/12053
```
