### PR TITLE
[Cherry-pick into next] [lldb] Add support for existential containers in embedded Swift

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -385,6 +385,15 @@ public:
     return ptr;
   }
 
+  std::optional<swift::remote::RemoteExistential>
+  ReadMetadataAndValueOpaqueExistential(
+      lldb::addr_t existential_address) override {
+    return m_reflection_ctx.readMetadataAndValueOpaqueExistential(
+        swift::remote::RemoteAddress(
+            existential_address,
+            swift::remote::RemoteAddress::DefaultAddressSpace));
+  }
+
   std::optional<bool> IsValueInlinedInExistentialContainer(
       swift::remote::RemoteAddress existential_address) override {
     return m_reflection_ctx.isValueInlinedInExistentialContainer(

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -156,6 +156,8 @@ public:
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual swift::remote::RemoteAbsolutePointer
   StripSignedPointer(swift::remote::RemoteAbsolutePointer pointer) = 0;
+  virtual std::optional<swift::remote::RemoteExistential>
+  ReadMetadataAndValueOpaqueExistential(lldb::addr_t existential_address) = 0;
   struct AsyncTaskInfo {
     bool isChildTask = false;
     bool isFuture = false;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -693,6 +693,23 @@ protected:
   CompilerType GetDynamicTypeAndAddress_EmbeddedClass(uint64_t instance_ptr,
                                                       CompilerType class_type);
 
+  /// Resolves the dynamic type of a class-constrained embedded Swift
+  /// existential.
+  std::optional<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type);
+
+  /// Resolves the dynamic type of an embedded Swift existential container.
+  std::optional<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+      lldb::addr_t existential_address, CompilerType existential_type);
+
+  /// Resolves the dynamic type of an embedded Swift existential.
+  /// Tries class-constrained first, then falls back to existential container.
+  llvm::Expected<std::pair<CompilerType, uint64_t>>
+  GetDynamicTypeAndAddress_ExistentialEmbedded(lldb::addr_t existential_address,
+                                               CompilerType existential_type);
+
   /// Dynamic type resolution tends to want to generate scalar data -
   /// but there are caveats Per original comment here "Our address is
   /// the location of the dynamic type stored in memory.  It isn't a

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2226,6 +2226,124 @@ CompilerType SwiftLanguageRuntime::GetDynamicTypeAndAddress_EmbeddedClass(
   return dynamic_type;
 }
 
+std::optional<std::pair<CompilerType, uint64_t>> SwiftLanguageRuntime::
+    GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+        lldb::addr_t existential_address, CompilerType existential_type) {
+  auto reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return std::nullopt;
+
+  auto maybe_addr_or_symbol = reflection_ctx->ReadPointer(existential_address);
+  if (!maybe_addr_or_symbol)
+    return std::nullopt;
+
+  uint64_t address = 0;
+  if (maybe_addr_or_symbol->getSymbol().empty() &&
+      maybe_addr_or_symbol->getOffset() == 0) {
+    address = maybe_addr_or_symbol->getResolvedAddress().getRawAddress();
+  } else {
+    SymbolContextList sc_list;
+    auto &module_list = GetProcess().GetTarget().GetImages();
+    module_list.FindSymbolsWithNameAndType(
+        ConstString(maybe_addr_or_symbol->getSymbol()), eSymbolTypeAny,
+        sc_list);
+    if (sc_list.GetSize() != 1)
+      return std::nullopt;
+
+    SymbolContext sc = sc_list[0];
+    Symbol *symbol = sc.symbol;
+    address = symbol->GetLoadAddress(&GetProcess().GetTarget());
+  }
+
+  CompilerType dynamic_type =
+      GetDynamicTypeAndAddress_EmbeddedClass(address, existential_type);
+  if (!dynamic_type)
+    return std::nullopt;
+
+  return std::make_pair(
+      dynamic_type, maybe_addr_or_symbol->getResolvedAddress().getRawAddress());
+}
+
+std::optional<std::pair<CompilerType, uint64_t>>
+SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+    lldb::addr_t existential_address, CompilerType existential_type) {
+  auto reflection_ctx = GetReflectionContext();
+  if (!reflection_ctx)
+    return std::nullopt;
+
+  auto existential_container =
+      reflection_ctx->ReadMetadataAndValueOpaqueExistential(
+          existential_address);
+  if (!existential_container)
+    return std::nullopt;
+
+  lldb::addr_t metadata_addr =
+      existential_container->MetadataAddress.getRawAddress();
+  if (metadata_addr == 0)
+    return std::nullopt;
+
+  auto dynamic_address = existential_container->PayloadAddress.getRawAddress();
+  if (dynamic_address == 0)
+    return std::nullopt;
+
+  // The value witness table pointer is stored at MetadataAddress - PointerSize.
+  size_t ptr_size = GetProcess().GetAddressByteSize();
+  lldb::addr_t vwt_ptr_addr = metadata_addr - ptr_size;
+
+  Status error;
+  lldb::addr_t vwt_addr =
+      GetProcess().ReadPointerFromMemory(vwt_ptr_addr, error);
+  if (error.Fail() || vwt_addr == 0 || vwt_addr == LLDB_INVALID_ADDRESS)
+    return std::nullopt;
+
+  Address vwt_address;
+  vwt_address.SetLoadAddress(vwt_addr, &GetProcess().GetTarget());
+  Symbol *symbol = vwt_address.CalculateSymbolContextSymbol();
+  if (!symbol)
+    return std::nullopt;
+
+  Mangled mangled = symbol->GetMangled();
+  if (!mangled)
+    return std::nullopt;
+
+  llvm::StringRef symbol_name = mangled.GetMangledName().GetStringRef();
+  TypeSystemSwiftTypeRefSP ts = existential_type.GetTypeSystem()
+                                    .dyn_cast_or_null<TypeSystemSwift>()
+                                    ->GetTypeSystemSwiftTypeRef();
+  if (!ts)
+    return std::nullopt;
+
+  CompilerType dynamic_type = ts->GetTypeFromValueWitnessTable(symbol_name);
+  if (!dynamic_type)
+    return std::nullopt;
+
+  return std::make_pair(dynamic_type,
+                        existential_container->PayloadAddress.getRawAddress());
+}
+
+llvm::Expected<std::pair<CompilerType, uint64_t>>
+SwiftLanguageRuntime::GetDynamicTypeAndAddress_ExistentialEmbedded(
+    lldb::addr_t existential_address, CompilerType existential_type) {
+  // In the embedded Swift case, if the existential is class constrained, it
+  // will simply point to the instance. If it's not class constrained, it will
+  // have an existential container. Since there is no metadata to distinguish
+  // between the cases, we need to try both cases.
+
+  // First, try class-constrained existential.
+  if (auto result =
+          GetDynamicTypeAndAddress_ClassConstrainedExistentialEmbedded(
+              existential_address, existential_type))
+    return *result;
+
+  // If that fails, try existential container.
+  if (auto result = GetDynamicTypeAndAddress_ExistentialContainerEmbedded(
+          existential_address, existential_type))
+    return *result;
+
+  return llvm::createStringError(
+      "failed to resolve dynamic type of embedded existential");
+}
+
 bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Class(
     ValueObject &in_value, CompilerType class_type,
     lldb::DynamicValueType use_dynamic, TypeAndOrName &class_type_or_name,
@@ -2498,40 +2616,14 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
       dynamic_type = ts->RemangleAsType(dem, node, flavor);
       dynamic_address = out_address.getRawAddress();
     } else {
-      // In the embedded Swift case, the existential container just points to
-      // the instance.
-      auto reflection_ctx = GetReflectionContext();
-      if (!reflection_ctx)
+      auto result_or_err = GetDynamicTypeAndAddress_ExistentialEmbedded(
+          existential_address, existential_type);
+      if (!result_or_err) {
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Types), result_or_err.takeError(),
+                       "{0}");
         return false;
