### PR TITLE
[llvm/CAS] Introduce `CASFSBuilder` which makes it convenient to create a CASFS tree

### DIFF
--- a/llvm/include/llvm/CAS/CASFSBuilder.h
+++ b/llvm/include/llvm/CAS/CASFSBuilder.h
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CAS_CASFSBUILDER_H
+#define LLVM_CAS_CASFSBUILDER_H
+
+#include "llvm/CAS/HierarchicalTreeBuilder.h"
+#include "llvm/Support/PrefixMapper.h"
+
+namespace llvm::cas {
+class CachingOnDiskFileSystem;
+
+/// Builds a CAS file-system tree that can be used with \c createCASFileSystem.
+/// Combines ingestion of paths from the on-disk file-system along with merging
+/// other CAS file-system roots.
+///
+/// Not thread-safe.
+class CASFSBuilder {
+public:
+  /// \param Prefix maps used for file system ingestion.
+  explicit CASFSBuilder(ObjectStore &DB,
+                        ArrayRef<MappedPrefix> PrefixMaps = {});
+
+  ~CASFSBuilder();
+
+  /// Ingest contents from the on-disk file-system. For a directory it will
+  /// recursively ingest its contents. Symlinks are not followed. Emits an error
+  /// if the path doesn't exist.
+  Error ingestFileSystemPath(const Twine &Path);
+
+  /// Merge a prior constructed CAS file-system tree root.
+  ///
+  /// \param Path the path to place the root at; can be empty.
+  void mergeCASFSRoot(ObjectRef Root, const Twine &Path = "");
+
+  /// Produce the merged CAS file-system tree root. \c CASFSBuilder should not
+  /// be used after calling this.
+  Expected<ObjectProxy> finish();
+
+private:
+  ObjectStore &DB;
+  SmallVector<MappedPrefix, 2> PrefixMaps;
+  HierarchicalTreeBuilder Builder;
+  IntrusiveRefCntPtr<CachingOnDiskFileSystem> FS;
+};
+
+} // namespace llvm::cas
+
+#endif // LLVM_CAS_CASFSBUILDER_H

--- a/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
+++ b/llvm/include/llvm/CAS/CachingOnDiskFileSystem.h
@@ -36,7 +36,8 @@ public:
 
   /// An extra API to pull out the \a CASID if \p Path refers to a file.
   virtual ErrorOr<vfs::Status> statusAndFileID(const Twine &Path,
-                                               std::optional<CASID> &FileID) = 0;
+                                               std::optional<CASID> &FileID,
+                                               bool FollowSymlinks) = 0;
 
   /// Start tracking all stats (and other accesses). Only affects this
   /// filesystem instance, not current (or future) proxies.

--- a/llvm/include/llvm/CAS/FileSystemCache.h
+++ b/llvm/include/llvm/CAS/FileSystemCache.h
@@ -296,7 +296,8 @@ public:
 
   /// Get the status with the requested name. Requires that this is not a
   /// symlink.
