### PR TITLE
[lldb/test] Fix API tests failing on a remote device due to missing dylib deployment

### DIFF
--- a/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
+++ b/lldb/test/API/functionalities/progress_reporting/swift_progress_reporting/TestSwiftProgressReporting.py
@@ -24,7 +24,8 @@ class TestSwiftProgressReporting(TestBase):
         self.build()
 
         target, process, thread, _ = lldbutil.run_to_source_breakpoint(self, 'break here',
-                                          lldb.SBFileSpec('main.swift'))
+                                          lldb.SBFileSpec('main.swift'),
+                                          extra_images=['Invisible'])
 
         self.assertGreater(thread.GetNumFrames(), 0)
         frame = thread.GetSelectedFrame()

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/Makefile
@@ -18,6 +18,7 @@ Framework.framework: Framework.swift
 		DYLIB_ONLY=YES DYLIB_SWIFT_SOURCES=Framework.swift \
 		SWIFT_OBJC_INTEROP=1 \
 		SWIFTFLAGS_EXTRAS="$(FOO_FLAGS)" \
-		FRAMEWORK=Framework
+		FRAMEWORK=Framework \
+		DYLIB_INSTALL_NAME="@executable_path/Framework"
 	$(call RM_F,$(BUILDDIR)/Framework.swiftmodule)
 	$(call LN_SF,$(BUILDDIR)/Framework.framework/Framework,$(BUILDDIR)/Framework) #FIXME

--- a/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
+++ b/lldb/test/API/lang/swift/clangimporter/hard_macro_conflict/TestSwiftHardMacroConflict.py
@@ -18,7 +18,7 @@ class TestSwiftHardMacroConflict(TestBase):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'break here', lldb.SBFileSpec('main.swift'),
-            extra_images=['Framework.framework'])
+            extra_images=['Framework'])
         b_breakpoint = target.BreakpointCreateBySourceRegex(
             'break here', lldb.SBFileSpec('Framework.swift'))
         log = self.getBuildArtifact("types.log")

--- a/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
+++ b/lldb/test/API/lang/swift/clashing_abi_name/TestSwiftClashingABIName.py
@@ -29,7 +29,8 @@ class TestSwiftClashingABIName(TestBase):
         self.build()
 
         lldbutil.run_to_source_breakpoint(
-            self, 'break for self', lldb.SBFileSpec('main.swift'))
+            self, 'break for self', lldb.SBFileSpec('main.swift'),
+            extra_images=['Library'])
 
         self.expect('expr --bind-generic-types true -- self', 
                     substrs=['a.Generic<a.One>', 't =', 'j = 98'])

--- a/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/Makefile
@@ -25,4 +25,6 @@ B.framework:
 		DYLIB_NAME=B \
 		FRAMEWORK=B \
 		DYLIB_ONLY=YES \
+		DYLIB_INSTALL_NAME="@executable_path/B" \
 		all
+	$(call LN_SF,$(BUILDDIR)/B.framework/B,$(BUILDDIR)/B)

--- a/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
+++ b/lldb/test/API/lang/swift/explicit_modules/chained_bridgingheader/TestSwiftExplicitModulesChainedBridgingHeader.py
@@ -17,7 +17,8 @@ class TestSwiftExplicitModulesChainedBridgingHeader(lldbtest.TestBase):
         os.unlink(secret)
 
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('main.swift'))
+            self, 'break here', lldb.SBFileSpec('main.swift'),
+            extra_images=['B'])
         log = self.getBuildArtifact("types.log")
         self.expect('log enable lldb types -f "%s"' % log)
         self.expect("frame variable a", substrs=['a = 23'])

--- a/lldb/test/API/lang/swift/expression/no_debuginfo/TestSwiftExpressionNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/expression/no_debuginfo/TestSwiftExpressionNoDebugInfo.py
@@ -12,7 +12,7 @@ class TestSwiftExpressionNoDebugInfo(TestBase):
         """Test running a Swift expression in a non-Swift context"""
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_name_breakpoint(
-            self, 'foo')
+            self, 'foo', extra_images=['Dylib'])
 
         types_log = self.getBuildArtifact("types.log")
         self.expect("log enable lldb types -f " + types_log)

