### PR TITLE
Add clang-cl support to clang-cache

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -878,8 +878,8 @@ llvm::Error expandResponseFiles(SmallVectorImpl<const char *> &Args,
                                 bool ClangCLMode, llvm::BumpPtrAllocator &Alloc,
                                 llvm::vfs::FileSystem *FS = nullptr);
 
-/// Checks whether a ParsedClangName::ModeSuffix value is for clang-cache mode.
-bool isClangCache(StringRef ModeSuffix);
+/// Checks whether a ProgName is for clang-cache mode.
+bool isClangCache(StringRef ProgName);
 
 /// Apply a space separated list of edits to the input argument lists.
 /// See applyOneOverrideOption.

--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -878,8 +878,8 @@ llvm::Error expandResponseFiles(SmallVectorImpl<const char *> &Args,
                                 bool ClangCLMode, llvm::BumpPtrAllocator &Alloc,
                                 llvm::vfs::FileSystem *FS = nullptr);
 
-/// Checks whether the value produced by getDriverMode is for 'cache' mode.
-bool isClangCache(StringRef DriverMode);
+/// Checks whether a ParsedClangName::ModeSuffix value is for clang-cache mode.
+bool isClangCache(StringRef ModeSuffix);
 
 /// Apply a space separated list of edits to the input argument lists.
 /// See applyOneOverrideOption.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7262,8 +7262,8 @@ llvm::Error driver::expandResponseFiles(SmallVectorImpl<const char *> &Args,
   return llvm::Error::success();
 }
 
