### PR TITLE
[Cherry-pick into next] [lldb] Fix the use of settings in test

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
@@ -11,6 +11,7 @@
 //===---------------------------------------------------------------------===//
 
 #include "LLDBExplicitModuleLoader.h"
+#include "lldb/Target/Target.h"
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
@@ -65,6 +65,10 @@ LLDBExplicitSwiftModuleLoader::create(
       std::move(casml), std::move(esml));
 }
 
+bool LLDBExplicitSwiftModuleLoader::enabled() const {
+  return Target::GetGlobalProperties().GetSwiftAllowExplicitModules();
+}
+
 void LLDBExplicitSwiftModuleLoader::collectVisibleTopLevelModuleNames(
     llvm::SmallVectorImpl<swift::Identifier> &names) const {
   if (m_casml)
@@ -87,6 +91,9 @@ std::error_code LLDBExplicitSwiftModuleLoader::findModuleFilesInDirectory(
 bool LLDBExplicitSwiftModuleLoader::canImportModule(
     swift::ImportPath::Module named, swift::SourceLoc loc,
     ModuleVersionInfo *versionInfo, bool isTestableImport) {
+  if (!enabled())
+    return false;
+
   if (m_casml &&
       llvm::cast<swift::SerializedModuleLoaderBase>(m_casml.get())
           ->canImportModule(named, loc, versionInfo, isTestableImport))
@@ -99,6 +106,9 @@ swift::ModuleDecl *
 LLDBExplicitSwiftModuleLoader::loadModule(swift::SourceLoc importLoc,
                                           swift::ImportPath::Module path,
                                           bool AllowMemoryCache) {
+  if (!enabled())
+    return nullptr;
+
   if (m_casml)
     if (swift::ModuleDecl *decl =
             m_casml->loadModule(importLoc, path, AllowMemoryCache))
@@ -108,6 +118,9 @@ LLDBExplicitSwiftModuleLoader::loadModule(swift::SourceLoc importLoc,
 
 void LLDBExplicitSwiftModuleLoader::loadExtensions(
     swift::NominalTypeDecl *nominal, unsigned previousGeneration) {
+  if (!enabled())
+    return;
+
   if (m_casml)
     m_casml->loadExtensions(nominal, previousGeneration);
   m_esml->loadExtensions(nominal, previousGeneration);
@@ -117,6 +130,9 @@ void LLDBExplicitSwiftModuleLoader::loadObjCMethods(
     swift::NominalTypeDecl *typeDecl, swift::ObjCSelector selector,
     bool isInstanceMethod, unsigned previousGeneration,
     llvm::TinyPtrVector<swift::AbstractFunctionDecl *> &methods) {
+  if (!enabled())
+    return;
+
   if (m_casml)
     m_casml->loadObjCMethods(typeDecl, selector, isInstanceMethod,
                              previousGeneration, methods);
@@ -127,6 +143,9 @@ void LLDBExplicitSwiftModuleLoader::loadObjCMethods(
 void LLDBExplicitSwiftModuleLoader::loadDerivativeFunctionConfigurations(
     swift::AbstractFunctionDecl *originalAFD, unsigned previousGeneration,
     llvm::SetVector<swift::AutoDiffConfig> &results) {
+  if (!enabled())
+    return;
+
   if (m_casml)
     m_casml->loadDerivativeFunctionConfigurations(originalAFD,
                                                   previousGeneration, results);
@@ -135,6 +154,9 @@ void LLDBExplicitSwiftModuleLoader::loadDerivativeFunctionConfigurations(
 }
 
 void LLDBExplicitSwiftModuleLoader::verifyAllModules() {
+  if (!enabled())
+    return;
+
   if (m_casml)
     m_casml->verifyAllModules();
   m_esml->verifyAllModules();
@@ -142,6 +164,9 @@ void LLDBExplicitSwiftModuleLoader::verifyAllModules() {
 
 swift::ExplicitSwiftModuleMap *
 LLDBExplicitSwiftModuleLoader::getExplicitSwiftModuleMap() {
+  if (!enabled())
+    return nullptr;
+
   if (m_casml)
     return m_casml->getExplicitSwiftModuleMap();
   return m_esml->getExplicitSwiftModuleMap();
@@ -149,6 +174,9 @@ LLDBExplicitSwiftModuleLoader::getExplicitSwiftModuleMap() {
 
 swift::ExplicitClangModuleMap *
 LLDBExplicitSwiftModuleLoader::getExplicitClangModuleMap() {
+  if (!enabled())
+    return nullptr;
+
   if (m_casml)
     return m_casml->getExplicitClangModuleMap();
   return m_esml->getExplicitClangModuleMap();

--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.h
@@ -47,6 +47,7 @@ public:
          std::unique_ptr<swift::ExplicitSwiftModuleMap> ExplicitSwiftModuleMap,
          std::unique_ptr<swift::ExplicitClangModuleMap> ExplicitClangModuleMap);
 
+  bool enabled() const;
   void collectVisibleTopLevelModuleNames(
       llvm::SmallVectorImpl<swift::Identifier> &names) const override;
   std::error_code findModuleFilesInDirectory(

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2323,6 +2323,12 @@ static std::string GetSDKPath(std::string m_description, XcodeSDK sdk) {
   }
   LOG_PRINTF(GetLog(LLDBLog::Types), "Host SDK path: \"%s\" (XcodeSDK: %s)",
              sdk_path.c_str(), sdk.GetString().str().c_str());
+
+#if not defined(__APPLE__)
+  // FXIME: The Swift compiler seems to be happier with an empty SDK path.
+  if (sdk_path == "/")
+    return {};
+#endif          
   return sdk_path;
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -3964,7 +3964,7 @@ public:
     if (!m_swift_ast_ctx.HasExplicitModules())
       return;
     // This setting is off by default and allows to return to the old behavior.
-    if (Target::GetGlobalProperties().GetSwiftAllowImplicitModules())
+    if (Target::GetGlobalProperties().GetSwiftAllowImplicitModuleLoader())
       return;
     m_swift_ast_ctx.SetImplicitModulesDisabled(true);
     LOG_PRINTF(GetLog(LLDBLog::Types), "Turning off implicit modules");

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -4186,6 +4186,9 @@ ThreadSafeASTContext SwiftASTContext::GetASTContext() {
   if (!m_ast_context_up->SearchPathOpts.getSDKPath().empty() ||
       TargetHasNoSDK()) {
     auto importer_diags = getScopedDiagnosticConsumer();
+    // Since swift::ClangImporter::create() may kick off the import of
+    // the bridging header, we need to switch to explicit mode if
+    // applicable.
     DisableImplicitImportsRAII(*this);
     clang_importer_up = swift::ClangImporter::create(
         *m_ast_context_up, &GetCompilerInvocation().getIRGenOptions(), "",

--- a/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
+++ b/lldb/test/API/lang/swift/explicit_modules/implicit_fallback/TestSwiftExplicitModulesImplicitFallback.py
@@ -69,7 +69,7 @@ class TestCase(lldbtest.TestBase):
 
         log = self.getBuildArtifact("types.log")
         self.runCmd(f"log enable lldb types -f '{log}'")
-        self.expect("settings set target.experimental.swift-allow-implicit-modules true")
+        self.expect("settings set target.experimental.swift-allow-implicit-module-loader true")
 
         self.expect("expression c")
 

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -25,6 +25,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         """Test disabling the explicit Swift module loader"""
         self.build()
         self.expect("settings set symbols.use-swift-explicit-module-loader false")
+        self.expect("settings set target.experimental.swift-allow-implicit-module-loader true")
 
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
             self, 'Set breakpoint here', lldb.SBFileSpec('main.swift'))

--- a/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
+++ b/lldb/test/API/lang/swift/explicit_modules/simple/TestSwiftExplicitModules.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExplicitModules(lldbtest.TestBase):
 
     @swiftTest
-    def XXXXtest(self):
+    def test(self):
         """Test explicit Swift modules"""
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -21,7 +21,7 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift"){{.*}} Module import remark: loaded module 'a'; source: '{{.*}}a.swiftmodule', loaded: '{{.*}}a.swiftmodule'
 
     @swiftTest
-    def XXXXXtest_disable_esml(self):
+    def test_disable_esml(self):
         """Test disabling the explicit Swift module loader"""
         self.build()
         self.expect("settings set symbols.use-swift-explicit-module-loader false")


### PR DESCRIPTION
```
commit acf0eef1881f036c3c70134505b9e9514f866383
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Mar 2 16:23:24 2026 -0800

    [lldb] Fix the use of settings in test

commit 00b2ae3aa78298d0215358af594abd868df41b9b
Author: Adrian Prantl <aprantl@apple.com>
Date:   Mon Mar 2 16:49:13 2026 -0800

    [LLDB] Don't set the SDK path to / on non-Apple hosts

commit aa66e8125409dab6c72f5e860b72b36144456a94
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 24 11:57:11 2026 -0800

    [LLDB] document DisableImplicitImportsRAII use

commit 724367188e2084f6b53a5649cc2413c8ba88932e
Author: Adrian Prantl <aprantl@apple.com>
Date:   Tue Feb 24 11:55:38 2026 -0800

    [LLDB] Re-enable accidentally enabled test
```
