### PR TITLE
[Cherry-pick into next] [LLDB] Turn of implicit modules during type reconstruction

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/LLDBExplicitModuleLoader.cpp
@@ -69,7 +69,7 @@ LLDBExplicitSwiftModuleLoader::create(
   llvm::for_each(*ExplicitClangModuleMap, addClangEntry);
 
   std::unique_ptr<swift::ExplicitCASModuleLoader> casml;
-  if (cas && action_cache) {
+  if ((cas_swift_mm->size() || cas_clang_mm->size()) && cas && action_cache) {
     casml = swift::ExplicitCASModuleLoader::create(
         ctx, *cas, *action_cache, tracker, loadMode, ExplicitSwiftModuleMapPath,
         ExplicitSwiftModuleInputs, IgnoreSwiftSourceInfoFile,

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -5304,6 +5304,8 @@ SwiftASTContext::ReconstructType(ConstString mangled_typename) {
   LOG_PRINTF(GetLog(LLDBLog::Types), "(\"%s\") -- not cached, searching",
              mangled_cstr);
 
+  // Avoid type reconstruction compiling additional implicit modules.
+  DisableImplicitImportsRAII no_imports(*this);
   found_type = swift::Demangle::getTypeForMangling(
                    **ast_ctx, mangled_typename.GetStringRef())
                    .getPointer();

--- a/lldb/test/API/lang/swift/explicit_modules/no-caching/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/no-caching/Makefile
@@ -1,0 +1,9 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_EXPLICIT_MODULES := YES
+
+all: a.out cas-config
+
+include Makefile.rules
+
+cas-config:
+	echo "{\"CASPath\": \"$(BUILDDIR)/cas\"}" > .cas-config

--- a/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
@@ -1,0 +1,24 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+class TestSwiftExplicitModuleNoCaching(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    def test(self):
+        """
+        Test that an uncached EBM build with a CAS config works.
+        """
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec('main.swift')
+        )
+        log = self.getBuildArtifact("types.log")
+        self.expect('log enable lldb types symbols -f "%s"' % log)
+        self.expect("expression 1+1")
+        self.filecheck_log(log, __file__)
+        # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::ConfigureCASStorage() -- Setup CAS {{.*}}cas
+        # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() -- Explicit module map entries
+        # CHECK: SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     Swift

--- a/lldb/test/API/lang/swift/explicit_modules/no-caching/main.swift
+++ b/lldb/test/API/lang/swift/explicit_modules/no-caching/main.swift
@@ -1,0 +1,1 @@
+print("break here")

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Dylib.swift
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Dylib.swift
@@ -1,0 +1,9 @@
+public protocol MyProtocol {}
+
+private struct PrivateImpl: MyProtocol {
+  var value: Int
+}
+
+public func makeInstance() -> some MyProtocol {
+  return PrivateImpl(value: 42)
+}

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Makefile
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/Makefile
@@ -1,0 +1,22 @@
+SWIFT_SOURCES := main.swift
+SWIFT_ENABLE_EXPLICIT_MODULES := YES
+SWIFTFLAGS_EXTRAS = -I$(BUILDDIR)
+LD_EXTRAS = -L$(BUILDDIR) -lDylib
+
+all: Dylib $(EXE)
+
+include Makefile.rules
+
+.PHONY: Dylib
+Dylib:
+	"$(MAKE)" MAKE_DSYM=$(MAKE_DSYM) CC=$(CC) SWIFTC=$(SWIFTC) \
+		ARCH=$(ARCH) DSYMUTIL=$(DSYMUTIL) \
+		VPATH=$(SRCDIR) -I $(SRCDIR) \
+		-f $(THIS_FILE_DIR)/Makefile.rules \
+		DYLIB_SWIFT_SOURCES=Dylib.swift \
+		DYLIB_NAME=Dylib \
+		DYLIB_ONLY=YES \
+		SWIFT_ENABLE_EXPLICIT_MODULES=YES \
+		SWIFT_SOURCES= \
+		LD_EXTRAS= \
+		all

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/TestSwiftExplicitModulePrivateTypeGeneric.py
@@ -1,0 +1,27 @@
+import lldb
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbtest as lldbtest
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftExplicitModulePrivateTypeGeneric(lldbtest.TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @swiftTest
+    @skipIfWindows
+    def test(self):
+        """Test frame variable of a generic struct specialized to a
+        private type from another explicitly-built module."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift"),
+            extra_images=["Dylib"])
+        log = self.getBuildArtifact("types.log")
+        self.expect('log enable lldb types symbols -f "%s"' % log)
+        self.expect("expr -d run -- s", error=True)
+        # FIXME: Expression shouldn't depend on all local variables.
+        self.expect("expression 1+1", error=True)
+        self.filecheck_log(log, __file__)
+        # CHECK: Turning off implicit modules
+        # CHECK: ReconstructType
+        # CHECK: Turning on implicit modules

--- a/lldb/test/API/lang/swift/explicit_modules/private_type_generic/main.swift
+++ b/lldb/test/API/lang/swift/explicit_modules/private_type_generic/main.swift
@@ -1,0 +1,12 @@
+import Dylib
+
+struct GenericStruct<T: MyProtocol> {
+  let t: T
+}
+
+func main() {
+  let s = GenericStruct(t: makeInstance())
+  print(s) // break here
+}
+
+main()


### PR DESCRIPTION
```
commit 2f0415784e4b6415ff4d9db013b79d9c02e25154
Author: Adrian Prantl <aprantl@apple.com>
Date:   Sat Mar 28 16:14:02 2026 -0700

    [LLDB] Turn of implicit modules during type reconstruction
    
    In an EBM context, implicit modules are turned off during the
    contextual imports. They should also be off during type
    reconstruction, since that may also trigger the import of additional
    modules, which would lead to unexpected performance cliffs.
    
    This is controllable via the same setting to allow implicit imports.
    
    rdar://173397549

commit ec493e29160c5454fd2018275272929ae53664b6
Author: Adrian Prantl <aprantl@apple.com>
Date:   Sat Mar 28 15:33:35 2026 -0700

    [LLDB] Log explicit module map for uncached builds if a CAS is found
```
