### PR TITLE
Add workaround for intermittent Windows ARM64 data corruption bug

### DIFF
--- a/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
@@ -234,6 +234,12 @@ void MappedFileRegionBumpPtr::destroyImpl() {
 
       if (Logger)
         Logger->log_MappedFileRegionBumpPtr_resizeFile(Path, Capacity, Size);
+    } else {
+#if defined(_WIN32) && (defined(__aarch64__) || defined(_M_ARM64))
+      // A workaround for intermittent data corruption bug on Windows
+      // ARM64 https://github.com/swiftlang/llvm-project/issues/12605
+      (void)Region.sync();
+#endif
     }
   }
 


### PR DESCRIPTION
This fixes flaky data corruption crashes on Windows ARM64. This seems a non-issue with Windows X64 or macOS.

Issue: https://github.com/swiftlang/llvm-project/issues/12605