### PR TITLE
[lldb][repl] fix output interleaving with the status line

### DIFF
--- a/lldb/include/lldb/Expression/REPL.h
+++ b/lldb/include/lldb/Expression/REPL.h
@@ -144,7 +144,7 @@ protected:
   virtual lldb::LanguageType GetLanguage() = 0;
 
   virtual bool PrintOneVariable(Debugger &debugger,
-                                lldb::StreamFileSP &output_sp,
+                                lldb::LockableStreamFileSP &output_stream_sp,
                                 lldb::ValueObjectSP &valobj_sp,
                                 ExpressionVariable *var = nullptr) = 0;
 

--- a/lldb/source/Expression/REPL.cpp
+++ b/lldb/source/Expression/REPL.cpp
@@ -189,29 +189,30 @@ int REPL::IOHandlerFixIndentation(IOHandler &io_handler,
 }
 
 static bool ReadCode(const std::string &path, std::string &code,
-                     lldb::StreamFileSP &error_sp) {
+                     lldb::LockableStreamFileSP &error_stream_sp) {
   auto &fs = FileSystem::Instance();
   llvm::Twine pathTwine(path);
   if (!fs.Exists(pathTwine)) {
-    error_sp->Printf("no such file at path '%s'\n", path.c_str());
+    error_stream_sp->Lock().Printf("no such file at path '%s'\n", path.c_str());
     return false;
   }
   if (!fs.Readable(pathTwine)) {
-    error_sp->Printf("could not read file at path '%s'\n", path.c_str());
+    error_stream_sp->Lock().Printf("could not read file at path '%s'\n",
+                                   path.c_str());
     return false;
   }
   const size_t file_size = fs.GetByteSize(pathTwine);
   const size_t max_size = code.max_size();
   if (file_size > max_size) {
-    error_sp->Printf("file at path '%s' too large: "
-                     "file_size = %zu, max_size = %zu\n",
-                     path.c_str(), file_size, max_size);
+    error_stream_sp->Lock().Printf("file at path '%s' too large: "
+                                   "file_size = %zu, max_size = %zu\n",
+                                   path.c_str(), file_size, max_size);
     return false;
   }
   auto data_sp = fs.CreateDataBuffer(pathTwine);
   if (data_sp == nullptr) {
-    error_sp->Printf("could not create buffer for file at path '%s'\n",
-                     path.c_str());
+    error_stream_sp->Lock().Printf(
+        "could not create buffer for file at path '%s'\n", path.c_str());
     return false;
   }
   code.assign((const char *)data_sp->GetBytes(), data_sp->GetByteSize());
@@ -219,10 +220,10 @@ static bool ReadCode(const std::string &path, std::string &code,
 }
 
 void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
-  lldb::StreamFileSP output_sp = std::make_shared<StreamFile>(
-      io_handler.GetOutputStreamFileSP()->GetUnlockedFileSP());
-  lldb::StreamFileSP error_sp = std::make_shared<StreamFile>(
-      io_handler.GetErrorStreamFileSP()->GetUnlockedFileSP());
+  lldb::LockableStreamFileSP output_stream_sp =
+      io_handler.GetOutputStreamFileSP();
+  lldb::LockableStreamFileSP error_stream_sp =
+      io_handler.GetErrorStreamFileSP();
   bool extra_line = false;
   bool did_quit = false;
 
@@ -258,8 +259,10 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
 
         // Execute the command
         CommandReturnObject result(debugger.GetUseColor());
-        result.SetImmediateOutputStream(output_sp);
-        result.SetImmediateErrorStream(error_sp);
+        result.SetImmediateOutputStream(std::make_shared<StreamFile>(
+            output_stream_sp->GetUnlockedFileSP()));
+        result.SetImmediateErrorStream(
+            std::make_shared<StreamFile>(error_stream_sp->GetUnlockedFileSP()));
         ci.HandleCommand(code.c_str(), eLazyBoolNo, result);
 
         if (saved_prompt_on_quit)
@@ -302,7 +305,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
         // User wants to read code from a file.
         // Interpret rest of line as a literal path.
         auto path = llvm::StringRef(code.substr(1)).trim().str();
-        if (!ReadCode(path, code, error_sp)) {
+        if (!ReadCode(path, code, error_stream_sp)) {
           return;
         }
       }
@@ -318,7 +321,8 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
         }
       }
 
