### PR TITLE
[lldb][windows] make TestStepThroughAllocatingInit.py cross platform

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -224,6 +224,9 @@ class _PlatformContext(object):
         self.shlib_prefix = shlib_prefix
         self.shlib_extension = shlib_extension
 
+    def getFullLibName(self, base_name):
+        return f"{self.shlib_prefix}{base_name}.{self.shlib_extension}"
+
 
 def createPlatformContext():
     if platformIsDarwin():

--- a/lldb/test/API/commands/target/create-deps/TestTargetCreateDeps.py
+++ b/lldb/test/API/commands/target/create-deps/TestTargetCreateDeps.py
@@ -74,22 +74,19 @@ class TargetDependentsTestCase(TestBase):
 
     @expectedFailureAndroid  # android will return mutiple images
     def test_dependents_implicit_default_lib(self):
-        ctx = self.platformContext
-        dylibName = ctx.shlib_prefix + "load_a." + ctx.shlib_extension
+        dylibName = self.platformContext.getFullLibName("load_a")
         lib = self.getBuildArtifact(dylibName)
         self.runCmd("target create " + lib, CURRENT_EXECUTABLE_SET)
         self.has_exactly_one_image(True)
 
     def test_dependents_explicit_default_lib(self):
-        ctx = self.platformContext
-        dylibName = ctx.shlib_prefix + "load_a." + ctx.shlib_extension
+        dylibName = self.platformContext.getFullLibName("load_a")
         lib = self.getBuildArtifact(dylibName)
         self.runCmd("target create -ddefault " + lib, CURRENT_EXECUTABLE_SET)
         self.has_exactly_one_image(True)
 
     def test_dependents_explicit_true_lib(self):
-        ctx = self.platformContext
-        dylibName = ctx.shlib_prefix + "load_a." + ctx.shlib_extension
+        dylibName = self.platformContext.getFullLibName("load_a")
         lib = self.getBuildArtifact(dylibName)
         self.runCmd("target create -dtrue " + lib, CURRENT_EXECUTABLE_SET)
         self.has_exactly_one_image(True)
@@ -100,15 +97,13 @@ class TargetDependentsTestCase(TestBase):
         triple=no_match(".*-android"),
     )
     def test_dependents_explicit_false_lib(self):
-        ctx = self.platformContext
-        dylibName = ctx.shlib_prefix + "load_a." + ctx.shlib_extension
+        dylibName = self.platformContext.getFullLibName("load_a")
         lib = self.getBuildArtifact(dylibName)
         self.runCmd("target create -dfalse " + lib, CURRENT_EXECUTABLE_SET)
         self.has_exactly_one_image(False)
 
     def test_dependents_implicit_false_lib(self):
-        ctx = self.platformContext
-        dylibName = ctx.shlib_prefix + "load_a." + ctx.shlib_extension
+        dylibName = self.platformContext.getFullLibName("load_a")
         lib = self.getBuildArtifact(dylibName)
         self.runCmd("target create -d " + lib, CURRENT_EXECUTABLE_SET)
         self.has_exactly_one_image(True)

--- a/lldb/test/API/functionalities/breakpoint/break_in_loaded_dylib/TestBreakInLoadedDylib.py
+++ b/lldb/test/API/functionalities/breakpoint/break_in_loaded_dylib/TestBreakInLoadedDylib.py
@@ -17,9 +17,7 @@ class TestBreakInLoadedDylib(TestBase):
         self.main_spec = lldb.SBFileSpec("main.cpp")
         self.b_spec = lldb.SBFileSpec("b.cpp")
         self.lib_shortname = "lib_b"
-        self.lib_fullname = (
-            ctx.shlib_prefix + self.lib_shortname + "." + ctx.shlib_extension
-        )
+        self.lib_fullname = ctx.getFullLibName(self.lib_shortname)
         self.lib_spec = lldb.SBFileSpec(self.lib_fullname)
 
     def test_break_in_dlopen_dylib_using_lldbutils(self):

--- a/lldb/test/API/functionalities/executable_first/TestExecutableFirst.py
+++ b/lldb/test/API/functionalities/executable_first/TestExecutableFirst.py
@@ -16,8 +16,7 @@ class TestExecutableIsFirst(TestBase):
     def test_executable_is_first_before_run(self):
         self.build()
 
