### PR TITLE
[LLDB] Sort the explicit Swift module map into cas|esml maps 

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
@@ -32,6 +32,14 @@ LLDBExplicitSwiftModuleLoader::LLDBExplicitSwiftModuleLoader(
       m_cas(cas), m_action_cache(action_cache), m_casml(std::move(casml)),
       m_esml(std::move(esml)) {}
 
+template <typename Map, typename Entry>
+void sortEntry(Map &cas_map, Map &esml_map, const Entry &entry) {
+  if (entry.getValue().moduleCacheKey)
+    cas_map.insert({entry.getKey(), entry.getValue()});
+  else
+    esml_map.insert({entry.getKey(), entry.getValue()});
+}
+
 std::unique_ptr<LLDBExplicitSwiftModuleLoader>
 LLDBExplicitSwiftModuleLoader::create(
     swift::ASTContext &ctx, std::shared_ptr<llvm::cas::ObjectStore> cas,
@@ -45,22 +53,43 @@ LLDBExplicitSwiftModuleLoader::create(
     std::unique_ptr<swift::ExplicitClangModuleMap> ExplicitClangModuleMap) {
   if (!MainSwiftModuleMap || !ExplicitSwiftModuleMap || !ExplicitClangModuleMap)
     return {};
+
+  std::unique_ptr<swift::ExplicitSwiftModuleMap> cas_swift_map, esml_swift_map;
+  std::unique_ptr<swift::ExplicitClangModuleMap> cas_clang_map, esml_clang_map;
+
+  // Filter the map for the approriate module loader. In practice, an
+  // explicit module map should be either all CAS or all paths, so it
+  // may be possible to optimize this into a check of the first
+  // element and and assigment.
+  cas_swift_map = std::make_unique<swift::ExplicitSwiftModuleMap>();
+  esml_swift_map = std::make_unique<swift::ExplicitSwiftModuleMap>();
+  cas_clang_map = std::make_unique<swift::ExplicitClangModuleMap>();
+  esml_clang_map = std::make_unique<swift::ExplicitClangModuleMap>();
+
+  for (auto &entry : *MainSwiftModuleMap)
+    sortEntry(*cas_swift_map, *esml_swift_map, entry);
+
+  for (auto &entry : *ExplicitSwiftModuleMap)
+    sortEntry(*cas_swift_map, *esml_swift_map, entry);
+
+  for (auto &entry : *ExplicitClangModuleMap)
+    sortEntry(*cas_clang_map, *esml_clang_map, entry);
+
   std::unique_ptr<swift::ExplicitCASModuleLoader> casml;
   if (cas && action_cache) {
     casml = swift::ExplicitCASModuleLoader::create(
         ctx, *cas, *action_cache, tracker, loadMode, ExplicitSwiftModuleMapPath,
         ExplicitSwiftModuleInputs, IgnoreSwiftSourceInfoFile,
-        std::move(ExplicitSwiftModuleMap), std::move(ExplicitClangModuleMap));
+        std::move(cas_swift_map), std::move(cas_clang_map));
+  } else if (cas_swift_map->size() || cas_clang_map->size()) {
+    LLDB_LOG(
+        GetLog(LLDBLog::Types),
+        "explicit Swift module map contains cache keys, but no CAS available");
   }
-  if (!ExplicitSwiftModuleMap)
-    ExplicitSwiftModuleMap = std::move(MainSwiftModuleMap);
-  else
-    for (auto &entry : *MainSwiftModuleMap)
-      ExplicitSwiftModuleMap->insert({entry.getKey(), entry.getValue()});
   auto esml = swift::ExplicitSwiftModuleLoader::create(
       ctx, tracker, loadMode, ExplicitSwiftModuleMapPath,
       ExplicitSwiftModuleInputs, IgnoreSwiftSourceInfoFile,
-      std::move(ExplicitSwiftModuleMap), std::move(ExplicitClangModuleMap));
+      std::move(esml_swift_map), std::move(esml_clang_map));
   return std::make_unique<LLDBExplicitSwiftModuleLoader>(
       ctx, cas, action_cache, tracker, loadMode, IgnoreSwiftSourceInfoFile,
       std::move(casml), std::move(esml));

--- a/lldb/test/Shell/Swift/caching.test
+++ b/lldb/test/Shell/Swift/caching.test
@@ -22,6 +22,15 @@
 # CAS-LOAD:      LogConfiguration() --     -fmodule-file-cache-key
 # CHECK:         (Int) ${{.*}} = 1
 
+## Test that the presence of a cache doesn't break regular debugging.
+# RUN: %target-swiftc -g -Onone -save-temps \
+# RUN:          -module-cache-path %t/cache %t/main.swift \
+# RUN:          -explicit-module-build \
+# RUN:          -module-name main -o %t/main
+# RUN: %lldb %t/main -s %t/lldb.script 2>&1 | FileCheck %s --check-prefix=UNCACHED
+# UNCACHED:  SwiftASTContextForExpressions(module: "main", cu: "main.swift")::LoadOneModule() -- Imported module main from {kind = Serialized Swift AST, filename = "{{.*}}main{{.*}}.swiftmodule";}
+# UNCACHED:         (Int) ${{.*}} = 1
+
 //--- main.swift
 func test() {
   print("break here")
@@ -29,8 +38,6 @@ func test() {
 test()
 
 //--- lldb.script.template
-# Force loading from interface to simulate no binary module available.
-settings set symbols.swift-module-loading-mode prefer-interface
 settings set symbols.cas-path DIR/cas
 log enable lldb types
 b test


### PR DESCRIPTION
The current implementation breaks if an EBM build is uncached, but LLDB's heuristics found a CAS configuration. To avoid non-CAS module map entries getting sent to the CAS loader, this patch filters the module map and sorts it into either int the CAS or the ESML module map.

rdar://171940576