### PR TITLE
[lldb][swift] Do not show XcodeSDK errors on non apple platforms

### DIFF
--- a/lldb/include/lldb/Target/Platform.h
+++ b/lldb/include/lldb/Target/Platform.h
@@ -27,6 +27,7 @@
 #include "lldb/Utility/FileSpec.h"
 #include "lldb/Utility/StructuredData.h"
 #include "lldb/Utility/Timeout.h"
+#include "lldb/Utility/UnimplementedError.h"
 #include "lldb/Utility/UserIDResolver.h"
 #include "lldb/Utility/XcodeSDK.h"
 #include "lldb/lldb-private-forward.h"
@@ -453,9 +454,7 @@ public:
   ///          (e.g., a public and internal SDK).
   virtual llvm::Expected<std::pair<XcodeSDK, bool>>
   GetSDKPathFromDebugInfo(Module &module) {
-    return llvm::createStringError(
-        llvm::formatv("{0} not implemented for '{1}' platform.",
-                      LLVM_PRETTY_FUNCTION, GetName()));
+    return llvm::make_error<UnimplementedError>();
   }
 
   /// Returns the full path of the most appropriate SDK for the
@@ -478,11 +477,9 @@ public:
   ///
   /// \param[in] unit The CU
   ///
-  /// \returns A parsed XcodeSDK object if successful, an Error otherwise. 
+  /// \returns A parsed XcodeSDK object if successful, an Error otherwise.
   virtual llvm::Expected<XcodeSDK> GetSDKPathFromDebugInfo(CompileUnit &unit) {
-    return llvm::createStringError(
-        llvm::formatv("{0} not implemented for '{1}' platform.",
-                      LLVM_PRETTY_FUNCTION, GetName()));
+    return llvm::make_error<UnimplementedError>();
   }
 
   /// Returns the full path of the most appropriate SDK for the

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -21,6 +21,7 @@
 #include "TypeSystemSwiftTypeRef.h"
 
 #include "lldb/Utility/Log.h"
+#include "lldb/Utility/UnimplementedError.h"
 #include "lldb/lldb-enumerations.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTDemangler.h"
@@ -2276,14 +2277,18 @@ static std::string GetSDKPath(std::string m_description, XcodeSDK sdk) {
 /// Force parsing of the CUs to extract the SDK info.
 static std::string GetSDKPathFromDebugInfo(std::string m_description,
                                            Module &module) {
-#ifdef __APPLE__ // Other platforms do not support XcodeSDK.
   auto platform_sp = Platform::GetHostPlatform();
   if (!platform_sp)
     return {};
   auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(module);
   if (!sdk_or_err) {
-    Debugger::ReportError("Error while parsing SDK path from debug info: " +
-                          toString(sdk_or_err.takeError()));
+    llvm::handleAllErrors(
+        sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
+        [&](const llvm::ErrorInfoBase &error) {
+          Debugger::ReportError(
+              "Error while parsing SDK path from debug info: " +
+              toString(sdk_or_err.takeError()));
+        });
     return {};
   }
 
@@ -2297,9 +2302,6 @@ static std::string GetSDKPathFromDebugInfo(std::string m_description,
         module.GetFileSpec().GetFilename().AsCString("<unknown module>"));
 
   return GetSDKPath(m_description, std::move(sdk));
-#else
-  return {};
-#endif
 }
 
 static std::vector<llvm::StringRef>
@@ -2947,21 +2949,25 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   }
 
   // Get the precise SDK from the symbol context.
