### PR TITLE
[cherry-pick] [lldb] Fix ThreadPlanStepThroughGenericTrampoline

### DIFF
--- a/lldb/source/Target/ThreadPlanStepThroughGenericTrampoline.cpp
+++ b/lldb/source/Target/ThreadPlanStepThroughGenericTrampoline.cpp
@@ -99,6 +99,8 @@ bool ThreadPlanStepThroughGenericTrampoline::ShouldStop(Event *event_ptr) {
               s.GetData());
   }
 
+  ClearNextBranchBreakpointExplainedStop();
+
   if (IsPlanComplete())
     return true;
 

--- a/lldb/test/API/lang/c/trampoline_stepping/TestTrampolineStepping.py
+++ b/lldb/test/API/lang/c/trampoline_stepping/TestTrampolineStepping.py
@@ -101,4 +101,4 @@ class TestTrampoline(TestBase):
         thread.StepInto()
         name = thread.frames[0].GetFunctionName()
         self.assertIn('unused_target', name)
-        
+


### PR DESCRIPTION
With the rework upstream of step plans, NextRangeBreakpointExplainsStop
was made stateless so the check if the break breakpoints needs to be
cleared needs to be moved to the ShoudStop method.

rdar://159531057
rdar://159675204

(cherry picked from commit ca682005509be42d69b5aebe37c66ca2de7e1869)