### PR TITLE
[🍒][APINotes][unsafe-buffer-usage] Add [[clang::unsafe_buffer_usage]] support in APINotes (#189775)

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -524,6 +524,15 @@ related warnings within the method body.
   foreign language personality with a given function. Note that this does not
   perform any ABI validation for the personality routine.
 
+- The ``[[clang::unsafe_buffer_usage]]`` attribute is now supported in API
+  notes. For example:
+  
+  .. code-block:: yaml
+
+    Functions:
+      - Name: myUnsafeFunction
+        UnsafeBufferUsage: true
+
 Improvements to Clang's diagnostics
 -----------------------------------
 - Added ``-Wlifetime-safety`` to enable lifetime safety analysis,

--- a/clang/include/clang/APINotes/Types.h
+++ b/clang/include/clang/APINotes/Types.h
@@ -648,6 +648,10 @@ public:
   /// A biased RetainCountConventionKind, where 0 means "unspecified".
   unsigned RawRetainCountConvention : 3;
 
+  /// Whether the function has the [[clang::unsafe_buffer_usage]] attribute
+  LLVM_PREFERRED_TYPE(bool)
+  unsigned UnsafeBufferUsage : 1;
+
   // NullabilityKindSize bits are used to encode the nullability. The info
   // about the return type is stored at position 0, followed by the nullability
   // of the parameters.
@@ -671,7 +675,7 @@ public:
 
   FunctionInfo()
       : NullabilityAudited(false), NumAdjustedNullable(0),
-        RawRetainCountConvention() {}
+        RawRetainCountConvention(), UnsafeBufferUsage(0) {}
 
   static unsigned getMaxNullabilityIndex() {
     return ((sizeof(NullabilityPayload) * CHAR_BIT) / NullabilityKindSize);
@@ -743,6 +747,7 @@ public:
 inline bool operator==(const FunctionInfo &LHS, const FunctionInfo &RHS) {
   return static_cast<const CommonEntityInfo &>(LHS) == RHS &&
          LHS.NullabilityAudited == RHS.NullabilityAudited &&
+         LHS.UnsafeBufferUsage == RHS.UnsafeBufferUsage &&
          LHS.NumAdjustedNullable == RHS.NumAdjustedNullable &&
          LHS.NullabilityPayload == RHS.NullabilityPayload &&
          LHS.ResultType == RHS.ResultType && LHS.Params == RHS.Params &&

--- a/clang/lib/APINotes/APINotesFormat.h
+++ b/clang/lib/APINotes/APINotesFormat.h
@@ -24,7 +24,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// API notes file minor version number.
 ///
 /// When the format changes IN ANY WAY, this number should be incremented.
-const uint16_t VERSION_MINOR = 39; // SwiftSafety (38) and TO_UPSTREAM(BoundsSafety) (39) 
+const uint16_t VERSION_MINOR = 40; // 40 for UnsafeBufferUsageAttr
 
 const uint8_t kSwiftConforms = 1;
 const uint8_t kSwiftDoesNotConform = 2;

--- a/clang/lib/APINotes/APINotesReader.cpp
+++ b/clang/lib/APINotes/APINotesReader.cpp
@@ -385,6 +385,9 @@ void ReadFunctionInfo(const uint8_t *&Data, FunctionInfo &Info) {
   ReadCommonEntityInfo(Data, Info);
 
   uint8_t Payload = endian::readNext<uint8_t, llvm::endianness::little>(Data);
+  if (Payload & 0x1)
+    Info.UnsafeBufferUsage = 1;
+  Payload >>= 0x1;
   if (auto RawConvention = Payload & 0x7) {
     auto Convention = static_cast<RetainCountConventionKind>(RawConvention - 1);
     Info.setRetainCountConvention(Convention);

--- a/clang/lib/APINotes/APINotesTypes.cpp
+++ b/clang/lib/APINotes/APINotesTypes.cpp
@@ -123,6 +123,7 @@ LLVM_DUMP_METHOD void ParamInfo::dump(llvm::raw_ostream &OS) const {
 LLVM_DUMP_METHOD void FunctionInfo::dump(llvm::raw_ostream &OS) const {
   static_cast<const CommonEntityInfo &>(*this).dump(OS);
   OS << (NullabilityAudited ? "[NullabilityAudited] " : "")
+     << (UnsafeBufferUsage ? "[UnsafeBufferUsage] " : "")
      << "RawRetainCountConvention: " << RawRetainCountConvention << ' ';
   if (!ResultType.empty())
     OS << "Result Type: " << ResultType << ' ';

--- a/clang/lib/APINotes/APINotesWriter.cpp
+++ b/clang/lib/APINotes/APINotesWriter.cpp
@@ -1175,6 +1175,8 @@ void emitFunctionInfo(raw_ostream &OS, const FunctionInfo &FI) {
   flags <<= 3;
   if (auto RCC = FI.getRetainCountConvention())
     flags |= static_cast<uint8_t>(RCC.value()) + 1;
+  flags <<= 0x01;
+  flags |= FI.UnsafeBufferUsage;
 
   llvm::support::endian::Writer writer(OS, llvm::endianness::little);
 

--- a/clang/lib/APINotes/APINotesYAMLCompiler.cpp
+++ b/clang/lib/APINotes/APINotesYAMLCompiler.cpp
@@ -481,6 +481,7 @@ struct Function {
   std::optional<BoundsSafetyNotes> ReturnBoundsSafety;
   /* TO_UPSTREAM(BoundsSafety) OFF */
   SwiftSafetyKind SafetyKind = SwiftSafetyKind::None;
+  bool UnsafeBufferUsage = false;
 };
 
 typedef std::vector<Function> FunctionsSeq;
@@ -509,6 +510,7 @@ template <> struct MappingTraits<Function> {
     IO.mapOptional("BoundsSafety", F.ReturnBoundsSafety);
     /* TO_UPSTREAM(BoundsSafety) OFF */
     IO.mapOptional("SwiftSafety", F.SafetyKind, SwiftSafetyKind::None);
+    IO.mapOptional("UnsafeBufferUsage", F.UnsafeBufferUsage, false);
   }
 };
 } // namespace yaml
@@ -1189,6 +1191,7 @@ public:
     FI.ResultType = std::string(Function.ResultType);
     FI.SwiftReturnOwnership = std::string(Function.SwiftReturnOwnership);
     FI.setRetainCountConvention(Function.RetainCountConvention);
+    FI.UnsafeBufferUsage = Function.UnsafeBufferUsage;
   }
 
   void convertTagContext(std::optional<Context> ParentContext, const Tag &T,

--- a/clang/lib/Sema/SemaAPINotes.cpp
+++ b/clang/lib/Sema/SemaAPINotes.cpp
@@ -642,6 +642,14 @@ static void ProcessAPINotes(Sema &S, FunctionOrMethod AnyFunc,
   if (Info.NullabilityAudited)
     applyNullability(S, D, Info.getReturnTypeInfo(), Metadata);
 
+  // Add [[clang::unsafe_buffer_usage]]
+  if (Info.UnsafeBufferUsage && !D->getAttr<UnsafeBufferUsageAttr>()) {
+    handleAPINotedAttribute<UnsafeBufferUsageAttr>(S, D, true, Metadata, [&]() {
+      return UnsafeBufferUsageAttr::Create(S.getASTContext(),
+                                           getPlaceholderAttrInfo());
+    });
+  }
+
   // Parameters.
   unsigned NumParams = FD ? FD->getNumParams() : MD->param_size();
 

--- a/clang/test/APINotes/Inputs/Headers/UnsafeBufferUsage.apinotes
+++ b/clang/test/APINotes/Inputs/Headers/UnsafeBufferUsage.apinotes
@@ -1,0 +1,10 @@
+---
+Name: UnsafeBufferUsage
+Functions:
+  - Name: unsafeFunc
+    UnsafeBufferUsage: true
+  - Name: annotatedUnsafeFunc
+    UnsafeBufferUsage: true
+  - Name: falseAPINotesButAnnotatedUnsafeFunc
+    UnsafeBufferUsage: false
+...

--- a/clang/test/APINotes/Inputs/Headers/UnsafeBufferUsage.h
+++ b/clang/test/APINotes/Inputs/Headers/UnsafeBufferUsage.h
@@ -1,0 +1,3 @@
+void unsafeFunc(int *p, int n);
+[[clang::unsafe_buffer_usage]] void annotatedUnsafeFunc(int *p, int n);
+[[clang::unsafe_buffer_usage]] void falseAPINotesButAnnotatedUnsafeFunc(int *p, int n);

--- a/clang/test/APINotes/Inputs/Headers/module.modulemap
+++ b/clang/test/APINotes/Inputs/Headers/module.modulemap
@@ -77,3 +77,8 @@ module SwiftImportAs {
 module SwiftReturnOwnershipForObjC {
   header "SwiftReturnOwnershipForObjC.h"
 }
+
+module UnsafeBufferUsage {
+  header "UnsafeBufferUsage.h"
+  export *
+}

--- a/clang/test/APINotes/unsafe-buffer-usage.cpp
+++ b/clang/test/APINotes/unsafe-buffer-usage.cpp
@@ -1,0 +1,54 @@
+// RUN: rm -rf %t && mkdir -p %t
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -verify -Wunsafe-buffer-usage -Wno-unused-value
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter unsafeFunc | FileCheck %s --check-prefixes=CHECK-UNSAFE
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter annotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter falseAPINotesButAnnotatedUnsafeFunc | FileCheck %s --check-prefixes=CHECK-ANNO-FALSE
+// RUN: %clang_cc1 -fmodules -fimplicit-module-maps -fmodules-cache-path=%t/ModulesCache -fdisable-module-hash -fapinotes-modules\
+// RUN:             -I %S/Inputs/Headers %s -x c++ -Wunused-value -ast-dump -ast-dump-filter funcWithoutAnnotation | FileCheck %s --check-prefixes=CHECK-UNANNO
+
+#include "UnsafeBufferUsage.h"
+
+// CHECK-UNSAFE: FunctionDecl {{.+}} unsafeFunc
+// CHECK-UNSAFE: UnsafeBufferUsageAttr
+
+// If the function already has the attribute, the APINotes does
+// nothing no matter how the attribute is specified in the .apinotes
+// file:
+
+// CHECK-ANNO: FunctionDecl {{.+}} annotatedUnsafeFunc
+// CHECK-ANNO: UnsafeBufferUsageAttr
+// CHECK-ANNO-NOT: UnsafeBufferUsageAttr
+// CHECK-ANNO: FunctionDecl {{.+}} annotatedUnsafeFunc
+
+// CHECK-ANNO-FALSE: FunctionDecl {{.+}} falseAPINotesButAnnotatedUnsafeFunc
+// CHECK-ANNO-FALSE: UnsafeBufferUsageAttr
+
+// CHECK-UNANNO: FunctionDecl {{.+}} funcWithoutAnnotation
+// CHECK-UNANNO-NOT: UnsafeBufferUsageAttr
+
+void unsafeFunc(int *p, int n) {
+  p[n]; // no warning
+}
+
+void annotatedUnsafeFunc(int *p, int n) {
+  p[n]; // no warning
+}
+
+void falseAPINotesButAnnotatedUnsafeFunc(int *p, int n) {
+  p[n]; // no warning
+}
+
+void funcWithoutAnnotation(int *p, int n) {
+  p[n]; // expected-warning{{unsafe buffer access}}
+}
+
+void caller(int *p, int n) {
+  unsafeFunc(p, n); // expected-warning{{function introduces unsafe buffer manipulation}}
+  annotatedUnsafeFunc(p, n); // expected-warning{{function introduces unsafe buffer manipulation}}
+  falseAPINotesButAnnotatedUnsafeFunc(p, n); // expected-warning{{function introduces unsafe buffer manipulation}}
+  funcWithoutAnnotation(p, n);   // no warning
+}


### PR DESCRIPTION
Support the ``[[clang::unsafe_buffer_usage]]`` attribute in APINotes, e.g.,
```
    Functions:
      - Name: myUnsafeFunction
        UnsafeBufferUsage: true
```

rdar://171859135
(cherry picked from commit 849de61619cc4e4b9fac4194dc015930a51f7a40)