### PR TITLE
[clang][deps] Minimize upstream diff

### DIFF
--- a/clang/include/clang/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/DependencyScanning/ModuleDepCollector.h
@@ -158,9 +158,6 @@ struct ModuleDeps {
   /// Whether this is a "system" module.
   bool IsSystem;
 
-  /// Whether current working directory is ignored.
-  bool IgnoreCWD;
-
   /// Whether this module is fully composed of file & module inputs from
   /// locations likely to stay the same across the active development and build
   /// cycle. For example, when all those input paths only resolve in Sysroot.
@@ -168,6 +165,9 @@ struct ModuleDeps {
   /// External paths, as opposed to virtual file paths, are always used
   /// for computing this value.
   bool IsInStableDirectories;
+
+  /// Whether current working directory is ignored.
+  bool IgnoreCWD;
 
   /// The path to the modulemap file which defines this module.
   ///


### PR DESCRIPTION
Build failure fix (b7e1c3e2dcf5b53f263c44cc49b8097e88218996) after merging upstream #184921 introduced unnecessary diff to upstream. This removes it.