### PR TITLE
[ConstraintElimination][NFC] Use `std::abs` for absolute value comparison

### DIFF
--- a/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
+++ b/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp
@@ -1149,7 +1149,7 @@ void State::addPointerBoundInfo(Value *PtrOp, Value *IdxOp, DomTreeNode *DTN,
 // AnnotationRemarks pass.
 static void annotateMissedPhiOptimisation(Instruction *PtrPHI, int64_t PHIStep,
                                           int64_t IntPHIStep) {
-  if (abs(PHIStep) == abs(IntPHIStep)) {
+  if (std::abs(PHIStep) == std::abs(IntPHIStep)) {
     annotateRuntimeChecks(
         PtrPHI, BoundsSafetyOptRemarkKind::BNS_MISSED_REMARK_PHI_DIRECTION);
   } else if (PHIStep != IntPHIStep)


### PR DESCRIPTION
This will fix below warnings:

```
[1654/3339] Building CXX object lib/Transforms/Scalar/CMakeFiles/LLVMScalarOpts.dir/ConstraintElimination.cpp.o
[...]/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp:1152:7: warning: absolute value function 'abs' given an argument of type 'int64_t' (aka 'long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
 1152 |   if (abs(PHIStep) == abs(IntPHIStep)) {
      |       ^
[...]/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp:1152:7: note: use function 'std::abs' instead
 1152 |   if (abs(PHIStep) == abs(IntPHIStep)) {
      |       ^~~
      |       std::abs
[...]/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp:1152:23: warning: absolute value function 'abs' given an argument of type 'int64_t' (aka 'long') but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
 1152 |   if (abs(PHIStep) == abs(IntPHIStep)) {
      |                       ^
[...]/llvm/lib/Transforms/Scalar/ConstraintElimination.cpp:1152:23: note: use function 'std::abs' instead
 1152 |   if (abs(PHIStep) == abs(IntPHIStep)) {
      |                       ^~~
      |                       std::abs
2 warnings generated.
```