### PR TITLE
Revert "[clang][Basic] Optimize getDiagnosticSeverity() (#141950)"

### DIFF
--- a/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/clang/lib/Basic/DiagnosticIDs.cpp
@@ -565,32 +565,26 @@ DiagnosticIDs::getDiagnosticSeverity(unsigned DiagID, SourceLocation Loc,
     return Result;
 
   const auto &SM = Diag.getSourceManager();
+
+  bool ShowInSystemHeader =
+      IsCustomDiag
+          ? CustomDiagInfo->getDescription(DiagID).ShouldShowInSystemHeader()
+          : !GetDiagInfo(DiagID) || GetDiagInfo(DiagID)->WarnShowInSystemHeader;
+
   // If we are in a system header, we ignore it. We look at the diagnostic class
   // because we also want to ignore extensions and warnings in -Werror and
   // -pedantic-errors modes, which *map* warnings/extensions to errors.
-  if (State->SuppressSystemWarnings && Loc.isValid() &&
-      SM.isInSystemHeader(SM.getExpansionLoc(Loc))) {
-    bool ShowInSystemHeader = true;
-    if (IsCustomDiag)
-      ShowInSystemHeader =
-          CustomDiagInfo->getDescription(DiagID).ShouldShowInSystemHeader();
-    else if (const StaticDiagInfoRec *Rec = GetDiagInfo(DiagID))
-      ShowInSystemHeader = Rec->WarnShowInSystemHeader;
+  if (State->SuppressSystemWarnings && !ShowInSystemHeader && Loc.isValid() &&
+      SM.isInSystemHeader(SM.getExpansionLoc(Loc)))
+    return diag::Severity::Ignored;
 
-    if (!ShowInSystemHeader)
-      return diag::Severity::Ignored;
-  }
   // We also ignore warnings due to system macros
-  if (State->SuppressSystemWarnings && Loc.isValid() &&
-      SM.isInSystemMacro(Loc)) {
+  bool ShowInSystemMacro =
+      !GetDiagInfo(DiagID) || GetDiagInfo(DiagID)->WarnShowInSystemMacro;
+  if (State->SuppressSystemWarnings && !ShowInSystemMacro && Loc.isValid() &&
+      SM.isInSystemMacro(Loc))
+    return diag::Severity::Ignored;
 
-    bool ShowInSystemMacro = true;
-    if (const StaticDiagInfoRec *Rec = GetDiagInfo(DiagID))
-      ShowInSystemMacro = Rec->WarnShowInSystemMacro;
-
-    if (!ShowInSystemMacro)
-      return diag::Severity::Ignored;
-  }
   // Clang-diagnostics pragmas always take precedence over suppression mapping.
   if (!Mapping.isPragma() && Diag.isSuppressedViaMapping(DiagID, Loc))
     return diag::Severity::Ignored;


### PR DESCRIPTION
This reverts commit f3f07a3f785d60a3afdc230641b91f044e4b2b99.

Preliminary perf measurements indicate 10% compile time slowdown. By the revert we slightly increase a number of `GetDiagInfo` calls but decrease a number of `SourceManager::getExpansionLoc`, `SourceManager::isInSystemHeader`, `SourceManager::isInSystemMacro` calls in cases warnings in system headers are enabled.