### PR TITLE
[stable/21.x][llvm][cas] Validate OnDiskKeyValueDB against the corresponding OnDiskGraphDB

### DIFF
--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -157,24 +157,31 @@ UnifiedOnDiskCache::faultInFromUpstreamKV(ArrayRef<uint8_t> Key) {
 }
 
 Error UnifiedOnDiskCache::validateActionCache() {
-  auto ValidateRef = [&](FileOffset Offset, ArrayRef<char> Value) -> Error {
-    assert(Value.size() == sizeof(uint64_t) && "should be validated already");
-    auto ID = ObjectID::fromOpaqueData(support::endian::read64le(Value.data()));
-    auto formatError = [&](Twine Msg) {
-      return createStringError(
-          llvm::errc::illegal_byte_sequence,
-          "bad record at 0x" +
-              utohexstr((unsigned)Offset.get(), /*LowerCase=*/true) + ": " +
-              Msg.str());
+  SmallVector<std::pair<OnDiskKeyValueDB *, OnDiskGraphDB *>> CachePairs;
+  CachePairs.emplace_back(PrimaryKVDB.get(), PrimaryGraphDB.get());
+  if (UpstreamKVDB && UpstreamGraphDB) {
+    CachePairs.emplace_back(UpstreamKVDB.get(), UpstreamGraphDB);
+  }
+
+  for (auto &CachePair : CachePairs) {
+    auto ValidateRef = [&](FileOffset Offset, ArrayRef<char> Value) -> Error {
+      assert(Value.size() == sizeof(uint64_t) && "should be validated already");
+      auto ID = ObjectID::fromOpaqueData(support::endian::read64le(Value.data()));
+      auto formatError = [&](Twine Msg) {
+        return createStringError(
+            llvm::errc::illegal_byte_sequence,
+            "bad record at 0x" +
+                utohexstr((unsigned)Offset.get(), /*LowerCase=*/true) + ": " +
+                Msg.str());
+      };
+      if (Error E = CachePair.second->validateObjectID(ID))
+        return formatError(llvm::toString(std::move(E)));
+      return Error::success();
     };
-    if (Error E = getGraphDB().validateObjectID(ID))
-      return formatError(llvm::toString(std::move(E)));
-    return Error::success();
-  };
-  if (Error E = PrimaryKVDB->validate(ValidateRef))
-    return E;
-  if (UpstreamKVDB)
-    return UpstreamKVDB->validate(ValidateRef);
+
+    if (Error E = CachePair.first->validate(ValidateRef))
+      return E;
+  }
   return Error::success();
 }
 

--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -27,6 +27,13 @@ RUN:   --data - >%t/abc.casid
 RUN: llvm-cas --cas %t/ac --put-cache-key @%t/abc.casid @%t/empty.casid
 RUN: llvm-cas --cas %t/ac --validate
 
+# Check that validation passes in an upstream db.
+RUN: mkdir %t/ac/v1.2
+RUN: llvm-cas --cas %t/ac --validate
+# Fault in from upstream DB.
+RUN: llvm-cas --cas %t/ac --get-cache-result @%t/abc.casid
+RUN: llvm-cas --cas %t/ac --validate
+
 # Check that validation fails if the objects referenced are missing.
 RUN: mv %t/ac/v1.1/v9.index %t/tmp.v9.index
 RUN: not llvm-cas --cas %t/ac --validate


### PR DESCRIPTION
Note: this is based on 59bcec268515 but not a direct cherry-pick since the code changes for passing the unified cache into the KVDB are not in this branch.

We were previously using the primary OnDiskGraphDB when validating the upstream OnDiskKeyValueDB, which is incorrect since the values being stored are direct offsets and therefore cannot be used across DBs without translating to a hash value first.

rdar://170067863