### PR TITLE
[llvm][clang] Revert split stacks implementation from runOnNewStack

### DIFF
--- a/llvm/include/llvm/Support/ProgramStack.h
+++ b/llvm/include/llvm/Support/ProgramStack.h
@@ -12,20 +12,6 @@
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/Support/Compiler.h"
 
-// FIXME: Temporarily disable split stacks. rdar://154158529
-#if 0
-// LLVM_HAS_SPLIT_STACKS is exposed in the header because CrashRecoveryContext
-// needs to know if it's running on another thread or not.
-//
-// Currently only Apple AArch64 is known to support split stacks in the debugger
-// and other tooling.
-#if defined(__APPLE__) && defined(__MACH__) && defined(__aarch64__) &&         \
-    __has_extension(gnu_asm)
-# define LLVM_HAS_SPLIT_STACKS
-# define LLVM_HAS_SPLIT_STACKS_AARCH64
-#endif
-#endif
-
 namespace llvm {
 
 /// \returns an address close to the current value of the stack pointer.

--- a/llvm/lib/Support/CrashRecoveryContext.cpp
+++ b/llvm/lib/Support/CrashRecoveryContext.cpp
@@ -526,10 +526,5 @@ bool CrashRecoveryContext::RunSafelyOnThread(function_ref<void()> Fn,
 
 bool CrashRecoveryContext::RunSafelyOnNewStack(function_ref<void()> Fn,
                                                unsigned RequestedStackSize) {
-#ifdef LLVM_HAS_SPLIT_STACKS
-  return runOnNewStack(RequestedStackSize,
-                       function_ref<bool()>([&]() { return RunSafely(Fn); }));
-#else
   return RunSafelyOnThread(Fn, RequestedStackSize);
-#endif
 }


### PR DESCRIPTION
This was potentially causing Clang to emit out of stack space warnings in rare cases, so I'm reverting it until I can verify the issue. This keeps the API change as that's known not to be the issue.

 (cherry-picked from 227d8d33c638985fcf2bd74e35323143d4b0df51)