### PR TITLE
[clang][cas] Remove CASOptions internal cache of CAS instances

### DIFF
--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -69,6 +69,16 @@ public:
                            std::shared_ptr<llvm::cas::ActionCache>>>
   getOrCreateDatabases() const;
 
+  /// Get a CAS & ActionCache defined by the options above. Ignores any cached
+  /// instances.
+  ///
+  /// If \p CreateEmptyDBsOnFailure, returns empty in-memory databases on
+  /// failure. Else, returns \c nullptr on failure.
+  std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+            std::shared_ptr<llvm::cas::ActionCache>>
+  createDatabases(DiagnosticsEngine &Diags,
+                  bool CreateEmptyDBsOnFailure = false) const;
+
   /// Freeze CAS Configuration. Future calls will return the same
   /// CAS instance, even if the configuration changes again later.
   ///
@@ -81,6 +91,10 @@ public:
   /// If the configuration is not for a persistent store, it modifies it to the
   /// default on-disk CAS, otherwise this is a noop.
   void ensurePersistentCAS();
+
+  /// Returns true if a CAS database instance has already been opened and
+  /// cached in this options object.
+  bool hasCachedDatabase() const { return static_cast<bool>(Cache.CAS); }
 
 private:
   /// Initialize Cached CAS and ActionCache.

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -37,11 +37,8 @@ class DiagnosticsEngine;
 /// CASOptions includes \a getOrCreateDatabases() for creating CAS and
 /// ActionCache.
 ///
