### PR TITLE
[lldb][macOS] Don't fetch settings in Host, to keep layering (#181406)

### DIFF
--- a/lldb/include/lldb/Core/ModuleList.h
+++ b/lldb/include/lldb/Core/ModuleList.h
@@ -81,6 +81,29 @@ static constexpr OptionEnumValueElement g_auto_download_enum_values[] = {
     },
 };
 
+static constexpr OptionEnumValueElement g_shared_cache_use_enum_values[] = {
+    {
+        lldb::eSymbolSharedCacheUseHostLLDBMemory,
+        "host-lldb-memory",
+        "Get binaries from the host lldb in-memory shared cache.",
+    },
+    {
+        lldb::eSymbolSharedCacheUseHostSharedCache,
+        "host-shared-cache",
+        "Get binaries from the host shared cache.",
+    },
+    {
+        lldb::eSymbolSharedCacheUseHostAndInferiorSharedCache,
+        "host-and-inferior-shared-cache",
+        "Get binaries from the host and inferior's shared caches.",
+    },
+    {
+        lldb::eSymbolSharedCacheUseInferiorSharedCacheOnly,
+        "inferior-shared-cache-only",
+        "Get binaries from inferior's shared cache only.",
+    },
+};
+
 class ModuleListProperties : public Properties {
   mutable llvm::sys::RWMutex m_symlink_paths_mutex;
   PathMappingList m_symlink_paths;
@@ -130,8 +153,7 @@ public:
   bool SetClangModulesCachePath(const FileSpec &path);
   bool GetEnableExternalLookup() const;
   bool SetEnableExternalLookup(bool new_value);
-  bool GetSharedCacheBinaryLoading() const;
-  bool SetSharedCacheBinaryLoading(bool new_value);
+  lldb::SymbolSharedCacheUse GetSharedCacheBinaryLoading() const;
   bool GetEnableLLDBIndexCache() const;
   bool SetEnableLLDBIndexCache(bool new_value);
   uint64_t GetLLDBIndexCacheMaxByteSize();

--- a/lldb/include/lldb/Host/HostInfoBase.h
+++ b/lldb/include/lldb/Host/HostInfoBase.h
@@ -190,16 +190,28 @@ public:
 
   /// Return information about module \p image_name if it is loaded in
   /// the current process's address space.
+  ///
+  /// \param[in] use_sc_binary_directly
+  ///     Flag to control if this method can try to read a shared
+  ///     cache binary blob directly, needed to keep user settings out of
+  ///     Host.
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name) {
+  GetSharedCacheImageInfo(llvm::StringRef image_name,
+                          lldb::SymbolSharedCacheUse sc_mode) {
     return {};
   }
 
   /// Return information about module \p image_name if it is loaded in
   /// the current process's address space using shared cache \p uuid.
   /// The shared cache UUID must have been previously indexed.
+  ///
+  /// \param[in] use_sc_binary_directly
+  ///     Flag to control if this method can try to read a shared
+  ///     cache binary blob directly, needed to keep user settings out of
+  ///     Host.
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid) {
+  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
+                          lldb::SymbolSharedCacheUse sc_mode) {
     return {};
   }
 
@@ -207,7 +219,8 @@ public:
   /// on the debug host.
   /// Returns false if the shared cache filepath did not exist, or uuid
   /// did not match.
-  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid) {
+  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
+                                    lldb::SymbolSharedCacheUse sc_mode) {
     return false;
   }
 

--- a/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
+++ b/lldb/include/lldb/Host/macosx/HostInfoMacOSX.h
@@ -65,12 +65,15 @@ public:
 
   /// Shared cache utilities
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name);
+  GetSharedCacheImageInfo(llvm::StringRef image_name,
+                          lldb::SymbolSharedCacheUse sc_mode);
 
   static SharedCacheImageInfo
-  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid);
+  GetSharedCacheImageInfo(llvm::StringRef image_name, const UUID &uuid,
+                          lldb::SymbolSharedCacheUse sc_mode);
 
-  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid);
+  static bool SharedCacheIndexFiles(FileSpec &filepath, UUID &uuid,
+                                    lldb::SymbolSharedCacheUse sc_mode);
 
 protected:
   static bool ComputeSupportExeDirectory(FileSpec &file_spec);

--- a/lldb/include/lldb/lldb-enumerations.h
+++ b/lldb/include/lldb/lldb-enumerations.h
@@ -1374,6 +1374,13 @@ enum SymbolDownload {
   eSymbolDownloadForeground = 2,
 };
 
