### PR TITLE
[Cherry-pick into swift/release/6.3] [Support] Support 5-component VersionTuples (#181275)

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -1225,10 +1225,14 @@ VersionTuple MachO::getLinkerVersion(const llvm::opt::ArgList &Args) const {
   }
 
   VersionTuple NewLinkerVersion;
-  if (Arg *A = Args.getLastArg(options::OPT_mlinker_version_EQ))
-    if (NewLinkerVersion.tryParse(A->getValue()))
+  if (Arg *A = Args.getLastArg(options::OPT_mlinker_version_EQ)) {
+    // Rejecting subbuild version is probably not necessary, but some
+    // existing tests depend on this.
+    if (NewLinkerVersion.tryParse(A->getValue()) ||
+        NewLinkerVersion.getSubbuild())
       getDriver().Diag(diag::err_drv_invalid_version_number)
-        << A->getAsString(Args);
+          << A->getAsString(Args);
+  }
 
   LinkerVersion = NewLinkerVersion;
   return *LinkerVersion;

--- a/lld/MachO/Driver.cpp
+++ b/lld/MachO/Driver.cpp
@@ -724,13 +724,12 @@ static PlatformVersion parsePlatformVersion(const Arg *arg) {
           .Default(PLATFORM_UNKNOWN);
   if (platformVersion.platform == PLATFORM_UNKNOWN)
     error(Twine("malformed platform: ") + platformStr);
-  // TODO: check validity of version strings, which varies by platform
-  // NOTE: ld64 accepts version strings with 5 components
-  // llvm::VersionTuple accepts no more than 4 components
-  // Has Apple ever published version strings with 5 components?
-  if (platformVersion.minimum.tryParse(minVersionStr))
+  // The underlying load command only supports 3 components.
+  if (platformVersion.minimum.tryParse(minVersionStr) ||
+      platformVersion.minimum.getBuild())
     error(Twine("malformed minimum version: ") + minVersionStr);
-  if (platformVersion.sdk.tryParse(sdkVersionStr))
+  if (platformVersion.sdk.tryParse(sdkVersionStr) ||
+      platformVersion.sdk.getBuild())
     error(Twine("malformed sdk version: ") + sdkVersionStr);
   return platformVersion;
 }

--- a/lld/test/MachO/platform-version.s
+++ b/lld/test/MachO/platform-version.s
@@ -25,10 +25,10 @@
 # RUN:        -platform_version iOS 1 2.a \
 # RUN:     | FileCheck --check-prefix=FAIL-MALFORM %s
 # RUN: not %no-arg-lld -arch x86_64 -o %t %t.o 2>&1 \
-# RUN:        -platform_version tvOS 1.2.3.4.5 10 \
+# RUN:        -platform_version tvOS 1.2.3.4 10 \
 # RUN:     | FileCheck --check-prefix=FAIL-MALFORM %s
 # RUN: not %no-arg-lld -arch x86_64 -o %t %t.o 2>&1 \
-# RUN:        -platform_version watchOS 10 1.2.3.4.5 \
+# RUN:        -platform_version watchOS 10 1.2.3.4 \
 # RUN:     | FileCheck --check-prefix=FAIL-MALFORM %s
 # FAIL-MALFORM-NOT: malformed platform: {{.*}}
 # FAIL-MALFORM: malformed {{minimum|sdk}} version: {{.*}}
@@ -40,7 +40,7 @@
 # RUN: %no-arg-lld -arch x86_64 -o %t %t.o 2>&1 \
 # RUN:        -platform_version "iOS Simulator" 1.2.3 5.6.7
 # RUN: %no-arg-lld -arch x86_64 -o %t %t.o 2>&1 \
-# RUN:        -platform_version tvOS-Simulator 1.2.3.4 5.6.7.8
+# RUN:        -platform_version tvOS-Simulator 1.2.3 5.6.7
 # RUN: %no-arg-lld -arch x86_64 -o %t %t.o 2>&1 \
 # RUN:        -platform_version watchOS-Simulator 1 5
 # RUN: %no-arg-lld -arch x86_64 -o %t %t.o 2>&1 \

--- a/llvm/include/llvm/Support/VersionTuple.h
+++ b/llvm/include/llvm/Support/VersionTuple.h
@@ -36,37 +36,52 @@ class VersionTuple {
   unsigned Subminor : 31;
   unsigned HasSubminor : 1;
 
-  unsigned Build : 31;
+  unsigned Build : 20;
+  unsigned Subbuild : 10;
   unsigned HasBuild : 1;
+  unsigned HasSubbuild : 1;
 
 public:
   constexpr VersionTuple()
       : Major(0), Minor(0), HasMinor(false), Subminor(0), HasSubminor(false),
-        Build(0), HasBuild(false) {}
+        Build(0), Subbuild(0), HasBuild(false), HasSubbuild(false) {}
 
   explicit constexpr VersionTuple(unsigned Major)
       : Major(Major), Minor(0), HasMinor(false), Subminor(0),
-        HasSubminor(false), Build(0), HasBuild(false) {}
+        HasSubminor(false), Build(0), Subbuild(0), HasBuild(false),
+        HasSubbuild(false) {}
 
   explicit constexpr VersionTuple(unsigned Major, unsigned Minor)
       : Major(Major), Minor(Minor), HasMinor(true), Subminor(0),
-        HasSubminor(false), Build(0), HasBuild(false) {}
+        HasSubminor(false), Build(0), Subbuild(0), HasBuild(false),
+        HasSubbuild(false) {}
 
   explicit constexpr VersionTuple(unsigned Major, unsigned Minor,
                                   unsigned Subminor)
       : Major(Major), Minor(Minor), HasMinor(true), Subminor(Subminor),
-        HasSubminor(true), Build(0), HasBuild(false) {}
+        HasSubminor(true), Build(0), Subbuild(0), HasBuild(false),
+        HasSubbuild(false) {}
 
   explicit constexpr VersionTuple(unsigned Major, unsigned Minor,
                                   unsigned Subminor, unsigned Build)
       : Major(Major), Minor(Minor), HasMinor(true), Subminor(Subminor),
-        HasSubminor(true), Build(Build), HasBuild(true) {}
+        HasSubminor(true), Build(Build), Subbuild(0), HasBuild(true),
+        HasSubbuild(false) {}
+
+  explicit constexpr VersionTuple(unsigned Major, unsigned Minor,
+                                  unsigned Subminor, unsigned Build,
+                                  unsigned Subbuild)
+      : Major(Major), Minor(Minor), HasMinor(true), Subminor(Subminor),
+        HasSubminor(true), Build(Build), Subbuild(Subbuild), HasBuild(true),
+        HasSubbuild(true) {}
+
+  std::tuple<unsigned, unsigned, unsigned, unsigned, unsigned> asTuple() const {
+    return {Major, Minor, Subminor, Build, Subbuild};
+  }
 
   /// Determine whether this version information is empty
   /// (e.g., all version components are zero).
-  bool empty() const {
-    return Major == 0 && Minor == 0 && Subminor == 0 && Build == 0;
-  }
+  bool empty() const { return *this == VersionTuple(); }
 
   /// Whether this is a non-empty version tuple.
   explicit operator bool () const { return !empty(); }
@@ -95,6 +110,13 @@ public:
     return Build;
   }
 
+  /// Retrieve the subbuild version number, if provided.
+  std::optional<unsigned> getSubbuild() const {
+    if (!HasSubbuild)
+      return std::nullopt;
+    return Subbuild;
+  }
+
   /// Return a version tuple that contains only the first 3 version components.
   VersionTuple withoutBuild() const {
     if (HasBuild)
@@ -109,12 +131,15 @@ public:
   /// Return a version tuple that contains only components that are non-zero.
   VersionTuple normalize() const {
     VersionTuple Result = *this;
-    if (Result.Build == 0) {
-      Result.HasBuild = false;
-      if (Result.Subminor == 0) {
-        Result.HasSubminor = false;
-        if (Result.Minor == 0)
-          Result.HasMinor = false;
+    if (Result.Subbuild == 0) {
+      Result.HasSubbuild = false;
+      if (Result.Build == 0) {
+        Result.HasBuild = false;
+        if (Result.Subminor == 0) {
+          Result.HasSubminor = false;
+          if (Result.Minor == 0)
+            Result.HasMinor = false;
+        }
       }
     }
     return Result;
@@ -123,8 +148,7 @@ public:
   /// Determine if two version numbers are equivalent. If not
   /// provided, minor and subminor version numbers are considered to be zero.
   friend bool operator==(const VersionTuple &X, const VersionTuple &Y) {
-    return X.Major == Y.Major && X.Minor == Y.Minor &&
-           X.Subminor == Y.Subminor && X.Build == Y.Build;
+    return X.asTuple() == Y.asTuple();
   }
 
   /// Determine if two version numbers are not equivalent.
@@ -140,8 +164,7 @@ public:
   /// If not provided, minor and subminor version numbers are considered to be
   /// zero.
   friend bool operator<(const VersionTuple &X, const VersionTuple &Y) {
-    return std::tie(X.Major, X.Minor, X.Subminor, X.Build) <
-           std::tie(Y.Major, Y.Minor, Y.Subminor, Y.Build);
+    return X.asTuple() < Y.asTuple();
   }
 
   /// Determine whether one version number follows another.
@@ -171,13 +194,13 @@ public:
   }
 
   friend hash_code hash_value(const VersionTuple &VT) {
-    return hash_combine(VT.Major, VT.Minor, VT.Subminor, VT.Build);
+    return hash_combine(VT.Major, VT.Minor, VT.Subminor, VT.Build, VT.Subbuild);
   }
 
   template <typename HasherT, llvm::endianness Endianness>
   friend void addHash(HashBuilder<HasherT, Endianness> &HBuilder,
                       const VersionTuple &VT) {
-    HBuilder.add(VT.Major, VT.Minor, VT.Subminor, VT.Build);
+    HBuilder.add(VT.Major, VT.Minor, VT.Subminor, VT.Build, VT.Subbuild);
   }
 
   /// Retrieve a string representation of the version number.
@@ -206,6 +229,8 @@ template <> struct DenseMapInfo<VersionTuple> {
       Result = detail::combineHashValue(Result, *Subminor);
     if (auto Build = Value.getBuild())
       Result = detail::combineHashValue(Result, *Build);
+    if (auto Subbuild = Value.getSubbuild())
+      Result = detail::combineHashValue(Result, *Subbuild);
 
     return Result;
   }

--- a/llvm/unittests/Support/VersionTupleTest.cpp
+++ b/llvm/unittests/Support/VersionTupleTest.cpp
@@ -17,6 +17,14 @@ TEST(VersionTuple, getAsString) {
   EXPECT_EQ("1.2", VersionTuple(1, 2).getAsString());
   EXPECT_EQ("1.2.3", VersionTuple(1, 2, 3).getAsString());
   EXPECT_EQ("1.2.3.4", VersionTuple(1, 2, 3, 4).getAsString());
+  EXPECT_EQ("1.2.3.4.5", VersionTuple(1, 2, 3, 4, 5).getAsString());
+
+  VersionTuple v(1, 2, 3, 4, 5);
+  EXPECT_EQ(v.getMajor(), 1u);
+  EXPECT_EQ(v.getMinor(), 2u);
+  EXPECT_EQ(v.getSubminor(), 3u);
+  EXPECT_EQ(v.getBuild(), 4u);
+  EXPECT_EQ(v.getSubbuild(), 5u);
 }
 
 TEST(VersionTuple, tryParse) {
@@ -34,18 +42,24 @@ TEST(VersionTuple, tryParse) {
   EXPECT_FALSE(VT.tryParse("1.2.3.4"));
   EXPECT_EQ("1.2.3.4", VT.getAsString());
 
+  EXPECT_FALSE(VT.tryParse("1.2.3.4.5"));
+  EXPECT_EQ("1.2.3.4.5", VT.getAsString());
+
   EXPECT_TRUE(VT.tryParse(""));
   EXPECT_TRUE(VT.tryParse("1."));
   EXPECT_TRUE(VT.tryParse("1.2."));
   EXPECT_TRUE(VT.tryParse("1.2.3."));
   EXPECT_TRUE(VT.tryParse("1.2.3.4."));
-  EXPECT_TRUE(VT.tryParse("1.2.3.4.5"));
+  EXPECT_TRUE(VT.tryParse("1.2.3.4.5."));
+  EXPECT_TRUE(VT.tryParse("1.2.3.4.5.6"));
   EXPECT_TRUE(VT.tryParse("1-2"));
   EXPECT_TRUE(VT.tryParse("1+2"));
   EXPECT_TRUE(VT.tryParse(".1"));
   EXPECT_TRUE(VT.tryParse(" 1"));
   EXPECT_TRUE(VT.tryParse("1 "));
   EXPECT_TRUE(VT.tryParse("."));
+  EXPECT_TRUE(VT.tryParse("1.2.3.1048576"));
+  EXPECT_TRUE(VT.tryParse("1.2.3.4.1024"));
 }
 
 TEST(VersionTuple, withMajorReplaced) {
@@ -76,4 +90,12 @@ TEST(VersionTuple, withMajorReplaced) {
   EXPECT_TRUE(ReplacedVersion.getSubminor().has_value());
   EXPECT_TRUE(ReplacedVersion.getBuild().has_value());
   EXPECT_EQ(VersionTuple(7, 11, 12, 2), ReplacedVersion);
+
+  VT = VersionTuple(101, 11, 12, 2, 8);
+  ReplacedVersion = VT.withMajorReplaced(7);
+  EXPECT_TRUE(ReplacedVersion.getMinor().has_value());
+  EXPECT_TRUE(ReplacedVersion.getSubminor().has_value());
+  EXPECT_TRUE(ReplacedVersion.getBuild().has_value());
+  EXPECT_TRUE(ReplacedVersion.getSubbuild().has_value());
+  EXPECT_EQ(VersionTuple(7, 11, 12, 2, 8), ReplacedVersion);
 }


### PR DESCRIPTION
```
commit 43fcc262e7504f1d4219435c38e4c251199cbeb7
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Feb 13 12:45:04 2026 -0800

    [Support] Support 5-component VersionTuples (#181275)
    
    LLDB parses compiler versions out of DW_AT_producer DWARF attributes
    into a VersionTuple. The Swift compiler recently switched to 5-component
    version numbers. In order to support this version scheme without growing
    the size of VersionTuple, this patch dedicates the last 10 bits of the
    build version to a 5th "sub-build" component. The Swift compiler
    currently uses 1 digit for this and promises to never use more than 3
    digits for the last 3 components.
    
    This patch still leaves 6 decimal digits for the build component for
    other version schemes.
    
    rdar://170181060
```
