### PR TITLE
[21.x][llvm/Support] Introduce `vfs::createSandboxingFileSystem()`

### DIFF
--- a/llvm/include/llvm/Support/SandboxingFileSystem.h
+++ b/llvm/include/llvm/Support/SandboxingFileSystem.h
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// VFS implementation that restricts access to only certain directories.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_SANDBOXINGFILESYSTEM_H
+#define LLVM_SUPPORT_SANDBOXINGFILESYSTEM_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/Support/Error.h"
+
+namespace llvm::vfs {
+class FileSystem;
+
+/// Creates a VFS that restricts access to only certain directories.
+///
+/// \param UnderlyingFS The base file-system that queries will be delegated for
+/// the unrestricted paths.
+/// \param Path A list of paths (and their sub-paths) to restrict access to.
+/// Queries for paths not included in the list will fail with "no such file or
+/// directory" error. If a path is relative it will be made absolute using the
+/// current working directory of \p UnderlyingFS at creation time.
+/// The check for whether a path is contained within one of the \p AllowedPaths
+/// is case-sensitive, and there's no path canonicalization happening.
+Expected<std::unique_ptr<FileSystem>>
+createSandboxingFileSystem(IntrusiveRefCntPtr<FileSystem> UnderlyingFS,
+                           ArrayRef<StringRef> AllowedPaths);
+
+} // end namespace llvm::vfs
+
+#endif // LLVM_SUPPORT_SANDBOXINGFILESYSTEM_H

