### PR TITLE
lldb: Update Swift type resolution for RemoteInspection changes.

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -42,6 +42,7 @@
 #include "swift/AST/ASTWalker.h"
 #include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/ManglingFlavor.h"
+#include "swift/RemoteInspection/DescriptorFinder.h"
 #include "swift/RemoteInspection/ReflectionContext.h"
 #include "swift/RemoteInspection/TypeRefBuilder.h"
 #include "swift/Strings.h"
@@ -475,14 +476,18 @@ const swift::reflection::TypeInfo *SwiftLanguageRuntime::emplaceClangTypeInfo(
     auto it_b = m_clang_type_info.insert(
         {clang_type.GetOpaqueQualType(),
          swift::reflection::TypeInfo(swift::reflection::TypeInfoKind::Builtin,
-                                     *byte_size, byte_align, byte_stride,
-                                     extra_inhabitants, true)});
+                 *byte_size, byte_align, byte_stride,
+                 extra_inhabitants,
+                 swift::reflection::BitwiseBorrowability::TakableAndBorrowable,
+                 /*AFD=*/ false)});
     return &*it_b.first->second;
   }
   auto it_b = m_clang_record_type_info.insert(
       {clang_type.GetOpaqueQualType(),
        swift::reflection::RecordTypeInfo(
-           *byte_size, byte_align, byte_stride, extra_inhabitants, false,
+           *byte_size, byte_align, byte_stride, extra_inhabitants,
+           swift::reflection::BitwiseBorrowability::None,
+           /*AFD=*/true,
            swift::reflection::RecordKind::Struct, fields)});
   return &*it_b.first->second;
 }

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -22,6 +22,7 @@
 
 #include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "swift/Demangling/ManglingFlavor.h"
+#include "swift/RemoteInspection/DescriptorFinder.h"
 #include "swift/RemoteInspection/TypeLowering.h"
 
 #include "lldb/Utility/LLDBLog.h"
@@ -235,9 +236,11 @@ public:
   DWARFBuiltinTypeDescriptorImpl(uint32_t size, uint32_t alignment,
                                  uint32_t stride,
                                  uint32_t num_extra_inhabitants,
-                                 bool is_bitwise_takable, ConstString type_name)
+                                 swift::reflection::BitwiseBorrowability borrowability,
+                                 bool addr_for_dependencies, ConstString type_name)
       : swift::reflection::BuiltinTypeDescriptorBase(
-            size, alignment, stride, num_extra_inhabitants, is_bitwise_takable),
+            size, alignment, stride, num_extra_inhabitants, borrowability,
+            addr_for_dependencies),
         m_type_name(ExtractTypeName(type_name.GetStringRef())) {}
   ~DWARFBuiltinTypeDescriptorImpl() override = default;
 
@@ -254,10 +257,12 @@ public:
   HardcodedBuiltinTypeDescriptorImpl(uint32_t size, uint32_t alignment,
                                      uint32_t stride,
                                      uint32_t num_extra_inhabitants,
-                                     bool is_bitwise_takable,
+                                     swift::reflection::BitwiseBorrowability borrowability,
+                                     bool addr_for_dependencies,
                                      std::string type_name)
       : swift::reflection::BuiltinTypeDescriptorBase(
-            size, alignment, stride, num_extra_inhabitants, is_bitwise_takable),
+            size, alignment, stride, num_extra_inhabitants, borrowability,
+            addr_for_dependencies),
         m_type_name(std::move(type_name)) {}
   ~HardcodedBuiltinTypeDescriptorImpl() override = default;
 
@@ -283,7 +288,9 @@ getHardcodedBuiltinTypeDescriptor(const swift::reflection::TypeRef *TR,
             /*alignment=*/pointer_size,
             /*stride=*/pointer_size,
             /*num_extra_inhabitants=*/num_extra_inhabitants,
-            /*is_bitwise_takable=*/true, std::move(name));
+            /*borrowability=*/swift::reflection::BitwiseBorrowability::TakableAndBorrowable,
+            /*addr_for_dependencies=*/false,
+            std::move(name));
       };
 
   // Builtin.NativeObject (Bo).
@@ -312,7 +319,9 @@ getHardcodedBuiltinTypeDescriptor(const swift::reflection::TypeRef *TR,
         /*alignment=*/pointer_size,
         /*stride=*/size,
         /*num_extra_inhabitants=*/0,
-        /*is_bitwise_takable=*/true, "BB");
+        /*borrowability=*/swift::reflection::BitwiseBorrowability::TakableAndBorrowable,
+        /*addr_for_dependencies=*/true,
+        "BB");
   }
 
   // Thin function type () -> ().
@@ -557,10 +566,13 @@ getDWARFBuiltinTypeDescriptor(TypeSystemSwiftTypeRef &swift_typesystem,
   auto num_extra_inhabitants = die.GetAttributeValueAsUnsigned(
       llvm::dwarf::DW_AT_LLVM_num_extra_inhabitants, 0);
 
-  auto is_bitwise_takable = true; // TODO: encode it in DWARF
+  // TODO: encode these in DWARF
+  auto borrowability = swift::reflection::BitwiseBorrowability::TakableAndBorrowable;
+  auto addressable_for_dependencies = false;
 
   return std::make_unique<DWARFBuiltinTypeDescriptorImpl>(
-      byte_size, alignment, stride, num_extra_inhabitants, is_bitwise_takable,
+      byte_size, alignment, stride, num_extra_inhabitants,
+      borrowability, addressable_for_dependencies,
       type.GetMangledTypeName());
 }
 


### PR DESCRIPTION
`Builtin.Borrow` needs two new bits of information for each type:

- whether it is bitwise-borrowable in addition to being bitwise-takable
- whether it is "addressable for dependencies", meaning it is passed by address to functions that produce lifetime-dependent values

The Swift-side APIs for forming reflection type descriptors gained new parameters to set these properties, so update lldb's use of these APIs to match.