### PR TITLE
[lldb] Allow tests to share a single build (#181720)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbinline.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbinline.py
@@ -216,4 +216,5 @@ def MakeInlineTest(__file, __globals, decorators=None, name=None, build_dict=Non
     # correctly in test results.
     test_class.test_filename = __file
     test_class.mydir = TestBase.compute_mydir(__file)
+    test_class.SHARED_BUILD_TESTCASE = False
     return test_class

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -540,6 +540,11 @@ class Base(unittest.TestCase):
     # Can be overridden by the LLDB_TIME_WAIT_NEXT_LAUNCH environment variable.
     timeWaitNextLaunch = 1.0
 
+    # Some test case classes require a separate build directory for each test
+    # function. Subclasses can set this to False in those cases. This slows down
+    # the test, but provides isolation where needed.
+    SHARED_BUILD_TESTCASE = True
+
     @staticmethod
     def compute_mydir(test_file):
         """Subclasses should call this function to correctly calculate the
@@ -725,7 +730,10 @@ class Base(unittest.TestCase):
         return os.path.join(configuration.test_src_root, self.mydir)
 
     def getBuildDirBasename(self):
-        return self.__class__.__module__ + "." + self.testMethodName
+        if self.SHARED_BUILD_TESTCASE:
+            return self.__class__.__module__
+        else:
+            return self.__class__.__module__ + "." + self.testMethodName
 
     def getBuildDir(self):
         """Return the full path to the current test."""
@@ -734,10 +742,10 @@ class Base(unittest.TestCase):
         )
 
     def makeBuildDir(self):
-        """Create the test-specific working directory, deleting any previous
-        contents."""
+        """Create the test-specific working directory, optionally deleting any
+        previous contents."""
         bdir = self.getBuildDir()
-        if os.path.isdir(bdir):
+        if os.path.isdir(bdir) and not self.SHARED_BUILD_TESTCASE:
             shutil.rmtree(bdir)
         lldbutil.mkdir_p(bdir)
 
@@ -1802,6 +1810,9 @@ class LLDBTestCaseFactory(type):
         )
         if original_testcase.NO_DEBUG_INFO_TESTCASE:
             return original_testcase
+
+        if getattr(original_testcase, "TEST_WITH_PDB_DEBUG_INFO", False):
+            original_testcase.SHARED_BUILD_TESTCASE = False
 
         # Default implementation for skip/xfail reason based on the debug category,
         # where "None" means to run the test as usual.

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1521,6 +1521,12 @@ class Base(unittest.TestCase):
         make_targets=None,
     ):
         """Platform specific way to build binaries."""
+        if debug_info or architecture or compiler or dictionary or make_targets:
+            self.assertFalse(
+                self.SHARED_BUILD_TESTCASE,
+                "shared build tests reuse the same compilation artifacts for all test functions",
+            )
+
         if not architecture and configuration.arch:
             architecture = configuration.arch
 

--- a/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
+++ b/lldb/test/API/api/check_public_api_headers/TestPublicAPIHeaders.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 @skipIfRemote
 @skipUnlessDarwin
 class SBDirCheckerCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
+++ b/lldb/test/API/api/command-return-object/TestSBCommandReturnObject.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestSBCommandReturnObject(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfNoSBHeaders

--- a/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/lldb/test/API/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestMultipleSimultaneousDebuggers(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     # Times out on heavily loaded Linux buildbots, don't want to get into tweaking

--- a/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
+++ b/lldb/test/API/api/multiple-targets/TestMultipleTargets.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestMultipleTargets(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])

--- a/lldb/test/API/api/multithreaded/TestMultithreaded.py
+++ b/lldb/test/API/api/multithreaded/TestMultithreaded.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 @unittest.skip("skipping due to frequent timeouts: rdar://28183131")
 @skipIfNoSBHeaders
 class SBBreakpointCallbackCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/arm/thumb-function-addr/TestThumbFunctionAddr.py
+++ b/lldb/test/API/arm/thumb-function-addr/TestThumbFunctionAddr.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestThumbFunctionAddr(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_thumb_function_test(self, language):
         self.build(dictionary={"CFLAGS_EXTRAS": f"-x {language} -mthumb"})
 

--- a/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
+++ b/lldb/test/API/commands/add-dsym/uuid/TestAddDsymCommand.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 
 @skipUnlessDarwin
 class AddDsymCommandCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.template = "main.cpp.template"

--- a/lldb/test/API/commands/expression/char/TestExprsChar.py
+++ b/lldb/test/API/commands/expression/char/TestExprsChar.py
@@ -5,6 +5,8 @@ from lldbsuite.test import lldbutil
 
 
 class ExprCharTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, dictionary=None):
         """These basic expression commands should work as expected."""
         self.build(dictionary=dictionary)

--- a/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
+++ b/lldb/test/API/commands/expression/weak_symbols/TestWeakSymbols.py
@@ -12,6 +12,7 @@ from lldbsuite.test.lldbtest import *
 
 
 class TestWeakSymbolsInExpressions(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipUnlessDarwin

--- a/lldb/test/API/commands/frame/var/TestFrameVar.py
+++ b/lldb/test/API/commands/frame/var/TestFrameVar.py
@@ -16,6 +16,7 @@ class TestFrameVar(TestBase):
     # set this to true.  That way it won't be run once for
     # each debug info format.
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_frame_var(self):
         self.build()

--- a/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
+++ b/lldb/test/API/commands/platform/connect/TestPlatformConnect.py
@@ -8,6 +8,7 @@ from lldbsuite.test import lldbutil
 
 class TestPlatformProcessConnect(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @skipIfRemote
     @expectedFailureAll(hostoslist=["windows"], triple=".*-android")

--- a/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
+++ b/lldb/test/API/commands/platform/launchgdbserver/TestPlatformLaunchGDBServer.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 class TestPlatformProcessLaunchGDBServer(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def _launch_and_connect(self, exe):
         hostname = socket.getaddrinfo("localhost", 0, proto=socket.IPPROTO_TCP)[0][4][0]

--- a/lldb/test/API/commands/process/attach/TestProcessAttach.py
+++ b/lldb/test/API/commands/process/attach/TestProcessAttach.py
@@ -14,6 +14,7 @@ exe_name = "ProcessAttach"  # Must match Makefile
 
 
 class ProcessAttachTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/process/launch/TestProcessLaunch.py
+++ b/lldb/test/API/commands/process/launch/TestProcessLaunch.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 class ProcessLaunchTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_dynamic_resize/TestSVEThreadedDynamic.py
@@ -21,6 +21,8 @@ class Mode(Enum):
 
 
 class RegisterCommandsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_supported_vg(self):
         # Changing VL trashes the register state, so we need to run the program
         # just to test this. Then run it again for the test.

--- a/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_registers/rw_access_static_config/TestSVERegisters.py
@@ -15,6 +15,8 @@ class Mode(Enum):
 
 
 class RegisterCommandsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def check_sve_register_size(self, set, name, expected):
         reg_value = set.GetChildMemberWithName(name)
         self.assertTrue(

--- a/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
+++ b/lldb/test/API/commands/register/register/aarch64_sve_simd_registers/TestSVESIMDRegisters.py
@@ -27,6 +27,8 @@ class Mode(Enum):
 
 
 class SVESIMDRegistersTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_build_flags(self, mode):
         cflags = "-march=armv8-a+sve"
         if mode == Mode.SSVE:

--- a/lldb/test/API/commands/settings/use_source_cache/TestUseSourceCache.py
+++ b/lldb/test/API/commands/settings/use_source_cache/TestUseSourceCache.py
@@ -12,6 +12,7 @@ from shutil import copy
 
 class SettingsUseSourceCacheTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_set_use_source_cache_false(self):
         """Test that after 'set use-source-cache false', files are not locked."""

--- a/lldb/test/API/commands/statistics/basic/TestStats.py
+++ b/lldb/test/API/commands/statistics/basic/TestStats.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_enable_disable(self):
         """

--- a/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
+++ b/lldb/test/API/commands/target/auto-install-main-executable/TestAutoInstallMainExecutable.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 
 class TestAutoInstallMainExecutable(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @skipIfRemote
     @skipIfWindows  # This test is flaky on Windows

--- a/lldb/test/API/commands/target/basic/TestTargetCommand.py
+++ b/lldb/test/API/commands/target/basic/TestTargetCommand.py
@@ -13,6 +13,8 @@ from lldbsuite.test import lldbutil
 
 
 class targetCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/commands/target/dump-separate-debug-info/dwo/TestDumpDwo.py
+++ b/lldb/test/API/commands/target/dump-separate-debug-info/dwo/TestDumpDwo.py
@@ -12,6 +12,7 @@ from lldbsuite.test_event.build_exception import BuildError
 
 class TestDumpDWO(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def get_dwos_from_json_output(self):
         """Returns a dictionary of `symfile` -> {`dwo_name` -> dwo_info object}."""

--- a/lldb/test/API/commands/target/dump-separate-debug-info/oso/TestDumpOso.py
+++ b/lldb/test/API/commands/target/dump-separate-debug-info/oso/TestDumpOso.py
@@ -10,6 +10,7 @@ from lldbsuite.test.decorators import *
 
 
 class TestDumpOso(lldbtest.TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def get_osos_from_json_output(self):

--- a/lldb/test/API/commands/trace/TestTraceStartStop.py
+++ b/lldb/test/API/commands/trace/TestTraceStartStop.py
@@ -7,6 +7,8 @@ from lldbsuite.test.decorators import *
 
 @skipIfNoIntelPT
 class TestTraceStartStop(TraceIntelPTTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def expectGenericHelpMessageForStartCommand(self):
         self.expect(
             "help thread trace start",

--- a/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
+++ b/lldb/test/API/commands/watchpoints/hello_watchlocation/TestWatchLocation.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class HelloWatchLocationTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/hello_watchpoint/TestMyFirstWatchpoint.py
+++ b/lldb/test/API/commands/watchpoints/hello_watchpoint/TestMyFirstWatchpoint.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class HelloWatchpointTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/multi_watchpoint_slots/TestWatchpointMultipleSlots.py
+++ b/lldb/test/API/commands/watchpoints/multi_watchpoint_slots/TestWatchpointMultipleSlots.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointSlotsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/variable_out_of_scope/TestWatchedVarHitWhenInScope.py
+++ b/lldb/test/API/commands/watchpoints/variable_out_of_scope/TestWatchedVarHitWhenInScope.py
@@ -10,6 +10,7 @@ from lldbsuite.test.decorators import *
 
 
 class WatchedVariableHitWhenInScopeTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     # This test depends on not tracking watchpoint expression hits if we have

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/TestWatchpointCommands.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/TestWatchpointCommands.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointCommandsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandLLDB.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandLLDB.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointLLDBCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandPython.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/command/TestWatchpointCommandPython.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointPythonCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_commands/condition/TestWatchpointConditionCmd.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_commands/condition/TestWatchpointConditionCmd.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointConditionCmdTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_on_vectors/TestValueOfVectorVariable.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_on_vectors/TestValueOfVectorVariable.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestValueOfVectorVariableTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def test_value_of_vector_variable_using_watchpoint_set(self):

--- a/lldb/test/API/commands/watchpoints/watchpoint_size/TestWatchpointSizes.py
+++ b/lldb/test/API/commands/watchpoints/watchpoint_size/TestWatchpointSizes.py
@@ -13,6 +13,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointSizeTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/debuginfod/Normal/TestDebuginfod.py
+++ b/lldb/test/API/debuginfod/Normal/TestDebuginfod.py
@@ -21,6 +21,7 @@ For no-split-dwarf scenarios, there are 2 variations:
 class DebugInfodTests(TestBase):
     # No need to try every flavor of debug inf.
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @skipUnlessPlatform(["linux", "freebsd"])
     def test_normal_no_symbols(self):

--- a/lldb/test/API/functionalities/archives/TestBSDArchives.py
+++ b/lldb/test/API/functionalities/archives/TestBSDArchives.py
@@ -10,6 +10,7 @@ import time
 
 
 class BSDArchivesTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     # If your test case doesn't stress debug info, then
     # set this to true.  That way it won't be run once for
     # each debug info format.

--- a/lldb/test/API/functionalities/asan/TestMemoryHistory.py
+++ b/lldb/test/API/functionalities/asan/TestMemoryHistory.py
@@ -11,6 +11,8 @@ from lldbsuite.test_event.build_exception import BuildError
 
 
 class MemoryHistoryTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @expectedFailureNetBSD
     @skipUnlessAddressSanitizer

--- a/lldb/test/API/functionalities/asan/TestReportData.py
+++ b/lldb/test/API/functionalities/asan/TestReportData.py
@@ -11,6 +11,8 @@ from lldbsuite.test_event.build_exception import BuildError
 
 
 class AsanTestReportDataCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfFreeBSD  # llvm.org/pr21136 runtimes not yet available by default
     @expectedFailureNetBSD
     @skipUnlessAddressSanitizer

--- a/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
+++ b/lldb/test/API/functionalities/asan/swift/TestSwiftAsan.py
@@ -22,6 +22,7 @@ import json
 
 
 class AsanSwiftTestCase(lldbtest.TestBase):
+    SHARED_BUILD_TESTCASE = False
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
@@ -14,6 +14,7 @@ import side_effect
 
 class BreakpointCommandTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
     def test_breakpoint_command_sequence(self):

--- a/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
+++ b/lldb/test/API/functionalities/breakpoint/breakpoint_locations/after_rebuild/TestLocationsAfterRebuild.py
@@ -12,6 +12,7 @@ import os
 
 
 class TestLocationsAfterRebuild(TestBase):
+    SHARED_BUILD_TESTCASE = False
     # If your test case doesn't stress debug info, then
     # set this to true.  That way it won't be run once for
     # each debug info format.

--- a/lldb/test/API/functionalities/breakpoint/comp_dir_symlink/TestCompDirSymLink.py
+++ b/lldb/test/API/functionalities/breakpoint/comp_dir_symlink/TestCompDirSymLink.py
@@ -16,6 +16,8 @@ _COMP_DIR_SYM_LINK_PROP = "symbols.debug-info-symlink-paths"
 
 
 class CompDirSymLinkTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
+++ b/lldb/test/API/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestCPPBreakpointLocations(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24764")
     def test(self):
         self.do_test(dict())

--- a/lldb/test/API/functionalities/breakpoint/objc/TestObjCBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/objc/TestObjCBreakpoints.py
@@ -13,6 +13,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCBreakpoints(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @add_test_categories(["objc"])
     def test_break(self):
         """Test setting Objective-C specific breakpoints (DWARF in .o files)."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/ObjCDataFormatterTestCase.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/ObjCDataFormatterTestCase.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjCDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def appkit_tester_impl(self, commands, use_constant_classes):
         if use_constant_classes:
             self.build()

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSBundle.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSBundle(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsbundle_with_run_command(self):
         """Test formatters for NSBundle."""
         self.appkit_tester_impl(self.nsbundle_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSContainer.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSContainer(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nscontainers_with_run_command(self):
         """Test formatters for  NS container classes."""
         self.appkit_tester_impl(self.nscontainers_data_formatter_commands, False)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSData.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSData(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsdata_with_run_command(self):
         """Test formatters for  NSData."""
         self.appkit_tester_impl(self.nsdata_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSDate.py
@@ -15,6 +15,8 @@ import datetime
 
 
 class ObjCDataFormatterNSDate(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsdate_with_run_command(self):
         """Test formatters for  NSDate."""
         self.appkit_tester_impl(self.nsdate_data_formatter_commands, False)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSError.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSError.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSError(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nserror_with_run_command(self):
         """Test formatters for NSError."""
         self.appkit_tester_impl(self.nserror_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSNumber.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSNumber.py
@@ -12,6 +12,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSNumber(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipUnlessDarwin
     def test_nsnumber_with_run_command(self):
         """Test formatters for  NS container classes."""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSURL.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjCNSURL.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSURL(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsurl_with_run_command(self):
         """Test formatters for NSURL."""
         self.appkit_tester_impl(self.nsurl_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjNSException.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-objc/TestDataFormatterObjNSException.py
@@ -13,6 +13,8 @@ from ObjCDataFormatterTestCase import ObjCDataFormatterTestCase
 
 
 class ObjCDataFormatterNSException(ObjCDataFormatterTestCase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_nsexception_with_run_command(self):
         """Test formatters for NSException."""
         self.appkit_tester_impl(self.nsexception_data_formatter_commands, True)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/atomic/TestDataFormatterStdAtomic.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdAtomicTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_variable(self, name):
         var = self.frame().FindVariable(name)
         var.SetPreferDynamicValue(lldb.eDynamicCanRunTarget)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/bitset/TestDataFormatterGenericBitset.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/bitset/TestDataFormatterGenericBitset.py
@@ -16,6 +16,8 @@ POINTER = "POINTER"
 
 
 class GenericBitsetDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         primes = [1] * 1000

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/chrono/TestDataFormatterStdChrono.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdChronoDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         """Test that that file and class static variables display correctly."""
         isNotWindowsHost = lldbplatformutil.getHostPlatform() != "windows"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/coroutine_handle/TestCoroutineHandle.py
@@ -13,6 +13,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class TestCoroutineHandle(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, stdlib_type):
         """Test std::coroutine_handle is displayed correctly."""
         self.build(dictionary={stdlib_type: "1"})

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/deque/TestDataFormatterGenericDeque.py
@@ -8,6 +8,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericDequeDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def findVariable(self, name):
         var = self.frame().FindVariable(name)
         self.assertTrue(var.IsValid())

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/forward_list/TestDataFormatterGenericForwardList.py
@@ -12,6 +12,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class TestDataFormatterGenericForwardList(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.line = line_number("main.cpp", "// break here")

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/function/TestDataFormatterStdFunction.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/function/TestDataFormatterStdFunction.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdFunctionTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     # Run frame var for a variable twice. Verify we do not hit the cache
     # the first time but do the second time.
     def run_frame_var_check_cache_use(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/initializer_list/TestDataFormatterStdInitializerList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/initializer_list/TestDataFormatterStdInitializerList.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class InitializerListTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         self.runCmd("file " + self.getBuildArtifact("a.out"), CURRENT_EXECUTABLE_SET)
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/iterator/TestDataFormatterStdIterator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/iterator/TestDataFormatterStdIterator.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdIteratorDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/TestDataFormatterGenericList.py
@@ -13,6 +13,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericListDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/loop/TestDataFormatterGenericListLoop.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/list/loop/TestDataFormatterGenericListLoop.py
@@ -14,6 +14,7 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericListDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def do_test_with_run_command(self, stdlib_type):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/map/TestDataFormatterStdMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/map/TestDataFormatterStdMap.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdMapDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         ns = "ndk" if lldbplatformutil.target_is_android() else ""

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multimap/TestDataFormatterGenericMultiMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multimap/TestDataFormatterGenericMultiMap.py
@@ -14,6 +14,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericMultiMapDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.namespace = "std"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/multiset/TestDataFormatterGenericMultiSet.py
@@ -13,6 +13,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericMultiSetDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.namespace = "std"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/optional/TestDataFormatterGenericOptional.py
@@ -8,6 +8,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericOptionalDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test_with_run_command(self, stdlib_type):
         """Test that that file and class static variables display correctly."""
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/queue/TestDataFormatterStdQueue.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestDataFormatterStdQueue(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.namespace = "std"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ranges/ref_view/TestDataFormatterStdRangesRefView.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/ranges/ref_view/TestDataFormatterStdRangesRefView.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdRangesRefViewDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def check_string_vec_children(self):
         return [
             ValueCheck(name="[0]", summary='"First"'),

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/set/TestDataFormatterGenericSet.py
@@ -13,6 +13,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericSetDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.namespace = "std"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/shared_ptr/TestDataFormatterStdSharedPtr.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         """Test `frame variable` output for `std::shared_ptr` types."""
         (_, process, _, bkpt) = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/span/TestDataFormatterStdSpan.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/span/TestDataFormatterStdSpan.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdSpanDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def findVariable(self, name):
         var = self.frame().FindVariable(name)
         self.assertTrue(var.IsValid())

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string/TestDataFormatterStdString.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string/TestDataFormatterStdString.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdStringDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string_view/TestDataFormatterStdStringView.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/string_view/TestDataFormatterStdStringView.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdStringViewDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/tuple/TestDataFormatterStdTuple.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/tuple/TestDataFormatterStdTuple.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestDataFormatterStdTuple(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.line = line_number("main.cpp", "// break here")

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/u8string/TestDataFormatterStdU8String.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/u8string/TestDataFormatterStdU8String.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdU8StringDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         lldbutil.run_to_source_breakpoint(
             self, "Set break point at this line.", lldb.SBFileSpec("main.cpp")

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unique_ptr/TestDataFormatterStdUniquePtr.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         """Test `frame variable` output for `std::unique_ptr` types."""
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered/TestDataFormatterGenericUnordered.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered/TestDataFormatterGenericUnordered.py
@@ -7,6 +7,8 @@ USE_LIBCPP = "USE_LIBCPP"
 
 
 class GenericUnorderedDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.namespace = "std"

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered_map-iterator/TestDataFormatterStdUnorderedMap.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/unordered_map-iterator/TestDataFormatterStdUnorderedMap.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdUnorderedMapDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def check_ptr_or_ref(self, var_name: str):
         var = self.frame().FindVariable(var_name)
         self.assertTrue(var)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/valarray/TestDataFormatterStdValarray.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdValarrayDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         (self.target, process, thread, bkpt) = lldbutil.run_to_source_breakpoint(
             self, "break here", lldb.SBFileSpec("main.cpp", False)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/variant/TestDataFormatterStdVariant.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdVariantDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self):
         """Test that that file and class static variables display correctly."""
 

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vbool/TestDataFormatterStdVBool.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdVBoolDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vector/TestDataFormatterStdVector.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/generic/vector/TestDataFormatterStdVector.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class StdVectorDataFormatterTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def check_numbers(self, var_name, show_ptr=False):
         patterns = []
         substrs = [

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/optional/TestDataFormatterLibcxxOptionalSimulator.py
@@ -11,6 +11,7 @@ import functools
 
 
 class LibcxxOptionalDataFormatterSimulatorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def _run_test(self, defines):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/string/TestDataFormatterLibcxxStringSimulator.py
@@ -11,6 +11,7 @@ import functools
 
 
 class LibcxxStringDataFormatterSimulatorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def _run_test(self, defines):

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-stl/libcxx-simulators/unique_ptr/TestDataFormatterLibcxxUniquePtrSimulator.py
@@ -11,6 +11,7 @@ import functools
 
 
 class LibcxxUniquePtrDataFormatterSimulatorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def _run_test(self, defines):

--- a/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/nsdictionarysynth/TestNSDictionarySynthetic.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class NSDictionarySyntheticTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/nssetsynth/TestNSSetSynthetic.py
+++ b/lldb/test/API/functionalities/data-formatter/nssetsynth/TestNSSetSynthetic.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class NSSetSyntheticTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
+++ b/lldb/test/API/functionalities/data-formatter/poarray/TestPrintObjectArray.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class PrintObjectArrayTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipUnlessDarwin
     def test_print_array(self):
         """Test that expr -O -Z works"""

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPlatformKill.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPlatformKill.py
@@ -7,6 +7,8 @@ from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
 
 
 class TestPlatformKill(GDBRemoteTestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfRemote
     def test_kill_different_platform(self):
         """Test connecting to a remote linux platform"""

--- a/lldb/test/API/functionalities/gdb_remote_client/TestPty.py
+++ b/lldb/test/API/functionalities/gdb_remote_client/TestPty.py
@@ -7,6 +7,8 @@ from lldbsuite.test.lldbgdbclient import GDBRemoteTestBase
 
 @skipIf(hostoslist=["windows"])
 class TestPty(GDBRemoteTestBase):
+    SHARED_BUILD_TESTCASE = False
+
     server_socket_class = PtyServerSocket
 
     def get_term_attrs(self):

--- a/lldb/test/API/functionalities/inferior-changed/TestInferiorChanged.py
+++ b/lldb/test/API/functionalities/inferior-changed/TestInferiorChanged.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class ChangedInferiorTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(hostoslist=["windows"])
     @no_debug_info_test
     def test_inferior_crashing(self):

--- a/lldb/test/API/functionalities/limit-debug-info/TestLimitDebugInfo.py
+++ b/lldb/test/API/functionalities/limit-debug-info/TestLimitDebugInfo.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class LimitDebugInfoTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _check_type(self, target, name):
         exe = target.FindModule(lldb.SBFileSpec("a.out"))
         type_ = exe.FindFirstType(name)

--- a/lldb/test/API/functionalities/module_cache/bsd/TestModuleCacheBSD.py
+++ b/lldb/test/API/functionalities/module_cache/bsd/TestModuleCacheBSD.py
@@ -10,6 +10,8 @@ import time
 
 
 class ModuleCacheTestcaseBSD(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/module_cache/debug_index/TestDebugIndexCache.py
+++ b/lldb/test/API/functionalities/module_cache/debug_index/TestDebugIndexCache.py
@@ -9,6 +9,8 @@ import time
 
 
 class DebugIndexCacheTestcase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/module_cache/simple_exe/TestModuleCacheSimple.py
+++ b/lldb/test/API/functionalities/module_cache/simple_exe/TestModuleCacheSimple.py
@@ -10,6 +10,8 @@ import time
 
 
 class ModuleCacheTestcaseSimple(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/plugins/command_plugin/TestPluginCommands.py
+++ b/lldb/test/API/functionalities/plugins/command_plugin/TestPluginCommands.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class PluginCommandTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
 

--- a/lldb/test/API/functionalities/plugins/python_os_plugin/os_plugin_in_dsym/TestOSIndSYM.py
+++ b/lldb/test/API/functionalities/plugins/python_os_plugin/os_plugin_in_dsym/TestOSIndSYM.py
@@ -16,6 +16,7 @@ import shutil
 
 
 class TestOSPluginIndSYM(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     # The port used by debugserver.

--- a/lldb/test/API/functionalities/rerun_and_expr/TestRerunAndExpr.py
+++ b/lldb/test/API/functionalities/rerun_and_expr/TestRerunAndExpr.py
@@ -11,6 +11,8 @@ from lldbsuite.test.decorators import *
 
 
 class TestRerunExpr(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     # FIXME: on Windows rebuilding the binary isn't enough to unload it
     #        on progrem restart. One will have to try hard to evict
     #        the module from the ModuleList (possibly including a call to

--- a/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
+++ b/lldb/test/API/functionalities/rerun_and_expr_dylib/TestRerunAndExprDylib.py
@@ -26,6 +26,8 @@ def isUbuntu18_04():
 
 
 class TestRerunExprDylib(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipTestIfFn(isUbuntu18_04, bugnumber="rdar://103831050")
     @skipIfWindows
     @skipIfRemote

--- a/lldb/test/API/functionalities/thread/step_until/TestStepUntil.py
+++ b/lldb/test/API/functionalities/thread/step_until/TestStepUntil.py
@@ -7,6 +7,8 @@ from lldbsuite.test_event.build_exception import BuildError
 
 
 class StepUntilTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/functionalities/thread/step_until/TestStepUntilAPI.py
+++ b/lldb/test/API/functionalities/thread/step_until/TestStepUntilAPI.py
@@ -6,6 +6,7 @@ from lldbsuite.test_event.build_exception import BuildError
 
 class TestStepUntilAPI(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         super().setUp()

--- a/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
+++ b/lldb/test/API/iohandler/sigint/TestProcessIOHandlerInterrupt.py
@@ -11,6 +11,8 @@ from lldbsuite.test.lldbpexpect import PExpectTest
 
 
 class TestCase(PExpectTest):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(macos_version=["<", "14.0"], asan=True)
     @skipIf(compiler="clang", compiler_version=["<", "11.0"])
     @skipIf(oslist=["linux"], archs=["arm$", "aarch64"])

--- a/lldb/test/API/lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py
+++ b/lldb/test/API/lang/BoundsSafety/array_of_ptrs/TestArrayOfBoundsSafetyPointers.py
@@ -4,6 +4,8 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 class TestArrayOfBoundsSafetyPointers(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def __run(self, build_dict):
         self.build(dictionary = build_dict)
 

--- a/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
+++ b/lldb/test/API/lang/BoundsSafety/soft_trap/TestBoundsSafetyInstrumentationPlugin.py
@@ -12,6 +12,8 @@ SOFT_TRAP_FUNC_WITH_STR = '__bounds_safety_soft_trap_s'
 
 
 class BoundsSafetyTestSoftTrapPlugin(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _check_stop_reason_impl(self,
                                 expected_soft_trap_func:str,
                                 expected_stop_reason:str,

--- a/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
+++ b/lldb/test/API/lang/c/calling-conventions/TestCCallingConventions.py
@@ -7,6 +7,7 @@ from lldbsuite.test_event.build_exception import BuildError
 
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def build_and_run(self, test_file):
         """

--- a/lldb/test/API/lang/c/forward/TestForwardDeclaration.py
+++ b/lldb/test/API/lang/c/forward/TestForwardDeclaration.py
@@ -8,6 +8,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class ForwardDeclarationTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, dictionary=None):
         """Display *bar_ptr when stopped on a function with forward declaration of struct bar."""
         self.build(dictionary=dictionary)

--- a/lldb/test/API/lang/c/shared_lib_stripped_symbols/TestSharedLibStrippedSymbols.py
+++ b/lldb/test/API/lang/c/shared_lib_stripped_symbols/TestSharedLibStrippedSymbols.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class SharedLibStrippedTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @expectedFailureAll(oslist=["windows"])
     # Sometimes fails with:
     # error: Couldn't allocate space for materialized struct: Couldn't malloc: address space is full

--- a/lldb/test/API/lang/cpp/abi_tag_lookup/TestAbiTagLookup.py
+++ b/lldb/test/API/lang/cpp/abi_tag_lookup/TestAbiTagLookup.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class AbiTagLookupTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfWindows
     @expectedFailureAll(debug_info=["dwarf", "gmodules", "dwo"])
     def test_abi_tag_lookup(self):

--- a/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
+++ b/lldb/test/API/lang/cpp/abi_tag_structors/TestAbiTagStructors.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class AbiTagStructorsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @expectedFailureAll(oslist=["windows"])
     def test_with_structor_linkage_names(self):
         self.build(dictionary={"CXXFLAGS_EXTRAS": "-gstructor-decl-linkage-names"})

--- a/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
+++ b/lldb/test/API/lang/cpp/const_static_integral_member/TestConstStaticIntegralMember.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/dynamic-value/TestCppValueCast.py
+++ b/lldb/test/API/lang/cpp/dynamic-value/TestCppValueCast.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class CppValueCastTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(bugnumber="llvm.org/PR36714")
     @add_test_categories(["pyapi"])
     def test_value_cast_with_virtual_inheritance(self):

--- a/lldb/test/API/lang/cpp/expr-definition-in-dylib/TestExprDefinitionInDylib.py
+++ b/lldb/test/API/lang/cpp/expr-definition-in-dylib/TestExprDefinitionInDylib.py
@@ -5,6 +5,7 @@ from lldbsuite.test import lldbutil
 
 
 class ExprDefinitionInDylibTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
 
     @skipIfWindows
     def test_with_structor_linkage_names(self):

--- a/lldb/test/API/lang/cpp/forward/TestCPPForwardDeclaration.py
+++ b/lldb/test/API/lang/cpp/forward/TestCPPForwardDeclaration.py
@@ -7,6 +7,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class ForwardDeclarationTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, dictionary=None):
         """Display *bar_ptr when stopped on a function with forward declaration of struct bar."""
         self.build(dictionary=dictionary)

--- a/lldb/test/API/lang/cpp/gmodules/alignment/TestPchAlignment.py
+++ b/lldb/test/API/lang/cpp/gmodules/alignment/TestPchAlignment.py
@@ -13,6 +13,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestPchAlignment(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @add_test_categories(["gmodules"])
     def test_expr(self):
         self.build()

--- a/lldb/test/API/lang/cpp/gmodules/basic/TestWithModuleDebugging.py
+++ b/lldb/test/API/lang/cpp/gmodules/basic/TestWithModuleDebugging.py
@@ -6,6 +6,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestWithGmodulesDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(bugnumber="llvm.org/pr36146", oslist=["linux"], archs=["i386"])
     @add_test_categories(["gmodules"])
     def test_specialized_typedef_from_pch(self):

--- a/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
+++ b/lldb/test/API/lang/cpp/gmodules/template-with-same-arg/TestTemplateWithSameArg.py
@@ -27,6 +27,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestTemplateWithSameArg(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         TestBase.setUp(self)
         self.build()

--- a/lldb/test/API/lang/cpp/limit-debug-info/TestWithLimitDebugInfo.py
+++ b/lldb/test/API/lang/cpp/limit-debug-info/TestWithLimitDebugInfo.py
@@ -5,6 +5,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestWithLimitDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _run_test(self, build_dict):
         self.build(dictionary=build_dict)
 

--- a/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
+++ b/lldb/test/API/lang/cpp/namespace/TestNamespaceLookup.py
@@ -11,6 +11,8 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbplatformutil
 
 class NamespaceLookupTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/cpp/nested-template/TestNestedTemplate.py
+++ b/lldb/test/API/lang/cpp/nested-template/TestNestedTemplate.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class NestedTemplateTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         self.build(dictionary=debug_flags)
         self.dbg.CreateTarget(self.getBuildArtifact("a.out"))

--- a/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
+++ b/lldb/test/API/lang/cpp/template-function/TestTemplateFunctions.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class TemplateFunctionsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test_template_function(self, add_cast):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
+++ b/lldb/test/API/lang/cpp/template/TestTemplateArgs.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 
 
 class TemplateArgsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     def prepareProcess(self):
         self.build()
 

--- a/lldb/test/API/lang/cpp/unique-types2/TestUniqueTypes2.py
+++ b/lldb/test/API/lang/cpp/unique-types2/TestUniqueTypes2.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class UniqueTypesTestCase2(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         """Test that we only display the requested Foo instantiation, not all Foo instantiations."""
         self.build(dictionary=debug_flags)

--- a/lldb/test/API/lang/cpp/unique-types3/TestUniqueTypes3.py
+++ b/lldb/test/API/lang/cpp/unique-types3/TestUniqueTypes3.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class UniqueTypesTestCase3(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         """Test that we display the correct template instantiation."""
         self.build(dictionary=debug_flags)

--- a/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
+++ b/lldb/test/API/lang/cpp/unique-types4/TestUniqueTypes4.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class UniqueTypesTestCase4(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_test(self, debug_flags):
         """Test that we display the correct template instantiation."""
         self.build(dictionary=debug_flags)

--- a/lldb/test/API/lang/objc/direct-dispatch-step/TestObjCDirectDispatchStepping.py
+++ b/lldb/test/API/lang/objc/direct-dispatch-step/TestObjCDirectDispatchStepping.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCDirectDispatchStepping(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/lang/objc/forward-decl/TestForwardDecl.py
+++ b/lldb/test/API/lang/objc/forward-decl/TestForwardDecl.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class ForwardDeclTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/foundation/TestConstStrings.py
+++ b/lldb/test/API/lang/objc/foundation/TestConstStrings.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 
 class ConstStringTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     d = {"OBJC_SOURCES": "const-strings.m"}
 
     def setUp(self):

--- a/lldb/test/API/lang/objc/foundation/TestObjectDescriptionAPI.py
+++ b/lldb/test/API/lang/objc/foundation/TestObjectDescriptionAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjectDescriptionAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/hidden-ivars/TestHiddenIvars.py
+++ b/lldb/test/API/lang/objc/hidden-ivars/TestHiddenIvars.py
@@ -1,6 +1,5 @@
 """Test that hidden ivars in a shared library are visible from the main executable."""
 
-
 import subprocess
 
 import unittest
@@ -11,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class HiddenIvarsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/modules-update/TestClangModulesUpdate.py
+++ b/lldb/test/API/lang/objc/modules-update/TestClangModulesUpdate.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestClangModuleUpdate(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @add_test_categories(["gmodules"])
     @skipIfDarwin  # rdar://76540904
     def test_expr(self):

--- a/lldb/test/API/lang/objc/objc-dyn-sbtype/TestObjCDynamicSBType.py
+++ b/lldb/test/API/lang/objc/objc-dyn-sbtype/TestObjCDynamicSBType.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjCDynamicSBTypeTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
+++ b/lldb/test/API/lang/objc/objc-ivar-stripped/TestObjCIvarStripped.py
@@ -1,6 +1,5 @@
 """Test printing ObjC objects that use unbacked properties - so that the static ivar offsets are incorrect."""
 
-
 import lldb
 from lldbsuite.test.decorators import *
 from lldbsuite.test.lldbtest import *
@@ -8,6 +7,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCIvarStripped(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/objc-struct-argument/TestObjCStructArgument.py
+++ b/lldb/test/API/lang/objc/objc-struct-argument/TestObjCStructArgument.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestObjCStructArgument(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/orderedset/TestOrderedSet.py
+++ b/lldb/test/API/lang/objc/orderedset/TestOrderedSet.py
@@ -5,6 +5,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestOrderedSet(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_ordered_set(self):
         self.build()
         self.run_tests()

--- a/lldb/test/API/lang/objc/print-obj/TestPrintObj.py
+++ b/lldb/test/API/lang/objc/print-obj/TestPrintObj.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class PrintObjTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
+++ b/lldb/test/API/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class MethodReturningBOOLTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/rdar-10967107/TestRdar10967107.py
+++ b/lldb/test/API/lang/objc/rdar-10967107/TestRdar10967107.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class Rdar10967107TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/rdar-12408181/TestRdar12408181.py
+++ b/lldb/test/API/lang/objc/rdar-12408181/TestRdar12408181.py
@@ -15,6 +15,8 @@ from lldbsuite.test import lldbutil
 # Note: Simply applying the @skipIf decorator here confuses the test harness
 # and gives a spurious failure.
 class Rdar12408181TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
+++ b/lldb/test/API/lang/objc/single-entry-dictionary/TestObjCSingleEntryDictionary.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class ObjCSingleEntryDictionaryTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
+++ b/lldb/test/API/lang/swift/availability/TestSwiftAvailability.py
@@ -27,7 +27,7 @@ def getOlderVersion(major, minor):
     return '%d.%d' % (major-1, minor)
 
 class TestAvailability(TestBase):
-
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -21,6 +21,7 @@ import os
 
 class TestSwiftDeploymentTarget(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @skipUnlessDarwin
     @skipIfDarwinEmbedded # This test uses macOS triples explicitly.

--- a/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/objc-header/TestSwiftDWARFImporter-Swift.py
@@ -6,8 +6,7 @@ import os
 
 
 class TestSwiftDWARFImporter_Swift(lldbtest.TestBase):
-
-    mydir = lldbtest.TestBase.compute_mydir(__file__)
+    SHARED_BUILD_TESTCASE = False
 
     def build(self):
         include = self.getBuildArtifact('include')

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -7,6 +7,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
+
     @swiftTest
     def test_missing_explicit_modules(self):
         """Test missing explicit Swift modules and fallback to implicit modules."""

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftExplicitModules(lldbtest.TestBase):
+    SHARED_BUILD_TESTCASE = False
 
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExpressionErrorReporting(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @swiftTest
     def test_missing_location(self):

--- a/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
+++ b/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
@@ -5,6 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftFrameworkPaths(lldbtest.TestBase):
+    SHARED_BUILD_TESTCASE = False
 
     @swiftTest
     # Don't run ClangImporter tests if Clangimporter is disabled.

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -22,6 +22,8 @@ import time
 
 @skipIfDarwin # rdar://problem/54322424 Sometimes failing, sometimes truncated output.
 class TestMainExecutable(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def launch_info(self):
         info = lldb.SBLaunchInfo([])
 

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -4,6 +4,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftLateDylib(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipUnlessDarwin
     @swiftTest
     @skipIfDarwinEmbedded

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 import os
 
 class TestSwiftMacro(lldbtest.TestBase):
-
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setupPluginServerForTesting(self):

--- a/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
+++ b/lldb/test/API/lang/swift/meta/TestSwiftMeta.py
@@ -17,8 +17,7 @@ import lldbsuite.test.lldbtest as lldbtest
 import os
 
 class TestSwiftMeta(lldbtest.TestBase):
-
-    mydir = lldbtest.TestBase.compute_mydir(__file__)
+    SHARED_BUILD_TESTCASE = False
 
     @swiftTest
     def test_swiftDecorator(self):

--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -11,6 +11,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftMetadataCache(TestBase):
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/dsym/TestSwiftInterfaceDsym.py
@@ -18,6 +18,8 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class TestSwiftInterfaceDSYM(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @swiftTest
     @skipIf(archs=no_match("x86_64"))
     @skipIf(debug_info=no_match(["dsym"]))

--- a/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/shared/TestSwiftInterfaceNoDebugInfo.py
@@ -26,6 +26,8 @@ import os.path
 
 
 class TestSwiftInterfaceNoDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @swiftTest
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""

--- a/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/parseable_interfaces/static/TestSwiftInterfaceStaticNoDebugInfo.py
@@ -26,6 +26,8 @@ import os.path
 
 
 class TestSwiftInterfaceStaticNoDebugInfo(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @swiftTest
     def test_swift_interface(self):
         """Test that we load and handle modules that only have textual .swiftinterface files"""

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -35,6 +35,8 @@ def execute_command(command):
 
 
 class TestSwiftPlaygrounds(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def get_build_triple(self):
         """We want to build the file with a deployment target earlier than the
            availability set in the source file."""

--- a/lldb/test/API/lang/swift/static_framework/TestSwiftStaticFramework.py
+++ b/lldb/test/API/lang/swift/static_framework/TestSwiftStaticFramework.py
@@ -9,6 +9,7 @@ class TestSwiftStaticFramework(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))

--- a/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
+++ b/lldb/test/API/lang/swift/xcode_sdk/TestSwiftXcodeSDK.py
@@ -9,6 +9,7 @@ class TestSwiftXcodeSDK(lldbtest.TestBase):
 
     mydir = lldbtest.TestBase.compute_mydir(__file__)
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def check_log(self, log, expected_path, expect_precise):
         import io

--- a/lldb/test/API/linux/loongarch64/simd_registers/TestLoongArch64LinuxSIMDRegisters.py
+++ b/lldb/test/API/linux/loongarch64/simd_registers/TestLoongArch64LinuxSIMDRegisters.py
@@ -15,6 +15,7 @@ class Mode(Enum):
 
 
 class LoongArch64LinuxRegisters(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def get_build_flags(self, mode):

--- a/lldb/test/API/macosx/add-dsym/TestAddDsymDownload.py
+++ b/lldb/test/API/macosx/add-dsym/TestAddDsymDownload.py
@@ -6,6 +6,8 @@ from lldbsuite.test import lldbutil
 
 @skipUnlessDarwin
 class AddDsymDownload(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     dwarfdump_uuid_regex = re.compile(r"UUID: ([-0-9a-fA-F]+) \(([^\(]+)\) .*")
 
     def get_uuid(self):

--- a/lldb/test/API/macosx/add-dsym/TestAddDsymMidExecutionCommand.py
+++ b/lldb/test/API/macosx/add-dsym/TestAddDsymMidExecutionCommand.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 @skipUnlessDarwin
 class AddDsymMidExecutionCommandCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/macosx/ctf/TestCTF.py
+++ b/lldb/test/API/macosx/ctf/TestCTF.py
@@ -6,6 +6,7 @@ import os
 
 
 class TestCTF(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def no_ctf_convert(self):

--- a/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
+++ b/lldb/test/API/macosx/dsym_modules/TestdSYMModuleInit.py
@@ -13,6 +13,8 @@ from lldbsuite.test.decorators import *
 
 @skipUnlessDarwin
 class TestdSYMModuleInit(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @no_debug_info_test
     def test_add_module(self):
         """This loads a file into a target and ensures that the python module was

--- a/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
+++ b/lldb/test/API/macosx/function-starts/TestFunctionStarts.py
@@ -12,6 +12,7 @@ exe_name = "StripMe"  # Must match Makefile
 
 
 class FunctionStartsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     @skipIfRemote

--- a/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
+++ b/lldb/test/API/macosx/lc-note/firmware-corefile/TestFirmwareCorefiles.py
@@ -12,6 +12,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestFirmwareCorefiles(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",

--- a/lldb/test/API/macosx/nslog/TestDarwinNSLogOutput.py
+++ b/lldb/test/API/macosx/nslog/TestDarwinNSLogOutput.py
@@ -18,6 +18,7 @@ from lldbsuite.test import lldbtest_config
 
 
 class DarwinNSLogOutputTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -7,6 +7,7 @@ import json
 
 class TestSimulatorPlatformLaunching(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def check_load_commands(self, expected_load_command):
         """sanity check the built binary for the expected number of load commands"""

--- a/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
+++ b/lldb/test/API/macosx/skinny-corefile/TestSkinnyCorefile.py
@@ -12,6 +12,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestSkinnyCorefile(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",

--- a/lldb/test/API/macosx/universal64/TestUniversal64.py
+++ b/lldb/test/API/macosx/universal64/TestUniversal64.py
@@ -4,6 +4,7 @@ from lldbsuite.test import lldbutil
 
 
 class Universal64TestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def do_test(self):

--- a/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
+++ b/lldb/test/API/python_api/class_members/TestSBTypeClassMembers.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class SBTypeMemberFunctionsTest(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
+++ b/lldb/test/API/python_api/debugger/TestDebuggerAPI.py
@@ -11,6 +11,7 @@ from lldbsuite.test import lldbutil
 
 class DebuggerAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def test_debugger_api_boundary_condition(self):
         """Exercise SBDebugger APIs with boundary conditions."""

--- a/lldb/test/API/python_api/event/TestEvents.py
+++ b/lldb/test/API/python_api/event/TestEvents.py
@@ -12,6 +12,7 @@ import random
 @skipIfLinux  # llvm.org/pr25924, sometimes generating SIGSEGV
 class EventAPITestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/python_api/formatters/TestFormattersSBAPI.py
+++ b/lldb/test/API/python_api/formatters/TestFormattersSBAPI.py
@@ -7,6 +7,7 @@ from lldbsuite.test import lldbutil
 
 
 class SBFormattersAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
+++ b/lldb/test/API/python_api/global_module_cache/TestGlobalModuleCache.py
@@ -14,6 +14,7 @@ import time
 
 
 class GlobalModuleCacheTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     # NO_DEBUG_INFO_TESTCASE = True
 
     def check_counter_var(self, thread, value):

--- a/lldb/test/API/python_api/hello_world/TestHelloWorld.py
+++ b/lldb/test/API/python_api/hello_world/TestHelloWorld.py
@@ -10,6 +10,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 
 class HelloWorldTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/python_api/module_section/TestModuleAndSection.py
+++ b/lldb/test/API/python_api/module_section/TestModuleAndSection.py
@@ -10,6 +10,8 @@ from lldbsuite.test.lldbutil import symbol_type_to_str
 
 
 class ModuleAndSectionAPIsTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_module_and_section(self):
         """Test module and section APIs."""
         self.build()

--- a/lldb/test/API/python_api/section/TestSectionAPI.py
+++ b/lldb/test/API/python_api/section/TestSectionAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class SectionAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @no_debug_info_test
     @skipIfXmlSupportMissing
     def test_get_target_byte_size(self):

--- a/lldb/test/API/python_api/target-arch-from-module/TestTargetArchFromModule.py
+++ b/lldb/test/API/python_api/target-arch-from-module/TestTargetArchFromModule.py
@@ -12,6 +12,8 @@ from lldbsuite.test import lldbutil
 
 
 class TargetArchFromModule(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(
         debug_info=no_match(["dsym"]),
         bugnumber="This test is looking explicitly for a dSYM",

--- a/lldb/test/API/python_api/target/TestTargetAPI.py
+++ b/lldb/test/API/python_api/target/TestTargetAPI.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class TargetAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/thread/TestThreadAPI.py
+++ b/lldb/test/API/python_api/thread/TestThreadAPI.py
@@ -10,6 +10,8 @@ from lldbsuite.test.lldbutil import get_stopped_thread, get_caller_symbol
 
 
 class ThreadAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_get_process(self):
         """Test Python SBThread.GetProcess() API."""
         self.build()

--- a/lldb/test/API/python_api/type/TestTypeList.py
+++ b/lldb/test/API/python_api/type/TestTypeList.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 from lldbsuite.test import lldbplatformutil
 
 class TypeAndTypeListTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/value/TestValueAPI.py
+++ b/lldb/test/API/python_api/value/TestValueAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class ValueAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
+++ b/lldb/test/API/python_api/value/change_values/TestChangeValueAPI.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class ChangeValueAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/python_api/value/linked_list/TestValueAPILinkedList.py
+++ b/lldb/test/API/python_api/value/linked_list/TestValueAPILinkedList.py
@@ -10,6 +10,7 @@ from lldbsuite.test import lldbutil
 
 
 class ValueAsLinkedListTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/python_api/value_var_update/TestValueVarUpdate.py
+++ b/lldb/test/API/python_api/value_var_update/TestValueVarUpdate.py
@@ -8,6 +8,8 @@ from lldbsuite.test import lldbutil
 
 
 class ValueVarUpdateTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_with_process_launch_api(self):
         """Test SBValue::GetValueDidChange"""
         # Get the full path to our executable to be attached/debugged.

--- a/lldb/test/API/python_api/watchpoint/condition/TestWatchpointConditionAPI.py
+++ b/lldb/test/API/python_api/watchpoint/condition/TestWatchpointConditionAPI.py
@@ -9,6 +9,7 @@ from lldbsuite.test import lldbutil
 
 
 class WatchpointConditionAPITestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
     NO_DEBUG_INFO_TESTCASE = True
 
     def setUp(self):

--- a/lldb/test/API/riscv/break-undecoded/TestBreakpointIllegal.py
+++ b/lldb/test/API/riscv/break-undecoded/TestBreakpointIllegal.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestBreakpointIllegal(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIf(archs=no_match(["rv64gc"]))
     def test_4(self):
         self.build()

--- a/lldb/test/API/riscv/step/TestSoftwareStep.py
+++ b/lldb/test/API/riscv/step/TestSoftwareStep.py
@@ -10,6 +10,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestSoftwareStep(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def do_sequence_test(self, filename, bkpt_name):
         source_file = filename + ".c"
         exe_file = filename + ".x"

--- a/lldb/test/API/source-manager/TestSourceManager.py
+++ b/lldb/test/API/source-manager/TestSourceManager.py
@@ -30,6 +30,7 @@ def ansi_color_surround_regex(inner_regex_text):
 
 class SourceManagerTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+    SHARED_BUILD_TESTCASE = False
 
     def setUp(self):
         # Call super's setUp().

--- a/lldb/test/API/test_utils/base/TestBaseTest.py
+++ b/lldb/test/API/test_utils/base/TestBaseTest.py
@@ -9,6 +9,8 @@ from lldbsuite.test_event import build_exception
 
 
 class TestBuildMethod(Base):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         super().setUp()
         self._traces = []

--- a/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
+++ b/lldb/test/API/tools/lldb-dap/attach/TestDAP_attach.py
@@ -22,6 +22,8 @@ def spawn_and_wait(program, delay):
 
 @skipIfDarwin  # rdar://164257003
 class TestDAP_attach(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def set_and_hit_breakpoint(self, continueToExit=True):
         source = "main.c"
         breakpoint1_line = line_number(source, "// breakpoint 1")

--- a/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
+++ b/lldb/test/API/tools/lldb-dap/breakpoint/TestDAP_setBreakpoints.py
@@ -13,6 +13,8 @@ import os
 
 
 class TestDAP_setBreakpoints(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         lldbdap_testcase.DAPTestCaseBase.setUp(self)
 

--- a/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
+++ b/lldb/test/API/tools/lldb-dap/commands/TestDAP_commands.py
@@ -7,6 +7,8 @@ from lldbsuite.test.decorators import *
 
 
 class TestDAP_commands(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def test_command_directive_quiet_on_success(self):
         program = self.getBuildArtifact("a.out")
         command_quiet = (

--- a/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
+++ b/lldb/test/API/tools/lldb-dap/disconnect/TestDAP_disconnect.py
@@ -14,6 +14,8 @@ import os
 
 
 class TestDAP_launch(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     source = "main.cpp"
 
     def disconnect_and_assert_no_output_printed(self):

--- a/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
+++ b/lldb/test/API/tools/lldb-dap/runInTerminal/TestDAP_runInTerminal.py
@@ -12,6 +12,8 @@ import json
 
 @skipIfBuildType(["debug"])
 class TestDAP_runInTerminal(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def read_pid_message(self, fifo_file):
         with open(fifo_file, "r") as file:
             self.assertIn("pid", file.readline())

--- a/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
+++ b/lldb/test/API/tools/lldb-dap/variables/TestDAP_variables.py
@@ -17,6 +17,8 @@ def make_buffer_verify_dict(start_idx, count, offset=0):
 
 
 class TestDAP_variables(lldbdap_testcase.DAPTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def verify_values(self, verify_dict, actual, varref_dict=None, expression=None):
         if "equals" in verify_dict:
             verify = verify_dict["equals"]

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -10,6 +10,8 @@ import re
 
 
 class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     # Number of stderr lines to read from the simctl output.
     READ_LINES = 10
 

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteCompletion.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteCompletion.py
@@ -6,6 +6,8 @@ from lldbgdbserverutils import *
 
 
 class GdbRemoteCompletionTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def init_lldb_server(self):
         self.debug_monitor_exe = get_lldb_server_exe()
         if not self.debug_monitor_exe:

--- a/lldb/test/API/tools/lldb-server/TestGdbRemoteForkNonStop.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemoteForkNonStop.py
@@ -5,6 +5,8 @@ from fork_testbase import GdbRemoteForkTestBase
 
 
 class TestGdbRemoteForkNonStop(GdbRemoteForkTestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         GdbRemoteForkTestBase.setUp(self)
         if self.getPlatform() == "linux" and self.getArchitecture() in [

--- a/lldb/test/API/tools/lldb-server/TestGdbRemotePlatformFile.py
+++ b/lldb/test/API/tools/lldb-server/TestGdbRemotePlatformFile.py
@@ -43,6 +43,8 @@ def uint32_trunc(x):
 
 
 class TestGdbRemotePlatformFile(GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfWindows
     @add_test_categories(["llgs"])
     def test_platform_file_rdonly(self):

--- a/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
+++ b/lldb/test/API/tools/lldb-server/TestLldbGdbServer.py
@@ -26,6 +26,8 @@ from lldbsuite.test import lldbutil, lldbplatformutil
 class LldbGdbServerTestCase(
     gdbremote_testcase.GdbRemoteTestCaseBase, DwarfOpcodeParser
 ):
+    SHARED_BUILD_TESTCASE = False
+
     def test_thread_suffix_supported(self):
         server = self.connect_to_debug_monitor()
         self.assertIsNotNone(server)

--- a/lldb/test/API/tools/lldb-server/attach-wait/TestGdbRemoteAttachWait.py
+++ b/lldb/test/API/tools/lldb-server/attach-wait/TestGdbRemoteAttachWait.py
@@ -9,6 +9,8 @@ from lldbsuite.test import lldbutil
 
 
 class TestGdbRemoteAttachWait(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     def _set_up_inferior(self):
         self._exe_to_attach = "%s_%d" % (self.testMethodName, os.getpid())
         self.build(dictionary={"EXE": self._exe_to_attach, "CXX_SOURCES": "main.cpp"})

--- a/lldb/test/API/tools/lldb-server/commandline/TestGdbRemoteConnection.py
+++ b/lldb/test/API/tools/lldb-server/commandline/TestGdbRemoteConnection.py
@@ -9,6 +9,8 @@ from lldbgdbserverutils import Pipe
 
 
 class TestGdbRemoteConnection(gdbremote_testcase.GdbRemoteTestCaseBase):
+    SHARED_BUILD_TESTCASE = False
+
     @skipIfRemote  # reverse connect is not a supported use case for now
     def test_reverse_connect(self):
         # Reverse connect is the default connection method.

--- a/lldb/test/API/types/AbstractBase.py
+++ b/lldb/test/API/types/AbstractBase.py
@@ -22,6 +22,8 @@ class GenericTester(TestBase):
     # printf() stmts (see basic_type.cpp).
     pattern = re.compile(r" (\*?a[^=]*) = '([^=]*)'$")
 
+    SHARED_BUILD_TESTCASE = False
+
     # Assert message.
     DATA_TYPE_GROKKED = "Data type from expr parser output is parsed correctly"
 

--- a/lldb/test/API/types/HideTestFailures.py
+++ b/lldb/test/API/types/HideTestFailures.py
@@ -13,6 +13,8 @@ from lldbsuite.test.lldbtest import *
 
 
 class DebugIntegerTypesFailures(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)

--- a/lldb/test/API/types/TestRecursiveTypes.py
+++ b/lldb/test/API/types/TestRecursiveTypes.py
@@ -2,13 +2,14 @@
 Test that recursive types are handled correctly.
 """
 
-
 import lldb
 import lldbsuite.test.lldbutil as lldbutil
 from lldbsuite.test.lldbtest import *
 
 
 class RecursiveTypesTestCase(TestBase):
+    SHARED_BUILD_TESTCASE = False
+
     def setUp(self):
         # Call super's setUp().
         TestBase.setUp(self)


### PR DESCRIPTION
This changes Python API tests to use a single build shared across all
test functions, instead of the previous default behavior of a separate
build dir for each test function.

This build behavior opt-out, tests can use the previous behavior of one
individual (unshared) build directory per test function, by setting
`SHARED_BUILD_TESTCASE` to False (in the test class).

The motivation is to make the test suite more efficient, by not
repeatedly building the same test source. When running tests on my macOS
machine, this reduces the time of `ninja check-lldb-api` by almost 60%
(sample numbers: from ~492s down to ~207s = 58%). Almost 5min time
saved.

Each test function still calls `self.build()`, but only the first call
will do a build, in the subsequent tests `make` will be a no-op because
the sources won't have changed.

(cherry picked from commit b9225e860769cc7c79bde294265e89eb22fb9ffc)