-  [[maybe_unused]] std::optional<XcodeSDK> sdk;
-#ifdef __APPLE__  // Other platforms do not support XcodeSDK.
+  std::optional<XcodeSDK> sdk;
   if (cu)
     if (auto platform_sp = Platform::GetHostPlatform()) {
       auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
-      if (!sdk_or_err)
-        Debugger::ReportError("Error while parsing SDK path from debug info: " +
-                              toString(sdk_or_err.takeError()));
-      else {
+      if (!sdk_or_err) {
+        llvm::handleAllErrors(
+            sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
+            [&](const llvm::ErrorInfoBase &error) {
+              Debugger::ReportError(
+                  "Error while parsing SDK path from debug info: " +
+                  toString(sdk_or_err.takeError()));
+            });
+
+      } else {
         sdk = *sdk_or_err;
         LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
                    sdk->GetString().str().c_str());
       }
     }
-#endif
   // Derive the triple next.
 
   // First, prime the compiler with the options from the main executable:

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2286,7 +2286,7 @@ static std::string GetSDKPathFromDebugInfo(std::string m_description,
         sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
         [&](const llvm::ErrorInfoBase &error) {
           Debugger::ReportError(
-              "Error while parsing SDK path from debug info: " +
+              "error while parsing SDK path from debug info: " +
               toString(sdk_or_err.takeError()));
         });
     return {};
@@ -2958,7 +2958,7 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
             sdk_or_err.takeError(), [&](const UnimplementedError &error) {},
             [&](const llvm::ErrorInfoBase &error) {
               Debugger::ReportError(
-                  "Error while parsing SDK path from debug info: " +
+                  "error while parsing SDK path from debug info: " +
                   toString(sdk_or_err.takeError()));
             });
 

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2952,10 +2952,10 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   if (cu)
     if (auto platform_sp = Platform::GetHostPlatform()) {
       auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
-      if (!sdk_or_err) {
+      if (!sdk_or_err)
         Debugger::ReportError("Error while parsing SDK path from debug info: " +
                               toString(sdk_or_err.takeError()));
-      } else {
+      else {
         sdk = *sdk_or_err;
         LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
                    sdk->GetString().str().c_str());

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2276,6 +2276,7 @@ static std::string GetSDKPath(std::string m_description, XcodeSDK sdk) {
 /// Force parsing of the CUs to extract the SDK info.
 static std::string GetSDKPathFromDebugInfo(std::string m_description,
                                            Module &module) {
+#ifdef __APPLE__ // Other platforms do not support XcodeSDK.
   auto platform_sp = Platform::GetHostPlatform();
   if (!platform_sp)
     return {};
@@ -2296,6 +2297,9 @@ static std::string GetSDKPathFromDebugInfo(std::string m_description,
         module.GetFileSpec().GetFilename().AsCString("<unknown module>"));
 
   return GetSDKPath(m_description, std::move(sdk));
+#else
+  return {};
+#endif
 }
 
 static std::vector<llvm::StringRef>
@@ -2943,20 +2947,21 @@ lldb::TypeSystemSP SwiftASTContext::CreateInstance(
   }
 
   // Get the precise SDK from the symbol context.
-  std::optional<XcodeSDK> sdk;
+  [[maybe_unused]] std::optional<XcodeSDK> sdk;
+#ifdef __APPLE__  // Other platforms do not support XcodeSDK.
   if (cu)
     if (auto platform_sp = Platform::GetHostPlatform()) {
       auto sdk_or_err = platform_sp->GetSDKPathFromDebugInfo(*cu);
-      if (!sdk_or_err)
+      if (!sdk_or_err) {
         Debugger::ReportError("Error while parsing SDK path from debug info: " +
                               toString(sdk_or_err.takeError()));
-      else {
+      } else {
         sdk = *sdk_or_err;
         LOG_PRINTF(GetLog(LLDBLog::Types), "Using precise SDK: %s",
                    sdk->GetString().str().c_str());
       }
     }
-
+#endif
   // Derive the triple next.
 
   // First, prime the compiler with the options from the main executable:


### PR DESCRIPTION
The SwiftASTContext always emit an error when it is used from the
debugger. It is not meaningful as it doesn't apply to other
platforms.

(cherry picked from commit https://github.com/swiftlang/llvm-project/commit/f7a6497d043fc095fb0fde8901375a5f13442eba)