### PR TITLE
[-Wunsafe-buffer-usage] Fix false positive on `snprintf((char*)0, 0, "")`

### DIFF
--- a/clang/lib/Analysis/UnsafeBufferUsage.cpp
+++ b/clang/lib/Analysis/UnsafeBufferUsage.cpp
@@ -1029,12 +1029,19 @@ static bool isCountAttributedPointerArgumentSafeImpl(
          "dependent value map.");
 
   const Expr *PtrArgNoImp = PtrArg->IgnoreParenImpCasts();
+
   if (const auto *DAE = dyn_cast<CXXDefaultArgExpr>(PtrArgNoImp))
     PtrArgNoImp = DAE->getExpr()->IgnoreParenImpCasts();
 
   // check form 0:
-  if (PtrArgNoImp->isNullPointerConstant(Context,
-                                         Expr::NPC_ValueDependentIsNotNull)) {
+  const Expr *PtrArgNoCast = PtrArgNoImp;
+
+  // For any type 'T', expression '(T *) nullptr' satisfies form 0. So we can
+  // ignore the cast:
+  if (const auto *CE = dyn_cast<CastExpr>(PtrArgNoCast))
+    PtrArgNoCast = CE->getSubExpr();
+  if (PtrArgNoCast->isNullPointerConstant(Context,
+                                          Expr::NPC_ValueDependentIsNotNull)) {
     if (isOrNull)
       return true;
     if (CountArg)

--- a/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
+++ b/clang/test/SemaCXX/warn-unsafe-buffer-usage-libc-functions.cpp
@@ -278,9 +278,9 @@ void test(StrBuff& str)
 }
 
 void dontCrashForInvalidFormatString() {
-  //snprintf((char*)0, 0, "%");  // FIXME: false positive rdar://166823188
+  snprintf((char*)0, 0, "%"); // Used to be a false positive rdar://166823188
   snprintf(nullptr, 0, "%");
-  //snprintf((char*)0, 0, "\0");
+  snprintf((char*)0, 0, "\0");
   snprintf(nullptr, 0, "\0");
 }
 


### PR DESCRIPTION
The analysis didn't recognize `(char*)0` as null. This fix adds the logic that for any type `T`, `(T*) c` is null pointer iff `c` evaluates to a null pointer constant.

rdar://166823188