### PR TITLE
[NFC][IR] Remove Dwarf.h from DebugInfoMetadata.h

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -20,7 +20,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/iterator_range.h"
-#include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DbgVariableFragmentInfo.h"
 #include "llvm/IR/Metadata.h"


### PR DESCRIPTION
This was originally removed in ffe8720aa060d66297500f30bb8ad02114e40326. The presence of the forward declaration of `dwarf::Tag` shows me that this was likely missed and should have been removed.