### PR TITLE
CAS,driver: properly handle build session ID with clang-cl

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5095,10 +5095,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &Job,
   {
     const OptSpecifier DepScanOpts[] = {options::OPT_fdepscan_EQ,
                                         options::OPT_fdepscan_share_EQ,
+                                        options::OPT_fno_depscan_share,
                                         options::OPT_fdepscan_share_identifier,
+                                        options::OPT_fdepscan_share_identifier_EQ,
                                         options::OPT_fdepscan_share_parent,
                                         options::OPT_fdepscan_share_parent_EQ,
-                                        options::OPT_fno_depscan_share,
                                         options::OPT_fdepscan_share_stop_EQ,
                                         options::OPT_fdepscan_daemon_EQ};
 

--- a/clang/test/CAS/driver-cache-launcher-clang-cl.c
+++ b/clang/test/CAS/driver-cache-launcher-clang-cl.c
@@ -1,0 +1,5 @@
+// RUN: rm -rf %t && mkdir %t
+// RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session -v %clang-cache %clang_cl -### -c -- %s 2>&1 | FileCheck %s
+
+// CHECK: note: setting LLVM_CACHE_BUILD_SESSION_ID=[[SESSION_ID:[0-9-]+]]
+// CHECK: "-fdepscan-share-identifier" "[[SESSION_ID]]"

--- a/clang/test/CAS/driver-cache-launcher.c
+++ b/clang/test/CAS/driver-cache-launcher.c
@@ -26,7 +26,7 @@
 // INCLUDE-TREE: "-cc1depscan" "-fdepscan=auto"
 
 // RUN: env LLVM_CACHE_CAS_PATH=%t/cas cache-build-session %clang-cache %clang -c %s -o %t.o -### 2>&1 | FileCheck %s -check-prefix=SESSION -DPREFIX=%t
-// SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
+// SESSION: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier={{.*}}"
 // SESSION: "-fcas-path" "[[PREFIX]]/cas"
 // SESSION: "-greproducible"
 
@@ -105,7 +105,7 @@
 // SESSION-CMAKE-PREFIX: note: setting LLVM_CACHE_PREFIX_MAPS=/llvm/build=/^build;/llvm/llvm-project/llvm=/^src;/llvm/llvm-project/clang=/^src-clang;/llvm/llvm-project/clang-tools-extra=/^src-clang-tools-extra;/llvm/llvm-project/third-party/benchmark=/^src-benchmark;/llvm/llvm-project/other/benchmark=/^src-benchmark-1;/llvm/llvm-project/another/benchmark=/^src-benchmark-2{{$}}
 // SESSION-CMAKE-PREFIX: note: setting LLVM_CACHE_BUILD_SESSION_ID=
 
-// CLANG-CMAKE-PREFIX: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier"
+// CLANG-CMAKE-PREFIX: "-cc1depscan" "-fdepscan=daemon" "-fdepscan-share-identifier={{.*}}"
 // CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "[[INPUTS]]/SDK" "/^sdk"
 // CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "[[INPUTS]]/toolchain_dir" "/^toolchain"
 // CLANG-CMAKE-PREFIX: "-fdepscan-prefix-map" "/llvm/build" "/^build"

--- a/clang/tools/driver/CacheLauncherMode.cpp
+++ b/clang/tools/driver/CacheLauncherMode.cpp
@@ -151,19 +151,18 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
         ArgsBeforeEOO.push_back(Saver.save(Arg).data());
         Passthrough = true;
       } else if (Arg.starts_with("-")) {
-        // Arguments which are not passed through to clang-frontend or
-        // LLVM need to go through the driver. `clang-cl` takes non-CL
-        // options with a `/clang:` prefix to namespace and maintain
-        // compatibility.
+        // Arguments which are not passed through to clang-frontend or LLVM need
+        // to go through the driver. `clang-cl` takes non-CL options with a
+        // `/clang:` prefix to namespace and maintain compatibility.
         if (IsCLMode && !Passthrough)
           ArgsBeforeEOO.push_back(Saver.save(llvm::Twine("/clang:") + Arg).data());
         else
           ArgsBeforeEOO.push_back(Saver.save(Arg).data());
         Passthrough = false;
       } else {
-        // We add -Xclang to flag arguments in cl mode because flags
-        // have a /clang: prefix. For example,
-        // /clang:-fdepscan-share-identifier -Xclang SessionId
+        // We add -Xclang to pass non-flag values in cl mode because the
+        // preceding option has a /clang: prefix. For example,
+        // /clang:-fdepscan-prefix-map -Xclang /path/=^path
         if (!Passthrough && IsCLMode)
           ArgsBeforeEOO.push_back("-Xclang");
         ArgsBeforeEOO.push_back(Saver.save(Arg).data());
@@ -190,7 +189,10 @@ static void addLauncherArgs(SmallVectorImpl<const char *> &AllArgs,
     // toolchains, with different clang versions, running under the same
     // `LLVM_CACHE_BUILD_SESSION_ID`; in such a case there will be one daemon
     // started and shared for each unique clang version.
-    AppendArgs({"-fdepscan=daemon", "-fdepscan-share-identifier", SessionId});
+    AppendArgs({
+      "-fdepscan=daemon",
+      (Twine{"-fdepscan-share-identifier="} + SessionId).str(),
+    });
   } else {
     AppendArgs({"-fdepscan"});
   }

--- a/clang/tools/driver/cc1depscan_main.cpp
+++ b/clang/tools/driver/cc1depscan_main.cpp
@@ -703,6 +703,7 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
     Sharing.Stop = A->getValue();
   if (Arg *A = Args.getLastArg(options::OPT_fdepscan_share_EQ,
                                options::OPT_fdepscan_share_identifier,
+                               options::OPT_fdepscan_share_identifier_EQ,
                                options::OPT_fdepscan_share_parent,
                                options::OPT_fdepscan_share_parent_EQ,
                                options::OPT_fno_depscan_share)) {
@@ -714,7 +715,8 @@ static int scanAndUpdateCC1(const char *Exec, ArrayRef<const char *> OldArgs,
     } else if (A->getOption().matches(options::OPT_fdepscan_share_parent)) {
       Sharing.Name = "";
       Sharing.OnlyShareParent = true;
-    } else if (A->getOption().matches(options::OPT_fdepscan_share_identifier)) {
+    } else if (A->getOption().matches(options::OPT_fdepscan_share_identifier) ||
+               A->getOption().matches(options::OPT_fdepscan_share_identifier_EQ)) {
       Sharing.Name = A->getValue();
       Sharing.ShareViaIdentifier = true;
     }


### PR DESCRIPTION
This adjusts the `clang-cache` command line alteration for supporting the build session ID propagation with `clang-cl`. The quoting rules for the arguments make this challenging. Simply use the joined form to avoid the argument being split apart prematurely.

The parameter for passing the build session id (`-fdepscan-share-identifier`) is not a `cl` style argument. As such we transmute the parameter in the cache launcher mode to `/clang:-fdepscan-share-identifier -Xclang SessionId` to transform the `-fdepscan-share-identifier` to the clang argument. The `-Xclang` parameters are collated and appended to the command line after the translation. As such, the `SessionId` is separated from the `-fdepscan-share-identifier` argument spelling. By using the joined form (i.e. `-fdepscan-share-identifier=SessionId`), we transform the argument into a single parameter where the value is not separated from the argument.

Fixes: #12544