### PR TITLE
Fix an assertion failure with CAS and pch for Windows (#12364)

### DIFF
--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1351,7 +1351,7 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
           if (!PCHFile)
             return reportError(PCHFile.takeError());
           PCHCASID = PCHFile->getID().toString();
-          PCHPath = PCHCASID;
+          PCHPath = PCHBuffer->getBufferIdentifier();
         } else {
           PCHPath = CI.getPreprocessorOpts().ImplicitPCHInclude;
           DisableValidation =

--- a/clang/test/CAS/clang-cache-pch.c
+++ b/clang/test/CAS/clang-cache-pch.c
@@ -1,0 +1,25 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -Xclang -emit-pch -Xclang -include -Xclang %t/cmake_pch.hxx -MD -MT %t/cmake_pch.hxx.pch -MF %t/cmake_pch.hxx.pch.d -o %t/cmake_pch.hxx.pch -c %t/cmake_pch.hxx.cxx
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang -Xclang -include-pch -Xclang %t/cmake_pch.hxx.pch -Xclang -include -Xclang %t/cmake_pch.hxx -MD -MT %t/Test.obj -MF %t/Test.obj.d -o %t/Test.obj -c %t/Test.cpp
+
+//--- Test.cpp
+#include "pch.h"
+
+int foo() {
+  return 42;
+}
+
+//--- pch.h
+#pragma once
+
+//--- cmake_pch.hxx.cxx
+// empty
+
+//--- cmake_pch.hxx
+#pragma clang system_header
+#include "pch.h"


### PR DESCRIPTION
Also fixes the existing tests with the same assertion failure:

Clang :: CAS/cmd-macro-and-pch.c
Clang :: CAS/fcas-include-tree-prefix-mapping.c
Clang :: CAS/pgo-profile-with-pch.c
Clang :: ClangScanDeps/include-tree-preserve-pch-path.c
Clang :: ClangScanDeps/include-tree-with-pch.c
Clang :: ClangScanDeps/modules-include-tree-missing-submodule.c
Clang :: ClangScanDeps/modules-include-tree-pch-common-stale-prefix-map.c
Clang :: ClangScanDeps/modules-include-tree-pch-common-stale.c
Clang :: ClangScanDeps/modules-include-tree-pch-with-private.c
Clang :: ClangScanDeps/modules-include-tree-with-pch.c
Clang :: ClangScanDeps/optimize-vfs-pch-tree.m

Issue: https://github.com/swiftlang/llvm-project/issues/12363

Cherry picked from commit c54842831d79785e9fb34d2f514197716f0506cb