### PR TITLE
[BoundsSafety] unify ParseLexedAttribute

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -1381,15 +1381,17 @@ private:
 
   /// Parse all attributes in LAs, and attach them to Decl D.
   void ParseLexedAttributeList(LateParsedAttrList &LAs, Decl *D,
-                               bool EnterScope, bool OnDefinition);
+                               bool EnterScope, bool OnDefinition,
+                               ParsedAttributes *OutAttrs = nullptr);
 
   /// Finish parsing an attribute for which parsing was delayed.
   /// This will be called at the end of parsing a class declaration
   /// for each LateParsedAttribute. We consume the saved tokens and
   /// create an attribute with the arguments filled in. We add this
   /// to the Attribute list for the decl.
-  void ParseLexedAttribute(LateParsedAttribute &LA, bool EnterScope,
-                           bool OnDefinition);
+  void ParseLexedAttribute(LateParsedAttribute &LPA, bool EnterScope,
+                           bool OnDefinition,
+                           ParsedAttributes *OutAttrs = nullptr);
 
   /// ParseLexedMethodDeclarations - We finished parsing the member
   /// specification of a top (non-nested) C++ class. Now go over the
@@ -1523,24 +1525,6 @@ private:
   bool TryAltiVecTokenOutOfLine(DeclSpec &DS, SourceLocation Loc,
                                 const char *&PrevSpec, unsigned &DiagID,
                                 bool &isInvalid);
-
-  void ParseLexedCAttributeList(LateParsedAttrList &LA,
-                                // TO_UPSTREAM(BoundsSafety)
-                                bool EnterScope,
-                                ParsedAttributes *OutAttrs = nullptr);
-
-  /// Finish parsing an attribute for which parsing was delayed.
-  /// This will be called at the end of parsing a class declaration
-  /// for each LateParsedAttribute. We consume the saved tokens and
-  /// create an attribute with the arguments filled in. We add this
-  /// to the Attribute list for the decl.
-  // TO_UPSTREAM(BoundsSafety) ON
-  /// Note: it's important the the LateParsedAttribute is removed after parsing
-  /// to prevent being reparsed later in the wrong context. This is handled
-  /// automatically by Parser::ParseLexedCAttributeList.
-  // TO_UPSTREAM(BoundsSafety) OFF
-  void ParseLexedCAttribute(LateParsedAttribute &LA, bool EnterScope,
-                            ParsedAttributes *OutAttrs = nullptr);
 
   void ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
                                // TO_UPSTREAM(BoundsSafety)

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -726,93 +726,102 @@ void Parser::ParseLexedAttributes(ParsingClass &Class) {
 }
 
 void Parser::ParseLexedAttributeList(LateParsedAttrList &LAs, Decl *D,
-                                     bool EnterScope, bool OnDefinition) {
+                                     bool EnterScope, bool OnDefinition,
+                                     ParsedAttributes *OutAttrs) {
   assert(LAs.parseSoon() &&
          "Attribute list should be marked for immediate parsing.");
   for (unsigned i = 0, ni = LAs.size(); i < ni; ++i) {
     if (D)
       LAs[i]->addDecl(D);
-    ParseLexedAttribute(*LAs[i], EnterScope, OnDefinition);
+    ParseLexedAttribute(*LAs[i], EnterScope, OnDefinition, OutAttrs);
     delete LAs[i];
   }
   LAs.clear();
 }
 
