### PR TITLE
🍒[clang][Dependency Scanning] Reland Fix the In-Memory Buffer Used for…

### DIFF
--- a/clang/lib/Tooling/DependencyScanning/DependencyScannerImpl.cpp
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScannerImpl.cpp
@@ -582,7 +582,7 @@ std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,
           std::vector<std::string>>
 initVFSForByNameScanning(IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
                          ArrayRef<std::string> CommandLine,
-                         StringRef WorkingDirectory, StringRef ModuleName,
+                         StringRef WorkingDirectory,
                          std::shared_ptr<cas::ObjectStore> CAS) {
   // Reset what might have been modified in the previous worker invocation.
   BaseFS->setCurrentWorkingDirectory(WorkingDirectory);
@@ -594,11 +594,14 @@ initVFSForByNameScanning(IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
       llvm::makeIntrusiveRefCnt<llvm::vfs::OverlayFileSystem>(BaseFS);
   auto InMemoryFS = llvm::makeIntrusiveRefCnt<llvm::vfs::InMemoryFileSystem>();
   InMemoryFS->setCurrentWorkingDirectory(WorkingDirectory);
-  SmallString<128> FakeInputPath;
-  // TODO: We should retry the creation if the path already exists.
-  llvm::sys::fs::createUniquePath(ModuleName + "-%%%%%%%%.input", FakeInputPath,
-                                  /*MakeAbsolute=*/false);
-  InMemoryFS->addFile(FakeInputPath, 0, llvm::MemoryBuffer::getMemBuffer(""));
+  StringRef FakeInputPath("module-include.input");
+  // The fake input buffer is read-only, and it is used to produce
+  // unique source locations for the diagnostics. Therefore sharing
+  // this global buffer across threads is ok.
+  static const std::string FakeInput(
+      CompilerInstanceWithContext::MaxNumOfQueries, ' ');
+  InMemoryFS->addFile(FakeInputPath, 0,
+                      llvm::MemoryBuffer::getMemBuffer(FakeInput));
   IntrusiveRefCntPtr<llvm::vfs::FileSystem> InMemoryOverlay = InMemoryFS;
 
   // If we are using a CAS, we need to provide the fake input file in a
@@ -930,8 +933,8 @@ bool CompilerInstanceWithContext::initialize(DiagnosticConsumer *DC) {
     DiagConsumer = &DiagPrinterWithOS->DiagPrinter;
   }
 
-  std::tie(OverlayFS, CommandLine) = initVFSForByNameScanning(
-      Worker.BaseFS, CommandLine, CWD, "ScanningByName", Worker.CAS);
+  std::tie(OverlayFS, CommandLine) =
+      initVFSForByNameScanning(Worker.BaseFS, CommandLine, CWD, Worker.CAS);
 
   DiagEngineWithCmdAndOpts = std::make_unique<DignosticsEngineWithDiagOpts>(
       CommandLine, OverlayFS, *DiagConsumer);
@@ -1000,6 +1003,9 @@ bool CompilerInstanceWithContext::initialize(DiagnosticConsumer *DC) {
 bool CompilerInstanceWithContext::computeDependencies(
     StringRef ModuleName, DependencyConsumer &Consumer,
     DependencyActionController &Controller) {
+  if (SrcLocOffset >= MaxNumOfQueries)
+    llvm::report_fatal_error("exceeded maximum by-name scans for worker");
+
   assert(CIPtr && "CIPtr must be initialized before calling this method");
   auto &CI = *CIPtr;
 

--- a/clang/lib/Tooling/DependencyScanning/DependencyScannerImpl.h
+++ b/clang/lib/Tooling/DependencyScanning/DependencyScannerImpl.h
@@ -127,7 +127,7 @@ std::pair<IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>,
           std::vector<std::string>>
 initVFSForByNameScanning(IntrusiveRefCntPtr<llvm::vfs::FileSystem> BaseFS,
                          ArrayRef<std::string> CommandLine,
-                         StringRef WorkingDirectory, StringRef ModuleName,
+                         StringRef WorkingDirectory,
                          std::shared_ptr<cas::ObjectStore> CAS);
 
 bool initializeScanCompilerInstance(
@@ -212,6 +212,15 @@ public:
   // The method below turns the return status from the above methods
   // into an llvm::Error using a default DiagnosticConsumer.
   llvm::Error handleReturnStatus(bool Success);
+
+  // scanning API (computeDependencies) can support after a
+  // CompilerInstanceWithContext is initialized. At the time of this commit, the
+  // estimated number of total unique importable names is around 3000 from
+  // Apple's SDKs. We usually import them in parallel, so it is unlikely that
+  // all names are all scanned by the same dependency scanning worker. Therefore
+  // the 64k (20x bigger than our estimate) size is sufficient to hold the
+  // unique source locations to report diagnostics per worker.
+  static const int32_t MaxNumOfQueries = 1 << 16;
 };
 } // namespace dependencies
 } // namespace tooling

--- a/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
+++ b/clang/test/ClangScanDeps/modules-full-by-mult-mod-names-diagnostics.c
@@ -27,11 +27,11 @@ module root2 { header "root2.h" }
 // RUN: cat %t/result.json | sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
 // ERROR: Error while scanning dependencies for modA:
-// ERROR-NEXT: {{.*}}: fatal error: module 'modA' not found
+// ERROR-NEXT: module-include.input:1:1: fatal error: module 'modA' not found
 // ERROR-NEXT: Error while scanning dependencies for modB:
-// ERROR-NEXT: {{.*}}: fatal error: module 'modB' not found
+// ERROR-NEXT: module-include.input:1:3: fatal error: module 'modB' not found
 // ERROR-NEXT: Error while scanning dependencies for modC:
-// ERROR-NEXT: {{.*}}: fatal error: module 'modC' not found
+// ERROR-NEXT: module-include.input:1:4: fatal error: module 'modC' not found
 // CHECK:      {
 // CHECK-NEXT:   "modules": [
 // CHECK-NEXT:     {

--- a/clang/test/Index/Core/scan-deps-by-mod-name.m
+++ b/clang/test/Index/Core/scan-deps-by-mod-name.m
@@ -32,5 +32,5 @@
 // CHECK-NEXT:     module-deps:
 // CHECK-NEXT:       ModA:[[HASH_MOD_A]]
 // CHECK-NEXT:     file-deps:
-// CHECK-NEXT:       {{.*}}ScanningByName-{{.*}}.input
+// CHECK-NEXT:       {{.*}}module-include.input
 // CHECK-NEXT:     build-args: -cc1 {{.*}} -fmodule-file={{(ModA=)?}}{{.*}}ModA_{{.*}}.pcm


### PR DESCRIPTION
… By-Name Scanning (#183396) (#185474)

This PR fixes two issues of the in-memory buffer we use for the input file when a dependency scanner performs by-name queries.

First, it renames the buffer. The temporary file was named `ScanningByName-%%%%%%%%.input`, which leads to weird diagnostics such as
```
ScanningByName-2d42a1e9.input:1:1: fatal error: could not build module 'X'
```

This PR changes the name of the file buffer, so we get diagnostics such as
```
module-include.input:1:1: fatal error: could not build module 'X'
```
which is more indicative.

Additionally, this PR fixes a bug where the source location may overflow the temporary buffer by creating a 64k empty string which the temporary buffer occupies. When the source location overflows, the diagnostics could point to some random file that comes after the fake file and is incorrect.

Currently, the maximum number of unique names from Apple's SDKs is around 3000. A 64k buffer per dependency scanning worker gives us around 20x capacity per worker (which scans fewer names than 3000 when the scanning is done in parallel). A fatal error is added to catch overflows.

(cherry picked from commit 22b4fccd888004571240e7edcbd5289321f569df)