### PR TITLE
[Cherry-pick into next] [LLDB] Test that String summary prover hides children

### DIFF
--- a/lldb/test/API/lang/swift/string/TestSwiftString.py
+++ b/lldb/test/API/lang/swift/string/TestSwiftString.py
@@ -13,5 +13,11 @@ class TestSwiftTuple(TestBase):
             self, 'break here', lldb.SBFileSpec('main.swift'))
 
         # FIXME: It would be even better if this were an error.
-        self.expect("frame variable zero", substrs=['<uninitialized>'])
-        self.expect("frame variable random", substrs=['cannot decode string'])
+        zero = self.frame().FindVariable("zero")
+        self.assertEqual(zero.GetSummary(), '<uninitialized>')
+        random = self.frame().FindVariable("random")
+        self.assertIn('cannot decode string', random.GetSummary())
+        good = self.frame().FindVariable("good")
+        self.assertIn('hello', good.GetSummary())
+        options = good.GetTypeSummary().GetOptions()
+        self.assertEqual(options & lldb.eTypeOptionHideChildren, lldb.eTypeOptionHideChildren, "String guts hidden")

--- a/lldb/test/API/lang/swift/string/main.swift
+++ b/lldb/test/API/lang/swift/string/main.swift
@@ -13,6 +13,7 @@ func main() {
       raw[1] = 0xfefefefefefefefe
     }
   }
+  var good : String = "hello"
   print("break here")
 }
 


### PR DESCRIPTION
```
commit c4abffaf2281efd6827686211c8ed2ad5ef221f2
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Mar 5 11:26:04 2026 -0800

    [LLDB] Test that String summary prover hides children
```