+enum SymbolSharedCacheUse {
+  eSymbolSharedCacheUseHostLLDBMemory = 1,
+  eSymbolSharedCacheUseHostSharedCache = 2,
+  eSymbolSharedCacheUseHostAndInferiorSharedCache = 3,
+  eSymbolSharedCacheUseInferiorSharedCacheOnly = 4,
+};
+
 /// Used in the SBProcess AddressMask/FixAddress methods.
 enum AddressMaskType {
   eAddressMaskTypeCode = 0,

--- a/lldb/source/Core/CoreProperties.td
+++ b/lldb/source/Core/CoreProperties.td
@@ -14,10 +14,11 @@ let Definition = "modulelist" in {
     DefaultEnumValue<"eSymbolDownloadOff">,
     EnumValues<"OptionEnumValues(g_auto_download_enum_values)">,
     Desc<"On macOS, automatically download symbols with dsymForUUID (or an equivalent script/binary) for relevant images in the debug session.">;
-  def SharedCacheBinaryLoading: Property<"shared-cache-binary-loading", "Boolean">,
+  def SharedCacheBinaryLoading: Property<"shared-cache-binary-loading", "Enum">,
     Global,
-    DefaultTrue,
-    Desc<"On macOS, load the binaries from a shared cache blob directly, instead of loading them from lldb's own in-process shared cache.">;
+    DefaultEnumValue<"eSymbolSharedCacheUseHostAndInferiorSharedCache">,
+    EnumValues<"OptionEnumValues(g_shared_cache_use_enum_values)">,
+    Desc<"On macOS, lldb can use its own in-memory shared cache, or operate on shared cache binaries directly, this setting controls which are used.">;
   def ClangModulesCachePath: Property<"clang-modules-cache-path", "FileSpec">,
     Global,
     DefaultStringValue<"">,

--- a/lldb/source/Core/ModuleList.cpp
+++ b/lldb/source/Core/ModuleList.cpp
@@ -175,14 +175,11 @@ SymbolDownload ModuleListProperties::GetSymbolAutoDownload() const {
                g_modulelist_properties[idx].default_uint_value));
 }
 
-bool ModuleListProperties::GetSharedCacheBinaryLoading() const {
+SymbolSharedCacheUse ModuleListProperties::GetSharedCacheBinaryLoading() const {
   const uint32_t idx = ePropertySharedCacheBinaryLoading;
-  return GetPropertyAtIndexAs<bool>(
-      idx, g_modulelist_properties[idx].default_uint_value != 0);
-}
-
-bool ModuleListProperties::SetSharedCacheBinaryLoading(bool new_value) {
-  return SetPropertyAtIndex(ePropertySharedCacheBinaryLoading, new_value);
+  return GetPropertyAtIndexAs<lldb::SymbolSharedCacheUse>(
+      idx, static_cast<lldb::SymbolSharedCacheUse>(
+               g_modulelist_properties[idx].default_uint_value));
 }
 
 FileSpec ModuleListProperties::GetClangModulesCachePath() const {

--- a/lldb/source/Host/macosx/objcxx/CMakeLists.txt
+++ b/lldb/source/Host/macosx/objcxx/CMakeLists.txt
@@ -20,7 +20,6 @@ add_lldb_library(lldbHostMacOSXObjCXX NO_PLUGIN_DEPENDENCIES
     Support
     TargetParser
   LINK_LIBS
-    lldbCore
     lldbUtility
     ${EXTRA_LIBS}
   )

--- a/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
+++ b/lldb/source/Plugins/DynamicLoader/MacOSX-DYLD/DynamicLoaderDarwin.cpp
@@ -141,14 +141,16 @@ ModuleSP DynamicLoaderDarwin::FindTargetModuleForImageInfo(
     LazyBool using_sc;
     LazyBool private_sc;
     FileSpec sc_path;
+    SymbolSharedCacheUse sc_mode = ModuleList::GetGlobalModuleListProperties()
+                                       .GetSharedCacheBinaryLoading();
     if (GetSharedCacheInformation(sc_base_addr, sc_uuid, using_sc, private_sc,
                                   sc_path) &&
         sc_uuid)
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath(), sc_uuid);
+          module_spec.GetFileSpec().GetPath(), sc_uuid, sc_mode);
     else
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath());
+          module_spec.GetFileSpec().GetPath(), sc_mode);
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.

--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinDevice.cpp
@@ -320,6 +320,8 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
     // exist on the filesystem, so let's use the images in our own memory
     // to create the modules.
 
