### PR TITLE
[lldb] Don't add remap entries for empty segments (#183651)

### DIFF
--- a/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
+++ b/lldb/source/Host/macosx/objcxx/HostInfoMacOSX.mm
@@ -818,7 +818,8 @@ static DataExtractorSP map_shared_cache_binary_segments(void *image) {
             g_dyld_image_segment_data_4HWTrace(image_copy, segmentName);
         (void)dispatch_data_create_map(data_from_libdyld, &seg.data, &seg.size);
 
-        segments.push_back(seg);
+        if (seg.size > 0 && seg.data != 0)
+          segments.push_back(seg);
       });
 
   if (!segments.size())


### PR DESCRIPTION
There are some binaries in the shared cache with a zero-length segment, or segments who get mapped to lldb address 0 to indicate a failure. Do not add entries to the VirtualDataExtractor's LookupTablefor those - they
are not readable.

rdar://171106338
(cherry picked from commit 07007b7c8d9eb4d3c4da4eb150aeae8d83c0f1f3)