### PR TITLE
[clang][deps] Emit CAS-specific diagnostics from the controller

### DIFF
--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -88,14 +88,14 @@ public:
 
   virtual void initializeScanInvocation(CompilerInvocation &ScanInvocation) {}
 
-  virtual llvm::Error initialize(CompilerInstance &ScanInstance,
-                                 CompilerInvocation &NewInvocation) {
-    return llvm::Error::success();
+  virtual bool initialize(CompilerInstance &ScanInstance,
+                          CompilerInvocation &NewInvocation) {
+    return true;
   }
 
-  virtual llvm::Error finalize(CompilerInstance &ScanInstance,
-                               CompilerInvocation &NewInvocation) {
-    return llvm::Error::success();
+  virtual bool finalize(CompilerInstance &ScanInstance,
+                        CompilerInvocation &NewInvocation) {
+    return true;
   }
 
   virtual std::optional<std::string>
@@ -103,19 +103,18 @@ public:
     return std::nullopt;
   }
 
-  virtual llvm::Error
-  initializeModuleBuild(CompilerInstance &ModuleScanInstance) {
-    return llvm::Error::success();
+  virtual bool initializeModuleBuild(CompilerInstance &ModuleScanInstance) {
+    return true;
   }
 
-  virtual llvm::Error
-  finalizeModuleBuild(CompilerInstance &ModuleScanInstance) {
-    return llvm::Error::success();
+  virtual bool finalizeModuleBuild(CompilerInstance &ModuleScanInstance) {
+    return true;
   }
 
-  virtual llvm::Error finalizeModuleInvocation(CowCompilerInvocation &CI,
-                                               const ModuleDeps &MD) {
-    return llvm::Error::success();
+  virtual bool finalizeModuleInvocation(CompilerInstance &ScanInstance,
+                                        CowCompilerInvocation &CI,
+                                        const ModuleDeps &MD) {
+    return true;
   }
 };
 

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -79,38 +79,50 @@ class DependencyActionController {
 public:
   virtual ~DependencyActionController();
 
-  /// Create a thread-safe copy of the controller.
+  /// Creates a thread-safe copy of the controller.
   virtual std::unique_ptr<DependencyActionController> clone() const = 0;
 
-  /// Provide output path for a given module dependency. Must be thread-safe.
+  /// Provides output path for a given module dependency. Must be thread-safe.
   virtual std::string lookupModuleOutput(const ModuleDeps &MD,
                                          ModuleOutputKind Kind) = 0;
 
+  /// Initializes the scan invocation.
   virtual void initializeScanInvocation(CompilerInvocation &ScanInvocation) {}
 
+  /// Initializes the scan instance and modifies the resulting TU invocation.
+  /// Returns true on success, false on failure.
   virtual bool initialize(CompilerInstance &ScanInstance,
                           CompilerInvocation &NewInvocation) {
     return true;
   }
 
+  /// Finalizes the scan instance and modifies the resulting TU invocation.
+  /// Returns true on success, false on failure.
   virtual bool finalize(CompilerInstance &ScanInstance,
                         CompilerInvocation &NewInvocation) {
     return true;
   }
 
+  /// Returns the cache key for the resulting invocation, or nullopt.
   virtual std::optional<std::string>
   getCacheKey(const CompilerInvocation &NewInvocation) {
     return std::nullopt;
   }
 
+  /// Initializes the module scan instance.
+  /// Returns true on success, false on failure.
   virtual bool initializeModuleBuild(CompilerInstance &ModuleScanInstance) {
     return true;
   }
 
+  /// Finalizes the module scan instance.
+  /// Returns true on success, false on failure.
   virtual bool finalizeModuleBuild(CompilerInstance &ModuleScanInstance) {
     return true;
   }
 
+  /// Modifies the resulting module invocation and the associated structure.
+  /// Returns true on success, false on failure.
   virtual bool finalizeModuleInvocation(CompilerInstance &ScanInstance,
                                         CowCompilerInvocation &CI,
                                         const ModuleDeps &MD) {

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/DependencyScanning/DependencyScannerImpl.h"
-#include "clang/Basic/DiagnosticCAS.h"
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/Basic/DiagnosticSerialization.h"
 #include "clang/DependencyScanning/DependencyScanningFilesystem.h"
@@ -388,8 +387,7 @@ public:
       : CI(CI), Controller(Controller) {}
 
   void HandleTranslationUnit(ASTContext &Ctx) override {
-    if (auto E = Controller.finalizeModuleBuild(CI))
-      Ctx.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
+    Controller.finalizeModuleBuild(CI);
   }
 
 private:
@@ -407,10 +405,8 @@ public:
 
 private:
   bool BeginInvocation(CompilerInstance &CI) override {
-    if (auto E = Controller.initializeModuleBuild(CI)) {
-      CI.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
+    if (!Controller.initializeModuleBuild(CI))
       return false;
-    }
     return WrapperFrontendAction::BeginInvocation(CI);
   }
 
@@ -889,11 +885,6 @@ bool DependencyScanningAction::runInvocation(
 
   if (Scanned) {
     CompilerInstance &ScanInstance = *ScanInstanceStorage;
-    auto reportError = [&ScanInstance](Error &&E) -> bool {
-      ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
-          << std::move(E);
-      return false;
-    };
 
     // Scanning runs once for the first -cc1 invocation in a chain of driver
     // jobs. For any dependent jobs, reuse the scanning result and just
@@ -902,8 +893,8 @@ bool DependencyScanningAction::runInvocation(
     if (MDC)
       MDC->applyDiscoveredDependencies(*OriginalInvocation);
 
-    if (Error E = Controller.finalize(ScanInstance, *OriginalInvocation))
-      return reportError(std::move(E));
+    if (!Controller.finalize(ScanInstance, *OriginalInvocation))
+      return false;
 
     std::optional<std::string> CacheKey =
         Controller.getCacheKey(*OriginalInvocation);
@@ -980,14 +971,8 @@ bool DependencyScanningAction::runInvocation(
   if (ScanInstance.getFrontendOpts().ProgramAction == frontend::GeneratePCH)
     ScanInstance.getLangOpts().CompilingPCH = true;
 
-  auto reportError = [&ScanInstance](Error &&E) -> bool {
-    ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
-        << std::move(E);
+  if (!Controller.initialize(ScanInstance, *OriginalInvocation))
     return false;
-  };
-
-  if (Error E = Controller.initialize(ScanInstance, *OriginalInvocation))
-    return reportError(std::move(E));
 
   if (ScanInstance.getDiagnostics().hasErrorOccurred())
     return false;
@@ -998,8 +983,8 @@ bool DependencyScanningAction::runInvocation(
     if (MDC)
       MDC->applyDiscoveredDependencies(*OriginalInvocation);
 
-    if (Error E = Controller.finalize(ScanInstance, *OriginalInvocation))
-      return reportError(std::move(E));
+    if (!Controller.finalize(ScanInstance, *OriginalInvocation))
+      return false;
 
     // Forward any CAS results to consumer.
     std::string ID = OriginalInvocation->getFrontendOpts().CASIncludeTreeID;

--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -8,6 +8,7 @@
 
 #include "clang/APINotes/APINotesManager.h"
 #include "clang/APINotes/APINotesReader.h"
+#include "clang/Basic/DiagnosticCAS.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/DependencyScanning/CachingActions.h"
 #include "clang/DependencyScanning/ScanAndUpdateArgs.h"
@@ -37,17 +38,18 @@ private:
   std::unique_ptr<DependencyActionController> clone() const override;
 
   void initializeScanInvocation(CompilerInvocation &ScanInvocation) override;
-  Error initialize(CompilerInstance &ScanInstance,
-                   CompilerInvocation &NewInvocation) override;
-  Error finalize(CompilerInstance &ScanInstance,
-                 CompilerInvocation &NewInvocation) override;
+  bool initialize(CompilerInstance &ScanInstance,
+                  CompilerInvocation &NewInvocation) override;
+  bool finalize(CompilerInstance &ScanInstance,
+                CompilerInvocation &NewInvocation) override;
   std::optional<std::string>
   getCacheKey(const CompilerInvocation &NewInvocation) override;
 
-  Error initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  Error finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
-  Error finalizeModuleInvocation(CowCompilerInvocation &CI,
-                                 const ModuleDeps &MD) override;
+  bool initializeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  bool finalizeModuleBuild(CompilerInstance &ModuleScanInstance) override;
+  bool finalizeModuleInvocation(CompilerInstance &ScanInstance,
+                                CowCompilerInvocation &CI,
+                                const ModuleDeps &MD) override;
 
 private:
   IncludeTreeBuilder &current() {
@@ -315,7 +317,7 @@ void IncludeTreeActionController::initializeScanInvocation(
   ScanInvocation.getCASOpts() = CASOpts;
 }
 
-Error IncludeTreeActionController::initialize(
+bool IncludeTreeActionController::initialize(
     CompilerInstance &ScanInstance, CompilerInvocation &NewInvocation) {
   DepscanPrefixMapping::configurePrefixMapper(NewInvocation, PrefixMapper);
 
@@ -352,11 +354,11 @@ Error IncludeTreeActionController::initialize(
       });
   ScanInstance.addDependencyCollector(std::move(DC));
 
-  return Error::success();
+  return true;
 }
 
-Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
-                                            CompilerInvocation &NewInvocation) {
+bool IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
+                                           CompilerInvocation &NewInvocation) {
   auto GetInputCacheKey = [&]() -> std::optional<StringRef> {
     if (NewInvocation.getFrontendOpts().Inputs.size() != 1)
       return {};
@@ -381,8 +383,11 @@ Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
     auto Builder = BuilderStack.pop_back_val();
     Error E = Builder->finishIncludeTree(ScanInstance, NewInvocation)
                   .moveInto(IncludeTreeResult);
-    if (E)
-      return E;
+    if (E) {
+      ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
+          << std::move(E);
+      return false;
+    }
     InputID = IncludeTreeResult->getID().toString();
     InputKind = CachingInputKind::IncludeTree;
   }
@@ -400,7 +405,7 @@ Error IncludeTreeActionController::finalize(CompilerInstance &ScanInstance,
   if (Key)
     OutputToCacheKey[NewInvocation.getFrontendOpts().OutputFile] =
         Key->toString();
-  return Error::success();
+  return true;
 }
 
 std::optional<std::string> IncludeTreeActionController::getCacheKey(
@@ -412,7 +417,7 @@ std::optional<std::string> IncludeTreeActionController::getCacheKey(
   return It->second;
 }
 
-Error IncludeTreeActionController::initializeModuleBuild(
+bool IncludeTreeActionController::initializeModuleBuild(
     CompilerInstance &ModuleScanInstance) {
   BuilderStack.push_back(
       std::make_unique<IncludeTreeBuilder>(DB, PrefixMapper));
@@ -429,10 +434,10 @@ Error IncludeTreeActionController::initializeModuleBuild(
   ModuleScanInstance.addDependencyCollector(std::move(DC));
   ModuleScanInstance.setPrefixMapper(PrefixMapper);
 
-  return Error::success();
+  return true;
 }
 
-Error IncludeTreeActionController::finalizeModuleBuild(
+bool IncludeTreeActionController::finalizeModuleBuild(
     CompilerInstance &ModuleScanInstance) {
   // FIXME: the scan invocation is incorrect here; we need the `NewInvocation`
   // from `finalizeModuleInvocation` to finish the tree.
@@ -446,25 +451,31 @@ Error IncludeTreeActionController::finalizeModuleBuild(
   // inconsistent since there is no guarantee that exitedInclude or
   // finalizeModuleBuild have been called for all imports.
   if (ModuleScanInstance.getDiagnostics().hasUnrecoverableErrorOccurred())
-    return Error::success(); // Already reported.
+    return true; // Already reported.
 
   auto Tree = Builder->finishIncludeTree(ModuleScanInstance,
                                          ModuleScanInstance.getInvocation());
-  if (!Tree)
-    return Tree.takeError();
+  if (Error E = Tree.takeError()) {
+    ModuleScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
+        << std::move(E);
+    return false;
+  }
 
   ModuleScanInstance.getPreprocessor().setCASIncludeTreeID(
       Tree->getID().toString());
 
-  return Error::success();
+  return true;
 }
 
-Error IncludeTreeActionController::finalizeModuleInvocation(
-    CowCompilerInvocation &CowCI, const ModuleDeps &MD) {
-  if (!MD.IncludeTreeID)
-    return llvm::createStringError(llvm::inconvertibleErrorCode(),
-                                   "missing include-tree for module '%s'",
-                                   MD.ID.ModuleName.c_str());
+bool IncludeTreeActionController::finalizeModuleInvocation(
+    CompilerInstance &ScanInstance, CowCompilerInvocation &CowCI,
+    const ModuleDeps &MD) {
+  if (!MD.IncludeTreeID) {
+    ScanInstance.getDiagnostics().Report(diag::err_cas_depscan_failed)
+        << llvm::format("missing include-tree for module '%s'",
+                        MD.ID.ModuleName.c_str());
+    return false;
+  }
 
   // TODO: Avoid this copy.
   CompilerInvocation CI(CowCI);
@@ -476,7 +487,7 @@ Error IncludeTreeActionController::finalizeModuleInvocation(
   DepscanPrefixMapping::remapInvocationPaths(CI, PrefixMapper);
 
   CowCI = CI;
-  return Error::success();
+  return true;
 }
 
 void IncludeTreeBuilder::enteredInclude(Preprocessor &PP, FileID FID) {

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -8,7 +8,6 @@
 
 #include "clang/DependencyScanning/ModuleDepCollector.h"
 
-#include "clang/Basic/DiagnosticCAS.h"
 #include "clang/Basic/MakeSupport.h"
 #include "clang/DependencyScanning/DependencyScanningWorker.h"
 #include "clang/Frontend/CompileJobCacheKey.h"
@@ -875,14 +874,12 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
             }
           });
 
-  auto &Diags = MDC.ScanInstance.getDiagnostics();
-
-  if (auto E = MDC.Controller.finalizeModuleInvocation(CI, MD))
-    Diags.Report(diag::err_cas_depscan_failed) << std::move(E);
+  MDC.Controller.finalizeModuleInvocation(MDC.ScanInstance, CI, MD);
 
   // Compute the cache key, if needed. Requires dependencies.
   if (MDC.ScanInstance.getFrontendOpts().CacheCompileJob) {
     auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
+    auto &Diags = MDC.ScanInstance.getDiagnostics();
     if (auto Key = createCompileJobCacheKey(CAS, Diags, CI))
       MD.ModuleCacheKey = Key->toString();
   }
@@ -904,6 +901,7 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
   // Verify the key has not changed with final arguments.
   if (MD.ModuleCacheKey) {
     auto &CAS = MDC.ScanInstance.getOrCreateObjectStore();
+    auto &Diags = MDC.ScanInstance.getDiagnostics();
     auto Key = createCompileJobCacheKey(CAS, Diags, CI);
     assert(Key);
     checkCompileCacheKeyMatch(CAS, *MD.ModuleCacheKey, *Key);

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -8,7 +8,6 @@
 
 #include "clang/Tooling/DependencyScanningTool.h"
 #include "clang/Basic/Diagnostic.h"
-#include "clang/Basic/DiagnosticCAS.h"
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/CAS/IncludeTree.h"
 #include "clang/DependencyScanning/CachingActions.h"
@@ -638,11 +637,8 @@ bool CompilerInstanceWithContext::computeDependencies(
       *OriginalInvocation, Controller, PrebuiltModuleASTMap, StableDirs, false);
 
   CompilerInvocation ModuleInvocation(*OriginalInvocation);
-  if (Error E = Controller.initialize(CI, ModuleInvocation)) {
-    CI.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
-    llvm::consumeError(std::move(E));
+  if (!Controller.initialize(CI, ModuleInvocation))
     return false;
-  }
 
   if (!SrcLocOffset) {
     // When SrcLocOffset is zero, we are at the beginning of the fake source
@@ -704,11 +700,8 @@ bool CompilerInstanceWithContext::computeDependencies(
 
   MDC->applyDiscoveredDependencies(ModuleInvocation);
 
-  if (Error E = Controller.finalize(CI, ModuleInvocation)) {
-    CI.getDiagnostics().Report(diag::err_cas_depscan_failed) << std::move(E);
-    llvm::consumeError(std::move(E));
+  if (!Controller.finalize(CI, ModuleInvocation))
     return false;
-  }
 
   std::string ID = ModuleInvocation.getFrontendOpts().CASIncludeTreeID;
   if (!ID.empty())


### PR DESCRIPTION
The downstream diff in the dependency scanner is getting quite difficult to manage again. I decided to alleviate that by upstreaming the missing `DependencyActionController` APIs, but found out that the scanner assumes any failures in the controller are CAS-related by using the `err_cas_depscan_failed` diagnostic kind. This does not exist upstream, I don't want to add it right now, and I don't want to increase the complexity further by adding new `DependencyActionController` API that would communicate the diagnostic kind to the rest of the dependency scanner.

So instead, I sunk the diagnostic emission into the controller itself. This makes upstreaming much easier.