### PR TITLE
[lldb] Replace marker protocol with Any before querying RemoteInspection 

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -133,11 +133,10 @@ public:
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
-  GetTypeRef(StringRef mangled_type_name,
-             swift::reflection::DescriptorFinder *descriptor_finder) override {
+  GetTypeRef(StringRef mangled_type_name) override {
     swift::Demangle::Demangler dem;
     swift::Demangle::NodePointer node = dem.demangleSymbol(mangled_type_name);
-    return GetTypeRef(dem, node, descriptor_finder);
+    return GetTypeRef(dem, node);
   }
 
   /// Sets the descriptor finder, and on scope exit clears it out.
@@ -149,9 +148,8 @@ public:
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
-  GetTypeRef(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
-             swift::reflection::DescriptorFinder *descriptor_finder) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+  GetTypeRef(swift::Demangle::Demangler &dem,
+             swift::Demangle::NodePointer node) override {
     auto type_ref_or_err =
         swift::Demangle::decodeMangledType(m_reflection_ctx.getBuilder(), node);
     if (type_ref_or_err.isError())

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContext.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/RemoteInspection/ReflectionContext.h"
+#include "Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h"
 #include "ReflectionContextInterface.h"
 #include "SwiftLanguageRuntime.h"
 #include "lldb/Utility/LLDBLog.h"
@@ -185,36 +186,13 @@ public:
   }
 
   llvm::Expected<const swift::reflection::TypeInfo &>
-  GetTypeInfo(const swift::reflection::TypeRef &type_ref,
-              swift::remote::TypeInfoProvider *provider,
+  GetTypeInfo(CompilerType type, swift::remote::TypeInfoProvider *provider,
               swift::reflection::DescriptorFinder *descriptor_finder) override {
-    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-
-    Log *log(GetLog(LLDBLog::Types));
-    if (log && log->GetVerbose()) {
-      std::stringstream ss;
-      type_ref.dump(ss);
-      LLDB_LOG(log,
-               "[TargetReflectionContext[{0:x}]::getTypeInfo] Getting type "
-               "info for typeref {1}",
-               provider ? provider->getId() : 0, ss.str());
-    }
-
-    auto type_info_or_err = m_reflection_ctx.getTypeInfo(type_ref, provider);
-    if (!type_info_or_err)
-      return llvm::joinErrors(
-          llvm::createStringError(
-              "Could not find reflection metadata for type"),
-          type_info_or_err.takeError());
-
-    if (log && log->GetVerbose()) {
-      std::stringstream ss;
-      type_info_or_err->dump(ss);
-      LLDB_LOG(log,
-               "[TargetReflectionContext::getTypeInfo] Found type info {0}",
-               ss.str());
-    }
-    return *type_info_or_err;
+    auto type_ref_or_err = GetCanonicalTypeRef(type);
+    if (!type_ref_or_err)
+      return type_ref_or_err.takeError();
+    return GetTypeInfoFromTypeRef(*type_ref_or_err, provider,
+                                  descriptor_finder);
   }
 
   llvm::Expected<const swift::reflection::TypeInfo &> GetTypeInfoFromInstance(
@@ -316,15 +294,23 @@ public:
     return {};
   }
 
-  std::optional<std::pair<const swift::reflection::TypeRef *,
-                          swift::reflection::RemoteAddress>>
+  llvm::Expected<std::pair<const swift::reflection::TypeRef *,
+                           swift::reflection::RemoteAddress>>
   ProjectExistentialAndUnwrapClass(
       swift::reflection::RemoteAddress existential_address,
-      const swift::reflection::TypeRef &existential_tr,
+      CompilerType existential_type,
       swift::reflection::DescriptorFinder *descriptor_finder) override {
+    auto type_ref_or_err = GetCanonicalTypeRef(existential_type);
+    if (!type_ref_or_err)
+      return type_ref_or_err.takeError();
+    auto &existential_tr = *type_ref_or_err;
     auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
-    return m_reflection_ctx.projectExistentialAndUnwrapClass(
+    auto result = m_reflection_ctx.projectExistentialAndUnwrapClass(
         existential_address, existential_tr);
+    if (!result)
+      return llvm::createStringError(
+          "failed to project existential and unwrap class");
+    return *result;
   }
 
   llvm::Expected<const swift::reflection::TypeRef &>
@@ -459,7 +445,8 @@ private:
   GetRecordTypeInfo(const swift::reflection::TypeRef &type_ref,
                     swift::remote::TypeInfoProvider *tip,
                     swift::reflection::DescriptorFinder *descriptor_finder) {
-    auto type_info_or_err = GetTypeInfo(type_ref, tip, descriptor_finder);
+    auto type_info_or_err =
+        GetTypeInfoFromTypeRef(type_ref, tip, descriptor_finder);
     if (!type_info_or_err)
       return type_info_or_err.takeError();
     auto *type_info = &*type_info_or_err;
@@ -473,6 +460,39 @@ private:
     type_ref.dump(ss);
     return llvm::createStringError(
         "Could not get record type info for typeref: " + ss.str());
+  }
+
+  llvm::Expected<const swift::reflection::TypeInfo &> GetTypeInfoFromTypeRef(
+      const swift::reflection::TypeRef &type_ref,
+      swift::remote::TypeInfoProvider *provider,
+      swift::reflection::DescriptorFinder *descriptor_finder) {
+    auto on_exit = PushDescriptorFinderAndPopOnExit(descriptor_finder);
+
+    Log *log(GetLog(LLDBLog::Types));
+    if (log && log->GetVerbose()) {
+      std::stringstream ss;
+      type_ref.dump(ss);
+      LLDB_LOG(log,
+               "[TargetReflectionContext[{0:x}]::getTypeInfo] Getting type "
+               "info for typeref {1}",
+               provider ? provider->getId() : 0, ss.str());
+    }
+
+    auto type_info_or_err = m_reflection_ctx.getTypeInfo(type_ref, provider);
+    if (!type_info_or_err)
+      return llvm::joinErrors(
+          llvm::createStringError(
+              "Could not find reflection metadata for type"),
+          type_info_or_err.takeError());
+
+    if (log && log->GetVerbose()) {
+      std::stringstream ss;
+      type_info_or_err->dump(ss);
+      LLDB_LOG(log,
+               "[TargetReflectionContext::getTypeInfo] Found type info {0}",
+               ss.str());
+    }
+    return *type_info_or_err;
   }
 };
 } // namespace
@@ -514,4 +534,29 @@ ReflectionContextInterface::CreateReflectionContext(
   }
   return {};
 }