-bool driver::isClangCache(StringRef DriverMode) {
-  return DriverMode == "cache";
+bool driver::isClangCache(StringRef ModeSuffix) {
+  return ModeSuffix == "clang-cache";
 }
 
 static const char *GetStableCStr(llvm::StringSet<> &SavedStrings, StringRef S) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7262,8 +7262,8 @@ llvm::Error driver::expandResponseFiles(SmallVectorImpl<const char *> &Args,
   return llvm::Error::success();
 }
 
-bool driver::isClangCache(StringRef ModeSuffix) {
-  return ModeSuffix == "clang-cache";
+bool driver::isClangCache(StringRef ProgName) {
+  return ProgName == "clang-cache";
 }
 
 static const char *GetStableCStr(llvm::StringSet<> &SavedStrings, StringRef S) {

--- a/clang/test/CAS/clang-cache-cl-mode.c
+++ b/clang/test/CAS/clang-cache-cl-mode.c
@@ -1,0 +1,14 @@
+// REQUIRES: ondisk_cas
+// REQUIRES: system-windows
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang_cl -Xclang -Rcompile-job-cache -- %t/test.c 2>&1 | FileCheck %s -check-prefix=CACHE-MISS
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang_cl -Xclang -Rcompile-job-cache -- %t/test.c 2>&1 | FileCheck %s -check-prefix=CACHE-HIT
+
+// CACHE-HIT: remark: compile job cache hit
+// CACHE-MISS: remark: compile job cache miss
+
+//--- test.c
+int main() { return 0; }

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -137,31 +137,35 @@ static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
 /// Arguments specific to \p clang-cache compiler launcher functionality.
 static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
                             llvm::StringSaver &Saver, bool SupportsMCCAS, bool IsCLMode) {
-  // Split the args at the end of option marker "--", if any.
+  // Split the args at the end of option (EOO) marker "--", if any.
   auto InsertPoint =
       llvm::find_if(AllArgs, [](const char *Elem) { return StringRef(Elem) == "--"; });
   SmallVector<const char *, 128> ArgsBeforeEOO(AllArgs.begin(), InsertPoint);
   SmallVector<const char *, 128> ArgsAfterEOO(InsertPoint, AllArgs.end());
-  auto AppendArgs = [&](ArrayRef<const char *> Args) {
-    bool RightAfterXClangOrMLLVM = false;
-    for (auto A : Args) {
-      StringRef Arg = A;
+  auto AppendArgs = [&](ArrayRef<StringRef> Args) {
+    bool Passthrough = false;
+    for (auto Arg : Args) {
       if (Arg == "-Xclang" || Arg == "-mllvm") {
         ArgsBeforeEOO.push_back(Saver.save(Arg).data());
-        RightAfterXClangOrMLLVM = true;
+        Passthrough = true;
       } else if (Arg.starts_with("-")) {
-        if (RightAfterXClangOrMLLVM || !IsCLMode) {
-          ArgsBeforeEOO.push_back(Saver.save(Arg).data());
-        } else {
+        // Arguments which are not passed through to clang-frontend or
+        // LLVM need to go through the driver. `clang-cl` takes non-CL
+        // options with a `/clang:` prefix to namespace and maintain
+        // compatibility.
+        if (IsCLMode && !Passthrough)
           ArgsBeforeEOO.push_back(Saver.save(llvm::Twine("/clang:") + Arg).data());
-        }
-        RightAfterXClangOrMLLVM = false;
+        else
+          ArgsBeforeEOO.push_back(Saver.save(Arg).data());
+        Passthrough = false;
       } else {
-        if (!RightAfterXClangOrMLLVM && IsCLMode) {
+        // We add -Xclang to flag arguments in cl mode because flags
+        // have a /clang: prefix. For example,
+        // /clang:-fdepscan-share-identifier -Xclang SessionId
+        if (!Passthrough && IsCLMode)
           ArgsBeforeEOO.push_back("-Xclang");
-        }
         ArgsBeforeEOO.push_back(Saver.save(Arg).data());
-        RightAfterXClangOrMLLVM = false;
+        Passthrough = false;
       }
     }
   };
@@ -170,8 +174,8 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
     // Instruct clang to connect to scanning daemon that is listening on the
     // provided socket path. The caller is responsible for ensuring the daemon
     // is compatible with the invoked clang.
-    AppendArgs("-fdepscan=daemon");
-    AppendArgs((Twine("-fdepscan-daemon=") + DaemonPath).str().data());
+    AppendArgs({"-fdepscan=daemon"});
+    AppendArgs({(Twine("-fdepscan-daemon=") + DaemonPath).str()});
   } else if (const char *SessionId = ::getenv("LLVM_CACHE_BUILD_SESSION_ID")) {
     // `LLVM_CACHE_BUILD_SESSION_ID` enables sharing of a depscan daemon
     // using the string it is set to. The clang invocations under the same
@@ -186,7 +190,7 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
     // started and shared for each unique clang version.
     AppendArgs({"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
   } else {
-    AppendArgs("-fdepscan");
+    AppendArgs({"-fdepscan"});
   }
 
   addCommonArgs(/*ForDriver*/ true, ArgsBeforeEOO, Saver);
@@ -199,7 +203,7 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
       std::tie(PrefixMap, Remaining) = Remaining.split(';');
       if (PrefixMap.empty())
         break;
-      AppendArgs((Twine("-fdepscan-prefix-map=") + PrefixMap).str().data());
+      AppendArgs({(Twine("-fdepscan-prefix-map=") + PrefixMap).str()});
     }
   }
 
@@ -209,7 +213,7 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
     AppendArgs({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
         ServicePath});
   }
-  AppendArgs("-greproducible");
+  AppendArgs({"-greproducible"});
 
   if (SupportsMCCAS && !ServicePath &&
       !llvm::sys::Process::GetEnv("CLANG_CACHE_DISABLE_MCCAS")) {
@@ -222,9 +226,8 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
 
   // Put them back together at the end
   AllArgs = ArgsBeforeEOO;
-  if (!ArgsAfterEOO.empty()) {
-    AllArgs.append(ArgsAfterEOO);
-  }
+  std::copy(std::begin(ArgsAfterEOO), std::end(ArgsAfterEOO),
+            std::back_inserter(AllArgs));
 }
 
 static void addScanServerArgs(const char *SocketPath,

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -8,6 +8,7 @@
 
 #include "CacheLauncherMode.h"
 #include "clang/Basic/DiagnosticCAS.h"
+#include "clang/Driver/Driver.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/CompilerInvocation.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
@@ -134,16 +135,43 @@ static void addCommonArgs(bool ForDriver, SmallVectorImpl<const char *> &Args,
 }
 
 /// Arguments specific to \p clang-cache compiler launcher functionality.
-static void addLauncherArgs(SmallVectorImpl<const char *> &Args,
-                            llvm::StringSaver &Saver, bool SupportsMCCAS) {
-
+static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
+                            llvm::StringSaver &Saver, bool SupportsMCCAS, bool IsCLMode) {
+  // Split the args at the end of option marker "--", if any.
+  auto InsertPoint =
+      llvm::find_if(AllArgs, [](const char *Elem) { return StringRef(Elem) == "--"; });
+  SmallVector<const char *, 128> ArgsBeforeEOO(AllArgs.begin(), InsertPoint);
+  SmallVector<const char *, 128> ArgsAfterEOO(InsertPoint, AllArgs.end());
+  auto AppendArgs = [&](ArrayRef<const char *> Args) {
+    bool RightAfterXClangOrMLLVM = false;
+    for (auto A : Args) {
+      StringRef Arg = A;
+      if (Arg == "-Xclang" || Arg == "-mllvm") {
+        ArgsBeforeEOO.push_back(Saver.save(Arg).data());
+        RightAfterXClangOrMLLVM = true;
+      } else if (Arg.starts_with("-")) {
+        if (RightAfterXClangOrMLLVM || !IsCLMode) {
+          ArgsBeforeEOO.push_back(Saver.save(Arg).data());
+        } else {
+          ArgsBeforeEOO.push_back(Saver.save(llvm::Twine("/clang:") + Arg).data());
+        }
+        RightAfterXClangOrMLLVM = false;
+      } else {
+        if (!RightAfterXClangOrMLLVM && IsCLMode) {
+          ArgsBeforeEOO.push_back("-Xclang");
+        }
+        ArgsBeforeEOO.push_back(Saver.save(Arg).data());
+        RightAfterXClangOrMLLVM = false;
+      }
+    }
+  };
   if (const char *DaemonPath =
           ::getenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH")) {
     // Instruct clang to connect to scanning daemon that is listening on the
     // provided socket path. The caller is responsible for ensuring the daemon
     // is compatible with the invoked clang.
-    Args.push_back("-fdepscan=daemon");
-    Args.push_back(Saver.save(Twine("-fdepscan-daemon=") + DaemonPath).data());
+    AppendArgs("-fdepscan=daemon");
+    AppendArgs((Twine("-fdepscan-daemon=") + DaemonPath).str().data());
   } else if (const char *SessionId = ::getenv("LLVM_CACHE_BUILD_SESSION_ID")) {
     // `LLVM_CACHE_BUILD_SESSION_ID` enables sharing of a depscan daemon
     // using the string it is set to. The clang invocations under the same
@@ -156,43 +184,46 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &Args,
     // toolchains, with different clang versions, running under the same
     // `LLVM_CACHE_BUILD_SESSION_ID`; in such a case there will be one daemon
     // started and shared for each unique clang version.
-    Args.append({"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
+    AppendArgs({"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
   } else {
-    Args.push_back("-fdepscan");
+    AppendArgs("-fdepscan");
   }
 
-  addCommonArgs(/*ForDriver*/ true, Args, Saver);
+  addCommonArgs(/*ForDriver*/ true, ArgsBeforeEOO, Saver);
 
   if (const char *PrefixMaps = ::getenv("LLVM_CACHE_PREFIX_MAPS")) {
-    Args.append({"-fdepscan-prefix-map-sdk=/^sdk",
-                 "-fdepscan-prefix-map-toolchain=/^toolchain"});
+    AppendArgs({"-fdepscan-prefix-map-sdk=/^sdk",
+        "-fdepscan-prefix-map-toolchain=/^toolchain"});
     StringRef PrefixMap, Remaining = PrefixMaps;
     while (true) {
       std::tie(PrefixMap, Remaining) = Remaining.split(';');
       if (PrefixMap.empty())
         break;
-      Args.push_back(Saver.save("-fdepscan-prefix-map=" + PrefixMap).data());
+      AppendArgs((Twine("-fdepscan-prefix-map=") + PrefixMap).str().data());
     }
   }
 
   const char *ServicePath = ::getenv("LLVM_CACHE_REMOTE_SERVICE_SOCKET_PATH");
 
   if (ServicePath) {
-    Args.append({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
-                 ServicePath});
+    AppendArgs({"-Xclang", "-fcompilation-caching-service-path", "-Xclang",
+        ServicePath});
   }
-  Args.append({"-greproducible"});
+  AppendArgs("-greproducible");
 
   if (SupportsMCCAS && !ServicePath &&
       !llvm::sys::Process::GetEnv("CLANG_CACHE_DISABLE_MCCAS")) {
-    Args.push_back("-Xclang");
-    Args.push_back("-fcas-backend");
+    AppendArgs({"-Xclang", "-fcas-backend"});
     if (llvm::sys::Process::GetEnv("CLANG_CACHE_VERIFY_MCCAS")) {
-      Args.push_back("-Xclang");
-      Args.push_back("-fcas-backend-mode=verify");
+      AppendArgs({"-Xclang", "-fcas-backend-mode=verify"});
     }
-    Args.push_back("-mllvm");
-    Args.push_back("-cas-friendly-debug-info");
+    AppendArgs({"-mllvm", "-cas-friendly-debug-info"});
+  }
+
+  // Put them back together at the end
+  AllArgs = ArgsBeforeEOO;
+  if (!ArgsAfterEOO.empty()) {
+    AllArgs.append(ArgsAfterEOO);
   }
 }
 
@@ -275,7 +306,8 @@ clang::handleClangCacheInvocation(SmallVectorImpl<const char *> &Args,
         return 1;
       return std::nullopt;
     }
-    addLauncherArgs(Args, Saver, SupportsMCCAS);
+    bool IsCLMode = driver::getDriverMode(compilerPath, ArrayRef(Args)) == "cl";
+    addLauncherArgs(Args, Saver, SupportsMCCAS, IsCLMode);
     return std::nullopt;
   }
 

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -283,14 +283,14 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
 
   const char *ProgName =
       ToolContext.NeedsPrependArg ? ToolContext.PrependArg : ToolContext.Path;
-  StringRef DriverMode = getDriverMode(ProgName, llvm::ArrayRef(Args).slice(1));
-  if (isClangCache(DriverMode)) {
+  if (isClangCache(ToolChain::getTargetAndModeFromProgramName(ProgName).ModeSuffix)) {
     if (std::optional<int> ExitCode = handleClangCacheInvocation(Args, Saver))
       return *ExitCode;
     // handleClangCacheInvocation resets the ProgName.
     ProgName = Args[0];
   }
 
+  StringRef DriverMode = getDriverMode(ProgName, llvm::ArrayRef(Args).slice(1));
   bool ClangCLMode = IsClangCL(DriverMode);
 
   auto VFS = llvm::vfs::getRealFileSystem();
@@ -355,7 +355,7 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   // constructor for `Driver` which uses this same value in `BuildCompilation`.
   // That path results in the wrong mode being selected. Explicitly adjust the
   // `Path` to point to the wrapped tool invocation.
-  if (isClangCache(getDriverMode(ToolContext.Path, {})))
+  if (isClangCache(ToolChain::getTargetAndModeFromProgramName(ToolContext.Path).ModeSuffix))
     Path = Args[0];
 
   // Whether the cc1 tool should be called inside the current process, or if we


### PR DESCRIPTION
Add the CAS options in the clang-cl style and insert options before the end of option marker "--", if any, as opposed to at the end.

cherry picked from commit 40da76a3df722cfe3304ec88c20a1952d604a264

Address review comments

cherry picked from commit 56fdeb7a0a1552b562da177fbb53646938abf98a