### PR TITLE
CAS: support daemon mode on Windows

### DIFF
--- a/clang/test/CAS/cache-launcher-scan-diagnostics.c
+++ b/clang/test/CAS/cache-launcher-scan-diagnostics.c
@@ -1,4 +1,4 @@
-// REQUIRES: system-darwin, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 
 // RUN: rm -rf %t && mkdir -p %t
 

--- a/clang/test/CAS/daemon-cas-recovery.c
+++ b/clang/test/CAS/daemon-cas-recovery.c
@@ -1,4 +1,4 @@
-// REQUIRES: system-darwin, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 
 // RUN: rm -rf %t && mkdir -p %t
 
@@ -7,7 +7,7 @@
 // RUN: rm %t/cas/v1.1/data.v1
 // RUN: not llvm-cas --cas %t/cas --validate --check-hash
 
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_FORCE_VALIDATION=1 %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_FORCE_VALIDATION=1 CLANG_CACHE_DISABLE_MCCAS=1 %clang-cache \
 // RUN:   %clang -fsyntax-only -x c %s
 
 int func(void);

--- a/clang/test/CAS/daemon-cwd.c
+++ b/clang/test/CAS/daemon-cwd.c
@@ -1,28 +1,27 @@
 // Test running -fdepscan with a daemon launched from different directory.
 //
-// REQUIRES: system-darwin, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 
-// RUN: rm -rf %t && mkdir -p %t/include
-// RUN: cp %S/Inputs/test.h %t/include
-// RUN: echo "#!/bin/sh" >> %t/cmd.sh
-// RUN: echo cd %t >> %t/cmd.sh
-// RUN: echo %clang -target x86_64-apple-macos11 -fdepscan=daemon         \
-// RUN:    -fdepscan-prefix-map=%S=/^source                               \
-// RUN:    -fdepscan-prefix-map=%t=/^build                                \
-// RUN:    -fdepscan-prefix-map-toolchain=/^toolchain                     \
-// RUN:    -fdepscan-daemon=%{clang-daemon-dir}/%basename_t               \
-// RUN:    -Xclang -fcas-path -Xclang %t/cas                              \
-// RUN:    -MD -MF %t/test.d -Iinclude                                    \
-// RUN:    -fsyntax-only -x c %s >> %t/cmd.sh
-// RUN: chmod +x %t/cmd.sh
+// RUN: rm -rf %t && split-file %s %t
 
-// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t      \
-// RUN:   -cas-args -fcas-path %t/cas -- %t/cmd.sh
-// RUN: cd %t
-// RUN: %clang -target x86_64-apple-macos11 -MD -MF %t/test2.d            \
-// RUN:    -Iinclude -fsyntax-only -x c %s
+// RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t       \
+// RUN:   -cas-args -fcas-path %t/cas --                                   \
+// RUN:     %clang -target x86_64-apple-macos11 -fdepscan=daemon           \
+// RUN:       -fdepscan-prefix-map=%S=/^source                             \
+// RUN:       -fdepscan-prefix-map=%t=/^build                              \
+// RUN:       -fdepscan-prefix-map-toolchain=/^toolchain                   \
+// RUN:       -fdepscan-daemon=%{clang-daemon-dir}/%basename_t             \
+// RUN:       -Xclang -fcas-path -Xclang %t/cas                            \
+// RUN:       -working-directory %t -MD -MF %t/test.d -Iinclude            \
+// RUN:       -fsyntax-only -x c %t/daemon-cwd.c
+// RUN: %clang -target x86_64-apple-macos11 -working-directory %t          \
+// RUN:   -MD -MF %t/test2.d -Iinclude -fsyntax-only -x c %t/daemon-cwd.c
 // RUN: diff %t/test.d %t/test2.d
 
+//--- daemon-cwd.c
 #include "test.h"
 
 int func(void);
+
+//--- include/test.h
+int test(void);

--- a/clang/test/CAS/depscan-cas-log.c
+++ b/clang/test/CAS/depscan-cas-log.c
@@ -2,7 +2,7 @@
 // It's hard to check this exhaustively, but in practice if the daemon does not
 // enable logging there are currently zero records in the log.
 
-// REQUIRES: system-darwin, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 
 // RUN: rm -rf %t && mkdir %t
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CAS_LOG=1 LLVM_CAS_DISABLE_VALIDATION=1 %clang \

--- a/clang/test/CAS/depscan-include-tree-daemon.c
+++ b/clang/test/CAS/depscan-include-tree-daemon.c
@@ -1,4 +1,5 @@
-// REQUIRES: system-darwin, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
+
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 

--- a/clang/test/CAS/depscan-with-error.c
+++ b/clang/test/CAS/depscan-with-error.c
@@ -1,4 +1,4 @@
-// REQUIRES: clang-cc1daemon, ansi-escape-sequences
+// REQUIRES: clang-cc1daemon
 
 // RUN: rm -rf %t && mkdir -p %t
 

--- a/clang/test/CAS/depscan.c
+++ b/clang/test/CAS/depscan.c
@@ -1,5 +1,4 @@
-// TODO: Enable for Windows when cc1depscand is implemented
-// REQUIRES: !system-windows, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 //
 // RUN: rm -rf %t && mkdir -p %t
 // RUN: %clang -cc1depscan -fdepscan=inline -cc1-args -cc1 -triple x86_64-apple-macos11.0 -x c %s -o %s.o -MT %s.o -dependency-file %t.d -fcas-path %t/cas 2>&1 | %PathSanitizingFileCheck %s --sanitize PREFIX=%/t --enable-yaml-compatibility

--- a/clang/test/CAS/fcas-include-tree-prefix-mapping.c
+++ b/clang/test/CAS/fcas-include-tree-prefix-mapping.c
@@ -26,10 +26,10 @@
 // CHECK-NOT: [[OUT_PREFIX]]
 // CHECK-NOT: [[SDK_PREFIX]]
 // CHECK-NOT: [[TOOLCHAIN_PREFIX]]
-// CHECK: /^src{{[/\\]}}main.c
-// CHECK: /^src{{[/\\]}}inc{{[/\\]}}t.h
-// CHECK: /^toolchain{{[/\\]}}lib{{[/\\]}}clang{{[/\\]}}1000{{[/\\]}}include{{[/\\]}}stdarg.h
-// CHECK: /^sdk{{[/\\]}}usr{{[/\\]}}include{{[/\\]}}stdlib.h
+// CHECK: {{/|\\}}^src{{[/\\]}}main.c
+// CHECK: {{/|\\}}^src{{[/\\]}}inc{{[/\\]}}t.h
+// CHECK: {{/|\\}}^toolchain{{[/\\]}}lib{{[/\\]}}clang{{[/\\]}}1000{{[/\\]}}include{{[/\\]}}stdarg.h
+// CHECK: {{/|\\}}^sdk{{[/\\]}}usr{{[/\\]}}include{{[/\\]}}stdlib.h
 
 // RUN: FileCheck %s -input-file %t/out/output.ll -check-prefix=IR -DSRC_PREFIX=%t/src -DOUT_PREFIX=%t/out -DSDK_PREFIX=%S/Inputs/SDK -DTOOLCHAIN_PREFIX=%S/Inputs/toolchain_dir
 // IR-NOT: [[SRC_PREFIX]]

--- a/clang/test/CAS/fdepscan-daemon.c
+++ b/clang/test/CAS/fdepscan-daemon.c
@@ -1,6 +1,6 @@
 // Test running -fdepscan.
 //
-// REQUIRES: system-darwin, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 
 // RUN: rm -rf %t
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t/cas -- \

--- a/clang/test/CAS/fdepscan.c
+++ b/clang/test/CAS/fdepscan.c
@@ -1,6 +1,6 @@
 // Test running -fdepscan.
 //
-// REQUIRES: system-darwin, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 
 // RUN: rm -rf %t-*.d %t.cas
 // RUN: %clang -cc1depscand -execute %{clang-daemon-dir}/%basename_t -cas-args -fcas-path %t.cas -- \

--- a/clang/test/CAS/include-tree-with-sanitizer.c
+++ b/clang/test/CAS/include-tree-with-sanitizer.c
@@ -17,7 +17,7 @@
 // CHECK: -fsanitize-ignorelist=[[OUT_DIR]]{{/|\\}}asan_ignorelist.txt \
 // CHECK: -fsanitize-ignorelist=[[OUT_DIR]]{{/|\\}}sys_asan_ignorelist.txt \
 
-// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_PREFIX_MAPS="%S=/^src;%{t-lower}=/^out" %clang-cache \
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas LLVM_CACHE_PREFIX_MAPS="%S=/src;%{t-lower}=/out" %clang-cache \
 // RUN:   %clang -fsanitize=address -Xclang -fsanitize-ignorelist=%t/asan_ignorelist.txt -Xclang -fsanitize-system-ignorelist=%t/sys_asan_ignorelist.txt \
 // RUN:   -target x86_64-apple-macos11 -c %s -o %t/output.o -Rcompile-job-cache 2> %t/output-tree2.txt
 
@@ -29,7 +29,7 @@
 // RUN: FileCheck %s -input-file %t/key2.txt -check-prefix=PREFIXED
 //
 // PREFIXED: -fsanitize=address \
-// PREFIXED: -fsanitize-ignorelist=/^out{{/|\\}}asan_ignorelist.txt \
-// PREFIXED: -fsanitize-ignorelist=/^out{{/|\\}}sys_asan_ignorelist.txt \
+// PREFIXED: -fsanitize-ignorelist={{/|\\}}out{{/|\\}}asan_ignorelist.txt \
+// PREFIXED: -fsanitize-ignorelist={{/|\\}}out{{/|\\}}sys_asan_ignorelist.txt \
 
 void test() {}

--- a/clang/test/CAS/pgo-profile.c
+++ b/clang/test/CAS/pgo-profile.c
@@ -22,9 +22,9 @@
 // RUN: mkdir -p %t.dir/a && mkdir -p %t.dir/b
 // RUN: cp %t.profdata %t.dir/a/a.profdata
 // RUN: cp %t.profdata %t.dir/b/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/a /^testdir  \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t4.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/a /testdir  \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use=clang -fprofile-instrument-use-path=%t.dir/a/a.profdata
-// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/b /^testdir \
+// RUN: %clang -cc1depscan -fdepscan=inline -o %t5.rsp -cc1-args -cc1 -triple x86_64-apple-macosx12.0.0 -emit-obj -O3 -Rcompile-job-cache -fdepscan-prefix-map %t.dir/b /testdir \
 // RUN:   -x c %s -o %t.o -fcas-path %t.dir/cas -fprofile-instrument-use=clang -fprofile-instrument-use-path=%t.dir/b/a.profdata
 // RUN: cat %t4.rsp | FileCheck %s --check-prefix=REMAP
 // RUN: %clang @%t4.rsp 2>&1 | FileCheck %s --check-prefix=CACHE-MISS
