### PR TITLE
[HierarchicalTreeBuilder] Change the validate check under `EXPENSIVE_CHECKS`

### DIFF
--- a/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
+++ b/llvm/lib/CAS/HierarchicalTreeBuilder.cpp
@@ -264,7 +264,7 @@ Expected<ObjectProxy> HierarchicalTreeBuilder::create(ObjectStore &CAS) {
   }
 
   Expected<ObjectProxy> Obj = cantFail(CAS.getProxy(*Root.Ref));
-#ifndef NDEBUG
+#ifdef EXPENSIVE_CHECKS
   if (Obj) {
     if (Error E = CAS.validateTree(Obj->getRef()))
       return std::move(E);


### PR DESCRIPTION
It can very much slow down a normal explicit modules build.

(cherry picked from commit f70e03309acc132ad4c9a916f244d8bb1c598d5a)