### PR TITLE
[🍒21.x][lldb] Fix plugin build after AsCString API change

### DIFF
--- a/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
+++ b/lldb/source/Plugins/Process/FreeBSD/NativeProcessFreeBSD.cpp
@@ -752,9 +752,9 @@ Status NativeProcessFreeBSD::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status::FromErrorStringWithFormat(
-      "Module file (%s) not found in process' memory map!",
-      module_file_spec.GetFilename().AsCString());
+  return Status::FromErrorStringWithFormatv(
+      "Module file ({0}) not found in process' memory map!",
+      module_file_spec.GetFilename());
 }
 
 Status

--- a/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
+++ b/lldb/source/Plugins/Process/NetBSD/NativeProcessNetBSD.cpp
@@ -773,9 +773,9 @@ Status NativeProcessNetBSD::GetLoadedModuleFileSpec(const char *module_path,
       return Status();
     }
   }
-  return Status::FromErrorStringWithFormat(
-      "Module file (%s) not found in process' memory map!",
-      module_file_spec.GetFilename().AsCString());
+  return Status::FromErrorStringWithFormatv(
+      "Module file ({0}) not found in process' memory map!",
+      module_file_spec.GetFilename());
 }
 
 Status NativeProcessNetBSD::GetFileLoadAddress(const llvm::StringRef &file_name,


### PR DESCRIPTION
The argument to `AsCString` was made explicit in 116b045b1e2bff462afff0dc0b06218e6074f427.

Not all use-sites were updated to pass an argument resulting in build failures. I'm updating the errors in the FreeBSD and NetBSD plugins to use formatv instead of expanding the C String, like what is done on Linux, avoiding the issue entirely.

rdar://174675042
(cherry picked from commit 78a1a7e1d9c81257727d90d44fb6c5061ce193b5)

Original PR: https://github.com/llvm/llvm-project/pull/192110