### PR TITLE
[lldb][swift] Do not show XcodeSDK errors on non apple platform

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -27,6 +27,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/Timeout.h"
+#include "lldb/Utility/UnimplementedError.h"
 #include "lldb/Utility/UserIDResolver.h"
 #include "lldb/Utility/XcodeSDK.h"
 #include "lldb/lldb-private-forward.h"
@@ -453,9 +454,7 @@ public:
   ///          (e.g., a public and internal SDK).
   virtual llvm::Expected<std::pair<XcodeSDK, bool>>
   GetSDKPathFromDebugInfo(Module &module) {
-    return llvm::createStringError(
-        llvm::formatv("{0} not implemented for '{1}' platform.",
-                      LLVM_PRETTY_FUNCTION, GetName()));
+    return llvm::make_error<UnimplementedError>();
   }
 
   /// Returns the full path of the most appropriate SDK for the
@@ -478,11 +477,9 @@ public:
   ///
   /// \param[in] unit The CU
   ///
-  /// \returns A parsed XcodeSDK object if successful, an Error otherwise. 
+  /// \returns A parsed XcodeSDK object if successful, an Error otherwise.
   virtual llvm::Expected<XcodeSDK> GetSDKPathFromDebugInfo(CompileUnit &unit) {
-    return llvm::createStringError(
-        llvm::formatv("{0} not implemented for '{1}' platform.",
-                      LLVM_PRETTY_FUNCTION, GetName()));
+    return llvm::make_error<UnimplementedError>();
   }
 
   /// Returns the full path of the most appropriate SDK for the

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2287,7 +2287,7 @@ static std::string GetSDKPathFromDebugInfo(std::string m_description,
         sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
         [&](const llvm::ErrorInfoBase &error) {
           Debugger::ReportError(
-              "Error while parsing SDK path from debug info: " +
+              "error while parsing SDK path from debug info: " +
               toString(sdk_or_err.takeError()));
         });
     return {};
@@ -2959,7 +2959,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
             sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
             [&](const llvm::ErrorInfoBase &error) {
               Debugger::ReportError(
-                  "Error while parsing SDK path from debug info: " +
+                  "error while parsing SDK path from debug info: " +
                   toString(sdk_or_err.takeError()));
             });
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -22,6 +22,7 @@
 
 #include "lldb/Symbol/CompilerType.h"
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/UnimplementedError.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
@@ -2277,14 +2278,18 @@ static std::string GetSDKPath(std::string m_description, XcodeSDK sdk) {
 /// Force parsing of the CUs to extract the SDK info.
 static std::string GetSDKPathFromDebugInfo(std::string m_description,
                                            Module &module) {
-#ifdef __APPLE__ // Other platforms do not support XcodeSDK.
   auto platform_sp = Platform::GetHostPlatform();
   if (!platform_sp)
     return {};
   auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(module);
   if (!sdk_or_err) {
-    Debugger::ReportError("Error while parsing SDK path from debug info: " +
-                          toString(sdk_or_err.takeError()));
+    llvm::handleAllErrors(
+        sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
+        [&](const llvm::ErrorInfoBase &error) {
+          Debugger::ReportError(
+              "Error while parsing SDK path from debug info: " +
+              toString(sdk_or_err.takeError()));
+        });
     return {};
   }
 
@@ -2298,9 +2303,6 @@ static std::string GetSDKPathFromDebugInfo(std::string m_description,
         module.GetFileSpec().GetFilename().AsCString("<unknown module>"));
 
   return GetSDKPath(m_description, std::move(sdk));
-#else
-  return {};
-#endif
 }
 
 static std::vector<llvm::StringRef>
@@ -2948,21 +2950,25 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   }
 
   // Get the precise SDK from the symbol context.
-  [[maybe_unused]] std::optional<XcodeSDK> sdk;
-#ifdef __APPLE__  // Other platforms do not support XcodeSDK.
+  std::optional<XcodeSDK> sdk;
   if (cu)
     if (auto platform_sp = Platform::GetHostPlatform()) {
       auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
-      if (!sdk_or_err)
-        Debugger::ReportError("Error while parsing SDK path from debug info: " +
-                              toString(sdk_or_err.takeError()));
-      else {
+      if (!sdk_or_err) {
+        llvm::handleAllErrors(
+            sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
+            [&](const llvm::ErrorInfoBase &error) {
+              Debugger::ReportError(
+                  "Error while parsing SDK path from debug info: " +
+                  toString(sdk_or_err.takeError()));
+            });
+
+      } else {
         sdk = *sdk_or_err;
         LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
                    sdk->GetString().str().c_str());
       }
     }
-#endif
   // Derive the triple next.
 
   // First, prime the compiler with the options from the main executable:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2277,6 +2277,7 @@ static std::string GetSDKPath(std::string m_description, XcodeSDK sdk) {
 /// Force parsing of the CUs to extract the SDK info.
 static std::string GetSDKPathFromDebugInfo(std::string m_description,
                                            Module &module) {
+#ifdef __APPLE__ // Other platforms do not support XcodeSDK.
   auto platform_sp = Platform::GetHostPlatform();
   if (!platform_sp)
     return {};
@@ -2297,6 +2298,9 @@ static std::string GetSDKPathFromDebugInfo(std::string m_description,
         module.GetFileSpec().GetFilename().AsCString("<unknown module>"));
 
   return GetSDKPath(m_description, std::move(sdk));
+#else
+  return {};
+#endif
 }
 
 static std::vector<llvm::StringRef>
@@ -2944,20 +2948,21 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   }
 
   // Get the precise SDK from the symbol context.
-  std::optional<XcodeSDK> sdk;
+  [[maybe_unused]] std::optional<XcodeSDK> sdk;
+#ifdef __APPLE__  // Other platforms do not support XcodeSDK.
   if (cu)
     if (auto platform_sp = Platform::GetHostPlatform()) {
       auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
-      if (!sdk_or_err)
+      if (!sdk_or_err) {
         Debugger::ReportError("Error while parsing SDK path from debug info: " +
                               toString(sdk_or_err.takeError()));
-      else {
+      } else {
         sdk = *sdk_or_err;
         LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
                    sdk->GetString().str().c_str());
       }
     }
-
+#endif
   // Derive the triple next.
 
   // First, prime the compiler with the options from the main executable:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2953,10 +2953,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   if (cu)
     if (auto platform_sp = Platform::GetHostPlatform()) {
       auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
-      if (!sdk_or_err) {
+      if (!sdk_or_err)
         Debugger::ReportError("Error while parsing SDK path from debug info: " +
                               toString(sdk_or_err.takeError()));
-      } else {
+      else {
         sdk = *sdk_or_err;
         LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
                    sdk->GetString().str().c_str());


### PR DESCRIPTION
The SwiftASTContext always emit an error when it is used from the debugger. It is not meaningful as it doesn't apply to other platforms.