### PR TITLE
[clang][Modules] Fix False Positive Module Redefinition Diagnostics for Include-Tree Modules Loaded Through a PCH

### DIFF
--- a/clang/lib/Lex/ModuleMap.cpp
+++ b/clang/lib/Lex/ModuleMap.cpp
@@ -1773,11 +1773,23 @@ void ModuleMapLoader::handleModuleDecl(const modulemap::ModuleDecl &MD) {
           Map.getContainingModuleMapFile(Existing);
       OptionalFileEntryRef CurrentModMapFile =
           SourceMgr.getFileEntryRefForID(ModuleMapFID);
-      if (ExistingModMapFile && CurrentModMapFile &&
-          *ExistingModMapFile == *CurrentModMapFile)
+      if (ExistingModMapFile && CurrentModMapFile) {
+        LoadedFromASTFile = (*ExistingModMapFile == *CurrentModMapFile);
+      } else if (!ExistingModMapFile) {
+        // If we cannot determine the existing module's module map file
+        // (e.g. Existing is a module loaded from a PCH built with include
+        // tree), we cannot tell whether this is a same-file or cross-file
+        // redefinition. We conservatively treat this case as Existing
+        // is loaded from a correct AST file, and do not check for duplicating
+        // declarations.
+        assert(Existing->Kind == Module::IncludeTreeModuleMap &&
+               Existing->DefinitionLoc.isInvalid() &&
+               "Expected include-tree module with invalid DefinitionLoc; "
+               "other module kinds should have a valid module map file");
         LoadedFromASTFile = true;
-      else
+      } else {
         LoadedFromASTFile = false;
+      }
     }
     //  - If we previously inferred this module from different module map file.
     bool Inferred = Existing->IsInferred;

--- a/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
+++ b/clang/test/ClangScanDeps/modules-byname-dup-module-decl-diag.c
@@ -19,6 +19,12 @@
 // RUN:   experimental-full -module-names=B,A 2>&1 | \
 // RUN:   sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
 
+// Same test with CAS/include-tree format.
+// RUN: not clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -format experimental-include-tree-full \
+// RUN:   -module-names=B,A 2>&1 | \
+// RUN:   sed 's:\\\\\?:/:g' | FileCheck -DPREFIX=%/t %s
+
 // CHECK: A.framework/Modules/module.modulemap:7:8: error: redefinition of module 'B'
 // CHECK: include/B/module.modulemap:1:8: note: previously defined here
 

--- a/clang/test/ClangScanDeps/modules-mmap-redef.c
+++ b/clang/test/ClangScanDeps/modules-mmap-redef.c
@@ -8,6 +8,12 @@
 // RUN:   experimental-full -module-names=A 2>&1 | sed 's:\\\\\?:/:g' | \
 // RUN:   FileCheck -DPREFIX=%/t %s
 
+// Same test with CAS/include-tree format.
+// RUN: not clang-scan-deps -compilation-database %t/cdb.json \
+// RUN:   -cas-path %t/cas -format experimental-include-tree-full \
+// RUN:   -module-names=A 2>&1 | sed 's:\\\\\?:/:g' | \
+// RUN:   FileCheck -DPREFIX=%/t %s
+
 // CHECK: include/A/module.modulemap:9:8: error: redefinition of module 'A'
 // CHECK-NEXT: include/A/module.modulemap:1:8: note: previously defined here
 


### PR DESCRIPTION
69e0367e8221b8002b5d438fb70ff3daf36257fc enhanced the duplicating module definition diagnostics to check across ModuleMaps in a very specific case. The check proved to be overly strict for CAS cached modules loaded through a PCH. This PR fixes the check for this specific situation. 

Assisted-by: claude-opus-4.6

rdar://174894322