+
+llvm::Expected<const swift::reflection::TypeRef &>
+ReflectionContextInterface::GetCanonicalTypeRef(CompilerType type) {
+  auto tss = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
+  if (!tss)
+    return llvm::createStringError("not a Swift type");
+  auto tr_ts = tss->GetTypeSystemSwiftTypeRef();
+  if (!tr_ts)
+    return llvm::createStringError("no TypeSystemSwiftTypeRef");
+
+  ConstString mangled_name = type.GetMangledTypeName();
+  swift::Demangle::Demangler dem;
+  swift::Demangle::NodePointer node =
+      tr_ts->GetCanonicalDemangleTree(dem, mangled_name);
+  if (!node)
+    return llvm::createStringError("could not canonically demangle type");
+
+  auto flavor =
+      SwiftLanguageRuntime::GetManglingFlavor(mangled_name.GetStringRef());
+  auto node_or_err = tr_ts->RemoveMarkerProtocols(dem, node, flavor);
+  if (!node_or_err)
+    return node_or_err.takeError();
+  return GetTypeRef(dem, *node_or_err);
+}
+
 } // namespace lldb_private

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -16,6 +16,7 @@
 #include <mutex>
 
 #include "LockGuarded.h"
+#include "lldb/Symbol/CompilerType.h"
 #include "lldb/lldb-defines.h"
 #include "lldb/lldb-types.h"
 #include "swift/ABI/ObjectFile.h"
@@ -88,14 +89,19 @@ public:
   virtual llvm::Expected<const swift::reflection::TypeRef &>
   GetTypeRef(swift::Demangle::Demangler &dem,
              swift::Demangle::NodePointer node) = 0;
