### PR TITLE
[lldb/test] Fix tests reading log from remote platform instead of host

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2381,6 +2381,16 @@ FileCheck output:
 
         self.assertTrue(cmd_status == 0)
 
+    def filecheck_log(
+        self, log_file, check_file, filecheck_options="", expect_cmd_failure=False
+    ):
+        return self.filecheck(
+            f"platform shell -h -- cat {log_file}",
+            check_file,
+            filecheck_options,
+            expect_cmd_failure,
+        )
+
     def expect(
         self,
         string,

--- a/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
+++ b/lldb/test/API/lang/objc/failing-description/TestObjCFailingDescription.py
@@ -16,16 +16,12 @@ class TestCase(TestBase):
             "expr -O -- bad",
             substrs=["`po` was unsuccessful, running `p` instead\n", "(Bad *) 0x"],
         )
-        self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
-        )
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-EXPR")
         # CHECK-EXPR: Object description fallback due to error: could not evaluate print object function: expression interrupted
 
         self.expect(
             "dwim-print -O -- bad",
             substrs=["`po` was unsuccessful, running `p` instead\n", "_lookHere = NO"],
         )
-        self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-DWIM-PRINT"
-        )
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-DWIM-PRINT")
         # CHECK-DWIM-PRINT: Object description fallback due to error: could not evaluate print object function: expression interrupted

--- a/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
+++ b/lldb/test/API/lang/objc/struct-description/TestObjCStructDescription.py
@@ -19,7 +19,7 @@ class TestCase(TestBase):
                 "(Pair) pair = (f = 2, e = 3)",
             ],
         )
-        self.filecheck(f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-VO")
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-VO")
         # CHECK-VO: Object description fallback due to error: not a pointer type
 
         self.expect(
@@ -29,7 +29,5 @@ class TestCase(TestBase):
                 "(Pair)  (f = 2, e = 3)",
             ],
         )
-        self.filecheck(
-            f"platform shell cat {log}", __file__, f"-check-prefix=CHECK-EXPR"
-        )
+        self.filecheck_log(log, __file__, f"-check-prefix=CHECK-EXPR")
         # CHECK-EXPR: Object description fallback due to error: not a pointer type

--- a/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
+++ b/lldb/test/API/lang/swift/clangimporter/Werror/TestSwiftStripWerror.py
@@ -25,7 +25,7 @@ class TestSwiftWerror(TestBase):
         self.expect('log enable lldb types -f "%s"' % log)
 
         self.expect("expression foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK-NOT: SwiftASTContextForExpressions{{.*}}-Werror
 #       CHECK:     SwiftASTContextForExpressions{{.*}}-DCONFLICT
 #       CHECK-NOT: SwiftASTContextForExpressions{{.*}}-Werror

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -27,7 +27,7 @@ class TestSwiftClangImporterCaching(TestBase):
         has_cas = data.GetValueForKey("SwiftHasCAS").GetBooleanValue()
         self.assertTrue(has_cas)
                 
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK Loading module ClangB from CAS at llvmcas://
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -triple

--- a/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
+++ b/lldb/test/API/lang/swift/clangimporter/clang_errorhandling/TestSwiftClangErrorHandling.py
@@ -30,5 +30,5 @@ class TestSwiftExtraClangFlags(TestBase):
 
         self.expect("expr 0", error=True,
                     substrs=['failed to import bridging header'])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: Clang error: {{.*}}bridging-header.h

--- a/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
+++ b/lldb/test/API/lang/swift/clangimporter/config_macros/TestSwiftDedupMacros.py
@@ -43,7 +43,7 @@ class TestSwiftDedupMacros(TestBase):
         self.expect('log enable lldb types -f "%s"' % log)
 
         self.expect("expression foo", DATA_TYPES_DISPLAYED_CORRECTLY, substrs=["42"])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: SwiftASTContextForExpressions{{.*}}-DDEBUG=1
 #       CHECK: SwiftASTContextForExpressions{{.*}}-DSPACE
 #       CHECK-NOT: {{ SPACE}}

--- a/lldb/test/API/lang/swift/clangimporter/explicit_cc1/TestSwiftClangImporterExplicitCC1.py
+++ b/lldb/test/API/lang/swift/clangimporter/explicit_cc1/TestSwiftClangImporterExplicitCC1.py
@@ -23,7 +23,7 @@ class TestSwiftClangImporterExplicitCC1(TestBase):
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["b ="])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -triple
 #       CHECK-NOT: -cc1

