### PR TITLE
[Cherry-pick into next] [LLDB] Diagnose SwiftASTContext fallback in DumpTypeValue

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -5440,11 +5440,15 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
       // typedefs such as CFString in the REPL. More investigation is
       // needed.
       if (auto swift_ast_context =
-              GetSwiftASTContext(GetSymbolContext(exe_scope)))
-        return swift_ast_context->DumpTypeValue(
-            ReconstructType(type, exe_scope), s, format, data, data_offset,
-            data_byte_size, bitfield_bit_size, bitfield_bit_offset, exe_scope,
-            is_base_class);
+              GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+        if (swift_ast_context->DumpTypeValue(
+                ReconstructType(type, exe_scope), s, format, data, data_offset,
+                data_byte_size, bitfield_bit_size, bitfield_bit_offset,
+                exe_scope, is_base_class)) {
+          DiagnoseSwiftASTContextFallback(__FUNCTION__, type);
+          return true;
+        }
+      }
       return false;
     }
     case Node::Kind::ConstrainedExistential:
@@ -5472,11 +5476,16 @@ bool TypeSystemSwiftTypeRef::DumpTypeValue(
     bool unresolved_typealias = false;
     CollectTypeInfo(dem, node, flavor, unresolved_typealias);
     if (!node || unresolved_typealias) {
-      if (auto swift_ast_ctx = GetSwiftASTContext(GetSymbolContext(exe_scope)))
-        return swift_ast_ctx->DumpTypeValue(
-            ReconstructType(type, exe_scope), s, format, data, data_offset,
-            data_byte_size, bitfield_bit_size, bitfield_bit_offset, exe_scope,
-            is_base_class);
+      if (auto swift_ast_ctx =
+              GetSwiftASTContext(GetSymbolContext(exe_scope))) {
+        if (swift_ast_ctx->DumpTypeValue(
+                ReconstructType(type, exe_scope), s, format, data, data_offset,
+                data_byte_size, bitfield_bit_size, bitfield_bit_offset,
+                exe_scope, is_base_class)) {
+          DiagnoseSwiftASTContextFallback(__FUNCTION__, type);
+          return true;
+        }
+      }
       return false;
     }
   }


### PR DESCRIPTION
```
commit e1ec0bda66774ef22470318b3ed090b9148c11ef
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Mar 13 08:36:18 2026 -0700

    [LLDB] Diagnose SwiftASTContext fallback in DumpTypeValue
```
