### PR TITLE
[Clang][CAS] Do not drop `requires` directive in modulemaps

### DIFF
--- a/clang/include/clang/CAS/IncludeTree.h
+++ b/clang/include/clang/CAS/IncludeTree.h
@@ -453,6 +453,7 @@ public:
 
   class ExportList;
   class LinkLibraryList;
+  class RequirementList;
 
   struct ModuleFlags {
     bool IsFramework : 1;
@@ -504,6 +505,11 @@ public:
       return getReference(*Index);
     return std::nullopt;
   }
+  std::optional<ObjectRef> getRequirementsRef() const {
+    if (std::optional<unsigned> Index = getRequirementsIndex())
+      return getReference(*Index);
+    return std::nullopt;
+  }
 
   /// The list of modules that this submodule re-exports.
   Expected<std::optional<ExportList>> getExports();
@@ -511,13 +517,17 @@ public:
   /// The list of modules that this submodule re-exports.
   Expected<std::optional<LinkLibraryList>> getLinkLibraries();
 
+  /// The list of requirements for this module (e.g. "requires cplusplus").
+  Expected<std::optional<RequirementList>> getRequirements();
+
   llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
 
   static Expected<Module> create(ObjectStore &DB, StringRef ModuleName,
                                  StringRef ExportAs, ModuleFlags Flags,
                                  ArrayRef<ObjectRef> Submodules,
                                  std::optional<ObjectRef> ExportList,
-                                 std::optional<ObjectRef> LinkLibraries);
+                                 std::optional<ObjectRef> LinkLibraries,
+                                 std::optional<ObjectRef> Requirements);
 
   static bool isValid(const ObjectProxy &Node) {
     if (!IncludeTreeBase::isValid(Node))
@@ -539,8 +549,10 @@ private:
   StringRef dataAfterFlags() const { return getData().drop_front(2); }
   bool hasExports() const;
   bool hasLinkLibraries() const;
+  bool hasRequirements() const;
   std::optional<unsigned> getExportsIndex() const;
   std::optional<unsigned> getLinkLibrariesIndex() const;
+  std::optional<unsigned> getRequirementsIndex() const;
 
   explicit Module(ObjectProxy Node) : IncludeTreeBase(std::move(Node)) {
     assert(isValid(*this));
@@ -666,6 +678,53 @@ private:
   }
 
   friend class IncludeTreeBase<LinkLibraryList>;
+  friend class Module;
+};
+
+/// The set of feature requirements for a module (e.g. "requires cplusplus").
+/// Stored as a single blob: for each requirement, a state byte (0 or 1)
+/// followed by a null-terminated feature name.
+class IncludeTree::Module::RequirementList
+    : public IncludeTreeBase<RequirementList> {
+public:
+  static constexpr StringRef getNodeKind() { return "ReqL"; }
+
+  struct Requirement {
+    StringRef FeatureName;
+    bool RequiredState;
+  };
+
+  /// Calls \p CB for each requirement.
+  llvm::Error
+  forEachRequirement(llvm::function_ref<llvm::Error(Requirement)> CB);
+
+  llvm::Error print(llvm::raw_ostream &OS, unsigned Indent = 0);
+
+  static Expected<RequirementList> create(ObjectStore &DB,
+                                          ArrayRef<Requirement> Requirements);
+
+  static bool isValid(const ObjectProxy &Node) {
+    if (!IncludeTreeBase::isValid(Node))
+      return false;
+    IncludeTreeBase Base(Node);
+    return Base.getNumReferences() == 0;
+  }
+  static bool isValid(ObjectStore &DB, ObjectRef Ref) {
+    auto Node = DB.getProxy(Ref);
+    if (!Node) {
+      llvm::consumeError(Node.takeError());
+      return false;
+    }
+    return isValid(*Node);
+  }
+
+private:
+  explicit RequirementList(ObjectProxy Node)
+      : IncludeTreeBase(std::move(Node)) {
+    assert(isValid(*this));
+  }
+
+  friend class IncludeTreeBase<RequirementList>;
   friend class Module;
 };
 