+    SymbolSharedCacheUse sc_mode = ModuleList::GetGlobalModuleListProperties()
+                                       .GetSharedCacheBinaryLoading();
     SharedCacheImageInfo image_info;
     if (process && process->GetDynamicLoader()) {
       addr_t sc_base_addr;
@@ -329,12 +331,12 @@ lldb_private::Status PlatformDarwinDevice::GetSharedModuleWithLocalCache(
       if (process->GetDynamicLoader()->GetSharedCacheInformation(
               sc_base_addr, sc_uuid, using_sc, private_sc, sc_path))
         image_info = HostInfo::GetSharedCacheImageInfo(
-            module_spec.GetFileSpec().GetPath(), sc_uuid);
+            module_spec.GetFileSpec().GetPath(), sc_uuid, sc_mode);
     }
 
     if (!image_info.GetUUID())
       image_info = HostInfo::GetSharedCacheImageInfo(
-          module_spec.GetFileSpec().GetPath());
+          module_spec.GetFileSpec().GetPath(), sc_mode);
 
     // If we found it and it has the correct UUID, let's proceed with
     // creating a module from the memory contents.

--- a/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
+++ b/lldb/source/Plugins/Process/gdb-remote/ProcessGDBRemote.cpp
@@ -4315,7 +4315,10 @@ StructuredData::ObjectSP ProcessGDBRemote::GetSharedCacheInfo() {
 
         // Attempt to open the shared cache at sc_path, and
         // if the uuid matches, index all the files.
-        HostInfo::SharedCacheIndexFiles(sc_path, uuid);
+        HostInfo::SharedCacheIndexFiles(
+            sc_path, uuid,
+            ModuleList::GetGlobalModuleListProperties()
+                .GetSharedCacheBinaryLoading());
       }
       m_shared_cache_info_sp = response_sp;
     }

--- a/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
+++ b/lldb/source/Plugins/SymbolLocator/DebugSymbols/SymbolLocatorDebugSymbols.cpp
@@ -202,8 +202,11 @@ std::optional<ModuleSpec> SymbolLocatorDebugSymbols::LocateExecutableObjectFile(
 
           // Check if the requested image is in our shared cache.
           if (!success) {
+            SymbolSharedCacheUse sc_mode =
+                ModuleList::GetGlobalModuleListProperties()
+                    .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPath());
+                module_spec.GetFileSpec().GetPath(), sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.
@@ -645,8 +648,11 @@ static int LocateMacOSXFilesUsingDebugSymbols(const ModuleSpec &module_spec,
 
           // Check if the requested image is in our shared cache.
           if (!success) {
+            SymbolSharedCacheUse sc_mode =
+                ModuleList::GetGlobalModuleListProperties()
+                    .GetSharedCacheBinaryLoading();
             SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-                module_spec.GetFileSpec().GetPath());
+                module_spec.GetFileSpec().GetPath(), sc_mode);
 
             // If we found it and it has the correct UUID, let's proceed with
             // creating a module from the memory contents.

--- a/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
+++ b/lldb/unittests/ObjectFile/MachO/TestObjectFileMachO.cpp
@@ -37,8 +37,8 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
 
   Platform::SetHostPlatform(PlatformRemoteMacOSX::CreateInstance(true, &arch));
 
-  SharedCacheImageInfo image_info =
-      HostInfo::GetSharedCacheImageInfo("/usr/lib/libobjc.A.dylib");
+  SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
+      "/usr/lib/libobjc.A.dylib", lldb::eSymbolSharedCacheUseHostSharedCache);
   EXPECT_TRUE(image_info.GetUUID());
   EXPECT_TRUE(image_info.GetExtractor());
 
@@ -86,7 +86,8 @@ TEST_F(ObjectFileMachOTest, ModuleFromSharedCacheInfo) {
 
 TEST_F(ObjectFileMachOTest, IndirectSymbolsInTheSharedCache) {
   SharedCacheImageInfo image_info = HostInfo::GetSharedCacheImageInfo(
-      "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit");
+      "/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit",
+      lldb::eSymbolSharedCacheUseHostSharedCache);
   ModuleSpec spec(FileSpec(), UUID(), image_info.GetExtractor());
   lldb::ModuleSP module = std::make_shared<Module>(spec);
 


### PR DESCRIPTION
I introduced a dependency from Host on Core without realizing it in an earlier PR, while adding a setting to disable the new shared cache binary blob scanning/reading in HostInfoMacOSX, which caused build problems. Thanks to Alex for figuring out the build failure I caused.

Add a bool to the methods in HostInfoMacOSX, and have the callers (in Core and various plugins etc) all fetch the
symbols.shared-cache-binary-loading setting from ModuleList, and pass the result in.

The least obvious part of this is in ProcessGDBRemote where we first learn the shared cache filepath & uuid, it calls
HostInfoMacOSX::SharedCacheIndexFiles() - this is only called when the shared cache binary loading is enabled, so I conditionalize the call to this method based on the setting.

rdar://148939795
(cherry picked from commit d406ce8e20600171b6030c9dcf728a23975c9eaf)