-  ErrorOr<vfs::Status> getStatus(const Twine &RequestedName);
+  ErrorOr<vfs::Status> getStatus(const Twine &RequestedName,
+                                 bool FollowSymlinks);
 
   FileSystemCache::Directory &asDirectory() const {
     assert(isDirectory());

--- a/llvm/lib/CAS/CASFSBuilder.cpp
+++ b/llvm/lib/CAS/CASFSBuilder.cpp
@@ -1,0 +1,80 @@
+//===- CASFSBuilder.cpp -----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/CASFSBuilder.h"
+#include "llvm/CAS/CachingOnDiskFileSystem.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+
+CASFSBuilder::CASFSBuilder(ObjectStore &DB, ArrayRef<MappedPrefix> PrefixMaps)
+    : DB(DB), PrefixMaps(PrefixMaps) {}
+
+CASFSBuilder::~CASFSBuilder() {}
+
+static Error recursiveAccess(CachingOnDiskFileSystem &FS, const Twine &Path) {
+  std::optional<llvm::cas::CASID> FileID;
+  auto ST = FS.statusAndFileID(Path, FileID, /*FollowSymlinks=*/false);
+  if (!ST)
+    return createFileError(Path, ST.getError());
+
+  if (ST->isDirectory()) {
+    std::error_code EC;
+    for (vfs::directory_iterator I = FS.dir_begin(Path, EC), IE; !EC && I != IE;
+         I.increment(EC)) {
+      auto Err = recursiveAccess(FS, I->path());
+      if (Err)
+        return Err;
+    }
+  }
+
+  return Error::success();
+}
+
+Error CASFSBuilder::ingestFileSystemPath(const Twine &Path) {
+  if (!FS) {
+    auto FS = createCachingOnDiskFileSystem(DB);
+    if (!FS)
+      return FS.takeError();
+    (*FS)->trackNewAccesses();
+    this->FS = std::move(*FS);
+  }
+
+  if (Error E = recursiveAccess(*FS, Path))
+    return E;
+  return Error::success();
+}
+
+void CASFSBuilder::mergeCASFSRoot(ObjectRef Root, const Twine &Path) {
+  Builder.pushTreeContent(Root, Path);
+}
+
+Expected<ObjectProxy> CASFSBuilder::finish() {
+  if (FS) {
+    auto createTree = [&]() -> Expected<ObjectProxy> {
+      if (PrefixMaps.empty())
+        return FS->createTreeFromNewAccesses();
+
+      TreePathPrefixMapper Mapper(FS);
+      Mapper.addRange(PrefixMaps);
+      Mapper.sort();
+      return FS->createTreeFromNewAccesses(
+          [&](const llvm::vfs::CachedDirectoryEntry &Entry,
+              SmallVectorImpl<char> &Storage) {
+            return Mapper.mapDirEntry(Entry, Storage);
+          });
+    };
+
+    auto TreeRef = createTree();
+    if (!TreeRef)
+      return TreeRef.takeError();
+    Builder.pushTreeContent(TreeRef->getRef(), "");
+  }
+
+  return Builder.create(DB);
+}

--- a/llvm/lib/CAS/CASFileSystem.cpp
+++ b/llvm/lib/CAS/CASFileSystem.cpp
@@ -125,7 +125,9 @@ private:
 
 class CASFileSystem::VFSFile final : public CASBackedFile {
 public:
-  ErrorOr<vfs::Status> status() final { return Entry->getStatus(Name); }
+  ErrorOr<vfs::Status> status() final {
+    return Entry->getStatus(Name, /*FollowSymlinks=*/true);
+  }
 
   ErrorOr<std::string> getName() final { return Name; }
 
@@ -321,7 +323,7 @@ ErrorOr<vfs::Status> CASFileSystem::status(const Twine &Path) {
       return errorToErrorCode(std::move(E));
   }
 
-  return Entry->getStatus(PathRef);
+  return Entry->getStatus(PathRef, /*FollowSymlinks=*/true);
 }
 
 Expected<const vfs::CachedDirectoryEntry *>

--- a/llvm/lib/CAS/CMakeLists.txt
+++ b/llvm/lib/CAS/CMakeLists.txt
@@ -10,6 +10,7 @@ add_llvm_component_library(LLVMCAS
   BuiltinUnifiedCASDatabases.cpp
   CASConfiguration.cpp
   CASFileSystem.cpp
+  CASFSBuilder.cpp
   CASNodeSchema.cpp
   CASOutputBackend.cpp
   CASProvidingFileSystem.cpp

--- a/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
+++ b/llvm/lib/CAS/CachingOnDiskFileSystem.cpp
@@ -86,7 +86,8 @@ public:
   preloadRealPath(DirectoryEntry &From, StringRef Remaining);
 
   ErrorOr<vfs::Status> statusAndFileID(const Twine &Path,
-                                       std::optional<CASID> &FileID) final;
+                                       std::optional<CASID> &FileID,
+                                       bool FollowSymlinks) final;
   ErrorOr<vfs::Status> status(const Twine &Path) final;
   bool exists(const Twine &Path) final;
   Expected<std::unique_ptr<CASBackedFile>>
@@ -220,7 +221,9 @@ CachingOnDiskFileSystem::CachingOnDiskFileSystem(ObjectStore &DB) : DB(DB) {}
 
 class CachingOnDiskFileSystemImpl::VFSFile final : public CASBackedFile {
 public:
-  ErrorOr<vfs::Status> status() final { return Entry->getStatus(Name); }
+  ErrorOr<vfs::Status> status() final {
+    return Entry->getStatus(Name, /*FollowSymlinks=*/true);
+  }
 
   ErrorOr<std::string> getName() final { return Name; }
 
@@ -406,9 +409,8 @@ CachingOnDiskFileSystemImpl::makeEntry(
   return makeFile(Parent, TreePathStorage.Path, *F, Status);
 }
 
-ErrorOr<vfs::Status>
-CachingOnDiskFileSystemImpl::statusAndFileID(const Twine &Path,
-                                             std::optional<CASID> &FileID) {
+ErrorOr<vfs::Status> CachingOnDiskFileSystemImpl::statusAndFileID(
+    const Twine &Path, std::optional<CASID> &FileID, bool FollowSymlinks) {
   FileID = std::nullopt;
   PathStorage PathStorage(Path);
   StringRef PathRef = PathStorage.Path;
@@ -418,13 +420,14 @@ CachingOnDiskFileSystemImpl::statusAndFileID(const Twine &Path,
   //
   // FIXME: Translate the error to a filesystem-like error to encapsulate the
   // user from CAS issues.
-  Expected<DirectoryEntry *> ExpectedEntry = lookupPath(PathRef);
+  Expected<DirectoryEntry *> ExpectedEntry =
+      lookupPath(PathRef, FollowSymlinks);
   if (!ExpectedEntry)
     return errorToErrorCode(ExpectedEntry.takeError());
 
   // Errors indicate a broken symlink.
   DirectoryEntry *Entry = *ExpectedEntry;
-  ErrorOr<vfs::Status> StatusOrErr = Entry->getStatus(PathRef);
+  ErrorOr<vfs::Status> StatusOrErr = Entry->getStatus(PathRef, FollowSymlinks);
   if (!StatusOrErr)
     return StatusOrErr.getError();
   if (Entry->isFile())
@@ -460,7 +463,7 @@ CachingOnDiskFileSystemImpl::getRealPath(const Twine &Path,
 
 ErrorOr<vfs::Status> CachingOnDiskFileSystemImpl::status(const Twine &Path) {
   std::optional<CASID> IgnoredID;
-  return statusAndFileID(Path, IgnoredID);
+  return statusAndFileID(Path, IgnoredID, /*FollowSymlinks=*/true);
 }
 
 bool CachingOnDiskFileSystemImpl::exists(const Twine &Path) {

--- a/llvm/lib/CAS/FileSystemCache.cpp
+++ b/llvm/lib/CAS/FileSystemCache.cpp
@@ -201,7 +201,6 @@ void FileSystemCache::finishLazyFile(DirectoryEntry &FileEntry, size_t Size) {
 }
 
 sys::fs::file_type DirectoryEntry::getFileType() const {
-  assert(!isSymlink() && "Expected symlink to be followed first");
   switch (Kind) {
   case Directory:
     return sys::fs::file_type::directory_file;
@@ -209,14 +208,15 @@ sys::fs::file_type DirectoryEntry::getFileType() const {
   case Executable:
     return sys::fs::file_type::regular_file;
   case Symlink:
-    llvm_unreachable("symlinks should be followed before getting file type");
+    return sys::fs::file_type::symlink_file;
   };
 }
 
-ErrorOr<vfs::Status> DirectoryEntry::getStatus(const Twine &RequestedName) {
+ErrorOr<vfs::Status> DirectoryEntry::getStatus(const Twine &RequestedName,
+                                               bool FollowSymlinks) {
   // Symlinks should be followed first. Getting here indicates a broken symlink
   // in directory iteration.
-  if (Kind == Symlink)
+  if (Kind == Symlink && FollowSymlinks)
     return std::errc::no_such_file_or_directory;
 
   const sys::fs::perms RegularPermissions =
@@ -243,7 +243,10 @@ ErrorOr<vfs::Status> DirectoryEntry::getStatus(const Twine &RequestedName) {
     break;
   }
   case Symlink:
-    llvm_unreachable("symlinks don't expose status");
+    Size = 0;
+    Permissions = RegularPermissions;
+    UniqueID = asSymlink().getUniqueID();
+    break;
   };
 
   return vfs::Status(RequestedName, UniqueID, sys::TimePoint<>(), /*User=*/0,

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -13,9 +13,8 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/CAS/ActionCache.h"
 #include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
+#include "llvm/CAS/CASFSBuilder.h"
 #include "llvm/CAS/CASFileSystem.h"
-#include "llvm/CAS/CachingOnDiskFileSystem.h"
-#include "llvm/CAS/HierarchicalTreeBuilder.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/CAS/TreeSchema.h"
 #include "llvm/CAS/Utils.h"
@@ -28,7 +27,6 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/raw_ostream.h"
 #include <memory>
 #include <system_error>
@@ -563,66 +561,19 @@ int traverseGraph(ObjectStore &CAS, const CASID &ID) {
   return 0;
 }
 
-static Error
-recursiveAccess(CachingOnDiskFileSystem &FS, StringRef Path,
-                llvm::DenseSet<llvm::sys::fs::UniqueID> &SeenDirectories) {
-  auto ST = FS.status(Path);
-
-  // Ignore missing entries, which can be a symlink to a missing file, which is
-  // not an error in the filesystem itself.
-  // FIXME: add status(follow=false) to VFS instead, which would let us detect
-  // this case directly.
-  if (ST.getError() == llvm::errc::no_such_file_or_directory)
-    return Error::success();
-
-  if (!ST)
-    return createFileError(Path, ST.getError());
-
-  // Check that this is the first time we see the directory to prevent infinite
-  // recursion into symlinks. The status() above will ensure all symlinks are
-  // ingested.
-  // FIXME: add status(follow=false) to VFS instead, and then only traverse
-  // a directory and not a symlink to a directory.
-  if (ST->isDirectory() && SeenDirectories.insert(ST->getUniqueID()).second) {
-    std::error_code EC;
-    for (llvm::vfs::directory_iterator I = FS.dir_begin(Path, EC), IE;
-         !EC && I != IE; I.increment(EC)) {
-      auto Err = recursiveAccess(FS, I->path(), SeenDirectories);
-      if (Err)
-        return Err;
-    }
-  }
-
-  return Error::success();
-}
-
 static Expected<ObjectProxy>
 ingestFileSystemImpl(ObjectStore &CAS, ArrayRef<std::string> Paths,
                      ArrayRef<std::string> PrefixMapPaths) {
-  auto FS = createCachingOnDiskFileSystem(CAS);
-  if (!FS)
-    return FS.takeError();
-
-  TreePathPrefixMapper Mapper(*FS);
   SmallVector<llvm::MappedPrefix> Split;
-  if (!PrefixMapPaths.empty()) {
+  if (!PrefixMapPaths.empty())
     MappedPrefix::transformJoinedIfValid(PrefixMapPaths, Split);
-    Mapper.addRange(Split);
-    Mapper.sort();
-  }
 
-  (*FS)->trackNewAccesses();
-
-  llvm::DenseSet<llvm::sys::fs::UniqueID> SeenDirectories;
+  CASFSBuilder Builder(CAS, Split);
   for (auto &Path : Paths)
-    if (Error E = recursiveAccess(**FS, Path, SeenDirectories))
+    if (Error E = Builder.ingestFileSystemPath(Path))
       return E;
 
-  return (*FS)->createTreeFromNewAccesses(
-      [&](const llvm::vfs::CachedDirectoryEntry &Entry,
-          SmallVectorImpl<char> &Storage) {
-        return Mapper.mapDirEntry(Entry, Storage);
-      });
+  return Builder.finish();
 }
 
 /// Check that we are not attempting to ingest the CAS into itself, which can
@@ -661,22 +612,21 @@ static int ingestFileSystem(ObjectStore &CAS, std::optional<StringRef> CASPath,
 static int mergeTrees(ObjectStore &CAS, ArrayRef<std::string> Objects) {
   ExitOnError ExitOnErr("llvm-cas: merge: ");
 
-  HierarchicalTreeBuilder Builder;
+  CASFSBuilder Builder(CAS);
   for (const auto &Object : Objects) {
     auto ID = CAS.parseID(Object);
     if (ID) {
       if (std::optional<ObjectRef> Ref = CAS.getReference(*ID))
-        Builder.pushTreeContent(*Ref, "");
+        Builder.mergeCASFSRoot(*Ref);
       else
         ExitOnErr(createStringError("unknown node with id: " + ID->toString()));
     } else {
       consumeError(ID.takeError());
-      auto Ref = ExitOnErr(ingestFileSystemImpl(CAS, Object, {}));
-      Builder.pushTreeContent(Ref.getRef(), "");
+      ExitOnErr(Builder.ingestFileSystemPath(Object));
     }
   }
 
-  auto Ref = ExitOnErr(Builder.create(CAS));
+  auto Ref = ExitOnErr(Builder.finish());
   outs() << Ref.getID() << "\n";
   return 0;
 }

--- a/llvm/unittests/CAS/CASFSBuilderTest.cpp
+++ b/llvm/unittests/CAS/CASFSBuilderTest.cpp
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/CAS/CASFSBuilder.h"
+#include "llvm/CAS/CASFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+#include "llvm/Testing/Support/SupportHelpers.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::cas;
+using llvm::sys::fs::UniqueID;
+using llvm::unittest::TempDir;
+using llvm::unittest::TempFile;
+using llvm::unittest::TempLink;
+
+TEST(CASFSBuilderTest, MergeRoots) {
+  std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
+  ASSERT_TRUE(CAS);
+
+  TempDir TestDirectory("casfs-builder-test", /*Unique*/ true);
+
+  TempDir a(TestDirectory.path("a"));
+  TempDir ab(TestDirectory.path("a/b"));
+  TempFile f1(ab.path("f1"), "", "aaaa");
+  TempDir c(TestDirectory.path("c"));
+  TempDir cd(TestDirectory.path("c/d"));
+  TempFile f2(cd.path("f2"), "", "aaaa");
+
+  std::optional<ObjectProxy> aRoot;
+  {
+    CASFSBuilder Builder(*CAS);
+    ASSERT_THAT_ERROR(Builder.ingestFileSystemPath(a.path()), Succeeded());
+    ASSERT_THAT_ERROR(Builder.finish().moveInto(aRoot), Succeeded());
+  }
+
+  std::optional<ObjectProxy> cRoot;
+  {
+    CASFSBuilder Builder(*CAS);
+    ASSERT_THAT_ERROR(Builder.ingestFileSystemPath(c.path()), Succeeded());
+    ASSERT_THAT_ERROR(Builder.finish().moveInto(cRoot), Succeeded());
+  }
+
+  std::optional<ObjectProxy> mergedRoot;
+  {
+    CASFSBuilder Builder(*CAS);
+    Builder.mergeCASFSRoot(aRoot->getRef());
+    Builder.mergeCASFSRoot(cRoot->getRef());
+    Builder.mergeCASFSRoot(cRoot->getRef(), "f/g");
+    ASSERT_THAT_ERROR(Builder.finish().moveInto(mergedRoot), Succeeded());
+  }
+
+  std::unique_ptr<vfs::FileSystem> CASFS;
+  ASSERT_THAT_ERROR(
+      createCASFileSystem(*CAS, mergedRoot->getID()).moveInto(CASFS),
+      Succeeded());
+
+  std::string FSStr;
+  llvm::raw_string_ostream OS(FSStr);
+  CASFS->print(OS, vfs::FileSystem::PrintType::RecursiveContents);
+  StringRef Printed(FSStr);
+  EXPECT_TRUE(Printed.consume_front("CASFileSystem")) << Printed;
+  EXPECT_TRUE(Printed.consume_front("\n  root: / llvmcas://")) << Printed;
+  Printed = Printed.drop_front(64); // 32 hash bytes in hex
+  EXPECT_TRUE(Printed.consume_front("\n    file llvmcas://")) << Printed;
+  Printed = Printed.drop_front(65); // 32 hash bytes in hex + 1 space
+  EXPECT_TRUE(Printed.consume_front("/f/g")) << Printed;
+  EXPECT_TRUE(Printed.consume_front(f2.path())) << Printed;
+  EXPECT_TRUE(Printed.consume_front("\n    file llvmcas://")) << Printed;
+  Printed = Printed.drop_front(65); // 32 hash bytes in hex + 1 space
+  EXPECT_TRUE(Printed.consume_front(f1.path())) << Printed;
+  EXPECT_TRUE(Printed.consume_front("\n    file llvmcas://")) << Printed;
+  Printed = Printed.drop_front(65); // 32 hash bytes in hex + 1 space
+  EXPECT_TRUE(Printed.consume_front(f2.path())) << Printed;
+  EXPECT_EQ(Printed, "\n");
+}
+
+TEST(CASFSBuilderTest, NoFollowSymlink) {
+  std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
+  ASSERT_TRUE(CAS);
+
+  TempDir TestDirectory("casfs-builder-test", /*Unique*/ true);
+
+  TempDir a(TestDirectory.path("a"));
+  TempDir ab(TestDirectory.path("a/b"));
+  TempFile f1(ab.path("f1"), "", "aaaa");
+  TempLink lnk("a", TestDirectory.path("lnk"));
+  TempLink abLnk1("l2", ab.path("l1"));
+  TempLink abLnk2("l1", ab.path("l2"));
+
+  std::optional<ObjectProxy> lnkRoot;
+  {
+    CASFSBuilder Builder(*CAS);
+    ASSERT_THAT_ERROR(Builder.ingestFileSystemPath(lnk.path()), Succeeded());
+    ASSERT_THAT_ERROR(Builder.finish().moveInto(lnkRoot), Succeeded());
+  }
+
+  {
+    std::unique_ptr<vfs::FileSystem> CASFS;
+    ASSERT_THAT_ERROR(
+        createCASFileSystem(*CAS, lnkRoot->getID()).moveInto(CASFS),
+        Succeeded());
+
+    std::string FSStr;
+    llvm::raw_string_ostream OS(FSStr);
+    CASFS->print(OS, vfs::FileSystem::PrintType::RecursiveContents);
+    StringRef Printed(FSStr);
+    EXPECT_TRUE(Printed.consume_front("CASFileSystem")) << Printed;
+    EXPECT_TRUE(Printed.consume_front("\n  root: / llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_TRUE(Printed.consume_front("\n    syml llvmcas://")) << Printed;
+    Printed = Printed.drop_front(65); // 32 hash bytes in hex + 1 space
+    EXPECT_TRUE(Printed.consume_front(lnk.path())) << Printed;
+    EXPECT_TRUE(Printed.consume_front(" -> a")) << Printed;
+    EXPECT_EQ(Printed, "\n");
+  }
+
+  std::optional<ObjectProxy> abRoot;
+  {
+    CASFSBuilder Builder(*CAS);
+    ASSERT_THAT_ERROR(Builder.ingestFileSystemPath(ab.path()), Succeeded());
+    ASSERT_THAT_ERROR(Builder.finish().moveInto(abRoot), Succeeded());
+  }
+
+  {
+    std::unique_ptr<vfs::FileSystem> CASFS;
+    ASSERT_THAT_ERROR(
+        createCASFileSystem(*CAS, abRoot->getID()).moveInto(CASFS),
+        Succeeded());
+
+    std::string FSStr;
+    llvm::raw_string_ostream OS(FSStr);
+    CASFS->print(OS, vfs::FileSystem::PrintType::RecursiveContents);
+    StringRef Printed(FSStr);
+    EXPECT_TRUE(Printed.consume_front("CASFileSystem")) << Printed;
+    EXPECT_TRUE(Printed.consume_front("\n  root: / llvmcas://")) << Printed;
+    Printed = Printed.drop_front(64); // 32 hash bytes in hex
+    EXPECT_TRUE(Printed.consume_front("\n    file llvmcas://")) << Printed;
+    Printed = Printed.drop_front(65); // 32 hash bytes in hex + 1 space
+    EXPECT_TRUE(Printed.consume_front(f1.path())) << Printed;
+    EXPECT_TRUE(Printed.consume_front("\n    syml llvmcas://")) << Printed;
+    Printed = Printed.drop_front(65); // 32 hash bytes in hex + 1 space
+    EXPECT_TRUE(Printed.consume_front(abLnk1.path())) << Printed;
+    EXPECT_TRUE(Printed.consume_front(" -> l2")) << Printed;
+    EXPECT_TRUE(Printed.consume_front("\n    syml llvmcas://")) << Printed;
+    Printed = Printed.drop_front(65); // 32 hash bytes in hex + 1 space
+    EXPECT_TRUE(Printed.consume_front(abLnk2.path())) << Printed;
+    EXPECT_TRUE(Printed.consume_front(" -> l1")) << Printed;
+    EXPECT_EQ(Printed, "\n");
+  }
+}
+
+TEST(CASFSBuilderTest, Missing) {
+  std::unique_ptr<ObjectStore> CAS = createInMemoryCAS();
+  ASSERT_TRUE(CAS);
+
+  TempDir TestDirectory("casfs-builder-test", /*Unique*/ true);
+
+  std::optional<ObjectProxy> Root;
+  {
+    CASFSBuilder Builder(*CAS);
+    EXPECT_THAT_ERROR(Builder.ingestFileSystemPath(TestDirectory.path("a")),
+                      Failed());
+  }
+}

--- a/llvm/unittests/CAS/CMakeLists.txt
+++ b/llvm/unittests/CAS/CMakeLists.txt
@@ -45,6 +45,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_unittest(CASTests
   ActionCacheTest.cpp
   CASFileSystemTest.cpp
+  CASFSBuilderTest.cpp
   CASTestConfig.cpp
   CASOutputBackendTest.cpp
   CASProvidingFileSystemTest.cpp


### PR DESCRIPTION
* Rebase `llvm-cas` functionality on top of using `CASFSBuilder`
* Enhance `statusAndFileID` to control whether to follow or not symlinks. `CASFSBuilder` does not follow symlinks, it ingests the file-system as is.
* Add unit tests for `CASFSBuilder` for things that are not already tested via `llvm-cas` tests.