### PR TITLE
[lldb][swift] Introduce task tree command

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -426,6 +426,7 @@ public:
       return llvm::createStringError(*error);
 
     AsyncTaskInfo result;
+    result.taskAddr = AsyncTaskPtr;
     result.isChildTask = task_info.IsChildTask;
     result.isFuture = task_info.IsFuture;
     result.isGroupChildTask = task_info.IsGroupChildTask;
@@ -443,8 +444,13 @@ public:
     result.enqueuePriority = task_info.EnqueuePriority;
     result.resumeAsyncContext = task_info.ResumeAsyncContext;
     result.runJob = task_info.RunJob;
+    result.parentTask = task_info.ParentTask;
     for (auto child : task_info.ChildTasks)
       result.childTasks.push_back(child);
+    for (auto waiting : task_info.WaitingTasks)
+      result.waitingTasks.push_back(waiting);
+    for (auto pc : task_info.AsyncBacktraceFrames)
+      result.asyncBacktracePcs.push_back(pc);
     return result;
   }
 

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -159,6 +159,7 @@ public:
   virtual std::optional<swift::remote::RemoteExistential>
   ReadMetadataAndValueOpaqueExistential(lldb::addr_t existential_address) = 0;
   struct AsyncTaskInfo {
+    lldb::addr_t taskAddr = 0;
     bool isChildTask = false;
     bool isFuture = false;
     bool isGroupChildTask = false;
@@ -177,7 +178,10 @@ public:
     uint32_t enqueuePriority = 0;
     lldb::addr_t resumeAsyncContext = LLDB_INVALID_ADDRESS;
     lldb::addr_t runJob = LLDB_INVALID_ADDRESS;
+    lldb::addr_t parentTask = 0; // Use the same default as RemoteInspection.
     std::vector<lldb::addr_t> childTasks;
+    std::vector<lldb::addr_t> waitingTasks;
+    std::vector<lldb::addr_t> asyncBacktracePcs;
   };
   // The default limits are copied from swift-inspect.
   virtual llvm::Expected<AsyncTaskInfo>

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.cpp
@@ -2278,6 +2278,283 @@ protected:
   }
 };
 