-      auto maybe_addr_or_symbol =
-          reflection_ctx->ReadPointer(existential_address);
-      if (!maybe_addr_or_symbol)
-        return false;
-
-      uint64_t address = 0;
-      if (maybe_addr_or_symbol->getSymbol().empty() &&
-          maybe_addr_or_symbol->getOffset() == 0) {
-        address = maybe_addr_or_symbol->getResolvedAddress().getRawAddress();
-      } else {
-        SymbolContextList sc_list;
-        auto &module_list = GetProcess().GetTarget().GetImages();
-        module_list.FindSymbolsWithNameAndType(
-            ConstString(maybe_addr_or_symbol->getSymbol()), eSymbolTypeAny,
-            sc_list);
-        if (sc_list.GetSize() != 1)
-          return false;
-
-        SymbolContext sc = sc_list[0];
-        Symbol *symbol = sc.symbol;
-        address = symbol->GetLoadAddress(&GetProcess().GetTarget());
       }
-
-      dynamic_type =
-          GetDynamicTypeAndAddress_EmbeddedClass(address, existential_type);
-      if (!dynamic_type)
-        return false;
-      dynamic_address =
-          maybe_addr_or_symbol->getResolvedAddress().getRawAddress();
+      std::tie(dynamic_type, dynamic_address) = *result_or_err;
     }
     class_type_or_name.SetCompilerType(dynamic_type);
     address.SetRawAddress(dynamic_address);

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -20,6 +20,7 @@
 #include "TypeSystemSwift.h"
 #include "TypeSystemSwiftTypeRef.h"
 
