### PR TITLE
[lldb][windows] skip TestPyObjSynthProvider.py

### DIFF
--- a/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
+++ b/lldb/test/API/functionalities/data-formatter/pyobjsynthprovider/TestPyObjSynthProvider.py
@@ -12,6 +12,7 @@ from lldbsuite.test import lldbutil
 class PyObjectSynthProviderTestCase(TestBase):
     NO_DEBUG_INFO_TESTCASE = True
 
+    @skipIfWindows # rdar://174542347
     def test_print_array(self):
         """Test that expr -Z works"""
         self.build()


### PR DESCRIPTION
Deactivate `TestPyObjSynthProvider.py` while investigating the failure.