+namespace {
+using TaskInfo = ReflectionContextInterface::AsyncTaskInfo;
+
+/// Finds the Thread that is currently running a task, otherwise creates a
+/// ThreadTask for it.
+static ThreadSP FindThreadForTask(ExecutionContext &exe_ctx,
+                                  const TaskInfo &task_info) {
+  // For running tasks, TaskInfo won't have frame information, but LLDB should.
+  if (task_info.isRunning) {
+    // See OperatingSystemSwiftTasks for how these are created.
+    constexpr uint64_t TASK_MASK = 0x0000000f00000000ULL;
+    uint64_t tid = task_info.id | TASK_MASK;
+
+    auto &thread_list = exe_ctx.GetProcessRef().GetThreadList();
+    if (ThreadSP thread = thread_list.FindThreadByID(tid, /*can_update=*/false))
+      return thread;
+  }
+
+  // There should always be frame information for Tasks that are not running. If
+  // not, fallback to runJob.
+  lldb::addr_t frame_zero_pc = task_info.asyncBacktracePcs.empty()
+                                   ? task_info.runJob
+                                   : task_info.asyncBacktracePcs[0];
+
+  return std::make_shared<ThreadTask>(
+      task_info.id, task_info.resumeAsyncContext, frame_zero_pc, exe_ctx);
+}
+
+/// Prints all the frames in the backtrace of the task represented by task_info.
+static void PrintFramesForTask(ExecutionContext &exe_ctx,
+                               const TaskInfo &task_info, Stream &str,
+                               uint64_t max_frames,
+                               llvm::StringRef frame_prefix) {
+  if (max_frames == 0)
+    return;
+
+  auto thread = FindThreadForTask(exe_ctx, task_info);
+  auto frame_list = thread ? thread->GetStackFrameList() : nullptr;
+  const uint64_t num_frames_available =
+      frame_list ? frame_list->GetNumFrames() : 0;
+  if (num_frames_available == 0)
+    return;
+
+  uint64_t frames_printed = 0;
+  for (uint64_t idx : llvm::seq(num_frames_available)) {
+    auto frame = thread->GetStackFrameAtIndex(idx);
+    if (!frame || frame->IsHidden())
+      continue;
+    str << frame_prefix;
+    str.Printf("frame #%u: ", frame->GetFrameIndex());
+    SymbolContext sc = frame->GetSymbolContext(eSymbolContextEverything);
+    sc.DumpStopContext(&str, exe_ctx.GetBestExecutionContextScope(),
+                       frame->GetFrameCodeAddress(),
+                       /*show_fullpaths=*/false,
+                       /*show_module=*/false, /*show_inlined_frames=*/true,
+                       /*show_function_arguments=*/true,
+                       /*show_function_name=*/true,
+                       /*show_function_display_name=*/true);
+    str << "\n";
+    frames_printed++;
+    if (frames_printed >= max_frames)
+      break;
+  }
+}
+
+/// A helper class to find Tasks in the swift program. It implements the
+/// algorithm described in g_task_list_tree_common_text.
+class TaskExplorer {
+public:
+  TaskExplorer(ReflectionContextInterface &reflection_ctx, Process &process)
+      : m_reflection_ctx(reflection_ctx) {
+    TaskInspector task_inspector;
+
+    for (const ThreadSP &thread : process.GetThreadList().Threads()) {
+      if (!thread)
+        continue;
+      std::optional<lldb::addr_t> maybe_task_addr =
+          task_inspector.GetTaskAddrFromThreadLocalStorage(*thread);
+      if (!maybe_task_addr)
+        continue;
+      int32_t max_nodes = 1000;
+      ExploreTask(*maybe_task_addr, max_nodes);
+    }
+  }
+
+  /// Returns a range containing all root Tasks discovered.
+  auto GetRootTasks() const {
+    auto filtered =
+        llvm::make_filter_range(llvm::make_second_range(m_known_tasks),
+                                [](const std::optional<TaskInfo> &info) {
+                                  return info && info->parentTask == 0;
+                                });
+    return llvm::map_range(filtered, [](auto &maybe_info) -> const TaskInfo & {
+      return *maybe_info;
+    });
+  }
+
+  /// Returns a range containing all Tasks discovered.
+  auto GetAllTasks() const {
+    auto filtered = llvm::make_filter_range(
+        llvm::make_second_range(m_known_tasks),
+        [](const std::optional<TaskInfo> &info) { return info.has_value(); });
+    return llvm::map_range(filtered, [](auto &maybe_info) -> const TaskInfo & {
+      return *maybe_info;
+    });
+  }
+
+  /// Returns the TaskInfo for the task in `task_addr`, if it exists.
+  const std::optional<TaskInfo> &FindTask(addr_t task_addr) {
+    int32_t max_nodes = 1000;
+    ExploreTask(task_addr, max_nodes);
+    auto it = m_known_tasks.find(task_addr);
+    assert(it != m_known_tasks.end());
+    return it->second;
+  }
+
+  /// Returns the TaskInfo of the task that `task_addr` is waiting on, if any.
+  const TaskInfo *GetDependency(addr_t task_addr) const {
+    auto it = m_blocked_by.find(task_addr);
+    return it != m_blocked_by.end() ? it->second : nullptr;
+  }
+
+private:
+  ReflectionContextInterface &m_reflection_ctx;
+  std::map<addr_t, std::optional<TaskInfo>> m_known_tasks;
+  /// Maps a task address to the TaskInfo it is waiting on. The pointers are
+  /// into m_known_tasks values, which is safe because std::map guarantees
+  /// pointer stability on insertion.
+  llvm::DenseMap<addr_t, TaskInfo *> m_blocked_by;
+
+  // Finds all Tasks reachable from the Task represented by `task_addr`.
+  // This follows child pointers, parent pointers, "waited by" pointers.
+  void ExploreTask(addr_t task_addr, int32_t &max_nodes) {
+    if (m_known_tasks.count(task_addr))
+      return;
+    if (--max_nodes <= 0) {
+      m_known_tasks.emplace(task_addr, std::nullopt);
+      return;
+    }
+
+    llvm::Expected<TaskInfo> task_info =
+        m_reflection_ctx.asyncTaskInfo(task_addr);
+    if (!task_info) {
+      llvm::consumeError(task_info.takeError());
+      m_known_tasks.emplace(task_addr, std::nullopt);
+      return;
+    }
+    if (task_info->id == 0) {
+      m_known_tasks.emplace(task_addr, std::nullopt);
+      return;
+    }
+
+    auto [it, _] = m_known_tasks.emplace(task_addr, std::move(*task_info));
+
+    for (addr_t child_addr : it->second->childTasks)
+      ExploreTask(child_addr, max_nodes);
+    if (it->second->parentTask != 0)
+      ExploreTask(it->second->parentTask, max_nodes);
+    for (addr_t waited_by_task_addr : it->second->waitingTasks) {
+      m_blocked_by.try_emplace(waited_by_task_addr, &*it->second);
+      ExploreTask(waited_by_task_addr, max_nodes);
+    }
+  }
+};
+
+/// Prints the symbols that make the output of task tree look like a tree of
+/// connected Tasks.
+static void PrintTaskTreePrefix(Stream &stream, StringRef prefix,
+                                bool is_last) {
+  static const bool supports_unicode = Terminal::SupportsUnicode();
+  if (supports_unicode)
+    stream << prefix << (is_last ? "└╴ " : "├╴ ");
+  else
+    stream << prefix << "|-";
+}
+
+/// Computes the prefixes to be used when printing one level deeper in the
+/// Parent-Child tree.
+static std::pair<std::string, std::string>
+ComputeNestedPrefixes(StringRef current_prefix, bool is_last,
+                      bool has_children) {
+  static const bool supports_unicode = Terminal::SupportsUnicode();
+
+  std::string child_prefix = [&] {
+    if (is_last)
+      return (current_prefix + "   ").str();
+    if (supports_unicode)
+      return (current_prefix + "│  ").str();
+    return (current_prefix + "|  ").str();
+  }();
+
+  std::string frame_prefix = [&] {
+    if (!has_children)
+      return child_prefix + "  ";
+    if (supports_unicode)
+      return child_prefix + "│ ";
+    return child_prefix + "| ";
+  }();
+  return {child_prefix, frame_prefix};
+}
+
+/// Prints a Task in the case where no TaskInfo was found.
+static void PrintNoInfoTaskTree(addr_t task_addr, Stream &stream,
+                                llvm::StringRef prefix, bool is_last) {
+  PrintTaskTreePrefix(stream, prefix, is_last);
+  stream << llvm::formatv("Task @ addr = {0:x}: no information available\n",
+                          task_addr)
+                .str();
+}
+
+/// Returns " ('<task_name>')" if the task has a name, otherwise "".
+static std::string getFormattedTaskNameIfAny(addr_t task_addr,
+                                             Process &process) {
+  if (auto name = GetTaskName(task_addr, process)) {
+    if (name->has_value())
+      return llvm::formatv(" ('{0}')", **name);
+  } else
+    llvm::consumeError(name.takeError());
+  return "";
+}
+
+// Prints basic information a task to stream, like its ID, name (if any),
+// address, whether it is running, etc.
+static void PrintTaskInfo(Stream &stream, const TaskInfo &task_info,
+                          TaskExplorer &task_explorer, Process &process) {
+  const std::string task_name =
+      getFormattedTaskNameIfAny(task_info.taskAddr, process);
+
+  stream << llvm::formatv("Task {0}{1}, addr = {2:x}", task_info.id, task_name,
+                          task_info.taskAddr)
+                .str();
+  if (const TaskInfo *dep = task_explorer.GetDependency(task_info.taskAddr))
+    stream << llvm::formatv(" [awaiting Task {0}]", dep->id).str();
+  if (task_info.isRunning)
+    stream << " [running]";
+  if (task_info.isEnqueued)
+    stream << " [enqueued]";
+  if (task_info.isSuspended)
+    stream << " [suspended]";
+}
+
+/// Prints the tree of all tasks rooted at the task represented by `task_addr`.
+static void PrintTaskTree(const TaskInfo &task_info, Stream &stream,
+                          ExecutionContext &exe_ctx,
+                          TaskExplorer &task_explorer, int64_t &max_nodes,
+                          uint64_t max_frames, llvm::StringRef prefix,
+                          bool is_last) {
+  if (task_info.isComplete)
+    return;
+
+  // Guard against corrupted data.
+  max_nodes--;
+  if (max_nodes <= 0) {
+    stream << "... output truncated ...\n";
+    return;
+  }
+
+  PrintTaskTreePrefix(stream, prefix, is_last);
+  PrintTaskInfo(stream, task_info, task_explorer, exe_ctx.GetProcessRef());
+  stream.EOL();
+
+  auto [child_prefix, frame_prefix] =
+      ComputeNestedPrefixes(prefix, is_last, task_info.childTasks.size() > 0);
+
+  PrintFramesForTask(exe_ctx, task_info, stream, max_frames, frame_prefix);
+  for (auto [idx, child_addr] : llvm::enumerate(task_info.childTasks)) {
+    const bool is_last = idx == task_info.childTasks.size() - 1;
+    if (const std::optional<TaskInfo> &child_info =
+            task_explorer.FindTask(child_addr))
+      PrintTaskTree(*child_info, stream, exe_ctx, task_explorer, max_nodes,
+                    max_frames, child_prefix, is_last);
+    else
+      PrintNoInfoTaskTree(child_addr, stream, child_prefix, is_last);
+  }
+}
+} // namespace
+
 /// Construct a `ThreadTask` instance for a live (yet to be completed) Task
 /// variable contained in the first argument.
 static llvm::Expected<ThreadSP>
