### PR TITLE
[lldb] Fix deadlock when scripted frame providers load on private state thread

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3189,9 +3189,10 @@ protected:
   struct PrivateStateThread {
     PrivateStateThread(Process &process, lldb::StateType public_state,
                        lldb::StateType private_state,
-                       llvm::StringRef thread_name)
+                       llvm::StringRef thread_name, bool is_override = false)
         : m_process(process), m_public_state(public_state),
-          m_private_state(private_state), m_thread_name(thread_name) {}
+          m_private_state(private_state), m_is_override(is_override),
+          m_thread_name(thread_name) {}
     // This returns false if we couldn't start up the thread.  If that happens,
     // you won't be doing any debugging today.
     bool StartupThread();
@@ -3208,6 +3209,8 @@ protected:
     }
 
     bool IsRunning() { return m_is_running; }
+
+    bool IsOverride() const { return m_is_override; }
 
     void SetThreadName(llvm::StringRef new_name) { m_thread_name = new_name; }
 
@@ -3278,6 +3281,7 @@ protected:
     ProcessRunLock m_public_run_lock;
     ProcessRunLock m_private_run_lock;
     bool m_is_running = false;
+    bool m_is_override = false;
     ///< This will be the thread name given to the Private State HostThread when
     ///< it gets spun up.
     std::string m_thread_name;
@@ -3521,7 +3525,7 @@ private:
   // Starts up the private state thread that will watch for events from the
   // debugee.
 
-  lldb::thread_result_t RunPrivateStateThread();
+  lldb::thread_result_t RunPrivateStateThread(bool is_override);
 
 protected:
   void HandlePrivateEvent(lldb::EventSP &event_sp);
@@ -3615,6 +3619,28 @@ public:
     if (m_process)
       m_process->SetRunningUtilityFunction(false);
   }
+};
+
+/// RAII guard that marks the current thread as a private state thread.
+///
+/// When RunThreadPlan detects it is running on the private state thread, it
+/// spins up an override thread and reassigns m_current_private_state_thread_sp
+/// to it. The original PST continues processing events via DoOnRemoval
+/// callbacks, but CurrentThreadIsPrivateStateThread() no longer recognizes it.
+/// This guard sets a thread_local flag so that GetStackFrameList can identify
+/// the original PST and return parent frames instead of provider-augmented
+/// frames.
+struct PrivateStateThreadGuard {
+  PrivateStateThreadGuard() { g_is_private_state_thread = true; }
+  ~PrivateStateThreadGuard() { g_is_private_state_thread = false; }
+  static bool IsPrivateStateThread() { return g_is_private_state_thread; }
+
+  // Non-copyable, non-movable.
+  PrivateStateThreadGuard(const PrivateStateThreadGuard &) = delete;
+  PrivateStateThreadGuard &operator=(const PrivateStateThreadGuard &) = delete;
+
+private:
+  static thread_local bool g_is_private_state_thread;
 };
 
 } // namespace lldb_private

--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -3053,11 +3053,12 @@ protected:
   };
 
   bool PrivateStateThreadIsRunning() const {
-    if (!m_current_private_state_thread ||
-        !m_current_private_state_thread->IsRunning())
+    if (!m_current_private_state_thread_sp ||
+        !m_current_private_state_thread_sp->IsRunning())
       return false;
 
-    lldb::StateType state = m_current_private_state_thread->GetPrivateState();
+    lldb::StateType state =
+        m_current_private_state_thread_sp->GetPrivateState();
     return state != lldb::eStateInvalid && state != lldb::eStateDetached &&
            state != lldb::eStateExited;
   }
