### PR TITLE
Move the ObjC blocks layout bitmap to the cstring section (#182398)

### DIFF
--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -2754,7 +2754,7 @@ llvm::Constant *CGObjCCommonMac::getBitmapBlockLayout(bool ComputeByrefLayout) {
     }
   }
 
-  auto *Entry = CreateCStringLiteral(BitMap, ObjCLabelType::ClassName,
+  auto *Entry = CreateCStringLiteral(BitMap, ObjCLabelType::LayoutBitMap,
                                      /*ForceNonFragileABI=*/true,
                                      /*NullTerminate=*/false);
   return getConstantGEP(VMContext, Entry, 0, 0);

--- a/clang/test/CodeGenObjC/block-layout-section.m
+++ b/clang/test/CodeGenObjC/block-layout-section.m
@@ -1,0 +1,24 @@
+// REQUIRES: target={{.*}}-{{darwin|macos}}{{.*}}
+// RUN: %clang_cc1 -fblocks -triple arm64-apple-darwin -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fblocks -x objective-c++ -triple arm64-apple-darwin -emit-llvm -o - %s | FileCheck %s
+
+typedef struct
+{
+  int a;
+} BlockState;
+
+typedef void(^InBlock)(int); 
+
+void sink(InBlock);
+
+int doMagic(void)
+{
+  __block BlockState state;
+  sink(^(int in) {
+    state.a += in;
+  });
+  return state.a;
+}
+
+// block layout in the regular c-string section
+// CHECK: @OBJC_LAYOUT_BITMAP_{{.*}} = private unnamed_addr constant {{.*}} section "__TEXT,__cstring,cstring_literals"


### PR DESCRIPTION
This is a follow-up to https://github.com/llvm/llvm-project/pull/174705

There's one additional place in the ObjC code gen logic to make sure the ObjC blocks layout is generated in the regular cstring section.