### PR TITLE
[BoundsSafety][NFC] Remove LateParsedAttrInfo; use LateParsedAttribute directly in DeclaratorChunk

### DIFF
--- a/clang/include/clang/Parse/Parser.h
+++ b/clang/include/clang/Parse/Parser.h
@@ -164,6 +164,53 @@ enum class CXX11AttributeKind {
   InvalidAttributeSpecifier
 };
 
+/// [class.mem]p1: "... the class is regarded as complete within
+/// - function bodies
+/// - default arguments
+/// - exception-specifications (TODO: C++0x)
+/// - and brace-or-equal-initializers for non-static data members
+/// (including such things in nested classes)."
+/// LateParsedDeclarations build the tree of those elements so they can
+/// be parsed after parsing the top-level class.
+class LateParsedDeclaration {
+public:
+  virtual ~LateParsedDeclaration();
+
+  virtual void ParseLexedMethodDeclarations();
+  virtual void ParseLexedMemberInitializers();
+  virtual void ParseLexedMethodDefs();
+  virtual void ParseLexedAttributes();
+  virtual void ParseLexedPragmas();
+};
+
+/// Contains the lexed tokens of an attribute with arguments that
+/// may reference member variables and so need to be parsed at the
+/// end of the class declaration after parsing all other member
+/// member declarations.
+/// FIXME: Perhaps we should change the name of LateParsedDeclaration to
+/// LateParsedTokens.
+struct LateParsedAttribute : public LateParsedDeclaration {
+  Parser *Self;
+  CachedTokens Toks;
+  IdentifierInfo &AttrName;
+  IdentifierInfo *MacroII = nullptr;
+  SourceLocation AttrNameLoc;
+  SmallVector<Decl *, 2> Decls;
+  // TO_UPSTREAM(BoundsSafety)
+  unsigned NestedTypeLevel;
+
+  explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
+                               SourceLocation Loc, unsigned Level = 0)
+    : Self(P), AttrName(Name), AttrNameLoc(Loc), NestedTypeLevel(Level) {}
+
+  void ParseLexedAttributes() override;
+
+  void addDecl(Decl *D) {
+    assert(D && "cannot add null decl!");
+    Decls.push_back(D);
+  }
+};
+
 /// Parser - This implements a parser for the C family of languages.  After
 /// parsing units of the grammar, productions are invoked to handle whatever has
 /// been read.
@@ -950,7 +997,6 @@ private:
   void SkipFunctionBody();
 
   struct ParsedTemplateInfo;
-  class LateParsedAttrList;
 
   /// ParseFunctionDefinition - We parsed and verified that the specified
   /// Declarator is well formed.  If this is a K&R-style function, read the
@@ -1120,26 +1166,9 @@ private:
   ///@{
 
 private:
+  friend struct LateParsedAttribute;
+
   struct ParsingClass;
-
-  /// [class.mem]p1: "... the class is regarded as complete within
-  /// - function bodies
-  /// - default arguments
-  /// - exception-specifications (TODO: C++0x)
-  /// - and brace-or-equal-initializers for non-static data members
-  /// (including such things in nested classes)."
-  /// LateParsedDeclarations build the tree of those elements so they can
-  /// be parsed after parsing the top-level class.
-  class LateParsedDeclaration {
-  public:
-    virtual ~LateParsedDeclaration();
-
-    virtual void ParseLexedMethodDeclarations();
-    virtual void ParseLexedMemberInitializers();
-    virtual void ParseLexedMethodDefs();
-    virtual void ParseLexedAttributes();
-    virtual void ParseLexedPragmas();
-  };
 
   /// Inner node of the LateParsedDeclaration tree that parses
   /// all its members recursively.
@@ -1163,34 +1192,6 @@ private:
     ParsingClass *Class;
   };
 
-  /// Contains the lexed tokens of an attribute with arguments that
-  /// may reference member variables and so need to be parsed at the
-  /// end of the class declaration after parsing all other member
-  /// member declarations.
-  /// FIXME: Perhaps we should change the name of LateParsedDeclaration to
-  /// LateParsedTokens.
-  struct LateParsedAttribute : public LateParsedDeclaration {
-    Parser *Self;
-    CachedTokens Toks;
-    IdentifierInfo &AttrName;
-    IdentifierInfo *MacroII = nullptr;
-    SourceLocation AttrNameLoc;
-    SmallVector<Decl *, 2> Decls;
-    // TO_UPSTREAM(BoundsSafety)
-    unsigned NestedTypeLevel;
-
-    explicit LateParsedAttribute(Parser *P, IdentifierInfo &Name,
-                                 SourceLocation Loc, unsigned Level = 0)
-      : Self(P), AttrName(Name), AttrNameLoc(Loc), NestedTypeLevel(Level) {}
-
-    void ParseLexedAttributes() override;
-
-    void addDecl(Decl *D) {
-      assert(D && "cannot add null decl!");
-      Decls.push_back(D);
-    }
-  };
-
   /// Contains the lexed tokens of a pragma with arguments that
   /// may reference member variables and so need to be parsed at the
   /// end of the class declaration after parsing all other member
@@ -1209,26 +1210,6 @@ private:
     AccessSpecifier getAccessSpecifier() const { return AS; }
 
     void ParseLexedPragmas() override;