+#include "lldb/Symbol/CompilerType.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTContext.h"
@@ -8405,6 +8406,26 @@ size_t SwiftASTContext::GetNumTemplateArguments(opaque_compiler_type_t type,
   }
 
   return 0;
+}
+
+lldb::TemplateArgumentKind
+SwiftASTContext::GetTemplateArgumentKind(lldb::opaque_compiler_type_t type,
+                                         size_t idx, bool expand_pack) {
+  switch (GetGenericArgumentKind(type, idx)) {
+  case eBoundGenericKindType:
+    return eTemplateArgumentKindType;
+  case eUnboundGenericKindType:
+    return eTemplateArgumentKindDeclaration;
+  default:
+    break;
+  }
+  return eTemplateArgumentKindNull;
+}
+
+CompilerType
+SwiftASTContext::GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+                                         size_t idx, bool expand_pack) {
+  return GetGenericArgumentType(type, idx);
 }
 
 bool SwiftASTContext::GetSelectedEnumCase(const CompilerType &type,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -780,6 +780,11 @@ public:
 
   size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
                                  bool expand_pack) override;
+  lldb::TemplateArgumentKind
+  GetTemplateArgumentKind(lldb::opaque_compiler_type_t type, size_t idx,
+                          bool expand_pack) override;
+  CompilerType GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+                                       size_t idx, bool expand_pack) override;
 
   lldb::GenericKind GetGenericArgumentKind(lldb::opaque_compiler_type_t type,
                                            size_t idx);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -409,6 +409,19 @@ CompilerType TypeSystemSwiftTypeRef::GetTypeFromTypeMetadataNode(
   return RemangleAsType(dem, type, flavor);
 }
 
