### PR TITLE
[lldb] Fix potential null deref in TypeSystemSwiftTypeRef::GetNodeForPrintingImpl

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -2022,7 +2022,7 @@ swift::Demangle::NodePointer TypeSystemSwiftTypeRef::GetNodeForPrintingImpl(
             NodePointer module = nullptr;
             if (node->getChild(0)->getNumChildren() > 1)
               module = node->getChild(0)->getChild(0);
-            if (module->getKind() != Node::Kind::Module)
+            if (!module || module->getKind() != Node::Kind::Module)
               break;
 
             canonical->addChild(module, dem);


### PR DESCRIPTION
(cherry picked from commit c65390cc6670e4cb2bd7173a56d72ccd21b0fc6d)