### PR TITLE
[lldb][windows] hardcode the Python version

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
+++ b/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
@@ -9,8 +9,5 @@ if(DEFINED LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME)
   target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME="${LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME}")
 endif()
 # BEGIN SWIFT
-find_package(Python ${Python3_VERSION} EXACT COMPONENTS Interpreter Development)
-if((DEFINED Python3_VERSION_MAJOR) AND (DEFINED Python3_VERSION_MINOR))
-  target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_VERSION="${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
-endif()
+target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_VERSION="3.10")
 # END SWIFT


### PR DESCRIPTION
This patch hardcodes the Python version used to build lldb to 3.10. The version will not be updated during the 6.3 release. 

This is to give us more time to properly fix the underlying issue.

Non hardcoded fix: https://github.com/swiftlang/llvm-project/pull/12690

This fixes https://github.com/swiftlang/swift/issues/88246.