### PR TITLE
[lldb] Remove quoting from Swift URL summaries

### DIFF
--- a/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
+++ b/lldb/source/Plugins/Language/Swift/FoundationValueTypes.cpp
@@ -130,7 +130,7 @@ bool lldb_private::formatters::swift::SwiftURL_SummaryProvider(
     return false;
 
   std::string base;
-  ValueObjectSP base_url_sp(valobj.GetChildAtNamePath({g__baseURL}));
+  ValueObjectSP base_url_sp(valobj.GetChildMemberWithName(g__baseURL));
   if (base_url_sp) {
     // `GetSyntheticValue()` + `HasChildren()` checks for non-nil Optional.
     if (ValueObjectSP synth = base_url_sp->GetSyntheticValue()) {
@@ -145,10 +145,16 @@ bool lldb_private::formatters::swift::SwiftURL_SummaryProvider(
   if (!rel_str_sp->GetSummaryAsCString(summary, options))
     return false;
 
+  auto unquoted = [](llvm::StringRef s) {
+    if (s.front() == '"' and s.back() == '"')
+      return s.drop_front().drop_back();
+    return s;
+  };
+
   // This format matches the implementation of _SwiftURL.description.
-  stream << summary;
+  stream << unquoted(summary);
   if (!base.empty())
-    stream << " -- " << base;
+    stream << " -- " << unquoted(base);
   return true;
 }
 

--- a/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
+++ b/lldb/test/API/lang/swift/foundation_value_types/url/TestSwiftFoundationTypeURL.py
@@ -56,18 +56,14 @@ class TestCase(TestBase):
             substrs=[
                 f"({foundation}.URL?)",
                 "relativeURL",
-                "relative",
-                "--",
-                "https://www.example.com/",
+                "relative -- https://www.example.com/",
             ],
         )
         self.expect(
             "expression -d run -- relativeURL",
             substrs=[
                 f"({foundation}.URL?)",
-                "relative",
-                "--",
-                "https://www.example.com/",
+                "relative -- https://www.example.com/",
             ],
         )
 


### PR DESCRIPTION
Change the Swift URL summary string to not include quoting. This is notable for relative URLs:

Before:
```
(Foundation.URL) relativeURL = "something" -- "https://www.example.com"
```

After:
```
(Foundation.URL) relativeURL = something -- https://www.example.com
```

This matches the output of `print(relativeURL)`.