### PR TITLE
[lldb] Fix embedded Swift tests failing on non-macOS platforms

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -154,8 +154,20 @@ endif
 ifeq "$(SWIFT_EMBEDDED_MODE)" "1"
 	SWIFTFLAGS += -gdwarf-types -enable-experimental-feature Embedded -enable-experimental-feature ValueGenerics -Xfrontend -disable-objc-interop -runtime-compatibility-version none
 	ifeq "$(OS)" "Darwin"
-		SWIFTFLAGS += -target $(ARCH)-apple-macos14
-		SWIFT_EMBEDDED_TRIPLE = $(ARCH)-apple-macos
+		# If TARGET_SWIFTFLAGS already specifies a -target (e.g. for remote-ios),
+		# honour it; the embedded triple is the target triple with the version
+		# number stripped (e.g. arm64-apple-ios26.0 → arm64-apple-ios).
+		# Otherwise default to a macOS host build.
+		ifneq "$(findstring -target,$(TARGET_SWIFTFLAGS))" ""
+			# Extract the triple from TARGET_SWIFTFLAGS (e.g. "-target arm64-apple-ios26.0"
+			# becomes "arm64-apple-ios26.0"), then strip the version number so the result
+			# matches the directory names under lib/swift/embedded/ (e.g. "arm64-apple-ios").
+			SWIFT_EMBEDDED_TRIPLE_VERSIONED = $(shell echo $(TARGET_SWIFTFLAGS) | sed -E 's/.*-target ([^ ]+).*/\1/')
+			SWIFT_EMBEDDED_TRIPLE = $(shell echo $(SWIFT_EMBEDDED_TRIPLE_VERSIONED) | sed -E 's/([^-]+-[^-]+-[^.0-9]+).*/\1/')
+		else
+			SWIFTFLAGS += -target $(ARCH)-apple-macos14
+			SWIFT_EMBEDDED_TRIPLE = $(ARCH)-apple-macos
+		endif
 	endif
 	SWIFT_WMO = 1
 endif


### PR DESCRIPTION
Swift.rules unconditionally appended `-target <ARCH>-apple-macos14` when building in SWIFT_EMBEDDED_MODE on Darwin, regardless of the actual target platform. Since Swift uses the last -target flag, this overrode any platform-specific triple already provided via TARGET_SWIFTFLAGS (e.g. `-target arm64-apple-ios26.0` for remote-ios), causing all embedded Swift tests to produce a macOS binary that remote-ios couldn't run, resulting in "No such file or directory" when the test tried to launch a.out on the device.

This patch fixes the SWIFT_EMBEDDED_MODE block to check whether TARGET_SWIFTFLAGS already specifies a -target triple. If it does, honour it and derive SWIFT_EMBEDDED_TRIPLE from it by stripping the version suffix (e.g. arm64-apple-ios18.2 → arm64-apple-ios) to match the directory names under lib/swift/embedded/ used by SWIFT_EMBEDDED_CONCURRENCY. If no platform-specific triple is provided, fall back to the existing macOS default.