### PR TITLE
[swift] Add prefix mapping test for swift caching

### DIFF
--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/Makefile
@@ -3,7 +3,7 @@ SWIFT_ENABLE_EXPLICIT_MODULES := YES
 SWIFT_ENABLE_COMPILE_CACHE := YES
 SWIFT_BRIDGING_HEADER := bridging.h
 HIDE_SWIFTMODULE := YES
-SWIFTFLAGS_EXTRAS = -Xcc -I$(BUILDDIR)/secret -scanner-prefix-map-paths $(BUILDDIR) /^build
+SWIFTFLAGS_EXTRAS = -Xcc -I$(BUILDDIR)/secret -scanner-prefix-map-paths $(BUILDDIR) /^build -scanner-prefix-map-paths $(SRCDIR) /^src
 
 all: cas-config secret.h $(EXE)
 
@@ -19,3 +19,4 @@ secret.h:
 
 cas-config:
 	echo "{\"CASPath\": \"$(BUILDDIR)/cas\"}" > .cas-config
+	echo "{\"/^build\": \"$(BUILDDIR)\", \"/^src\": \"$(SRCDIR)\"}" > compilation-prefix-map.json

--- a/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/bridgingheader_caching/TestSwiftExplicitModulesBridgingHeaderCaching.py
@@ -34,3 +34,10 @@ class TestSwiftExplicitModules(lldbtest.TestBase):
         self.expect("frame variable m", substrs=['j = 42'])
         self.expect("expression s", substrs=['i = 23'])
         self.expect("expression m", substrs=['j = 42'])
+
+        # Verify the prefix map was applied: the frame's source file should
+        # resolve to the real on-disk path, not the virtual /^src path baked
+        # into the debug info by -scanner-prefix-map-paths.
+        file_spec = thread.GetFrameAtIndex(0).GetLineEntry().GetFileSpec()
+        self.assertEqual(file_spec.GetDirectory(), self.getSourceDir())
+        self.assertEqual(file_spec.GetFilename(), "main.swift")


### PR DESCRIPTION
Add downstream tests for prefix mapping when swift caching is used.