### PR TITLE
[clang][deps] Replace include-tree output formats with "compilation mode"

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -37,12 +37,11 @@ public:
       DependencyConsumer &Consumer, DependencyActionController &Controller,
       llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS,
       bool EmitDependencyFile, bool DiagGenerationAsCompilation,
-      const CASOptions &CASOpts,
-      std::optional<StringRef> ModuleName = std::nullopt,
+      CASOptions CASOpts, std::optional<StringRef> ModuleName = std::nullopt,
       raw_ostream *VerboseOS = nullptr)
       : Service(Service), WorkingDirectory(WorkingDirectory),
         Consumer(Consumer), Controller(Controller), DepFS(std::move(DepFS)),
-        CASOpts(CASOpts), EmitDependencyFile(EmitDependencyFile),
+        CASOpts(std::move(CASOpts)), EmitDependencyFile(EmitDependencyFile),
         DiagGenerationAsCompilation(DiagGenerationAsCompilation),
         VerboseOS(VerboseOS) {}
   bool runInvocation(std::string Executable,
@@ -60,7 +59,7 @@ private:
   DependencyConsumer &Consumer;
   DependencyActionController &Controller;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
-  const CASOptions &CASOpts;
+  CASOptions CASOpts;
   bool EmitDependencyFile = false;
   bool DiagGenerationAsCompilation;
   std::optional<StringRef> ModuleName;

--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -15,6 +15,8 @@
 #include "llvm/ADT/BitmaskEnum.h"
 #include "llvm/CAS/ActionCache.h"
 
+#include <variant>
+
 namespace clang {
 namespace dependencies {
 
@@ -84,6 +86,18 @@ enum class ScanningOptimizations {
   FullIncludeTreeIrrelevant = HeaderSearch | VFS,
 };
 
+struct RegularCompilation {};
+struct IncludeTreeCompilation {
+  /// The CAS configuration.
+  CASOptions CASOpts;
+  /// The CAS database to use.
+  std::shared_ptr<cas::ObjectStore> CAS;
+  /// The CAS cache to use.
+  std::shared_ptr<cas::ActionCache> Cache;
+};
+using CompilationMode =
+    std::variant<RegularCompilation, IncludeTreeCompilation>;
+
 #undef DSS_LAST_BITMASK_ENUM
 
 bool shouldCacheNegativeStatsDefault();
@@ -105,12 +119,8 @@ struct DependencyScanningServiceOptions {
   ScanningMode Mode = ScanningMode::DependencyDirectivesScan;
   /// What output format are we expected to produce.
   ScanningOutputFormat Format = ScanningOutputFormat::Full;
-  /// The CAS configuration.
-  CASOptions CASOpts;
-  /// The CAS database to use.
-  std::shared_ptr<llvm::cas::ObjectStore> CAS;
-  /// The CAS cache to use.
-  std::shared_ptr<llvm::cas::ActionCache> Cache;
+  /// How to compile the resulting modules and translation units.
+  CompilationMode Compilation = RegularCompilation{};
   /// How to optimize resulting explicit module command lines.
   ScanningOptimizations OptimizeArgs = ScanningOptimizations::Default;
   /// Whether the resulting command lines should load explicit PCMs eagerly.

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -217,12 +217,7 @@ public:
       DependencyActionController &Controller, DiagnosticConsumer &DiagsConsumer,
       raw_ostream *VerboseOS, bool DiagGenerationAsCompilation);
 
-  ScanningOutputFormat getScanningFormat() const {
-    return Service.getOpts().Format;
-  }
-
-  const CASOptions &getCASOpts() const { return CASOpts; }
-  std::shared_ptr<cas::ObjectStore> getCAS() const { return CAS; }
+  const DependencyScanningService &getService() const { return Service; }
 
   llvm::vfs::FileSystem &getVFS() const { return *DepFS; }
 
@@ -233,9 +228,6 @@ private:
   /// This is the caching (and optionally dependency-directives-providing) VFS
   /// overlaid on top of the base VFS passed in the constructor.
   IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
-
-  CASOptions CASOpts;
-  std::shared_ptr<cas::ObjectStore> CAS;
 
   friend CompilerInstanceWithContext;
   std::unique_ptr<CompilerInstanceWithContext> CIWithContext;

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -221,12 +221,11 @@ public:
     return Service.getOpts().Format;
   }
 
-  const CASOptions &getCASOpts() const {
+  CASOptions getCASOpts() const {
     if (auto *IncludeTree =
             std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
       return IncludeTree->CASOpts;
-    static CASOptions Default;
-    return Default;
+    return {};
   }
 
   std::shared_ptr<cas::ObjectStore> getCAS() const {

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -217,7 +217,24 @@ public:
       DependencyActionController &Controller, DiagnosticConsumer &DiagsConsumer,
       raw_ostream *VerboseOS, bool DiagGenerationAsCompilation);
 
-  const DependencyScanningService &getService() const { return Service; }
+  ScanningOutputFormat getScanningFormat() const {
+    return Service.getOpts().Format;
+  }
+
+  const CASOptions &getCASOpts() const {
+    if (auto *IncludeTree =
+            std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
+      return IncludeTree->CASOpts;
+    static CASOptions Default;
+    return Default;
+  }
+
+  std::shared_ptr<cas::ObjectStore> getCAS() const {
+    if (auto *IncludeTree =
+            std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
+      return IncludeTree->CAS;
+    return nullptr;
+  }
 
   llvm::vfs::FileSystem &getVFS() const { return *DepFS; }
 

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -182,11 +182,9 @@ public:
 
   llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
 
-  clang::dependencies::ScanningOutputFormat getScanningFormat() const {
-    return Worker.getScanningFormat();
+  const dependencies::DependencyScanningService &getService() const {
+    return Worker.getService();
   }
-
-  const CASOptions &getCASOpts() const { return Worker.getCASOpts(); }
 
   static std::unique_ptr<clang::dependencies::DependencyActionController>
   createActionController(

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -182,9 +182,7 @@ public:
 
   llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
 
-  const dependencies::DependencyScanningService &getService() const {
-    return Worker.getService();
-  }
+  const CASOptions &getCASOpts() const { return Worker.getCASOpts(); }
 
   static std::unique_ptr<clang::dependencies::DependencyActionController>
   createActionController(

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -182,7 +182,7 @@ public:
 
   llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
 
-  const CASOptions &getCASOpts() const { return Worker.getCASOpts(); }
+  CASOptions getCASOpts() const { return Worker.getCASOpts(); }
 
   static std::unique_ptr<clang::dependencies::DependencyActionController>
   createActionController(

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -1031,7 +1031,9 @@ bool CompilerInstanceWithContext::initialize(
       Worker.PCHContainerOps, std::move(ModCache));
   auto &CI = *CIPtr;
 
-  CI.getInvocation().getCASOpts() = Worker.CASOpts;
+  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
+          &Worker.getService().getOpts().Compilation))
+    CI.getInvocation().getCASOpts() = IncludeTree->CASOpts;
   initializeScanCompilerInstance(
       CI, OverlayFS, DiagEngineWithCmdAndOpts->DiagEngine->getClient(),
       Worker.Service, Worker.DepFS);

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -1031,9 +1031,7 @@ bool CompilerInstanceWithContext::initialize(
       Worker.PCHContainerOps, std::move(ModCache));
   auto &CI = *CIPtr;
 
-  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
-          &Worker.getService().getOpts().Compilation))
-    CI.getInvocation().getCASOpts() = IncludeTree->CASOpts;
+  CI.getInvocation().getCASOpts() = Worker.getCASOpts();
   initializeScanCompilerInstance(
       CI, OverlayFS, DiagEngineWithCmdAndOpts->DiagEngine->getClient(),
       Worker.Service, Worker.DepFS);

--- a/clang/lib/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningService.cpp
@@ -51,9 +51,9 @@ DependencyScanningServiceOptions::DependencyScanningServiceOptions()
 DependencyScanningService::DependencyScanningService(
     DependencyScanningServiceOptions OptsArg)
     : Opts(std::move(OptsArg)) {
-  // The FullIncludeTree output format completely subsumes header search and
-  // VFS optimizations due to how it works. Disable these optimizations so
-  // we're not doing unneeded work.
-  if (Opts.Format == ScanningOutputFormat::FullIncludeTree)
+  // Include-tree compilation completely subsumes header search and VFS
+  // optimizations due to how it works. Disable these optimizations so we're not
+  // doing unneeded work.
+  if (std::holds_alternative<IncludeTreeCompilation>(Opts.Compilation))
     Opts.OptimizeArgs &= ~ScanningOptimizations::FullIncludeTreeIrrelevant;
 }

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -23,8 +23,7 @@ using llvm::Error;
 
 DependencyScanningWorker::DependencyScanningWorker(
     DependencyScanningService &Service)
-    : Service(Service), CASOpts(Service.getOpts().CASOpts),
-      CAS(Service.getOpts().CAS) {
+    : Service(Service) {
   PCHContainerOps = std::make_shared<PCHContainerOperations>();
   // We need to read object files from PCH built outside the scanner.
   PCHContainerOps->registerReader(
@@ -88,10 +87,14 @@ bool DependencyScanningWorker::computeDependencies(
     FS->setCurrentWorkingDirectory(WorkingDirectory);
   }
 
+  CASOptions CASOpts;
+  if (auto *IncludeTree =
+          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
+    CASOpts = IncludeTree->CASOpts;
   DependencyScanningAction Action(
       Service, WorkingDirectory, DepConsumer, Controller, DepFS,
       /*EmitDependencyFile=*/false,
-      /*DiagGenerationAsCompilation=*/false, getCASOpts());
+      /*DiagGenerationAsCompilation=*/false, CASOpts);
 
   const bool Success = llvm::all_of(CommandLines, [&](const auto &Cmd) {
     if (StringRef(Cmd[1]) != "-cc1") {
@@ -145,12 +148,16 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     DepFile = Path.str().str();
   }
 
+  CASOptions CASOpts;
+  if (auto *IncludeTree =
+          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
+    CASOpts = IncludeTree->CASOpts;
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
   DependencyScanningAction Action(Service, WorkingDirectory, DepsConsumer,
                                   Controller, DepFS,
                                   /*EmitDependencyFile=*/!DepFile.empty(),
-                                  DiagGenerationAsCompilation, getCASOpts(),
+                                  DiagGenerationAsCompilation, CASOpts,
                                   /*ModuleName=*/std::nullopt, VerboseOS);
 
   // Ignore result; we're just collecting dependencies.
@@ -162,6 +169,10 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
 
 bool DependencyScanningWorker::initializeCompilerInstanceWithContext(
     StringRef CWD, ArrayRef<std::string> CommandLine, DiagnosticConsumer &DC) {
+  std::shared_ptr<cas::ObjectStore> CAS;
+  if (auto *IncludeTree =
+          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
+    CAS = IncludeTree->CAS;
   auto [OverlayFS, ModifiedCommandLine] =
       initVFSForByNameScanning(DepFS, CommandLine, CWD, "ScanningByName", CAS);
   auto DiagEngineWithCmdAndOpts =

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -87,14 +87,10 @@ bool DependencyScanningWorker::computeDependencies(
     FS->setCurrentWorkingDirectory(WorkingDirectory);
   }
 
-  CASOptions CASOpts;
-  if (auto *IncludeTree =
-          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
-    CASOpts = IncludeTree->CASOpts;
   DependencyScanningAction Action(
       Service, WorkingDirectory, DepConsumer, Controller, DepFS,
       /*EmitDependencyFile=*/false,
-      /*DiagGenerationAsCompilation=*/false, CASOpts);
+      /*DiagGenerationAsCompilation=*/false, getCASOpts());
 
   const bool Success = llvm::all_of(CommandLines, [&](const auto &Cmd) {
     if (StringRef(Cmd[1]) != "-cc1") {
@@ -148,16 +144,12 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
     DepFile = Path.str().str();
   }
 
-  CASOptions CASOpts;
-  if (auto *IncludeTree =
-          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
-    CASOpts = IncludeTree->CASOpts;
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
   DependencyScanningAction Action(Service, WorkingDirectory, DepsConsumer,
                                   Controller, DepFS,
                                   /*EmitDependencyFile=*/!DepFile.empty(),
-                                  DiagGenerationAsCompilation, CASOpts,
+                                  DiagGenerationAsCompilation, getCASOpts(),
                                   /*ModuleName=*/std::nullopt, VerboseOS);
 
   // Ignore result; we're just collecting dependencies.
@@ -169,12 +161,8 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
 
 bool DependencyScanningWorker::initializeCompilerInstanceWithContext(
     StringRef CWD, ArrayRef<std::string> CommandLine, DiagnosticConsumer &DC) {
-  std::shared_ptr<cas::ObjectStore> CAS;
-  if (auto *IncludeTree =
-          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
-    CAS = IncludeTree->CAS;
-  auto [OverlayFS, ModifiedCommandLine] =
-      initVFSForByNameScanning(DepFS, CommandLine, CWD, "ScanningByName", CAS);
+  auto [OverlayFS, ModifiedCommandLine] = initVFSForByNameScanning(
+      DepFS, CommandLine, CWD, "ScanningByName", getCAS());
   auto DiagEngineWithCmdAndOpts =
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine,
                                                       OverlayFS, DC);

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -362,9 +362,13 @@ DependencyScanningTool::getTranslationUnitDependencies(
   IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS = nullptr;
   std::vector<std::string> CommandLineWithTUBufferInput;
   if (TUBuffer) {
+    std::shared_ptr<cas::ObjectStore> CAS;
+    if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
+            &Worker.getService().getOpts().Compilation))
+      CAS = IncludeTree->CAS;
     std::tie(OverlayFS, CommandLineWithTUBufferInput) =
         initVFSForTUBufferScanning(&Worker.getVFS(), CommandLine, CWD,
-                                   *TUBuffer, Worker.getCAS());
+                                   *TUBuffer, CAS);
     CommandLine = CommandLineWithTUBufferInput;
   }
 
@@ -426,8 +430,12 @@ bool DependencyScanningTool::initializeWorkerCIWithContextFromCommandline(
   // The input command line is either a driver-style command line, or
   // ill-formed. In this case, we will first call the Driver to build a -cc1
   // command line for this compilation or diagnose any ill-formed input.
+  std::shared_ptr<cas::ObjectStore> CAS;
+  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
+          &Worker.getService().getOpts().Compilation))
+    CAS = IncludeTree->CAS;
   auto [OverlayFS, ModifiedCommandLine] = initVFSForByNameScanning(
-      &Worker.getVFS(), CommandLine, CWD, "ScanningByName", Worker.getCAS());
+      &Worker.getVFS(), CommandLine, CWD, "ScanningByName", CAS);
   auto DiagEngineWithCmdAndOpts =
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine,
                                                       OverlayFS, DC);
@@ -481,9 +489,10 @@ std::unique_ptr<DependencyActionController>
 DependencyScanningTool::createActionController(
     DependencyScanningWorker &Worker,
     LookupModuleOutputCallback LookupModuleOutput) {
-  if (Worker.getScanningFormat() == ScanningOutputFormat::FullIncludeTree)
+  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
+          &Worker.getService().getOpts().Compilation))
     return createIncludeTreeActionController(LookupModuleOutput,
-                                             *Worker.getCAS());
+                                             *IncludeTree->CAS);
   return std::make_unique<CallbackActionController>(LookupModuleOutput);
 }
 
@@ -497,9 +506,14 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
     DependencyScanningTool &Tool, DiagnosticConsumer &DiagsConsumer,
     raw_ostream *VerboseOS, CompilerInvocation &Invocation,
     StringRef WorkingDirectory, llvm::cas::ObjectStore &DB) {
+  CASOptions CASOpts;
+  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
+          &Tool.getService().getOpts().Compilation))
+    CASOpts = IncludeTree->CASOpts;
+
   // Override the CASOptions. They may match (the caller having sniffed them
   // out of InputArgs) but if they have been overridden we want the new ones.
-  Invocation.getCASOpts() = Tool.getCASOpts();
+  Invocation.getCASOpts() = CASOpts;
 
   llvm::PrefixMapper Mapper;
   DepscanPrefixMapping::configurePrefixMapper(Invocation, Mapper);
@@ -523,7 +537,7 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
   // Turn off dependency outputs. Should have already been emitted.
   Invocation.getDependencyOutputOpts().OutputFile.clear();
 
-  configureInvocationForCaching(Invocation, Tool.getCASOpts(), Root->toString(),
+  configureInvocationForCaching(Invocation, CASOpts, Root->toString(),
                                 CachingInputKind::IncludeTree,
                                 WorkingDirectory.str());
   DepscanPrefixMapping::remapInvocationPaths(Invocation, Mapper);

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -362,13 +362,9 @@ DependencyScanningTool::getTranslationUnitDependencies(
   IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS = nullptr;
   std::vector<std::string> CommandLineWithTUBufferInput;
   if (TUBuffer) {
-    std::shared_ptr<cas::ObjectStore> CAS;
-    if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
-            &Worker.getService().getOpts().Compilation))
-      CAS = IncludeTree->CAS;
     std::tie(OverlayFS, CommandLineWithTUBufferInput) =
         initVFSForTUBufferScanning(&Worker.getVFS(), CommandLine, CWD,
-                                   *TUBuffer, CAS);
+                                   *TUBuffer, Worker.getCAS());
     CommandLine = CommandLineWithTUBufferInput;
   }
 
@@ -430,12 +426,8 @@ bool DependencyScanningTool::initializeWorkerCIWithContextFromCommandline(
   // The input command line is either a driver-style command line, or
   // ill-formed. In this case, we will first call the Driver to build a -cc1
   // command line for this compilation or diagnose any ill-formed input.
-  std::shared_ptr<cas::ObjectStore> CAS;
-  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
-          &Worker.getService().getOpts().Compilation))
-    CAS = IncludeTree->CAS;
   auto [OverlayFS, ModifiedCommandLine] = initVFSForByNameScanning(
-      &Worker.getVFS(), CommandLine, CWD, "ScanningByName", CAS);
+      &Worker.getVFS(), CommandLine, CWD, "ScanningByName", Worker.getCAS());
   auto DiagEngineWithCmdAndOpts =
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine,
                                                       OverlayFS, DC);
@@ -489,10 +481,9 @@ std::unique_ptr<DependencyActionController>
 DependencyScanningTool::createActionController(
     DependencyScanningWorker &Worker,
     LookupModuleOutputCallback LookupModuleOutput) {
-  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
-          &Worker.getService().getOpts().Compilation))
+  if (Worker.getScanningFormat() == ScanningOutputFormat::FullIncludeTree)
     return createIncludeTreeActionController(LookupModuleOutput,
-                                             *IncludeTree->CAS);
+                                             *Worker.getCAS());
   return std::make_unique<CallbackActionController>(LookupModuleOutput);
 }
 
@@ -506,14 +497,9 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
     DependencyScanningTool &Tool, DiagnosticConsumer &DiagsConsumer,
     raw_ostream *VerboseOS, CompilerInvocation &Invocation,
     StringRef WorkingDirectory, llvm::cas::ObjectStore &DB) {
-  CASOptions CASOpts;
-  if (auto *IncludeTree = std::get_if<IncludeTreeCompilation>(
-          &Tool.getService().getOpts().Compilation))
-    CASOpts = IncludeTree->CASOpts;
-
   // Override the CASOptions. They may match (the caller having sniffed them
   // out of InputArgs) but if they have been overridden we want the new ones.
-  Invocation.getCASOpts() = CASOpts;
+  Invocation.getCASOpts() = Tool.getCASOpts();
 
   llvm::PrefixMapper Mapper;
   DepscanPrefixMapping::configurePrefixMapper(Invocation, Mapper);
@@ -537,7 +523,7 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
   // Turn off dependency outputs. Should have already been emitted.
   Invocation.getDependencyOutputOpts().OutputFile.clear();
 
-  configureInvocationForCaching(Invocation, CASOpts, Root->toString(),
+  configureInvocationForCaching(Invocation, Tool.getCASOpts(), Root->toString(),
                                 CachingInputKind::IncludeTree,
                                 WorkingDirectory.str());
   DepscanPrefixMapping::remapInvocationPaths(Invocation, Mapper);

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1304,9 +1304,8 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
   };
   Opts.Mode = ScanMode;
   Opts.Format = Format;
-  Opts.CASOpts = CASOpts;
-  Opts.CAS = CAS;
-  Opts.Cache = Cache;
+  if (CAS && Cache)
+    Opts.Compilation = IncludeTreeCompilation{CASOpts, CAS, Cache};
   Opts.OptimizeArgs = OptimizeArgs;
   Opts.EagerLoadModules = EagerLoadModules;
   Opts.TraceVFS = Verbose;

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -901,9 +901,7 @@ int ScanServer::listen() {
         CAS, llvm::vfs::createPhysicalFileSystem());
   };
   Opts.Format = dependencies::ScanningOutputFormat::IncludeTree;
