### PR TITLE
[cherry-pick] [lldb] Fix empty array formatting in embedded Swift

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -26,6 +26,7 @@
 #include "Plugins/Language/ObjC/Cocoa.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/Demangling/Demangler.h"
+#include "swift/Demangling/ManglingFlavor.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -66,11 +67,12 @@ ValueObjectSP SwiftArrayNativeBufferHandler::GetElementAtIndex(size_t idx) {
 
 SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
     ValueObject &valobj, lldb::addr_t native_ptr, CompilerType elem_type)
-    : m_metadata_ptr(LLDB_INVALID_ADDRESS),
-      m_reserved_word(LLDB_INVALID_ADDRESS), m_size(0), m_capacity(0),
-      m_first_elem_ptr(LLDB_INVALID_ADDRESS), m_elem_type(elem_type),
-      m_element_size(0), m_element_stride(0),
-      m_exe_ctx_ref(valobj.GetExecutionContextRef()) {
+    : m_elem_type(elem_type), m_exe_ctx_ref(valobj.GetExecutionContextRef()) {
+  if (ConstString mangled = valobj.GetCompilerType().GetMangledTypeName())
+    m_is_embedded_swift =
+        SwiftLanguageRuntime::GetManglingFlavor(mangled.GetStringRef()) ==
+        ::swift::Mangle::ManglingFlavor::Embedded;
+
   if (native_ptr == LLDB_INVALID_ADDRESS)
     return;
   if (native_ptr == 0) {
@@ -118,7 +120,12 @@ SwiftArrayNativeBufferHandler::SwiftArrayNativeBufferHandler(
 }
 
 bool SwiftArrayNativeBufferHandler::IsValid() {
-  return m_metadata_ptr != LLDB_INVALID_ADDRESS && m_metadata_ptr &&
+  // In embedded Swift, the empty array singleton (_swiftEmptyArrayStorage)
+  // has metadata_ptr = 0 because there's no runtime type metadata, so we check
+  // if either the metadata ptr is valid OR if we're dealing with an embedded
+  // swift type.
+  return (m_is_embedded_swift ||
+          (m_metadata_ptr != LLDB_INVALID_ADDRESS && m_metadata_ptr)) &&
          m_first_elem_ptr != LLDB_INVALID_ADDRESS && m_capacity >= m_size &&
          m_elem_type.IsValid();
 }

--- a/lldb/source/Plugins/Language/Swift/SwiftArray.h
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.h
@@ -87,15 +87,16 @@ protected:
   friend class SwiftArrayBufferHandler;
 
 private:
-  lldb::addr_t m_metadata_ptr;
-  uint64_t m_reserved_word;
-  lldb::addr_t m_size;
-  lldb::addr_t m_capacity;
-  lldb::addr_t m_first_elem_ptr;
+  lldb::addr_t m_metadata_ptr = LLDB_INVALID_ADDRESS;
+  uint64_t m_reserved_word = LLDB_INVALID_ADDRESS;
+  lldb::addr_t m_size = 0;
+  lldb::addr_t m_capacity = 0;
+  lldb::addr_t m_first_elem_ptr = LLDB_INVALID_ADDRESS;
   lldb_private::CompilerType m_elem_type;
-  size_t m_element_size;
-  size_t m_element_stride;
+  size_t m_element_size = 0;
+  size_t m_element_stride = 0;
   lldb_private::ExecutionContextRef m_exe_ctx_ref;
+  bool m_is_embedded_swift = false;
 };
 
 class SwiftArrayBridgedBufferHandler : public SwiftArrayBufferHandler {

--- a/lldb/test/API/lang/swift/embedded/empty_array/Makefile
+++ b/lldb/test/API/lang/swift/embedded/empty_array/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/empty_array/TestSwiftEmbeddedEmptyArray.py
+++ b/lldb/test/API/lang/swift/embedded/empty_array/TestSwiftEmbeddedEmptyArray.py
@@ -1,0 +1,34 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedEmptyArray(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test empty array formatting in embedded Swift."""
+        self.build()
+        # Disable the ast context so we don't pass the test by silently falling 
+        # back to the ast context implementation.
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable emptyInts",
+            substrs=["0 values"],
+        )
+
+        self.expect(
+            "frame variable emptyPoints",
+            substrs=["0 values"],
+        )
+
+        self.expect(
+            "frame variable nonEmptyInts",
+            substrs=["3 values"],
+        )

--- a/lldb/test/API/lang/swift/embedded/empty_array/main.swift
+++ b/lldb/test/API/lang/swift/embedded/empty_array/main.swift
@@ -1,0 +1,15 @@
+struct Point {
+    var x: Int
+    var y: Int
+}
+
+
+func test() {
+    let emptyInts: [Int] = []
+    let emptyPoints: [Point] = []
+    let nonEmptyInts: [Int] = [1, 2, 3]
+
+    print("break here") // break here
+}
+
+test()


### PR DESCRIPTION
Empty Swift arrays were showing "<uninitialized>" in the debugger because
SwiftArrayNativeBufferHandler::IsValid() was returning false for arrays
with size 0. This happened because in embedded Swift, the empty array
singleton (_swiftEmptyArrayStorage) has metadata_ptr = 0 since there's
no runtime type metadata system.

rdar://170194105