-/// FIXME: The the caching is done here, instead of as a field in \a
-/// CompilerInstance, in order to ensure that \a
-/// clang::createVFSFromCompilerInvocation() uses the same CAS instance that
-/// the rest of the compiler job does, without updating all callers. Probably
-/// it would be better to update all callers and remove it from here.
+/// FIXME: Remove the caching that is done here. It should now be in the
+/// CompilerInstance.
 class CASOptions : public llvm::cas::CASConfiguration {
 public:
   enum CASKind {

--- a/clang/include/clang/CAS/CASOptions.h
+++ b/clang/include/clang/CAS/CASOptions.h
@@ -34,37 +34,17 @@ class DiagnosticsEngine;
 /// Options configuring which CAS to use. User-accessible fields should be
 /// defined in CASConfiguration to enable caching a CAS instance.
 ///
-/// CASOptions includes \a getOrCreateDatabases() for creating CAS and
-/// ActionCache.
-///
-/// FIXME: Remove the caching that is done here. It should now be in the
-/// CompilerInstance.
+/// CASOptions includes \a createDatabases() convenience for creating CAS and
+/// ActionCache and reporting diagnostics.
 class CASOptions : public llvm::cas::CASConfiguration {
 public:
   enum CASKind {
-    UnknownCAS,
     InMemoryCAS,
     OnDiskCAS,
   };
 
   /// Kind of CAS to use.
-  CASKind getKind() const {
-    return IsFrozen ? UnknownCAS : CASPath.empty() ? InMemoryCAS : OnDiskCAS;
-  }
-  /// Get a CAS & ActionCache defined by the options above. Future calls will
-  /// return the same instances... unless the configuration has changed, in
-  /// which case new ones will be created.
-  ///
-  /// If \p CreateEmptyDBsOnFailure, returns empty in-memory databases on
-  /// failure. Else, returns \c nullptr on failure.
-  std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
-            std::shared_ptr<llvm::cas::ActionCache>>
-  getOrCreateDatabases(DiagnosticsEngine &Diags,
-                       bool CreateEmptyDBsOnFailure = false) const;
-
-  llvm::Expected<std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
-                           std::shared_ptr<llvm::cas::ActionCache>>>
-  getOrCreateDatabases() const;
+  CASKind getKind() const { return CASPath.empty() ? InMemoryCAS : OnDiskCAS; }
 
   /// Get a CAS & ActionCache defined by the options above. Ignores any cached
   /// instances.
@@ -76,41 +56,9 @@ public:
   createDatabases(DiagnosticsEngine &Diags,
                   bool CreateEmptyDBsOnFailure = false) const;
 
-  /// Freeze CAS Configuration. Future calls will return the same
-  /// CAS instance, even if the configuration changes again later.
-  ///
-  /// The configuration will be wiped out to prevent it being observable or
-  /// affecting the output of something that takes \a CASOptions as an input.
-  /// This also "locks in" the return value of \a getOrCreateDatabases():
-  /// future calls will not check if the configuration has changed.
-  void freezeConfig(DiagnosticsEngine &Diags);
-
   /// If the configuration is not for a persistent store, it modifies it to the
   /// default on-disk CAS, otherwise this is a noop.
   void ensurePersistentCAS();
-
-  /// Returns true if a CAS database instance has already been opened and
-  /// cached in this options object.
-  bool hasCachedDatabase() const { return static_cast<bool>(Cache.CAS); }
-
-private:
-  /// Initialize Cached CAS and ActionCache.
-  llvm::Error initCache() const;
-
-  struct CachedCAS {
-    /// A cached CAS instance.
-    std::shared_ptr<llvm::cas::ObjectStore> CAS;
-    /// An ActionCache instnace.
-    std::shared_ptr<llvm::cas::ActionCache> AC;
-
-    /// Remember how the CAS was created.
-    CASConfiguration Config;
-  };
-  mutable CachedCAS Cache;
-
-  /// Whether the configuration has been "frozen", in order to hide the kind of
-  /// CAS that's in use.
-  bool IsFrozen = false;
 };
 
 } // end namespace clang

--- a/clang/include/clang/CodeGen/BackendUtil.h
+++ b/clang/include/clang/CodeGen/BackendUtil.h
@@ -41,11 +41,10 @@ enum BackendAction {
 };
 
 void emitBackendOutput(CompilerInstance &CI, CodeGenOptions &CGOpts,
-		                   const CASOptions &CASOpts, // MCCAS 
                        StringRef TDesc, llvm::Module *M, BackendAction Action,
                        llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
                        std::unique_ptr<raw_pwrite_stream> OS,
-                       std::unique_ptr<raw_pwrite_stream> CasidOS = nullptr,		       
+                       std::unique_ptr<raw_pwrite_stream> CasidOS = nullptr,
                        BackendConsumer *BC = nullptr);
 
 void EmbedBitcode(llvm::Module *M, const CodeGenOptions &CGOpts,

--- a/clang/include/clang/DependencyScanning/DependencyScanningService.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningService.h
@@ -151,6 +151,10 @@ public:
 
   ModuleCacheEntries &getModuleCacheEntries() { return ModCacheEntries; }
 
+  CASOptions getCASOpts() const;
+  std::shared_ptr<cas::ObjectStore> getCAS() const;
+  std::shared_ptr<cas::ActionCache> getActionCache() const;
+
 private:
   /// The options customizing dependency scanning behavior.
   DependencyScanningServiceOptions Opts;

--- a/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
+++ b/clang/include/clang/DependencyScanning/DependencyScanningWorker.h
@@ -196,20 +196,6 @@ public:
     return Service.getOpts().Format;
   }
 
-  CASOptions getCASOpts() const {
-    if (auto *IncludeTree =
-            std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
-      return IncludeTree->CASOpts;
-    return {};
-  }
-
-  std::shared_ptr<cas::ObjectStore> getCAS() const {
-    if (auto *IncludeTree =
-            std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
-      return IncludeTree->CAS;
-    return nullptr;
-  }
-
   llvm::vfs::FileSystem &getVFS() const { return *DepFS; }
 
 private:

--- a/clang/include/clang/Frontend/ASTUnit.h
+++ b/clang/include/clang/Frontend/ASTUnit.h
@@ -110,6 +110,8 @@ class ASTUnit {
   std::unique_ptr<HeaderSearchOptions> HSOpts;
   std::shared_ptr<PreprocessorOptions>    PPOpts;
   IntrusiveRefCntPtr<ASTReader> Reader;
+  std::shared_ptr<cas::ObjectStore> CAS;
+  std::shared_ptr<cas::ActionCache> ActionCache;
   bool HadModuleLoaderFatalFailure = false;
   bool StorePreamblesInMemory = false;
 

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -1061,7 +1061,7 @@ public:
 
   std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
             std::shared_ptr<llvm::cas::ActionCache>>
-  getOrCreateCASDatabases();
+  getOrCreateCASDatabases(DiagnosticsEngine *Diags = nullptr);
 
   void setCASDatabases(std::shared_ptr<llvm::cas::ObjectStore> CAS,
                        std::shared_ptr<llvm::cas::ActionCache> Cache);

--- a/clang/include/clang/Frontend/CompilerInstance.h
+++ b/clang/include/clang/Frontend/CompilerInstance.h
@@ -1062,6 +1062,9 @@ public:
   std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
             std::shared_ptr<llvm::cas::ActionCache>>
   getOrCreateCASDatabases();
+
+  void setCASDatabases(std::shared_ptr<llvm::cas::ObjectStore> CAS,
+                       std::shared_ptr<llvm::cas::ActionCache> Cache);
 };
 
 } // end namespace clang

--- a/clang/include/clang/Frontend/CompilerInvocation.h
+++ b/clang/include/clang/Frontend/CompilerInvocation.h
@@ -446,14 +446,15 @@ public:
   /// @}
 };
 
-IntrusiveRefCntPtr<llvm::vfs::FileSystem> createVFSFromCompilerInvocation(
-    const CompilerInvocation &CI, DiagnosticsEngine &Diags,
-    std::shared_ptr<llvm::cas::ObjectStore> OverrideCAS = nullptr);
+IntrusiveRefCntPtr<llvm::vfs::FileSystem>
+createVFSFromCompilerInvocation(const CompilerInvocation &CI,
+                                DiagnosticsEngine &Diags,
+                                std::shared_ptr<llvm::cas::ObjectStore> CAS);
 
 IntrusiveRefCntPtr<llvm::vfs::FileSystem> createVFSFromCompilerInvocation(
     const CompilerInvocation &CI, DiagnosticsEngine &Diags,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
-    std::shared_ptr<llvm::cas::ObjectStore> OverrideCAS = nullptr);
+    std::shared_ptr<llvm::cas::ObjectStore> CAS);
 
 IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 createVFSFromOverlayFiles(ArrayRef<std::string> VFSOverlayFiles,

--- a/clang/include/clang/Frontend/FrontendOptions.h
+++ b/clang/include/clang/Frontend/FrontendOptions.h
@@ -507,6 +507,11 @@ public:
   /// Use the blob in the CAS object as the input.
   std::string CASInputFileCASID;
 
+  bool needsCAS() const {
+    return !CASIncludeTreeID.empty() || !CASInputFileCacheKey.empty() ||
+           !CASInputFileCASID.empty();
+  }
+
   /// If ignore all the CAS info from serialized AST like modules and PCHs.
   bool ModuleLoadIgnoreCAS = false;
 

--- a/clang/include/clang/Tooling/DependencyScanningTool.h
+++ b/clang/include/clang/Tooling/DependencyScanningTool.h
@@ -140,7 +140,10 @@ public:
 
   llvm::vfs::FileSystem &getWorkerVFS() const { return Worker.getVFS(); }
 
-  CASOptions getCASOpts() const { return Worker.getCASOpts(); }
+  std::shared_ptr<cas::ObjectStore> getCAS() const {
+    return Worker.getService().getCAS();
+  }
+  CASOptions getCASOpts() const { return Worker.getService().getCASOpts(); }
 
   static std::unique_ptr<clang::dependencies::DependencyActionController>
   createActionController(

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -35,6 +35,23 @@ CASOptions::getOrCreateDatabases(DiagnosticsEngine &Diags,
   return {Cache.CAS, Cache.AC};
 }
 
+std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
+          std::shared_ptr<llvm::cas::ActionCache>>
+CASOptions::createDatabases(DiagnosticsEngine &Diags,
+                            bool CreateEmptyDBsOnFailure) const {
+  auto DBs = CASConfiguration::createDatabases();
+  if (DBs)
+    return std::move(*DBs);
+
+  Diags.Report(diag::err_cas_cannot_be_initialized)
+      << toString(DBs.takeError());
+
+  if (CreateEmptyDBsOnFailure)
+    return {llvm::cas::createInMemoryCAS(),
+            llvm::cas::createInMemoryActionCache()};
+  return {nullptr, nullptr};
+}
+
 llvm::Expected<std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
                          std::shared_ptr<llvm::cas::ActionCache>>>
 CASOptions::getOrCreateDatabases() const {

--- a/clang/lib/CAS/CASOptions.cpp
+++ b/clang/lib/CAS/CASOptions.cpp
@@ -20,23 +20,6 @@ using namespace llvm::cas;
 
 std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
           std::shared_ptr<llvm::cas::ActionCache>>
-CASOptions::getOrCreateDatabases(DiagnosticsEngine &Diags,
-                                 bool CreateEmptyDBsOnFailure) const {
-  if (IsFrozen)
-    return {Cache.CAS, Cache.AC};
-
-  if (auto E = initCache())
-    Diags.Report(diag::err_cas_cannot_be_initialized) << toString(std::move(E));
-
-  if (!Cache.CAS && CreateEmptyDBsOnFailure)
-    Cache.CAS = llvm::cas::createInMemoryCAS();
-  if (!Cache.AC && CreateEmptyDBsOnFailure)
-    Cache.AC = llvm::cas::createInMemoryActionCache();
-  return {Cache.CAS, Cache.AC};
-}
-
-std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
-          std::shared_ptr<llvm::cas::ActionCache>>
 CASOptions::createDatabases(DiagnosticsEngine &Diags,
                             bool CreateEmptyDBsOnFailure) const {
   auto DBs = CASConfiguration::createDatabases();
@@ -52,65 +35,12 @@ CASOptions::createDatabases(DiagnosticsEngine &Diags,
   return {nullptr, nullptr};
 }
 
-llvm::Expected<std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
-                         std::shared_ptr<llvm::cas::ActionCache>>>
-CASOptions::getOrCreateDatabases() const {
-  if (auto E = initCache())
-    return std::move(E);
-  return std::pair{Cache.CAS, Cache.AC};
-}
-
-void CASOptions::freezeConfig(DiagnosticsEngine &Diags) {
-  if (IsFrozen)
-    return;
-
-  // Make sure the cache is initialized.
-  if (auto E = initCache())
-    Diags.Report(diag::err_cas_cannot_be_initialized) << toString(std::move(E));
-
-  // Freeze the CAS and wipe out the visible config to hide it from future
-  // accesses. For example, future diagnostics cannot see this. Something that
-  // needs direct access to the CAS configuration will need to be
-  // scheduled/executed at a level that has access to the configuration.
-  auto &CurrentConfig = static_cast<CASConfiguration &>(*this);
-  CurrentConfig = CASConfiguration();
-  IsFrozen = true;
-
-  if (Cache.CAS) {
-    // Set the CASPath to the hash schema, since that leaks through CASContext's
-    // API and is observable.
-    CurrentConfig.CASPath =
-        Cache.CAS->getContext().getHashSchemaIdentifier().str();
-    CurrentConfig.PluginPath.clear();
-    CurrentConfig.PluginOptions.clear();
-  }
-}
-
 void CASOptions::ensurePersistentCAS() {
-  assert(!IsFrozen && "Expected to check for a persistent CAS before freezing");
   switch (getKind()) {
-  case UnknownCAS:
-    llvm_unreachable("Cannot ensure persistent CAS if it's unknown / frozen");
   case InMemoryCAS:
     CASPath = "auto";
     break;
   case OnDiskCAS:
     break;
   }
-}
-
-llvm::Error CASOptions::initCache() const {
-  auto &CurrentConfig = static_cast<const CASConfiguration &>(*this);
-  if (CurrentConfig == Cache.Config && Cache.CAS && Cache.AC)
-    return llvm::Error::success();
-
-  Cache.Config = CurrentConfig;
-  StringRef CASPath = Cache.Config.CASPath;
-
-  auto DBs = Cache.Config.createDatabases();
-  if (!DBs)
-    return DBs.takeError();
-
-  std::tie(Cache.CAS, Cache.AC) = std::move(*DBs);
-  return llvm::Error::success();
 }

--- a/clang/lib/CodeGen/BackendConsumer.h
+++ b/clang/lib/CodeGen/BackendConsumer.h
@@ -33,7 +33,6 @@ class BackendConsumer : public ASTConsumer {
   const CodeGenOptions &CodeGenOpts;
   const TargetOptions &TargetOpts;
   const LangOptions &LangOpts;
-  const CASOptions &CASOpts; // MCCAS
   std::unique_ptr<raw_pwrite_stream> AsmOutStream;
   std::unique_ptr<raw_pwrite_stream> CasIDStream;
   ASTContext *Context = nullptr;
@@ -69,7 +68,6 @@ class BackendConsumer : public ASTConsumer {
 public:
   BackendConsumer(CompilerInstance &CI, BackendAction Action,
                   IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
-                  const CASOptions &CASOpts,
                   llvm::LLVMContext &C, SmallVector<LinkModule, 4> LinkModules,
                   StringRef InFile, std::unique_ptr<raw_pwrite_stream> OS,
                   CoverageSourceInfo *CoverageInfo,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -149,7 +149,6 @@ class EmitAssemblyHelper {
   const CodeGenOptions &CodeGenOpts;
   const clang::TargetOptions &TargetOpts;
   const LangOptions &LangOpts;
-  const CASOptions &CASOpts; // MCCAS
   llvm::Module *TheModule;
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS;
 
@@ -213,12 +212,10 @@ class EmitAssemblyHelper {
 
 public:
   EmitAssemblyHelper(CompilerInstance &CI, CodeGenOptions &CGOpts,
-		                 const CASOptions &CASOpts, // MCCAS
                      llvm::Module *M,
                      IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS)
       : CI(CI), Diags(CI.getDiagnostics()), CodeGenOpts(CGOpts),
         TargetOpts(CI.getTargetOpts()), LangOpts(CI.getLangOpts()),
-        CASOpts(CASOpts), // MCCAS
         TheModule(M), VFS(std::move(VFS)),
         TargetTriple(TheModule->getTargetTriple()) {}
 
@@ -361,11 +358,8 @@ static std::string flattenClangCommandLine(ArrayRef<std::string> Args,
   return FlatCmdLine;
 }
 
-static bool initTargetOptions(const CompilerInstance &CI,
-                              DiagnosticsEngine &Diags,
-                              llvm::TargetOptions &Options,
-			      const CASOptions &CASOpts // MCCAS
-			      ) {
+static bool initTargetOptions(CompilerInstance &CI, DiagnosticsEngine &Diags,
+                              llvm::TargetOptions &Options) {
   const auto &CodeGenOpts = CI.getCodeGenOpts();
   const auto &TargetOpts = CI.getTargetOpts();
   const auto &LangOpts = CI.getLangOpts();
@@ -494,7 +488,8 @@ static bool initTargetOptions(const CompilerInstance &CI,
 
   // BEGIN MCCAS
   Options.UseCASBackend = CodeGenOpts.UseCASBackend; // MCCAS
-  Options.MCOptions.CAS = CASOpts.getOrCreateDatabases(Diags).first;
+  if (Options.UseCASBackend)
+    Options.MCOptions.CAS = CI.getOrCreateCASDatabases().first;
   Options.MCOptions.ResultCallBack = CodeGenOpts.MCCallBack;
   Options.MCOptions.CASObjMode = CodeGenOpts.getCASObjMode();
   // END MCCAS
@@ -624,7 +619,7 @@ void EmitAssemblyHelper::CreateTargetMachine(bool MustCreateTM) {
   CodeGenOptLevel OptLevel = *OptLevelOrNone;
 
   llvm::TargetOptions Options;
-  if (!initTargetOptions(CI, Diags, Options, CASOpts))
+  if (!initTargetOptions(CI, Diags, Options))
     return;
   TM.reset(TheTarget->createTargetMachine(Triple, TargetOpts.CPU, FeaturesStr,
                                           Options, RM, CM, OptLevel));
@@ -1334,9 +1329,7 @@ void EmitAssemblyHelper::emitAssembly(BackendAction Action,
 
 static void
 runThinLTOBackend(CompilerInstance &CI, ModuleSummaryIndex *CombinedIndex,
-                  llvm::Module *M,
-                  const CASOptions &CASOpts, // MCCAS 
-		  std::unique_ptr<raw_pwrite_stream> OS,
+                  llvm::Module *M, std::unique_ptr<raw_pwrite_stream> OS,
                   std::string SampleProfile, std::string ProfileRemapping,
                   BackendAction Action) {
   DiagnosticsEngine &Diags = CI.getDiagnostics();
@@ -1379,7 +1372,7 @@ runThinLTOBackend(CompilerInstance &CI, ModuleSummaryIndex *CombinedIndex,
   assert(OptLevelOrNone && "Invalid optimization level!");
   Conf.CGOptLevel = *OptLevelOrNone;
   Conf.OptLevel = CGOpts.OptimizationLevel;
-  initTargetOptions(CI, Diags, Conf.Options, CASOpts/* MCCAS */);
+  initTargetOptions(CI, Diags, Conf.Options);
   Conf.SampleProfile = std::move(SampleProfile);
   Conf.PTO.LoopUnrolling = CGOpts.UnrollLoops;
   Conf.PTO.LoopInterchange = CGOpts.InterchangeLoops;
@@ -1451,7 +1444,6 @@ runThinLTOBackend(CompilerInstance &CI, ModuleSummaryIndex *CombinedIndex,
 }
 
 void clang::emitBackendOutput(CompilerInstance &CI, CodeGenOptions &CGOpts,
-                              const CASOptions &CASOpts, // MCCAS
                               StringRef TDesc, llvm::Module *M,
                               BackendAction Action,
                               IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
@@ -1484,8 +1476,7 @@ void clang::emitBackendOutput(CompilerInstance &CI, CodeGenOptions &CGOpts,
     // of an error).
     if (CombinedIndex) {
       if (!CombinedIndex->skipModuleByDistributedBackend()) {
-        runThinLTOBackend(CI, CombinedIndex.get(), M, CASOpts/* MCCAS */,
-                          std::move(OS),
+        runThinLTOBackend(CI, CombinedIndex.get(), M, std::move(OS),
                           CGOpts.SampleProfileFile, CGOpts.ProfileRemappingFile,
                           Action);
         return;
@@ -1502,7 +1493,7 @@ void clang::emitBackendOutput(CompilerInstance &CI, CodeGenOptions &CGOpts,
     }
   }
 
-  EmitAssemblyHelper AsmHelper(CI, CGOpts, CASOpts/* MCCAS */, M, VFS);
+  EmitAssemblyHelper AsmHelper(CI, CGOpts, M, VFS);
   AsmHelper.emitAssembly(Action, std::move(OS), std::move(CasIDOS), BC);
 
   // Verify clang's TargetInfo DataLayout against the LLVM TargetMachine's

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -109,7 +109,6 @@ static void reportOptRecordError(Error E, DiagnosticsEngine &Diags,
 
 BackendConsumer::BackendConsumer(CompilerInstance &CI, BackendAction Action,
                                  IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS,
-				 const CASOptions &CASOpts,
                                  LLVMContext &C,
                                  SmallVector<LinkModule, 4> LinkModules,
                                  StringRef InFile,
@@ -119,7 +118,7 @@ BackendConsumer::BackendConsumer(CompilerInstance &CI, BackendAction Action,
                                  llvm::Module *CurLinkModule)
     : CI(CI), Diags(CI.getDiagnostics()), CodeGenOpts(CI.getCodeGenOpts()),
       TargetOpts(CI.getTargetOpts()), LangOpts(CI.getLangOpts()),
-      CASOpts(CASOpts), AsmOutStream(std::move(OS)),
+      AsmOutStream(std::move(OS)),
       CasIDStream(std::move(CasIDOS)), FS(VFS), Action(Action),
       Gen(CreateLLVMCodeGen(CI, InFile, C, CoverageInfo)),
       LinkModules(std::move(LinkModules)), CurLinkModule(CurLinkModule) {
@@ -312,7 +311,7 @@ void BackendConsumer::HandleTranslationUnit(ASTContext &C) {
 
   EmbedBitcode(getModule(), CodeGenOpts, llvm::MemoryBufferRef());
 
-  emitBackendOutput(CI, CI.getCodeGenOpts(), CASOpts,
+  emitBackendOutput(CI, CI.getCodeGenOpts(),
                     C.getTargetInfo().getDataLayoutString(), getModule(),
                     Action, FS, std::move(AsmOutStream), std::move(CasIDStream),
                     this);
@@ -991,9 +990,7 @@ CodeGenAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
         CI.getPreprocessor());
 
   std::unique_ptr<BackendConsumer> Result(new BackendConsumer(
-      CI, BA, CI.getVirtualFileSystemPtr(),
-      CI.getCASOpts(), // MCCAS
-      *VMContext, std::move(LinkModules),
+      CI, BA, CI.getVirtualFileSystemPtr(), *VMContext, std::move(LinkModules),
       InFile, std::move(OS), CoverageInfo, std::move(CasIDOS)));
   BEConsumer = Result.get();
 
@@ -1172,10 +1169,9 @@ void CodeGenAction::ExecuteAction() {
 
   // Set clang diagnostic handler. To do this we need to create a fake
   // BackendConsumer.
-  BackendConsumer Result(CI, BA, CI.getVirtualFileSystemPtr(), CI.getCASOpts(),
-                         *VMContext,
-                         std::move(LinkModules), "", nullptr, nullptr,
-                         nullptr, TheModule.get());
+  BackendConsumer Result(CI, BA, CI.getVirtualFileSystemPtr(), *VMContext,
+                         std::move(LinkModules), "", nullptr, nullptr, nullptr,
+                         TheModule.get());
 
   // Link in each pending link module.
   if (!CodeGenOpts.LinkBitcodePostopt && Result.LinkInModules(&*TheModule))
@@ -1203,7 +1199,6 @@ void CodeGenAction::ExecuteAction() {
   LLVMRemarkFileHandle OptRecordFile = std::move(*OptRecordFileOrErr);
 
   emitBackendOutput(CI, CI.getCodeGenOpts(),
-                    CI.getCASOpts(), // MCCAS
                     CI.getTarget().getDataLayoutString(), TheModule.get(), BA,
                     CI.getFileManager().getVirtualFileSystemPtr(),
                     std::move(OS));

--- a/clang/lib/CodeGen/ObjectFilePCHContainerWriter.cpp
+++ b/clang/lib/CodeGen/ObjectFilePCHContainerWriter.cpp
@@ -329,15 +329,14 @@ public:
       // Print the IR for the PCH container to the debug output.
       llvm::SmallString<0> Buffer;
       clang::emitBackendOutput(
-          CI, CodeGenOpts, CASOpts /* MCCAS */,
-          Ctx.getTargetInfo().getDataLayoutString(), M.get(),
+          CI, CodeGenOpts, Ctx.getTargetInfo().getDataLayoutString(), M.get(),
           BackendAction::Backend_EmitLL, FS,
           std::make_unique<llvm::raw_svector_ostream>(Buffer));
       llvm::dbgs() << Buffer;
     });
 
     // Use the LLVM backend to emit the pch container.
-    clang::emitBackendOutput(CI, CodeGenOpts, CASOpts, // MCCAS
+    clang::emitBackendOutput(CI, CodeGenOpts,
                              Ctx.getTargetInfo().getDataLayoutString(), M.get(),
                              BackendAction::Backend_EmitObj, FS, std::move(OS));
 

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -521,6 +521,13 @@ void dependencies::initializeScanCompilerInstance(
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS,
     DiagnosticConsumer *DiagConsumer, DependencyScanningService &Service,
     IntrusiveRefCntPtr<DependencyScanningWorkerFilesystem> DepFS) {
+  // Pre-set the shared CAS databases on the scan instance so that code which
+  // calls getOrCreateObjectStore()/getOrCreateActionCache() before
+  // createVirtualFileSystem() gets the correct shared instance.
+  if (auto *IT =
+          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
+    ScanInstance.setCASDatabases(IT->CAS, IT->Cache);
+
   ScanInstance.setBuildingModule(false);
   ScanInstance.createVirtualFileSystem(FS, DiagConsumer);
   ScanInstance.createDiagnostics(DiagConsumer, /*ShouldOwnClient=*/false);

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -524,9 +524,7 @@ void dependencies::initializeScanCompilerInstance(
   // Pre-set the shared CAS databases on the scan instance so that code which
   // calls getOrCreateObjectStore()/getOrCreateActionCache() before
   // createVirtualFileSystem() gets the correct shared instance.
-  if (auto *IT =
-          std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
-    ScanInstance.setCASDatabases(IT->CAS, IT->Cache);
+  ScanInstance.setCASDatabases(Service.getCAS(), Service.getActionCache());
 
   ScanInstance.setBuildingModule(false);
   ScanInstance.createVirtualFileSystem(FS, DiagConsumer);
@@ -809,13 +807,9 @@ struct AsyncModuleCompile : PPCallbacks {
         llvm::makeIntrusiveRefCnt<DependencyScanningWorkerFilesystem>(
             Service, Service.getOpts().MakeVFS());
 
-    std::shared_ptr<cas::ObjectStore> CAS;
-    if (auto *IncludeTree =
-            std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
-      CAS = IncludeTree->CAS;
-
-    VFS = createVFSFromCompilerInvocation(
-        CI.getInvocation(), CI.getDiagnostics(), std::move(VFS), CAS);
+    VFS =
+        createVFSFromCompilerInvocation(CI.getInvocation(), CI.getDiagnostics(),
+                                        std::move(VFS), Service.getCAS());
     auto DC = std::make_unique<DiagnosticConsumer>();
     auto MC = makeInProcessModuleCache(Service.getModuleCacheEntries());
     CompilerInstance::ThreadSafeCloneConfig CloneConfig(std::move(VFS), *DC,

--- a/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/DependencyScanning/DependencyScannerImpl.cpp
@@ -808,8 +808,14 @@ struct AsyncModuleCompile : PPCallbacks {
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
         llvm::makeIntrusiveRefCnt<DependencyScanningWorkerFilesystem>(
             Service, Service.getOpts().MakeVFS());
-    VFS = createVFSFromCompilerInvocation(CI.getInvocation(),
-                                          CI.getDiagnostics(), std::move(VFS));
+
+    std::shared_ptr<cas::ObjectStore> CAS;
+    if (auto *IncludeTree =
+            std::get_if<IncludeTreeCompilation>(&Service.getOpts().Compilation))
+      CAS = IncludeTree->CAS;
+
+    VFS = createVFSFromCompilerInvocation(
+        CI.getInvocation(), CI.getDiagnostics(), std::move(VFS), CAS);
     auto DC = std::make_unique<DiagnosticConsumer>();
     auto MC = makeInProcessModuleCache(Service.getModuleCacheEntries());
     CompilerInstance::ThreadSafeCloneConfig CloneConfig(std::move(VFS), *DC,

--- a/clang/lib/DependencyScanning/DependencyScanningService.cpp
+++ b/clang/lib/DependencyScanning/DependencyScanningService.cpp
@@ -57,3 +57,25 @@ DependencyScanningService::DependencyScanningService(
   if (std::holds_alternative<IncludeTreeCompilation>(Opts.Compilation))
     Opts.OptimizeArgs &= ~ScanningOptimizations::FullIncludeTreeIrrelevant;
 }
+
+CASOptions DependencyScanningService::getCASOpts() const {
+  if (auto *IncludeTree =
+          std::get_if<IncludeTreeCompilation>(&Opts.Compilation))
+    return IncludeTree->CASOpts;
+  return {};
+}
+
+std::shared_ptr<cas::ObjectStore> DependencyScanningService::getCAS() const {
+  if (auto *IncludeTree =
+          std::get_if<IncludeTreeCompilation>(&Opts.Compilation))
+    return IncludeTree->CAS;
+  return nullptr;
+}
+
+std::shared_ptr<cas::ActionCache>
+DependencyScanningService::getActionCache() const {
+  if (auto *IncludeTree =
+          std::get_if<IncludeTreeCompilation>(&Opts.Compilation))
+    return IncludeTree->Cache;
+  return nullptr;
+}

--- a/clang/lib/Driver/CreateASTUnitFromArgs.cpp
+++ b/clang/lib/Driver/CreateASTUnitFromArgs.cpp
@@ -129,7 +129,10 @@ std::unique_ptr<ASTUnit> clang::CreateASTUnitFromCommandLine(
   AST->Diagnostics = Diags;
   AST->FileSystemOpts = CI->getFileSystemOpts();
   AST->CodeGenOpts = std::make_unique<CodeGenOptions>(CI->getCodeGenOpts());
-  VFS = createVFSFromCompilerInvocation(*CI, *Diags, VFS);
+  if (CI->getFrontendOpts().needsCAS())
+    std::tie(AST->CAS, AST->ActionCache) = CI->getCASOpts().createDatabases(
+        *Diags, /*CreateEmptyDBsOnFailure=*/true);
+  VFS = createVFSFromCompilerInvocation(*CI, *Diags, VFS, AST->CAS);
   AST->FileMgr =
       llvm::makeIntrusiveRefCnt<FileManager>(AST->FileSystemOpts, VFS);
   AST->StorePreamblesInMemory = StorePreamblesInMemory;

--- a/clang/lib/Frontend/ASTUnit.cpp
+++ b/clang/lib/Frontend/ASTUnit.cpp
@@ -1474,8 +1474,11 @@ ASTUnit::create(std::shared_ptr<CompilerInvocation> CI,
                 bool UserFilesAreVolatile) {
   std::unique_ptr<ASTUnit> AST(new ASTUnit(false));
   ConfigureDiags(Diags, *AST, CaptureDiagnostics);
+  if (CI->getFrontendOpts().needsCAS())
+    std::tie(AST->CAS, AST->ActionCache) = CI->getCASOpts().createDatabases(
+        *Diags, /*CreateEmptyDBsOnFailure=*/true);
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS =
-      createVFSFromCompilerInvocation(*CI, *Diags);
+      createVFSFromCompilerInvocation(*CI, *Diags, AST->CAS);
   AST->DiagOpts = std::move(DiagOpts);
   AST->Diagnostics = std::move(Diags);
   AST->FileSystemOpts = CI->getFileSystemOpts();
@@ -1540,6 +1543,9 @@ ASTUnit *ASTUnit::LoadFromCompilerInvocationAction(
   // Create the compiler instance to use for building the AST.
   auto Clang = std::make_unique<CompilerInstance>(std::move(CI),
                                                   std::move(PCHContainerOps));
+
+  if (AST->CAS && AST->ActionCache)
+    Clang->setCASDatabases(AST->CAS, AST->ActionCache);
 
   // Recover resources if we crash before exiting this method.
   llvm::CrashRecoveryContextCleanupRegistrar<CompilerInstance>

--- a/clang/lib/Frontend/CompileJobCacheKey.cpp
+++ b/clang/lib/Frontend/CompileJobCacheKey.cpp
@@ -200,7 +200,7 @@ canonicalizeForCaching(const llvm::cas::ObjectStore &CAS,
   // TODO: Extract CASOptions.Path first if we need it later since it'll
   // disappear here.
   Invocation.getCASOpts() = {};
-  // Set the CASPath to the hash schema to match CASOptions::freezeConfig.
+  // Set the CASPath to the hash schema.
   Invocation.getCASOpts().CASPath =
       CAS.getContext().getHashSchemaIdentifier().str();
 
@@ -219,24 +219,14 @@ void clang::canonicalizeCASCompilerInvocation(const ObjectStore &CAS,
 }
 
 std::optional<std::pair<llvm::cas::CASID, llvm::cas::CASID>>
-clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS,
-                                      ActionCache &Cache,
+clang::canonicalizeAndCreateCacheKeys(ObjectStore &CAS, ActionCache &Cache,
                                       DiagnosticsEngine &Diags,
                                       CompilerInvocation &CI,
                                       CompileJobCachingOptions &Opts) {
-  // Preserve and freeze CASOptions so that we do not modify behaviour of
-  // Invocation.getCASOpts().getOrCreateDatabases().
-  CASOptions CASOpts(CI.getCASOpts());
-  CASOpts.freezeConfig(Diags);
-
   Opts = canonicalizeForCaching(CAS, CI);
   auto CacheKey = createCompileJobCacheKeyImpl(CAS, Diags, CI);
   if (!CacheKey)
     return std::nullopt;
-
-  assert(CI.getCASOpts().CASPath == CASOpts.CASPath &&
-         "cas instance has incompatible hash with cas options");
-  CI.getCASOpts() = std::move(CASOpts);
 
   if (CI.getFrontendOpts().CASInputFileCacheKey.empty())
     return std::make_pair(*CacheKey, *CacheKey);

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -297,9 +297,8 @@ void CompilerInstance::createVirtualFileSystem(
   DiagnosticsEngine Diags(DiagnosticIDs::create(), DiagOpts, DC,
                           /*ShouldOwnClient=*/false);
 
-  std::tie(CAS, ActionCache) =
-      getInvocation().getCASOpts().getOrCreateDatabases(
-          Diags, /*CreateEmptyCASOnFailure=*/false);
+  // CAS is passed here so that if we have cached a CAS already it is shared.
+  // Otherwise, createBaseFS will handle it.
 
   VFS = createVFSFromCompilerInvocation(getInvocation(), Diags,
                                         std::move(BaseFS), CAS);
@@ -986,6 +985,16 @@ CompilerInstance::getOrCreateCASDatabases() {
   return {CAS, ActionCache};
 }
 
+void CompilerInstance::setCASDatabases(
+    std::shared_ptr<llvm::cas::ObjectStore> CAS,
+    std::shared_ptr<llvm::cas::ActionCache> ActionCache) {
+  assert((!this->CAS || this->CAS == CAS) && "modifying CompilerInstance CAS");
+  assert((!this->ActionCache || this->ActionCache == ActionCache) &&
+         "modifying CompilerInstance Cache");
+  this->CAS = std::move(CAS);
+  this->ActionCache = std::move(ActionCache);
+}
+
 llvm::cas::ObjectStore &CompilerInstance::getOrCreateObjectStore() {
   if (!CAS)
     getOrCreateCASDatabases();
@@ -1410,6 +1419,9 @@ std::unique_ptr<CompilerInstance> CompilerInstance::cloneForModuleCompileImpl(
   auto &Instance = *InstancePtr;
 
   auto &Inv = Instance.getInvocation();
+
+  if (CAS)
+    Instance.setCASDatabases(CAS, ActionCache);
 
   if (ThreadSafeConfig) {
     Instance.setVirtualFileSystem(ThreadSafeConfig->getVFS());

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -874,10 +874,9 @@ void CompilerInstance::createSema(TranslationUnitKind TUKind,
           currentModule, getLangOpts().APINotesModules,
           getAPINotesOpts().ModuleSearchPaths);
     else
-      loadAPINotesFromIncludeTree(
-          *getCASOpts().getOrCreateDatabases(getDiagnostics()).first,
-          TheSema->APINotes, getDiagnostics(),
-          getFrontendOpts().CASIncludeTreeID);
+      loadAPINotesFromIncludeTree(getOrCreateObjectStore(), TheSema->APINotes,
+                                  getDiagnostics(),
+                                  getFrontendOpts().CASIncludeTreeID);
 
     // Check for any attributes we should add to the module
     for (auto reader : TheSema->APINotes.getCurrentModuleReaders()) {
@@ -1027,17 +1026,15 @@ void CompilerInstance::initializeDelayedInputFileFromCAS() {
     Diagnostics->Report(diag::err_fe_unable_to_load_include_tree)
         << Opts.CASIncludeTreeID << llvm::toString(std::move(E));
   };
-  auto CAS = Invocation->getCASOpts().getOrCreateDatabases(*Diagnostics).first;
-  if (!CAS)
-    return;
+  auto &CAS = getOrCreateObjectStore();
   if (!Opts.CASIncludeTreeID.empty()) {
-    auto ID = CAS->parseID(Opts.CASIncludeTreeID);
+    auto ID = CAS.parseID(Opts.CASIncludeTreeID);
     if (!ID)
       return reportError(ID.takeError());
-    auto Object = CAS->getReference(*ID);
+    auto Object = CAS.getReference(*ID);
     if (!Object)
       return reportError(llvm::cas::ObjectStore::createUnknownObjectError(*ID));
-    auto Root = cas::IncludeTreeRoot::get(*CAS, *Object);
+    auto Root = cas::IncludeTreeRoot::get(CAS, *Object);
     if (!Root)
       return reportError(Root.takeError());
     auto MainTree = Root->getMainFileTree();
@@ -1069,14 +1066,14 @@ void CompilerInstance::initializeDelayedInputFileFromCAS() {
     return;
   }
   if (!Opts.CASInputFileCASID.empty()) {
-    auto ID = CAS->parseID(Opts.CASInputFileCASID);
+    auto ID = CAS.parseID(Opts.CASInputFileCASID);
     if (!ID)
       return reportError(ID.takeError());
-    auto ValueRef = CAS->getReference(*ID);
+    auto ValueRef = CAS.getReference(*ID);
     if (!ValueRef)
       return reportError(llvm::cas::ObjectStore::createUnknownObjectError(*ID));
 
-    cas::CompileJobResultSchema Schema(*CAS);
+    cas::CompileJobResultSchema Schema(CAS);
     auto Result = Schema.load(*ValueRef);
     if (!Result)
       return reportError(Result.takeError());
@@ -1086,7 +1083,7 @@ void CompilerInstance::initializeDelayedInputFileFromCAS() {
       return reportError(
           llvm::createStringError("unable to get the main compilation output"));
 
-    auto OutProxy = CAS->getProxy(Output->Object);
+    auto OutProxy = CAS.getProxy(Output->Object);
     if (!OutProxy)
       return reportError(OutProxy.takeError());
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -976,13 +976,14 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputManager() {
 std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
           std::shared_ptr<llvm::cas::ActionCache>>
 CompilerInstance::getOrCreateCASDatabases(DiagnosticsEngine *Diags) {
+  if (CAS && ActionCache)
+    return {CAS, ActionCache};
   if (!Diags)
     Diags = this->Diagnostics.get();
-  // Create a new CAS databases from the CompilerInvocation. Future calls to
-  // createFileManager() will use the same CAS.
+  // Create a new CAS databases from the CompilerInvocation. Future calls will
+  // use the same CAS.
   std::tie(CAS, ActionCache) =
-      getInvocation().getCASOpts().getOrCreateDatabases(
-          *Diags, /*CreateEmptyCASOnFailure=*/true);
+      getCASOpts().createDatabases(*Diags, /*CreateEmptyDBsOnFailure=*/true);
   return {CAS, ActionCache};
 }
 

--- a/clang/lib/Frontend/CompilerInstance.cpp
+++ b/clang/lib/Frontend/CompilerInstance.cpp
@@ -297,8 +297,8 @@ void CompilerInstance::createVirtualFileSystem(
   DiagnosticsEngine Diags(DiagnosticIDs::create(), DiagOpts, DC,
                           /*ShouldOwnClient=*/false);
 
-  // CAS is passed here so that if we have cached a CAS already it is shared.
-  // Otherwise, createBaseFS will handle it.
+  if (getFrontendOpts().needsCAS())
+    getOrCreateCASDatabases(&Diags);
 
   VFS = createVFSFromCompilerInvocation(getInvocation(), Diags,
                                         std::move(BaseFS), CAS);
@@ -975,13 +975,14 @@ llvm::vfs::OutputBackend &CompilerInstance::getOrCreateOutputManager() {
 
 std::pair<std::shared_ptr<llvm::cas::ObjectStore>,
           std::shared_ptr<llvm::cas::ActionCache>>
-CompilerInstance::getOrCreateCASDatabases() {
+CompilerInstance::getOrCreateCASDatabases(DiagnosticsEngine *Diags) {
+  if (!Diags)
+    Diags = this->Diagnostics.get();
   // Create a new CAS databases from the CompilerInvocation. Future calls to
   // createFileManager() will use the same CAS.
   std::tie(CAS, ActionCache) =
       getInvocation().getCASOpts().getOrCreateDatabases(
-          getDiagnostics(),
-          /*CreateEmptyCASOnFailure=*/true);
+          *Diags, /*CreateEmptyCASOnFailure=*/true);
   return {CAS, ActionCache};
 }
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1508,10 +1508,6 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
   if (FEOpts.CASIncludeTreeID.empty())
     return BaseFS;
 
-  // If no CAS was provided, create one with CASOptions.
-  if (!CAS)
-    CAS = CASOpts.getOrCreateDatabases(Diags).first;
-
   // Helper for creating a valid (but empty) CAS FS if an error is encountered.
   auto makeEmptyCASFS = [&CAS]() {
     // Try to use the configured CAS, if any.
@@ -1536,6 +1532,8 @@ createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
   };
 
   // CAS couldn't be created. The error was already reported to Diags.
+  assert((CAS || Diags.hasErrorOccurred()) &&
+         "CAS is missing but not diagnosed");
   if (!CAS)
     return makeEmptyCASFS();
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1504,12 +1504,11 @@ static IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 createBaseFS(const FileSystemOptions &FSOpts, const FrontendOptions &FEOpts,
              const CASOptions &CASOpts, DiagnosticsEngine &Diags,
              IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
-             std::shared_ptr<llvm::cas::ObjectStore> OverrideCAS) {
+             std::shared_ptr<llvm::cas::ObjectStore> CAS) {
   if (FEOpts.CASIncludeTreeID.empty())
     return BaseFS;
 
   // If no CAS was provided, create one with CASOptions.
-  std::shared_ptr<llvm::cas::ObjectStore> CAS = std::move(OverrideCAS);
   if (!CAS)
     CAS = CASOpts.getOrCreateDatabases(Diags).first;
 
@@ -5956,21 +5955,20 @@ void CompilerInvocation::clearImplicitModuleBuildOptions() {
 IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 clang::createVFSFromCompilerInvocation(
     const CompilerInvocation &CI, DiagnosticsEngine &Diags,
-    std::shared_ptr<llvm::cas::ObjectStore> OverrideCAS) {
+    std::shared_ptr<llvm::cas::ObjectStore> CAS) {
   return createVFSFromCompilerInvocation(
-      CI, Diags, llvm::vfs::getRealFileSystem(), std::move(OverrideCAS));
+      CI, Diags, llvm::vfs::getRealFileSystem(), std::move(CAS));
 }
 
 IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 clang::createVFSFromCompilerInvocation(
     const CompilerInvocation &CI, DiagnosticsEngine &Diags,
     IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
-    std::shared_ptr<llvm::cas::ObjectStore> OverrideCAS) {
+    std::shared_ptr<llvm::cas::ObjectStore> CAS) {
   return createVFSFromOverlayFiles(
       CI.getHeaderSearchOpts().VFSOverlayFiles, Diags,
       createBaseFS(CI.getFileSystemOpts(), CI.getFrontendOpts(),
-                   CI.getCASOpts(), Diags, std::move(BaseFS),
-                   std::move(OverrideCAS)));
+                   CI.getCASOpts(), Diags, std::move(BaseFS), std::move(CAS)));
 }
 
 IntrusiveRefCntPtr<llvm::vfs::FileSystem> clang::createVFSFromOverlayFiles(

--- a/clang/lib/Tooling/DependencyScanningTool.cpp
+++ b/clang/lib/Tooling/DependencyScanningTool.cpp
@@ -271,9 +271,9 @@ Expected<cas::IncludeTreeRoot> DependencyScanningTool::getIncludeTree(
     const std::vector<std::string> &CommandLine, StringRef CWD,
     LookupModuleOutputCallback LookupModuleOutput,
     DiagnosticConsumer &DiagsConsumer) {
-  GetIncludeTree Consumer(*Worker.getCAS());
-  auto Controller = createIncludeTreeActionController(
-      LookupModuleOutput, getCASOpts(), *Worker.getCAS());
+  GetIncludeTree Consumer(*getCAS());
+  auto Controller = createIncludeTreeActionController(LookupModuleOutput,
+                                                      getCASOpts(), *getCAS());
   if (!computeDependencies(Worker, CWD, CommandLine, Consumer, *Controller,
                            DiagsConsumer))
     return llvm::make_error<AlreadyReportedDiagnosticError>();
@@ -286,9 +286,9 @@ DependencyScanningTool::getIncludeTreeFromCompilerInvocation(
     LookupModuleOutputCallback LookupModuleOutput,
     DiagnosticConsumer &DiagsConsumer, raw_ostream *VerboseOS,
     bool DiagGenerationAsCompilation) {
-  GetIncludeTree Consumer(*Worker.getCAS());
-  auto Controller = createIncludeTreeActionController(
-      LookupModuleOutput, getCASOpts(), *Worker.getCAS());
+  GetIncludeTree Consumer(*getCAS());
+  auto Controller = createIncludeTreeActionController(LookupModuleOutput,
+                                                      getCASOpts(), *getCAS());
   Worker.computeDependenciesFromCompilerInvocation(
       std::move(Invocation), CWD, Consumer, *Controller, DiagsConsumer,
       VerboseOS, DiagGenerationAsCompilation);
@@ -442,7 +442,7 @@ DependencyScanningTool::getTranslationUnitDependencies(
   if (TUBuffer) {
     std::tie(OverlayFS, CommandLineWithTUBufferInput) =
         initVFSForTUBufferScanning(&Worker.getVFS(), CommandLine, CWD,
-                                   *TUBuffer, Worker.getCAS());
+                                   *TUBuffer, getCAS());
     CommandLine = CommandLineWithTUBufferInput;
   }
 
@@ -494,7 +494,7 @@ CompilerInstanceWithContext::initializeFromCommandline(
     ArrayRef<std::string> CommandLine, DependencyActionController &Controller,
     DiagnosticConsumer &DC) {
   auto [OverlayFS, ModifiedCommandLine] = initVFSForByNameScanning(
-      &Tool.Worker.getVFS(), CommandLine, CWD, Tool.Worker.getCAS());
+      &Tool.Worker.getVFS(), CommandLine, CWD, Tool.getCAS());
 
   auto DiagEngineWithCmdAndOpts =
       std::make_unique<DiagnosticsEngineWithDiagOpts>(ModifiedCommandLine,
@@ -569,8 +569,9 @@ DependencyScanningTool::createActionController(
     DependencyScanningWorker &Worker,
     LookupModuleOutputCallback LookupModuleOutput) {
   if (Worker.getScanningFormat() == ScanningOutputFormat::FullIncludeTree)
-    return createIncludeTreeActionController(
-        LookupModuleOutput, Worker.getCASOpts(), *Worker.getCAS());
+    return createIncludeTreeActionController(LookupModuleOutput,
+                                             Worker.getService().getCASOpts(),
+                                             *Worker.getService().getCAS());
   return std::make_unique<CallbackActionController>(LookupModuleOutput);
 }
 

--- a/clang/tools/clang-cas-test/ClangCASTest.cpp
+++ b/clang/tools/clang-cas-test/ClangCASTest.cpp
@@ -84,9 +84,7 @@ int main(int Argc, const char **Argv) {
     }
   }
 
-  auto CAS =
-      Opts.getOrCreateDatabases(*Diags, /*CreateEmptyCASOnFailure=*/false)
-          .first;
+  auto CAS = Opts.createDatabases(*Diags).first;
   if (!CAS)
     return 1;
 

--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1086,7 +1086,7 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
     if (!InMemoryCAS)
       CASOpts.ensurePersistentCAS();
 
-    std::tie(CAS, Cache) = CASOpts.getOrCreateDatabases(Diags);
+    std::tie(CAS, Cache) = CASOpts.createDatabases(Diags);
     if (!CAS)
       return 1;
   }

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -544,7 +544,6 @@ scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
                        llvm::function_ref<const char *(const Twine &)> SaveArg,
                        const CASOptions &CASOpts, DiagnosticsEngine &Diag,
                        std::optional<llvm::cas::CASID> &RootID) {
-  assert(!CASOpts.hasCachedDatabase() && "expected CAS to not be opened yet");
   auto [DB, Cache] = CASOpts.createDatabases(Diag);
   if (!DB || !Cache)
     return 1;
@@ -633,7 +632,6 @@ static int scanAndUpdateCC1UsingDaemon(
 
   // Create CAS after daemon returns the result so daemon can perform corrupted
   // CAS recovery.
-  assert(!CASOpts.hasCachedDatabase() && "expected CAS to not be opened yet");
   auto [CAS, _] = CASOpts.createDatabases(Diag);
   if (!CAS)
     return 1;
@@ -993,7 +991,6 @@ int ScanServer::listen() {
   DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts);
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
-  assert(!CASOpts.hasCachedDatabase() && "expected CAS to not be opened yet");
   std::tie(CAS, Cache) = CASOpts.createDatabases(Diags);
   if (!CAS)
     reportError("cannot create CAS");

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -544,7 +544,8 @@ scanAndUpdateCC1Inline(const char *Exec, ArrayRef<const char *> InputArgs,
                        llvm::function_ref<const char *(const Twine &)> SaveArg,
                        const CASOptions &CASOpts, DiagnosticsEngine &Diag,
                        std::optional<llvm::cas::CASID> &RootID) {
-  auto [DB, Cache] = CASOpts.getOrCreateDatabases(Diag);
+  assert(!CASOpts.hasCachedDatabase() && "expected CAS to not be opened yet");
+  auto [DB, Cache] = CASOpts.createDatabases(Diag);
   if (!DB || !Cache)
     return 1;
 
@@ -632,7 +633,8 @@ static int scanAndUpdateCC1UsingDaemon(
 
   // Create CAS after daemon returns the result so daemon can perform corrupted
   // CAS recovery.
-  auto [CAS, _] = CASOpts.getOrCreateDatabases(Diag);
+  assert(!CASOpts.hasCachedDatabase() && "expected CAS to not be opened yet");
+  auto [CAS, _] = CASOpts.createDatabases(Diag);
   if (!CAS)
     return 1;
 
@@ -991,7 +993,8 @@ int ScanServer::listen() {
   DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts);
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> Cache;
-  std::tie(CAS, Cache) = CASOpts.getOrCreateDatabases(Diags);
+  assert(!CASOpts.hasCachedDatabase() && "expected CAS to not be opened yet");
+  std::tie(CAS, Cache) = CASOpts.createDatabases(Diags);
   if (!CAS)
     reportError("cannot create CAS");
   if (!Cache)

--- a/clang/tools/libclang/CCAS.cpp
+++ b/clang/tools/libclang/CCAS.cpp
@@ -137,7 +137,7 @@ CXCASDatabases clang_experimental_cas_Databases_create(CXCASOptions COpts,
       IntrusiveRefCntPtr<DiagnosticIDs>(new DiagnosticIDs()), DiagOpts,
       &DiagPrinter, /*ShouldOwnClient=*/false);
 
-  auto [CAS, Cache] = Opts.getOrCreateDatabases(Diags);
+  auto [CAS, Cache] = Opts.createDatabases(Diags);
   if (!CAS || !Cache) {
     if (Error)
       *Error = cxstring::createDup(OS.str());

--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -942,7 +942,7 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
     ReproducerCASOpts.CASPath = CASPath.str();
     ReproducerCASOpts.PluginPath = Opts.CASOpts.PluginPath;
     ReproducerCASOpts.PluginOptions = Opts.CASOpts.PluginOptions;
-    auto DBsOrErr = ReproducerCASOpts.getOrCreateDatabases();
+    auto DBsOrErr = ReproducerCASOpts.CASConfiguration::createDatabases();
     if (!DBsOrErr)
       return ReportFailure() << "failed to create a CAS database\n"
                              << toString(DBsOrErr.takeError());

--- a/clang/unittests/CAS/CASOptionsTest.cpp
+++ b/clang/unittests/CAS/CASOptionsTest.cpp
@@ -38,18 +38,16 @@ TEST(CASOptionsTest, getKind) {
   EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
 }
 
-TEST(CASOptionsTest, getOrCreateDatabases) {
+TEST(CASOptionsTest, createDatabases) {
   DiagnosticOptions DiagOpts;
   DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts,
                           new IgnoringDiagConsumer());
 
   // Create an in-memory CAS.
   CASOptions Opts;
-  auto [InMemoryCAS, InMemoryAC] = Opts.getOrCreateDatabases(Diags);
+  auto [InMemoryCAS, InMemoryAC] = Opts.createDatabases(Diags);
   ASSERT_TRUE(InMemoryCAS);
   ASSERT_TRUE(InMemoryAC);
-  EXPECT_EQ(InMemoryCAS, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(InMemoryAC, Opts.getOrCreateDatabases(Diags).second);
   EXPECT_EQ(CASOptions::InMemoryCAS, Opts.getKind());
 
   if (!llvm::cas::isOnDiskCASEnabled())
@@ -58,39 +56,33 @@ TEST(CASOptionsTest, getOrCreateDatabases) {
   // Create an on-disk CAS.
   unittest::TempDir Dir("cas-options", /*Unique=*/true);
   Opts.CASPath = Dir.path("cas").str().str();
-  auto [OnDiskCAS, OnDiskAC] = Opts.getOrCreateDatabases(Diags);
+  auto [OnDiskCAS, OnDiskAC] = Opts.createDatabases(Diags);
   EXPECT_NE(InMemoryCAS, OnDiskCAS);
   EXPECT_NE(InMemoryAC, OnDiskAC);
-  EXPECT_EQ(OnDiskCAS, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(OnDiskAC, Opts.getOrCreateDatabases(Diags).second);
   EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
 
   // Create an on-disk CAS at a different OnDisk location.
   Opts.CASPath = Dir.path("cas2").str().str();
-  auto [OnDiskCAS2, OnDiskAC2] = Opts.getOrCreateDatabases(Diags);
+  auto [OnDiskCAS2, OnDiskAC2] = Opts.createDatabases(Diags);
   EXPECT_NE(InMemoryCAS, OnDiskCAS2);
   EXPECT_NE(InMemoryAC, OnDiskAC2);
   EXPECT_NE(OnDiskCAS, OnDiskCAS2);
   EXPECT_NE(OnDiskAC, OnDiskAC2);
-  EXPECT_EQ(OnDiskCAS2, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(OnDiskAC2, Opts.getOrCreateDatabases(Diags).second);
   EXPECT_EQ(CASOptions::OnDiskCAS, Opts.getKind());
 
   // Create another in-memory CAS. It won't be the same one.
   Opts.CASPath = "";
-  auto [InMemoryCAS2, InMemoryAC2] = Opts.getOrCreateDatabases(Diags);
+  auto [InMemoryCAS2, InMemoryAC2] = Opts.createDatabases(Diags);
   EXPECT_NE(InMemoryCAS, InMemoryCAS2);
   EXPECT_NE(InMemoryAC, InMemoryAC2);
   EXPECT_NE(OnDiskCAS, InMemoryCAS2);
   EXPECT_NE(OnDiskAC, InMemoryAC2);
   EXPECT_NE(OnDiskCAS2, InMemoryCAS2);
   EXPECT_NE(OnDiskAC2, InMemoryAC2);
-  EXPECT_EQ(InMemoryCAS2, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(InMemoryAC2, Opts.getOrCreateDatabases(Diags).second);
   EXPECT_EQ(CASOptions::InMemoryCAS, Opts.getKind());
 }
 
-TEST(CASOptionsTest, getOrCreateObjectStoreInvalid) {
+TEST(CASOptionsTest, createObjectStoreInvalid) {
   if (!llvm::cas::isOnDiskCASEnabled())
     return;
 
@@ -106,13 +98,13 @@ TEST(CASOptionsTest, getOrCreateObjectStoreInvalid) {
 
   CASOptions Opts;
   Opts.CASPath = File.path().str();
-  EXPECT_EQ(nullptr, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(nullptr, Opts.getOrCreateDatabases(Diags).second);
+  EXPECT_EQ(nullptr, Opts.createDatabases(Diags).first);
+  EXPECT_EQ(nullptr, Opts.createDatabases(Diags).second);
 
   auto [EmptyCAS, EmptyAC] =
-      Opts.getOrCreateDatabases(Diags, /*CreateEmptyCASOnFailure=*/true);
-  EXPECT_EQ(EmptyCAS, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(EmptyAC, Opts.getOrCreateDatabases(Diags).second);
+      Opts.createDatabases(Diags, /*CreateEmptyCASOnFailure=*/true);
+  EXPECT_NE(nullptr, EmptyCAS);
+  EXPECT_NE(nullptr, EmptyAC);
 
   // Ensure the file wasn't clobbered.
   std::unique_ptr<MemoryBuffer> MemBuffer;
@@ -120,40 +112,6 @@ TEST(CASOptionsTest, getOrCreateObjectStoreInvalid) {
       errorOrToExpected(MemoryBuffer::getFile(File.path())).moveInto(MemBuffer),
       Succeeded());
   ASSERT_EQ(Contents, MemBuffer->getBuffer());
-}
-
-TEST(CASOptionsTest, freezeConfig) {
-  if (!llvm::cas::isOnDiskCASEnabled())
-    return;
-
-  DiagnosticOptions DiagOpts;
-  DiagnosticsEngine Diags(new DiagnosticIDs(), DiagOpts,
-                          new IgnoringDiagConsumer());
-
-  // Hide the CAS configuration when creating it.
-  unittest::TempDir Dir("cas-options", /*Unique=*/true);
-  CASOptions Opts;
-  Opts.CASPath = Dir.path("cas").str().str();
-  Opts.freezeConfig(Diags);
-  auto [CAS, AC] = Opts.getOrCreateDatabases(Diags);
-  ASSERT_TRUE(CAS);
-  ASSERT_TRUE(AC);
-  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
-
-  // Check that the configuration is hidden, but calls to
-  // getOrCreateObjectStore() still return the original CAS.
-  EXPECT_EQ(CAS->getContext().getHashSchemaIdentifier(), Opts.CASPath);
-
-  // Check that new paths are ignored.
-  Opts.CASPath = "";
-  EXPECT_EQ(CAS, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(AC, Opts.getOrCreateDatabases(Diags).second);
-  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
-
-  Opts.CASPath = Dir.path("ignored-cas").str().str();
-  EXPECT_EQ(CAS, Opts.getOrCreateDatabases(Diags).first);
-  EXPECT_EQ(AC, Opts.getOrCreateDatabases(Diags).second);
-  EXPECT_EQ(CASOptions::UnknownCAS, Opts.getKind());
 }
 
 TEST(CASOptionsTest, equal) {

--- a/clang/unittests/CAS/IncludeTreeTest.cpp
+++ b/clang/unittests/CAS/IncludeTreeTest.cpp
@@ -18,7 +18,8 @@ using namespace clang::tooling;
 TEST(IncludeTree, IncludeTreeScan) {
   StringRef PathSep = llvm::sys::path::get_separator();
   CASOptions CASOpts;
-  auto [DB, Cache] = llvm::cantFail(CASOpts.getOrCreateDatabases());
+  auto [DB, Cache] =
+      llvm::cantFail(CASOpts.CASConfiguration::createDatabases());
   auto FS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   FS->setCurrentWorkingDirectory("/root");
   auto add = [&](StringRef Path, StringRef Contents) {


### PR DESCRIPTION
The goal is to stop caching the CAS databases inside the CASOptions, which is surprising, and move it to natural places like the CompilerInstance. All callers of `getOrCreateDatabases` are migrated to either create their own CAS instances using `createDatabases` or to use the ones stored inside the `CompilerInstance`.  This required plumbing CAS instances around in more places to avoid opening the same CAS multiple times, particularly around the use of `createVirtualFileSystem`. 

The final commits in this series will require out-of-tree users of `CASOptions::getOrCreateDatabases` and `createVirtualFileSystem`, such as Swift's `ClangImporter` to be updated before they are cherry-picked.

I verified that there are no regressions in the number of calls to the underlying `createDatabases` function across all of the tests.  In fact we now make significantly fewer CAS instances, because of the change to not unconditionally create a (usually in-memory) CAS.  But I also verified that even without that change we get the same number of CAS instances created, so there should be no situations that regressed.