### PR TITLE
[TEST-ONLY] Avoid writing to system default CAS

### DIFF
--- a/clang/test/CAS/clang-cache-mode.c
+++ b/clang/test/CAS/clang-cache-mode.c
@@ -1,3 +1,3 @@
-// RUN: %clang-cache %clang -v -fsyntax-only -x c %s 2>&1 | FileCheck %s
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -v -fsyntax-only -x c %s 2>&1 | FileCheck %s
 
 // CHECK: -fdepscan


### PR DESCRIPTION
Fix a test case that writes to system default CAS that leaks its temporary output outside the build directory.

(cherry picked from commit 7c9408d60b0bc5eeb22517080f811fce45f636f9)