+
+  /// Build a TypeRef suitable for use in reflection context queries. This
+  /// performs canonical demangling (type alias resolution and
+  /// @_originallyDefinedIn module fixups) and strips marker protocols.
+  llvm::Expected<const swift::reflection::TypeRef &>
+  GetCanonicalTypeRef(CompilerType type);
   virtual llvm::Expected<const swift::reflection::RecordTypeInfo &>
   GetClassInstanceTypeInfo(
       const swift::reflection::TypeRef &type_ref,
       swift::remote::TypeInfoProvider *provider,
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual llvm::Expected<const swift::reflection::TypeInfo &>
-  GetTypeInfo(const swift::reflection::TypeRef &type_ref,
-              swift::remote::TypeInfoProvider *provider,
+  GetTypeInfo(CompilerType type, swift::remote::TypeInfoProvider *provider,
               swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual llvm::Expected<const swift::reflection::TypeInfo &>
   GetTypeInfoFromInstance(
@@ -121,11 +127,11 @@ public:
                         const swift::reflection::TypeRef *tr,
                         std::function<bool(SuperClassType)> fn) = 0;
 
-  virtual std::optional<std::pair<const swift::reflection::TypeRef *,
-                                  swift::remote::RemoteAddress>>
+  virtual llvm::Expected<std::pair<const swift::reflection::TypeRef *,
+                                   swift::remote::RemoteAddress>>
   ProjectExistentialAndUnwrapClass(
       swift::remote::RemoteAddress existential_addess,
-      const swift::reflection::TypeRef &existential_tr,
+      CompilerType existential_type,
       swift::reflection::DescriptorFinder *descriptor_finder) = 0;
   virtual std::optional<int32_t> ProjectEnumValue(
       swift::remote::RemoteAddress enum_addr,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/ReflectionContextInterface.h
@@ -84,11 +84,10 @@ public:
           std::optional<llvm::sys::MemoryBlock> FileBuffer,
           llvm::SmallVector<llvm::StringRef, 1> likely_module_names = {}) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &>
-  GetTypeRef(llvm::StringRef mangled_type_name,
-             swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  GetTypeRef(llvm::StringRef mangled_type_name) = 0;
   virtual llvm::Expected<const swift::reflection::TypeRef &>
-  GetTypeRef(swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
-             swift::reflection::DescriptorFinder *descriptor_finder) = 0;
+  GetTypeRef(swift::Demangle::Demangler &dem,
+             swift::Demangle::NodePointer node) = 0;
   virtual llvm::Expected<const swift::reflection::RecordTypeInfo &>
   GetClassInstanceTypeInfo(
       const swift::reflection::TypeRef &type_ref,

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -1933,8 +1933,7 @@ CompilerType SwiftLanguageRuntime::GetBaseClass(CompilerType class_ty) {
   if (!tr_ts)
     return {};
   auto type_ref_or_err =
-      reflection_ctx->GetTypeRef(class_ty.GetMangledTypeName().GetStringRef(),
-                                 tr_ts->GetDescriptorFinder());
+      reflection_ctx->GetTypeRef(class_ty.GetMangledTypeName().GetStringRef());
   if (!type_ref_or_err) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions | LLDBLog::Types),
                    type_ref_or_err.takeError(), "{0}");
@@ -2164,8 +2163,7 @@ SwiftLanguageRuntime::BindGenericPackType(StackFrame &frame,
           });
 
       // Build a TypeRef from the demangle tree.
-      auto type_ref_or_err = reflection_ctx->GetTypeRef(
-          dem, pack_element, ts->GetDescriptorFinder());
+      auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, pack_element);
       if (!type_ref_or_err)
         return type_ref_or_err.takeError();
       auto &type_ref = *type_ref_or_err;
@@ -2902,8 +2900,7 @@ CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
   if (!tr_ts)
     return unbound_type;
 
-  auto type_ref_or_err = reflection_ctx->GetTypeRef(
-      dem, unbound_node, tr_ts->GetDescriptorFinder());
+  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, unbound_node);
   if (!type_ref_or_err) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Expressions | LLDBLog::Types),
                    type_ref_or_err.takeError(),
@@ -2929,8 +2926,8 @@ CompilerType SwiftLanguageRuntime::BindGenericTypeParameters(
       return;
     }
 
-    auto type_ref_or_err = reflection_ctx->GetTypeRef(
-        type.GetMangledTypeName().GetStringRef(), tr_ts->GetDescriptorFinder());
+    auto type_ref_or_err =
+        reflection_ctx->GetTypeRef(type.GetMangledTypeName().GetStringRef());
     if (!type_ref_or_err) {
       LLDB_LOG_ERROR(
           GetLog(LLDBLog::Expressions | LLDBLog::Types),
@@ -3026,8 +3023,7 @@ SwiftLanguageRuntime::BindGenericTypeParameters(StackFrame &stack_frame,
     return get_canonical();
 
   // Build a TypeRef from the demangle tree.
-  auto type_ref_or_err =
-      reflection_ctx->GetTypeRef(dem, canonical, ts.GetDescriptorFinder());
+  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, canonical);
   if (!type_ref_or_err)
     return llvm::joinErrors(
         llvm::createStringError("cannot bind generic parameters"),
@@ -3708,8 +3704,7 @@ SwiftLanguageRuntime::GetTypeRef(CompilerType type,
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
 
-  auto type_ref_or_err = reflection_ctx->GetTypeRef(
-      dem, node, module_holder->GetDescriptorFinder());
+  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, node);
   if (!type_ref_or_err)
     return llvm::joinErrors(
         llvm::createStringError("cannot get typeref for type %s",
@@ -3947,8 +3942,7 @@ SwiftLanguageRuntime::ResolveTypeAlias(CompilerType alias) {
         auto mangling = swift_demangle::GetMangledName(dem, child, flavor);
         if (!mangling.isSuccess())
           continue;
-        auto type_ref_or_err = reflection_ctx->GetTypeRef(
-            mangling.result(), tr_ts->GetDescriptorFinder());
+        auto type_ref_or_err = reflection_ctx->GetTypeRef(mangling.result());
         if (!type_ref_or_err) {
           LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), type_ref_or_err.takeError(),
                           "{0}");

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -2626,15 +2626,6 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
     return false;
   }
 
-  auto tr_or_err =
-      GetTypeRef(existential_type, tss->GetTypeSystemSwiftTypeRef().get());
-  if (!tr_or_err) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Types), tr_or_err.takeError(),
-                   "Could not get existential typeref: {0}");
-    return false;
-  }
-  const swift::reflection::TypeRef *existential_typeref = &*tr_or_err;
-
   lldb::addr_t existential_address;
   bool use_local_buffer = false;
 
@@ -2689,12 +2680,12 @@ bool SwiftLanguageRuntime::GetDynamicTypeAndAddress_Existential(
     uint64_t dynamic_address = 0;
     if (flavor == swift::Mangle::ManglingFlavor::Default) {
       auto pair = reflection_ctx->ProjectExistentialAndUnwrapClass(
-          remote_existential, *existential_typeref,
-          tr_ts->GetDescriptorFinder());
+          remote_existential, existential_type, tr_ts->GetDescriptorFinder());
 
       if (!pair) {
-        if (log)
-          log->Printf("Runtime failed to get dynamic type of existential");
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Types), pair.takeError(),
+                       "Runtime failed to get dynamic type of existential: "
+                       "{0}");
         return false;
       }
 
