### PR TITLE
[lldb][Darwin] Don't try to insert breakpoint on corefiles (#184749)

### DIFF
--- a/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
+++ b/lldb/source/Plugins/DynamicLoader/Darwin-Kernel/DynamicLoaderDarwinKernel.cpp
@@ -1547,7 +1547,8 @@ void DynamicLoaderDarwinKernel::PrivateInitialize(Process *process) {
 }
 
 void DynamicLoaderDarwinKernel::SetNotificationBreakpointIfNeeded() {
-  if (m_break_id == LLDB_INVALID_BREAK_ID && m_kernel.GetModule()) {
+  if (m_break_id == LLDB_INVALID_BREAK_ID && m_kernel.GetModule() &&
+      m_process->IsLiveDebugSession()) {
     DEBUG_PRINTF("DynamicLoaderDarwinKernel::%s() process state = %s\n",
                  __FUNCTION__, StateAsCString(m_process->GetState()));
 


### PR DESCRIPTION
lldb is printing an error that the kext-loaded notification breakpoint can't be set when debugging a kernel corefile. The breakpoint only needs to be inserted in live debug sessions.

rdar://170813438
(cherry picked from commit c9555f6675471ddff5e158ba3f65f8a5a09dd97e)