### PR TITLE
[LLDB] Adapt LLDB for serailization flag change GH88239

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1065,6 +1065,7 @@ void SwiftASTContext::SetCompilerInvocationLLDBOverrides() {
   // to avoid crashing due to module recovery issues.
   swift::LangOptions &lang_opts = m_compiler_invocation_up->getLangOptions();
   lang_opts.AllowDeserializingImplementationOnly = true;
+  lang_opts.DisableDeserializationOfExplicitPaths = false;
   lang_opts.DebuggerSupport = true;
 
   // ModuleFileSharedCore::getTransitiveLoadingBehavior() has a


### PR DESCRIPTION
Since the compiler turns on DisableDeserializationOfExplicitPaths by default, LLDB now needs to initialize the setting manually.