@@ -3675,36 +3666,19 @@ SwiftLanguageRuntime::GetTypeRef(CompilerType type,
               "type: %s\n",
               type.GetMangledTypeName().GetCString());
 
-  // Demangle the mangled name.
-  swift::Demangle::Demangler dem;
-  llvm::StringRef mangled_name = type.GetMangledTypeName().GetStringRef();
   auto ts = type.GetTypeSystem().dyn_cast_or_null<TypeSystemSwift>();
   if (!ts)
     return llvm::createStringError("not a Swift type");
 
-  // List of commonly used types known to have been been annotated with
-  // @_originallyDefinedIn to a different module.
-  static llvm::StringMap<llvm::StringRef> known_types_with_redefined_modules = {
-      {"$s14CoreFoundation7CGFloatVD", "$s12CoreGraphics7CGFloatVD"}};
-
-  auto it = known_types_with_redefined_modules.find(mangled_name);
-  if (it != known_types_with_redefined_modules.end())
-    mangled_name = it->second;
-
   if (!module_holder)
     return llvm::createStringError("no module holder");
-
-  swift::Demangle::NodePointer node =
-      module_holder->GetCanonicalDemangleTree(dem, mangled_name);
-  if (!node)
-    return llvm::createStringError("could not demangle");
 
   // Build a TypeRef.
   ThreadSafeReflectionContext reflection_ctx = GetReflectionContext();
   if (!reflection_ctx)
     return llvm::createStringError("no reflection context");
 
-  auto type_ref_or_err = reflection_ctx->GetTypeRef(dem, node);
+  auto type_ref_or_err = reflection_ctx->GetCanonicalTypeRef(type);
   if (!type_ref_or_err)
     return llvm::joinErrors(
         llvm::createStringError("cannot get typeref for type %s",
@@ -3824,8 +3798,7 @@ SwiftLanguageRuntime::GetSwiftRuntimeTypeInfo(
                                                         : g_reflection,
       &GetProcess().GetTarget().GetDebugger(), *GetMemoryReader());
   LLDBTypeInfoProvider provider(*this, ts);
-  return reflection_ctx->GetTypeInfo(*type_ref_or_err, &provider,
-                                     ts.GetDescriptorFinder());
+  return reflection_ctx->GetTypeInfo(type, &provider, ts.GetDescriptorFinder());
 }
 
 bool SwiftLanguageRuntime::IsStoredInlineInBuffer(CompilerType type) {

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -56,7 +56,7 @@ static bool IsMarkerProtocol(const DWARFDIE &die) {
       continue;
     const char *name =
         child.GetAttributeValueAsString(llvm::dwarf::DW_AT_name, nullptr);
-    if (llvm::StringRef(name) == "$swift_marker")
+    if (llvm::StringRef(name) == "swift.MarkerProtocol")
       return child.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_const_value,
                                                0) != 0;
   }
@@ -279,9 +279,25 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         // read the size from DWARF.
         dwarf_byte_size, nullptr, LLDB_INVALID_UID, Type::eEncodingIsUID, &decl,
         compiler_type, Type::ResolveState::Full);
+
     if (IsMarkerProtocol(die))
       type_sp->SetPayload(
           TypePayloadSwift(TypePayloadSwift::Options::IsMarkerProtocol));
