### PR TITLE
[BoundsSafety] look up definition of forward declared structs in pointee type

### DIFF
--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
@@ -3515,8 +3515,8 @@ RecordDecl *FlexibleArrayMemberUtils::GetFlexibleRecord(QualType QT) {
   if (!RT)
     return nullptr;
 
-  auto *RD = RT->getDecl();
-  if (!RD->hasFlexibleArrayMember())
+  auto *RD = RT->getDecl()->getDefinition();
+  if (!RD || !RD->hasFlexibleArrayMember())
     return nullptr;
 
   const CountAttributedType *DCPTy = nullptr;

--- a/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
+++ b/clang/lib/Sema/DynamicCountPointerAssignmentAnalysis.cpp
@@ -3547,7 +3547,8 @@ RecordDecl *FlexibleArrayMemberUtils::GetFlexibleRecord(QualType QT) {
 bool FlexibleArrayMemberUtils::Find(
     RecordDecl *RD, SmallVectorImpl<FieldDecl *> &PathToFlex,
     ArrayRef<TypeCoupledDeclRefInfo> &CountDecls) {
-  if (!RD->hasFlexibleArrayMember())
+  RD = RD->getDefinition();
+  if (!RD || !RD->hasFlexibleArrayMember())
     return false;
 
   const CountAttributedType *DCPTy = nullptr;

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -914,8 +914,8 @@ static RecordDecl *getImmediateDeclForFlexibleArrayPromotion(QualType T) {
   if (T->isSinglePointerType() && !T->isBoundsAttributedType()) {
     auto *PT = T->getAs<PointerType>();
     if (auto *RecordPointee = PT->getPointeeType()->getAs<RecordType>()) {
-      auto *RD = RecordPointee->getDecl();
-      if (RD->hasFlexibleArrayMember() &&
+      auto *RD = RecordPointee->getDecl()->getDefinition();
+      if (RD && RD->hasFlexibleArrayMember() &&
           RD->getTagKind() != TagTypeKind::Union) {
         return RD;
       }

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -718,7 +718,7 @@ PromoteBoundsSafetyFlexibleArrayMember(Sema &S, MemberExpr *M, Expr *ArrayBase) 
     if (!PT->getPointerAttributes().hasUpperBound()) {
       auto *RecordPointee = PT->getPointeeType()->getAs<RecordType>();
       auto *RD = RecordPointee->getDecl()->getDefinition();
-      assert(RD->hasFlexibleArrayMember() &&
+      assert(RD && RD->hasFlexibleArrayMember() &&
              RD->getTagKind() != TagTypeKind::Union);
       // Skipping the null check for the struct base because it must have been
       // explicitly dereferenced (e.g., base->array) to get here.

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -26990,7 +26990,8 @@ ExprResult BoundsCheckBuilder::CheckFlexibleArrayMemberSizeImpl(
   ArrayRef<TypeCoupledDeclRefInfo> CountDecls;
   auto *RT = FAMPtr->getType()->getPointeeType()->getAs<RecordType>();
   bool Found = FlexUtils.Find(RT->getDecl(), PathToFlex, CountDecls);
-  assert(Found); (void)Found;
+  assert(Found);
+  (void)Found;
 
   Expr *FlexibleObj = FlexUtils.SelectFlexibleObject(PathToFlex, OpaqueRoot);
 

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -717,7 +717,7 @@ PromoteBoundsSafetyFlexibleArrayMember(Sema &S, MemberExpr *M, Expr *ArrayBase) 
   if (auto *PT = BasePtr->getType()->getAs<PointerType>()) {
     if (!PT->getPointerAttributes().hasUpperBound()) {
       auto *RecordPointee = PT->getPointeeType()->getAs<RecordType>();
-      auto *RD = RecordPointee->getDecl();
+      auto *RD = RecordPointee->getDecl()->getDefinition();
       assert(RD->hasFlexibleArrayMember() &&
              RD->getTagKind() != TagTypeKind::Union);
       // Skipping the null check for the struct base because it must have been

--- a/clang/test/BoundsSafety/AST/flexible-array-member-typedef-before-definition.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-typedef-before-definition.c
@@ -45,8 +45,21 @@ int bar(S_ptr __bidi_indexable p) { return (*p).count; }
 // CHECK-NEXT: {{^}}|       `-MemberExpr {{.+}} .count
 // CHECK-NEXT: {{^}}|         `-ParenExpr
 // CHECK-NEXT: {{^}}|           `-UnaryOperator {{.+}} cannot overflow
-// CHECK-NEXT: {{^}}|             `-ImplicitCastExpr {{.+}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable' <LValueToRValue>
-// CHECK-NEXT: {{^}}|               `-DeclRefExpr {{.+}} [[var_p_1]]
+// CHECK-NEXT: {{^}}|             `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}|               |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}|               | |-PredefinedBoundsCheckExpr {{.+}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable' <FlexibleArrayCountDeref(BasePtr, FamPtr, Count)>
+// CHECK-NEXT: {{^}}|               | | |-OpaqueValueExpr [[ove_1:0x[^ ]+]] {{.*}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | | |-OpaqueValueExpr [[ove_1]] {{.*}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
+// CHECK-NEXT: {{^}}|               | | | `-MemberExpr {{.+}} ->fam
+// CHECK-NEXT: {{^}}|               | | |   `-OpaqueValueExpr [[ove_1]] {{.*}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: {{^}}|               | |   `-MemberExpr {{.+}} ->count
+// CHECK-NEXT: {{^}}|               | |     `-OpaqueValueExpr [[ove_1]] {{.*}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | `-OpaqueValueExpr [[ove_1]]
+// CHECK-NEXT: {{^}}|               |   `-ImplicitCastExpr {{.+}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: {{^}}|               |     `-DeclRefExpr {{.+}} [[var_p_1]]
+// CHECK-NEXT: {{^}}|               `-OpaqueValueExpr [[ove_1]] {{.*}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable'
 
 int baz(S_ptr p) { return foo(p); }
 // CHECK:      {{^}}`-FunctionDecl [[func_baz:0x[^ ]+]] {{.+}} baz

--- a/clang/test/BoundsSafety/AST/flexible-array-member-typedef-before-definition.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-typedef-before-definition.c
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fbounds-safety -ast-dump -Wno-bounds-attributes-implicit-conversion-single-to-explicit-indexable %s 2>&1 | FileCheck %s
-// RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump -Wno-bounds-attributes-implicit-conversion-single-to-explicit-indexable %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fbounds-safety -ast-dump %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump %s 2>&1 | FileCheck %s
 
 #include <ptrcheck.h>
 
@@ -69,7 +69,19 @@ int baz(S_ptr p) { return foo(p); }
 // CHECK-NEXT: {{^}}      `-CallExpr
 // CHECK-NEXT: {{^}}        |-ImplicitCastExpr {{.+}} 'int (*__single)(struct S *__bidi_indexable)' <FunctionToPointerDecay>
 // CHECK-NEXT: {{^}}        | `-DeclRefExpr {{.+}} [[func_foo]]
-// CHECK-NEXT: {{^}}        `-ImplicitCastExpr {{.+}} 'struct S *__bidi_indexable' <BoundsSafetyPointerCast>
-// CHECK-NEXT: {{^}}          `-ImplicitCastExpr {{.+}} 'struct S *__single' <LValueToRValue>
-// CHECK-NEXT: {{^}}            `-DeclRefExpr {{.+}} [[var_p_2]]
+// CHECK-NEXT: {{^}}        `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}          |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}          | |-BoundsSafetyPointerPromotionExpr {{.+}} 'struct S *__bidi_indexable'
+// CHECK-NEXT: {{^}}          | | |-OpaqueValueExpr [[ove_2:0x[^ ]+]] {{.*}} 'struct S *__single'
+// CHECK:      {{^}}          | | |-BinaryOperator {{.+}} 'int *' '+'
+// CHECK-NEXT: {{^}}          | | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
+// CHECK-NEXT: {{^}}          | | | | `-MemberExpr {{.+}} ->fam
+// CHECK-NEXT: {{^}}          | | | |   `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct S *__single'
+// CHECK:      {{^}}          | | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: {{^}}          | | |   `-MemberExpr {{.+}} ->count
+// CHECK-NEXT: {{^}}          | | |     `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct S *__single'
+// CHECK:      {{^}}          | `-OpaqueValueExpr [[ove_2]]
+// CHECK-NEXT: {{^}}          |   `-ImplicitCastExpr {{.+}} 'struct S *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}          |     `-DeclRefExpr {{.+}} [[var_p_2]]
+// CHECK-NEXT: {{^}}          `-OpaqueValueExpr [[ove_2]] {{.*}} 'struct S *__single'
 

--- a/clang/test/BoundsSafety/AST/flexible-array-member-typedef-before-definition.c
+++ b/clang/test/BoundsSafety/AST/flexible-array-member-typedef-before-definition.c
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -fbounds-safety -ast-dump -Wno-bounds-attributes-implicit-conversion-single-to-explicit-indexable %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -ast-dump -Wno-bounds-attributes-implicit-conversion-single-to-explicit-indexable %s 2>&1 | FileCheck %s
+
+#include <ptrcheck.h>
+
+struct S;
+typedef struct S *S_ptr;
+
+struct S {
+    int count;
+    int fam[__counted_by(count)];
+};
+
+int foo(struct S *__bidi_indexable p) { return (*p).count; }
+// CHECK:      {{^}}|-FunctionDecl [[func_foo:0x[^ ]+]] {{.+}} foo
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_p:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-CompoundStmt
+// CHECK-NEXT: {{^}}|   `-ReturnStmt
+// CHECK-NEXT: {{^}}|     `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: {{^}}|       `-MemberExpr {{.+}} .count
+// CHECK-NEXT: {{^}}|         `-ParenExpr
+// CHECK-NEXT: {{^}}|           `-UnaryOperator {{.+}} cannot overflow
+// CHECK-NEXT: {{^}}|             `-MaterializeSequenceExpr {{.+}} <Unbind>
+// CHECK-NEXT: {{^}}|               |-MaterializeSequenceExpr {{.+}} <Bind>
+// CHECK-NEXT: {{^}}|               | |-PredefinedBoundsCheckExpr {{.+}} 'struct S *__bidi_indexable' <FlexibleArrayCountDeref(BasePtr, FamPtr, Count)>
+// CHECK-NEXT: {{^}}|               | | |-OpaqueValueExpr [[ove:0x[^ ]+]] {{.*}} 'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | | |-OpaqueValueExpr [[ove]] {{.*}} 'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | | |-ImplicitCastExpr {{.+}} 'int *' <ArrayToPointerDecay>
+// CHECK-NEXT: {{^}}|               | | | `-MemberExpr {{.+}} ->fam
+// CHECK-NEXT: {{^}}|               | | |   `-OpaqueValueExpr [[ove]] {{.*}} 'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | | `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: {{^}}|               | |   `-MemberExpr {{.+}} ->count
+// CHECK-NEXT: {{^}}|               | |     `-OpaqueValueExpr [[ove]] {{.*}} 'struct S *__bidi_indexable'
+// CHECK:      {{^}}|               | `-OpaqueValueExpr [[ove]]
+// CHECK-NEXT: {{^}}|               |   `-ImplicitCastExpr {{.+}} 'struct S *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: {{^}}|               |     `-DeclRefExpr {{.+}} [[var_p]]
+// CHECK-NEXT: {{^}}|               `-OpaqueValueExpr [[ove]] {{.*}} 'struct S *__bidi_indexable'
+
+int bar(S_ptr __bidi_indexable p) { return (*p).count; }
+// CHECK:      {{^}}|-FunctionDecl [[func_bar:0x[^ ]+]] {{.+}} bar
+// CHECK-NEXT: {{^}}| |-ParmVarDecl [[var_p_1:0x[^ ]+]]
+// CHECK-NEXT: {{^}}| `-CompoundStmt
+// CHECK-NEXT: {{^}}|   `-ReturnStmt
+// CHECK-NEXT: {{^}}|     `-ImplicitCastExpr {{.+}} 'int' <LValueToRValue>
+// CHECK-NEXT: {{^}}|       `-MemberExpr {{.+}} .count
+// CHECK-NEXT: {{^}}|         `-ParenExpr
+// CHECK-NEXT: {{^}}|           `-UnaryOperator {{.+}} cannot overflow
+// CHECK-NEXT: {{^}}|             `-ImplicitCastExpr {{.+}} 'S_ptr __bidi_indexable':'struct S *__bidi_indexable' <LValueToRValue>
+// CHECK-NEXT: {{^}}|               `-DeclRefExpr {{.+}} [[var_p_1]]
+
+int baz(S_ptr p) { return foo(p); }
+// CHECK:      {{^}}`-FunctionDecl [[func_baz:0x[^ ]+]] {{.+}} baz
+// CHECK-NEXT: {{^}}  |-ParmVarDecl [[var_p_2:0x[^ ]+]]
+// CHECK-NEXT: {{^}}  `-CompoundStmt
+// CHECK-NEXT: {{^}}    `-ReturnStmt
+// CHECK-NEXT: {{^}}      `-CallExpr
+// CHECK-NEXT: {{^}}        |-ImplicitCastExpr {{.+}} 'int (*__single)(struct S *__bidi_indexable)' <FunctionToPointerDecay>
+// CHECK-NEXT: {{^}}        | `-DeclRefExpr {{.+}} [[func_foo]]
+// CHECK-NEXT: {{^}}        `-ImplicitCastExpr {{.+}} 'struct S *__bidi_indexable' <BoundsSafetyPointerCast>
+// CHECK-NEXT: {{^}}          `-ImplicitCastExpr {{.+}} 'struct S *__single' <LValueToRValue>
+// CHECK-NEXT: {{^}}            `-DeclRefExpr {{.+}} [[var_p_2]]
+

--- a/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-2.c
+++ b/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-2.c
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
 // RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
 
+// expected-no-diagnostics
+
 #include <ptrcheck.h>
 
 struct S;
@@ -12,10 +14,7 @@ struct S {
 };
 
 void sink(struct S *__bidi_indexable p);
-// expected-note@-1{{passing argument to parameter 'p' here}}
 
 void foo(struct S *__single p) { sink(p); }
 void bar(S_ptr p) { sink(p); }
-// expected-warning@-1{{passing type 'struct S *__single' to parameter of type 'struct S *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'p'}}
-// expected-note@-2{{pointer 'p' declared here}}
 

--- a/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-2.c
+++ b/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-2.c
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+#include <ptrcheck.h>
+
+struct S;
+typedef struct S *S_ptr;
+
+struct S {
+    int count;
+    int fam[__counted_by(count)];
+};
+
+void sink(struct S *__bidi_indexable p);
+// expected-note@-1{{passing argument to parameter 'p' here}}
+
+void foo(struct S *__single p) { sink(p); }
+void bar(S_ptr p) { sink(p); }
+// expected-warning@-1{{passing type 'struct S *__single' to parameter of type 'struct S *__bidi_indexable' results in a __bidi_indexable pointer that will trap if a non-zero offset is dereferenced. consider adding '__counted_by' to 'p'}}
+// expected-note@-2{{pointer 'p' declared here}}
+

--- a/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-3.c
+++ b/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-3.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+// expected-no-diagnostics
+
+#include <ptrcheck.h>
+
+struct S;
+typedef struct S *S_ptr;
+
+struct S {
+    int count;
+    int fam[__counted_by(count)];
+};
+
+void sink(int *__bidi_indexable p);
+
+// XFAIL: *
+// FIXME: crash/assert
+void test_fam_member_access(S_ptr p) {
+    sink(p->fam);
+}

--- a/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-3.c
+++ b/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition-3.c
@@ -15,8 +15,6 @@ struct S {
 
 void sink(int *__bidi_indexable p);
 
-// XFAIL: *
-// FIXME: crash/assert
 void test_fam_member_access(S_ptr p) {
     sink(p->fam);
 }

--- a/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition.c
+++ b/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition.c
@@ -15,8 +15,6 @@ struct S {
 
 void sink(struct S *__single p);
 
-// XFAIL: *
-// FIXME: crash/assert
 void test(S_ptr __bidi_indexable p) {
     sink(p);
 }

--- a/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition.c
+++ b/clang/test/BoundsSafety/Sema/flexible-array-member-typedef-before-definition.c
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fbounds-safety -x objective-c -fexperimental-bounds-safety-objc -verify %s
+
+// expected-no-diagnostics
+
+#include <ptrcheck.h>
+
+struct S;
+typedef struct S *S_ptr;
+
+struct S {
+    int count;
+    int fam[__counted_by(count)];
+};
+
+void sink(struct S *__single p);
+
+// XFAIL: *
+// FIXME: crash/assert
+void test(S_ptr __bidi_indexable p) {
+    sink(p);
+}


### PR DESCRIPTION
This fixes various crashes and missing bounds checks along a common theme: the `RecordDecl` is fetched from a pointee type, which we either look for a flexible array member in, or assume that there is one. But because the declaration we get out is a forward declaration, we don't find any FAM. If there is a definition later on we can still find it with `getDefinition()` however.

rdar://163630987