### PR TITLE
Add support for anyAppleOS availability

### DIFF
--- a/clang/include/clang/AST/Availability.h
+++ b/clang/include/clang/AST/Availability.h
@@ -66,6 +66,11 @@ public:
 
   bool isDomainName() const { return !DomainName.empty(); }
   StringRef getDomainName() const { return DomainName; }
+
+  /// Returns true if the anyAppleOS version is valid (empty or >= 26.0).
+  static bool validateAnyAppleOSVersion(const llvm::VersionTuple &Version) {
+    return Version.empty() || Version >= llvm::VersionTuple(26, 0);
+  }
 };
 
 class Decl;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -284,7 +284,8 @@ class VariadicParamOrParamIdxArgument<string name> : Argument<name, 1>;
 class ParamIdxArgument<string name, bit opt = 0> : Argument<name, opt>;
 
 // A version of the form major.minor[.subminor].
-class VersionArgument<string name, bit opt = 0> : Argument<name, opt>;
+class VersionArgument<string name, bit opt = 0, bit fake = 0>
+    : Argument<name, opt, fake>;
 
 // This one's a doozy, so it gets its own special type
 // It can be an unsigned integer, or a type. Either can
@@ -1107,7 +1108,8 @@ def Availability : InheritableAttr {
               VersionArgument<"deprecated">, VersionArgument<"obsoleted">,
               BoolArgument<"unavailable">, StringArgument<"message">,
               BoolArgument<"strict">, StringArgument<"replacement">,
-              IntArgument<"priority">, IdentifierArgument<"environment">];
+              IntArgument<"priority">, IdentifierArgument<"environment">,
+              VersionArgument<"origAnyAppleOSVersion", 0, 1>];
   let AdditionalMembers =
 [{static llvm::StringRef getPrettyPlatformName(llvm::StringRef Platform) {
     return llvm::StringSwitch<llvm::StringRef>(Platform)
@@ -1126,6 +1128,7 @@ def Availability : InheritableAttr {
              .Case("maccatalyst_app_extension", "macCatalyst (App Extension)")
              .Case("xros", "visionOS")
              .Case("xros_app_extension", "visionOS (App Extension)")
+             .Case("anyappleos", "any Apple OS")
              .Case("swift", "Swift")
              .Case("shadermodel", "Shader Model")
              .Case("ohos", "OpenHarmony OS")
@@ -1145,6 +1148,7 @@ static llvm::StringRef getPlatformNameSourceSpelling(llvm::StringRef Platform) {
              .Case("maccatalyst_app_extension", "macCatalystApplicationExtension")
              .Case("xros", "visionOS")
              .Case("xros_app_extension", "visionOSApplicationExtension")
+             .Case("anyappleos", "anyAppleOS")
              .Case("zos", "z/OS")
              .Case("shadermodel", "ShaderModel")
              .Default(Platform);
@@ -1167,6 +1171,7 @@ static llvm::StringRef canonicalizePlatformName(llvm::StringRef Platform) {
              .Case("visionOSApplicationExtension", "xros_app_extension")
              .Case("visionos", "xros")
              .Case("visionos_app_extension", "xros_app_extension")
+             .Case("anyAppleOS", "anyappleos")
              .Case("ShaderModel", "shadermodel")
              .Default(Platform);
 }
@@ -1198,6 +1203,8 @@ static std::vector<llvm::StringRef> equivalentPlatformNames(llvm::StringRef Plat
              .Case("xros_app_extension", {"visionOSApplicationExtension", "visionos_app_extension", "xros_app_extension"})
              .Case("visionOSApplicationExtension", {"visionOSApplicationExtension", "visionos_app_extension", "xros_app_extension"})
              .Case("visionos_app_extension", {"visionOSApplicationExtension", "visionos_app_extension", "xros_app_extension"})
+             .Case("anyappleos", {"anyappleos", "anyAppleOS"})
+             .Case("anyAppleOS", {"anyappleos", "anyAppleOS"})
              .Default({Platform});
 }
 static llvm::Triple::EnvironmentType getEnvironmentType(llvm::StringRef Environment) {

--- a/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1216,6 +1216,8 @@ def err_avail_query_expected_platform_name : Error<
 
 def err_avail_query_unrecognized_platform_name : Error<
   "unrecognized platform name %0">;
+def err_avail_query_anyappleos_min_version : Error<
+  "invalid anyAppleOS version '%0' in availability check">;
 def err_availability_query_wildcard_required: Error<
   "must handle potential future platforms with '*'">;
 def err_availability_query_repeated_platform: Error<

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -4161,6 +4161,8 @@ def warn_at_available_unchecked_use : Warning<
 def warn_availability_invalid_os_version
     : Warning<"invalid %1 version '%0' in availability attribute">, InGroup<DiagGroup<"invalid-version-availability">>;
 def note_availability_invalid_os_version_adjusted: Note<"implicitly treating version as '%0'">;
+def err_availability_invalid_anyappleos_version
+    : Error<"invalid anyAppleOS version '%0' in availability attribute">;
 
 def warn_missing_sdksettings_for_availability_checking : Warning<
   "%0 availability is ignored without a valid 'SDKSettings.json' in the SDK">,

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -5213,7 +5213,16 @@ public:
 
     /// The availability attribute for a specific platform was inferred from
     /// an availability attribute for another platform.
-    AP_InferredFromOtherPlatform = 2
+    AP_InferredFromOtherPlatform = 2,
+
+    /// The availability attribute was inferred from an 'anyAppleOS'
+    /// availability attribute.
+    AP_InferredFromAnyAppleOS = 3,
+
+    /// The availability attribute was inferred from an 'anyAppleOS'
+    /// availability attribute that was applied using '#pragma clang attribute'.
+    /// This has the lowest priority.
+    AP_PragmaClangAttribute_InferredFromAnyAppleOS = 4
   };
 
   /// Describes the reason a calling convention specification was ignored, used
@@ -5331,7 +5340,8 @@ public:
                         VersionTuple Obsoleted, bool IsUnavailable,
                         StringRef Message, bool IsStrict, StringRef Replacement,
                         AvailabilityMergeKind AMK, int Priority,
-                        const IdentifierInfo *IIEnvironment);
+                        const IdentifierInfo *IIEnvironment,
+                        VersionTuple OrigAnyAppleOSVersion = {});
 
   TypeVisibilityAttr *
   mergeTypeVisibilityAttr(Decl *D, const AttributeCommonInfo &CI,

--- a/clang/lib/Parse/ParseExpr.cpp
+++ b/clang/lib/Parse/ParseExpr.cpp
@@ -3497,6 +3497,15 @@ std::optional<AvailabilitySpec> Parser::ParseAvailabilitySpec() {
       return std::nullopt;
     }
 
+    // Validate anyAppleOS version; reject versions older than 26.0.
+    if (Platform == "anyappleos" &&
+        !AvailabilitySpec::validateAnyAppleOSVersion(Version)) {
+      Diag(VersionRange.getBegin(),
+           diag::err_avail_query_anyappleos_min_version)
+          << Version.getAsString();
+      return std::nullopt;
+    }
+
     return AvailabilitySpec(Version, Platform, PlatformIdentifier->getLoc(),
                             VersionRange.getEnd());
   }

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -271,7 +271,8 @@ static void ProcessAPINotes(Sema &S, Decl *D,
               /*Strict=*/false,
               /*Replacement=*/StringRef(),
               /*Priority=*/Sema::AP_Explicit,
-              /*Environment=*/nullptr);
+              /*Environment=*/nullptr,
+              /*OrigAnyAppleOSVersion=*/VersionTuple());
         },
         [](const Decl *D) {
           return llvm::find_if(D->attrs(), [](const Attr *next) -> bool {

--- a/clang/lib/Sema/SemaAvailability.cpp
+++ b/clang/lib/Sema/SemaAvailability.cpp
@@ -979,12 +979,26 @@ void DiagnoseUnguardedAvailability::DiagnoseDeclAvailability(
     const char *ExtraIndentation = "    ";
     std::string FixItString;
     llvm::raw_string_ostream FixItOS(FixItString);
-    FixItOS << "if (" << (SemaRef.getLangOpts().ObjC ? "@available"
-                                                     : "__builtin_available")
-            << "("
-            << AvailabilityAttr::getPlatformNameSourceSpelling(
-                   SemaRef.getASTContext().getTargetInfo().getPlatformName())
-            << " " << Introduced.getAsString() << ", *)) {\n"
+    // If the attr was derived from anyAppleOS, emit the fix-it using
+    // anyAppleOS and the original anyAppleOS version rather than the
+    // platform-specific name and version.
+    VersionTuple OrigAnyAppleOSVersion = AA->getOrigAnyAppleOSVersion();
+    StringRef FixItPlatformName;
+    VersionTuple FixItVersion;
+
+    if (OrigAnyAppleOSVersion.empty()) {
+      FixItPlatformName = AvailabilityAttr::getPlatformNameSourceSpelling(
+          SemaRef.getASTContext().getTargetInfo().getPlatformName());
+      FixItVersion = Introduced;
+    } else {
+      FixItPlatformName = "anyAppleOS";
+      FixItVersion = OrigAnyAppleOSVersion;
+    }
+    FixItOS << "if ("
+            << (SemaRef.getLangOpts().ObjC ? "@available"
+                                           : "__builtin_available")
+            << "(" << FixItPlatformName << " " << FixItVersion.getAsString()
+            << ", *)) {\n"
             << Indentation << ExtraIndentation;
     FixitDiag << FixItHint::CreateInsertion(IfInsertionLoc, FixItOS.str());
     SourceLocation ElseInsertionLoc = Lexer::findLocationAfterToken(

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2877,7 +2877,8 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
         D, *AA, AA->getPlatform(), AA->isImplicit(), AA->getIntroduced(),
         AA->getDeprecated(), AA->getObsoleted(), AA->getUnavailable(),
         AA->getMessage(), AA->getStrict(), AA->getReplacement(), AMK,
-        AA->getPriority(), AA->getEnvironment());
+        AA->getPriority(), AA->getEnvironment(),
+        AA->getOrigAnyAppleOSVersion());
   else if (const auto *VA = dyn_cast<VisibilityAttr>(Attr))
     NewAttr = S.mergeVisibilityAttr(D, *VA, VA->getVisibility());
   else if (const auto *VA = dyn_cast<TypeVisibilityAttr>(Attr))

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -15,6 +15,7 @@
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTMutationListener.h"
+#include "clang/AST/Availability.h"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
@@ -2254,7 +2255,8 @@ AvailabilityAttr *Sema::mergeAvailabilityAttr(
     bool Implicit, VersionTuple Introduced, VersionTuple Deprecated,
     VersionTuple Obsoleted, bool IsUnavailable, StringRef Message,
     bool IsStrict, StringRef Replacement, AvailabilityMergeKind AMK,
-    int Priority, const IdentifierInfo *Environment) {
+    int Priority, const IdentifierInfo *Environment,
+    VersionTuple OrigAnyAppleOSVersion) {
   VersionTuple MergedIntroduced = Introduced;
   VersionTuple MergedDeprecated = Deprecated;
   VersionTuple MergedObsoleted = Obsoleted;
@@ -2413,7 +2415,8 @@ AvailabilityAttr *Sema::mergeAvailabilityAttr(
       !OverrideOrImpl) {
     auto *Avail = ::new (Context) AvailabilityAttr(
         Context, CI, Platform, Introduced, Deprecated, Obsoleted, IsUnavailable,
-        Message, IsStrict, Replacement, Priority, Environment);
+        Message, IsStrict, Replacement, Priority, Environment,
+        OrigAnyAppleOSVersion);
     Avail->setImplicit(Implicit);
     return Avail;
   }
@@ -2666,6 +2669,63 @@ static void handleAvailabilityAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
              diag::err_availability_unexpected_parameter)
           << "environment" << /* C/C++ */ 1;
     }
+  }
+
+  // Handle anyAppleOS specially: create implicit platform-specific attributes
+  // instead of the original anyAppleOS attribute.
+  if (II->getName() == "anyappleos") {
+    // Validate anyAppleOS versions; reject versions older than 26.0.
+    auto ValidateVersion = [&](const llvm::VersionTuple &Version,
+                               SourceLocation Loc) -> bool {
+      if (AvailabilitySpec::validateAnyAppleOSVersion(Version))
+        return true;
+      S.Diag(Loc, diag::err_availability_invalid_anyappleos_version)
+          << Version.getAsString();
+      return false;
+    };
+
+    // Validate the versions; bail out if any are invalid.
+    bool Valid = ValidateVersion(Introduced.Version, Introduced.KeywordLoc);
+    Valid &= ValidateVersion(Deprecated.Version, Deprecated.KeywordLoc);
+    Valid &= ValidateVersion(Obsoleted.Version, Obsoleted.KeywordLoc);
+    if (!Valid)
+      return;
+
+    llvm::Triple T = S.Context.getTargetInfo().getTriple();
+
+    // Only create implicit attributes for Darwin OSes.
+    if (!T.isOSDarwin())
+      return;
+
+    StringRef PlatformName;
+
+    // Determine the platform name based on the target triple.
+    if (T.isMacOSX())
+      PlatformName = "macos";
+    else if (T.getOS() == llvm::Triple::IOS && T.isMacCatalystEnvironment())
+      PlatformName = "maccatalyst";
+    else // For iOS, tvOS, watchOS, visionOS, bridgeOS, etc.
+      PlatformName = llvm::Triple::getOSTypeName(T.getOS());
+
+    IdentifierInfo *NewII = &S.Context.Idents.get(PlatformName);
+
+    // Use the special low-priority value for pragma push anyAppleOS.
+    int ExpandedPriority =
+        (PriorityModifier == Sema::AP_PragmaClangAttribute)
+            ? Sema::AP_PragmaClangAttribute_InferredFromAnyAppleOS
+            : Sema::AP_InferredFromAnyAppleOS;
+
+    AvailabilityAttr *NewAttr = S.mergeAvailabilityAttr(
+        ND, AL, NewII, /*Implicit=*/true, Introduced.Version,
+        Deprecated.Version, Obsoleted.Version, IsUnavailable, Str, IsStrict,
+        Replacement, AvailabilityMergeKind::None, ExpandedPriority,
+        IIEnvironment, Introduced.Version);
+    if (NewAttr)
+      D->addAttr(NewAttr);
+
+    // Don't add the original anyAppleOS attribute - only the implicit
+    // platform-specific attributes.
+    return;
   }
 
   AvailabilityAttr *NewAttr = S.mergeAvailabilityAttr(

--- a/clang/lib/Sema/SemaExprObjC.cpp
+++ b/clang/lib/Sema/SemaExprObjC.cpp
@@ -5183,6 +5183,17 @@ ExprResult SemaObjC::ActOnObjCAvailabilityCheckExpr(
         return Spec.getPlatform() == "ios";
       });
     }
