### PR TITLE
[lldb] Add target.process.always-run-thread-names setting (#192870)

### DIFF
--- a/lldb/include/lldb/Target/Process.h
+++ b/lldb/include/lldb/Target/Process.h
@@ -114,6 +114,7 @@ public:
   bool GetOSPluginReportsAllThreads() const;
   void SetOSPluginReportsAllThreads(bool does_report);
   bool GetSteppingRunsAllThreads() const;
+  Args GetAlwaysRunThreadNames() const;
   FollowForkMode GetFollowForkMode() const;
   bool TrackMemoryCacheChanges() const;
 

--- a/lldb/source/Target/Process.cpp
+++ b/lldb/source/Target/Process.cpp
@@ -355,6 +355,13 @@ bool ProcessProperties::GetSteppingRunsAllThreads() const {
       idx, g_process_properties[idx].default_uint_value != 0);
 }
 
+Args ProcessProperties::GetAlwaysRunThreadNames() const {
+  Args args;
+  const uint32_t idx = ePropertyAlwaysRunThreadNames;
+  m_collection_sp->GetPropertyAtIndexAsArgs(idx, args);
+  return args;
+}
+
 bool ProcessProperties::GetOSPluginReportsAllThreads() const {
   const bool fail_value = true;
   const Property *exp_property =

--- a/lldb/source/Target/TargetProperties.td
+++ b/lldb/source/Target/TargetProperties.td
@@ -383,6 +383,12 @@ let Definition = "process" in {
   def TrackMemoryCacheChanges: Property<"track-memory-cache-changes", "Boolean">,
     DefaultTrue,
     Desc<"If true, memory cache modifications (which happen often during expressions evaluation) will bump process state ID (and invalidate all synthetic children). Disabling this option helps to avoid synthetic children reevaluation when pretty printers heavily use expressions. The downside of disabled setting is that convenience variables won't reevaluate synthetic children automatically.">;
+  def AlwaysRunThreadNames
+      : Property<"always-run-thread-names", "Array">,
+        ElementType<"String">,
+        Desc<"A list of thread names. Threads with any of these names will "
+             "always be resumed when the process resumes, even when other "
+             "threads are suspended during single-stepping operations.">;
 }
 
 let Definition = "platform" in {

--- a/lldb/source/Target/ThreadList.cpp
+++ b/lldb/source/Target/ThreadList.cpp
@@ -613,6 +613,28 @@ bool ThreadList::WillResume(RunDirection &direction) {
     m_process.StopNoticingNewThreads();
   }
 
+  // Check if any threads should always be allowed to run based on their name.
+  Args always_run_names = m_process.GetAlwaysRunThreadNames();
+  auto resume_state_for_thread = [&](const ThreadSP &thread_sp) -> StateType {
+    if (always_run_names.GetArgumentCount() == 0)
+      return eStateSuspended;
+    const char *name = thread_sp->GetName();
+    if (!name)
+      return eStateSuspended;
+    llvm::StringRef name_str(name);
+    Log *log = GetLog(LLDBLog::Step);
+    for (size_t i = 0; i < always_run_names.GetArgumentCount(); ++i) {
+      if (name_str == always_run_names.GetArgumentAtIndex(i)) {
+        LLDB_LOG(log,
+                 "Thread \"{0}\" (tid={1:x}) will continue due to "
+                 "always-run-thread-names setting",
+                 name, thread_sp->GetID());
+        return eStateRunning;
+      }
+    }
+    return eStateSuspended;
+  };
+
   bool need_to_resume = true;
 
   if (thread_to_run == nullptr) {
@@ -623,7 +645,7 @@ bool ThreadList::WillResume(RunDirection &direction) {
       if (thread_sp->GetResumeState() != eStateSuspended)
         run_state = thread_sp->GetCurrentPlan()->RunState();
       else
-        run_state = eStateSuspended;
+        run_state = resume_state_for_thread(thread_sp);
       if (!thread_sp->ShouldResume(run_state))
         need_to_resume = false;
     }
@@ -648,7 +670,7 @@ bool ThreadList::WillResume(RunDirection &direction) {
         if (!thread_sp->ShouldResume(thread_sp->GetCurrentPlan()->RunState()))
           need_to_resume = false;
       } else
-        thread_sp->ShouldResume(eStateSuspended);
+        thread_sp->ShouldResume(resume_state_for_thread(thread_sp));
     }
   }
 

--- a/lldb/test/API/functionalities/always-run-threads/Makefile
+++ b/lldb/test/API/functionalities/always-run-threads/Makefile
@@ -1,0 +1,4 @@
+CXX_SOURCES := main.cpp
+ENABLE_THREADS := YES
+
+include Makefile.rules

--- a/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
+++ b/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
@@ -19,17 +19,21 @@ class AlwaysRunThreadNamesTestCase(TestBase):
         # Configure the setting to keep our helper thread running.
         self.runCmd("settings set target.process.always-run-thread-names always-run")
 
+        # Tell step_over_me() to block until the helper thread advances.
+        self.runCmd("expression g_sync_with_helper = true")
+
         # Record the helper thread's counter before stepping.
         counter_before = target.FindFirstGlobalVariable("g_helper_count")
         self.assertTrue(counter_before.IsValid())
         val_before = counter_before.GetValueAsUnsigned()
 
-        # Step over -- this normally suspends all other threads.
+        # The step over normally suspends all other threads, but the
+        # always-run-thread-names setting keeps the helper thread running.
+        # Because g_sync_with_helper is true, step_over_me() will spin until
+        # the helper thread increments the counter.
         thread.StepOver(lldb.eOnlyThisThread)
         self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
 
-        # The helper thread should have been allowed to run, so its counter
-        # should have advanced.
         counter_after = target.FindFirstGlobalVariable("g_helper_count")
         val_after = counter_after.GetValueAsUnsigned()
         self.assertGreater(

--- a/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
+++ b/lldb/test/API/functionalities/always-run-threads/TestAlwaysRunThreadNames.py
@@ -1,0 +1,69 @@
+import lldb
+from lldbsuite.test.decorators import *
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test import lldbutil
+
+
+class AlwaysRunThreadNamesTestCase(TestBase):
+    NO_DEBUG_INFO_TESTCASE = True
+
+    @skipIfWindows
+    def test_always_run_thread_resumes_during_step(self):
+        """Test that a thread named in always-run-thread-names continues
+        running when another thread single-steps."""
+        self.build()
+        (target, _, thread, _) = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        # Configure the setting to keep our helper thread running.
+        self.runCmd("settings set target.process.always-run-thread-names always-run")
+
+        # Record the helper thread's counter before stepping.
+        counter_before = target.FindFirstGlobalVariable("g_helper_count")
+        self.assertTrue(counter_before.IsValid())
+        val_before = counter_before.GetValueAsUnsigned()
+
+        # Step over -- this normally suspends all other threads.
+        thread.StepOver(lldb.eOnlyThisThread)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
+
+        # The helper thread should have been allowed to run, so its counter
+        # should have advanced.
+        counter_after = target.FindFirstGlobalVariable("g_helper_count")
+        val_after = counter_after.GetValueAsUnsigned()
+        self.assertGreater(
+            val_after,
+            val_before,
+            "Helper thread counter did not advance during step-over "
+            "(expected it to run because of always-run-thread-names).",
+        )
+
+    @skipIfWindows
+    def test_without_setting_thread_is_suspended(self):
+        """Test that without the setting, the helper thread is suspended
+        during single-stepping (baseline)."""
+        self.build()
+        (target, _, thread, _) = lldbutil.run_to_source_breakpoint(
+            self, "// break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        # Do NOT set always-run-thread-names.
+        counter_before = target.FindFirstGlobalVariable("g_helper_count")
+        self.assertTrue(counter_before.IsValid())
+        val_before = counter_before.GetValueAsUnsigned()
+
+        # Step over with only-this-thread mode.
+        thread.StepOver(lldb.eOnlyThisThread)
+        self.assertStopReason(thread.GetStopReason(), lldb.eStopReasonPlanComplete)
+
+        # The helper thread should have been suspended, so its counter should
+        # not have changed.
+        counter_after = target.FindFirstGlobalVariable("g_helper_count")
+        val_after = counter_after.GetValueAsUnsigned()
+        self.assertEqual(
+            val_after,
+            val_before,
+            "Helper thread counter advanced during step-over "
+            "(expected it to be suspended without always-run-thread-names).",
+        )

--- a/lldb/test/API/functionalities/always-run-threads/main.cpp
+++ b/lldb/test/API/functionalities/always-run-threads/main.cpp
@@ -1,5 +1,4 @@
 #include <atomic>
-#include <chrono>
 #include <pthread.h>
 #include <thread>
 
@@ -15,6 +14,7 @@ static void set_thread_name(const char *name) {
 
 volatile int g_helper_count = 0;
 volatile bool g_stop = false;
+volatile bool g_sync_with_helper = false;
 std::atomic<bool> g_ready{false};
 
 void helper_thread_func() {
@@ -22,15 +22,16 @@ void helper_thread_func() {
   g_ready.store(true);
   while (!g_stop) {
     g_helper_count++;
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
 
 int step_over_me() {
-  int result = 0;
-  for (int i = 0; i < 1000; i++)
-    result += i;
-  return result;
+  if (g_sync_with_helper) {
+    int count_at_entry = g_helper_count;
+    while (g_helper_count <= count_at_entry)
+      ;
+  }
+  return 42;
 }
 
 int main() {

--- a/lldb/test/API/functionalities/always-run-threads/main.cpp
+++ b/lldb/test/API/functionalities/always-run-threads/main.cpp
@@ -1,0 +1,48 @@
+#include <atomic>
+#include <chrono>
+#include <pthread.h>
+#include <thread>
+
+static void set_thread_name(const char *name) {
+#if defined(__APPLE__)
+  ::pthread_setname_np(name);
+#elif defined(__FreeBSD__) || defined(__linux__)
+  ::pthread_setname_np(::pthread_self(), name);
+#elif defined(__NetBSD__)
+  ::pthread_setname_np(::pthread_self(), "%s", const_cast<char *>(name));
+#endif
+}
+
+volatile int g_helper_count = 0;
+volatile bool g_stop = false;
+std::atomic<bool> g_ready{false};
+
+void helper_thread_func() {
+  set_thread_name("always-run");
+  g_ready.store(true);
+  while (!g_stop) {
+    g_helper_count++;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+int step_over_me() {
+  int result = 0;
+  for (int i = 0; i < 1000; i++)
+    result += i;
+  return result;
+}
+
+int main() {
+  std::thread helper(helper_thread_func);
+  // Wait for the helper thread to start and set its name.
+  while (!g_ready.load())
+    ;
+
+  int val = step_over_me(); // break here
+  val += step_over_me();    // after step
+
+  g_stop = true;
+  helper.join();
+  return val > 0 ? 0 : 1;
+}


### PR DESCRIPTION
Add a process setting that keeps named threads running during single-stepping operations. Some programs install in-process Mach exception handler threads that must continue running to forward exceptions. When lldb single-steps and suspends all other threads, these handler threads stall, potentially causing a deadlock if the stepped instruction raises an exception.

The new `target.process.always-run-thread-names` setting accepts a list of thread name strings. In `ThreadList::WillResume`, threads whose names match an entry in this list are resumed with `eStateRunning` instead of `eStateSuspended`, ensuring they appear in vCont packets even during single-thread stepping.

rdar://175038920
(cherry picked from commit 9332051a2e7a73a4436b6930db2130c66d7b0437)