### PR TITLE
[lldb] Remove copied statement to match comments in SwiftUserExpression Parse

### DIFF
--- a/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
+++ b/lldb/source/Plugins/ExpressionParser/Swift/SwiftUserExpression.cpp
@@ -921,7 +921,6 @@ bool SwiftUserExpression::Parse(DiagnosticManager &diagnostic_manager,
       parse_result = GetTextAndSetExpressionParser(
           second_try_diagnostic_manager, source_code, exe_ctx, exe_scope);
 
-        diagnostic_manager.Consume(std::move(second_try_diagnostic_manager));
         if (parse_result == SwiftExpressionParser::ParseResult::success ||
             first_expression_not_supported)
           // If we succeeded the second time around, copy any diagnostics we


### PR DESCRIPTION
Removing this copied statement to match the intent expressed in the comments. This copied line was not present in the [original commit](https://github.com/swiftlang/llvm-project/commit/5e4ece7ec10b0f64b496a60f5619f12ae2a876e0), perhaps a conflict resolution artifact.

Assisted-by: claude