+    // Use "anyappleos" spec if no platform-specific spec is found and the
+    // target is an Apple OS.
+    if (Spec == AvailSpecs.end()) {
+      // Check if this OS is a Darwin/Apple OS.
+      const llvm::Triple &Triple = Context.getTargetInfo().getTriple();
+      if (Triple.isOSDarwin()) {
+        Spec = llvm::find_if(AvailSpecs, [&](const AvailabilitySpec &Spec) {
+          return Spec.getPlatform() == "anyappleos";
+        });
+      }
+    }
     if (Spec == AvailSpecs.end())
       return std::nullopt;
     return ObjCAvailabilityCheckExpr::VersionAsWritten{llvm::Triple::getCanonicalVersionForOS(

--- a/clang/test/CodeGen/availability-check-anyappleos.c
+++ b/clang/test/CodeGen/availability-check-anyappleos.c
@@ -1,0 +1,128 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macosx27.0 -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-MACOS %s
+// RUN: %clang_cc1 -triple arm64-apple-ios27.0 -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-IOS %s
+// RUN: %clang_cc1 -triple aarch64-linux-android27 -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-ANDROID %s
+
+void test_anyappleos_older_than_deployment(void) {
+  // Deployment target is 27.0, so anyAppleOS 26.0 should fold to true.
+  // CHECK-MACOS-LABEL: define{{.*}} void @test_anyappleos_older_than_deployment
+  // CHECK-MACOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-MACOS: br i1 true
+  // CHECK-IOS-LABEL: define{{.*}} void @test_anyappleos_older_than_deployment
+  // CHECK-IOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-IOS: br i1 true
+  // CHECK-ANDROID-LABEL: define{{.*}} void @test_anyappleos_older_than_deployment
+  // CHECK-ANDROID-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(anyAppleOS 26.0, *))
+    ;
+}
+
+void test_anyappleos_equal_to_deployment(void) {
+  // Deployment target is 27.0, so anyAppleOS 27.0 should fold to true.
+  // CHECK-MACOS-LABEL: define{{.*}} void @test_anyappleos_equal_to_deployment
+  // CHECK-MACOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-MACOS: br i1 true
+  // CHECK-IOS-LABEL: define{{.*}} void @test_anyappleos_equal_to_deployment
+  // CHECK-IOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-IOS: br i1 true
+  // CHECK-ANDROID-LABEL: define{{.*}} void @test_anyappleos_equal_to_deployment
+  // CHECK-ANDROID-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(anyAppleOS 27.0, *))
+    ;
+}
+
+void test_anyappleos_newer_than_deployment(void) {
+  // Deployment target is 27.0, so anyAppleOS 28.0 requires runtime check.
+  // CHECK-MACOS-LABEL: define{{.*}} void @test_anyappleos_newer_than_deployment
+  // CHECK-MACOS: call i32 @__isPlatformVersionAtLeast(i32 1, i32 28, i32 0, i32 0)
+  // CHECK-MACOS-NEXT: icmp ne
+  // CHECK-IOS-LABEL: define{{.*}} void @test_anyappleos_newer_than_deployment
+  // CHECK-IOS: call i32 @__isPlatformVersionAtLeast(i32 2, i32 28, i32 0, i32 0)
+  // CHECK-IOS-NEXT: icmp ne
+  // CHECK-ANDROID-LABEL: define{{.*}} void @test_anyappleos_newer_than_deployment
+  // CHECK-ANDROID-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(anyAppleOS 28.0, *))
+    ;
+}
+void test_ios_check_on_macos(void) {
+  // On macOS, checking for iOS should fold to true (different OS).
+  // On iOS, checking for iOS 28.0 with deployment 27.0 requires runtime check.
+  // On Android, checking for any Apple OS should fold to true.
+  // CHECK-MACOS-LABEL: define{{.*}} void @test_ios_check_on_macos
+  // CHECK-MACOS: br i1 true
+  // CHECK-IOS-LABEL: define{{.*}} void @test_ios_check_on_macos
+  // CHECK-IOS: call i32 @__isPlatformVersionAtLeast(i32 2, i32 28, i32 0, i32 0)
+  // CHECK-IOS-NEXT: icmp ne
+  // CHECK-ANDROID-LABEL: define{{.*}} void @test_ios_check_on_macos
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(ios 28.0, *))
+    ;
+}
+
+void test_macos_check_on_ios(void) {
+  // On macOS, checking for macOS 28.0 with deployment 27.0 requires runtime check.
+  // On iOS, checking for macOS should fold to true (different OS).
+  // On Android, checking for any Apple OS should fold to true.
+  // CHECK-MACOS-LABEL: define{{.*}} void @test_macos_check_on_ios
+  // CHECK-MACOS: call i32 @__isPlatformVersionAtLeast(i32 1, i32 28, i32 0, i32 0)
+  // CHECK-MACOS-NEXT: icmp ne
+  // CHECK-IOS-LABEL: define{{.*}} void @test_macos_check_on_ios
+  // CHECK-IOS: br i1 true
+  // CHECK-ANDROID-LABEL: define{{.*}} void @test_macos_check_on_ios
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(macos 28.0, *))
+    ;
+}
+
+void test_priority(void) {
+  // Platform-specific checks take priority over anyAppleOS.
+
+  // On macOS: macos 28.0 applies (platform-specific), requires runtime check since deployment is 27.0.
+  // On iOS: anyAppleOS 26.0 applies, folds to true since deployment is 27.0.
+  // On Android: Non-Apple OS, folds to true.
+  // CHECK-MACOS-LABEL: define{{.*}} void @test_priority
+  // CHECK-MACOS: call i32 @__isPlatformVersionAtLeast(i32 1, i32 28, i32 0, i32 0)
+  // CHECK-MACOS-NEXT: icmp ne
+  // CHECK-IOS-LABEL: define{{.*}} void @test_priority
+  // CHECK-IOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-IOS: br i1 true
+  // CHECK-ANDROID-LABEL: define{{.*}} void @test_priority
+  // CHECK-ANDROID-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(anyAppleOS 26.0, macos 28.0, *))
+    ;
+
+  // Order of checks shouldn't matter; same behavior as above.
+  // CHECK-MACOS: call i32 @__isPlatformVersionAtLeast(i32 1, i32 28, i32 0, i32 0)
+  // CHECK-MACOS-NEXT: icmp ne
+  // CHECK-IOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-IOS: br i1 true
+  // CHECK-ANDROID-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(macos 28.0, anyAppleOS 26.0, *))
+    ;
+
+  // On macOS: macos 26.0 applies (platform-specific), folds to true since deployment is 27.0.
+  // On iOS: anyAppleOS 28.0 applies, requires runtime check since deployment is 27.0.
+  // On Android: Non-Apple OS, folds to true.
+  // CHECK-MACOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-MACOS: br i1 true
+  // CHECK-IOS: call i32 @__isPlatformVersionAtLeast(i32 2, i32 28, i32 0, i32 0)
+  // CHECK-IOS-NEXT: icmp ne
+  // CHECK-ANDROID-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(anyAppleOS 28.0, macos 26.0, *))
+    ;
+
+  // Order of checks shouldn't matter; same behavior as above.
+  // CHECK-MACOS-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-MACOS: br i1 true
+  // CHECK-IOS: call i32 @__isPlatformVersionAtLeast(i32 2, i32 28, i32 0, i32 0)
+  // CHECK-IOS-NEXT: icmp ne
+  // CHECK-ANDROID-NOT: call i32 @__isPlatformVersionAtLeast
+  // CHECK-ANDROID: br i1 true
+  if (__builtin_available(macos 26.0, anyAppleOS 28.0, *))
+    ;
+}