-void Parser::ParseLexedAttribute(LateParsedAttribute &LA,
-                                 bool EnterScope, bool OnDefinition) {
+void Parser::ParseLexedAttribute(LateParsedAttribute &LPA, bool EnterScope,
+                                 bool OnDefinition,
+                                 ParsedAttributes *OutAttrs) {
   // Create a fake EOF so that attribute parsing won't go off the end of the
   // attribute.
   Token AttrEnd;
   AttrEnd.startToken();
   AttrEnd.setKind(tok::eof);
   AttrEnd.setLocation(Tok.getLocation());
-  AttrEnd.setEofData(LA.Toks.data());
-  LA.Toks.push_back(AttrEnd);
+  AttrEnd.setEofData(LPA.Toks.data());
+  LPA.Toks.push_back(AttrEnd);
 
   // Append the current token at the end of the new token stream so that it
   // doesn't get lost.
-  LA.Toks.push_back(Tok);
-  PP.EnterTokenStream(LA.Toks, true, /*IsReinject=*/true);
+  LPA.Toks.push_back(Tok);
+  PP.EnterTokenStream(LPA.Toks, true, /*IsReinject=*/true);
   // Consume the previously pushed token.
   ConsumeAnyToken(/*ConsumeCodeCompletionTok=*/true);
 
   ParsedAttributes Attrs(AttrFactory);
 
-  if (LA.Decls.size() > 0) {
-    Decl *D = LA.Decls[0];
-    NamedDecl *ND  = dyn_cast<NamedDecl>(D);
+  if (LPA.Decls.size() > 0) {
+    Decl *D = LPA.Decls[0];
+    bool HasFuncScope = EnterScope && LPA.Decls.size() == 1 &&
+                        D->isFunctionOrFunctionTemplate();
+    bool IsCPlusPlus = getLangOpts().CPlusPlus;
+
+    NamedDecl *ND = dyn_cast<NamedDecl>(D);
     RecordDecl *RD = dyn_cast_or_null<RecordDecl>(D->getDeclContext());
 
     // Allow 'this' within late-parsed attributes.
     Sema::CXXThisScopeRAII ThisScope(Actions, RD, Qualifiers(),
-                                     ND && ND->isCXXInstanceMember());
+                                     IsCPlusPlus && ND &&
+                                         ND->isCXXInstanceMember());
 
-    if (LA.Decls.size() == 1) {
-      // If the Decl is templatized, add template parameters to scope.
-      ReenterTemplateScopeRAII InDeclScope(*this, D, EnterScope);
+    // If the Decl is templatized, add template parameters to the scope.
+    ReenterTemplateScopeRAII InDeclScope(*this, D, IsCPlusPlus && EnterScope);
 
-      // If the Decl is on a function, add function parameters to the scope.
-      bool HasFunScope = EnterScope && D->isFunctionOrFunctionTemplate();
-      if (HasFunScope) {
-        InDeclScope.Scopes.Enter(Scope::FnScope | Scope::DeclScope |
-                                 Scope::CompoundStmtScope);
-        Actions.ActOnReenterFunctionContext(Actions.CurScope, D);
-      }
-
-      ParseGNUAttributeArgs(&LA.AttrName, LA.AttrNameLoc, Attrs, nullptr,
-                            nullptr, SourceLocation(), ParsedAttr::Form::GNU(),
-                            nullptr);
-
-      if (HasFunScope)
-        Actions.ActOnExitFunctionContext();
-    } else {
-      // If there are multiple decls, then the decl cannot be within the
-      // function scope.
-      ParseGNUAttributeArgs(&LA.AttrName, LA.AttrNameLoc, Attrs, nullptr,
-                            nullptr, SourceLocation(), ParsedAttr::Form::GNU(),
-                            nullptr);
+    // If the Decl is on a function, add function parameters to the scope.
+    if (HasFuncScope) {
+      InDeclScope.Scopes.Enter(Scope::FnScope | Scope::DeclScope |
+                               Scope::CompoundStmtScope);
+      Actions.ActOnReenterFunctionContext(Actions.CurScope, D);
     }
+
+    ParseGNUAttributeArgs(&LPA.AttrName, LPA.AttrNameLoc, Attrs,
+                          /*EndLoc=*/nullptr, /*ScopeName=*/nullptr,
+                          SourceLocation(), ParsedAttr::Form::GNU(),
+                          /*D=*/nullptr,
+                          // TO_UPSTREAM(BoundsSafety)
+                          LPA.NestedTypeLevel);
+
+    if (HasFuncScope)
+      Actions.ActOnExitFunctionContext();
+  } else if (OutAttrs) {
+    // A late C attribute may be parsed without a decl, in which case the
+    // parsed attribute is collected into OutAttrs.
+    ParseGNUAttributeArgs(&LPA.AttrName, LPA.AttrNameLoc, Attrs,
+                          /*EndLoc=*/nullptr, /*ScopeName=*/nullptr,
+                          SourceLocation(), ParsedAttr::Form::GNU(),
+                          /*D=*/nullptr,
+                          // TO_UPSTREAM(BoundsSafety)
+                          LPA.NestedTypeLevel);
   } else {
-    Diag(Tok, diag::warn_attribute_no_decl) << LA.AttrName.getName();
+    Diag(Tok, diag::warn_attribute_no_decl) << LPA.AttrName.getName();
   }
 
   if (OnDefinition && !Attrs.empty() && !Attrs.begin()->isCXX11Attribute() &&
       Attrs.begin()->isKnownToGCC())
-    Diag(Tok, diag::warn_attribute_on_function_definition)
-      << &LA.AttrName;
+    Diag(Tok, diag::warn_attribute_on_function_definition) << &LPA.AttrName;
 
   /* TO_UPSTREAM(BoundsSafety) ON */
-  if (LA.MacroII) {
+  if (LPA.MacroII) {
     const auto &SM = PP.getSourceManager();
-    CharSourceRange ExpansionRange = SM.getExpansionRange(LA.AttrNameLoc);
+    CharSourceRange ExpansionRange = SM.getExpansionRange(LPA.AttrNameLoc);
     for (unsigned i = 0; i < Attrs.size(); ++i)
-      Attrs[i].setMacroIdentifier(LA.MacroII, ExpansionRange.getBegin(),
-                                  SM.isInSystemMacro(LA.AttrNameLoc));
+      Attrs[i].setMacroIdentifier(LPA.MacroII, ExpansionRange.getBegin(),
+                                  SM.isInSystemMacro(LPA.AttrNameLoc));
   }
   /* TO_UPSTREAM(BoundsSafety) OFF */
 
-  for (unsigned i = 0, ni = LA.Decls.size(); i < ni; ++i)
-    Actions.ActOnFinishDelayedAttribute(getCurScope(), LA.Decls[i], Attrs);
+  for (auto *D : LPA.Decls)
+    Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
 
   // Due to a parsing error, we either went over the cached tokens or
   // there are still cached tokens left, so we skip the leftover tokens.
@@ -821,6 +830,9 @@ void Parser::ParseLexedAttribute(LateParsedAttribute &LA,
 
   if (Tok.is(tok::eof) && Tok.getEofData() == AttrEnd.getEofData())
     ConsumeAnyToken();
+
+  if (OutAttrs)
+    OutAttrs->takeAllAppendingFrom(Attrs);
 }
 
 void Parser::ParseLexedPragmas(ParsingClass &Class) {

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2482,7 +2482,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
   if (getLangOpts().BoundsSafetyAttributes && BoundsSafetyLateAttrs) {
     DistributeCLateParsedAttrs(D, FirstDecl, BoundsSafetyLateAttrs);
     if (BoundsSafetyLateAttrs->size() > 0)
-      ParseLexedCAttributeList(*BoundsSafetyLateAttrs, true);
+      ParseLexedAttributeList(*BoundsSafetyLateAttrs, /*D=*/nullptr,
+                              /*EnterScope=*/true, /*OnDefinition=*/false);
   }
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
@@ -2552,7 +2553,8 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
       if (getLangOpts().BoundsSafetyAttributes && BoundsSafetyLateAttrs) {
         DistributeCLateParsedAttrs(D, ThisDecl, BoundsSafetyLateAttrs);
         if (BoundsSafetyLateAttrs->size() > 0)
-          ParseLexedCAttributeList(*BoundsSafetyLateAttrs, true);
+          ParseLexedAttributeList(*BoundsSafetyLateAttrs, /*D=*/nullptr,
+                                  /*EnterScope=*/true, /*OnDefinition=*/false);
       }
       /* TO_UPSTREAM(BoundsSafety) OFF*/
 
@@ -3349,7 +3351,8 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
     LateAttrs->append(DCLateAttrs);
     NestedLevel++;
   }
-  ParseLexedCAttributeList(ProtoLateAttrs, false);
+  ParseLexedAttributeList(ProtoLateAttrs, /*D=*/nullptr, /*EnterScope=*/false,
+                          /*OnDefinition=*/false);
   /* TO_UPSTREAM(BoundsSafety) OFF */
 }
 
@@ -5043,21 +5046,6 @@ void Parser::ParseStructDeclaration(
   }
 }
 
-// TODO: All callers of this function should be moved to
-// `Parser::ParseLexedAttributeList`.
-void Parser::ParseLexedCAttributeList(LateParsedAttrList &LAs,
-                                      // TO_UPSTREAM(BoundsSafety)
-                                      bool EnterScope,
-                                      ParsedAttributes *OutAttrs) {
-  assert(LAs.parseSoon() &&
-         "Attribute list should be marked for immediate parsing.");
-  for (auto *LA : LAs) {
-    ParseLexedCAttribute(*LA, EnterScope, OutAttrs);
-    delete LA;
-  }
-  LAs.clear();
-}
-
 ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA,
                                                     // TO_UPSTREAM(BoundsSafety)
                                                     bool EnterScope) {
@@ -5133,19 +5121,6 @@ ParsedAttributes Parser::ParseLexedCAttributeTokens(LateParsedAttribute &LA,
     ConsumeAnyToken();
 
   return Attrs;
-}
-
-void Parser::ParseLexedCAttribute(LateParsedAttribute &LA,
-                                  // TO_UPSTREAM(BoundsSafety)
-                                  bool EnterScope,
-                                  ParsedAttributes *OutAttrs) {
-  ParsedAttributes Attrs = ParseLexedCAttributeTokens(LA, EnterScope);
-
-  for (Decl *D : LA.Decls)
-    Actions.ActOnFinishDelayedAttribute(getCurScope(), D, Attrs);
-
-  if (OutAttrs)
-    OutAttrs->takeAllAppendingFrom(Attrs);
 }
 
 void Parser::ParseLexedTypeAttribute(LateParsedTypeAttribute &LA,
@@ -5312,7 +5287,8 @@ void Parser::ParseStructUnionBody(SourceLocation RecordLoc,
     for (auto *LateAttr : LateFieldAttrs)
       LateAttr->ParseLexedAttributes();
   } /* TO_UPSTREAM(BoundsSafety) OFF */ else
-    ParseLexedCAttributeList(LateFieldAttrs, /*EnterScope=*/false);
+    ParseLexedAttributeList(LateFieldAttrs, /*D=*/nullptr, /*EnterScope=*/false,
+                            /*OnDefinition=*/false);
 
   StructScope.Exit();
   Actions.ActOnTagFinishDefinition(getCurScope(), TagDecl, T.getRange());
@@ -6908,7 +6884,9 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
               LateAttr->NestedTypeLevel = NestedLevel;
             }
           }
-          ParseLexedCAttributeList(LateAttrs, false, &D.getAttributes());
+          ParseLexedAttributeList(LateAttrs, /*D=*/nullptr,
+                                  /*EnterScope=*/false, /*OnDefinition=*/false,
+                                  &D.getAttributes());
           LateAttrs.clear();
         }
       }
