### PR TITLE
[lldb-dap] Initialise the call mutex before the progress_event_reporter (llvm#181941)

### DIFF
--- a/lldb/tools/lldb-dap/DAP.h
+++ b/lldb/tools/lldb-dap/DAP.h
@@ -127,6 +127,7 @@ struct DAP {
   bool configuration_done;
 
   bool waiting_for_run_in_terminal = false;
+  std::mutex call_mutex;
   ProgressEventReporter progress_event_reporter;
 
   /// Keep track of the last stop thread index IDs as threads won't go away
@@ -134,7 +135,6 @@ struct DAP {
   llvm::DenseSet<lldb::tid_t> thread_ids;
 
   uint32_t reverse_request_seq = 0;
-  std::mutex call_mutex;
   llvm::SmallDenseMap<int64_t, std::unique_ptr<ResponseHandler>>
       inflight_reverse_requests;
   ReplMode repl_mode;


### PR DESCRIPTION

The progress event reporter has a thread that reports events every 250 millisecond. and is destroyed in its destructor.

When in event reporter desctructor, the event reporter may have pending event but the call mutex is destroyed leading to the crash.

Relevant stack trace from CI.
```
[2026-02-13T17:46:13.577Z] libc++abi: terminating due to uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
[2026-02-13T17:46:13.577Z] PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash report from ~/Library/Logs/DiagnosticReports/.

[2026-02-13T17:46:13.577Z]  #0 0x0000000102b6943c llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x10008943c)
[2026-02-13T17:46:13.577Z]  #1 0x0000000102b67368 llvm::sys::RunSignalHandlers() (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x100087368)
[2026-02-13T17:46:13.577Z]  #2 0x0000000102b69f20 SignalHandler(int, __siginfo*, void*) (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x100089f20)
[2026-02-13T17:46:13.577Z]  #3 0x000000018bbdb744 (/usr/lib/system/libsystem_platform.dylib+0x1804e3744)
[2026-02-13T17:46:13.577Z]  #4 0x000000018bbd1888 (/usr/lib/system/libsystem_pthread.dylib+0x1804d9888)
[2026-02-13T17:46:13.577Z]  #5 0x000000018bad6850 (/usr/lib/system/libsystem_c.dylib+0x1803de850)
[2026-02-13T17:46:13.577Z]  #6 0x000000018bb85858 (/usr/lib/libc++abi.dylib+0x18048d858)
[2026-02-13T17:46:13.577Z]  #7 0x000000018bb744bc (/usr/lib/libc++abi.dylib+0x18047c4bc)
[2026-02-13T17:46:13.577Z]  #8 0x000000018b7a0424 (/usr/lib/libobjc.A.dylib+0x1800a8424)
[2026-02-13T17:46:13.577Z]  #9 0x000000018bb84c2c (/usr/lib/libc++abi.dylib+0x18048cc2c)
[2026-02-13T17:46:13.577Z] #10 0x000000018bb88394 (/usr/lib/libc++abi.dylib+0x180490394)
[2026-02-13T17:46:13.577Z] #11 0x000000018bb8833c (/usr/lib/libc++abi.dylib+0x18049033c)
[2026-02-13T17:46:13.577Z] #12 0x000000018bb01b90 (/usr/lib/libc++.1.dylib+0x180409b90)
[2026-02-13T17:46:13.577Z] #13 0x000000018bb01b34 (/usr/lib/libc++.1.dylib+0x180409b34)
[2026-02-13T17:46:13.577Z] #14 0x000000018bb038a0 (/usr/lib/libc++.1.dylib+0x18040b8a0)
[2026-02-13T17:46:13.577Z] #15 0x0000000102b6fbac lldb_dap::DAP::Send(std::__1::variant<lldb_dap::protocol::Request, lldb_dap::protocol::Response, lldb_dap::protocol::Event> const&) (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x10008fbac)
[2026-02-13T17:46:13.577Z] #16 0x0000000102b6f890 lldb_dap::DAP::SendJSON(llvm::json::Value const&) (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x10008f890)
[2026-02-13T17:46:13.577Z] #17 0x0000000102b78788 std::__1::__function::__func<lldb_dap::DAP::DAP(lldb_dap::Log&, lldb_dap::ReplMode, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, bool, llvm::StringRef, lldb_private::transport::JSONTransport<lldb_dap::ProtocolDescriptor>&, lldb_private::MainLoopPosix&)::$_0, std::__1::allocator<lldb_dap::DAP::DAP(lldb_dap::Log&, lldb_dap::ReplMode, std::__1::vector<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::allocator<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>>, bool, llvm::StringRef, lldb_private::transport::JSONTransport<lldb_dap::ProtocolDescriptor>&, lldb_private::MainLoopPosix&)::$_0>, void (lldb_dap::ProgressEvent&)>::operator()(lldb_dap::ProgressEvent&) (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x100098788)
[2026-02-13T17:46:13.577Z] #18 0x0000000102b8939c lldb_dap::ProgressEventManager::ReportIfNeeded() (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x1000a939c)
[2026-02-13T17:46:13.577Z] #19 0x0000000102b8982c lldb_dap::ProgressEventReporter::ReportStartEvents() (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x1000a982c)
[2026-02-13T17:46:13.577Z] #20 0x0000000102b8a038 void* std::__1::__thread_proxy[abi:nn200100]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, lldb_dap::ProgressEventReporter::ProgressEventReporter(std::__1::function<void (lldb_dap::ProgressEvent&)>)::$_0>>(void*) (/Users/ec2-user/jenkins/workspace/llvm.org/as-lldb-cmake-os-verficiation/lldb-build/bin/lldb-dap+0x1000aa038)
[2026-02-13T17:46:13.577Z] #21 0x000000018bbd1c08 (/usr/lib/system/libsystem_pthread.dylib+0x1804d9c08) [2026-02-13T17:46:13.577Z] #22 0x000000018bbccba8 (/usr/lib/system/libsystem_pthread.dylib+0x1804d4ba8)
```
rdar://170331108

(cherry picked from commit c5a0742d17219053994a5d7a33c4a21fd1d12d15)