### PR TITLE
[lldb/test] Add swift clang importer test variants to test infrastructure

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -226,6 +226,16 @@ def _skipForVariant(variant_name, expected_fn, bugnumber=None):
         return skipImpl
 
 
+def _is_setting_enabled(value):
+    """Return True if a setting value represents an enabled state."""
+    return str(value).lower() in ("true", "1", "yes", "on")
+
+
+def _is_setting_disabled(value):
+    """Return True if a setting value represents a disabled state."""
+    return str(value).lower() in ("false", "0", "no", "off")
+
+
 def _decorateTest(
     mode,
     bugnumber=None,
@@ -243,7 +253,27 @@ def _decorateTest(
     dwarf_version=None,
     setting=None,
     asan=None,
+    swift_module_importer=None,
 ):
+    # Backward compat: map clangimporter/dwarfimporter settings to
+    # swift_module_importer variant dimension.
+    if setting and not swift_module_importer:
+        key, val = setting[0], setting[1]
+        if key == "symbols.use-swift-clangimporter":
+            if _is_setting_disabled(val):
+                swift_module_importer = ["dwarfimporter"]
+                setting = None
+            elif _is_setting_enabled(val):
+                swift_module_importer = ["clangimporter"]
+                setting = None
+        elif key == "symbols.use-swift-dwarfimporter":
+            if _is_setting_disabled(val):
+                swift_module_importer = ["clangimporter"]
+                setting = None
+            elif _is_setting_enabled(val):
+                swift_module_importer = ["dwarfimporter"]
+                setting = None
+
     def fn(**actual_variants):
         skip_for_os = _match_decorator_property(
             lldbplatform.translate(oslist), lldbplatformutil.getPlatform()
@@ -259,6 +289,9 @@ def _decorateTest(
         )
         skip_for_debug_info = _match_decorator_property(
             debug_info, actual_variants.get("debug_info")
+        )
+        skip_for_swift_module_importer = _match_decorator_property(
+            swift_module_importer, actual_variants.get("swift_module_importer")
         )
         skip_for_triple = _match_decorator_property(
             triple, lldb.selected_platform.GetTriple()
@@ -306,6 +339,7 @@ def _decorateTest(
             (compiler, skip_for_compiler, "compiler or version"),
             (archs, skip_for_arch, "architecture"),
             (debug_info, skip_for_debug_info, "debug info format"),
+            (swift_module_importer, skip_for_swift_module_importer, "swift variant"),
             (triple, skip_for_triple, "target triple"),
             (swig_version, skip_for_swig_version, "swig version"),
             (py_version, skip_for_py_version, "python version"),
@@ -338,10 +372,14 @@ def _decorateTest(
         return reason_str
 
     if mode == DecorateMode.Skip:
+        if swift_module_importer:
+            return _skipForVariant("swift_module_importer", fn, bugnumber)
         if debug_info:
             return _skipForVariant("debug_info", fn, bugnumber)
         return skipTestIfFn(fn, bugnumber)
     elif mode == DecorateMode.Xfail:
+        if swift_module_importer:
+            return _xfailForVariant("swift_module_importer", fn, bugnumber)
         if debug_info:
             return _xfailForVariant("debug_info", fn, bugnumber)
         return expectedFailureIf(fn(), bugnumber)
@@ -373,6 +411,7 @@ def expectedFailureAll(
     dwarf_version=None,
     setting=None,
     asan=None,
+    swift_module_importer=None,
 ):
     return _decorateTest(
         DecorateMode.Xfail,
@@ -391,6 +430,7 @@ def expectedFailureAll(
         dwarf_version=dwarf_version,
         setting=setting,
         asan=asan,
+        swift_module_importer=swift_module_importer,
     )
 
 
@@ -416,6 +456,7 @@ def skipIf(
     dwarf_version=None,
     setting=None,
     asan=None,
+    swift_module_importer=None,
 ):
     return _decorateTest(
         DecorateMode.Skip,
@@ -434,6 +475,7 @@ def skipIf(
         dwarf_version=dwarf_version,
         setting=setting,
         asan=asan,
+        swift_module_importer=swift_module_importer,
     )
 
 
@@ -854,6 +896,7 @@ def swiftTest(func):
             # This configuration is Swift-compatible
             return None
 
+    func.__swift_test__ = True
     return skipTestIfFn(is_not_swift_compatible)(func)
 
 

--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -166,12 +166,28 @@ def skipTestIfFn(expected_fn, bugnumber=None):
         return skipTestIfFn_impl
 
 
-def _xfailForDebugInfo(expected_fn, bugnumber=None):
+def _xfailForVariant(variant_name, expected_fn, bugnumber=None):
+    """Mark a test method as expected-failure for a specific variant dimension.
+
+    Adds *expected_fn* to the decorated function's `__variant_xfail__`
+    dictionary under the key *variant_name*.  When the `LLDBTestCaseFactory`
+    metaclass expands the test method, it looks up *variant_name* in this
+    dictionary and calls the corresponding function with the concrete variant
+    value.  If the function returns a reason string, the expanded test method
+    is marked as expected failure via `unittest.expectedFailure`.
+
+    Args:
+        variant_name: The variant dimension name (e.g. `"debug_info"`).
+        expected_fn: Callable `(**{variant_name: value}) -> reason | None`.
+        bugnumber: Optional bug reference or the decorated function itself
+            (when the decorator is used without parentheses).
+    """
     def expectedFailure_impl(func):
         if isinstance(func, type) and issubclass(func, unittest.TestCase):
             raise Exception("Decorator can only be used to decorate a test method")
-
-        func.__xfail_for_debug_info_cat_fn__ = expected_fn
+        xfail_dict = getattr(func, "__variant_xfail__", {})
+        xfail_dict[variant_name] = expected_fn
+        func.__variant_xfail__ = xfail_dict
         return func
 
     if callable(bugnumber):
@@ -180,12 +196,28 @@ def _xfailForDebugInfo(expected_fn, bugnumber=None):
         return expectedFailure_impl
 
 
-def _skipForDebugInfo(expected_fn, bugnumber=None):
+def _skipForVariant(variant_name, expected_fn, bugnumber=None):
+    """Mark a test method as skipped for a specific variant dimension.
+
+    Adds *expected_fn* to the decorated function's `__variant_skip__`
+    dictionary under the key *variant_name*.  When the `LLDBTestCaseFactory`
+    metaclass expands the test method, it looks up *variant_name* in this
+    dictionary and calls the corresponding function with the concrete variant
+    value.  If the function returns a reason string, the expanded test method
+    is skipped via `unittest.skip(reason)`.
+
+    Args:
+        variant_name: The variant dimension name (e.g. `"debug_info"`).
+        expected_fn: Callable `(**{variant_name: value}) -> reason | None`.
+        bugnumber: Optional bug reference or the decorated function itself
+            (when the decorator is used without parentheses).
+    """
     def skipImpl(func):
         if isinstance(func, type) and issubclass(func, unittest.TestCase):
             raise Exception("Decorator can only be used to decorate a test method")
-
-        func.__skip_for_debug_info_cat_fn__ = expected_fn
+        skip_dict = getattr(func, "__variant_skip__", {})
+        skip_dict[variant_name] = expected_fn
+        func.__variant_skip__ = skip_dict
         return func
 
     if callable(bugnumber):
@@ -212,7 +244,7 @@ def _decorateTest(
     setting=None,
     asan=None,
 ):
-    def fn(actual_debug_info=None):
+    def fn(**actual_variants):
         skip_for_os = _match_decorator_property(
             lldbplatform.translate(oslist), lldbplatformutil.getPlatform()
         )
@@ -225,7 +257,9 @@ def _decorateTest(
         skip_for_arch = _match_decorator_property(
             archs, lldbplatformutil.getArchitecture()
         )
-        skip_for_debug_info = _match_decorator_property(debug_info, actual_debug_info)
+        skip_for_debug_info = _match_decorator_property(
+            debug_info, actual_variants.get("debug_info")
+        )
         skip_for_triple = _match_decorator_property(
             triple, lldb.selected_platform.GetTriple()
         )
@@ -305,11 +339,11 @@ def _decorateTest(
 
     if mode == DecorateMode.Skip:
         if debug_info:
-            return _skipForDebugInfo(fn, bugnumber)
+            return _skipForVariant("debug_info", fn, bugnumber)
         return skipTestIfFn(fn, bugnumber)
     elif mode == DecorateMode.Xfail:
         if debug_info:
-            return _xfailForDebugInfo(fn, bugnumber)
+            return _xfailForVariant("debug_info", fn, bugnumber)
         return expectedFailureIf(fn(), bugnumber)
     else:
         return None

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1502,6 +1502,9 @@ class Base(unittest.TestCase):
     def getDebugInfo(self):
         return self.getVariant("debug_info")
 
+    def getSwiftModuleImporterVariant(self):
+        return self.getVariant("swift_module_importer")
+
     def build(
         self,
         debug_info=None,
@@ -1796,10 +1799,14 @@ class Base(unittest.TestCase):
 class TestVariant:
     """Describes a test variant dimension for test method expansion.
 
-    Test variants add extra dimensions to the test matrix. When a variant is
-    registered in `_test_variants`, the `LLDBTestCaseFactory` metaclass
-    iterates over every `test*` method and, for each method that matches the
-    variant's predicate, replaces it with one copy per enabled value.
+    Test variants multiply test methods by different configurations.
+    Each variant adds a new dimension to the test matrix, creating copies
+    of test methods for each category in the variant. For example, Swift
+    tests are run with both 'clangimporter' and 'dwarfimporter' settings.
+
+    When a variant is registered in `_test_variants`, the `LLDBTestCaseFactory`
+    metaclass iterates over every `test*` method and, for each method that
+    matches the variant's predicate, replaces it with one copy per enabled value.
 
     For example, a variant with values `{"a": True, "b": True}` turns
     `test_foo` into `test_foo_a` and `test_foo_b`.  If multiple variants
@@ -1930,7 +1937,22 @@ def _expand_test_variants(attrname, methods, variant, xfail_fns, skip_fns):
     return expanded
 
 
-_test_variants = []
+def _swift_module_importer_setup(test_instance, variant_value):
+    if variant_value == "dwarfimporter":
+        test_instance.runCmd("settings set symbols.use-swift-clangimporter false")
+    elif variant_value == "clangimporter":
+        test_instance.runCmd("settings set symbols.use-swift-clangimporter true")
+
+
+_test_variants = [
+    TestVariant(
+        name="swift_module_importer",
+        values=test_categories.swift_module_importer_categories,
+        predicate=lambda m: getattr(m, "__swift_test__", False),
+        setup_fn=_swift_module_importer_setup,
+        attrs_to_preserve=("debug_info",),
+    ),
+]
 
 
 class LLDBTestCaseFactory(type):
@@ -2012,7 +2034,7 @@ class LLDBTestCaseFactory(type):
                     # NO_DEBUG_INFO_TESTCASE — put method in newattrs for variant expansion
                     newattrs[attrname] = attrvalue
 
-                # Expand test variants (e.g. additional variant dimensions)
+                # Expand test variants (e.g. swift clangimporter/dwarfimporter)
                 for variant in _test_variants:
                     if variant.should_expand(attrvalue):
                         xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
@@ -2143,7 +2165,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
         # And the result object.
         self.res = lldb.SBCommandReturnObject()
 
-        # Apply variant-specific settings.
+        # Apply variant-specific settings (e.g. swift clangimporter/dwarfimporter).
         for variant in _test_variants:
             variant_value = self.getVariant(variant.name)
             if variant_value is not None:

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -1495,9 +1495,12 @@ class Base(unittest.TestCase):
             option_str += " -C " + comp
         return option_str
 
-    def getDebugInfo(self):
+    def getVariant(self, variant_name):
         method = getattr(self, self.testMethodName)
-        return getattr(method, "debug_info", None)
+        return getattr(method, variant_name, None)
+
+    def getDebugInfo(self):
+        return self.getVariant("debug_info")
 
     def build(
         self,
@@ -1790,17 +1793,165 @@ class Base(unittest.TestCase):
 # level by using the decorator @no_debug_info_test.
 
 
+class TestVariant:
+    """Describes a test variant dimension for test method expansion.
+
+    Test variants add extra dimensions to the test matrix. When a variant is
+    registered in `_test_variants`, the `LLDBTestCaseFactory` metaclass
+    iterates over every `test*` method and, for each method that matches the
+    variant's predicate, replaces it with one copy per enabled value.
+
+    For example, a variant with values `{"a": True, "b": True}` turns
+    `test_foo` into `test_foo_a` and `test_foo_b`.  If multiple variants
+    match, the expansion is applied sequentially, producing the cross product
+    (e.g. `test_foo_dwarf_a`, `test_foo_dwarf_b`, ...).
+
+    Variant-aware `@expectedFailureAll` / `@skipIf` decorators use
+    `_xfailForVariant` / `_skipForVariant` in `decorators.py` to store
+    predicate functions in the `__variant_xfail__` / `__variant_skip__`
+    dictionaries on the **original** test method, keyed by variant name.
+    During expansion the metaclass looks up the predicate for each variant,
+    evaluates it for each value, and wraps the copy with
+    `unittest.expectedFailure` or `unittest.skip` accordingly.
+
+    At test run-time, `TestBase.setUp` calls `apply_settings` for every
+    registered variant so the test process is configured for the value that
+    the current method was expanded into.
+    """
+
+    def __init__(
+        self, name, values, predicate=None, setup_fn=None, attrs_to_preserve=()
+    ):
+        """Create a new test variant dimension.
+
+        Args:
+            name: Attribute name set on each expanded method to record which
+                value it was created for (e.g. `"debug_info"`).  Used to
+                look up xfail/skip predicates in the `__variant_xfail__`
+                / `__variant_skip__` dictionaries on the test method.
+            values: `dict[str, bool]` mapping variant value names to whether
+                they should be enabled.  Values with a `False` entry
+                are present in the dict for documentation but are skipped
+                during expansion.
+            predicate: Optional callable `(test_method) -> bool`.  When
+                given, only methods for which the predicate returns `True`
+                are expanded.  `None` means *every* test method is expanded.
+            setup_fn: Optional callable `(test_instance, variant_value)`
+                invoked from `TestBase.setUp` to apply run-time
+                configuration for the given variant value.
+            attrs_to_preserve: Tuple of attribute names that should be copied
+                from the source method to each expanded copy (e.g.
+                `("debug_info",)` so that a second-pass variant preserves
+                the debug-info value set by the first pass).
+        """
+        self.name = name
+        self.values = values
+        self.predicate = predicate
+        self.setup_fn = setup_fn
+        self.attrs_to_preserve = attrs_to_preserve
+
+    def should_expand(self, test_method):
+        """Return True if *test_method* should be expanded by this variant."""
+        if self.predicate is None:
+            return True
+        return self.predicate(test_method)
+
+    def get_enabled_values(self):
+        """Return the list of value names whose entry is True."""
+        return [n for n, enabled in self.values.items() if enabled]
+
+    def apply_settings(self, test_instance, variant_value):
+        """Configure *test_instance* for *variant_value* via the setup_fn."""
+        if self.setup_fn:
+            self.setup_fn(test_instance, variant_value)
+
+
+def _expand_test_variants(attrname, methods, variant, xfail_fns, skip_fns):
+    """Expand test methods in *methods* along the given *variant* dimension.
+
+    Only methods whose name equals *attrname* or starts with `attrname + "_"`
+    are expanded (this keeps methods from other `test*` functions untouched
+    when multiple test methods coexist in the same `newattrs` dict).
+
+    For each matching method and each enabled value in *variant*, a new
+    wrapper method is created with the value name appended
+    (`method_name + "_" + value_name`).  The wrapper delegates to the original
+    method, carries the variant attribute, and is optionally wrapped with
+    `unittest.expectedFailure` or `unittest.skip` based on predicates
+    found in *xfail_fns* / *skip_fns*.
+
+    Args:
+        attrname: The original test method name being processed by the
+            metaclass (e.g. `"test_foo"`).
+        methods: `dict[str, callable]` of accumulated methods (`newattrs`).
+        variant: The `TestVariant` to expand along.
+        xfail_fns: `__variant_xfail__` dict from the original test method.
+        skip_fns: `__variant_skip__` dict from the original test method.
+
+    Returns:
+        A new dict with the original matching methods replaced by their
+        per-value copies.  Non-matching entries are passed through.
+    """
+    no_reason = lambda *args, **kwargs: None
+    xfail_fn = xfail_fns.get(variant.name, no_reason)
+    skip_fn = skip_fns.get(variant.name, no_reason)
+    expanded = {}
+    for method_name, method in methods.items():
+        if not method_name.startswith("test"):
+            expanded[method_name] = method
+            continue
+        if method_name != attrname and not method_name.startswith(attrname + "_"):
+            expanded[method_name] = method
+            continue
+        for value_name in variant.get_enabled_values():
+            new_name = method_name + "_" + value_name
+
+            @decorators.add_test_categories([value_name])
+            @wraps(method)
+            def variant_method(self, method=method):
+                return method(self)
+
+            variant_method.__name__ = new_name
+            setattr(variant_method, variant.name, value_name)
+
+            for attr in variant.attrs_to_preserve:
+                if hasattr(method, attr):
+                    setattr(variant_method, attr, getattr(method, attr))
+
+            xfail_reason = xfail_fn(**{variant.name: value_name})
+            if xfail_reason:
+                variant_method = unittest.expectedFailure(variant_method)
+
+            skip_reason = skip_fn(**{variant.name: value_name})
+            if skip_reason:
+                variant_method = unittest.skip(skip_reason)(variant_method)
+
+            expanded[new_name] = variant_method
+    return expanded
+
+
+_test_variants = []
+
+
 class LLDBTestCaseFactory(type):
     def __new__(cls, name, bases, attrs):
         original_testcase = super(LLDBTestCaseFactory, cls).__new__(
             cls, name, bases, attrs
         )
-        if original_testcase.NO_DEBUG_INFO_TESTCASE:
+
+        # Check if any test methods need variant expansion
+        has_variant_tests = any(
+            attrname.startswith("test")
+            and any(v.should_expand(attrvalue) for v in _test_variants)
+            for attrname, attrvalue in attrs.items()
+        )
+
+        if original_testcase.NO_DEBUG_INFO_TESTCASE and not has_variant_tests:
             return original_testcase
 
         # Default implementation for skip/xfail reason based on the debug category,
         # where "None" means to run the test as usual.
-        def no_reason(_):
+        def no_reason(*args, **kwargs):
             return None
 
         newattrs = {}
@@ -1808,52 +1959,71 @@ class LLDBTestCaseFactory(type):
             if attrname.startswith("test") and not getattr(
                 attrvalue, "__no_debug_info_test__", False
             ):
-                # If any debug info categories were explicitly tagged, assume that list to be
-                # authoritative.  If none were specified, try with all debug info formats.
-                test_method_categories = set(getattr(attrvalue, "categories", []))
-                all_dbginfo_categories = set(
-                    test_categories.debug_info_categories.keys()
-                )
-                dbginfo_categories = test_method_categories & all_dbginfo_categories
-                other_categories = list(test_method_categories - all_dbginfo_categories)
-                if not dbginfo_categories:
-                    dbginfo_categories = [
-                        category
-                        for category, can_replicate in test_categories.debug_info_categories.items()
-                        if can_replicate
-                    ]
+                # Create debug info variants unless NO_DEBUG_INFO_TESTCASE
+                if not original_testcase.NO_DEBUG_INFO_TESTCASE:
+                    # If any debug info categories were explicitly tagged, assume that list to be
+                    # authoritative.  If none were specified, try with all debug info formats.
+                    test_method_categories = set(getattr(attrvalue, "categories", []))
+                    all_dbginfo_categories = set(
+                        test_categories.debug_info_categories.keys()
+                    )
+                    dbginfo_categories = test_method_categories & all_dbginfo_categories
+                    other_categories = list(
+                        test_method_categories - all_dbginfo_categories
+                    )
+                    if not dbginfo_categories:
+                        dbginfo_categories = [
+                            category
+                            for category, enabled in test_categories.debug_info_categories.items()
+                            if enabled
+                        ]
 
                     # PDB is off by default, because it has a lot of failures right now.
                     # See llvm.org/pr149498
                     if original_testcase.TEST_WITH_PDB_DEBUG_INFO:
                         dbginfo_categories.append("pdb")
 
-                xfail_for_debug_info_cat_fn = getattr(
-                    attrvalue, "__xfail_for_debug_info_cat_fn__", no_reason
-                )
-                skip_for_debug_info_cat_fn = getattr(
-                    attrvalue, "__skip_for_debug_info_cat_fn__", no_reason
-                )
-                for cat in dbginfo_categories:
+                    xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
+                    skip_fns = getattr(attrvalue, "__variant_skip__", {})
+                    xfail_for_debug_info_cat_fn = xfail_fns.get("debug_info", no_reason)
+                    skip_for_debug_info_cat_fn = skip_fns.get("debug_info", no_reason)
+                    for cat in dbginfo_categories:
 
-                    @wraps(attrvalue)
-                    def test_method(self, attrvalue=attrvalue):
-                        return attrvalue(self)
+                        @decorators.add_test_categories([cat])
+                        @wraps(attrvalue)
+                        def test_method(self, attrvalue=attrvalue):
+                            return attrvalue(self)
 
-                    method_name = attrname + "_" + cat
-                    test_method.__name__ = method_name
-                    test_method.debug_info = cat
-                    test_method.categories = other_categories + [cat]
+                        method_name = attrname + "_" + cat
+                        test_method.__name__ = method_name
+                        test_method.debug_info = cat
+                        test_method.categories = other_categories + [cat]
 
-                    xfail_reason = xfail_for_debug_info_cat_fn(cat)
-                    if xfail_reason:
-                        test_method = unittest.expectedFailure(test_method)
+                        xfail_reason = xfail_for_debug_info_cat_fn(debug_info=cat)
+                        if xfail_reason:
+                            test_method = unittest.expectedFailure(test_method)
 
-                    skip_reason = skip_for_debug_info_cat_fn(cat)
-                    if skip_reason:
-                        test_method = unittest.skip(skip_reason)(test_method)
+                        skip_reason = skip_for_debug_info_cat_fn(debug_info=cat)
+                        if skip_reason:
+                            test_method = unittest.skip(skip_reason)(test_method)
 
-                    newattrs[method_name] = test_method
+                        newattrs[method_name] = test_method
+                else:
+                    # NO_DEBUG_INFO_TESTCASE — put method in newattrs for variant expansion
+                    newattrs[attrname] = attrvalue
+
+                # Expand test variants (e.g. additional variant dimensions)
+                for variant in _test_variants:
+                    if variant.should_expand(attrvalue):
+                        xfail_fns = getattr(attrvalue, "__variant_xfail__", {})
+                        skip_fns = getattr(attrvalue, "__variant_skip__", {})
+                        newattrs = _expand_test_variants(
+                            attrname,
+                            newattrs,
+                            variant,
+                            xfail_fns=xfail_fns,
+                            skip_fns=skip_fns,
+                        )
 
             else:
                 newattrs[attrname] = attrvalue
@@ -1972,6 +2142,12 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
 
         # And the result object.
         self.res = lldb.SBCommandReturnObject()
+
+        # Apply variant-specific settings.
+        for variant in _test_variants:
+            variant_value = self.getVariant(variant.name)
+            if variant_value is not None:
+                variant.apply_settings(self, variant_value)
 
     def registerSharedLibrariesWithTarget(self, target, shlibs):
         """If we are remotely running the test suite, register the shared libraries with the target so they get uploaded, otherwise do nothing

--- a/lldb/packages/Python/lldbsuite/test/test_categories.py
+++ b/lldb/packages/Python/lldbsuite/test/test_categories.py
@@ -20,6 +20,11 @@ debug_info_categories = {
     "gmodules": False,
 }
 
+swift_module_importer_categories = {
+    "clangimporter": True,
+    "dwarfimporter": True,
+}
+
 all_categories = {
     "basic_process": "Basic process execution sniff tests.",
     "cmdline": "Tests related to the LLDB command-line interface",
@@ -49,6 +54,8 @@ all_categories = {
     "stresstest": "Tests related to stressing lldb limits",
     "swiftmaccatalyst": "Tests which require swift maccatalyst stdlib support",
     "watchpoint": "Watchpoint-related tests",
+    "clangimporter": "Tests run with the Swift ClangImporter",
+    "dwarfimporter": "Tests run with the Swift DWARFImporter",
 }
 
 

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -6,8 +6,8 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftClangImporterCaching(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
-    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))
+    @skipIf(swift_module_importer="dwarfimporter")
+    @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
@@ -12,7 +12,7 @@ class TestSwiftExtraClangFlags(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=['windows'])
+    @skipIf(oslist=["windows"])
     @swiftTest
     def test_extra_clang_flags(self):
         """

--- a/lldb/test/API/lang/swift/clangimporter/explicit_cc1/TestSwiftClangImporterExplicitCC1.py
+++ b/lldb/test/API/lang/swift/clangimporter/explicit_cc1/TestSwiftClangImporterExplicitCC1.py
@@ -9,7 +9,7 @@ class TestSwiftClangImporterExplicitCC1(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(setting=('symbols.swift-precise-compiler-invocation', 'false'))
+    @skipIf(setting=("symbols.swift-precise-compiler-invocation", "false"))
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/extra_clang_flags/TestSwiftExtraClangFlags.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExtraClangFlags(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=['windows'])
+    @skipIf(oslist=["windows"])
     @swiftTest
     def test_sanity(self):
         self.build()
@@ -17,7 +17,7 @@ class TestSwiftExtraClangFlags(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=['windows'])
+    @skipIf(oslist=["windows"])
     @swiftTest
     def test_extra_clang_flags(self):
         """
@@ -61,7 +61,7 @@ class TestSwiftExtraClangFlags(TestBase):
 
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
-    @skipIf(oslist=['windows'])
+    @skipIf(oslist=["windows"])
     @swiftTest
     def test_invalid_extra_clang_flags(self):
         """

--- a/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/headermap_conflict/TestSwiftHeadermapConflict.py
@@ -18,8 +18,10 @@ import os
 import shutil
 
 class TestSwiftHeadermapConflict(TestBase):
-    @skipIf(bugnumber="rdar://60396797",
-            setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(
+        bugnumber="rdar://60396797",
+        setting=("symbols.use-swift-clangimporter", "false"),
+    )
     @skipUnlessDarwin
     @swiftTest
     def test(self):

--- a/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/objcmain_conflicting_dylibs_failing_import/TestSwiftObjCMainConflictingDylibsFailingImport.py
@@ -62,4 +62,3 @@ class TestSwiftObjCMainConflictingDylibsFailingImport(TestBase):
         # self.expect("expression foo", "expected result", substrs=["$R3", "23"])
         # self.expect("expression $R3", "expected result", substrs=["23"])
         # self.expect("expression $R4", "expected result", substrs=["23"])
-

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingClass.py
@@ -1,15 +1,15 @@
 
 """
-Test that Swift types are displayed correctly in C++
+Test stepping from C++ into Swift class types
 """
 from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 
-class TestSwiftBackwardInteropStepping(TestBase):
+class TestSwiftBackwardInteropSteppingClass(TestBase):
 
     def setup(self, bkpt_str):
         self.build()
-        
+
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
             self, bkpt_str, lldb.SBFileSpec('main.cpp'))
         return thread
@@ -34,22 +34,10 @@ class TestSwiftBackwardInteropStepping(TestBase):
 
     @swiftTest
     @skipIfWindows
-    def test_func_step_in(self):
-        thread = self.setup('Break here for func')
-        self.check_step_in(thread, 'testFunc', 'swiftFunc')
-        
-    @swiftTest
-    @skipIfWindows
-    def test_func_step_over(self):
-        thread = self.setup('Break here for func')
-        self.check_step_over(thread, 'testFunc')
-
-    @swiftTest
-    @skipIfWindows
     def test_method_step_in_class(self):
         thread = self.setup('Break here for method - class')
         self.check_step_in(thread, 'testMethod', 'SwiftClass.swiftMethod')
-        
+
     @swiftTest
     @skipIfWindows
     def test_method_step_over_class(self):
@@ -61,7 +49,7 @@ class TestSwiftBackwardInteropStepping(TestBase):
     def test_init_step_in_class(self):
         thread = self.setup('Break here for constructor - class')
         self.check_step_in(thread, 'testConstructor', 'SwiftClass.init')
-        
+
     @swiftTest
     @skipIfWindows
     def test_init_step_over_class(self):
@@ -73,7 +61,7 @@ class TestSwiftBackwardInteropStepping(TestBase):
     def test_static_method_step_in_class(self):
         thread = self.setup('Break here for static method - class')
         self.check_step_in(thread, 'testStaticMethod', 'SwiftClass.swiftStaticMethod')
-        
+
     @swiftTest
     @skipIfWindows
     def test_static_method_step_over_class(self):
@@ -85,7 +73,7 @@ class TestSwiftBackwardInteropStepping(TestBase):
     def test_getter_step_in_class(self):
         thread = self.setup('Break here for getter - class')
         self.check_step_in(thread, 'testGetter', 'SwiftClass.swiftProperty.getter')
-        
+
     @swiftTest
     @skipIfWindows
     def test_getter_step_over_class(self):
@@ -97,7 +85,7 @@ class TestSwiftBackwardInteropStepping(TestBase):
     def test_setter_step_in_class(self):
         thread = self.setup('Break here for setter - class')
         self.check_step_in(thread, 'testSetter', 'SwiftClass.swiftProperty.setter')
-        
+
     @swiftTest
     @skipIfWindows
     def test_setter_step_over_class(self):
@@ -110,70 +98,9 @@ class TestSwiftBackwardInteropStepping(TestBase):
     def test_overriden_step_in_class(self):
         thread = self.setup('Break here for overridden - class')
         self.check_step_in(thread, 'testOverridenMethod', 'SwiftSubclass.overrideableMethod')
-        
+
     @swiftTest
     @skipIfWindows
     def test_overriden_step_over_class(self):
         thread = self.setup('Break here for overridden')
         self.check_step_over(thread, 'testOverridenMethod')
-
-    @swiftTest
-    @skipIfWindows
-    def test_method_step_in_struct_class(self):
-        thread = self.setup('Break here for method - struct')
-        self.check_step_in(thread, 'testMethod', 'SwiftStruct.swiftMethod')
-        
-    @swiftTest
-    @skipIfWindows
-    def test_method_step_over_struct_class(self):
-        thread = self.setup('Break here for method - struct')
-        self.check_step_over(thread, 'testMethod')
-
-    @swiftTest
-    @skipIfWindows
-    def test_init_step_in_struct_class(self):
-        thread = self.setup('Break here for constructor - struct')
-        self.check_step_in(thread, 'testConstructor', 'SwiftStruct.init')
-        
-    @swiftTest
-    @skipIfWindows
-    def test_init_step_over_struct_class(self):
-        thread = self.setup('Break here for constructor - struct')
-        self.check_step_over(thread, 'testConstructor')
-
-    @swiftTest
-    @skipIfWindows
-    def test_static_method_step_in_struct(self):
-        thread = self.setup('Break here for static method - struct')
-        self.check_step_in(thread, 'testStaticMethod', 'SwiftStruct.swiftStaticMethod')
-        
-    @swiftTest
-    @skipIfWindows
-    def test_static_method_step_over_struct(self):
-        thread = self.setup('Break here for static method - struct')
-        self.check_step_over(thread, 'testStaticMethod')
-
-    @swiftTest
-    @skipIfWindows
-    def test_getter_step_in_struct(self):
-        thread = self.setup('Break here for getter - struct')
-        self.check_step_in(thread, 'testGetter', 'SwiftStruct.swiftProperty.getter')
-        
-    @swiftTest
-    @skipIfWindows
-    def test_getter_step_over_struct(self):
-        thread = self.setup('Break here for getter - struct')
-        self.check_step_over(thread, 'testGetter')
-
-    @swiftTest
-    @skipIfWindows
-    def test_setter_step_in_struct(self):
-        thread = self.setup('Break here for setter - struct')
-        self.check_step_in(thread, 'testSetter', 'SwiftStruct.swiftProperty.setter')
-        
-    @swiftTest
-    @skipIfWindows
-    def test_setter_step_over_struct(self):
-        thread = self.setup('Break here for setter - struct')
-        self.check_step_over(thread, 'testSetter')
-

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingFunc.py
@@ -1,0 +1,46 @@
+"""
+Test stepping from C++ into Swift free functions
+"""
+
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSwiftBackwardInteropSteppingFunc(TestBase):
+
+    def setup(self, bkpt_str):
+        self.build()
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, bkpt_str, lldb.SBFileSpec("main.cpp")
+        )
+        return thread
+
+    def check_step_in(self, thread, caller, callee):
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(caller, name)
+        thread.StepInto()
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(callee, name)
+        thread.StepOut()
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(caller, name)
+
+    def check_step_over(self, thread, func):
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(func, name)
+        thread.StepOver()
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(func, name)
+
+    @swiftTest
+    @skipIfWindows
+    def test_func_step_in(self):
+        thread = self.setup("Break here for func")
+        self.check_step_in(thread, "testFunc", "swiftFunc")
+
+    @swiftTest
+    @skipIfWindows
+    def test_func_step_over(self):
+        thread = self.setup("Break here for func")
+        self.check_step_over(thread, "testFunc")

--- a/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct.py
+++ b/lldb/test/API/lang/swift/cxx_interop/backward/stepping/TestSwiftBackwardInteropSteppingStruct.py
@@ -1,0 +1,94 @@
+"""
+Test stepping from C++ into Swift struct types
+"""
+
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+
+
+class TestSwiftBackwardInteropSteppingStruct(TestBase):
+
+    def setup(self, bkpt_str):
+        self.build()
+
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, bkpt_str, lldb.SBFileSpec("main.cpp")
+        )
+        return thread
+
+    def check_step_in(self, thread, caller, callee):
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(caller, name)
+        thread.StepInto()
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(callee, name)
+        thread.StepOut()
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(caller, name)
+
+    def check_step_over(self, thread, func):
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(func, name)
+        thread.StepOver()
+        name = thread.frames[0].GetFunctionName()
+        self.assertIn(func, name)
+
+    @swiftTest
+    @skipIfWindows
+    def test_method_step_in_struct(self):
+        thread = self.setup("Break here for method - struct")
+        self.check_step_in(thread, "testMethod", "SwiftStruct.swiftMethod")
+
+    @swiftTest
+    @skipIfWindows
+    def test_method_step_over_struct(self):
+        thread = self.setup("Break here for method - struct")
+        self.check_step_over(thread, "testMethod")
+
+    @swiftTest
+    @skipIfWindows
+    def test_init_step_in_struct(self):
+        thread = self.setup("Break here for constructor - struct")
+        self.check_step_in(thread, "testConstructor", "SwiftStruct.init")
+
+    @swiftTest
+    @skipIfWindows
+    def test_init_step_over_struct(self):
+        thread = self.setup("Break here for constructor - struct")
+        self.check_step_over(thread, "testConstructor")
+
+    @swiftTest
+    @skipIfWindows
+    def test_static_method_step_in_struct(self):
+        thread = self.setup("Break here for static method - struct")
+        self.check_step_in(thread, "testStaticMethod", "SwiftStruct.swiftStaticMethod")
+
+    @swiftTest
+    @skipIfWindows
+    def test_static_method_step_over_struct(self):
+        thread = self.setup("Break here for static method - struct")
+        self.check_step_over(thread, "testStaticMethod")
+
+    @swiftTest
+    @skipIfWindows
+    def test_getter_step_in_struct(self):
+        thread = self.setup("Break here for getter - struct")
+        self.check_step_in(thread, "testGetter", "SwiftStruct.swiftProperty.getter")
+
+    @swiftTest
+    @skipIfWindows
+    def test_getter_step_over_struct(self):
+        thread = self.setup("Break here for getter - struct")
+        self.check_step_over(thread, "testGetter")
+
+    @swiftTest
+    @skipIfWindows
+    def test_setter_step_in_struct(self):
+        thread = self.setup("Break here for setter - struct")
+        self.check_step_in(thread, "testSetter", "SwiftStruct.swiftProperty.setter")
+
+    @swiftTest
+    @skipIfWindows
+    def test_setter_step_over_struct(self):
+        thread = self.setup("Break here for setter - struct")
+        self.check_step_over(thread, "testSetter")

--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
@@ -9,20 +9,21 @@ from lldbsuite.test.decorators import *
 class TestSwiftForwardInteropExpressions(TestBase):
 
     def setup(self, bkpt_str):
-         self.build()
-         
-         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
-             self, bkpt_str, lldb.SBFileSpec('main.swift'))
-         return thread
+        self.build()
 
-    @skipIfLinux # rdar://106871422"
-    @skipIf(setting=('symbols.use-swift-clangimporter', 'false')) # rdar://106871275
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, bkpt_str, lldb.SBFileSpec("main.swift")
+        )
+        return thread
+
+    @skipIfLinux  # rdar://106871422"
+    @skipIf(setting=("symbols.use-swift-clangimporter", "false"))  # rdar://106871275
     @swiftTest
     def test(self):
-        self.setup('Break here')
-        
-        types_log = self.getBuildArtifact('types.log')
-        self.expect("log enable lldb types -v -f "+ types_log)
+        self.setup("Break here")
+
+        types_log = self.getBuildArtifact("types.log")
+        self.expect("log enable lldb types -v -f " + types_log)
         # Check that we can call free functions.
         self.expect('expr returnsInt()', substrs=['Int32', '42'])
 
@@ -64,4 +65,3 @@ class TestSwiftForwardInteropExpressions(TestBase):
         self.setup('Break here')
 
         self.expect('po CxxSubclass()', substrs=['CxxClass', 'a : 100', 'b : 101', 'c : 102'])
-

--- a/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/nested-classes/TestCxxForwardInteropNestedClasses.py
@@ -8,7 +8,7 @@ from lldbsuite.test.decorators import *
 
 class TestCxxForwardInteropNestedClasses(TestBase):
 
-    @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(swift_module_importer="dwarfimporter")
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -8,8 +8,10 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftForwardInteropSTLTypes(TestBase):
 
-    @skipIfLinux # rdar://106532498
-    @skipIf(setting=('symbols.use-swift-clangimporter', 'false')) # rdar://106438227 (TestSTLTypes fails when clang importer is disabled)
+    @skipIfLinux  # rdar://106532498
+    @skipIf(
+        setting=("symbols.use-swift-clangimporter", "false")
+    )  # rdar://106438227 (TestSTLTypes fails when clang importer is disabled)
     @swiftTest
     @skipIfWindows
     def test(self):

--- a/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
@@ -8,7 +8,7 @@ class TestSwiftErrorHandlingMissingTypes(TestBase):
 
     @swiftTest
     @expectedFailureWindows
-    @skipIf(setting=('symbols.use-swift-clangimporter', 'true'))
+    @skipIf(swift_module_importer="clangimporter")
     def test(self):
         """Test that errors are surfaced"""
         self.build()

--- a/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/data/TestSwiftFoundationTypeData.py
@@ -12,9 +12,16 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-        decorators=[
-            swiftTest,skipUnlessFoundation,skipIf(oslist=['windows']),
-            skipIf(bugnumber="rdar://60396797", # should work but crashes.
-                   setting=('symbols.use-swift-clangimporter', 'false'))
-])
+lldbinline.MakeInlineTest(
+    __file__,
+    globals(),
+    decorators=[
+        swiftTest,
+        skipUnlessFoundation,
+        skipIf(oslist=["windows"]),
+        skipIf(
+            bugnumber="rdar://60396797",  # should work but crashes.
+            setting=("symbols.use-swift-clangimporter", "false"),
+        ),
+    ],
+)

--- a/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/main_executable/TestMainExecutable.py
@@ -37,8 +37,10 @@ class TestMainExecutable(TestBase):
 
         return info
 
-    @skipIf(bugnumber="rdar://problem/54322424", # This test is unreliable.
-            setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(
+        bugnumber="rdar://problem/54322424",  # This test is unreliable.
+        setting=("symbols.use-swift-clangimporter", "false"),
+    )
     @swiftTest
     @skipIfWindows
     def test_implementation_only_import_main_executable(self):
@@ -60,8 +62,10 @@ class TestMainExecutable(TestBase):
         self.expect("expr container", substrs=["(main.ContainsTwoInts)", "wrapped = (first = 2, second = 3)", "other = 10"])
         self.expect("expr TwoInts(4, 5)", substrs=["(SomeLibrary.TwoInts)", "= (first = 4, second = 5)"])
 
-    @skipIf(bugnumber="rdar://problem/54322424", # This test is unreliable.
-            setting=('symbols.use-swift-clangimporter', 'false'))
+    @skipIf(
+        bugnumber="rdar://problem/54322424",  # This test is unreliable.
+        setting=("symbols.use-swift-clangimporter", "false"),
+    )
     @swiftTest
     @skipIfWindows
     @skipIfLinux # rdar://problem/67348391

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -13,6 +13,12 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
     @skipIf(bugnumber="rdar://171278439") # randomly fails to dlopen in CI
+    # FIXME: Without the ClangImporter, transitive module dependencies can't be
+    # fully resolved, so collectLinkLibraries() misses autolinked frameworks.
+    # This causes DoLoadImage() to allocate memory while the process is still
+    # running, which fails and leaves the process in a bad state, ultimately
+    # timing out with "didn't get any event after resume".
+    @expectedFailureAll(setting=("symbols.use-swift-clangimporter", "false"))
     def test(self):
         """Test that a framework that is registered as autolinked in a Swift
            module used in the target, but not linked against the target is

--- a/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
+++ b/lldb/test/API/lang/swift/protocol_extension_computed_property/TestProtocolExtensionComputerProperty.py
@@ -2,9 +2,14 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
-    __file__, globals(),
-        decorators=[
-            swiftTest,skipUnlessDarwin,
-            expectedFailureAll(bugnumber="rdar://60396797",
-                   setting=('symbols.use-swift-clangimporter', 'false'))
-    ])
+    __file__,
+    globals(),
+    decorators=[
+        swiftTest,
+        skipUnlessDarwin,
+        expectedFailureAll(
+            bugnumber="rdar://60396797",
+            setting=("symbols.use-swift-clangimporter", "false"),
+        ),
+    ],
+)


### PR DESCRIPTION
This patch integrates DWARFImporter testing directly into the test variant system by making `@swiftTest`-decorated tests automatically create two variants: one with `symbols.use-swift-clangimporter=true` (clangimporter) and one with false (dwarfimporter).

Previously, the build script ran lit twice: once for all tests with default settings, and a second time filtering only swift tests with `--param 'dotest-args=--setting symbols.use-swift-clangimporter=false'`.

The implementation extends `LLDBTestCaseFactory` to produce a cross-product of debug info variants × swift importer variants for `@swiftTest` methods. A test like `test_foo` decorated with @swiftTest now becomes `test_foo_dwarf_clangimporter`, `test_foo_dwarf_dwarfimporter`, `test_foo_dsym_clangimporter`, `test_foo_dsym_dwarfimporter`. For `NO_DEBUG_INFO_TESTCASE` classes with `@swiftTest` methods, only the two swift variants are created. Non-swift tests are unaffected.

The `@swiftTest` decorator now sets a `__swift_test__` attribute so the metaclass can detect swift tests. New `_skipForSwiftVariant` and `_xfailForSwiftVariant` helpers mirror the existing debug_info helpers, and `skipIf`/`expectedFailureAll` now accept a swift_variant parameter.

This patch also converts all existing
`@skipIf(setting=('symbols.use-swift-clangimporter', ...))` decorators to use the new `@skipIf(swift_variant=...)` form.