+
+    // If this is a protocol composition, force parsing the protocols which this
+    // type is composed  of. We want to make sure we parse every marker protocol
+    // since that will be important when looking up type information via
+    // reflection context.
+    if (TypeSystemSwiftTypeRef::IsProtocolComposition(
+            compiler_type.GetMangledTypeName())) {
+      for (auto child : die.children()) {
+        if (child.Tag() == llvm::dwarf::DW_TAG_inheritance) {
+          DWARFDIE type =
+              child.GetAttributeValueAsReferenceDIE(llvm::dwarf::DW_AT_type);
+          ParseTypeFromDWARF(sc, type, nullptr);
+        }
+      }
+    }
   }
 
   // Cache this type.

--- a/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/DWARF/DWARFASTParserSwift.cpp
@@ -47,6 +47,22 @@ DWARFASTParserSwift::DWARFASTParserSwift(
 
 DWARFASTParserSwift::~DWARFASTParserSwift() {}
 
+/// Returns true if the DIE represents a protocol annotated with @_marker.
+static bool IsMarkerProtocol(const DWARFDIE &die) {
+  if (die.Tag() != llvm::dwarf::DW_TAG_structure_type)
+    return false;
+  for (DWARFDIE child : die.children()) {
+    if (child.Tag() != llvm::dwarf::DW_TAG_LLVM_annotation)
+      continue;
+    const char *name =
+        child.GetAttributeValueAsString(llvm::dwarf::DW_AT_name, nullptr);
+    if (llvm::StringRef(name) == "$swift_marker")
+      return child.GetAttributeValueAsUnsigned(llvm::dwarf::DW_AT_const_value,
+                                               0) != 0;
+  }
+  return false;
+}
+
 static llvm::StringRef GetTypedefName(const DWARFDIE &die) {
   if (die.Tag() != llvm::dwarf::DW_TAG_typedef)
     return {};
@@ -188,7 +204,8 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
       if (auto wrapped_type = get_type(die.GetFirstChild())) {
         // Create a unique pointer for the type + fixed buffer flag.
         type_sp = wrapped_type->GetSymbolFile()->CopyType(wrapped_type);
-        type_sp->SetPayload(TypePayloadSwift(true));
+        type_sp->SetPayload(
+            TypePayloadSwift(TypePayloadSwift::Options::FixedValueBuffer));
         return type_sp;
       }
     }
@@ -262,6 +279,9 @@ lldb::TypeSP DWARFASTParserSwift::ParseTypeFromDWARF(const SymbolContext &sc,
         // read the size from DWARF.
         dwarf_byte_size, nullptr, LLDB_INVALID_UID, Type::eEncodingIsUID, &decl,
         compiler_type, Type::ResolveState::Full);
+    if (IsMarkerProtocol(die))
+      type_sp->SetPayload(
+          TypePayloadSwift(TypePayloadSwift::Options::IsMarkerProtocol));
   }
 
   // Cache this type.

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -222,10 +222,6 @@ CompilerType lldb_private::ToCompilerType(swift::Type qual_type) {
   return {ast_ctx->weak_from_this(), qual_type.getPointer()};
 }
 
-TypePayloadSwift::TypePayloadSwift(bool is_fixed_value_buffer) {
-  SetIsFixedValueBuffer(is_fixed_value_buffer);
-}
-
 CompilerType SwiftASTContext::GetCompilerType(ConstString mangled_name) {
   if (auto ts = GetTypeSystemSwiftTypeRef())
     return ts->GetTypeFromMangledTypename(mangled_name);

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.cpp
@@ -196,6 +196,11 @@ TypeSystemSwift::GetUInt8Type(swift::Mangle::ManglingFlavor flavor) {
       ConstString(SwiftLanguageRuntime::MakeMangledName("s5UInt8VD", flavor)));
 }
 
