### PR TITLE
[lldb] Add missing error control flow in SwiftLanguageRuntime::ResolveTypeAlias

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -3919,6 +3919,7 @@ SwiftLanguageRuntime::ResolveTypeAlias(CompilerType alias) {
         if (!type_ref_or_err) {
           LLDB_LOG_ERRORV(GetLog(LLDBLog::Types), type_ref_or_err.takeError(),
                           "{0}");
+          continue;
         }
         auto &type_ref = *type_ref_or_err;
         substitutions.insert({{0, idx++}, &type_ref});


### PR DESCRIPTION
Assisted-by: claude