--- a/llvm/lib/Support/CMakeLists.txt
+++ b/llvm/lib/Support/CMakeLists.txt
@@ -240,6 +240,7 @@ add_llvm_component_library(LLVMSupport
   RISCVAttributes.cpp
   RISCVAttributeParser.cpp
   RISCVISAUtils.cpp
+  SandboxingFileSystem.cpp
   ScaledNumber.cpp
   ScopedPrinter.cpp
   SHA1.cpp

--- a/llvm/lib/Support/SandboxingFileSystem.cpp
+++ b/llvm/lib/Support/SandboxingFileSystem.cpp
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// VFS implementation that restricts access to only certain directories.
+///
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/SandboxingFileSystem.h"
+#include "llvm/Support/VirtualFileSystem.h"
+
+using namespace llvm;
+
+// FIXME: Move to llvm/Support/Path.h?
+/// \returns true if \p Path is a nested directory in \p ParentPath.
+/// \p Path should be absolute. Returns false if \p ParentPath is relative.
+static bool isPathNestedIn(StringRef Path, StringRef ParentPath) {
+  assert(sys::path::is_absolute(Path));
+  if (Path.size() <= ParentPath.size())
+    return false;
+  if (!Path.starts_with(ParentPath))
+    return false;
+  return sys::path::is_separator(Path.drop_front(ParentPath.size()).front());
+}
+
+namespace {
+class SandboxingFileSystem final
+    : public llvm::RTTIExtends<SandboxingFileSystem, vfs::FileSystem> {
+  IntrusiveRefCntPtr<vfs::FileSystem> FS;
+  SmallVector<std::string, 3> AllowedPaths;
+
+  ErrorOr<bool> isInSandbox(const Twine &Path) const {
+    SmallString<256> PathToCheck;
+    Path.toVector(PathToCheck);
+    if (std::error_code EC = FS->makeAbsolute(PathToCheck))
+      return EC;
+
+    for (const auto &AllowedPath : AllowedPaths) {
+      if (isPathNestedIn(PathToCheck, AllowedPath))
+        return true;
+    }
+    return false;
+  }
+
+public:
+  SandboxingFileSystem(IntrusiveRefCntPtr<vfs::FileSystem> FS)
+      : FS(std::move(FS)) {}
+
+  static const char ID;
+
+  Error addAllowedPaths(ArrayRef<StringRef> AllowedPaths) {
+    SmallString<256> PathBuf;
+    for (StringRef Path : AllowedPaths) {
+      PathBuf.clear();
+      PathBuf += Path;
+      if (std::error_code EC = FS->makeAbsolute(PathBuf))
+        return createFileError(Path, EC);
+      this->AllowedPaths.push_back(PathBuf.str().str());
+    }
+    return Error::success();
+  }
+
+  ErrorOr<vfs::Status> status(const Twine &Path) override {
+    ErrorOr<bool> inSandbox = isInSandbox(Path);
+    if (!inSandbox)
+      return inSandbox.getError();
+    if (!*inSandbox)
+      return std::make_error_code(std::errc::no_such_file_or_directory);
+
+    return FS->status(Path);
+  }
+
+  llvm::ErrorOr<std::unique_ptr<vfs::File>>
+  openFileForRead(const Twine &Path) override {
+    ErrorOr<bool> inSandbox = isInSandbox(Path);
+    if (!inSandbox)
+      return inSandbox.getError();
+    if (!*inSandbox)
+      return std::make_error_code(std::errc::no_such_file_or_directory);
+
+    return FS->openFileForRead(Path);
+  }
+
+  vfs::directory_iterator dir_begin(const Twine &Dir,
+                                    std::error_code &EC) override {
+    ErrorOr<bool> inSandbox = isInSandbox(Dir);
+    if (!inSandbox) {
+      EC = inSandbox.getError();
+      return vfs::directory_iterator();
+    }
+    if (!*inSandbox) {
+      EC = std::make_error_code(std::errc::no_such_file_or_directory);
+      return vfs::directory_iterator();
+    }
+
+    return FS->dir_begin(Dir, EC);
+  }
+
+  std::error_code setCurrentWorkingDirectory(const Twine &Path) override {
+    return FS->setCurrentWorkingDirectory(Path);
+  }
+
+  llvm::ErrorOr<std::string> getCurrentWorkingDirectory() const override {
+    return FS->getCurrentWorkingDirectory();
+  }
+};
+} // namespace
+
+const char SandboxingFileSystem::ID = 0;
+
+Expected<std::unique_ptr<vfs::FileSystem>> vfs::createSandboxingFileSystem(
+    IntrusiveRefCntPtr<vfs::FileSystem> UnderlyingFS,
+    ArrayRef<StringRef> AllowedPaths) {
+  auto FS = std::make_unique<SandboxingFileSystem>(std::move(UnderlyingFS));
+  if (Error E = FS->addAllowedPaths(AllowedPaths))
+    return E;
+  return FS;
+}

--- a/llvm/unittests/Support/CMakeLists.txt
+++ b/llvm/unittests/Support/CMakeLists.txt
@@ -79,6 +79,7 @@ add_llvm_unittest(SupportTests
   ReverseIterationTest.cpp
   ReplaceFileTest.cpp
   RISCVAttributeParserTest.cpp
+  SandboxingFileSystemTest.cpp
   ScaledNumberTest.cpp
   ScopedPrinterTest.cpp
   SHA256.cpp

--- a/llvm/unittests/Support/SandboxingFileSystemTest.cpp
+++ b/llvm/unittests/Support/SandboxingFileSystemTest.cpp
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/SandboxingFileSystem.h"
+#include "llvm/Support/VirtualFileSystem.h"
+#include "llvm/Testing/Support/Error.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+
+TEST(SandboxingFileSystemTest, Basic) {
+  auto BaseFS = makeIntrusiveRefCnt<vfs::InMemoryFileSystem>();
+  BaseFS->addFile("//root/dir1/a1", 0, MemoryBuffer::getMemBuffer("contents"));
+  BaseFS->addFile("//root/dir2/a2", 0, MemoryBuffer::getMemBuffer("contents"));
+  BaseFS->addFile("//root/dir1a/aa", 0, MemoryBuffer::getMemBuffer("contents"));
+  BaseFS->addFile("//root/dir3/a3", 0, MemoryBuffer::getMemBuffer("contents"));
+  BaseFS->setCurrentWorkingDirectory("//root");
+
+  std::unique_ptr<vfs::FileSystem> SandBoxFS;
+  ASSERT_THAT_ERROR(
+      vfs::createSandboxingFileSystem(BaseFS, {"//root/dir1", "dir3"})
+          .moveInto(SandBoxFS),
+      Succeeded());
+  EXPECT_TRUE(SandBoxFS->exists("//root/dir1/a1"));
+  EXPECT_FALSE(SandBoxFS->exists("//root/dir2/a2"));
+  EXPECT_FALSE(SandBoxFS->exists("//root/dir1a/aa"));
+  EXPECT_TRUE(SandBoxFS->exists("//root/dir3/a3"));
+  EXPECT_FALSE(SandBoxFS->exists("//ROOT/dir1/a1"));
+  EXPECT_TRUE(SandBoxFS->exists("dir1/a1"));
+  EXPECT_FALSE(SandBoxFS->exists("dir2/a2"));
+}


### PR DESCRIPTION
This creates a VFS that restricts access to only certain directories.

(cherry picked from commit 135f053ccae437bfdfe3a1edbeb33f3570793ecd)