### PR TITLE
[lldb][NativePDB] Support Swift integral constants

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
@@ -26,6 +26,10 @@
 #include "PdbFPOProgramToDWARFExpression.h"
 #include <optional>
 
+#if LLDB_ENABLE_SWIFT
+#include "swift/Demangling/Demangle.h"
+#endif
+
 using namespace lldb;
 using namespace lldb_private;
 using namespace lldb_private::npdb;
@@ -102,6 +106,47 @@ GetIntegralTypeInfo(TypeIndex ti, TpiStream &tpi) {
       return std::move(err);
     return GetIntegralTypeInfo(er.UnderlyingType, tpi);
   }
+#if LLDB_ENABLE_SWIFT
+  // Swift integral types are structs.
+  case LF_STRUCTURE:
+  case LF_CLASS: {
+    ClassRecord cr;
+    if (auto err = TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr))
+      return std::move(err);
+    if (!cr.hasUniqueName() || !swift::Demangle::isSwiftSymbol(cr.UniqueName))
+      return llvm::make_error<llvm::StringError>(
+          "Class/structure type is not a Swift type",
+          llvm::inconvertibleErrorCode());
+
+    if (cr.isForwardRef()) {
+      auto expected_ti = tpi.findFullDeclForForwardRef(ti);
+      if (!expected_ti)
+        return expected_ti.takeError();
+      CVType resolved_cvt = tpi.getType(*expected_ti);
+      ClassRecord resolved_cr;
+      if (auto err = TypeDeserializer::deserializeAs<ClassRecord>(
+              resolved_cvt, resolved_cr))
+        return std::move(err);
+      cr = std::move(resolved_cr);
+    }
+
+    // Display name is qualified (for example "Swift::Int".
+    llvm::StringRef name = cr.Name;
+    name.consume_front("Swift::");
+
+    // Check against hardcoded allowlists.
+    static constexpr llvm::StringLiteral kSignedIntTypes[] = {
+        "Int", "Int8", "Int16", "Int32", "Int64"};
+    static constexpr llvm::StringLiteral kUnsignedIntTypes[] = {
+        "UInt", "UInt8", "UInt16", "UInt32", "UInt64", "Bool"};
+    if (llvm::is_contained(kSignedIntTypes, name))
+      return std::make_pair(cr.getSize(), true);
+    if (llvm::is_contained(kUnsignedIntTypes, name))
+      return std::make_pair(cr.getSize(), false);
+    return llvm::make_error<llvm::StringError>(
+        "Swift type is not an integral type", llvm::inconvertibleErrorCode());
+  }
+#endif
   default:
     return llvm::make_error<llvm::StringError>("Type is not integral",
                                                llvm::inconvertibleErrorCode());

--- a/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/DWARFLocationExpression.cpp
@@ -26,9 +26,11 @@
 #include "PdbFPOProgramToDWARFExpression.h"
 #include <optional>
 
+// BEGIN SWIFT
 #if LLDB_ENABLE_SWIFT
 #include "swift/Demangling/Demangle.h"
-#endif
+#endif // LLDB_ENABLE_SWIFT
+// END SWIFT
 
 using namespace lldb;
 using namespace lldb_private;
@@ -106,6 +108,7 @@ GetIntegralTypeInfo(TypeIndex ti, TpiStream &tpi) {
       return std::move(err);
     return GetIntegralTypeInfo(er.UnderlyingType, tpi);
   }
+// BEGIN SWIFT
 #if LLDB_ENABLE_SWIFT
   // Swift integral types are structs.
   case LF_STRUCTURE:
@@ -146,7 +149,8 @@ GetIntegralTypeInfo(TypeIndex ti, TpiStream &tpi) {
     return llvm::make_error<llvm::StringError>(
         "Swift type is not an integral type", llvm::inconvertibleErrorCode());
   }
-#endif
+#endif // LLDB_ENABLE_SWIFT
+// END SWIFT
   default:
     return llvm::make_error<llvm::StringError>("Type is not integral",
                                                llvm::inconvertibleErrorCode());

--- a/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
@@ -28,14 +28,20 @@ func main() {
     var myString: String = "hello"
     var myPoint: Point = Point(x: 10, y: 20)
     var myDirection: Direction = .north
+    let constInt: Int = 100
+    let constInt8: Int8 = -42
+    let constUInt16: UInt16 = 1000
+    let constBool: Bool = false
+    let constString: String = "world"
     print(myInt32, myBool, myUInt64, myFloat, myDouble,
-          myString, myPoint, myDirection)
+          myString, myPoint, myDirection,
+          constInt, constInt8, constUInt16, constBool, constString)
 }
 
 main()
 
 #--- commands.input
-b main.swift:20
+b main.swift:25
 run
 frame variable
 
@@ -49,3 +55,9 @@ frame variable
 # CHECK: (String) myString = "hello"
 # CHECK: (main.Point) myPoint = (x = 10, y = 20)
 # CHECK: (main.Direction) myDirection = north
+# Local constants
+# CHECK: (Int) constInt = 100
+# CHECK: (Int8) constInt8 = -42
+# CHECK: (UInt16) constUInt16 = 1000
+# CHECK: (Bool) constBool = false
+# CHECK: (String) constString = "world"


### PR DESCRIPTION
CodeView expects integral constants to be simple types, but they are structs in Swift. This change adds an arm to the code that calculates size and signedness to look at structs as well, and checks the display name against an allowlist to determine signedness.