-      const bool colorize_err = error_sp->GetFile().GetIsTerminalWithColors();
+      const bool colorize_err =
+          error_stream_sp->Lock().GetFile().GetIsTerminalWithColors();
 
       EvaluateExpressionOptions expr_options = m_expr_options;
       expr_options.SetCoerceToId(m_varobj_options.use_object_desc);
@@ -352,8 +356,8 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
 
       if (!persistent_state)
       {
-        error_sp->PutCString("error getting the expression "
-                             "context for the REPL.\n");
+        error_stream_sp->Lock().PutCString("error getting the expression "
+                                           "context for the REPL.\n");
         io_handler.SetIsDone(true);
         return;
       }
@@ -367,7 +371,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
       if (llvm::Error err = OnExpressionEvaluated(exe_ctx, code, expr_options,
                                                   execution_results,
                                                   result_valobj_sp, error)) {
-        *error_sp << llvm::toString(std::move(err)) << "\n";
+        error_stream_sp->Lock() << llvm::toString(std::move(err)) << "\n";
       } else if (process_sp && process_sp->IsAlive()) {
         bool add_to_code = true;
         bool handled = false;
@@ -375,11 +379,12 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
           lldb::Format format = m_format_options.GetFormat();
 
           if (result_valobj_sp->GetError().Success()) {
-            handled |= PrintOneVariable(debugger, output_sp, result_valobj_sp);
+            handled |=
+                PrintOneVariable(debugger, output_stream_sp, result_valobj_sp);
           } else if (result_valobj_sp->GetError().GetError() ==
                      UserExpression::kNoResult) {
             if (format != lldb::eFormatVoid && debugger.GetNotifyVoid()) {
-              error_sp->PutCString("(void)\n");
+              error_stream_sp->Lock().PutCString("(void)\n");
               handled = true;
             }
           }
@@ -392,13 +397,15 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
                 persistent_state->GetVariableAtIndex(vi);
             lldb::ValueObjectSP valobj_sp = persistent_var_sp->GetValueObject();
 
-            PrintOneVariable(debugger, output_sp, valobj_sp,
+            PrintOneVariable(debugger, output_stream_sp, valobj_sp,
                              persistent_var_sp.get());
           }
         }
 
         if (!handled) {
-          bool useColors = error_sp->GetFile().GetIsTerminalWithColors();
+          LockedStreamFile locked_error_stream = error_stream_sp->Lock();
+          bool useColors =
+              locked_error_stream.GetFile().GetIsTerminalWithColors();
           switch (execution_results) {
           case lldb::eExpressionSetupError:
           case lldb::eExpressionParseError:
@@ -408,7 +415,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
             // FIXME: BEGIN SWIFT
             if (error.Success() && result_valobj_sp) {
               // The color detection in RenderDiagnosticDetails doesn't work
-              // with error_sp.
+              // with locked_error_stream.
               StreamString diag_stream(useColors);
               std::vector<DiagnosticDetail> diags;
               llvm::Error error = result_valobj_sp->GetError().ToError();
@@ -419,40 +426,43 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
               unsigned prompt_len =
                   llvm::StringRef(io_handler.GetPrompt()).size() + 3;
               RenderDiagnosticDetails(diag_stream, prompt_len, true, diags);
-              *error_sp << diag_stream.GetString();
+              locked_error_stream << diag_stream.GetString();
               if (error)
-                *error_sp << toString(std::move(error));
+                locked_error_stream << toString(std::move(error));
             } else
               // END SWIFT
-              error_sp->Printf("%s\n", error.AsCString());
+              locked_error_stream.Printf("%s\n", error.AsCString());
             break;
 
           case lldb::eExpressionCompleted:
             break;
           case lldb::eExpressionInterrupted:
             if (useColors) {
-              error_sp->Printf(ANSI_ESCAPE1(ANSI_FG_COLOR_RED));
-              error_sp->Printf(ANSI_ESCAPE1(ANSI_CTRL_BOLD));
+              locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_FG_COLOR_RED));
+              locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_BOLD));
             }
-            error_sp->Printf("Execution interrupted. ");
+            locked_error_stream.Printf("Execution interrupted. ");
             if (useColors)
