### PR TITLE
[lldb][NativePDB] Disable incremental linking for API tests

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -25,9 +25,10 @@ else
 endif
 
 ifeq "$(MAKE_PDB)" "YES"
-	# Use lld until https://github.com/swiftlang/swift/issues/88566
-	# is resolved.
-	SWIFT_DEBUG_INFO_FLAG ?= -g -debug-info-format=codeview -use-ld=lld
+	# Need to disable incremental linking to keep Edit-and-Continue padding
+	# from breaking metadata sections.
+	# See https://github.com/swiftlang/swift/issues/88566 for details.
+	SWIFT_DEBUG_INFO_FLAG ?= -g -debug-info-format=codeview -Xlinker /INCREMENTAL:NO
 else ifeq "$(OS)" "Windows_NT"
 	SWIFT_DEBUG_INFO_FLAG ?= -g -use-ld=lld -Xlinker -debug:dwarf
 else

--- a/lldb/packages/Python/lldbsuite/test/make/Swift.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Swift.rules
@@ -25,7 +25,9 @@ else
 endif
 
 ifeq "$(MAKE_PDB)" "YES"
-	SWIFT_DEBUG_INFO_FLAG ?= -g -debug-info-format=codeview
+	# Use lld until https://github.com/swiftlang/swift/issues/88566
+	# is resolved.
+	SWIFT_DEBUG_INFO_FLAG ?= -g -debug-info-format=codeview -use-ld=lld
 else ifeq "$(OS)" "Windows_NT"
 	SWIFT_DEBUG_INFO_FLAG ?= -g -use-ld=lld -Xlinker -debug:dwarf
 else


### PR DESCRIPTION
Toy Swift programs linked with link.exe end up with metadata sections that crash the metadata parser due to `Edit-and-Continue (see https://github.com/swiftlang/swift/issues/88566).

Disabling incremental linking turns off the extra padding.