### PR TITLE
🍒 [lldb][NativePDB] Remove cantFail uses (1 out of ?) 

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.cpp
@@ -24,6 +24,8 @@
 #include "llvm/Support/Path.h"
 
 #include "lldb/Utility/LLDBAssert.h"
+#include "lldb/Utility/LLDBLog.h"
+#include "lldb/Utility/Log.h"
 
 using namespace lldb;
 using namespace lldb_private;
@@ -46,22 +48,31 @@ static bool IsMainFile(llvm::StringRef main, llvm::StringRef other) {
   return main.equals_insensitive(normalized);
 }
 
-static void ParseCompile3(const CVSymbol &sym, CompilandIndexItem &cci) {
+static llvm::Error ParseCompile3(const CVSymbol &sym, CompilandIndexItem &cci) {
   cci.m_compile_opts.emplace();
-  llvm::cantFail(
-      SymbolDeserializer::deserializeAs<Compile3Sym>(sym, *cci.m_compile_opts));
+  if (auto err = SymbolDeserializer::deserializeAs<Compile3Sym>(
+          sym, *cci.m_compile_opts)) {
+    cci.m_compile_opts.reset();
+    return err;
+  }
+  return llvm::Error::success();
 }
 
-static void ParseObjname(const CVSymbol &sym, CompilandIndexItem &cci) {
+static llvm::Error ParseObjname(const CVSymbol &sym, CompilandIndexItem &cci) {
   cci.m_obj_name.emplace();
-  llvm::cantFail(
-      SymbolDeserializer::deserializeAs<ObjNameSym>(sym, *cci.m_obj_name));
+  if (auto err =
+          SymbolDeserializer::deserializeAs<ObjNameSym>(sym, *cci.m_obj_name)) {
+    cci.m_obj_name.reset();
+    return err;
+  }
+  return llvm::Error::success();
 }
 
-static void ParseBuildInfo(PdbIndex &index, const CVSymbol &sym,
-                           CompilandIndexItem &cci) {
+static llvm::Error ParseBuildInfo(PdbIndex &index, const CVSymbol &sym,
+                                  CompilandIndexItem &cci) {
   BuildInfoSym bis(SymbolRecordKind::BuildInfoSym);
-  llvm::cantFail(SymbolDeserializer::deserializeAs<BuildInfoSym>(sym, bis));
+  if (auto err = SymbolDeserializer::deserializeAs<BuildInfoSym>(sym, bis))
+    return err;
 
   // S_BUILDINFO just points to an LF_BUILDINFO in the IPI stream.  Let's do
   // a little extra work to pull out the LF_BUILDINFO.
@@ -69,11 +80,13 @@ static void ParseBuildInfo(PdbIndex &index, const CVSymbol &sym,
   std::optional<CVType> cvt = types.tryGetType(bis.BuildId);
 
   if (!cvt || cvt->kind() != LF_BUILDINFO)
-    return;
+    return llvm::Error::success();
 
   BuildInfoRecord bir;
-  llvm::cantFail(TypeDeserializer::deserializeAs<BuildInfoRecord>(*cvt, bir));
+  if (auto err = TypeDeserializer::deserializeAs<BuildInfoRecord>(*cvt, bir))
+    return err;
   cci.m_build_info.assign(bir.ArgIndices.begin(), bir.ArgIndices.end());
+  return llvm::Error::success();
 }
 
 static void ParseExtendedInfo(PdbIndex &index, CompilandIndexItem &item) {
@@ -85,18 +98,25 @@ static void ParseExtendedInfo(PdbIndex &index, CompilandIndexItem &item) {
   lldbassert(!item.m_compile_opts);
   lldbassert(item.m_build_info.empty());
 
+  Log *log = GetLog(LLDBLog::Symbols);
   // We're looking for 3 things.  S_COMPILE3, S_OBJNAME, and S_BUILDINFO.
   int found = 0;
   for (const CVSymbol &sym : syms) {
     switch (sym.kind()) {
     case S_COMPILE3:
-      ParseCompile3(sym, item);
+      if (auto err = ParseCompile3(sym, item))
+        LLDB_LOG_ERROR(log, std::move(err),
+                       "Failed to parse S_COMPILE3 record: {0}");
       break;
     case S_OBJNAME:
-      ParseObjname(sym, item);
+      if (auto err = ParseObjname(sym, item))
+        LLDB_LOG_ERROR(log, std::move(err),
+                       "Failed to parse S_OBJNAME record: {0}");
       break;
     case S_BUILDINFO:
-      ParseBuildInfo(index, sym, item);
+      if (auto err = ParseBuildInfo(index, sym, item))
+        LLDB_LOG_ERROR(log, std::move(err),
+                       "Failed to parse S_BUILDINFO record: {0}");
       break;
     default:
       continue;
@@ -107,6 +127,7 @@ static void ParseExtendedInfo(PdbIndex &index, CompilandIndexItem &item) {
 }
 
 static void ParseInlineeLineTableForCompileUnit(CompilandIndexItem &item) {
+  Log *log = GetLog(LLDBLog::Symbols);
   for (const auto &ss : item.m_debug_stream.getSubsectionsArray()) {
     if (ss.kind() != DebugSubsectionKind::InlineeLines)
       continue;
@@ -114,7 +135,8 @@ static void ParseInlineeLineTableForCompileUnit(CompilandIndexItem &item) {
     DebugInlineeLinesSubsectionRef inlinee_lines;
     llvm::BinaryStreamReader reader(ss.getRecordData());
     if (llvm::Error error = inlinee_lines.initialize(reader)) {
-      consumeError(std::move(error));
+      LLDB_LOG_ERROR(log, std::move(error),
+                     "Failed to initialize inlinee lines subsection: {0}");
       continue;
     }
 
@@ -155,7 +177,14 @@ CompilandIndexItem &CompileUnitIndex::GetOrCreateCompiland(uint16_t modi) {
   llvm::pdb::ModuleDebugStreamRef debug_stream(descriptor,
                                                std::move(stream_data));
 
-  cantFail(debug_stream.reload());
+  if (llvm::Error err = debug_stream.reload()) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                   "Failed to reload debug stream for module {1}: {0}", modi);
+    llvm::pdb::ModuleDebugStreamRef empty_stream(descriptor, nullptr);
+    cci = std::make_unique<CompilandIndexItem>(
+        PdbCompilandId{modi}, empty_stream, std::move(descriptor));
+    return *cci;
+  }
 
   cci = std::make_unique<CompilandIndexItem>(
       PdbCompilandId{modi}, std::move(debug_stream), std::move(descriptor));
@@ -167,7 +196,8 @@ CompilandIndexItem &CompileUnitIndex::GetOrCreateCompiland(uint16_t modi) {
     cci->m_strings.initialize(cci->m_debug_stream.getSubsectionsArray());
     cci->m_strings.setStrings(strings->getStringTable());
   } else {
-    consumeError(strings.takeError());
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), strings.takeError(),
+                   "Failed to get PDB string table: {0}");
   }
 
   // We want the main source file to always comes first.  Note that we can't
@@ -176,7 +206,14 @@ CompilandIndexItem &CompileUnitIndex::GetOrCreateCompiland(uint16_t modi) {
   // have to iterate the module file list comparing each one to the main file
   // name until we find it, and we can cache that one since the memory is backed
   // by a contiguous chunk inside the mapped PDB.
-  llvm::SmallString<64> main_file = GetMainSourceFile(*cci);
+  llvm::SmallString<64> main_file;
+  if (auto main_file_or_err = GetMainSourceFile(*cci)) {
+    main_file = std::move(*main_file_or_err);
+  } else {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), main_file_or_err.takeError(),
+                   "Failed to determine main source file for module {1}: {0}",
+                   modi);
+  }
   llvm::sys::path::native(main_file);
 
   uint32_t file_count = modules.getSourceFileCount(modi);
@@ -208,7 +245,7 @@ CompilandIndexItem *CompileUnitIndex::GetCompiland(uint16_t modi) {
   return iter->second.get();
 }
 
-llvm::SmallString<64>
+llvm::Expected<llvm::SmallString<64>>
 CompileUnitIndex::GetMainSourceFile(const CompilandIndexItem &item) const {
   // LF_BUILDINFO contains a list of arg indices which point to LF_STRING_ID
   // records in the IPI stream.  The order of the arg indices is as follows:
@@ -222,7 +259,7 @@ CompileUnitIndex::GetMainSourceFile(const CompilandIndexItem &item) const {
   // We need to form the path [0]\[2] to generate the full path to the main
   // file.source
   if (item.m_build_info.size() < 3)
-    return {""};
+    return llvm::SmallString<64>("");
 
   LazyRandomTypeCollection &types = m_index.ipi().typeCollection();
 
@@ -230,10 +267,12 @@ CompileUnitIndex::GetMainSourceFile(const CompilandIndexItem &item) const {
   StringIdRecord file_name;
   CVType dir_cvt = types.getType(item.m_build_info[0]);
   CVType file_cvt = types.getType(item.m_build_info[2]);
-  llvm::cantFail(
-      TypeDeserializer::deserializeAs<StringIdRecord>(dir_cvt, working_dir));
-  llvm::cantFail(
-      TypeDeserializer::deserializeAs<StringIdRecord>(file_cvt, file_name));
+  if (auto err =
+          TypeDeserializer::deserializeAs<StringIdRecord>(dir_cvt, working_dir))
+    return std::move(err);
+  if (auto err =
+          TypeDeserializer::deserializeAs<StringIdRecord>(file_cvt, file_name))
+    return std::move(err);
 
   llvm::sys::path::Style style = working_dir.String.starts_with("/")
                                      ? llvm::sys::path::Style::posix

--- a/lldb/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/CompileUnitIndex.h
@@ -21,6 +21,7 @@
 #include "llvm/DebugInfo/PDB/Native/DbiModuleDescriptor.h"
 #include "llvm/DebugInfo/PDB/Native/ModuleDebugStream.h"
 #include "llvm/DebugInfo/PDB/PDBTypes.h"
+#include "llvm/Support/Error.h"
 
 #include "PdbSymUid.h"
 
@@ -100,7 +101,8 @@ public:
 
   CompilandIndexItem *GetCompiland(uint16_t modi);
 
-  llvm::SmallString<64> GetMainSourceFile(const CompilandIndexItem &item) const;
+  llvm::Expected<llvm::SmallString<64>>
+  GetMainSourceFile(const CompilandIndexItem &item) const;
 };
 } // namespace npdb
 } // namespace lldb_private

--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
@@ -91,7 +91,7 @@ static std::pair<size_t, bool> GetIntegralTypeInfo(TypeIndex ti,
   case LF_POINTER: {
     PointerRecord pr;
     llvm::cantFail(TypeDeserializer::deserializeAs<PointerRecord>(cvt, pr));
-    return GetIntegralTypeInfo(pr.ReferentType, tpi);
+    return {pr.getSize(), false};
   }
   case LF_ENUM: {
     EnumRecord er;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
@@ -74,33 +74,37 @@ static bool IsSimpleTypeSignedInteger(SimpleTypeKind kind) {
   }
 }
 
-static std::pair<size_t, bool> GetIntegralTypeInfo(TypeIndex ti,
-                                                   TpiStream &tpi) {
+static llvm::Expected<std::pair<size_t, bool>>
+GetIntegralTypeInfo(TypeIndex ti, TpiStream &tpi) {
   if (ti.isSimple()) {
     SimpleTypeKind stk = ti.getSimpleKind();
-    return {GetTypeSizeForSimpleKind(stk), IsSimpleTypeSignedInteger(stk)};
+    return std::make_pair(GetTypeSizeForSimpleKind(stk),
+                          IsSimpleTypeSignedInteger(stk));
   }
 
   CVType cvt = tpi.getType(ti);
   switch (cvt.kind()) {
   case LF_MODIFIER: {
     ModifierRecord mfr;
-    llvm::cantFail(TypeDeserializer::deserializeAs<ModifierRecord>(cvt, mfr));
+    if (auto err = TypeDeserializer::deserializeAs<ModifierRecord>(cvt, mfr))
+      return std::move(err);
     return GetIntegralTypeInfo(mfr.ModifiedType, tpi);
   }
   case LF_POINTER: {
     PointerRecord pr;
-    llvm::cantFail(TypeDeserializer::deserializeAs<PointerRecord>(cvt, pr));
-    return {pr.getSize(), false};
+    if (auto err = TypeDeserializer::deserializeAs<PointerRecord>(cvt, pr))
+      return std::move(err);
+    return std::make_pair(pr.getSize(), false);
   }
   case LF_ENUM: {
     EnumRecord er;
-    llvm::cantFail(TypeDeserializer::deserializeAs<EnumRecord>(cvt, er));
+    if (auto err = TypeDeserializer::deserializeAs<EnumRecord>(cvt, er))
+      return std::move(err);
     return GetIntegralTypeInfo(er.UnderlyingType, tpi);
   }
   default:
-    assert(false && "Type is not integral!");
-    return {0, false};
+    return llvm::make_error<llvm::StringError>("Type is not integral",
+                                               llvm::inconvertibleErrorCode());
   }
 }
 
@@ -224,15 +228,18 @@ DWARFExpression lldb_private::npdb::MakeGlobalLocationExpression(
       });
 }
 
-DWARFExpression lldb_private::npdb::MakeConstantLocationExpression(
-    TypeIndex underlying_ti, TpiStream &tpi, const llvm::APSInt &constant,
-    ModuleSP module) {
+llvm::Expected<DWARFExpression>
+lldb_private::npdb::MakeConstantLocationExpression(TypeIndex underlying_ti,
+                                                   TpiStream &tpi,
+                                                   const llvm::APSInt &constant,
+                                                   ModuleSP module) {
   const ArchSpec &architecture = module->GetArchitecture();
   uint32_t address_size = architecture.GetAddressByteSize();
 
-  size_t size = 0;
-  bool is_signed = false;
-  std::tie(size, is_signed) = GetIntegralTypeInfo(underlying_ti, tpi);
+  auto type_info = GetIntegralTypeInfo(underlying_ti, tpi);
+  if (!type_info)
+    return type_info.takeError();
+  auto [size, is_signed] = *type_info;
 
   union {
     llvm::support::little64_t I;

--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.h
@@ -12,6 +12,7 @@
 #include "lldb/lldb-forward.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/DebugInfo/CodeView/CodeView.h"
+#include "llvm/Support/Error.h"
 #include <map>
 
 namespace llvm {
@@ -44,7 +45,7 @@ DWARFExpression MakeVFrameRelLocationExpression(llvm::StringRef fpo_program,
                                                 lldb::ModuleSP module);
 DWARFExpression MakeGlobalLocationExpression(uint16_t section, uint32_t offset,
                                              lldb::ModuleSP module);
-DWARFExpression MakeConstantLocationExpression(
+llvm::Expected<DWARFExpression> MakeConstantLocationExpression(
     llvm::codeview::TypeIndex underlying_ti, llvm::pdb::TpiStream &tpi,
     const llvm::APSInt &constant, lldb::ModuleSP module);
 DWARFExpression MakeEnregisteredLocationExpressionForComposite(

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -27,6 +27,7 @@
 #include "llvm/DebugInfo/CodeView/CVRecord.h"
 #include "llvm/DebugInfo/CodeView/CVTypeVisitor.h"
 #include "llvm/DebugInfo/CodeView/DebugLinesSubsection.h"
+#include "llvm/DebugInfo/CodeView/Formatters.h"
 #include "llvm/DebugInfo/CodeView/LazyRandomTypeCollection.h"
 #include "llvm/DebugInfo/CodeView/RecordName.h"
 #include "llvm/DebugInfo/CodeView/SymbolDeserializer.h"
@@ -436,7 +437,11 @@ Block *SymbolFileNativePDB::CreateBlock(PdbCompilandSymId block_id) {
     // contains 1 big block.  So just get the parent block and add this block
     // to it.
     BlockSym block(static_cast<SymbolRecordKind>(sym.kind()));
-    cantFail(SymbolDeserializer::deserializeAs<BlockSym>(sym, block));
+    if (auto err = SymbolDeserializer::deserializeAs<BlockSym>(sym, block)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize BlockSym record: {0}");
+      return nullptr;
+    }
     lldbassert(block.Parent != 0);
     PdbCompilandSymId parent_id(block_id.modi, block.Parent);
     Block *parent_block = GetOrCreateBlock(parent_id);
@@ -520,7 +525,11 @@ lldb::FunctionSP SymbolFileNativePDB::CreateFunction(PdbCompilandSymId func_id,
     return nullptr;
 
   ProcSym proc(static_cast<SymbolRecordKind>(sym_record.kind()));
-  cantFail(SymbolDeserializer::deserializeAs<ProcSym>(sym_record, proc));
+  if (auto err = SymbolDeserializer::deserializeAs<ProcSym>(sym_record, proc)) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                   "Failed to deserialize ProcSym record: {0}");
+    return nullptr;
+  }
   if (proc.FunctionType == TypeIndex::None())
     return nullptr;
   TypeSP func_type = GetOrCreateType(proc.FunctionType);
@@ -558,8 +567,13 @@ SymbolFileNativePDB::CreateCompileUnit(const CompilandIndexItem &cci) {
   if (cci.m_compile_opts && cci.m_compile_opts->hasOptimizations())
     optimized = eLazyBoolYes;
 
-  llvm::SmallString<64> source_file_name =
-      m_index->compilands().GetMainSourceFile(cci);
+  llvm::SmallString<64> source_file_name;
+  if (auto main_file_or_err = m_index->compilands().GetMainSourceFile(cci)) {
+    source_file_name = std::move(*main_file_or_err);
+  } else {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), main_file_or_err.takeError(),
+                   "Failed to determine main source file: {0}");
+  }
   FileSpec fs(llvm::sys::path::convert_to_slash(
       source_file_name, llvm::sys::path::Style::windows_backslash));
 
@@ -751,50 +765,92 @@ TypeSP SymbolFileNativePDB::CreateType(PdbTypeSymId type_id, CompilerType ct) {
 
   if (cvt.kind() == LF_MODIFIER) {
     ModifierRecord modifier;
-    llvm::cantFail(
-        TypeDeserializer::deserializeAs<ModifierRecord>(cvt, modifier));
+    if (auto err =
+            TypeDeserializer::deserializeAs<ModifierRecord>(cvt, modifier)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ModifierRecord record ({1}): {0}",
+                     type_id.index);
+      return nullptr;
+    }
     return CreateModifierType(type_id, modifier, ct);
   }
 
   if (cvt.kind() == LF_POINTER) {
     PointerRecord pointer;
-    llvm::cantFail(
-        TypeDeserializer::deserializeAs<PointerRecord>(cvt, pointer));
+    if (auto err =
+            TypeDeserializer::deserializeAs<PointerRecord>(cvt, pointer)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize PointerRecord record ({1}): {0}",
+                     type_id.index);
+      return nullptr;
+    }
     return CreatePointerType(type_id, pointer, ct);
   }
 
   if (IsClassRecord(cvt.kind())) {
     ClassRecord cr;
-    llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
+    if (auto err = TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ClassRecord record ({1}): {0}",
+                     type_id.index);
+      return nullptr;
+    }
     return CreateTagType(type_id, cr, ct);
   }
 
   if (cvt.kind() == LF_ENUM) {
     EnumRecord er;
-    llvm::cantFail(TypeDeserializer::deserializeAs<EnumRecord>(cvt, er));
+    if (auto err = TypeDeserializer::deserializeAs<EnumRecord>(cvt, er)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize EnumRecord record ({1}): {0}",
+                     type_id.index);
+      return nullptr;
+    }
     return CreateTagType(type_id, er, ct);
   }
 
   if (cvt.kind() == LF_UNION) {
     UnionRecord ur;
-    llvm::cantFail(TypeDeserializer::deserializeAs<UnionRecord>(cvt, ur));
+    if (auto err = TypeDeserializer::deserializeAs<UnionRecord>(cvt, ur)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize UnionRecord record ({1}): {0}",
+                     type_id.index);
+      return nullptr;
+    }
     return CreateTagType(type_id, ur, ct);
   }
 
   if (cvt.kind() == LF_ARRAY) {
     ArrayRecord ar;
-    llvm::cantFail(TypeDeserializer::deserializeAs<ArrayRecord>(cvt, ar));
+    if (auto err = TypeDeserializer::deserializeAs<ArrayRecord>(cvt, ar)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ArrayRecord record ({1}): {0}",
+                     type_id.index);
+      return nullptr;
+    }
     return CreateArrayType(type_id, ar, ct);
   }
 
   if (cvt.kind() == LF_PROCEDURE) {
     ProcedureRecord pr;
-    llvm::cantFail(TypeDeserializer::deserializeAs<ProcedureRecord>(cvt, pr));
+    if (auto err = TypeDeserializer::deserializeAs<ProcedureRecord>(cvt, pr)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ProcedureRecord record ({1}): {0}",
+                     type_id.index);
+      return nullptr;
+    }
     return CreateProcedureType(type_id, pr, ct);
   }
   if (cvt.kind() == LF_MFUNCTION) {
     MemberFunctionRecord mfr;
-    llvm::cantFail(TypeDeserializer::deserializeAs<MemberFunctionRecord>(cvt, mfr));
+    if (auto err =
+            TypeDeserializer::deserializeAs<MemberFunctionRecord>(cvt, mfr)) {
+      LLDB_LOG_ERROR(
+          GetLog(LLDBLog::Symbols), std::move(err),
+          "Failed to deserialize MemberFunctionRecord record ({1}): {0}",
+          type_id.index);
+      return nullptr;
+    }
     return CreateFunctionType(type_id, mfr, ct);
   }
 
@@ -890,7 +946,11 @@ VariableSP SymbolFileNativePDB::CreateGlobalVariable(PdbGlobalSymId var_id) {
     [[fallthrough]];
   case S_LDATA32: {
     DataSym ds(sym.kind());
-    llvm::cantFail(SymbolDeserializer::deserializeAs<DataSym>(sym, ds));
+    if (auto err = SymbolDeserializer::deserializeAs<DataSym>(sym, ds)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize DataSym record: {0}");
+      return nullptr;
+    }
     ti = ds.Type;
     scope = (sym.kind() == S_GDATA32) ? eValueTypeVariableGlobal
                                       : eValueTypeVariableStatic;
@@ -905,8 +965,12 @@ VariableSP SymbolFileNativePDB::CreateGlobalVariable(PdbGlobalSymId var_id) {
     [[fallthrough]];
   case S_LTHREAD32: {
     ThreadLocalDataSym tlds(sym.kind());
-    llvm::cantFail(
-        SymbolDeserializer::deserializeAs<ThreadLocalDataSym>(sym, tlds));
+    if (auto err =
+            SymbolDeserializer::deserializeAs<ThreadLocalDataSym>(sym, tlds)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ThreadLocalDataSym record: {0}");
+      return nullptr;
+    }
     ti = tlds.Type;
     name = tlds.Name;
     section = tlds.Segment;
@@ -967,7 +1031,12 @@ SymbolFileNativePDB::CreateConstantSymbol(PdbGlobalSymId var_id,
   TpiStream &tpi = m_index->tpi();
   ConstantSym constant(cvs.kind());
 
-  llvm::cantFail(SymbolDeserializer::deserializeAs<ConstantSym>(cvs, constant));
+  if (auto err =
+          SymbolDeserializer::deserializeAs<ConstantSym>(cvs, constant)) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                   "Failed to deserialize ConstantSym record: {0}");
+    return nullptr;
+  }
   std::string global_name("::");
   global_name += constant.Name;
   PdbTypeSymId tid(constant.Type, false);
@@ -977,10 +1046,15 @@ SymbolFileNativePDB::CreateConstantSymbol(PdbGlobalSymId var_id,
   Declaration decl;
   Variable::RangeList ranges;
   ModuleSP module = GetObjectFile()->GetModule();
-  DWARFExpressionList location(module,
-                               MakeConstantLocationExpression(
-                                   constant.Type, tpi, constant.Value, module),
-                               nullptr);
+  auto location_or_err = MakeConstantLocationExpression(constant.Type, tpi,
+                                                        constant.Value, module);
+  if (!location_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), location_or_err.takeError(),
+                   "Failed to make constant location expression for {1}: {0}",
+                   constant.Name);
+    return nullptr;
+  }
+  DWARFExpressionList location(module, std::move(*location_or_err), nullptr);
 
   bool external = false;
   bool artificial = false;
@@ -1436,7 +1510,12 @@ void SymbolFileNativePDB::ParseInlineSite(PdbCompilandSymId id,
   CompUnitSP comp_unit = GetOrCreateCompileUnit(*cii);
 
   InlineSiteSym inline_site(static_cast<SymbolRecordKind>(sym.kind()));
-  cantFail(SymbolDeserializer::deserializeAs<InlineSiteSym>(sym, inline_site));
+  if (auto err =
+          SymbolDeserializer::deserializeAs<InlineSiteSym>(sym, inline_site)) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                   "Failed to deserialize InlineSiteSym record: {0}");
+    return;
+  }
   PdbCompilandSymId parent_id(id.modi, inline_site.Parent);
 
   std::shared_ptr<InlineSite> inline_site_sp =
@@ -1604,22 +1683,33 @@ void SymbolFileNativePDB::ParseInlineSite(PdbCompilandSymId id,
   std::string inlinee_name;
   if (inlinee_cvt.kind() == LF_MFUNC_ID) {
     MemberFuncIdRecord mfr;
-    cantFail(
-        TypeDeserializer::deserializeAs<MemberFuncIdRecord>(inlinee_cvt, mfr));
-    LazyRandomTypeCollection &types = m_index->tpi().typeCollection();
-    inlinee_name.append(std::string(types.getTypeName(mfr.ClassType)));
-    inlinee_name.append("::");
-    inlinee_name.append(mfr.getName().str());
+    if (auto err = TypeDeserializer::deserializeAs<MemberFuncIdRecord>(
+            inlinee_cvt, mfr)) {
+      inlinee_name =
+          "[error reading function name: " + llvm::toString(std::move(err)) +
+          "]";
+    } else {
+      LazyRandomTypeCollection &types = m_index->tpi().typeCollection();
+      inlinee_name.append(std::string(types.getTypeName(mfr.ClassType)));
+      inlinee_name.append("::");
+      inlinee_name.append(mfr.getName().str());
+    }
   } else if (inlinee_cvt.kind() == LF_FUNC_ID) {
     FuncIdRecord fir;
-    cantFail(TypeDeserializer::deserializeAs<FuncIdRecord>(inlinee_cvt, fir));
-    TypeIndex parent_idx = fir.getParentScope();
-    if (!parent_idx.isNoneType()) {
-      LazyRandomTypeCollection &ids = m_index->ipi().typeCollection();
-      inlinee_name.append(std::string(ids.getTypeName(parent_idx)));
-      inlinee_name.append("::");
+    if (auto err =
+            TypeDeserializer::deserializeAs<FuncIdRecord>(inlinee_cvt, fir)) {
+      inlinee_name =
+          "[error reading function name: " + llvm::toString(std::move(err)) +
+          "]";
+    } else {
+      TypeIndex parent_idx = fir.getParentScope();
+      if (!parent_idx.isNoneType()) {
+        LazyRandomTypeCollection &ids = m_index->ipi().typeCollection();
+        inlinee_name.append(std::string(ids.getTypeName(parent_idx)));
+        inlinee_name.append("::");
+      }
+      inlinee_name.append(fir.getName().str());
     }
-    inlinee_name.append(fir.getName().str());
   }
   inline_site_sp->inline_function_info = std::make_shared<InlineFunctionInfo>(
       inlinee_name.c_str(), llvm::StringRef(), decl_up.get(),
@@ -1820,7 +1910,13 @@ size_t SymbolFileNativePDB::ParseTypes(CompileUnit &comp_unit) {
     if (sym.kind() != S_UDT)
       continue;
 
-    UDTSym udt = llvm::cantFail(SymbolDeserializer::deserializeAs<UDTSym>(sym));
+    auto udt_or_err = SymbolDeserializer::deserializeAs<UDTSym>(sym);
+    if (!udt_or_err) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), udt_or_err.takeError(),
+                     "Failed to deserialize UDTSym record: {0}");
+      continue;
+    }
+    UDTSym udt = std::move(*udt_or_err);
     bool is_typedef = true;
     if (IsTagRecord(PdbTypeSymId{udt.Type, false}, m_index->tpi())) {
       CVType cvt = m_index->tpi().getType(udt.Type);
@@ -1889,15 +1985,25 @@ VariableSP SymbolFileNativePDB::CreateLocalVariable(PdbCompilandSymId scope_id,
     CVSymbol sym = cii->m_debug_stream.readSymbolAtOffset(var_id.offset);
     assert(sym.kind() == S_CONSTANT);
     ConstantSym constant(sym.kind());
-    cantFail(SymbolDeserializer::deserializeAs<ConstantSym>(sym, constant));
+    if (auto err =
+            SymbolDeserializer::deserializeAs<ConstantSym>(sym, constant)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ConstantSym record: {0}");
+      return nullptr;
+    }
 
     var_info.name = constant.Name;
     var_info.type = constant.Type;
-    var_info.location = DWARFExpressionList(
-        module,
-        MakeConstantLocationExpression(constant.Type, m_index->tpi(),
-                                       constant.Value, module),
-        nullptr);
+    auto location_or_err = MakeConstantLocationExpression(
+        constant.Type, m_index->tpi(), constant.Value, module);
+    if (!location_or_err) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), location_or_err.takeError(),
+                     "Failed to make constant location expression for {1}: {0}",
+                     constant.Name);
+      return nullptr;
+    }
+    var_info.location =
+        DWARFExpressionList(module, std::move(*location_or_err), nullptr);
   } else {
     // Get function block.
     Block *func_block = block;
@@ -1966,7 +2072,13 @@ TypeSP SymbolFileNativePDB::CreateTypedef(PdbGlobalSymId id) {
   CVSymbol sym = m_index->ReadSymbolRecord(id);
   lldbassert(sym.kind() == SymbolKind::S_UDT);
 
-  UDTSym udt = llvm::cantFail(SymbolDeserializer::deserializeAs<UDTSym>(sym));
+  auto udt_or_err = SymbolDeserializer::deserializeAs<UDTSym>(sym);
+  if (!udt_or_err) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), udt_or_err.takeError(),
+                   "Failed to deserialize UDTSym record: {0}");
+    return nullptr;
+  }
+  UDTSym udt = std::move(*udt_or_err);
 
   TypeSP target_type = GetOrCreateType(udt.Type);
 
@@ -2012,7 +2124,11 @@ size_t SymbolFileNativePDB::ParseVariablesForBlock(PdbCompilandSymId block_id) {
   case S_GPROC32:
   case S_LPROC32: {
     ProcSym proc(static_cast<SymbolRecordKind>(sym.kind()));
-    cantFail(SymbolDeserializer::deserializeAs<ProcSym>(sym, proc));
+    if (auto err = SymbolDeserializer::deserializeAs<ProcSym>(sym, proc)) {
+      LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                     "Failed to deserialize ProcSym record: {0}");
+      return 0;
+    }
     CVType signature = m_index->tpi().getType(proc.FunctionType);
     if (signature.kind() == LF_PROCEDURE) {
       ProcedureRecord sig;


### PR DESCRIPTION
With a bonus CP of a minor commit to avoid resolving the conflict:
- https://github.com/llvm/llvm-project/pull/180987

**Original description:**
This is a follow-up to https://github.com/swiftlang/llvm-project/pull/12317#discussion_r2850297229

Per that discussion, given that deserializers *can* fail given a corrupt PDB, it's preferable to handle the error instead of crashing.

This specific change is limited to "easy" changes (read: I have high confidence in their correctness). The ideal end state is funneling all errors to a few central places in `SymbolFileNativePDB`.