### PR TITLE
[llvm][cas] Fix assertion when capacity == size

### DIFF
--- a/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
@@ -225,7 +225,7 @@ void MappedFileRegionBumpPtr::destroyImpl() {
     if (tryLockFileThreadSafe(*SharedLockFD) == std::error_code()) {
       size_t Size = size();
       size_t Capacity = capacity();
-      assert(Size < Capacity);
+      assert(Size <= Capacity);
       // sync to file system to make sure all contents are up-to-date.
       (void)Region.sync();
       Region.unmap();

--- a/llvm/test/CAS/mapping-size-too-small.test
+++ b/llvm/test/CAS/mapping-size-too-small.test
@@ -1,0 +1,22 @@
+RUN: rm -rf %t && mkdir -p %t
+RUN: split-file %s %t
+
+# Check that if we start with a larger CAS it does not blow up when read with a smaller size.
+RUN: env LLVM_CAS_MAX_MAPPING_SIZE=10240 llvm-cas -cas %t/cas -make-blob -data %t/input > %t/casid
+RUN: env LLVM_CAS_MAX_MAPPING_SIZE=1024 llvm-cas -cas %t/cas -cat-blob @%t/casid | FileCheck %s
+# CHECK: 01234567890
+
+RUN: rm -rf %t/cas
+RUN: env LLVM_CAS_MAX_MAPPING_SIZE=1024 not llvm-cas -cas %t/cas -make-blob -data %t/input 2>&1 | FileCheck %s -check-prefix=TOO_SMALL
+# TOO_SMALL: memory mapped file allocator is out of space
+
+
+//--- input
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890
+01234567890


### PR DESCRIPTION
Other than allocating exactly capacity bytes in the allocator, which is possible but unlikely, one easy way this can happen is a large cas is later opened with a small LLVM_CAS_MAX_MAPPING_SIZE. In that case we set capacity = size when we open it and it will later assert when closing.

rdar://170740036