### PR TITLE
[Clang][CodeGen] Fix ptrauth tests after upstream change

### DIFF
--- a/clang/test/CodeGen/ptrauth-function-init-wrapper-globals.c
+++ b/clang/test/CodeGen/ptrauth-function-init-wrapper-globals.c
@@ -12,7 +12,7 @@ void f(void);
 #ifdef __cplusplus
 
 // CXX-LABEL: define internal void @__cxx_global_var_init()
-// CXX: store ptr getelementptr inbounds (i32, ptr @f.ptrauth, i64 2), ptr @_ZL2fp, align 8
+// CXX: store ptr getelementptr inbounds nuw (i8, ptr @f.ptrauth, i64 8), ptr @_ZL2fp, align 8
 
 __attribute__((used))
 void (*const fp)(void) = (void (*)(void))((int *)&f + 2); // Error in C mode.
@@ -22,7 +22,7 @@ void (*const fp)(void) = (void (*)(void))((int *)&f + 2); // Error in C mode.
 // CHECK-LABEL: define void @t1()
 void t1() {
   // CHECK: [[PF:%.*]] = alloca ptr
-  // CHECK: store ptr getelementptr inbounds (i32, ptr @f.ptrauth, i64 2), ptr [[PF]]
+  // CHECK: store ptr getelementptr inbounds nuw (i8, ptr @f.ptrauth, i64 8), ptr [[PF]]
 
   void (*pf)(void) = (void (*)(void))((int *)&f + 2);
   (void)pf;


### PR DESCRIPTION
This fixes fallout after 5a88dffc, which changed the order of parameters for `ptr getelementptr inbounds`.

rdar://171892343