--- a/lldb/test/API/lang/swift/clangimporter/explicit_mixed_cc1/TestSwiftClangImporterExplicitMixedCC1.py
+++ b/lldb/test/API/lang/swift/clangimporter/explicit_mixed_cc1/TestSwiftClangImporterExplicitMixedCC1.py
@@ -21,5 +21,5 @@ class TestSwiftClangImporterExplicitCC1(TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expr -l Swift -- 1+1")
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: SwiftASTContextForExpressions(module: "{{.*}}", cu: "*")::AddDiagnostic() -- Mixing and matching of cc1 and driver options detected

--- a/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
+++ b/lldb/test/API/lang/swift/clangimporter/explict_noimplicit/TestSwiftClangImporterExplicitNoImplicit.py
@@ -25,7 +25,7 @@ class TestSwiftClangImporterExplicitNoImplicit(TestBase):
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expression obj", DATA_TYPES_DISPLAYED_CORRECTLY,
                     substrs=["hidden"])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: Turning off implicit modules
         # CHECK: Turning on implicit modules
         # CHECK: loaded module 'Hidden'

--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -18,7 +18,7 @@ class TestSwiftFModuleFlags(TestBase):
         self.expect("expression 1", substrs=["1"])
 
         # Scan through the types log.
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: PCM validation is
 #       CHECK: -DMARKER1
 #       CHECK-NOT: -fno-implicit-modules

--- a/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
+++ b/lldb/test/API/lang/swift/clangimporter/override_options/TestSwiftClangOverrideOptions.py
@@ -18,6 +18,6 @@ class TestCase(lldbtest.TestBase):
         lldbutil.run_to_name_breakpoint(self, "main", bkpt_module="a.out")
         self.expect("expression 1")
 
-        self.filecheck(f"platform shell cat {log}", __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: CCC_OVERRIDE_OPTIONS: x-DDELETEME=1
         # CHECK: Deleting argument -DDELETEME=1

--- a/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
+++ b/lldb/test/API/lang/swift/clangimporter/remap_sdk_path/TestSwiftRemapSDKPath.py
@@ -18,5 +18,5 @@ class TestSwiftRewriteClangPaths(TestBase):
         self.expect("expression 1", substrs=["1"])
 
         # Scan through the types log.
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RemapClangImporterOptions() -- remapped{{.*}}/LocalSDK/

--- a/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
+++ b/lldb/test/API/lang/swift/clangimporter/rewrite_clang_paths/TestSwiftRewriteClangPaths.py
@@ -89,8 +89,9 @@ class TestSwiftRewriteClangPaths(TestBase):
 
         # Scan through the types log.
         suffix = "REMAP" if remap else "NORMAL"
-        self.filecheck('platform shell cat "%s"' % log, __file__,
-                       '--check-prefix=CHECK_' + suffix)
+        self.filecheck_log(log, __file__, "--check-prefix=CHECK_" + suffix)
+
+
 # CHECK_REMAP-NOT: remapped -iquote
 # CHECK_REMAP-NOT: error:{{.*}}Foo
 # CHECK_NORMAL: error:{{.*}}Foo

--- a/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/expressions/TestSwiftForwardInteropExpressions.py
@@ -55,7 +55,7 @@ class TestSwiftForwardInteropExpressions(TestBase):
         # Check that po prints the fields of a base class
         self.expect('po cxxClass', substrs=['CxxClass', 'a : 100', 'b : 101'])
 
-        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        self.filecheck_log(types_log, __file__)
         # CHECK: [CheckFlagInCU] Found flag -enable-experimental-cxx-interop in CU:
 
     @expectedFailureAll(bugnumber="rdar://106216567")

--- a/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/langopt/TestSwiftForwardInteropCxxLangOpt.py
@@ -25,7 +25,7 @@ class TestSwiftForwardInteropCxxLangOpt(TestBase):
         self.expect('expr 0')
         lldbutil.continue_to_breakpoint(process, dylib_bkpt)
         self.expect('expr 1')
-        self.filecheck('platform shell cat ""%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Swift/C++ interop : on
 #       CHECK:  SwiftASTContextForExpressions(module: "Dylib", cu: "Dylib.swift")::LogConfiguration(){{.*}}Swift/C++ interop : off
 

--- a/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
+++ b/lldb/test/API/lang/swift/cxx_interop/forward/stl-types/TestSwiftForwardInteropSTLTypes.py
@@ -60,5 +60,5 @@ class TestSwiftForwardInteropSTLTypes(TestBase):
             '[2] = 9.19'])
 
         # Make sure lldb picks the correct C++ stdlib.
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK-NOT: but current compilation uses unknown C++ stdlib

