### PR TITLE
build: alter condition for adding `_DEBUG` CPP macro (#183120)

### DIFF
--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
+++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
@@ -111,8 +111,8 @@ if(LLVM_PARALLEL_TABLEGEN_JOBS)
 endif()
 
 if( LLVM_ENABLE_ASSERTIONS )
-  # MSVC doesn't like _DEBUG on release builds. See PR 4379.
-  if( NOT MSVC )
+  # MS STL doesn't like _DEBUG on release builds. See PR 4379.
+  if(NOT WIN32 OR MINGW)
     add_compile_definitions(_DEBUG)
   endif()
   # On non-Debug builds cmake automatically defines NDEBUG, so we


### PR DESCRIPTION
Unlike many other platforms, Microsoft does not maintain ABI across debug and release binaries. When building LLVM in release+asserts, the injection of `_DEBUG` which controls the behaviour of `assert` as per the C specification, also alters the behaviour of the C/C++ runtime's internal assertions and relies on debug only symbols. As such, the `_DEBUG` macro handling is not _MSVC_ specific but rather MS STL and UCRT specific. Adjust the build condition from `MSVC` to `WIN32` to indicate that this is a Windows-ism. Note that `MINGW` is the proper way to check for MinGW, so that should not be impacted by this change. Making this more precise permits the use of `clang` and `clang++` to build LLVM for Windows.

(cherry picked from commit 219b5a0de468c16e2ee5bf035a2c4ce73161b858)