### PR TITLE
[cas] Check invalid value in Slot in OnDiskHashMappedTrie

### DIFF
--- a/llvm/lib/CAS/OnDiskTrieRawHashMap.cpp
+++ b/llvm/lib/CAS/OnDiskTrieRawHashMap.cpp
@@ -1047,9 +1047,11 @@ Error TrieVisitor::visit() {
       SubtrieHandle S(Trie.getRegion(), Slot, Trie.getLogger());
       Subs.push_back(S);
       Prefixes.push_back(SubtriePrefix);
-    }
-    if (auto Err = visitSlot(I, Root, SubtriePrefix, Slot))
-      return Err;
+    } else if (Slot.isData()) {
+      if (auto Err = visitSlot(I, Root, SubtriePrefix, Slot))
+        return Err;
+    } else
+      return createInvalidTrieError(Offset, "invalid slot value");
   }
 
   for (size_t I = 0, E = Subs.size(); I != E; ++I) {


### PR DESCRIPTION
The slot in OnDiskHashMappedTrie cannot have a value of 0. That is not considered to be data or subtrie. The trie visitor should return error on it so verifier can properly return error instead of fatal error out.

rdar://170841238