### PR TITLE
[CAS/GRPCRelayCAS] Fix for `GRPCRelayCAS::storeFromOpenFileImpl()`

### DIFF
--- a/llvm/lib/RemoteCachingService/CAS/GRPCRelayCAS.cpp
+++ b/llvm/lib/RemoteCachingService/CAS/GRPCRelayCAS.cpp
@@ -377,6 +377,10 @@ ArrayRef<char> GRPCRelayCAS::getData(ObjectHandle Handle,
 Expected<ObjectRef>
 GRPCRelayCAS::storeFromOpenFileImpl(sys::fs::file_t FD,
                                     std::optional<sys::fs::file_status> FS) {
+  if (!FS.has_value()) {
+    if (std::error_code EC = sys::fs::status(FD, *FS))
+      return errorCodeToError(EC);
+  }
   std::error_code EC;
   sys::fs::mapped_file_region Map(FD, sys::fs::mapped_file_region::readonly,
                                   FS->getSize(),


### PR DESCRIPTION
Make sure to check whether `FS` is not set.

rdar://170582043
(cherry picked from commit bf188bbc43b48765751272aab4d0d3f0dbf8ba10)