### PR TITLE
[BoundsSafety] Backport TypeLoc improvements from #167287

### DIFF
--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -1346,9 +1346,7 @@ public:
   void initializeLocal(ASTContext &Context, SourceLocation Loc) {
     setAttrRange({Loc, Loc});
   }
-  void setAttrRange(SourceRange Range) {
-    getLocalData()->Range = Range;
-  }
+  void setAttrRange(SourceRange Range) { getLocalData()->Range = Range; }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
 
   StringRef getAttrNameAsWritten(Sema &S) const;

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -43,6 +43,7 @@ class ObjCInterfaceDecl;
 class ObjCProtocolDecl;
 class ObjCTypeParamDecl;
 class ParmVarDecl;
+class Sema;
 class TemplateTypeParmDecl;
 class UnqualTypeLoc;
 class UnresolvedUsingTypenameDecl;
@@ -1333,7 +1334,6 @@ public:
   }
 };
 
-class Sema;
 struct BoundsAttributedLocInfo {
   SourceRange Range;
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -1333,6 +1333,7 @@ public:
   }
 };
 
+class Sema;
 struct BoundsAttributedLocInfo {
   SourceRange Range;
 };
@@ -1349,6 +1350,9 @@ public:
     getLocalData()->Range = Range;
   }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
+
+  StringRef getAttrNameAsWritten(Sema &S) const;
+  SourceRange getAttrNameRange(Sema &S) const;
 
   unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -19,7 +19,6 @@
 #include "clang/AST/NestedNameSpecifierBase.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TypeBase.h"
-#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
@@ -43,7 +42,6 @@ class ObjCInterfaceDecl;
 class ObjCProtocolDecl;
 class ObjCTypeParamDecl;
 class ParmVarDecl;
-class Sema;
 class TemplateTypeParmDecl;
 class UnqualTypeLoc;
 class UnresolvedUsingTypenameDecl;
@@ -1349,8 +1347,8 @@ public:
   void setAttrRange(SourceRange Range) { getLocalData()->Range = Range; }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
 
-  StringRef getAttrNameAsWritten(Sema &S) const;
-  SourceRange getAttrNameRange(Sema &S) const;
+  StringRef getAttrNameAsWritten(const ASTContext &Ctx) const;
+  SourceRange getAttrNameRange(const ASTContext &Ctx) const;
 
   unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -1346,6 +1346,7 @@ public:
   }
   void setAttrRange(SourceRange Range) { getLocalData()->Range = Range; }
   SourceRange getAttrRange() const { return getLocalData()->Range; }
+  SourceRange getLocalSourceRange() const { return getAttrRange(); }
 
   StringRef getAttrNameAsWritten(const ASTContext &Ctx) const;
   SourceRange getAttrNameRange(const ASTContext &Ctx) const;

--- a/clang/include/clang/AST/TypeLoc.h
+++ b/clang/include/clang/AST/TypeLoc.h
@@ -19,6 +19,7 @@
 #include "clang/AST/NestedNameSpecifierBase.h"
 #include "clang/AST/TemplateBase.h"
 #include "clang/AST/TypeBase.h"
+#include "clang/Basic/IdentifierTable.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
@@ -1332,7 +1333,9 @@ public:
   }
 };
 
-struct BoundsAttributedLocInfo {};
+struct BoundsAttributedLocInfo {
+  SourceRange Range;
+};
 class BoundsAttributedTypeLoc
     : public ConcreteTypeLoc<UnqualTypeLoc, BoundsAttributedTypeLoc,
                              BoundsAttributedType, BoundsAttributedLocInfo> {
@@ -1340,10 +1343,14 @@ public:
   TypeLoc getInnerLoc() const { return getInnerTypeLoc(); }
   QualType getInnerType() const { return getTypePtr()->desugar(); }
   void initializeLocal(ASTContext &Context, SourceLocation Loc) {
-    // nothing to do
+    setAttrRange({Loc, Loc});
   }
-  // LocalData is empty and TypeLocBuilder doesn't handle DataSize 1.
-  unsigned getLocalDataSize() const { return 0; }
+  void setAttrRange(SourceRange Range) {
+    getLocalData()->Range = Range;
+  }
+  SourceRange getAttrRange() const { return getLocalData()->Range; }
+
+  unsigned getLocalDataSize() const { return sizeof(BoundsAttributedLocInfo); }
 };
 
 class CountAttributedTypeLoc final
@@ -1354,8 +1361,6 @@ public:
   Expr *getCountExpr() const { return getTypePtr()->getCountExpr(); }
   bool isCountInBytes() const { return getTypePtr()->isCountInBytes(); }
   bool isOrNull() const { return getTypePtr()->isOrNull(); }
-
-  SourceRange getLocalSourceRange() const;
 };
 
 /* TO_UPSTREAM(BoundsSafety) ON */

--- a/clang/lib/AST/TypeLoc.cpp
+++ b/clang/lib/AST/TypeLoc.cpp
@@ -590,10 +590,6 @@ SourceRange AttributedTypeLoc::getLocalSourceRange() const {
   return getAttr() ? getAttr()->getRange() : SourceRange();
 }
 
