### PR TITLE
[llvm][cas] Teach createCASFromIdentifier to create an action cache

### DIFF
--- a/llvm/include/llvm/CAS/ObjectStore.h
+++ b/llvm/include/llvm/CAS/ObjectStore.h
@@ -399,7 +399,9 @@ Error getDefaultOnDiskCASPath(SmallVectorImpl<char> &Path);
 /// user.
 llvm::Expected<std::string> getDefaultOnDiskCASPath();
 
-/// Create ObjectStore from a string identifier.
+class ActionCache;
+
+/// Create ObjectStore and ActionCache from a string identifier.
 /// Currently the string identifier is using URL scheme with following supported
 /// schemes:
 ///  * InMemory CAS: mem://
@@ -414,14 +416,14 @@ llvm::Expected<std::string> getDefaultOnDiskCASPath();
 /// on-disk directory that the plugin should use, otherwise the default
 /// OnDiskCAS location will be used.
 /// FIXME: Need to implement proper URL encoding scheme that allows "%".
-Expected<std::shared_ptr<ObjectStore>> createCASFromIdentifier(StringRef Path);
+Expected<std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
+createCASFromIdentifier(StringRef Path);
 
 /// Register a URL scheme to CAS Identifier.
-using ObjectStoreCreateFuncTy =
-    Expected<std::shared_ptr<ObjectStore>>(const Twine &);
+using ObjectStoreCreateFuncTy = Expected<
+    std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>(
+    const Twine &);
 void registerCASURLScheme(StringRef Prefix, ObjectStoreCreateFuncTy *Func);
-
-class ActionCache;
 
 /// Create \c ObjectStore and \c ActionCache instances using the plugin
 /// interface.

--- a/llvm/lib/CAS/ObjectStore.cpp
+++ b/llvm/lib/CAS/ObjectStore.cpp
@@ -13,7 +13,8 @@
 #include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/CAS/UnifiedOnDiskCache.h"
+#include "llvm/CAS/ActionCache.h"
+#include "llvm/CAS/BuiltinUnifiedCASDatabases.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/FileSystem.h"
@@ -352,17 +353,21 @@ ObjectProxy::getMemoryBuffer(StringRef Name,
   return CAS->getMemoryBuffer(H, Name, RequiresNullTerminator);
 }
 
-static Expected<std::shared_ptr<ObjectStore>>
+static Expected<
+    std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
 createOnDiskCASImpl(const Twine &Path) {
-  return createOnDiskCAS(Path);
+  SmallString<128> Buffer;
+  return createOnDiskUnifiedCASDatabases(Path.toStringRef(Buffer));
 }
 
-static Expected<std::shared_ptr<ObjectStore>>
+static Expected<
+    std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
 createInMemoryCASImpl(const Twine &) {
-  return createInMemoryCAS();
+  return std::make_pair(createInMemoryCAS(), createInMemoryActionCache());
 }
 
-static Expected<std::shared_ptr<ObjectStore>>
+static Expected<
+    std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
 createPluginCASImpl(const Twine &URL) {
   // Format used is
   //   plugin://${PATH_TO_PLUGIN}?${OPT1}=${VAL1}&${OPT2}=${VAL2}..
@@ -390,12 +395,7 @@ createPluginCASImpl(const Twine &URL) {
     OnDiskPath = *Path;
   }
 
-  std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>> CASDBs;
-  if (Error E = createPluginCASDatabases(PluginPath, OnDiskPath, PluginArgs)
-                    .moveInto(CASDBs))
-    return std::move(E);
-
-  return std::move(CASDBs.first);
+  return createPluginCASDatabases(PluginPath, OnDiskPath, PluginArgs);
 }
 
 static ManagedStatic<StringMap<ObjectStoreCreateFuncTy *>> RegisteredScheme;
@@ -409,7 +409,7 @@ static StringMap<ObjectStoreCreateFuncTy *> &getRegisteredScheme() {
   return *RegisteredScheme;
 }
 