--- a/clang/test/FixIt/fixit-availability-anyappleos.m
+++ b/clang/test/FixIt/fixit-availability-anyappleos.m
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple x86_64-apple-macos26.0 -Wunguarded-availability -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
+
+// Test that the @available fix-it uses anyAppleOS when the availability attr
+// was derived from anyAppleOS, and the platform-specific name when an explicit
+// platform attr takes priority.
+
+// Declaration with only anyAppleOS availability: fix-it should use anyAppleOS.
+void func_anyappleos(void) __attribute__((availability(anyAppleOS, introduced=27.0)));
+
+// Declaration with anyAppleOS + explicit macos: the macos attr takes priority,
+// so the fix-it should use macOS and the macOS-specific version.
+void func_macos(void)
+    __attribute__((availability(anyAppleOS, introduced=27.0)))
+    __attribute__((availability(macos, introduced=28.0)));
+
+void test(void) {
+  func_anyappleos();
+// CHECK: fix-it:{{.*}}:{[[@LINE-1]]:3-[[@LINE-1]]:3}:"if (@available(anyAppleOS 27.0, *)) {\n      "
+// CHECK-NEXT: fix-it:{{.*}}:{[[@LINE-2]]:21-[[@LINE-2]]:21}:"\n  } else {\n      // Fallback on earlier versions\n  }"
+
+  func_macos();
+// CHECK: fix-it:{{.*}}:{[[@LINE-1]]:3-[[@LINE-1]]:3}:"if (@available(macOS 28.0, *)) {\n      "
+// CHECK-NEXT: fix-it:{{.*}}:{[[@LINE-2]]:16-[[@LINE-2]]:16}:"\n  } else {\n      // Fallback on earlier versions\n  }"
+}

