### PR TITLE
Revert "[LLDB] Adapt LLDB for serailization flag change GH88239"

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1067,7 +1067,6 @@ void SwiftASTContext::SetCompilerInvocationLLDBOverrides() {
   // to avoid crashing due to module recovery issues.
   swift::LangOptions &lang_opts = m_compiler_invocation_up->getLangOptions();
   lang_opts.AllowDeserializingImplementationOnly = true;
-  lang_opts.DisableDeserializationOfExplicitPaths = false;
   lang_opts.DebuggerSupport = true;
 
   // ModuleFileSharedCore::getTransitiveLoadingBehavior() has a


### PR DESCRIPTION
This reverts commit a2f8e46e51e16b6666c3f1127b2705c44df56731.

The automerger should not have succeeded merging this commit.