### PR TITLE
[llvm/CAS] Add file-based APIs to `ObjectStore` (#180657)

### DIFF
--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -146,6 +146,27 @@ public:
   /// Get an ID for \p Ref.
   virtual CASID getID(ObjectRef Ref) const = 0;
 
+  /// Stores the data of a file into ObjectStore.
+  ///
+  /// An underlying implementation could perform optimizations that reduce I/O
+  /// and disk space consumption.
+  ///
+  /// If there are any concurrent modifications to the file, the contents in the
+  /// CAS may be corrupt.
+  ///
+  /// \param FilePath the path of the file data.
+  virtual Expected<ObjectRef> storeFromFile(StringRef Path);
+
+  /// Exports the data of an object to a file path. It does not include any
+  /// references of the object.
+  ///
+  /// An underlying implementation could perform optimizations that reduce I/O
+  /// and disk space consumption.
+  ///
+  /// \param Node the object to read data from.
+  /// \param FilePath the path of the file data.
+  virtual Error exportDataToFile(ObjectHandle Node, StringRef Path) const;
+
   /// Get an existing reference to the object called \p ID.
   ///
   /// Returns \c None if the object is not stored in this CAS.
@@ -366,6 +387,11 @@ public:
 
   /// Get the content of the node. Valid as long as the CAS is valid.
   StringRef getData() const { return CAS->getDataString(H); }
+
+  /// Exports the data of an object to a file path.
+  Error exportDataToFile(StringRef Path) const {
+    return CAS->exportDataToFile(H, Path);
+  }
 
   friend bool operator==(const ObjectProxy &Proxy, ObjectRef Ref) {
     return Proxy.getRef() == Ref;

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -10,12 +10,15 @@
 #include "BuiltinCAS.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/UnifiedOnDiskCache.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ManagedStatic.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/SmallVectorMemoryBuffer.h"
 #include <deque>
 
@@ -192,6 +195,43 @@ ObjectStore::storeFromOpenFileImpl(sys::fs::file_t FD,
   if (Error E = sys::fs::readNativeFileToEOF(FD, Data, ChunkSize))
     return std::move(E);
   return store({}, ArrayRef(Data.data(), Data.size()));
+}
+
+Expected<ObjectRef> ObjectStore::storeFromFile(StringRef Path) {
+  sys::fs::file_t FD;
+  if (Error E = sys::fs::openNativeFileForRead(Path).moveInto(FD))
+    return E;
+  auto CloseFile = scope_exit([&FD] { sys::fs::closeFile(FD); });
+  return storeFromOpenFile(FD);
+}
+
+Error ObjectStore::exportDataToFile(ObjectHandle Node, StringRef Path) const {
+  SmallString<256> TmpPath;
+  SmallString<256> Model;
+  Model += sys::path::parent_path(Path);
+  sys::path::append(Model, "%%%%%%%.tmp");
+  if (std::error_code EC = sys::fs::createUniqueFile(Model, TmpPath))
+    return createFileError(Model, EC);
+  auto RemoveTmpFile = scope_exit([&] {
+    if (!TmpPath.empty())
+      sys::fs::remove(TmpPath);
+  });
+
+  ArrayRef<char> Data = getData(Node);
+  std::error_code EC;
+  raw_fd_ostream FS(TmpPath, EC);
+  if (EC)
+    return createFileError(TmpPath, EC);
+  FS.write(Data.begin(), Data.size());
+  FS.close();
+  if (FS.has_error())
+    return createFileError(TmpPath, FS.error());
+
+  if (std::error_code EC = sys::fs::rename(TmpPath, Path))
+    return createFileError(Path, EC);
+  TmpPath.clear();
+
+  return Error::success();
 }
 
 Error ObjectStore::validateTree(ObjectRef Root) {

--- a/llvm/lib/CAS/OnDiskCAS.cpp
+++ b/llvm/lib/CAS/OnDiskCAS.cpp
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "BuiltinCAS.h"
+#include "OnDiskCommon.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/CAS/BuiltinCASContext.h"
+#include "llvm/CAS/BuiltinObjectHasher.h"
 #include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/CAS/OnDiskGraphDB.h"
 #include "llvm/CAS/UnifiedOnDiskCache.h"
@@ -36,6 +39,10 @@ public:
   Expected<bool> isMaterialized(ObjectRef Ref) const final;
 
   ArrayRef<char> getDataConst(ObjectHandle Node) const final;
+
+  Expected<ObjectRef> storeFromFile(StringRef Path) final;
+
+  Error exportDataToFile(ObjectHandle Node, StringRef Path) const final;
 
   void print(raw_ostream &OS) const final;
   Error validate(bool CheckHash) const final;
@@ -145,6 +152,53 @@ Expected<ObjectRef> OnDiskCAS::storeImpl(ArrayRef<uint8_t> ComputedHash,
   if (Error E = DB->store(*StoredID, IDs, Data))
     return std::move(E);
   return convertRef(*StoredID);
+}
+
+Expected<ObjectRef> OnDiskCAS::storeFromFile(StringRef Path) {
+  auto Hash = BuiltinObjectHasher<HasherT>::hashFile(Path);
+  if (LLVM_UNLIKELY(!Hash))
+    return Hash.takeError();
+  auto StoredID = DB->getReference(*Hash);
+  if (LLVM_UNLIKELY(!StoredID))
+    return StoredID.takeError();
+  if (Error E = DB->storeFile(*StoredID, Path))
+    return E;
+  return convertRef(*StoredID);
+}
+
+Error OnDiskCAS::exportDataToFile(ObjectHandle Node, StringRef Path) const {
+  auto FBData = DB->getInternalFileBackedObjectData(convertHandle(Node));
+  if (!FBData.FileInfo.has_value())
+    return BuiltinCAS::exportDataToFile(Node, Path);
+
+  // Optimized version using the underlying database file.
+  assert(FBData.FileInfo.has_value());
+
+  ondisk::UniqueTempFile UniqueTmp;
+  auto ExpectedPath = UniqueTmp.createAndCopyFrom(sys::path::parent_path(Path),
+                                                  FBData.FileInfo->FilePath);
+  if (!ExpectedPath)
+    return ExpectedPath.takeError();
+  StringRef TmpPath = *ExpectedPath;
+
+  if (FBData.FileInfo->IsFileNulTerminated) {
+    // Remove the nul terminator.
+    int FD;
+    if (std::error_code EC =
+            sys::fs::openFileForWrite(TmpPath, FD, sys::fs::CD_OpenExisting))
+      return createFileError(TmpPath, EC);
+    auto CloseFile = scope_exit([&FD] {
+      sys::fs::file_t File = sys::fs::convertFDToNativeFile(FD);
+      sys::fs::closeFile(File);
+    });
+    if (std::error_code EC = sys::fs::resize_file(FD, FBData.Data.size()))
+      return createFileError(TmpPath, EC);
+  }
+
+  if (Error E = UniqueTmp.renameTo(Path))
+    return E;
+
+  return Error::success();
 }
 
 Error OnDiskCAS::forEachRef(ObjectHandle Node,

--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -10,6 +10,8 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/config.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
 #include <limits>
 #include <mutex>
@@ -152,4 +154,41 @@ Expected<size_t> cas::ondisk::preallocateFileTail(int FD, size_t CurrentSize, si
 #else
   return NewSize; // Pretend it worked.
 #endif
+}
+
+Expected<StringRef>
+cas::ondisk::UniqueTempFile::createAndCopyFrom(StringRef ParentPath,
+                                               StringRef CopyFromPath) {
+  // \c clonefile requires that the destination path doesn't exist. We create
+  // a "placeholder" temporary file, then modify its path a bit and use that
+  // for \c clonefile to write to.
+  // FIXME: Instead of creating a dummy file, add a new file system API for
+  // copying to a unique path that can loop while checking EEXIST.
+  SmallString<256> UniqueTmpPath;
+  SmallString<256> Model;
+  Model += ParentPath;
+  sys::path::append(Model, "%%%%%%%.tmp");
+  if (std::error_code EC = sys::fs::createUniqueFile(Model, UniqueTmpPath))
+    return createFileError(Model, EC);
+  TmpPath = UniqueTmpPath;
+  TmpPath += ".tmp"; // modify so that there's no file at that path.
+  // \c copy_file will use \c clonefile when applicable.
+  if (std::error_code EC = sys::fs::copy_file(CopyFromPath, TmpPath))
+    return createFileError(TmpPath, EC);
+
+  return TmpPath;
+}
+
+Error cas::ondisk::UniqueTempFile::renameTo(StringRef RenameToPath) {
+  if (std::error_code EC = sys::fs::rename(TmpPath, RenameToPath))
+    return createFileError(RenameToPath, EC);
+  TmpPath.clear();
+  return Error::success();
+}
+
+cas::ondisk::UniqueTempFile::~UniqueTempFile() {
+  if (!TmpPath.empty())
+    sys::fs::remove(TmpPath);
+  if (!UniqueTmpPath.empty())
+    sys::fs::remove(UniqueTmpPath);
 }

--- a/llvm/lib/CAS/OnDiskCommon.h
+++ b/llvm/lib/CAS/OnDiskCommon.h
@@ -9,6 +9,7 @@
 #ifndef LLVM_LIB_CAS_ONDISKCOMMON_H
 #define LLVM_LIB_CAS_ONDISKCOMMON_H
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Error.h"
 #include <chrono>
 #include <optional>
@@ -50,6 +51,29 @@ std::error_code tryLockFileThreadSafe(
 ///
 /// \returns the new size of the file, or an \c Error.
 Expected<size_t> preallocateFileTail(int FD, size_t CurrentSize, size_t NewSize);
+
+/// Helper RAII class for copying a file to a unique file path. At destruction
+/// time it will delete any new temporary files created.
+class UniqueTempFile {
+public:
+  UniqueTempFile() = default;
+  ~UniqueTempFile();
+
+  /// Create a new unique file path under \p ParentPath and copy the contents
+  /// of \p CopyFromPath into it. It will use file cloning when applicable.
+  ///
+  /// \returns the new unique file path.
+  Expected<StringRef> createAndCopyFrom(StringRef ParentPath,
+                                        StringRef CopyFromPath);
+
+  /// Rename the new unique file to \p RenameToPath. This is useful to indicate
+  /// that the unique file doesn't need to be cleared at destruction time.
+  Error renameTo(StringRef RenameToPath);
+
+private:
+  SmallString<256> TmpPath;
+  SmallString<256> UniqueTmpPath;
+};
 
 } // namespace llvm::cas::ondisk
 

--- a/llvm/lib/CAS/OnDiskGraphDB.cpp
+++ b/llvm/lib/CAS/OnDiskGraphDB.cpp
@@ -1633,31 +1633,11 @@ Error OnDiskGraphDB::storeFile(
     return store(ID, {}, arrayRefFromStringRef<char>((*Buf)->getBuffer()));
   }
 
-  StringRef FromPath;
-  SmallString<256> TmpPath;
-
-  auto RemoveTmpFile = scope_exit([&TmpPath] {
-    if (!TmpPath.empty())
-      sys::fs::remove(TmpPath);
-  });
-
-  // \c clonefile requires that the destination path doesn't exist. We create
-  // a "placeholder" temporary file, then modify its path a bit and use that
-  // for \c clonefile to write to.
-  // FIXME: Instead of creating a dummy file, add a new file system API for
-  // copying to a unique path that can loop while checking EEXIST.
-  SmallString<256> UniqueTmpPath;
-  if (std::error_code EC =
-          sys::fs::createUniqueFile(RootPath + "/tmp.%%%%%%%", UniqueTmpPath))
-    return createFileError(RootPath + "/tmp.%%%%%%%", EC);
-  auto RemoveUniqueFile =
-      scope_exit([&UniqueTmpPath] { sys::fs::remove(UniqueTmpPath); });
-  TmpPath = UniqueTmpPath;
-  TmpPath += 'c'; // modify so that there's no file at that path.
-  // \c copy_file will use \c clonefile when applicable.
-  if (std::error_code EC = sys::fs::copy_file(FilePath, TmpPath))
-    return createFileError(FilePath, EC);
-  FromPath = TmpPath;
+  UniqueTempFile UniqueTmp;
+  auto ExpectedPath = UniqueTmp.createAndCopyFrom(RootPath, FilePath);
+  if (!ExpectedPath)
+    return ExpectedPath.takeError();
+  StringRef TmpPath = *ExpectedPath;
 
   TrieRecord::StorageKind SK;
   if (ImportKind.has_value()) {
@@ -1678,23 +1658,22 @@ Error OnDiskGraphDB::storeFile(
     if (Leaf0) {
       // Add a nul byte at the end.
       std::error_code EC;
-      raw_fd_ostream OS(FromPath, EC, sys::fs::CD_OpenExisting,
+      raw_fd_ostream OS(TmpPath, EC, sys::fs::CD_OpenExisting,
                         sys::fs::FA_Write, sys::fs::OF_Append);
       if (EC)
-        return createFileError(FromPath, EC);
+        return createFileError(TmpPath, EC);
       OS.write(0);
       OS.close();
       if (OS.has_error())
-        return createFileError(FromPath, OS.error());
+        return createFileError(TmpPath, OS.error());
     }
   }
 
   SmallString<256> StandalonePath;
   getStandalonePath(TrieRecord::getStandaloneFileSuffix(SK), I->Offset,
                     StandalonePath);
-  if (std::error_code EC = sys::fs::rename(FromPath, StandalonePath))
-    return createFileError(FromPath, EC);
-  TmpPath.clear();
+  if (Error E = UniqueTmp.renameTo(StandalonePath))
+    return E;
 
   // Store the object reference.
   TrieRecord::Data Existing;

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -30,6 +30,7 @@ add_llvm_unittest(CASTests
   MockGRPCServer.cpp
   ObjectStoreTest.cpp
   OnDiskCASLoggerTest.cpp
+  OnDiskCommonUtils.cpp
   OnDiskGraphDBTest.cpp
   OnDiskHashMappedTrieTest.cpp
   OnDiskKeyValueDBTest.cpp

--- a/llvm/unittests/CAS/ObjectStoreTest.cpp
+++ b/llvm/unittests/CAS/ObjectStoreTest.cpp
@@ -7,7 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/CAS/ObjectStore.h"
+#include "OnDiskCommonUtils.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Testing/Support/Error.h"
@@ -269,6 +271,47 @@ TEST_P(CASTest, NodesBig) {
 
   for (auto ID : CreatedNodes)
     ASSERT_THAT_ERROR(CAS->validateObject(CAS->getID(ID)), Succeeded());
+}
+
+TEST_P(CASTest, FileAPIs) {
+  std::shared_ptr<ObjectStore> CAS = createObjectStore();
+
+  auto runCommonTests =
+      [&CAS](function_ref<std::unique_ptr<unittest::TempFile>(char)>
+                 createFileFn) {
+        auto TmpFile = createFileFn('a');
+        auto Path = TmpFile->path();
+
+        std::optional<ObjectRef> ID1;
+        ASSERT_THAT_ERROR(CAS->storeFromFile(Path).moveInto(ID1), Succeeded());
+        std::optional<ObjectProxy> Obj1;
+        ASSERT_THAT_ERROR(CAS->getProxy(*ID1).moveInto(Obj1), Succeeded());
+        EXPECT_EQ(Obj1->getNumReferences(), size_t(0));
+        StringRef Contents = Obj1->getData();
+        {
+          ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+              MemoryBuffer::getFile(Path);
+          ASSERT_TRUE(!!MB);
+          ASSERT_NE(*MB, nullptr);
+          EXPECT_EQ((*MB)->getBuffer(), Contents);
+        }
+
+        unittest::TempFile TmpFile2("somefile.o", /*Suffix=*/"",
+                                    /*Contents=*/"",
+                                    /*Unique=*/true);
+        ASSERT_THAT_ERROR(Obj1->exportDataToFile(TmpFile2.path()), Succeeded());
+        {
+          ErrorOr<std::unique_ptr<MemoryBuffer>> MB =
+              MemoryBuffer::getFile(TmpFile2.path());
+          ASSERT_TRUE(!!MB);
+          ASSERT_NE(*MB, nullptr);
+          EXPECT_EQ((*MB)->getBuffer(), Contents);
+        }
+      };
+
+  runCommonTests(createSmallFile);
+  runCommonTests(createLargeFile);
+  runCommonTests(createLargePageAlignedFile);
 }
 
 /// Common test functionality for creating blobs in parallel. You can vary which

--- a/llvm/unittests/CAS/OnDiskCommonUtils.cpp
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.cpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "OnDiskCommonUtils.h"
+#include "llvm/Support/Alignment.h"
+#include "llvm/Support/Process.h"
+
+using namespace llvm;
+
+// Create a file with small size and and controlling the initial byte so
+// caller can create different contents.
+std::unique_ptr<unittest::TempFile>
+unittest::cas::createSmallFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "smallfile.o", /*Suffix=*/"", /*Contents=*/"", /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<200> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != 200; ++i) {
+    Data += i;
+  }
+  Out.write(Data.data(), Data.size());
+  return TmpFile;
+}
+
+std::unique_ptr<unittest::TempFile>
+unittest::cas::createLargeFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largefile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<200> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != 200; ++i) {
+    Data += i;
+  }
+  for (unsigned i = 0; i != 1000; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  return TmpFile;
+}
+
+std::unique_ptr<unittest::TempFile>
+unittest::cas::createLargePageAlignedFile(char initChar) {
+  auto TmpFile = std::make_unique<unittest::TempFile>(
+      "largepagealignedfile.o", /*Suffix=*/"", /*Contents=*/"",
+      /*Unique=*/true);
+  StringRef Path = TmpFile->path();
+  std::error_code EC;
+  raw_fd_stream Out(Path, EC);
+  EXPECT_FALSE(EC);
+  SmallString<256> Data;
+  Data += initChar;
+  for (unsigned i = 1; i != sys::Process::getPageSizeEstimate(); ++i) {
+    Data += char(i);
+  }
+  for (unsigned i = 0; i != 64; ++i) {
+    Out.write(Data.data(), Data.size());
+  }
+  Out.close();
+  uint64_t FileSize;
+  EC = sys::fs::file_size(Path, FileSize);
+  EXPECT_FALSE(EC);
+  assert(isAligned(Align(sys::Process::getPageSizeEstimate()), FileSize));
+  return TmpFile;
+}

--- a/llvm/unittests/CAS/OnDiskCommonUtils.h
+++ b/llvm/unittests/CAS/OnDiskCommonUtils.h
@@ -84,4 +84,8 @@ inline Error printTree(OnDiskGraphDB &DB, ObjectID ID, raw_ostream &OS,
   return Error::success();
 }
 
+std::unique_ptr<unittest::TempFile> createSmallFile(char initChar);
+std::unique_ptr<unittest::TempFile> createLargeFile(char initChar);
+std::unique_ptr<unittest::TempFile> createLargePageAlignedFile(char initChar);
+
 } // namespace llvm::unittest::cas

--- a/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
+++ b/llvm/unittests/CAS/OnDiskGraphDBTest.cpp
@@ -8,9 +8,7 @@
 
 #include "CASTestConfig.h"
 #include "OnDiskCommonUtils.h"
-#include "llvm/Support/Alignment.h"
 #include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/Process.h"
 #include "llvm/Testing/Support/Error.h"
 #include "llvm/Testing/Support/SupportHelpers.h"
 #include "gtest/gtest.h"
@@ -298,50 +296,6 @@ TEST(OnDiskGraphDBTest, FaultInPolicyConflict) {
                            OnDiskGraphDB::FaultInPolicy::SingleNode);
 }
 
-static std::unique_ptr<unittest::TempFile> createLargeFile(char initChar) {
-  auto TmpFile = std::make_unique<unittest::TempFile>(
-      "largefile.o", /*Suffix=*/"", /*Contents=*/"",
-      /*Unique=*/true);
-  StringRef Path = TmpFile->path();
-  std::error_code EC;
-  raw_fd_stream Out(Path, EC);
-  EXPECT_FALSE(EC);
-  SmallString<200> Data;
-  Data += initChar;
-  for (unsigned i = 1; i != 200; ++i) {
-    Data += i;
-  }
-  for (unsigned i = 0; i != 1000; ++i) {
-    Out.write(Data.data(), Data.size());
-  }
-  return TmpFile;
-}
-
-static std::unique_ptr<unittest::TempFile>
-createLargePageAlignedFile(char initChar) {
-  auto TmpFile = std::make_unique<unittest::TempFile>(
-      "largepagealignedfile.o", /*Suffix=*/"", /*Contents=*/"",
-      /*Unique=*/true);
-  StringRef Path = TmpFile->path();
-  std::error_code EC;
-  raw_fd_stream Out(Path, EC);
-  EXPECT_FALSE(EC);
-  SmallString<256> Data;
-  Data += initChar;
-  for (unsigned i = 1; i != sys::Process::getPageSizeEstimate(); ++i) {
-    Data += char(i);
-  }
-  for (unsigned i = 0; i != 64; ++i) {
-    Out.write(Data.data(), Data.size());
-  }
-  Out.close();
-  uint64_t FileSize;
-  EC = sys::fs::file_size(Path, FileSize);
-  EXPECT_FALSE(EC);
-  assert(isAligned(Align(sys::Process::getPageSizeEstimate()), FileSize));
-  return TmpFile;
-}
-
 TEST(OnDiskGraphDBTest, OnDiskGraphDBFaultInLargeFile) {
   auto runCommonTests =
       [](function_ref<std::unique_ptr<unittest::TempFile>(char)> createFileFn) {
@@ -398,23 +352,9 @@ TEST(OnDiskGraphDBTest, OnDiskGraphDBFileAPIs) {
 
   SmallVector<std::unique_ptr<unittest::TempFile>, 4> TempFiles;
 
-  // Create a file with small size and and controlling the initial byte so
-  // caller can create different contents.
   auto createSmallFile = [&TempFiles](char initChar) -> StringRef {
-    TempFiles.push_back(std::make_unique<unittest::TempFile>(
-        "smallfile.o", /*Suffix=*/"", /*Contents=*/"",
-        /*Unique=*/true));
-    StringRef Path = TempFiles.back()->path();
-    std::error_code EC;
-    raw_fd_stream Out(Path, EC);
-    EXPECT_FALSE(EC);
-    SmallString<200> Data;
-    Data += initChar;
-    for (unsigned i = 1; i != 200; ++i) {
-      Data += i;
-    }
-    Out.write(Data.data(), Data.size());
-    return Path;
+    TempFiles.push_back(::createSmallFile(initChar));
+    return TempFiles.back()->path();
   };
 
   auto createLargeFile = [&TempFiles](char initChar) -> StringRef {


### PR DESCRIPTION
Also add optimized implementations for `OnDiskCAS` that can take advantage of file cloning.

(cherry picked from commit 382697a6f0c10fcf2d0f3c679747c42be7d16821)