### PR TITLE
Refactor: adjust condition for `/bigobj` application

### DIFF
--- a/clang/lib/Tooling/Refactor/CMakeLists.txt
+++ b/clang/lib/Tooling/Refactor/CMakeLists.txt
@@ -43,6 +43,6 @@ add_clang_library(clangToolingRefactor
   clangRewrite
   )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+if(MSVC)
   set_source_files_properties(Extract.cpp PROPERTIES COMPILE_FLAGS /bigobj)
 endif()


### PR DESCRIPTION
This is a CL flag that is shared across MSVC (`cl`) and Clang (`clang-cl`). Adjust the application to be based on the compiler driver rather than the platform. This allows us to use the GNU frontend for building the Windows target.