### PR TITLE
[CoroSplit] Fix infinite loop in CoroSplit

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -827,8 +827,9 @@ static void updateScopeLine(Instruction *ActiveSuspend,
       ActiveSuspend->getNextNonDebugInstruction()->getIterator();
   // Corosplit splits the BB around ActiveSuspend, so the meaningful
   // instructions are not in the same BB.
-  while (auto *Branch = dyn_cast_or_null<BranchInst>(Successor)) {
-    if (!Branch->isUnconditional())
+  for (unsigned Repeat = 0; Repeat < 2; Repeat++) {
+    auto *Branch = dyn_cast_or_null<BranchInst>(Successor);
+    if (!Branch || !Branch->isUnconditional())
       break;
     Successor = Branch->getSuccessor(0)->getFirstNonPHIOrDbg();
   }


### PR DESCRIPTION
Optimized code may generate an uncoditional branch to the same BB.