### PR TITLE
[next] [lldb][swift] Support parsing Builtin.FixedArray<A, B>'s DWARF representation

### DIFF
--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -169,6 +169,20 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
     return get_type(die.GetFirstChild());
   }
 
+  if (die.Tag() == llvm::dwarf::DW_TAG_array_type) {
+    TypeSP elementTy = get_type(die);
+    CompilerType elementCompilerTy = elementTy->GetForwardCompilerType();
+
+    // Detect the special case of the unsubstituted Builtin.FixedArray<A, B>
+    // which is represented as an array type of τ_0_1 ($eq_D or $sq_D).
+    if (auto ts = elementCompilerTy.GetTypeSystem()
+                      .dyn_cast_or_null<TypeSystemSwift>()) {
+      auto flavor = SwiftLanguageRuntime::GetManglingFlavor(die.GetName());
+      if (elementTy->GetName() == "τ_0_1")
+        compiler_type = ts->GetUnsubstitutedFixedArrayType(flavor);
+    }
+  }
+
   if (!mangled_name && name) {
     if (name.GetStringRef() == "$swift.fixedbuffer") {
       if (auto wrapped_type = get_type(die.GetFirstChild())) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -164,6 +164,12 @@ TypeSystemSwift::GetUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor) {
       ConstString(SwiftLanguageRuntime::MakeMangledName("SVD", flavor)));
 }
 
+CompilerType TypeSystemSwift::GetUnsubstitutedFixedArrayType(
+    swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("xq_BVD", flavor)));
+}
+
 CompilerType
 TypeSystemSwift::GetUInt64Type(swift::Mangle::ManglingFlavor flavor) {
   return GetTypeFromMangledTypename(

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -212,6 +212,10 @@ public:
   GetBuiltinUnknownObjectType(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetBoolType(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor);
+  /// The unsubstituted FixedArray<A, B> type.
+  CompilerType
+  GetUnsubstitutedFixedArrayType(swift::Mangle::ManglingFlavor flavor);
+  CompilerType Get(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetUInt64Type(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetTaskPriorityType(swift::Mangle::ManglingFlavor flavor);
   CompilerType


### PR DESCRIPTION
Cherry-pick of 1e1af5326ed98b01af80289df762df87cf0f09dc to `next`.