### PR TITLE
[clang][modules] Introduce a flag to keep redundant module lookups on relocation checks

### DIFF
--- a/clang/include/clang/Lex/PreprocessorOptions.h
+++ b/clang/include/clang/Lex/PreprocessorOptions.h
@@ -84,6 +84,11 @@ public:
   /// Perform extra checks when loading PCM files for mutable file systems.
   bool ModulesCheckRelocated = true;
 
+  /// Perform redundant module lookups. This is typically for
+  /// compilations that rely on side effects of module lookup due to
+  /// poor modularization.
+  bool ModulesForceRedundantLookup = false;
+
   /// Initialize the preprocessor with the compiler and target specific
   /// predefines.
   bool UsePredefines = true;

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -8962,6 +8962,11 @@ def disable_pragma_debug_crash : Flag<["-"], "disable-pragma-debug-crash">,
 def source_date_epoch : Separate<["-"], "source-date-epoch">,
   MetaVarName<"<time since Epoch in seconds>">,
   HelpText<"Time to be used in __DATE__, __TIME__, and __TIMESTAMP__ macros">;
+def fmodules_force_redundant_lookup
+    : Flag<["-"], "fmodules-force-redundant-lookup">,
+      Group<f_Group>,
+      HelpText<"Force redundant module lookup when loading PCM files">,
+      MarshallingInfoFlag<PreprocessorOpts<"ModulesForceRedundantLookup">>;
 
 } // let Visibility = [CC1Option]
 

--- a/clang/test/Modules/force-redundant-lookup.c
+++ b/clang/test/Modules/force-redundant-lookup.c
@@ -1,0 +1,23 @@
+// Verify `-fmodules-force-redundant-lookup` is recognized in a typical
+// compilation that relies on build session optimizations.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: touch %t/session.timestamp
+
+// RUN: %clang -fmodules -fimplicit-module-maps -fsyntax-only %t/tu1.c \
+// RUN:   -fmodules-cache-path=%t/cache -I%t/include \
+// RUN:   -fbuild-session-file=%t/session.timestamp -fmodules-validate-once-per-build-session \
+// RUN:   -Xclang -fmodules-force-redundant-lookup 2>&1 | FileCheck %s --allow-empty
+
+// CHECK-NOT: warning: 
+// CHECK-NOT: error: 
+
+//--- include/module.modulemap
+module Dep { header "Dep.h" }
+//--- include/Dep.h
+int foo(void);
+
+//--- tu1.c
+#include "Dep.h"


### PR DESCRIPTION
This is intentionally a no-op to unblock a rebranch where the option
actually gates how often a relocation check triggers redundant lookups.
Pulling in that chain of changes is too risky at this moment.

resolves: rdar://186106679