### PR TITLE
[lldb][windows] enable Swift tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/decorators.py
+++ b/lldb/packages/Python/lldbsuite/test/decorators.py
@@ -967,9 +967,9 @@ def swiftTest(func):
     # The OS check is static and can be evaluated at decoration time.
     # Using unittest.skip (which sets __unittest_skip__ on the method) causes
     # Python's TestCase.run() to skip setUp() before it is called.
-    if sys.platform not in ["darwin", "linux"]:
+    if sys.platform not in ["darwin", "linux", "win32"]:
         return unittest.skip(
-            "skipping Swift test because only Darwin and Linux are supported OSes"
+            "skipping Swift test because only Darwin, Linux and Windows are supported OSes"
         )(func)
 
     def is_not_swift_compatible(self):

--- a/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
+++ b/lldb/test/API/commands/dwim-print/swift/TestSwiftDWIMPrint.py
@@ -9,7 +9,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245096
     def test_swift_po_address(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
@@ -22,7 +22,7 @@ class TestCase(TestBase):
         self.expect(f"dwim-print -O -- {addr}", patterns=[f"Object@0x0*{hex_addr}"])
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245096
     def test_swift_po_non_address_hex(self):
         """No special handling of non-memory integer values."""
         self.build()
@@ -32,7 +32,7 @@ class TestCase(TestBase):
         self.expect(f"dwim-print -O -- 0x1000", substrs=["4096"])
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245096
     def test_print_swift_object_does_not_show_name(self):
         """Ensure that objects are printed without a name, and without the '='
         that would follow the name."""

--- a/lldb/test/API/commands/expression/persistent_result/swift/TestSwiftPersistentResult.py
+++ b/lldb/test/API/commands/expression/persistent_result/swift/TestSwiftPersistentResult.py
@@ -10,7 +10,6 @@ from lldbsuite.test import lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_enable_persistent_result(self):
         """Test explicitly enabling result variables persistence."""
         self.build()
@@ -22,7 +21,6 @@ class TestCase(TestBase):
         self.expect("expression $R0", startstr="(Int) $R1 = 30")
 
     @swiftTest
-    @expectedFailureWindows
     def test_disable_persistent_result(self):
         """Test explicitly disabling persistent result variables."""
         self.build()
@@ -34,7 +32,6 @@ class TestCase(TestBase):
         self.expect("expression $R0", error=True)
 
     @swiftTest
-    @expectedFailureWindows
     def test_expression_persists_result(self):
         """Test `expression`'s default behavior is to persist a result variable."""
         self.build()
@@ -45,7 +42,6 @@ class TestCase(TestBase):
         self.expect("expression $R0", startstr="(Int) $R1 = 30")
 
     @swiftTest
-    @expectedFailureWindows
     def test_p_does_not_persist_results(self):
         """Test `p` does not persist a result variable."""
         self.build()

--- a/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
+++ b/lldb/test/API/commands/target/modules/swift/TestSwiftImageLookupPC.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftAddressExpressionTest(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that you can use register names in image lookup in a swift frame."""
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_exception/TestExpressionErrorBreakpoint.py
@@ -22,21 +22,18 @@ import os
 class TestSwiftErrorBreakpoint(TestBase):
     @decorators.skipIfLinux  # <rdar://problem/30909618>
     @swiftTest
-    @expectedFailureWindows
     def test_swift_error_no_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests(None)
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_error_matching_base_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()
         self.do_tests("EnumError")
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_error_matching_full_typename(self):
         """Tests that swift error throws are correctly caught by the Swift Error breakpoint"""
         self.build()

--- a/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
+++ b/lldb/test/API/functionalities/breakpoint/swift_property_accessors/TestSwiftPropertyAccessorBreakpoints.py
@@ -5,7 +5,6 @@ from lldbsuite.test.decorators import *
 
 class TestCase(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that a breakpoint on a property accessor can be set by name."""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-typealias/TestSwiftTypeAliasFormatters.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftTypeAliasFormatters(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_type_alias_formatters(self):
         """Test that Swift typealiases get formatted properly"""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift-unsafe/TestSwiftUnsafeTypeFormatters.py
@@ -5,6 +5,4 @@ Test that Swift unsafe types get formatted properly
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/array-slice/TestSwiftArraySliceFormatters.py
@@ -9,7 +9,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_array_slice_formatters(self):
         """Test ArraySlice synthetic types."""
         self.build()

--- a/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
+++ b/lldb/test/API/functionalities/data-formatter/swift/substring/TestSwiftSubstringFormatters.py
@@ -10,7 +10,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_substring_formatters(self):
         """Test Subtring summary strings."""
         self.build()

--- a/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
+++ b/lldb/test/API/lang/swift/accelerate_simd/TestAccelerateSIMD.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
+++ b/lldb/test/API/lang/swift/address_of/TestSwiftAddressOf.py
@@ -45,7 +45,6 @@ class TestSwiftAddressOf(lldbtest.TestBase):
 
         
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
+++ b/lldb/test/API/lang/swift/any/TestSwiftAnyType.py
@@ -24,7 +24,6 @@ class TestSwiftAnyType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_any_type(self):
         """Test the Any type"""
         self.build()

--- a/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
+++ b/lldb/test/API/lang/swift/any_object/TestSwiftAnyObjectType.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftAnyObjectType(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_any_object_type(self):
         """Test the AnyObject type"""
         self.build()

--- a/lldb/test/API/lang/swift/anytype_array/TestAnyTypeArray.py
+++ b/lldb/test/API/lang/swift/anytype_array/TestAnyTypeArray.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
+++ b/lldb/test/API/lang/swift/archetype_in_expression/TestArchetypeInExpression.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestArchetypeInExpression(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests that a user can refer to the archetypes in their expressions"""         
         self.build()

--- a/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
+++ b/lldb/test/API/lang/swift/archetype_resolution/TestSwiftArchetypeResolution.py
@@ -21,7 +21,7 @@ import os
 
 class TestSwiftArchetypeResolution(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245096
     def test_swift_archetype_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""
         self.build()

--- a/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
+++ b/lldb/test/API/lang/swift/archetype_resolution_subclass/TestArchetypeResolutionSubclass.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
+++ b/lldb/test/API/lang/swift/array_element/TestSwiftArrayElement.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
+++ b/lldb/test/API/lang/swift/array_enum/TestArrayEnum.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
+++ b/lldb/test/API/lang/swift/array_uninitialized/TestSwiftArrayUninitialized.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftArrayUninitialized(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test(self):
         """Test unitialized global arrays"""
         self.build()

--- a/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
+++ b/lldb/test/API/lang/swift/associated_self_type/TestSwiftAssociatedSelfType.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
+++ b/lldb/test/API/lang/swift/associated_type_resolution/TestSwiftAssociatedTypeResolution.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftArchetypeResolution(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_associated_type_resolution(self):
         """Test that archetype-typed objects get resolved to their proper location in memory"""
         self.build()

--- a/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
+++ b/lldb/test/API/lang/swift/async/actors/unprioritised_jobs/TestSwiftActorUnprioritisedJobs.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_actor_unprioritised_jobs(self):
         """Verify that an actor exposes its unprioritised jobs (queue)."""
         self.build()

--- a/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
+++ b/lldb/test/API/lang/swift/async/continuations/TestSwiftContinuationSynthetic.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_unsafe_continuation_printing(self):
         """Print an UnsafeContinuation and verify its children."""
         self.build()
@@ -35,7 +35,7 @@ class TestCase(TestBase):
         )
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_checked_continuation_printing(self):
         """Print an CheckedContinuation and verify its children."""
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/TestSwiftTaskSyntheticProvider.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_top_level_task(self):
         """Test Task synthetic child provider for top-level Task."""
         self.build()
@@ -35,7 +35,7 @@ class TestCase(TestBase):
         )
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     @skipIfLinux
     def test_current_task(self):
         """Test Task synthetic child for UnsafeCurrentTask (from an async let)."""

--- a/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/complete/TestSwiftTaskComplete.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/name/TestSwiftTaskName.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_summary_contains_name(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -17,7 +17,7 @@ class TestCase(TestBase):
         self.expect("v task", patterns=[r'"Chore" id:[1-9]'])
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     @skipIfLinux  # rdar://151471067
     def test_thread_contains_name(self):
         self.build()

--- a/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
+++ b/lldb/test/API/lang/swift/async/formatters/task/suspended/TestSwiftTaskSuspended.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
+++ b/lldb/test/API/lang/swift/async/formatters/taskpriority/TestSwiftTaskPrioritySummary.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test(self):
         """Test summary formatter for TaskPriority."""
         self.build()

--- a/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
+++ b/lldb/test/API/lang/swift/async/taskgroups/TestSwiftTaskGroupSynthetic.py
@@ -8,7 +8,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_print_task_group(self):
         """Print a TaskGroup and verify its children."""
         self.build()
@@ -18,7 +18,7 @@ class TestCase(TestBase):
         self.do_test_print()
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_print_throwing_task_group(self):
         """Print a ThrowingTaskGroup and verify its children."""
         self.build()
@@ -62,7 +62,7 @@ class TestCase(TestBase):
         )
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_api_task_group(self):
         """Verify a TaskGroup contains its expected children."""
         self.build()
@@ -72,7 +72,7 @@ class TestCase(TestBase):
         self.do_test_api(process)
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_api_throwing_task_group(self):
         """Verify a ThrowingTaskGroup contains its expected children."""
         self.build()

--- a/lldb/test/API/lang/swift/big_multi_payload_enum/TestSwiftBigMultiPayloadEnum.py
+++ b/lldb/test/API/lang/swift/big_multi_payload_enum/TestSwiftBigMultiPayloadEnum.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftBigMultiPayloadEnum(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
+++ b/lldb/test/API/lang/swift/break_by_partial_name/TestSwiftBreakByPartialName.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftPartialBreakTest(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_partial_break(self):
         """Tests that we can break on a partial name of a Swift function"""
         self.build()

--- a/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
+++ b/lldb/test/API/lang/swift/bt_printing/TestSwiftBacktracePrinting.py
@@ -20,7 +20,6 @@ import os
 
 class TestSwiftBacktracePrinting(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_backtrace_printing(self):
         """Test printing Swift backtrace"""
         self.build()

--- a/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
+++ b/lldb/test/API/lang/swift/c_type_ivar/TestSwiftCTypeIvar.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftCTypeIvar(TestBase):
     @swiftTest
-    @expectedFailureWindows
     @skipIf(setting=("symbols.use-swift-clangimporter", "false"))
     def test(self):
         """Test that the extra inhabitants are correctly computed for various

--- a/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
+++ b/lldb/test/API/lang/swift/clangimporter/custom_alignment/TestSwiftClangImporterCustomAlignment.py
@@ -21,7 +21,6 @@ class TestSwiftClangImporterCustomAlignment(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/expr_import/TestSwiftExprImport.py
@@ -7,7 +7,6 @@ class TestSwiftExprImport(TestBase):
     # Don't run ClangImporter tests if Clangimporter is disabled.
     @skipIf(setting=('symbols.use-swift-clangimporter', 'false'))
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test error handling if the expression evaluator
            encounters a Clang import failure.

--- a/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
+++ b/lldb/test/API/lang/swift/clangimporter/submodules/TestSwiftSubmoduleImport.py
@@ -5,7 +5,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftSubmoduleImport(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245705
     def test(self):
         """Test imports of Clang submodules"""
         self.build()

--- a/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
+++ b/lldb/test/API/lang/swift/class_baseclass/TestSwiftClassBaseClass.py
@@ -7,7 +7,7 @@ class TestSwiftClassBaseClass(TestBase):
 
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245096
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(self, "break here",

--- a/lldb/test/API/lang/swift/class_empty/TestSwiftClassEmpty.py
+++ b/lldb/test/API/lang/swift/class_empty/TestSwiftClassEmpty.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/class_error/TestClassError.py
+++ b/lldb/test/API/lang/swift/class_error/TestClassError.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
+++ b/lldb/test/API/lang/swift/class_static/TestSwiftClassStatic.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
+++ b/lldb/test/API/lang/swift/closure_shortcuts/TestClosureShortcuts.py
@@ -16,7 +16,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestClosureShortcuts(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
+++ b/lldb/test/API/lang/swift/closures_var_not_captured/TestSwiftClosureVarNotCaptured.py
@@ -52,7 +52,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         return (target, process, thread)
 
     @swiftTest
-    @expectedFailureWindows
     def test_simple_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_simple_closure")
@@ -61,7 +60,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
-    @expectedFailureWindows
     def test_nested_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_double_closure_1")
@@ -86,7 +84,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
-    @expectedFailureWindows
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
     def test_async_closure(self):
@@ -110,7 +107,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
-    @expectedFailureWindows
     # Async variable inspection on Linux/Windows are still problematic.
     @skipIf(oslist=["windows", "linux"])
     def test_task_inside_non_async_func(self):
@@ -123,7 +119,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         )
 
     @swiftTest
-    @expectedFailureWindows
     def test_ctor_class_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_class")
@@ -181,7 +176,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
-    @expectedFailureWindows
     def test_ctor_struct_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_struct")
@@ -239,7 +233,6 @@ class TestSwiftClosureVarNotCaptured(TestBase):
         check_no_enhanced_diagnostic(self, thread.frames[0], "dont_find_me")
 
     @swiftTest
-    @expectedFailureWindows
     def test_ctor_enum_closure(self):
         self.build()
         (target, process, thread) = self.get_to_bkpt("break_ctor_enum")

--- a/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
+++ b/lldb/test/API/lang/swift/command_memory_find/TestSwiftCommandMemoryFind.py
@@ -19,7 +19,7 @@ class TestSwiftCommandMemoryFind(TestBase):
                     substrs=["data found at location"])
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173244841
     def test(self):
         self.build()
         target, _, _, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
+++ b/lldb/test/API/lang/swift/command_memory_read/TestSwiftMemoryRead.py
@@ -6,7 +6,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_scalar_types(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(
@@ -36,7 +36,7 @@ class TestCase(TestBase):
             )
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     @expectedFailureAll
     def test_generic_types(self):
         self.build()

--- a/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
+++ b/lldb/test/API/lang/swift/conditional_breakpoints/TestSwiftConditionalBreakpoint.py
@@ -19,7 +19,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConditionalBreakpoint(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_conditional_breakpoint(self):
         """Tests that we can set a conditional breakpoint in Swift code"""
         self.build()

--- a/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
+++ b/lldb/test/API/lang/swift/constrained_existential/TestSwiftConstrainedExistential.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftConstrainedExistential(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test constrained existential types"""
 

--- a/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
+++ b/lldb/test/API/lang/swift/debug_prefix_map/TestSwiftDebugPrefixMap.py
@@ -23,7 +23,6 @@ import shutil
 
 class TestSwiftDebugPrefixMap(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_debug_prefix_map(self):
         self.do_test()
 

--- a/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
+++ b/lldb/test/API/lang/swift/delayed_parsing_crash/TestDelayedParsingCrash.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
+++ b/lldb/test/API/lang/swift/designated_initializer_self/TestDesignatedInitializerSelf.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
+++ b/lldb/test/API/lang/swift/different_abi_name/TestSwiftDifferentABIName.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftDifferentABIName(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
+++ b/lldb/test/API/lang/swift/dwarfimporter/MemberTypes/TestSwiftDWARFImporterMemberTypes.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test looking up a Clang typedef type that isn't directly
         referenced by debug info in the Swift object file.

--- a/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
+++ b/lldb/test/API/lang/swift/dynamic_self/TestSwiftDynamicSelf.py
@@ -30,7 +30,6 @@ class TestSwiftDynamicSelf(lldbtest.TestBase):
         lldbutil.check_variable(self, member_v, False, value=v_val)
 
     @swiftTest
-    @expectedFailureWindows
     def test_dynamic_self(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
+++ b/lldb/test/API/lang/swift/dynamic_value/TestSwiftDynamicValue.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftDynamicValueTest(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_dynamic_value(self):
         """Tests that dynamic values work correctly for Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
+++ b/lldb/test/API/lang/swift/enum_as_value/TestSwiftEnumAsValue.py
@@ -9,7 +9,6 @@ class TestSwiftAnyType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_any_type(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
+++ b/lldb/test/API/lang/swift/enum_associated/TestEnumAssociated.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
+++ b/lldb/test/API/lang/swift/enum_objc/TestSwiftEnumObjC.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftDWARFImporterC(lldbtest.TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     @expectedFailureAll(oslist=["linux"], bugnumber="rdar://83444822")
     def test(self):
         self.build()

--- a/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
+++ b/lldb/test/API/lang/swift/enum_tagged/TestEnumTagged.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/enums/extension/TestSwiftEnumExtension.py
+++ b/lldb/test/API/lang/swift/enums/extension/TestSwiftEnumExtension.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test indirect enums"""
         self.build()

--- a/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
+++ b/lldb/test/API/lang/swift/enums/indirect/TestSwiftEnumIndirect.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test indirect enums"""
         self.build()

--- a/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
+++ b/lldb/test/API/lang/swift/enums/single_case_indirect/TestSwiftSingleCaseIndirectEnum.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftSingleCaseIndirectEnum(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test single-case indirect enum projection"""
         self.build()

--- a/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
+++ b/lldb/test/API/lang/swift/error_handling_missing_type/TestSwiftErrorHandlingMissingType.py
@@ -7,8 +7,7 @@ class TestSwiftErrorHandlingMissingTypes(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @expectedFailureWindows
-    @skipIf(swift_module_importer="clangimporter")
+    @skipIf(setting=('symbols.use-swift-clangimporter', 'true'))
     def test(self):
         """Test that errors are surfaced"""
         self.build()

--- a/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
+++ b/lldb/test/API/lang/swift/explicit_modules/no-caching/TestSwiftExplicitModuleNoCaching.py
@@ -7,6 +7,7 @@ class TestSwiftExplicitModuleNoCaching(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
+    @expectedFailureWindows
     def test(self):
         """
         Test that an uncached EBM build with a CAS config works.

--- a/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
+++ b/lldb/test/API/lang/swift/expression/access_control/TestSwiftExpressionAccessControl.py
@@ -8,7 +8,6 @@ import os
 class TestSwiftExpressionAccessControl(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_expression_access_control(self):
         """Make sure expressions ignore access control"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
+++ b/lldb/test/API/lang/swift/expression/actor/TestSwiftExpressionActor.py
@@ -7,7 +7,6 @@ import os
 
 class TestSwiftExpressionActor(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_static_func(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -17,7 +16,6 @@ class TestSwiftExpressionActor(TestBase):
         self.expect("expr self", substrs=["A.Type"])
 
     @swiftTest
-    @expectedFailureWindows
     def test_func(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
+++ b/lldb/test/API/lang/swift/expression/allocator/TestSwiftExprAllocator.py
@@ -10,7 +10,6 @@ class TestSwiftExprAllocator(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_allocator_self(self):
         """Test expressions involving self in a allocating constructor. In an
         allocator, self is just a local variable, not being passed in, but

--- a/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
+++ b/lldb/test/API/lang/swift/expression/basic/TestSwiftBasicExpression.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
+++ b/lldb/test/API/lang/swift/expression/class_constrained_protocol/TestClassConstrainedProtocol.py
@@ -15,28 +15,24 @@ from lldbsuite.test.decorators import *
 
 class TestClassConstrainedProtocol(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_extension_weak_self(self):
         """Test that we can reconstruct weak self captured in a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for weak self", needs_dynamic=False)
 
     @swiftTest
-    @expectedFailureWindows
     def test_extension_self (self):
         """Test that we can reconstruct self in method of a class constrained protocol."""
         self.build()
         self.do_self_test("Break here in class protocol", needs_dynamic=False)
 
     @swiftTest
-    @expectedFailureWindows
     def test_method_weak_self(self):
         """Test that we can reconstruct weak self capture in method of a class conforming to a class constrained protocol."""
         self.build()
         self.do_self_test("Break here for method weak self", needs_dynamic=False)
 
     @swiftTest
-    @expectedFailureWindows
     def test_method_self(self):
         """Test that we can reconstruct self in method of a class conforming to a class constrained protocol."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
+++ b/lldb/test/API/lang/swift/expression/classes/open/TestSwiftExpressionOpenClass.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestExpressionOpenClass(TestBase):
     NO_DEBUG_INFO_TEST = True
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests calling an open function"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/lldb/test/API/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -21,7 +21,6 @@ import os
 
 class TestExpressionsInSwiftMethodsPureSwift(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_expressions_in_methods(self):
         """Tests that we can run simple Swift expressions correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/empty_self/TestEmptySelf.py
+++ b/lldb/test/API/lang/swift/expression/empty_self/TestEmptySelf.py
@@ -13,6 +13,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
+++ b/lldb/test/API/lang/swift/expression/error_reporting/TestSwiftExpressionErrorReporting.py
@@ -7,7 +7,6 @@ class TestSwiftExpressionErrorReporting(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @expectedFailureWindows
     def test_missing_location(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
@@ -35,7 +34,6 @@ class TestSwiftExpressionErrorReporting(TestBase):
         )
 
     @swiftTest
-    @expectedFailureWindows
     def test_missing_var(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""
@@ -90,7 +88,6 @@ class TestSwiftExpressionErrorReporting(TestBase):
         check(value)
 
     @swiftTest
-    @expectedFailureWindows
     def test_missing_type(self):
         """Test error reporting in expressions reports
         only diagnostics in user code"""

--- a/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
+++ b/lldb/test/API/lang/swift/expression/exclusivity_suppression/TestExclusivitySuppression.py
@@ -32,7 +32,6 @@ class TestExclusivitySuppression(TestBase):
     # Test that we can evaluate w.s.i at Breakpoint 1 without triggering
     # a failure due to exclusivity
     @swiftTest
-    @expectedFailureWindows
     def test_basic_exclusivity_suppression(self):
         """Test that exclusively owned values can still be accessed"""
 
@@ -53,7 +52,6 @@ class TestExclusivitySuppression(TestBase):
     # (5) Evaluating w.s.i again to check that finishing the nested expression
     #     did not prematurely re-enable exclusivity checks.
     @swiftTest
-    @expectedFailureWindows
     def test_exclusivity_suppression_for_concurrent_expressions(self):
         """Test that exclusivity suppression works with concurrent expressions"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/function_definition/TestSwiftFunctionDefinition.py
+++ b/lldb/test/API/lang/swift/expression/function_definition/TestSwiftFunctionDefinition.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftFunctionDefinition(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that persistent variables are mutable."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/lldb/test/API/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -29,14 +29,12 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    @expectedFailureWindows
     def test_generic_expressions(self):
         """Test expressions in generic contexts"""
         self.build()
         self.do_test()
 
     @swiftTest
-    @expectedFailureWindows
     def test_ivars_in_generic_expressions(self):
         """Test ivar access through expressions in generic contexts"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/generic_protocol_extension/TestGenericProtocolExtension.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/expression/language_version/TestSwiftExpressionLanguageVersion.py
+++ b/lldb/test/API/lang/swift/expression/language_version/TestSwiftExpressionLanguageVersion.py
@@ -7,7 +7,6 @@ class TestSwiftExpressionLanguageVersion(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test changing the Swift language version"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
+++ b/lldb/test/API/lang/swift/expression/missing_type/TestSwiftExprMissingType.py
@@ -5,7 +5,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftExprMissingType(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
+++ b/lldb/test/API/lang/swift/expression/mutable_persistent_var/TestSwiftMutablePersistentVar.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftMutablePersistentVar(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that persistent variables are mutable."""
         self.build()

--- a/lldb/test/API/lang/swift/expression/mutating_struct_extension/TestMutatingStructExtension.py
+++ b/lldb/test/API/lang/swift/expression/mutating_struct_extension/TestMutatingStructExtension.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
+++ b/lldb/test/API/lang/swift/expression/optional_amibiguity/TestOptionalAmbiguity.py
@@ -16,7 +16,6 @@ from lldbsuite.test.lldbtest import *
 
 class TestOptionalAmbiguity(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_sample_rename_this(self):
         self.build()
         self.main_source_file = lldb.SBFileSpec("main.swift")

--- a/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
+++ b/lldb/test/API/lang/swift/expression/overload/TestDefiningOverloadedFunctions.py
@@ -21,7 +21,6 @@ import os
 
 class TestDefiningOverloadedFunctions(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_simple_overload_expressions(self):
         """Test defining overloaded functions"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension/TestExprInProtocolExtension.py
@@ -32,7 +32,6 @@ class TestSwiftExprInProtocolExtension(TestBase):
         self.target.BreakpointDelete(bkpt.GetID())
 
     @swiftTest
-    @expectedFailureWindows
     def test_protocol_extension(self):
         """Tests that swift expressions in protocol extension functions behave correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
+++ b/lldb/test/API/lang/swift/expression/protocol_extension_self/TestSwiftProtocolExtensionSelf.py
@@ -5,7 +5,6 @@ from lldbsuite.test.decorators import *
 
 class TestSwiftProtocolExtensionSelf(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that the generic self in a protocol extension works in the expression evaluator.
         """

--- a/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/lldb/test/API/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftExpressionScopes(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_expression_scopes(self):
         """Tests that swift expressions resolve scoped variables correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/self/TestSwiftSelf.py
+++ b/lldb/test/API/lang/swift/expression/self/TestSwiftSelf.py
@@ -13,6 +13,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
+++ b/lldb/test/API/lang/swift/expression/simple/TestSwiftSimpleExpressions.py
@@ -22,7 +22,6 @@ import sys
 
 class TestSwiftSimpleExpressions(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_simple_swift_expressions(self):
         """Tests that we can run simple Swift expressions correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/lldb/test/API/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftExpressionsInClassFunctions(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_expressions_in_class_functions(self):
         """Test expressions in class func contexts"""
         self.build()

--- a/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
+++ b/lldb/test/API/lang/swift/expression/typealias/TestSwiftExpressionTypeAlias.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftExpressionTypeAlias(lldbtest.TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_generic_self/TestSwiftWeakGenericSelf.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftWeakGenericSelf(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Confirms that expression evaluation works with a generic class
         type within a closure that weakly captures it"""

--- a/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
+++ b/lldb/test/API/lang/swift/expression/weak_self/TestWeakSelf.py
@@ -19,7 +19,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGenericExtension(TestBase):
      @swiftTest
-     @expectedFailureWindows
      def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
+++ b/lldb/test/API/lang/swift/file_private/TestFilePrivate.py
@@ -30,7 +30,6 @@ class TestFilePrivate(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that we find the right file-local private decls using the discriminator"""
         self.build()

--- a/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
+++ b/lldb/test/API/lang/swift/fixits/TestSwiftFixIts.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftFixIts(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_fixits(self):
         """Test applying fixits to expressions"""
         self.build()

--- a/lldb/test/API/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
+++ b/lldb/test/API/lang/swift/frame_var_object_fully_realized/TestFullyRealizedFrameVar.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
+++ b/lldb/test/API/lang/swift/generic_arg_in_extension/TestSwiftGenericArgInExtension.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
+++ b/lldb/test/API/lang/swift/generic_arguments/TestSwiftGenericArgumentTypes.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         _, _, thread, _ = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
+++ b/lldb/test/API/lang/swift/generic_class/TestSwiftGenericClass.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftGenericClassTest(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests that a generic class type can be resolved from the instance metadata alone"""
         self.build()

--- a/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
+++ b/lldb/test/API/lang/swift/generic_class_arg/TestSwiftGenericClassArg.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
+++ b/lldb/test/API/lang/swift/generic_class_nested_in_function/TestSwiftGenericClassNestedInFunction.py
@@ -7,7 +7,7 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftGenericClassNestedInFunctionTest(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245096
     def test(self):
         """Tests that a generic class type nested inside a function can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/generic_error/TestGenericError.py
+++ b/lldb/test/API/lang/swift/generic_error/TestGenericError.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
+++ b/lldb/test/API/lang/swift/generic_error_tuple/TestGenericErrorTuple.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
+++ b/lldb/test/API/lang/swift/generic_existentials/TestGenericExistentials.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
+++ b/lldb/test/API/lang/swift/generic_extension/TestSwiftGenericExtension.py
@@ -18,7 +18,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGenericExtension(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
+++ b/lldb/test/API/lang/swift/generic_extensions_typealias/TestGenericExtensionsTypealias.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
+++ b/lldb/test/API/lang/swift/generic_function_name/TestSwiftGenericFunctionName.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftGenericFunction(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test display of generic function names"""
         self.build()

--- a/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
+++ b/lldb/test/API/lang/swift/generic_self/TestSwiftGenericSelf.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
+++ b/lldb/test/API/lang/swift/generic_tuple/TestSwiftGenericTuple.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
+++ b/lldb/test/API/lang/swift/generic_type_of_nested_archetype/TestSwiftGenericTypeOfNestedArchetype.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
+++ b/lldb/test/API/lang/swift/generics/TestSwiftGenericsResolution.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftDynamicTypeGenericsTest(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_genericresolution_commands(self):
         """Check that we can correctly figure out the dynamic type of generic things"""
         self.build()

--- a/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
+++ b/lldb/test/API/lang/swift/get_value/TestSwiftGetValueAsUnsigned.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftGetValueAsUnsignedAPITest(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_get_value_as_unsigned_sbapi(self):
         """Tests that the SBValue::GetValueAsUnsigned() API works for Swift types"""
         self.build()

--- a/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
+++ b/lldb/test/API/lang/swift/hashed_container_storing_nested_generic/TestHashedContainerStoringNestedGeneric.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftGenericClassInHashedContainerTest(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests that the type of hashed container whose value type is a non-generic class declared inside a generic class can be read from instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
+++ b/lldb/test/API/lang/swift/hashed_containers_enums/TestSwiftHashedContainerEnum.py
@@ -12,7 +12,7 @@ import os
 
 class TestSwiftHashedContainerEnum(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173243316
     def test_any_object_type(self):
         """Test combinations of hashed swift containers with enums"""
         self.build()

--- a/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
+++ b/lldb/test/API/lang/swift/hide_runtimesupport/TestSwiftHideRuntimeSupport.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftHideRuntimeSupport(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_hide_runtime_support(self):
         """Test that we hide runtime support values"""
 

--- a/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
+++ b/lldb/test/API/lang/swift/instance_pointer_set_sp/TestSwiftInstancePointerSetSP.py
@@ -24,7 +24,6 @@ class TestSwiftInstancePointerSetSP(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_instancepointerset_sp(self):
         """Test that we correctly track instance pointers in ValueObjectPrinter"""
         self.build()

--- a/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
+++ b/lldb/test/API/lang/swift/let_int/TestSwiftLetInt.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftLetIntSupport(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_let_int(self):
         """Test that a 'let' Int is formatted properly"""
         self.build()

--- a/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
+++ b/lldb/test/API/lang/swift/local_closure_types/TestSwiftLocalClosureTypes.py
@@ -15,5 +15,9 @@ from lldbsuite.test.decorators import *
 lldbinline.MakeInlineTest(
     __file__,
     globals(),
-    decorators=[swiftTest, expectedFailureWindows,
-                skipIf(oslist=["macosx"],bugnumber="rdar://26051759")])
+    decorators=[
+        swiftTest,
+        skipIf(oslist=["macosx"], bugnumber="rdar://26051759"),
+        skipIfWindows # rdar://173245096
+    ],
+)

--- a/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
+++ b/lldb/test/API/lang/swift/local_types/TestSwiftLocalTypes.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
+++ b/lldb/test/API/lang/swift/materializer_archetype_binding/TestSwiftMaterializerArchetypeBinding.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
+++ b/lldb/test/API/lang/swift/metadata_cache/TestSwiftMetadataCache.py
@@ -41,7 +41,6 @@ class TestSwiftMetadataCache(TestBase):
             
         
     @swiftTest
-    @expectedFailureWindows
     def test_swift_metadata_cache(self):
         """Test the swift metadata cache."""
         

--- a/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
+++ b/lldb/test/API/lang/swift/metatype/TestSwiftMetatype.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftMetatype(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_metatype(self):
         """Test the formatting of Swift metatypes"""
         self.build()

--- a/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
+++ b/lldb/test/API/lang/swift/module_import/TestSwiftModuleImport.py
@@ -9,7 +9,6 @@ class TestSwiftModuleImport(lldbtest.TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
+++ b/lldb/test/API/lang/swift/module_search_paths/TestSwiftModuleSearchPaths.py
@@ -26,7 +26,6 @@ class TestSwiftModuleSearchPaths(TestBase):
 
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_module_search_paths(self):
         """
         Tests that we can import modules located using

--- a/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
+++ b/lldb/test/API/lang/swift/multi_optionals/TestMultiOptionals.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/multibases/TestSwiftMultipleBases.py
+++ b/lldb/test/API/lang/swift/multibases/TestSwiftMultipleBases.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
+++ b/lldb/test/API/lang/swift/multipayload_enum/TestSwiftMultipayloadEnum.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftMultipayloadEnum(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_multipayload_enum(self):
         """Test that LLDB understands generic enums with more than one payload type"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
+++ b/lldb/test/API/lang/swift/nested_arrays/TestSwiftNestedArray.py
@@ -38,7 +38,6 @@ class TestSwiftNestedArray(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_nested_array(self):
         """Test Arrays of Arrays in Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
+++ b/lldb/test/API/lang/swift/nested_c_enums/TestSwiftNestedCEnums.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
+++ b/lldb/test/API/lang/swift/nested_generic/TestSwiftNestedGeneric.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftNestedGeneric(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test the inline array synthetic child provider and summary"""
         self.build()

--- a/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/nested_generic_class/TestSwiftNestedGenericClass.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftNestedGenericClass(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests that a generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
+++ b/lldb/test/API/lang/swift/no_runtime/TestSwiftNoRuntime.py
@@ -7,7 +7,6 @@ class TestSwiftNoRuntime(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test running a Swift expression in a C program"""
         self.build()

--- a/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
+++ b/lldb/test/API/lang/swift/one_case_enum/TestSwiftOneCaseEnum.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftOneCaseEnum(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_one_case_enum(self):
         """Test that an enum with only one case does not crash LLDB"""
         self.build()

--- a/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
+++ b/lldb/test/API/lang/swift/opaque_existentials/TestOpaqueExistentials.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
+++ b/lldb/test/API/lang/swift/opaque_return/TestBoundOpaqueArchetype.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestBoundOpaqueArchetype(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         
         self.build()

--- a/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
+++ b/lldb/test/API/lang/swift/opaque_return_frame_var/TestSwiftGlobalOpaque.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftGlobalOpaque(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests that a type bound to an opaque archetype can be resolved correctly"""         
         self.build()

--- a/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
+++ b/lldb/test/API/lang/swift/opaque_return_types/TestOpaqueReturnTypes.py
@@ -6,7 +6,6 @@ lldbinline.MakeInlineTest(
     globals(),
     decorators=[
         swiftTest,
-        expectedFailureWindows,
         skipIf(macos_version=["<", "10.15"]),
     ],
 )

--- a/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
+++ b/lldb/test/API/lang/swift/opaque_type/TestSwiftOpaqueType.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftOpaque(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test opaque types in parameter positions"""         
         self.build()

--- a/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
+++ b/lldb/test/API/lang/swift/optimized_code/bound_generic_enum/TestSwiftOptimizedBoundGenericEnum.py
@@ -10,7 +10,6 @@ class TestSwiftOptimizedBoundGenericEnum(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test the bound generic enum types in "optimized" code."""
         self.build()

--- a/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
+++ b/lldb/test/API/lang/swift/orig_defined_payload/TestSwiftOriginallyDefinedInPayload.py
@@ -7,7 +7,6 @@ import os
 
 class TestSwiftOriginallyDefinedInPayload(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
+++ b/lldb/test/API/lang/swift/originally_defined_in/TestSwiftOriginallyDefinedIn.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 
@@ -38,7 +37,6 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
         )
     
     @swiftTest
-    @expectedFailureWindows
     def test_expr(self):
         """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
     
@@ -67,7 +65,6 @@ class TestSwiftOriginallyDefinedIn(lldbtest.TestBase):
         )
     
     @swiftTest
-    @expectedFailureWindows
     def test_expr_from_generic(self):
          """Test that types with the @_originallyDefinedIn attribute can still be found in metadata"""
 

--- a/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/class/TestSwiftPartiallyGenericFuncClass.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/continuations/TestSwiftPartiallyGenericFuncContinuation.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/enum/TestSwiftPartiallyGenericFuncEnum.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
+++ b/lldb/test/API/lang/swift/partially_generic_func/struct/TestSwiftPartiallyGenericFuncStruct.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
+++ b/lldb/test/API/lang/swift/po/conflicted_name/TestSwiftPOConflictedTypes.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
+++ b/lldb/test/API/lang/swift/po/pointer_and_mangled_typename/TestSwiftPrintObjectPointerAndTypeName.py
@@ -16,7 +16,7 @@ class TestCase(TestBase):
         self.filecheck_log(self.log, __file__, f"-check-prefix=CHECK-{key}")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_int(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -27,7 +27,7 @@ class TestCase(TestBase):
         # CHECK-INT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SiD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_string(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -38,7 +38,7 @@ class TestCase(TestBase):
         # CHECK-STRING: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "SSD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -49,7 +49,7 @@ class TestCase(TestBase):
         # CHECK-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a6StructVD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -60,7 +60,7 @@ class TestCase(TestBase):
         # CHECK-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a5ClassCD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -71,7 +71,7 @@ class TestCase(TestBase):
         # CHECK-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a4EnumOD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_generic_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -82,7 +82,7 @@ class TestCase(TestBase):
         # CHECK-GEN-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a13GenericStructVySSGD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_generic_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -93,7 +93,7 @@ class TestCase(TestBase):
         # CHECK-GEN-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a12GenericClassCySSGD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_generic_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -104,7 +104,7 @@ class TestCase(TestBase):
         # CHECK-GEN-ENUM: stringForPrintObject(UnsafeRawPointer(bitPattern: {{.*}}), mangledTypeName: "1a11GenericEnumOySSGD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_described_struct(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -115,7 +115,7 @@ class TestCase(TestBase):
         # CHECK-DESC-STRUCT: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a15DescribedStructVD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_described_class(self):
         self.build()
         lldbutil.run_to_source_breakpoint(
@@ -126,7 +126,7 @@ class TestCase(TestBase):
         # CHECK-DESC-CLASS: stringForPrintObject(UnsafeRawPointer(bitPattern: {{[0-9]+}}), mangledTypeName: "1a14DescribedClassCD")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_described_enum(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
+++ b/lldb/test/API/lang/swift/po/private_subclass/TestSwiftPrintObjectPrivateSubclass.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestCase(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
+++ b/lldb/test/API/lang/swift/po/recursive/TestSwiftPORecursiveBehavior.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
+++ b/lldb/test/API/lang/swift/po/ref_types/TestSwiftPORefTypes.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
+++ b/lldb/test/API/lang/swift/po/val_types/TestSwiftPOValTypes.py
@@ -18,7 +18,6 @@ from lldbsuite.test.decorators import *
 class TestSwiftPOValueTypes(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test_value_types(self):
         """Test 'po' on a variety of value types with and without custom descriptions."""
         self.build()
@@ -40,7 +39,6 @@ class TestSwiftPOValueTypes(TestBase):
         self.expect("po patatino", substrs=['foo'])
 
     @swiftTest
-    @expectedFailureWindows
     def test_ignore_bkpts_in_po(self):
         """Run a po expression with a breakpoint in the debugDescription, make sure we don't hit it."""
 

--- a/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
+++ b/lldb/test/API/lang/swift/printdecl/TestSwiftTypeLookup.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftTypeLookup(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_type_lookup(self):
         """Test the ability to look for type definitions at the command line"""
         self.build()

--- a/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
+++ b/lldb/test/API/lang/swift/private_decl_name/TestSwiftPrivateDeclName.py
@@ -28,7 +28,6 @@ class TestSwiftPrivateDeclName(TestBase):
         self.b_source_spec = lldb.SBFileSpec(self.b_source)
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_private_decl_name(self):
         """Test that we correctly find private decls"""
         self.build()

--- a/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
+++ b/lldb/test/API/lang/swift/private_generic_self/TestSwiftPrivateGenericSelf.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
+++ b/lldb/test/API/lang/swift/private_nested_generic_class/TestSwiftPrivateNestedGenericClass.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class SwiftPrivateNestedGenericClassTest(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Tests that a private generic class type nested inside another generic class can be resolved correctly from the instance metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
+++ b/lldb/test/API/lang/swift/private_self/TestSwiftPrivateSelf.py
@@ -13,5 +13,5 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+    __file__, globals(), decorators=[swiftTest]
 )

--- a/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
+++ b/lldb/test/API/lang/swift/private_typealias/TestSwiftPrivateTypeAlias.py
@@ -21,7 +21,7 @@ import os
 
 class TestSwiftPrivateTypeAlias(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173243316
     def test_swift_private_typealias(self):
         """Test that we can correctly print variables whose types are private type aliases"""
         self.build()

--- a/lldb/test/API/lang/swift/private_var/TestSwiftPrivateVar.py
+++ b/lldb/test/API/lang/swift/private_var/TestSwiftPrivateVar.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
+++ b/lldb/test/API/lang/swift/protocol_composition_expr/TestSwiftProtocolCompositionExpr.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftProtocolCompositionExpr(lldbtest.TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that expression evaluation can call functions in protocol composition existentials"""
 

--- a/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
+++ b/lldb/test/API/lang/swift/protocol_default_extension_no_self_reference/TestDefaultProtocolExtensionNoSelfReference.py
@@ -8,7 +8,6 @@ from lldbsuite.test.decorators import *
 
 class TestDefaultProtocolExtensionNoSelfReference(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_protocol_default_extension_no_self_reference(self):
         """
         Test that we can resolve "self" even if there are no references to it in a dynamic context

--- a/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
+++ b/lldb/test/API/lang/swift/protocol_extension_two/TestProtocolExtensionTwo.py
@@ -1,6 +1,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
+++ b/lldb/test/API/lang/swift/protocol_optional/TestSwiftProtocolOptional.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
+++ b/lldb/test/API/lang/swift/ranges/TestSwiftRangeTypes.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftRangeType(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_range_type(self):
         """Test the Swift.Range<T> type"""
         self.build()

--- a/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
+++ b/lldb/test/API/lang/swift/reference_storage_types/TestSwiftReferenceStorageTypes.py
@@ -22,7 +22,6 @@ import os
 class TestSwiftReferenceStorageTypes(TestBase):
     @decorators.skipIf(archs=['ppc64le']) #SR-10215
     @swiftTest
-    @expectedFailureWindows
     def test_swift_reference_storage_types(self):
         """Test weak, unowned and unmanaged types"""
         self.build()

--- a/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
+++ b/lldb/test/API/lang/swift/regex/TestSwiftRegex.py
@@ -25,8 +25,8 @@ class TestSwiftRegex(TestBase):
         self.main_source_spec = lldb.SBFileSpec(self.main_source)
 
     @swiftTest
-    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
+    @expectedFailureWindows
     def test_swift_regex_frame_var(self):
         """Test frame variable support for Swift regexes."""
         self.build()
@@ -38,7 +38,6 @@ class TestSwiftRegex(TestBase):
                     substrs=['(_StringProcessing.Regex<Substring>) dslRegex = {'])
 
     @swiftTest
-    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_expr_desc(self):
         """Test expression object description support for Swift regexes."""
@@ -51,7 +50,6 @@ class TestSwiftRegex(TestBase):
                     substrs=['Regex<Substring>'])
 
     @swiftTest
-    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_frame_var_desc(self):
         """Test frame variable object description support for Swift regexes."""
@@ -64,8 +62,8 @@ class TestSwiftRegex(TestBase):
                     substrs=['Regex<Substring>'])
 
     @swiftTest
-    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
+    @expectedFailureWindows
     def test_swift_regex_expr(self):
         """Test expression support for Swift regexes."""
         self.build()
@@ -77,7 +75,6 @@ class TestSwiftRegex(TestBase):
                     substrs=['(_StringProcessing.Regex<Substring>) $R1 = {'])
 
     @swiftTest
-    @expectedFailureWindows
     @skipIf(macos_version=["<", "13"])
     def test_swift_regex_in_exp(self):
         """Test Swift's regex support"""

--- a/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
+++ b/lldb/test/API/lang/swift/resilience_private_field/TestSwiftResiliencePrivateField.py
@@ -9,7 +9,6 @@ class TestSwiftResiliencePrivateField(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/runtime_failure_recognizer/TestSwiftRuntimeFailureRecognizer.py
+++ b/lldb/test/API/lang/swift/runtime_failure_recognizer/TestSwiftRuntimeFailureRecognizer.py
@@ -23,7 +23,6 @@ class TestSwiftRuntimeRecognizer(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_runtime_recognizer(self):
         """Test Swift Runtime Failure Recognizer"""
         self.build()

--- a/lldb/test/API/lang/swift/span/TestSwiftSpan.py
+++ b/lldb/test/API/lang/swift/span/TestSwiftSpan.py
@@ -7,7 +7,7 @@ from lldbsuite.test import lldbutil
 class TestCase(TestBase):
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test(self):
         self.build()
         lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
+++ b/lldb/test/API/lang/swift/split_debug/TestSwiftSplitDebug.py
@@ -24,7 +24,6 @@ class TestSwiftSplitDebug(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_split_debug_info(self):
         """Test split debug info"""
         self.build()

--- a/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
+++ b/lldb/test/API/lang/swift/stdlib/ContiguousArray/TestContiguousArray.py
@@ -13,7 +13,6 @@ class TestContiguousArray(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_frame_contiguous_array(self):
         """Test that contiguous array prints correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
+++ b/lldb/test/API/lang/swift/step_into_override/TestStepIntoOverride.py
@@ -9,7 +9,6 @@ class TestStepIntoOverride(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_stepping(self):
         self.build()
         self.do_test()

--- a/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
+++ b/lldb/test/API/lang/swift/step_through_allocating_init/TestStepThroughAllocatingInit.py
@@ -9,14 +9,12 @@ class TestStepThroughAllocatingInit(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_stepping_api(self):
         """Test that step in using the Python API steps through thunk."""
         self.build()
         self.do_test(True)
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_stepping_cli(self):
         """Same test with the cli - it goes a slightly different path than
            the API."""

--- a/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
+++ b/lldb/test/API/lang/swift/stepping/TestSwiftStepping.py
@@ -24,7 +24,6 @@ class TestSwiftStepping(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     @skipIf(oslist=["linux"], archs=no_match("x86_64"))
     def test_swift_stepping(self):
         """Tests that we can step reliably in swift code."""

--- a/lldb/test/API/lang/swift/string/TestSwiftString.py
+++ b/lldb/test/API/lang/swift/string/TestSwiftString.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftTuple(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test the String formatter under adverse conditions"""
         self.build()

--- a/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
+++ b/lldb/test/API/lang/swift/struct_change_rerun/TestSwiftStructChangeRerun.py
@@ -22,7 +22,6 @@ import shutil
 
 class TestSwiftStructChangeRerun(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_struct_change_rerun(self):
         """Test that we display self correctly for an inline-initialized struct"""
         copied_main_swift = self.getBuildArtifact("main.swift")

--- a/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
+++ b/lldb/test/API/lang/swift/substituted_typealias/TestSwiftSubstitutedTypeAlias.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/swift_callback/TestSwiftCallback.py
+++ b/lldb/test/API/lang/swift/swift_callback/TestSwiftCallback.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
+++ b/lldb/test/API/lang/swift/swift_reference_counting/TestSwiftReferenceCount.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
+++ b/lldb/test/API/lang/swift/symbolic_extended_existential/TestSwiftSymbolicExtendedExistential.py
@@ -7,7 +7,6 @@ import lldbsuite.test.lldbutil as lldbutil
 class TestSwiftSymbolicExtendedExistential(lldbtest.TestBase):
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test symbolic extended existentials"""
         self.build()

--- a/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
+++ b/lldb/test/API/lang/swift/tuple/TestSwiftTuple.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftTuple(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_tuples(self):
         """Test that LLDB understands tuple lowering"""
         self.build()

--- a/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
+++ b/lldb/test/API/lang/swift/type_metadata/TestSwiftTypeMetadata.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class SwiftTypeMetadataTest(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_type_metadata(self):
         """Test that LLDB can effectively use the type metadata to reconstruct dynamic types for Swift"""
         self.build()

--- a/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
+++ b/lldb/test/API/lang/swift/typealias_recursive/TestSwiftTypeAliasRecursive.py
@@ -4,7 +4,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTypeAliasRecurtsive(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test that type aliases of type aliases can be resolved"""
         self.build()

--- a/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
+++ b/lldb/test/API/lang/swift/union/TestSwiftCUnion.py
@@ -10,7 +10,6 @@ class TestSwiftCUnion(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_c_unions(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
+++ b/lldb/test/API/lang/swift/variables/actor/TestSwiftActorTypes.py
@@ -10,7 +10,6 @@ import os
 
 class TestSwiftActorTypes(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_class_types(self):
         """Test swift Actor types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
+++ b/lldb/test/API/lang/swift/variables/array/TestSwiftArrayType.py
@@ -24,7 +24,6 @@ class TestSwiftArrayType(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @swiftTest
-    @expectedFailureWindows
     def test_array(self):
         """Check formatting for Swift.Array<T>"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
+++ b/lldb/test/API/lang/swift/variables/bool/TestSwiftBool.py
@@ -21,7 +21,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftBool(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_bool(self):
         """Test that we can inspect various Swift bools"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
+++ b/lldb/test/API/lang/swift/variables/bulky_enums/TestBulkyEnumsVariables.py
@@ -21,7 +21,6 @@ import os
 
 class TestBulkyEnumVariables(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_bulky_enum_variables(self):
         """Tests that large-size Enum variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
+++ b/lldb/test/API/lang/swift/variables/class/TestSwiftClassTypes.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftClassTypes(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_class_types(self):
         """Test swift Class types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/closure_types/TestSwiftClosureTypes.py
+++ b/lldb/test/API/lang/swift/variables/closure_types/TestSwiftClosureTypes.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftClosureTypes(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         self.build()
 

--- a/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator/TestSwiftConsumeOperator.py
@@ -27,7 +27,6 @@ class TestSwiftConsumeOperatorType(TestBase):
     # Skip on aarch64 linux: rdar://91005071
     @skipIf(archs=['aarch64'], oslist=['linux'])
     @swiftTest
-    @expectedFailureWindows
     def test_swift_consume_operator(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.

--- a/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
+++ b/lldb/test/API/lang/swift/variables/consume_operator_async/TestSwiftConsumeOperatorAsync.py
@@ -25,7 +25,7 @@ def stderr_print(line):
 
 class TestSwiftConsumeOperatorAsyncType(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://176009590
     def test_swift_consume_operator_async(self):
         """Check that we properly show variables at various points of the CFG while
         stepping with the consume operator.

--- a/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/lldb/test/API/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -84,7 +84,7 @@ class TestSwiftStdlibDictionary(TestBase):
                         (key_str, value_str)))
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173243316
     # @skipIfLinux  # bugs.swift.org/SR-844
     def test_swift_stdlib_dictionary(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary"""

--- a/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/enums/TestSwiftEnumVariables.py
@@ -21,7 +21,6 @@ import os
 
 class TestEnumVariables(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_enum_variables(self):
         """Tests that Enum variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
+++ b/lldb/test/API/lang/swift/variables/error_type/TestSwiftErrorType.py
@@ -16,7 +16,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftErrorType(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test handling of Swift Error types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
+++ b/lldb/test/API/lang/swift/variables/func/TestSwiftFunctionVariables.py
@@ -20,7 +20,7 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestFunctionVariables(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245096
     def test_function_variables(self):
         """Tests that function type variables display correctly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
+++ b/lldb/test/API/lang/swift/variables/generic_enums/TestSwiftGenericEnums.py
@@ -27,7 +27,6 @@ class TestSwiftGenericEnumTypes(TestBase):
         return var
 
     @swiftTest
-    @expectedFailureWindows
     def test_swift_generic_enum_types(self):
         """Test that we handle reasonably generically-typed enums"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_apply/TestSwiftGenericStructDebugInfoGenericApply.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_array/TestSwiftGenericStructDebugInfoGenericArray.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
+++ b/lldb/test/API/lang/swift/variables/generic_struct_debug_info/generic_flatmap/TestSwiftGenericStructDebugInfoGenericFlatMap.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
+++ b/lldb/test/API/lang/swift/variables/generic_tuple_labels/TestSwiftGenericTupleLabels.py
@@ -27,7 +27,6 @@ class TestSwiftGenericTupleLabels(lldbtest.TestBase):
         lldbtest.TestBase.setUp(self)
 
     @swiftTest
-    @expectedFailureWindows
     def test_generic_tuple_labels(self):
         """Test that LLDB can reconstruct tuple labels from metadata"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
+++ b/lldb/test/API/lang/swift/variables/generics/TestSwiftGenericTypes.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftGenericTypes(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_generic_types(self):
         """Test support for generic types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/lldb/test/API/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftGlobals(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_globals(self):
         """Check that we can examine module globals in the expression parser"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/lldb/test/API/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -21,14 +21,12 @@ import os
 
 class TestIndirectEnumVariables(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_indirect_cases_variables(self):
         """Tests that indirect Enum variables display correctly when cases are indirect"""
         self.build()
         self.do_test("indirect case break here")
 
     @swiftTest
-    @expectedFailureWindows
     def test_indirect_enum_variables(self):
         """Tests that indirect Enum variables display correctly when enum is indirect"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
+++ b/lldb/test/API/lang/swift/variables/inout/TestInOutVariables.py
@@ -19,7 +19,7 @@ import os
 
 class TestInOutVariables(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173243316
     def test_in_out_variables(self):
         """Test that @inout variables display reasonably"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
+++ b/lldb/test/API/lang/swift/variables/let/TestSwiftLetConstants.py
@@ -6,7 +6,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftLetConstants(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_let_constants(self):
         """Test that let constants aren't writeable"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
+++ b/lldb/test/API/lang/swift/variables/optionals/TestSwiftOptionals.py
@@ -21,7 +21,6 @@ import os
 
 class TestSwiftOptionalType(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_optional_type(self):
         """Check formatting for T? and T!"""
         self.do_check_consistency()

--- a/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
+++ b/lldb/test/API/lang/swift/variables/protocol/TestSwiftProtocolTypes.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftProtocolTypes(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_protocol_types(self):
         """Test support for protocol types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
+++ b/lldb/test/API/lang/swift/variables/set/TestSwiftStdlibSet.py
@@ -21,7 +21,7 @@ import os
 
 class TestSwiftStdlibSet(TestBase):
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173243316
     def test_swift_stdlib_set(self):
         """Tests that we properly vend synthetic children for Swift.Set"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/static_string/TestSwiftStaticStringVariables.py
@@ -24,7 +24,6 @@ import os
 
 class TestSwiftStaticStringVariables(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_static_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
+++ b/lldb/test/API/lang/swift/variables/string/TestSwiftStringVariables.py
@@ -24,7 +24,6 @@ import os
 
 class TestSwiftStringVariables(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_string_variables(self):
         """Test that Swift.String formats properly"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
+++ b/lldb/test/API/lang/swift/variables/tuples/TestSwiftTupleTypes.py
@@ -20,7 +20,6 @@ import lldbsuite.test.lldbutil as lldbutil
 
 class TestSwiftTupleTypes(TestBase):
     @swiftTest
-    @expectedFailureWindows
     def test_swift_tuple_types(self):
         """Test support for tuple types"""
         self.build()

--- a/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
+++ b/lldb/test/API/lang/swift/variables/uninitialized/TestSwiftUninitializedVariable.py
@@ -2,5 +2,8 @@ import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
 lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
+    __file__, globals(), decorators=[
+        swiftTest,
+        skipIfWindows # rdar://173243316
+    ]  
 )

--- a/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
+++ b/lldb/test/API/lang/swift/variables/unsafe/TestSwiftUnsafeTypes.py
@@ -15,7 +15,6 @@ class TestSwiftUnsafeTypes(TestBase):
         self.assertEqual(child.GetSummary(), 'nil')
 
     @swiftTest
-    @expectedFailureWindows
     def test(self):
         """Test formatters for unsafe types"""
         self.build()

--- a/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
+++ b/lldb/test/API/lang/swift/yielding_accessors/TestSwiftYieldingAccessors.py
@@ -42,7 +42,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         return hit_line
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245044
     def test_correct_number_of_breakpoints(self):
         self.build()
         exe = self.getBuildArtifact("a.out")
@@ -53,7 +53,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         self.assertEqual(breakpoint.GetNumLocations(), 1, breakpoint)
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245044
     @skipIf(oslist=["linux"], archs=no_match("x86_64")) # rdar://170532470
     def test_step_over_starting_inside_coroutine(self):
         self.build()
@@ -70,7 +70,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         self.hit_correct_line(thread, "last main line")
 
     @swiftTest
-    @expectedFailureWindows
+    @skipIfWindows # rdar://173245044
     def test_step_in_and_out_callsite(self):
         self.build()
         target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(

--- a/lldb/test/API/lang/swift/zero_size_generic_self/TestSwiftZeroSizeGenericSelf.py
+++ b/lldb/test/API/lang/swift/zero_size_generic_self/TestSwiftZeroSizeGenericSelf.py
@@ -12,6 +12,4 @@
 import lldbsuite.test.lldbinline as lldbinline
 from lldbsuite.test.decorators import *
 
-lldbinline.MakeInlineTest(
-    __file__, globals(), decorators=[swiftTest, expectedFailureWindows]
-)
+lldbinline.MakeInlineTest(__file__, globals(), decorators=[swiftTest])

--- a/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
+++ b/lldb/test/API/python_api/sbvalue_updates/TestSBValueUpdates.py
@@ -12,7 +12,6 @@ class TestSBValueUpdates(lldbtest.TestBase):
     mydir = lldbtest.TestBase.compute_mydir(__file__)
 
     @decorators.swiftTest
-    @decorators.expectedFailureWindows
     def test_update_and_format_with_type_change(self):
         """Test that an SBValue can update and format itself as its type
         changes"""


### PR DESCRIPTION
This patch enables running the Swift lldb tests on Windows.

This patch depends on:
- https://github.com/swiftlang/llvm-project/pull/12738
- https://github.com/swiftlang/llvm-project/pull/12632
- https://github.com/llvm/llvm-project/pull/188772
- https://github.com/swiftlang/llvm-project/pull/12661
- https://github.com/swiftlang/llvm-project/pull/12699