### PR TITLE
[lldb][test] Disable statusline module deadlock test on Linux

### DIFF
--- a/lldb/test/API/functionalities/statusline/TestStatusline.py
+++ b/lldb/test/API/functionalities/statusline/TestStatusline.py
@@ -126,6 +126,7 @@ class TestStatusline(PExpectTest):
     @skipIfRemote
     @skipIfWindows
     @skipIfDarwin
+    @skipIfLinux # https://github.com/llvm/llvm-project/issues/154763
     @add_test_categories(["lldb-server"])
     def test_modulelist_deadlock(self):
         """Regression test for a deadlock that occurs when the status line is enabled before connecting


### PR DESCRIPTION
It has been flaky in CI and Linaro's AArch64 Linux bot.

See #154763.

(cherry picked from commit 4fc8bffbaafec55a43e50ff5888163aa2cd5c744)