+CompilerType TypeSystemSwiftTypeRef::GetTypeFromValueWitnessTable(
+    llvm::StringRef mangled_name) {
+  Demangler dem;
+  NodePointer node = dem.demangleSymbol(mangled_name);
+  NodePointer type = swift_demangle::NodeAtPath(
+      node,
+      {Node::Kind::Global, Node::Kind::ValueWitnessTable, Node::Kind::Type});
+  if (!type)
+    return {};
+  auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
+  return RemangleAsType(dem, type, flavor);
+}
+
 TypeSP TypeSystemSwiftTypeRef::LookupClangType(StringRef name_ref,
                                                SymbolContext sc) {
   llvm::SmallVector<CompilerContext, 2> decl_context;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -29,6 +29,7 @@
 #include "lldb/Host/StreamFile.h"
 #include "lldb/Interpreter/CommandReturnObject.h"
 #include "lldb/Symbol/CompileUnit.h"
+#include "lldb/Symbol/CompilerType.h"
 #include "lldb/Symbol/SymbolContext.h"
 #include "lldb/Symbol/TypeList.h"
 #include "lldb/Symbol/TypeMap.h"
@@ -4623,29 +4624,38 @@ TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type,
 
 lldb::TemplateArgumentKind TypeSystemSwiftTypeRef::GetTemplateArgumentKind(
     lldb::opaque_compiler_type_t type, size_t idx, bool expand_pack) {
-  Demangler dem;
-  NodePointer node = DemangleCanonicalOutermostType(dem, type);
-  if (auto *type_list = GetTemplateTypeListNode(node))
-    if (idx < type_list->getNumChildren())
-      return lldb::eTemplateArgumentKindType;
+  auto impl = [&]() {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = DemangleCanonicalOutermostType(dem, type);
+    if (auto *type_list = GetTemplateTypeListNode(node))
+      if (idx < type_list->getNumChildren())
+        return lldb::eTemplateArgumentKindType;
 
-  return lldb::eTemplateArgumentKindNull;
+    return lldb::eTemplateArgumentKindNull;
+  };
+  VALIDATE_AND_RETURN(impl, GetTemplateArgumentKind, type, g_no_exe_ctx,
+                      (ReconstructType(type), idx, expand_pack));
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetTypeTemplateArgument(
     lldb::opaque_compiler_type_t type, size_t idx, bool expand_pack) {
-  using namespace swift::Demangle;
-  Demangler dem;
-  NodePointer node = DemangleCanonicalOutermostType(dem, type);
-  if (auto *type_list = GetTemplateTypeListNode(node))
-    if (idx < type_list->getNumChildren()) {
-      const auto *mangled_name = AsMangledName(type);
-      auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
-      auto *template_type = type_list->getChild(idx);
-      return RemangleAsType(dem, template_type, flavor);
-    }
+  auto impl = [&]() {
+    using namespace swift::Demangle;
+    Demangler dem;
+    NodePointer node = DemangleCanonicalOutermostType(dem, type);
+    if (auto *type_list = GetTemplateTypeListNode(node))
+      if (idx < type_list->getNumChildren()) {
+        const auto *mangled_name = AsMangledName(type);
+        auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
+        auto *template_type = type_list->getChild(idx);
+        return RemangleAsType(dem, template_type, flavor);
+      }
 
-  return {};
+    return CompilerType();
+  };
+  VALIDATE_AND_RETURN(impl, GetTypeTemplateArgument, type, g_no_exe_ctx,
+                      (ReconstructType(type), idx, expand_pack));
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -4580,6 +4580,31 @@ size_t TypeSystemSwiftTypeRef::GetIndexOfChildMemberWithName(
   return {};
 }
 
+static NodePointer GetTemplateTypeListNode(NodePointer type) {
+  if (!type)
+    return nullptr;
+
+  switch (type->getKind()) {
+  case Node::Kind::BoundGenericClass:
+  case Node::Kind::BoundGenericEnum:
+  case Node::Kind::BoundGenericStructure:
+  case Node::Kind::BoundGenericProtocol:
+  case Node::Kind::BoundGenericOtherNominalType:
+  case Node::Kind::BoundGenericTypeAlias:
+  case Node::Kind::BoundGenericFunction: {
+    if (type->getNumChildren() > 1)
+      if (auto *child = type->getChild(1))
+        if (child->getKind() == Node::Kind::TypeList)
+          return child;
+    break;
+  }
+  default:
+    break;
+  }
+
+  return nullptr;
+}
+
 size_t
 TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type,
                                                 bool expand_pack) {
@@ -4587,31 +4612,40 @@ TypeSystemSwiftTypeRef::GetNumTemplateArguments(opaque_compiler_type_t type,
     using namespace swift::Demangle;
     Demangler dem;
     NodePointer node = DemangleCanonicalOutermostType(dem, type);
+    if (auto *type_list = GetTemplateTypeListNode(node))
+      return type_list->getNumChildren();
 
-    if (!node)
-      return 0;
-
-    switch (node->getKind()) {
-    case Node::Kind::BoundGenericClass:
-    case Node::Kind::BoundGenericEnum:
-    case Node::Kind::BoundGenericStructure:
-    case Node::Kind::BoundGenericProtocol:
-    case Node::Kind::BoundGenericOtherNominalType:
-    case Node::Kind::BoundGenericTypeAlias:
-    case Node::Kind::BoundGenericFunction: {
-      if (node->getNumChildren() > 1) {
-        NodePointer child = node->getChild(1);
-        if (child && child->getKind() == Node::Kind::TypeList)
-          return child->getNumChildren();
-      }
-    } break;
-    default:
-      break;
-    }
     return 0;
   };
   VALIDATE_AND_RETURN(impl, GetNumTemplateArguments, type, g_no_exe_ctx,
                       (ReconstructType(type), expand_pack));
+}
+
+lldb::TemplateArgumentKind TypeSystemSwiftTypeRef::GetTemplateArgumentKind(
+    lldb::opaque_compiler_type_t type, size_t idx, bool expand_pack) {
+  Demangler dem;
+  NodePointer node = DemangleCanonicalOutermostType(dem, type);
+  if (auto *type_list = GetTemplateTypeListNode(node))
+    if (idx < type_list->getNumChildren())
+      return lldb::eTemplateArgumentKindType;
+
+  return lldb::eTemplateArgumentKindNull;
+}
+
+CompilerType TypeSystemSwiftTypeRef::GetTypeTemplateArgument(
+    lldb::opaque_compiler_type_t type, size_t idx, bool expand_pack) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodePointer node = DemangleCanonicalOutermostType(dem, type);
+  if (auto *type_list = GetTemplateTypeListNode(node))
+    if (idx < type_list->getNumChildren()) {
+      const auto *mangled_name = AsMangledName(type);
+      auto flavor = SwiftLanguageRuntime::GetManglingFlavor(mangled_name);
+      auto *template_type = type_list->getChild(idx);
+      return RemangleAsType(dem, template_type, flavor);
+    }
+
+  return {};
 }
 
 CompilerType

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -250,6 +250,11 @@ public:
                                 std::vector<uint32_t> &child_indexes) override;
   size_t GetNumTemplateArguments(lldb::opaque_compiler_type_t type,
                                  bool expand_pack) override;