@@ -39,4 +39,4 @@
 // RUN: grep llvmcas %t.dir/cache-key1
 // RUN: diff -u %t.dir/cache-key1 %t.dir/cache-key2
 
-// REMAP: -fprofile-instrument-use-path=/^testdir{{/|\\\\}}a.profdata
+// REMAP: -fprofile-instrument-use-path={{/|\\\\}}testdir{{/|\\\\}}a.profdata

--- a/clang/test/CAS/validate-once.c
+++ b/clang/test/CAS/validate-once.c
@@ -1,5 +1,4 @@
-// TODO: Enable for Windows when cc1depscand is implemented
-// REQUIRES: !system-windows, clang-cc1daemon
+// REQUIRES: clang-cc1daemon
 
 // RUN: rm -rf %t
 

--- a/clang/tools/driver/cc1depscanProtocol.cpp
+++ b/clang/tools/driver/cc1depscanProtocol.cpp
@@ -17,72 +17,18 @@
 #include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/StringSaver.h"
+#include "llvm/Support/Program.h"
+#include <chrono>
 #include <cstdlib>
-
-#if LLVM_ON_UNIX
-#include <sys/socket.h> // FIXME: Unix-only. Not portable.
-#include <sys/types.h>  // FIXME: Unix-only. Not portable.
-#include <sys/un.h>     // FIXME: Unix-only. Not portable.
+#include <thread>
 
 using namespace clang;
 using namespace clang::cc1depscand;
 using namespace llvm;
 