-              error_sp->Printf(ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
-            error_sp->Printf("Enter code to recover and continue.\nEnter LLDB "
-                             "commands to investigate (type :help for "
-                             "assistance.)\n");
+              locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
+            locked_error_stream.Printf(
+                "Enter code to recover and continue.\nEnter LLDB "
+                "commands to investigate (type :help for "
+                "assistance.)\n");
             break;
 
           case lldb::eExpressionHitBreakpoint:
             // Breakpoint was hit, drop into LLDB command interpreter
             if (useColors) {
-              error_sp->Printf(ANSI_ESCAPE1(ANSI_FG_COLOR_RED));
-              error_sp->Printf(ANSI_ESCAPE1(ANSI_CTRL_BOLD));
+              locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_FG_COLOR_RED));
+              locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_BOLD));
             }
-            output_sp->Printf("Execution stopped at breakpoint.  ");
+            output_stream_sp->Lock().Printf(
+                "Execution stopped at breakpoint.  ");
             if (useColors)
-              error_sp->Printf(ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
-            output_sp->Printf("Enter LLDB commands to investigate (type help "
-                              "for assistance.)\n");
+              locked_error_stream.Printf(ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
+            locked_error_stream.Printf(
+                "Enter LLDB commands to investigate (type help "
+                "for assistance.)\n");
             {
               lldb::IOHandlerSP io_handler_sp(ci.GetIOHandler());
               if (io_handler_sp) {
@@ -463,24 +473,24 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
             break;
 
           case lldb::eExpressionTimedOut:
-            error_sp->Printf("error: timeout\n");
+            locked_error_stream.Printf("error: timeout\n");
             if (error.AsCString())
-              error_sp->Printf("error: %s\n", error.AsCString());
+              locked_error_stream.Printf("error: %s\n", error.AsCString());
             break;
           case lldb::eExpressionResultUnavailable:
             // Shoulnd't happen???
-            error_sp->Printf("error: could not fetch result -- %s\n",
-                             error.AsCString());
+            locked_error_stream.Printf("error: could not fetch result -- %s\n",
+                                       error.AsCString());
             break;
           case lldb::eExpressionStoppedForDebug:
             // Shoulnd't happen???
-            error_sp->Printf("error: stopped for debug -- %s\n",
-                             error.AsCString());
+            locked_error_stream.Printf("error: stopped for debug -- %s\n",
+                                       error.AsCString());
             break;
           case lldb::eExpressionThreadVanished:
             // Shoulnd't happen???
-            error_sp->Printf("error: expression thread vanished -- %s\n",
-                             error.AsCString());
+            locked_error_stream.Printf(
+                "error: expression thread vanished -- %s\n", error.AsCString());
             break;
           }
         }
@@ -505,8 +515,9 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
               file.get()->Close();
             } else {
               std::string message = llvm::toString(file.takeError());
-              error_sp->Printf("error: couldn't open %s: %s\n",
-                               m_repl_source_path.c_str(), message.c_str());
+              error_stream_sp->Lock().Printf("error: couldn't open %s: %s\n",
+                                             m_repl_source_path.c_str(),
+                                             message.c_str());
             }
 
             // Now set the default file and line to the REPL source file
@@ -517,16 +528,15 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
           static_cast<IOHandlerEditline &>(io_handler)
               .SetBaseLineNumber(m_code.GetSize() + 1);
         }