--- a/clang/test/Sema/attr-availability-anyappleos-ast.c
+++ b/clang/test/Sema/attr-availability-anyappleos-ast.c
@@ -1,0 +1,35 @@
+// RUN: %clang_cc1 -triple arm64-apple-ios26.0 -fsyntax-only -ast-dump %s | FileCheck --check-prefix=CHECK-IOS %s
+// RUN: %clang_cc1 -triple x86_64-apple-macosx26.0 -fsyntax-only -ast-dump %s | FileCheck --check-prefix=CHECK-MACOS %s
+// RUN: %clang_cc1 -triple arm64-apple-tvos26.0 -fsyntax-only -ast-dump %s | FileCheck --check-prefix=CHECK-TVOS %s
+// RUN: %clang_cc1 -triple arm64-apple-watchos26.0 -fsyntax-only -ast-dump %s | FileCheck --check-prefix=CHECK-WATCHOS %s
+// RUN: %clang_cc1 -triple arm64-apple-xros26.0 -fsyntax-only -ast-dump %s | FileCheck --check-prefix=CHECK-XROS %s
+// RUN: %clang_cc1 -triple arm64-apple-ios26.0-macabi -fsyntax-only -ast-dump %s | FileCheck --check-prefix=CHECK-MACCATALYST %s
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fsyntax-only -ast-dump %s | FileCheck --check-prefix=CHECK-LINUX %s
+
+// Test that anyAppleOS availability creates implicit platform-specific
+// attributes for the target platform.
+
+extern int func1 __attribute__((availability(anyAppleOS, introduced=26.0)));
+// CHECK-IOS: AvailabilityAttr {{.*}} Implicit ios 26.0 0 0 "" "" 3
+// CHECK-MACOS: AvailabilityAttr {{.*}} Implicit macos 26.0 0 0 "" "" 3
+// CHECK-TVOS: AvailabilityAttr {{.*}} Implicit tvos 26.0 0 0 "" "" 3
+// CHECK-WATCHOS: AvailabilityAttr {{.*}} Implicit watchos 26.0 0 0 "" "" 3
+// CHECK-XROS: AvailabilityAttr {{.*}} Implicit xros 26.0 0 0 "" "" 3
+// CHECK-MACCATALYST: AvailabilityAttr {{.*}} Implicit maccatalyst 26.0 0 0 "" "" 3
+// CHECK-LINUX-NOT: AvailabilityAttr {{.*}} Implicit
+
+extern int func2 __attribute__((availability(anyAppleOS, introduced=26.0, deprecated=27.0)));
+// CHECK-IOS: AvailabilityAttr {{.*}} Implicit ios 26.0 27.0 0 "" "" 3
+// CHECK-MACOS: AvailabilityAttr {{.*}} Implicit macos 26.0 27.0 0 "" "" 3
+
+extern int func3 __attribute__((availability(anyAppleOS, introduced=26.0, deprecated=27.0, obsoleted=28.0)));
+// CHECK-IOS: AvailabilityAttr {{.*}} Implicit ios 26.0 27.0 28.0 "" "" 3
+// CHECK-MACOS: AvailabilityAttr {{.*}} Implicit macos 26.0 27.0 28.0 "" "" 3
+
+extern int func4 __attribute__((availability(anyAppleOS, unavailable)));
+// CHECK-IOS: AvailabilityAttr {{.*}} Implicit ios 0 0 0 Unavailable "" "" 3
+// CHECK-MACOS: AvailabilityAttr {{.*}} Implicit macos 0 0 0 Unavailable "" "" 3
+
+extern int func5 __attribute__((availability(anyAppleOS, unavailable, message="Use something else")));
+// CHECK-IOS: AvailabilityAttr {{.*}} Implicit ios 0 0 0 Unavailable "Use something else" "" 3
+// CHECK-MACOS: AvailabilityAttr {{.*}} Implicit macos 0 0 0 Unavailable "Use something else" "" 3

