### PR TITLE
[PrefixMap] Teach lldb to auto-load compilation-prefix-map.json

### DIFF
--- a/lldb/include/lldb/Core/Module.h
+++ b/lldb/include/lldb/Core/Module.h
@@ -889,7 +889,7 @@ public:
   ///     /b true if \a orig_spec was successfully located and
   ///     \a new_spec is filled in with an existing file spec,
   ///     \b false otherwise.
-  bool FindSourceFile(const FileSpec &orig_spec, FileSpec &new_spec) const;
+  bool FindSourceFile(const FileSpec &orig_spec, FileSpec &new_spec);
 
   /// Remaps a source file given \a path into \a new_path.
   ///
@@ -903,8 +903,13 @@ public:
   /// \return
   ///     The newly remapped filespec that is may or may not exist if
   ///     \a path was successfully located.
-  std::optional<std::string> RemapSourceFile(llvm::StringRef path) const;
+  std::optional<std::string> RemapSourceFile(llvm::StringRef path);
   bool RemapSourceFile(const char *, std::string &) const = delete;
+
+  /// Register a directory to be searched for \c compilation-prefix-map.json
+  /// on the first call to RemapSourceFile or FindSourceFile. Duplicate
+  /// directories are silently ignored.
+  void AddPrefixMapSearchDir(FileSpec dir);
 
   void ClearModuleDependentCaches();
 
@@ -1117,6 +1122,15 @@ protected:
   /// module that doesn't match where the sources currently are.
   PathMappingList m_source_mappings =
       ModuleList::GetGlobalModuleListProperties().GetSymlinkMappings();
+
+  /// Directories registered via AddPrefixMapSearchDir, searched lazily on the
+  /// first call to RemapSourceFile or FindSourceFile. Cleared after searching.
+  llvm::DenseSet<ConstString> m_prefix_map_search_dirs;
+
+  /// Search each registered directory upward for compilation-prefix-map.json
+  /// and apply any found mappings to m_source_mappings. Called at most once.
+  /// Must be called with m_mutex held.
+  void LoadPrefixMapsIfNeeded();
 
   lldb::SectionListUP m_sections_up; ///< Unified section list for module that
                                      /// is used by the ObjectFile and

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -66,7 +66,9 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/JSON.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Signals.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
@@ -1696,9 +1698,9 @@ bool Module::MatchesModuleSpec(const ModuleSpec &module_ref) {
   return true;
 }
 
