### PR TITLE
[next] [lldb][swift] Fix deadlock when loading frameworks

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -9975,9 +9975,14 @@ llvm::Error SwiftASTContext::GetCompileUnitImportsImpl(
     std::vector<SourceModule> cu_imports = compile_unit->GetImportedModules();
     LOG_PRINTF(GetLog(LLDBLog::Types), "Importing dependencies of current CU");
 
-    ThreadSafeASTContext ast = GetASTContext();
-    if (!ast)
-      return llvm::createStringError("invalid swift AST (nullptr)");
+    {
+      // Check if the AST is valid. We cannot hold the lock beyond this point
+      // as the code below might trigger the loading of libraries, which then
+      // in turn will try to access this AST to register themselves.
+      ThreadSafeASTContext ast = GetASTContext();
+      if (!ast)
+        return llvm::createStringError("invalid swift AST (nullptr)");
+    }
 
     std::string category = "Importing dependencies for ";
     category += compile_unit->GetPrimaryFile().GetFilename().GetString();

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -17,7 +17,7 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
     # This causes DoLoadImage() to allocate memory while the process is still
     # running, which fails and leaves the process in a bad state, ultimately
     # timing out with "didn't get any event after resume".
-    @expectedFailureAll(setting=("symbols.use-swift-clangimporter", "false"))
+    @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     def test(self):
         """Test that a framework that is registered as autolinked in a Swift
            module used in the target, but not linked against the target is

--- a/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
+++ b/lldb/test/API/lang/swift/lazy_framework/TestSwiftLazyFramework.py
@@ -12,7 +12,6 @@ class TestSwiftLazyFramework(lldbtest.TestBase):
 
     @swiftTest
     @skipIf(oslist=no_match(["macosx"]))
-    @skipIf(bugnumber="rdar://171278439") # randomly fails to dlopen in CI
     # FIXME: Without the ClangImporter, transitive module dependencies can't be
     # fully resolved, so collectLinkLibraries() misses autolinked frameworks.
     # This causes DoLoadImage() to allocate memory while the process is still


### PR DESCRIPTION
Cherry-pick of 7dc68ba245a5c78fc392511d27cf1cd5cd6bbca9 to `next`.