--- a/clang/test/Sema/attr-availability-anyappleos-builtin.m
+++ b/clang/test/Sema/attr-availability-anyappleos-builtin.m
@@ -1,0 +1,141 @@
+// RUN: %clang_cc1 -triple arm64-apple-ios26.0 -fsyntax-only -verify=expected,ios %s
+// RUN: %clang_cc1 -triple x86_64-apple-macos26.0 -fsyntax-only -verify=expected,macos %s
+// RUN: %clang_cc1 -triple arm64-apple-tvos26.0 -fsyntax-only -verify=expected,tvos %s
+// RUN: %clang_cc1 -triple x86_64-apple-macos26.0 -darwin-target-variant-triple x86_64-apple-ios27.0-macabi -fsyntax-only -verify=expected,macos %s
+
+// Test @available and __builtin_available with anyAppleOS.
+
+// Declarations with anyAppleOS availability.
+void func_introduced_26(void) __attribute__((availability(anyAppleOS, introduced=26.0)));
+void func_introduced_27(void) __attribute__((availability(anyAppleOS, introduced=27.0))); // \
+  // ios-note {{'func_introduced_27' has been marked as being introduced in iOS 27.0 here, but the deployment target is iOS 26.0}} \
+  // macos-note 2 {{'func_introduced_27' has been marked as being introduced in macOS 27.0 here, but the deployment target is macOS 26.0}} \
+  // tvos-note 2 {{'func_introduced_27' has been marked as being introduced in tvOS 27.0 here, but the deployment target is tvOS 26.0}}
+void func_deprecated_27(void) __attribute__((availability(anyAppleOS, introduced=26.0, deprecated=27.0)));
+void func_obsoleted_28(void) __attribute__((availability(anyAppleOS, introduced=26.0, obsoleted=28.0)));
+void func_unavailable(void) __attribute__((availability(anyAppleOS, unavailable))); // expected-note {{has been explicitly marked unavailable here}}
+
+void test_builtin_available() {
+  // Guard with __builtin_available - should suppress warnings
+  if (__builtin_available(anyAppleOS 27, *)) {
+    func_introduced_27(); // No warning - properly guarded
+  }
+
+  // Mixing anyAppleOS with platform-specific checks
+  if (__builtin_available(anyAppleOS 26, iOS 28, *)) {
+    func_introduced_26(); // No warning
+  }
+
+  // FIXME: The tvOS diagnostic is incorrect. When an explicit iOS version
+  // check (iOS 27) is present alongside anyAppleOS, tvOS should infer its
+  // availability from iOS. Therefore, the iOS 27 check should satisfy the tvOS
+  // 27 requirement and no tvOS diagnostic should be emitted here.
+  if (__builtin_available(anyAppleOS 26, iOS 27, *))
+    func_introduced_27(); // \
+    // macos-warning {{'func_introduced_27' is only available on macOS 27.0 or newer}} \
+    // macos-note {{enclose 'func_introduced_27' in an @available check}} \
+    // tvos-warning {{'func_introduced_27' is only available on tvOS 27.0 or newer}} \
+    // tvos-note {{enclose 'func_introduced_27' in an @available check}}
+
+  if (__builtin_available(iOS 27, anyAppleOS 26, *))
+    func_introduced_27(); // \
+    // macos-warning {{'func_introduced_27' is only available on macOS 27.0 or newer}} \
+    // macos-note {{enclose 'func_introduced_27' in an @available check}} \
+    // tvos-warning {{'func_introduced_27' is only available on tvOS 27.0 or newer}} \
+    // tvos-note {{enclose 'func_introduced_27' in an @available check}}
+
+  // FIXME: Diagnostics should be emitted for tvOS and macCatalyst here.
+  if (__builtin_available(anyAppleOS 27, iOS 26, *))
+    func_introduced_27(); // \
+    // ios-warning {{'func_introduced_27' is only available on iOS 27.0 or newer}} \
+    // ios-note {{enclose 'func_introduced_27' in an @available check}} \
+
+  // Guard for multiple versions
+  if (__builtin_available(anyAppleOS 26, *)) {
+    func_introduced_26(); // No warning
+    func_deprecated_27(); // No warning
+    func_obsoleted_28(); // No warning
+  }
+
+  // Even with guard, unavailable is still an error
+  if (__builtin_available(anyAppleOS 26, *)) {
+    func_unavailable(); // expected-error {{'func_unavailable' is unavailable}}
+  }
+}
+
+void test_at_available() {
+  // Guard with @available - should suppress warnings
+  if (@available(anyAppleOS 27, *)) {
+    func_introduced_27(); // No warning - properly guarded
+  }
+
+  // Mixing anyAppleOS with platform-specific checks
+  if (@available(anyAppleOS 26, macOS 28, *)) {
+    func_introduced_26(); // No warning
+  }
+
+  // Guard for multiple versions
+  if (@available(anyAppleOS 26, *)) {
+    func_introduced_26(); // No warning
+    func_deprecated_27(); // No warning
+    func_obsoleted_28(); // No warning
+  }
+}
+
+void test_multiple_guards() {
+  // Test that both @available and __builtin_available work
+  if (@available(anyAppleOS 27, *)) {
+    if (__builtin_available(anyAppleOS 27, *)) {
+      func_introduced_27(); // No warning - doubly guarded
+    }
+  }
+}
+
+// Additional declarations for testing insufficient guards.
+void func_introduced_28(void) __attribute__((availability(anyAppleOS, introduced=28.0))); // expected-note 2 {{has been marked as being introduced in}}
+
+void test_invalid_versions() {
+  // Test invalid version numbers (< 26.0) in __builtin_available
+  if (__builtin_available(anyAppleOS 25, *)) { // expected-error {{invalid anyAppleOS version '25' in availability check}}
+    func_introduced_26();
+  }
+
+  if (__builtin_available(anyAppleOS 14, *)) { // expected-error {{invalid anyAppleOS version '14' in availability check}}
+    func_introduced_26();
+  }
+
+  // Test invalid version numbers in @available
+  if (@available(anyAppleOS 25, *)) { // expected-error {{invalid anyAppleOS version '25' in availability check}}
+    func_introduced_26();
+  }
+
+  if (@available(anyAppleOS 10, *)) { // expected-error {{invalid anyAppleOS version '10' in availability check}}
+    func_introduced_26();
+  }
+}
+
+void test_insufficient_guard_too_old() {
+  // Guard version is too old - function needs 28.0 but guard only checks 27.0
+  if (__builtin_available(anyAppleOS 27, *)) {
+    func_introduced_28(); // expected-warning {{only available on}} expected-note {{enclose 'func_introduced_28' in an @available check to silence this warning}}
+  }
+
+  // Same with @available
+  if (@available(anyAppleOS 27, *)) {
+    func_introduced_28(); // expected-warning {{only available on}} expected-note {{enclose 'func_introduced_28' in an @available check to silence this warning}}
+  }
+}
+
+void test_duplicate_anyappleos() {
+  // Duplicate anyAppleOS specs should be an error
+  if (__builtin_available(anyAppleOS 27, anyAppleOS 28, *)) { // expected-error {{version for 'anyappleos' already specified}}
+  }
+
+  if (@available(anyAppleOS 27, anyAppleOS 28, *)) { // expected-error {{version for 'anyappleos' already specified}}
+  }
+}
+
+// Note: Platform-specific precedence is tested implicitly throughout this file.
+// When a platform-specific version is present (e.g., iOS 27), it takes precedence
+// over anyAppleOS for that platform. anyAppleOS acts as a fallback when no
+// platform-specific version is specified for the target platform.

