### PR TITLE
[lldb] remove quotes around URLs in tests

### DIFF
--- a/lldb/test/API/lang/swift/array_tuple_resilient/main.swift
+++ b/lldb/test/API/lang/swift/array_tuple_resilient/main.swift
@@ -7,11 +7,11 @@ var patatino : [(URL, Int64)] = [(URL(string: "https://github.com")!, 1001)]
 var tinky : [(URL, URL)] = [(URL(string: "https://github.com")!,
                             URL(string: "https://github.com")!)]
 print(patatino) //%self.expect('frame variable -d run -- patatino',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = 1001)'])
+                //%             substrs=['[0] = (0 = https://github.com, 1 = 1001)'])
                 //%self.expect('expr -d run -- patatino',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = 1001)'])
+                //%             substrs=['[0] = (0 = https://github.com, 1 = 1001)'])
 
 print(tinky)    //%self.expect('frame variable -d run -- tinky',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = "https://github.com")'])
+                //%             substrs=['[0] = (0 = https://github.com, 1 = https://github.com)'])
                 //%self.expect('expr -d run -- tinky',
-                //%             substrs=['[0] = (0 = "https://github.com", 1 = "https://github.com")'])
+                //%             substrs=['[0] = (0 = https://github.com, 1 = https://github.com)'])

--- a/lldb/test/Shell/SwiftREPL/ResilientArray.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientArray.test
@@ -7,6 +7,6 @@ import Foundation
 
 let x : [URL] = [URL(string: "https://github.com")!, URL(string: "https://apple.com")!]
 // CHECK: {{x}}: [Foundation.URL] = 2 values {
-// CHECK-NEXT:  [0] = "https://github.com"
-// CHECK-NEXT:  [1] = "https://apple.com"
+// CHECK-NEXT:  [0] = https://github.com
+// CHECK-NEXT:  [1] = https://apple.com
 // CHECK-NEXT: }

--- a/lldb/test/Shell/SwiftREPL/ResilientDict.test
+++ b/lldb/test/Shell/SwiftREPL/ResilientDict.test
@@ -11,13 +11,13 @@ import Foundation
 let x : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
 // DICT-LABEL: {{x}}: [Foundation.URL : Int] = 2 key/value pairs {
 // DICT:      [{{[0-1]}}] = {
-// DICT:         key = "https://apple.com"
+// DICT:         key = https://apple.com
 // DICT-NEXT:    value = 23
 // DICT-NEXT:  }
 
 let y : [URL:Int] = [URL(string: "https://github.com")!: 4, URL(string: "https://apple.com")!: 23]
 // DICT-LABEL: {{y}}: [Foundation.URL : Int] = 2 key/value pairs {
 // DICT:       [{{[0-1]}}] = {
-// DICT:          key = "https://github.com"
+// DICT:          key = https://github.com
 // DICT-NEXT:     value = 4
 // DICT-NEXT:  }


### PR DESCRIPTION
This is a follow up to https://github.com/swiftlang/llvm-project/pull/12578, which removes quotes around URLs.

rdar://172745616