### PR TITLE
[LLDB] Turn of implicit modules during type reconstruction

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5303,6 +5303,8 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
   LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- not cached, searching",
              mangled_cstr);
 
+  // Avoid type reconstruction compiling additional implicit modules.
+  DisableImplicitImportsRAII no_imports(*this);
   found_type = swift::Demangle::getTypeForMangling(
                    **ast_ctx, mangled_typename.GetStringRef())
                    .getPointer();

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Dylib.swift
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Dylib.swift
@@ -1,0 +1,9 @@
+public protocol MyProtocol {}
+
+private struct PrivateImpl: MyProtocol {
+  var value: Int
+}
+
+public func makeInstance() -> some MyProtocol {
+  return PrivateImpl(value: 42)
+}

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Makefile
@@ -1,0 +1,22 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_EXPLICIT_MODULES := YES
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+LD_EXTRAS = -L$(BUILDDIR) -lDylib
+
+all: Dylib $(EXE)
+
+include Makefile.rules
+
+.PHONY: Dylib
+Dylib:
+	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(THIS_FILE_DIR)/Makefile.rules \
+		DYLIB_SWIFT_SOURCES=Dylib.swift \
+		DYLIB_NAME=Dylib \
+		DYLIB_ONLY=YES \
+		SWIFT_ENABLE_EXPLICIT_MODULES=YES \
+		SWIFT_SOURCES= \
+		LD_EXTRAS= \
+		all

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    @skipIfWindows
+    def test(self):
+        """Test frame variable of a generic struct specialized to a
+        private type from another explicitly-built module."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"),
+            extra_images=["Dylib"])
+        log = self.getBuildArtifact("types.log")
+        self.expect('log enable lldb types symbols -f "%s"' % log)
+        self.expect("expr -d run -- s", error=True)
+        # FIXME: Expression shouldn't depend on all local variables.
+        self.expect("expression 1+1", error=True)
+        self.filecheck_log(log, __file__)
+        # CHECK: Turning off implicit modules
+        # CHECK: ReconstructType
+        # CHECK: Turning on implicit modules

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/main.swift
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/main.swift
@@ -1,0 +1,12 @@
+import Dylib
+
+struct GenericStruct<T: MyProtocol> {
+  let t: T
+}
+
+func main() {
+  let s = GenericStruct(t: makeInstance())
+  print(s) // break here
+}
+
+main()


### PR DESCRIPTION
In an EBM context, implicit modules are turned off during the contextual imports. They should also be off during type reconstruction, since that may also trigger the import of additional modules, which would lead to unexpected performance cliffs.

This is controllable via the same setting to allow implicit imports.

rdar://173397549