--- a/clang/test/Sema/attr-availability-anyappleos.c
+++ b/clang/test/Sema/attr-availability-anyappleos.c
@@ -1,0 +1,203 @@
+// RUN: %clang_cc1 "-triple" "x86_64-apple-macosx27.0" -fsyntax-only -verify=macos %s
+// RUN: %clang_cc1 "-triple" "arm64-apple-ios27.0" -fsyntax-only -verify=ios %s
+// RUN: %clang_cc1 "-triple" "arm64-apple-tvos27.0" -fsyntax-only -verify=tvos %s
+// RUN: %clang_cc1 "-triple" "arm64-apple-watchos27.0" -fsyntax-only -verify=watchos %s
+// RUN: %clang_cc1 "-triple" "arm64-apple-xros27.0" -fsyntax-only -isysroot %S/Inputs/XROS26.0.sdk -verify=xros %s
+// RUN: %clang_cc1 "-triple" "arm64-apple-ios27.0-macabi" -fsyntax-only -verify=maccatalyst %s
+// RUN: %clang_cc1 "-triple" "arm64-apple-driverkit27.0" -fsyntax-only -verify=driverkit %s
+// RUN: %clang_cc1 "-triple" "aarch64-linux-android27" -fsyntax-only -verify=android %s
+
+
+void f_introduced_26(void) __attribute__((availability(anyAppleOS, introduced=26.0)));
+
+void f_introduced_25(void) __attribute__((availability(anyAppleOS, introduced=25.0))); // \
+  macos-error{{invalid anyAppleOS version '25.0' in availability attribute}} \
+  ios-error{{invalid anyAppleOS version '25.0' in availability attribute}} \
+  tvos-error{{invalid anyAppleOS version '25.0' in availability attribute}} \
+  watchos-error{{invalid anyAppleOS version '25.0' in availability attribute}} \
+  xros-error{{invalid anyAppleOS version '25.0' in availability attribute}} \
+  maccatalyst-error{{invalid anyAppleOS version '25.0' in availability attribute}} \
+  driverkit-error{{invalid anyAppleOS version '25.0' in availability attribute}} \
+  android-error{{invalid anyAppleOS version '25.0' in availability attribute}}
+
+void f_introduced_28(void) __attribute__((availability(anyAppleOS, introduced=28.0))); // \
+  macos-note{{'f_introduced_28' has been marked as being introduced in macOS 28.0 here, but the deployment target is macOS 27.0}} \
+  ios-note{{'f_introduced_28' has been marked as being introduced in iOS 28.0 here, but the deployment target is iOS 27.0}} \
+  tvos-note{{'f_introduced_28' has been marked as being introduced in tvOS 28.0 here, but the deployment target is tvOS 27.0}} \
+  watchos-note{{'f_introduced_28' has been marked as being introduced in watchOS 28.0 here, but the deployment target is watchOS 27.0}} \
+  xros-note{{'f_introduced_28' has been marked as being introduced in visionOS 28.0 here, but the deployment target is visionOS 27.0}} \
+  maccatalyst-note{{'f_introduced_28' has been marked as being introduced in macCatalyst 28.0 here, but the deployment target is macCatalyst 27.0}} \
+  driverkit-note{{'f_introduced_28' has been marked as being introduced in DriverKit 28.0 here, but the deployment target is DriverKit 27.0}}
+
+void f_deprecated_27(void) __attribute__((availability(anyAppleOS, introduced=26.0, deprecated=27.0))); // \
+  macos-note{{'f_deprecated_27' has been explicitly marked deprecated here}} \
+  ios-note{{'f_deprecated_27' has been explicitly marked deprecated here}} \
+  tvos-note{{'f_deprecated_27' has been explicitly marked deprecated here}} \
+  watchos-note{{'f_deprecated_27' has been explicitly marked deprecated here}} \
+  xros-note{{'f_deprecated_27' has been explicitly marked deprecated here}} \
+  maccatalyst-note{{'f_deprecated_27' has been explicitly marked deprecated here}} \
+  driverkit-note{{'f_deprecated_27' has been explicitly marked deprecated here}}
+
+void f_obsoleted_27(void) __attribute__((availability(anyAppleOS, introduced=26.0, obsoleted=27.0))); // \
+  macos-note{{'f_obsoleted_27' has been explicitly marked unavailable here}} \
+  ios-note{{'f_obsoleted_27' has been explicitly marked unavailable here}} \
+  tvos-note{{'f_obsoleted_27' has been explicitly marked unavailable here}} \
+  watchos-note{{'f_obsoleted_27' has been explicitly marked unavailable here}} \
+  xros-note{{'f_obsoleted_27' has been explicitly marked unavailable here}} \
+  maccatalyst-note{{'f_obsoleted_27' has been explicitly marked unavailable here}} \
+  driverkit-note{{'f_obsoleted_27' has been explicitly marked unavailable here}}
+
+void f_deprecated_28(void) __attribute__((availability(anyAppleOS, introduced=26.0, deprecated=28.0)));
+
+void f_obsoleted_28(void) __attribute__((availability(anyAppleOS, introduced=26.0, obsoleted=28.0)));
+
+void f_unavailable(void) __attribute__((availability(anyAppleOS, unavailable))); // \
+  macos-note{{'f_unavailable' has been explicitly marked unavailable here}} \
+  ios-note{{'f_unavailable' has been explicitly marked unavailable here}} \
+  tvos-note{{'f_unavailable' has been explicitly marked unavailable here}} \
+  watchos-note{{'f_unavailable' has been explicitly marked unavailable here}} \
+  xros-note{{'f_unavailable' has been explicitly marked unavailable here}} \
+  maccatalyst-note{{'f_unavailable' has been explicitly marked unavailable here}} \
+  driverkit-note{{'f_unavailable' has been explicitly marked unavailable here}}
+
+void f_introduced_26_tvos28(void) __attribute__((availability(anyAppleOS, introduced=26.0), availability(tvos, introduced=28.0))); // \
+  tvos-note{{'f_introduced_26_tvos28' has been marked as being introduced in tvOS 28.0 here, but the deployment target is tvOS 27.0}}
+
+void f_introduced_tvos28_26(void) __attribute__((availability(tvos, introduced=28.0), availability(anyAppleOS, introduced=26.0))); // \
+  tvos-note{{'f_introduced_tvos28_26' has been marked as being introduced in tvOS 28.0 here, but the deployment target is tvOS 27.0}}
+
+#pragma clang attribute push (__attribute__((availability(tvos, introduced=29.0))), apply_to=function)
+void f_introduced_26_tvos29(void) __attribute__((availability(anyAppleOS, introduced=26.0))); // \
+  tvos-note{{'f_introduced_26_tvos29' has been marked as being introduced in tvOS 29.0 here, but the deployment target is tvOS 27.0}}
+#pragma clang attribute pop
+
+#pragma clang attribute push (__attribute__((availability(anyAppleOS, introduced=26.0), availability(tvos, introduced=29.1))), apply_to=function)
+void f_introduced_26_tvos29_1(void); // \
+  tvos-note{{'f_introduced_26_tvos29_1' has been marked as being introduced in tvOS 29.1 here, but the deployment target is tvOS 27.0}}
+#pragma clang attribute pop
+
+#pragma clang attribute push (__attribute__((availability(anyAppleOS, introduced=26.0))), apply_to=function)
+void f_introduced_26_tvos29_2(void) __attribute__((availability(anyAppleOS, introduced=29.2))); // \
+  macos-note{{'f_introduced_26_tvos29_2' has been marked as being introduced in macOS 29.2 here, but the deployment target is macOS 27.0}} \
+  ios-note{{'f_introduced_26_tvos29_2' has been marked as being introduced in iOS 29.2 here, but the deployment target is iOS 27.0}} \
+  tvos-note{{'f_introduced_26_tvos29_2' has been marked as being introduced in tvOS 29.2 here, but the deployment target is tvOS 27.0}} \
+  watchos-note{{'f_introduced_26_tvos29_2' has been marked as being introduced in watchOS 29.2 here, but the deployment target is watchOS 27.0}} \
+  xros-note{{'f_introduced_26_tvos29_2' has been marked as being introduced in visionOS 29.2 here, but the deployment target is visionOS 27.0}} \
+  maccatalyst-note{{'f_introduced_26_tvos29_2' has been marked as being introduced in macCatalyst 29.2 here, but the deployment target is macCatalyst 27.0}} \
+  driverkit-note{{'f_introduced_26_tvos29_2' has been marked as being introduced in DriverKit 29.2 here, but the deployment target is DriverKit 27.0}}
+#pragma clang attribute pop
+
+void f_introduced_ios26_29(void) __attribute__((availability(ios, introduced=26.0), availability(anyAppleOS, introduced=29.0))); // \
+  macos-note{{'f_introduced_ios26_29' has been marked as being introduced in macOS 29.0 here, but the deployment target is macOS 27.0}} \
+  driverkit-note{{'f_introduced_ios26_29' has been marked as being introduced in DriverKit 29.0 here, but the deployment target is DriverKit 27.0}}
+
+void f_introduced_29_ios26(void) __attribute__((availability(anyAppleOS, introduced=29.0), availability(ios, introduced=26.0))); // \
+  macos-note{{'f_introduced_29_ios26' has been marked as being introduced in macOS 29.0 here, but the deployment target is macOS 27.0}} \
+  driverkit-note{{'f_introduced_29_ios26' has been marked as being introduced in DriverKit 29.0 here, but the deployment target is DriverKit 27.0}}
+
+void f_ios26_unavailable(void) __attribute__((availability(ios, introduced=26.0), availability(anyAppleOS, unavailable))); // \
+  macos-note{{'f_ios26_unavailable' has been explicitly marked unavailable here}} \
+  driverkit-note{{'f_ios26_unavailable' has been explicitly marked unavailable here}}
+
+void test(void) {
+  f_introduced_26();
+
+  // f_introduced_25 has an invalid version so no implicit availability
+  // attribute was created; no diagnostic at the call site.
+  f_introduced_25();
+
+  f_introduced_28(); // \
+    macos-warning{{'f_introduced_28' is only available on macOS 28.0 or newer}} \
+    macos-note{{enclose 'f_introduced_28' in a __builtin_available check to silence this warning}} \
+    ios-warning{{'f_introduced_28' is only available on iOS 28.0 or newer}} \
+    ios-note{{enclose 'f_introduced_28' in a __builtin_available check to silence this warning}} \
+    tvos-warning{{'f_introduced_28' is only available on tvOS 28.0 or newer}} \
+    tvos-note{{enclose 'f_introduced_28' in a __builtin_available check to silence this warning}} \
+    watchos-warning{{'f_introduced_28' is only available on watchOS 28.0 or newer}} \
+    watchos-note{{enclose 'f_introduced_28' in a __builtin_available check to silence this warning}} \
+    xros-warning{{'f_introduced_28' is only available on visionOS 28.0 or newer}} \
+    xros-note{{enclose 'f_introduced_28' in a __builtin_available check to silence this warning}} \
+    maccatalyst-warning{{'f_introduced_28' is only available on macCatalyst 28.0 or newer}} \
+    maccatalyst-note{{enclose 'f_introduced_28' in a __builtin_available check to silence this warning}} \
+    driverkit-warning{{'f_introduced_28' is only available on DriverKit 28.0 or newer}} \
+    driverkit-note{{enclose 'f_introduced_28' in a __builtin_available check to silence this warning}}
+
+  f_deprecated_27(); // \
+    macos-warning{{'f_deprecated_27' is deprecated: first deprecated in macOS 27.0}} \
+    ios-warning{{'f_deprecated_27' is deprecated: first deprecated in iOS 27.0}} \
+    tvos-warning{{'f_deprecated_27' is deprecated: first deprecated in tvOS 27.0}} \
+    watchos-warning{{'f_deprecated_27' is deprecated: first deprecated in watchOS 27.0}} \
+    xros-warning{{'f_deprecated_27' is deprecated: first deprecated in visionOS 27.0}} \
+    maccatalyst-warning{{'f_deprecated_27' is deprecated: first deprecated in macCatalyst 27.0}} \
+    driverkit-warning{{'f_deprecated_27' is deprecated: first deprecated in DriverKit 27.0}}
+
+  f_deprecated_28();
+
+  f_obsoleted_27(); // \
+    macos-error{{'f_obsoleted_27' is unavailable: obsoleted in macOS 27.0}} \
+    ios-error{{'f_obsoleted_27' is unavailable: obsoleted in iOS 27.0}} \
+    tvos-error{{'f_obsoleted_27' is unavailable: obsoleted in tvOS 27.0}} \
+    watchos-error{{'f_obsoleted_27' is unavailable: obsoleted in watchOS 27.0}} \
+    xros-error{{'f_obsoleted_27' is unavailable: obsoleted in visionOS 27.0}} \
+    maccatalyst-error{{'f_obsoleted_27' is unavailable: obsoleted in macCatalyst 27.0}} \
+    driverkit-error{{'f_obsoleted_27' is unavailable: obsoleted in DriverKit 27.0}}
+
+  f_obsoleted_28();
+
+  f_unavailable(); // \
+    macos-error{{'f_unavailable' is unavailable}} \
+    ios-error{{'f_unavailable' is unavailable}} \
+    tvos-error{{'f_unavailable' is unavailable}} \
+    watchos-error{{'f_unavailable' is unavailable}} \
+    xros-error{{'f_unavailable' is unavailable}} \
+    maccatalyst-error{{'f_unavailable' is unavailable}} \
+    driverkit-error{{'f_unavailable' is unavailable}}
+
+  f_introduced_26_tvos28(); // \
+    tvos-warning{{'f_introduced_26_tvos28' is only available on tvOS 28.0 or newer}} \
+    tvos-note{{enclose 'f_introduced_26_tvos28' in a __builtin_available check to silence this warning}}
+
+  f_introduced_tvos28_26(); // \
+    tvos-warning{{'f_introduced_tvos28_26' is only available on tvOS 28.0 or newer}} \
+    tvos-note{{enclose 'f_introduced_tvos28_26' in a __builtin_available check to silence this warning}}
+
+  f_introduced_26_tvos29(); // \
+    tvos-warning{{'f_introduced_26_tvos29' is only available on tvOS 29.0 or newer}} \
+    tvos-note{{enclose 'f_introduced_26_tvos29' in a __builtin_available check to silence this warning}}
+
+  f_introduced_26_tvos29_1(); // \
+    tvos-warning{{'f_introduced_26_tvos29_1' is only available on tvOS 29.1 or newer}} \
+    tvos-note{{enclose 'f_introduced_26_tvos29_1' in a __builtin_available check to silence this warning}}
+
+  f_introduced_26_tvos29_2(); // \
+    macos-warning{{'f_introduced_26_tvos29_2' is only available on macOS 29.2 or newer}} \
+    macos-note{{enclose 'f_introduced_26_tvos29_2' in a __builtin_available check to silence this warning}} \
+    ios-warning{{'f_introduced_26_tvos29_2' is only available on iOS 29.2 or newer}} \
+    ios-note{{enclose 'f_introduced_26_tvos29_2' in a __builtin_available check to silence this warning}} \
+    tvos-warning{{'f_introduced_26_tvos29_2' is only available on tvOS 29.2 or newer}} \
+    tvos-note{{enclose 'f_introduced_26_tvos29_2' in a __builtin_available check to silence this warning}} \
+    watchos-warning{{'f_introduced_26_tvos29_2' is only available on watchOS 29.2 or newer}} \
+    watchos-note{{enclose 'f_introduced_26_tvos29_2' in a __builtin_available check to silence this warning}} \
+    xros-warning{{'f_introduced_26_tvos29_2' is only available on visionOS 29.2 or newer}} \
+    xros-note{{enclose 'f_introduced_26_tvos29_2' in a __builtin_available check to silence this warning}} \
+    maccatalyst-warning{{'f_introduced_26_tvos29_2' is only available on macCatalyst 29.2 or newer}} \
+    maccatalyst-note{{enclose 'f_introduced_26_tvos29_2' in a __builtin_available check to silence this warning}} \
+    driverkit-warning{{'f_introduced_26_tvos29_2' is only available on DriverKit 29.2 or newer}} \
+    driverkit-note{{enclose 'f_introduced_26_tvos29_2' in a __builtin_available check to silence this warning}}
+
+  f_introduced_ios26_29(); // \
+    macos-warning{{'f_introduced_ios26_29' is only available on macOS 29.0 or newer}} \
+    macos-note{{enclose 'f_introduced_ios26_29' in a __builtin_available check to silence this warning}} \
+    driverkit-warning{{'f_introduced_ios26_29' is only available on DriverKit 29.0 or newer}} \
+    driverkit-note{{enclose 'f_introduced_ios26_29' in a __builtin_available check to silence this warning}}
+
+  f_introduced_29_ios26(); // \
+    macos-warning{{'f_introduced_29_ios26' is only available on macOS 29.0 or newer}} \
+    macos-note{{enclose 'f_introduced_29_ios26' in a __builtin_available check to silence this warning}} \
+    driverkit-warning{{'f_introduced_29_ios26' is only available on DriverKit 29.0 or newer}} \
+    driverkit-note{{enclose 'f_introduced_29_ios26' in a __builtin_available check to silence this warning}}
+
+  f_ios26_unavailable(); // \
+    macos-error{{'f_ios26_unavailable' is unavailable: not available on macOS}} \
+    driverkit-error{{'f_ios26_unavailable' is unavailable: not available on DriverKit}}
+}