-static constexpr const char *SocketExtension = ".sock";
-
-int cc1depscand::createSocket() { return ::socket(AF_UNIX, SOCK_STREAM, 0); }
-
-int cc1depscand::acceptSocket(int Socket) {
-  sockaddr_un DataAddress;
-  socklen_t DataLength;
-  return ::accept(Socket, reinterpret_cast<sockaddr *>(&DataAddress),
-                  &DataLength);
-}
-
-static sockaddr_un configureAddress(StringRef BasePath) {
-  sockaddr_un Address;
-  SmallString<128> SocketPath = BasePath;
-  SocketPath.append(SocketExtension);
-
-  Address.sun_family = AF_UNIX;
-  if (SocketPath.size() >= sizeof(Address.sun_path))
-    llvm::cantFail(llvm::errorCodeToError(
-        std::error_code(ENAMETOOLONG, std::generic_category())));
-  ::strncpy(Address.sun_path, SocketPath.c_str(), sizeof(Address.sun_path));
-  return Address;
-}
-
-void cc1depscand::unlinkBoundSocket(StringRef BasePath) {
-  SmallString<128> SocketPath = BasePath;
-  SocketPath.append(SocketExtension);
-  ::unlink(SocketPath.c_str());
-}
-
-int cc1depscand::connectToSocket(StringRef BasePath, int Socket) {
-  sockaddr_un Address = configureAddress(BasePath);
-  return ::connect(Socket, reinterpret_cast<sockaddr *>(&Address),
-                   sizeof(Address));
-}
-int cc1depscand::bindToSocket(StringRef BasePath, int Socket) {
-  sockaddr_un Address = configureAddress(BasePath);
-  if (int Failure = ::bind(Socket, reinterpret_cast<sockaddr *>(&Address),
-                           sizeof(Address))) {
-    if (errno == EADDRINUSE) {
-      unlinkBoundSocket(BasePath);
-      Failure = ::bind(Socket, reinterpret_cast<sockaddr *>(&Address),
-                       sizeof(Address));
-    }
-    if (Failure)
-      return Failure;
-  }
-
-  // FIXME: shouldn't compute socket path twice. Also, not sure this is working
-  // on crashes.
-  SmallString<128> SocketPath = BasePath;
-  SocketPath.append(SocketExtension);
-  llvm::sys::RemoveFileOnSignal(SocketPath);
-  return 0;
-}
+//===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
 
 std::string cc1depscand::getBasePath(StringRef DaemonKey) {
   assert(!DaemonKey.empty() && "Expected valid daemon key");
@@ -96,176 +42,11 @@ std::string cc1depscand::getBasePath(StringRef DaemonKey) {
   return BasePath.str().str();
 }
 
-Expected<OpenSocket> OpenSocket::create(StringRef BasePath) {
-  OpenSocket Socket(::socket(AF_UNIX, SOCK_STREAM, 0));
-  if (Socket == -1)
-    return llvm::errorCodeToError(
-        std::error_code(errno, std::generic_category()));
-  return std::move(Socket);
-}
+static constexpr const char *SocketExtension = ".sock";
 
-Expected<ScanDaemon> ScanDaemon::connectToDaemon(StringRef BasePath,
-                                                 bool ShouldWait) {
-  auto reportError = [BasePath](Error &&E) -> Error {
-    return llvm::createStringError(
-        llvm::inconvertibleErrorCode(),
-        Twine("could not connect to scan daemon on path '") + BasePath +
-            "': " + toString(std::move(E)));
-  };
-
-  Expected<OpenSocket> Socket = OpenSocket::create(BasePath);
-  if (!Socket)
-    return reportError(Socket.takeError());
-
-  // Wait up to 60 seconds.
-  constexpr int MaxWait = 60 * 1000 * 1000;
-  int NextBackoff = 0;
-  int TotalBackoff = 0;
-  while (TotalBackoff < MaxWait) {
-    TotalBackoff += NextBackoff;
-    if (NextBackoff > 0) {
-      if (!ShouldWait)
-        break;
-      ::usleep(NextBackoff);
-    }
-    ++NextBackoff;
-
-    // The daemon owns the .pid. Try to connect to the server with the .socket.
-    if (!cc1depscand::connectToSocket(BasePath, *Socket))
-      return ScanDaemon(std::move(*Socket));
-
-    if (errno != ENOENT && errno != ECONNREFUSED)
-      return reportError(llvm::errorCodeToError(
-          std::error_code(errno, std::generic_category())));
-  }
-
-  return llvm::createStringError(
-      std::make_error_code(std::errc::timed_out),
-      "timeout when connecting to scan daemon on path: '" + BasePath + "'");
-}
-
-Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
-                                              const char *Arg0,
-                                              const DepscanSharing &Sharing) {
-  std::string BasePathCStr = BasePath.str();
-  const char *Args[] = {
-      Arg0,
-      "-cc1depscand",
-      "-run",
-      BasePathCStr.c_str(),
-  };
-
-  ArrayRef<const char *> InitialArgs = ArrayRef(Args);
-  SmallVector<const char *> LaunchArgs(InitialArgs.begin(), InitialArgs.end());
-
-  llvm::BumpPtrAllocator Alloc;
-  llvm::StringSaver Saver(Alloc);
-
-  if (Sharing.ShareViaIdentifier) {
-    // Invocations that share state via identifier will be isolated from
-    // unrelated daemons, so the daemon they share is safe to stay alive longer.
-    LaunchArgs.push_back("-long-running");
-  }
-  LaunchArgs.push_back("-cas-args");
-  LaunchArgs.append(Sharing.CASArgs);
-  LaunchArgs.push_back(nullptr);
-
-  // Spawn attributes
-  posix_spawnattr_t Attrs;
-  if (int EC = posix_spawnattr_init(&Attrs))
-    return llvm::errorCodeToError(std::error_code(EC, std::generic_category()));
-  llvm::scope_exit Attrs_cleanup([&] { posix_spawnattr_destroy(&Attrs); });
-
-#ifdef POSIX_SPAWN_CLOEXEC_DEFAULT
-  // In the spawned process, close all file descriptors that are not explicitly
-  // described by the file actions object. This is particularly relevant for
-  // llbuild which waits on a "control file handle" and, if inherited, it would
-  // cause llbuild to wait for the spawned process to exit.
-  // FIXME: This is Darwin-specific extension, perform the same function on
-  // non-darwin platforms.
-  if (int EC = posix_spawnattr_setflags(&Attrs, POSIX_SPAWN_CLOEXEC_DEFAULT))
-    return llvm::errorCodeToError(std::error_code(EC, std::generic_category()));
-#endif
-
-  static constexpr const char *PassThroughEnv[] = {
-      "LLVM_CAS_LOG",
-      "LLVM_CAS_DISABLE_VALIDATION",
-      "LLVM_CAS_MAX_MAPPING_SIZE",
-  };
-  SmallVector<const char *> EnvP;
-  for (const char *Name : PassThroughEnv)
-    if (const char *Value = getenv(Name))
-      EnvP.push_back(Saver.save(llvm::Twine(Name) + "=" + Value).data());
-  EnvP.push_back(nullptr);
-
-  ::pid_t Pid;
-  int EC = ::posix_spawn(&Pid, Args[0], /*file_actions=*/nullptr, &Attrs,
-                         const_cast<char **>(LaunchArgs.data()),
-                         const_cast<char **>(EnvP.data()));
-  if (EC)
-    return llvm::errorCodeToError(std::error_code(EC, std::generic_category()));
-
-  return connectToJustLaunchedDaemon(BasePath);
-}
-
-Expected<ScanDaemon> ScanDaemon::create(StringRef BasePath, const char *Arg0,
-                                        const DepscanSharing &Sharing) {
-  if (Expected<ScanDaemon> Daemon = connectToExistingDaemon(BasePath))
-    return Daemon;
-  else
-    llvm::consumeError(Daemon.takeError()); // FIXME: Sometimes return.
-
-  return launchDaemon(BasePath, Arg0, Sharing);
-}
-
-Expected<ScanDaemon>
-ScanDaemon::constructAndShakeHands(StringRef BasePath, const char *Arg0,
-                                   const DepscanSharing &Sharing) {
-  auto Daemon = ScanDaemon::create(BasePath, Arg0, Sharing);
-  if (!Daemon)
-    return Daemon.takeError();
-
-  // If handshake failed, try relaunch the daemon.
-  if (auto E = Daemon->shakeHands()) {
-    logAllUnhandledErrors(std::move(E), llvm::errs(),
-                          "Restarting daemon due to error: ");
-
-    auto NewDaemon = launchDaemon(BasePath, Arg0, Sharing);
-    // If recover failed, return Error.
-    if (!NewDaemon)
-      return NewDaemon.takeError();
-    if (auto NE = NewDaemon->shakeHands())
-      return std::move(NE);
-
-    return NewDaemon;
-  }
-
-  return Daemon;
-}
-
-Expected<ScanDaemon> ScanDaemon::connectToDaemonAndShakeHands(StringRef Path) {
-  auto Daemon = ScanDaemon::connectToExistingDaemon(Path);
-  if (!Daemon)
-    return Daemon.takeError();
-
-  if (auto E = Daemon->shakeHands())
-    return std::move(E);
-
-  return Daemon;
-}
-
-Error ScanDaemon::shakeHands() const {
-  cc1depscand::CC1DepScanDProtocol Comms(*this);
-  cc1depscand::CC1DepScanDProtocol::ResultKind Result;
-  if (auto E = Comms.getResultKind(Result))
-    return E;
-
-  if (Result != cc1depscand::CC1DepScanDProtocol::SuccessResult)
-    return llvm::errorCodeToError(
-        std::error_code(ENOTCONN, std::generic_category()));
-
-  return llvm::Error::success();
-}
+//===----------------------------------------------------------------------===//
+// Protocol Implementation
+//===----------------------------------------------------------------------===//
 
 llvm::Error CC1DepScanDProtocol::putArgs(ArrayRef<const char *> Args) {
   // Construct the args block.
@@ -312,6 +93,27 @@ CC1DepScanDProtocol::getCommand(llvm::StringSaver &Saver,
   return llvm::Error::success();
 }
 
+llvm::Error CC1DepScanDProtocol::putScanResultSuccess(
+    StringRef RootID, ArrayRef<const char *> Args, StringRef DiagnosticOutput) {
+  if (Error E = putResultKind(SuccessResult))
+    return E;
+  if (Error E = putString(RootID))
+    return E;
+  if (Error E = putArgs(Args))
+    return E;
+  return putString(DiagnosticOutput);
+}
+
+llvm::Error
+CC1DepScanDProtocol::putScanResultFailed(StringRef Reason,
+                                         StringRef DiagnosticOutput) {
+  if (Error E = putResultKind(ErrorResult))
+    return E;
+  if (Error E = putString(Reason))
+    return E;
+  return putString(DiagnosticOutput);
+}
+
 llvm::Error
 CC1DepScanDProtocol::getScanResult(llvm::StringSaver &Saver, ResultKind &Result,
                                    StringRef &FailedReason, StringRef &RootID,
@@ -338,25 +140,179 @@ CC1DepScanDProtocol::getScanResult(llvm::StringSaver &Saver, ResultKind &Result,
   return getString(Saver, DiagnosticOutput);
 }
 
-llvm::Error CC1DepScanDProtocol::putScanResultSuccess(
-    StringRef RootID, ArrayRef<const char *> Args, StringRef DiagnosticOutput) {
-  if (Error E = putResultKind(SuccessResult))
-    return E;
-  if (Error E = putString(RootID))
-    return E;
-  if (Error E = putArgs(Args))
-    return E;
-  return putString(DiagnosticOutput);
+//===----------------------------------------------------------------------===//
+// Daemon Connection & Lifecycle
+//===----------------------------------------------------------------------===//
+
+Expected<ScanDaemon> ScanDaemon::connectToDaemon(StringRef BasePath,
+                                                 bool ShouldWait) {
+  // Construct the socket path.
+  SmallString<128> SocketPath = BasePath;
+  SocketPath.append(SocketExtension);
+
+  auto reportError = [SocketPath](Error &&E) -> Error {
+    return llvm::createStringError(
+        llvm::inconvertibleErrorCode(),
+        Twine("could not connect to scan daemon on path '") + SocketPath +
+            "': " + toString(std::move(E)));
+  };
+
+  // Wait up to 60 seconds.
+  constexpr int MaxWait = 60 * 1000 * 1000;
+  int NextBackoff = 0;
+  int TotalBackoff = 0;
+  while (TotalBackoff < MaxWait) {
+    TotalBackoff += NextBackoff;
+    if (NextBackoff > 0) {
+      if (!ShouldWait)
+        break;
+      std::this_thread::sleep_for(std::chrono::microseconds(NextBackoff));
+    }
+    ++NextBackoff;
+
+    // Try to connect to the daemon socket.
+    Expected<std::unique_ptr<llvm::raw_socket_stream>> Stream =
+        llvm::raw_socket_stream::createConnectedUnix(SocketPath);
+
+    if (Stream)
+      return ScanDaemon(std::move(*Stream));
+
+    // Check if we should retry based on the error.
+    Error E = Stream.takeError();
+    std::error_code EC = errorToErrorCode(std::move(E));
+
+    bool ShouldRetry = (EC == std::errc::no_such_file_or_directory ||
+                        EC == std::errc::connection_refused);
+#ifdef _WIN32
+    // On Windows, AF_UNIX may return WSAENETDOWN (10050) or WSAECONNREFUSED
+    // (10061) when the socket file exists but the daemon isn't ready yet.
+    if (EC.value() == 10050 || EC.value() == 10061)
+      ShouldRetry = true;
+#endif
+
+    if (!ShouldRetry)
+      return reportError(llvm::errorCodeToError(EC));
+
+    // Consume the error and retry.
+    llvm::consumeError(llvm::errorCodeToError(EC));
+  }
+
+  return llvm::createStringError(
+      std::make_error_code(std::errc::timed_out),
+      "timeout when connecting to scan daemon on path: '" + BasePath + "'");
 }
 
-llvm::Error
-CC1DepScanDProtocol::putScanResultFailed(StringRef Reason,
-                                         StringRef DiagnosticOutput) {
-  if (Error E = putResultKind(ErrorResult))
-    return E;
-  if (Error E = putString(Reason))
-    return E;
-  return putString(DiagnosticOutput);
+Expected<ScanDaemon> ScanDaemon::launchDaemon(StringRef BasePath,
+                                              const char *Arg0,
+                                              const DepscanSharing &Sharing) {
+  SmallVector<StringRef> LaunchArgs;
+  // First argument must be the program name (argv[0])
+  LaunchArgs.push_back(Arg0);
+  LaunchArgs.push_back("-cc1depscand");
+  LaunchArgs.push_back("-run");
+  LaunchArgs.push_back(BasePath);
+
+  if (Sharing.ShareViaIdentifier) {
+    // Invocations that share state via identifier will be isolated from
+    // unrelated daemons, so the daemon they share is safe to stay alive longer.
+    LaunchArgs.push_back("-long-running");
+  }
+  LaunchArgs.push_back("-cas-args");
+  for (const char *Arg : Sharing.CASArgs)
+    LaunchArgs.push_back(Arg);
+
+  // Set up environment variables to pass through.
+  static constexpr const char *PassThroughEnv[] = {
+      "LLVM_CAS_LOG",
+      "LLVM_CAS_DISABLE_VALIDATION",
+      "LLVM_CAS_MAX_MAPPING_SIZE",
+#if defined(_WIN32)
+      "SYSTEMROOT",
+      "Path",
+#endif
+  };
+  llvm::BumpPtrAllocator Alloc;
+  llvm::StringSaver Saver(Alloc);
+  SmallVector<StringRef> Env;
+  for (const char *Name : PassThroughEnv)
+    if (const char *Value = getenv(Name))
+      Env.push_back(Saver.save(llvm::Twine(Name) + "=" + Value));
+
+  // Spawn the daemon process without waiting for it.
+  std::string ErrMsg;
+  bool ExecutionFailed = false;
+  std::optional<ArrayRef<StringRef>> EnvOpt =
+      Env.empty() ? std::nullopt : std::optional<ArrayRef<StringRef>>(Env);
+
+  llvm::sys::ProcessInfo PI = llvm::sys::ExecuteNoWait(
+      Arg0, LaunchArgs, EnvOpt, {}, 0, &ErrMsg, &ExecutionFailed);
+
+  if (ExecutionFailed || PI.Pid == llvm::sys::ProcessInfo::InvalidPid)
+    return llvm::createStringError(std::make_error_code(std::errc::invalid_argument),
+                                   Twine("failed to launch daemon: ") + ErrMsg);
+
+  // Give the daemon a moment to start up and create the socket before attempting
+  // to connect. This reduces spurious connection failures and retries.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  return connectToJustLaunchedDaemon(BasePath);
 }
 
-#endif /* LLVM_ON_UNIX */
+Error ScanDaemon::shakeHands() {
+  cc1depscand::CC1DepScanDProtocol Comms(getStream());
+  cc1depscand::CC1DepScanDProtocol::ResultKind Result;
+  if (auto E = Comms.getResultKind(Result))
+    return E;
+
+  if (Result != cc1depscand::CC1DepScanDProtocol::SuccessResult)
+    return llvm::createStringError(std::errc::not_connected,
+                                   "handshake failed");
+
+  return llvm::Error::success();
+}
+
+Expected<ScanDaemon> ScanDaemon::create(StringRef BasePath, const char *Arg0,
+                                        const DepscanSharing &Sharing) {
+  Expected<ScanDaemon> Daemon = connectToExistingDaemon(BasePath);
+  if (Daemon)
+    return Daemon;
+
+  llvm::consumeError(Daemon.takeError()); // FIXME: Sometimes return.
+  return launchDaemon(BasePath, Arg0, Sharing);
+}
+
+Expected<ScanDaemon>
+ScanDaemon::constructAndShakeHands(StringRef BasePath, const char *Arg0,
+                                   const DepscanSharing &Sharing) {
+  auto Daemon = ScanDaemon::create(BasePath, Arg0, Sharing);
+  if (!Daemon)
+    return Daemon.takeError();
+
+  // If handshake failed, try relaunch the daemon.
+  if (auto E = Daemon->shakeHands()) {
+    logAllUnhandledErrors(std::move(E), llvm::errs(),
+                          "Restarting daemon due to error: ");
+
+    auto NewDaemon = launchDaemon(BasePath, Arg0, Sharing);
+    // If recover failed, return Error.
+    if (!NewDaemon)
+      return NewDaemon.takeError();
+    if (auto NE = NewDaemon->shakeHands())
+      return std::move(NE);
+
+    return NewDaemon;
+  }
+
+  return Daemon;
+}
+
+Expected<ScanDaemon> ScanDaemon::connectToDaemonAndShakeHands(StringRef Path) {
+  auto Daemon = ScanDaemon::connectToExistingDaemon(Path);
+  if (!Daemon)
+    return Daemon.takeError();
+
+  if (auto E = Daemon->shakeHands())
+    return std::move(E);
+
+  return Daemon;
+}

--- a/clang/tools/driver/cc1depscanProtocol.h
+++ b/clang/tools/driver/cc1depscanProtocol.h
@@ -14,15 +14,11 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/StringSaver.h"
-
-#if LLVM_ON_UNIX
-#include <spawn.h>      // FIXME: Unix-only. Not portable.
-#include <sys/socket.h> // FIXME: Unix-only. Not portable.
-#include <sys/types.h>  // FIXME: Unix-only. Not portable.
-#include <sys/un.h>     // FIXME: Unix-only. Not portable.
-#include <unistd.h>     // FIXME: Unix-only. Not portable.
+#include "llvm/Support/raw_socket_stream.h"
 
 namespace clang::cc1depscand {
+
+/// Configuration for sharing dependency scanning daemon instances.
 struct DepscanSharing {
   bool OnlyShareParent = false;
   bool ShareViaIdentifier = false;
@@ -32,54 +28,104 @@ struct DepscanSharing {
   SmallVector<const char *> CASArgs;
 };
 
+/// Represents an argument edit for automatic argument updates.
 struct AutoArgEdit {
   uint32_t Index = -1u;
   StringRef NewArg;
 };
 
+/// Get the base path for daemon socket based on a daemon key.
 std::string getBasePath(StringRef DaemonKey);
 
-int createSocket();
-int connectToSocket(StringRef BasePath, int Socket);
-int bindToSocket(StringRef BasePath, int Socket);
-void unlinkBoundSocket(StringRef BasePath);
-int acceptSocket(int Socket);
+/// Manages a connection to a dependency scanning daemon process.
+/// Handles daemon lifecycle (launching, connecting, handshaking) and provides
+/// access to the underlying socket stream for communication.
+class ScanDaemon {
+public:
+  static Expected<ScanDaemon> create(StringRef BasePath, const char *Arg0,
+                                     const DepscanSharing &Sharing);
+
+  static Expected<ScanDaemon>
+  constructAndShakeHands(StringRef BasePath, const char *Arg0,
+                         const DepscanSharing &Sharing);
+
+  static Expected<ScanDaemon> connectToDaemonAndShakeHands(StringRef BasePath);
+
+  llvm::Error shakeHands();
+
+  llvm::raw_socket_stream &getStream() { return *Stream; }
+  const llvm::raw_socket_stream &getStream() const { return *Stream; }
+
+  ScanDaemon(ScanDaemon &&) = default;
+  ScanDaemon &operator=(ScanDaemon &&) = default;
+
+  ScanDaemon(const ScanDaemon &) = delete;
+  ScanDaemon &operator=(const ScanDaemon &) = delete;
+
+  // Destructor explicitly closes the socket and clears any errors to prevent
+  // fatal error in raw_ostream destructor. On Windows, socket close can trigger
+  // errors when the peer has already closed the connection.
+  // By calling close() first, we set FD = -1 and ShouldClose = false, so the
+  // base class destructor's close path is skipped entirely.
+  ~ScanDaemon() {
+    if (Stream) {
+      Stream->close();
+      Stream->clear_error();
+    }
+  }
+
+private:
+  static Expected<ScanDaemon> launchDaemon(StringRef BasePath, const char *Arg0,
+                                           const DepscanSharing &Sharing);
+  static Expected<ScanDaemon> connectToDaemon(StringRef BasePath,
+                                              bool ShouldWait);
+  static Expected<ScanDaemon> connectToExistingDaemon(StringRef BasePath) {
+    return connectToDaemon(BasePath, /*ShouldWait=*/false);
+  }
+  static Expected<ScanDaemon> connectToJustLaunchedDaemon(StringRef BasePath) {
+    return connectToDaemon(BasePath, /*ShouldWait=*/true);
+  }
+
+  explicit ScanDaemon(std::unique_ptr<llvm::raw_socket_stream> Stream)
+      : Stream(std::move(Stream)) {}
+
+  std::unique_ptr<llvm::raw_socket_stream> Stream;
+};
 
 class CC1DepScanDProtocol {
 public:
-  llvm::Error getMessage(size_t BytesToRead, SmallVectorImpl<char> &Bytes) {
+  llvm::Error getMessage(size_t BytesToRead, llvm::SmallVectorImpl<char> &Bytes) {
     Bytes.clear();
     while (BytesToRead) {
       constexpr size_t BufferSize = 4096;
       char Buffer[BufferSize];
-      size_t BytesRead = ::read(Socket, static_cast<void *>(Buffer),
-                                std::min(BytesToRead, BufferSize));
-      if (BytesRead == -1ull)
-        return llvm::errorCodeToError(
-            std::error_code(errno, std::generic_category()));
-      Bytes.append(Buffer, Buffer + BytesRead);
+      ssize_t BytesRead = Stream.read(Buffer, std::min(BytesToRead, BufferSize));
 
-      if (!BytesRead || BytesRead > BytesToRead)
-        return llvm::errorCodeToError(
-            std::error_code(EMSGSIZE, std::generic_category()));
+      if (BytesRead < 0) {
+        std::error_code EC = Stream.error();
+        if (EC)
+          return llvm::errorCodeToError(EC);
+        return llvm::createStringError(std::errc::io_error,
+                                       "socket read error");
+      }
+
+      if (BytesRead == 0)
+        return llvm::createStringError(std::errc::message_size,
+                                       "unexpected end of stream");
+
+      Bytes.append(Buffer, Buffer + BytesRead);
       BytesToRead -= BytesRead;
     }
     return llvm::Error::success();
   }
 
   llvm::Error putMessage(size_t BytesToWrite, const char *Bytes) {
-    while (BytesToWrite) {
-      size_t BytesWritten = ::write(Socket, Bytes, BytesToWrite);
-      if (BytesWritten == -1ull)
-        return llvm::errorCodeToError(
-            std::error_code(errno, std::generic_category()));
+    Stream.write(Bytes, BytesToWrite);
+    Stream.flush();
 
-      if (!BytesWritten || BytesWritten > BytesToWrite)
-        return llvm::errorCodeToError(
-            std::error_code(EMSGSIZE, std::generic_category()));
-      BytesToWrite -= BytesWritten;
-      Bytes += BytesWritten;
-    }
+    if (std::error_code EC = Stream.error())
+      return llvm::errorCodeToError(EC);
+
     return llvm::Error::success();
   }
 
@@ -149,86 +195,14 @@ public:
                             SmallVectorImpl<const char *> &Args,
                             StringRef &DiagnosticOutput);
 
-  explicit CC1DepScanDProtocol(int Socket) : Socket(Socket) {}
+  explicit CC1DepScanDProtocol(llvm::raw_socket_stream &Stream)
+      : Stream(Stream) {}
   CC1DepScanDProtocol() = delete;
 
 private:
-  int Socket;
+  llvm::raw_socket_stream &Stream;
   SmallString<128> Message;
 };
+}
 
-class FileDescriptor {
-public:
-  operator int() const { return FD; }
-
-  FileDescriptor() = default;
-  explicit FileDescriptor(int FD) : FD(FD) {}
-
-  FileDescriptor(FileDescriptor &&X) : FD(X) { X.FD = -1; }
-  FileDescriptor &operator=(FileDescriptor &&X) {
-    close();
-    FD = X.FD;
-    X.FD = -1;
-    return *this;
-  }
-
-  FileDescriptor(const FileDescriptor &) = delete;
-  FileDescriptor &operator=(const FileDescriptor &) = delete;
-
-  ~FileDescriptor() { close(); }
-
-private:
-  void close() {
-    if (FD == -1)
-      return;
-    ::close(FD);
-    FD = -1;
-  }
-  int FD = -1;
-};
-
-class OpenSocket : public FileDescriptor {
-public:
-  static Expected<OpenSocket> create(StringRef BasePath);
-
-  OpenSocket() = delete;
-
-  OpenSocket(OpenSocket &&) = default;
-  OpenSocket &operator=(OpenSocket &&Socket) = default;
-
-private:
-  explicit OpenSocket(int FD) : FileDescriptor(FD) {}
-};
-
-class ScanDaemon : public OpenSocket {
-public:
-  static Expected<ScanDaemon> create(StringRef BasePath, const char *Arg0,
-                                     const DepscanSharing &Sharing);
-
-  static Expected<ScanDaemon>
-  constructAndShakeHands(StringRef BasePath, const char *Arg0,
-                         const DepscanSharing &Sharing);
-
-  static Expected<ScanDaemon> connectToDaemonAndShakeHands(StringRef BasePath);
-
-  llvm::Error shakeHands() const;
-
-private:
-  static Expected<ScanDaemon> launchDaemon(StringRef BasePath, const char *Arg0,
-                                           const DepscanSharing &Sharing);
-  static Expected<ScanDaemon> connectToDaemon(StringRef BasePath,
-                                              bool ShouldWait);
-  static Expected<ScanDaemon> connectToExistingDaemon(StringRef BasePath) {
-    return connectToDaemon(BasePath, /*ShouldWait=*/false);
-  }
-  static Expected<ScanDaemon> connectToJustLaunchedDaemon(StringRef BasePath) {
-    return connectToDaemon(BasePath, /*ShouldWait=*/true);
-  }
-
-  explicit ScanDaemon(OpenSocket S) : OpenSocket(std::move(S)) {}
-};
-
-} // namespace clang::cc1depscand
-
-#endif /* LLVM_ON_UNIX */
 #endif // LLVM_CLANG_TOOLS_DRIVER_CC1DEPSCANPROTOCOL_H

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -25,6 +25,7 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/CAS/CASProvidingFileSystem.h"
@@ -35,7 +36,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/IOSandbox.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
@@ -44,13 +45,24 @@
 #include "llvm/Support/ThreadPool.h"
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/raw_socket_stream.h"
+#include "llvm/Support/ConvertUTF.h"
+#include <chrono>
+#include <cstdio>
 #include <mutex>
 #include <optional>
 
 #if LLVM_ON_UNIX
-#include <sys/file.h> // FIXME: Unix-only. Not portable.
-#include <sys/signal.h> // FIXME: Unix-only. Not portable.
+#include <sys/file.h>
+#include <sys/signal.h>
+#include <unistd.h>
 #endif // LLVM_ON_UNIX
+
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#include <tlhelp32.h> // For process enumeration
+#endif
 
 #ifdef CLANG_HAVE_RLIMITS
 #include <sys/resource.h>
@@ -58,9 +70,7 @@
 
 using namespace clang;
 using namespace llvm::opt;
-#if LLVM_ON_UNIX
 using cc1depscand::DepscanSharing;
-#endif // LLVM_ON_UNIX
 using llvm::Error;
 
 #define DEBUG_TYPE "cc1depscand"
@@ -155,6 +165,28 @@ static void ensureSufficientStack() {
   // that we can actually use that much, if necessary.
   ensureStackAddressSpace();
 }
+#elif defined(_WIN32)
+/// Check that we have sufficient stack space on Windows.
+/// Note: Unlike Unix, Windows stack size cannot be changed at runtime.
+/// It's set at process creation time via the PE header or CreateThread.
+static void ensureSufficientStack() {
+  // GetCurrentThreadStackLimits requires Windows 8 or later
+  ULONG_PTR LowLimit, HighLimit;
+  GetCurrentThreadStackLimits(&LowLimit, &HighLimit);
+
+  // Calculate available stack size
+  size_t StackSize = HighLimit - LowLimit;
+
+  // If we don't have enough stack space, warn the user
+  // We can't increase it dynamically on Windows like we can on Unix
+  if (StackSize < DesiredStackSize) {
+    llvm::errs() << "Warning: Stack size (" << StackSize
+                 << " bytes) is less than desired size ("
+                 << DesiredStackSize << " bytes).\n";
+    llvm::errs() << "Consider increasing stack size via linker flags "
+                 << "(/STACK on MSVC) or executable properties.\n";
+  }
+}
 #else
 static void ensureSufficientStack() {}
 #endif
@@ -197,13 +229,19 @@ private:
 };
 } // namespace
 
-#ifdef LLVM_ON_UNIX
 namespace {
-/// FIXME: Move to LLVMSupport; probably llvm/Support/Process.h.
+/// Process ancestry information for daemon sharing.
 ///
-/// TODO: Get this working on Linux:
-/// - Reading `/proc/[pid]/comm` for the command names.
-/// - Walk up the `ppid` fields in `/proc/[pid]/stat`.
+/// Provides cross-platform access to process parent/child relationships:
+/// - Apple: Uses libproc API (proc_pidinfo)
+/// - Linux: Reads /proc/[pid]/stat and /proc/[pid]/comm
+/// - Windows: Uses CreateToolhelp32Snapshot for process enumeration
+///
+/// All three platforms provide PID, parent PID, and process name.
+///
+/// Note: This could potentially be moved to llvm/Support/Process.h as a
+/// cross-platform utility, but process ancestry is primarily used for
+/// daemon sharing heuristics and may not have broad applicability.
 struct ProcessAncestor {
   uint64_t PID = ~0ULL;
   uint64_t PPID = ~0ULL;
@@ -244,20 +282,45 @@ private:
 } // end namespace
 
 uint64_t ProcessAncestorIterator::getThisPID() {
-  // FIXME: Not portable.
-  return ::getpid();
+  return llvm::sys::Process::getProcessId();
 }
 
 uint64_t ProcessAncestorIterator::getParentPID() {
-  // FIXME: Not portable.
+#if defined(_WIN32)
+  DWORD CurrentPID = GetCurrentProcessId();
+  HANDLE Snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if (Snapshot == INVALID_HANDLE_VALUE)
+    return ~0ULL;
+
+  // Use ANSI version explicitly to ensure char-based strings
+  PROCESSENTRY32 Entry;
+  Entry.dwSize = sizeof(PROCESSENTRY32);
+
+  bool Found = false;
+  DWORD ParentPID = 0;
+  if (Process32First(Snapshot, &Entry)) {
+    do {
+      if (Entry.th32ProcessID == CurrentPID) {
+        ParentPID = Entry.th32ParentProcessID;
+        Found = true;
+        break;
+      }
+    } while (Process32Next(Snapshot, &Entry));
+  }
+
+  CloseHandle(Snapshot);
+  return Found ? static_cast<uint64_t>(ParentPID) : ~0ULL;
+#else
   return ::getppid();
+#endif
 }
 
 ProcessAncestorIterator &ProcessAncestorIterator::setPID(uint64_t NewPID) {
   // Reset state in case NewPID isn't found.
   Ancestor = ProcessAncestor();
 
-#ifdef USE_APPLE_LIBPROC_FOR_DEPSCAN_ANCESTORS
+#if defined(USE_APPLE_LIBPROC_FOR_DEPSCAN_ANCESTORS)
+  // Apple: Use libproc API
   pid_t TypeCorrectPID = NewPID;
   if (proc_pidinfo(TypeCorrectPID, PROC_PIDTBSDINFO, 0, &ProcInfo,
                    sizeof(ProcInfo)) != sizeof(ProcInfo))
@@ -266,9 +329,104 @@ ProcessAncestorIterator &ProcessAncestorIterator::setPID(uint64_t NewPID) {
   Ancestor.PID = NewPID;
   Ancestor.PPID = ProcInfo.pbi_ppid;
   Ancestor.Name = StringRef(ProcInfo.pbi_name);
+
+#elif defined(__linux__)
+  // Linux: Read from /proc filesystem
+  SmallString<64> StatPath;
+  llvm::raw_svector_ostream(StatPath) << "/proc/" << NewPID << "/stat";
+
+  auto StatBuf = llvm::MemoryBuffer::getFile(StatPath);
+  if (!StatBuf)
+    return *this; // Process not found or no access
+
+  // Parse the stat file: PID (name) state ppid ...
+  // The name can contain spaces and parentheses, so we need to find the last ')'
+  StringRef StatContent = StatBuf.get()->getBuffer();
+  size_t LastParen = StatContent.rfind(')');
+  if (LastParen == StringRef::npos)
+    return *this; // Invalid format
+
+  // Extract PPID (4th field after the closing parenthesis)
+  StringRef AfterName = StatContent.substr(LastParen + 1).ltrim();
+  SmallVector<StringRef, 8> Fields;
+  AfterName.split(Fields, ' ', /*MaxSplit=*/3);
+  if (Fields.size() < 3)
+    return *this; // Not enough fields
+
+  uint64_t PPID;
+  if (Fields[1].getAsInteger(10, PPID))
+    return *this; // Failed to parse PPID
+
+  // Read process name from /proc/[pid]/comm
+  SmallString<64> CommPath;
+  llvm::raw_svector_ostream(CommPath) << "/proc/" << NewPID << "/comm";
+
+  auto CommBuf = llvm::MemoryBuffer::getFile(CommPath);
+  StringRef ProcName;
+  if (CommBuf) {
+    ProcName = CommBuf.get()->getBuffer().trim();
+    // Store the name in a static container to ensure it persists
+    static llvm::StringMap<std::string> ProcessNames;
+    auto [It, Inserted] = ProcessNames.try_emplace(ProcName.str(), ProcName.str());
+    ProcName = It->second;
+  }
+
+  Ancestor.PID = NewPID;
+  Ancestor.PPID = PPID;
+  Ancestor.Name = ProcName;
+
+#elif defined(_WIN32)
+  // Windows: Use CreateToolhelp32Snapshot to enumerate processes
+  HANDLE Snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+  if (Snapshot == INVALID_HANDLE_VALUE)
+    return *this; // Cannot create snapshot
+
+  // Use Unicode version to properly handle international characters
+  PROCESSENTRY32W Entry;
+  Entry.dwSize = sizeof(PROCESSENTRY32W);
+
+  bool Found = false;
+  if (Process32FirstW(Snapshot, &Entry)) {
+    do {
+      if (Entry.th32ProcessID == static_cast<DWORD>(NewPID)) {
+        // Convert UTF-16 process name to UTF-8
+        std::string ExePathUTF8;
+        size_t ExeFileLen = wcslen(Entry.szExeFile);
+        ArrayRef<llvm::UTF16> ExeFileUTF16(
+            reinterpret_cast<const llvm::UTF16 *>(Entry.szExeFile), ExeFileLen);
+
+        if (!convertUTF16ToUTF8String(ExeFileUTF16, ExePathUTF8)) {
+          // If conversion fails, skip this process
+          CloseHandle(Snapshot);
+          return *this;
+        }
+
+        // Extract the executable name (without path)
+        StringRef ExePath(ExePathUTF8);
+        StringRef ExeName = llvm::sys::path::filename(ExePath);
+
+        // Store the name in a static container to ensure it persists
+        static llvm::StringMap<std::string> ProcessNames;
+        auto [It, Inserted] = ProcessNames.try_emplace(ExeName.str(), ExeName.str());
+
+        Ancestor.PID = NewPID;
+        Ancestor.PPID = Entry.th32ParentProcessID;
+        Ancestor.Name = It->second;
+        Found = true;
+        break;
+      }
+    } while (Process32NextW(Snapshot, &Entry));
+  }
+
+  CloseHandle(Snapshot);
+  if (!Found)
+    return *this; // Process not found
+
 #else
+  // Other platforms: No process ancestry support
   (void)NewPID;
 #endif
+
   return *this;
 }
 
@@ -349,7 +507,36 @@ makeDepscanDaemonPath(StringRef Mode, const DepscanSharing &Sharing) {
 
   return std::nullopt;
 }
-#endif // LLVM_ON_UNIX
+
+
+//===----------------------------------------------------------------------===//
+// Shared Scanning Functions
+//===----------------------------------------------------------------------===//
+
+static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
+    tooling::dependencies::DependencyScanningTool &Tool,
+    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS, const char *Exec,
+    ArrayRef<const char *> InputArgs, StringRef WorkingDirectory,
+    SmallVectorImpl<const char *> &OutputArgs, llvm::cas::ObjectStore &DB,
+    llvm::function_ref<const char *(const Twine &)> SaveArg) {
+  DiagnosticOptions DiagOpts;
+  DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts);
+  Diags.setClient(&DiagsConsumer, /*ShouldOwnClient=*/false);
+  auto Invocation = std::make_shared<CompilerInvocation>();
+  if (!CompilerInvocation::CreateFromArgs(*Invocation, InputArgs, Diags, Exec))
+    return llvm::createStringError(llvm::inconvertibleErrorCode(),
+                                   "failed to create compiler invocation");
+
+  Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
+      Tool, DiagsConsumer, VerboseOS, *Invocation, WorkingDirectory, DB);
+  if (!Root)
+    return Root;
+
+  OutputArgs.resize(1);
+  OutputArgs[0] = "-cc1";
+  Invocation->generateCC1CommandLine(OutputArgs, SaveArg);
+  return *Root;
+}
 
 static int
 scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
@@ -357,16 +544,43 @@ scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
                        SmallVectorImpl<const char *> &OutputArgs,
                        llvm::function_ref<const char *(const Twine &)> SaveArg,
                        const CASOptions &CASOpts, DiagnosticsEngine &Diag,
-                       std::optional<llvm::cas::CASID> &RootID);
+                       std::optional<llvm::cas::CASID> &RootID) {
+  auto [DB, Cache] = CASOpts.getOrCreateDatabases(Diag);
+  if (!DB || !Cache)
+    return 1;
 
-static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
-    tooling::DependencyScanningTool &Tool,
-    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS, const char *Exec,
-    ArrayRef<const char *> InputArgs, StringRef WorkingDirectory,
-    SmallVectorImpl<const char *> &OutputArgs, llvm::cas::ObjectStore &DB,
-    llvm::function_ref<const char *(const Twine &)> SaveArg);
+  tooling::dependencies::DependencyScanningService Service(
+      tooling::dependencies::ScanningMode::DependencyDirectivesScan,
+      tooling::dependencies::ScanningOutputFormat::IncludeTree, CASOpts, DB,
+      Cache);
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> UnderlyingFS =
+      llvm::vfs::createPhysicalFileSystem();
+  UnderlyingFS =
+      llvm::cas::createCASProvidingFileSystem(DB, std::move(UnderlyingFS));
+  tooling::dependencies::DependencyScanningTool Tool(Service,
+                                                     std::move(UnderlyingFS));
 
