### PR TITLE
[lldb] Skip unnecessary setup for expressions using new stringForPrintObject

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1456,35 +1456,36 @@ SwiftExpressionParser::ParseAndImport(
         local_context_is_swift = false;
     }
 
-    if (local_context_is_swift &&
-        !m_options.GetUseContextFreeSwiftPrintObject()) {
-      llvm::Error error = AddRequiredAliases(
-          m_sc.block, stack_frame_sp, m_swift_ast_ctx, *code_manipulator,
-          m_options.GetUseDynamic(), m_options.GetBindGenericTypes());
-      if (error)
-        return error;
+    if (!m_options.GetUseContextFreeSwiftPrintObject()) {
+      if (local_context_is_swift) {
+        llvm::Error error = AddRequiredAliases(
+            m_sc.block, stack_frame_sp, m_swift_ast_ctx, *code_manipulator,
+            m_options.GetUseDynamic(), m_options.GetBindGenericTypes());
+        if (error)
+          return error;
+      }
+      //
+      // Register all magic variables.
+      llvm::SmallVector<swift::Identifier, 2> special_names;
+      llvm::StringRef persistent_var_prefix;
+      if (!repl)
+        persistent_var_prefix = "$";
+
+      code_manipulator->FindSpecialNames(special_names, persistent_var_prefix);
+
+      ResolveSpecialNames(m_sc, *m_exe_scope, m_swift_ast_ctx, special_names,
+                          m_local_variables);
+
+      code_manipulator->AddExternalVariables(m_local_variables);
+
+      auto type_aliases = AddArchetypeTypeAliases(
+          code_manipulator, *stack_frame_sp.get(), m_swift_ast_ctx);
+      if (!type_aliases)
+        diagnostic_manager.PutString(eSeverityWarning,
+                                     llvm::toString(type_aliases.takeError()));
+      else
+        external_lookup->RegisterTypeAliases(*type_aliases);
     }
-    //
-    // Register all magic variables.
-    llvm::SmallVector<swift::Identifier, 2> special_names;
-    llvm::StringRef persistent_var_prefix;
-    if (!repl)
-      persistent_var_prefix = "$";
-
-    code_manipulator->FindSpecialNames(special_names, persistent_var_prefix);
-
-    ResolveSpecialNames(m_sc, *m_exe_scope, m_swift_ast_ctx, special_names,
-                        m_local_variables);
-
-    code_manipulator->AddExternalVariables(m_local_variables);
-
-    auto type_aliases = AddArchetypeTypeAliases(
-        code_manipulator, *stack_frame_sp.get(), m_swift_ast_ctx);
-    if (!type_aliases)
-      diagnostic_manager.PutString(eSeverityWarning,
-                                   llvm::toString(type_aliases.takeError()));
-    else
-      external_lookup->RegisterTypeAliases(*type_aliases);
     stack_frame_sp.reset();
   }
 

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftExpressionParser.cpp
@@ -1456,7 +1456,8 @@ SwiftExpressionParser::ParseAndImport(
         local_context_is_swift = false;
     }
 
