### PR TITLE
🍒[6.2][lldb] Remove sdk line from TestSwiftOtherArchDylib

### DIFF
--- a/lldb/test/API/lang/swift/other_arch_dylib/Makefile
+++ b/lldb/test/API/lang/swift/other_arch_dylib/Makefile
@@ -15,7 +15,6 @@ OtherArch.framework/Versions/A/OtherArch: $(SRCDIR)/OtherArch.swift
 		FRAMEWORK=OtherArch \
 		FRAMEWORK_MODULES=OtherArch.swiftinterface \
 		FRAMEWORK_HEADERS=OtherArch.h \
-		SWIFTFLAGS_EXTRAS="-target arm64e-apple-macos15" \
-		SDKROOT=$(shell xcrun --sdk macosx.internal --show-sdk-path)
+		SWIFTFLAGS_EXTRAS="-target arm64e-apple-macos15"
 	rm -f $(BUILDDIR)/OtherArch.swiftmodule $(BUILDDIR)/OtherArch.swiftinterface
 	rm -f OtherArch.o OtherArch.h OtherArch.partial.swiftmodule


### PR DESCRIPTION
**Explanation**:
Remove a flag in the build command for TestSwiftOtherArchDylib test so that we search the Swift stdlib from the SDK, not the just built toolchain.

 **Scope**:
TestSwiftOtherArchDylib.py test in LLDB

**Issues**:
N/A, this will allow 6.2 cherry-picks for Swift to test successfully for Apple Silicon

**Original PRs**:
#11941

**Risk**:
Low
* this change is already part of `swift/release/6.3` and `stable/21.x` for a few months now, where the failure as not surfaced to the best of my knowledge
* at worst, the fix will have no effect (i.e. it will not regress other configurations in CI)

**Testing**:
* tested this at desk
* cross testing in CI to support https://github.com/swiftlang/swift/pull/87782

 **Reviewers**:
None at the time this template is filled