### PR TITLE
[lldb][kernel debug] Add a missing call to scan local fs for kexts (#190281)

### DIFF
--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
@@ -760,6 +760,7 @@ Status PlatformDarwinKernel::GetSharedModuleKext(
   Status error;
   module_sp.reset();
   const FileSpec &platform_file = module_spec.GetFileSpec();
+  UpdateKextandKernelsLocalScan();
 
   // Treat the file's path as a kext bundle ID (e.g.
   // "com.apple.driver.AppleIRController") and search our kext index.


### PR DESCRIPTION


A kernel developer noticed that I missed a call to index the local filesystem in one of our codepaths, and had a use case that depended on that working.

rdar://173814556
(cherry picked from commit 124b0a8fbb540c85e3a47d235a8ce10c48d1c7ca)