### PR TITLE
[cherry-pick] [lldb] Remove TypeSystemSwiftTypeRef::GetManglingFlavor

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -461,7 +461,9 @@ NativeHashedStorageHandler::NativeHashedStorageHandler(
         return;
       std::vector<TypeSystemSwift::TupleElement> tuple_elements{
           {g_key, key_type}, {g_value, value_type}};
-      m_element_type = type_system->CreateTupleType(tuple_elements);
+      m_element_type = type_system->CreateTupleType(
+          tuple_elements, SwiftLanguageRuntime::GetManglingFlavor(
+                              key_type.GetMangledTypeName()));
       if (auto result = runtime->GetMemberVariableOffset(
               m_element_type, nativeStorage_sp.get(), "1"))
         m_key_stride_padded = *result;

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -926,7 +926,9 @@ static CompilerType ExtractSwiftTypeFromCxxInteropTypeName(
         // convertible to Swift (for example, int -> Int32). Attempt to
         // convert it to a Swift type.
         if (!substituted_type)
-          substituted_type = ts.ConvertClangTypeToSwiftType(templated_type);
+          substituted_type = ts.ConvertClangTypeToSwiftType(
+              templated_type, SwiftLanguageRuntime::GetManglingFlavor(
+                                  swift_type.GetMangledTypeName()));
         return substituted_type;
       });
   return bound_type;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -1328,7 +1328,8 @@ ValueObjectSP SwiftLanguageRuntime::CalculateErrorValueObjectFromValue(
   if (!ast_context)
     return error_valobj_sp;
 
-  CompilerType swift_error_proto_type = ast_context->GetErrorType();
+  CompilerType swift_error_proto_type =
+      ast_context->GetErrorType(swift::Mangle::ManglingFlavor::Default);
   value.SetCompilerType(swift_error_proto_type);
 
   error_valobj_sp = ValueObjectConstResult::Create(&GetProcess(), value, name);
@@ -1412,7 +1413,8 @@ SwiftLanguageRuntime::CalculateErrorValue(StackFrameSP frame_sp,
   arg0->GetScalar().GetBytes(buffer_up->GetData());
   lldb::DataBufferSP buffer(std::move(buffer_up));
 
-  CompilerType swift_error_proto_type = scratch_ctx->GetErrorType();
+  CompilerType swift_error_proto_type =
+      scratch_ctx->GetErrorType(swift::Mangle::ManglingFlavor::Default);
   if (!swift_error_proto_type.IsValid())
     return error_valobj_sp;
 
@@ -1462,7 +1464,8 @@ void SwiftLanguageRuntime::RegisterGlobalError(Target &target, ConstString name,
                      module_decl);
   var_decl->setInterfaceType(
       llvm::expectedToStdOptional(
-          swift_ast_ctx->GetSwiftType(swift_ast_ctx->GetErrorType()))
+          swift_ast_ctx->GetSwiftType(
+              swift_ast_ctx->GetErrorType(swift_ast_ctx->GetManglingFlavor())))
           .value_or(swift::Type()));
   var_decl->setDebuggerVar(true);
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -398,7 +398,9 @@ public:
           auto *key = swift_type.GetMangledTypeName().AsCString();
           m_runtime.RegisterAnonymousClangType(key, field_type);
         } else {
-          swift_type = typesystem.ConvertClangTypeToSwiftType(field_type);
+          // TODO: The mangling flavor should be threaded through getTypeInfo.
+          swift_type = typesystem.ConvertClangTypeToSwiftType(
+              field_type, swift::Mangle::ManglingFlavor::Default);
         }
         const swift::reflection::TypeRef *typeref = nullptr;
         auto typeref_or_err = m_runtime.GetTypeRef(swift_type, &typesystem);
@@ -861,7 +863,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
     auto swiftify = [&](CompilerType type) {
       if (!type.GetTypeSystem().isa_and_nonnull<TypeSystemClang>())
         return type;
-      CompilerType swift_type = ts.ConvertClangTypeToSwiftType(type);
+      CompilerType swift_type = ts.ConvertClangTypeToSwiftType(type, m_flavor);
       return swift_type ? swift_type : type;
     };
     unsigned depth = 0;