--- a/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
+++ b/lldb/test/API/lang/swift/deployment_target/TestSwiftDeploymentTarget.py
@@ -62,7 +62,7 @@ class TestSwiftDeploymentTarget(TestBase):
             self, "break here", lldb.SBFileSpec("main.swift")
         )
         self.expect("expression f", substrs=["i = 23"])
-        self.filecheck('platform shell cat ""%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::SetTriple({{.*}}apple-macosx11.0.0
 #       CHECK-NOT: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RegisterSectionModules("a.out"){{.*}} AST Data blobs
 
@@ -87,8 +87,6 @@ class TestSwiftDeploymentTarget(TestBase):
             substrs=["-apple-macosx11.1.0"],
         )
         self.expect("expression self", substrs=["i = 23"])
-        self.filecheck(
-            f'platform shell cat "{log}"', __file__, "-check-prefix=CHECK-PRECISE"
-        )
+        self.filecheck_log(log, __file__, "-check-prefix=CHECK-PRECISE")
 #       CHECK-PRECISE: SwiftASTContextForExpressions(module: "NewerTarget", cu: "NewerTarget.swift")::CreateInstance() -- Fully specified triple {{.*}}-apple-macosx11.1.0
 #       CHECK-PRECISE: SwiftASTContextForExpressions(module: "NewerTarget", cu: "NewerTarget.swift")::SetTriple("{{.*}}-apple-macosx11.1.0")

--- a/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/C/TestSwiftDWARFImporterC.py
@@ -58,14 +58,17 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
                              "sub", "x = 1", "y = 2", "z = 3",
                              "swift struct c member"])
         self.expect("target variable typedef", substrs=["x = 5", "y = 6"])
-        self.expect("target variable union",
-                    substrs=["(DoubleLongUnion)", "long_val = 42"])
-        self.expect("target variable fromSubmodule",
-                    substrs=["(FromSubmodule)", "x = 1", "y = 2", "z = 3"])
-        self.expect("target variable withPointer",
-                    substrs=["(WithPointer)", "ptr = nil"])
-        self.filecheck('platform shell cat ""%s"' % log, __file__,
-                       '--check-prefix=CHECK-TYPEINFO')
+        self.expect(
+            "target variable union", substrs=["(DoubleLongUnion)", "long_val = 42"]
+        )
+        self.expect(
+            "target variable fromSubmodule",
+            substrs=["(FromSubmodule)", "x = 1", "y = 2", "z = 3"],
+        )
+        self.expect(
+            "target variable withPointer", substrs=["(WithPointer)", "ptr = nil"]
+        )
+        self.filecheck_log(log, __file__, "--check-prefix=CHECK-TYPEINFO")
         # CHECK-TYPEINFO: [LLDBTypeInfoProvider] Looking up debug type info for So4CMYKV
 
     @skipIf(archs=['ppc64le'], bugnumber='SR-10214')
@@ -112,6 +115,5 @@ class TestSwiftDWARFImporterC(lldbtest.TestBase):
         # This can't be resolved.
         self.expect("expr swiftStructCMember", error=True)
 
-        self.filecheck('platform shell cat ""%s"' % log, __file__,
-                       '--check-prefix=CHECK-MISSING')
+        self.filecheck_log(log, __file__, "--check-prefix=CHECK-MISSING")
         # CHECK-MISSING: missing required module

--- a/lldb/test/API/lang/swift/embedded/expr/TestSwiftEmbeddedExpression.py
+++ b/lldb/test/API/lang/swift/embedded/expr/TestSwiftEmbeddedExpression.py
@@ -19,5 +19,5 @@ class TestSwiftEmbeddedExpression(TestBase):
 
         self.expect("expr a.foo()", substrs=["(Int)", " = 16"])
 
-        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        self.filecheck_log(types_log, __file__)
         # CHECK: [CheckFlagInCU] Found flag -enable-embedded-swift in CU:

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader/TestSwiftExplicitModulesBridgingHeader.py
@@ -27,7 +27,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
                     substrs=["could not find file", "referenced by AST file", ".pch"])
         self.expect("expression m", error=True,
                     substrs=["could not find file", "referenced by AST file", ".pch"])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: LogConfiguration
         # CHECK-NOT: secret
         # CHECK: Import 

