### PR TITLE
[lldb][swift] Support parsing Builtin.FixedArray<A, B>'s DWARF representation

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -169,6 +169,20 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
     return get_type(die.GetFirstChild());
   }
 
+  if (die.Tag() == llvm::dwarf::DW_TAG_array_type) {
+    TypeSP elementTy = get_type(die);
+    CompilerType elementCompilerTy = elementTy->GetForwardCompilerType();
+
+    // Detect the special case of the unsubstituted Builtin.FixedArray<A, B>
+    // which is represented as an array type of τ_0_1 ($eq_D or $sq_D).
+    if (auto ts = elementCompilerTy.GetTypeSystem()
+                      .dyn_cast_or_null<TypeSystemSwift>()) {
+      auto flavor = SwiftLanguageRuntime::GetManglingFlavor(die.GetName());
+      if (elementTy->GetName() == "τ_0_1")
+        compiler_type = ts->GetUnsubstitutedFixedArrayType(flavor);
+    }
+  }
+
   if (!mangled_name && name) {
     if (name.GetStringRef() == "$swift.fixedbuffer") {
       if (auto wrapped_type = get_type(die.GetFirstChild())) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -162,6 +162,12 @@ TypeSystemSwift::GetUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor) {
       ConstString(SwiftLanguageRuntime::MakeMangledName("SVD", flavor)));
 }
 
+CompilerType TypeSystemSwift::GetUnsubstitutedFixedArrayType(
+    swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("xq_BVD", flavor)));
+}
+
 CompilerType
 TypeSystemSwift::GetUInt64Type(swift::Mangle::ManglingFlavor flavor) {
   return GetTypeFromMangledTypename(

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -212,6 +212,10 @@ public:
   GetBuiltinUnknownObjectType(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetBoolType(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor);
+  /// The unsubstituted FixedArray<A, B> type.
+  CompilerType
+  GetUnsubstitutedFixedArrayType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType Get(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetUInt64Type(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetTaskPriorityType(swift::Mangle::ManglingFlavor flavor);
   CompilerType


### PR DESCRIPTION
Swift commit fcbebc51c71e21 added support for emitting Builtin.FixedArray as a DW_TAG_array_type. With https://github.com/swiftlang/swift/pull/87569 this code path is now also taken for `Builtin.FixedArray<A, B>` which is the non-substituted `FixedArray` class. Before PR #87569 the DWARF emitted for `FixedArray<A, B>` looked like this:

    DW_TAG_structure_type
        DW_AT_name ("$exq_BVD")
        DW_AT_linkage_name ("$exq_BVD")
        DW_AT_declaration (true)
        DW_AT_APPLE_runtime_class (DW_LANG_Swift)

and the new DWARF that is emitted now takes the FixedArray code path which produces this DWARF:

    DW_TAG_array_type
        DW_AT_type	(0x00006c70 "$eq_D")

    DW_TAG_structure_type
        DW_AT_name	("$eq_D")
        DW_AT_byte_size	(0x00)
        DW_AT_APPLE_runtime_class	(DW_LANG_Swift)

The patch adds support for parsing this specific pattern. We curiously don't need to ever parse the substituted array types for embedded Swift, so this patch just adds enough support for the unsubstituted type.