### PR TITLE
[Clang][CodeGenCXX] Fix ptrauth tests after upstream change

### DIFF
--- a/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call-2-wrapper-globals.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call-2-wrapper-globals.cpp
@@ -18,8 +18,8 @@ struct B : virtual A {
 void B::VF() {}
 
 void FUNC(B* p) {
-// CHECK: [[T1:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @_ZTV1A, i64 2)
-// CHECK-NEXT:  [[BT1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds (ptr, ptr @_ZTV1A, i64 2) to i64), i64 12401)
+// CHECK: [[T1:%.*]] = load ptr, ptr getelementptr inbounds nuw (i8, ptr @_ZTV1A, i64 16)
+// CHECK-NEXT:  [[BT1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds nuw (i8, ptr @_ZTV1A, i64 16) to i64), i64 12401)
 // CHECK-NEXT:  [[T2:%.*]] = call noundef ptr [[T1]](ptr noundef {{.*}}) [ "ptrauth"(i32 0, i64 [[BT1]]) ]
   const char* c = p->A::abc();
 }
@@ -34,8 +34,8 @@ struct Derived : public Base {
 };
 
 void FUNC1(Derived* p) {
-// CHECK: [[U1:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @_ZTV4Base, i64 2)
-// CHECK-NEXT: [[BU1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds (ptr, ptr @_ZTV4Base, i64 2) to i64), i64 64320)
+// CHECK: [[U1:%.*]] = load ptr, ptr getelementptr inbounds nuw (i8, ptr @_ZTV4Base, i64 16)
+// CHECK-NEXT: [[BU1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds nuw (i8, ptr @_ZTV4Base, i64 16) to i64), i64 64320)
 // CHECK-NEXT:  [[U2:%.*]] = call noundef ptr [[U1]](ptr noundef {{.*}}) [ "ptrauth"(i32 0, i64 [[BU1]]) ]
   char* c = p->Base::abc();
 }
@@ -51,8 +51,8 @@ struct Derived2 : virtual Base2 {
 char* Derived2::efg(void) const { return 0; }
 
 void FUNC2(Derived2* p) {
-// CHECK: [[V1:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @_ZTV8Derived2, i64 3)
-// CHECK-NEXT:  [[BV1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds (ptr, ptr @_ZTV8Derived2, i64 3) to i64), i64 36603)
+// CHECK: [[V1:%.*]] = load ptr, ptr getelementptr inbounds nuw (i8, ptr @_ZTV8Derived2, i64 24)
+// CHECK-NEXT:  [[BV1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds nuw (i8, ptr @_ZTV8Derived2, i64 24) to i64), i64 36603)
 // CHECK-NEXT:  [[V2:%.*]] = call noundef ptr [[V1]](ptr noundef {{.*}}) [ "ptrauth"(i32 0, i64 [[BV1]]) ]
   char* c = p->Derived2::efg();
 }
@@ -73,8 +73,8 @@ struct Sub : D1, D2 {
 char* D2::abc(void) const { return 0; }
 
 void FUNC3(Sub* p) {
-// CHECK: [[W1:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @_ZTV2D2, i64 3)
-// CHECK-NEXT:  [[BW1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds (ptr, ptr @_ZTV2D2, i64 3) to i64), i64 20222)
+// CHECK: [[W1:%.*]] = load ptr, ptr getelementptr inbounds nuw (i8, ptr @_ZTV2D2, i64 24)
+// CHECK-NEXT:  [[BW1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds nuw (i8, ptr @_ZTV2D2, i64 24) to i64), i64 20222)
 // CHECK-NEXT:  [[W2:%.*]] = call noundef ptr [[W1]](ptr noundef {{.*}}) [ "ptrauth"(i32 0, i64 [[BW1]]) ]
   char* c = p->D2::abc();
 }

--- a/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call-wrapper-globals.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-call-wrapper-globals.cpp
@@ -12,7 +12,7 @@ void FUNC(Base* p) {
   p->Base::abc();
 }
 
-// CHECK: getelementptr inbounds (ptr, ptr @_ZTV4Base, i64 2)
+// CHECK: getelementptr inbounds nuw (i8, ptr @_ZTV4Base, i64 16)
 // CHECK-NOT: call void @_ZNK4Base3abcEv
 
 template<class T>
@@ -37,6 +37,6 @@ void f(SubTempl<int>* t) {
   t->Templ::f();
 }
 
-// CHECK: getelementptr inbounds (ptr, ptr @_ZTV5TemplIiE, i64 2)
+// CHECK: getelementptr inbounds nuw (i8, ptr @_ZTV5TemplIiE, i64 16)
 // CHECK: define internal void @_ZN5TemplIiE1fEv(ptr noundef nonnull align {{[0-9]+}} dereferenceable(8) %this)
 // CHECK: define internal void @_ZN5TemplIiE1gEv(ptr noundef nonnull align {{[0-9]+}} dereferenceable(8) %this)

--- a/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-virtual-dtor-call-wrapper-globals.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-virtual-dtor-call-wrapper-globals.cpp
@@ -12,12 +12,12 @@ void DELETE(B1 *pb1) {
   pb1->B1::~B1();
 }
 // CHECK-LABEL: define void @_ZN2B1D0Ev
-// CHECK: [[T1:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @_ZTV2B1, i64 2)
-// CHECK-NEXT: [[B1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds (ptr, ptr @_ZTV2B1, i64 2) to i64), i64 14635)
+// CHECK: [[T1:%.*]] = load ptr, ptr getelementptr inbounds nuw (i8, ptr @_ZTV2B1, i64 16)
+// CHECK-NEXT: [[B1:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds nuw (i8, ptr @_ZTV2B1, i64 16) to i64), i64 14635)
 // CHECK-NEXT: call noundef ptr [[T1]](ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) [[T2:%.*]]) [ "ptrauth"(i32 0, i64 [[B1]]) ]
 // CHECK-LABEL: define void @_Z6DELETEP2B1
-// CHECK: [[T3:%.*]] = load ptr, ptr getelementptr inbounds (ptr, ptr @_ZTV2B1, i64 2)
-// CHECK-NEXT: [[B3:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds (ptr, ptr @_ZTV2B1, i64 2) to i64), i64 14635)
+// CHECK: [[T3:%.*]] = load ptr, ptr getelementptr inbounds nuw (i8, ptr @_ZTV2B1, i64 16)
+// CHECK-NEXT: [[B3:%.*]] = call i64 @llvm.ptrauth.blend(i64 ptrtoint (ptr getelementptr inbounds nuw (i8, ptr @_ZTV2B1, i64 16) to i64), i64 14635)
 // CHECK-NEXT:  call noundef ptr [[T3]](ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8) [[T4:%.*]]) [ "ptrauth"(i32 0, i64 [[B3]])
 
 template<class T>
@@ -44,7 +44,7 @@ void f(SubTempl<int>* t) {
   t->Templ::~Templ();
 }
 
-// CHECK: getelementptr inbounds (ptr, ptr @_ZTV5TemplIiE, i64 2)
+// CHECK: getelementptr inbounds nuw (i8, ptr @_ZTV5TemplIiE, i64 16)
 // CHECK: declare void @_ZN5TemplIiED0Ev(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8))
 // CHECK: define internal void @_ZN5TemplIiE1fEv(ptr noundef nonnull align 8 dereferenceable(8) %this)
 // CHECK: define internal void @_ZN5TemplIiE1gEv(ptr noundef nonnull align 8 dereferenceable(8) %this)


### PR DESCRIPTION
This fixes fallout after b3d99ac2, which changed the order of parameters for `getelementptr inbounds`.

rdar://171892191