### PR TITLE
Fix ImplFunctionType to FunctionType rewriting for closure types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1939,23 +1939,46 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
       NodePointer rett = dem.createNode(Node::Kind::ReturnType);
       NodePointer args_ty = dem.createNode(Node::Kind::Type);
       NodePointer args_tuple = dem.createNode(Node::Kind::Tuple);
+      std::vector<NodePointer> result_types;
       for (NodePointer child : *node) {
         if (child->getKind() == Node::Kind::ImplParameter) {
-          for (NodePointer type : *node)
-            if (type->getKind() == Node::Kind::Type &&
-                type->getNumChildren() == 1)
-              rett->addChild(type->getChild(0), dem);
+          // Find Type child within ImplParameter and add to args_tuple.
+          for (NodePointer param_child : *child)
+            if (param_child->getKind() == Node::Kind::Type) {
+              // Wrap in TupleElement for the argument tuple.
+              NodePointer tuple_elem = dem.createNode(Node::Kind::TupleElement);
+              tuple_elem->addChild(param_child, dem);
+              args_tuple->addChild(tuple_elem, dem);
+            }
         } else if (child->getKind() == Node::Kind::ImplResult) {
-          for (NodePointer type : *node)
-            if (type->getKind() == Node::Kind::Type)
-              rett->addChild(type, dem);
+          // Collect Type children from ImplResult.
+          for (NodePointer result_child : *child)
+            if (result_child->getKind() == Node::Kind::Type)
+              result_types.push_back(result_child);
         }
       }
       args_ty->addChild(args_tuple, dem);
       args->addChild(args_ty, dem);
       fnty->addChild(args, dem);
-      if (rett->getNumChildren() != 1)
-        rett->addChild(dem.createNode(Node::Kind::Tuple), dem);
+      if (result_types.empty()) {
+        // No results: void return.
+        NodePointer ret_ty = dem.createNode(Node::Kind::Type);
+        ret_ty->addChild(dem.createNode(Node::Kind::Tuple), dem);
+        rett->addChild(ret_ty, dem);
+      } else if (result_types.size() == 1) {
+        rett->addChild(result_types[0], dem);
+      } else {
+        // Multiple results become a tuple return type.
+        NodePointer ret_tuple = dem.createNode(Node::Kind::Tuple);
+        for (NodePointer rt : result_types) {
+          NodePointer tuple_elem = dem.createNode(Node::Kind::TupleElement);
+          tuple_elem->addChild(rt, dem);
+          ret_tuple->addChild(tuple_elem, dem);
+        }
+        NodePointer ret_ty = dem.createNode(Node::Kind::Type);
+        ret_ty->addChild(ret_tuple, dem);
+        rett->addChild(ret_ty, dem);
+      }
       fnty->addChild(rett, dem);
       return fnty;
     }

