### PR TITLE
[cherry-pick] [lldb] Test finding the first field of Observation.Extent

### DIFF
--- a/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
+++ b/lldb/test/API/lang/swift/observation/TestSwiftObservation.py
@@ -3,19 +3,26 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 
+
 class TestSwiftObservation(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
+
     @swiftTest
     def test(self):
         """Test that types with private discriminators read from the file cache work"""
         self.build()
-        lldbutil.run_to_source_breakpoint(self, 'break here',
-                                          lldb.SBFileSpec('main.swift'))
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
         # FIXME: Private discriminators are UUIDs in DWARF and pointers
         # in Reflection metafdata, making tham not comparable.
-        # rdar://74374120 
-        self.expect("settings set symbols.swift-validate-typesystem false")
-        self.expect("settings set target.experimental.swift-read-metadata-from-file-cache true")
+        # rdar://74374120
+        self.expect("settings set symbols.swift-enable-ast-context false")
+        self.expect(
+            "settings set target.experimental.swift-read-metadata-from-file-cache true"
+        )
         r = self.frame().FindVariable("r")
         extent = r.GetChildAtIndex(0)
         self.assertEqual(extent.GetName(), "extent")
+        context = extent.GetChildAtIndex(0)
+        self.assertEqual(context.GetName(), "context")


### PR DESCRIPTION
"Extent" is the class with the private discriminator, which we want to
test, but to test it we need to access its fields.

(cherry picked from commit 5ff9388b21b725120e6ce46c5fb435e30ef93cbc)