### PR TITLE
[analyzer] Ignore old spellings of the moved checker

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -557,6 +557,9 @@ def err_analyzer_checker_incompatible_analyzer_option : Error<
 def err_analyzer_not_built_with_z3 : Error<
   "analyzer constraint manager 'z3' is only available if LLVM was built with "
   "-DLLVM_ENABLE_Z3_SOLVER=ON">;
+def warn_drv_analyzer_explicitly_enabled_checker_was_renamed : Warning<
+  "checker '%0' was renamed to '%1'. Enable the new checker name "
+  "or stop explicitly enabling the old checker name">;
 
 def warn_drv_needs_hvx : Warning<
   "%0 requires HVX, use -mhvx/-mhvx= to enable it">,

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -253,7 +253,6 @@ def NonnullGlobalConstantsChecker: Checker<"NonnilStringConstants">,
   Documentation<NotDocumented>,
   Hidden;
 
-// This is a temporary checker to make the old spelling of the checker valid.
 def MigrateOldUsesOfCoreFixedAddressDereferenceChecker :
   Checker<"FixedAddressDereference">,
   HelpText<

--- a/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
+++ b/clang/include/clang/StaticAnalyzer/Checkers/Checkers.td
@@ -253,6 +253,18 @@ def NonnullGlobalConstantsChecker: Checker<"NonnilStringConstants">,
   Documentation<NotDocumented>,
   Hidden;
 