--- a/lldb/test/API/lang/swift/embedded/closure_types/Makefile
+++ b/lldb/test/API/lang/swift/embedded/closure_types/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/closure_types/TestSwiftEmbeddedClosureTypes.py
+++ b/lldb/test/API/lang/swift/embedded/closure_types/TestSwiftEmbeddedClosureTypes.py
@@ -1,0 +1,29 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedClosureTypes(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+
+        self.assertEqual(frame.FindVariable("f0_0").GetDisplayTypeName(), "() -> ()")
+        self.assertEqual(frame.FindVariable("f0_1").GetDisplayTypeName(), "() -> Int")
+        self.assertEqual(frame.FindVariable("f0_2").GetDisplayTypeName(), "() -> (Int, Double)")
+
+        self.assertEqual(frame.FindVariable("f1_0").GetDisplayTypeName(), "(Float) -> ()")
+        self.assertEqual(frame.FindVariable("f1_1").GetDisplayTypeName(), "(Int) -> Double")
+        self.assertEqual(frame.FindVariable("f1_2").GetDisplayTypeName(), "(Double) -> (Float, Int)")
+
+        self.assertEqual(frame.FindVariable("f2_0").GetDisplayTypeName(), "(Int, Double) -> ()")
+        self.assertEqual(frame.FindVariable("f2_1").GetDisplayTypeName(), "(Float, Int) -> Double")
+        self.assertEqual(frame.FindVariable("f2_2").GetDisplayTypeName(), "(Int, Float) -> (Double, Int)")

--- a/lldb/test/API/lang/swift/embedded/closure_types/main.swift
+++ b/lldb/test/API/lang/swift/embedded/closure_types/main.swift
@@ -1,0 +1,18 @@
+func test() {
+    let f0_0: () -> Void = { }
+    let f0_1: () -> Int = { 42 }
+    let f0_2: () -> (Int, Double) = { (1, 2.0) }
+
+    let f1_0: (Float) -> Void = { _ in }
+    let f1_1: (Int) -> Double = { Double($0) }
+    let f1_2: (Double) -> (Float, Int) = { (Float($0), 1) }
+
+    let f2_0: (Int, Double) -> Void = { _, _ in }
+    let f2_1: (Float, Int) -> Double = { Double($0) + Double($1) }
+    let f2_2: (Int, Float) -> (Double, Int) = { (Double($0), Int($1)) }
+
+    let string = StaticString("break here")
+    print(string) // break here
+}
+
+test()

--- a/lldb/test/API/lang/swift/variables/closure_types/Makefile
+++ b/lldb/test/API/lang/swift/variables/closure_types/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/variables/closure_types/TestSwiftClosureTypes.py
+++ b/lldb/test/API/lang/swift/variables/closure_types/TestSwiftClosureTypes.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftClosureTypes(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+
+        self.assertEqual(frame.FindVariable("f0_0").GetDisplayTypeName(), "() -> ()")
+        self.assertEqual(frame.FindVariable("f0_1").GetDisplayTypeName(), "() -> Int")
+        self.assertEqual(frame.FindVariable("f0_2").GetDisplayTypeName(), "() -> (Int, Double)")
+
+        self.assertEqual(frame.FindVariable("f1_0").GetDisplayTypeName(), "(Float) -> ()")
+        self.assertEqual(frame.FindVariable("f1_1").GetDisplayTypeName(), "(Int) -> Double")
+        self.assertEqual(frame.FindVariable("f1_2").GetDisplayTypeName(), "(Double) -> (Float, Int)")
+
+        self.assertEqual(frame.FindVariable("f2_0").GetDisplayTypeName(), "(Int, Double) -> ()")
+        self.assertEqual(frame.FindVariable("f2_1").GetDisplayTypeName(), "(Float, Int) -> Double")
+        self.assertEqual(frame.FindVariable("f2_2").GetDisplayTypeName(), "(Int, Float) -> (Double, Int)")

--- a/lldb/test/API/lang/swift/variables/closure_types/main.swift
+++ b/lldb/test/API/lang/swift/variables/closure_types/main.swift
@@ -1,0 +1,17 @@
+func test() {
+    let f0_0: () -> Void = { }
+    let f0_1: () -> Int = { 42 }
+    let f0_2: () -> (Int, Double) = { (1, 2.0) }
+
+    let f1_0: (Float) -> Void = { _ in }
+    let f1_1: (Int) -> Double = { Double($0) }
+    let f1_2: (Double) -> (Float, Int) = { (Float($0), 1) }
+
+    let f2_0: (Int, Double) -> Void = { _, _ in }
+    let f2_1: (Float, Int) -> Double = { Double($0) + Double($1) }
+    let f2_2: (Int, Float) -> (Double, Int) = { (Double($0), Int($1)) }
+
+    print("break here") // break here
+}
+
+test()


### PR DESCRIPTION
The old code had two bugs when converting ImplFunctionType demangle nodes into FunctionType nodes for display:

1. Both the ImplParameter and ImplResult handlers iterated over the parent node's children (`*node`) instead of their own children (`*child`), so they looked for Type nodes at the wrong level of the tree and produced incorrect parameter/return types.

2. Multiple ImplResult nodes (tuple returns) were added as separate Type children of ReturnType.

rdar://170678177
(cherry picked from commit 98742fabdd91bd7b328d84b09a4947fa58688d91)