-    if (local_context_is_swift) {
+    if (local_context_is_swift &&
+        !m_options.GetUseContextFreeSwiftPrintObject()) {
       llvm::Error error = AddRequiredAliases(
           m_sc.block, stack_frame_sp, m_swift_ast_ctx, *code_manipulator,
           m_options.GetUseDynamic(), m_options.GetBindGenericTypes());

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -639,7 +639,7 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
 
   llvm::SmallVector<SwiftASTManipulator::VariableInfo> local_variables;
 
-  if (!m_options.GetUseContextFreeSwiftPrintObject())
+  if (!m_options.GetUseContextFreeSwiftPrintObject()) {
     if (llvm::Error error = RegisterAllVariables(
             sc, stack_frame, *m_swift_ast_ctx, local_variables,
             m_options.GetUseDynamic(), m_options.GetBindGenericTypes())) {
@@ -652,25 +652,26 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
       return ParseResult::retry_bind_generic_params;
     }
 
-  auto ts = m_swift_ast_ctx->GetTypeSystemSwiftTypeRef();
-  if (ts && stack_frame) {
-    // Extract the generic signature of the context.
-    ConstString func_name =
-        stack_frame->GetSymbolContext(lldb::eSymbolContextFunction)
-            .GetFunctionName(Mangled::ePreferMangled);
-    m_generic_signature = SwiftLanguageRuntime::GetGenericSignature(
-        func_name.GetStringRef(), *ts);
-  }
+    auto ts = m_swift_ast_ctx->GetTypeSystemSwiftTypeRef();
+    if (ts && stack_frame) {
+      // Extract the generic signature of the context.
+      ConstString func_name =
+          stack_frame->GetSymbolContext(lldb::eSymbolContextFunction)
+              .GetFunctionName(Mangled::ePreferMangled);
+      m_generic_signature = SwiftLanguageRuntime::GetGenericSignature(
+          func_name.GetStringRef(), *ts);
+    }
 
-  if (!SwiftASTManipulator::ShouldBindGenericTypes(
-          m_options.GetBindGenericTypes()) &&
-      !CanEvaluateExpressionWithoutBindingGenericParams(
-          local_variables, m_generic_signature, *m_swift_ast_ctx, sc.block,
-          *stack_frame.get())) {
-    diagnostic_manager.PutString(
-        lldb::eSeverityError,
-        "Could not evaluate the expression without binding generic types.");
-    return ParseResult::retry_bind_generic_params_not_supported;
+    if (!SwiftASTManipulator::ShouldBindGenericTypes(
+            m_options.GetBindGenericTypes()) &&
+        !CanEvaluateExpressionWithoutBindingGenericParams(
+            local_variables, m_generic_signature, *m_swift_ast_ctx, sc.block,
+            *stack_frame.get())) {
+      diagnostic_manager.PutString(
+          lldb::eSeverityError,
+          "Could not evaluate the expression without binding generic types.");
+      return ParseResult::retry_bind_generic_params_not_supported;
+    }
   }
 
   uint32_t first_body_line = 0;

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -288,7 +288,8 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
       m_is_weak_self = true;
     }
 
-  m_needs_object_ptr = !m_in_static_method;
+  m_needs_object_ptr =
+      !m_in_static_method && !m_options.GetUseContextFreeSwiftPrintObject();
 
   LLDB_LOGF(log, "  [SUE::SC] Containing class name: %s",
             info.type.GetTypeName().AsCString());

--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -290,6 +290,8 @@ void SwiftUserExpression::ScanContext(ExecutionContext &exe_ctx, Status &err) {
 
   m_needs_object_ptr =
       !m_in_static_method && !m_options.GetUseContextFreeSwiftPrintObject();
+  LLDB_LOGF(log, "  [SUE::SC] Expression captures self: %s",
+            m_needs_object_ptr ? "true" : "false");
 
   LLDB_LOGF(log, "  [SUE::SC] Containing class name: %s",
             info.type.GetTypeName().AsCString());
@@ -637,17 +639,18 @@ SwiftUserExpression::GetTextAndSetExpressionParser(
 
   llvm::SmallVector<SwiftASTManipulator::VariableInfo> local_variables;
 
-  if (llvm::Error error = RegisterAllVariables(
-          sc, stack_frame, *m_swift_ast_ctx, local_variables,
-          m_options.GetUseDynamic(), m_options.GetBindGenericTypes())) {
-    diagnostic_manager.PutString(lldb::eSeverityInfo,
-                                 llvm::toString(std::move(error)));
-    diagnostic_manager.PutString(
-        lldb::eSeverityError,
-        "Couldn't realize Swift AST type of self. Hint: using `v` to "
-        "directly inspect variables and fields may still work.");
-    return ParseResult::retry_bind_generic_params;
-  }
+  if (!m_options.GetUseContextFreeSwiftPrintObject())
+    if (llvm::Error error = RegisterAllVariables(
+            sc, stack_frame, *m_swift_ast_ctx, local_variables,
+            m_options.GetUseDynamic(), m_options.GetBindGenericTypes())) {
+      diagnostic_manager.PutString(lldb::eSeverityInfo,
+                                   llvm::toString(std::move(error)));
+      diagnostic_manager.PutString(
+          lldb::eSeverityError,
+          "Couldn't realize Swift AST type of self. Hint: using `v` to "
+          "directly inspect variables and fields may still work.");
+      return ParseResult::retry_bind_generic_params;
+    }
 
   auto ts = m_swift_ast_ctx->GetTypeSystemSwiftTypeRef();
   if (ts && stack_frame) {

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -30,4 +30,5 @@ class TestCase(TestBase):
         # and not the private dynamic type.
         #
         # CHECK: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a10PublicBaseCD")
+        # CHECK: Expression captures self: false
         # CHECK: stringForPrintObject(_:mangledTypeName:) succeeded

--- a/lldb/test/API/lang/swift/po/private_subclass/main.swift
+++ b/lldb/test/API/lang/swift/po/private_subclass/main.swift
@@ -8,9 +8,11 @@ func makeIt() -> PublicBase {
   return PrivateSubclass()
 }
 
-func main() {
-  let x = makeIt()
-  print("break here \(x)")
+class Main {
+  func main() {
+    let x = makeIt()
+    print("break here \(x)")
+  }
 }
 
-main()
+Main().main()


### PR DESCRIPTION
When an expression uses the new Swift `po` function (`stringForPrintObject(_:mangledTypeName:)`), it does not need to capture `self`. The two arguments are a pointer, and a mangled name (string).

After making the initial change to prevent the capture of `self`, through testing and AI review, other steps of the expression setup can and should also be skipped for the context-free `po`. The skippable expression setup steps are:

1. Capturing `self`
2. `RegisterAllVariables`
3. Handling of special variables (`$` prefixed persistent variables)
4. `AddExternalVariables`
5. `AddRequiredAliases`
6. `AddArchetypeTypeAliases`
7. `RegisterTypeAliases`
8. `CanEvaluateExpressionWithoutBindingGenericParams`

Avoiding the above work side steps any would be issues with the swift AST context.

rdar://169415680