### PR TITLE
[clang][BoundsSafety] Support `counted_by` on `void *` to align with upstream

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6428,7 +6428,7 @@ public:
       // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
       // attribute to be used on code that prefers to keep its pointees
       // incomplete until they need to be used.
-      //
+
       // NOTE: we treat void as if it has an implicit size of 1 byte for pointer
       // arithmetic (following GNU convention). Therefore, counted_by on void*
       // is allowed and behaves equivalently to sized_by (treating the count as

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -6428,9 +6428,16 @@ public:
       // see `HasCountedByAttrOnIncompletePointee()`. This allows the counted_by
       // attribute to be used on code that prefers to keep its pointees
       // incomplete until they need to be used.
-      if (PointeeTy->isAlwaysIncompleteType() || PointeeTy->isFunctionType() ||
-          PointeeTy->isSizelessType() ||
-          PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
+      //
+      // NOTE: we treat void as if it has an implicit size of 1 byte for pointer
+      // arithmetic (following GNU convention). Therefore, counted_by on void*
+      // is allowed and behaves equivalently to sized_by (treating the count as
+      // bytes).
+      if (PointeeTy->isVoidType()) {
+        CountInBytes = true;
+      } else if (PointeeTy->isAlwaysIncompleteType() ||
+                 PointeeTy->isFunctionType() || PointeeTy->isSizelessType() ||
+                 PointeeTy->isStructureTypeWithFlexibleArrayMember()) {
         // Use unspecified pointer attributes for diagnostic purposes.
         QualType Unsp = S.Context.getBoundsSafetyPointerType(
             CanonTy, BoundsSafetyPointerAttributes::unspecified());

--- a/clang/test/BoundsSafety/CodeGen/counted_by_void.c
+++ b/clang/test/BoundsSafety/CodeGen/counted_by_void.c
@@ -1,0 +1,188 @@
+// RUN: %clang_cc1 -O0 -triple x86_64 -fbounds-safety -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -O0 -triple x86_64 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -emit-llvm %s -o - | FileCheck %s
+
+#include <ptrcheck.h>
+struct Item {
+  void *__counted_by(len) buf;
+  unsigned len;
+};
+
+// TEST 1: Basic Access
+// CHECK-LABEL: @TestAccess(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[S_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[I_ADDR:%.*]] = alloca i32, align 4
+// CHECK-NEXT:    [[AGG_TEMP:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable", align 8
+// CHECK-NEXT:    [[AGG_TEMP1:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    store ptr [[S:%.*]], ptr [[S_ADDR]], align 8
+// CHECK-NEXT:    store i32 [[I:%.*]], ptr [[I_ADDR]], align 4
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[S_ADDR]], align 8
+// CHECK-NEXT:    [[LEN:%.*]] = getelementptr inbounds nuw %struct.Item, ptr [[TMP0]], i32 0, i32 1
+// CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[LEN]], align 8
+// CHECK-NEXT:    [[BUF:%.*]] = getelementptr inbounds nuw %struct.Item, ptr [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP2:%.*]] = load ptr, ptr [[BUF]], align 8
+// CHECK-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[TMP1]] to i64
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP2]], i64 [[IDX_EXT]]
+// CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP1]], i32 0, i32 0
+// CHECK-NEXT:    store ptr [[TMP2]], ptr [[TMP3]], align 8
+// CHECK-NEXT:    [[TMP4:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP1]], i32 0, i32 1
+// CHECK-NEXT:    store ptr [[ADD_PTR]], ptr [[TMP4]], align 8
+// CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP1]], i32 0, i32 2
+// CHECK-NEXT:    store ptr [[TMP2]], ptr [[TMP5]], align 8
+// CHECK-NEXT:    [[WIDE_PTR_PTR_ADDR:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP1]], i32 0, i32 0
+// CHECK-NEXT:    [[WIDE_PTR_PTR:%.*]] = load ptr, ptr [[WIDE_PTR_PTR_ADDR]], align 8
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP1]], i32 0, i32 1
+// CHECK-NEXT:    [[WIDE_PTR_UB:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR]], align 8
+// CHECK-NEXT:    [[WIDE_PTR_LB_ADDR:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP1]], i32 0, i32 2
+// CHECK-NEXT:    [[WIDE_PTR_LB:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR]], align 8
+// CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP]], i32 0, i32 0
+// CHECK-NEXT:    store ptr [[WIDE_PTR_PTR]], ptr [[TMP6]], align 8
+// CHECK-NEXT:    [[TMP7:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP]], i32 0, i32 1
+// CHECK-NEXT:    store ptr [[WIDE_PTR_UB]], ptr [[TMP7]], align 8
+// CHECK-NEXT:    [[TMP8:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP]], i32 0, i32 2
+// CHECK-NEXT:    store ptr [[WIDE_PTR_LB]], ptr [[TMP8]], align 8
+// CHECK-NEXT:    [[WIDE_PTR_PTR_ADDR2:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP]], i32 0, i32 0
+// CHECK-NEXT:    [[WIDE_PTR_PTR3:%.*]] = load ptr, ptr [[WIDE_PTR_PTR_ADDR2]], align 8
+// CHECK-NEXT:    [[TMP9:%.*]] = load i32, ptr [[I_ADDR]], align 4
+// CHECK-NEXT:    [[IDXPROM:%.*]] = sext i32 [[TMP9]] to i64
+// CHECK-NEXT:    [[ARRAYIDX:%.*]] = getelementptr i8, ptr [[WIDE_PTR_PTR3]], i64 [[IDXPROM]]
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR4:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP]], i32 0, i32 1
+// CHECK-NEXT:    [[WIDE_PTR_UB5:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR4]], align 8
+// CHECK-NEXT:    [[WIDE_PTR_LB_ADDR6:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP]], i32 0, i32 2
+// CHECK-NEXT:    [[WIDE_PTR_LB7:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR6]], align 8
+// CHECK-NEXT:    [[TMP10:%.*]] = icmp ult ptr [[ARRAYIDX]], [[WIDE_PTR_UB5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[TMP10]], label [[CONT:%.*]], label [[TRAP:%.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       trap:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR3:[0-9]+]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       cont:
+// CHECK-NEXT:    [[TMP11:%.*]] = icmp uge ptr [[ARRAYIDX]], [[WIDE_PTR_LB7]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[TMP11]], label [[CONT9:%.*]], label [[TRAP8:%.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       trap8:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       cont9:
+// CHECK-NEXT:    [[TMP12:%.*]] = load i8, ptr [[ARRAYIDX]], align 1
+// CHECK-NEXT:    ret i8 [[TMP12]]
+//
+char TestAccess(struct Item *s, int i) {
+  return ((char *)s->buf)[i];
+}
+
+// TEST 2: Increment/Decrement
+// CHECK-LABEL: @TestInc(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[S_ADDR:%.*]] = alloca ptr, align 8
+// CHECK-NEXT:    [[AGG_TEMP:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    [[TMP:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    [[AGG_TEMP2:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    [[AGG_TEMP3:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    [[AGG_TEMP6:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    [[AGG_TEMP9:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    [[AGG_TEMP17:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    [[AGG_TEMP20:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable", align 8
+// CHECK-NEXT:    [[AGG_TEMP21:%.*]] = alloca %"__bounds_safety::wide_ptr.bidi_indexable.0", align 8
+// CHECK-NEXT:    store ptr [[S:%.*]], ptr [[S_ADDR]], align 8
+// CHECK-NEXT:    [[TMP0:%.*]] = load ptr, ptr [[S_ADDR]], align 8
+// CHECK-NEXT:    [[BUF:%.*]] = getelementptr inbounds nuw %struct.Item, ptr [[TMP0]], i32 0, i32 0
+// CHECK-NEXT:    [[LEN:%.*]] = getelementptr inbounds nuw %struct.Item, ptr [[TMP0]], i32 0, i32 1
+// CHECK-NEXT:    [[TMP1:%.*]] = load i32, ptr [[LEN]], align 8
+// CHECK-NEXT:    [[TMP2:%.*]] = load ptr, ptr [[BUF]], align 8
+// CHECK-NEXT:    [[IDX_EXT:%.*]] = zext i32 [[TMP1]] to i64
+// CHECK-NEXT:    [[ADD_PTR:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP2]], i64 [[IDX_EXT]]
+// CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[TMP]], i32 0, i32 0
+// CHECK-NEXT:    store ptr [[TMP2]], ptr [[TMP3]], align 8
+// CHECK-NEXT:    [[TMP4:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[TMP]], i32 0, i32 1
+// CHECK-NEXT:    store ptr [[ADD_PTR]], ptr [[TMP4]], align 8
+// CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[TMP]], i32 0, i32 2
+// CHECK-NEXT:    store ptr [[TMP2]], ptr [[TMP5]], align 8
+// CHECK-NEXT:    [[TMP6:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[TMP]], i32 0, i32 0
+// CHECK-NEXT:    [[TMP7:%.*]] = load ptr, ptr [[TMP6]], align 8
+// CHECK-NEXT:    [[BOUND_PTR_ARITH:%.*]] = getelementptr i8, ptr [[TMP7]], i64 1
+// CHECK-NEXT:    [[TMP8:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP]], i32 0, i32 0
+// CHECK-NEXT:    store ptr [[BOUND_PTR_ARITH]], ptr [[TMP8]], align 8
+// CHECK-NEXT:    [[TMP9:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[TMP]], i32 0, i32 1
+// CHECK-NEXT:    [[TMP10:%.*]] = load ptr, ptr [[TMP9]], align 8
+// CHECK-NEXT:    [[TMP11:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP]], i32 0, i32 1
+// CHECK-NEXT:    store ptr [[TMP10]], ptr [[TMP11]], align 8
+// CHECK-NEXT:    [[TMP12:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[TMP]], i32 0, i32 2
+// CHECK-NEXT:    [[TMP13:%.*]] = load ptr, ptr [[TMP12]], align 8
+// CHECK-NEXT:    [[TMP14:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP]], i32 0, i32 2
+// CHECK-NEXT:    store ptr [[TMP13]], ptr [[TMP14]], align 8
+// CHECK-NEXT:    [[TMP15:%.*]] = load ptr, ptr [[S_ADDR]], align 8
+// CHECK-NEXT:    [[LEN1:%.*]] = getelementptr inbounds nuw %struct.Item, ptr [[TMP15]], i32 0, i32 1
+// CHECK-NEXT:    [[TMP16:%.*]] = load i32, ptr [[LEN1]], align 8
+// CHECK-NEXT:    [[SUB:%.*]] = sub i32 [[TMP16]], 1
+// CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[AGG_TEMP2]], ptr align 8 [[AGG_TEMP]], i64 24, i1 false), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR_ADDR:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP2]], i32 0, i32 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR:%.*]] = load ptr, ptr [[WIDE_PTR_PTR_ADDR]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP2]], i32 0, i32 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB_ADDR:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP2]], i32 0, i32 2, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[AGG_TEMP3]], ptr align 8 [[AGG_TEMP]], i64 24, i1 false), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR4:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP3]], i32 0, i32 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB5:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR4]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP:%.*]] = icmp ule ptr [[WIDE_PTR_PTR]], [[WIDE_PTR_UB5]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[CMP]], label [[LAND_LHS_TRUE:%.*]], label [[LAND_END:%.*]], {{!annotation ![0-9]+}}
+// CHECK:       land.lhs.true:
+// CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[AGG_TEMP6]], ptr align 8 [[AGG_TEMP]], i64 24, i1 false), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB_ADDR7:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP6]], i32 0, i32 2, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB8:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR7]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[AGG_TEMP9]], ptr align 8 [[AGG_TEMP]], i64 24, i1 false), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR_ADDR10:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP9]], i32 0, i32 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR11:%.*]] = load ptr, ptr [[WIDE_PTR_PTR_ADDR10]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR12:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP9]], i32 0, i32 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB13:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR12]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB_ADDR14:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP9]], i32 0, i32 2, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB15:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR14]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP16:%.*]] = icmp ule ptr [[WIDE_PTR_LB8]], [[WIDE_PTR_PTR11]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[CMP16]], label [[LAND_RHS:%.*]], label [[LAND_END]], {{!annotation ![0-9]+}}
+// CHECK:       land.rhs:
+// CHECK-NEXT:    [[CONV:%.*]] = zext i32 [[SUB]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[AGG_TEMP17]], ptr align 8 [[AGG_TEMP]], i64 24, i1 false), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR18:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP17]], i32 0, i32 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB19:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR18]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[AGG_TEMP21]], ptr align 8 [[AGG_TEMP]], i64 24, i1 false), {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR_ADDR22:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP21]], i32 0, i32 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR23:%.*]] = load ptr, ptr [[WIDE_PTR_PTR_ADDR22]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR24:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP21]], i32 0, i32 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB25:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR24]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB_ADDR26:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable.0", ptr [[AGG_TEMP21]], i32 0, i32 2, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB27:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR26]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP17:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP20]], i32 0, i32 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    store ptr [[WIDE_PTR_PTR23]], ptr [[TMP17]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP18:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP20]], i32 0, i32 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    store ptr [[WIDE_PTR_UB25]], ptr [[TMP18]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[TMP19:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP20]], i32 0, i32 2, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    store ptr [[WIDE_PTR_LB27]], ptr [[TMP19]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR_ADDR28:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP20]], i32 0, i32 0, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_PTR29:%.*]] = load ptr, ptr [[WIDE_PTR_PTR_ADDR28]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB_ADDR30:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP20]], i32 0, i32 1, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_UB31:%.*]] = load ptr, ptr [[WIDE_PTR_UB_ADDR30]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB_ADDR32:%.*]] = getelementptr inbounds nuw %"__bounds_safety::wide_ptr.bidi_indexable", ptr [[AGG_TEMP20]], i32 0, i32 2, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[WIDE_PTR_LB33:%.*]] = load ptr, ptr [[WIDE_PTR_LB_ADDR32]], align 8, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_LHS_CAST:%.*]] = ptrtoint ptr [[WIDE_PTR_UB19]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_RHS_CAST:%.*]] = ptrtoint ptr [[WIDE_PTR_PTR29]] to i64, {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[SUB_PTR_SUB:%.*]] = sub i64 [[SUB_PTR_LHS_CAST]], [[SUB_PTR_RHS_CAST]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    [[CMP34:%.*]] = icmp sle i64 [[CONV]], [[SUB_PTR_SUB]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br label [[LAND_END]], {{!annotation ![0-9]+}}
+// CHECK:       land.end:
+// CHECK-NEXT:    [[TMP20:%.*]] = phi i1 [ false, [[LAND_LHS_TRUE]] ], [ false, [[ENTRY:%.*]] ], [ [[CMP34]], [[LAND_RHS]] ], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    br i1 [[TMP20]], label [[CONT:%.*]], label [[TRAP:%.*]], {{!prof ![0-9]+}}, {{!annotation ![0-9]+}}
+// CHECK:       trap:
+// CHECK-NEXT:    call void @llvm.ubsantrap(i8 25) #[[ATTR3]], {{!annotation ![0-9]+}}
+// CHECK-NEXT:    unreachable, {{!annotation ![0-9]+}}
+// CHECK:       cont:
+// CHECK-NEXT:    [[TMP21:%.*]] = load ptr, ptr [[BUF]], align 8
+// CHECK-NEXT:    [[INCDEC_PTR:%.*]] = getelementptr inbounds nuw i8, ptr [[TMP21]], i32 1
+// CHECK-NEXT:    store ptr [[INCDEC_PTR]], ptr [[BUF]], align 8
+// CHECK-NEXT:    [[TMP22:%.*]] = load i32, ptr [[LEN1]], align 8
+// CHECK-NEXT:    [[DEC:%.*]] = add i32 [[TMP22]], -1
+// CHECK-NEXT:    store i32 [[DEC]], ptr [[LEN1]], align 8
+// CHECK-NEXT:    ret void
+//
+void TestInc(struct Item *s) {
+  s->buf++;
+  s->len--;
+}