@@ -968,7 +970,7 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
         child.language_flags = 0;
         return child;
       };
-      CompilerType type = ts.GetRawPointerType();
+      CompilerType type = ts.GetRawPointerType(m_flavor);
       if (auto err = visit_callback(type, depth, get_name, get_info))
         return err;
       return success;
@@ -1051,8 +1053,8 @@ SwiftRuntimeTypeVisitor::VisitImpl(std::optional<unsigned> visit_only,
             child.language_flags = 0;
             return child;
           };
-          if (auto err =
-                  visit_callback(ts.GetRawPointerType(), 0, get_name, get_info))
+          if (auto err = visit_callback(ts.GetRawPointerType(m_flavor), 0,
+                                        get_name, get_info))
             return err;
           return success;
         }
@@ -1669,7 +1671,7 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
         for (auto &field : rti->getFields())
           elts.emplace_back(ConstString(),
                             GetTypeFromTypeRef(ts, field.TR, flavor));
-        payload_type = ts.CreateTupleType(elts);
+        payload_type = ts.CreateTupleType(elts, flavor);
         break;
       }
       default:
@@ -2089,7 +2091,7 @@ SwiftLanguageRuntime::BindGenericPackType(StackFrame &frame,
     // TODO: Could we get rid of this code path?
     if (rewrite_indirect) {
       // Create a tuple type with all the concrete types in the pack.
-      CompilerType tuple = ts->CreateTupleType(elements);
+      CompilerType tuple = ts->CreateTupleType(elements, flavor);
       // TODO: Remove unnecessary mangling roundtrip.
       // Wrap the type inside a SILPackType to mark it for GetChildAtIndex.
       CompilerType sil_pack_type = ts->CreateSILPackType(tuple, rewrite_indirect);
@@ -2727,9 +2729,10 @@ CompilerType SwiftLanguageRuntime::GetTypeFromMetadata(TypeSystemSwift &ts,
   using namespace swift::Demangle;
   Demangler dem;
   NodePointer node = type_ref.getDemangling(dem);
-  // TODO: the mangling flavor should come from the TypeRef.
+  // Reading a type from an instance pointer should always result in a regular
+  // swift type.
   return ts.GetTypeSystemSwiftTypeRef()->RemangleAsType(
-      dem, node, ts.GetTypeSystemSwiftTypeRef()->GetManglingFlavor());
+      dem, node, swift::Mangle::ManglingFlavor::Default);
 }
 
 std::optional<lldb::addr_t>
@@ -3642,7 +3645,8 @@ SwiftLanguageRuntime::GetReflectionTypeSystem(CompilerType for_type,
   if (auto *tr_ts =
           llvm::dyn_cast_or_null<TypeSystemSwiftTypeRefForExpressions>(
               ts_sp.get())) {
-    if (tr_ts->GetManglingFlavor(&exe_ctx) ==
+    if (SwiftLanguageRuntime::GetManglingFlavor(
+            for_type.GetMangledTypeName()) ==
         swift::Mangle::ManglingFlavor::Embedded) {
       if (auto *frame = exe_ctx.GetFramePtr()) {
         auto &sc = frame->GetSymbolContext(eSymbolContextModule);

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -230,7 +230,10 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
       // Make sure we at least have some function type. The mangling for
       // the "top_level_code" is returning the empty tuple type "()",
       // which is not a function type.
-      compiler_type = m_swift_typesystem.GetVoidFunctionType();
+      compiler_type = m_swift_typesystem.GetVoidFunctionType(
+          mangled_name ? SwiftLanguageRuntime::GetManglingFlavor(
+                             mangled_name.GetStringRef())
+                       : swift::Mangle::ManglingFlavor::Default);
     }
     break;
   default:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5719,7 +5719,8 @@ swift::irgen::IRGenModule &SwiftASTContext::GetIRGenModule() {
 }
 
 CompilerType
-SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements) {
+SwiftASTContext::CreateTupleType(const std::vector<TupleElement> &elements,
+                                 swift::Mangle::ManglingFlavor flavor) {
   VALID_OR_RETURN(CompilerType());
 
   Status error;
@@ -5783,7 +5784,8 @@ CompilerType SwiftASTContext::CreateGenericTypeParamType(
       swift::GenericTypeParamType::getType(depth, index, **ast_ctx));
 }
 
-CompilerType SwiftASTContext::GetErrorType() {
+CompilerType
+SwiftASTContext::GetErrorType(swift::Mangle::ManglingFlavor flavor) {
   VALID_OR_RETURN(CompilerType());
 
   ThreadSafeASTContext swift_ctx = GetASTContext();
@@ -9108,12 +9110,12 @@ std::string SwiftASTContext::GetSwiftName(const clang::Decl *clang_decl,
   return {};
 }
 
-CompilerType
-SwiftASTContext::ConvertClangTypeToSwiftType(CompilerType clang_type) {
+CompilerType SwiftASTContext::ConvertClangTypeToSwiftType(
+    CompilerType clang_type, swift::Mangle::ManglingFlavor flavor) {
   auto ts = GetTypeSystemSwiftTypeRef();
   if (!ts)
     return {};
-  auto typeref_type = ts->ConvertClangTypeToSwiftType(clang_type);
+  auto typeref_type = ts->ConvertClangTypeToSwiftType(clang_type, flavor);
 
   if (!typeref_type)
     return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -452,7 +452,9 @@ public:
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.
-  CompilerType ConvertClangTypeToSwiftType(CompilerType clang_type) override;
+  CompilerType
+  ConvertClangTypeToSwiftType(CompilerType clang_type,
+                              swift::Mangle::ManglingFlavor flavor) override;
 
   bool TypeHasArchetype(CompilerType type);
 
@@ -505,8 +507,8 @@ public:
     return m_dwarfimporter_delegate_up.get();
   }
 
-  CompilerType
-  CreateTupleType(const std::vector<TupleElement> &elements) override;
+  CompilerType CreateTupleType(const std::vector<TupleElement> &elements,
+                               swift::Mangle::ManglingFlavor flavor) override;
   bool IsTupleType(lldb::opaque_compiler_type_t type) override;
   std::optional<NonTriviallyManagedReferenceKind>
   GetNonTriviallyManagedReferenceKind(
@@ -517,7 +519,7 @@ public:
   CreateGenericTypeParamType(unsigned int depth, unsigned int index,
                              swift::Mangle::ManglingFlavor flavor) override;
 
-  CompilerType GetErrorType() override;
+  CompilerType GetErrorType(swift::Mangle::ManglingFlavor flavor) override;
 
   /// Error handling
   /// \{

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -146,7 +146,7 @@ public:
                               CompilerType *original_type) = 0;
   virtual bool IsErrorType(lldb::opaque_compiler_type_t type,
                            const ExecutionContext *exe_ctx) = 0;
-  virtual CompilerType GetErrorType() = 0;
+  virtual CompilerType GetErrorType(swift::Mangle::ManglingFlavor flavor) = 0;
   virtual CompilerType GetWeakReferent(lldb::opaque_compiler_type_t type) {
     return {};
   }
@@ -167,7 +167,8 @@ public:
         : element_name(name), element_type(type) {}
   };
   virtual CompilerType
-  CreateTupleType(const std::vector<TupleElement> &elements) = 0;
+  CreateTupleType(const std::vector<TupleElement> &elements,
+                  swift::Mangle::ManglingFlavor flavor) = 0;
   virtual bool IsTupleType(lldb::opaque_compiler_type_t type) = 0;
 
   enum class NonTriviallyManagedReferenceKind : uint8_t {
@@ -211,7 +212,9 @@ public:
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.
-  virtual CompilerType ConvertClangTypeToSwiftType(CompilerType clang_type) = 0;
+  virtual CompilerType
+  ConvertClangTypeToSwiftType(CompilerType clang_type,
+                              swift::Mangle::ManglingFlavor flavor) = 0;
 
   /// \see lldb_private::TypeSystem::Dump
   void Dump(llvm::raw_ostream &output, llvm::StringRef filter) override;

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -3133,7 +3133,7 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
 #ifndef NDEBUG
 // Due to the lack of a symbol context, this only does the validation
 // on TypeSystemSwiftTypeRefForExpressions.
-#define VALIDATE_AND_RETURN_STATIC(IMPL, REFERENCE)                            \
+#define VALIDATE_AND_RETURN_STATIC(IMPL, REFERENCE, ...)                       \
   do {                                                                         \
     auto result = IMPL();                                                      \
     if (!ModuleList::GetGlobalModuleListProperties()                           \
@@ -3146,7 +3146,7 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
         SymbolContext(target_sp, target_sp->GetExecutableModule()));           \
     if (!swift_ast_ctx)                                                        \
       return result;                                                           \
-    assert(Equivalent(result, swift_ast_ctx->REFERENCE()) &&                   \
+    assert(Equivalent(result, swift_ast_ctx->REFERENCE(__VA_ARGS__)) &&        \
            "TypeSystemSwiftTypeRef diverges from SwiftASTContext");            \
     return result;                                                             \
   } while (0)
@@ -3222,8 +3222,7 @@ constexpr ExecutionContextScope *g_no_exe_ctx = nullptr;
   } while (0)
 
 #else
-#define VALIDATE_AND_RETURN_STATIC(IMPL, REFERENCE)                            \
-  return IMPL()
+#define VALIDATE_AND_RETURN_STATIC(IMPL, REFERENCE, ...) return IMPL()
 #define VALIDATE_AND_RETURN(IMPL, REFERENCE, TYPE, EXE_CTX, ARGS)  \
   return IMPL();
 #define VALIDATE_AND_RETURN_CUSTOM(IMPL, REFERENCE, TYPE, COMPARISON, EXE_CTX, ARGS)       \
@@ -3974,7 +3973,8 @@ TypeSystemSwiftTypeRef::GetPointerType(opaque_compiler_type_t type) {
                       (ReconstructType(type)));
 }
 
-CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
+CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType(
+    swift::Mangle::ManglingFlavor flavor) {
   using namespace swift::Demangle;
   Demangler dem;
   NodePointer type = dem.createNode(Node::Kind::Type);
@@ -3992,7 +3992,7 @@ CompilerType TypeSystemSwiftTypeRef::GetVoidFunctionType() {
   rett->addChild(ret_ty, dem);
   NodePointer ret_tuple = dem.createNode(Node::Kind::Tuple);
   ret_ty->addChild(ret_tuple, dem);
-  return RemangleAsType(dem, type, GetManglingFlavor());
+  return RemangleAsType(dem, type, flavor);
 }
 
 // Exploring the type
@@ -4332,8 +4332,8 @@ TypeSystemSwiftTypeRef::GetClangTypeTypeNode(swift::Demangle::Demangler &dem,
   return type;
 }
 
-CompilerType
-TypeSystemSwiftTypeRef::ConvertClangTypeToSwiftType(CompilerType clang_type) {
+CompilerType TypeSystemSwiftTypeRef::ConvertClangTypeToSwiftType(
+    CompilerType clang_type, swift::Mangle::ManglingFlavor flavor) {
   assert(clang_type.GetTypeSystem().isa_and_nonnull<TypeSystemClang>() &&
          "Unexpected type system!");
 
@@ -4342,10 +4342,10 @@ TypeSystemSwiftTypeRef::ConvertClangTypeToSwiftType(CompilerType clang_type) {
 
   swift::Demangle::Demangler dem;
   swift::Demangle::NodePointer node = GetClangTypeTypeNode(dem, clang_type);
-  CompilerType result = RemangleAsType(dem, node, GetManglingFlavor());
+  CompilerType result = RemangleAsType(dem, node, flavor);
   m_imported_type_map.Insert(result.GetMangledTypeName().AsCString(),
                              clang_type);
-  return result;  
+  return result;
 }
 
 llvm::Expected<CompilerType>
@@ -4804,14 +4804,15 @@ bool TypeSystemSwiftTypeRef::IsExistentialType(
   }
 }
 
-CompilerType TypeSystemSwiftTypeRef::GetRawPointerType() {
+CompilerType TypeSystemSwiftTypeRef::GetRawPointerType(
+    swift::Mangle::ManglingFlavor flavor) {
   using namespace swift::Demangle;
   Demangler dem;
   NodePointer raw_ptr = dem.createNode(Node::Kind::BuiltinTypeName,
                                        swift::BUILTIN_TYPE_NAME_RAWPOINTER);
   NodePointer node = dem.createNode(Node::Kind::Type);
   node->addChild(raw_ptr, dem);
-  return RemangleAsType(dem, node, GetManglingFlavor());
+  return RemangleAsType(dem, node, flavor);
 }
 
 bool TypeSystemSwiftTypeRef::IsErrorType(opaque_compiler_type_t type,
@@ -4843,7 +4844,8 @@ bool TypeSystemSwiftTypeRef::IsErrorType(opaque_compiler_type_t type,
                       (ReconstructType(type, exe_ctx), exe_ctx));
 }
 
-CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
+CompilerType
+TypeSystemSwiftTypeRef::GetErrorType(swift::Mangle::ManglingFlavor flavor) {
   auto impl = [&]() {
     using namespace swift::Demangle;
     Demangler dem;
@@ -4868,9 +4870,9 @@ CompilerType TypeSystemSwiftTypeRef::GetErrorType() {
         dem);
     parent->addChild(dem.createNode(Node::Kind::Identifier, "Error"), dem);
 
-    return RemangleAsType(dem, error_type, GetManglingFlavor());
+    return RemangleAsType(dem, error_type, flavor);
   };
-  VALIDATE_AND_RETURN_STATIC(impl, GetErrorType);
+  VALIDATE_AND_RETURN_STATIC(impl, GetErrorType, flavor);
 }
 
 CompilerType
@@ -5090,7 +5092,8 @@ CompilerType TypeSystemSwiftTypeRef::GetSILPackElementAtIndex(CompilerType type,
 }
 
 CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
-    const std::vector<TupleElement> &elements) {
+    const std::vector<TupleElement> &elements,
+    swift::Mangle::ManglingFlavor flavor) {
   auto impl = [&]() -> CompilerType {
     using namespace swift::Demangle;
     Demangler dem;
@@ -5098,10 +5101,7 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
     auto *tuple = dem.createNode(Node::Kind::Tuple);
     tuple_type->addChild(tuple, dem);
     if (elements.empty())
-      return RemangleAsType(dem, tuple_type, GetManglingFlavor());
-
-    auto flavor = SwiftLanguageRuntime::GetManglingFlavor(
-        elements.front().element_type.GetMangledTypeName());
+      return RemangleAsType(dem, tuple_type, flavor);
 
     for (const auto &element : elements) {
       auto *tuple_element = dem.createNode(Node::Kind::TupleElement);
@@ -5149,11 +5149,11 @@ CompilerType TypeSystemSwiftTypeRef::CreateTupleType(
                          element.element_name,
                          ReconstructType(element.element_type, nullptr));
                    });
-    bool equivalent =
-        Equivalent(result, swift_ast_ctx->CreateTupleType(ast_elements));
+    bool equivalent = Equivalent(
+        result, swift_ast_ctx->CreateTupleType(ast_elements, flavor));
     if (!equivalent) {
       result.dump();
-      auto a = swift_ast_ctx->CreateTupleType(elements);
+      auto a = swift_ast_ctx->CreateTupleType(elements, flavor);
       llvm::dbgs() << "AST type: " << a.GetMangledTypeName() << "\n";
       llvm::dbgs() << "failing tuple type\n";
     }
@@ -5829,37 +5829,6 @@ TypeSystemSwiftTypeRef::GetDependentGenericParamListForType(
     dependent_params.emplace_back(depth->getIndex(), index->getIndex());
   }
   return dependent_params;
-}
-
-swift::Mangle::ManglingFlavor
-TypeSystemSwiftTypeRef::GetManglingFlavor(const ExecutionContext *exe_ctx) {
-  if (!exe_ctx)
-    return swift::Mangle::ManglingFlavor::Default;
-  auto sc = GetSymbolContext(exe_ctx);
-  CompileUnit *cu = sc.comp_unit;
-  // If we didn't find a compile unit, try to go up the stack until we find one.
-  // Limit the search to avoid iterating through a very large stack if
-  // interrupted during infinite recursion.
-  if (!cu) {
-    if (auto *thread = exe_ctx->GetThreadPtr()) {
-      constexpr uint32_t max_frames = 128;
-      for (uint32_t i = 0; i < max_frames; ++i) {
-        auto stack_frame = thread->GetStackFrameAtIndex(i);
-        if (!stack_frame)
-          break;
-        cu = stack_frame->GetSymbolContext(lldb::eSymbolContextCompUnit)
-                 .comp_unit;
-        if (cu)
-          break;
-      }
-    }
-  }
-  // Cache the result for the last recently used CU.
-  if (cu != m_lru_is_embedded.first)
-    m_lru_is_embedded = {cu, ShouldEnableEmbeddedSwift(cu)
-                                 ? swift::Mangle::ManglingFlavor::Embedded
-                                 : swift::Mangle::ManglingFlavor::Default};
-  return m_lru_is_embedded.second;
 }
 
 #ifndef NDEBUG

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -214,7 +214,7 @@ public:
   CompilerType GetPointerType(lldb::opaque_compiler_type_t type) override;
 
   /// Get a function type that returns nothing and take no parameters.
-  CompilerType GetVoidFunctionType();
+  CompilerType GetVoidFunctionType(swift::Mangle::ManglingFlavor flavor);
 
   // Exploring the type
   llvm::Expected<uint64_t>
@@ -329,7 +329,7 @@ public:
                                     bool *is_imported = nullptr);
   bool IsErrorType(lldb::opaque_compiler_type_t type,
                    const ExecutionContext *exe_ctx) override;
-  CompilerType GetErrorType() override;
+  CompilerType GetErrorType(swift::Mangle::ManglingFlavor flavor) override;
   CompilerType GetWeakReferent(lldb::opaque_compiler_type_t type) override;
   CompilerType GetReferentType(lldb::opaque_compiler_type_t type) override;
   CompilerType GetInstanceType(lldb::opaque_compiler_type_t type,
@@ -348,8 +348,8 @@ public:
   };
   std::optional<PackTypeInfo> IsSILPackType(CompilerType type);
   CompilerType GetSILPackElementAtIndex(CompilerType type, unsigned i);
-  CompilerType
-  CreateTupleType(const std::vector<TupleElement> &elements) override;
+  CompilerType CreateTupleType(const std::vector<TupleElement> &elements,
+                               swift::Mangle::ManglingFlavor flavor) override;
   bool IsTupleType(lldb::opaque_compiler_type_t type) override;
   std::optional<NonTriviallyManagedReferenceKind>
   GetNonTriviallyManagedReferenceKind(
@@ -380,7 +380,7 @@ public:
       swift::Demangle::Demangler &dem);
 
   /// Get the Swift raw pointer type.
-  CompilerType GetRawPointerType();
+  CompilerType GetRawPointerType(swift::Mangle::ManglingFlavor flavor);
   /// Determine whether \p type is a protocol.
   bool IsExistentialType(lldb::opaque_compiler_type_t type,
                          const ExecutionContext *exe_ctx);
@@ -479,7 +479,9 @@ public:
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.
-  CompilerType ConvertClangTypeToSwiftType(CompilerType clang_type) override;
+  CompilerType
+  ConvertClangTypeToSwiftType(CompilerType clang_type,
+                              swift::Mangle::ManglingFlavor flavor) override;
 
   /// Gets the descriptor finder belonging to this instance's
   /// module.
@@ -491,11 +493,6 @@ public:
   /// Desugar a CompilerType and resolve type aliases by looking up
   /// their types in the debug info.
   CompilerType Canonicalize(CompilerType type);
-
-  /// Returns the mangling flavor associated with the ASTContext corresponding
-  /// with this TypeSystem.
-  swift::Mangle::ManglingFlavor
-  GetManglingFlavor(const ExecutionContext *exe_ctx = nullptr);
 
 protected:
   /// Determine whether the fallback is enabled via setting.
@@ -656,10 +653,6 @@ protected:
 
   /// A cache of Clang types that this TypeSystem mapped into Swift.
   ThreadSafeDenseMap<const char *, CompilerType> m_imported_type_map;
-
-  /// An LRU cache for \ref GetManglingFlavor().
-  std::pair<CompileUnit *, swift::Mangle::ManglingFlavor> m_lru_is_embedded = {
-      nullptr, swift::Mangle::ManglingFlavor::Default};
 };
 
 /// This one owns a SwiftASTContextForExpressions.

--- a/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
+++ b/lldb/unittests/Symbol/TestTypeSystemSwiftTypeRef.cpp
@@ -483,12 +483,12 @@ TEST_F(TestTypeSystemSwiftTypeRef, Tuple) {
     // Test unnamed tuple elements.
     auto int_element = makeElement(b.IntType());
     auto float_element = makeElement(b.FloatType());
-    auto int_float_tuple =
-        m_swift_ts->CreateTupleType({int_element, float_element});
+    auto int_float_tuple = m_swift_ts->CreateTupleType(
+        {int_element, float_element}, swift::Mangle::ManglingFlavor::Default);
     ASSERT_EQ(int_float_tuple.GetMangledTypeName(),
               "$ss0016BuiltinInt_gCJAcV_s0019BuiltinFPIEEE_CJEEdVtD");
-    auto float_int_tuple =
-        m_swift_ts->CreateTupleType({float_element, int_element});
+    auto float_int_tuple = m_swift_ts->CreateTupleType(
+        {float_element, int_element}, swift::Mangle::ManglingFlavor::Default);
     ASSERT_EQ(float_int_tuple.GetMangledTypeName(),
               "$ss0019BuiltinFPIEEE_CJEEdV_s0016BuiltinInt_gCJAcVtD");
   }
@@ -496,12 +496,12 @@ TEST_F(TestTypeSystemSwiftTypeRef, Tuple) {
     // Test named tuple elements.
     auto int_element = makeElement(b.IntType(), "i");
     auto float_element = makeElement(b.FloatType(), "f");
-    auto int_float_tuple =
-        m_swift_ts->CreateTupleType({int_element, float_element});
+    auto int_float_tuple = m_swift_ts->CreateTupleType(
+        {int_element, float_element}, swift::Mangle::ManglingFlavor::Default);
     ASSERT_EQ(int_float_tuple.GetMangledTypeName(),
               "$ss0016BuiltinInt_gCJAcV1i_s0019BuiltinFPIEEE_CJEEdV1ftD");
-    auto float_int_tuple =
-        m_swift_ts->CreateTupleType({float_element, int_element});
+    auto float_int_tuple = m_swift_ts->CreateTupleType(
+        {float_element, int_element}, swift::Mangle::ManglingFlavor::Default);
     ASSERT_EQ(float_int_tuple.GetMangledTypeName(),
               "$ss0019BuiltinFPIEEE_CJEEdV1f_s0016BuiltinInt_gCJAcV1itD");
   }
@@ -606,7 +606,9 @@ TEST_F(TestTypeSystemSwiftTypeRef, TypeClass) {
 }
 
 TEST_F(TestTypeSystemSwiftTypeRef, MangledTypeName) {
-  ASSERT_EQ(m_swift_ts->GetErrorType().GetMangledTypeName(), "$ss5Error_pD");
+  ASSERT_EQ(m_swift_ts->GetErrorType(swift::Mangle::ManglingFlavor::Default)
+                .GetMangledTypeName(),
+            "$ss5Error_pD");
 }
 
 TEST_F(TestTypeSystemSwiftTypeRef, ImportedType) {
@@ -629,7 +631,10 @@ TEST_F(TestTypeSystemSwiftTypeRef, ImportedType) {
 }
 
 TEST_F(TestTypeSystemSwiftTypeRef, RawPointer) {
-  ASSERT_EQ(m_swift_ts->GetRawPointerType().GetMangledTypeName(), "$sBpD");
+  ASSERT_EQ(
+      m_swift_ts->GetRawPointerType(swift::Mangle::ManglingFlavor::Default)
+          .GetMangledTypeName(),
+      "$sBpD");
 }
 
 TEST_F(TestTypeSystemSwiftTypeRef, GetNumTemplateArguments) {


### PR DESCRIPTION
There's no reliable way to TypeSystemSwiftTypeRef::GetManglingFlavor()
get the mangling flavor, so remove it instead. Most callers could obtain
the mangling flavor from some other source, the remaining few that are
hardcoded should be fixed later on (for example, when TypeRefs carry
their mangling flavor or a similar mechanism), or the mangling flavor is
inconsequential.

(cherry picked from commit 5f00c99bdfe9c2cb1238538210d311bc630036d2)