### PR TITLE
Support: convert paths to native representation

### DIFF
--- a/llvm/lib/Support/PrefixMapper.cpp
+++ b/llvm/lib/Support/PrefixMapper.cpp
@@ -143,9 +143,10 @@ std::optional<StringRef> PrefixMapper::mapImpl(StringRef Path,
     if (!llvm::sys::path::is_separator(Suffix.front(), PathStyle))
       continue;
 
-    // Drop the separator, append, and return.
+    // Drop the separator, append, and return the native representation.
     Storage.assign(New.begin(), New.end());
     llvm::sys::path::append(Storage, PathStyle, Suffix.drop_front());
+    llvm::sys::path::native(Storage, PathStyle);
     return StringRef(Storage.begin(), Storage.size());
   }
   return std::nullopt;


### PR DESCRIPTION
This is important for Windows where we have the ability to consume a non-native path separator (`/`). We should always return the native path representation to ensure that the output is always canonical. This simplifies the expectation in the tests.