--- a/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
@@ -25,7 +25,7 @@ class TestSwiftExplicitModulesChainedBridgingHeader(lldbtest.TestBase):
         self.expect("frame variable b") # FIXME: substrs=['b = 42'])
         self.expect("expression a", substrs=['a = 23'])
         self.expect("expression b") # FIXME: substrs=['b = 42'])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: LogConfiguration{{.*}}Bridging Header PCH{{.*}}a-{{.*}}ChainedBridgingHeader{{.*}}.pch
         # CHECK: LogConfiguration{{.*}}Explicit module map{{.*}}
         # CHECK-NOT: secret

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -26,7 +26,7 @@ class TestCase(lldbtest.TestBase):
 
         self.expect("expression c", substrs=["hello implicit fallback"])
 
-        self.filecheck(f"platform shell cat {log}", __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: Nonexistent explicit module file
         # CHECK: Explicit modules : false (downgraded
 
@@ -52,8 +52,7 @@ class TestCase(lldbtest.TestBase):
         self.expect("expression c")
         # FIXME: self.expect("expression -- import Foundation")
 
-        self.filecheck(f"platform shell cat {log}", __file__,
-                       '--check-prefix=CHECK-SANITY')
+        self.filecheck_log(log, __file__, "--check-prefix=CHECK-SANITY")
         # CHECK-SANITY: Explicit modules : true
         # CHECK-SANITY: Turning off implicit modules
         # CHECK-SANITY: Turning on implicit modules
@@ -73,7 +72,6 @@ class TestCase(lldbtest.TestBase):
 
         self.expect("expression c")
 
-        self.filecheck(f"platform shell cat {log}", __file__,
-                       '--check-prefix=CHECK-SETTING')
+        self.filecheck_log(log, __file__, "--check-prefix=CHECK-SETTING")
         # CHECK-SETTING: Explicit modules : true
         # CHECK-SETTING-NOT: Turning {{.*}} implicit modules

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -16,7 +16,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expression c", substrs=['hello explicit'])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Discovered main module {{.*}}a.swiftmodule
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Module import remark: loaded module 'a'; source: '{{.*}}a.swiftmodule', loaded: '{{.*}}a.swiftmodule'
 
@@ -31,8 +31,8 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
 
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
-        self.expect("expression c", substrs=['hello explicit'])
-        self.filecheck('platform shell cat "%s"' % log, __file__, '--check-prefix=DISABLED')
+        self.expect("expression c", substrs=["hello explicit"])
+        self.filecheck_log(log, __file__, "--check-prefix=DISABLED")
         # DISABLED: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Discovered main module{{.*}}a.swiftmodule
         # DISABLED: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Module import remark: loaded module 'a'; source: 'a', loaded: 'a'
 

--- a/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
+++ b/lldb/test/API/lang/swift/expression/import_search_paths/TestSwiftImportSearchPaths.py
@@ -35,9 +35,10 @@ class TestSwiftImportSearchPaths(lldbtest.TestBase):
         if flag == 'true':
             prefix = 'POSITIVE'
         else:
-            prefix = 'NEGATIVE'
-        self.filecheck('platform shell cat "%s"' % types_log, __file__,
-                       '--check-prefix=CHECK_EXP_'+prefix)
+            prefix = "NEGATIVE"
+        self.filecheck_log(types_log, __file__, "--check-prefix=CHECK_EXP_" + prefix)
+
+
 # CHECK_EXP_POSITIVE: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*hidden$}}
 # CHECK_EXP_NEGATIVE-NOT: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*hidden$}}
 # CHECK_EXP_NEGATIVE: SwiftASTContextForExpressions{{.*}}::LogConfiguration(){{.*}}Extra clang arguments

--- a/lldb/test/API/lang/swift/expression/no_debuginfo/TestSwiftExpressionNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/expression/no_debuginfo/TestSwiftExpressionNoDebugInfo.py
@@ -17,6 +17,6 @@ class TestSwiftExpressionNoDebugInfo(TestBase):
         types_log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f " + types_log)
         self.expect('expr -l Swift -- 1')
-        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        self.filecheck_log(types_log, __file__)
         # CHECK: No Swift debug info: prefer target triple.
         # CHECK: Using SDK: {{.*}}MacOSX

--- a/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
+++ b/lldb/test/API/lang/swift/framework_paths/TestSwiftFrameworkPaths.py
@@ -19,6 +19,5 @@ class TestSwiftFrameworkPaths(lldbtest.TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expression -- 0")
-        self.filecheck('platform shell cat "%s"' % log, __file__,
-                       '--check-prefix=CHECK_SYS')
+        self.filecheck_log(log, __file__, "--check-prefix=CHECK_SYS")
         # CHECK_SYS: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}/secret_path

--- a/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
+++ b/lldb/test/API/lang/swift/late_expr_dylib/TestSwiftLateExprDylib.py
@@ -19,7 +19,7 @@ class TestSwiftLateDylib(TestBase):
                                           lldb.SBFileSpec("main.swift"))
         self.expect("expr -- import Dylib")
         # Scan through the types log.
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Architecture{{.*}}-apple-macosx11.0.0
 # CHECK-NOT: __PATH_FROM_DYLIB__
 #       Verify that the deployment target didn't change:

--- a/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
+++ b/lldb/test/API/lang/swift/macro/TestSwiftMacro.py
@@ -104,7 +104,7 @@ class TestSwiftMacro(lldbtest.TestBase):
         self.expect('log enable lldb types -f "%s"' % types_log)
         self.expect('expression -- import Macro')
         self.expect('expression -- #stringify(1)', substrs=['0 = 1', '1 = "1"'])
-        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        self.filecheck_log(types_log, __file__)
 #       CHECK: CacheUserImports(){{.*}}: Macro.
 #       CHECK: SwiftASTContextForExpressions{{.*}}::LoadOneModule(){{.*}}Imported module Macro from {kind = Serialized Swift AST, filename = "{{.*}}Macro.swiftmodule";}
 #       CHECK: CacheUserImports(){{.*}}Scanning for search paths in{{.*}}Macro.swiftmodule

--- a/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
+++ b/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
@@ -17,5 +17,5 @@ class TestSwiftModuleImport(lldbtest.TestBase):
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb types -f "%s"' % log)
         self.expect("expression -- 0")
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: SwiftASTContextForExpressions{{.*}}Module import remark: loaded module 'a'

--- a/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
+++ b/lldb/test/API/lang/swift/other_arch_dylib/TestSwiftOtherArchDylib.py
@@ -32,6 +32,6 @@ class TestSwiftOtherArchDylib(TestBase):
         self.expect("expression 1", substrs=['1'])
 
         # Check the types log.
-        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        self.filecheck_log(types_log, __file__)
         # CHECK: SwiftASTContextForExpressions(module: "OtherArch", cu: "OtherArch.swift")::LogConfiguration(){{.*}}arm64e-apple-macos
         # CHECK: SwiftASTContextForExpressions(module: "arm64-apple-macos{{.*}})::LogConfiguration(){{.*}}arm64-apple-macos

--- a/lldb/test/API/lang/swift/playgrounds-repl/dylib/TestPlaygroundREPLImport.py
+++ b/lldb/test/API/lang/swift/playgrounds-repl/dylib/TestPlaygroundREPLImport.py
@@ -23,5 +23,5 @@ class TestPlaygroundREPLImport(repl.PlaygroundREPLTest):
         self.assertIn("and back again", playground_output.GetSummary())
 
         # Scan through the types log to make sure the SwiftASTContext was poisoned.
-        self.filecheck('platform shell cat ""%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: New Swift image added{{.*}}Versions/A/Dylib{{.*}}ClangImporter needs to be reinitialized

--- a/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
+++ b/lldb/test/API/lang/swift/playgrounds/TestSwiftPlaygrounds.py
@@ -198,7 +198,7 @@ class TestSwiftPlaygrounds(TestBase):
         self.assertIn("Hello from the Dylib", playground_output)
 
         # Scan through the types log to make sure the SwiftASTContext was poisoned.
-        self.filecheck('platform shell cat ""%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: RegisterSectionModules("AuxSources") 
 #       CHECK: Playground : true
 #       If we wanted this to work, SwiftASTContext would need to find the AuxSources image and switch the symbol context to there.

--- a/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
+++ b/lldb/test/API/lang/swift/po/objc/TestSwiftPOObjC.py
@@ -19,7 +19,7 @@ class TestSwiftPOObjC(TestBase):
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("expr -O -- base", substrs=["Hello from Swift"])
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 ### -cc1 should be round-tripped so there is no more `-cc1` in the extra args. Look for `-triple` which is a cc1 flag.
 #       CHECK-NOT: parsed module "a"
 #       CHECK:  SwiftASTContextForExpressions(module: "{{.*-.*-.*}}", cu: "*")::LogConfiguration()

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -13,7 +13,7 @@ class TestCase(TestBase):
         self.runCmd(f"log enable lldb expr -f {self.log}")
 
     def _filecheck(self, key):
-        self.filecheck(f"platform shell cat {self.log}", __file__, f"-check-prefix=CHECK-{key}")
+        self.filecheck_log(self.log, __file__, f"-check-prefix=CHECK-{key}")
 
     @swiftTest
     def test_int(self):

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
         self.runCmd(f"log enable lldb expr -f {log}")
 
         self.expect("frame variable -O x", substrs=["Easy as pie"])
-        self.filecheck(f"platform shell cat {log}", __file__)
+        self.filecheck_log(log, __file__)
 
         # Clear the log.
         self.runCmd(f"log disable lldb expr")
@@ -24,7 +24,7 @@ class TestCase(TestBase):
         self.runCmd(f"log enable lldb expr -f {log}")
 
         self.expect("dwim-print -O -- x", substrs=["Easy as pie"])
-        self.filecheck(f"platform shell cat {log}", __file__)
+        self.filecheck_log(log, __file__)
 
         # Verify po used the mangled name of the static type - which is public,
         # and not the private dynamic type.

--- a/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
+++ b/lldb/test/API/lang/swift/private_import/TestSwiftPrivateImport.py
@@ -28,7 +28,7 @@ class TestSwiftPrivateImport(TestBase):
         # because type reconstruction will still trigger an import of
         # the "Invisible" module that we can't prevent later one.
         self.expect("expression 1+1")
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK:  Module import remark: loaded module 'Library'
 #       CHECK-NOT: Module import remark: loaded module 'Invisible'
 

--- a/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
+++ b/lldb/test/API/lang/swift/reflection_loading/TestSwiftReflectionLoading.py
@@ -26,6 +26,6 @@ class TestSwiftReflectionLoading(lldbtest.TestBase):
         lldbutil.check_variable(self, var_c_x, value="23")
 
         # Scan through the types log.
-        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        self.filecheck_log(types_log, __file__)
         # CHECK: {{Adding reflection metadata in .*a\.out}}
         # CHECK: {{Adding reflection metadata in .*dynamic_lib}}

--- a/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
+++ b/lldb/test/API/lang/swift/runtime_library_path/TestSwiftRuntimeLibraryPath.py
@@ -25,5 +25,5 @@ class TestSwiftRuntimeLibraryPath(lldbtest.TestBase):
             self, 'main')
 
         self.expect("expression 1")
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(){{.*}}Runtime library paths{{.*}}2 items

--- a/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
+++ b/lldb/test/API/lang/swift/system_framework/TestSwiftSystemFramework.py
@@ -19,6 +19,6 @@ class TestSwiftSystemFramework(lldbtest.TestBase):
         log = self.getBuildArtifact("types.log")
         self.runCmd('log enable lldb types -f "%s"' % log)
         self.expect("expression -- 0")
-        self.filecheck('platform shell cat "%s"' % log, __file__)
+        self.filecheck_log(log, __file__)
 #       CHECK: SwiftASTContextForExpressions{{.*}}LogConfiguration()
 #       CHECK-NOT: LogConfiguration(){{.*}}/System/Library/Frameworks

--- a/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
+++ b/lldb/test/API/lang/swift/tripleDetection/TestSwiftTripleDetection.py
@@ -25,7 +25,7 @@ class TestSwiftTripleDetection(TestBase):
         bkpt = target.BreakpointCreateByName("main")
         process = target.LaunchSimple(None, None, self.get_process_working_directory())
         self.expect("expression 1")
-        self.filecheck('platform shell cat "%s"' % types_log, __file__)
+        self.filecheck_log(types_log, __file__)
         # CHECK: {{SwiftASTContextForExpressions.*Module triple: ".*-apple-macos.[0-9.]+"}}
         # CHECK: {{SwiftASTContextForExpressions.*Target triple: ".*-apple-macos-unknown"}}
         # CHECK: {{SwiftASTContextForExpressions.*setting to ".*-apple-macos.[0-9.]+"}}


### PR DESCRIPTION
Many swift tests are using logs to validate that a test behaves correctly however they used `platform shell cat {log}` to read the logfile.

This doesn't work when running the testsuite against a remote platform since the logs are saved on the host's filesystem.

This patch addresses those failures by using the new `filecheck_log` helper to make sure we already read the log file from the host platform.