--- a/clang/lib/CAS/IncludeTree.cpp
+++ b/clang/lib/CAS/IncludeTree.cpp
@@ -362,6 +362,7 @@ static constexpr uint16_t ModuleFlagHasExports = 1 << 7;
 static constexpr uint16_t ModuleFlagHasLinkLibraries = 1 << 8;
 static constexpr uint16_t ModuleFlagUseExportAsModuleLinkName = 1 << 9;
 static constexpr uint16_t ModuleFlagModuleMapIsPrivate = 1 << 10;
+static constexpr uint16_t ModuleFlagHasRequirements = 1 << 11;
 
 IncludeTree::Module::ModuleFlags IncludeTree::Module::getFlags() const {
   uint16_t Raw = rawFlags();
@@ -383,6 +384,8 @@ size_t IncludeTree::Module::getNumSubmodules() const {
   if (hasExports())
     Count -= 1;
   if (hasLinkLibraries())
+    Count -= 1;
+  if (hasRequirements())
     Count -= 1;
   return Count;
 }
@@ -406,7 +409,8 @@ IncludeTree::Module::create(ObjectStore &DB, StringRef ModuleName,
                             StringRef ExportAs, ModuleFlags Flags,
                             ArrayRef<ObjectRef> Submodules,
                             std::optional<ObjectRef> ExportList,
-                            std::optional<ObjectRef> LinkLibraries) {
+                            std::optional<ObjectRef> LinkLibraries,
+                            std::optional<ObjectRef> Requirements) {
   // Data:
   // - 2 bytes for Flags
   // - ModuleName (String, null-terminated)
@@ -415,6 +419,7 @@ IncludeTree::Module::create(ObjectStore &DB, StringRef ModuleName,
   // - Submodules (IncludeTreeModule)
   // - (optional) ExportList
   // - (optional) LinkLibaryList
+  // - (optional) RequirementList
 
   uint16_t RawFlags = 0;
   if (Flags.IsFramework)
@@ -439,6 +444,8 @@ IncludeTree::Module::create(ObjectStore &DB, StringRef ModuleName,
     RawFlags |= ModuleFlagUseExportAsModuleLinkName;
   if (Flags.ModuleMapIsPrivate)
     RawFlags |= ModuleFlagModuleMapIsPrivate;
+  if (Requirements)
+    RawFlags |= ModuleFlagHasRequirements;
 
   SmallString<64> Buffer;
   llvm::raw_svector_ostream BufOS(Buffer);
@@ -454,6 +461,8 @@ IncludeTree::Module::create(ObjectStore &DB, StringRef ModuleName,
     Refs.push_back(*ExportList);
   if (LinkLibraries)
     Refs.push_back(*LinkLibraries);
+  if (Requirements)
+    Refs.push_back(*Requirements);
 
   return IncludeTreeBase::create(DB, Refs, Buffer);
 }
@@ -469,14 +478,32 @@ bool IncludeTree::Module::hasExports() const {
 bool IncludeTree::Module::hasLinkLibraries() const {
   return rawFlags() & ModuleFlagHasLinkLibraries;
 }
+bool IncludeTree::Module::hasRequirements() const {
+  return rawFlags() & ModuleFlagHasRequirements;
+}
 
 std::optional<unsigned> IncludeTree::Module::getExportsIndex() const {
-  if (hasExports())
-    return getNumReferences() - (hasLinkLibraries() ? 2 : 1);
+  if (hasExports()) {
+    unsigned Offset = 1;
+    if (hasRequirements())
+      Offset++;
+    if (hasLinkLibraries())
+      Offset++;
+    return getNumReferences() - Offset;
+  }
   return std::nullopt;
 }
 std::optional<unsigned> IncludeTree::Module::getLinkLibrariesIndex() const {
-  if (hasLinkLibraries())
+  if (hasLinkLibraries()) {
+    unsigned Offset = 1;
+    if (hasRequirements())
+      Offset++;
+    return getNumReferences() - Offset;
+  }
+  return std::nullopt;
+}
+std::optional<unsigned> IncludeTree::Module::getRequirementsIndex() const {
+  if (hasRequirements())
     return getNumReferences() - 1;
   return std::nullopt;
 }
@@ -500,6 +527,17 @@ IncludeTree::Module::getLinkLibraries() {
     if (!N)
       return N.takeError();
     return LinkLibraryList(std::move(*N));
+  }
+  return std::nullopt;
+}
+
+Expected<std::optional<IncludeTree::Module::RequirementList>>
+IncludeTree::Module::getRequirements() {
+  if (auto Ref = getRequirementsRef()) {
+    auto N = getCAS().getProxy(*Ref);
+    if (!N)
+      return N.takeError();
+    return RequirementList(std::move(*N));
   }
   return std::nullopt;
 }
@@ -596,6 +634,36 @@ IncludeTree::Module::LinkLibraryList::create(ObjectStore &DB,
   writeBitSet(Writer, FrameworkBits);
 
   return IncludeTreeBase::create(DB, Refs, Buffer);
+}
+
+llvm::Error IncludeTree::Module::RequirementList::forEachRequirement(
+    llvm::function_ref<llvm::Error(Requirement)> CB) {
+  StringRef Data = getData();
+  while (!Data.empty()) {
+    bool State = Data[0] != 0;
+    Data = Data.drop_front(1);
+    size_t NullPos = Data.find('\0');
+    assert(NullPos != StringRef::npos);
+    StringRef Name = Data.take_front(NullPos);
+    Data = Data.drop_front(NullPos + 1);
+    if (llvm::Error E = CB({Name, State}))
+      return E;
+  }
+  return llvm::Error::success();
+}
+Expected<IncludeTree::Module::RequirementList>
+IncludeTree::Module::RequirementList::create(
+    ObjectStore &DB, ArrayRef<Requirement> Requirements) {
+  // Data: for each requirement, a state byte (0 or 1) followed by a
+  // null-terminated feature name.
+  SmallString<32> Buffer;
+  for (const Requirement &R : Requirements) {
+    Buffer.push_back(R.RequiredState ? 1 : 0);
+    Buffer.append(R.FeatureName);
+    Buffer.push_back('\0');
+  }
+
+  return IncludeTreeBase::create(DB, {}, Buffer);
 }
 
 Expected<IncludeTree::ModuleMap>
@@ -792,6 +860,12 @@ llvm::Error IncludeTree::Module::print(llvm::raw_ostream &OS, unsigned Indent) {
   if (*LinkLibraries)
     if (llvm::Error E = (*LinkLibraries)->print(OS, Indent + 2))
       return E;
+  auto Requirements = getRequirements();
+  if (!Requirements)
+    return Requirements.takeError();
+  if (*Requirements)
+    if (llvm::Error E = (*Requirements)->print(OS, Indent + 2))
+      return E;
   return forEachSubmodule(
       [&](Module Sub) { return Sub.print(OS, Indent + 2); });
 }
@@ -815,6 +889,17 @@ llvm::Error IncludeTree::Module::LinkLibraryList::print(llvm::raw_ostream &OS,
     if (E.IsFramework)
       OS << " (framework)";
     OS << '\n';
+    return llvm::Error::success();
+  });
+}
+
+llvm::Error IncludeTree::Module::RequirementList::print(llvm::raw_ostream &OS,
+                                                        unsigned Indent) {
+  return forEachRequirement([&](Requirement R) {
+    OS.indent(Indent) << "requires ";
+    if (!R.RequiredState)
+      OS << "!";
+    OS << R.FeatureName << '\n';
     return llvm::Error::success();
   });
 }

--- a/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
+++ b/clang/lib/DependencyScanning/IncludeTreeActionController.cpp
@@ -658,8 +658,20 @@ getIncludeTreeModule(cas::ObjectStore &DB, Module *M) {
     LinkLibraries = LL->getRef();
   }
 
+  SmallVector<ITModule::RequirementList::Requirement> Requirements;
+  for (const auto &R : M->Requirements) {
+    Requirements.push_back({R.FeatureName, R.RequiredState});
+  }
+  std::optional<cas::ObjectRef> RequirementsList;
+  if (!Requirements.empty()) {
+    auto RL = ITModule::RequirementList::create(DB, Requirements);
+    if (!RL)
+      return RL.takeError();
+    RequirementsList = RL->getRef();
+  }
+
   return ITModule::create(DB, M->Name, M->ExportAsModule, Flags, Submodules,
-                          ExportList, LinkLibraries);
+                          ExportList, LinkLibraries, RequirementsList);
 }
 
 Expected<cas::IncludeTreeRoot>

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -862,6 +862,19 @@ static Expected<Module *> makeIncludeTreeModule(CompilerInstance &CI,
       return std::move(Err);
   }
 
