### PR TITLE
[clang] Fix a performance regression in FileManager

### DIFF
--- a/clang/lib/Basic/FileManager.cpp
+++ b/clang/lib/Basic/FileManager.cpp
@@ -586,8 +586,7 @@ FileManager::getBufferForFileImpl(StringRef Filename, int64_t FileSize,
       else
         *CASContents = std::nullopt;
     }
-    return FS->getBufferForFile(Name, FileSize, RequiresNullTerminator,
-                                isVolatile, IsText);
+    return (*F)->getBuffer(Name, FileSize, RequiresNullTerminator, isVolatile);
   };
 
   if (FileSystemOpts.WorkingDir.empty())

--- a/clang/unittests/Basic/FileManagerTest.cpp
+++ b/clang/unittests/Basic/FileManagerTest.cpp
@@ -582,6 +582,28 @@ TEST_F(FileManagerTest, getBypassFile) {
   EXPECT_EQ(&FE, &SearchRef->getFileEntry());
 }
 
+TEST_F(FileManagerTest, TraceCount) {
+  auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
+
+  InMemoryFS->addFile("/foo", 0, llvm::MemoryBuffer::getMemBuffer(""));
+
+  auto InstrumentingFS =
+      llvm::makeIntrusiveRefCnt<llvm::vfs::TracingFileSystem>(InMemoryFS);
+
+  FileSystemOptions Opts;
+  FileManager Manager(Opts, InstrumentingFS);
+
+  llvm::vfs::Status Status;
+  Manager.getNoncachedStatValue("/foo", Status);
+  EXPECT_EQ(InstrumentingFS->NumStatusCalls, 1u);
+
+  Manager.getBufferForFile("/foo");
+  EXPECT_EQ(InstrumentingFS->NumOpenFileForReadCalls, 1u);
+
+  Manager.getBufferForFile("/foo");
+  EXPECT_EQ(InstrumentingFS->NumOpenFileForReadCalls, 2u);
+}
+
 TEST_F(FileManagerTest, CASProvider) {
   std::shared_ptr<ObjectStore> DB = llvm::cas::createInMemoryCAS();
   auto FS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();


### PR DESCRIPTION
Fix a bug that the file is opened twice when reading the buffer from clang FileManager.

rdar://170666414