### PR TITLE
[lldb][swift] Fix deadlock when loading frameworks

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -9994,9 +9994,14 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     std::vector<SourceModule> cu_imports = compile_unit->GetImportedModules();
     LOG_PRINTF(GetLog(LLDBLog::Types), "Importing dependencies of current CU");
 
-    ThreadSafeASTContext ast = GetASTContext();
-    if (!ast)
-      return llvm::createStringError("invalid swift AST (nullptr)");
+    {
+      // Check if the AST is valid. We cannot hold the lock beyond this point
+      // as the code below might trigger the loading of libraries, which then
+      // in turn will try to access this AST to register themselves.
+      ThreadSafeASTContext ast = GetASTContext();
+      if (!ast)
+        return llvm::createStringError("invalid swift AST (nullptr)");
+    }
 
     std::string category = "Importing dependencies for ";
     category += compile_unit->GetPrimaryFile().GetFilename().GetString();

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -17,7 +17,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
     # This causes DoLoadImage() to allocate memory while the process is still
     # running, which fails and leaves the process in a bad state, ultimately
     # timing out with "didn't get any event after resume".
-    @expectedFailureAll(setting=("symbols.use-swift-clangimporter", "false"))
+    @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     def test(self):
         """Test that a framework that is registered as autolinked in a Swift
            module used in the target, but not linked against the target is

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -12,7 +12,6 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
-    @skipIf(bugnumber="rdar://171278439") # randomly fails to dlopen in CI
     # FIXME: Without the ClangImporter, transitive module dependencies can't be
     # fully resolved, so collectLinkLibraries() misses autolinked frameworks.
     # This causes DoLoadImage() to allocate memory while the process is still


### PR DESCRIPTION
Starting with commit `f9824a0c5db94408e965dc0789ae422d37341976`, `SwiftASTContext::GetCompileUnitImportsImpl` started holding the AST lock while importing dependencies.

Unfortunately, the `LoadOneModule` call we do in the same function can call back into the same ASTContext via a different thread, which would (in theory) deadlock LLDB.

In practice the deadlock manifests as a long delay and a failed import as `LoadOneModule` ends up calling `dlopen` via the function caller, and this `dlopen` call is guarded with a timeout. Once the timeout resolves, we simply fail loading the module and the callback from the loaded image resolves. The specific deadlock happens with the following backtraces:

```
 Thread #1 (main) holds the SwiftASTContext recursive mutex
 SwiftASTContext::GetCompileUnitImportsImpl  -- holds recursive_mutex
  → LoadOneModule ("_StringProcessing")
   → SwiftASTContext::LoadModule
    → SwiftASTContext::LoadLibraryUsingPaths
     → PlatformPOSIX::DoLoadImage
      → FunctionCaller::ExecuteFunction
       → Process::RunThreadPlan
        → Process::Halt
         → WaitForProcessToStop -- waiting for callback on thread #18

 Thread #18 (internal-state) needs the same mutex, waiting for #1:
 Process::HandlePrivateEvent
  → BreakpointLocation::ShouldStop   -- processing dyld breakpoint
   → DynamicLoaderMacOS::NotifyBreakpointHit
    → DynamicLoaderDarwin::AddModulesUsingPreloadedModules
     → Target::ModulesDidLoad
      → TypeSystemSwiftTypeRefForExpressions::ModulesDidLoad
       → SwiftASTContextForExpressions::ModulesDidLoad
        → RegisterSectionModules
         → SwiftASTContext::GetASTContext -- BLOCKED by thread #1
```

In other words, we see the following set of events:

1. `GetCompileUnitImportsImpl` is called and sets the lock.
2. `LoadOneModule` is called.
3. `LoadOneModule` calls `dlopen` to load the dylib.
4. The loaded dylib triggers a callback (on a different thread) to register the loaded module.
5. This callback also tries to set the lock and we are now stuck.
6. Eventually the dlopen call timeout is reached, and the original thread is released and everything gets unstuck (and a bunch of errors are triggered).

This patch just shortens the lock duration to fix the deadlock. The long-term fix for this should be that registering logic should not actually *need* the lock, but just queue up what needs to be registered.