### PR TITLE
[lldb/test] Fix TestSwiftExpressionNoDebugInfo on non-macOS platforms

### DIFF
--- a/lldb/test/API/lang/swift/expression/no_debuginfo/TestSwiftExpressionNoDebugInfo.py
+++ b/lldb/test/API/lang/swift/expression/no_debuginfo/TestSwiftExpressionNoDebugInfo.py
@@ -19,4 +19,4 @@ class TestSwiftExpressionNoDebugInfo(TestBase):
         self.expect('expr -l Swift -- 1')
         self.filecheck_log(types_log, __file__)
         # CHECK: No Swift debug info: prefer target triple.
-        # CHECK: Using SDK: {{.*}}MacOSX
+        # CHECK: Using SDK: {{.*}}.sdk


### PR DESCRIPTION
The CHECK pattern was hardcoded to match "MacOSX" in the SDK path, which fails on iOS, tvOS, watchOS and visionOS where the SDK name differs (e.g. iPhoneOS, AppleTVOS). Match any SDK path instead.

rdar://172701887