### PR TITLE
[lldb][windows] add Swift runtime libraries to the tests search path

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/dotest.py
+++ b/lldb/packages/Python/lldbsuite/test/dotest.py
@@ -323,6 +323,8 @@ def parseOptionsAndInitTestdirs():
     # Set SDKROOT if we are using an Apple SDK
     if args.sysroot:
         configuration.sdkroot = args.sysroot
+        if sys.platform == "win32":
+            os.environ["SDKROOT"] = args.sysroot
     elif platform_system == "Darwin" and args.apple_sdk:
         configuration.sdkroot = seven.get_command_output(
             'xcrun --sdk "%s" --show-sdk-path 2> /dev/null' % (args.apple_sdk)
@@ -351,6 +353,21 @@ def parseOptionsAndInitTestdirs():
 
     if args.swiftcompiler:
         configuration.swiftCompiler = args.swiftcompiler
+
+        # On Windows, the Swift runtime DLLs (swiftCore.dll etc.) live alongside
+        # swiftc. Add that directory to the inferior's PATH so that Swift test
+        # binaries can find them at launch.
+        if sys.platform == "win32":
+            swift_bin_dir = os.path.dirname(
+                os.path.abspath(configuration.swiftCompiler)
+            )
+            path = f"{swift_bin_dir};{os.environ['PATH']}".replace('"', '\\"')
+            path_entry = f'PATH="{path}"'
+
+            if lldbtest_config.inferior_env is None:
+                lldbtest_config.inferior_env = path_entry
+            else:
+                lldbtest_config.inferior_env += " " + path_entry
 
     if args.xfail_categories:
         configuration.xfail_categories += test_categories.validate(


### PR DESCRIPTION
Swift test targets need to be able to load the Swift runtime libraries to run. This patch adds them to the path in dotest.py.

This is needed for https://github.com/swiftlang/llvm-project/pull/12739.