### PR TITLE
Relax URL summary formatter test (NFC)

### DIFF
--- a/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -12,6 +12,61 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(__file__, globals(),
-                          decorators=[swiftTest,skipUnlessDarwin,
-                            expectedFailureAll(archs=['arm64_32'], bugnumber="<rdar://problem/58065423>")])
+class TestCase(TestBase):
+    @expectedFailureAll(archs=["arm64_32"], bugnumber="<rdar://problem/58065423>")
+    @skipUnlessFoundation
+    @swiftTest
+    def test_swift_url_formatters(self):
+        """Test URL summary strings."""
+        self.build()
+
+        foundation = "Foundation" if sys.platform == "darwin" else "FoundationEssentials"
+
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame var url",
+            substrs=[
+                f"({foundation}.URL?)",
+                "url",
+                'https://www.example.com/path?query#fragment',
+            ],
+        )
+        self.expect(
+            "expression -d run -- url",
+            substrs=[
+                f"({foundation}.URL?)",
+                "https://www.example.com/path?query#fragment",
+            ],
+        )
+
+        self.expect(
+            "frame var relativeURL",
+            substrs=[
+                f"({foundation}.URL?)",
+                "relativeURL",
+                "relative",
+                "--",
+                "https://www.example.com/",
+            ],
+        )
+        self.expect(
+            "expression -d run -- relativeURL",
+            substrs=[
+                f"({foundation}.URL?)",
+                "relative",
+                "--",
+                "https://www.example.com/",
+            ],
+        )
+
+        self.expect(
+            "frame var g_url",
+            substrs=[f"({foundation}.URL)", "g_url", "http://www.apple.com"],
+        )
+        self.expect(
+            "expression -d run -- g_url",
+            substrs=[f"({foundation}.URL)", "http://www.apple.com"],
+        )


### PR DESCRIPTION
This test started failing in CI and my current best theory I can offer is that depending on what underlying storage method the String wrapped in URL is using; LLDB's NSString formatter quotes its summary differently than the Swift.String formatter does.

While the investigation pending, I'm removing that detail from the test, since it's mostly cosmetic anyway.

(cherry picked from commit b75161fdc5b0b762b89eb862a329154f59a2dad2)

 Conflicts:
	lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py