### PR TITLE
🍒 [lldb][windows] fix a typo improperly referencing the Python version

### DIFF
--- a/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
+++ b/lldb/source/Host/windows/PythonPathSetup/CMakeLists.txt
@@ -9,8 +9,7 @@ if(DEFINED LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME)
   target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME="${LLDB_PYTHON_RUNTIME_LIBRARY_FILENAME}")
 endif()
 # BEGIN SWIFT
-find_package(Python ${Python3_VERSION} EXACT COMPONENTS Interpreter Development)
 if((DEFINED Python3_VERSION_MAJOR) AND (DEFINED Python3_VERSION_MINOR))
-  target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_VERSION="${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+  target_compile_definitions(lldbHostPythonPathSetup PRIVATE LLDB_PYTHON_VERSION="${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
 endif()
 # END SWIFT


### PR DESCRIPTION
**Explanation**: On Windows lldb fails to print the Python version needed (3.10) if it can't find any suitable Python installation. This is because of a typo in the `PythonPathSetup/CMakeLists.txt` file. Switching to `Python3_*` references the correct variable.
**Scope**: lldb Embedded Python path resolution.
**Risk**: Low. `LLDB_PYTHON_VERSION` generates a string for helping users troubleshoot their Python installation
**Issue**: rdar://173864646
**Testing**: Passed the current test suite and tested at desk.
**Reviewer**: @compnerd @adrian-prantl