-        ctx = self.platformContext
-        lib_name = ctx.shlib_prefix + "bar." + ctx.shlib_extension
+        lib_name = self.platformContext.getFullLibName("bar")
 
         exe = self.getBuildArtifact("a.out")
         lib = self.getBuildArtifact(lib_name)

--- a/lldb/test/API/functionalities/load_after_attach/TestLoadAfterAttach.py
+++ b/lldb/test/API/functionalities/load_after_attach/TestLoadAfterAttach.py
@@ -15,8 +15,7 @@ class TestCase(TestBase):
             self, "process_ready"
         )
 
-        ctx = self.platformContext
-        lib_name = ctx.shlib_prefix + "lib_b." + ctx.shlib_extension
+        lib_name = self.platformContext.getFullLibName("lib_b")
 
         exe = self.getBuildArtifact("a.out")
         lib = self.getBuildArtifact(lib_name)

--- a/lldb/test/API/functionalities/load_lazy/TestLoadUsingLazyBind.py
+++ b/lldb/test/API/functionalities/load_lazy/TestLoadUsingLazyBind.py
@@ -25,16 +25,8 @@ class LoadUsingLazyBind(TestBase):
         self.build()
         wd = os.path.realpath(self.getBuildDir())
 
-        def make_lib_name(name):
-            return (
-                self.platformContext.shlib_prefix
-                + name
-                + "."
-                + self.platformContext.shlib_extension
-            )
-
         def make_lib_path(name):
-            libpath = os.path.join(wd, make_lib_name(name))
+            libpath = os.path.join(wd, self.platformContext.getFullLibName(name))
             self.assertTrue(os.path.exists(libpath))
             return libpath
 
@@ -51,7 +43,7 @@ class LoadUsingLazyBind(TestBase):
 
         # Load libt1; should fail unless we use RTLD_LAZY
         error = lldb.SBError()
-        lib_spec = lldb.SBFileSpec(make_lib_name("t1"))
+        lib_spec = lldb.SBFileSpec(self.platformContext.getFullLibName("t1"))
         paths = lldb.SBStringList()
         paths.AppendString(wd)
         out_spec = lldb.SBFileSpec()

--- a/lldb/test/API/functionalities/load_unload/TestLoadUnload.py
+++ b/lldb/test/API/functionalities/load_unload/TestLoadUnload.py
@@ -243,8 +243,7 @@ class LoadUnloadTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
 
-        ctx = self.platformContext
-        dylibName = ctx.shlib_prefix + "loadunload_a." + ctx.shlib_extension
+        dylibName = self.platformContext.getFullLibName("loadunload_a")
         localDylibPath = self.getBuildArtifact(dylibName)
         if lldb.remote_platform:
             wd = lldb.remote_platform.GetWorkingDirectory()

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -33,8 +33,9 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
         exe_name = "a.out"
         exe = self.getBuildArtifact(exe_name)
 
+        library_name = self.platformContext.getFullLibName("swiftCore")
         self.runCmd(
-            "settings set target.process.thread.step-avoid-libraries libswiftCore.dylib"
+            f"settings set target.process.thread.step-avoid-libraries {library_name}"
         )
 
         target, process, thread, breakpoint = lldbutil.run_to_source_breakpoint(self,

--- a/lldb/test/API/symbol_ondemand/shared_library/TestSharedLibOnDemand.py
+++ b/lldb/test/API/symbol_ondemand/shared_library/TestSharedLibOnDemand.py
@@ -31,8 +31,7 @@ class SharedLibTestCase(TestBase):
             self.target, self.shlib_names
         )
 
-        ctx = self.platformContext
-        self.shared_lib_name = ctx.shlib_prefix + "foo." + ctx.shlib_extension
+        self.shared_lib_name = self.platformContext.getFullLibName("foo")
 
     @skipIfWindows
     def test_source_line_breakpoint(self):


### PR DESCRIPTION
`libswiftCore.dylib` is called `swiftCore.dll` on Windows.

rdar://173326298