### PR TITLE
[dsymutil][cas] Update CAS loading options.

### DIFF
--- a/clang/test/ClangScanDeps/gmodules.c
+++ b/clang/test/ClangScanDeps/gmodules.c
@@ -47,9 +47,9 @@
 // RUN: dsymutil %t/a.out -o %t/a2.dSYM 2>&1 | FileCheck %s --check-prefix=WARN --allow-empty
 // WARN-NOT: warning:
 
+// RUN: echo "bad" > %t/.cas-config
 // RUN: dsymutil -cas %t/cas-empty %t/a.out -o %t/a3.dSYM 2>&1 | FileCheck %s --check-prefix=WARN-CAS --check-prefix=WARN-FILE
 // WARN-CAS: warning: failed to load CAS object
-// RUN: echo "bad" > %t/.cas-config
 // RUN: dsymutil %t/a.out -o %t/a4.dSYM 2>&1 | FileCheck %s --check-prefix=WARN-FILE
 // WARN-FILE: warning:
 // WARN-FILE-SAME: No such file or directory

--- a/llvm/tools/dsymutil/BinaryHolder.cpp
+++ b/llvm/tools/dsymutil/BinaryHolder.cpp
@@ -43,9 +43,8 @@ getMachOFatMemoryBuffers(StringRef Filename, MemoryBuffer &Mem,
 }
 
 BinaryHolder::BinaryHolder(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
-                           BinaryHolder::Options Opts,
-                           std::shared_ptr<cas::ObjectStore> CAS)
-    : VFS(VFS), GlobalCAS(std::move(CAS)), Opts(Opts) {}
+                           BinaryHolder::Options Opts)
+    : VFS(VFS), GlobalCAS(nullptr), Opts(Opts) {}
 
 Error BinaryHolder::ArchiveEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
                                        StringRef Filename,
@@ -146,9 +145,12 @@ Error BinaryHolder::ObjectEntry::load(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
   return Error::success();
 }
 