-#ifdef LLVM_ON_UNIX
+  std::unique_ptr<DiagnosticOptions> DiagOpts =
+      CreateAndPopulateDiagOpts(InputArgs);
+  auto DiagsConsumer =
+      std::make_unique<TextDiagnosticPrinter>(llvm::errs(), *DiagOpts, false);
+
+  auto E = scanAndUpdateCC1InlineWithTool(
+               Tool, *DiagsConsumer, /*VerboseOS*/ nullptr, Exec, InputArgs,
+               WorkingDirectory, OutputArgs, *DB, SaveArg)
+               .moveInto(RootID);
+  if (E) {
+    Diag.Report(diag::err_cas_depscan_failed) << std::move(E);
+    return 1;
+  }
+
+  return DiagsConsumer->getNumErrors() != 0;
+}
+
+//===----------------------------------------------------------------------===//
+// Client-Side Code
+//===----------------------------------------------------------------------===//
+
 static int scanAndUpdateCC1UsingDaemon(
     const char *Exec, ArrayRef<const char *> OldArgs,
     StringRef WorkingDirectory, SmallVectorImpl<const char *> &NewArgs,
@@ -388,7 +602,7 @@ static int scanAndUpdateCC1UsingDaemon(
                     : ScanDaemon::constructAndShakeHands(Path, Exec, Sharing);
   if (!Daemon)
     return reportScanFailure(Daemon.takeError());
-  CC1DepScanDProtocol Comms(*Daemon);
+  CC1DepScanDProtocol Comms(Daemon->getStream());
 
   // llvm::dbgs() << "sending request...\n";
   if (auto E = Comms.putCommand(WorkingDirectory, OldArgs))
@@ -428,7 +642,6 @@ static int scanAndUpdateCC1UsingDaemon(
 
   return 0;
 }
-#endif // LLVM_ON_UNIX
 
 // FIXME: This is a copy of Command::writeResponseFile. Command is too deeply
 // tied with clang::Driver to use directly.
@@ -477,7 +690,6 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
   }
 
   // Collect these before returning to ensure they're claimed.
-#ifdef LLVM_ON_UNIX
   DepscanSharing Sharing;
   if (Arg *A = Args.getLastArg(options::OPT_fdepscan_share_stop_EQ))
     Sharing.Stop = A->getValue();
@@ -513,17 +725,13 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
     }
   }
 