-Expected<std::shared_ptr<ObjectStore>>
+Expected<std::pair<std::shared_ptr<ObjectStore>, std::shared_ptr<ActionCache>>>
 cas::createCASFromIdentifier(StringRef Path) {
   for (auto &Scheme : getRegisteredScheme()) {
     if (Path.consume_front(Scheme.getKey()))
@@ -429,10 +429,7 @@ cas::createCASFromIdentifier(StringRef Path) {
   }
 
   // Fallback is to create UnifiedOnDiskCache.
-  auto UniDB = builtin::createBuiltinUnifiedOnDiskCache(Path);
-  if (!UniDB)
-    return UniDB.takeError();
-  return builtin::createObjectStoreFromUnifiedOnDiskCache(std::move(*UniDB));
+  return createOnDiskUnifiedCASDatabases(Path);
 }
 
 void cas::registerCASURLScheme(StringRef Prefix,

--- a/llvm/lib/RemoteCachingService/RemoteCachingService.cpp
+++ b/llvm/lib/RemoteCachingService/RemoteCachingService.cpp
@@ -11,6 +11,20 @@
 
 using namespace llvm;
 
+static Expected<std::pair<std::shared_ptr<cas::ObjectStore>,
+                          std::shared_ptr<cas::ActionCache>>>
+createGRPCRelayDBs(const llvm::Twine &Path) {
+  std::shared_ptr<cas::ObjectStore> CAS;
+  std::shared_ptr<cas::ActionCache> AC;
+  SmallString<128> Buffer;
+  Path.toVector(Buffer);
+  if (Error E = cas::createGRPCRelayCAS(Buffer).moveInto(CAS))
+    return std::move(E);
+  if (Error E = cas::createGRPCActionCache(Buffer).moveInto(AC))
+    return std::move(E);
+  return std::make_pair(std::move(CAS), std::move(AC));
+}
+
 cas::RegisterGRPCCAS::RegisterGRPCCAS() {
-  cas::registerCASURLScheme("grpc://", &cas::createGRPCRelayCAS);
+  cas::registerCASURLScheme("grpc://", createGRPCRelayDBs);
 }

--- a/llvm/test/tools/llvm-cas/validation.test
+++ b/llvm/test/tools/llvm-cas/validation.test
@@ -12,6 +12,9 @@ RUN: llvm-cas --cas %t/cas --ingest %S/Inputs > %t/cas.id
 RUN: llvm-cas --cas %t/cas --validate
 RUN: llvm-cas --cas %t/cas --validate --check-hash
 
+# Check that validation works with a relative path.
+RUN: cd %t && llvm-cas --cas cas --validate --check-hash
+
 RUN: rm %t/cas/v1.1/data.v1
 RUN: not llvm-cas --cas %t/cas --validate
 RUN: not llvm-cas --cas %t/cas --validate --check-hash

--- a/llvm/tools/llc/llc.cpp
+++ b/llvm/tools/llc/llc.cpp
@@ -397,7 +397,7 @@ static std::shared_ptr<cas::ObjectStore> getCAS() {
     return cas::createInMemoryCAS();
   auto MaybeCAS = cas::createCASFromIdentifier(CASPath);
   if (MaybeCAS)
-    return std::move(*MaybeCAS);
+    return std::move(MaybeCAS->first);
   reportError(toString(MaybeCAS.takeError()));
 }
 

--- a/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
+++ b/llvm/tools/llvm-cas-dump/llvm-cas-dump.cpp
@@ -165,7 +165,7 @@ int main(int argc, char *argv[]) {
                             HexDumpOneLine,    Verbose,   DIERefs};
 
   std::shared_ptr<ObjectStore> CAS =
-      ExitOnErr(createCASFromIdentifier(CASPath));
+      ExitOnErr(createCASFromIdentifier(CASPath)).first;
   MCCASPrinter Printer(Options, *CAS, llvm::outs());
 
   StringMap<ObjectRef> Files;

--- a/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
+++ b/llvm/tools/llvm-cas-object-format/llvm-cas-object-format.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[]) {
   cl::ParseCommandLineOptions(argc, argv);
 
   std::shared_ptr<ObjectStore> CAS =
-      ExitOnErr(createCASFromIdentifier(CASPath));
+      ExitOnErr(createCASFromIdentifier(CASPath)).first;
 
   for (StringRef IF : InputFiles) {
     ExitOnError ExitOnErr;

--- a/llvm/tools/llvm-cas/llvm-cas.cpp
+++ b/llvm/tools/llvm-cas/llvm-cas.cpp
@@ -272,7 +272,7 @@ int main(int Argc, char **Argv) {
           ExitOnErr(createOnDiskUnifiedCASDatabases(Opts.CASPath));
     }
   } else {
-    CAS = ExitOnErr(createCASFromIdentifier(Opts.CASPath));
+    std::tie(CAS, AC) = ExitOnErr(createCASFromIdentifier(Opts.CASPath));
   }
   assert(CAS);
 
@@ -313,7 +313,8 @@ int main(int Argc, char **Argv) {
     if (Opts.UpstreamCASPath.empty())
       ExitOnErr(createStringError("missing '-upstream-cas'"));
 
-    auto UpstreamCAS = ExitOnErr(createCASFromIdentifier(Opts.UpstreamCASPath));
+    auto UpstreamCAS =
+        ExitOnErr(createCASFromIdentifier(Opts.UpstreamCASPath)).first;
 
     return import(*UpstreamCAS, *CAS, Opts.Inputs);
   }

--- a/llvm/tools/llvm-mc/llvm-mc.cpp
+++ b/llvm/tools/llvm-mc/llvm-mc.cpp
@@ -622,7 +622,7 @@ int main(int argc, char **argv) {
       WithColor::error() << toString(MaybeCAS.takeError()) << "\n";
       return 1;
     }
-    CAS = std::move(*MaybeCAS);
+    CAS = std::move(MaybeCAS->first);
   }
   // END MCCAS
 


### PR DESCRIPTION
Previously it only created an ObjectStore. This had the negative impact of diverging behaviour between a cas path and a cas identifier (even if it was just on on disk cas under the hood). In particular, it meant llvm-cas with a relative cas path would not create an action cache.