### PR TITLE
[lldb][windows] skip TestFrameProviderThreadFilter.py

### DIFF
--- a/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/thread_filter/TestFrameProviderThreadFilter.py
@@ -59,6 +59,7 @@ class FrameProviderThreadFilterTestCase(TestBase):
             )
             self.assertTrue(error.Success(), f"Should register {cls}: {error}")
 
+    @skipIfWindows # rdar://174542116
     def test_bt_provider_star_with_thread_filter(self):
         """
         Register EvenThreadProvider, OddThreadProvider, and UpperCaseProvider.


### PR DESCRIPTION
Skip `TestFrameProviderThreadFilter.py` while investigating the failure.