### PR TITLE
[stable/21.x] Suppress spurious C++ interop warnings in the Swift compiler build

### DIFF
--- a/llvm/include/llvm/Object/DXContainer.h
+++ b/llvm/include/llvm/Object/DXContainer.h
@@ -536,9 +536,11 @@ public:
       return Tmp;
     }
 
+#ifndef __swift__
     bool operator==(const PartIterator &RHS) const {
       return OffsetIt == RHS.OffsetIt;
     }
+#endif
 
     bool operator!=(const PartIterator &RHS) const {
       return OffsetIt != RHS.OffsetIt;

--- a/llvm/include/llvm/Object/IRSymtab.h
+++ b/llvm/include/llvm/Object/IRSymtab.h
@@ -351,7 +351,9 @@ public:
     read();
   }
 
+#ifndef __swift__
   bool operator==(const SymbolRef &Other) const { return SymI == Other.SymI; }
+#endif
 };
 
 inline Reader::symbol_range Reader::symbols() const {


### PR DESCRIPTION
Avoids warnings like this:

```
warning: cycle detected while resolving 'PartIterator' in swift_name attribute for 'operator==' [#ClangDeclarationImport]
```

Cherry-pick of https://github.com/swiftlang/llvm-project/pull/12676.