### PR TITLE
[lldb] Improve SwiftUI formatter tests

### DIFF
--- a/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
+++ b/lldb/test/API/lang/swift/swiftui_formatters/TestSwiftUIFormatters.py
@@ -4,18 +4,8 @@ from lldbsuite.test.lldbtest import *
 from lldbsuite.test import lldbutil
 
 
-@skip(bugnumber="rdar://174869708")
 @skipIf(archs=["x86_64"], bugnumber="rdar://174750739")
 class TestCase(TestBase):
-
-    @skipUnlessDarwin
-    @swiftTest
-    def test_before(self):
-        self.build()
-        _, _, self.thread, _ = lldbutil.run_to_source_breakpoint(
-            self, "break before", lldb.SBFileSpec("main.swift")
-        )
-        self._do_test("view._count", 41, is_graph_update=False)
 
     @skipUnlessDarwin
     @swiftTest
@@ -28,24 +18,28 @@ class TestCase(TestBase):
 
     @skipUnlessDarwin
     @swiftTest
-    def test_after(self):
+    def test_appear(self):
         self.build()
         log = self.getBuildArtifact("types.log")
         self.expect(f"log enable lldb types -v -f {log}")
         _, _, self.thread, _ = lldbutil.run_to_source_breakpoint(
-            self, "break after", lldb.SBFileSpec("main.swift")
+            self, "break appear", lldb.SBFileSpec("main.swift")
         )
-        self._do_test("self._count", 15, is_graph_update=False)
+        self._do_test("self._count", 41, is_graph_update=False)
 
     @skipUnlessDarwin
     @swiftTest
-    def test_final(self):
+    def test_change(self):
         self.build()
         log = self.getBuildArtifact("types.log")
         self.expect(f"log enable lldb types -v -f {log}")
-        _, _, self.thread, _ = lldbutil.run_to_source_breakpoint(
-            self, "break final", lldb.SBFileSpec("main.swift")
+        _, process, self.thread, _ = lldbutil.run_to_source_breakpoint(
+            self, "break change", lldb.SBFileSpec("main.swift")
         )
+        # Assignment in onAppear
+        self._do_test("self._count", 23, is_graph_update=False)
+        process.Continue()
+        # Callback in onChange
         self._do_test("self._count", 23, is_graph_update=False)
 
     def _do_test(self, var_name: str, value: int, *, is_graph_update: bool):

--- a/lldb/test/API/lang/swift/swiftui_formatters/main.swift
+++ b/lldb/test/API/lang/swift/swiftui_formatters/main.swift
@@ -5,24 +5,23 @@ struct TestView: View {
     @State var count: Int = 41
 
     var body: some View {
-        count = 15 // This assignment does not become visible until after the graph update.
         print("break body")
         return Text("\(count)")
-            .onAppear { [self]
-                // count's value will be 15 at this point.
-                print("break after")
+            .onAppear {
+                print("break appear")
                 count = 23
-                print("break final")
+                print("break change")
+            }
+            .onChange(of: count) {
+                print("break change", self)
             }
     }
 }
 
 @main enum Entry {
     static func main() {
-        let view = TestView()
-        print("break before")
-
         // Cause the SwiftUI graph to call `body`, without showing a window.
+        let view = TestView()
         let hostingView = NSHostingView(rootView: view)
         hostingView.frame = .zero
         hostingView.layout()


### PR DESCRIPTION
Fixes the following mistakes

1. Remove the assignment to count in the `body` getter. Assignment to state properties is not allowed during view updates ("Modifying state during view update, this will cause undefined behavior")
2. Remove ill formed capture of `self` (should have been `[self] in`), because explicit capture is by-copy, but capture by-reference is what was intended. Implicit capture does that.