-        if (extra_line) {
-          output_sp->Printf("\n");
-        }
+        if (extra_line)
+          output_stream_sp->Lock().Printf("\n");
       }
     }
 
     // Don't complain about the REPL process going away if we are in the
     // process of quitting.
     if (!did_quit && (!process_sp || !process_sp->IsAlive())) {
-      error_sp->Printf(
+      error_stream_sp->Lock().Printf(
           "error: REPL process is no longer alive, exiting REPL\n");
       io_handler.SetIsDone(true);
     }

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.cpp
@@ -464,7 +464,8 @@ bool isThrownError(ValueObjectSP valobj_sp) {
   return true;
 }
 
-bool SwiftREPL::PrintOneVariable(Debugger &debugger, StreamFileSP &output_sp,
+bool SwiftREPL::PrintOneVariable(Debugger &debugger,
+                                 LockableStreamFileSP &output_stream_sp,
                                  ValueObjectSP &valobj_sp,
                                  ExpressionVariable *var) {
   bool is_computed = false;
@@ -562,20 +563,26 @@ bool SwiftREPL::PrintOneVariable(Debugger &debugger, StreamFileSP &output_sp,
           new StringSummaryFormat(flags, "<computed property>")));
     }
 
-    if (colorize_out) {
-      const char *color = isThrownError(valobj_sp)
-                              ? ANSI_ESCAPE1(ANSI_FG_COLOR_RED)
-                              : ANSI_ESCAPE1(ANSI_FG_COLOR_CYAN);
-      fprintf(output_sp->GetFile().GetStream(), "%s", color);
+    {
+      // Suspend the statusline while printing to prevent its ANSI cursor
+      // save/restore sequences from interleaving with the output.
+      LockedStreamFile locked_stream = output_stream_sp->Lock();
+      if (colorize_out) {
+        const char *color = isThrownError(valobj_sp)
+                                ? ANSI_ESCAPE1(ANSI_FG_COLOR_RED)
+                                : ANSI_ESCAPE1(ANSI_FG_COLOR_CYAN);
+        fprintf(locked_stream.GetFile().GetStream(), "%s", color);
+      }
+
+      if (llvm::Error error = valobj_sp->Dump(locked_stream, options))
+        locked_stream << "error: " << toString(std::move(error));
+
+      if (colorize_out)
+        fprintf(locked_stream.GetFile().GetStream(),
+                ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
+
+      handled = true;
     }
-
-    if (llvm::Error error = valobj_sp->Dump(*output_sp, options))
-      *output_sp << "error: " << toString(std::move(error));
-
-    if (colorize_out)
-      fprintf(output_sp->GetFile().GetStream(), ANSI_ESCAPE1(ANSI_CTRL_NORMAL));
-
-    handled = true;
   }
 
   return handled;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftREPL.h
@@ -68,7 +68,8 @@ protected:
 
   lldb::LanguageType GetLanguage() override;
 
-  bool PrintOneVariable(Debugger &debugger, lldb::StreamFileSP &output_sp,
+  bool PrintOneVariable(Debugger &debugger,
+                        lldb::LockableStreamFileSP &output_stream_sp,
                         lldb::ValueObjectSP &valobj_sp,
                         ExpressionVariable *var = nullptr) override;
 

--- a/lldb/source/Plugins/REPL/Clang/ClangREPL.h
+++ b/lldb/source/Plugins/REPL/Clang/ClangREPL.h
@@ -48,7 +48,8 @@ protected:
 
   lldb::LanguageType GetLanguage() override;
 
-  bool PrintOneVariable(Debugger &debugger, lldb::StreamFileSP &output_sp,
+  bool PrintOneVariable(Debugger &debugger,
+                        lldb::LockableStreamFileSP &output_stream_sp,
                         lldb::ValueObjectSP &valobj_sp,
                         ExpressionVariable *var = nullptr) override;
 

--- a/lldb/test/API/lang/swift/repl/TestSwiftREPLStatusline.py
+++ b/lldb/test/API/lang/swift/repl/TestSwiftREPLStatusline.py
@@ -1,0 +1,35 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.lldbpexpect import PExpectTest
+
+
+class TestSwiftREPLStatusline(PExpectTest):
+    # PExpect uses many timeouts internally and doesn't play well
+    # under ASAN on a loaded machine..
+    @skipIfAsan
+    @skipUnlessDarwin
+    @swiftTest
+    def test_repl_no_statusline_interleaving(self):
+        """Test that statusline ANSI sequences don't interleave with REPL output."""
+        self.launch(extra_args=["--repl"], executable=None, dimensions=(10, 60))
+
+        # Wait for the REPL to be ready.
+        self.child.expect_exact("1>")
+
+        # Send an expression that produces multi-line output to expose any
+        # interleaving.
+        self.child.sendline('Array("0123456789")')
+        for i, c in enumerate("0123456789"):
+            self.child.expect_exact('[{}] = "{}"'.format(i, c))
+
+        self.child.expect_exact("2>")
+
+        self.quit()
+
+    def setUpCommands(self):
+        # TODO: Create a REPL test case class to avoid redefining these methods.
+        return []  # REPL doesn't take any setup commands.
+
+    def expect_prompt(self):
+        pass  # No constant prompt on the REPL.


### PR DESCRIPTION
This patch fixes the status line draws being interleaved with the output of the REPL by blocking the statusline drawing when printing a value in the repl.

**Before**
<img width="671" height="291" alt="Screenshot 2026-02-26 at 16 19 52" src="https://github.com/user-attachments/assets/404093bd-45ae-4421-8c0d-38fa8608e7df" />

**After**
<img width="669" height="296" alt="Screenshot 2026-02-26 at 16 20 41" src="https://github.com/user-attachments/assets/f34a9048-7257-40f4-89d8-8fd77550619b" />


rdar://171033413