-#endif // LLVM_ON_UNIX
-
   auto SaveArg = [&Args](const Twine &T) { return Args.MakeArgString(T); };
-#ifdef LLVM_ON_UNIX
   CompilerInvocation::GenerateCASArgs(CASOpts, Sharing.CASArgs, SaveArg);
 
   if (auto DaemonPath = makeDepscanDaemonPath(Mode, Sharing))
     return scanAndUpdateCC1UsingDaemon(Exec, OldArgs, WorkingDirectory, NewArgs,
                                        *DaemonPath, Sharing, Diag, SaveArg,
                                        CASOpts, RootID);
-#endif // LLVM_ON_UNIX
 
   return scanAndUpdateCC1Inline(Exec, OldArgs, WorkingDirectory, NewArgs,
                                 SaveArg, CASOpts, Diag, RootID);
@@ -590,8 +798,12 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
   CompilerInvocation::ParseCASArgs(CASOpts, ParsedCC1Args, Diags);
   CASOpts.ensurePersistentCAS();
 
-  if (int Ret = scanAndUpdateCC1(Argv0, CC1Args->getValues(), NewArgs, *VFS,
-                                 Diags, Args, CASOpts, RootID))
+#if defined(_WIN32)
+  llvm::WSABalancer _;
+#endif
+
+  if (int Ret = scanAndUpdateCC1(Argv0, CC1Args->getValues(), NewArgs, Diags,
+                                 Args, CASOpts, RootID))
     return Ret;
 
   // FIXME: Use OutputBackend to OnDisk only now.
