### PR TITLE
[lldb] Speed up SymbolContextList::AppendIfUnique (#181952)

### DIFF
--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -954,7 +954,7 @@ void Module::FindFunctions(const RegularExpression &regex,
                 if (pos == end)
                   sc_list.Append(sc);
                 else
-                  sc_list[pos->second].symbol = sc.symbol;
+                  sc_list.SetSymbolAtIndex(pos->second, sc.symbol);
               }
             }
           }

--- a/lldb/source/Symbol/SymbolContext.cpp
+++ b/lldb/source/Symbol/SymbolContext.cpp
@@ -1198,21 +1198,19 @@ SymbolContextList::SymbolContextList() : m_symbol_contexts() {}
 SymbolContextList::~SymbolContextList() = default;
 
 void SymbolContextList::Append(const SymbolContext &sc) {
-  m_symbol_contexts.push_back(sc);
+  m_symbol_contexts.insert(sc);
 }
 
 void SymbolContextList::Append(const SymbolContextList &sc_list) {
-  collection::const_iterator pos, end = sc_list.m_symbol_contexts.end();
-  for (pos = sc_list.m_symbol_contexts.begin(); pos != end; ++pos)
-    m_symbol_contexts.push_back(*pos);
+  for (const auto &sc : sc_list.m_symbol_contexts)
+    m_symbol_contexts.insert(sc);
 }
 
 uint32_t SymbolContextList::AppendIfUnique(const SymbolContextList &sc_list,
                                            bool merge_symbol_into_function) {
   uint32_t unique_sc_add_count = 0;
-  collection::const_iterator pos, end = sc_list.m_symbol_contexts.end();
-  for (pos = sc_list.m_symbol_contexts.begin(); pos != end; ++pos) {
-    if (AppendIfUnique(*pos, merge_symbol_into_function))
+  for (const auto &sc : sc_list.m_symbol_contexts) {
+    if (AppendIfUnique(sc, merge_symbol_into_function))
       ++unique_sc_add_count;
   }
   return unique_sc_add_count;
@@ -1220,30 +1218,28 @@ uint32_t SymbolContextList::AppendIfUnique(const SymbolContextList &sc_list,
 
 bool SymbolContextList::AppendIfUnique(const SymbolContext &sc,
                                        bool merge_symbol_into_function) {
-  collection::iterator pos, end = m_symbol_contexts.end();
-  for (pos = m_symbol_contexts.begin(); pos != end; ++pos) {
-    // Because symbol contexts might first be built without the symbol,
-    // which is then appended later on, compare the symbol contexts taking into
-    // accout that one (or either) of them might not have a symbol yet.
-    if (SymbolContext::CompareConsideringPossiblyNullSymbol(*pos, sc))
-      return false;
-  }
+  if (m_symbol_contexts.contains(sc))
+    return false;
+
+  // This path is only taken when sc is an "isolated symbol" (only symbol field
+  // is set), so it's not the hot path.
   if (merge_symbol_into_function && sc.symbol != nullptr &&
       sc.comp_unit == nullptr && sc.function == nullptr &&
       sc.block == nullptr && !sc.line_entry.IsValid()) {
     if (sc.symbol->ValueIsAddress()) {
-      for (pos = m_symbol_contexts.begin(); pos != end; ++pos) {
+      for (size_t i = 0, e = m_symbol_contexts.size(); i != e; ++i) {
+        const auto &pos = m_symbol_contexts[i];
         // Don't merge symbols into inlined function symbol contexts
-        if (pos->block && pos->block->GetContainingInlinedBlock())
+        if (pos.block && pos.block->GetContainingInlinedBlock())
           continue;
 
-        if (pos->function) {
-          if (pos->function->GetAddress() == sc.symbol->GetAddressRef()) {
+        if (pos.function) {
+          if (pos.function->GetAddress() == sc.symbol->GetAddressRef()) {
             // Do we already have a function with this symbol?
-            if (pos->symbol == sc.symbol)
+            if (pos.symbol == sc.symbol)
               return false;
-            if (pos->symbol == nullptr) {
-              pos->symbol = sc.symbol;
+            if (pos.symbol == nullptr) {
+              SetSymbolAtIndex(i, sc.symbol);
               return false;
             }
           }
@@ -1251,7 +1247,8 @@ bool SymbolContextList::AppendIfUnique(const SymbolContext &sc,
       }
     }
   }
-  m_symbol_contexts.push_back(sc);
+
+  m_symbol_contexts.insert(sc);
   return true;
 }
 
@@ -1265,10 +1262,8 @@ void SymbolContextList::Dump(Stream *s, Target *target) const {
   s->EOL();
   s->IndentMore();
 
-  collection::const_iterator pos, end = m_symbol_contexts.end();
-  for (pos = m_symbol_contexts.begin(); pos != end; ++pos) {
-    // pos->Dump(s, target);
-    pos->GetDescription(s, eDescriptionLevelVerbose, target);
+  for (const auto &sc : m_symbol_contexts) {
+    sc.GetDescription(s, eDescriptionLevelVerbose, target);
   }
   s->IndentLess();
 }


### PR DESCRIPTION
d7fb086668dff68 changed some calls from SymbolContextList::Append to SymbolContextList::AppendIfUnique. This has unfortunately caused a huge slow down in operations involving a large amount of symbol contexts (for example, trying to autocomplete from an empty input "b <TAB>" will add every function to the list), since AppendIfUnique scans the entire symbol context list. Speed this up by adding a hash set to quickly answer whether a symbol context is on the list or not.

This takes the time from running "b <TAB>" when debugging yaml2obj on my machine from 600 seconds down to 13, which is about the same as before d7fb086668dff68.

Note that AppendIfUnique has a logic error, which has been present since its introduction. This has to do with the behavior controlled by "merge_symbol_into_function", which will try to merge symbols with symbol context containing the equivalent function to that symbol.

The previous patch tried to correct this by adding CompareConsideringPossiblyNullSymbol(), which is not quite correct.

With CompareConsideringPossiblyNullSymbol(), if symbols are added in this order:

- Symbol context without symbol.
- Equivalent symbol context with symbol.

The list will have only one symbol context WITHOUT the symbol.

If we stop using CompareConsideringPossiblyNullSymbol() and instead go back to the == operator which d7fb086668dff68 introduced, with symbols added in this order, the following will happen:

- Symbol context without symbol.
- Equivalent symbol context with symbol.
- The bare symbol, with "merge_symbol_into_function = true", the list will have the same symbol twice.

This patch does not attempt to solve this, and instead focuses on the performance issue d7fb086668dff68 introduced.

rdar://170477680
(cherry picked from commit b3f3b57aed375b53d1801d532333bd66417b11ef)