+  lldb::TemplateArgumentKind
+  GetTemplateArgumentKind(lldb::opaque_compiler_type_t type, size_t idx,
+                          bool expand_pack) override;
+  CompilerType GetTypeTemplateArgument(lldb::opaque_compiler_type_t type,
+                                       size_t idx, bool expand_pack) override;
   CompilerType GetTypeForFormatters(lldb::opaque_compiler_type_t type) override;
   LazyBool ShouldPrintAsOneLiner(lldb::opaque_compiler_type_t type,
                                  ValueObject *valobj) override;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -447,6 +447,10 @@ public:
   /// CompilerType with that Type.
   CompilerType GetTypeFromTypeMetadataNode(llvm::StringRef mangled_name);
 
+  /// Given a mangled name that mangles a "value witness table for Type",
+  /// return a CompilerType with that Type.
+  CompilerType GetTypeFromValueWitnessTable(llvm::StringRef mangled_name);
+
   /// Use API notes to determine the swiftified name of \p clang_decl.
   std::string GetSwiftName(const clang::Decl *clang_decl,
                            TypeSystemClang &clang_typesystem) override;

--- a/lldb/test/API/lang/swift/embedded/existential_type_resolution/Makefile
+++ b/lldb/test/API/lang/swift/embedded/existential_type_resolution/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/existential_type_resolution/TestSwiftEmbeddedExistentialTypeResolution.py
+++ b/lldb/test/API/lang/swift/embedded/existential_type_resolution/TestSwiftEmbeddedExistentialTypeResolution.py
@@ -1,0 +1,21 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedExistentialTypeResolution(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.expect('frame variable pStruct', substrs=['a.S', 'structField = 111'])
+        self.expect('frame variable pClass', substrs=['a.C', 'classField = 222'])
+        self.expect('frame variable pSubclass', substrs=['a.Sub', 'a.C', 'classField = 222', 'subField = 333'])
+        self.expect('frame variable pEnumFirst', substrs=['a.E', 'first'])
+        self.expect('frame variable pEnumSecond', substrs=['a.E', 'second'])

--- a/lldb/test/API/lang/swift/embedded/existential_type_resolution/main.swift
+++ b/lldb/test/API/lang/swift/embedded/existential_type_resolution/main.swift
@@ -1,0 +1,32 @@
+protocol P {
+}
+
+struct S: P {
+    let structField = 111
+}
+
+class C: P {
+    let classField = 222
+}
+
+class Sub: C {
+    let subField = 333
+}
+
+enum E: P {
+    case first
+    case second(Int)
+}
+
+func f() {
+    let pStruct: any P = S()
+    let pClass: any P = C()
+    let pSubclass: any P = Sub()
+    // FIXME: rdar://168697959 (Debug info for enums is not generated, if there are no variables/parameter with the enum type in embedded swift)
+    let bug = E.first
+    let pEnumFirst: any P = E.first
+    let pEnumSecond: any P = E.second(444)
+    print("break here")
+}
+
+f()

--- a/lldb/test/API/lang/swift/generic_arguments/Makefile
+++ b/lldb/test/API/lang/swift/generic_arguments/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -1,0 +1,18 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    def test(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.selected_frame
+        array_type = frame.var("array").type
+        generic_type = array_type.GetTemplateArgumentType(0)
+        self.assertTrue(generic_type.IsValid())
+        self.assertEqual(generic_type.name, "Swift.Int")
+        self.assertEqual(generic_type.GetDisplayTypeName(), "Int")

--- a/lldb/test/API/lang/swift/generic_arguments/main.swift
+++ b/lldb/test/API/lang/swift/generic_arguments/main.swift
@@ -1,0 +1,6 @@
+@main enum Entry {
+    static func main() {
+        let array = [1, 2, 4]
+        print("break here", array)
+    }
+}


### PR DESCRIPTION
```
commit f004b05f9d5046dfcf9c4bcbcb8fc3ca0d5c9c43
Author: Augusto Noronha <anoronha@apple.com>
Date:   Thu Jan 22 13:01:49 2026 -0800

    [lldb] Add support for existential containers in embedded Swift
    
    Embedded Swift now supports existential containers for non-class-constrained
    protocols. This change adds support for resolving the dynamic type of these
    existentials.

commit 20e13c3737433fb0a6d7bbe9cbc1934992c4c71b
Author: Dave Lee <davelee.com@gmail.com>
Date:   Thu Jan 29 19:32:11 2026 -0800

    [lldb] Implement GetTemplateArgumentType for TypeSystemSwiftTypeRef

commit b8e416e17ba478f66f5d4df95e51900a1ac27af2
Author: Dave Lee <davelee.com@gmail.com>
Date:   Fri Jan 30 15:21:29 2026 -0800

    Implement same methods in SwiftASTContext
```
