### PR TITLE
Make StopInfoMachException return the right data. (#180088)

### DIFF
--- a/lldb/test/API/macosx/stop-reason-exception/Makefile
+++ b/lldb/test/API/macosx/stop-reason-exception/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/macosx/stop-reason-exception/TestMachExceptionData.py
+++ b/lldb/test/API/macosx/stop-reason-exception/TestMachExceptionData.py
@@ -1,0 +1,36 @@
+"""
+Test that we get the type code and subcode for MachExceptions
+"""
+
+
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestMachExceptionData(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipUnlessDarwin
+    def test_exc_bad_access(self):
+        """Test that we get type 1, code 1 and the right address for
+        a EXC_BAD_ACCESS mach exception."""
+        self.build()
+        self.main_source_file = lldb.SBFileSpec("main.c")
+
+        (target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
+            self, "Set a breakpoint here", self.main_source_file
+        )
+
+        # Now continue and we should crash:
+        process.Continue()
+        self.assertEqual(
+            lldb.eStopReasonException,
+            thread.GetStopReason(),
+            "Got the right stop reason",
+        )
+        self.assertEqual(thread.GetStopReasonDataCount(), 3, "Got all the codes")
+        self.assertEqual(thread.stop_reason_data[0], 1, "1 is EXC_BAD_ACCESS")
+        self.assertEqual(thread.stop_reason_data[1], 1, "1 is 'access invalid memory'")
+        self.assertEqual(thread.stop_reason_data[2], 0x400, "That's the bad address")

--- a/lldb/test/API/macosx/stop-reason-exception/main.c
+++ b/lldb/test/API/macosx/stop-reason-exception/main.c
@@ -1,0 +1,5 @@
+int main() {
+  char *bad_ptr = (char *)0x400; // Set a breakpoint here
+  bad_ptr[0] = 'a';
+  return 0;
+}


### PR DESCRIPTION
When I changed lldb so that the StopInfo's compute their own stop reason data (before it was oddly done in SBThread::GetStopReasonData...) I didn't notice that StopInfoMachException was relying on that routine's default of returning the Value as the 0th exception data, and didn't actually return its own data.
This fixes that, and makes us report the exception type, and the code and subcode if the exception has them. I also added a test for this.

rdar://169755672
(cherry picked from commit 85d94e17144f2ca250c91b827b59e6ddea675d31)