--- a/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
+++ b/lldb/test/API/lang/swift/implementation_only_imports/library_resilient/TestLibraryResilient.py
@@ -46,7 +46,8 @@ class TestLibraryResilient(TestBase):
         """
 
         self.build()
-        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info(),
+                                           extra_images=['SomeLibrary', 'SomeLibraryCore'])
 
         # This test is deliberately checking what the user will see, rather than
         # the structure provided by the Python API, in order to test the recovery.
@@ -67,7 +68,8 @@ class TestLibraryResilient(TestBase):
         self.build()
         os.remove(self.getBuildArtifact("SomeLibraryCore.swiftmodule"))
         os.remove(self.getBuildArtifact("SomeLibraryCore.swiftinterface"))
-        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info())
+        lldbutil.run_to_source_breakpoint(self, "break here", lldb.SBFileSpec("main.swift"), self.launch_info(),
+                                           extra_images=['SomeLibrary', 'SomeLibraryCore'])
 
         # This test is deliberately checking what the user will see, rather than
         # the structure provided by the Python API, in order to test the recovery.

--- a/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
+++ b/lldb/test/API/lang/swift/private_generic_type/TestSwiftPrivateGenericType.py
@@ -23,7 +23,7 @@ class TestSwiftPrivateGenericType(TestBase):
 
         target, process, _, _ = lldbutil.run_to_source_breakpoint(self, 
                 'break here for struct', lldb.SBFileSpec('Public.swift'),
-                extra_images=['Public'])
+                extra_images=['Public', 'Private'])
         # Make sure this fails without generic expression evaluation.
         self.expect("expr --bind-generic-types true -- self", 
                     substrs=["Couldn't realize Swift AST type of self."], 

--- a/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
+++ b/lldb/test/API/lang/swift/resilience_other_module/TestSwiftResilienceOtherModule.py
@@ -19,7 +19,8 @@ class TestSwiftResilienceOtherModule(TestBase):
     def impl(self, break_str):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, break_str, lldb.SBFileSpec('main.swift'))
+            self, break_str, lldb.SBFileSpec('main.swift'),
+            extra_images=['WithDebInfo', 'WithoutDebInfo'])
 
         self.expect("expression s.a", substrs=["Int", "100"])
         self.expect("expression s.b", substrs=["Int", "200"])

--- a/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
+++ b/lldb/test/API/lang/swift/resilience_superclass_other_mod/TestSwiftResilienceSuperclassOtherMod.py
@@ -10,6 +10,7 @@ class TestSwiftResilienceSuperclassOtherMod(TestBase):
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
-            self, 'break here', lldb.SBFileSpec('ModWithClass.swift'))
+            self, 'break here', lldb.SBFileSpec('ModWithClass.swift'),
+            extra_images=['ModWithClass', 'ModWithSuper'])
 
         self.expect("expression c.v", substrs=["Int", "42"])

--- a/lldb/test/API/macosx/delay-init-dependency/TestDelayInitDependency.py
+++ b/lldb/test/API/macosx/delay-init-dependency/TestDelayInitDependency.py
@@ -12,6 +12,7 @@ class TestDelayInitDependencies(TestBase):
 
     @skipUnlessDarwin
     @skipIf(macos_version=["<", "15.0"])
+    @skipIfRemote
     def test_delay_init_dependency(self):
         TestBase.setUp(self)
         out = subprocess.run(


### PR DESCRIPTION
On remote platforms, secondary dylibs and frameworks are only uploaded to the device if they are registered with the target via `extra_images`. Without this, dyld aborts at launch trying to resolve missing dependencies, leaving the process stopped at a signal rather than at the expected breakpoint, causing "Expected 1 thread to stop at breakpoint, 0 did."

For regular dylibs, the fix is straightforward: pass the missing library names via extra_images to run_to_source/name_breakpoint so that registerSharedLibrariesWithTarget uploads them and sets `DYLD_LIBRARY_PATH` on the remote process.

Framework tests require a different approach because @executable_path/Foo.framework/Versions/A/Foo install names cannot be satisfied by uploading a flat file. The fix overrides `DYLIB_INSTALL_NAME` to @executable_path/Foo in the framework sub-make, so the main binary records a flat load command. A symlink from the build dir (Foo -> Foo.framework/Foo) then gives registerSharedLibrariesWithTarget a file path it can upload and the remote process a name it can find at @executable_path.

TestDelayInitDependency is a macOS-local test (uses xcrun ld-delay_library) that should never run against a remote platform.