@@ -7781,7 +7759,8 @@ void Parser::ParseFunctionDeclarator(Declarator &D,
   }
 
   /* TO_UPSTREAM(BoundsSafety) ON*/
-  ParseLexedCAttributeList(LateParamAttrs, true, nullptr);
+  ParseLexedAttributeList(LateParamAttrs, /*D=*/nullptr, /*EnterScope=*/true,
+                          /*OnDefinition=*/false, /*OutAttrs=*/nullptr);
   /* TO_UPSTREAM(BoundsSafety) OFF*/
 
   // Collect non-parameter declarations from the prototype if this is a function

--- a/clang/lib/Parse/ParseObjc.cpp
+++ b/clang/lib/Parse/ParseObjc.cpp
@@ -1235,7 +1235,8 @@ Decl *Parser::ParseObjCMethodDecl(SourceLocation mLoc,
         // there are no parameters with late attrs to parse
         assert(LateAttr->Decls.empty());
         LateAttr->addDecl(Result);
-        ParseLexedCAttribute(*LateAttr, true);
+        ParseLexedAttribute(*LateAttr, /*EnterScope=*/true,
+                            /*OnDefinition=*/false);
       }
     }
     /* TO_UPSTREAM(BoundsSafety) OFF */
@@ -1410,8 +1411,9 @@ Decl *Parser::ParseObjCMethodDecl(SourceLocation mLoc,
     // ParseLexedCAttribute.
     Actions.ObjC().ActOnEnterObjCMethodContextForLateParsedAttrs(
         getCurScope(), cast<ObjCMethodDecl>(Result));
-    ParseLexedCAttributeList(LateParsedAttrs,
-                             /*we already have parameters in scope*/ false);
+    ParseLexedAttributeList(LateParsedAttrs, /*D=*/nullptr,
+                            /*we already have parameters in scope*/ false,
+                            /*OnDefinition=*/false);
     Actions.ActOnExitFunctionContext();
   }
   /* TO_UPSTREAM(BoundsSafety) OFF */

--- a/clang/lib/Parse/Parser.cpp
+++ b/clang/lib/Parse/Parser.cpp
@@ -1443,7 +1443,8 @@ Decl *Parser::ParseFunctionDefinition(ParsingDeclarator &D,
     BoundsSafetyLateAttrs = &BoundsSafetyAttrList;
   DistributeCLateParsedAttrs(D, Res, BoundsSafetyLateAttrs);
   if (BoundsSafetyLateAttrs->size() > 0)
-    ParseLexedCAttributeList(*BoundsSafetyLateAttrs, false);
+    ParseLexedAttributeList(*BoundsSafetyLateAttrs, /*D=*/nullptr,
+                            /*EnterScope=*/false, /*OnDefinition=*/false);
   /*TO_UPSTREAM(BoundsSafety) OFF*/
 
   return ParseFunctionStatementBody(Res, BodyScope);


### PR DESCRIPTION
Resolves #12436 

I also unified the `ParseLexedAttributeList` as mentioned in the upstream [issue](https://github.com/llvm/llvm-project/issues/93263).

While testing, I noticed that C test files run with `-x c++`  will take the C++ path in the unified function. I'm not sure if this should be handled by using an extra flag in `ParseLexedAttribute`, or if it’s fine as is.