### PR TITLE
[lldb/Target] Revert overly broad locking in StackFrameList::FetchFramesUpTo

### DIFF
--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -71,24 +71,13 @@ bool SyntheticStackFrameList::FetchFramesUpTo(
   size_t num_synthetic_frames = 0;
   // Use the provider to generate frames lazily.
   if (m_provider) {
-    // Get starting index under lock.
-    uint32_t start_idx = 0;
-    {
-      std::shared_lock<std::shared_mutex> guard(m_list_mutex);
-      start_idx = m_frames.size();
-    }
-
     // Keep fetching until we reach end_idx or the provider returns an error.
-    for (uint32_t idx = start_idx; idx <= end_idx; idx++) {
+    for (uint32_t idx = m_frames.size(); idx <= end_idx; idx++) {
       if (allow_interrupt &&
           m_thread.GetProcess()->GetTarget().GetDebugger().InterruptRequested())
         return true;
 
-      // Call Python WITHOUT holding lock - prevents deadlock.
       auto frame_or_err = m_provider->GetFrameAtIndex(idx);
-
-      // Acquire lock to modify m_frames.
-      std::unique_lock<std::shared_mutex> guard(m_list_mutex);
 
       if (!frame_or_err) {
         // Provider returned error - we've reached the end.
@@ -423,10 +412,6 @@ bool StackFrameList::GetFramesUpTo(uint32_t end_idx,
     FetchOnlyConcreteFramesUpTo(end_idx);
     return false;
   }
-
-  // Release lock before FetchFramesUpTo which may call Python.
-  // FetchFramesUpTo will acquire locks as needed.
-  guard.unlock();
 
   // We're adding concrete and inlined frames now:
   was_interrupted = FetchFramesUpTo(end_idx, allow_interrupt);


### PR DESCRIPTION
This patch fixes a data race introduced in c373d76 where m_list_mutex is released in GetFramesUpTo before calling FetchFramesUpTo, which then modifies m_frames without re-acquiring the lock.

Prior to that change, the whole function was guarded by the lock, but this caused frame providers to deadlock when unwinding frames from Python FrameProviders.

The race manifests as:
- Thread A: GetFrameWithStackID holds a shared_lock and performs a binary search on m_frames via llvm::lower_bound.
- Thread B: FetchFramesUpTo modifies m_frames via push_back without any lock.

This causes a PAC failure when Thread A dereferences an iterator invalidated by Thread B's concurrent push_back.

The fine-grained locking inside FetchFramesUpTo and the early unlock in GetFramesUpTo were originally introduced to prevent a deadlock caused by StackFrame holding a back-reference to its StackFrameList.

Now that StackFrame no longer holds a StackFrameListWP, the deadlock condition shouldn't occur and the extra locking is unnecessary. Moreover, splitting the critical section into smaller ones doesn't solve the race since another thread can still modify m_frames between acquisitions.

rdar://169982918


(cherry picked from commit 1d8ecc6ff2c04d16bebbd7aa0ecb70233d1656ff)