### PR TITLE
[clang][cas] Introduce a frontend option to write CAS hash to an xattr

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -152,6 +152,8 @@ def err_fe_incompatible_option_with_remote_cache : Error<
   "'%0' is incompatible with remote caching backend">;
 def err_fe_mccas_incompatible_target : Error<
   "-fcas-backend is incompatible with target '%0'; requires mach-o object format">;
+def err_fe_incompatible_option_with_write_xattr : Error<
+  "'%0' is incompatible with '-fwrite-output-hash-xattr'">;
 def err_fe_unable_to_load_include_tree : Error<
   "unable to load the CAS include-tree '%0': '%1'">;
 def err_unable_to_load_include_tree_node : Error<

--- a/clang/include/clang/Frontend/CompileJobCache.h
+++ b/clang/include/clang/Frontend/CompileJobCache.h
@@ -87,6 +87,7 @@ public:
                      cas::CompileJobCacheResult &CachedResult,
                      SmallVectorImpl<char> &DiagText,
                      bool WriteOutputAsCASID = false,
+                     bool WriteOutputHashXAttr = false,
                      std::optional<llvm::cas::CASID> *MCOutputID = nullptr);
 
   class CachingOutputs;

--- a/clang/include/clang/Frontend/CompileJobCacheKey.h
+++ b/clang/include/clang/Frontend/CompileJobCacheKey.h
@@ -46,6 +46,8 @@ struct CompileJobCachingOptions {
   bool DisableCachedCompileJobReplay;
   /// See \c FrontendOptions::WriteOutputAsCASID.
   bool WriteOutputAsCASID;
+  /// See \c FrontendOptions::WriteOutputHashXAttr.
+  bool WriteOutputHashXAttr;
   /// See \c FrontendOptions::PathPrefixMappings.
   std::vector<std::pair<std::string, std::string>> PathPrefixMappings;
 };

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -431,6 +431,11 @@ public:
   /// FIXME: Add clang tests for this functionality.
   unsigned WriteOutputAsCASID : 1;
 
+  /// When using CacheCompileJob, write the output file's hash (as determined by
+  /// the CAS hashing schema) as a file extended attribute (xattr).
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned WriteOutputHashXAttr : 1;
+
   /// Output (and read) PCM files regardless of compiler errors.
   LLVM_PREFERRED_TYPE(bool)
   unsigned AllowPCMWithCompilerErrors : 1;
@@ -628,7 +633,8 @@ public:
         UseTemporary(true), CacheCompileJob(false), ForIncludeTreeScan(false),
         DisableCachedCompileJobReplay(false), IncludeTreePreservePCHPath(false),
         MayEmitDiagnosticsAfterProcessingSourceFiles(false),
-        WriteOutputAsCASID(false), AllowPCMWithCompilerErrors(false),
+        WriteOutputAsCASID(false), WriteOutputHashXAttr(false),
+        AllowPCMWithCompilerErrors(false),
         ModulesShareFileManager(true), EmitSymbolGraph(false),
         EmitExtensionSymbolGraphs(false),
         EmitSymbolGraphSymbolLabelsForTesting(false),

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -9434,6 +9434,12 @@ defm casid_output : BoolFOption<"casid-output",
                          " write a CASID for the output file.">,
     NegFlag<SetFalse>>;
 
+defm write_output_hash_xattr : BoolFOption<"write-output-hash-xattr",
+    FrontendOpts<"WriteOutputHashXAttr">, DefaultFalse,
+    PosFlag<SetTrue, [], [], "When caching, write the output file's "
+    "hash (as determined by the CAS hashing schema) as a file extended attribute.">,
+    NegFlag<SetFalse>>;
+
 defm include_tree_preserve_pch_path : BoolFOption<"include-tree-preserve-pch-path",
     FrontendOpts<"IncludeTreePreservePCHPath">, DefaultFalse,
     PosFlag<SetTrue, [], [], "Keep the original PCH path in include-tree rather than canonicalizing">,

--- a/clang/lib/Frontend/CompileJobCache.cpp
+++ b/clang/lib/Frontend/CompileJobCache.cpp
@@ -39,7 +39,7 @@ public:
 
   CachingOutputs(CompilerInstance &Clang, StringRef Workingdir,
                  llvm::PrefixMapper Mapper, bool WriteOutputAsCASID,
-                 bool UseCASBackend);
+                 bool WriteOutputHashXAttr, bool UseCASBackend);
   virtual ~CachingOutputs() = default;
 
   /// \returns true if result was found and replayed, false otherwise.
@@ -75,6 +75,7 @@ protected:
   CompilerInstance &Clang;
   const llvm::PrefixMapper PrefixMapper;
   const bool WriteOutputAsCASID;
