### PR TITLE
"[lldb] Unhardcode mangled flavor" and  "[lldb] Fix empty dict/set formatting in embedded Swift"

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -551,13 +551,15 @@ AddRequiredAliases(Block *block, lldb::StackFrameSP &stack_frame_sp,
                    lldb::DynamicValueType use_dynamic,
                    lldb::BindGenericTypes bind_generic_types) {
   // Alias builtin types, since we can't use them directly in source code.
-  auto builtin_ptr_t = swift_ast_context.GetBuiltinRawPointerType();
-  auto alias = manipulator.MakeTypealias(
+  CompilerType builtin_ptr_t = swift_ast_context.GetBuiltinRawPointerType(
+      swift_ast_context.GetManglingFlavor());
+  llvm::Expected<swift::TypeAliasDecl *> alias = manipulator.MakeTypealias(
       swift_ast_context.GetASTContext()->getIdentifier("$__lldb_builtin_ptr_t"),
       builtin_ptr_t, false);
   if (!alias)
     return alias.takeError();
-  auto builtin_int_t = swift_ast_context.GetBuiltinIntType();
+  CompilerType builtin_int_t = swift_ast_context.GetBuiltinIntType(
+      swift_ast_context.GetManglingFlavor());
   alias = manipulator.MakeTypealias(
       swift_ast_context.GetASTContext()->getIdentifier("$__lldb_builtin_int_t"),
       builtin_int_t, false);

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -339,7 +339,8 @@ static llvm::Error AddVariableInfo(
   // parameters, and we can't have a type with unbound generics in a non-generic
   // function.
   if (should_not_bind_generic_types && is_self)
-    target_type = ast_context.GetBuiltinRawPointerType();
+    target_type =
+        ast_context.GetBuiltinRawPointerType(ast_context.GetManglingFlavor());
   else if (is_unbound_pack)
     target_type = variable_sp->GetType()->GetForwardCompilerType();
   else {

--- a/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftDictionary.cpp
@@ -41,8 +41,9 @@ DictionaryConfig::DictionaryConfig()
   // Note: We need have use the old _Tt names here because those are
   // still used to name classes in the ObjC runtime.
 
-  m_nativeStorageRoot_mangled =
-    ConstString("$ss22__RawDictionaryStorageCD");
+  // This is stored WITHOUT the mangling flavor suffix.
+  m_nativeStorageRoot_mangledSuffix =
+      ConstString("s22__RawDictionaryStorageCD");
   m_nativeStorageRoot_demangled =
     ConstString("Swift.__RawDictionaryStorage");
 

--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -770,7 +770,9 @@ private:
   bool m_indirect = false;
 };
 
-static std::string mangledTypenameForTasksTuple(size_t count) {
+static std::string
+mangledTypenameForTasksTuple(size_t count,
+                             ::swift::Mangle::ManglingFlavor flavor) {
   /*
   Global > TypeMangling > Type > Tuple
     TupleElement > Type > Structure
@@ -795,7 +797,7 @@ static std::string mangledTypenameForTasksTuple(size_t count) {
     }
   }
 
-  return mangleNode(root).result();
+  return mangleNode(root, flavor).result();
 }
 
 /// Synthetic provider for `Swift.Task`.
@@ -849,9 +851,10 @@ public:
       return {};
     }
 
-    // TypeMangling for "Swift.Bool"
-    CompilerType bool_type =
-        ts->GetTypeFromMangledTypename(ConstString("$sSbD"));
+    auto flavor =
+        SwiftLanguageRuntime::GetManglingFlavor(type.GetMangledTypeName());
+
+    CompilerType bool_type = ts->GetBoolType(flavor);
 
 #define RETURN_CHILD(FIELD, NAME, TYPE)                                        \
   if (!FIELD) {                                                                \
@@ -866,9 +869,7 @@ public:
     switch (idx) {
     case 0:
       if (!m_address_sp) {
-        // TypeMangling for "Swift.UnsafeRawPointer"
-        CompilerType raw_pointer_type =
-            ts->GetTypeFromMangledTypename(ConstString("$sSVD"));
+        CompilerType raw_pointer_type = ts->GetUnsafeRawPointerType(flavor);
 
         addr_t value = m_task_ptr;
         if (auto process_sp = m_backend.GetProcessSP())
@@ -882,15 +883,11 @@ public:
       }
       return m_address_sp;
     case 1: {
-      // TypeMangling for "Swift.UInt64"
-      CompilerType uint64_type =
-          ts->GetTypeFromMangledTypename(ConstString("$ss6UInt64VD"));
+      CompilerType uint64_type = ts->GetUInt64Type(flavor);
       RETURN_CHILD(m_id_sp, id, uint64_type);
     }
     case 2: {
-      // TypeMangling for "Swift.TaskPriority"
-      CompilerType priority_type =
-          ts->GetTypeFromMangledTypename(ConstString("$sScPD"));
+      CompilerType priority_type = ts->GetTaskPriorityType(flavor);
       RETURN_CHILD(m_enqueue_priority_sp, enqueuePriority, priority_type);
     }
     case 3: {
@@ -899,9 +896,8 @@ public:
         if (!process_sp)
           return {};
 
-        // TypeMangling for "Swift.Optional<Swift.UnsafeRawPointer>"
         CompilerType raw_pointer_type =
-            ts->GetTypeFromMangledTypename(ConstString("$sSVSgD"));
+            ts->GetOptionalUnsafeRawPointerType(flavor);
 
         addr_t parent_addr = 0;
         if (m_task_info.isChildTask) {
@@ -942,7 +938,7 @@ public:
           });
 
         std::string mangled_typename =
-            mangledTypenameForTasksTuple(tasks.size());
+            mangledTypenameForTasksTuple(tasks.size(), flavor);
         CompilerType tasks_tuple_type =
             ts->GetTypeFromMangledTypename(ConstString(mangled_typename));
         DataExtractor data{tasks.data(), tasks.size() * sizeof(task_type),
@@ -1062,9 +1058,11 @@ public:
       if (auto ts_or_err =
               target_sp->GetScratchTypeSystemForLanguage(eLanguageTypeSwift)) {
         if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
-                ts_or_err->get()))
-          // TypeMangling for "Swift.UnsafeCurrentTask"
-          m_task_type = ts->GetTypeFromMangledTypename(ConstString("$sSctD"));
+                ts_or_err->get())) {
+          auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+              m_backend.GetCompilerType().GetMangledTypeName());
+          m_task_type = ts->GetUnsafeCurrentTaskType(flavor);
+        }
       } else {
         LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
                        ts_or_err.takeError(),
@@ -1142,9 +1140,11 @@ public:
       if (auto ts_or_err =
               target_sp->GetScratchTypeSystemForLanguage(eLanguageTypeSwift)) {
         if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
-                ts_or_err->get()))
-          // TypeMangling for "Swift.UnsafeCurrentTask"
-          m_task_type = ts->GetTypeFromMangledTypename(ConstString("$sSctD"));
+                ts_or_err->get())) {
+          auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+              m_backend.GetCompilerType().GetMangledTypeName());
+          m_task_type = ts->GetUnsafeCurrentTaskType(flavor);
+        }
       } else {
         LLDB_LOG_ERROR(
             GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
@@ -1281,9 +1281,11 @@ public:
         if (auto ts_or_err = target_sp->GetScratchTypeSystemForLanguage(
                 eLanguageTypeSwift)) {
           if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
-                  ts_or_err->get()))
-            // TypeMangling for "Swift.UnsafeCurrentTask"
-            m_task_type = ts->GetTypeFromMangledTypename(ConstString("$sSctD"));
+                  ts_or_err->get())) {
+            auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+                m_backend.GetCompilerType().GetMangledTypeName());
+            m_task_type = ts->GetUnsafeCurrentTaskType(flavor);
+          }
         } else {
           LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
                          ts_or_err.takeError(),
@@ -1445,8 +1447,10 @@ public:
     }
 
     if (!m_unprioritised_jobs_sp) {
+      auto flavor =
+          SwiftLanguageRuntime::GetManglingFlavor(type.GetMangledTypeName());
       std::string mangled_typename =
-          mangledTypenameForTasksTuple(m_job_addrs.size());
+          mangledTypenameForTasksTuple(m_job_addrs.size(), flavor);
       CompilerType tasks_tuple_type =
           ts->GetTypeFromMangledTypename(ConstString(mangled_typename));
       DataExtractor data{m_job_addrs.data(),
@@ -1477,9 +1481,11 @@ public:
         if (auto ts_or_err = target_sp->GetScratchTypeSystemForLanguage(
                 eLanguageTypeSwift)) {
           if (auto *ts = llvm::dyn_cast_or_null<TypeSystemSwiftTypeRef>(
-                  ts_or_err->get()))
-            // TypeMangling for "Swift.UnsafeCurrentTask"
-            m_task_type = ts->GetTypeFromMangledTypename(ConstString("$sSctD"));
+                  ts_or_err->get())) {
+            auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+                m_backend.GetCompilerType().GetMangledTypeName());
+            m_task_type = ts->GetUnsafeCurrentTaskType(flavor);
+          }
         } else {
           LLDB_LOG_ERROR(GetLog(LLDBLog::DataFormatters | LLDBLog::Types),
                          ts_or_err.takeError(),

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -281,10 +281,9 @@ HashedCollectionConfig::CreateEmptyHandler(CompilerType elem_type) const {
   return HashedStorageHandlerUP(new EmptyHashedStorageHandler(elem_type));
 }
 
-ValueObjectSP
-HashedCollectionConfig::StorageObjectAtAddress(
-    const ExecutionContext &exe_ctx,
-    lldb::addr_t address) const {
+ValueObjectSP HashedCollectionConfig::StorageObjectAtAddress(
+    const ExecutionContext &exe_ctx, lldb::addr_t address,
+    ::swift::Mangle::ManglingFlavor flavor) const {
 
   if (address == LLDB_INVALID_ADDRESS)
     return nullptr;
@@ -304,8 +303,11 @@ HashedCollectionConfig::StorageObjectAtAddress(
     return nullptr;
   if (error.Fail())
     return nullptr;
+  // Add the right mangling flavor on the type's mangled name.
+  std::string mangled_name = SwiftLanguageRuntime::MakeMangledName(
+      m_nativeStorageRoot_mangledSuffix.GetStringRef(), flavor);
   CompilerType rawStorage_type =
-      scratch_ctx->GetTypeFromMangledTypename(m_nativeStorageRoot_mangled);
+      scratch_ctx->GetTypeFromMangledTypename(ConstString(mangled_name));
   if (!rawStorage_type.IsValid())
     return nullptr;
 
@@ -636,7 +638,11 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
   if (valobj_sp->GetObjectRuntimeLanguage() != eLanguageTypeSwift &&
       valobj_sp->IsPointerType()) {
     lldb::addr_t address = valobj_sp->GetPointerValue().address;
-    if (auto swiftval_sp = StorageObjectAtAddress(exe_ctx, address))
+    // Since we're creating a formatter for a dictionary, this is ObjC, which
+    // embedded swift doesn't have access to, so this definitely uses the
+    // default mangling.
+    if (auto swiftval_sp = StorageObjectAtAddress(
+            exe_ctx, address, ::swift::Mangle::ManglingFlavor::Default))
       valobj_sp = swiftval_sp;
   }
   valobj_sp = valobj_sp->GetQualifiedRepresentationIfAvailable(
@@ -685,8 +691,10 @@ HashedCollectionConfig::CreateHandler(ValueObject &valobj) const {
     swift_runtime->MaskMaybeBridgedPointer(storage_location);
 
   if (masked_storage_location == storage_location) {
-    // Native storage
-    auto storage_sp = StorageObjectAtAddress(exe_ctx, storage_location);
+    // Native storage.
+    auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
+        valobj.GetCompilerType().GetMangledTypeName());
+    auto storage_sp = StorageObjectAtAddress(exe_ctx, storage_location, flavor);
     if (!storage_sp)
       return nullptr;
     return CreateNativeHandler(valobj_sp, storage_sp);

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -73,6 +73,10 @@ public:
 
   virtual bool IsValid() override;
 
+  bool IsEmptyEmbeddedCollection() {
+    return m_is_embedded_swift && m_count == 0;
+  }
+
   virtual ~NativeHashedStorageHandler() override {}
 
 protected:
@@ -128,21 +132,22 @@ protected:
   }
 
 private:
-  ValueObject *m_storage;
-  Process *m_process;
-  uint32_t m_ptr_size;
-  uint64_t m_count;
-  uint64_t m_scale;
-  lldb::addr_t m_metadata_ptr;
-  lldb::addr_t m_keys_ptr;
-  lldb::addr_t m_values_ptr;
+  ValueObject *m_storage = nullptr;
+  Process *m_process = nullptr;
+  uint32_t m_ptr_size = 0;
+  uint64_t m_count = 0;
+  uint64_t m_scale = 0;
+  lldb::addr_t m_metadata_ptr = LLDB_INVALID_ADDRESS;
+  lldb::addr_t m_keys_ptr = LLDB_INVALID_ADDRESS;
+  lldb::addr_t m_values_ptr = LLDB_INVALID_ADDRESS;
   CompilerType m_element_type;
-  uint64_t m_key_stride;
-  uint64_t m_value_stride;
-  uint64_t m_key_stride_padded;
+  uint64_t m_key_stride = 0;
+  uint64_t m_value_stride = 0;
+  uint64_t m_key_stride_padded = 0;
+  bool m_is_embedded_swift = false;
   // Cached mapping from index to occupied bucket.
   std::vector<Bucket> m_occupiedBuckets;
-  bool m_failedToGetBuckets;
+  bool m_failedToGetBuckets = false;
 };
 
 class CocoaHashedStorageHandler: public HashedStorageHandler {
@@ -421,11 +426,7 @@ HashedCollectionConfig::CreateCocoaHandler(ValueObjectSP storage_sp) const {
 NativeHashedStorageHandler::NativeHashedStorageHandler(
     ValueObjectSP nativeStorage_sp, CompilerType key_type,
     CompilerType value_type)
-    : m_storage(nativeStorage_sp.get()), m_process(nullptr), m_ptr_size(0),
-      m_count(0), m_scale(0), m_metadata_ptr(LLDB_INVALID_ADDRESS),
-      m_keys_ptr(LLDB_INVALID_ADDRESS), m_values_ptr(LLDB_INVALID_ADDRESS),
-      m_element_type(), m_key_stride(), m_value_stride(0),
-      m_key_stride_padded(), m_occupiedBuckets(), m_failedToGetBuckets(false) {
+    : m_storage(nativeStorage_sp.get()) {
   static ConstString g__count("_count");
   static ConstString g__scale("_scale");
   static ConstString g__rawElements("_rawElements");
@@ -446,6 +447,11 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
   m_process = m_storage->GetProcessSP().get();
   if (!m_process)
     return;
+
+  if (ConstString mangled = m_storage->GetCompilerType().GetMangledTypeName())
+    m_is_embedded_swift =
+        SwiftLanguageRuntime::GetManglingFlavor(mangled.GetStringRef()) ==
+        ::swift::Mangle::ManglingFlavor::Embedded;
 
   auto key_stride = key_type.GetByteStride(m_process);
   if (key_stride) {
@@ -509,8 +515,10 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
 
   m_metadata_ptr = last_field_ptr + m_ptr_size;
 
-  // Make sure we can read the first and last word of the bitmap.  
-  if (IsValid()) {
+  // Make sure we can read the first and last word of the bitmap.
+  // Skip this for empty embedded collections since there are no buckets to
+  // read.
+  if (IsValid() && !IsEmptyEmbeddedCollection()) {
     Status error;
     GetMetadataWord(0, error);
     GetMetadataWord(GetWordCount() - 1, error);
@@ -521,22 +529,28 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
 }
 
 bool NativeHashedStorageHandler::IsValid() {
-  return (m_storage != nullptr)
-    && (m_process != nullptr)
-    && (m_ptr_size > 0)
-    && (m_element_type.IsValid())
-    && (m_metadata_ptr != LLDB_INVALID_ADDRESS)
-    && (m_keys_ptr != LLDB_INVALID_ADDRESS)
-    && (m_value_stride == 0 || m_values_ptr != LLDB_INVALID_ADDRESS)
-    // Check counts.
-    && ((m_scale < (sizeof(size_t) * 8)) && (m_count <= GetBucketCount()))
-    // Buffers are tail-allocated in this order: metadata, keys, values
-    && (m_metadata_ptr < m_keys_ptr)
-    && (m_value_stride == 0 || m_keys_ptr < m_values_ptr);
+  if (!m_storage || !m_process || !m_element_type.IsValid())
+    return false;
+
+  // In embedded Swift, the empty singleton has no allocated buffer (all raw
+  // pointers are 0), so skip the buffer pointer ordering checks.
+  if (IsEmptyEmbeddedCollection())
+    return true;
+
+  return (m_ptr_size > 0) && (m_metadata_ptr != LLDB_INVALID_ADDRESS) &&
+         (m_keys_ptr != LLDB_INVALID_ADDRESS) &&
+         (m_value_stride == 0 || m_values_ptr != LLDB_INVALID_ADDRESS)
+         // Check counts.
+         && ((m_scale < (sizeof(size_t) * 8)) && (m_count <= GetBucketCount()))
+         // Buffers are tail-allocated in this order: metadata, keys, values.
+         && (m_metadata_ptr < m_keys_ptr) &&
+         (m_value_stride == 0 || m_keys_ptr < m_values_ptr);
 }
 
 uint64_t
 NativeHashedStorageHandler::GetMetadataWord(int index, Status &error) {
+  assert(!IsEmptyEmbeddedCollection() &&
+         "Cannot read from empty embedded hash collection!");
   if (static_cast<size_t>(index) >= GetWordCount()) {
     error = Status::FromErrorString("index out of bounds");
     return 0;
@@ -560,6 +574,9 @@ NativeHashedStorageHandler::UpdateBuckets() {
   if (m_failedToGetBuckets)
     return false;
   if (!m_occupiedBuckets.empty())
+    return true;
+  // Empty embedded collections have no allocated buffer to scan.
+  if (IsEmptyEmbeddedCollection())
     return true;
   // Scan bitmap for occupied buckets.
   m_occupiedBuckets.reserve(m_count);

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.h
@@ -23,6 +23,8 @@
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Target/Target.h"
 
+#include "swift/Demangling/ManglingFlavor.h"
+
 #include <functional>
 
 namespace lldb_private {
@@ -71,9 +73,8 @@ private:
   CreateCocoaHandler(lldb::ValueObjectSP storage_sp) const;
 
   lldb::ValueObjectSP
-  StorageObjectAtAddress(
-    const ExecutionContext &exe_ctx,
-    lldb::addr_t address) const;
+  StorageObjectAtAddress(const ExecutionContext &exe_ctx, lldb::addr_t address,
+                         ::swift::Mangle::ManglingFlavor flavor) const;
 
   lldb::ValueObjectSP
   CocoaObjectAtAddress(
@@ -96,8 +97,8 @@ protected:
   ConstString m_syntheticChildrenName;
 
   ConstString m_collection_demangledRegex;
-  
-  ConstString m_nativeStorageRoot_mangled;
+
+  ConstString m_nativeStorageRoot_mangledSuffix;
   ConstString m_nativeStorageRoot_demangled;
 
   ConstString m_nativeStorage_mangledRegex_ObjC;

--- a/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftSet.cpp
@@ -42,8 +42,8 @@ SetConfig::SetConfig()
   // Note: We need to have the old _Tt names here because those are
   // still used to name classes in the ObjC runtime.
 
-  m_nativeStorageRoot_mangled =
-    ConstString("$ss15__RawSetStorageCD");
+  // This is stored WITHOUT the mangling flavor suffix.
+  m_nativeStorageRoot_mangledSuffix = ConstString("s15__RawSetStorageCD");
   m_nativeStorageRoot_demangled =
     ConstString("Swift.__RawSetStorage");
 

--- a/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftUnsafeTypes.cpp
@@ -309,8 +309,9 @@ lldb::ChildCacheState SwiftUnsafeRawBufferPointer::Update() {
       return ChildCacheState::eRefetch;
     }
 
-    CompilerType compiler_type =
-        type_system->GetTypeFromMangledTypename(ConstString("$ss5UInt8VD"));
+    auto flavor =
+        SwiftLanguageRuntime::GetManglingFlavor(type.GetMangledTypeName());
+    CompilerType compiler_type = type_system->GetUInt8Type(flavor);
     if (!compiler_type.IsValid()) {
       LLDB_LOG(GetLog(LLDBLog::DataFormatters),
                "{0}: Couldn't get a valid compiler type for 'Swift.UInt8'.",

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2455,6 +2455,7 @@ private:
     }
 
     // TypeMangling for "Swift.UnsafeCurrentTask"
+    // TODO: figure out if this need to be updated to support embedded swift.
     CompilerType task_type =
         ts->GetTypeFromMangledTypename(ConstString("$sSctD"));
     auto task_sp = ValueObject::CreateValueObjectFromAddress(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -160,6 +160,14 @@ public:
       return swift::Mangle::ManglingFlavor::Embedded;
     return swift::Mangle::ManglingFlavor::Default;
   }
+
+  /// Construct a full mangled name from a suffix (without "$s"/"$e" prefix)
+  /// and a mangling flavor.
+  static std::string MakeMangledName(llvm::StringRef suffix,
+                                     swift::Mangle::ManglingFlavor flavor) {
+    return ((flavor == swift::Mangle::ManglingFlavor::Embedded) ? "$e" : "$s") +
+           suffix.str();
+  }
   enum class FuncletComparisonResult {
     NotBothFunclets,
     DifferentAsyncFunctions,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -670,8 +670,10 @@ GetExistentialSyntheticChildren(TypeSystemSwiftTypeRef &ts,
                             return GetTypeFromTypeRef(*ts_sp, super_class_tr,
                                                       flavor);
                           else
-                            return rti ? ts_sp->GetBuiltinUnknownObjectType()
-                                       : ts_sp->GetBuiltinRawPointerType();
+                            return rti ? ts_sp->GetBuiltinUnknownObjectType(
+                                             flavor)
+                                       : ts_sp->GetBuiltinRawPointerType(
+                                             flavor);
                         }});
     if (rti) {
       auto &fields = rti->getFields();
@@ -1680,7 +1682,7 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
             "unexpected kind of indirect record enum");
       }
     } else {
-      payload_type = ts.GetBuiltinRawPointerType();
+      payload_type = ts.GetBuiltinRawPointerType(flavor);
     }
 
     return ValueObjectMemory::Create(exe_ctx.GetBestExecutionContextScope(),

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -8859,9 +8859,11 @@ SwiftASTContext::ConvertClangTypeToSwiftType(CompilerType clang_type) {
   return {this->weak_from_this(), *ast_type};
 }
 
-CompilerType SwiftASTContext::GetBuiltinIntType() {
+CompilerType
+SwiftASTContext::GetBuiltinIntType(swift::Mangle::ManglingFlavor flavor) {
   // FIXME: use target int size!
-  return GetTypeFromMangledTypename(ConstString("$sBi64_D"));
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("Bi64_D", flavor)));
 }
 
 bool SwiftASTContext::TypeHasArchetype(CompilerType type) {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -434,7 +434,7 @@ public:
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;
 
-  CompilerType GetBuiltinIntType();
+  CompilerType GetBuiltinIntType(swift::Mangle::ManglingFlavor flavor);
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -138,12 +138,58 @@ bool TypeSystemSwift::IsScalarType(opaque_compiler_type_t type) {
   return (GetTypeInfo(type, nullptr) & eTypeIsScalar) != 0;
 }
 
-CompilerType TypeSystemSwift::GetBuiltinRawPointerType() {
-  return GetTypeFromMangledTypename(ConstString("$sBpD"));
+CompilerType TypeSystemSwift::GetBuiltinRawPointerType(
+    swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("BpD", flavor)));
 }
 
-CompilerType TypeSystemSwift::GetBuiltinUnknownObjectType() {
-  return GetTypeFromMangledTypename(ConstString("$sBOD"));
+CompilerType TypeSystemSwift::GetBuiltinUnknownObjectType(
+    swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("BOD", flavor)));
+}
+
+CompilerType
+TypeSystemSwift::GetBoolType(swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("SbD", flavor)));
+}
+
+CompilerType
+TypeSystemSwift::GetUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("SVD", flavor)));
+}
+
+CompilerType
+TypeSystemSwift::GetUInt64Type(swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("s6UInt64VD", flavor)));
+}
+
+CompilerType
+TypeSystemSwift::GetTaskPriorityType(swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("ScPD", flavor)));
+}
+
+CompilerType TypeSystemSwift::GetOptionalUnsafeRawPointerType(
+    swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("SVSgD", flavor)));
+}
+
+CompilerType TypeSystemSwift::GetUnsafeCurrentTaskType(
+    swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("SctD", flavor)));
+}
+
+CompilerType
+TypeSystemSwift::GetUInt8Type(swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("s5UInt8VD", flavor)));
 }
 
 bool TypeSystemSwift::ShouldTreatScalarValueAsAddress(

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -206,8 +206,17 @@ public:
   virtual std::string GetSwiftName(const clang::Decl *clang_decl,
                                    TypeSystemClang &clang_typesystem) = 0;
 
-  CompilerType GetBuiltinRawPointerType();
-  CompilerType GetBuiltinUnknownObjectType();
+  CompilerType GetBuiltinRawPointerType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType
+  GetBuiltinUnknownObjectType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType GetBoolType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType GetUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType GetUInt64Type(swift::Mangle::ManglingFlavor flavor);
+  CompilerType GetTaskPriorityType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType
+  GetOptionalUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType GetUnsafeCurrentTaskType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType GetUInt8Type(swift::Mangle::ManglingFlavor flavor);
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2961,10 +2961,20 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
 
   ConstString lhs = l.GetMangledTypeName();
   ConstString rhs = r.GetMangledTypeName();
-  if (lhs == ConstString("$sSiD") && rhs == ConstString("$sSuD"))
+
+  // Strip the mangling flavor prefix ($s or $e) for comparisons.
+  auto strip_flavor = [](llvm::StringRef s) -> llvm::StringRef {
+    if (s.starts_with("$s") || s.starts_with("$e"))
+      return s.drop_front(2);
+    return s;
+  };
+
+  if (strip_flavor(lhs.GetStringRef()) == "SiD" &&
+      strip_flavor(rhs.GetStringRef()) == "SuD")
     return true;
-  if (lhs.GetStringRef() == "$sSPySo0023unnamedstruct_hEEEdhdEaVGSgD" &&
-      rhs.GetStringRef() == "$ss13OpaquePointerVSgD")
+  if (strip_flavor(lhs.GetStringRef()) ==
+          "SPySo0023unnamedstruct_hEEEdhdEaVGSgD" &&
+      strip_flavor(rhs.GetStringRef()) == "s13OpaquePointerVSgD")
     return true;
   // Ignore missing sugar.
   swift::Demangle::Demangler dem;
@@ -2990,7 +3000,7 @@ template <> bool Equivalent<CompilerType>(CompilerType l, CompilerType r) {
     return true;
 
   // SwiftASTContext hardcodes some less-precise types.
-  if (rhs.GetStringRef() == "$sBpD")
+  if (strip_flavor(rhs.GetStringRef()) == "BpD")
     return true;
 
   // If the type is a Clang-imported type ignore mismatches. Since we

--- a/lldb/test/API/lang/swift/embedded/dictionary_formatting/Makefile
+++ b/lldb/test/API/lang/swift/embedded/dictionary_formatting/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/dictionary_formatting/TestSwiftEmbeddedDictionaryFormatting.py
+++ b/lldb/test/API/lang/swift/embedded/dictionary_formatting/TestSwiftEmbeddedDictionaryFormatting.py
@@ -36,8 +36,7 @@ class TestSwiftEmbeddedDictionaryFormatting(TestBase):
         self.assertEqual(keys, {1, 2, 3})
         self.assertEqual(values, {10, 20, 30})
 
-        # rdar://170883616
-        # emptyDict = frame.FindVariable("emptyDict")
-        # lldbutil.check_variable(
-        #     self, emptyDict, False, summary="0 key/value pairs"
-        # )
+        emptyDict = frame.FindVariable("emptyDict")
+        lldbutil.check_variable(
+            self, emptyDict, False, summary="0 key/value pairs"
+        )

--- a/lldb/test/API/lang/swift/embedded/dictionary_formatting/TestSwiftEmbeddedDictionaryFormatting.py
+++ b/lldb/test/API/lang/swift/embedded/dictionary_formatting/TestSwiftEmbeddedDictionaryFormatting.py
@@ -1,0 +1,43 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedDictionaryFormatting(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test Dictionary data formatter children in embedded Swift."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        dictionary = frame.FindVariable("dict")
+        lldbutil.check_variable(
+            self, dictionary, False, summary="3 key/value pairs"
+        )
+
+        self.assertEqual(dictionary.GetNumChildren(), 3)
+        keys = set()
+        values = set()
+        for i in range(3):
+            child = dictionary.GetChildAtIndex(i)
+            key = child.GetChildMemberWithName("key")
+            value = child.GetChildMemberWithName("value")
+            keys.add(int(key.GetValue()))
+            values.add(int(value.GetValue()))
+        self.assertEqual(keys, {1, 2, 3})
+        self.assertEqual(values, {10, 20, 30})
+
+        # rdar://170883616
+        # emptyDict = frame.FindVariable("emptyDict")
+        # lldbutil.check_variable(
+        #     self, emptyDict, False, summary="0 key/value pairs"
+        # )

--- a/lldb/test/API/lang/swift/embedded/dictionary_formatting/main.swift
+++ b/lldb/test/API/lang/swift/embedded/dictionary_formatting/main.swift
@@ -1,0 +1,7 @@
+func f() {
+    var dict: [Int: Int] = [1: 10, 2: 20, 3: 30]
+    let emptyDict: [Int: Int] = [:]
+    print("break here") // break here
+}
+
+f()

--- a/lldb/test/API/lang/swift/embedded/set/Makefile
+++ b/lldb/test/API/lang/swift/embedded/set/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/set/TestSwiftEmbeddedSet.py
+++ b/lldb/test/API/lang/swift/embedded/set/TestSwiftEmbeddedSet.py
@@ -1,0 +1,34 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedSet(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test Set data formatter in embedded Swift."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        s = frame.FindVariable("s")
+        lldbutil.check_variable(self, s, False, summary="5 values")
+
+        self.assertEqual(s.GetNumChildren(), 5)
+        elements = set()
+        for i in range(5):
+            child = s.GetChildAtIndex(i)
+            elements.add(int(child.GetValue()))
+        self.assertEqual(elements, {1, 2, 3, 4, 5})
+        
+        # rdar://170883616
+        # emptySet = frame.FindVariable("emptySet")
+        # lldbutil.check_variable(self, emptySet, False, summary="0 values")

--- a/lldb/test/API/lang/swift/embedded/set/TestSwiftEmbeddedSet.py
+++ b/lldb/test/API/lang/swift/embedded/set/TestSwiftEmbeddedSet.py
@@ -29,6 +29,5 @@ class TestSwiftEmbeddedSet(TestBase):
             elements.add(int(child.GetValue()))
         self.assertEqual(elements, {1, 2, 3, 4, 5})
         
-        # rdar://170883616
-        # emptySet = frame.FindVariable("emptySet")
-        # lldbutil.check_variable(self, emptySet, False, summary="0 values")
+        emptySet = frame.FindVariable("emptySet")
+        lldbutil.check_variable(self, emptySet, False, summary="0 values")

--- a/lldb/test/API/lang/swift/embedded/set/main.swift
+++ b/lldb/test/API/lang/swift/embedded/set/main.swift
@@ -1,0 +1,7 @@
+func f() {
+    var s: Set<Int> = [1, 2, 3, 4, 5]
+    let emptySet: Set<Int> = []
+    print("break here") // break here
+}
+
+f()

--- a/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/Makefile
+++ b/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/TestSwiftEmbeddedUnsafeRawBufferPointer.py
+++ b/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/TestSwiftEmbeddedUnsafeRawBufferPointer.py
@@ -1,0 +1,28 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedUnsafeRawBufferPointer(TestBase):
+    @skipIf(bugnumber="rdar://170883698")
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test UnsafeRawBufferPointer formatter in embedded Swift."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.frames[0]
+        self.assertTrue(frame, "Frame 0 is valid.")
+
+        # 3 Ints * 8 bytes = 24 bytes.
+        buffer = frame.FindVariable("buffer")
+        lldbutil.check_variable(self, buffer, False, summary="24 values")
+
+        # Verify children are accessible.
+        self.assertEqual(buffer.GetNumChildren(), 24)

--- a/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/main.swift
+++ b/lldb/test/API/lang/swift/embedded/unsafe_raw_buffer_pointer/main.swift
@@ -1,0 +1,8 @@
+func f() {
+    let array: [Int] = [10, 20, 30]
+    array.withUnsafeBytes { buffer in
+        print("break here") // break here
+    }
+}
+
+f()


### PR DESCRIPTION
    [lldb] Unhardcode mangled flavor

    Many fundamental swift types that lldb uses were hardcoded to use the
    default mangling flavor $s. Now that there's a different mangling
    flavor, these should be created on the context of whether the type is a
    regular or embedded swift type.

    rdar://170879704

And:

    [lldb] Fix empty dict/set formatting in embedded Swift

    Similar to 63f364f7269724ab29d0185322b1fca37e7d0df2, on embedded swift
    the formatter cannot count on metadata being present for empty hashed
    collections.

    rdar://170883616