### PR TITLE
[cherry-pick] [lldb] Disable LLDBMemoryReader::resolvePointerAsSymbol on Linux

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/LLDBMemoryReader.cpp
@@ -180,6 +180,14 @@ LLDBMemoryReader::resolvePointerAsSymbol(swift::remote::RemoteAddress address) {
   if (!target.GetSwiftUseReflectionSymbols())
     return {};
 
+  auto &triple = m_process.GetTarget().GetArchitecture().GetTriple();
+  // On Linux, there seems to be a bug where we can't reliably look for symbols by address,
+  // since these symbols have an actual size and can overlap.
+  // This could be an LLDB bug or a compiler bug.
+  // rdar://166344740
+  if (triple.isOSLinux())
+    return {};
+
   std::optional<Address> maybeAddr = remoteAddressToLLDBAddress(address);
   // This is not an assert, but should never happen.
   if (!maybeAddr)


### PR DESCRIPTION
Address::CalculateSymbolContextSymbol() finds the wrong symbol on
Linux when debugging swift application because symbols have an
actual size (as opposed to macOS, where they have size 0). This is
either an LLDB or a swift compiler bug.

For now, disable this optimization on Linux.

(cherry picked from commit 841e53e4ad38ab047dc3cb82f823883aa8b851fa)