### PR TITLE
[lldb][windows] deactivate swift tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -812,9 +812,9 @@ def swiftTest(func):
 
         if "i386" == self.getArchitecture():
             return "skipping Swift test because i386 is not a supported architecture"
-        elif not (any(x in sys.platform for x in ["darwin", "linux", "win32"])):
+        elif sys.platform not in ["darwin", "linux"]:
             return (
-                "skipping Swift test because only Darwin, Linux and Windows are supported OSes"
+                "skipping Swift test because only Darwin and Linux are supported OSes"
             )
         else:
             # This configuration is Swift-compatible


### PR DESCRIPTION
The swift lldb tests which were enabled on Windows in https://github.com/swiftlang/llvm-project/pull/12581 are still too flaky. Some of them fail in PR testing with unrelated changes. Deactivate them for now.

rdar://173331287