@@ -3186,15 +3187,11 @@ protected:
   /// private state thread that we spin up when we need to run an expression on
   /// the private state thread.
   struct PrivateStateThread {
-    PrivateStateThread(
-        Process &process, lldb::StateType public_state,
-        lldb::StateType private_state,
-        bool is_secondary_thread, // FIXME: Can I get rid of this?
-        llvm::StringRef thread_name)
+    PrivateStateThread(Process &process, lldb::StateType public_state,
+                       lldb::StateType private_state,
+                       llvm::StringRef thread_name)
         : m_process(process), m_public_state(public_state),
-          m_private_state(private_state),
-          m_is_secondary_thread(is_secondary_thread),
-          m_thread_name(thread_name) {}
+          m_private_state(private_state), m_thread_name(thread_name) {}
     // This returns false if we couldn't start up the thread.  If that happens,
     // you won't be doing any debugging today.
     bool StartupThread();
@@ -3281,67 +3278,62 @@ protected:
     ProcessRunLock m_public_run_lock;
     ProcessRunLock m_private_run_lock;
     bool m_is_running = false;
-    /// If we need to run an expression modally in the private state thread, we
-    /// have to spin up a secondary private state thread to manage the events
-    /// that drive that interaction.  This will be true if this is a modal
-    /// private state thread.
-    bool m_is_secondary_thread;
     ///< This will be the thread name given to the Private State HostThread when
     ///< it gets spun up.
     std::string m_thread_name;
   };
 
   bool SetPrivateRunLockToStopped() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPrivateRunLockToStopped();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPrivateRunLockToStopped();
     return false;
   }
   bool SetPrivateRunLockToRunning() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPrivateRunLockToStopped();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPrivateRunLockToStopped();
     return false;
   }
   bool SetPublicRunLockToStopped() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPublicRunLockToStopped();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPublicRunLockToStopped();
     return false;
   }
   bool SetPublicRunLockToRunning() {
-    assert(m_current_private_state_thread);
-    if (m_current_private_state_thread)
-      return m_current_private_state_thread->SetPublicRunLockToRunning();
+    assert(m_current_private_state_thread_sp);
+    if (m_current_private_state_thread_sp)
+      return m_current_private_state_thread_sp->SetPublicRunLockToRunning();
     return false;
   }
 
   std::recursive_mutex &GetPrivateStateMutex() {
-    assert(m_current_private_state_thread);
-    return m_current_private_state_thread->GetPrivateStateMutex();
+    assert(m_current_private_state_thread_sp);
+    return m_current_private_state_thread_sp->GetPrivateStateMutex();
   }
 
   lldb::StateType GetPublicState() const {
-    if (!m_current_private_state_thread)
+    if (!m_current_private_state_thread_sp)
       return lldb::eStateUnloaded;
-    return m_current_private_state_thread->GetPublicState();
+    return m_current_private_state_thread_sp->GetPublicState();
   }
 
   lldb::StateType GetPrivateState() const {
-    if (!m_current_private_state_thread)
+    if (!m_current_private_state_thread_sp)
       return lldb::eStateUnloaded;
-    return m_current_private_state_thread->GetPrivateState();
+    return m_current_private_state_thread_sp->GetPrivateState();
   }
 
   lldb::StateType GetPrivateStateNoLock() const {
-    if (!m_current_private_state_thread)
+    if (!m_current_private_state_thread_sp)
       return lldb::eStateUnloaded;
-    return m_current_private_state_thread->GetPrivateStateNoLock();
+    return m_current_private_state_thread_sp->GetPrivateStateNoLock();
   }
 
   void SetPrivateStateNoLock(lldb::StateType new_state) {
-    assert(m_current_private_state_thread);
-    m_current_private_state_thread->SetPrivateStateNoLock(new_state);
+    assert(m_current_private_state_thread_sp);
+    m_current_private_state_thread_sp->SetPrivateStateNoLock(new_state);
   }
 
   // Member variables
@@ -3356,12 +3348,12 @@ protected:
                                                    // private state thread.
   lldb::ListenerSP m_private_state_listener_sp; // This is the listener for the
                                                 // private state thread.
-  ///< This is filled on construction with the "main" private state which will
-  ///< be exposed to clients of this process.  It won't have a running private
-  ///< state thread until you call StartupThread.  This needs to be a pointer
-  ///< so I can transparently swap it out for the modal one, but there will
-  ///< always be a private state thread in this slot.
-  PrivateStateThread *m_current_private_state_thread;
+  /// This is filled on construction with the "main" private state which will
+  /// be exposed to clients of this process.  It won't have a running private
+  /// state thread until you call StartupThread.  This needs to be a pointer
+  /// so I can transparently swap it out for the modal one, but there will
+  /// always be a private state thread in this slot.
+  std::shared_ptr<PrivateStateThread> m_current_private_state_thread_sp;
 
   ProcessModID m_mod_id; ///< Tracks the state of the process over stops and
                          ///other alterations.
@@ -3509,10 +3501,15 @@ protected:
   void SetPrivateState(lldb::StateType state);
 
   // Starts the private state thread and assigns it to
-  // m_current_private_state_thread.  Clients who are making a secondary thread
-  // for now have to manage backing that up by hand.
-  bool StartPrivateStateThread(lldb::StateType state, bool run_lock_is_running,
-                               bool is_secondary_thread = false);
+  // m_current_private_state_thread_sp.  If backup_ptr is non-null, this is
+  // a "secondary" thread, and the current thread will be backed up into
+  // backup_ptr before being replaced by the new thread. Pass a non-null
+  // backup_ptr in the case where you have to temporarily spin up a secondary
+  // state thread to handle events from a hand-called function on the primary
+  // private state thread.
+  bool StartPrivateStateThread(
+      lldb::StateType state, bool run_lock_is_running,
+      std::shared_ptr<PrivateStateThread> *backup_ptr = nullptr);
 
   void StopPrivateStateThread();
 
@@ -3521,10 +3518,8 @@ protected:
   void ResumePrivateStateThread();
 
 private:
