### PR TITLE
[cherry-pick] [lldb] Canonicalize enum payload types when building field records from DWARF

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwiftDescriptorFinder.cpp
@@ -481,11 +481,22 @@ public:
           member.GetAttributeValueAsString(llvm::dwarf::DW_AT_name, "");
       auto *member_type = dwarf_parser->GetTypeForDIE(member);
 
-      // Empty enum cases don' have a type.
-      auto member_mangled_typename =
-          member_type
-              ? member_type->GetForwardCompilerType().GetMangledTypeName()
-              : ConstString();
+      // Empty enum cases don't have a type.
+      ConstString member_mangled_typename;
+      if (member_type) {
+        CompilerType member_compiler_type =
+            member_type->GetForwardCompilerType();
+        // TypeRefBuilder expects types to be canonical.
+        CompilerType canonical =
+            m_type_system.Canonicalize(member_compiler_type);
+        if (!canonical) {
+          LLDB_LOG(GetLog(LLDBLog::Types),
+                   "Could not build canonical type: {0}",
+                   member_compiler_type.GetMangledTypeName());
+          canonical = member_compiler_type;
+        }
+        member_mangled_typename = canonical.GetMangledTypeName();
+      }
 
       // Only matters for enums, so set to false for structs.
       bool is_indirect_case = false;

--- a/lldb/test/API/lang/swift/embedded/enum_typealias_payload/Makefile
+++ b/lldb/test/API/lang/swift/embedded/enum_typealias_payload/Makefile
@@ -1,0 +1,4 @@
+SWIFT_SOURCES := main.swift
+SWIFT_EMBEDDED_MODE := 1
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/embedded/enum_typealias_payload/TestSwiftEmbeddedEnumTypealiasPayload.py
+++ b/lldb/test/API/lang/swift/embedded/enum_typealias_payload/TestSwiftEmbeddedEnumTypealiasPayload.py
@@ -1,0 +1,61 @@
+"""
+Test that enums with typealiased payload types work in embedded Swift.
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftEmbeddedEnumTypealiasPayload(TestBase):
+    @skipUnlessDarwin
+    @swiftTest
+    def test(self):
+        """Test enums with typealiased payload types."""
+        self.build()
+        self.runCmd("setting set symbols.swift-enable-ast-context false")
+
+        target, process, thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        self.expect(
+            "frame variable intCase",
+            substrs=["AliasedPayloadEnum", "intCase", "42"],
+        )
+
+        self.expect(
+            "frame variable doubleCase",
+            substrs=["AliasedPayloadEnum", "doubleCase", "3.14"],
+        )
+
+        self.expect(
+            "frame variable empty",
+            substrs=["AliasedPayloadEnum", "empty"],
+        )
+
+        self.expect(
+            "frame variable first",
+            substrs=["NestedAliasedPayloadEnum", "first", "100"],
+        )
+
+        self.expect(
+            "frame variable second",
+            substrs=["NestedAliasedPayloadEnum", "second", "2.5"],
+        )
+
+        self.expect(
+            "frame variable genericInt",
+            substrs=["GenericAliasedPayloadEnum<Int>", "payload", "99"],
+        )
+
+        self.expect(
+            "frame variable genericDouble",
+            substrs=["GenericAliasedPayloadEnum<Double>", "payload", "1.5"],
+        )
+
+        self.expect(
+            "frame variable genericEmpty",
+            substrs=["GenericAliasedPayloadEnum<Int>", "empty"],
+        )

--- a/lldb/test/API/lang/swift/embedded/enum_typealias_payload/main.swift
+++ b/lldb/test/API/lang/swift/embedded/enum_typealias_payload/main.swift
@@ -1,0 +1,35 @@
+typealias MyInt = Int
+typealias MyDouble = Double
+
+enum AliasedPayloadEnum {
+    case intCase(MyInt)
+    case doubleCase(MyDouble)
+    case empty
+}
+
+enum NestedAliasedPayloadEnum {
+    typealias MyNestedInt = Int
+    typealias MyNestedDouble = Double
+    case first(MyNestedInt)
+    case second(MyNestedDouble)
+}
+
+enum GenericAliasedPayloadEnum<T> {
+    typealias Value = T
+    case payload(Value)
+    case empty
+}
+
+func f() {
+    let intCase = AliasedPayloadEnum.intCase(42)
+    let doubleCase = AliasedPayloadEnum.doubleCase(3.14)
+    let empty = AliasedPayloadEnum.empty
+    let first = NestedAliasedPayloadEnum.first(100)
+    let second = NestedAliasedPayloadEnum.second(2.5)
+    let genericInt = GenericAliasedPayloadEnum<Int>.payload(99)
+    let genericDouble = GenericAliasedPayloadEnum<Double>.payload(1.5)
+    let genericEmpty = GenericAliasedPayloadEnum<Int>.empty
+    let string = StaticString("break here")
+    print(string)
+}
+f()


### PR DESCRIPTION
When building field descriptors from DWARF for embedded Swift, TypeRef
builder expect the types to be canonical (no sugar or typealiases).

In 2ad453d6b488c4bb1562d76d02e3733aeb395434 I added canonicalization for
structs and classes but forgot about enums. This adds that missing code.

rdar://170669109

(cherry picked from commit fbaf5253fac2b635ccb229143173256a091de9b0)