### PR TITLE
[lldb][test] Replace deprecated/removed assertEquals with assertEqual

### DIFF
--- a/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
+++ b/lldb/test/API/lang/swift/async_breakpoints/TestSwiftAsyncBreakpoints.py
@@ -21,19 +21,19 @@ class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
         breakpoint3 = target.BreakpointCreateBySourceRegex("Breakpoint3", filespec)
         breakpoint4 = target.BreakpointCreateBySourceRegex("Breakpoint4", filespec)
         breakpoint5 = target.BreakpointCreateBySourceRegex("Breakpoint5", filespec)
-        self.assertEquals(breakpoint1.GetNumLocations(), 1)
-        self.assertEquals(breakpoint2.GetNumLocations(), 1)
-        self.assertEquals(breakpoint3.GetNumLocations(), 1)
-        self.assertEquals(breakpoint4.GetNumLocations(), 2)
-        self.assertEquals(breakpoint5.GetNumLocations(), 1)
+        self.assertEqual(breakpoint1.GetNumLocations(), 1)
+        self.assertEqual(breakpoint2.GetNumLocations(), 1)
+        self.assertEqual(breakpoint3.GetNumLocations(), 1)
+        self.assertEqual(breakpoint4.GetNumLocations(), 2)
+        self.assertEqual(breakpoint5.GetNumLocations(), 1)
 
         location11 = breakpoint1.GetLocationAtIndex(0)
-        self.assertEquals(location11.GetHitCount(), 1)
+        self.assertEqual(location11.GetHitCount(), 1)
 
-        self.assertEquals(thread.GetStopDescription(128), "breakpoint 1.1")
+        self.assertEqual(thread.GetStopDescription(128), "breakpoint 1.1")
         process.Continue()
 
-        self.assertEquals(thread.GetStopDescription(128), "breakpoint 2.1")
+        self.assertEqual(thread.GetStopDescription(128), "breakpoint 2.1")
         self.expect("expr timestamp1", substrs=["42"])
 
         process.Continue()
@@ -44,4 +44,4 @@ class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
         breakpoint1_no_filter = target.BreakpointCreateBySourceRegex(
             "Breakpoint1", filespec
         )
-        self.assertEquals(breakpoint1_no_filter.GetNumLocations(), 2)
+        self.assertEqual(breakpoint1_no_filter.GetNumLocations(), 2)

--- a/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
+++ b/lldb/test/API/lang/swift/async_breakpoints_over_many_funclets/TestSwiftAsyncBreakpointsOverManyFunclets.py
@@ -16,14 +16,14 @@ class TestSwiftAsyncBreakpoints(lldbtest.TestBase):
             self, "breakpoint_start", filespec
         )
         breakpoint = target.BreakpointCreateBySourceRegex("breakhere", filespec)
-        self.assertEquals(breakpoint.GetNumLocations(), 2)
+        self.assertEqual(breakpoint.GetNumLocations(), 2)
 
         process.Continue()
         self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
-        self.assertEquals(thread.GetStopDescription(128), "breakpoint 2.1")
+        self.assertEqual(thread.GetStopDescription(128), "breakpoint 2.1")
         self.expect("expr argument", substrs=["1"])
 
         process.Continue()
         self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonBreakpoint)
-        self.assertEquals(thread.GetStopDescription(128), "breakpoint 2.2")
+        self.assertEqual(thread.GetStopDescription(128), "breakpoint 2.2")
         self.expect("expr argument", substrs=["2"])

--- a/lldb/test/API/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/notification/TestSwiftFoundationTypeNotification.py
@@ -36,4 +36,4 @@ class TestSwiftFoundationTypeNotification(lldbtest.TestBase):
         name = self.frame().FindVariable("name")
         # This is a "don't crash" test.
         child = name.GetChildAtIndex(0)
-        self.assertEquals(name.GetSummary(), '"MyNotification"')
+        self.assertEqual(name.GetSummary(), '"MyNotification"')


### PR DESCRIPTION
`assertEquals` was removed in Python 3.12. `assertEqual` is what the rest of the test suite uses since its beginning.