### PR TITLE
[clang-scan-deps][test] Update symlink test to use build session flags

### DIFF
--- a/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
+++ b/clang/test/ClangScanDeps/modules-cas-fs-symlink-dir-from-module.c
@@ -9,6 +9,8 @@
 // RUN: sed -e "s|DIR|%/t|g" %t/cdb.json.in > %t/cdb.json
 // RUN: ln -s module %t/include/symlink-to-module
 
+// RUN: touch %t/session.timestamp
+
 // RUN: clang-scan-deps -cas-path %t/cas -compilation-database %t/cdb.json -j 1 \
 // RUN:   -format experimental-full  -mode=preprocess-dependency-directives \
 // RUN:   -optimize-args=header-search -module-files-dir %t/build > %t/deps.json
@@ -30,7 +32,7 @@
 //--- cdb.json.in
 [{
   "directory": "DIR",
-  "command": "clang -fsyntax-only DIR/test.c -F DIR/Frameworks -I DIR/include -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache",
+  "command": "clang -fsyntax-only DIR/test.c -F DIR/Frameworks -I DIR/include -fmodules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache -fbuild-session-file=DIR/session.timestamp -fmodules-validate-once-per-build-session",
   "file": "DIR/test.c"
 }]
 


### PR DESCRIPTION
This test initially failed when relocation checks were enabled because it depends on reloading PCMs instead of direct search path lookup within a single TU. This test's scenario is the same as the non-cas version, where the workaround is to skip relocation checks within a single build because the intention is to check for relocated modules between build sessions.


resolves: rdar://171553269