### PR TITLE
[lldb] Fix synthetic frame identity loss during incremental fetches (…

### DIFF
--- a/lldb/source/Target/StackFrameList.cpp
+++ b/lldb/source/Target/StackFrameList.cpp
@@ -69,9 +69,19 @@ SyntheticStackFrameList::SyntheticStackFrameList(
 bool SyntheticStackFrameList::FetchFramesUpTo(
     uint32_t end_idx, InterruptionControl allow_interrupt) {
 
-  size_t num_synthetic_frames = 0;
   // Use the provider to generate frames lazily.
   if (m_provider) {
+    // Count how many synthetic frames already exist so we assign unique CFAs
+    // to new ones. This must not be a local initialized to zero — when
+    // FetchFramesUpTo is called incrementally (first for a small range, then
+    // for the full stack), a zero-initialized counter would hand out duplicate
+    // CFA values, creating StackID collisions for PC-less synthetic frames.
+    size_t num_synthetic_frames = 0;
+    for (const auto &f : m_frames) {
+      if (f && f->IsSynthetic())
+        num_synthetic_frames++;
+    }
+
     // Keep fetching until we reach end_idx or the provider returns an error.
     for (uint32_t idx = m_frames.size(); idx <= end_idx; idx++) {
       if (allow_interrupt &&

--- a/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/TestScriptedFrameProvider.py
@@ -1235,3 +1235,29 @@ class ScriptedFrameProviderTestCase(TestBase):
             expected_thread_ids,
             "All threads should broadcast eBroadcastBitStackChanged on clear",
         )
+
+    def test_incremental_fetch_synthetic_frame_identity(self):
+        """Test that incrementally fetched PC-less synthetic frames each get a
+        unique StackID so they resolve to the correct frame."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "Break here", lldb.SBFileSpec(self.source), only_one_thread=False
+        )
+
+        script_path = os.path.join(self.getSourceDir(), "test_frame_providers.py")
+        self.runCmd("command script import " + script_path)
+
+        error = lldb.SBError()
+        target.RegisterScriptedFrameProvider(
+            "test_frame_providers.PythonSourceFrameProvider",
+            lldb.SBStructuredData(),
+            error,
+        )
+        self.assertSuccess(error)
+
+        # Fetch frames one at a time to trigger separate FetchFramesUpTo calls.
+        frame0 = thread.GetFrameAtIndex(0)
+        frame1 = thread.GetFrameAtIndex(1)
+
+        self.assertEqual(frame0.GetFunctionName(), "compute_fibonacci")
+        self.assertEqual(frame1.GetFunctionName(), "process_data")


### PR DESCRIPTION
…#191903)

When `SyntheticStackFrameList::FetchFramesUpTo` is called incrementally, PC-less synthetic frames can end up with identical `StackID` values. This happens because `num_synthetic_frames` is reset to zero on each call, handing out duplicate call frame addresses. Since PC-less frames all share `LLDB_INVALID_ADDRESS` as their PC, the `StackID` equality check cannot distinguish them, and `ExecutionContextRef` resolves the wrong frame.

The fix counts existing synthetic frames in `m_frames` before starting the fetch loop so new frames receive unique call frame addresses.

(cherry picked from commit 16f793876e0768f6e322918d1cd99f4d85a2e30d)