--- a/clang/test/BoundsSafety/Sema/count-bound-attrs.c
+++ b/clang/test/BoundsSafety/Sema/count-bound-attrs.c
@@ -28,7 +28,7 @@ void Test(void) {
     int *__counted_by(len12) __unsafe_indexable countUnsafe;
 
     int len13;
-    void *__counted_by(len13) countVoid; // expected-error{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
+    void *__counted_by(len13) countVoid;
     int len14;
     void *__sized_by(len14) byteCountVoid;
 }

--- a/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size.c
@@ -11,12 +11,10 @@ int len;
 //------------------------------------------------------------------------------
 // void pointer
 //------------------------------------------------------------------------------
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:7-[[@LINE+2]]:19}:"__sized_by"
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
+// void *__counted_by is allowed (treated as byte count)
 void *__counted_by(len) voidPtr;
 
-// CHECK: fix-it:"{{.+}}":{[[@LINE+2]]:7-[[@LINE+2]]:27}:"__sized_by_or_null"
-// expected-error@+1{{cannot apply '__counted_by_or_null' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
+// void *__counted_by is allowed (treated as byte count)
 void *__counted_by_or_null(len) voidPtrOrNull;
 
 //------------------------------------------------------------------------------

--- a/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size_no_fixit.c
+++ b/clang/test/BoundsSafety/Sema/counted_by_type_unknown_size_no_fixit.c
@@ -1,19 +1,18 @@
 
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
-// RUN: not %clang_cc1 -fsyntax-only -fbounds-safety  -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety  -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s --allow-empty
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
-// RUN: not %clang_cc1 -fsyntax-only -fbounds-safety  -x objective-c -fexperimental-bounds-safety-objc -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety  -x objective-c -fexperimental-bounds-safety-objc -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s --allow-empty
+// expected-no-diagnostics
 
 #include <ptrcheck.h>
 
 int len;
 
