### PR TITLE
[SwiftASTContext] Handle `-working-directory=path`.

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1706,7 +1706,10 @@ void SwiftASTContext::AddExtraClangArgs(const std::vector<std::string> &source,
 
     // Consume any -working-directory arguments.
     StringRef cwd(clang_argument);
-    if (cwd.consume_front("-working-directory")) {
+    if (cwd.consume_front("-working-directory=")) {
+      cur_working_dir = cwd;
+      continue;
+    } else if (cwd.consume_front("-working-directory")) {
       cur_working_dir = cwd;
       continue;
     }

--- a/lldb/unittests/Symbol/TestSwiftASTContext.cpp
+++ b/lldb/unittests/Symbol/TestSwiftASTContext.cpp
@@ -188,6 +188,42 @@ TEST_F(TestSwiftASTContext, PluginPath) {
       server);
 }
 
+TEST_F(TestSwiftASTContext, WorkingDirectoryVariousForms) {
+  std::string module_map_flag = "-fmodule-map-file=module.modulemap";
+  const std::vector<std::string> expected = {
+      "-fmodule-map-file=/abs/dir/module.modulemap"};
+
+  {
+    // Separate
+    const std::vector<std::string> source = {"-working-directory", "/abs/dir",
+                                             module_map_flag};
+    std::vector<std::string> dest;
+    SwiftASTContext::AddExtraClangArgs(source, dest);
+
+    const std::vector<std::string> expected = {
+        "-fmodule-map-file=/abs/dir/module.modulemap"};
+    EXPECT_EQ(dest, expected);
+  }
+  {
+    // Joined with no '='
+    const std::vector<std::string> source = {"-working-directory/abs/dir",
+                                             module_map_flag};
+    std::vector<std::string> dest;
+    SwiftASTContext::AddExtraClangArgs(source, dest);
+
+    EXPECT_EQ(dest, expected);
+  }
+  {
+    // Joined with '='
+    const std::vector<std::string> source = {"-working-directory=/abs/dir",
+                                             module_map_flag};
+    std::vector<std::string> dest;
+    SwiftASTContext::AddExtraClangArgs(source, dest);
+
+    EXPECT_EQ(dest, expected);
+  }
+}
+
 namespace {
 const std::vector<std::string> duplicated_flags = {
     "-DMACRO1",


### PR DESCRIPTION
The current implementation only checks for a prefix of `-working-directory` (after combining it with the following argument is space-separated), so if the `=` form is used, it incorrectly interprets the working directory as `=path` instead of `path`.