### PR TITLE
[lldb][swift] Add test for entry funclet with user code

### DIFF
--- a/lldb/test/API/lang/swift/async/variables/Makefile
+++ b/lldb/test/API/lang/swift/async/variables/Makefile
@@ -1,3 +1,3 @@
 SWIFT_SOURCES := main.swift
-SWIFTFLAGS_EXTRAS := -parse-as-library
+SWIFTFLAGS_EXTRAS := -parse-as-library -Xfrontend -enable-upcoming-feature -Xfrontend NonisolatedNonsendingByDefault
 include Makefile.rules


### PR DESCRIPTION
This changes an existing test so that the entry funclet is no longer empty. It should not cause any loss of coverage, as that test is never stopping on an entry funclet, and other tests already cover the "normal" funclet cases.

(cherry picked from commit 3e06ac3ffd73f055a17267a98cda65627a5dec1e)