### PR TITLE
Add missing LLVM_ABI annotations

### DIFF
--- a/llvm/include/llvm/CAS/ActionCache.h
+++ b/llvm/include/llvm/CAS/ActionCache.h
@@ -72,8 +72,8 @@ public:
   }
 
   /// Asynchronous version of \c get.
-  std::future<AsyncCASIDValue> getFuture(const CacheKey &ActionKey,
-                                         bool Globally = false) const;
+  LLVM_ABI std::future<AsyncCASIDValue> getFuture(const CacheKey &ActionKey,
+                                                  bool Globally = false) const;
 
   /// Asynchronous version of \c get.
   void getAsync(const CacheKey &ActionKey, bool Globally,
@@ -97,9 +97,9 @@ public:
   }
 
   /// Asynchronous version of \c put.
-  std::future<AsyncErrorValue> putFuture(const CacheKey &ActionKey,
-                                         const CASID &Result,
-                                         bool Globally = false);
+  LLVM_ABI std::future<AsyncErrorValue> putFuture(const CacheKey &ActionKey,
+                                                  const CASID &Result,
+                                                  bool Globally = false);
 
   /// Asynchronous version of \c put.
   /// \param[out] CancelObj Optional pointer to receive a cancellation object.

--- a/llvm/include/llvm/CAS/BuiltinObjectHasher.h
+++ b/llvm/include/llvm/CAS/BuiltinObjectHasher.h
@@ -40,7 +40,7 @@ public:
     return H.finish();
   }
 
-  static Expected<HashT> hashFile(StringRef FilePath);
+  LLVM_ABI static Expected<HashT> hashFile(StringRef FilePath);
 
 private:
   HashT finish() { return Hasher.final(); }

--- a/llvm/include/llvm/CAS/CASConfiguration.h
+++ b/llvm/include/llvm/CAS/CASConfiguration.h
@@ -58,10 +58,10 @@ public:
   createDatabases() const;
 
   /// Write CAS configuration file.
-  void writeConfigurationFile(raw_ostream &OS) const;
+  LLVM_ABI void writeConfigurationFile(raw_ostream &OS) const;
 
   /// Create CASConfiguration from config file content.
-  static llvm::Expected<CASConfiguration>
+  LLVM_ABI static llvm::Expected<CASConfiguration>
   createFromConfig(llvm::StringRef Content);
 
   /// Create CASConfiguration from recurively search config file from a path.
@@ -75,7 +75,7 @@ public:
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS = nullptr);
 
   /// Get resolved CASPath.
-  Error getResolvedCASPath(llvm::SmallVectorImpl<char> &Result) const;
+  LLVM_ABI Error getResolvedCASPath(llvm::SmallVectorImpl<char> &Result) const;
 
   /// DenseMap support \{
   static cas::CASConfiguration getDenseMapEmptyKey() { return {}; }