+  auto Reqs = Mod.getRequirements();
+  if (!Reqs)
+    return Reqs.takeError();
+  if (*Reqs) {
+    llvm::Error Err = (*Reqs)->forEachRequirement([&](auto R) {
+      M->addRequirement(R.FeatureName, R.RequiredState, CI.getLangOpts(),
+                        CI.getTarget());
+      return llvm::Error::success();
+    });
+    if (Err)
+      return std::move(Err);
+  }
+
   llvm::Error Err = Mod.forEachSubmodule([&](cas::IncludeTree::Module Sub) {
     return makeIncludeTreeModule(CI, Sub, M).takeError();
   });

--- a/clang/test/ClangScanDeps/modules-include-tree-requires.c
+++ b/clang/test/ClangScanDeps/modules-include-tree-requires.c
@@ -1,0 +1,76 @@
+// Check that 'requires' clauses are preserved in include-tree modules.
+
+// REQUIRES: ondisk_cas
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: sed "s|DIR|%/t|g" %t/cdb.json.template > %t/cdb.json
+
+// RUN: clang-scan-deps -compilation-database %t/cdb.json -j 1 \
+// RUN:   -cas-path %t/cas -module-files-dir %t/outputs \
+// RUN:   -format experimental-include-tree-full -mode preprocess-dependency-directives \
+// RUN:   > %t/deps.json
+
+// Extract the include-tree commands
+// RUN: %deps-to-rsp %t/deps.json --module-name Mod > %t/Mod.rsp
+// RUN: %deps-to-rsp %t/deps.json --module-name NotCxx > %t/NotCxx.rsp
+// RUN: %deps-to-rsp %t/deps.json --tu-index 0 > %t/tu.rsp
+
+// Print the include trees and check that requirements are preserved.
+// RUN: cat %t/Mod.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/Mod.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/Mod.casid | FileCheck %s -check-prefix=MOD
+// RUN: cat %t/NotCxx.rsp | sed -E 's|.*"-fcas-include-tree" "(llvmcas://[[:xdigit:]]+)".*|\1|' > %t/NotCxx.casid
+// RUN: clang-cas-test -cas %t/cas -print-include-tree @%t/NotCxx.casid | FileCheck %s -check-prefix=NOTCXX
+
+// MOD: Module Map:
+// MOD-NEXT: Mod
+// MOD:        Plain
+// MOD:        CxxOnly
+// MOD-NEXT:     requires cplusplus
+
+// NOTCXX: Module Map:
+// NOTCXX-NEXT: NotCxx
+// NOTCXX-NEXT:   requires !cplusplus
+
+// Build the modules and verify compilation succeeds.
+// RUN: %clang @%t/Mod.rsp
+// RUN: %clang @%t/NotCxx.rsp
+// RUN: %clang @%t/tu.rsp
+
+//--- cdb.json.template
+[{
+  "file": "DIR/tu.c",
+  "directory": "DIR",
+  "command": "clang -fsyntax-only DIR/tu.c -I DIR -fmodules -fimplicit-modules -fimplicit-module-maps -fmodules-cache-path=DIR/module-cache"
+}]
+
+//--- module.modulemap
+module Mod {
+  module Plain { header "Plain.h" }
+  module CxxOnly {
+    requires cplusplus
+    header "CxxOnly.h"
+  }
+}
+module NotCxx {
+  requires !cplusplus
+  header "NotCxx.h"
+}
+
+//--- Plain.h
+void plain(void);
+
+//--- CxxOnly.h
+void cxx_only(void);
+
+//--- NotCxx.h
+void not_cxx(void);
+
+//--- tu.c
+#include "Plain.h"
+#include "NotCxx.h"
+
+void tu(void) {
+  plain();
+  not_cxx();
+}


### PR DESCRIPTION
Swift/C++ interop relies on the presence of `requires cplusplus` directives in Clang modules to determine if C++-specific logic should be applied to certain types from that module.

When building certain projects, we have discovered that the `requires` directives are absent from Clang modules that declare them in their modulemaps (`clang::Module::Requirements` is empty).

This adjusts CAS to preserve the `requires` directives for Clang modules.

rdar://169297366