### PR DESCRIPTION
The number of Apple platforms has grown over the years, resulting in availability annotations becoming increasingly verbose. Now that OS version names have been unified starting with version 26.0, this patch introduces a shorthand syntax that applies availability across all Apple platforms:

```
// Declaration.
void foo __attribute__((availability(anyAppleOS, introduced=26.0)));

// Guard.
if (__builtin_available(anyAppleOS 27.0, *))
```

Implementation:

The `anyAppleOS` platform name is expanded at parse time into implicit platform-specific availability attributes for the target platform. For example, when targeting `macOS`, `anyAppleOS` creates an implicit `macOS` availability attribute with the same version.

A priority system ensures correct attribute merging. Attributes expanded from `anyAppleOS` have lower priority than existing availability attributes:
- Direct platform-specific attributes on declarations
- Platform-specific attributes from #pragma clang attribute push
- Attributes inferred from other platforms

Among `anyAppleOS` attributes themselves, direct `anyAppleOS` annotations have higher priority than `anyAppleOS` applied through `#pragma clang attribute push`.

The minimum supported version for `anyAppleOS` is 26.0. Versions older than 26.0 are rejected with a diagnostic error.

`AvailabilityAttr` gains an `origAnyAppleOSVersion` field that stores the original `anyAppleOS` version when a platform-specific availability attribute is implicitly derived from an `anyAppleOS` annotation. This field is used in `@available`/`__builtin_available` fix-it hints to emit the `anyAppleOS` platform name and version rather than the expanded platform-specific name.

For `__builtin_available` checks, `anyAppleOS` is lowered to platform-specific version checks in CodeGen.

This reduces the burden of adding availability annotations to new APIs in Apple's SDKs and simplifies guards in applications.

rdar://159386357