### PR TITLE
[lldb] Remove sdk line from TestSwiftOtherArchDylib

### DIFF
--- a/lldb/test/API/lang/swift/other_arch_dylib/Makefile
+++ b/lldb/test/API/lang/swift/other_arch_dylib/Makefile
@@ -15,7 +15,6 @@ OtherArch.framework/Versions/A/OtherArch: $(SRCDIR)/OtherArch.swift
 		FRAMEWORK=OtherArch \
 		FRAMEWORK_MODULES=OtherArch.swiftinterface \
 		FRAMEWORK_HEADERS=OtherArch.h \
-		SWIFTFLAGS_EXTRAS="-target arm64e-apple-macos15" \
-		SDKROOT=$(shell xcrun --sdk macosx.internal --show-sdk-path)
+		SWIFTFLAGS_EXTRAS="-target arm64e-apple-macos15"
 	rm -f $(BUILDDIR)/OtherArch.swiftmodule $(BUILDDIR)/OtherArch.swiftinterface
 	rm -f OtherArch.o OtherArch.h OtherArch.partial.swiftmodule


### PR DESCRIPTION
(cherry picked from commit 7c32771712d1cf9324b71753aa7cfb301d1267d0)