### PR TITLE
[lldb] Add ClusteredBitVectorLess comparator for SwiftCStyleEnumDescriptor

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -427,8 +427,7 @@ public:
   }
 };
 
-namespace std {
-template <> struct less<swift::ClusteredBitVector> {
+struct ClusteredBitVectorLess {
   bool operator()(const swift::ClusteredBitVector &lhs,
                   const swift::ClusteredBitVector &rhs) const {
     int iL = lhs.size() - 1;
@@ -444,7 +443,6 @@ template <> struct less<swift::ClusteredBitVector> {
     return false;
   }
 };
-} // namespace std
 
 static std::string Dump(const swift::ClusteredBitVector &bit_vector) {
   std::string buffer;
@@ -595,7 +593,9 @@ public:
 
 private:
   swift::ClusteredBitVector m_nopayload_elems_bitmask;
-  std::map<swift::ClusteredBitVector, std::unique_ptr<ElementInfo>> m_elements;
+  std::map<swift::ClusteredBitVector, std::unique_ptr<ElementInfo>,
+           ClusteredBitVectorLess>
+      m_elements;
   std::map<uint64_t, ElementInfo *> m_element_indexes;
   bool m_is_objc_enum = false;
 };


### PR DESCRIPTION
swift::ClusteredBitVector has no operator< and specializing std::less for it doesn't satisfy the requirements for the original std templates, and could result in undefined behavior. Instead, provide an explicit ClusteredBitVectorLess comparator for the m_elements map in SwiftCStyleEnumDescriptor.

rdar://170706387