--- a/llvm/include/llvm/CAS/CASFSBuilder.h
+++ b/llvm/include/llvm/CAS/CASFSBuilder.h
@@ -23,26 +23,26 @@ class CachingOnDiskFileSystem;
 class CASFSBuilder {
 public:
   /// \param Prefix maps used for file system ingestion.
-  explicit CASFSBuilder(ObjectStore &DB,
-                        ArrayRef<MappedPrefix> PrefixMaps = {});
+  LLVM_ABI explicit CASFSBuilder(ObjectStore &DB,
+                                 ArrayRef<MappedPrefix> PrefixMaps = {});
 
-  ~CASFSBuilder();
+  LLVM_ABI ~CASFSBuilder();
 
   /// Ingest contents from the on-disk file-system. Symlinks are not followed.
   /// Emits an error if the path doesn't exist.
   ///
   /// \param Recursive if true, and path is a directory, its contents will be
   /// ingested recursively, otherwise only the path will be included.
-  Error ingestFileSystemPath(const Twine &Path, bool Recursive = true);
+  LLVM_ABI Error ingestFileSystemPath(const Twine &Path, bool Recursive = true);
 
   /// Merge a prior constructed CAS file-system tree root.
   ///
   /// \param Path the path to place the root at; can be empty.
-  void mergeCASFSRoot(ObjectRef Root, const Twine &Path = "");
+  LLVM_ABI void mergeCASFSRoot(ObjectRef Root, const Twine &Path = "");
 
   /// Produce the merged CAS file-system tree root. \c CASFSBuilder should not
   /// be used after calling this.
-  Expected<ObjectProxy> finish();
+  LLVM_ABI Expected<ObjectProxy> finish();
 
 private:
   ObjectStore &DB;

--- a/llvm/include/llvm/CAS/CASFileSystem.h
+++ b/llvm/include/llvm/CAS/CASFileSystem.h
@@ -36,7 +36,8 @@ public:
   /// open the file twice.
   /// The IsText parameter is used to distinguish whether the file should be
   /// opened as a binary or text file.
-  llvm::Expected<std::pair<std::unique_ptr<llvm::MemoryBuffer>, cas::ObjectRef>>
+  LLVM_ABI llvm::Expected<
+      std::pair<std::unique_ptr<llvm::MemoryBuffer>, cas::ObjectRef>>
   getBufferAndObjectRefForFile(const Twine &Name, int64_t FileSize = -1,
                                bool RequiresNullTerminator = true,
                                bool IsVolatile = false, bool IsText = true);

--- a/llvm/include/llvm/CAS/HashMappedTrie.h
+++ b/llvm/include/llvm/CAS/HashMappedTrie.h
@@ -52,7 +52,7 @@ public:
   static constexpr size_t DefaultNumSubtrieBits = 4;
 
   LLVM_DUMP_METHOD void dump() const;
-  void print(raw_ostream &OS) const;
+  LLVM_ABI void print(raw_ostream &OS) const;
 
 protected:
   /// Result of a lookup. Suitable for an insertion hint. Maybe could be
@@ -82,27 +82,27 @@ protected:
     unsigned B = 0;
   };
 
-  PointerBase find(ArrayRef<uint8_t> Hash) const;
+  LLVM_ABI PointerBase find(ArrayRef<uint8_t> Hash) const;
 
   /// Insert and return the stored content.
-  PointerBase
+  LLVM_ABI PointerBase
   insert(PointerBase Hint, ArrayRef<uint8_t> Hash,
          function_ref<const uint8_t *(void *Mem, ArrayRef<uint8_t> Hash)>
              Constructor);
 
   ThreadSafeHashMappedTrieBase() = delete;
 
-  ThreadSafeHashMappedTrieBase(size_t ContentAllocSize,
-                               size_t ContentAllocAlign, size_t ContentOffset,
-                               std::optional<size_t> NumRootBits = std::nullopt,
-                               std::optional<size_t> NumSubtrieBits = std::nullopt);
+  LLVM_ABI ThreadSafeHashMappedTrieBase(
+      size_t ContentAllocSize, size_t ContentAllocAlign, size_t ContentOffset,
+      std::optional<size_t> NumRootBits = std::nullopt,
+      std::optional<size_t> NumSubtrieBits = std::nullopt);
 
   /// Destructor, which asserts if there's anything to do. Subclasses should
   /// call \a destroyImpl().
   ///
   /// \pre \a destroyImpl() was already called.
-  ~ThreadSafeHashMappedTrieBase();
-  void destroyImpl(function_ref<void (void *ValueMem)> Destructor);
+  LLVM_ABI ~ThreadSafeHashMappedTrieBase();
+  LLVM_ABI void destroyImpl(function_ref<void (void *ValueMem)> Destructor);
 
   ThreadSafeHashMappedTrieBase(ThreadSafeHashMappedTrieBase &&RHS);
 

--- a/llvm/include/llvm/CAS/HierarchicalTreeBuilder.h
+++ b/llvm/include/llvm/CAS/HierarchicalTreeBuilder.h
@@ -78,7 +78,7 @@ public:
   ///   * Calling push() for every non-tree
   ///
   /// Allows merging the contents of multiple directories.
-  void pushTreeContent(ObjectRef Ref, const Twine &Path);
+  LLVM_ABI void pushTreeContent(ObjectRef Ref, const Twine &Path);
 
   /// Drop all entries.
   void clear() { Entries.clear(); }

--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -455,7 +455,8 @@ LLVM_ABI llvm::Expected<std::string> getDefaultOnDiskCASPath();
 /// on-disk directory that the plugin should use, otherwise the default
 /// OnDiskCAS location will be used.
 /// FIXME: Need to implement proper URL encoding scheme that allows "%".
