### PR TITLE
[lldb] Use MultiMemRead to speed up OperatingSystemSwiftTasks

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -3080,18 +3080,8 @@ MultiReadPointers(Process &process,
     }
   }
 
-  /// TODO: convert this loop into a call to the vectorized memory read, once
-  /// that is available in Process.
-  llvm::SmallVector<std::optional<addr_t>> read_results;
-  for (addr_t pointer : to_read) {
-    Status status;
-    addr_t result = process.ReadPointerFromMemory(pointer, status);
-    if (status.Fail())
-      read_results.push_back(std::nullopt);
-    else
-      read_results.push_back(result);
-  }
-
+  llvm::SmallVector<std::optional<addr_t>> read_results =
+      process.ReadPointersFromMemory(to_read);
   llvm::MutableArrayRef<std::optional<addr_t>> results_ref = read_results;
 
   // Move the results in the slots not filled by errors from the input.

--- a/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
+++ b/lldb/source/Plugins/OperatingSystem/SwiftTasks/OperatingSystemSwiftTasks.cpp
@@ -204,19 +204,9 @@ FindTaskIds(llvm::ArrayRef<std::optional<addr_t>> maybe_task_addrs,
     }
   }
 
-  /// TODO: replace this loop with a vectorized memory read.
-  llvm::SmallVector<std::optional<addr_t>> read_results;
-  for (addr_t task_id_addr : to_read) {
-    Status error;
-    // The Task ID is at offset job_id_offset from the Task pointer.
-    constexpr uint32_t num_bytes_task_id = 4;
-    auto task_id = process.ReadUnsignedIntegerFromMemory(
-        task_id_addr, num_bytes_task_id, LLDB_INVALID_ADDRESS, error);
-    if (error.Fail())
-      read_results.push_back(std::nullopt);
-    else
-      read_results.push_back(task_id);
-  }
+  constexpr uint32_t num_bytes_task_id = 4;
+  llvm::SmallVector<std::optional<addr_t>> read_results =
+      process.ReadUnsignedIntegersFromMemory(to_read, num_bytes_task_id);
 
   // Move the results into the slots not filled by errors from the input.
   llvm::ArrayRef<std::optional<addr_t>> results_ref = read_results;

--- a/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
+++ b/lldb/test/API/lang/swift/async/stepping/step_over/TestSwiftAsyncStepOver.py
@@ -38,3 +38,32 @@ class TestCase(lldbtest.TestBase):
             self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
             self.check_is_in_line(thread, expected_line_num)
             self.check_x_is_available(thread.frames[0])
+
+    @skipIfOutOfTreeDebugserver
+    @swiftTest
+    @skipIf(oslist=["windows", "linux"])
+    def test_efficient_step_over_packets(self):
+        """Test that MultiMemRead is used while stepping"""
+        logfile = os.path.join(self.getBuildDir(), "log.txt")
+        self.runCmd(f"log enable -f {logfile} gdb-remote packets process")
+        self.addTearDownHook(lambda: self.runCmd("log disable gdb-remote packets"))
+
+        self.build()
+
+        source_file = lldb.SBFileSpec("main.swift")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "BREAK HERE", source_file
+        )
+        bkpt.SetEnabled(False) # avoid hitting multiple locations in async breakpoints
+
+        self.runCmd(f"proc plugin packet send StartTesting", check=False)
+        thread.StepOver()
+        self.runCmd(f"proc plugin packet send EndTesting", check=False)
+        stop_reason = thread.GetStopReason()
+        self.assertStopReason(stop_reason, lldb.eStopReasonPlanComplete)
+
+        self.assertTrue(os.path.exists(logfile))
+        log_text = open(logfile).read()
+        log_text = log_text.split("StartTesting", 1)[-1].split("EndTesting", 1)[0]
+        self.assertIn("MultiMemRead:", log_text)
+        self.assertNotIn("MultiMemRead error", log_text)


### PR DESCRIPTION
This concludes the work to remove the extra packets created by OperatingSystemSwiftTasks.

(cherry picked from commit ce39e63f1f0be14fa2f99614f876f5f9b84cfda4) (cherry picked from commit a4f99fbe47f4c7089af1785289d8ac5c0d7d9fe4)