### PR TITLE
[lldb] Support mangled type names in `memory read`

### DIFF
--- a/lldb/source/Commands/CommandObjectMemory.cpp
+++ b/lldb/source/Commands/CommandObjectMemory.cpp
@@ -463,6 +463,13 @@ protected:
       TypeResults results;
       target->GetImages().FindTypes(search_first.get(), query, results);
       TypeSP type_sp = results.GetFirstType();
+      if (!type_sp) {
+        // Retry, searching for typename as a mangled name.
+        query.SetSearchByMangledName(true);
+        TypeResults results;
+        target->GetImages().FindTypes(search_first.get(), query, results);
+        type_sp = results.GetFirstType();
+      }
 
       if (!type_sp && lookup_type_name.GetCString()) {
         LanguageType language_for_type =


### PR DESCRIPTION
(cherry picked from commit 3f6b4d692a5d3a0a2439d6aaada8365d42d1ff6a)

(cherry picked from commit 50ed085e5abd8935a1441cab1b182dfa28953029)