-bool Module::FindSourceFile(const FileSpec &orig_spec,
-                            FileSpec &new_spec) const {
+bool Module::FindSourceFile(const FileSpec &orig_spec, FileSpec &new_spec) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
+  LoadPrefixMapsIfNeeded();
   if (auto remapped = m_source_mappings.FindFile(orig_spec)) {
     new_spec = *remapped;
     return true;
@@ -1706,8 +1708,66 @@ bool Module::FindSourceFile(const FileSpec &orig_spec,
   return false;
 }
 
-std::optional<std::string> Module::RemapSourceFile(llvm::StringRef path) const {
+void Module::AddPrefixMapSearchDir(FileSpec dir) {
   std::lock_guard<std::recursive_mutex> guard(m_mutex);
+  m_prefix_map_search_dirs.insert(ConstString(dir.GetPath()));
+}
+
+void Module::LoadPrefixMapsIfNeeded() {
+  // Must be called with m_mutex held.
+  if (m_prefix_map_search_dirs.empty())
+    return;
+
+  Log *log = GetLog(LLDBLog::Symbols);
+  llvm::vfs::FileSystem &vfs = *llvm::vfs::getRealFileSystem();
+  // Track visited directories so two starting paths that share ancestors
+  // don't redundantly walk the same directory.
+  llvm::DenseSet<ConstString> searched;
+  for (ConstString start_cs : m_prefix_map_search_dirs) {
+    for (FileSpec current(start_cs.GetStringRef());;) {
+      ConstString directory_cs(current.GetPath());
+      if (!searched.insert(directory_cs).second)
+        break;
+      FileSpec map_file(current);
+      map_file.AppendPathComponent("compilation-prefix-map.json");
+      llvm::ErrorOr<std::unique_ptr<llvm::vfs::File>> file =
+          vfs.openFileForRead(map_file.GetPath());
+      if (file && *file) {
+        LLDB_LOG(log, "found compilation-prefix-map.json at {0}",
+                 map_file.GetPath());
+        llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> buf =
+            (*file)->getBuffer(map_file.GetPath());
+        if (buf && *buf) {
+          llvm::Expected<llvm::json::Value> val =
+              llvm::json::parse((*buf)->getBuffer());
+          if (val) {
+            if (llvm::json::Object *obj = val->getAsObject()) {
+              for (const llvm::json::Object::value_type &kv : *obj)
+                if (std::optional<llvm::StringRef> to =
+                        kv.second.getAsString()) {
+                  LLDB_LOG(log, "applying prefix map: '{0}' -> '{1}'", kv.first,
+                           *to);
+                  m_source_mappings.AppendUnique(kv.first.str(), to->str(),
+                                                 /*notify=*/false);
+                }
+            }
+          }
+        }
+        break;
+      }
+      FileSpec parent = current;
+      parent.RemoveLastPathComponent();
+      if (parent == current)
+        break;
+      current = parent;
+    }
+  }
+  m_prefix_map_search_dirs.clear();
+}
+
+std::optional<std::string> Module::RemapSourceFile(llvm::StringRef path) {
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
+  LoadPrefixMapsIfNeeded();
   if (auto remapped = m_source_mappings.RemapPath(path))
     return remapped->GetPath();
   return {};

--- a/lldb/source/Core/Module.cpp
+++ b/lldb/source/Core/Module.cpp
@@ -1718,7 +1718,7 @@ void Module::LoadPrefixMapsIfNeeded() {
   if (m_prefix_map_search_dirs.empty())
     return;
 
-  Log *log = GetLog(LLDBLog::Symbols);
+  Log *log = GetLog(LLDBLog::Object | LLDBLog::Modules);
   llvm::vfs::FileSystem &vfs = *llvm::vfs::getRealFileSystem();
   // Track visited directories so two starting paths that share ancestors
   // don't redundantly walk the same directory.
@@ -1740,17 +1740,19 @@ void Module::LoadPrefixMapsIfNeeded() {
         if (buf && *buf) {
           llvm::Expected<llvm::json::Value> val =
               llvm::json::parse((*buf)->getBuffer());
-          if (val) {
-            if (llvm::json::Object *obj = val->getAsObject()) {
-              for (const llvm::json::Object::value_type &kv : *obj)
-                if (std::optional<llvm::StringRef> to =
-                        kv.second.getAsString()) {
-                  LLDB_LOG(log, "applying prefix map: '{0}' -> '{1}'", kv.first,
-                           *to);
-                  m_source_mappings.AppendUnique(kv.first.str(), to->str(),
-                                                 /*notify=*/false);
-                }
-            }
+          if (!val) {
+            LLDB_LOG_ERROR(log, val.takeError(), "failed to parse {1}: {0}",
+                           map_file.GetPath());
+            continue;
+          }
+          if (llvm::json::Object *obj = val->getAsObject()) {
+            for (const llvm::json::Object::value_type &kv : *obj)
+              if (std::optional<llvm::StringRef> to = kv.second.getAsString()) {
+                LLDB_LOG(log, "applying prefix map: '{0}' -> '{1}'", kv.first,
+                         *to);
+                m_source_mappings.AppendUnique(kv.first.str(), to->str(),
+                                               /*notify=*/false);
+              }
           }
         }
         break;

--- a/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/SymbolFileDWARFDebugMap.cpp
@@ -600,6 +600,15 @@ CompUnitSP SymbolFileDWARFDebugMap::ParseCompileUnitAtIndex(uint32_t cu_idx) {
     if (oso_module) {
       FileSpec so_file_spec;
       if (GetFileSpecForSO(cu_idx, so_file_spec)) {
+        // Apply the module's source path remappings so that compile units
+        // created from N_SO stabs (which may contain paths rewritten by
+        // -fdebug-prefix-map at build time) report their real on-disk paths.
+        // This mirrors what MakeAbsoluteAndRemap does for the dSYM case.
+        if (ModuleSP module_sp = m_objfile_sp->GetModule())
+          if (auto remapped =
+                  module_sp->RemapSourceFile(so_file_spec.GetPath()))
+            so_file_spec.SetFile(*remapped, FileSpec::Style::native);
+
         // User zero as the ID to match the compile unit at offset zero in each
         // .o file.
         lldb::user_id_t cu_id = 0;

--- a/lldb/source/Symbol/SymbolFile.cpp
+++ b/lldb/source/Symbol/SymbolFile.cpp
@@ -18,6 +18,7 @@
 #include "lldb/Symbol/TypeMap.h"
 #include "lldb/Symbol/TypeSystem.h"
 #include "lldb/Symbol/VariableList.h"
+#include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 #include "lldb/Utility/StreamString.h"
 #include "lldb/Utility/StructuredData.h"
@@ -102,6 +103,16 @@ SymbolFile *SymbolFile::FindPlugin(ObjectFileSP objfile_sp) {
       // Let the winning symbol file parser initialize itself more completely
       // now that it has been chosen
       best_symfile_up->InitializeObject();
+
+      // Register the object file's directory so the module can lazily search
+      // for a compilation-prefix-map.json when source paths are first remapped.
+      if (ObjectFile *obj = best_symfile_up->GetMainObjectFile())
+        if (ModuleSP mod = obj->GetModule()) {
+          FileSpec dir = obj->GetFileSpec();
+          dir.ClearFilename();
+          if (dir)
+            mod->AddPrefixMapSearchDir(std::move(dir));
+        }
     }
   }
   return best_symfile_up.release();

--- a/lldb/test/API/functionalities/compilation-prefix-map/Makefile
+++ b/lldb/test/API/functionalities/compilation-prefix-map/Makefile
@@ -1,0 +1,9 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS = -fdebug-prefix-map=$(SRCDIR)=/fake/srcdir
+
+all: $(EXE) compilation-prefix-map.json
+
+include Makefile.rules
+
+compilation-prefix-map.json:
+	printf '{ "/fake/srcdir": "%s" }' "$(SRCDIR)" > $(BUILDDIR)/compilation-prefix-map.json

--- a/lldb/test/API/functionalities/compilation-prefix-map/TestCompilationPrefixMap.py
+++ b/lldb/test/API/functionalities/compilation-prefix-map/TestCompilationPrefixMap.py
@@ -1,0 +1,43 @@
+# TestCompilationPrefixMap.py
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+"""
+Test that LLDB auto-loads compilation-prefix-map.json to resolve remapped
+source paths without requiring manual `settings set target.source-map`.
+"""
+import os
+
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCompilationPrefixMap(TestBase):
+    @skipIfWindows
+    def test_compilation_prefix_map(self):
+        """
+        Build a binary with -fdebug-prefix-map remapping the source directory
+        to /fake/srcdir, place compilation-prefix-map.json next to the binary
+        mapping /fake/srcdir back to the real source directory, and verify that
+        LLDB resolves a source-line breakpoint without any manual source-map
+        configuration.
+        """
+        self.build()
+
+        src_dir = self.getSourceDir()
+
+        log = self.getBuildArtifact("symbol.log")
+        self.runCmd('log enable lldb symbol -f "%s"' % log)
+
+        source_spec = lldb.SBFileSpec(os.path.join(src_dir, "main.c"))
+        lldbutil.run_to_source_breakpoint(self, "return x", source_spec)
+
+        self.filecheck_log(log, __file__)
+
+
+#       CHECK: found compilation-prefix-map.json
+#       CHECK: applying prefix map: '/fake/srcdir'

--- a/lldb/test/API/functionalities/compilation-prefix-map/TestCompilationPrefixMap.py
+++ b/lldb/test/API/functionalities/compilation-prefix-map/TestCompilationPrefixMap.py
@@ -18,6 +18,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCompilationPrefixMap(TestBase):
     @skipIfWindows
+    @skipIfHostIncompatibleWithTarget
     def test_compilation_prefix_map(self):
         """
         Build a binary with -fdebug-prefix-map remapping the source directory
@@ -30,8 +31,8 @@ class TestCompilationPrefixMap(TestBase):
 
         src_dir = self.getSourceDir()
 
-        log = self.getBuildArtifact("symbol.log")
-        self.runCmd('log enable lldb symbol -f "%s"' % log)
+        log = self.getBuildArtifact("module.log")
+        self.runCmd('log enable lldb module -f "%s"' % log)
 
         source_spec = lldb.SBFileSpec(os.path.join(src_dir, "main.c"))
         lldbutil.run_to_source_breakpoint(self, "return x", source_spec)

--- a/lldb/test/API/functionalities/compilation-prefix-map/main.c
+++ b/lldb/test/API/functionalities/compilation-prefix-map/main.c
@@ -1,0 +1,5 @@
+int add(int x, int y) {
+  return x + y; // breakpoint here.
+}
+
+int main() { return add(1, 2); }

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/Makefile
@@ -3,7 +3,7 @@ SWIFT_ENABLE_EXPLICIT_MODULES := YES
 SWIFT_ENABLE_COMPILE_CACHE := YES
 SWIFT_BRIDGING_HEADER := bridging.h
 HIDE_SWIFTMODULE := YES
-SWIFTFLAGS_EXTRAS = -Xcc -I$(BUILDDIR)/secret -scanner-prefix-map-paths $(BUILDDIR) /^build
+SWIFTFLAGS_EXTRAS = -Xcc -I$(BUILDDIR)/secret -scanner-prefix-map-paths $(BUILDDIR) /^build -scanner-prefix-map-paths $(SRCDIR) /^src
 
 all: cas-config secret.h $(EXE)
 
@@ -19,3 +19,4 @@ secret.h:
 
 cas-config:
 	echo "{\"CASPath\": \"$(BUILDDIR)/cas\"}" > .cas-config
+	echo "{\"/^build\": \"$(BUILDDIR)\", \"/^src\": \"$(SRCDIR)\"}" > compilation-prefix-map.json

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
@@ -34,3 +34,10 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         self.expect("frame variable m", substrs=['j = 42'])
         self.expect("expression s", substrs=['i = 23'])
         self.expect("expression m", substrs=['j = 42'])
+
+        # Verify the prefix map was applied: the frame's source file should
+        # resolve to the real on-disk path, not the virtual /^src path baked
+        # into the debug info by -scanner-prefix-map-paths.
+        file_spec = thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec()
+        self.assertEqual(file_spec.GetDirectory(), self.getSourceDir())
+        self.assertEqual(file_spec.GetFilename(), "main.swift")


### PR DESCRIPTION
Add a LoadCompilationPrefixMap() helper in SymbolFile::FindPlugin that walks up from the symbol file's directory looking for a compilation-prefix-map.json file. When found, each key→value entry is applied to the module's source path mapping list, allowing LLDB to resolve source file paths that were rewritten by -fdebug-prefix-map at build time without requiring manual `settings set target.source-map`.

The JSON file format maps fake paths (as written into debug info) back to their real on-disk counterparts: { "/fake/srcdir": "/real/srcdir" }

Directory results are cached so the filesystem is walked at most once per unique directory across all modules loaded in a session.

Also apply the module's source path remappings in SymbolFileDWARFDebugMap::ParseCompileUnitAtIndex when constructing compile units from N_SO stabs. This mirrors what MakeAbsoluteAndRemap does for the dSYM case so that fake paths baked into the debug map are transparently resolved to real paths.

rdar://84824567

Assisted-By: Claude