### PR TITLE
[clang][cas] Fall back to loading PCMs from `InMemoryModuleCache`

### DIFF
--- a/clang/lib/Serialization/ModuleManager.cpp
+++ b/clang/lib/Serialization/ModuleManager.cpp
@@ -156,6 +156,16 @@ ModuleManager::AddModuleResult ModuleManager::addModule(
 
   std::optional<ModuleFileKey> FileKey = FileName.makeKey(FileMgr);
   if (!FileKey) {
+    // FIXME: This is a hack to accommodate module files in the CAS that are not
+    // on disk. Represent these explicitly in ModuleFileName.
+    if (auto *KnownBuffer =
+            getModuleCache().getInMemoryModuleCache().lookupPCM(FileName)) {
+      FileEntryRef File =
+          FileMgr.getVirtualFileRef(FileName, KnownBuffer->getBufferSize(), 0);
+      FileKey = ModuleFileKey(File);
+    }
+  }
+  if (!FileKey) {
     ErrorStr = "module file not found";
     return Missing;
   }


### PR DESCRIPTION
Upstream https://github.com/llvm/llvm-project/pull/185765 introduced `ModuleFile{Name,Key}` in order to remove the assumption that module files are always backed by `FileEntry`.

Downstream, caching compilations work by looking at the command-line, loading PCMs from CAS, storing them into the `InMemoryModuleCache`, implemented by `addCachedModuleFileToInMemoryCache()`. Later, virtual `FileEntry` objects are created for these PCMs in `ModuleManager`, and this code got dropped during merge.

The goal of this PR is to fix the failing CAS tests ASAP, that's why I'm simply replicating the hack.

The proper long-term solution is to stop abusing the in-memory module cache for this, represent the PCM files stored in CAS explicitly via new kind of `ModuleFile{Name,Key}` and then load them from CAS explicitly in `ModuleManager`. I want to implement this after landing the same special-casing for implicit modules, which will be loaded via `ModuleCache` instead of `FileManager`.