### PR TITLE
[LLDB] Add nullptr guards to Swift collection data formatters

### DIFF
--- a/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftArray.cpp
@@ -124,6 +124,8 @@ bool SwiftArrayNativeBufferHandler::IsValid() {
 }
 
 size_t SwiftArrayBridgedBufferHandler::GetCount() {
+  if (!m_frontend)
+    return 0;
   return m_frontend->CalculateNumChildrenIgnoringErrors();
 }
 
@@ -135,6 +137,8 @@ lldb_private::CompilerType SwiftArrayBridgedBufferHandler::GetElementType() {
 
 lldb::ValueObjectSP
 SwiftArrayBridgedBufferHandler::GetElementAtIndex(size_t idx) {
+  if (!m_frontend)
+    return {};
   return m_frontend->GetChildAtIndex(idx);
 }
 
@@ -276,10 +280,14 @@ SwiftArrayInlineBufferHandler::SwiftArrayInlineBufferHandler(
 bool SwiftArrayInlineBufferHandler::IsValid() { return m_valobj_sp.get(); }
 
 size_t SwiftSyntheticFrontEndBufferHandler::GetCount() {
+  if (!m_frontend)
+    return 0;
   return m_frontend->CalculateNumChildrenIgnoringErrors();
 }
 
 size_t SwiftSyntheticFrontEndBufferHandler::GetCapacity() {
+  if (!m_frontend)
+    return 0;
   return m_frontend->CalculateNumChildrenIgnoringErrors();
 }
 
@@ -291,6 +299,8 @@ SwiftSyntheticFrontEndBufferHandler::GetElementType() {
 
 lldb::ValueObjectSP
 SwiftSyntheticFrontEndBufferHandler::GetElementAtIndex(size_t idx) {
+  if (!m_frontend)
+    return {};
   return m_frontend->GetChildAtIndex(idx);
 }
 

--- a/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
+++ b/lldb/source/Plugins/Language/Swift/SwiftHashedContainer.cpp
@@ -153,6 +153,8 @@ public:
     : m_cocoaObject_sp(cocoaObject_sp), m_frontend(frontend) {}
 
   virtual size_t GetCount() override {
+    if (!m_frontend)
+      return 0;
     return m_frontend->CalculateNumChildrenIgnoringErrors();
   }
 
@@ -162,6 +164,8 @@ public:
   }
 
   virtual ValueObjectSP GetElementAtIndex(size_t idx) override {
+    if (!m_frontend)
+      return {};
     return m_frontend->GetChildAtIndex(idx);
   }
 


### PR DESCRIPTION
There is a pretty direct code path where the constructor of the formatter fails and leaves the synthetic frontend as a nullptr. This patch patches all similar situations I could find.

rdar://173769620