### PR TITLE
[clang][ssaf] Add UnsafeBufferUsage summary data structures

### DIFF
--- a/clang/include/clang/Analysis/Scalable/Analyses/UnsafeBufferUsage.h
+++ b/clang/include/clang/Analysis/Scalable/Analyses/UnsafeBufferUsage.h
@@ -1,0 +1,116 @@
+//===- UnsafeBufferUsage.h --------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_ANALYSIS_SCALABLE_ANALYSES_UNSAFEBUFFERUSAGE_H
+#define LLVM_CLANG_ANALYSIS_SCALABLE_ANALYSES_UNSAFEBUFFERUSAGE_H
+
+#include "clang/Analysis/Scalable/Model/EntityId.h"
+#include "clang/Analysis/Scalable/TUSummary/EntitySummary.h"
+#include "clang/Analysis/Scalable/TUSummary/TUSummaryBuilder.h"
+#include "clang/Analysis/Scalable/TUSummary/TUSummaryExtractor.h"
+#include "llvm/ADT/SmallVector.h"
+#include <limits>
+#include <memory>
+#include <set>
+
+namespace clang::ssaf {
+
+/// A PointerKindVariable is associated with a pointer type as (a spelling part
+/// of) the declared type of an entity.  In other words,  a PointerKindVariable
+/// is associated with a `*` in the fully expanded spelling of the declared
+/// type.
+///
+/// For example, for `int **p;`, there are two PointerKindVariables. One is
+/// associated with `int **` and the other is associated with `int *`.
+///
+/// A PointerKindVariable can be identified by an EntityId, of which the
+/// declared type is a pointer type, and an unsigned integer indicating the
+/// pointer level with 1 referring to the whole declared pointer type.
+///
+/// For the same example `int **p;`, the two PointerKindVariables are:
+/// `(p, 1)` for `int **` and `(p, 2)` for `int *`.
+///
+/// Reserve pointer level value 0 for implementation-internal use.
+class PointerKindVariable {
+  const EntityId Entity;
+  const unsigned PointerLevel;
+
+  friend class UnsafeBufferUsageTUSummaryBuilder;
+  friend class UnsafeBufferUsageEntitySummary;
+
+  PointerKindVariable(EntityId Entity, unsigned PointerLevel)
+      : Entity(Entity), PointerLevel(PointerLevel) {}
+
+public:
+  EntityId getEntity() const { return Entity; }
+  unsigned getPointerLevel() const { return PointerLevel; }
+
+  bool operator==(const PointerKindVariable &Other) const {
+    return Entity == Other.Entity && PointerLevel == Other.PointerLevel;
+  }
+
+  bool operator!=(const PointerKindVariable &Other) const {
+    return !(*this == Other);
+  }
+
+  bool operator<(const PointerKindVariable &Other) const {
+    if (Entity == Other.Entity)
+      return PointerLevel < Other.PointerLevel;
+    return Entity < Other.Entity;
+  }
+};
+
+using PointerKindVariableSet = std::set<PointerKindVariable>;
+
+/// An UnsafeBufferUsageEntitySummary is an immutable set of unsafe buffers, in
+/// the form of PointerKindVariable.
+class UnsafeBufferUsageEntitySummary : public EntitySummary {
+  const PointerKindVariableSet UnsafeBuffers;
+
+  friend class UnsafeBufferUsageTUSummaryBuilder;
+
+  UnsafeBufferUsageEntitySummary(PointerKindVariableSet &&UnsafeBuffers)
+      : EntitySummary(SummaryName{"UnsafeBufferUsage"}),
+        UnsafeBuffers(std::move(UnsafeBuffers)) {}
+
+public:
+  using const_iterator = PointerKindVariableSet::const_iterator;
+
+  const_iterator begin() const { return UnsafeBuffers.begin(); }
+  const_iterator end() const { return UnsafeBuffers.end(); }
+
+  const_iterator find(const PointerKindVariable &V) const {
+    return UnsafeBuffers.find(V);
+  }
+
+  llvm::iterator_range<const_iterator> getSubsetOf(EntityId Entity) const {
+    auto Begin = UnsafeBuffers.lower_bound({Entity, 0});
+    auto End = UnsafeBuffers.upper_bound(
+        {Entity, std::numeric_limits<unsigned>::max()});
+    return {Begin, End};
+  }
+
+  size_t getNumUnsafeBuffers() { return UnsafeBuffers.size(); }
+};
+
+class UnsafeBufferUsageTUSummaryBuilder : public TUSummaryBuilder {
+public:
+  PointerKindVariable buildPointerKindVariable(EntityId Entity,
+                                               unsigned PointerLevel) {
+    return {Entity, PointerLevel};
+  }
+
+  std::unique_ptr<UnsafeBufferUsageEntitySummary>
+  buildUnsafeBufferUsageEntitySummary(PointerKindVariableSet &&UnsafeBuffers) {
+    return std::unique_ptr<UnsafeBufferUsageEntitySummary>(
+        new UnsafeBufferUsageEntitySummary(std::move(UnsafeBuffers)));
+  }
+};
+} // namespace clang::ssaf
+
+#endif // LLVM_CLANG_ANALYSIS_SCALABLE_ANALYSES_UNSAFEBUFFERUSAGE_H

