### PR TITLE
[6.3] Disable clangimporter/fmodule_flags/TestSwiftFModuleFlags.py

### DIFF
--- a/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
+++ b/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
@@ -4,6 +4,7 @@ from lldbsuite.test.decorators import *
 import lldbsuite.test.lldbutil as lldbutil
 import os
 
+@skipIf(bugnumber = "rdar://173057018")
 class TestSwiftFModuleFlags(TestBase):
     @skipIf(macos_version=["<", "14.0"])
     @skipIfDarwinEmbedded


### PR DESCRIPTION


Test failure: 

```
[2026-03-21T08:18:26.166Z] FAIL: lldb-api :: lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py (121 of 539)
[2026-03-21T08:18:26.166Z] ******************** TEST 'lldb-api :: lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py' FAILED ********************
[2026-03-21T08:18:26.166Z] Script:
[2026-03-21T08:18:26.166Z] --
[2026-03-21T08:18:26.166Z] /usr/bin/python3.11 /home/build-user/llvm-project/lldb/test/API/dotest.py -u CXXFLAGS -u CFLAGS --inferior-env DYLD_LIBRARY_PATH="/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/macosx:/home/build-user/build/buildbot_linux/lldb-linux-x86_64/./lib/lldb/clang/lib/darwin" --inferior-env LD_LIBRARY_PATH="/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/x86_64" --inferior-env SIMCTL_CHILD_DYLD_LIBRARY_PATH="/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/macosx" --env LLVM_LIBS_DIR=/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib --env LLDB_LIBS_DIR=/home/build-user/build/buildbot_linux/lldb-linux-x86_64/./lib --env LLVM_INCLUDE_DIR=/home/build-user/build/buildbot_linux/llvm-linux-x86_64/include --env LLVM_TOOLS_DIR=/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./bin --arch x86_64 --build-dir /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex --lldb-module-cache-dir /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/module-cache-lldb/lldb-api --clang-module-cache-dir /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/module-cache-clang/lldb-api --swift-libs-dir /home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift --executable /home/build-user/build/buildbot_linux/lldb-linux-x86_64/./bin/lldb --compiler /home/build-user/build/buildbot_linux/llvm-linux-x86_64/./bin/clang --swift-compiler /home/build-user/build/buildbot_linux/swift-linux-x86_64/bin/swiftc --dsymutil /home/build-user/build/buildbot_linux/llvm-linux-x86_64/./bin/dsymutil --make /usr/bin/gmake --llvm-tools-dir /home/build-user/build/buildbot_linux/llvm-linux-x86_64/./bin --lldb-obj-root /home/build-user/build/buildbot_linux/lldb-linux-x86_64 --lldb-libs-dir /home/build-user/build/buildbot_linux/lldb-linux-x86_64/./lib --skip-category=swiftmaccatalyst --cmake-build-type Release --build-dir /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex --skip-category=watchpoint --skip-category=dwo -E -I/home/build-user/build/buildbot_linux/foundation-linux-x86_64 -F/home/build-user/build/buildbot_linux/foundation-linux-x86_64 -I/home/build-user/build/buildbot_linux/foundation-linux-x86_64/swift -I/home/build-user/swift-corelibs-libdispatch -L/home/build-user/build/buildbot_linux/libdispatch-linux-x86_64 -L/home/build-user/build/buildbot_linux/libdispatch-linux-x86_64/src -L/home/build-user/build/buildbot_linux/foundation-linux-x86_64 -L/home/build-user/build/buildbot_linux/foundation-linux-x86_64/Foundation -L/home/build-user/build/buildbot_linux/foundation-linux-x86_64/Sources/Foundation -L/home/build-user/build/buildbot_linux/foundation-linux-x86_64/Sources/FoundationNetworking -L/home/build-user/build/buildbot_linux/foundation-linux-x86_64/Sources/FoundationXML -L/home/build-user/build/buildbot_linux/foundation-linux-x86_64/lib -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/libdispatch-linux-x86_64 -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/libdispatch-linux-x86_64/src -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/foundation-linux-x86_64 -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/foundation-linux-x86_64/Foundation -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/foundation-linux-x86_64/Sources/Foundation -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/foundation-linux-x86_64/Sources/FoundationNetworking -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/foundation-linux-x86_64/Sources/FoundationXML -Xlinker -rpath -Xlinker /home/build-user/build/buildbot_linux/foundation-linux-x86_64/lib --setting symbols.use-swift-clangimporter=true /home/build-user/llvm-project/lldb/test/API/lang/swift/clangimporter/fmodule_flags -p TestSwiftFModuleFlags.py
[2026-03-21T08:18:26.166Z] --
[2026-03-21T08:18:26.166Z] Exit Code: 1
[2026-03-21T08:18:26.166Z] 
[2026-03-21T08:18:26.166Z] Command Output (stdout):
[2026-03-21T08:18:26.166Z] --
[2026-03-21T08:18:26.166Z] lldb version 21.0.0 (https://github.com/swiftlang/llvm-project.git revision b6f042d4515f83404d3f44012144b5e67b2c5791)
[2026-03-21T08:18:26.166Z] Swift version 6.3 (swift-6.3-RELEASE)
[2026-03-21T08:18:26.166Z] Skipping the following test categories: ['frame-diagnose', 'watchpoints', 'swiftmaccatalyst', 'watchpoint', 'dwo', 'libc++', 'msvcstl', 'dsym', 'gmodules', 'debugserver', 'objc']
[2026-03-21T08:18:26.166Z] 
[2026-03-21T08:18:26.166Z] --
[2026-03-21T08:18:26.166Z] Command Output (stderr):
[2026-03-21T08:18:26.166Z] --
[2026-03-21T08:18:26.166Z] UNSUPPORTED: LLDB (/home/build-user/build/buildbot_linux/llvm-linux-x86_64/bin/clang-x86_64) :: test_dsym (TestSwiftFModuleFlags.TestSwiftFModuleFlags.test_dsym) (test case does not fall in any category of interest for this run) 
[2026-03-21T08:18:26.166Z] 
[2026-03-21T08:18:26.166Z] --- FileCheck trace (code=1) ---
[2026-03-21T08:18:26.166Z] /home/build-user/build/buildbot_linux/llvm-linux-x86_64/./bin/FileCheck /home/build-user/llvm-project/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
[2026-03-21T08:18:26.166Z] 
[2026-03-21T08:18:26.166Z] FileCheck input:
[2026-03-21T08:18:26.166Z] python3.11       TypeSystemSwiftTypeRef("a.out")::TypeSystemSwiftTypeRef()
[2026-03-21T08:18:26.166Z] python3.11       TypeSystemSwiftTypeRefForExpressions::TypeSystemSwiftTypeRefForExpressions()
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::CreateInstance(Target)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::CreateInstance() -- Module triple: "x86_64--linux"
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::CreateInstance() -- Target triple: "x86_64-unknown-linux-gnu"
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::CreateInstance() -- No Swift debug info: prefer target triple.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::CreateInstance() -- Fully specified triple x86_64-unknown-linux-gnu.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::SetTriple("x86_64-unknown-linux-gnu") setting to "x86_64-unknown-linux-gnu"
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetSDKPath() -- Host SDK path: "/" (XcodeSDK: Linux.sdk)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::CreateInstance() -- Using SDK: /
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ConfigureCASStorage() -- Did not create CAS: no CAS available
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ProcessModule("a.out")::GetASTBuffersFromModule() -- Found 1 AST file data entries in /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.test_dwarf/a.out.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ProcessModule("a.out")::operator()() -- Ignoring missing Swift plugin at path: /home/build-user/build/buildbot_linux/swift-linux-x86_64/local/lib/swift/host/plugins
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ProcessModule("a.out")::DeserializeAllCompilerFlags() -- SDK path from module "a" was "".
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ConfigureModuleValidation() -- PCM validation is enabled
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::InitializeSearchPathOptions() -- Setting SDK path "/"
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetASTContext() -- Using Clang module cache path: /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/module-cache-lldb/lldb-api
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetASTContext() -- Using prebuilt Swift module cache path: /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/prebuilt-modules
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetASTContext() -- Swift module loading mode forced to PreferSerialized
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::RegisterSectionModules("a.out") retrieved 1 AST Data blobs from the symbol vendor (filter="x86_64-unknown-linux-gnu").
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::operator()() -- parsed module "a" from Swift AST section 1/1 in image "a.out" (filter="x86_64-unknown-linux-gnu").
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::CreateInstance((Target*)0x21a4eb0) = 0x21f28d0
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration(SwiftASTContext*)0x21f28d0:
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Swift/C++ interop                : off
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Swift/Objective-C interop        : off
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Architecture                     : x86_64-unknown-linux-gnu
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   SDK path                         : /
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Runtime resource path            : /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Runtime library paths            : (1 items)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Runtime library import paths     : (4 items)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/x86_64
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /usr/lib/swift/linux
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     /usr/lib/swift/linux/x86_64
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Framework search paths           : (0 items)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Import search paths              : (0 items)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Explicit modules              : true
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Extra clang arguments            : (7 items)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -gmodules
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -gdwarf-4
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -fno-color-diagnostics
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DMARKER1
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DMARKER2
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -ffile-compilation-dir=/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.test_dwarf
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -fno-modules-check-relocated
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --   Plugin search options            : (1 items)
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -external-plugin-path /home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/host/plugins#/home/build-user/build/buildbot_linux/swift-linux-x86_64/bin/swift-plugin-server
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetCompileUnitImportsImpl() -- Turning off implicit modules
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetCompileUnitImportsImpl() -- Importing dependencies of current CU
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Importing module a
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("a")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'a'; source: 'a', loaded: 'a'
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("a") -- found a
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Imported module a from {kind = Serialized Swift AST, filename = "a";}
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Importing module Swift
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("Swift")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'SwiftShims'; source: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/shims/module.modulemap', loaded: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/module-cache-lldb/lldb-api/3DQEUNFQC6JZP/SwiftShims-1JK6ZVRT502H9.pcm'
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'Swift'; source: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/Swift.swiftmodule/x86_64-unknown-linux-gnu.private.swiftinterface', loaded: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/Swift.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule'
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("Swift") -- found Swift
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::operator()() -- Loading linked library "swiftCore".
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadLibraryUsingPaths() -- Skipping module libswiftCore.so as it is already loaded.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Imported module Swift from {kind = Serialized Swift AST, filename = "/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/Swift.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule";}
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("Swift")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Importing module _StringProcessing
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("_StringProcessing")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module '_StringProcessing'; source: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/_StringProcessing.swiftmodule/x86_64-unknown-linux-gnu.private.swiftinterface', loaded: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/_StringProcessing.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule'
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("_StringProcessing") -- found _StringProcessing
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::operator()() -- Loading linked library "swift_StringProcessing".
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadLibraryUsingPaths() -- Found library at: /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/libswift_StringProcessing.so.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::operator()() -- Loading linked library "swift_RegexParser".
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadLibraryUsingPaths() -- Skipping module libswift_RegexParser.so as it is already loaded.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Imported module _StringProcessing from {kind = Serialized Swift AST, filename = "/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/_StringProcessing.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule";}
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("_StringProcessing")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Importing module _Concurrency
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("_Concurrency")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module '_Concurrency'; source: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/_Concurrency.swiftmodule/x86_64-unknown-linux-gnu.private.swiftinterface', loaded: '/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/_Concurrency.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule'
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("_Concurrency") -- found _Concurrency
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::operator()() -- Loading linked library "swift_Concurrency".
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadLibraryUsingPaths() -- Found library at: /home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/libswift_Concurrency.so.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Imported module _Concurrency from {kind = Serialized Swift AST, filename = "/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/_Concurrency.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule";}
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("_Concurrency")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetCompileUnitImportsImpl() -- Turning off implicit modules
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetCompileUnitImportsImpl() -- Importing dependencies of current CU
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Importing module a
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("a")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Imported module a from {kind = Serialized Swift AST, filename = "a";}
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Importing module Swift
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetModule("Swift")
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::operator()() -- Loading linked library "swiftCore".
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadLibraryUsingPaths() -- Skipping module libswiftCore.so as it is already loaded.
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LoadOneModule() -- Imported module Swift from {kind = Serialized Swift AST, filename = "/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lib/lldb/swift/linux/Swift.swiftmodule/x86_64-unknown-linux-gnu.swiftmodule";}
[2026-03-21T08:18:26.166Z] python3.11       Initializing a 64-bit reflection context (x86_64--linux) for "Swift only"
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ReconstructType("$sBpD") -- not cached, searching
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ReconstructType("$sBpD") -- found Builtin.RawPointer
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ReconstructType("$sBi64_D") -- not cached, searching
[2026-03-21T08:18:26.166Z] python3.11       SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ReconstructType("$sBi64_D") -- found Builtin.Int64
[2026-03-21T08:18:26.166Z] python3.11       [MemoryReader] Could not resolve find module containing pointer 0x7f077dbb7e54 read from 0x7f077dc6be68.
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] FileCheck output:
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] /home/build-user/llvm-project/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py:26:10: error: CHECK: expected string not found in input
[2026-03-21T08:18:26.167Z] # CHECK: PCM validation is
[2026-03-21T08:18:26.167Z]          ^
[2026-03-21T08:18:26.167Z] <stdin>:44:105: note: scanning from here
[2026-03-21T08:18:26.167Z] python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -DMARKER2
[2026-03-21T08:18:26.167Z]                                                                                                         ^
[2026-03-21T08:18:26.167Z] <stdin>:45:76: note: possible intended match here
[2026-03-21T08:18:26.167Z] python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -ffile-compilation-dir=/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.test_dwarf
[2026-03-21T08:18:26.167Z]                                                                            ^
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] Input file: <stdin>
[2026-03-21T08:18:26.167Z] Check file: /home/build-user/llvm-project/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] -dump-input=help explains the following input dump.
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] Input was:
[2026-03-21T08:18:26.167Z] <<<<<<
[2026-03-21T08:18:26.167Z]             .
[2026-03-21T08:18:26.167Z]             .
[2026-03-21T08:18:26.167Z]             .
[2026-03-21T08:18:26.167Z]            39: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- Extra clang arguments : (7 items) 
[2026-03-21T08:18:26.167Z]            40: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -gmodules 
[2026-03-21T08:18:26.167Z]            41: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -gdwarf-4 
[2026-03-21T08:18:26.167Z]            42: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -fno-color-diagnostics 
[2026-03-21T08:18:26.167Z]            43: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -DMARKER1 
[2026-03-21T08:18:26.167Z]            44: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -DMARKER2 
[2026-03-21T08:18:26.167Z] check:26'0                                                                                                             X error: no match found
[2026-03-21T08:18:26.167Z]            45: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -ffile-compilation-dir=/home/build-user/build/buildbot_linux/lldb-linux-x86_64/lldb-test-build.noindex/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.test_dwarf 
[2026-03-21T08:18:26.167Z] check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026-03-21T08:18:26.167Z] check:26'1                                                                                ?                                                                                                                                                                                                   possible intended match
[2026-03-21T08:18:26.167Z]            46: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -fno-modules-check-relocated 
[2026-03-21T08:18:26.167Z] check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026-03-21T08:18:26.167Z]            47: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- Plugin search options : (1 items) 
[2026-03-21T08:18:26.167Z] check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026-03-21T08:18:26.167Z]            48: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- -external-plugin-path /home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/host/plugins#/home/build-user/build/buildbot_linux/swift-linux-x86_64/bin/swift-plugin-server 
[2026-03-21T08:18:26.167Z] check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026-03-21T08:18:26.167Z]            49: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetCompileUnitImportsImpl() -- Turning off implicit modules 
[2026-03-21T08:18:26.167Z] check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026-03-21T08:18:26.167Z]            50: python3.11 SwiftASTContextForExpressions(module: "a", cu: "main.swift")::GetCompileUnitImportsImpl() -- Importing dependencies of current CU 
[2026-03-21T08:18:26.167Z] check:26'0     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[2026-03-21T08:18:26.167Z]             .
[2026-03-21T08:18:26.167Z]             .
[2026-03-21T08:18:26.167Z]             .
[2026-03-21T08:18:26.167Z] >>>>>>
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] FAIL: LLDB (/home/build-user/build/buildbot_linux/llvm-linux-x86_64/bin/clang-x86_64) :: test_dwarf (TestSwiftFModuleFlags.TestSwiftFModuleFlags.test_dwarf)
[2026-03-21T08:18:26.167Z] UNSUPPORTED: LLDB (/home/build-user/build/buildbot_linux/llvm-linux-x86_64/bin/clang-x86_64) :: test_dwo (TestSwiftFModuleFlags.TestSwiftFModuleFlags.test_dwo) (test case does not fall in any category of interest for this run) 
[2026-03-21T08:18:26.167Z] ======================================================================
[2026-03-21T08:18:26.167Z] FAIL: test_dwarf (TestSwiftFModuleFlags.TestSwiftFModuleFlags.test_dwarf)
[2026-03-21T08:18:26.167Z]    Test that -fmodule flags get stripped out
[2026-03-21T08:18:26.167Z] ----------------------------------------------------------------------
[2026-03-21T08:18:26.167Z] Traceback (most recent call last):
[2026-03-21T08:18:26.167Z]   File "/home/build-user/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 1838, in test_method
[2026-03-21T08:18:26.167Z]     return attrvalue(self)
[2026-03-21T08:18:26.167Z]            ^^^^^^^^^^^^^^^
[2026-03-21T08:18:26.167Z]   File "/home/build-user/llvm-project/lldb/packages/Python/lldbsuite/test/decorators.py", line 154, in wrapper
[2026-03-21T08:18:26.167Z]     return func(*args, **kwargs)
[2026-03-21T08:18:26.167Z]            ^^^^^^^^^^^^^^^^^^^^^
[2026-03-21T08:18:26.167Z]   File "/home/build-user/llvm-project/lldb/packages/Python/lldbsuite/test/decorators.py", line 154, in wrapper
[2026-03-21T08:18:26.167Z]     return func(*args, **kwargs)
[2026-03-21T08:18:26.167Z]            ^^^^^^^^^^^^^^^^^^^^^
[2026-03-21T08:18:26.167Z]   File "/home/build-user/llvm-project/lldb/test/API/lang/swift/clangimporter/fmodule_flags/TestSwiftFModuleFlags.py", line 21, in test
[2026-03-21T08:18:26.167Z]     self.filecheck('platform shell cat "%s"' % log, __file__)
[2026-03-21T08:18:26.167Z]   File "/home/build-user/llvm-project/lldb/packages/Python/lldbsuite/test/lldbtest.py", line 2377, in filecheck
[2026-03-21T08:18:26.167Z]     self.assertTrue(cmd_status == 0)
[2026-03-21T08:18:26.167Z] AssertionError: False is not true
[2026-03-21T08:18:26.167Z] Config=x86_64-/home/build-user/build/buildbot_linux/llvm-linux-x86_64/bin/clang
[2026-03-21T08:18:26.167Z] ----------------------------------------------------------------------
[2026-03-21T08:18:26.167Z] Ran 3 tests in 1.404s
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] FAILED (failures=1, skipped=2)
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] --
[2026-03-21T08:18:26.167Z] 
[2026-03-21T08:18:26.167Z] ********************
```