-  Opts.CASOpts = CASOpts;
-  Opts.CAS = CAS;
-  Opts.Cache = Cache;
+  Opts.Compilation = dependencies::IncludeTreeCompilation{CASOpts, CAS, Cache};
   dependencies::DependencyScanningService Service(std::move(Opts));
 
   std::atomic<int> NumRunning(0);
@@ -1120,9 +1118,7 @@ scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
         DB, llvm::vfs::createPhysicalFileSystem());
   };
   Opts.Format = dependencies::ScanningOutputFormat::IncludeTree;
-  Opts.CASOpts = CASOpts;
-  Opts.CAS = DB;
-  Opts.Cache = Cache;
+  Opts.Compilation = dependencies::IncludeTreeCompilation{CASOpts, DB, Cache};
   dependencies::DependencyScanningService Service(std::move(Opts));
   tooling::DependencyScanningTool Tool(Service);
 

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -184,17 +184,17 @@ ScanningOutputFormat DependencyScannerServiceOptions::getFormat() const {
 CXDependencyScannerService
 clang_experimental_DependencyScannerService_create_v1(
     CXDependencyScannerServiceOptions WrappedOpts) {
+  std::shared_ptr<cas::ObjectStore> CAS = unwrap(WrappedOpts)->CAS;
+  std::shared_ptr<cas::ActionCache> Cache = unwrap(WrappedOpts)->Cache;
   // FIXME: Pass default CASOpts now.
   DependencyScanningServiceOptions Opts;
   Opts.Format = unwrap(WrappedOpts)->getFormat();
-  Opts.CASOpts = unwrap(WrappedOpts)->CASOpts;
-  Opts.CAS = unwrap(WrappedOpts)->CAS;
-  Opts.Cache = unwrap(WrappedOpts)->Cache;
-  Opts.MakeVFS = [Format = Opts.Format, CAS = Opts.CAS] {
-    bool IsIncludeTreeOutput = Format == ScanningOutputFormat::IncludeTree ||
-                               Format == ScanningOutputFormat::FullIncludeTree;
+  if (CAS && Cache)
+    Opts.Compilation =
+        IncludeTreeCompilation{unwrap(WrappedOpts)->CASOpts, CAS, Cache};
+  Opts.MakeVFS = [CAS = CAS] {
     auto FS = llvm::vfs::createPhysicalFileSystem();
-    if (IsIncludeTreeOutput)
+    if (CAS)
       FS = llvm::cas::createCASProvidingFileSystem(CAS, std::move(FS));
     return FS;
   };
@@ -335,8 +335,9 @@ enum CXErrorCode clang_experimental_DependencyScannerWorker_getDepGraph(
 
   DependencyScanningWorker *Worker = unwrap(W);
 
-  if (Worker->getScanningFormat() != ScanningOutputFormat::Full &&
-      Worker->getScanningFormat() != ScanningOutputFormat::FullIncludeTree)
+  if (Worker->getService().getOpts().Format != ScanningOutputFormat::Full &&
+      Worker->getService().getOpts().Format !=
+          ScanningOutputFormat::FullIncludeTree)
     return CXError_InvalidArguments;
 
   std::vector<std::string> Compilation{argv, argv + argc};
@@ -797,9 +798,8 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
           UpstreamCAS, llvm::vfs::createPhysicalFileSystem());
     };
     ServiceOpts.Format = ScanningOutputFormat::FullIncludeTree;
-    ServiceOpts.CASOpts = Opts.CASOpts;
-    ServiceOpts.CAS = UpstreamCAS;
-    ServiceOpts.Cache = Opts.Cache;
+    ServiceOpts.Compilation =
+        IncludeTreeCompilation{Opts.CASOpts, Opts.CAS, Opts.Cache};
   }
   DependencyScanningService DepsService(std::move(ServiceOpts));
   DependencyScanningTool DepsTool(DepsService);

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -335,9 +335,8 @@ enum CXErrorCode clang_experimental_DependencyScannerWorker_getDepGraph(
 
   DependencyScanningWorker *Worker = unwrap(W);
 
-  if (Worker->getService().getOpts().Format != ScanningOutputFormat::Full &&
-      Worker->getService().getOpts().Format !=
-          ScanningOutputFormat::FullIncludeTree)
+  if (Worker->getScanningFormat() != ScanningOutputFormat::Full &&
+      Worker->getScanningFormat() != ScanningOutputFormat::FullIncludeTree)
     return CXError_InvalidArguments;
 
   std::vector<std::string> Compilation{argv, argv + argc};

--- a/clang/unittests/Tooling/DependencyScannerTest.cpp
+++ b/clang/unittests/Tooling/DependencyScannerTest.cpp
@@ -437,8 +437,7 @@ TEST(DependencyScanner, NoNegativeCacheCAS) {
   DependencyScanningServiceOptions Opts;
   Opts.MakeVFS = [VFS] { return VFS; };
   Opts.Format = ScanningOutputFormat::FullIncludeTree;
-  Opts.CAS = DB;
-  Opts.Cache = Cache;
+  Opts.Compilation = IncludeTreeCompilation{CASOptions(), DB, Cache};
   DependencyScanningService Service(std::move(Opts));
   DependencyScanningTool ScanTool(Service);
 


### PR DESCRIPTION
Together with https://github.com/llvm/llvm-project/pull/182063 and https://github.com/llvm/llvm-project/pull/182069, this PR works towards making the scanning logic independent of the requested output file format. This patch implements this idea for include-tree, where instead of relying on the output format, we introduce new service argument "compilation mode", which signals what kind of compilation the consumer would like the scanner to prepare.

I believe this more closely models what the intent is. Moreover, this works towards making it impossible to misconfigure the service - currently each scanner client needs to ensure `Format`, `CASOptions`, `ObjectStore`, `ActionCache` and `MakeVFS` are all configured for include-tree. In the future, `Format` will no longer exist on this level, the scanner will automatically wrap the result of `MakeVFS` with the CAS-providing VFS if necessary, and this PR makes sure `CASOptions`, `ObjectStore` and `ActionCache` are configured all together in the compilation mode object.

Besides cleaning up the code, this will make it possible to mix-and-match compilation modes with output formats, so it will be possible to generate Makefiles for regular explicitly-built modules or for include-tree based explicitly-built modules compilations, etc.

No functional change intended.