### PR TITLE
[llvm][Support] Make createUniquePath require at least one wildcard marker (#184688)

### DIFF
--- a/clang/tools/libclang/CDependencies.cpp
+++ b/clang/tools/libclang/CDependencies.cpp
@@ -806,11 +806,20 @@ enum CXErrorCode clang_experimental_DependencyScanner_generateReproducer(
                              << EC.message();
     SmallString<128> Path(*Opts.ReproducerLocation);
     llvm::sys::path::append(Path, "reproducer");
-    const char *UniqueSuffix = Opts.UseUniqueReproducerName ? "-%%%%%%" : "";
-    if (auto EC = llvm::sys::fs::createUniqueFile(Path + UniqueSuffix + ".sh",
-                                                  ScriptFD, ReproScriptPath))
-      return ReportFailure() << "failed to create a reproducer script file\n"
-                             << EC.message();
+    if (Opts.UseUniqueReproducerName) {
+      if (auto EC = llvm::sys::fs::createUniqueFile(Path + "-%%%%%%.sh",
+                                                    ScriptFD, ReproScriptPath))
+        return ReportFailure() << "failed to create a reproducer script file\n"
+                              << EC.message();
+    } else {
+      llvm::sys::path::replace_extension(Path, "sh");
+      if (auto EC = llvm::sys::fs::openFileForReadWrite(Path, ScriptFD,
+                                         llvm::sys::fs::CD_OpenAlways, llvm::sys::fs::OF_None)) {
+        return ReportFailure() << "failed to create a reproducer script file\n"
+                               << EC.message();
+      }
+      ReproScriptPath = Path;
+    }
   } else {
     if (auto EC = llvm::sys::fs::createTemporaryFile(
             "reproducer", "sh", ScriptFD, ReproScriptPath)) {

--- a/lldb/unittests/Host/SocketTest.cpp
+++ b/lldb/unittests/Host/SocketTest.cpp
@@ -403,8 +403,8 @@ TEST_F(SocketTest, DomainSocketFromBoundNativeSocket) {
 TEST_F(SocketTest, AbstractSocketFromBoundNativeSocket) {
   // Generate a name for the abstract socket.
   llvm::SmallString<100> name;
-  llvm::sys::fs::createUniquePath("AbstractSocketFromBoundNativeSocket", name,
-                                  true);
+  llvm::sys::fs::createUniquePath("AbstractSocketFromBoundNativeSocket-%%%%%%",
+                                  name, true);
   llvm::sys::path::append(name, "test");
 
   // Skip the test if the $TMPDIR is too long to hold a domain socket.

--- a/lldb/unittests/Interpreter/TestCompletion.cpp
+++ b/lldb/unittests/Interpreter/TestCompletion.cpp
@@ -72,8 +72,9 @@ protected:
 
     const char *DirNames[] = {"foo", "fooa", "foob",        "fooc",
                               "bar", "baz",  "test_folder", "foo/nested"};
-    const char *FileNames[] = {"aa1234.tmp",  "ab1234.tmp",  "ac1234.tmp",
-                               "foo1234.tmp", "bar1234.tmp", "baz1234.tmp"};
+    const char *FileNames[] = {"aa1234-%%%%.tmp",  "ab1234-%%%%.tmp",
+                               "ac1234-%%%%.tmp",  "foo1234-%%%%.tmp",
+                               "bar1234-%%%%.tmp", "baz1234-%%%%.tmp"};
     SmallString<128> *Dirs[] = {&DirFoo, &DirFooA, &DirFooB,       &DirFooC,
                                 &DirBar, &DirBaz,  &DirTestFolder, &DirNested};
     for (auto Dir : llvm::zip(DirNames, Dirs)) {

--- a/llvm/include/llvm/Support/FileSystem.h
+++ b/llvm/include/llvm/Support/FileSystem.h
@@ -794,7 +794,7 @@ enum OpenFlags : unsigned {
 ///
 /// Example: clang-%%-%%-%%-%%-%%.s => clang-a0-b1-c2-d3-e4.s
 ///
-/// @param Model Name to base unique path off of.
+/// @param Model Name to base unique path off of. Must contain at least one '%'.
 /// @param ResultPath Set to the file's path.
 /// @param MakeAbsolute Whether to use the system temp directory.
 LLVM_ABI void createUniquePath(const Twine &Model,

--- a/llvm/lib/Support/Path.cpp
+++ b/llvm/lib/Support/Path.cpp
@@ -847,6 +847,9 @@ void createUniquePath(const Twine &Model, SmallVectorImpl<char> &ResultPath,
   SmallString<128> ModelStorage;
   Model.toVector(ModelStorage);
 
+  assert(llvm::is_contained(ModelStorage, '%') &&
+         "createUniquePath: Model must contain at least one '%'");
+
   if (MakeAbsolute) {
     // Make model absolute by prepending a temp directory if it's not already.
     if (!sys::path::is_absolute(Twine(ModelStorage))) {

--- a/llvm/unittests/Support/Path.cpp
+++ b/llvm/unittests/Support/Path.cpp
@@ -937,19 +937,19 @@ TEST_F(FileSystemTest, TempFiles) {
 #ifdef _WIN32
   // Path name > 260 chars should get an error.
   const char *Path270 =
-    "abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz8"
-    "abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz6"
-    "abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz4"
-    "abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz2"
-    "abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz0";
+      "abcdefghijklmnopqrstuvwxyz9abcdefghijklmnopqrstuvwxyz8"
+      "abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz6"
+      "abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz4"
+      "abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz2"
+      "abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz%";
   EXPECT_EQ(fs::createUniqueFile(Path270, FileDescriptor, TempPath),
             errc::invalid_argument);
   // Relative path < 247 chars, no problem.
   const char *Path216 =
-    "abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz6"
-    "abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz4"
-    "abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz2"
-    "abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstuvwxyz0";
+      "abcdefghijklmnopqrstuvwxyz7abcdefghijklmnopqrstuvwxyz6"
+      "abcdefghijklmnopqrstuvwxyz5abcdefghijklmnopqrstuvwxyz4"
+      "abcdefghijklmnopqrstuvwxyz3abcdefghijklmnopqrstuvwxyz2"
+      "abcdefghijklmnopqrstuvwxyz1abcdefghijklmnopqrstu%%%%%%";
   ASSERT_NO_ERROR(fs::createTemporaryFile(Path216, "", TempPath));
   ASSERT_NO_ERROR(fs::remove(Twine(TempPath)));
 #endif
@@ -2077,8 +2077,8 @@ TEST_F(FileSystemTest, is_local) {
 
   int FD;
   SmallString<128> TempPath;
-  ASSERT_NO_ERROR(
-      fs::createUniqueFile(Twine(TestDirectory) + "/temp", FD, TempPath));
+  ASSERT_NO_ERROR(fs::createUniqueFile(Twine(TestDirectory) + "/temp-%%%%%%",
+                                       FD, TempPath));
   FileRemover Cleanup(TempPath);
 
   // Make sure it exists.

--- a/llvm/unittests/Support/raw_socket_stream_test.cpp
+++ b/llvm/unittests/Support/raw_socket_stream_test.cpp
@@ -32,7 +32,8 @@ TEST(raw_socket_streamTest, CLIENT_TO_SERVER_AND_SERVER_TO_CLIENT) {
     GTEST_SKIP();
 
   SmallString<100> SocketPath;
-  llvm::sys::fs::createUniquePath("client_server_comms.sock", SocketPath, true);
+  llvm::sys::fs::createUniquePath("client_server_comms-%%%%%%.sock", SocketPath,
+                                  true);
 
   // Make sure socket file does not exist. May still be there from the last test
   std::remove(SocketPath.c_str());
@@ -73,7 +74,8 @@ TEST(raw_socket_streamTest, READ_WITH_TIMEOUT) {
     GTEST_SKIP();
 
   SmallString<100> SocketPath;
-  llvm::sys::fs::createUniquePath("read_with_timeout.sock", SocketPath, true);
+  llvm::sys::fs::createUniquePath("read_with_timeout-%%%%%%.sock", SocketPath,
+                                  true);
 
   // Make sure socket file does not exist. May still be there from the last test
   std::remove(SocketPath.c_str());
@@ -105,7 +107,8 @@ TEST(raw_socket_streamTest, ACCEPT_WITH_TIMEOUT) {
     GTEST_SKIP();
 
   SmallString<100> SocketPath;
-  llvm::sys::fs::createUniquePath("accept_with_timeout.sock", SocketPath, true);
+  llvm::sys::fs::createUniquePath("accept_with_timeout-%%%%%%.sock", SocketPath,
+                                  true);
 
   // Make sure socket file does not exist. May still be there from the last test
   std::remove(SocketPath.c_str());
@@ -126,8 +129,8 @@ TEST(raw_socket_streamTest, ACCEPT_WITH_SHUTDOWN) {
     GTEST_SKIP();
 
   SmallString<100> SocketPath;
-  llvm::sys::fs::createUniquePath("accept_with_shutdown.sock", SocketPath,
-                                  true);
+  llvm::sys::fs::createUniquePath("accept_with_shutdown-%%%%%%.sock",
+                                  SocketPath, true);
 
   // Make sure socket file does not exist. May still be there from the last test
   std::remove(SocketPath.c_str());


### PR DESCRIPTION
The API was a bit easy to accidentally mis-use, as it silently accepted Model strings without any randomness marker characters (`%`), which results in a unique path that's not at all unique. To avoid this foot-gun, we now assert that the model contains at least one, and update all the broken usages accordingly.

rdar://170349565

(cherry picked from commit 521c2e14957a20bd0f13595cd4262443d841a3a4)