@@ -2400,6 +2677,192 @@ private:
   }
 };
 
+static const char g_task_list_tree_common_text[] = R"(
+1. Running on a thread.
+2. A parent or a child of a task from 1,
+3. Waiting on a tasks from 1 or 2.
+
+This process is repeated recursively until no new Tasks are found.
+
+This command fails to discover some tasks created through unstructured concurrency.
+Specifically, consider some such Task T that does not have a parent Task. Task T will not
+be discovered if all of the below are true:
+
+* T is not running on a thread.
+* No descendant of T is running on a thread.
+* Neither T nor a descendant of T is waiting on a Task discovered in steps 1, 2 and 3.
+
+As a corollary, no descendant of T will be discovered either.
+)";
+
+class CommandObjectLanguageSwiftTaskList final : public CommandObjectParsed {
+public:
+  CommandObjectLanguageSwiftTaskList(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "list",
+                            "List all discovered Swift Tasks.",
+                            "language swift task list") {
+    SetHelpLong("Lists all Swift Tasks that are either: " +
+                std::string(g_task_list_tree_common_text));
+  }
+
+private:
+  void DoExecute(Args &command, CommandReturnObject &result) override {
+    if (m_exe_ctx.GetProcessPtr() == nullptr) {
+      result.AppendError("must be run from a running process");
+      return;
+    }
+
+    auto *runtime = SwiftLanguageRuntime::Get(m_exe_ctx.GetProcessSP());
+    if (!runtime) {
+      result.AppendError("Failed to find Swift Language runtime");
+      return;
+    }
+
+    auto reflection_ctx = runtime->GetReflectionContext();
+    if (!reflection_ctx) {
+      result.AppendError("Failed to get a Swift reflection context");
+      return;
+    }
+
+    TaskExplorer task_explorer(**reflection_ctx, m_exe_ctx.GetProcessRef());
+
+    // Make a copy so we can sort by Task id.
+    llvm::SmallVector<TaskInfo> all_tasks(task_explorer.GetAllTasks());
+    llvm::sort(all_tasks,
+               [](const auto &t1, const auto &t2) { return t1.id < t2.id; });
+
+    Stream &strm = result.GetOutputStream();
+    for (const TaskInfo &task_info : all_tasks) {
+      if (task_info.isComplete)
+        continue;
+
+      ThreadSP thread = FindThreadForTask(m_exe_ctx, task_info);
+      if (!thread)
+        continue;
+
+      PrintTaskInfo(strm, task_info, task_explorer, m_exe_ctx.GetProcessRef());
+
+      StackFrameSP frame = thread->GetStackFrameAtIndex(0);
+      if (!frame) {
+        strm.EOL();
+        continue;
+      }
+
+      SymbolContext sc = frame->GetSymbolContext(eSymbolContextEverything);
+      strm << ", ";
+      sc.DumpStopContext(&strm, m_exe_ctx.GetBestExecutionContextScope(),
+                         frame->GetFrameCodeAddress(),
+                         /*show_fullpaths=*/false,
+                         /*show_module=*/true, /*show_inlined_frames=*/true,
+                         /*show_function_arguments=*/true,
+                         /*show_function_name=*/true,
+                         /*show_function_display_name=*/true);
+      strm.EOL();
+    }
+
+    result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
+  }
+};
+
+static OptionDefinition g_task_tree_options[] = {
+    // clang-format off
+  {LLDB_OPT_SET_1, false, "max-frames", 'f', OptionParser::eRequiredArgument, nullptr, {}, 1, eArgTypeCount, "Maximum number of stack frames to show per task."},
+    // clang-format on
+};
+
+class CommandObjectLanguageSwiftTaskTree final : public CommandObjectParsed {
+public:
+  CommandObjectLanguageSwiftTaskTree(CommandInterpreter &interpreter)
+      : CommandObjectParsed(interpreter, "tree",
+                            "Prints the Parent-Child task trees of Tasks.",
+                            "language swift task tree [--max-frames <count>]"),
+        m_options() {
+    SetHelpLong("Prints all Parent-Child task trees (possibly a forest) of "
+                "Swift Tasks that are either: " +
+                std::string(g_task_list_tree_common_text));
+  }
+
+  Options *GetOptions() override { return &m_options; }
+
+private:
+  void DoExecute(Args &command, CommandReturnObject &result) override {
+    if (m_exe_ctx.GetProcessPtr() == nullptr) {
+      result.AppendError("must be run from a running process");
+      return;
+    }
+
+    auto *runtime = SwiftLanguageRuntime::Get(m_exe_ctx.GetProcessSP());
+    if (!runtime) {
+      result.AppendError("Failed to find Swift Language runtime");
+      return;
+    }
+
+    auto reflection_ctx = runtime->GetReflectionContext();
+    if (!reflection_ctx) {
+      result.AppendError("Failed to get a Swift reflection context");
+      return;
+    }
+
+    TaskExplorer task_explorer(**reflection_ctx, m_exe_ctx.GetProcessRef());
+
+    // Make a copy of the TaskInfos so that the range may be sorted by Task id.
+    llvm::SmallVector<TaskInfo> root_tasks(task_explorer.GetRootTasks());
+    llvm::sort(root_tasks,
+               [](const auto &t1, const auto &t2) { return t1.id < t2.id; });
+
+    int64_t max_nodes = 10000;
+    for (auto [idx, task_info] : llvm::enumerate(root_tasks))
+      PrintTaskTree(task_info, result.GetOutputStream(), m_exe_ctx,
+                    task_explorer, max_nodes, m_options.m_max_frames,
+                    /*prefix=*/"", idx == root_tasks.size() - 1);
+
+    result.SetStatus(lldb::eReturnStatusSuccessFinishResult);
+  }
+
+  class CommandOptions : public Options {
+  public:
+    CommandOptions() : Options() { OptionParsingStarting(nullptr); }
+
+    ~CommandOptions() override = default;
+
+    Status SetOptionValue(uint32_t option_idx, llvm::StringRef option_arg,
+                          ExecutionContext *execution_context) override {
+      Status error;
+      const int short_option = m_getopt_table[option_idx].val;
+      switch (short_option) {
+      case 'f': {
+        uint64_t count;
+        if (option_arg.getAsInteger(0, count)) {
+          error = Status::FromErrorStringWithFormat(
+              "invalid integer value for option '%c': %s", short_option,
+              option_arg.data());
+        } else {
+          m_max_frames = count;
+        }
+        break;
+      }
+      default:
+        error = Status::FromErrorStringWithFormat(
+            "invalid short option character '%c'", short_option);
+        break;
+      }
+      return error;
+    }
+
+    void OptionParsingStarting(ExecutionContext *execution_context) override {
+      m_max_frames = 8;
+    }
+
+    llvm::ArrayRef<OptionDefinition> GetDefinitions() override {
+      return llvm::ArrayRef(g_task_tree_options);
+    }
+
+    uint64_t m_max_frames = 8;
+  };
+
+  CommandOptions m_options;
+};
+
 class CommandObjectLanguageSwiftTaskInfo final : public CommandObjectParsed {
 public:
   CommandObjectLanguageSwiftTaskInfo(CommandInterpreter &interpreter)
@@ -2492,6 +2955,12 @@ public:
     LoadSubCommand(
         "info",
         CommandObjectSP(new CommandObjectLanguageSwiftTaskInfo(interpreter)));
+    LoadSubCommand(
+        "list",
+        CommandObjectSP(new CommandObjectLanguageSwiftTaskList(interpreter)));
+    LoadSubCommand(
+        "tree",
+        CommandObjectSP(new CommandObjectLanguageSwiftTaskTree(interpreter)));
   }
 };
 

