### PR TITLE
[lldb] Stop variables in test from being optimized away

### DIFF
--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -17,7 +17,6 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
-
 class TestSwiftConditionalBreakpoint(TestBase):
     @swiftTest
     def test_swift_conditional_breakpoint(self):

--- a/lldb/test/API/lang/swift/conditional_breakpoints/main.swift
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/main.swift
@@ -12,7 +12,7 @@
 
 
 func foo(_ x: Int, _ y: Int) -> Int {
-  return x - y + 1 // Set breakpoint here
+  return x - y + Int.random(in: 0..<100) // Set breakpoint here
 }
 
 foo(1,4)


### PR DESCRIPTION
The variables in TestSwiftConditionalBreakpoint are being optimized away. This only started happening after rebranch, which seems to indicate that the compiler is being smart enough to optimize some intra-procedural code, something that didn't use to happen.

rdar://159531288
(cherry picked from commit f3acc12515709f9487ee3bc31bceca27a2805f5a)