-SourceRange CountAttributedTypeLoc::getLocalSourceRange() const {
-  return getCountExpr() ? getCountExpr()->getSourceRange() : SourceRange();
-}
-
 /* TO_UPSTREAM(BoundsSafety) ON */
 SourceRange DynamicRangePointerTypeLoc::getLocalSourceRange() const {
   return getEndPointer() ? getEndPointer()->getSourceRange() : SourceRange();

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -11,6 +11,7 @@
 /// (e.g. `counted_by`)
 ///
 //===----------------------------------------------------------------------===//
+
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/StmtVisitor.h"
@@ -22,7 +23,6 @@
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/Initialization.h"
 #include "clang/Sema/Sema.h"
-
 #include "llvm/ADT/StringSwitch.h"
 
 namespace clang {

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -392,8 +392,10 @@ static void EmitIncompleteCountedByPointeeNotes(Sema &S,
       llvm::StringSwitch<StringRef>(Spelling)
           .Case("__counted_by", "__sized_by")
           .Case("counted_by", "sized_by")
+          .Case("__counted_by__", "__sized_by__")
           .Case("__counted_by_or_null", "__sized_by_or_null")
           .Case("counted_by_or_null", "sized_by_or_null")
+          .Case("__counted_by_or_null__", "__sized_by_or_null__")
           .Default("");
   FixItHint Fix;
   if (!FixedSpelling.empty())

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -11,6 +11,13 @@
 /// (e.g. `counted_by`)
 ///
 //===----------------------------------------------------------------------===//
+#include "clang/AST/Decl.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/StmtVisitor.h"
+#include "clang/AST/TypeBase.h"
+#include "clang/AST/TypeLoc.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Lex/Lexer.h"
 #include "clang/Sema/Initialization.h"
@@ -284,166 +291,69 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
   return false;
 }
 
-/* TO_UPSTREAM(BoundsSafety) ON*/
-static SourceRange SourceRangeFor(const CountAttributedType *CATy, Sema &S) {
-  // Note: This implementation relies on `CountAttributedType` being unique.
-  // E.g.:
-  //
-  // struct Foo {
-  //   int count;
-  //   char* __counted_by(count) buffer;
-  //   char* __counted_by(count) buffer2;
-  // };
-  //
-  // The types of `buffer` and `buffer2` are unique. The types being
-  // unique means the SourceLocation of the `counted_by` expression can be used
-  // to find where the attribute was written.
-
-  auto Fallback = CATy->getCountExpr()->getSourceRange();
-  auto CountExprBegin = CATy->getCountExpr()->getBeginLoc();
-
-  // FIXME: We currently don't support the count expression being a macro
-  // itself. E.g.:
-  //
-  // #define ZERO 0
-  // int* __counted_by(ZERO) x;
-  //
-  if (S.SourceMgr.isMacroBodyExpansion(CountExprBegin))
-    return Fallback;
-
-  auto FetchIdentifierTokenFromOffset =
-      [&](ssize_t Offset) -> std::optional<Token> {
-    SourceLocation OffsetLoc = CountExprBegin.getLocWithOffset(Offset);
-    Token Result;
-    if (Lexer::getRawToken(OffsetLoc, Result, S.SourceMgr, S.getLangOpts()))
-      return std::optional<Token>(); // Failed
-
-    if (!Result.isAnyIdentifier())
-      return std::optional<Token>(); // Failed
-
-    return Result; // Success
-  };
-
-  auto CountExprEnd = CATy->getCountExpr()->getEndLoc();
-  auto FindRParenTokenAfter = [&]() -> std::optional<Token> {
-    auto CountExprEndSpelling = S.SourceMgr.getSpellingLoc(CountExprEnd);
-    auto MaybeRParenTok = Lexer::findNextToken(
-        CountExprEndSpelling, S.getSourceManager(), S.getLangOpts());
-
-    if (!MaybeRParenTok.has_value())
-      return std::nullopt;
-
-    if (!MaybeRParenTok->is(tok::r_paren))
-      return std::nullopt;
-
-    return *MaybeRParenTok;
-  };
-
-  // Step back two characters to point at the last character of the attribute
-  // text.
-  //
-  // __counted_by(count)
-  //            ^ ^
-  //            | |
-  //            ---
-  auto MaybeLastAttrCharToken = FetchIdentifierTokenFromOffset(-2);
-  if (!MaybeLastAttrCharToken)
-    return Fallback;
-
-  auto LastAttrCharToken = MaybeLastAttrCharToken.value();
-
-  if (LastAttrCharToken.getLength() > 1) {
-    // Special case: When the character is part of a macro the Token we get
-    // is the whole macro name (e.g. `__counted_by`).
-    if (LastAttrCharToken.getRawIdentifier() !=
-        CATy->getAttributeName(/*WithMacroPrefix=*/true))
-      return Fallback;
-
-    // Found the beginning of the `__counted_by` macro
-    SourceLocation Begin = LastAttrCharToken.getLocation();
-    // Now try to find the closing `)` of the macro.
-    auto MaybeRParenTok = FindRParenTokenAfter();
-    if (!MaybeRParenTok.has_value())
-      return Fallback;
-
-    return SourceRange(Begin, MaybeRParenTok->getLocation());
-  }
-
-  assert(LastAttrCharToken.getLength() == 1);
-  // The Token we got back is just the last character of the identifier.
-  // This means a macro is not being used and instead the attribute is being
-  // used directly. We need to find the beginning of the identifier. We support
-  // two cases:
-  //
-  // * Non-affixed version. E.g: `counted_by`
-  // * Affixed version. E.g.: `__counted_by__`
-
-  // Try non-affixed version. E.g.:
-  //
-  // __attribute__((counted_by(count)))
-  //                ^          ^
-  //                |          |
-  //                ------------
-
-  // +1 is for `(`
-  const ssize_t NonAffixedSkipCount =
-      CATy->getAttributeName(/*WithMacroPrefix=*/false).size() + 1;
-  auto MaybeNonAffixedBeginToken =
-      FetchIdentifierTokenFromOffset(-NonAffixedSkipCount);
-  if (!MaybeNonAffixedBeginToken)
-    return Fallback;
-
-  auto NonAffixedBeginToken = MaybeNonAffixedBeginToken.value();
-  if (NonAffixedBeginToken.getRawIdentifier() ==
-      CATy->getAttributeName(/*WithMacroPrefix=*/false)) {
-    // Found the beginning of the `counted_by`-like attribute
-    auto SL = NonAffixedBeginToken.getLocation();
-
-    // Now try to find the closing `)` of the attribute
-    auto MaybeRParenTok = FindRParenTokenAfter();
-    if (!MaybeRParenTok.has_value())
-      return Fallback;
-
-    return SourceRange(SL, MaybeRParenTok->getLocation());
-  }
-
-  // Try affixed version. E.g.:
-  //
-  // __attribute__((__counted_by__(count)))
-  //                ^              ^
-  //                |              |
-  //                ----------------
-  std::string AffixedTokenStr =
-      (llvm::Twine("__") + CATy->getAttributeName(/*WithMacroPrefix=*/false) +
-       llvm::Twine("__"))
-          .str();
-  // +1 is for `(`
-  // +4 is for the 4 `_` characters
-  const ssize_t AffixedSkipCount =
-      CATy->getAttributeName(/*WithMacroPrefix=*/false).size() + 1 + 4;
-  auto MaybeAffixedBeginToken =
-      FetchIdentifierTokenFromOffset(-AffixedSkipCount);
-  if (!MaybeAffixedBeginToken)
-    return Fallback;
-
-  auto AffixedBeginToken = MaybeAffixedBeginToken.value();
-  if (AffixedBeginToken.getRawIdentifier() != AffixedTokenStr)
-    return Fallback;
-
-  // Found the beginning of the `__counted_by__`-like like attribute.
-  auto SL = AffixedBeginToken.getLocation();
-  // Now try to find the closing `)` of the attribute
-  auto MaybeRParenTok = FindRParenTokenAfter();
-  if (!MaybeRParenTok.has_value())
-    return Fallback;
-
-  return SourceRange(SL, MaybeRParenTok->getLocation());
+// FIXME: for some reason diagnostics highlight the end character, while
+// getSourceText() does not include the end character.
+static SourceRange getAttrNameRangeImpl(Sema &S, SourceLocation Begin,
+                                        bool IsForDiagnostics) {
+  SourceManager &SM = S.getSourceManager();
+  SourceLocation TokenStart = Begin;
+  while (TokenStart.isMacroID())
+    TokenStart = SM.getImmediateExpansionRange(TokenStart).getBegin();
+  unsigned Offset = IsForDiagnostics ? 1 : 0;
+  SourceLocation End = S.getLocForEndOfToken(TokenStart, Offset);
+  return {TokenStart, End};
 }
-/* TO_UPSTREAM(BoundsSafety) OFF*/
+
+StringRef BoundsAttributedTypeLoc::getAttrNameAsWritten(Sema &S) const {
+  SourceRange Range = getAttrNameRangeImpl(S, getAttrRange().getBegin(), false);
+  CharSourceRange NameRange = CharSourceRange::getCharRange(Range);
+  return Lexer::getSourceText(NameRange, S.getSourceManager(), S.getLangOpts());
+}
+
+SourceRange BoundsAttributedTypeLoc::getAttrNameRange(Sema &S) const {
+  return getAttrNameRangeImpl(S, getAttrRange().getBegin(), true);
+}
+
+static TypeSourceInfo *getTSI(const Decl *D) {
+  if (const auto* DD = dyn_cast<DeclaratorDecl>(D)) {
+    return DD->getTypeSourceInfo();
+  }
+  return nullptr;
+}
+
+struct TypeLocFinder : public ConstStmtVisitor<TypeLocFinder, TypeLoc> {
+  TypeLoc VisitParenExpr(const ParenExpr* E) {
+    return Visit(E->getSubExpr());
+  }
+
+  TypeLoc VisitDeclRefExpr(const DeclRefExpr *E) {
+    return getTSI(E->getDecl())->getTypeLoc();
+  }
+
+  TypeLoc VisitMemberExpr(const MemberExpr *E) {
+    return getTSI(E->getMemberDecl())->getTypeLoc();
+  }
+
+  TypeLoc VisitExplicitCastExpr(const ExplicitCastExpr *E) {
+    return E->getTypeInfoAsWritten()->getTypeLoc();
+  }
+
+  TypeLoc VisitCallExpr(const CallExpr *E) {
+    if (const auto *D = E->getCalleeDecl()) {
+      FunctionTypeLoc FTL = getTSI(D)->getTypeLoc().getAs<FunctionTypeLoc>();
+      if (FTL.isNull()) {
+        return FTL;
+      }
+      return FTL.getReturnLoc();
+    }
+    return {};
+  }
+};
 
 static void EmitIncompleteCountedByPointeeNotes(Sema &S,
                                                 const CountAttributedType *CATy,
-                                                NamedDecl *IncompleteTyDecl) {
+                                                NamedDecl *IncompleteTyDecl,
+                                                TypeLoc TL) {
   assert(IncompleteTyDecl == nullptr || isa<TypeDecl>(IncompleteTyDecl));
 
   if (IncompleteTyDecl) {
@@ -463,26 +373,36 @@ static void EmitIncompleteCountedByPointeeNotes(Sema &S,
         << CATy->getPointeeType();
   }
 
-  // Suggest using __sized_by(_or_null) instead of __counted_by(_or_null) as
-  // __sized_by(_or_null) doesn't have the complete type restriction.
-  //
-  // We use the source range of the expression on the CountAttributedType as an
-  // approximation for the source range of the attribute. This isn't quite right
-  // but isn't easy to fix right now.
-  //
-  // TODO: Implement logic to find the relevant TypeLoc for the attribute and
-  // get the SourceRange from that (#113582).
-  //
-  // TODO: We should emit a fix-it here.
+  CountAttributedTypeLoc CATL;
+  if (!TL.isNull())
+    CATL = TL.getAs<CountAttributedTypeLoc>();
 
-  /* TO_UPSTREAM(BoundsSafety) ON*/
-  // TODO: Upstream probably won't accept `SourceRangeFor` so we should consider
-  // removing it and its related tests.
-  // SourceRange AttrSrcRange = CATy->getCountExpr()->getSourceRange();
-  SourceRange AttrSrcRange = SourceRangeFor(CATy, S);
-  /* TO_UPSTREAM(BoundsSafety) OFF*/
+  if (CATL.isNull()) {
+    // Fall back to pointing to the count expr - not great, but close enough.
+    // This should happen rarely, if ever.
+    S.Diag(CATy->getCountExpr()->getExprLoc(),
+           diag::note_counted_by_consider_using_sized_by)
+        << CATy->isOrNull();
+    return;
+  }
+  SourceRange AttrSrcRange = CATL.getAttrNameRange(S);
+
+  StringRef Spelling = CATL.getAttrNameAsWritten(S);
+  StringRef FixedSpelling;
+  if (Spelling == "__counted_by")
+    FixedSpelling = "__sized_by";
+  else if (Spelling == "counted_by")
+    FixedSpelling = "sized_by";
+  else if (Spelling == "__counted_by_or_null")
+    FixedSpelling = "__sized_by_or_null";
+  else if (Spelling == "counted_by_or_null")
+    FixedSpelling = "sized_by_or_null";
+  FixItHint Fix;
+  if (!FixedSpelling.empty())
+    Fix = FixItHint::CreateReplacement(AttrSrcRange, FixedSpelling);
+
   S.Diag(AttrSrcRange.getBegin(), diag::note_counted_by_consider_using_sized_by)
-      << CATy->isOrNull() << AttrSrcRange;
+      << CATy->isOrNull() << AttrSrcRange << Fix;
 }
 
 static std::tuple<const CountAttributedType *, QualType>
@@ -551,7 +471,11 @@ static bool CheckAssignmentToCountAttrPtrWithIncompletePointeeTy(
       << CATy->getAttributeName(/*WithMacroPrefix=*/true) << PointeeTy
       << CATy->isOrNull() << RHSExpr->getSourceRange();
 
-  EmitIncompleteCountedByPointeeNotes(S, CATy, IncompleteTyDecl);
+  TypeLoc TL;
+  if (TypeSourceInfo *TSI = getTSI(Assignee))
+    TL = TSI->getTypeLoc();
+
+  EmitIncompleteCountedByPointeeNotes(S, CATy, IncompleteTyDecl, TL);
   return false; // check failed
 }
 
@@ -624,7 +548,8 @@ bool Sema::BoundsSafetyCheckUseOfCountAttrPtr(const Expr *E) {
       << CATy->getAttributeName(/*WithMacroPrefix=*/true) << CATy->isOrNull()
       << E->getSourceRange();
 
-  EmitIncompleteCountedByPointeeNotes(*this, CATy, IncompleteTyDecl);
+  TypeLoc TL = TypeLocFinder().Visit(E);
+  EmitIncompleteCountedByPointeeNotes(*this, CATy, IncompleteTyDecl, TL);
   return false;
 }
 

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -315,16 +315,14 @@ SourceRange BoundsAttributedTypeLoc::getAttrNameRange(Sema &S) const {
 }
 
 static TypeSourceInfo *getTSI(const Decl *D) {
-  if (const auto* DD = dyn_cast<DeclaratorDecl>(D)) {
+  if (const auto *DD = dyn_cast<DeclaratorDecl>(D)) {
     return DD->getTypeSourceInfo();
   }
   return nullptr;
 }
 
 struct TypeLocFinder : public ConstStmtVisitor<TypeLocFinder, TypeLoc> {
-  TypeLoc VisitParenExpr(const ParenExpr* E) {
-    return Visit(E->getSubExpr());
-  }
+  TypeLoc VisitParenExpr(const ParenExpr *E) { return Visit(E->getSubExpr()); }
 
   TypeLoc VisitDeclRefExpr(const DeclRefExpr *E) {
     return getTSI(E->getDecl())->getTypeLoc();

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -296,24 +296,30 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
 
 // FIXME: for some reason diagnostics highlight the end character, while
 // getSourceText() does not include the end character.
-static SourceRange getAttrNameRangeImpl(const ASTContext &Ctx, SourceLocation Begin,
+static SourceRange getAttrNameRangeImpl(const ASTContext &Ctx,
+                                        SourceLocation Begin,
                                         bool IsForDiagnostics) {
   const SourceManager &SM = Ctx.getSourceManager();
   SourceLocation TokenStart = Begin;
   while (TokenStart.isMacroID())
     TokenStart = SM.getImmediateExpansionRange(TokenStart).getBegin();
   unsigned Offset = IsForDiagnostics ? 1 : 0;
-  SourceLocation End = Lexer::getLocForEndOfToken(TokenStart, Offset, SM, Ctx.getLangOpts());
+  SourceLocation End =
+      Lexer::getLocForEndOfToken(TokenStart, Offset, SM, Ctx.getLangOpts());
   return {TokenStart, End};
 }
 
-StringRef BoundsAttributedTypeLoc::getAttrNameAsWritten(const ASTContext &Ctx) const {
-  SourceRange Range = getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), false);
+StringRef
+BoundsAttributedTypeLoc::getAttrNameAsWritten(const ASTContext &Ctx) const {
+  SourceRange Range =
+      getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), false);
   CharSourceRange NameRange = CharSourceRange::getCharRange(Range);
-  return Lexer::getSourceText(NameRange, Ctx.getSourceManager(), Ctx.getLangOpts());
+  return Lexer::getSourceText(NameRange, Ctx.getSourceManager(),
+                              Ctx.getLangOpts());
 }
 
-SourceRange BoundsAttributedTypeLoc::getAttrNameRange(const ASTContext &Ctx) const {
+SourceRange
+BoundsAttributedTypeLoc::getAttrNameRange(const ASTContext &Ctx) const {
   return getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), true);
 }
 

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -12,6 +12,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "clang/AST/ASTContext.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/StmtVisitor.h"
@@ -295,25 +296,25 @@ bool Sema::CheckCountedByAttrOnField(FieldDecl *FD, Expr *E, bool CountInBytes,
 
 // FIXME: for some reason diagnostics highlight the end character, while
 // getSourceText() does not include the end character.
-static SourceRange getAttrNameRangeImpl(Sema &S, SourceLocation Begin,
+static SourceRange getAttrNameRangeImpl(const ASTContext &Ctx, SourceLocation Begin,
                                         bool IsForDiagnostics) {
-  SourceManager &SM = S.getSourceManager();
+  const SourceManager &SM = Ctx.getSourceManager();
   SourceLocation TokenStart = Begin;
   while (TokenStart.isMacroID())
     TokenStart = SM.getImmediateExpansionRange(TokenStart).getBegin();
   unsigned Offset = IsForDiagnostics ? 1 : 0;
-  SourceLocation End = S.getLocForEndOfToken(TokenStart, Offset);
+  SourceLocation End = Lexer::getLocForEndOfToken(TokenStart, Offset, SM, Ctx.getLangOpts());
   return {TokenStart, End};
 }
 
-StringRef BoundsAttributedTypeLoc::getAttrNameAsWritten(Sema &S) const {
-  SourceRange Range = getAttrNameRangeImpl(S, getAttrRange().getBegin(), false);
+StringRef BoundsAttributedTypeLoc::getAttrNameAsWritten(const ASTContext &Ctx) const {
+  SourceRange Range = getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), false);
   CharSourceRange NameRange = CharSourceRange::getCharRange(Range);
-  return Lexer::getSourceText(NameRange, S.getSourceManager(), S.getLangOpts());
+  return Lexer::getSourceText(NameRange, Ctx.getSourceManager(), Ctx.getLangOpts());
 }
 
-SourceRange BoundsAttributedTypeLoc::getAttrNameRange(Sema &S) const {
-  return getAttrNameRangeImpl(S, getAttrRange().getBegin(), true);
+SourceRange BoundsAttributedTypeLoc::getAttrNameRange(const ASTContext &Ctx) const {
+  return getAttrNameRangeImpl(Ctx, getAttrRange().getBegin(), true);
 }
 
 static TypeSourceInfo *getTSI(const Decl *D) {
@@ -385,9 +386,9 @@ static void EmitIncompleteCountedByPointeeNotes(Sema &S,
         << CATy->isOrNull();
     return;
   }
-  SourceRange AttrSrcRange = CATL.getAttrNameRange(S);
+  SourceRange AttrSrcRange = CATL.getAttrNameRange(S.getASTContext());
 
-  StringRef Spelling = CATL.getAttrNameAsWritten(S);
+  StringRef Spelling = CATL.getAttrNameAsWritten(S.getASTContext());
   StringRef FixedSpelling =
       llvm::StringSwitch<StringRef>(Spelling)
           .Case("__counted_by", "__sized_by")

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -23,6 +23,8 @@
 #include "clang/Sema/Initialization.h"
 #include "clang/Sema/Sema.h"
 
+#include "llvm/ADT/StringSwitch.h"
+
 namespace clang {
 
 // In upstream the return type is `CountAttributedType::DynamicCountPointerKind`
@@ -386,15 +388,13 @@ static void EmitIncompleteCountedByPointeeNotes(Sema &S,
   SourceRange AttrSrcRange = CATL.getAttrNameRange(S);
 
   StringRef Spelling = CATL.getAttrNameAsWritten(S);
-  StringRef FixedSpelling;
-  if (Spelling == "__counted_by")
-    FixedSpelling = "__sized_by";
-  else if (Spelling == "counted_by")
-    FixedSpelling = "sized_by";
-  else if (Spelling == "__counted_by_or_null")
-    FixedSpelling = "__sized_by_or_null";
-  else if (Spelling == "counted_by_or_null")
-    FixedSpelling = "sized_by_or_null";
+  StringRef FixedSpelling =
+      llvm::StringSwitch<StringRef>(Spelling)
+          .Case("__counted_by", "__sized_by")
+          .Case("counted_by", "sized_by")
+          .Case("__counted_by_or_null", "__sized_by_or_null")
+          .Case("counted_by_or_null", "sized_by_or_null")
+          .Default("");
   FixItHint Fix;
   if (!FixedSpelling.empty())
     Fix = FixItHint::CreateReplacement(AttrSrcRange, FixedSpelling);

--- a/clang/lib/Sema/SemaBoundsSafety.cpp
+++ b/clang/lib/Sema/SemaBoundsSafety.cpp
@@ -619,14 +619,26 @@ static bool BoundsSafetyCheckFunctionParamOrCountAttrWithIncompletePointeeTy(
   if (ParamDecl)
     ParamName = ParamDecl->getName();
 
-  auto SR = SourceRangeFor(CATy, S);
+  TypeLoc TL;
+  if (ParamDecl)
+    if (auto *TSI = getTSI(ParamDecl))
+      TL = TSI->getTypeLoc();
+
+  CountAttributedTypeLoc CATL;
+  if (!TL.isNull())
+    CATL = TL.getAs<CountAttributedTypeLoc>();
+
+  SourceRange SR = CATL.isNull()
+  	? CATy->getCountExpr()->getSourceRange()
+  	: CATL.getAttrNameRange(S.getASTContext());
+
   S.Diag(SR.getBegin(),
          diag::err_bounds_safety_counted_by_on_incomplete_type_on_func_def)
       << /*0*/ CATy->getAttributeName(/*WithMacroPrefix*/ true)
       << /*1*/ (ParamDecl ? 1 : 0) << /*2*/ (ParamName.size() > 0)
       << /*3*/ ParamName << /*4*/ Ty << /*5*/ PointeeTy << SR;
 
-  EmitIncompleteCountedByPointeeNotes(S, CATy, IncompleteTyDecl);
+  EmitIncompleteCountedByPointeeNotes(S, CATy, IncompleteTyDecl, TL);
   return false;
 }
 
@@ -655,7 +667,19 @@ BoundsSafetyCheckVarDeclCountAttrPtrWithIncompletePointeeTy(Sema &S,
   if (!CATy)
     return true;
 
-  SourceRange SR = SourceRangeFor(CATy, S);
+  TypeLoc TL;
+  if (VD)
+    if (auto *TSI = getTSI(VD))
+      TL = TSI->getTypeLoc();
+
+  CountAttributedTypeLoc CATL;
+  if (!TL.isNull())
+    CATL = TL.getAs<CountAttributedTypeLoc>();
+
+  SourceRange SR = CATL.isNull()
+  	? CATy->getCountExpr()->getSourceRange()
+  	: CATL.getAttrNameRange(S.getASTContext());
+
   S.Diag(SR.getBegin(),
          diag::err_bounds_safety_counted_by_on_incomplete_type_on_var_decl)
       << /*0*/ CATy->getAttributeName(/*WithMacroPrefix=*/true)
@@ -664,7 +688,7 @@ BoundsSafetyCheckVarDeclCountAttrPtrWithIncompletePointeeTy(Sema &S,
       << /*2*/ VD->getName() << /*3*/ VD->getType() << /*4*/ PointeeTy
       << /*5*/ CATy->isOrNull() << SR;
 
-  EmitIncompleteCountedByPointeeNotes(S, CATy, IncompleteTyDecl);
+  EmitIncompleteCountedByPointeeNotes(S, CATy, IncompleteTyDecl, TL);
   return false;
 }
 

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -12,10 +12,12 @@
 
 #include "DynamicCountPointerAssignmentAnalysis.h"
 #include "TreeTransform.h"
+#include "TypeLocBuilder.h"
 #include "clang/AST/APValue.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTMutationListener.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -29,6 +31,8 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/TypeVisitor.h"
+#include "clang/AST/TypeBase.h"
+#include "clang/AST/TypeLoc.h"
 #include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Cuda.h"
 #include "clang/Basic/DarwinSDKInfo.h"
@@ -8372,9 +8376,14 @@ static void handleCountedByAttrField(Sema &S, Decl *D, const ParsedAttr &AL) {
   if (S.CheckCountedByAttrOnField(FD, CountExpr, CountInBytes, OrNull))
     return;
 
+  TypeLocBuilder TLB;
   QualType CAT = S.BuildCountAttributedArrayOrPointerType(
       FD->getType(), CountExpr, CountInBytes, OrNull);
+  TLB.pushFullCopy(FD->getTypeSourceInfo()->getTypeLoc());
+  CountAttributedTypeLoc CATL = TLB.push<CountAttributedTypeLoc>(CAT);
+  CATL.setAttrRange(AL.getRange());
   FD->setType(CAT);
+  FD->setTypeSourceInfo(TLB.getTypeSourceInfo(S.getASTContext(), CAT));
 }
 
 static void handleFunctionReturnThunksAttr(Sema &S, Decl *D,

--- a/clang/test/Sema/bounds-safety-source-ranges.c
+++ b/clang/test/Sema/bounds-safety-source-ranges.c
@@ -1,5 +1,5 @@
-// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -fdiagnostics-parseable-fixits %s 2>%t.txt
-// RUN: FileCheck %s --implicit-check-not error --implicit-check-not note --implicit-check-not fix --implicit-check-not warning < %t.txt
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -fdiagnostics-parseable-fixits %s 2>&1 | \
+// RUN:   FileCheck %s --implicit-check-not error --implicit-check-not note --implicit-check-not fix --implicit-check-not warning
 
 #define __counted_by(f)  __attribute__((counted_by(f)))
 

--- a/clang/test/Sema/bounds-safety-source-ranges.c
+++ b/clang/test/Sema/bounds-safety-source-ranges.c
@@ -1,0 +1,197 @@
+// RUN: not %clang_cc1 -fsyntax-only -fdiagnostics-print-source-range-info -fdiagnostics-parseable-fixits %s 2>%t.txt
+// RUN: FileCheck %s --implicit-check-not error --implicit-check-not note --implicit-check-not fix --implicit-check-not warning < %t.txt
+
+#define __counted_by(f)  __attribute__((counted_by(f)))
+
+struct IncompleteTy;
+typedef struct IncompleteTy Incomplete_t; 
+
+struct Container__cb {
+  int count;
+  struct IncompleteTy* buf __counted_by(count);
+  Incomplete_t* buf_typedef __counted_by(count);
+};
+
+void consume_struct_IncompleteTy(struct IncompleteTy* buf);
+int idx(void);
+
+void test_Container__cb(struct Container__cb* ptr) {
+  struct Container__cb uninit;
+  uninit.count = 0;
+
+  uninit.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:14:{[[@LINE-1]]:16-[[@LINE-1]]:19}: error: cannot assign to 'Container__cb::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+
+  struct IncompleteTy* addr_elt_zero_ptr = &ptr->buf[0];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:45:{[[@LINE-1]]:45-[[@LINE-1]]:53}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+
+  struct IncompleteTy* addr_elt_idx_ptr = &ptr->buf[idx()];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:44:{[[@LINE-1]]:44-[[@LINE-1]]:52}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  consume_struct_IncompleteTy(uninit.buf);
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:31:{[[@LINE-1]]:31-[[@LINE-1]]:41}: error: cannot use 'uninit.buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  consume_struct_IncompleteTy(ptr->buf);
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:31:{[[@LINE-1]]:31-[[@LINE-1]]:39}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+
+  uninit.buf[0] = uninit.buf[1];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:3:{[[@LINE-1]]:3-[[@LINE-1]]:13}: error: cannot use 'uninit.buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-6]]:19:{[[@LINE-6]]:19-[[@LINE-6]]:29}: error: cannot use 'uninit.buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  ptr->buf[0] = ptr->buf[1];
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:3:{[[@LINE-1]]:3-[[@LINE-1]]:11}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+  
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-6]]:17:{[[@LINE-6]]:17-[[@LINE-6]]:25}: error: cannot use 'ptr->buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:11:28:{11:28-11:40}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{11:28-11:40}:"__sized_by"
+}
+
+
+struct Container__cb___nomacro {
+  int count;
+  struct IncompleteTy* buf __attribute__((__counted_by__(count)));
+};
+
+void test_Container__cb___nomacro(struct Container__cb___nomacro* ptr) {
+  struct Container__cb___nomacro local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Container__cb___nomacro::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:43:{[[@LINE-9]]:43-[[@LINE-9]]:57}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:43-[[@LINE-10]]:57}:"__sized_by__"
+}
+
+
+struct Containercb_nomacro {
+  int count;
+  struct IncompleteTy* buf __attribute__((counted_by(count)));
+};
+
+void test_Containercb_nomacro(struct Containercb_nomacro* ptr) {
+  struct Containercb_nomacro local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Containercb_nomacro::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:43:{[[@LINE-9]]:43-[[@LINE-9]]:53}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:43-[[@LINE-10]]:53}:"sized_by"
+}
+
+
+#define aaaaaaaa(x) __attribute__((counted_by(x)))
+struct Container_aaaaaaaa {
+  int count;
+  struct IncompleteTy* buf aaaaaaaa(count);
+};
+
+void test_Container_aaaaaaaa(struct Container_aaaaaaaa* ptr) {
+  struct Container_aaaaaaaa local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Container_aaaaaaaa::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:28:{[[@LINE-9]]:28-[[@LINE-9]]:36}: note: consider using '__sized_by' instead of '__counted_by'
+  // no fix-it
+}
+
+
+struct Container_macro1 {
+  int count;
+  struct IncompleteTy* buf __attribute__((counted_by(count)));
+};
+
+#define A() \
+void test_Contain_macro1(struct Container_macro1* ptr) { \
+  struct Container_macro1 local; \
+  local.count = 0; \
+  local.buf = 0x0; \
+}
+
+A()
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:1:{[[@LINE-1]]:1-[[@LINE-1]]:4}: error: cannot assign to 'Container_macro1::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-5]]:13:{[[@LINE-5]]:15-[[@LINE-5]]:18}: note: expanded from macro 'A'
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-14]]:43:{[[@LINE-14]]:43-[[@LINE-14]]:53}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-15]]:43-[[@LINE-15]]:53}:"sized_by"
+
+
+#define B() \
+struct Container_macro2 { \
+  int count; \
+  struct IncompleteTy* buf __attribute__((counted_by(count))); \
+};
+B()
+
+void test_Contain_macro2(struct Container_macro2* ptr) {
+  struct Container_macro2 local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Container_macro2::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-8]]:1:{[[@LINE-8]]:1-[[@LINE-8]]:2}: note: consider using '__sized_by' instead of '__counted_by'
+  // no fix-it
+}
+
+
+#define counted_by(x) __attribute__((counted_by(x)))
+
+struct Containercb {
+  int count;
+  struct IncompleteTy* buf counted_by(count);
+};
+
+void test_Containercb(struct Containercb* ptr) {
+  struct Containercb local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Containercb::buf' with '__counted_by' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:28:{[[@LINE-9]]:28-[[@LINE-9]]:38}: note: consider using '__sized_by' instead of '__counted_by'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:28-[[@LINE-10]]:38}:"sized_by"
+}
+
+
+struct Containercbon {
+  int count;
+  struct IncompleteTy* buf __attribute__((counted_by_or_null(count)));
+};
+
+void test_Containercbon(struct Containercbon* ptr) {
+  struct Containercbon local;
+  local.count = 0;
+  local.buf = 0x0;
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-1]]:13:{[[@LINE-1]]:15-[[@LINE-1]]:18}: error: cannot assign to 'Containercbon::buf' with '__counted_by_or_null' {{.*}} because the pointee type 'struct IncompleteTy' is incomplete
+  // CHECK: bounds-safety-source-ranges.c:6:1: note: consider providing a complete definition for 'struct IncompleteTy'
+  // CHECK: bounds-safety-source-ranges.c:[[@LINE-9]]:43:{[[@LINE-9]]:43-[[@LINE-9]]:61}: note: consider using '__sized_by_or_null' instead of '__counted_by_or_null'
+  // CHECK: fix-it:"{{.*}}bounds-safety-source-ranges.c":{[[@LINE-10]]:43-[[@LINE-10]]:61}:"sized_by_or_null"
+}
+
+// prevent 'error' from being unmatched
+// CHECK: errors generated


### PR DESCRIPTION
Fixes #12435 

This PR cherry-picks commits from [llvm#167287](https://github.com/llvm/llvm-project/pull/167287) to add TypeLoc support for bounds-safety attributes.

## Changes
- cherry-pick all 9 commits from the upstream PR [llvm#167287](https://github.com/llvm/llvm-project/pull/167287)
- resolved merge conflicts
- removed the downstream `SourceRangeFor` hack and replaced with a TypeLoc-based approach

## Tests
- `ninja clang` builds successfully
- `LIT_FILTER=BoundsSafety ninja check-clang` had 958 tests pass but 11 fail

Failures appear related to source location tracking for macro forms of `__counted_by`:
- BoundsSafety/Sema/source-location-for-counted-attribute-type.c
- BoundsSafety/AST/typedef-function-*.c
- (and others)