-  // The starts up the private state thread that will watch for events from the
-  // debugee. Pass true for is_secondary_thread in the case where you have to
-  // temporarily spin up a secondary state thread to handle events from a hand-
-  // called function on the primary private state thread.
+  // Starts up the private state thread that will watch for events from the
+  // debugee.
 
   lldb::thread_result_t RunPrivateStateThread();
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -4100,7 +4100,8 @@ bool Process::ShouldBroadcastEvent(Event *event_ptr) {
 bool Process::PrivateStateThread::StartupThread() {
   llvm::Expected<HostThread> private_state_thread =
       ThreadLauncher::LaunchThread(
-          m_thread_name, [this] { return m_process.RunPrivateStateThread(); },
+          m_thread_name,
+          [this] { return m_process.RunPrivateStateThread(m_is_override); },
           8 * 1024 * 1024);
   if (!private_state_thread) {
     LLDB_LOG_ERROR(GetLog(LLDBLog::Host), private_state_thread.takeError(),
@@ -4158,7 +4159,8 @@ bool Process::StartPrivateStateThread(
     // place already, so do that first:
     *backup_ptr = m_current_private_state_thread_sp;
     m_current_private_state_thread_sp.reset(new PrivateStateThread(
-        *this, GetPublicState(), GetPrivateState(), thread_name));
+        *this, GetPublicState(), GetPrivateState(), thread_name,
+        /*is_override=*/true));
   } else
     m_current_private_state_thread_sp->SetThreadName(thread_name);
 
@@ -4378,7 +4380,15 @@ Status Process::HaltPrivate() {
   return error;
 }
 
-thread_result_t Process::RunPrivateStateThread() {
+thread_local bool PrivateStateThreadGuard::g_is_private_state_thread = false;
+
+thread_result_t Process::RunPrivateStateThread(bool is_override) {
+  // Override PSTs exist solely to service RunThreadPlan expression evaluation.
+  // They must see parent frames, not provider-augmented frames.
+  std::optional<PrivateStateThreadGuard> pst_guard;
+  if (is_override)
+    pst_guard.emplace();
+
   bool control_only = true;
 
   Log *log = GetLog(LLDBLog::Process);
@@ -5586,6 +5596,13 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     // still succeed.
     bool miss_first_event = true;
 #endif
+
+    // If we spawned an override PST, mark the current (original) PST so
+    // GetStackFrameList returns parent frames during event processing.
+    std::optional<PrivateStateThreadGuard> private_state_thread_guard;
+    if (backup_private_state_thread)
+      private_state_thread_guard.emplace();
+
     while (true) {
       // We usually want to resume the process if we get to the top of the
       // loop. The only exception is if we get two running events with no
@@ -5927,6 +5944,8 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
           continue;
       }
     } // END WAIT LOOP
+
+    private_state_thread_guard.reset();
 
     // If we had to start up a temporary private state thread to run this
     // thread plan, shut it down now.

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -456,8 +456,8 @@ Process::Process(lldb::TargetSP target_sp, ListenerSP listener_sp,
           nullptr, "lldb.process.internal_state_control_broadcaster"),
       m_private_state_listener_sp(
           Listener::MakeListener("lldb.process.internal_state_listener")),
-      m_current_private_state_thread(new PrivateStateThread(
-          *this, eStateUnloaded, eStateUnloaded, false, "rename-this-thread")),
+      m_current_private_state_thread_sp(std::make_shared<PrivateStateThread>(
+          *this, eStateUnloaded, eStateUnloaded, "rename-this-thread")),
       m_mod_id(), m_process_unique_id(0), m_thread_index_id(0),
       m_thread_id_to_index_id_map(), m_exit_status(-1),
       m_thread_list_real(*this), m_thread_list(*this), m_thread_plans(*this),
@@ -1213,7 +1213,7 @@ bool Process::SetExitStatus(int status, llvm::StringRef exit_string) {
 }
 
 bool Process::IsAlive() {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return false;
 
   switch (GetPrivateState()) {
@@ -1422,7 +1422,7 @@ uint32_t Process::AssignIndexIDToThread(uint64_t thread_id) {
 }
 
 StateType Process::GetState() {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return eStateUnloaded;
 
   if (CurrentThreadPosesAsPrivateStateThread())
@@ -1447,7 +1447,7 @@ void Process::SetPublicState(StateType new_state, bool restarted) {
   LLDB_LOGF(log, "(plugin = %s, state = %s, restarted = %i)",
            GetPluginName().data(), StateAsCString(new_state), restarted);
   const StateType old_state = GetPublicState();
-  m_current_private_state_thread->SetPublicState(new_state);
+  m_current_private_state_thread_sp->SetPublicState(new_state);
 
   // On the transition from Run to Stopped, we unlock the writer end of the run
   // lock.  The lock gets locked in Resume, which is the public API to tell the
@@ -1551,7 +1551,7 @@ void Process::SetPrivateState(StateType new_state) {
   if (m_destructing)
     return;
 
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return;
 
   Log *log(GetLog(LLDBLog::State | LLDBLog::Process | LLDBLog::Unwind));
@@ -2918,7 +2918,7 @@ Status Process::Launch(ProcessLaunchInfo &launch_info) {
     ResumePrivateStateThread();
   } else {
     StartPrivateStateThread(state_after_launch, false);
-    if (!m_current_private_state_thread) {
+    if (!m_current_private_state_thread_sp) {
       // We are not going to get any further here. The only way this could fail
       // is if we can't start a host thread, so we're pretty much toast at that
       // point.
@@ -3079,7 +3079,7 @@ Status Process::LoadCore() {
     else {
       StartPrivateStateThread(lldb::eStateStopped,
                               /*RunLock is stopped*/ false);
-      if (!m_current_private_state_thread) {
+      if (!m_current_private_state_thread_sp) {
         // We are not going to get any further here. The only way this
         // could fail is if we can't start a host thread, so we're pretty much
         //  toast at that point.
@@ -3291,7 +3291,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
             SetNextEventAction(new Process::AttachCompletionHandler(
                 this, attach_info.GetResumeCount()));
             StartPrivateStateThread(lldb::eStateAttaching, true);
-            if (!m_current_private_state_thread) {
+            if (!m_current_private_state_thread_sp) {
               // We are not going to get any further here.  The only way
               // this could fail is if we can't start a host thread, and we're
               // pretty much toast at that point.
@@ -3354,7 +3354,7 @@ Status Process::Attach(ProcessAttachInfo &attach_info) {
             this, attach_info.GetResumeCount()));
 
         StartPrivateStateThread(lldb::eStateAttaching, true);
-        if (!m_current_private_state_thread) {
+        if (!m_current_private_state_thread_sp) {
           // We are not going to get any further here.  The only way this
           // could fail is if we can't start a host thread, so we're pretty much
           // toast at thatpoint.
@@ -3541,7 +3541,7 @@ Status Process::ConnectRemote(llvm::StringRef remote_url) {
     else {
       StartPrivateStateThread(lldb::eStateStopped,
                               /*RunLock is stopped */ false);
-      if (!m_current_private_state_thread) {
+      if (!m_current_private_state_thread_sp) {
         // We are not going to get any further here.  The only way this
         // could fail is if we can't start a host thread, so we're pretty much
         // toast at that point.
@@ -4119,9 +4119,9 @@ bool Process::PrivateStateThread::IsOnThread(const HostThread &thread) const {
   return m_private_state_thread.EqualsThread(thread);
 }
 
-bool Process::StartPrivateStateThread(lldb::StateType state,
-                                      bool run_lock_is_running,
-                                      bool is_secondary_thread) {
+bool Process::StartPrivateStateThread(
+    lldb::StateType state, bool run_lock_is_running,
+    std::shared_ptr<PrivateStateThread> *backup_ptr) {
   Log *log = GetLog(LLDBLog::Events);
 
   bool already_running = PrivateStateThreadIsRunning();
@@ -4129,7 +4129,7 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
             already_running ? " already running"
                             : " starting private state thread");
 
-  if (!is_secondary_thread && already_running)
+  if (backup_ptr == nullptr && already_running)
     return true;
 
   // Create a thread that watches our internal state and controls which events
@@ -4153,15 +4153,14 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
                "<lldb.process.internal-state(pid=%" PRIu64 ")>", GetID());
   }
 
-  if (is_secondary_thread) {
-    PrivateStateThread *new_private_state_thread =
-        new PrivateStateThread(*this, GetPublicState(), GetPrivateState(),
-                               is_secondary_thread, thread_name);
-    // StartupThread expects the m_current_private_state_thread to be in place
-    // already, so do that first:
-    m_current_private_state_thread = new_private_state_thread;
+  if (backup_ptr) {
+    // StartupThread expects the m_current_private_state_thread_sp to be in
+    // place already, so do that first:
+    *backup_ptr = m_current_private_state_thread_sp;
+    m_current_private_state_thread_sp.reset(new PrivateStateThread(
+        *this, GetPublicState(), GetPrivateState(), thread_name));
   } else
-    m_current_private_state_thread->SetThreadName(thread_name);
+    m_current_private_state_thread_sp->SetThreadName(thread_name);
 
   SetPublicState(state, /*restarted=*/false);
   if (run_lock_is_running)
@@ -4169,7 +4168,7 @@ bool Process::StartPrivateStateThread(lldb::StateType state,
   else
     SetPublicRunLockToStopped();
 
-  return m_current_private_state_thread->StartupThread();
+  return m_current_private_state_thread_sp->StartupThread();
 }
 
 void Process::PausePrivateStateThread() {
@@ -4181,10 +4180,10 @@ void Process::ResumePrivateStateThread() {
 }
 
 void Process::StopPrivateStateThread() {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return;
 
-  if (m_current_private_state_thread->IsJoinable())
+  if (m_current_private_state_thread_sp->IsJoinable())
     ControlPrivateStateThread(eBroadcastInternalStateControlStop);
   else {
     Log *log = GetLog(LLDBLog::Process);
@@ -4204,7 +4203,7 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
   LLDB_LOGF(log, "Process::%s (signal = %d)", __FUNCTION__, signal);
 
   // Signal the private state thread
-  if (m_current_private_state_thread->IsJoinable()) {
+  if (m_current_private_state_thread_sp->IsJoinable()) {
     // Broadcast the event.
     // It is important to do this outside of the if below, because it's
     // possible that the thread state is invalid but that the thread is waiting
@@ -4233,7 +4232,7 @@ void Process::ControlPrivateStateThread(uint32_t signal) {
     }
 
     if (signal == eBroadcastInternalStateControlStop)
-      m_current_private_state_thread->JoinAndReset();
+      m_current_private_state_thread_sp->JoinAndReset();
 
   } else {
     LLDB_LOGF(
@@ -5448,11 +5447,11 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     selected_tid = LLDB_INVALID_THREAD_ID;
   }
 
-  PrivateStateThread *backup_private_state_thread = nullptr;
+  std::shared_ptr<PrivateStateThread> backup_private_state_thread;
   lldb::StateType old_state = eStateInvalid;
   lldb::ThreadPlanSP stopper_base_plan_sp;
 
-  if (m_current_private_state_thread->IsOnThread(Host::GetCurrentThread())) {
+  if (m_current_private_state_thread_sp->IsOnThread(Host::GetCurrentThread())) {
     // Yikes, we are running on the private state thread!  So we can't wait for
     // public events on this thread, since we are the thread that is generating
     // public events. The simplest thing to do is to spin up a temporary thread
@@ -5460,8 +5459,6 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     // events here.
     LLDB_LOGF(log, "Running thread plan on private state thread, spinning up "
                    "another state thread to handle the events.");
-
-    backup_private_state_thread = m_current_private_state_thread;
 
     // One other bit of business: we want to run just this thread plan and
     // anything it pushes, and then stop, returning control here. But in the
@@ -5475,12 +5472,12 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
     // Have to make sure our public state is stopped, since otherwise the
     // reporting logic below doesn't work correctly.
     old_state = GetPublicState();
-    m_current_private_state_thread->SetPublicStateNoLock(eStateStopped);
+    m_current_private_state_thread_sp->SetPublicStateNoLock(eStateStopped);
 
     // Now spin up the private state thread:
     StartPrivateStateThread(lldb::eStateStopped, /* RunLock is stopped*/ false,
-                            /*secondary_thread=*/true);
-    if (!m_current_private_state_thread) {
+                            &backup_private_state_thread);
+    if (!m_current_private_state_thread_sp) {
       // If we can't spin up a thread here we can't run this expression.  But
       // presumably the old private state thread is still good, so just put it
       // back and return an error.
@@ -5488,7 +5485,7 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
           lldb::eSeverityError,
           "could not spin up a thread to handle events for an expression"
           " run on the private state thread.");
-      m_current_private_state_thread = backup_private_state_thread;
+      m_current_private_state_thread_sp = backup_private_state_thread;
       return eExpressionSetupError;
     }
   }
@@ -5937,12 +5934,12 @@ Process::RunThreadPlan(ExecutionContext &exe_ctx,
         backup_private_state_thread->IsJoinable()) {
       StopPrivateStateThread();
       Status error;
-      m_current_private_state_thread = backup_private_state_thread;
+      m_current_private_state_thread_sp = backup_private_state_thread;
       if (stopper_base_plan_sp) {
         thread->DiscardThreadPlansUpToPlan(stopper_base_plan_sp);
       }
       if (old_state != eStateInvalid)
-        m_current_private_state_thread->SetPublicStateNoLock(old_state);
+        m_current_private_state_thread_sp->SetPublicStateNoLock(old_state);
     }
 
     // If our thread went away on us, we need to get out of here without
@@ -6245,23 +6242,25 @@ void Process::ClearPreResumeAction(PreResumeActionCallback callback, void *baton
 }
 
 ProcessRunLock &Process::GetRunLock() {
-  return m_current_private_state_thread->GetRunLock();
+  return m_current_private_state_thread_sp->GetRunLock();
 }
 
 bool Process::CurrentThreadIsPrivateStateThread()
 {
-  if (!m_current_private_state_thread)
+  if (!m_current_private_state_thread_sp)
     return true;
-  return m_current_private_state_thread->IsOnThread(Host::GetCurrentThread());
+  return m_current_private_state_thread_sp->IsOnThread(
+      Host::GetCurrentThread());
 }
 
 bool Process::CurrentThreadPosesAsPrivateStateThread() {
   // If we haven't started up the private state thread yet, then whatever thread
   // is fetching this event should be temporarily the private state thread.
-  if (!m_current_private_state_thread ||
-      !m_current_private_state_thread->IsRunning())
+  if (!m_current_private_state_thread_sp ||
+      !m_current_private_state_thread_sp->IsRunning())
     return true;
-  return m_current_private_state_thread->IsOnThread(Host::GetCurrentThread());
+  return m_current_private_state_thread_sp->IsOnThread(
+      Host::GetCurrentThread());
 }
 
 void Process::Flush() {

--- a/lldb/source/Target/ProcessTrace.cpp
+++ b/lldb/source/Target/ProcessTrace.cpp
@@ -66,7 +66,7 @@ void ProcessTrace::DidAttach(ArchSpec &process_arch) {
 
   SetCanJIT(false);
   StartPrivateStateThread(lldb::eStateStopped, false);
-  if (!m_current_private_state_thread) {
+  if (!m_current_private_state_thread_sp) {
     LLDB_LOG(GetLog(LLDBLog::Process), "ProcessTrace: failed to start private "
                                        "state thread.");
     return;

--- a/lldb/source/Target/Thread.cpp
+++ b/lldb/source/Target/Thread.cpp
@@ -1537,30 +1537,56 @@ bool Thread::IsAnyProviderActive() {
 StackFrameListSP Thread::GetStackFrameList() {
   std::lock_guard<std::recursive_mutex> guard(m_frame_mutex);
 
-  // If a provider is currently fetching frames, return the provider's input
-  // frames instead of m_curr_frames_sp. m_curr_frames_sp IS the
-  // SyntheticStackFrameList, and accessing it would trigger provider code on
-  // THIS thread too. That is dangerous because:
-  //  - On the provider's own host thread: circular dependency / deadlock.
-  //  - On the private state thread: the provider may call EvaluateExpression
-  //    which needs the private state thread to process events -> deadlock.
-  //  - On any other thread: would run the provider concurrently.
-  // Returning the input (parent) frames is always safe.
+  // Determine if we must return the parent frames instead of the
+  // provider-augmented frames on this call.
+  //
+  // Frame providers are a public illusion layered on top of the private
+  // reality (the unwinder stack, or a scripted process playing that
+  // role). The private state thread (PST) manages the stop of that private
+  // reality, so the correct view for its logic IS the private reality
+  // -- the public illusion is only applied once the process has settled
+  // and clients query the stopped state.
+  //
+  // When RunThreadPlan spawns an override PST, the original PST changes
+  // role: it becomes the public event listener for the override, but it is
+  // still working to manage the private side of the process.  So it also should
+  // see the private reality and not the public illusion. Feeding it the public
+  // illusion instead of the private reality is incorrect and can lead to
+  // deadlocks as a side effect, since provider code may try to acquire locks
+  // already held further up the call stack.
+  //
+  // We return parent frames in two situations:
+  //
+  //  1. Re-entrancy: a provider is already active on some host thread.
+  //     - Same thread: the provider's get_frame_at_index() calls
+  //       HandleCommand("bt") or accesses input_frames, which re-enters
+  //       GetStackFrameList() -> infinite recursion.
+  //     - Private state thread: the provider called EvaluateExpression()
+  //       which resumed the process via RunThreadPlan; the private state
+  //       thread must process the resulting stop event, but if it tries to
+  //       build the synthetic frame list it will re-enter the provider ->
+  //       deadlock.
+  //     - Any other thread: would run the provider concurrently with the
+  //       thread that is already mid-construction.
+  //
+  //  2. Current thread is a private state thread that should see the
+  //     private reality (PrivateStateThreadGuard::IsPrivateStateThread).
+  //
+  // For case 1, if a provider is active we return its input (parent)
+  // frames. For case (2), we return/create the unwinder frame list
+  // without caching it in m_curr_frames_sp so that non-private-state
+  // callers still get the public illusion once the process settles.
+  ProcessSP process_sp = GetProcess();
   {
     std::lock_guard<std::mutex> pguard(m_provider_frames_mutex);
     if (!m_active_frame_providers_by_thread.empty()) {
-      // Check if the current host thread is inside a provider call.
+      // Case 1a: current host thread is inside a provider call.
       HostThread current(Host::GetCurrentThread());
       auto it = m_active_frame_providers_by_thread.find(current);
       if (it != m_active_frame_providers_by_thread.end() && !it->second.empty())
         return it->second.back();
 
-      // If the private state thread calls GetStackFrameList while a provider
-      // is active on another thread, return parent frames too. The provider
-      // may call EvaluateExpression which needs the private state thread to
-      // process events — touching m_curr_frames_sp (the synthetic list) would
-      // trigger the provider and deadlock.
-      ProcessSP process_sp = GetProcess();
+      // Case 1b: private state thread while a provider is active elsewhere.
       if (process_sp && process_sp->CurrentThreadIsPrivateStateThread())
         return m_active_frame_providers_by_thread.begin()->second.back();
     }
@@ -1569,9 +1595,21 @@ StackFrameListSP Thread::GetStackFrameList() {
   if (m_curr_frames_sp)
     return m_curr_frames_sp;
 
+  // For case 2, PST must see the private reality, not the public illusion.
+  // PrivateStateThreadGuard is a thread_local flag set by RunThreadPlan
+  // (for the original PST) and RunPrivateStateThread (for override PSTs).
+  // We cannot use CurrentThreadIsPrivateStateThread() here because
+  // RunThreadPlan reassigns m_current_private_state_thread_sp to the
+  // override, so the original PST is no longer recognized.
+  if (PrivateStateThreadGuard::IsPrivateStateThread()) {
+    if (!m_unwinder_frames_sp)
+      m_unwinder_frames_sp = std::make_shared<StackFrameList>(
+          *this, m_prev_frames_sp, true, /*provider_id=*/0);
+    return m_unwinder_frames_sp;
+  }
+
   // First, try to load frame providers if we don't have any yet.
   if (m_frame_providers.empty()) {
-    ProcessSP process_sp = GetProcess();
     if (process_sp) {
       Target &target = process_sp->GetTarget();
       const auto &descriptors = target.GetScriptedFrameProviderDescriptors();

--- a/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/Makefile
+++ b/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/Makefile
@@ -1,0 +1,4 @@
+C_SOURCES := main.c
+CFLAGS_EXTRAS := -std=c99
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/TestWasHitWithFrameProviderDeadlock.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/TestWasHitWithFrameProviderDeadlock.py
@@ -1,0 +1,119 @@
+"""
+Test that a scripted breakpoint's was_hit callback calling EvaluateExpression
+does not deadlock when a scripted frame provider is also registered.
+
+This reproduces the deadlock from:
+    lldb-rpc-server sample showing two private state threads in mutual wait:
+
+    Thread A (lldb.process.internal-state):
+      BreakpointResolverScripted::WasHit -> Python -> SBFrame.EvaluateExpression
+        -> RunThreadPlan -> Halt -> WaitForProcessToStop
+        (holds mutex, waits for state change event)
+
+    Thread B (lldb.process.internal-state-override):
+      HandlePrivateEvent -> ShouldStop -> GetStackFrameList
+        -> LoadScriptedFrameProvider -> ScriptedFrameProvider.__init__
+        -> Python -> SBThread.__bool__ -> GetStoppedExecutionContext
+        -> recursive_mutex::lock (BLOCKED - mutex held by Thread A)
+
+    Thread A waits for the event that Thread B would deliver, but Thread B
+    is blocked on the mutex Thread A holds.
+"""
+
+import os
+import lldb
+import lldbsuite.test.lldbutil as lldbutil
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+
+
+class TestWasHitWithFrameProviderDeadlock(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @expectedFailureAll(oslist=["windows"], bugnumber="llvm.org/pr24528")
+    def test_was_hit_with_frame_provider_no_deadlock(self):
+        """
+        Test that a scripted breakpoint doing EvaluateExpression in was_hit
+        does not deadlock when a scripted frame provider is registered.
+        """
+        self.build()
+
+        target, process, thread, _ = lldbutil.run_to_name_breakpoint(self, "main")
+
+        # Import both the breakpoint resolver and the frame provider scripts.
+        resolver_path = os.path.join(self.getSourceDir(), "bkpt_resolver.py")
+        provider_path = os.path.join(self.getSourceDir(), "frame_provider.py")
+        self.runCmd("command script import " + resolver_path)
+        self.runCmd("command script import " + provider_path)
+
+        # Register the scripted frame provider FIRST.
+        # This means that when any stop event is processed and the thread's
+        # stack frames are accessed, the provider will be loaded, calling
+        # its __init__ which accesses SBThread.
+        error = lldb.SBError()
+        provider_id = target.RegisterScriptedFrameProvider(
+            "frame_provider.SBAPIAccessInInitProvider",
+            lldb.SBStructuredData(),
+            error,
+        )
+        self.assertTrue(
+            error.Success(),
+            f"Should register frame provider: {error}",
+        )
+        self.assertNotEqual(provider_id, 0, "Provider ID should be non-zero")
+
+        # Create the scripted breakpoint that calls EvaluateExpression in was_hit.
+        extra_args = lldb.SBStructuredData()
+        stream = lldb.SBStream()
+        stream.Print('{"symbol": "target_func"}')
+        extra_args.SetFromJSON(stream)
+
+        bkpt = target.BreakpointCreateFromScript(
+            "bkpt_resolver.ExprEvalResolver",
+            extra_args,
+            lldb.SBFileSpecList(),
+            lldb.SBFileSpecList(),
+        )
+        self.assertTrue(bkpt.IsValid(), "Scripted breakpoint should be valid")
+        self.assertGreater(
+            bkpt.GetNumLocations(), 0, "Breakpoint should have locations"
+        )
+
+        # Continue the process. When the breakpoint is hit:
+        # 1. was_hit runs on private state thread, calls EvaluateExpression
+        # 2. EvaluateExpression -> RunThreadPlan -> Halt -> WaitForProcessToStop
+        #    (holds mutex, waits for state event)
+        # 3. Override state thread processes the stop, loads frame provider
+        # 4. Provider __init__ calls SBThread.__bool__ -> GetStoppedExecutionContext
+        #    -> tries to acquire mutex held by step 2 -> DEADLOCK
+        #
+        # If this test completes without hanging, the deadlock is fixed.
+        process.Continue()
+        self.assertState(process.GetState(), lldb.eStateStopped)
+
+        thread = process.GetSelectedThread()
+        self.assertTrue(thread.IsValid(), "Thread should be valid")
+        self.assertEqual(
+            thread.GetStopReason(),
+            lldb.eStopReasonBreakpoint,
+            "Should stop at breakpoint",
+        )
+
+        # Verify that EvaluateExpression in was_hit actually ran successfully
+        # by checking that g_value was incremented.
+        g_value = target.FindFirstGlobalVariable("g_value")
+        self.assertTrue(g_value.IsValid(), "Should find g_value")
+        self.assertGreater(
+            g_value.GetValueAsUnsigned(),
+            0,
+            "g_value should have been incremented by the was_hit callback",
+        )
+
+        # Continue to hit the breakpoint again to ensure it's not a one-off.
+        process.Continue()
+        self.assertState(process.GetState(), lldb.eStateStopped)
+        self.assertEqual(
+            thread.GetStopReason(),
+            lldb.eStopReasonBreakpoint,
+            "Should stop at breakpoint again",
+        )

--- a/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/bkpt_resolver.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/bkpt_resolver.py
@@ -1,0 +1,47 @@
+"""
+Scripted breakpoint resolver whose was_hit callback calls EvaluateExpression.
+
+This reproduces the deadlock seen in the sample where:
+1. BreakpointResolverScripted::WasHit runs on the private state thread
+2. was_hit calls SBFrame.EvaluateExpression -> RunThreadPlan -> Halt ->
+   WaitForProcessToStop (holds a mutex, waits for state event)
+3. The override private state thread handles the stop and loads a scripted
+   frame provider
+4. The provider's __init__ calls SBThread.__bool__ -> GetStoppedExecutionContext
+   -> tries to acquire the same mutex -> DEADLOCK
+"""
+
+import lldb
+
+
+class ExprEvalResolver:
+    """Scripted breakpoint resolver that evaluates an expression in was_hit."""
+
+    def __init__(self, bkpt, extra_args, dict):
+        self.bkpt = bkpt
+        sym_name = extra_args.GetValueForKey("symbol").GetStringValue(100)
+        self.sym_name = sym_name
+        self.facade_loc = None
+
+    def __callback__(self, sym_ctx):
+        sym = sym_ctx.module.FindSymbol(self.sym_name, lldb.eSymbolTypeCode)
+        if sym.IsValid():
+            self.bkpt.AddLocation(sym.GetStartAddress())
+            self.facade_loc = self.bkpt.AddFacadeLocation()
+
+    def get_short_help(self):
+        return f"ExprEvalResolver for {self.sym_name}"
+
+    def was_hit(self, frame, bp_loc):
+        # This runs on the private state thread. Calling EvaluateExpression
+        # here triggers RunThreadPlan -> Halt -> WaitForProcessToStop, which
+        # holds a mutex and waits for a state change event.
+        options = lldb.SBExpressionOptions()
+        options.SetStopOthers(True)
+        options.SetTryAllThreads(False)
+
+        result = frame.EvaluateExpression("increment()", options)
+        if not result.error.success:
+            return lldb.LLDB_INVALID_BREAK_ID
+
+        return self.facade_loc

--- a/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/frame_provider.py
+++ b/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/frame_provider.py
@@ -1,0 +1,41 @@
+"""
+Scripted frame provider that accesses the SB API in __init__.
+
+This provider checks SBThread validity during construction, which calls
+GetStoppedExecutionContext and tries to acquire a recursive_mutex.
+When combined with the scripted breakpoint's was_hit callback doing
+EvaluateExpression on the private state thread, this causes a deadlock:
+
+- Thread A (private state): holds the mutex in RunThreadPlan/WaitForProcessToStop
+- Thread B (override state): loads this provider, calls SBThread.__bool__ ->
+  GetStoppedExecutionContext -> tries to lock the same mutex -> DEADLOCK
+"""
+
+import lldb
+from lldb.plugins.scripted_frame_provider import ScriptedFrameProvider
+
+
+class SBAPIAccessInInitProvider(ScriptedFrameProvider):
+    """Provider that accesses SBThread (triggering mutex acquisition) in __init__."""
+
+    def __init__(self, input_frames, args):
+        super().__init__(input_frames, args)
+        # This is the key line that triggers the deadlock: checking if the
+        # thread is valid calls SBThread::operator bool() ->
+        # GetStoppedExecutionContext -> recursive_mutex::lock().
+        # When the private state thread holds that mutex (during
+        # RunThreadPlan/WaitForProcessToStop from a was_hit callback),
+        # this blocks forever.
+        if self.thread:
+            self.thread_is_valid = bool(self.thread)
+        else:
+            self.thread_is_valid = False
+
+    @staticmethod
+    def get_description():
+        return "Provider that accesses SB API in __init__ (deadlock reproducer)"
+
+    def get_frame_at_index(self, idx):
+        if idx < len(self.input_frames):
+            return idx
+        return None

--- a/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/main.c
+++ b/lldb/test/API/functionalities/scripted_frame_provider/was_hit_deadlock/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+int g_value = 0;
+
+int increment() { return ++g_value; }
+
+int target_func() {
+  printf("target_func: %d\n", g_value);
+  return g_value;
+}
+
+int main() {
+  for (int i = 0; i < 10; i++) {
+    target_func();
+  }
+  increment();
+  return 0;
+}


### PR DESCRIPTION
Frame providers are an overlay on top of the parent reality (the unwinder or scripted process stack). The private state thread (PST) manages the stop of that parent reality, so the correct view for PST logic should be the parent -- providers should only be applied once the process has settled and clients query the stopped state.

When a scripted breakpoint's `was_hit` callback calls `EvaluateExpression` on the PST, `RunThreadPlan` spawns an override PST (Thread B) and reassigns `m_current_private_state_thread_sp` to it. Two threads then need to see parent frames:

  - Thread B (override PST): processes stop events via `HandlePrivateEvent` -> `ShouldStop` -> `GetStackFrameList`. If it loads a provider, the provider's Python code can acquire locks held by Thread A, causing a deadlock.

  - Thread A (original PST): processes events inline via `FindNextEventInternal` -> `DoOnRemoval` -> `GetStackFrameList`. After the override is created, `CurrentThreadIsPrivateStateThread` no longer recognizes Thread A (it checks against `m_current_private_state_thread_sp`, which now points to Thread B).

The existing re-entrancy guard in `GetStackFrameList` (e1cd558) only triggers when a provider is already active. In the deadlock scenario, provider loading is being initiated for the first time, so the guard does not trigger.

This patch introduces `PrivateStateThreadGuard`, an RAII guard that sets a `thread_local` flag checked by `GetStackFrameList` to return parent frames instead of loading providers. The guard is activated in two places:

  - `RunPrivateStateThread`: for override PSTs only (identified via a new `is_override` flag on `PrivateStateThread`). The original PST does not set the guard here, so normal stepping still sees provider-augmented frames.

  - `RunThreadPlan`: for the original PST, scoped to the event processing window when an override has been spawned.

rdar://174679105

Signed-off-by: Med Ismail Bennani <ismail@bennani.ma>
(cherry picked from commit bcaa03876b0c2e1bee1aef34a592d0a00d640704)