--- a/lldb/test/API/lang/swift/async/tasks/list/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/list/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/list/TestSwiftTaskList.py
+++ b/lldb/test/API/lang/swift/async/tasks/list/TestSwiftTaskList.py
@@ -1,0 +1,38 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import TestBase
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestCase(TestBase):
+
+    @skipUnlessPlatform(["macosx"])
+    @swiftTest
+    def test_task_list(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("language swift task list")
+
+        # Expected output (4 tasks, sorted by id):
+        #   Task 1, addr = 0x... [awaiting Task 2] [suspended], ... Task<>() at Task.swift
+        #   Task 2 'factorial-main', addr = 0x... [awaiting Task 3] [suspended], ... factorial ... at main.swift:7
+        #   Task 3, addr = 0x..., ... factorial ... at main.swift:7
+        #   Task 4, addr = 0x... [running], ... factorial ... at main.swift:3:5
+
+        result = self.res.GetOutput()
+        lines = [l for l in result.splitlines() if l.strip()]
+        self.assertEqual(len(lines), 4)
+
+        self.assertRegex(lines[0], r"Task 1, addr = 0x[0-9a-fA-F]+")
+        self.assertIn("Task<>", lines[0])
+
+        self.assertRegex(lines[1], r"Task 2 \('factorial-main'\), addr = 0x[0-9a-fA-F]+")
+        self.assertIn("factorial", lines[1])
+
+        self.assertRegex(lines[2], r"Task 3, addr = 0x[0-9a-fA-F]+")
+        self.assertIn("factorial", lines[2])
+
+        self.assertRegex(lines[3], r"Task 4, addr = 0x[0-9a-fA-F]+.*\[running\]")
+        self.assertIn("factorial", lines[3])
+        self.assertIn("main.swift:3", lines[3])

--- a/lldb/test/API/lang/swift/async/tasks/list/main.swift
+++ b/lldb/test/API/lang/swift/async/tasks/list/main.swift
@@ -1,0 +1,17 @@
+func factorial(n: Int) async -> Int {
+  if n == 1 {
+    return 1  //break here
+  }
+  async let n1 = factorial(n: n - 1)
+
+  return await n1 * n
+}
+
+@main struct Main {
+  static func main() async {
+    let task = Task (name: "factorial-main") {
+      await factorial(n: 3)
+    }
+    await task.value
+  }
+}

--- a/lldb/test/API/lang/swift/async/tasks/tree/Makefile
+++ b/lldb/test/API/lang/swift/async/tasks/tree/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS := -parse-as-library
+include Makefile.rules

--- a/lldb/test/API/lang/swift/async/tasks/tree/TestSwiftTaskTree.py
+++ b/lldb/test/API/lang/swift/async/tasks/tree/TestSwiftTaskTree.py
@@ -1,0 +1,38 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import TestBase
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestCase(TestBase):
+
+    @skipUnlessPlatform(["macosx"])
+    @swiftTest
+    def test_task_tree(self):
+        self.build()
+        _, _, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("language swift task tree --max-frames 1")
+
+        # (lldb) task tree --max-frames 1
+        # ├╴ Task 1, addr = 0x... [awaiting Task 2] [suspended]
+        # │    frame #0: Task<>.value.getter at Task.swift:277:7
+        # └╴ Task 2 'factorial-main', addr = 0x... [awaiting Task 3] [suspended]
+        #    │ frame #0: factorial(n:) at main.swift:7
+        #    └╴ Task 3, addr = 0x...
+        #       │ frame #0: factorial(n:) at main.swift:7
+        #       └╴ Task 4, addr = 0x... [running]
+        #            frame #0: factorial(n:) + 60 at main.swift:3:5
+
+        result = self.res.GetOutput().splitlines()
+
+        self.assertRegex(result[0], r"Task 1, addr = 0x[0-9a-fA-F]+")
+        self.assertRegex(result[1], r"frame #0: Task<>.value.getter")
+
+        result = result[2:]
+        self.assertRegex(result[0], r"Task 2 \('factorial-main'\), addr = 0x[0-9a-fA-F]+")
+        self.assertRegex(result[1], r"frame #0: factorial.* at main.swift:7")
+        self.assertRegex(result[2], r"Task 3, addr = 0x[0-9a-fA-F]+")
+        self.assertRegex(result[3], r"frame #0: factorial.* at main.swift:7")
+        self.assertRegex(result[4], r"Task 4, addr = 0x[0-9a-fA-F]+.*\[running\]")
+        self.assertRegex(result[5], r"frame #0: factorial.* at main.swift:3")

--- a/lldb/test/API/lang/swift/async/tasks/tree/main.swift
+++ b/lldb/test/API/lang/swift/async/tasks/tree/main.swift
@@ -1,0 +1,17 @@
+func factorial(n: Int) async -> Int {
+  if n == 1 {
+    return 1  //break here
+  }
+  async let n1 = factorial(n: n - 1)
+
+  return await n1 * n
+}
+
+@main struct Main {
+  static func main() async {
+    let task = Task (name: "factorial-main") {
+      await factorial(n: 3)
+    }
+    await task.value
+  }
+}


### PR DESCRIPTION
This PR introduces two new commands: `task {tree, list}`, allowing for better discovery and inspection of swift tasks. See each commit individually,

rdar://169471480