### PR TITLE
[cherry-pick] [lldb] Use new indirect TR to recover the type of an indirect enum payload

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1642,20 +1642,51 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
       SwiftLanguageRuntime::GetManglingFlavor(enum_type.GetMangledTypeName());
 
   auto project_indirect_enum =
-      [&](uint64_t offset, std::string name) -> llvm::Expected<ValueObjectSP> {
+      [&](const swift::reflection::FieldInfo &field_info)
+      -> llvm::Expected<ValueObjectSP> {
+    // Get the pointer to the box.
     lldb::addr_t pointer = ::MaskMaybeBridgedPointer(
         GetProcess(), valobj.GetPointerValue().address);
-    lldb::addr_t payload = pointer + offset;
+
+    // Skip heap object header to get to payload.
+    unsigned pointer_size = GetProcess().GetAddressByteSize();
+    uint64_t heap_header_size = 2 * pointer_size;
+    lldb::addr_t payload_addr = pointer + heap_header_size;
+
+    // Get payload type from the preserved indirect payload TypeRef.
+    const swift::reflection::TypeRef *payload_tr = field_info.IndirectPayloadTR;
+    if (!payload_tr)
+      return llvm::createStringError("no payload type for indirect case");
+
+    CompilerType payload_type = GetTypeFromTypeRef(ts, payload_tr, flavor);
+    if (!payload_type)
+      return llvm::createStringError("could not get payload type");
+
+    return ValueObjectMemory::Create(exe_ctx.GetBestExecutionContextScope(),
+                                     "$indirect." + field_info.Name,
+                                     payload_addr, payload_type);
+  };
+
+  // Type infos of single case enums simply are the payload's type's type info,
+  // in the case of an indirect enum this is just Builtin.NativeObject, so we
+  // still have to read metadata to figure out the real type.
+  // TODO: this won't work for embedded swift, perhaps we can change
+  // TypeLowering.cpp to store the payload type in this case as well.
+  auto project_single_case_indirect_enum =
+      [&]() -> llvm::Expected<ValueObjectSP> {
+    lldb::addr_t pointer = ::MaskMaybeBridgedPointer(
+        GetProcess(), valobj.GetPointerValue().address);
 
     ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
     // The indirect enum field should point to a closure context.
     LLDBTypeInfoProvider tip(*this, ts);
     auto ti_or_err = reflection_ctx->GetTypeInfoFromInstance(
-        payload, &tip, ts.GetDescriptorFinder());
+        pointer, &tip, ts.GetDescriptorFinder());
     if (!ti_or_err)
       return ti_or_err.takeError();
 
     CompilerType payload_type;
+    lldb::addr_t payload = pointer;
     auto *ti = &*ti_or_err;
     if (auto *rti = llvm::dyn_cast<swift::reflection::RecordTypeInfo>(ti)) {
       switch (rti->getRecordKind()) {
@@ -1685,14 +1716,14 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
     }
 
     return ValueObjectMemory::Create(exe_ctx.GetBestExecutionContextScope(),
-                                     "$indirect." + name, payload,
+                                     "$indirect.$single_case", payload,
                                      payload_type);
   };
 
   // Is this single-case indirect enum? These get lowered into their payload
   // type.
   if (ti->getKind() != swift::reflection::TypeInfoKind::Enum)
-    return project_indirect_enum(0, "$single_case");
+    return project_single_case_indirect_enum();
 
   // Prepare to project the enum to get the active case.
   MemoryReaderLocalBufferHolder holder;
@@ -1731,14 +1762,9 @@ SwiftLanguageRuntime::ProjectEnum(ValueObject &valobj) {
   if (!field_info.TR)
     return ValueObjectSP();
 
-  bool is_indirect_enum =
-      !field_info.Offset && field_info.TR &&
-      llvm::isa<swift::reflection::BuiltinTypeRef>(field_info.TR) &&
-      llvm::isa<swift::reflection::ReferenceTypeInfo>(field_info.TI) &&
-      llvm::cast<swift::reflection::ReferenceTypeInfo>(field_info.TI)
-              .getReferenceKind() == swift::reflection::ReferenceKind::Strong;
+  bool is_indirect_enum = field_info.IndirectPayloadTR != nullptr;
   if (is_indirect_enum)
-    return project_indirect_enum(field_info.Offset, field_info.Name);
+    return project_indirect_enum(field_info);
 
   CompilerType projected_type = GetTypeFromTypeRef(ts, field_info.TR, flavor);
   if (field_info.Offset != 0) {

--- a/lldb/test/API/lang/swift/enums/single_case_indirect/Makefile
+++ b/lldb/test/API/lang/swift/enums/single_case_indirect/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
+++ b/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
@@ -1,0 +1,89 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftSingleCaseIndirectEnum(TestBase):
+    @swiftTest
+    def test(self):
+        """Test single-case indirect enum projection"""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+
+        # Single-case indirect enum with a struct payload.
+        single_struct = frame.FindVariable("single_struct")
+        self.assertEqual(single_struct.GetNumChildren(), 2)
+        lldbutil.check_variable(
+            self, single_struct.GetChildMemberWithName("x"), False, value="42"
+        )
+        lldbutil.check_variable(
+            self, single_struct.GetChildMemberWithName("y"), False,
+            summary='"hello"',
+        )
+
+        # Single-case indirect enum with a class payload.
+        single_class = frame.FindVariable("single_class")
+        self.assertEqual(single_class.GetNumChildren(), 1)
+        lldbutil.check_variable(
+            self, single_class.GetChildMemberWithName("v"), False, value="100"
+        )
+
+        # Single-case indirect enum with a tuple payload.
+        single_tuple = frame.FindVariable("single_tuple")
+        self.assertEqual(single_tuple.GetNumChildren(), 2)
+        lldbutil.check_variable(
+            self, single_tuple.GetChildAtIndex(0), False, value="7"
+        )
+        lldbutil.check_variable(
+            self, single_tuple.GetChildAtIndex(1), False, summary='"world"'
+        )
+
+        # Single-case indirect enum with a large struct payload.
+        single_large = frame.FindVariable("single_large")
+        self.assertEqual(single_large.GetNumChildren(), 4)
+        lldbutil.check_variable(
+            self, single_large.GetChildMemberWithName("a"), False, value="1"
+        )
+        lldbutil.check_variable(
+            self, single_large.GetChildMemberWithName("b"), False, value="2"
+        )
+        lldbutil.check_variable(
+            self, single_large.GetChildMemberWithName("c"), False, value="3"
+        )
+        lldbutil.check_variable(
+            self, single_large.GetChildMemberWithName("d"), False,
+            summary='"big"',
+        )
+
+        # Single-case indirect enum with a scalar payload.
+        single_int = frame.FindVariable("single_int")
+        self.assertEqual(single_int.GetNumChildren(), 1)
+        lldbutil.check_variable(
+            self, single_int.GetChildAtIndex(0), False, value="99"
+        )
+
+        # Recursive single-case indirect enum (linked list).
+        list_var = frame.FindVariable("list")
+        self.assertEqual(list_var.GetNumChildren(), 2)
+        lldbutil.check_variable(
+            self, list_var.GetChildAtIndex(0), False, value="10"
+        )
+        # Second child is Optional<List<Int>> wrapping the next node.
+        node2 = list_var.GetChildAtIndex(1)
+        self.assertEqual(node2.GetNumChildren(), 2)
+        lldbutil.check_variable(
+            self, node2.GetChildAtIndex(0), False, value="20"
+        )
+        node3 = node2.GetChildAtIndex(1)
+        self.assertEqual(node3.GetNumChildren(), 2)
+        lldbutil.check_variable(
+            self, node3.GetChildAtIndex(0), False, value="30"
+        )
+        # Tail is nil.
+        tail = node3.GetChildAtIndex(1)
+        lldbutil.check_variable(self, tail, False, num_children=0,
+                                summary="nil")

--- a/lldb/test/API/lang/swift/enums/single_case_indirect/main.swift
+++ b/lldb/test/API/lang/swift/enums/single_case_indirect/main.swift
@@ -1,0 +1,59 @@
+struct S {
+  let x: Int
+  let y: String
+}
+
+class C {
+  init(_ v: Int) { self.v = v }
+  let v: Int
+}
+
+struct LargePayload {
+  let a: Int
+  let b: Int
+  let c: Int
+  let d: String
+}
+
+// Single-case indirect enum with a struct payload.
+indirect enum SingleStruct {
+  case value(S)
+}
+
+// Single-case indirect enum with a class payload.
+indirect enum SingleClass {
+  case value(C)
+}
+
+// Single-case indirect enum with a tuple payload.
+indirect enum SingleTuple {
+  case value(Int, String)
+}
+
+// Single-case indirect enum with a large struct payload.
+indirect enum SingleLargePayload {
+  case value(LargePayload)
+}
+
+// Single-case indirect enum with a scalar payload.
+indirect enum SingleInt {
+  case value(Int)
+}
+
+// Recursive single-case indirect enum (linked list).
+indirect enum List<T> {
+  case node(T, List<T>?)
+}
+
+func main() {
+  let single_struct = SingleStruct.value(S(x: 42, y: "hello"))
+  let single_class = SingleClass.value(C(100))
+  let single_tuple = SingleTuple.value(7, "world")
+  let single_large = SingleLargePayload.value(
+      LargePayload(a: 1, b: 2, c: 3, d: "big"))
+  let single_int = SingleInt.value(99)
+  let list = List<Int>.node(10, List<Int>.node(20, List<Int>.node(30, nil)))
+  print("break here")
+}
+
+main()


### PR DESCRIPTION
Currently we read reflection metadata to figure out what the type of an
indirect enum's payload is. This is not necessary anymore, since the
EnumTypeInfo now carries the payload type as well.

Besides being a slight performance boost (reading less metadata), this
is also in preparation to support indirect enums in embedded Swift,
since in that scenario there is no metadata at all.

rdar://170685141

(cherry picked from commit 35963677d1c1f07918f647713338f95fae045335)