### PR TITLE
[lldb][NFC] fix formatting

### DIFF
--- a/lldb/source/Expression/REPL.cpp
+++ b/lldb/source/Expression/REPL.cpp
@@ -357,7 +357,7 @@ void REPL::IOHandlerInputComplete(IOHandler &io_handler, std::string &code) {
       if (!persistent_state)
       {
         error_stream_sp->Lock().PutCString("error getting the expression "
-                             "context for the REPL.\n");
+                                           "context for the REPL.\n");
         io_handler.SetIsDone(true);
         return;
       }


### PR DESCRIPTION
This is a follow up to 205e6dce73fb0d719fb317807c41cf30a23ccad0 to fix a code formatting issue during merge conflict resolution.