### PR TITLE
[lldb] Fix index bounds check in GetTupleElement

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -1433,7 +1433,7 @@ TypeSystemSwiftTypeRef::GetTupleElement(lldb::opaque_compiler_type_t type,
       dem, type, exe_ctx);
   if (!node || node->getKind() != Node::Kind::Tuple)
     return {};
-  if (node->getNumChildren() < idx)
+  if (idx >= node->getNumChildren())
     return {};
   NodePointer child = node->getChild(idx);
   if (child->getNumChildren() != 1 &&


### PR DESCRIPTION
If a tuple has say 3 elements, and for some reason GetTupleElement is called with index 3, then `if (3 < 3)` fails, causing the line `node->getChild(3)` to be the next to execute, which is invalid.

Assisted-by: claude