### PR TITLE
[lldb][windows] fix a typo improperly referencing the Python version

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
+++ b/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
@@ -9,8 +9,7 @@ if(DEFINED LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME)
   target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME="${LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME}")
 endif()
 # BEGIN SWIFT
-find_package(Python ${Python3_VERSION} EXACT COMPONENTS Interpreter Development)
 if((DEFINED Python3_VERSION_MAJOR) AND (DEFINED Python3_VERSION_MINOR))
-  target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_VERSION="${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+  target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_VERSION="${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
 endif()
 # END SWIFT


### PR DESCRIPTION
This patch fixes a typo in the use of the variables `Python3_VERSION_MAJOR` and `Python3_VERSION_MINOR`.