### PR TITLE
[clang][deps] Always initialize scan invocation with controller

### DIFF
--- a/clang/include/clang/DependencyScanning/CachingActions.h
+++ b/clang/include/clang/DependencyScanning/CachingActions.h
@@ -15,7 +15,7 @@ namespace clang::dependencies {
 
 std::unique_ptr<DependencyActionController>
 createIncludeTreeActionController(LookupModuleOutputCallback LookupModuleOutput,
-                                  cas::ObjectStore &DB);
+                                  CASOptions CASOpts, cas::ObjectStore &DB);
 
 /// The PCH recorded file paths with canonical paths, create a VFS that
 /// allows remapping back to the non-canonical source paths so that they are

--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -37,11 +37,11 @@ public:
       DependencyConsumer &Consumer, DependencyActionController &Controller,
       llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS,
       bool EmitDependencyFile, bool DiagGenerationAsCompilation,
-      CASOptions CASOpts, std::optional<StringRef> ModuleName = std::nullopt,
+      std::optional<StringRef> ModuleName = std::nullopt,
       raw_ostream *VerboseOS = nullptr)
       : Service(Service), WorkingDirectory(WorkingDirectory),
         Consumer(Consumer), Controller(Controller), DepFS(std::move(DepFS)),
-        CASOpts(std::move(CASOpts)), EmitDependencyFile(EmitDependencyFile),
+        EmitDependencyFile(EmitDependencyFile),
         DiagGenerationAsCompilation(DiagGenerationAsCompilation),
         VerboseOS(VerboseOS) {}
   bool runInvocation(std::string Executable,
@@ -58,7 +58,6 @@ private:
   DependencyConsumer &Consumer;
   DependencyActionController &Controller;
   llvm::IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS;
-  CASOptions CASOpts;
   bool EmitDependencyFile = false;
   bool DiagGenerationAsCompilation;
   std::optional<StringRef> ModuleName;

--- a/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/include/clang/DependencyScanning/DependencyScannerImpl.h
@@ -160,6 +160,7 @@ public:
   // The two methods below returns false when they fail, with the detail
   // accumulated in \c DiagEngineWithDiagOpts's diagnostic consumer.
   bool initialize(
+      DependencyActionController &Controller,
       std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
       IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS);
   bool computeDependencies(StringRef ModuleName, DependencyConsumer &Consumer,

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -83,6 +83,8 @@ public:
   virtual std::string lookupModuleOutput(const ModuleDeps &MD,
                                          ModuleOutputKind Kind) = 0;
 
+  virtual void initialize(CompilerInvocation &ScanInvocation) {}
+
   virtual llvm::Error initialize(CompilerInstance &ScanInstance,
                                  CompilerInvocation &NewInvocation) {
     return llvm::Error::success();
@@ -174,9 +176,9 @@ public:
   /// @param CWD The current working directory used during the scan.
   /// @param CommandLine The commandline used for the scan.
   /// @return False if the initializaiton fails.
-  bool initializeCompilerInstanceWithContext(StringRef CWD,
-                                             ArrayRef<std::string> CommandLine,
-                                             DiagnosticConsumer &DC);
+  bool initializeCompilerInstanceWithContext(
+      StringRef CWD, ArrayRef<std::string> CommandLine,
+      DependencyActionController &Controller, DiagnosticConsumer &DC);
 
   /// @brief Initializing the context and the compiler instance.
   /// @param CWD The current working directory used during the scan.
@@ -187,6 +189,7 @@ public:
   /// @return False if the initializaiton fails.
   bool initializeCompilerInstanceWithContext(
       StringRef CWD, ArrayRef<std::string> CommandLine,
+      DependencyActionController &Controller,
       std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithCmdAndOpts,
       IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS);
 

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -83,7 +83,7 @@ public:
   virtual std::string lookupModuleOutput(const ModuleDeps &MD,
                                          ModuleOutputKind Kind) = 0;
 
-  virtual void initialize(CompilerInvocation &ScanInvocation) {}
+  virtual void initializeScanInvocation(CompilerInvocation &ScanInvocation) {}
 
   virtual llvm::Error initialize(CompilerInstance &ScanInstance,
                                  CompilerInvocation &NewInvocation) {

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -88,7 +88,7 @@ public:
   }
 
   Expected<cas::IncludeTreeRoot>
-  getIncludeTree(cas::ObjectStore &DB,
+  getIncludeTree(CASOptions CASOpts, cas::ObjectStore &DB,
                  const std::vector<std::string> &CommandLine, StringRef CWD,
                  dependencies::LookupModuleOutputCallback LookupModuleOutput,
                  DiagnosticConsumer &DiagConsumer);
@@ -98,8 +98,8 @@ public:
   /// message and the serialized diagnostics file emitted if the
   /// \p DiagOpts.DiagnosticSerializationFile setting is set for the invocation.
   Expected<cas::IncludeTreeRoot> getIncludeTreeFromCompilerInvocation(
-      cas::ObjectStore &DB, std::shared_ptr<CompilerInvocation> Invocation,
-      StringRef CWD,
+      CASOptions CASOpts, cas::ObjectStore &DB,
+      std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
       clang::dependencies::LookupModuleOutputCallback LookupModuleOutput,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
       bool DiagGenerationAsCompilation);
@@ -152,7 +152,8 @@ public:
   /// @param CommandLine The commandline used for the scan.
   /// @return Error if the initializaiton fails.
   llvm::Error initializeCompilerInstanceWithContextOrError(
-      StringRef CWD, ArrayRef<std::string> CommandLine);
+      StringRef CWD, ArrayRef<std::string> CommandLine,
+      dependencies::LookupModuleOutputCallback LookupModuleOutput);
 
   /// @brief Computes the dependeny for the module named ModuleName.
   /// @param ModuleName The name of the module for which this method computes
@@ -195,7 +196,9 @@ public:
   ///        fails.
   static bool initializeWorkerCIWithContextFromCommandline(
       clang::dependencies::DependencyScanningWorker &Worker, StringRef CWD,
-      ArrayRef<std::string> CommandLine, DiagnosticConsumer &DC);
+      ArrayRef<std::string> CommandLine,
+      dependencies::DependencyActionController &Controller,
+      DiagnosticConsumer &DC);
 
 private:
   std::unique_ptr<clang::dependencies::DependencyActionController>

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -88,8 +88,7 @@ public:
   }
 
   Expected<cas::IncludeTreeRoot>
-  getIncludeTree(CASOptions CASOpts, cas::ObjectStore &DB,
-                 const std::vector<std::string> &CommandLine, StringRef CWD,
+  getIncludeTree(const std::vector<std::string> &CommandLine, StringRef CWD,
                  dependencies::LookupModuleOutputCallback LookupModuleOutput,
                  DiagnosticConsumer &DiagConsumer);
 
@@ -98,7 +97,6 @@ public:
   /// message and the serialized diagnostics file emitted if the
   /// \p DiagOpts.DiagnosticSerializationFile setting is set for the invocation.
   Expected<cas::IncludeTreeRoot> getIncludeTreeFromCompilerInvocation(
-      CASOptions CASOpts, cas::ObjectStore &DB,
       std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
       clang::dependencies::LookupModuleOutputCallback LookupModuleOutput,
       DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
@@ -235,8 +233,7 @@ bool computeDependencies(
 Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::DependencyScanningTool &Tool,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
-    CompilerInvocation &Invocation, StringRef WorkingDirectory,
-    llvm::cas::ObjectStore &DB);
+    CompilerInvocation &Invocation, StringRef WorkingDirectory);
 
 } // end namespace clang
 

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -592,7 +592,7 @@ createScanCompilerInvocation(const CompilerInvocation &Invocation,
   // and thus won't write out the extra '.d' files to disk.
   ScanInvocation->getDependencyOutputOpts() = {};
 
-  Controller.initialize(*ScanInvocation);
+  Controller.initializeScanInvocation(*ScanInvocation);
 
   return ScanInvocation;
 }

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -930,7 +930,6 @@ bool DependencyScanningAction::runInvocation(
         std::make_shared<CompilerInvocation>(*ScanInvocation), PCHContainerOps,
         std::move(ModCache));
     CompilerInstance &ScanInstance = *ScanInstanceStorage;
-    ScanInstance.getInvocation().getCASOpts() = CASOpts;
 
     DiagnosticConsumer DiagConsumer;
     initializeScanCompilerInstance(ScanInstance, FS, &DiagConsumer, Service,
@@ -955,7 +954,6 @@ bool DependencyScanningAction::runInvocation(
   ScanInstanceStorage.emplace(std::move(ScanInvocation),
                               std::move(PCHContainerOps), std::move(ModCache));
   CompilerInstance &ScanInstance = *ScanInstanceStorage;
-  ScanInstance.getInvocation().getCASOpts() = CASOpts;
   if (VerboseOS)
     ScanInstance.setVerboseOutputStream(*VerboseOS);
 

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -549,6 +549,7 @@ void dependencies::initializeScanCompilerInstance(
 static std::shared_ptr<CompilerInvocation>
 createScanCompilerInvocation(const CompilerInvocation &Invocation,
                              const DependencyScanningService &Service,
+                             DependencyActionController &Controller,
                              bool DiagGenerationAsCompilation) {
   auto ScanInvocation = std::make_shared<CompilerInvocation>(Invocation);
 
@@ -590,6 +591,8 @@ createScanCompilerInvocation(const CompilerInvocation &Invocation,
   // Ensure that the scanner does not create new dependency collectors,
   // and thus won't write out the extra '.d' files to disk.
   ScanInvocation->getDependencyOutputOpts() = {};
+
+  Controller.initialize(*ScanInvocation);
 
   return ScanInvocation;
 }
@@ -917,7 +920,7 @@ bool DependencyScanningAction::runInvocation(
 
   // Create a compiler instance to handle the actual work.
   auto ScanInvocation = createScanCompilerInvocation(
-      *OriginalInvocation, Service, DiagGenerationAsCompilation);
+      *OriginalInvocation, Service, Controller, DiagGenerationAsCompilation);
 
   // Quickly discovers and compiles modules for the real scan below.
   std::optional<AsyncModuleCompiles> AsyncCompiles;
@@ -1019,6 +1022,7 @@ bool DependencyScanningAction::runInvocation(
 }
 
 bool CompilerInstanceWithContext::initialize(
+    DependencyActionController &Controller,
     std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
     IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS) {
   assert(DiagEngineWithDiagOpts && "Valid diagnostics engine required!");
@@ -1052,11 +1056,11 @@ bool CompilerInstanceWithContext::initialize(
       makeInProcessModuleCache(Worker.Service.getModuleCacheEntries());
   CIPtr = std::make_unique<CompilerInstance>(
       createScanCompilerInvocation(*OriginalInvocation, Worker.Service,
+                                   Controller,
                                    /*DiagGenerationAsCompilation=*/false),
       Worker.PCHContainerOps, std::move(ModCache));
   auto &CI = *CIPtr;
 
-  CI.getInvocation().getCASOpts() = Worker.getCASOpts();
   initializeScanCompilerInstance(
       CI, OverlayFS, DiagEngineWithCmdAndOpts->DiagEngine->getClient(),
       Worker.Service, Worker.DepFS);

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -87,10 +87,10 @@ bool DependencyScanningWorker::computeDependencies(
     FS->setCurrentWorkingDirectory(WorkingDirectory);
   }
 
-  DependencyScanningAction Action(
-      Service, WorkingDirectory, DepConsumer, Controller, DepFS,
-      /*EmitDependencyFile=*/false,
-      /*DiagGenerationAsCompilation=*/false, getCASOpts());
+  DependencyScanningAction Action(Service, WorkingDirectory, DepConsumer,
+                                  Controller, DepFS,
+                                  /*EmitDependencyFile=*/false,
+                                  /*DiagGenerationAsCompilation=*/false);
 
   const bool Success = llvm::all_of(CommandLines, [&](const auto &Cmd) {
     if (StringRef(Cmd[1]) != "-cc1") {
@@ -142,11 +142,10 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
 
   // FIXME: EmitDependencyFile should only be set when it's for a real
   // compilation.
-  DependencyScanningAction Action(Service, WorkingDirectory, DepsConsumer,
-                                  Controller, DepFS,
-                                  /*EmitDependencyFile=*/!DepFile.empty(),
-                                  DiagGenerationAsCompilation, getCASOpts(),
-                                  /*ModuleName=*/std::nullopt, VerboseOS);
+  DependencyScanningAction Action(
+      Service, WorkingDirectory, DepsConsumer, Controller, DepFS,
+      /*EmitDependencyFile=*/!DepFile.empty(), DiagGenerationAsCompilation,
+      /*ModuleName=*/std::nullopt, VerboseOS);
 
   // Ignore result; we're just collecting dependencies.
   //

--- a/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningWorker.cpp
@@ -156,24 +156,27 @@ void DependencyScanningWorker::computeDependenciesFromCompilerInvocation(
 }
 
 bool DependencyScanningWorker::initializeCompilerInstanceWithContext(
-    StringRef CWD, ArrayRef<std::string> CommandLine, DiagnosticConsumer &DC) {
+    StringRef CWD, ArrayRef<std::string> CommandLine,
+    DependencyActionController &Controller, DiagnosticConsumer &DC) {
   auto [OverlayFS, ModifiedCommandLine] = initVFSForByNameScanning(
       DepFS, CommandLine, CWD, "ScanningByName", getCAS());
   auto DiagEngineWithCmdAndOpts =
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine,
                                                       OverlayFS, DC);
   return initializeCompilerInstanceWithContext(
-      CWD, ModifiedCommandLine, std::move(DiagEngineWithCmdAndOpts), OverlayFS);
+      CWD, ModifiedCommandLine, Controller, std::move(DiagEngineWithCmdAndOpts),
+      OverlayFS);
 }
 
 bool DependencyScanningWorker::initializeCompilerInstanceWithContext(
     StringRef CWD, ArrayRef<std::string> CommandLine,
+    DependencyActionController &Controller,
     std::unique_ptr<DiagnosticsEngineWithDiagOpts> DiagEngineWithDiagOpts,
     IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem> OverlayFS) {
   CIWithContext =
       std::make_unique<CompilerInstanceWithContext>(*this, CWD, CommandLine);
-  return CIWithContext->initialize(std::move(DiagEngineWithDiagOpts),
-                                   OverlayFS);
+  return CIWithContext->initialize(
+      Controller, std::move(DiagEngineWithDiagOpts), OverlayFS);
 }
 
 bool DependencyScanningWorker::computeDependenciesByNameWithContext(

--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -26,15 +26,17 @@ class IncludeTreeBuilder;
 
 class IncludeTreeActionController : public CallbackActionController {
 public:
-  IncludeTreeActionController(cas::ObjectStore &DB,
+  IncludeTreeActionController(CASOptions CASOpts, cas::ObjectStore &DB,
                               LookupModuleOutputCallback LookupOutput)
-      : CallbackActionController(LookupOutput), DB(DB) {}
+      : CallbackActionController(LookupOutput), CASOpts(std::move(CASOpts)),
+        DB(DB) {}
 
   Expected<cas::IncludeTreeRoot> getIncludeTree();
 
 private:
   std::unique_ptr<DependencyActionController> clone() const override;
 
+  void initialize(CompilerInvocation &ScanInvocation) override;
   Error initialize(CompilerInstance &ScanInstance,
                    CompilerInvocation &NewInvocation) override;
   Error finalize(CompilerInstance &ScanInstance,
@@ -54,8 +56,8 @@ private:
   }
 
 private:
-  cas::ObjectStore &DB;
   CASOptions CASOpts;
+  cas::ObjectStore &DB;
   llvm::PrefixMapper PrefixMapper;
   // IncludeTreePPCallbacks keeps a pointer to the current builder, so use a
   // pointer so the builder cannot move when resizing.
@@ -301,7 +303,16 @@ Expected<cas::IncludeTreeRoot> IncludeTreeActionController::getIncludeTree() {
 
 std::unique_ptr<DependencyActionController>
 IncludeTreeActionController::clone() const {
-  return std::make_unique<IncludeTreeActionController>(DB, LookupModuleOutput);
+  return std::make_unique<IncludeTreeActionController>(CASOpts, DB,
+                                                       LookupModuleOutput);
+}
+
+void IncludeTreeActionController::initialize(
+    CompilerInvocation &ScanInvocation) {
+  // Enable include-tree in scanning PCMs and caching in the resulting commands.
+  ScanInvocation.getFrontendOpts().CacheCompileJob = true;
+  ScanInvocation.getFrontendOpts().ForIncludeTreeScan = true;
+  ScanInvocation.getCASOpts() = CASOpts;
 }
 
 Error IncludeTreeActionController::initialize(
@@ -340,11 +351,6 @@ Error IncludeTreeActionController::initialize(
         return std::make_unique<LookupPCHModulesListener>(R);
       });
   ScanInstance.addDependencyCollector(std::move(DC));
-
-  // Enable caching in the resulting commands.
-  ScanInstance.getFrontendOpts().CacheCompileJob = true;
-  ScanInstance.getFrontendOpts().ForIncludeTreeScan = true;
-  CASOpts = ScanInstance.getCASOpts();
 
   return Error::success();
 }
@@ -951,6 +957,8 @@ IncludeTreeBuilder::createIncludeFile(StringRef Filename,
 
 std::unique_ptr<DependencyActionController>
 dependencies::createIncludeTreeActionController(
-    LookupModuleOutputCallback LookupModuleOutput, cas::ObjectStore &DB) {
-  return std::make_unique<IncludeTreeActionController>(DB, LookupModuleOutput);
+    LookupModuleOutputCallback LookupModuleOutput, CASOptions CASOpts,
+    cas::ObjectStore &DB) {
+  return std::make_unique<IncludeTreeActionController>(std::move(CASOpts), DB,
+                                                       LookupModuleOutput);
 }

--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -36,7 +36,7 @@ public:
 private:
   std::unique_ptr<DependencyActionController> clone() const override;
 
-  void initialize(CompilerInvocation &ScanInvocation) override;
+  void initializeScanInvocation(CompilerInvocation &ScanInvocation) override;
   Error initialize(CompilerInstance &ScanInstance,
                    CompilerInvocation &NewInvocation) override;
   Error finalize(CompilerInstance &ScanInstance,
@@ -307,7 +307,7 @@ IncludeTreeActionController::clone() const {
                                                        LookupModuleOutput);
 }
 
-void IncludeTreeActionController::initialize(
+void IncludeTreeActionController::initializeScanInvocation(
     CompilerInvocation &ScanInvocation) {
   // Enable include-tree in scanning PCMs and caching in the resulting commands.
   ScanInvocation.getFrontendOpts().CacheCompileJob = true;

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -264,11 +264,13 @@ char AlreadyReportedDiagnosticError::ID = 0;
 } // namespace
 
 Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
-    cas::ObjectStore &DB, const std::vector<std::string> &CommandLine,
-    StringRef CWD, LookupModuleOutputCallback LookupModuleOutput,
+    CASOptions CASOpts, cas::ObjectStore &DB,
+    const std::vector<std::string> &CommandLine, StringRef CWD,
+    LookupModuleOutputCallback LookupModuleOutput,
     DiagnosticConsumer &DiagsConsumer) {
   GetIncludeTree Consumer(DB);
-  auto Controller = createIncludeTreeActionController(LookupModuleOutput, DB);
+  auto Controller = createIncludeTreeActionController(LookupModuleOutput,
+                                                      std::move(CASOpts), DB);
   if (!computeDependencies(Worker, CWD, CommandLine, Consumer, *Controller,
                            DiagsConsumer))
     return llvm::make_error<AlreadyReportedDiagnosticError>();
@@ -277,12 +279,14 @@ Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
 
 Expected<cas::IncludeTreeRoot>
 DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
-    cas::ObjectStore &DB, std::shared_ptr<CompilerInvocation> Invocation,
-    StringRef CWD, LookupModuleOutputCallback LookupModuleOutput,
+    CASOptions CASOpts, cas::ObjectStore &DB,
+    std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
+    LookupModuleOutputCallback LookupModuleOutput,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation) {
   GetIncludeTree Consumer(DB);
-  auto Controller = createIncludeTreeActionController(LookupModuleOutput, DB);
+  auto Controller = createIncludeTreeActionController(LookupModuleOutput,
+                                                      std::move(CASOpts), DB);
   Worker.computeDependenciesFromCompilerInvocation(
       std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
@@ -379,8 +383,8 @@ DependencyScanningTool::getModuleDependencies(
     StringRef ModuleName, ArrayRef<std::string> CommandLine, StringRef CWD,
     const llvm::DenseSet<ModuleID> &AlreadySeen,
     LookupModuleOutputCallback LookupModuleOutput) {
-  if (auto Error =
-          initializeCompilerInstanceWithContextOrError(CWD, CommandLine))
+  if (auto Error = initializeCompilerInstanceWithContextOrError(
+          CWD, CommandLine, LookupModuleOutput))
     return Error;
 
   return computeDependenciesByNameWithContextOrError(ModuleName, AlreadySeen,
@@ -411,11 +415,13 @@ static std::optional<SmallVector<std::string, 0>> getFirstCC1CommandLine(
 
 bool DependencyScanningTool::initializeWorkerCIWithContextFromCommandline(
     DependencyScanningWorker &Worker, StringRef CWD,
-    ArrayRef<std::string> CommandLine, DiagnosticConsumer &DC) {
+    ArrayRef<std::string> CommandLine, DependencyActionController &Controller,
+    DiagnosticConsumer &DC) {
   if (CommandLine.size() >= 2 && CommandLine[1] == "-cc1") {
     // The input command line is already a -cc1 invocation; initialize the
     // compiler instance directly from it.
-    return Worker.initializeCompilerInstanceWithContext(CWD, CommandLine, DC);
+    return Worker.initializeCompilerInstanceWithContext(CWD, CommandLine,
+                                                        Controller, DC);
   }
 
   // The input command line is either a driver-style command line, or
@@ -433,17 +439,23 @@ bool DependencyScanningTool::initializeWorkerCIWithContextFromCommandline(
     return false;
 
   return Worker.initializeCompilerInstanceWithContext(
-      CWD, *MaybeFirstCC1, std::move(DiagEngineWithCmdAndOpts), OverlayFS);
+      CWD, *MaybeFirstCC1, Controller, std::move(DiagEngineWithCmdAndOpts),
+      OverlayFS);
 }
 
 llvm::Error
 DependencyScanningTool::initializeCompilerInstanceWithContextOrError(
-    StringRef CWD, ArrayRef<std::string> CommandLine) {
+    StringRef CWD, ArrayRef<std::string> CommandLine,
+    LookupModuleOutputCallback LookupModuleOutput) {
+  // It might seem wasteful to create fresh controller just for initializing the
+  // compiler instance, but repeated uses of the instance do that as well, so
+  // this gets amortized.
+  auto Controller = createActionController(LookupModuleOutput);
   DiagPrinterWithOS =
       std::make_unique<TextDiagnosticsPrinterWithOutput>(CommandLine);
 
   bool Result = initializeWorkerCIWithContextFromCommandline(
-      Worker, CWD, CommandLine, DiagPrinterWithOS->DiagPrinter);
+      Worker, CWD, CommandLine, *Controller, DiagPrinterWithOS->DiagPrinter);
 
   if (Result)
     return llvm::Error::success();
@@ -470,8 +482,8 @@ DependencyScanningTool::createActionController(
     DependencyScanningWorker &Worker,
     LookupModuleOutputCallback LookupModuleOutput) {
   if (Worker.getScanningFormat() == ScanningOutputFormat::FullIncludeTree)
-    return createIncludeTreeActionController(LookupModuleOutput,
-                                             *Worker.getCAS());
+    return createIncludeTreeActionController(
+        LookupModuleOutput, Worker.getCASOpts(), *Worker.getCAS());
   return std::make_unique<CallbackActionController>(LookupModuleOutput);
 }
 
@@ -485,10 +497,6 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
     DependencyScanningTool &Tool, DiagnosticConsumer &DiagsConsumer,
     raw_ostream *VerboseOS, CompilerInvocation &Invocation,
     StringRef WorkingDirectory, llvm::cas::ObjectStore &DB) {
-  // Override the CASOptions. They may match (the caller having sniffed them
-  // out of InputArgs) but if they have been overridden we want the new ones.
-  Invocation.getCASOpts() = Tool.getCASOpts();
-
   llvm::PrefixMapper Mapper;
   DepscanPrefixMapping::configurePrefixMapper(Invocation, Mapper);
 
@@ -500,12 +508,12 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
   LookupModuleOutputCallback Lookup;
 
   std::optional<llvm::cas::CASID> Root;
-  if (Error E =
-          Tool.getIncludeTreeFromCompilerInvocation(
-                  DB, std::move(ScanInvocation), WorkingDirectory,
-                  /*LookupModuleOutput=*/nullptr, DiagsConsumer, VerboseOS,
-                  /*DiagGenerationAsCompilation*/ true)
-              .moveInto(Root))
+  if (Error E = Tool.getIncludeTreeFromCompilerInvocation(
+                        Tool.getCASOpts(), DB, std::move(ScanInvocation),
+                        WorkingDirectory, /*LookupModuleOutput=*/nullptr,
+                        DiagsConsumer, VerboseOS,
+                        /*DiagGenerationAsCompilation=*/true)
+                    .moveInto(Root))
     return std::move(E);
 
   // Turn off dependency outputs. Should have already been emitted.

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -264,13 +264,12 @@ char AlreadyReportedDiagnosticError::ID = 0;
 } // namespace
 
 Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
-    CASOptions CASOpts, cas::ObjectStore &DB,
     const std::vector<std::string> &CommandLine, StringRef CWD,
     LookupModuleOutputCallback LookupModuleOutput,
     DiagnosticConsumer &DiagsConsumer) {
-  GetIncludeTree Consumer(DB);
-  auto Controller = createIncludeTreeActionController(LookupModuleOutput,
-                                                      std::move(CASOpts), DB);
+  GetIncludeTree Consumer(*Worker.getCAS());
+  auto Controller = createIncludeTreeActionController(
+      LookupModuleOutput, getCASOpts(), *Worker.getCAS());
   if (!computeDependencies(Worker, CWD, CommandLine, Consumer, *Controller,
                            DiagsConsumer))
     return llvm::make_error<AlreadyReportedDiagnosticError>();
@@ -279,14 +278,13 @@ Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
 
 Expected<cas::IncludeTreeRoot>
 DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
-    CASOptions CASOpts, cas::ObjectStore &DB,
     std::shared_ptr<CompilerInvocation> Invocation, StringRef CWD,
     LookupModuleOutputCallback LookupModuleOutput,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation) {
-  GetIncludeTree Consumer(DB);
-  auto Controller = createIncludeTreeActionController(LookupModuleOutput,
-                                                      std::move(CASOpts), DB);
+  GetIncludeTree Consumer(*Worker.getCAS());
+  auto Controller = createIncludeTreeActionController(
+      LookupModuleOutput, getCASOpts(), *Worker.getCAS());
   Worker.computeDependenciesFromCompilerInvocation(
       std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
@@ -496,7 +494,7 @@ DependencyScanningTool::createActionController(
 Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
     DependencyScanningTool &Tool, DiagnosticConsumer &DiagsConsumer,
     raw_ostream *VerboseOS, CompilerInvocation &Invocation,
-    StringRef WorkingDirectory, llvm::cas::ObjectStore &DB) {
+    StringRef WorkingDirectory) {
   llvm::PrefixMapper Mapper;
   DepscanPrefixMapping::configurePrefixMapper(Invocation, Mapper);
 
@@ -508,11 +506,11 @@ Expected<llvm::cas::CASID> clang::scanAndUpdateCC1InlineWithTool(
   LookupModuleOutputCallback Lookup;
 
   std::optional<llvm::cas::CASID> Root;
-  if (Error E = Tool.getIncludeTreeFromCompilerInvocation(
-                        Tool.getCASOpts(), DB, std::move(ScanInvocation),
-                        WorkingDirectory, /*LookupModuleOutput=*/nullptr,
-                        DiagsConsumer, VerboseOS,
-                        /*DiagGenerationAsCompilation=*/true)
+  if (Error E =
+          Tool.getIncludeTreeFromCompilerInvocation(
+                  std::move(ScanInvocation), WorkingDirectory,
+                  /*LookupModuleOutput=*/nullptr, DiagsConsumer, VerboseOS,
+                  /*DiagGenerationAsCompilation=*/true)
                     .moveInto(Root))
     return std::move(E);
 

--- a/clang/test/ClangScanDeps/modules-include-tree-async.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-async.c
@@ -1,0 +1,14 @@
+// This test checks that we only create single scanning module in asynchronous
+// include-tree scans.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -async-scan-modules -- \
+// RUN:   %clang -fmodules -fmodules-cache-path=%t/cache -c %t/tu.c -o %t/tu.o
+// RUN: find %t/cache -name '*.pcm' | wc -l | grep 1
+
+//--- tu.c
+#include "m.h"
+//--- m.h
+//--- module.modulemap
+module m { header "m.h" }

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1169,7 +1169,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
           HadErrors = true;
       } else if (Format == ScanningOutputFormat::IncludeTree) {
         auto MaybeTree = WorkerTool.getIncludeTree(
-            *CAS, Input->CommandLine, CWD, LookupOutput, DiagConsumer);
+            CASOpts, *CAS, Input->CommandLine, CWD, LookupOutput, DiagConsumer);
         std::unique_lock<std::mutex> LockGuard(Lock);
         TreeResults.emplace_back(LocalIndex, std::move(Filename),
                                  std::move(MaybeTree));
@@ -1230,7 +1230,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
         } else {
           if (llvm::Error Err =
                   WorkerTool.initializeCompilerInstanceWithContextOrError(
-                      CWD, Input->CommandLine)) {
+                      CWD, Input->CommandLine, LookupOutput)) {
             handleErrorWithInfoString(
                 "Compiler instance with context setup error", std::move(Err),
                 DependencyOS, Errs);

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1168,8 +1168,8 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
         else
           HadErrors = true;
       } else if (Format == ScanningOutputFormat::IncludeTree) {
-        auto MaybeTree = WorkerTool.getIncludeTree(
-            CASOpts, *CAS, Input->CommandLine, CWD, LookupOutput, DiagConsumer);
+        auto MaybeTree = WorkerTool.getIncludeTree(Input->CommandLine, CWD,
+                                                   LookupOutput, DiagConsumer);
         std::unique_lock<std::mutex> LockGuard(Lock);
         TreeResults.emplace_back(LocalIndex, std::move(Filename),
                                  std::move(MaybeTree));

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -517,7 +517,6 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
     tooling::DependencyScanningTool &Tool, DiagnosticConsumer &DiagsConsumer,
     raw_ostream *VerboseOS, const char *Exec, ArrayRef<const char *> InputArgs,
     StringRef WorkingDirectory, SmallVectorImpl<const char *> &OutputArgs,
-    llvm::cas::ObjectStore &DB,
     llvm::function_ref<const char *(const Twine &)> SaveArg) {
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts);
@@ -528,7 +527,7 @@ static Expected<llvm::cas::CASID> scanAndUpdateCC1InlineWithTool(
                                    "failed to create compiler invocation");
 
   Expected<llvm::cas::CASID> Root = scanAndUpdateCC1InlineWithTool(
-      Tool, DiagsConsumer, VerboseOS, *Invocation, WorkingDirectory, DB);
+      Tool, DiagsConsumer, VerboseOS, *Invocation, WorkingDirectory);
   if (!Root)
     return Root;
 
@@ -567,7 +566,7 @@ scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
 
   auto E = scanAndUpdateCC1InlineWithTool(
                Tool, *DiagsConsumer, /*VerboseOS*/ nullptr, Exec, InputArgs,
-               WorkingDirectory, OutputArgs, *DB, SaveArg)
+               WorkingDirectory, OutputArgs, SaveArg)
                .moveInto(RootID);
   if (E) {
     Diag.Report(diag::err_cas_depscan_failed) << std::move(E);
@@ -1017,7 +1016,7 @@ int ScanServer::listen() {
 
   SharedStream SharedOS(llvm::errs());
 
-  auto ServiceLoop = [this, &CAS, &Service, &NumRunning, &Start,
+  auto ServiceLoop = [this, &Service, &NumRunning, &Start,
                       &SecondsSinceLastClose, &SharedOS,
                       &AcceptLock](unsigned I) {
     std::optional<tooling::DependencyScanningTool> Tool;
@@ -1122,7 +1121,7 @@ int ScanServer::listen() {
       SmallVector<const char *> NewArgs;
       auto RootID = scanAndUpdateCC1InlineWithTool(
           *Tool, *DiagsConsumer, &DiagsOS, Argv0, Args, WorkingDirectory,
-          NewArgs, *CAS, [&](const Twine &T) { return Saver.save(T).data(); });
+          NewArgs, [&](const Twine &T) { return Saver.save(T).data(); });
       if (!RootID) {
         consumeError(Comms.putScanResultFailed(toString(RootID.takeError()),
                                                DiagsOS.str()));

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -358,7 +358,8 @@ enum CXErrorCode clang_experimental_DependencyScannerWorker_getDepGraph(
   if (ModuleName) {
     Result =
         DependencyScanningTool::initializeWorkerCIWithContextFromCommandline(
-            *Worker, WorkingDirectory, Compilation, *SerialDiagConsumer);
+            *Worker, WorkingDirectory, Compilation, *Controller,
+            *SerialDiagConsumer);
 
     if (!Result)
       return CXError_Failure;

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -17,7 +17,8 @@ using namespace clang::tooling;
 
 TEST(IncludeTree, IncludeTreeScan) {
   StringRef PathSep = llvm::sys::path::get_separator();
-  std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
+  CASOptions CASOpts;
+  auto [DB, Cache] = llvm::cantFail(CASOpts.getOrCreateDatabases());
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   FS->setCurrentWorkingDirectory("/root");
   auto add = [&](StringRef Path, StringRef Contents) {
@@ -48,7 +49,7 @@ TEST(IncludeTree, IncludeTreeScan) {
   add("sys_indirect.h", "");
 
   DependencyScanningServiceOptions Opts;
-  Opts.MakeVFS = [DB, FS] {
+  Opts.MakeVFS = [DB = DB, FS] {
     return llvm::cas::createCASProvidingFileSystem(DB, FS);
   };
   Opts.Format = ScanningOutputFormat::IncludeTree;
@@ -67,11 +68,9 @@ TEST(IncludeTree, IncludeTreeScan) {
                                           "-o"
                                           "t.cpp.o"};
   std::optional<IncludeTreeRoot> Root;
-  ASSERT_THAT_ERROR(
-      ScanTool
-          .getIncludeTree(*DB, CommandLine, /*CWD*/ "", nullptr, DiagConsumer)
-          .moveInto(Root),
-      llvm::Succeeded());
+  Expected<IncludeTreeRoot> ExpectedRoot = ScanTool.getIncludeTree(
+      CASOpts, *DB, CommandLine, /*CWD*/ "", nullptr, DiagConsumer);
+  ASSERT_THAT_ERROR(std::move(ExpectedRoot).moveInto(Root), llvm::Succeeded());
 
   std::optional<IncludeTree::File> MainFile;
   std::optional<IncludeTree::File> A1File;

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -53,6 +53,7 @@ TEST(IncludeTree, IncludeTreeScan) {
     return llvm::cas::createCASProvidingFileSystem(DB, FS);
   };
   Opts.Format = ScanningOutputFormat::IncludeTree;
+  Opts.Compilation = IncludeTreeCompilation{CASOpts, DB, Cache};
   DependencyScanningService Service(std::move(Opts));
   DependencyScanningTool ScanTool(Service);
 
@@ -68,8 +69,8 @@ TEST(IncludeTree, IncludeTreeScan) {
                                           "-o"
                                           "t.cpp.o"};
   std::optional<IncludeTreeRoot> Root;
-  Expected<IncludeTreeRoot> ExpectedRoot = ScanTool.getIncludeTree(
-      CASOpts, *DB, CommandLine, /*CWD*/ "", nullptr, DiagConsumer);
+  Expected<IncludeTreeRoot> ExpectedRoot =
+      ScanTool.getIncludeTree(CommandLine, /*CWD*/ "", nullptr, DiagConsumer);
   ASSERT_THAT_ERROR(std::move(ExpectedRoot).moveInto(Root), llvm::Succeeded());
 
   std::optional<IncludeTree::File> MainFile;


### PR DESCRIPTION
This PR splits out new `DependencyActionController::initializeScanInvocation()` API. This is done to correctly initialize the invocation (specifically the context hash) for asynchronous module scans using include-tree without attaching all the listeners used for constructing the include-tree to the instance. These extras would be unnecessary for the pre-scan step and would add overhead.

The main motivation for this is to stop compiling scanning PCMs with the non-include-tree context hash in the async configuration, which was pure overhead. Now, the asynchronously compiled scanning PCMs are built with the correct context hash and with the include-tree, which was the intention all along.

The new controller API is now also responsible for initializing the scan invocation's `CASOptions`. This was previously done unconditionally by grabbing (potentially default-constructed) `CASOptions` from the service, which seemed like a missing abstraction from the perspective of the worker in non-CAS scans.

This would be a tiny PR, but the APIs for compiler instance sharing for by-module scans are quite large.