### PR TITLE
[lldb][windows] fix UB in Python setup

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
+++ b/lldb/source/Host/windows/PythonPathSetup/PythonPathSetup.cpp
@@ -52,7 +52,7 @@ bool AddPythonDLLToSearchPath() {
   sys::fs::make_absolute(path);
 
   SmallVector<wchar_t, 1> path_wide;
-  if (sys::windows::widenPath(path.data(), path_wide))
+  if (sys::windows::widenPath(StringRef(path.data(), path.size()), path_wide))
     return false;
 
   if (sys::fs::exists(path))


### PR DESCRIPTION
**Explanation**: On Windows, resolving the path of the Embedded Python shared library (python.dll) fails on the NoAsserts build but not on the Asserts variant. This is due to an incorrect call to `sys::windows::widenPath` which is undefined behavior. Wrapping the path in a StringRef fixes the UB.
**Scope**: lldb Embedded Python path resolution.
**Risk**: Low. Converting to an argument from a type to another.
**Issue**: rdar://173864724
**Testing**: Passed the current test suite and tested at desk.
**Reviewer**: @compnerd @adrian-prantl