-  };
-
-  // A list of late-parsed attributes.  Used by ParseGNUAttributes.
-  class LateParsedAttrList : public SmallVector<LateParsedAttribute *, 2> {
-  public:
-    LateParsedAttrList(bool PSoon = false,
-                       bool LateAttrParseExperimentalExtOnly = false)
-        : ParseSoon(PSoon),
-          LateAttrParseExperimentalExtOnly(LateAttrParseExperimentalExtOnly) {}
-
-    bool parseSoon() { return ParseSoon; }
-    /// returns true iff the attribute to be parsed should only be late parsed
-    /// if it is annotated with `LateAttrParseExperimentalExt`
-    bool lateAttrParseExperimentalExtOnly() {
-      return LateAttrParseExperimentalExtOnly;
-    }
-
-  private:
-    bool ParseSoon; // Are we planning to parse these shortly after creation?
-    bool LateAttrParseExperimentalExtOnly;
   };
 
   /// Contains the lexed tokens of a member function definition

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -52,165 +52,165 @@ namespace clang {
   struct TemplateIdAnnotation;
   struct LateParsedAttribute;
 
-/// Represents a C++ nested-name-specifier or a global scope specifier.
-///
-/// These can be in 3 states:
-///   1) Not present, identified by isEmpty()
-///   2) Present, identified by isNotEmpty()
-///      2.a) Valid, identified by isValid()
-///      2.b) Invalid, identified by isInvalid().
-///
-/// isSet() is deprecated because it mostly corresponded to "valid" but was
-/// often used as if it meant "present".
-///
-/// The actual scope is described by getScopeRep().
-///
-/// If the kind of getScopeRep() is TypeSpec then TemplateParamLists may be empty
-/// or contain the template parameter lists attached to the current declaration.
-/// Consider the following example:
-/// template <class T> void SomeType<T>::some_method() {}
-/// If CXXScopeSpec refers to SomeType<T> then TemplateParamLists will contain
-/// a single element referring to template <class T>.
-
-class CXXScopeSpec {
-  SourceRange Range;
-  NestedNameSpecifierLocBuilder Builder;
-  ArrayRef<TemplateParameterList *> TemplateParamLists;
-
-public:
-  SourceRange getRange() const { return Range; }
-  void setRange(SourceRange R) { Range = R; }
-  void setBeginLoc(SourceLocation Loc) { Range.setBegin(Loc); }
-  void setEndLoc(SourceLocation Loc) { Range.setEnd(Loc); }
-  SourceLocation getBeginLoc() const { return Range.getBegin(); }
-  SourceLocation getEndLoc() const { return Range.getEnd(); }
-
-  void setTemplateParamLists(ArrayRef<TemplateParameterList *> L) {
-    TemplateParamLists = L;
-  }
-  ArrayRef<TemplateParameterList *> getTemplateParamLists() const {
-    return TemplateParamLists;
-  }
-
-  /// Retrieve the representation of the nested-name-specifier.
-  NestedNameSpecifier getScopeRep() const {
-    return Builder.getRepresentation();
-  }
-
-  /// Make a nested-name-specifier of the form 'type::'.
+  /// Represents a C++ nested-name-specifier or a global scope specifier.
   ///
-  /// \param Context The AST context in which this nested-name-specifier
-  /// resides.
+  /// These can be in 3 states:
+  ///   1) Not present, identified by isEmpty()
+  ///   2) Present, identified by isNotEmpty()
+  ///      2.a) Valid, identified by isValid()
+  ///      2.b) Invalid, identified by isInvalid().
   ///
-  /// \param TemplateKWLoc The location of the 'template' keyword, if present.
+  /// isSet() is deprecated because it mostly corresponded to "valid" but was
+  /// often used as if it meant "present".
   ///
-  /// \param TL The TypeLoc that describes the type preceding the '::'.
+  /// The actual scope is described by getScopeRep().
   ///
-  /// \param ColonColonLoc The location of the trailing '::'.
-  void Make(ASTContext &Context, TypeLoc TL, SourceLocation ColonColonLoc);
+  /// If the kind of getScopeRep() is TypeSpec then TemplateParamLists may be
+  /// empty or contain the template parameter lists attached to the current
+  /// declaration. Consider the following example: template <class T> void
+  /// SomeType<T>::some_method() {} If CXXScopeSpec refers to SomeType<T> then
+  /// TemplateParamLists will contain a single element referring to template
+  /// <class T>.
 
-  /// Extend the current nested-name-specifier by another
-  /// nested-name-specifier component of the form 'namespace::'.
-  ///
-  /// \param Context The AST context in which this nested-name-specifier
-  /// resides.
-  ///
-  /// \param Namespace The namespace or the namespace alias.
-  ///
-  /// \param NamespaceLoc The location of the namespace name or the namespace
-  /// alias.
-  ///
-  /// \param ColonColonLoc The location of the trailing '::'.
-  void Extend(ASTContext &Context, NamespaceBaseDecl *Namespace,
-              SourceLocation NamespaceLoc, SourceLocation ColonColonLoc);
+  class CXXScopeSpec {
+    SourceRange Range;
+    NestedNameSpecifierLocBuilder Builder;
+    ArrayRef<TemplateParameterList *> TemplateParamLists;
 
-  /// Turn this (empty) nested-name-specifier into the global
-  /// nested-name-specifier '::'.
-  void MakeGlobal(ASTContext &Context, SourceLocation ColonColonLoc);
+  public:
+    SourceRange getRange() const { return Range; }
+    void setRange(SourceRange R) { Range = R; }
+    void setBeginLoc(SourceLocation Loc) { Range.setBegin(Loc); }
+    void setEndLoc(SourceLocation Loc) { Range.setEnd(Loc); }
+    SourceLocation getBeginLoc() const { return Range.getBegin(); }
+    SourceLocation getEndLoc() const { return Range.getEnd(); }
 
-  /// Turns this (empty) nested-name-specifier into '__super'
-  /// nested-name-specifier.
-  ///
-  /// \param Context The AST context in which this nested-name-specifier
-  /// resides.
-  ///
-  /// \param RD The declaration of the class in which nested-name-specifier
-  /// appeared.
-  ///
-  /// \param SuperLoc The location of the '__super' keyword.
-  /// name.
-  ///
-  /// \param ColonColonLoc The location of the trailing '::'.
-  void MakeMicrosoftSuper(ASTContext &Context, CXXRecordDecl *RD,
-                          SourceLocation SuperLoc,
-                          SourceLocation ColonColonLoc);
+    void setTemplateParamLists(ArrayRef<TemplateParameterList *> L) {
+      TemplateParamLists = L;
+    }
+    ArrayRef<TemplateParameterList *> getTemplateParamLists() const {
+      return TemplateParamLists;
+    }
 
-  /// Make a new nested-name-specifier from incomplete source-location
-  /// information.
-  ///
-  /// FIXME: This routine should be used very, very rarely, in cases where we
-  /// need to synthesize a nested-name-specifier. Most code should instead use
-  /// \c Adopt() with a proper \c NestedNameSpecifierLoc.
-  void MakeTrivial(ASTContext &Context, NestedNameSpecifier Qualifier,
-                   SourceRange R);
+    /// Retrieve the representation of the nested-name-specifier.
+    NestedNameSpecifier getScopeRep() const {
+      return Builder.getRepresentation();
+    }
 
-  /// Adopt an existing nested-name-specifier (with source-range
-  /// information).
-  void Adopt(NestedNameSpecifierLoc Other);
+    /// Make a nested-name-specifier of the form 'type::'.
+    ///
+    /// \param Context The AST context in which this nested-name-specifier
+    /// resides.
+    ///
+    /// \param TemplateKWLoc The location of the 'template' keyword, if present.
+    ///
+    /// \param TL The TypeLoc that describes the type preceding the '::'.
+    ///
+    /// \param ColonColonLoc The location of the trailing '::'.
+    void Make(ASTContext &Context, TypeLoc TL, SourceLocation ColonColonLoc);
 
-  /// Retrieve a nested-name-specifier with location information, copied
-  /// into the given AST context.
-  ///
-  /// \param Context The context into which this nested-name-specifier will be
-  /// copied.
-  NestedNameSpecifierLoc getWithLocInContext(ASTContext &Context) const;
+    /// Extend the current nested-name-specifier by another
+    /// nested-name-specifier component of the form 'namespace::'.
+    ///
+    /// \param Context The AST context in which this nested-name-specifier
+    /// resides.
+    ///
+    /// \param Namespace The namespace or the namespace alias.
+    ///
+    /// \param NamespaceLoc The location of the namespace name or the namespace
+    /// alias.
+    ///
+    /// \param ColonColonLoc The location of the trailing '::'.
+    void Extend(ASTContext &Context, NamespaceBaseDecl *Namespace,
+                SourceLocation NamespaceLoc, SourceLocation ColonColonLoc);
 
-  /// Retrieve the location of the name in the last qualifier
-  /// in this nested name specifier.
-  ///
-  /// For example, the location of \c bar
-  /// in
-  /// \verbatim
-  ///   \::foo::bar<0>::
-  ///           ^~~
-  /// \endverbatim
-  SourceLocation getLastQualifierNameLoc() const;
+    /// Turn this (empty) nested-name-specifier into the global
+    /// nested-name-specifier '::'.
+    void MakeGlobal(ASTContext &Context, SourceLocation ColonColonLoc);
 
-  /// No scope specifier.
-  bool isEmpty() const { return Range.isInvalid() && !getScopeRep(); }
-  /// A scope specifier is present, but may be valid or invalid.
-  bool isNotEmpty() const { return !isEmpty(); }
+    /// Turns this (empty) nested-name-specifier into '__super'
+    /// nested-name-specifier.
+    ///
+    /// \param Context The AST context in which this nested-name-specifier
+    /// resides.
+    ///
+    /// \param RD The declaration of the class in which nested-name-specifier
+    /// appeared.
+    ///
+    /// \param SuperLoc The location of the '__super' keyword.
+    /// name.
+    ///
+    /// \param ColonColonLoc The location of the trailing '::'.
+    void MakeMicrosoftSuper(ASTContext &Context, CXXRecordDecl *RD,
+                            SourceLocation SuperLoc,
+                            SourceLocation ColonColonLoc);
 
-  /// An error occurred during parsing of the scope specifier.
-  bool isInvalid() const { return Range.isValid() && !getScopeRep(); }
-  /// A scope specifier is present, and it refers to a real scope.
-  bool isValid() const { return bool(getScopeRep()); }
+    /// Make a new nested-name-specifier from incomplete source-location
+    /// information.
+    ///
+    /// FIXME: This routine should be used very, very rarely, in cases where we
+    /// need to synthesize a nested-name-specifier. Most code should instead use
+    /// \c Adopt() with a proper \c NestedNameSpecifierLoc.
+    void MakeTrivial(ASTContext &Context, NestedNameSpecifier Qualifier,
+                     SourceRange R);
 
-  /// Indicate that this nested-name-specifier is invalid.
-  void SetInvalid(SourceRange R) {
-    assert(R.isValid() && "Must have a valid source range");
-    if (Range.getBegin().isInvalid())
-      Range.setBegin(R.getBegin());
-    Range.setEnd(R.getEnd());
-    Builder.Clear();
-  }
+    /// Adopt an existing nested-name-specifier (with source-range
+    /// information).
+    void Adopt(NestedNameSpecifierLoc Other);
 
-  /// Deprecated.  Some call sites intend isNotEmpty() while others intend
-  /// isValid().
-  bool isSet() const { return bool(getScopeRep()); }
+    /// Retrieve a nested-name-specifier with location information, copied
+    /// into the given AST context.
+    ///
+    /// \param Context The context into which this nested-name-specifier will be
+    /// copied.
+    NestedNameSpecifierLoc getWithLocInContext(ASTContext &Context) const;
 
-  void clear() {
-    Range = SourceRange();
-    Builder.Clear();
-  }
+    /// Retrieve the location of the name in the last qualifier
+    /// in this nested name specifier.
+    ///
+    /// For example, the location of \c bar
+    /// in
+    /// \verbatim
+    ///   \::foo::bar<0>::
+    ///           ^~~
+    /// \endverbatim
+    SourceLocation getLastQualifierNameLoc() const;
 
-  /// Retrieve the data associated with the source-location information.
-  char *location_data() const { return Builder.getBuffer().first; }
+    /// No scope specifier.
+    bool isEmpty() const { return Range.isInvalid() && !getScopeRep(); }
+    /// A scope specifier is present, but may be valid or invalid.
+    bool isNotEmpty() const { return !isEmpty(); }
 
-  /// Retrieve the size of the data associated with source-location
-  /// information.
-  unsigned location_size() const { return Builder.getBuffer().second; }
-};
+    /// An error occurred during parsing of the scope specifier.
+    bool isInvalid() const { return Range.isValid() && !getScopeRep(); }
+    /// A scope specifier is present, and it refers to a real scope.
+    bool isValid() const { return bool(getScopeRep()); }
+
+    /// Indicate that this nested-name-specifier is invalid.
+    void SetInvalid(SourceRange R) {
+      assert(R.isValid() && "Must have a valid source range");
+      if (Range.getBegin().isInvalid())
+        Range.setBegin(R.getBegin());
+      Range.setEnd(R.getEnd());
+      Builder.Clear();
+    }
+
+    /// Deprecated.  Some call sites intend isNotEmpty() while others intend
+    /// isValid().
+    bool isSet() const { return bool(getScopeRep()); }
+
+    void clear() {
+      Range = SourceRange();
+      Builder.Clear();
+    }
+
+    /// Retrieve the data associated with the source-location information.
+    char *location_data() const { return Builder.getBuffer().first; }
+
+    /// Retrieve the size of the data associated with source-location
+    /// information.
+    unsigned location_size() const { return Builder.getBuffer().second; }
+  };
 
 /// Captures information about "declaration specifiers".
 ///

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -50,6 +50,7 @@ namespace clang {
   class Declarator;
   class OverflowBehaviorType;
   struct TemplateIdAnnotation;
+  struct LateParsedAttribute;
 
 /// Represents a C++ nested-name-specifier or a global scope specifier.
 ///
@@ -1248,6 +1249,26 @@ public:
 
 /// A set of tokens that has been cached for later parsing.
 typedef SmallVector<Token, 4> CachedTokens;
+
+// A list of late-parsed attributes.  Used by ParseGNUAttributes.
+class LateParsedAttrList : public SmallVector<LateParsedAttribute *, 2> {
+public:
+  LateParsedAttrList(bool PSoon = false,
+                     bool LateAttrParseExperimentalExtOnly = false)
+      : ParseSoon(PSoon),
+        LateAttrParseExperimentalExtOnly(LateAttrParseExperimentalExtOnly) {}
+
+  bool parseSoon() { return ParseSoon; }
+  /// returns true iff the attribute to be parsed should only be late parsed
+  /// if it is annotated with `LateAttrParseExperimentalExt`
+  bool lateAttrParseExperimentalExtOnly() {
+    return LateAttrParseExperimentalExtOnly;
+  }
+
+private:
+  bool ParseSoon; // Are we planning to parse these shortly after creation?
+  bool LateAttrParseExperimentalExtOnly;
+};
 
 /// One instance of this struct is used for each type in a
 /// declarator that is parsed.

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -1275,7 +1275,7 @@ private:
 ///
 /// This is intended to be a small value object.
 struct DeclaratorChunk {
-  DeclaratorChunk() {};
+  DeclaratorChunk() : LateAttrList(/*ParseSoon*/true, /*LateAttrParseExperimentalExtOnly*/true) {};
 
   enum {
     Pointer, Reference, Array, Function, BlockPointer, MemberPointer, Paren, Pipe
@@ -1293,20 +1293,7 @@ struct DeclaratorChunk {
   }
 
   ParsedAttributesView AttrList;
-
-  /* TO_UPSTREAM(BoundsSafety) ON */
-  struct LateParsedAttrInfo {
-    CachedTokens Toks;
-    IdentifierInfo &AttrName;
-    IdentifierInfo *MacroII = nullptr;
-    SourceLocation AttrNameLoc;
-
-    explicit LateParsedAttrInfo(CachedTokens Toks, IdentifierInfo &AttrName,
-                                IdentifierInfo *MacroII,
-                                SourceLocation AttrNameLoc)
-        : Toks(Toks), AttrName(AttrName), MacroII(MacroII), AttrNameLoc(AttrNameLoc) {}
-  };
-  /* TO_UPSTREAM(BoundsSafety) OFF */
+  LateParsedAttrList LateAttrList;
 
   struct PointerTypeInfo {
     /// The type qualifiers: const/volatile/restrict/unaligned/atomic.
@@ -1336,26 +1323,8 @@ struct DeclaratorChunk {
     LLVM_PREFERRED_TYPE(bool)
     unsigned OverflowBehaviorIsWrap : 1;
 
-    /* TO_UPSTREAM(BoundsSafety) ON */
-    // LateParsedAttrInfo objects and their count.
-    unsigned NumLateParsedAttrs;
-    LateParsedAttrInfo **LateAttrInfos;
-    /* TO_UPSTREAM(BoundsSafety) OFF */
-
     void destroy() {
-      /* TO_UPSTREAM(BoundsSafety) ON */
-      for (unsigned i = 0; i < NumLateParsedAttrs; ++i)
-        delete LateAttrInfos[i];
-      if (NumLateParsedAttrs != 0)
-        delete[] LateAttrInfos;
-      /* TO_UPSTREAM(BoundsSafety) OFF */
     }
-
-    /* TO_UPSTREAM(BoundsSafety) ON */
-    ArrayRef<LateParsedAttrInfo *> getLateParsedAttrInfos() const {
-      return {LateAttrInfos, NumLateParsedAttrs};
-    }
-    /* TO_UPSTREAM(BoundsSafety) OFF */
   };
 
   struct ReferenceTypeInfo {
@@ -1386,26 +1355,7 @@ struct DeclaratorChunk {
     /// expression class on all clients, NumElts is untyped.
     Expr *NumElts;
 
-    /* TO_UPSTREAM(BoundsSafety) ON */
-    // LateParsedAttrInfo objects and their count.
-    unsigned NumLateParsedAttrs;
-    LateParsedAttrInfo **LateAttrInfos;
-    /* TO_UPSTREAM(BoundsSafety) OFF */
-
-    void destroy() {
-      /* TO_UPSTREAM(BoundsSafety) ON */
-      for (unsigned i = 0; i < NumLateParsedAttrs; ++i)
-        delete LateAttrInfos[i];
-      if (NumLateParsedAttrs != 0)
-        delete[] LateAttrInfos;
-      /* TO_UPSTREAM(BoundsSafety) OFF */
-    }
-
-    /* TO_UPSTREAM(BoundsSafety) ON */
-    ArrayRef<LateParsedAttrInfo *> getLateParsedAttrInfos() const {
-      return {LateAttrInfos, NumLateParsedAttrs};
-    }
-    /* TO_UPSTREAM(BoundsSafety) OFF */
+    void destroy() {}
   };
 
   /// ParamInfo - An array of paraminfo objects is allocated whenever a function
@@ -1756,9 +1706,7 @@ struct DeclaratorChunk {
                                     SourceLocation AtomicQualLoc,
                                     SourceLocation UnalignedQualLoc,
                                     SourceLocation OverflowBehaviorLoc = {},
-                                    bool OverflowBehaviorIsWrap = false,
-                                    // TO_UPSTREAM(BoundsSafety)
-                                    ArrayRef<LateParsedAttrInfo*> LateAttrInfos = {}) {
+                                    bool OverflowBehaviorIsWrap = false) {
     DeclaratorChunk I;
     I.Kind                = Pointer;
     I.Loc                 = Loc;
@@ -1771,14 +1719,6 @@ struct DeclaratorChunk {
     I.Ptr.UnalignedQualLoc = UnalignedQualLoc;
     I.Ptr.OverflowBehaviorLoc = OverflowBehaviorLoc;
     I.Ptr.OverflowBehaviorIsWrap = OverflowBehaviorIsWrap;
-    /* TO_UPSTREAM(BoundsSafety) ON */
-    I.Ptr.NumLateParsedAttrs = LateAttrInfos.size();
-    if (!LateAttrInfos.empty()) {
-      I.Ptr.LateAttrInfos = new LateParsedAttrInfo *[LateAttrInfos.size()];
-      for (size_t J = 0; J < LateAttrInfos.size(); ++J)
-        I.Ptr.LateAttrInfos[J] = LateAttrInfos[J];
-    }
-    /* TO_UPSTREAM(BoundsSafety) OFF */
     return I;
   }
 
@@ -1796,9 +1736,7 @@ struct DeclaratorChunk {
   /// Return a DeclaratorChunk for an array.
   static DeclaratorChunk getArray(unsigned TypeQuals,
                                   bool isStatic, bool isStar, Expr *NumElts,
-                                  SourceLocation LBLoc, SourceLocation RBLoc,
-                                  // TO_UPSTREAM(BoundsSafety)
-                                  ArrayRef<LateParsedAttrInfo*> LateAttrInfos = {}) {
+                                  SourceLocation LBLoc, SourceLocation RBLoc) {
     DeclaratorChunk I;
     I.Kind          = Array;
     I.Loc           = LBLoc;
@@ -1807,14 +1745,6 @@ struct DeclaratorChunk {
     I.Arr.hasStatic = isStatic;
     I.Arr.isStar    = isStar;
     I.Arr.NumElts   = NumElts;
-    /* TO_UPSTREAM(BoundsSafety) ON */
-    I.Arr.NumLateParsedAttrs = LateAttrInfos.size();
-    if (!LateAttrInfos.empty()) {
-      I.Arr.LateAttrInfos = new LateParsedAttrInfo *[LateAttrInfos.size()];
-      for (size_t J = 0; J < LateAttrInfos.size(); ++J)
-        I.Arr.LateAttrInfos[J] = LateAttrInfos[J];
-    }
-    /* TO_UPSTREAM(BoundsSafety) OFF */
     return I;
   }
 
@@ -2464,13 +2394,16 @@ public:
   /// This function takes attrs by R-Value reference because it takes ownership
   /// of those attributes from the parameter.
   void AddTypeInfo(const DeclaratorChunk &TI, ParsedAttributes &&attrs,
-                   SourceLocation EndLoc) {
+                   SourceLocation EndLoc,
+                   const LateParsedAttrList &LateAttrs = {}) {
     DeclTypeInfo.push_back(TI);
     DeclTypeInfo.back().getAttrs().prepend(attrs.begin(), attrs.end());
     getAttributePool().takeAllFrom(attrs.getPool());
 
     if (!EndLoc.isInvalid())
       SetRangeEnd(EndLoc);
+
+    DeclTypeInfo.back().LateAttrList.append(LateAttrs);
   }
 
   /// AddTypeInfo - Add a chunk to this declarator. Also extend the range to
@@ -2516,21 +2449,6 @@ public:
     assert(i < DeclTypeInfo.size() && "Invalid type chunk");
     return DeclTypeInfo[i];
   }
-
-  /*TO_UPSTREAM(BoundsSafety) ON*/
-  /// Add all DeclaratorChunks from Other to the end of this declarator, and
-  /// remove them from Other. This transfers ownership of the DeclaratorChunks
-  /// and their attributes to this object.
-  void TakeTypeObjects(Declarator &Other) {
-    DeclTypeInfo.append(Other.DeclTypeInfo); // Keep the ordering
-    while (!Other.DeclTypeInfo.empty()) {
-      // Remove without calling destroy(), so it won't be destroyed when
-      // calling the destructor on Other
-      DeclaratorChunk Removed = Other.DeclTypeInfo.pop_back_val();
-      getAttributePool().takeFrom(Removed.getAttrs(), Other.getAttributePool());
-    }
-  }
-  /*TO_UPSTREAM(BoundsSafety) OFF*/
 
   typedef SmallVectorImpl<DeclaratorChunk>::const_iterator type_object_iterator;
   typedef llvm::iterator_range<type_object_iterator> type_object_range;

--- a/clang/include/clang/Sema/DeclSpec.h
+++ b/clang/include/clang/Sema/DeclSpec.h
@@ -1275,7 +1275,9 @@ private:
 ///
 /// This is intended to be a small value object.
 struct DeclaratorChunk {
-  DeclaratorChunk() : LateAttrList(/*ParseSoon*/true, /*LateAttrParseExperimentalExtOnly*/true) {};
+  DeclaratorChunk()
+      : LateAttrList(/*PSoon=*/true,
+                     /*LateAttrParseExperimentalExtOnly=*/true) {};
 
   enum {
     Pointer, Reference, Array, Function, BlockPointer, MemberPointer, Paren, Pipe

--- a/clang/lib/Parse/ParseCXXInlineMethods.cpp
+++ b/clang/lib/Parse/ParseCXXInlineMethods.cpp
@@ -269,12 +269,12 @@ void Parser::ParseCXXNonStaticMemberInitializer(Decl *VarD) {
   Toks.push_back(Eof);
 }
 
-Parser::LateParsedDeclaration::~LateParsedDeclaration() {}
-void Parser::LateParsedDeclaration::ParseLexedMethodDeclarations() {}
-void Parser::LateParsedDeclaration::ParseLexedMemberInitializers() {}
-void Parser::LateParsedDeclaration::ParseLexedMethodDefs() {}
-void Parser::LateParsedDeclaration::ParseLexedAttributes() {}
-void Parser::LateParsedDeclaration::ParseLexedPragmas() {}
+LateParsedDeclaration::~LateParsedDeclaration() {}
+void LateParsedDeclaration::ParseLexedMethodDeclarations() {}
+void LateParsedDeclaration::ParseLexedMemberInitializers() {}
+void LateParsedDeclaration::ParseLexedMethodDefs() {}
+void LateParsedDeclaration::ParseLexedAttributes() {}
+void LateParsedDeclaration::ParseLexedPragmas() {}
 
 Parser::LateParsedClass::LateParsedClass(Parser *P, ParsingClass *C)
   : Self(P), Class(C) {}
@@ -315,7 +315,7 @@ void Parser::LateParsedMemberInitializer::ParseLexedMemberInitializers() {
   Self->ParseLexedMemberInitializer(*this);
 }
 
-void Parser::LateParsedAttribute::ParseLexedAttributes() {
+void LateParsedAttribute::ParseLexedAttributes() {
   Self->ParseLexedAttribute(*this, true, false);
 }
 

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -2215,7 +2215,7 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
                                               ParsedTemplateInfo &TemplateInfo,
                                               SourceLocation *DeclEnd,
                                               ForRangeInit *FRI,
-                                              // TO_UPSTREAM(BoundsSafety) 
+                                              // TO_UPSTREAM(BoundsSafety)
                                               LateParsedAttrList *BoundsSafetyLateAttrs) {
   // Parse the first declarator.
   // Consume all of the attributes from `Attrs` by moving them to our own local
@@ -2851,7 +2851,7 @@ void Parser::ParseSpecifierQualifierList(
               ? LateAttrs->lateAttrParseExperimentalExtOnly()
               : true) &&
          "Experimental late parsing must be enabled for BoundsSafety");
-  /*TO_UPSTREAM(BoundsSafety) OFF*/ 
+  /*TO_UPSTREAM(BoundsSafety) OFF*/
 
   ParsedTemplateInfo TemplateInfo;
   // TO_UPSTREAM(BoundsSafety): Pass LateAttrs
@@ -3281,18 +3281,20 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
     unsigned Index = 0;
   } FuncInfo;
   std::unique_ptr<ParseScope> ProtoScope;
-  LateParsedAttrList ProtoLateAttrs(true);
+  LateParsedAttrList ProtoLateAttrs(/*ParseSoon*/true);
 
   for (unsigned i = 0; i < D.getNumTypeObjects(); ++i) {
     DeclaratorChunk &DC = D.getTypeObject(i);
 
-    ArrayRef<DeclaratorChunk::LateParsedAttrInfo *> LPAI;
+    LateParsedAttrList DCLateAttrs(/*ParseSoon*/true);
     switch (DC.Kind) {
     case DeclaratorChunk::Pointer:
-      LPAI = DC.Ptr.getLateParsedAttrInfos();
+      DCLateAttrs.append(DC.LateAttrList);
+      DC.LateAttrList.clear();
       break;
     case DeclaratorChunk::Array:
-      LPAI = DC.Arr.getLateParsedAttrInfos();
+      DCLateAttrs.append(DC.LateAttrList);
+      DC.LateAttrList.clear();
       break;
     case DeclaratorChunk::Function:
       FuncInfo.Index = i;
@@ -3302,7 +3304,7 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
       continue;
     }
 
-    if (!LPAI.empty() && FuncInfo.Valid && !ProtoScope) {
+    if (!DCLateAttrs.empty() && FuncInfo.Valid && !ProtoScope) {
       const DeclaratorChunk &FuncChunk = D.getTypeObject(FuncInfo.Index);
       ProtoScope.reset(new ParseScope(this, Scope::FunctionPrototypeScope |
                                             Scope::DeclScope));
@@ -3313,15 +3315,12 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
       }
       LateAttrs = &ProtoLateAttrs;
     }
-    for (const auto *LI : LPAI) {
-      LateParsedAttribute *LA = new LateParsedAttribute(
-          this, LI->AttrName, LI->AttrNameLoc, NestedLevel);
-      LA->MacroII = std::move(LI->MacroII);
-      LA->Toks = std::move(LI->Toks);
+    for (auto *LA : DCLateAttrs) {
+      LA->NestedTypeLevel = NestedLevel;
       if (Dcl)
         LA->addDecl(Dcl);
-      LateAttrs->push_back(LA);
     }
+    LateAttrs->append(DCLateAttrs);
     NestedLevel++;
   }
   ParseLexedCAttributeList(ProtoLateAttrs, false);
@@ -6802,7 +6801,6 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
         D.getBeginLoc(), [&] { ParseDeclaratorInternal(D, DirectDeclParser); });
     if (Kind == tok::star) {
       /* TO_UPSTREAM(BoundsSafety) ON */
-      SmallVector<DeclaratorChunk::LateParsedAttrInfo *, 0> LateAttrInfos;
       // We parse '__counted_by' or '__ended_by' attributes immediately
       // if this is a function declarator. We need these attributes to be
       // parsed early so we can construct the full function type before Sema
@@ -6840,15 +6838,8 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
             }
           }
           ParseLexedCAttributeList(LateAttrs, false, &D.getAttributes());
-        } else {
-          for (auto LA : LateAttrs) {
-            auto LI = new DeclaratorChunk::LateParsedAttrInfo(
-                LA->Toks, LA->AttrName, LA->MacroII, LA->AttrNameLoc);
-            LateAttrInfos.push_back(LI);
-            delete LA;
-          }
+          LateAttrs.clear();
         }
-        LateAttrs.clear();
       }
       /* TO_UPSTREAM(BoundsSafety) OFF */
       // Remember that we parsed a pointer type, and remember the type-quals.
@@ -6856,10 +6847,9 @@ void Parser::ParseDeclaratorInternal(Declarator &D,
                         DS.getTypeQualifiers(), Loc, DS.getConstSpecLoc(),
                         DS.getVolatileSpecLoc(), DS.getRestrictSpecLoc(),
                         DS.getAtomicSpecLoc(), DS.getUnalignedSpecLoc(),
-                        DS.getOverflowBehaviorLoc(), DS.isWrapSpecified(),
-                        // TO_UPSTREAM(BoundsSafety)
-                        LateAttrInfos),
-                    std::move(DS.getAttributes()), SourceLocation());
+                        DS.getOverflowBehaviorLoc(), DS.isWrapSpecified()),
+                    std::move(DS.getAttributes()), SourceLocation(),
+                    std::move(LateAttrs));
     } else
       // Remember that we parsed a Block type, and remember the type-quals.
       D.AddTypeInfo(
@@ -8255,24 +8245,12 @@ void Parser::ParseBracketDeclarator(Declarator &D) {
 
   MaybeParseCXX11Attributes(DS.getAttributes());
 
-  /* TO_UPSTREAM(BoundsSafety) ON */
-  SmallVector<clang::DeclaratorChunk::LateParsedAttrInfo *, 0> LateAttrInfos;
-  for (auto LA : LateAttrs) {
-    auto LI = new DeclaratorChunk::LateParsedAttrInfo(
-        LA->Toks, LA->AttrName, LA->MacroII, LA->AttrNameLoc);
-    LateAttrInfos.push_back(LI);
-    delete LA;
-  }
-  /* TO_UPSTREAM(BoundsSafety) OFF */
-
   // Remember that we parsed a array type, and remember its features.
   D.AddTypeInfo(
       DeclaratorChunk::getArray(DS.getTypeQualifiers(), StaticLoc.isValid(),
                                 isStar, NumElements.get(), T.getOpenLocation(),
-                                T.getCloseLocation(),
-                                // TO_UPSTREAM(BoundsSafety)
-                                LateAttrInfos),
-      std::move(DS.getAttributes()), T.getCloseLocation());
+                                T.getCloseLocation()),
+      std::move(DS.getAttributes()), T.getCloseLocation(), std::move(LateAttrs));
 }
 
 void Parser::ParseMisplacedBracketDeclarator(Declarator &D) {
@@ -8330,15 +8308,10 @@ void Parser::ParseMisplacedBracketDeclarator(Declarator &D) {
   }
 
   // Adding back the bracket info to the end of the Declarator.
-  /* TO_UPSTREAM(BoundsSafety) ON*/
-  if (getLangOpts().BoundsSafetyAttributes)
-    D.TakeTypeObjects(TempDeclarator);
-  else
-  /* TO_UPSTREAM(BoundsSafety) OFF*/
-    for (unsigned i = 0, e = TempDeclarator.getNumTypeObjects(); i < e; ++i) {
-      const DeclaratorChunk &Chunk = TempDeclarator.getTypeObject(i);
-      D.AddTypeInfo(Chunk, TempDeclarator.getAttributePool(), SourceLocation());
-    }
+  for (unsigned i = 0, e = TempDeclarator.getNumTypeObjects(); i < e; ++i) {
+    const DeclaratorChunk &Chunk = TempDeclarator.getTypeObject(i);
+    D.AddTypeInfo(Chunk, TempDeclarator.getAttributePool(), SourceLocation());
+  }
 
   // The missing name would have been diagnosed in ParseDirectDeclarator.
   // If parentheses are required, always suggest them.

--- a/clang/lib/Parse/ParseDecl.cpp
+++ b/clang/lib/Parse/ParseDecl.cpp
@@ -3281,12 +3281,12 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
     unsigned Index = 0;
   } FuncInfo;
   std::unique_ptr<ParseScope> ProtoScope;
-  LateParsedAttrList ProtoLateAttrs(/*ParseSoon*/true);
+  LateParsedAttrList ProtoLateAttrs(/*ParseSoon=*/true);
 
   for (unsigned i = 0; i < D.getNumTypeObjects(); ++i) {
     DeclaratorChunk &DC = D.getTypeObject(i);
 
-    LateParsedAttrList DCLateAttrs(/*ParseSoon*/true);
+    LateParsedAttrList DCLateAttrs(/*ParseSoon=*/true);
     switch (DC.Kind) {
     case DeclaratorChunk::Pointer:
       DCLateAttrs.append(DC.LateAttrList);
@@ -3315,7 +3315,7 @@ void Parser::DistributeCLateParsedAttrs(Declarator &D, Decl *Dcl,
       }
       LateAttrs = &ProtoLateAttrs;
     }
-    for (auto *LA : DCLateAttrs) {
+    for (LateParsedAttribute *LA : DCLateAttrs) {
       LA->NestedTypeLevel = NestedLevel;
       if (Dcl)
         LA->addDecl(Dcl);


### PR DESCRIPTION
Cherry-pick of llvm/llvm-project#192145 plus downstream cleanup, which is needed before merging the upstream PR:

- Move `LateParsedDeclaration` and `LateParsedAttribute` from inside the `Parser` class to namespace level in `Parser.h`
- Move `LateParsedAttrList` from `Parser.h` to `DeclSpec.h` with a forward declaration of `LateParsedAttribute`
- Remove `DeclaratorChunk::LateParsedAttrInfo`, which was a workaround that copied data from `LateParsedAttribute` because the latter was previously inaccessible from `DeclSpec.h`. `DeclaratorChunk` now stores `LateParsedAttribute*` pointers directly, eliminating the copy/delete cycle.

Resolves https://github.com/swiftlang/llvm-project/issues/12764
rdar://175200683