-// Using attribute directly should not suggest a fix-it.
-// expected-error-re@+1{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size{{$}}}}
+// void *__counted_by is allowed (treated as byte count)
 void *__attribute__((__counted_by__(len))) voidPtr;
 
-// Using a custom macro that wraps the attribute should not suggest a fix-it.
-// expected-error-re@+2{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size{{$}}}}
+// void *__counted_by is allowed (treated as byte count)
 #define my_custom_counted_by(X) __attribute__((__counted_by__(X)))
 void * my_custom_counted_by(len) voidPtr2;
 

--- a/clang/test/BoundsSafety/Sema/fptr-count-return.c
+++ b/clang/test/BoundsSafety/Sema/fptr-count-return.c
@@ -6,7 +6,7 @@
 // CHECK: VarDecl {{.*}} fptr 'int *__single*__single __counted_by(len)(*__single)(int)'
 int **__counted_by(len) (*fptr)(int len);
 
-// expected-error@+1{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
+// void *__counted_by is allowed (treated as byte count)
 void *__counted_by(len) (*fptr1)(int len);
 
 // expected-error@+1{{'__counted_by' attribute on nested pointer type is only allowed on indirect parameters}}

--- a/clang/test/Sema/attr-counted-by-void-ptr-gnu.c
+++ b/clang/test/Sema/attr-counted-by-void-ptr-gnu.c
@@ -4,9 +4,6 @@
 
 // expected-nowarn-no-diagnostics
 
