### PR TITLE
🍒 [clang][DebugInfo] Add a flag to preserve the old macro behaviour. (#174895)

### DIFF
--- a/clang/include/clang/Basic/DebugOptions.def
+++ b/clang/include/clang/Basic/DebugOptions.def
@@ -100,6 +100,10 @@ DEBUGOPT(ReproducibleDebugInfo, 1, 0, Affecting)
 /// Whether to generate macro debug info.
 DEBUGOPT(MacroDebugInfo, 1, 0, Affecting)
 
+/// Whether to use expansion location for debug info.
+/// TODO: #175249: Remove once testing is complete for sample pgo users.
+DEBUGOPT(DebugInfoMacroExpansionLoc, 1, 0, Compatible)
+
 /// Tune the debug info for this debugger.
 ENUM_DEBUGOPT(DebuggerTuning, llvm::DebuggerKind, 3,
               llvm::DebuggerKind::Default, Affecting)

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7833,6 +7833,10 @@ let Visibility = [CC1Option, CC1AsOption] in {
 def debug_info_macro : Flag<["-"], "debug-info-macro">,
   HelpText<"Emit macro debug information">,
   MarshallingInfoFlag<CodeGenOpts<"MacroDebugInfo">>;
+def debug_info_macro_expansion_loc
+    : Flag<["-"], "debug-info-macro-expansion-loc">,
+      HelpText<"Use expansion location for debug info for multi line macros">,
+      MarshallingInfoFlag<CodeGenOpts<"DebugInfoMacroExpansionLoc">>;
 def default_function_attr : Separate<["-"], "default-function-attr">,
   HelpText<"Apply given attribute to all functions">,
   MarshallingInfoStringVector<CodeGenOpts<"DefaultFunctionAttrs">>;

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -65,6 +65,13 @@ static llvm::cl::opt<bool> ClArrayBoundsPseudoFn(
     llvm::cl::desc("Emit debug info that places array-bounds instrumentation "
                    "in an inline function called __ubsan_check_array_bounds."));
 
+static SourceLocation getMacroDebugLoc(const CodeGenModule &CGM,
+                                       SourceLocation Loc) {
+  if (CGM.getCodeGenOpts().DebugInfoMacroExpansionLoc)
+    return Loc;
+  return CGM.getContext().getSourceManager().getFileLoc(Loc);
+}
+
 static uint32_t getTypeAlignIfRequired(const Type *Ty, const ASTContext &Ctx) {
   auto TI = Ctx.getTypeInfo(Ty);
   if (TI.isAlignRequired())
@@ -357,7 +364,8 @@ void CGDebugInfo::setLocation(SourceLocation Loc) {
   if (Loc.isInvalid())
     return;
 
-  CurLoc = CGM.getContext().getSourceManager().getFileLoc(Loc);
+  CurLoc = CGM.getContext().getSourceManager().getExpansionLoc(
+      getMacroDebugLoc(CGM, Loc));
 
   // If we've changed files in the middle of a lexical scope go ahead
   // and create a new lexical scope with file node if it's different
@@ -584,7 +592,7 @@ llvm::DIFile *CGDebugInfo::getOrCreateFile(SourceLocation Loc) {
     FileName = TheCU->getFile()->getFilename();
     CSInfo = TheCU->getFile()->getChecksum();
   } else {
-    PresumedLoc PLoc = SM.getPresumedLoc(SM.getFileLoc(Loc));
+    PresumedLoc PLoc = SM.getPresumedLoc(getMacroDebugLoc(CGM, Loc));
     FileName = PLoc.getFilename();
 
     if (FileName.empty()) {
@@ -612,7 +620,7 @@ llvm::DIFile *CGDebugInfo::getOrCreateFile(SourceLocation Loc) {
       CSInfo.emplace(*CSKind, Checksum);
   }
   return createFile(FileName, CSInfo,
-                    getSource(SM, SM.getFileID(SM.getFileLoc(Loc))));
+                    getSource(SM, SM.getFileID(getMacroDebugLoc(CGM, Loc))));
 }
 
 llvm::DIFile *CGDebugInfo::createFile(
@@ -667,7 +675,7 @@ unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {
   if (Loc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  return SM.getPresumedLoc(SM.getFileLoc(Loc)).getLine();
+  return SM.getPresumedLoc(getMacroDebugLoc(CGM, Loc)).getLine();
 }
 
 unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
@@ -680,7 +688,7 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
   PresumedLoc PLoc =
-      SM.getPresumedLoc(Loc.isValid() ? SM.getFileLoc(Loc) : CurLoc);
+      SM.getPresumedLoc(Loc.isValid() ? getMacroDebugLoc(CGM, Loc) : CurLoc);
   return PLoc.isValid() ? PLoc.getColumn() : 0;
 }
 
@@ -5013,7 +5021,9 @@ void CGDebugInfo::EmitLocation(CGBuilderTy &Builder, SourceLocation Loc) {
   // Update our current location
   setLocation(Loc);
 
-  if (CurLoc.isInvalid() || LexicalBlockStack.empty())
+  if (CurLoc.isInvalid() ||
+      (CGM.getCodeGenOpts().DebugInfoMacroExpansionLoc && CurLoc.isMacroID()) ||
+      LexicalBlockStack.empty())
     return;
 
   llvm::MDNode *Scope = LexicalBlockStack.back();
@@ -6290,7 +6300,7 @@ void CGDebugInfo::AddStringLiteralDebugInfo(llvm::GlobalVariable *GV,
                                             const StringLiteral *S) {
   SourceLocation Loc = S->getStrTokenLoc(0);
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(SM.getFileLoc(Loc));
+  PresumedLoc PLoc = SM.getPresumedLoc(getMacroDebugLoc(CGM, Loc));
   if (!PLoc.isValid())
     return;
 

--- a/clang/test/CodeGen/macro-info.c
+++ b/clang/test/CodeGen/macro-info.c
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -o - | FileCheck %s --check-prefix=NEW
+// RUN: %clang_cc1 %s -debug-info-kind=standalone -emit-llvm -debug-info-macro-expansion-loc -o - | FileCheck %s --check-prefix=OLD
 
 #define GLOBAL(num) global## num
 #define DECL_GLOBAL(x) int x
@@ -9,11 +10,13 @@
 
 SAME_ORDER(
   int
-// CHECK: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE+1]]
+// NEW: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE+2]]
+// OLD: DIGlobalVariable(name: "global",{{.*}} line: [[@LINE-3]]
     GLOBAL  // <- global
       () = 42,
   const char* s() {
-// CHECK: DIGlobalVariable({{.*}}line: [[@LINE+1]],{{.*}} type: [[TYPEID:![0-9]+]]
+// NEW: DIGlobalVariable({{.*}}line: [[@LINE+2]],{{.*}} type: [[TYPEID:![0-9]+]]
+// OLD: DIGlobalVariable({{.*}}line: [[@LINE-8]],{{.*}} type: [[TYPEID:![0-9]+]]
     return "1234567890";
   }
 )
@@ -21,8 +24,10 @@ SAME_ORDER(
 SWAP_ORDER(
   int GLOBAL(  // <- global2
     2) = 43,
-// CHECK: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE+3]]
-// CHECK: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE-3]]
+// NEW: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE+5]]
+// NEW: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE-3]]
+// OLD: DIGlobalVariable(name: "global3",{{.*}} line: [[@LINE-5]]
+// OLD: DIGlobalVariable(name: "global2",{{.*}} line: [[@LINE-6]]
   DECL_GLOBAL(
     GLOBAL(  // <- global3
       3)) = 44
@@ -30,6 +35,7 @@ SWAP_ORDER(
 
 
 DECL_GLOBAL(
-// CHECK: DIGlobalVariable(name: "global4",{{.*}} line: [[@LINE+1]]
+// NEW: DIGlobalVariable(name: "global4",{{.*}} line: [[@LINE+2]]
+// OLD: DIGlobalVariable(name: "global4",{{.*}} line: [[@LINE-2]]
   GLOBAL(  // <- global4
     4));


### PR DESCRIPTION
[Clang][DebugInfo] Add a flag to use expansion loc for macro params.

This patch adds a flag to allow users to preserve the old behaviour - use the macro expansion location for parameters. This is useful for wider testing of sample profile driven PGO which relies on debug information based mapping. This flag is intended to be temporary and should be safe to remove by EOY 2026. Filed #175249 to track the cleanup.

---------

Assisted-by: Gemini

(cherry picked from commit 85b90f560d90e1b52272e78902de138cbe1612d2)

rdar://171173214