--- a/clang/unittests/Analysis/Scalable/CMakeLists.txt
+++ b/clang/unittests/Analysis/Scalable/CMakeLists.txt
@@ -11,6 +11,7 @@ add_distinct_clang_unittest(ClangScalableAnalysisTests
   Registries/SerializationFormatRegistryTest.cpp
   Registries/SummaryExtractorRegistryTest.cpp
   SummaryNameTest.cpp
+  UnsafeBufferUsageTest.cpp
 
   CLANG_LIBS
   clangAnalysisScalable

--- a/clang/unittests/Analysis/Scalable/UnsafeBufferUsageTest.cpp
+++ b/clang/unittests/Analysis/Scalable/UnsafeBufferUsageTest.cpp
@@ -1,0 +1,93 @@
+//===- unittests/Analysis/Scalable/UnsafeBufferUsageExtractorTest.cpp ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/Analysis/Scalable/Analyses/UnsafeBufferUsage.h"
+#include "clang/Analysis/Scalable/Model/EntityId.h"
+#include "clang/Analysis/Scalable/Model/EntityIdTable.h"
+#include "clang/Analysis/Scalable/Model/EntityName.h"
+#include "gtest/gtest.h"
+#include <memory>
+
+using namespace clang::ssaf;
+using namespace clang;
+
+namespace {
+
+class UnsafeBufferUsageTest : public testing::Test {
+protected:
+  EntityIdTable Table;
+  UnsafeBufferUsageTUSummaryBuilder Builder;
+};
+
+//////////////////////////////////////////////////////////////
+//                   Data Structure Tests                   //
+//////////////////////////////////////////////////////////////
+
+TEST_F(UnsafeBufferUsageTest, PointerKindVariableComparison) {
+  EntityId E1 = Table.getId({"c:@F@foo", "", {}});
+  EntityId E2 = Table.getId({"c:@F@bar", "", {}});
+
+  auto P1 = Builder.buildPointerKindVariable(E1, 2);
+  auto P2 = Builder.buildPointerKindVariable(E1, 2);
+  auto P3 = Builder.buildPointerKindVariable(E1, 1);
+  auto P4 = Builder.buildPointerKindVariable(E2, 2);
+
+  EXPECT_EQ(P1, P2);
+  EXPECT_NE(P1, P3);
+  EXPECT_NE(P1, P4);
+  EXPECT_NE(P3, P4);
+  EXPECT_TRUE(P3 < P2);
+  EXPECT_TRUE(P3 < P4);
+  EXPECT_FALSE(P1 < P2);
+  EXPECT_FALSE(P2 < P1);
+}
+
+TEST_F(UnsafeBufferUsageTest, UnsafeBufferUsageEntitySummaryTest) {
+  EntityId E1 = Table.getId({"c:@F@foo", "", {}});
+  EntityId E2 = Table.getId({"c:@F@bar", "", {}});
+  EntityId E3 = Table.getId({"c:@F@baz", "", {}});
+
+  auto P1 = Builder.buildPointerKindVariable(E1, 1);
+  auto P2 = Builder.buildPointerKindVariable(E1, 2);
+  auto P3 = Builder.buildPointerKindVariable(E2, 1);
+  auto P4 = Builder.buildPointerKindVariable(E2, 2);
+  auto P5 = Builder.buildPointerKindVariable(E3, 1);
+  auto P6 = Builder.buildPointerKindVariable(E3, 2);
+
+  PointerKindVariableSet Set{P1, P2, P3, P4, P5};
+  auto ES = Builder.buildUnsafeBufferUsageEntitySummary(std::move(Set));
+
+  EXPECT_NE(ES->find(P1), ES->end());
+  EXPECT_NE(ES->find(P2), ES->end());
+  EXPECT_NE(ES->find(P3), ES->end());
+  EXPECT_NE(ES->find(P4), ES->end());
+  EXPECT_NE(ES->find(P5), ES->end());
+  EXPECT_EQ(ES->find(P6), ES->end());
+
+  PointerKindVariableSet Subset1{ES->getSubsetOf(E1).begin(),
+                                 ES->getSubsetOf(E1).end()};
+
+  EXPECT_NE(Subset1.find(P1), Subset1.end());
+  EXPECT_NE(Subset1.find(P2), Subset1.end());
+  EXPECT_EQ(Subset1.size(), static_cast<size_t>(2));
+
+  PointerKindVariableSet Subset2{ES->getSubsetOf(E2).begin(),
+                                 ES->getSubsetOf(E2).end()};
+
+  EXPECT_NE(Subset2.find(P3), Subset2.end());
+  EXPECT_NE(Subset2.find(P4), Subset2.end());
+  EXPECT_EQ(Subset2.size(), static_cast<size_t>(2));
+
+  PointerKindVariableSet Subset3{ES->getSubsetOf(E3).begin(),
+                                 ES->getSubsetOf(E3).end()};
+
+  EXPECT_NE(Subset3.find(P5), Subset3.end());
+  EXPECT_EQ(Subset3.find(P6), Subset3.end());
+  EXPECT_EQ(Subset3.size(), static_cast<size_t>(1));
+}
+} // namespace


### PR DESCRIPTION
An UnsafeBufferUsage summary is the ssaf representation of the set of unsafe buffer pointers found by `-Wunsafe-buffer-usage` in a translation unit.

rdar://170176278