+// This is a temporary checker to make the old spelling of the checker valid.
+def MigrateOldUsesOfCoreFixedAddressDereferenceChecker :
+  Checker<"FixedAddressDereference">,
+  HelpText<
+    "This is a temporary checker to make the old spelling of the checker valid. "
+    "Users should migrate from using 'core.FixedAddressDereference' to "
+    "'optin.core.FixedAddressDereference' who wish to keep using the checker. "
+    "This placeholder checker will be removed in the future."
+  >,
+  Documentation<NotDocumented>,
+  Hidden;
+
 } // end "core"
 
 let ParentPackage = CoreAlpha in {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1199,6 +1199,18 @@ static bool ParseAnalyzerArgs(AnalyzerOptions &Opts, ArgList &Args,
     for (const StringRef &CheckerOrPackage : CheckersAndPackages)
       Opts.CheckersAndPackages.emplace_back(std::string(CheckerOrPackage),
                                             IsEnabled);
+
+    // If the command-line explicitly enabled the old checker name, warn them
+    // that they should explicitly enable the new name instead.
+    bool ExplicitlyEnablingTheOldChecker =
+        IsEnabled &&
+        llvm::is_contained(CheckersAndPackages, "core.FixedAddressDereference");
+    if (ExplicitlyEnablingTheOldChecker) {
+      Diags.Report(
+          diag::warn_drv_analyzer_explicitly_enabled_checker_was_renamed)
+          << "core.FixedAddressDereference"
+          << "optin.core.FixedAddressDereference";
+    }
   }
 
   // Go through the analyzer configuration options.

--- a/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
+++ b/clang/lib/StaticAnalyzer/Checkers/CMakeLists.txt
@@ -140,6 +140,9 @@ add_clang_library(clangStaticAnalyzerCheckers
   WebKit/RawPtrRefLocalVarsChecker.cpp
   WebKit/RawPtrRefMemberChecker.cpp
 
+  # This is a temporary checker to make the old spelling of the checker valid.
+  MigrateOldUsesOfCoreFixedAddressDereferenceChecker.cpp
+
   LINK_LIBS
   clangAST
   clangASTMatchers

--- a/clang/lib/StaticAnalyzer/Checkers/MigrateOldUsesOfCoreFixedAddressDereferenceChecker.cpp
+++ b/clang/lib/StaticAnalyzer/Checkers/MigrateOldUsesOfCoreFixedAddressDereferenceChecker.cpp
@@ -1,0 +1,43 @@
+//===-- MigrateOldUsesOfCoreFixedAddressDereferenceChecker.cpp ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This is a temporary checker to make the old spelling of the checker valid.
+// `core.FixedAddressDereference` was moved to
+// `optin.core.FixedAddressDereference`
+// Enabling the old checker name has no effect.
+// Users who wish to keep the checker enabled, now need to explicitly opt-in
+// by enabling this checker.
+//
+// This checker will be removed in the future once the migration concludes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/StaticAnalyzer/Checkers/BuiltinCheckerRegistration.h"
+#include "clang/StaticAnalyzer/Core/Checker.h"
+#include "clang/StaticAnalyzer/Core/CheckerManager.h"
+
+using namespace clang;
+using namespace ento;
+
+namespace {
+class MigrateOldUsesOfCoreFixedAddressDereferenceChecker
+    : public Checker<check::ASTDecl<TranslationUnitDecl>> {
+public:
+// Empty checker callback to make this checker valid.
+void checkASTDecl(const TranslationUnitDecl *, AnalysisManager&,
+                    BugReporter &) const {}
+};
+} // namespace
+
+void ento::registerMigrateOldUsesOfCoreFixedAddressDereferenceChecker(CheckerManager &Mgr) {
+  Mgr.registerChecker<MigrateOldUsesOfCoreFixedAddressDereferenceChecker>();
+}
+
+bool ento::shouldRegisterMigrateOldUsesOfCoreFixedAddressDereferenceChecker(const CheckerManager &) {
+  return true;
+}

--- a/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
+++ b/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
@@ -1,0 +1,62 @@
+// Testing all explicit combinations of the old and new checkers.
+
+// -old => no-warning
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -analyzer-disable-checker=core.FixedAddressDereference \
+// RUN:   -verify=disabled-old %s
+// disabled-old-no-diagnostics
+
+// +old => warn to use the new checker name
+// RUN: %clang_analyze_cc1 -analyzer-checker=core %s 2>&1 \
+// RUN:   -analyzer-checker=core.FixedAddressDereference \
+// RUN: | FileCheck %s --check-prefix=WARN-USE-NEW-CHECKER-NAME
+// WARN-USE-NEW-CHECKER-NAME:      checker 'core.FixedAddressDereference' was renamed to 'optin.core.FixedAddressDereference'.
+// WARN-USE-NEW-CHECKER-NAME-SAME: Enable the new checker name or stop explicitly enabling the old checker name
+
+// -new => no-warning
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -analyzer-disable-checker=optin.core.FixedAddressDereference \
+// RUN:   -verify=disabled-new %s
+// disabled-new-no-diagnostics
+
+// +new => no-warning
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -analyzer-checker=optin.core.FixedAddressDereference \
+// RUN:   -verify=optin-core-checker %s
+// disabled-new-no-diagnostics
+
+// -old,-new => no-warning
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -analyzer-disable-checker=core.FixedAddressDereference \
+// RUN:   -analyzer-disable-checker=optin.core.FixedAddressDereference \
+// RUN:   -verify=disabled-old-disabled-new %s
+// disabled-old-disabled-new-no-diagnostics
+
+// +old,-new => no-warning
+// RUN: %clang_analyze_cc1 -analyzer-checker=core %s 2>&1 \
+// RUN:   -analyzer-checker=core.FixedAddressDereference \
+// RUN:   -analyzer-disable-checker=optin.core.FixedAddressDereference \
+// RUN: | FileCheck %s --check-prefix=WARN-USE-NEW-CHECKER-NAME
+
+// -old,+new => warn: finds the issue
+// RUN: %clang_analyze_cc1 -analyzer-checker=core \
+// RUN:   -analyzer-disable-checker=core.FixedAddressDereference \
+// RUN:   -analyzer-checker=optin.core.FixedAddressDereference \
+// RUN:   -verify=optin-core-checker %s
+
+// +old,+new => warn: finds the issue, and also emits the warning about the old checker name
+// RUN: %clang_analyze_cc1 -analyzer-checker=core %s 2>&1 \
+// RUN:   -analyzer-checker=core.FixedAddressDereference \
+// RUN:   -analyzer-checker=optin.core.FixedAddressDereference \
+// RUN: | FileCheck %s --check-prefixes=WARN-USE-NEW-CHECKER-NAME,FINDING
+// FINDING: dereference of a fixed address [optin.core.FixedAddressDereference]
+
+// Testing the default configuration:
+// By default, the 'optin.core.FixedAddressDereference' should be NOT enabled.
+// RUN: %clang_analyze_cc1 -analyzer-checker=core -verify=default-optin-not-enabled %s
+// default-optin-not-enabled-no-diagnostics
+
+void test() {
+  int *p = (int *)0x020;
+  int x = p[0]; // optin-core-checker-warning {{dereference of a fixed address [optin.core.FixedAddressDereference]}}
+}

--- a/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
+++ b/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
@@ -32,7 +32,7 @@
 // RUN:   -verify=disabled-old-disabled-new %s
 // disabled-old-disabled-new-no-diagnostics
 
-// +old,-new => no-warning
+// +old,-new => warn to use the new checker name
 // RUN: %clang_analyze_cc1 -analyzer-checker=core %s 2>&1 \
 // RUN:   -analyzer-checker=core.FixedAddressDereference \
 // RUN:   -analyzer-disable-checker=optin.core.FixedAddressDereference \

--- a/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
+++ b/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
@@ -10,7 +10,7 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core %s 2>&1 \
 // RUN:   -analyzer-checker=core.FixedAddressDereference \
 // RUN: | FileCheck %s --check-prefix=WARN-USE-NEW-CHECKER-NAME
-// WARN-USE-NEW-CHECKER-NAME:      checker 'core.FixedAddressDereference' was renamed to 'optin.core.FixedAddressDereference'.
+// WARN-USE-NEW-CHECKER-NAME:      warning: checker 'core.FixedAddressDereference' was renamed to 'optin.core.FixedAddressDereference'.
 // WARN-USE-NEW-CHECKER-NAME-SAME: Enable the new checker name or stop explicitly enabling the old checker name
 
 // -new => no-warning

--- a/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
+++ b/clang/test/Analysis/FixedAddressDereferenceCheckerMigration.cpp
@@ -56,6 +56,14 @@
 // RUN: %clang_analyze_cc1 -analyzer-checker=core -verify=default-optin-not-enabled %s
 // default-optin-not-enabled-no-diagnostics
 
+// Test that -Werror does not transform this warning into an error.
+// -Werror, +old => warn to use the new checker name; not an ERROR!
+// RUN: %clang_analyze_cc1 -analyzer-checker=core %s 2>&1 \
+// RUN:   -Werror \
+// RUN:   -analyzer-checker=core.FixedAddressDereference \
+// RUN:   -analyzer-disable-checker=optin.core.FixedAddressDereference \
+// RUN: | FileCheck %s --check-prefix=WARN-USE-NEW-CHECKER-NAME
+
 void test() {
   int *p = (int *)0x020;
   int x = p[0]; // optin-core-checker-warning {{dereference of a fixed address [optin.core.FixedAddressDereference]}}

--- a/clang/test/Analysis/analyzer-enabled-checkers.c
+++ b/clang/test/Analysis/analyzer-enabled-checkers.c
@@ -17,6 +17,7 @@
 // CHECK-NEXT: core.DereferenceModeling
 // CHECK-NEXT: core.DivideZero
 // CHECK-NEXT: core.DynamicTypePropagation
+// CHECK-NEXT: core.FixedAddressDereference
 // CHECK-NEXT: core.NonNullParamChecker
 // CHECK-NEXT: core.NonnilStringConstants
 // CHECK-NEXT: core.NullDereference

--- a/clang/test/Analysis/std-c-library-functions-arg-enabled-checkers.c
+++ b/clang/test/Analysis/std-c-library-functions-arg-enabled-checkers.c
@@ -25,6 +25,7 @@
 // CHECK-NEXT: core.DereferenceModeling
 // CHECK-NEXT: core.DivideZero
 // CHECK-NEXT: core.DynamicTypePropagation
+// CHECK-NEXT: core.FixedAddressDereference
 // CHECK-NEXT: core.NonNullParamChecker
 // CHECK-NEXT: core.NonnilStringConstants
 // CHECK-NEXT: core.NullDereference


### PR DESCRIPTION
This is **not** a backport commit.

The checker 'core.FixedAddressDereference' was moved to 'optin.core.FixedAddressDereference'.
This caused to downstream users, as the explicit
'-analyzer-disable-checker=XXX' would raise a compiler error if it refers to an unknown checker/package. This means that after the rename, their build started to fail.

To mitigate this, and give time for migration, in this patch I introduce a stub/empty checker that would make the flags accept the old spelling.

- Note that users who disabled the old checker will need to drop their suppression in the future, but now it' will be accepted.
- Users who explicitly enabled the old checker will get a warning about that they should instead enable the new checker name.
- Users who didn't explicitly enable/disable the old checker name, will not enable the new 'optin' checker by default.

This patch depends on #12402, when the mentioned checker was moved to the 'optin' checker package.

rdar://171603915