+CompilerType TypeSystemSwift::GetAnyType(swift::Mangle::ManglingFlavor flavor) {
+  return GetTypeFromMangledTypename(
+      ConstString(SwiftLanguageRuntime::MakeMangledName("ypD", flavor)));
+}
+
 bool TypeSystemSwift::ShouldTreatScalarValueAsAddress(
     opaque_compiler_type_t type) {
   return Flags(GetTypeInfo(type, nullptr))

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -228,6 +228,7 @@ public:
   GetOptionalUnsafeRawPointerType(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetUnsafeCurrentTaskType(swift::Mangle::ManglingFlavor flavor);
   CompilerType GetUInt8Type(swift::Mangle::ManglingFlavor flavor);
+  CompilerType GetAnyType(swift::Mangle::ManglingFlavor flavor);
 
   /// Attempts to convert a Clang type into a Swift type.
   /// For example, int is converted to Int32.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwift.h
@@ -44,29 +44,35 @@ typedef std::shared_ptr<SwiftASTContextForExpressions>
 
 /// The implementation of lldb::Type's m_payload field for TypeSystemSwift.
 class TypePayloadSwift {
-  /// Layout: bit 1 ... IsFixedValueBuffer.
-  Type::Payload m_payload = 0;
-
-  static constexpr unsigned FixedValueBufferBit = 1;
-
 public:
+  enum class Options : uint32_t {
+    FixedValueBuffer = 1,
+    IsMarkerProtocol = 1 << 1
+  };
   TypePayloadSwift() = default;
-  explicit TypePayloadSwift(bool is_fixed_value_buffer);
-  explicit TypePayloadSwift(Type::Payload opaque_payload)
-      : m_payload(opaque_payload) {}
-  operator Type::Payload() { return m_payload; }
+
+  explicit TypePayloadSwift(Options option) {
+    m_flags.Set(llvm::to_underlying(option));
+  }
+
+  explicit TypePayloadSwift(Type::Payload opaque_payload) {
+    m_flags.Reset(opaque_payload);
+  }
+
+  operator Type::Payload() { return m_flags.Get(); }
 
   /// \return whether this is a Swift fixed-size buffer. Resilient variables in
   /// fixed-size buffers may be indirect depending on the runtime size of the
   /// type. This is more a property of the value than of its type.
   bool IsFixedValueBuffer() {
-    return Flags(m_payload).Test(FixedValueBufferBit);
+    return m_flags.Test(llvm::to_underlying(Options::FixedValueBuffer));
   }
-  void SetIsFixedValueBuffer(bool is_fixed_value_buffer) {
-    m_payload = is_fixed_value_buffer
-                    ? Flags(m_payload).Set(FixedValueBufferBit)
-                    : Flags(m_payload).Clear(FixedValueBufferBit);
+  bool IsMarkerProtocol() {
+    return m_flags.Test(llvm::to_underlying(Options::IsMarkerProtocol));
   }
+
+private:
+  Flags m_flags;
 };
 
 /// Abstract base class for all Swift TypeSystems.

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2769,6 +2769,47 @@ void TypeSystemSwiftTypeRef::SetCachedType(ConstString mangled,
   m_swift_type_map.Insert(mangled.GetCString(), type_sp);
 }
 
+bool TypeSystemSwiftTypeRef::IsMarkerProtocol(ConstString mangled_name) {
+  if (auto lldb_type = GetCachedType(mangled_name)) {
+    TypePayloadSwift payload(lldb_type->GetPayload());
+    return payload.IsMarkerProtocol();
+  }
+  return false;
+}
+
+llvm::Expected<swift::Demangle::NodePointer>
+TypeSystemSwiftTypeRef::RemoveMarkerProtocols(
+    swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
+    swift::Mangle::ManglingFlavor flavor) {
+  using namespace swift::Demangle;
+  NodePointer type_list_node = swift_demangle::NodeAtPath(
+      node, {Node::Kind::Global, Node::Kind::TypeMangling, Node::Kind::Type,
+             Node::Kind::ProtocolList, Node::Kind::TypeList});
+  if (!type_list_node)
+    return node;
+
+  // Collect indices of marker protocols, then remove in reverse order so
+  // that earlier indices remain valid.
+  swift_demangle::NodeBuilder b(dem);
+  llvm::SmallVector<size_t> to_remove;
+  for (size_t i = 0; i < type_list_node->getNumChildren(); ++i) {
+    // Mangle a single-protocol type for this child so we can look it up in the
+    // type cache.
+    auto *protocol_list =
+        b.Node(Node::Kind::ProtocolList,
+               b.Node(Node::Kind::TypeList, type_list_node->getChild(i)));
+    auto mangling = mangleNode(b.GlobalType(protocol_list), flavor);
+    if (!mangling.isSuccess())
+      return llvm::createStringError("failed to mangle protocol in type: " +
+                                     nodeToString(node));
+    if (IsMarkerProtocol(ConstString(mangling.result())))
+      to_remove.push_back(i);
+  }
+  for (size_t i : llvm::reverse(to_remove))
+    type_list_node->removeChildAt(i);
+  return node;
+}
+
 bool TypeSystemSwiftTypeRef::SupportsLanguage(lldb::LanguageType language) {
   return language == eLanguageTypeSwift;
 }
@@ -5740,6 +5781,23 @@ bool TypeSystemSwiftTypeRef::IsOptionalType(lldb::opaque_compiler_type_t type) {
          module->getText() == swift::STDLIB_NAME &&
          identifier->getKind() == Node::Kind::Identifier &&
          identifier->getText() == "Optional";
+}
+
+bool TypeSystemSwiftTypeRef::IsProtocolComposition(
+    llvm::StringRef mangled_name) {
+  using namespace swift::Demangle;
+  Demangler dem;
+  NodePointer global = dem.demangleSymbol(mangled_name);
+  using Kind = Node::Kind;
+  NodePointer type_list =
+      swift_demangle::ChildAtPath(global, {Kind::TypeMangling, Kind::Type,
+                                           Kind::ProtocolList, Kind::TypeList});
+  if (!type_list)
+    return false;
+  // In the demangle tree a ProtocolList with more than one TypeList child
+  // represents a protocol composition (e.g., `P & Q`). Zero children
+  // encodes the `Any` type, and exactly one child is a plain protocol.
+  return type_list->getNumChildren() > 1;
 }
 
 CompilerType TypeSystemSwiftTypeRef::GetOptionalType(CompilerType type) {

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -320,11 +320,23 @@ public:
   lldb::TypeSP GetCachedType(ConstString mangled);
   lldb::TypeSP GetCachedType(lldb::opaque_compiler_type_t type);
   void SetCachedType(ConstString mangled, const lldb::TypeSP &type_sp);
+  bool IsMarkerProtocol(ConstString mangled_name);
+  /// Remove marker protocols from a protocol list in a demangle tree.
+  /// Marker protocols are compile-time concepts only and the reflection
+  /// context does not expect them as input. Note: this mutates \p node
+  /// in place.
+  llvm::Expected<swift::Demangle::NodePointer>
+  RemoveMarkerProtocols(swift::Demangle::Demangler &dem,
+                        swift::Demangle::NodePointer node,
+                        swift::Mangle::ManglingFlavor flavor);
   bool IsImportedType(lldb::opaque_compiler_type_t type,
                       CompilerType *original_type) override;
   /// Determine whether this is a builtin SIMD type.
   static bool IsSIMDType(CompilerType type);
   static bool IsOptionalType(lldb::opaque_compiler_type_t type);
+  /// Determine whether the mangled name refers to a protocol composition
+  /// (i.e., a ProtocolList with more than one Type child in its TypeList).
+  static bool IsProtocolComposition(llvm::StringRef mangled_name);
   static CompilerType GetOptionalType(CompilerType type);
   /// Like \p IsImportedType(), but even returns Clang types that are also Swift
   /// builtins (int <-> Swift.Int) as Clang types.

--- a/lldb/test/API/lang/swift/marker_protocol_existential/Makefile
+++ b/lldb/test/API/lang/swift/marker_protocol_existential/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/marker_protocol_existential/TestMarkerProtocolExistential.py
+++ b/lldb/test/API/lang/swift/marker_protocol_existential/TestMarkerProtocolExistential.py
@@ -1,0 +1,64 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestMarkerProtocolExistential(lldbtest.TestBase):
+    @swiftTest
+    def test_marker_only(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break marker only", lldb.SBFileSpec("main.swift")
+        )
+
+        s = self.frame().FindVariable("v")
+        self.assertEqual(s.GetTypeName(), "a.S")
+        x = s.GetChildMemberWithName("x")
+        lldbutil.check_variable(self, x, value="42")
+
+    @swiftTest
+    def test_marker_composition(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break composition", lldb.SBFileSpec("main.swift")
+        )
+
+        t = self.frame().FindVariable("v")
+        a = t.GetChildMemberWithName("a")
+        lldbutil.check_variable(self, a, value="10")
+
+    @swiftTest
+    def test_two_markers(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break two markers", lldb.SBFileSpec("main.swift")
+        )
+
+        u = self.frame().FindVariable("v")
+        self.assertEqual(u.GetTypeName(), "a.U")
+        b = u.GetChildMemberWithName("b")
+        lldbutil.check_variable(self, b, value="20")
+
+    @swiftTest
+    def test_any_and_marker(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break any and marker", lldb.SBFileSpec("main.swift")
+        )
+
+        s = self.frame().FindVariable("v")
+        self.assertEqual(s.GetTypeName(), "a.S")
+        x = s.GetChildMemberWithName("x")
+        lldbutil.check_variable(self, x, value="42")
+
+    @swiftTest
+    def test_any_marker_and_non_marker(self):
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break any marker and non marker", lldb.SBFileSpec("main.swift")
+        )
+
+        v = self.frame().FindVariable("v")
+        d = v.GetChildMemberWithName("d")
+        lldbutil.check_variable(self, d, value="30")

--- a/lldb/test/API/lang/swift/marker_protocol_existential/main.swift
+++ b/lldb/test/API/lang/swift/marker_protocol_existential/main.swift
@@ -1,0 +1,51 @@
+@_marker protocol MyMarker {}
+@_marker protocol MyMarker2 {}
+
+protocol MyProto {}
+
+struct S: MyMarker {
+    var x = 42
+}
+
+struct T: MyMarker, MyProto {
+    var a = 10
+}
+
+struct U: MyMarker, MyMarker2 {
+    var b = 20
+}
+
+struct V: MyMarker, MyMarker2, MyProto {
+    var d = 30
+}
+
+func marker_only() {
+    let v: any MyMarker = S()
+    print(v) // break marker only
+}
+
+func marker_composition() {
+    let v: any MyMarker & MyProto = T()
+    print(v) // break composition
+}
+
+func two_markers() {
+    let v: any MyMarker & MyMarker2 = U()
+    print(v) // break two markers
+}
+
+func any_and_marker() {
+    let v: any Any & MyMarker = S()
+    print(v) // break any and marker
+}
+
+func any_marker_and_non_marker() {
+    let v: any Any & MyMarker & MyProto = V()
+    print(v) // break any marker and non marker
+}
+
+marker_only()
+marker_composition()
+two_markers()
+any_and_marker()
+any_marker_and_non_marker()

--- a/llvm/include/llvm/IR/DIBuilder.h
+++ b/llvm/include/llvm/IR/DIBuilder.h
@@ -587,12 +587,15 @@ namespace llvm {
     /// \param NumExtraInhabitants The number of extra inhabitants of the type.
     /// An extra inhabitant is a bit pattern that does not represent a valid
     /// value for instances of a given type. This is used by the Swift language.
+    /// \param Annotations  Attribute annotations, emitted as
+    /// DW_TAG_LLVM_annotation entries.
     LLVM_ABI DICompositeType *createStructType(
         DIScope *Scope, StringRef Name, DIFile *File, unsigned LineNumber,
         uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
         DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang = 0,
         DIType *VTableHolder = nullptr, StringRef UniqueIdentifier = "",
-        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0);
+        DIType *Specification = nullptr, uint32_t NumExtraInhabitants = 0,
+        DINodeArray Annotations = nullptr);
 
     /// Create debugging information entry for an union.
     /// \param Scope        Scope in which this union is defined.

--- a/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
+++ b/llvm/lib/DebugInfo/DWARF/DWARFVerifier.cpp
@@ -1894,6 +1894,9 @@ void DWARFVerifier::verifyNameIndexCompleteness(
   case DW_TAG_member:
     return;
 
+  case DW_TAG_LLVM_annotation:
+    return;
+
   // According to a strict reading of the specification, enumerators should not
   // be indexed (and LLVM currently does not do that). However, this causes
   // problems for the debuggers, so we may need to reconsider this.

--- a/llvm/lib/IR/DIBuilder.cpp
+++ b/llvm/lib/IR/DIBuilder.cpp
@@ -612,13 +612,13 @@ DICompositeType *DIBuilder::createStructType(
     uint64_t SizeInBits, uint32_t AlignInBits, DINode::DIFlags Flags,
     DIType *DerivedFrom, DINodeArray Elements, unsigned RunTimeLang,
     DIType *VTableHolder, StringRef UniqueIdentifier, DIType *Specification,
-    uint32_t NumExtraInhabitants) {
+    uint32_t NumExtraInhabitants, DINodeArray Annotations) {
   auto *R = DICompositeType::get(
       VMContext, dwarf::DW_TAG_structure_type, Name, File, LineNumber,
       getNonCompileUnitScope(Context), DerivedFrom, SizeInBits, AlignInBits, 0,
       Flags, Elements, RunTimeLang, /*EnumKind=*/std::nullopt, VTableHolder,
       nullptr, UniqueIdentifier, nullptr, nullptr, nullptr, nullptr, nullptr,
-      nullptr, Specification, NumExtraInhabitants);
+      Annotations, Specification, NumExtraInhabitants);
   trackIfUnresolved(R);
   return R;
 }


### PR DESCRIPTION
[lldb] Replace marker protocol with Any before querying RemoteInspection

    Since marker protocols are a compile time concept only and have no
    metadata emitted, remote inspection does not expect to process them.

    Before querying it, we must then replace any existential of this type
    with the "Any" type.

    rdar://172869300


[lldb] Detect @_marker protocols

    Parse DW_TAG_LLVM_annotation children of structure types to detect
    the "$swift_marker" annotation.

    Also refactor TypePayloadSwift to use a flags-based enum and add an
    IsMarkerProtocol flag.

    rdar://172869300



[NFC][lldb] Remove DescriptorFinder parameter from GetTypeRef

    The descriptor finder is not needed in this function, since no type
    lookup is done by it.



[NFC][DebugInfo] Add Annotations parameter to DIBuilder::createStructType

    DICompositeType already has an "Annotations" ivar. This simply adds a
    way to set it from the "createStructType" function.