### PR TITLE
🍒 [lldb] Reduce size of TestSwiftAsyncUnwindRegisterPressure.py

### DIFF
--- a/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/TestSwiftAsyncUnwindRegisterPressure.py
+++ b/lldb/test/API/lang/swift/async/unwind/unwind_register_pressure/TestSwiftAsyncUnwindRegisterPressure.py
@@ -84,4 +84,4 @@ class TestCase(lldbtest.TestBase):
         # have some sanity check that we have hit at least a decent chunk of
         # them.
         breakpoints_not_hit = len(breakpoints)
-        self.assertLess(breakpoints_not_hit / num_breakpoints, 0.25)
+        self.assertLess(breakpoints_not_hit / num_breakpoints, 0.3)


### PR DESCRIPTION
This test times out on CI every now and then, so this PR attempts to reduce how many instructions are generated in the code.

(cherry picked from commit 3ecbe377a97346f2e828a303a4d9d7391bebe224)