### PR TITLE
Revert "[Thread Analysis] Fix a bug in context update in alias-analysis (#178952) (#12354)"

### DIFF
--- a/clang/lib/Analysis/ThreadSafety.cpp
+++ b/clang/lib/Analysis/ThreadSafety.cpp
@@ -1668,14 +1668,10 @@ class BuildLockset : public ConstStmtVisitor<BuildLockset> {
   FactSet FSet;
   // The fact set for the function on exit.
   const FactSet &FunctionExitFSet;
-  // Use `LVarCtx` to keep track of the context at each program point, which
-  // will be used to translate variables (by `SExprBuilder::translateVariable`)
-  // to their canonical definitions:
   LocalVariableMap::Context LVarCtx;
   unsigned CtxIndex;
 
-  // To update the context used in attr-expr translation.  If `S` is non-null,
-  // the context is updated to the program point right after 'S'.
+  // To update and adjust the context.
   void updateLocalVarMapCtx(const Stmt *S) {
     if (S)
       LVarCtx = Analyzer->LocalVarMap.getNextContext(CtxIndex, S, LVarCtx);
@@ -2213,8 +2209,9 @@ void BuildLockset::VisitUnaryOperator(const UnaryOperator *UO) {
 void BuildLockset::VisitBinaryOperator(const BinaryOperator *BO) {
   if (!BO->isAssignmentOp())
     return;
-  checkAccess(BO->getLHS(), AK_Written);
+
   updateLocalVarMapCtx(BO);
+  checkAccess(BO->getLHS(), AK_Written);
 }
 
 /// Whenever we do an LValue to Rvalue cast, we are reading a variable and
@@ -2259,6 +2256,8 @@ void BuildLockset::examineArguments(const FunctionDecl *FD,
 }
 
 void BuildLockset::VisitCallExpr(const CallExpr *Exp) {
+  updateLocalVarMapCtx(Exp);
+
   if (const auto *CE = dyn_cast<CXXMemberCallExpr>(Exp)) {
     const auto *ME = dyn_cast<MemberExpr>(CE->getCallee());
     // ME can be null when calling a method pointer
@@ -2322,9 +2321,9 @@ void BuildLockset::VisitCallExpr(const CallExpr *Exp) {
   }
 
   auto *D = dyn_cast_or_null<NamedDecl>(Exp->getCalleeDecl());
-  if (D)
-    handleCall(Exp, D);
-  updateLocalVarMapCtx(Exp);
+  if (!D)
+    return;
+  handleCall(Exp, D);
 }
 
 void BuildLockset::VisitCXXConstructExpr(const CXXConstructExpr *Exp) {
@@ -2353,6 +2352,8 @@ static const Expr *UnpackConstruction(const Expr *E) {
 }
 
 void BuildLockset::VisitDeclStmt(const DeclStmt *S) {
+  updateLocalVarMapCtx(S);
+
   for (auto *D : S->getDeclGroup()) {
     if (auto *VD = dyn_cast_or_null<VarDecl>(D)) {
       const Expr *E = VD->getInit();
@@ -2372,7 +2373,6 @@ void BuildLockset::VisitDeclStmt(const DeclStmt *S) {
       }
     }
   }
-  updateLocalVarMapCtx(S);
 }
 
 void BuildLockset::VisitMaterializeTemporaryExpr(

--- a/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
+++ b/clang/test/SemaCXX/warn-thread-safety-analysis.cpp
@@ -7412,32 +7412,7 @@ void testPointerAliasEscapeMultiple(Foo *F) {
     escapeAliasMultiple(&L, &L, &Fp);
     Fp->mu.Unlock(); // expected-warning{{releasing mutex 'Fp->mu' that was not held}}
 } // expected-warning{{mutex 'F->mu' is still held at the end of function}}
-
-void unlockFooWithEscapablePointer(Foo **Fp) EXCLUSIVE_UNLOCK_FUNCTION((*Fp)->mu);
-void testEscapeInvalidationHappensRightAfterTheCall(Foo* F) {
-    Foo* L;
-    L = F;
-    L->mu.Lock();
-    // Release the lock held by 'L' before clearing its definition.
-    unlockFooWithEscapablePointer(&L);
-}
-
-void testEscapeInvalidationHappensRightAfterTheCtorCall(Foo* F) {
-  Foo* L = F;
-  MutexLock ScopeLock(&L->mu);
-
-  struct {
-    int DataMember GUARDED_BY(F->mu);
-  } Data;
-
-  Data.DataMember = 0;
-}
-
-void testCleanUpFunctionWithLocalVarUpdated(Foo* F) {
-  F->mu.Lock();
-  Foo * __attribute__((unused, cleanup(unlockFooWithEscapablePointer))) L = F;
-}
-
+  
 void testPointerAliasTryLock1() {
   Foo *ptr = returnsFoo();
   if (ptr->mu.TryLock()) {


### PR DESCRIPTION
This reverts commit aa0004767a8c4dac969a98750ee7c6856fe2422c.

The reverted fix surfaced conservative behaviors of Wthread-safety which could break our downstream usage.

rdar://171657667