+  const bool WriteOutputHashXAttr;
   const bool UseCASBackend;
   clang::cas::CompileJobCacheResult::Builder CachedResultBuilder;
   std::string OutputFile;
@@ -90,12 +91,12 @@ class ObjectStoreCachingOutputs : public CompileJobCache::CachingOutputs {
 public:
   ObjectStoreCachingOutputs(CompilerInstance &Clang, StringRef WorkingDir,
                             llvm::PrefixMapper Mapper, bool WriteOutputAsCASID,
-                            bool UseCASBackend,
+                            bool WriteOutputHashXAttr, bool UseCASBackend,
                             std::optional<llvm::cas::CASID> &MCOutputID,
                             std::shared_ptr<llvm::cas::ObjectStore> DB,
                             std::shared_ptr<llvm::cas::ActionCache> Cache)
       : CachingOutputs(Clang, WorkingDir, std::move(Mapper), WriteOutputAsCASID,
-                       UseCASBackend),
+                       WriteOutputHashXAttr, UseCASBackend),
         ComputedJobNeedsReplay(WriteOutputAsCASID || UseCASBackend),
         MCOutputID(MCOutputID), CAS(std::move(DB)), Cache(std::move(Cache)) {
     if (CAS)
@@ -202,6 +203,7 @@ public:
                        llvm::cas::remote::ClientServices Clients)
       : CachingOutputs(Clang, WorkingDir, std::move(Mapper),
                        /*WriteOutputAsCASID*/ false,
+                       /*WriteOutputHashXAttr=*/false,
                        /*UseCASBackend*/ false) {
     RemoteKVClient = std::move(Clients.KVDB);
     RemoteCASClient = std::move(Clients.CASDB);
@@ -347,7 +349,9 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
     if (!Clients)
       return reportCachingBackendError(Clang.getDiagnostics(),
                                        Clients.takeError());
-    assert(!CacheOpts.WriteOutputAsCASID &&
+    assert(!CacheOpts.WriteOutputAsCASID && !CacheOpts.WriteOutputHashXAttr &&
+           "combination of options not rejected earlier?");
+    assert(!CacheOpts.WriteOutputHashXAttr &&
            "combination of options not rejected earlier?");
     assert(!UseCASBackend && "combination of options not rejected earlier?");
     CacheBackend = std::make_unique<RemoteCachingOutputs>(
@@ -355,7 +359,8 @@ std::optional<int> CompileJobCache::initialize(CompilerInstance &Clang) {
   } else {
     CacheBackend = std::make_unique<ObjectStoreCachingOutputs>(
         Clang, /*WorkingDir=*/"", std::move(PrefixMapper),
-        CacheOpts.WriteOutputAsCASID, UseCASBackend, MCOutputID, CAS, Cache);
+        CacheOpts.WriteOutputAsCASID, CacheOpts.WriteOutputHashXAttr,
+        UseCASBackend, MCOutputID, CAS, Cache);
   }
 
   return std::nullopt;
@@ -365,9 +370,11 @@ CompileJobCache::CachingOutputs::CachingOutputs(CompilerInstance &Clang,
                                                 StringRef WorkingDir,
                                                 llvm::PrefixMapper Mapper,
                                                 bool WriteOutputAsCASID,
+                                                bool WriteOutputHashXAttr,
                                                 bool UseCASBackend)
     : Clang(Clang), PrefixMapper(std::move(Mapper)),
-      WriteOutputAsCASID(WriteOutputAsCASID), UseCASBackend(UseCASBackend) {
+      WriteOutputAsCASID(WriteOutputAsCASID),
+      WriteOutputHashXAttr(WriteOutputHashXAttr), UseCASBackend(UseCASBackend) {
   CompilerInvocation &Invocation = Clang.getInvocation();
   FrontendOptions &FrontendOpts = Invocation.getFrontendOpts();
   if (!Clang.hasFileManager())
@@ -613,7 +620,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
     std::shared_ptr<CompilerInvocation> Invok, StringRef WorkingDir,
     const llvm::cas::CASID &CacheKey, cas::CompileJobCacheResult &CachedResult,
     SmallVectorImpl<char> &DiagText, bool WriteOutputAsCASID,
-    std::optional<llvm::cas::CASID> *OutMCOutputID) {
+    bool WriteOutputHashXAttr, std::optional<llvm::cas::CASID> *OutMCOutputID) {
   CompilerInstance Clang(std::move(Invok));
   llvm::raw_svector_ostream DiagOS(DiagText);
   Clang.createVirtualFileSystem(llvm::vfs::getRealFileSystem());
@@ -647,6 +654,7 @@ Expected<std::optional<int>> CompileJobCache::replayCachedResult(
   std::optional<llvm::cas::CASID> MCOutputID;
   ObjectStoreCachingOutputs CachingOutputs(
       Clang, WorkingDir, std::move(PrefixMapper), WriteOutputAsCASID,
+      WriteOutputHashXAttr,
       Clang.getInvocation().getCodeGenOpts().UseCASBackend, MCOutputID,
       /*CAS*/ nullptr, /*Cache*/ nullptr);
   if (OutMCOutputID)
@@ -758,7 +766,7 @@ Error ObjectStoreCachingOutputs::finishComputedResult(
 std::optional<int> ObjectStoreCachingOutputs::replayCachedResult(
     const llvm::cas::CASID &ResultCacheKey, llvm::cas::ObjectRef ResultID,
     bool JustComputedResult) {
-  if (JustComputedResult && !WriteOutputAsCASID)
+  if (JustComputedResult && !WriteOutputAsCASID && !WriteOutputHashXAttr)
     return std::nullopt;
 
   // FIXME: Stop calling report_fatal_error().
@@ -779,7 +787,7 @@ std::optional<int> ObjectStoreCachingOutputs::replayCachedResult(
 Expected<std::optional<int>> ObjectStoreCachingOutputs::replayCachedResult(
     const llvm::cas::CASID &ResultCacheKey,
     clang::cas::CompileJobCacheResult &Result, bool JustComputedResult) {
-  if (JustComputedResult && !WriteOutputAsCASID)
+  if (JustComputedResult && !WriteOutputAsCASID && !WriteOutputHashXAttr)
     return std::nullopt;
 
   llvm::cas::ObjectStore &CAS = Result.getCAS();
@@ -847,21 +855,24 @@ Expected<std::optional<int>> ObjectStoreCachingOutputs::replayCachedResult(
       return Output->keep();
     }
 
-    if (JustComputedResult)
-      return Error::success(); // continue
-
-    auto Output = Backend.createFile(Path);
-    if (!Output)
-      return Output.takeError();
-    if (O.Kind == OutputKind::Dependencies) {
-      if (auto E = CASDependencyCollector::replay(
-              Clang.getDependencyOutputOpts(), CAS, *Obj, *Output))
+    if (!JustComputedResult) {
+      auto Output = Backend.createFile(Path);
+      if (!Output)
+        return Output.takeError();
+      if (O.Kind == OutputKind::Dependencies) {
+        if (auto E = CASDependencyCollector::replay(
+                Clang.getDependencyOutputOpts(), CAS, *Obj, *Output))
+          return E;
+      } else {
+        *Output << Obj->getData();
+      }
+      if (Error E = Output->keep())
         return E;
-    } else {
-      *Output << Obj->getData();
     }
 
-    return Output->keep();
+    if (IsOutputFile && WriteOutputHashXAttr)
+      return llvm::cas::writeCASHashXAttr(CAS.getID(O.Object), Path);
+    return Error::success();
   };
 
   if (auto Err = Result.forEachLoadedOutput(processOutput))

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -185,6 +185,8 @@ canonicalizeForCaching(const llvm::cas::ObjectStore &CAS,
   FrontendOpts.CompilationCachingServicePath.clear();
   Opts.WriteOutputAsCASID = FrontendOpts.WriteOutputAsCASID;
   FrontendOpts.WriteOutputAsCASID = false;
+  Opts.WriteOutputHashXAttr = FrontendOpts.WriteOutputHashXAttr;
+  FrontendOpts.WriteOutputHashXAttr = false;
   Opts.DisableCachedCompileJobReplay =
       FrontendOpts.DisableCachedCompileJobReplay;
   FrontendOpts.DisableCachedCompileJobReplay = false;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -5532,7 +5532,7 @@ bool CompilerInvocation::CreateFromArgsImpl(
                    Res.getFileSystemOpts(), Res.getFrontendOpts(),
                    Res.getCASOpts());
 
-  // BEGIN MCCAS
+  // BEGIN CAS
   if (!Res.getFrontendOpts().CompilationCachingServicePath.empty()) {
     if (Res.getCodeGenOpts().UseCASBackend)
       Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
@@ -5540,10 +5540,21 @@ bool CompilerInvocation::CreateFromArgsImpl(
     if (Res.getFrontendOpts().WriteOutputAsCASID)
       Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
           << "-fcasid-output";
+    if (Res.getFrontendOpts().WriteOutputHashXAttr)
+      Diags.Report(diag::err_fe_incompatible_option_with_remote_cache)
+          << "-fwrite-output-hash-xattr";
+  }
+  if (Res.getFrontendOpts().WriteOutputHashXAttr) {
+    if (Res.getCodeGenOpts().UseCASBackend)
+      Diags.Report(diag::err_fe_incompatible_option_with_write_xattr)
+          << "-fcas-backend";
+    if (Res.getFrontendOpts().WriteOutputAsCASID)
+      Diags.Report(diag::err_fe_incompatible_option_with_write_xattr)
+          << "-fcasid-output";
   }
   if (Res.getCodeGenOpts().UseCASBackend && !T.isOSBinFormatMachO())
     Diags.Report(diag::err_fe_mccas_incompatible_target) << T.str();
-  // END MCCAS
+  // END CAS
 
   // FIXME: Override value name discarding when asan or msan is used because the
   // backend passes depend on the name of the alloca in order to print out

--- a/clang/test/CAS/fwrite-output-hash-xattr.c
+++ b/clang/test/CAS/fwrite-output-hash-xattr.c
@@ -1,0 +1,42 @@
+// RUN: rm -rf %t && mkdir -p %t
+
+// REQUIRES: system-darwin
+
+// Check if -fwrite-output-hash-xattr on a cache miss with file based caching
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fwrite-output-hash-xattr -g -c %s -o %t/test.o -Rcompile-job-cache 2> %t/diag_miss
+// RUN: xattr -lx %t/test.o | FileCheck %s
+// RUN: FileCheck %s -check-prefix=MISS -input-file %t/diag_miss
+// RUN: rm -f %t/test.o
+
+// Check if -fwrite-output-hash-xattr works on a cache hit with file based caching
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fwrite-output-hash-xattr -g -c %s -o %t/test.o -Rcompile-job-cache 2> %t/diag_hit
+// RUN: xattr -lx %t/test.o | FileCheck %s
+// RUN: rm -f %t/test.o
+// RUN: FileCheck %s -check-prefix=HIT -input-file %t/diag_hit
+
+// The following checks the hash schema name and the 32-byte hash size.
+// CHECK: com.apple.clang.cas_output_hash:
+// CHECK: 00000000  6C 6C 76 6D 2E 63 61 73 2E 62 75 69 6C 74 69 6E  |llvm.cas.builtin|
+// CHECK: 00000010  2E 76 32 5B 42 4C 41 4B 45 33 5D 00 20 00 00 00  |.v2[BLAKE3]. ...|
+// CHECK: 00000020  {{(([A-F0-9]{2} ){16})}}|
+// CHECK: 00000030  {{(([A-F0-9]{2} ){16})}}|
+
+// HIT: compile job cache hit for
+// MISS: compile job cache miss for
+
+// Check errors.
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fwrite-output-hash-xattr -g -c %s -o %t/test.o 2>&1 | FileCheck %s -check-prefix=INCOMPAT_MCCAS
+// INCOMPAT_MCCAS: error: '-fcas-backend' is incompatible with '-fwrite-output-hash-xattr'
+
+// RUN: not env LLVM_CACHE_CAS_PATH=%t/cas CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache %clang -target x86_64-apple-macos11 -Xclang -fwrite-output-hash-xattr -Xclang -fcasid-output -g -c %s -o %t/test.o 2>&1 | FileCheck %s -check-prefix=INCOMPAT_CASIDOUT
+// INCOMPAT_CASIDOUT: error: '-fcasid-output' is incompatible with '-fwrite-output-hash-xattr'
+
+// Check libclang replay.
+// RUN: cat %t/diag_hit | grep llvmcas | sed \
+// RUN:   -e "s/^.*hit for '//" \
+// RUN:   -e "s/' .*$//" > %t/cache-key
+
+// RUN: c-index-test core -replay-cached-job -cas-path %t/cas @%t/cache-key \
+// RUN:   -working-dir %t \
+// RUN: -- -target x86_64-apple-macos11 -fwrite-output-hash-xattr -emit-obj %s -o %t/test.o
+// RUN: xattr -lx %t/test.o | FileCheck %s

--- a/clang/test/CAS/remote-cache-incompatible-options.c
+++ b/clang/test/CAS/remote-cache-incompatible-options.c
@@ -1,3 +1,4 @@
-// RUN: not %clang_cc1 -triple x86_64-apple-macos11 -fcompilation-caching-service-path %t -fcas-backend -fcasid-output -emit-obj %s -o %t.o 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -triple x86_64-apple-macos11 -fcompilation-caching-service-path %t -fcas-backend -fcasid-output -fwrite-output-hash-xattr -emit-obj %s -o %t.o 2>&1 | FileCheck %s
 // CHECK: error: '-fcas-backend' is incompatible with remote caching backend
 // CHECK: error: '-fcasid-output' is incompatible with remote caching backend
+// CHECK: error: '-fwrite-output-hash-xattr' is incompatible with remote caching backend

--- a/clang/tools/libclang/CCAS.cpp
+++ b/clang/tools/libclang/CCAS.cpp
@@ -576,9 +576,12 @@ CXCASReplayResult clang_experimental_cas_replayCompilation(
 
   SmallString<256> DiagText;
   std::optional<int> Ret;
+  bool WriteOutputAsCASID = Invok->getFrontendOpts().WriteOutputAsCASID;
+  bool WriteOutputHashXAttr = Invok->getFrontendOpts().WriteOutputHashXAttr;
   if (Error E = CompileJobCache::replayCachedResult(
                     std::move(Invok), WorkingDirectory, WComp.CacheKey,
-                    WComp.CachedResult, DiagText)
+                    WComp.CachedResult, DiagText, WriteOutputAsCASID,
+                    WriteOutputHashXAttr)
                     .moveInto(Ret)) {
     passAsCXError(std::move(E), OutError);
     return nullptr;

--- a/llvm/include/llvm/CASUtil/Utils.h
+++ b/llvm/include/llvm/CASUtil/Utils.h
@@ -25,6 +25,16 @@ Expected<CASID> readCASIDBuffer(cas::ObjectStore &CAS,
 
 void writeCASIDBuffer(const CASID &ID, llvm::raw_ostream &OS);
 
+/// Writes an extended attribute to \p Path containing the hash from \p ID
+/// along with information about the hash schema.
+///
+/// The xattr name is `com.apple.clang.cas_output_hash`.
+/// The data format is:
+/// * Null-terminated hash schema name, e.g. llvm.builtin.v2[BLAKE3]
+/// * Hash length (4 bytes little-endian, e.g. 32)
+/// * Hash bytes
+Error writeCASHashXAttr(const CASID &ID, const llvm::Twine &Path);
+
 } // namespace cas
 
 namespace casobjectformats {

--- a/llvm/lib/CASUtil/Utils.cpp
+++ b/llvm/lib/CASUtil/Utils.cpp
@@ -11,7 +11,12 @@
 #include "llvm/CAS/CASID.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/CASObjectFormats/Encoding.h"
+#include "llvm/Support/EndianStream.h"
 #include "llvm/Support/MemoryBufferRef.h"
+#include "llvm/Support/raw_ostream.h"
+#if __has_include(<sys/xattr.h>) && defined(__APPLE__)
+#include <sys/xattr.h>
+#endif
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -45,4 +50,33 @@ void cas::writeCASIDBuffer(const CASID &ID, llvm::raw_ostream &OS) {
   SmallString<2> SizeBuf;
   encoding::writeVBR8(CASIDStr.size(), SizeBuf);
   OS << SizeBuf << CASIDStr;
+}
+
+Error cas::writeCASHashXAttr(const CASID &ID, const llvm::Twine &Path) {
+#if __has_include(<sys/xattr.h>) && defined(__APPLE__)
+  SmallString<64> Buffer;
+  raw_svector_ostream OS(Buffer);
+  // Null-terminated hash schema identifier.
+  OS << ID.getContext().getHashSchemaIdentifier() << '\0';
+  // Hash size, little-endian, 4 bytes.
+  support::endian::write(OS, static_cast<uint32_t>(ID.getHash().size()),
+                         endianness::little);
+  // Hash bytes.
+  OS.write((const char *)ID.getHash().data(), ID.getHash().size());
+
+  SmallString<128> PathStorage;
+  StringRef PathRef = Path.toNullTerminatedStringRef(PathStorage);
+
+  int RC =
+      setxattr(PathRef.begin(), "com.apple.clang.cas_output_hash",
+               Buffer.data(), Buffer.size(), /*Position=*/0, /*Options=*/0);
+
+  if (RC)
+    return createFileError(Path, make_error<StringError>(errnoAsErrorCode(),
+                                                         "failed to setxattr"));
+  return Error::success();
+#else
+  return createStringError(std::errc::not_supported,
+                           "Platform does not support setxattr");
+#endif
 }


### PR DESCRIPTION
With the new option, when doing caching we write the hash that we already computed for the main output file to an extended attribute (xattr) on the file. The format of the xattr is name: com.apple.clang.cas_output_hash
data:
* Null-terminated hash schema name, e.g. llvm.builtin.v2[BLAKE3].
* Hash length (4 bytes, little-endian).
* Hash bytes

rdar://169540192