### PR TITLE
[stable/21.x][clang][darwin] macOS no longer infers a minimum deployment version from the OS version

### DIFF
--- a/clang/lib/Driver/ToolChains/Darwin.cpp
+++ b/clang/lib/Driver/ToolChains/Darwin.cpp
@@ -2067,9 +2067,12 @@ struct DarwinPlatform {
                                           const DarwinSDKInfo &SDKInfo) {
     const DarwinSDKInfo::SDKPlatformInfo PlatformInfo =
         SDKInfo.getCanonicalPlatformInfo();
-    DarwinPlatform Result(InferredFromSDK,
-                          getPlatformFromOS(PlatformInfo.getOS()),
-                          SDKInfo.getVersion());
+    const llvm::Triple::OSType OS = PlatformInfo.getOS();
+    VersionTuple Version = SDKInfo.getVersion();
+    if (OS == llvm::Triple::MacOSX)
+      Version = getVersionFromString(
+          getSystemOrSDKMacOSVersion(Version.getAsString()));
+    DarwinPlatform Result(InferredFromSDK, getPlatformFromOS(OS), Version);
     Result.Environment = getEnvKindFromEnvType(PlatformInfo.getEnvironment());
     Result.InferSimulatorFromArch = false;
     Result.InferredSource = SDKRoot;

--- a/clang/test/Driver/darwin-sdk-vs-os-version.c
+++ b/clang/test/Driver/darwin-sdk-vs-os-version.c
@@ -7,4 +7,8 @@
 // RUN: %clang -target x86_64-apple-darwin -isysroot %t/SDKs/MacOSX99.99.99.sdk %s -### 2>&1 \
 // RUN:   | FileCheck --check-prefix=CHECK-MACOSX-SYSTEM-VERSION %s
 
-// CHECK-MACOSX-SYSTEM-VERSION-NOT: 99.99.99"
+// RUN: sed -e 's/15\.1/99\.99\.99/g' %S/Inputs/MacOSX15.1.sdk/SDKSettings.json > %t/SDKs/MacOSX99.99.99.sdk/SDKSettings.json
+// RUN: %clang -target x86_64-apple-darwin -isysroot %t/SDKs/MacOSX99.99.99.sdk %s -### 2>&1 \
+// RUN:   | FileCheck --check-prefix=CHECK-MACOSX-SYSTEM-VERSION %s
+
+// CHECK-MACOSX-SYSTEM-VERSION-NOT: "-triple" "{{[[:alnum:]_-]*}}99.99.99"


### PR DESCRIPTION
The recent createFromSDKInfo refactor lost the getSystemOrSDKMacOSVersion version adjustment on macOS, causing -arch builds to create binaries that can't run on the host that built them.

rdar://170007161