### PR TITLE
[Cherry-pick into next] [LLDB] Add a synthetic child provider for Swift.String to hide its children

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftFormatters.cpp
@@ -435,7 +435,10 @@ bool lldb_private::formatters::swift::String_SummaryProvider(
     const TypeSummaryOptions &summary_options,
     StringPrinter::ReadStringAndDumpToStreamOptions read_options) {
   static ConstString g_guts("_guts");
-  ValueObjectSP guts_sp = valobj.GetChildMemberWithName(g_guts, true);
+  ValueObjectSP non_synth = valobj.GetNonSyntheticValue();
+  if (!non_synth)
+    return false;
+  ValueObjectSP guts_sp = non_synth->GetChildMemberWithName(g_guts, true);
   if (guts_sp)
     return StringGuts_SummaryProvider(*guts_sp, stream, summary_options,
                                       read_options);

--- a/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftLanguage.cpp
@@ -473,6 +473,11 @@ static void LoadSwiftFormatters(lldb::TypeCategoryImplSP swift_category_sp) {
                 lldb_private::formatters::swift::Character_SummaryProvider,
                 "Swift.Character summary provider",
                 ConstString("Swift.Character"), summary_flags);
+  // Hide children.
+  AddCXXSynthetic(
+      swift_category_sp,
+      lldb_private::formatters::swift::SwiftBasicTypeSyntheticFrontEndCreator,
+      "Swift.String", ConstString("Swift.String"), basic_synth_flags);
   bool (*string_summary_provider)(ValueObject &, Stream &,
                                   const TypeSummaryOptions &) =
       lldb_private::formatters::swift::String_SummaryProvider;

--- a/lldb/test/API/lang/swift/string/TestSwiftString.py
+++ b/lldb/test/API/lang/swift/string/TestSwiftString.py
@@ -20,4 +20,11 @@ class TestSwiftTuple(TestBase):
         good = self.frame().FindVariable("good")
         self.assertIn('hello', good.GetSummary())
         options = good.GetTypeSummary().GetOptions()
-        self.assertEqual(options & lldb.eTypeOptionHideChildren, lldb.eTypeOptionHideChildren, "String guts hidden")
+        self.assertEqual(
+            options & lldb.eTypeOptionHideChildren,
+            lldb.eTypeOptionHideChildren,
+            "String guts hidden",
+        )
+        self.assertEqual(
+            good.GetSyntheticValue().GetNumChildren(), 0, "String guts hidden"
+        )

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -92,13 +92,13 @@ class TestSwiftOptionalType(TestBase):
             self,
             optString_Some,
             use_dynamic=False,
-            num_children=1)
+            num_children=0)
         uoptString_Some = self.frame().FindVariable("uoptString_Some")
         lldbutil.check_variable(
             self,
             uoptString_Some,
             use_dynamic=False,
-            num_children=1)
+            num_children=0)
         uoptString_Some.GetChildAtIndex(99)
 
         optTrue = self.frame().FindVariable("optTrue")

--- a/lldb/test/Shell/SwiftREPL/Optional.test
+++ b/lldb/test/Shell/SwiftREPL/Optional.test
@@ -17,10 +17,7 @@ let x : Optional<Test> = nil
 
 let y : Optional<Test> = Test(a: 1, b: Patatino.first)
 
-// CHECK-NEXT: {{y}}: Test? = some {
-// CHECK-NEXT: a = 1
-// CHECK-NEXT: b = first
-// CHECK-NEXT: }
+// CHECK-NEXT: {{y}}: Test? = (a = 1, b = first)
 
 class A {
   var x : Int


### PR DESCRIPTION
```
commit 988ff71ddb2ee91e0fb670d3624fb9492112f936
Author: Adrian Prantl <aprantl@apple.com>
Date:   Thu Mar 5 14:20:17 2026 -0800

    [LLDB] Add a synthetic child provider for Swift.String to hide its children
    
    rdar://171646109
```
