### PR TITLE
[windows] Don't allow env vars that differ only in case in LLVMConfig

### DIFF
--- a/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
@@ -1,7 +1,6 @@
 # Test that frame variable works for Swift types with NativePDB debug info.
 
 # Won't pass until https://github.com/swiftlang/llvm-project/issues/12289 is resolved.
-# XFAIL: system-windows
 # REQUIRES: swift, system-windows
 
 # RUN: split-file %s %t

--- a/llvm/utils/lit/lit/llvm/config.py
+++ b/llvm/utils/lit/lit/llvm/config.py
@@ -228,6 +228,14 @@ class LLVMConfig(object):
         return None
 
     def with_environment(self, variable, value, append_path=False):
+        ### BEGIN SWIFT
+        # On Windows, env vars are case-insensitive and swiftc will
+        # crash if passed two variables that differ only in case.
+        if platform.system() == "Windows":
+            for key in list(self.config.environment):
+                if key.lower() == variable.lower() and key != variable:
+                    del self.config.environment[key]
+        ### END SWIFT
         if append_path:
             # For paths, we should be able to take a list of them and process
             # all of them.


### PR DESCRIPTION
For example, in LLDB shell tests, both `SystemRoot` and `SYSTEMROOT` are forwarded to Swift, resulting in:
```
  # .---command stderr------------
  # | Swift/NativeDictionary.swift:823: Fatal error: Duplicate values for key: 'ProcessEnvironmentKey(value:
  "SYSTEMROOT")'
  # `-----------------------------
  # error: command failed with exit status: 0xc000001d
```

Per
https://github.com/swiftlang/swift/issues/84428#issuecomment-3320471717, this is intended behavior.

This change adjusts `with_environment` to a "last wins" policy, removing any existing keys that will clash with new keys.