### PR TITLE
[Module] Remove downstream XFAIL that is no longer needed

### DIFF
--- a/clang/test/Modules/GH154840.cpp
+++ b/clang/test/Modules/GH154840.cpp
@@ -1,7 +1,3 @@
-/// Due to module bypass workaround for non-darwin platforms, relative and absolute path do not match after bypass.
-/// See: https://github.com/llvm/llvm-project/issues/130795
-// XFAIL: !system-darwin
-
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file %s %t

--- a/clang/test/Modules/GH170084.cpp
+++ b/clang/test/Modules/GH170084.cpp
@@ -1,7 +1,3 @@
-/// Due to module bypass workaround for non-darwin platforms, relative and absolute path do not match after bypass.
-/// See: https://github.com/llvm/llvm-project/issues/130795
-// XFAIL: !system-darwin
-
 // RUN: rm -rf %t
 // RUN: mkdir -p %t
 // RUN: split-file %s %t

--- a/clang/test/Modules/explicit-build-relpath.cpp
+++ b/clang/test/Modules/explicit-build-relpath.cpp
@@ -1,7 +1,3 @@
-/// Due to module bypass workaround for non-darwin platforms, relative and absolute path do not match after bypass.
-/// See: https://github.com/llvm/llvm-project/issues/130795
-// XFAIL: !system-darwin
-
 // RUN: rm -rf %t
 // RUN: mkdir %t
 // RUN: cd %t


### PR DESCRIPTION
Now the module file bypass workaround is removed, XFAIL is causing failures downstream on non-apple platforms. Remove downstream diff and fix the tests.