-// FIXME: We don't allow `counted_by` on `void *` yet, unlike upstream.
-// See: https://github.com/swiftlang/llvm-project/issues/11807
-
 #define NULL (void*)0
 #define __counted_by(f)  __attribute__((counted_by(f)))
 #define __counted_by_or_null(f)  __attribute__((counted_by_or_null(f)))
@@ -18,7 +15,6 @@
 
 struct test_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   void* buf __counted_by(count);
@@ -26,7 +22,6 @@ struct test_void_ptr_gnu {
 
 struct test_const_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'const void *' because 'const void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   const void* buf __counted_by(count);
@@ -34,7 +29,6 @@ struct test_const_void_ptr_gnu {
 
 struct test_volatile_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'volatile void *' because 'volatile void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   volatile void* buf __counted_by(count);
@@ -42,7 +36,6 @@ struct test_volatile_void_ptr_gnu {
 
 struct test_const_volatile_void_ptr_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by' attribute to 'const volatile void *' because 'const volatile void' has unknown size; did you mean to use '__sized_by' instead?}}
   // expected-warn-warning@+2{{'counted_by' on a pointer to void is a GNU extension, treated as 'sized_by'}}
   // expected-warn-note@+1{{use '__sized_by' to suppress this warning}}
   const volatile void* buf __counted_by(count);
@@ -60,7 +53,6 @@ struct test_sized_by_void_ptr {
 
 struct test_void_ptr_or_null_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by_or_null' attribute to 'void *' because 'void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
   // expected-warn-warning@+2{{'counted_by_or_null' on a pointer to void is a GNU extension, treated as 'sized_by_or_null'}}
   // expected-warn-note@+1{{use '__sized_by_or_null' to suppress this warning}}
   void* buf __counted_by_or_null(count);
@@ -68,7 +60,6 @@ struct test_void_ptr_or_null_gnu {
 
 struct test_const_void_ptr_or_null_gnu {
   int count;
-  // expected-bounds-error@+3{{cannot apply '__counted_by_or_null' attribute to 'const void *' because 'const void' has unknown size; did you mean to use '__sized_by_or_null' instead?}}
   // expected-warn-warning@+2{{'counted_by_or_null' on a pointer to void is a GNU extension, treated as 'sized_by_or_null'}}
   // expected-warn-note@+1{{use '__sized_by_or_null' to suppress this warning}}
   const void* buf __counted_by_or_null(count);


### PR DESCRIPTION
Fixes #11807

### Changes
- Adjusted the conditions for bounds safety in semantic analysis to treat `void *` as a count on bytes without throwing errors.
- It seems like the handling of `void *` with `counted_by` in codegen already existed so no other changes were needed to be done.
- Changed the test cases to not expect using `counted_by` with `void *` to fail.