-Expected<std::shared_ptr<ObjectStore>> createCASFromIdentifier(StringRef Path);
+LLVM_ABI Expected<std::shared_ptr<ObjectStore>>
+createCASFromIdentifier(StringRef Path);
 
 /// Register a URL scheme to CAS Identifier.
 using ObjectStoreCreateFuncTy =

--- a/llvm/include/llvm/CAS/OnDiskCASLogger.h
+++ b/llvm/include/llvm/CAS/OnDiskCASLogger.h
@@ -30,8 +30,8 @@ public:
   /// \param Path The parent directory of the log file.
   /// \param LogAllocations Whether to log all low-level allocations. This is
   ///                       on the order of twice as expensive to log.
-  static Expected<std::unique_ptr<OnDiskCASLogger>> open(const Twine &Path,
-                                                         bool LogAllocations);
+  LLVM_ABI static Expected<std::unique_ptr<OnDiskCASLogger>>
+  open(const Twine &Path, bool LogAllocations);
 
   /// Create or append to a log file inside the given CAS directory \p Path if
   /// logging is enabled by the environment variable \c LLVM_CAS_LOG. If
@@ -39,37 +39,43 @@ public:
   static Expected<std::unique_ptr<OnDiskCASLogger>>
   openIfEnabled(const Twine &Path);
 
-  ~OnDiskCASLogger();
+  LLVM_ABI ~OnDiskCASLogger();
 
   /// An offset into an \c OnDiskHashMappedTrie.
   using TrieOffset = int64_t;
 
-  void log_compare_exchange_strong(void *Region, TrieOffset Trie, size_t SlotI,
-                                   TrieOffset Expected, TrieOffset New,
-                                   TrieOffset Previous);
-  void log_SubtrieHandle_create(void *Region, TrieOffset Trie,
-                                uint32_t StartBit, uint32_t NumBits);
-  void log_HashMappedTrieHandle_createRecord(void *Region,
-                                             TrieOffset TrieOffset,
-                                             ArrayRef<uint8_t> Hash);
-  void log_MappedFileRegionBumpPtr_resizeFile(StringRef Path, size_t Before,
-                                              size_t After);
-  void log_MappedFileRegionBumpPtr_create(StringRef Path, int FD, void *Region,
-                                          size_t Capacity, size_t Size);
-  void log_MappedFileRegionBumpPtr_oom(StringRef Path, size_t Capacity,
-                                       size_t Size, size_t AllocSize);
-  void log_MappedFileRegionBumpPtr_close(StringRef Path);
-  void log_MappedFileRegionBumpPtr_allocate(void *Region, TrieOffset Off,
-                                            size_t Size);
-  void log_UnifiedOnDiskCache_collectGarbage(StringRef Path);
-  void log_UnifiedOnDiskCache_validateIfNeeded(
+  LLVM_ABI void log_compare_exchange_strong(void *Region, TrieOffset Trie,
+                                            size_t SlotI, TrieOffset Expected,
+                                            TrieOffset New,
+                                            TrieOffset Previous);
+  LLVM_ABI void log_SubtrieHandle_create(void *Region, TrieOffset Trie,
+                                         uint32_t StartBit, uint32_t NumBits);
+  LLVM_ABI void log_HashMappedTrieHandle_createRecord(void *Region,
+                                                      TrieOffset TrieOffset,
+                                                      ArrayRef<uint8_t> Hash);
+  LLVM_ABI void log_MappedFileRegionBumpPtr_resizeFile(StringRef Path,
+                                                       size_t Before,
+                                                       size_t After);
+  LLVM_ABI void log_MappedFileRegionBumpPtr_create(StringRef Path, int FD,
+                                                   void *Region,
+                                                   size_t Capacity,
+                                                   size_t Size);
+  LLVM_ABI void log_MappedFileRegionBumpPtr_oom(StringRef Path, size_t Capacity,
+                                                size_t Size, size_t AllocSize);
+  LLVM_ABI void log_MappedFileRegionBumpPtr_close(StringRef Path);
+  LLVM_ABI void log_MappedFileRegionBumpPtr_allocate(void *Region,
+                                                     TrieOffset Off,
+                                                     size_t Size);
+  LLVM_ABI void log_UnifiedOnDiskCache_collectGarbage(StringRef Path);
+  LLVM_ABI void log_UnifiedOnDiskCache_validateIfNeeded(
       StringRef Path, uint64_t BootTime, uint64_t ValidationTime,
       bool CheckHash, bool AllowRecovery, bool Force,
       std::optional<StringRef> LLVMCas, StringRef ValidationError, bool Skipped,
       bool Recovered);
-  void log_TempFile_create(StringRef Name);
-  void log_TempFile_keep(StringRef TmpName, StringRef Name, std::error_code EC);
-  void log_TempFile_remove(StringRef TmpName, std::error_code EC);
+  LLVM_ABI void log_TempFile_create(StringRef Name);
+  LLVM_ABI void log_TempFile_keep(StringRef TmpName, StringRef Name,
+                                  std::error_code EC);
+  LLVM_ABI void log_TempFile_remove(StringRef TmpName, std::error_code EC);
 
 private:
   OnDiskCASLogger(raw_fd_ostream &OS, bool LogAllocations);

--- a/llvm/include/llvm/CAS/OnDiskGraphDB.h
+++ b/llvm/include/llvm/CAS/OnDiskGraphDB.h
@@ -341,7 +341,8 @@ public:
   /// loading the data in memory and then writing it to a file, the client could
   /// clone the underlying file directly. The client *must not* write to or
   /// delete the underlying file, the path is provided only for reading/copying.
-  FileBackedData getInternalFileBackedObjectData(ObjectHandle Node) const;
+  LLVM_ABI_FOR_TEST FileBackedData
+  getInternalFileBackedObjectData(ObjectHandle Node) const;
 
   /// \returns Total size of stored objects.
   ///

--- a/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
+++ b/llvm/include/llvm/CAS/OnDiskHashMappedTrie.h
@@ -181,7 +181,7 @@ public:
     return pointer(CP.getOffset(), V);
   }
 
