### PR TITLE
[IncludeTree] Preserve ModuleMapIsPrivate in include-tree

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -463,11 +463,12 @@ public:
     bool InferExplicitSubmodules : 1;
     bool InferExportWildcard : 1;
     bool UseExportAsModuleLinkName: 1;
+    bool ModuleMapIsPrivate : 1;
     ModuleFlags()
         : IsFramework(false), IsExplicit(false), IsExternC(false),
           IsSystem(false), InferSubmodules(false),
           InferExplicitSubmodules(false), InferExportWildcard(false),
-          UseExportAsModuleLinkName(false) {}
+          UseExportAsModuleLinkName(false), ModuleMapIsPrivate(false) {}
   };
 
   ModuleFlags getFlags() const;

--- a/clang/include/clang/DependencyScanning/ModuleDepCollector.h
+++ b/clang/include/clang/DependencyScanning/ModuleDepCollector.h
@@ -158,6 +158,10 @@ struct ModuleDeps {
   /// Whether this is a "system" module.
   bool IsSystem;
 
+  /// Whether this module is defined in a private module map
+  /// (i.e. a module.private.modulemap file).
+  bool ModuleMapIsPrivate;
+
   /// Whether this module is fully composed of file & module inputs from
   /// locations likely to stay the same across the active development and build
   /// cycle. For example, when all those input paths only resolve in Sysroot.

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -361,6 +361,7 @@ static constexpr uint16_t ModuleFlagInferInferExportWildcard = 1 << 6;
 static constexpr uint16_t ModuleFlagHasExports = 1 << 7;
 static constexpr uint16_t ModuleFlagHasLinkLibraries = 1 << 8;
 static constexpr uint16_t ModuleFlagUseExportAsModuleLinkName = 1 << 9;
+static constexpr uint16_t ModuleFlagModuleMapIsPrivate = 1 << 10;
 
 IncludeTree::Module::ModuleFlags IncludeTree::Module::getFlags() const {
   uint16_t Raw = rawFlags();
@@ -373,6 +374,7 @@ IncludeTree::Module::ModuleFlags IncludeTree::Module::getFlags() const {
   Flags.InferExplicitSubmodules = Raw & ModuleFlagInferExplicitSubmodules;
   Flags.InferExportWildcard = Raw & ModuleFlagInferInferExportWildcard;
   Flags.UseExportAsModuleLinkName = Raw & ModuleFlagUseExportAsModuleLinkName;
+  Flags.ModuleMapIsPrivate = Raw & ModuleFlagModuleMapIsPrivate;
   return Flags;
 }
 
@@ -435,6 +437,8 @@ IncludeTree::Module::create(ObjectStore &DB, StringRef ModuleName,
     RawFlags |= ModuleFlagHasLinkLibraries;
   if (Flags.UseExportAsModuleLinkName)
     RawFlags |= ModuleFlagUseExportAsModuleLinkName;
+  if (Flags.ModuleMapIsPrivate)
+    RawFlags |= ModuleFlagModuleMapIsPrivate;
 
   SmallString<64> Buffer;
   llvm::raw_svector_ostream BufOS(Buffer);
@@ -761,6 +765,8 @@ llvm::Error IncludeTree::Module::print(llvm::raw_ostream &OS, unsigned Indent) {
     OS << " (extern_c)";
   if (Flags.IsSystem)
     OS << " (system)";
+  if (Flags.ModuleMapIsPrivate)
+    OS << " (private)";
   OS << '\n';
   auto ExportAs = getExportAsModule();
   if (!ExportAs.empty())

--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -624,6 +624,7 @@ getIncludeTreeModule(cas::ObjectStore &DB, Module *M) {
   Flags.InferExplicitSubmodules = M->InferExplicitSubmodules;
   Flags.InferExportWildcard = M->InferExportWildcard;
   Flags.UseExportAsModuleLinkName = M->UseExportAsModuleLinkName;
+  Flags.ModuleMapIsPrivate = M->ModuleMapIsPrivate;
 
   bool GlobalWildcardExport = false;
   SmallVector<ITModule::ExportList::Export> Exports;

--- a/clang/lib/DependencyScanning/ModuleDepCollector.cpp
+++ b/clang/lib/DependencyScanning/ModuleDepCollector.cpp
@@ -774,6 +774,7 @@ ModuleDepCollectorPP::handleTopLevelModule(const Module *M) {
 
   MD.ID.ModuleName = M->getFullModuleName();
   MD.IsSystem = M->IsSystem;
+  MD.ModuleMapIsPrivate = M->ModuleMapIsPrivate;
 
   // Start off with the assumption that this module is shareable when there
   // are stable directories. As more dependencies are discovered, check if those

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -826,6 +826,7 @@ static Expected<Module *> makeIncludeTreeModule(CompilerInstance &CI,
   M->InferExplicitSubmodules = Flags.InferExplicitSubmodules;
   M->InferExportWildcard = Flags.InferExportWildcard;
   M->UseExportAsModuleLinkName = Flags.UseExportAsModuleLinkName;
+  M->ModuleMapIsPrivate = Flags.ModuleMapIsPrivate;
   M->ExportAsModule = Mod.getExportAsModule();
 
   auto ExportList = Mod.getExports();

--- a/clang/test/ClangScanDeps/modules-include-tree-private-modulemap.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-private-modulemap.c
@@ -1,0 +1,42 @@
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: clang-scan-deps -format experimental-include-tree-full -cas-path %t/cas -o %t/deps.json -- \
+// RUN:     %clang -c %t/tu.c -o %t/tu.o -F %t/frameworks -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/cache
+
+// RUN: %deps-to-rsp %t/deps.json --module-name A > %t/mod_A.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name A_Private > %t/mod_AP.rsp
+// RUN: %clang @%t/mod_A.rsp -o %t/A.pcm
+// RUN: %clang @%t/mod_AP.rsp -o %t/AP.pcm
+
+// RUN: cat %t/mod_A.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/A.casid
+// RUN: cat %t/mod_AP.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/AP.casid
+
+/// Check the serialization.
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/A.casid | FileCheck %s --check-prefix PUBLIC
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/AP.casid | FileCheck %s --check-prefix PRIVATE
+
+// PUBLIC: A (framework)
+// PUBLIC-NOT: (private)
+// PRIVATE: A_Private (framework) (private)
+
+//--- frameworks/A.framework/Modules/module.modulemap
+framework module A { header "A.h" export *}
+
+//--- frameworks/A.framework/Modules/module.private.modulemap
+framework module A_Private { header "A_Private.h" export *}
+
+//--- frameworks/A.framework/Headers/A.h
+struct A {
+  int x;
+};
+
+//--- frameworks/A.framework/PrivateHeaders/A_Private.h
+#include "A/A.h"
+struct AP {
+  int x;
+};
+
+//--- tu.c
+#import "A/A_Private.h"


### PR DESCRIPTION
ModuleMapIsPrivate helps diagnoses private module inclusion issue. It should be preserved when building with include tree.

rdar://172494000