@@ -626,16 +838,25 @@ int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
   return 0;
 }
 
-#ifdef LLVM_ON_UNIX
+//===----------------------------------------------------------------------===//
+// Server-Side Code
+//===----------------------------------------------------------------------===//
+
 namespace {
+llvm::ExitOnError ExitOnErr("clang -cc1depscand: ");
+
+void reportError(const llvm::Twine &Message) {
+  ExitOnErr(llvm::createStringError(llvm::inconvertibleErrorCode(), Message));
+}
+
 struct ScanServer {
   const char *Argv0 = nullptr;
   SmallString<128> BasePath;
   CASOptions CASOpts;
   int PidFD = -1;
-  int ListenSocket = -1;
   /// \p std::nullopt means it runs indefinitely.
   std::optional<unsigned> TimeoutSeconds;
+  std::unique_ptr<llvm::ListeningSocket> Listener;
   std::atomic<bool> ShutDown{false};
 
   ~ScanServer() { shutdown(); }
@@ -647,160 +868,37 @@ struct ScanServer {
   /// jobs to finish.
   void shutdown() {
     ShutDown.store(true);
-    // Unlock pidfile first so another daemon can spin up when it can't find
-    // the socket.
-    ::flock(PidFD, LOCK_UN);
-    cc1depscand::unlinkBoundSocket(BasePath);
     // Clean up the pidfile when we're done.
-    if (PidFD != -1)
-      ::close(PidFD);
-    ::shutdown(ListenSocket, SHUT_RD);
-    ::close(ListenSocket);
+    if (PidFD != -1) {
+      // Unlock pidfile first so another daemon can spin up when it can't find
+      // the socket.
+      llvm::sys::fs::unlockFile(PidFD);
+      llvm::sys::Process::SafelyCloseFileDescriptor(PidFD);
+      PidFD = -1;  // Prevent double-close
+    }
+    if (Listener)
+      Listener->shutdown();
   }
 };
-} // anonymous namespace
 
-static llvm::ExitOnError ExitOnErr("clang -cc1depscand: ");
-
-static void reportError(const llvm::Twine &Message) {
-  ExitOnErr(llvm::createStringError(llvm::inconvertibleErrorCode(), Message));
-}
-
-/// Accepted options are:
-///
-/// * -run <path> [-long-running] [-cas-args ...]
-/// Runs the daemon until a timeout is reached without a new connection.
-/// "-long-running" increases the timeout. stdout/stderr are redirected to files
-/// relative to <path>. This is how the clang driver auto-spawns a new daemon.
-///
-/// * -serve <path> [-cas-args ...]
-/// Runs indefinitely (until ctrl+c or the process is killed). There's no
-/// stdout/stderr redirection. Useful for debugging and for starting a permanent
-/// daemon before directing clang invocations to connect to it.
-///
-/// * -execute <path> [-cas-args ...] -- <command ...>
-/// Sets up the socket path, sets \p CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH
-/// enviroment variable to the socket path, and executes the provided command.
-/// It exits with the same exit code as the command. Useful for lit testing.
-int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
-                     void *MainAddr) {
-  ensureSufficientStack();
-
-  if (Argv.size() < 2)
-    reportError("missing command and base-path");
-
-  ScanServer Server;
-  Server.Argv0 = Argv0;
-
-  StringRef Command = Argv[0];
-  Server.BasePath = Argv[1];
-
-  ArrayRef<const char *> CommandArgsToExecute;
-  auto Sep = llvm::find_if(
-      Argv, [](const char *Arg) { return StringRef(Arg) == "--"; });
-  if (Sep != Argv.end()) {
-    CommandArgsToExecute = Argv.drop_front(Sep - Argv.begin() + 1);
-    Argv = Argv.slice(0, Sep - Argv.begin());
-  }
-
-  // Whether the daemon can safely stay alive a longer period of time.
-  // FIXME: Consider designing a mechanism to notify daemons, started for a
-  // particular "build session", to shutdown, then have it stay alive until the
-  // session is finished.
-  bool LongRunning = false;
-  ArrayRef<const char *> CASArgs;
-  for (const auto *A = Argv.begin() + 2; A != Argv.end(); ++A) {
-    StringRef Arg(*A);
-    if (Arg == "-long-running")
-      LongRunning = true;
-    else if (Arg == "-cas-args") {
-      CASArgs = ArrayRef(A + 1, Argv.end());
-      break;
-    }
-  }
-
-  // Create the base directory if necessary.
-  StringRef BaseDir = llvm::sys::path::parent_path(Server.BasePath);
-  if (std::error_code EC = llvm::sys::fs::create_directories(BaseDir))
-    reportError(Twine("cannot create basedir: ") + EC.message());
-
-  if (Command == "-serve") {
-    Server.start(/*Exclusive*/ true, CASArgs);
-    return Server.listen();
-
-  } else if (Command == "-execute") {
-    SmallVector<StringRef, 32> RefArgs;
-    RefArgs.reserve(CommandArgsToExecute.size());
-    for (const char *Arg : CommandArgsToExecute) {
-      RefArgs.push_back(Arg);
-    }
-
-    // Make sure to start the server before executing the command.
-    Server.start(/*Exclusive*/ true, CASArgs);
-    std::thread ServerThread([&Server]() { Server.listen(); });
-
-    setenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH", Server.BasePath.c_str(),
-           true);
-
-    std::string ErrMsg;
-    int Result = llvm::sys::ExecuteAndWait(
-        RefArgs.front(), RefArgs, /*Env*/ std::nullopt,
-        /*Redirects*/ {}, /*SecondsToWait*/ 0,
-        /*MemoryLimit*/ 0, &ErrMsg);
-
-    Server.shutdown();
-    ServerThread.join();
-
-    if (!ErrMsg.empty())
-      reportError("failed executing command: " + ErrMsg);
-    return Result;
-
-  } else if (Command != "-run") {
-    reportError("unknown command '" + Command + "'");
-  }
-
-  Server.TimeoutSeconds = LongRunning ? 120 : 15;
-
-  // Daemonize.
-  if (::signal(SIGHUP, SIG_IGN) == SIG_ERR)
-    reportError("failed to ignore SIGHUP");
-  if (::setsid() == -1)
-    reportError("setsid failed");
-
-  // Check the pidfile.
-  SmallString<128> LogOutPath, LogErrPath;
-  (Server.BasePath + ".out").toVector(LogOutPath);
-  (Server.BasePath + ".err").toVector(LogErrPath);
-
-  auto openAndReplaceFD = [&](int ReplacedFD, StringRef Path) {
-    int FD;
-    if (std::error_code EC = llvm::sys::fs::openFile(
-            Path, FD, llvm::sys::fs::CD_CreateAlways, llvm::sys::fs::FA_Write,
-            llvm::sys::fs::OF_None)) {
-      // Ignoring error?
-      ::close(ReplacedFD);
-      return;
-    }
-    ::dup2(FD, ReplacedFD);
-    ::close(FD);
-  };
-  openAndReplaceFD(1, LogOutPath);
-  openAndReplaceFD(2, LogErrPath);
-
-  Server.start(/*Exclusive*/ false, CASArgs);
-  return Server.listen();
-}
-
-static std::optional<StringRef>
+std::optional<StringRef>
 findLLVMCasBinary(const char *Argv0, llvm::SmallVectorImpl<char> &Storage) {
   using namespace llvm::sys;
+
   std::string Path = fs::getMainExecutable(Argv0, (void *)cc1depscan_main);
   Storage.assign(Path.begin(), Path.end());
   path::remove_filename(Storage);
+#if defined(_WIN32)
+  path::append(Storage, "llvm-cas.exe");
+#else
   path::append(Storage, "llvm-cas");
+#endif
+
   StringRef PathStr(Storage.data(), Storage.size());
   if (fs::exists(PathStr))
     return PathStr;
+
+#if LLVM_ON_UNIX
   // Look for a corresponding usr/local/bin/llvm-cas
   PathStr = path::parent_path(PathStr);
   if (path::filename(PathStr) != "bin")
@@ -811,8 +909,11 @@ findLLVMCasBinary(const char *Argv0, llvm::SmallVectorImpl<char> &Storage) {
   PathStr = StringRef{Storage.data(), Storage.size()};
   if (fs::exists(PathStr))
     return PathStr;
+#endif
+
   return std::nullopt;
 }
+
 
 void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
   // Parse CAS options and validate if needed.
@@ -821,8 +922,7 @@ void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
 
   const OptTable &Opts = getDriverOptTable();
   unsigned MissingArgIndex, MissingArgCount;
-  auto ParsedCASArgs =
-      Opts.ParseArgs(CASArgs, MissingArgIndex, MissingArgCount);
+  auto ParsedCASArgs = Opts.ParseArgs(CASArgs, MissingArgIndex, MissingArgCount);
   CompilerInvocation::ParseCASArgs(CASOpts, ParsedCASArgs, Diags);
   CASOpts.ensurePersistentCAS();
 
@@ -858,7 +958,8 @@ void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
       reportError("cannot open pidfile");
 
     // Try to lock; failure means there's another daemon running.
-    if (::flock(PidFD, LOCK_EX | LOCK_NB)) {
+    if (std::error_code EC = llvm::sys::fs::tryLockFile(
+            PidFD, std::chrono::milliseconds(0), /*Exclusive=*/true)) {
       if (Exclusive)
         reportError("another daemon using the base path");
       ::exit(0);
@@ -867,18 +968,18 @@ void ScanServer::start(bool Exclusive, ArrayRef<const char *> CASArgs) {
     // FIXME: Should we actually write the pid here? Maybe we don't care.
   }();
 
-  // Open the socket and start listening.
-  ListenSocket = cc1depscand::createSocket();
-  if (ListenSocket == -1)
-    reportError("cannot open socket");
-
-  if (cc1depscand::bindToSocket(BasePath, ListenSocket))
-    reportError(StringRef() + "cannot bind to socket" + ": " + strerror(errno));
-
   unsigned MaxBacklog =
       llvm::hardware_concurrency().compute_thread_count() * 16;
-  if (::listen(ListenSocket, MaxBacklog))
-    reportError("cannot listen to socket");
+
+  SmallString<128> SocketPath = BasePath;
+  SocketPath.append(".sock");
+
+  // Open the socket and start listening.
+  llvm::Expected<llvm::ListeningSocket> Socket =
+      llvm::ListeningSocket::createUnix(SocketPath, MaxBacklog);
+  if (!Socket)
+    reportError("cannot create listener: " + llvm::toString(Socket.takeError()));
+  Listener = std::make_unique<llvm::ListeningSocket>(std::move(*Socket));
 }
 
 int ScanServer::listen() {
@@ -907,27 +1008,50 @@ int ScanServer::listen() {
   dependencies::DependencyScanningService Service(std::move(Opts));
 
   std::atomic<int> NumRunning(0);
+  std::mutex AcceptLock;
 
   std::chrono::steady_clock::time_point Start =
       std::chrono::steady_clock::now();
-  std::atomic<uint64_t> SecondsSinceLastClose;
+  std::atomic<uint64_t> SecondsSinceLastClose(0);
 
   SharedStream SharedOS(llvm::errs());
 
   auto ServiceLoop = [this, &CAS, &Service, &NumRunning, &Start,
-                      &SecondsSinceLastClose, &SharedOS](unsigned I) {
-    std::optional<tooling::DependencyScanningTool> Tool;
+                      &SecondsSinceLastClose, &SharedOS,
+                      &AcceptLock](unsigned I) {
+    std::optional<tooling::dependencies::DependencyScanningTool> Tool;
     SmallString<256> Message;
     while (true) {
       if (ShutDown.load())
         return;
 
-      int Data = cc1depscand::acceptSocket(ListenSocket);
-      if (Data == -1)
-        continue;
+      std::unique_ptr<llvm::raw_socket_stream> stream;
+      {
+        std::unique_lock<std::mutex> Guard(AcceptLock);
+        if (ShutDown.load())
+          return;
 
-      llvm::scope_exit CloseData([&]() { ::close(Data); });
-      cc1depscand::CC1DepScanDProtocol Comms(Data);
+        llvm::Expected<std::unique_ptr<llvm::raw_socket_stream>> fd =
+            Listener->accept(std::chrono::milliseconds(1000));
+        if (!fd) {
+          // Timeout or error - continue waiting for next connection
+          llvm::consumeError(fd.takeError());
+          continue;
+        }
+        stream = std::move(*fd);
+      }
+
+      cc1depscand::CC1DepScanDProtocol Comms(*stream);
+
+      // Explicitly close the socket and clear any errors before the stream is
+      // destroyed to prevent fatal error in raw_ostream destructor. On Windows,
+      // socket close can trigger errors when the peer has already closed the
+      // connection. By calling close() first, we set FD = -1 and ShouldClose =
+      // false, so the base class destructor's close path is skipped entirely.
+      auto ClearStreamError = llvm::make_scope_exit([&]() {
+        stream->close();
+        stream->clear_error();
+      });
 
       llvm::scope_exit StopRunning([&]() {
         SecondsSinceLastClose.store(
@@ -1049,7 +1173,7 @@ int ScanServer::listen() {
   const uint64_t SecondsBeforeDestruction = *TimeoutSeconds;
   uint64_t SleepTime = SecondsBeforeDestruction;
   while (true) {
-    ::sleep(SleepTime);
+    std::this_thread::sleep_for(std::chrono::seconds(SleepTime));
     SleepTime = SecondsBetweenAttempts;
 
     if (NumRunning.load())
@@ -1075,70 +1199,156 @@ int ScanServer::listen() {
 
   return 0;
 }
-#endif // LLVM_ON_UNIX
+} // anonymous namespace
 
-static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
-    tooling::DependencyScanningTool &Tool,
-    DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS, const char *Exec,
-    ArrayRef<const char *> InputArgs, StringRef WorkingDirectory,
-    SmallVectorImpl<const char *> &OutputArgs, llvm::cas::ObjectStore &DB,
-    llvm::function_ref<const char *(const Twine &)> SaveArg) {
-  DiagnosticOptions DiagOpts;
-  DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts);
-  Diags.setClient(&DiagsConsumer, /*ShouldOwnClient=*/false);
-  auto Invocation = std::make_shared<CompilerInvocation>();
-  if (!CompilerInvocation::CreateFromArgs(*Invocation, InputArgs, Diags, Exec))
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "failed to create compiler invocation");
 
-  Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
-      Tool, DiagsConsumer, VerboseOS, *Invocation, WorkingDirectory, DB);
-  if (!Root)
-    return Root;
 
-  OutputArgs.resize(1);
-  OutputArgs[0] = "-cc1";
-  Invocation->generateCC1CommandLine(OutputArgs, SaveArg);
-  return *Root;
-}
+/// Accepted options are:
+///
+/// * -run <path> [-long-running] [-cas-args ...]
+/// Runs the daemon until a timeout is reached without a new connection.
+/// "-long-running" increases the timeout. stdout/stderr are redirected to files
+/// relative to <path>. This is how the clang driver auto-spawns a new daemon.
+///
+/// * -serve <path> [-cas-args ...]
+/// Runs indefinitely (until ctrl+c or the process is killed). There's no
+/// stdout/stderr redirection. Useful for debugging and for starting a permanent
+/// daemon before directing clang invocations to connect to it.
+///
+/// * -execute <path> [-cas-args ...] -- <command ...>
+/// Sets up the socket path, sets \p CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH
+/// enviroment variable to the socket path, and executes the provided command.
+/// It exits with the same exit code as the command. Useful for lit testing.
+int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0, void *MainAddr) {
+  if (Argv.size() < 2)
+    reportError("missing command and base-path");
 
-static int
-scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
-                       StringRef WorkingDirectory,
-                       SmallVectorImpl<const char *> &OutputArgs,
-                       llvm::function_ref<const char *(const Twine &)> SaveArg,
-                       const CASOptions &CASOpts, DiagnosticsEngine &Diag,
-                       std::optional<llvm::cas::CASID> &RootID) {
-  auto [DB, Cache] = CASOpts.getOrCreateDatabases(Diag);
-  if (!DB || !Cache)
-    return 1;
+  ensureSufficientStack();
 
-  dependencies::DependencyScanningServiceOptions Opts;
-  Opts.MakeVFS = [DB = DB] {
-    auto BypassSandbox = llvm::sys::sandbox::scopedDisable();
-    return llvm::cas::createCASProvidingFileSystem(
-        DB, llvm::vfs::createPhysicalFileSystem());
-  };
-  Opts.Format = dependencies::ScanningOutputFormat::IncludeTree;
-  Opts.CASOpts = CASOpts;
-  Opts.CAS = DB;
-  Opts.Cache = Cache;
-  dependencies::DependencyScanningService Service(std::move(Opts));
-  tooling::DependencyScanningTool Tool(Service);
+#if defined(_WIN32)
+  llvm::WSABalancer _;
+#endif
 
-  std::unique_ptr<DiagnosticOptions> DiagOpts =
-      CreateAndPopulateDiagOpts(InputArgs);
-  auto DiagsConsumer =
-      std::make_unique<TextDiagnosticPrinter>(llvm::errs(), *DiagOpts, false);
+  StringRef Command = Argv[0];
 
-  auto E = scanAndUpdateCC1InlineWithTool(
-               Tool, *DiagsConsumer, /*VerboseOS*/ nullptr, Exec, InputArgs,
-               WorkingDirectory, OutputArgs, *DB, SaveArg)
-               .moveInto(RootID);
-  if (E) {
-    Diag.Report(diag::err_cas_depscan_failed) << std::move(E);
-    return 1;
+  ScanServer Server;
+  Server.Argv0 = Argv0;
+  Server.BasePath = Argv[1];
+
+  ArrayRef<const char *> CommandArgsToExecute;
+  auto Sep = llvm::find_if(Argv, [](const char *Arg) { return StringRef(Arg) == "--"; });
+  if (Sep != Argv.end()) {
+    CommandArgsToExecute = Argv.drop_front(Sep - Argv.begin() + 1);
+    Argv = Argv.slice(0, Sep - Argv.begin());
   }
 
-  return DiagsConsumer->getNumErrors() != 0;
+  // Whether the daemon can safely stay alive a longer period of time.
+  // FIXME: Consider designing a mechanism to notify daemons, started for a
+  // particular "build session", to shutdown, then have it stay alive until the
+  // session is finished.
+  bool LongRunning = false;
+  ArrayRef<const char *> CASArgs;
+  for (auto [Index, Arg] : llvm::enumerate(Argv)) {
+    if (StringRef(Arg) == "-long-running") {
+      LongRunning = true;
+    } else if (StringRef(Arg) == "-cas-args") {
+      CASArgs = Argv.drop_front(Index + 1);
+      break;
+    }
+  }
+
+  // Create the base directory if necessary.
+  StringRef BaseDir = llvm::sys::path::parent_path(Server.BasePath);
+  if (std::error_code EC = llvm::sys::fs::create_directories(BaseDir))
+    reportError(Twine("cannot create basedir: ") + EC.message());
+
+  if (Command == "-serve") {
+    Server.start(/*Exclusive*/ true, CASArgs);
+    return Server.listen();
+  } else if (Command == "-execute") {
+    SmallVector<StringRef, 32> RefArgs;
+    RefArgs.reserve(CommandArgsToExecute.size());
+    for (const char *Arg : CommandArgsToExecute)
+      RefArgs.push_back(Arg);
+
+    // Make sure to start the server before executing the command.
+    Server.start(/*Exclusive*/ true, CASArgs);
+    std::thread ServerThread([&Server]() { Server.listen(); });
+
+#if defined(_WIN32)
+    static_cast<void>(::_putenv_s("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH",
+                                  Server.BasePath.c_str()));
+#else
+    setenv("CLANG_CACHE_SCAN_DAEMON_SOCKET_PATH", Server.BasePath.c_str(), true);
+#endif
+
+    std::string ErrMsg;
+    int Result = llvm::sys::ExecuteAndWait(
+        RefArgs.front(), RefArgs, /*Env*/ std::nullopt,
+        /*Redirects*/ {}, /*SecondsToWait*/ 0,
+        /*MemoryLimit*/ 0, &ErrMsg);
+
+    Server.shutdown();
+    ServerThread.join();
+
+    if (!ErrMsg.empty())
+      reportError("failed executing command: " + ErrMsg);
+    return Result;
+  } else if (Command != "-run") {
+    reportError("unknown command '" + Command + "'");
+  }
+
+  Server.TimeoutSeconds = LongRunning ? 120 : 15;
+
+  // Setup signal handlers for graceful shutdown (cross-platform).
+  llvm::sys::AddSignalHandler(
+      [](void *Cookie) {
+        auto *Srv = static_cast<ScanServer *>(Cookie);
+        Srv->shutdown();
+      },
+      &Server);
+
+  llvm::sys::SetInterruptFunction([]() {
+    // Note: This handler is called on interrupt (Ctrl+C).
+    // Cannot call non-reentrant functions here, so just exit immediately.
+    std::_Exit(0);
+  });
+
+  // Redirect stdout/stderr to log files.
+  SmallString<128> LogOutPath, LogErrPath;
+  (Server.BasePath + ".out").toVector(LogOutPath);
+  (Server.BasePath + ".err").toVector(LogErrPath);
+
+#ifdef _WIN32
+  // On Windows, redirect stdout/stderr using freopen.
+  // We don't call FreeConsole() to avoid invalidating these handles.
+  if (std::freopen(LogOutPath.c_str(), "w", stdout) == nullptr)
+    reportError("failed to redirect stdout");
+  if (std::freopen(LogErrPath.c_str(), "w", stderr) == nullptr)
+    reportError("failed to redirect stderr");
+#else
+  // On Unix, create a new session and redirect stdio.
+  if (::signal(SIGHUP, SIG_IGN) == SIG_ERR)
+    reportError("failed to ignore SIGHUP");
+  if (::setsid() == -1)
+    reportError("setsid failed");
+
+  // Redirect stdout and stderr using dup2.
+  auto openAndReplaceFD = [&](int ReplacedFD, StringRef Path) {
+    int FD;
+    if (std::error_code EC = llvm::sys::fs::openFile(
+            Path, FD, llvm::sys::fs::CD_CreateAlways, llvm::sys::fs::FA_Write,
+            llvm::sys::fs::OF_None)) {
+      llvm::sys::Process::SafelyCloseFileDescriptor(ReplacedFD);
+      return;
+    }
+    ::dup2(FD, ReplacedFD);
+    llvm::sys::Process::SafelyCloseFileDescriptor(FD);
+  };
+  openAndReplaceFD(1, LogOutPath);
+  openAndReplaceFD(2, LogErrPath);
+#endif
+
+  Server.start(/*Exclusive*/ false, CASArgs);
+  return Server.listen();
 }

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -90,10 +90,10 @@ static const char *GetStableCStr(llvm::StringSet<> &SavedStrings, StringRef S) {
 
 extern int cc1_main(ArrayRef<const char *> Argv, const char *Argv0,
                     void *MainAddr);
-#if LLVM_ON_UNIX
+
 extern int cc1depscand_main(ArrayRef<const char *> Argv, const char *Argv0,
                             void *MainAddr);
-#endif /* LLVM_ON_UNIX */
+
 extern int cc1depscan_main(ArrayRef<const char *> Argv, const char *Argv0,
                            void *MainAddr);
 extern int cc1as_main(ArrayRef<const char *> Argv, const char *Argv0,
@@ -249,11 +249,9 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV,
     }
     return cc1_main(ArrayRef(ArgV).slice(1), ArgV[0], GetExecutablePathVP);
   }
-#if LLVM_ON_UNIX
   if (Tool == "-cc1depscand")
     return cc1depscand_main(ArrayRef(ArgV).slice(2), ArgV[0],
                             GetExecutablePathVP);
-#endif /* LLVM_ON_UNIX */
   if (Tool == "-cc1depscan")
     return cc1depscan_main(ArrayRef(ArgV).slice(2), ArgV[0],
                            GetExecutablePathVP);

--- a/llvm/lib/CAS/UnifiedOnDiskCache.cpp
+++ b/llvm/lib/CAS/UnifiedOnDiskCache.cpp
@@ -86,7 +86,17 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/raw_ostream.h"
+#include <chrono>
 #include <optional>
+
+#if __has_include(<sys/sysctl.h>)
+#include <sys/sysctl.h>
+#endif
+
+#ifdef _WIN32
+#define NOMINMAX
+#include <windows.h>
+#endif
 
 using namespace llvm;
 using namespace llvm::cas;
@@ -268,6 +278,38 @@ static Error validateInProcess(StringRef RootPath, StringRef HashName,
   if (Error E = UniDB->validateActionCache())
     return E;
   return Error::success();
+}
+
+static Expected<uint64_t> getBootTime() {
+#if __has_include(<sys/sysctl.h>) && defined(KERN_BOOTTIME)
+  // macOS/BSD: Use sysctl to get boot time
+  struct timeval TV;
+  size_t TVLen = sizeof(TV);
+  int KernBoot[2] = {CTL_KERN, KERN_BOOTTIME};
+  if (sysctl(KernBoot, 2, &TV, &TVLen, nullptr, 0) < 0)
+    return createStringError(llvm::errnoAsErrorCode(),
+                             "failed to get boottime");
+  if (TVLen != sizeof(TV))
+    return createStringError("sysctl kern.boottime unexpected format");
+  return TV.tv_sec;
+#elif defined(__linux__)
+  // Linux: Use the mtime for /proc, which is recreated during system boot.
+  // We could also read /proc/stat and search for 'btime'.
+  sys::fs::file_status Status;
+  if (std::error_code EC = sys::fs::status("/proc", Status))
+    return createFileError("/proc", EC);
+  return Status.getLastModificationTime().time_since_epoch().count();
+#elif defined(_WIN32)
+  // Windows: Calculate boot time from current time minus uptime
+  // GetTickCount64() returns milliseconds since boot
+  auto now = std::chrono::system_clock::now();
+  ULONGLONG uptimeMs = GetTickCount64();
+  auto bootTime = now - std::chrono::milliseconds(uptimeMs);
+  return std::chrono::duration_cast<std::chrono::seconds>(
+      bootTime.time_since_epoch()).count();
+#else
+  llvm::report_fatal_error("getBootTime unimplemented for this platform");
+#endif
 }
 
 Expected<ValidationResult> UnifiedOnDiskCache::validateIfNeeded(


### PR DESCRIPTION
Rewrite the CAS scandeps daemon to use LLVM primitives for Unix Domain Sockets and file system primitives. Additionally, add in some logic for Windows specific process tracking and stack management. This gives us a working daemon on Windows which shares most of the code paths with the other platforms.

Also enable the associated CAS tests on Windows so that we can ensure test coverage.

(cherry picked from commit 504491720e5c790e859f262b0d937b0cb766bb56)