-bool BinaryHolder::ObjectEntry::load(cas::ObjectStore &CAS,
+bool BinaryHolder::ObjectEntry::load(cas::ObjectStore *CAS,
                                      StringRef PossibleID, Options Opts) {
-  auto ID = CAS.parseID(PossibleID);
+  if (!CAS)
+    return false;
+
+  auto ID = CAS->parseID(PossibleID);
   if (!ID) {
     // This maybe not a CASID since we always try to load from CAS first. Ignore
     // any error happening when parsing the CASID.
@@ -159,7 +161,7 @@ bool BinaryHolder::ObjectEntry::load(cas::ObjectStore &CAS,
   if (Opts.Verbose)
     WithColor::note() << "resolving cas object " << PossibleID << "\n";
 
-  auto Ref = CAS.getProxy(*ID);
+  auto Ref = CAS->getProxy(*ID);
   if (!Ref) {
     WithColor::warning() << "failed to load CAS object: "
                          << toString(Ref.takeError()) << "\n";
@@ -267,16 +269,54 @@ BinaryHolder::ArchiveEntry::getObjectEntry(StringRef Filename,
   return *(MemberCache[Key] = std::move(OE));
 }
 
-Expected<std::shared_ptr<cas::ObjectStore>>
-BinaryHolder::searchAndCreateCAS(StringRef Path) {
+Error BinaryHolder::setGlobalCASConfiguration(cas::CASConfiguration Config) {
+  if (Config.CASPath.empty())
+    return Error::success();
+
+  auto DB = Config.createDatabases();
+  if (!DB)
+    return DB.takeError();
+
   std::scoped_lock<std::mutex> CASLock(CASMutex);
-  auto Opened = LocalCAS.find(Path);
-  if (Opened != LocalCAS.end())
-    return Opened->second;
+  auto Insert = OpenedCAS.try_emplace(Config, std::move(DB->first));
+  GlobalCAS = Insert.first->second.get();
+  return Error::success();
+}
+
+bool BinaryHolder::updateGlobalCASFromPath(StringRef Path) {
+  auto DB = searchAndCreateCAS(Path);
+  if (!DB) {
+    consumeError(DB.takeError());
+    return false;
+  }
+  if (*DB) {
+    GlobalCAS = *DB;
+    return true;
+  }
+  return false;
+}
+
+Expected<cas::ObjectStore *> BinaryHolder::searchAndCreateCAS(StringRef Path) {
+  std::scoped_lock<std::mutex> CASLock(CASMutex);
+  // The directory has been searched.
+  auto Cached = CASLookupCache.find(Path);
+  if (Cached != CASLookupCache.end())
+    return Cached->second;
+
+  auto addToCache = [&](cas::ObjectStore *CAS) {
+    CASLookupCache.try_emplace(Path, CAS);
+    return CAS;
+  };
 
   auto Config = cas::CASConfiguration::createFromSearchConfigFile(Path);
+  // Use backup CAS if no local CAS can be found.
   if (!Config)
     return nullptr;
+
+  // The configuration has been opened.
+  auto Opened = OpenedCAS.find(Config->second);
+  if (Opened != OpenedCAS.end())
+    return addToCache(Opened->second.get());
 
   auto DB = Config->second.createDatabases();
   if (!DB)
@@ -285,7 +325,9 @@ BinaryHolder::searchAndCreateCAS(StringRef Path) {
   if (Opts.Verbose)
     WithColor::note() << "create CAS using configuration: " << Config->first
                       << "'\n";
-  return LocalCAS.try_emplace(Path, std::move(DB->first)).first->second;
+
+  auto Insert = OpenedCAS.try_emplace(Config->second, std::move(DB->first));
+  return addToCache(Insert.first->second.get());
 }
 
 Expected<const BinaryHolder::ObjectEntry &>
@@ -337,24 +379,20 @@ BinaryHolder::getObjectEntryFromCAS(StringRef MaybeCASID, StringRef Filename) {
     WithColor::note() << "trying to load '" << MaybeCASID << "' from '"
                       << Filename << "'\n";
 
-  auto DB = GlobalCAS;
-  if (!DB) {
-    // If no global CAS, infer from Filename and search from the parent path of
-    // the binary file.
-    auto MaybeCAS = searchAndCreateCAS(sys::path::parent_path(Filename));
-    if (!MaybeCAS)
-      return MaybeCAS.takeError();
-    DB = std::move(*MaybeCAS);
-  }
-  // No CAS available to lookup, return nullptr.
+  auto DB = searchAndCreateCAS(sys::path::parent_path(Filename));
   if (!DB)
+    return DB.takeError();
+
+  // No CAS available to lookup, return nullptr.
+  if (!*DB && !GlobalCAS)
     return nullptr;
 
   std::lock_guard<std::mutex> Lock(ObjectCacheMutex);
   ObjectRefCounter[MaybeCASID]++;
   if (!ObjectCache.count(MaybeCASID)) {
     auto OE = std::make_unique<ObjectEntry>();
-    if (!OE->load(*DB, MaybeCASID, Opts))
+    if (!OE->load(*DB, MaybeCASID, Opts) &&
+        !OE->load(GlobalCAS, MaybeCASID, Opts))
       return nullptr;
     ObjectCache[MaybeCASID] = std::move(OE);
   }

--- a/llvm/tools/dsymutil/BinaryHolder.h
+++ b/llvm/tools/dsymutil/BinaryHolder.h
@@ -15,6 +15,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/CAS/CASConfiguration.h"
 #include "llvm/CAS/ObjectStore.h"
 #include "llvm/Object/Archive.h"
 #include "llvm/Object/Error.h"
@@ -47,8 +48,7 @@ public:
   };
 
   BinaryHolder(IntrusiveRefCntPtr<vfs::FileSystem> VFS,
-               BinaryHolder::Options Opts = {},
-               std::shared_ptr<cas::ObjectStore> CAS = nullptr);
+               BinaryHolder::Options Opts = {});
 
   // Forward declarations for friend declaration.
   class ObjectEntry;
@@ -69,7 +69,7 @@ public:
     Error load(IntrusiveRefCntPtr<vfs::FileSystem> VFS, StringRef Filename,
                TimestampTy Timestamp, BinaryHolder::Options = {});
 
-    bool load(cas::ObjectStore &CAS, StringRef Filename,
+    bool load(cas::ObjectStore *CAS, StringRef Filename,
               BinaryHolder::Options = {});
 
     /// Access all owned ObjectFiles.
@@ -147,9 +147,12 @@ public:
   Expected<const ObjectEntry *> getObjectEntryFromCAS(StringRef MaybeCASID,
                                                       StringRef Filename);
 
+  /// Set GlobalCAS Configuration.
+  Error setGlobalCASConfiguration(cas::CASConfiguration Config);
+  /// Update GlobalCAS with path, return true if a global CAS is set.
+  bool updateGlobalCASFromPath(StringRef Path);
   /// Search and create CAS.
-  Expected<std::shared_ptr<cas::ObjectStore>>
-  searchAndCreateCAS(StringRef Path);
+  Expected<cas::ObjectStore *> searchAndCreateCAS(StringRef Path);
 
   void clear();
   void eraseObjectEntry(StringRef Filename);
@@ -169,9 +172,12 @@ private:
   /// Virtual File System instance.
   IntrusiveRefCntPtr<vfs::FileSystem> VFS;
 
-  /// CAS Instance.
-  std::shared_ptr<cas::ObjectStore> GlobalCAS;
-  StringMap<std::shared_ptr<cas::ObjectStore>> LocalCAS;
+  /// A map for all opened local CAS configurations from directory search.
+  DenseMap<cas::CASConfiguration, std::shared_ptr<cas::ObjectStore>> OpenedCAS;
+  /// A cache to lookup CAS instance from directory path.
+  StringMap<cas::ObjectStore *> CASLookupCache;
+  /// Global CAS used fallback when local CAS are not available.
+  cas::ObjectStore *GlobalCAS;
   std::mutex CASMutex;
 
   Options Opts;

--- a/llvm/tools/dsymutil/dsymutil.cpp
+++ b/llvm/tools/dsymutil/dsymutil.cpp
@@ -681,24 +681,12 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
       return EXIT_FAILURE;
     }
 
-  // Create CAS. Only support unified database for now.
-  std::shared_ptr<llvm::cas::ObjectStore> CAS;
-  if (!Options.CASOptions.CASPath.empty()) {
-    auto DB = Options.CASOptions.createDatabases();
-    if (!DB) {
-      WithColor::error() << "failed to open CAS: " << toString(DB.takeError())
-                         << "\n";
-      return EXIT_FAILURE;
-    }
-    CAS = std::move(DB->first);
-  }
-
   for (auto &InputFile : Options.InputFiles) {
     // Shared a single binary holder for all the link steps.
     BinaryHolder::Options BinOpts;
     BinOpts.Verbose = Options.LinkOpts.Verbose;
     BinOpts.Warn = !Options.NoObjectTimestamp;
-    BinaryHolder BinHolder(Options.LinkOpts.VFS, BinOpts, CAS);
+    BinaryHolder BinHolder(Options.LinkOpts.VFS, BinOpts);
 
     // Dump the symbol table for each input file and requested arch
     if (Options.DumpStab) {
@@ -748,6 +736,13 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
     }
     Options.LinkOpts.ResourceDir = OutputLocationOrErr->getResourceDir();
 
+    // Compute a global CAS.
+    if (auto E = BinHolder.setGlobalCASConfiguration(Options.CASOptions)) {
+      WithColor::error() << "failed to open CAS: " << toString(std::move(E))
+                         << "\n";
+      return EXIT_FAILURE;
+    }
+
     // Statistics only require different architectures to be processed
     // sequentially, the link itself can still happen in parallel. Change the
     // thread pool strategy here instead of modifying LinkOpts.Threads.
@@ -784,6 +779,15 @@ int dsymutil_main(int argc, char **argv, const llvm::ToolContext &) {
 
         if (Options.DumpDebugMap)
           continue;
+
+        // Update the global CAS if it is not available on the command-line.
+        if (Options.CASOptions.CASPath.empty()) {
+          for (auto &F : *Map) {
+            if (BinHolder.updateGlobalCASFromPath(
+                    sys::path::parent_path(F->getObjectFilename())))
+              break;
+          }
+        }
 
         if (Map->begin() == Map->end()) {
           if (!Options.LinkOpts.Quiet) {


### PR DESCRIPTION
Update how dsymutil is loading inputs from a CAS so dsymutil supports:
* Loading from multiple CAS, trying CAS specified by a local `.cas_config` first, before fallback to a global CAS.
* The global CAS that is used as fallback can be configured via either command-line option, or by the first `.cas_config` file found when searching from files specified in DebugMap.
* Improve CAS opening logic so it no longer open the same CAS configuration twice.

    rdar://172571538


