### PR TITLE
[lldb] Have ObjectFile::FindPlugin send a copy of the DE (#185727)

### DIFF
--- a/lldb/include/lldb/Utility/DataExtractor.h
+++ b/lldb/include/lldb/Utility/DataExtractor.h
@@ -189,6 +189,12 @@ public:
   /// any references to shared data that this object may contain.
   void Clear();
 
+  /// Return a shared pointer to a copy of this object.
+  /// May be overridden by a subclass, so the object is copied correctly.
+  virtual lldb::DataExtractorSP Clone() const {
+    return std::make_shared<DataExtractor>(*this);
+  }
+
   /// Dumps the binary data as \a type objects to stream \a s (or to Log() if
   /// \a s is nullptr) starting \a offset bytes into the data and stopping
   /// after dumping \a length bytes. The offset into the data is displayed at

--- a/lldb/include/lldb/Utility/VirtualDataExtractor.h
+++ b/lldb/include/lldb/Utility/VirtualDataExtractor.h
@@ -46,6 +46,10 @@ public:
   VirtualDataExtractor(const lldb::DataBufferSP &data_sp,
                        LookupTable lookup_table);
 
+  lldb::DataExtractorSP Clone() const override {
+    return std::make_shared<VirtualDataExtractor>(*this);
+  }
+
   const void *GetData(lldb::offset_t *offset_ptr,
                       lldb::offset_t length) const override;
 

--- a/lldb/source/Symbol/ObjectFile.cpp
+++ b/lldb/source/Symbol/ObjectFile.cpp
@@ -138,8 +138,12 @@ ObjectFileSP ObjectFile::FindPlugin(const lldb::ModuleSP &module_sp,
          (callback = PluginManager::GetObjectFileCreateCallbackAtIndex(idx)) !=
          nullptr;
          ++idx) {
-      ObjectFileSP object_file_sp(callback(module_sp, extractor_sp, data_offset,
-                                           file, file_offset, file_size));
+      // Make a copy of the extractor in case any plugin modifies it while
+      // processing.
+      DataExtractorSP extractor_copy_sp = extractor_sp->Clone();
+      ObjectFileSP object_file_sp(callback(module_sp, extractor_copy_sp,
+                                           data_offset, file, file_offset,
+                                           file_size));
       if (object_file_sp.get())
         return object_file_sp;
     }


### PR DESCRIPTION
ObjectFile::FindPlugin iterates over plugins to find one that can handle the binary provided. It is currently sending the one DataExtractorSP to each subclass, but some subclasses may modify this DataExtractor during their processing, e.g. calling DataExtractor::SetData on it, and I think it is safer to isolate these with a copy of the DataExtractor so the order the plugins are tried cannot possibly change behavior.

(cherry picked from commit 4398b5fa8c1a8384feb62f20fb7b13b443f149b7)