### PR TITLE
Lex,Driver: perform depscanning for PCH builds

### DIFF
--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -59,12 +59,12 @@ TYPE("hlsl",                     HLSL,         PP_CXX,          "hlsl",   phases
 
 // C family input files to precompile.
 TYPE("c-header-cpp-output",      PP_CHeader,   INVALID,         "i",      phases::Precompile)
-TYPE("c-header",                 CHeader,      PP_CHeader,      "h",      phases::Preprocess, phases::Precompile)
+TYPE("c-header",                 CHeader,      PP_CHeader,      "h",      phases::Depscan, phases::Preprocess, phases::Precompile)
 TYPE("cl-header",                CLHeader,     PP_CHeader,      "h",      phases::Preprocess, phases::Precompile)
 TYPE("objective-c-header-cpp-output", PP_ObjCHeader, INVALID,   "mi",     phases::Precompile)
 TYPE("objective-c-header",       ObjCHeader,   PP_ObjCHeader,   "h",      phases::Preprocess, phases::Precompile)
 TYPE("c++-header-cpp-output",    PP_CXXHeader, INVALID,         "ii",     phases::Precompile)
-TYPE("c++-header",               CXXHeader,    PP_CXXHeader,    "hh",     phases::Preprocess, phases::Precompile)
+TYPE("c++-header",               CXXHeader,    PP_CXXHeader,    "hh",     phases::Depscan, phases::Preprocess, phases::Precompile)
 TYPE("c++-header-unit-cpp-output", PP_CXXHeaderUnit,INVALID,    "iih",    phases::Precompile)
 TYPE("c++-header-unit-header",   CXXHUHeader,  PP_CXXHeaderUnit,"hh",     phases::Preprocess, phases::Precompile)
 TYPE("c++-system-header",        CXXSHeader,   PP_CXXHeaderUnit,"hh",     phases::Preprocess, phases::Precompile)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5114,7 +5114,9 @@ Action *Driver::ConstructPhaseAction(
   case phases::IfsMerge:
     llvm_unreachable("ifsmerge action invalid here.");
   case phases::Depscan:
-    return C.MakeAction<DepscanJobAction>(Input, types::TY_ResponseFile);
+    return (Args.getLastArgValue(options::OPT_fdepscan_EQ, "off") == "off")
+        ? Input
+        : C.MakeAction<DepscanJobAction>(Input, types::TY_ResponseFile);
   case phases::Preprocess: {
     types::ID OutputTy;
     // -M and -MM specify the dependency file name by altering the output type,

--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -1018,8 +1018,8 @@ OptionalFileEntryRef Preprocessor::LookupFile(
         BuildSystemModule = getCurrentModule()->IsSystem;
       } else if ((FileEnt = SourceMgr.getFileEntryRefForID(
                       SourceMgr.getMainFileID()))) {
-        auto CWD = FileMgr.getOptionalDirectoryRef(".");
-        Includers.push_back(std::make_pair(*FileEnt, *CWD));
+        if (auto CWD = FileMgr.getOptionalDirectoryRef("."))
+          Includers.push_back(std::make_pair(*FileEnt, *CWD));
       }
     } else {
       Includers.push_back(std::make_pair(*FileEnt, FileEnt->getDir()));

--- a/clang/test/CAS/clang-cache-pch-cl-mode.c
+++ b/clang/test/CAS/clang-cache-pch-cl-mode.c
@@ -1,0 +1,22 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang_cl /Yc%t/cmake_pch.hh /Fp%t/cmake_pch.pch /FI%t/cmake_pch.hh /Fo%t/cmake_pch.cc.obj /Fd%t -Xclang -Rcompile-job-cache -c -- %t/cmake_pch.cc 2>&1 | FileCheck -check-prefix CHECK-CACHE-MISS
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang_cl /Yc%t/cmake_pch.hh /Fp%t/cmake_pch.pch /FI%t/cmake_pch.hh /Fo%t/cmake_pch.cc.obj /Fd%t -Xclang -Rcompile-job-cache -c -- %t/cmake_pch.cc 2>&1 | FileCheck -check-prefix CHECK-CACHE-HIT
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas %clang-cache %clang_cl /Yu%t/cmake_pch.hh /Fp%t/cmake_pch.pch /FI%t/cmake_pch.hh /Fo%t/test.cc.obj /Fd%t -Xclang -Rcompile-job-cache -c -- %t/test.cc 2>&1 | FileCheck -check-prefix CHECK-CACHE-HIT
+
+// CHECK-CACHE-HIT: remark: compile job cache hit
+// CHECK-CACHE-MISS: remark: compile job cache miss
+
+//--- test.cc
+#include "header.h"
+
+//--- header.h
+#pragma once
+
+//--- cmake_pch.cc
+extern int _;
+
+//--- cmake_pch.hh
+#pragma clang system_header
+#include "header.h"


### PR DESCRIPTION
When building with the clang-cl driver, we build PCHs differently, building the headers themselves (/Yc) and then consuming them (/Yu). This exposed a case where we did not feed the content to the depscan phase.

The processing of the header would result in a failure to find the current workding directory as that is removed during the caching mode.

This allows us to build CoreFoundation's PCH with caching, allowing us to use clang-cl driver with clang-cache and enable the CAS for building the toolchain.

Fixes: #12512