-  const_pointer find(ArrayRef<uint8_t> Hash) const;
+  LLVM_ABI const_pointer find(ArrayRef<uint8_t> Hash) const;
   pointer find(ArrayRef<uint8_t> Hash) {
     return getMutablePointer(
         const_cast<const OnDiskHashMappedTrie *>(this)->find(Hash));
@@ -194,7 +194,7 @@ public:
             HashBegin));
   }
 
-  const_pointer recoverFromFileOffset(FileOffset Offset) const;
+  LLVM_ABI const_pointer recoverFromFileOffset(FileOffset Offset) const;
   pointer recoverFromFileOffset(FileOffset Offset) {
     return getMutablePointer(
         const_cast<const OnDiskHashMappedTrie *>(this)->recoverFromFileOffset(
@@ -221,9 +221,10 @@ public:
   /// The in-memory \a HashMappedTrie uses LazyAtomicPointer to synchronize
   /// simultaneous writes, but that seems dangerous to use in a memory-mapped
   /// file in case a process crashes in the busy state.
-  Expected<pointer> insertLazy(ArrayRef<uint8_t> Hash,
-                               LazyInsertOnConstructCB OnConstruct = nullptr,
-                               LazyInsertOnLeakCB OnLeak = nullptr);
+  LLVM_ABI Expected<pointer>
+  insertLazy(ArrayRef<uint8_t> Hash,
+             LazyInsertOnConstructCB OnConstruct = nullptr,
+             LazyInsertOnLeakCB OnLeak = nullptr);
 
   Expected<pointer> insert(const ConstValueProxy &Value) {
     return insertLazy(Value.Hash, [&](FileOffset, ValueProxy Allocated) {
@@ -253,7 +254,7 @@ public:
   /// adding more tables to a single file.
   ///
   /// FIXME: Rename to getOrCreate().
-  static Expected<OnDiskHashMappedTrie>
+  LLVM_ABI static Expected<OnDiskHashMappedTrie>
   create(const Twine &Path, const Twine &TrieName, size_t NumHashBits,
          uint64_t DataSize, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
@@ -261,9 +262,9 @@ public:
          std::optional<size_t> NewTableNumRootBits = std::nullopt,
          std::optional<size_t> NewTableNumSubtrieBits = std::nullopt);
 
-  OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS);
-  OnDiskHashMappedTrie &operator=(OnDiskHashMappedTrie &&RHS);
-  ~OnDiskHashMappedTrie();
+  LLVM_ABI OnDiskHashMappedTrie(OnDiskHashMappedTrie &&RHS);
+  LLVM_ABI OnDiskHashMappedTrie &operator=(OnDiskHashMappedTrie &&RHS);
+  LLVM_ABI ~OnDiskHashMappedTrie();
 
 private:
   struct ImplType;
@@ -329,7 +330,7 @@ public:
   size_t size() const;
   size_t capacity() const;
 
-  static Expected<OnDiskDataAllocator>
+  LLVM_ABI static Expected<OnDiskDataAllocator>
   create(const Twine &Path, const Twine &TableName, uint64_t MaxFileSize,
          std::optional<uint64_t> NewFileInitialSize,
          uint32_t UserHeaderSize = 0,

--- a/llvm/include/llvm/CAS/TreeSchema.h
+++ b/llvm/include/llvm/CAS/TreeSchema.h
@@ -69,8 +69,8 @@ private:
 
 class TreeProxy : public ObjectProxy {
 public:
-  static Expected<TreeProxy> get(const TreeSchema &Schema,
-                                     Expected<ObjectProxy> Ref);
+  LLVM_ABI static Expected<TreeProxy> get(const TreeSchema &Schema,
+                                          Expected<ObjectProxy> Ref);
 
   static Expected<TreeProxy> create(TreeSchema &Schema,
                                         ArrayRef<NamedTreeEntry> Entries);

--- a/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
+++ b/llvm/include/llvm/CAS/UnifiedOnDiskCache.h
@@ -52,7 +52,7 @@ public:
   ///
   /// \returns the \p ObjectID associated with the \p Key. It may be different
   /// than \p Value if another value was already associated with this key.
-  Expected<ObjectID> KVPut(ArrayRef<uint8_t> Key, ObjectID Value);
+  LLVM_ABI Expected<ObjectID> KVPut(ArrayRef<uint8_t> Key, ObjectID Value);
 
   /// Associate an \p ObjectID, of the \p OnDiskGraphDB instance, with a key.
   /// An \p ObjectID as a key is equivalent to its digest bytes.
@@ -62,11 +62,11 @@ public:
   ///
   /// \returns the \p ObjectID associated with the \p Key. It may be different
   /// than \p Value if another value was already associated with this key.
-  Expected<ObjectID> KVPut(ObjectID Key, ObjectID Value);
+  LLVM_ABI Expected<ObjectID> KVPut(ObjectID Key, ObjectID Value);
 
   /// \returns the \p ObjectID, of the \p OnDiskGraphDB instance, associated
   /// with the \p Key, or \p std::nullopt if the key does not exist.
-  Expected<std::optional<ObjectID>> KVGet(ArrayRef<uint8_t> Key);
+  LLVM_ABI Expected<std::optional<ObjectID>> KVGet(ArrayRef<uint8_t> Key);
 
   /// Open a \p UnifiedOnDiskCache instance for a directory.
   ///
@@ -109,7 +109,7 @@ public:
   /// was invalid but has been cleared, \c Skipped if validation is not needed,
   /// or an \c Error if validation cannot be performed or if the data is left
   /// in an invalid state because \p AllowRecovery is false.
-  static Expected<ValidationResult>
+  LLVM_ABI_FOR_TEST static Expected<ValidationResult>
   validateIfNeeded(StringRef Path, StringRef HashName, unsigned HashByteSize,
                    bool CheckHash, OnDiskGraphDB::HashingFuncT HashFn,
                    bool AllowRecovery, bool ForceValidation,
@@ -153,11 +153,11 @@ public:
   LLVM_ABI_FOR_TEST static Error
   collectGarbage(StringRef Path, ondisk::OnDiskCASLogger *Logger = nullptr);
 
-  Error collectGarbage();
+  LLVM_ABI_FOR_TEST Error collectGarbage();
 
   LLVM_ABI_FOR_TEST ~UnifiedOnDiskCache();
 
-  Error validateActionCache();
+  LLVM_ABI_FOR_TEST Error validateActionCache();
 
   OnDiskGraphDB *getUpstreamGraphDB() const { return UpstreamGraphDB; }
 

--- a/llvm/include/llvm/CASUtil/Utils.h
+++ b/llvm/include/llvm/CASUtil/Utils.h
@@ -20,8 +20,8 @@ namespace cas {
 class ObjectStore;
 class CASID;
 
-Expected<CASID> readCASIDBuffer(cas::ObjectStore &CAS,
-                                llvm::MemoryBufferRef Buffer);
+LLVM_ABI Expected<CASID> readCASIDBuffer(cas::ObjectStore &CAS,
+                                         llvm::MemoryBufferRef Buffer);
 
 LLVM_ABI void writeCASIDBuffer(const CASID &ID, llvm::raw_ostream &OS);
 
@@ -33,7 +33,7 @@ LLVM_ABI void writeCASIDBuffer(const CASID &ID, llvm::raw_ostream &OS);
 /// * Null-terminated hash schema name, e.g. llvm.builtin.v2[BLAKE3]
 /// * Hash length (4 bytes little-endian, e.g. 32)
 /// * Hash bytes
-Error writeCASHashXAttr(const CASID &ID, const llvm::Twine &Path);
+LLVM_ABI Error writeCASHashXAttr(const CASID &ID, const llvm::Twine &Path);
 
 } // namespace cas
 

--- a/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
+++ b/llvm/include/llvm/LTO/legacy/ThinLTOCodeGenerator.h
@@ -253,7 +253,7 @@ public:
 
   /// Set the path to a directory where to save temporaries from the remote
   /// service.
-  void setRemoteServiceTempsDir(std::string Path);
+  LLVM_ABI void setRemoteServiceTempsDir(std::string Path);
 
   /// Set the path to a directory where to save generated object files. This
   /// path can be used by a linker to request on-disk files instead of in-memory

--- a/llvm/include/llvm/MCCAS/MCCASObjectV1.h
+++ b/llvm/include/llvm/MCCAS/MCCASObjectV1.h
@@ -194,9 +194,9 @@ class MCCASReader;
 // FIXME: Using the same structure from ObjectV1 from CASObjectFormat.
 class MCObjectProxy : public cas::ObjectProxy {
 public:
-  static Expected<MCObjectProxy> get(const MCSchema &Schema,
-                                     Expected<cas::ObjectProxy> Ref);
-  StringRef getKindString() const;
+  LLVM_ABI static Expected<MCObjectProxy> get(const MCSchema &Schema,
+                                              Expected<cas::ObjectProxy> Ref);
+  LLVM_ABI StringRef getKindString() const;
 
   /// Return the data skipping the type-id character.
   StringRef getData() const { return cas::ObjectProxy::getData().drop_front(); }
@@ -213,7 +213,7 @@ public:
                                 SmallVectorImpl<char> &Data,
                                 SmallVectorImpl<cas::ObjectRef> &IDs);
 
-  static Expected<SmallVector<cas::ObjectRef>>
+  LLVM_ABI static Expected<SmallVector<cas::ObjectRef>>
   decodeReferences(const MCObjectProxy &Node, StringRef &Remaining);
 
 protected:
@@ -371,14 +371,14 @@ protected:
     static Expected<RefName> get(const MCSchema &Schema, cas::ObjectRef ID) {  \
       return get(Schema.get(ID));                                              \
     }                                                                          \
-    static std::optional<RefName> Cast(MCObjectProxy Ref) {                         \
+    static std::optional<RefName> Cast(MCObjectProxy Ref) {                    \
       auto Specific = SpecificRefT::Cast(Ref);                                 \
       if (!Specific)                                                           \
         return std::nullopt;                                                   \
       return RefName(*Specific);                                               \
     }                                                                          \
-    Expected<uint64_t> materialize(MCCASReader &Reader,                        \
-                                   raw_ostream *Stream = nullptr) const;       \
+    LLVM_ABI Expected<uint64_t>                                                \
+    materialize(MCCASReader &Reader, raw_ostream *Stream = nullptr) const;     \
                                                                                \
   private:                                                                     \
     explicit RefName(SpecificRefT Ref) : SpecificRefT(Ref) {}                  \
@@ -683,7 +683,8 @@ public:
   /// copy the Fragment contents into the section buffer.
   uint64_t AddendBufferIndex = 0;
 
-  MCCASReader(raw_ostream &OS, const Triple &Target, const MCSchema &Schema);
+  LLVM_ABI MCCASReader(raw_ostream &OS, const Triple &Target,
+                       const MCSchema &Schema);
   endianness getEndian() {
     return Target.isLittleEndian() ? endianness::little : endianness::big;
   }
@@ -795,7 +796,7 @@ Expected<SmallVector<RefTy>> loadAllRefs(MCObjectProxy Obj) {
 /// HadChildren is provided to indicate whether this Tag had children DIE.
 /// * NewBlockCallback is called to indicate that data from a new CAS block is
 /// about to be read.
-Error visitDebugInfo(
+LLVM_ABI Error visitDebugInfo(
     SmallVectorImpl<StringRef> &TotAbbrevEntries,
     Expected<DIETopLevelRef> TopLevelRef,
     std::function<void(StringRef)> HeaderCallback,
@@ -807,7 +808,7 @@ Error visitDebugInfo(
     std::function<void(StringRef)> NewBlockCallback = [](StringRef) {});
 
 /// If MCCAS supports the target.
-bool isSupportedTarget(Triple Triple);
+LLVM_ABI bool isSupportedTarget(Triple Triple);
 
 } // namespace v1
 } // namespace mccasformats

--- a/llvm/include/llvm/RemoteCachingService/RemoteCachingService.h
+++ b/llvm/include/llvm/RemoteCachingService/RemoteCachingService.h
@@ -22,7 +22,7 @@ Expected<std::unique_ptr<ActionCache>> createGRPCActionCache(StringRef Path);
 // Register GRPC CAS.
 class RegisterGRPCCAS {
 public:
-  RegisterGRPCCAS();
+  LLVM_ABI RegisterGRPCCAS();
 };
 
 } // namespace llvm::cas

--- a/llvm/include/llvm/Support/PrefixMapper.h
+++ b/llvm/include/llvm/Support/PrefixMapper.h
@@ -42,12 +42,14 @@ struct MappedPrefix {
   LLVM_ABI static std::optional<MappedPrefix>
   getFromJoined(StringRef JoinedMapping);
 
-  static Error transformJoined(ArrayRef<StringRef> Joined,
-                               SmallVectorImpl<MappedPrefix> &Split);
-  static Error transformJoined(ArrayRef<std::string> Joined,
-                               SmallVectorImpl<MappedPrefix> &Split);
-  static void transformJoinedIfValid(ArrayRef<StringRef> Joined,
-                                     SmallVectorImpl<MappedPrefix> &Split);
+  LLVM_ABI static Error transformJoined(ArrayRef<StringRef> Joined,
+                                        SmallVectorImpl<MappedPrefix> &Split);
+  LLVM_ABI static Error transformJoined(ArrayRef<std::string> Joined,
+                                        SmallVectorImpl<MappedPrefix> &Split);
+  LLVM_ABI static void
+  transformJoinedIfValid(ArrayRef<StringRef> Joined,
+                         SmallVectorImpl<MappedPrefix> &Split);
+  LLVM_ABI
   static void transformJoinedIfValid(ArrayRef<std::string> Joined,
                                      SmallVectorImpl<MappedPrefix> &Split);
   LLVM_ABI static void
@@ -176,7 +178,7 @@ private:
   std::optional<StringRef> getTreePath(StringRef Path);
 
 public:
-  void add(const MappedPrefix &Mapping) override;
+  LLVM_ABI void add(const MappedPrefix &Mapping) override;
 
   LLVM_ABI StringRef mapDirEntry(const vfs::CachedDirectoryEntry &Entry,
                                  SmallVectorImpl<char> &Storage);

--- a/llvm/include/llvm/Transforms/IPO/SampleContextTracker.h
+++ b/llvm/include/llvm/Transforms/IPO/SampleContextTracker.h
@@ -189,8 +189,8 @@ public:
 
 #ifndef NDEBUG
   // Get a context string from root to current node.
-  std::string getContextString(const FunctionSamples &FSamples) const;
-  std::string getContextString(ContextTrieNode *Node) const;
+  LLVM_ABI std::string getContextString(const FunctionSamples &FSamples) const;
+  LLVM_ABI std::string getContextString(ContextTrieNode *Node) const;
 #endif
   // Dump the internal context profile trie.
   LLVM_ABI void dump();


### PR DESCRIPTION
This is required to build LLVM as a DLL on Windows for the Swift toolchain. The missing annotations either concern:
* CAS, which is partially upstreamed, with many APIs not present upstream.
* Files that have been removed or renamed upstream.
* Annotations that are already present upstream.

The effort to ship the Swift toolchain with LLVM built as a DLL is tracked in swiftlang/swift#85241.