### PR TITLE
[lldb] Fix GetBasicTypeFromAST for int/long

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -4063,16 +4063,16 @@ TypeSystemSwiftTypeRef::GetBasicTypeFromAST(lldb::BasicType basic_type) {
     // FIXME: Not yet implemented.
     return {};
   case eBasicTypeInt:
-    n = createBuiltin("Int64");
-    break;
-  case eBasicTypeUnsignedInt:
-    n = createBuiltin("UInt64");
-    break;
-  case eBasicTypeLong:
     n = createBuiltin("Int32");
     break;
-  case eBasicTypeUnsignedLong:
+  case eBasicTypeUnsignedInt:
     n = createBuiltin("UInt32");
+    break;
+  case eBasicTypeLong:
+    n = createBuiltin("Int64");
+    break;
+  case eBasicTypeUnsignedLong:
+    n = createBuiltin("UInt64");
     break;
   case eBasicTypeLongLong:
     n = createBuiltin("Int64");


### PR DESCRIPTION
(cherry picked from commit c3e8f6408d43070497483e2627691e4b0149f49f)