### PR TITLE
[analyzer] Fixup #12488 by putting the new diag into a group

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -559,7 +559,8 @@ def err_analyzer_not_built_with_z3 : Error<
   "-DLLVM_ENABLE_Z3_SOLVER=ON">;
 def warn_drv_analyzer_explicitly_enabled_checker_was_renamed : Warning<
   "checker '%0' was renamed to '%1'. Enable the new checker name "
-  "or stop explicitly enabling the old checker name">;
+  "or stop explicitly enabling the old checker name">,
+  InGroup<DiagGroup<"analyzer-configuration">>;
 
 def warn_drv_needs_hvx : Warning<
   "%0 requires HVX, use -mhvx/-mhvx= to enable it">,


### PR DESCRIPTION
fixup! [analyzer] Ignore old spellings of the moved checker (#12488) c61537a3ba41944bcae6691703def6b897e67736

The following test file started failing after the related PR, because
**all** diagnostics should be in some diagnostic group.
However, the diagnostic I added in that PR, was not attached to any group.

Failed: clang/test/Misc/warning-flags.c
Fixes: rdar://171689664