### PR TITLE
[lldb][NativePDB] Recognize bound generic pattern

### DIFF
--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -31,15 +31,7 @@ using namespace llvm::codeview;
 using namespace llvm::pdb;
 
 namespace {
-// To avoid issues with uniquing, bound generics are emitted as follows in DWARF:
-// - A sized outer structure with no name or identifier
-// - A sizeless inner structure with the mangled name as the name and no identifier.
-// The latter is an unnamed member of the former.
-// CodeView deviates in two major ways:
-// - Unnamed types are emitted as module name + `::<unnamed-tag>` instead of having an empty name.
-// - Unnamed forward declared members are dropped entirely. To get around this, we name
-//   the member with the mangled name of the inner type, since this is illegal in a
-//   user-written type. See https://github.com/swiftlang/swift/issues/87093
+// Fills `mangled_name` if `cr` is shaped like a bound generic.
 struct BoundGenericVisitor : public TypeVisitorCallbacks {
   TpiStream &tpi;
   llvm::StringRef outer_prefix;
@@ -75,6 +67,32 @@ struct BoundGenericVisitor : public TypeVisitorCallbacks {
 };
 } // namespace
 
+std::optional<llvm::Expected<llvm::StringRef>>
+PdbAstBuilderSwift::MaybeUnwrapBoundGeneric(const ClassRecord &cr,
+                                            TpiStream &tpi) {
+  if (!cr.Name.ends_with("::<unnamed-tag>") || cr.FieldList.isNoneType())
+    return std::nullopt;
+
+  CVType field_list_cvt = tpi.getType(cr.FieldList);
+  if (field_list_cvt.kind() != LF_FIELDLIST)
+    return std::nullopt;
+
+  FieldListRecord field_list;
+  if (llvm::Error err = TypeDeserializer::deserializeAs<FieldListRecord>(
+          field_list_cvt, field_list))
+    return std::move(err);
+
+  llvm::StringRef outer_prefix =
+      cr.Name.drop_back(llvm::StringRef("<unnamed-tag>").size());
+  BoundGenericVisitor visitor(tpi, outer_prefix);
+  if (llvm::Error err = visitMemberRecordStream(field_list.Data, visitor))
+    return std::move(err);
+
+  if (visitor.mangled_name.empty())
+    return std::nullopt;
+  return visitor.mangled_name;
+}
+
 PdbAstBuilderSwift::PdbAstBuilderSwift(TypeSystemSwiftTypeRef &swift_ts)
     : m_swift_ts(swift_ts) {}
 
@@ -97,33 +115,16 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
     }
     if (cr.hasUniqueName()) {
       decorated = cr.UniqueName;
-    } else if (cr.Name.ends_with("::<unnamed-tag>") &&
-               !cr.FieldList.isNoneType()) {
-      // See comment at BoundGenericVisitor for details.
-      CVType field_list_cvt = tpi.getType(cr.FieldList);
-      if (field_list_cvt.kind() != LF_FIELDLIST)
-        return {};
-      FieldListRecord field_list;
-      if (auto err = TypeDeserializer::deserializeAs<FieldListRecord>(
-              field_list_cvt, field_list)) {
-        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
-                       "Failed to deserialize FieldListRecord: {0}");
-        return {};
-      }
-      // Grab the outer prefix so we can make sure member name matches the inner type name.
-      llvm::StringRef outer_prefix =
-          cr.Name.drop_back(llvm::StringRef("<unnamed-tag>").size());
-      BoundGenericVisitor visitor(tpi, outer_prefix);
-      if (auto err = visitMemberRecordStream(field_list.Data, visitor)) {
-        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
-                       "Failed to walk bound generic field list: {0}");
-        return {};
-      }
-      if (visitor.mangled_name.empty())
-        return {};
-      decorated = visitor.mangled_name;
     } else {
-      return {};
+      auto unwrapped = MaybeUnwrapBoundGeneric(cr, tpi);
+      if (!unwrapped)
+        return {};
+      if (!*unwrapped) {
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), unwrapped->takeError(),
+                       "Deserialization failure while checking for Swift bound generic: {0}");
+        return {};
+      }
+      decorated = **unwrapped;
     }
     break;
   }

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -17,7 +17,9 @@
 #include "lldb/Utility/LLDBLog.h"
 #include "lldb/Utility/Log.h"
 
+#include "llvm/DebugInfo/CodeView/CVTypeVisitor.h"
 #include "llvm/DebugInfo/CodeView/TypeDeserializer.h"
+#include "llvm/DebugInfo/CodeView/TypeVisitorCallbacks.h"
 #include "llvm/DebugInfo/PDB/Native/TpiStream.h"
 #include "llvm/Support/ErrorHandling.h"
 
@@ -27,6 +29,51 @@ using namespace lldb_private;
 using namespace lldb_private::npdb;
 using namespace llvm::codeview;
 using namespace llvm::pdb;
+
+namespace {
+// To avoid issues with uniquing, bound generics are emitted as follows in DWARF:
+// - A sized outer structure with no name or identifier
+// - A sizeless inner structure with the mangled name as the name and no identifier.
+// The latter is an unnamed member of the former.
+// CodeView deviates in two major ways:
+// - Unnamed types are emitted as module name + `::<unnamed-tag>` instead of having an empty name.
+// - Unnamed forward declared members are dropped entirely. To get around this, we name
+//   the member with the mangled name of the inner type, since this is illegal in a
+//   user-written type. See https://github.com/swiftlang/swift/issues/87093
+struct BoundGenericVisitor : public TypeVisitorCallbacks {
+  TpiStream &tpi;
+  llvm::StringRef outer_prefix;
+  llvm::StringRef mangled_name;
+  bool seen = false;
+
+  BoundGenericVisitor(TpiStream &tpi, llvm::StringRef outer_prefix)
+      : tpi(tpi), outer_prefix(outer_prefix) {}
+
+  llvm::Error visitKnownMember(CVMemberRecord &,
+                               DataMemberRecord &member) override {
+    if (seen) {
+      // More than one member = doesn't match the pattern.
+      mangled_name = {};
+      return llvm::Error::success();
+    }
+    seen = true;
+    CVType inner_cvt = tpi.getType(member.Type);
+    if (!llvm::is_contained({LF_STRUCTURE, LF_CLASS}, inner_cvt.kind()))
+      return llvm::Error::success();
+    ClassRecord inner;
+    if (llvm::Error err =
+            TypeDeserializer::deserializeAs<ClassRecord>(inner_cvt, inner))
+      return err;
+    llvm::StringRef inner_mangled = inner.Name;
+    if (!inner_mangled.consume_front(outer_prefix) ||
+        inner_mangled != member.Name ||
+        !swift::Demangle::isSwiftSymbol(member.Name))
+      return llvm::Error::success();
+    mangled_name = member.Name;
+    return llvm::Error::success();
+  }
+};
+} // namespace
 
 PdbAstBuilderSwift::PdbAstBuilderSwift(TypeSystemSwiftTypeRef &swift_ts)
     : m_swift_ts(swift_ts) {}
@@ -48,9 +95,36 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
                      "Failed to deserialize ClassRecord: {0}");
       return {};
     }
-    if (!cr.hasUniqueName())
+    if (cr.hasUniqueName()) {
+      decorated = cr.UniqueName;
+    } else if (cr.Name.ends_with("::<unnamed-tag>") &&
+               !cr.FieldList.isNoneType()) {
+      // See comment at BoundGenericVisitor for details.
+      CVType field_list_cvt = tpi.getType(cr.FieldList);
+      if (field_list_cvt.kind() != LF_FIELDLIST)
+        return {};
+      FieldListRecord field_list;
+      if (auto err = TypeDeserializer::deserializeAs<FieldListRecord>(
+              field_list_cvt, field_list)) {
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                       "Failed to deserialize FieldListRecord: {0}");
+        return {};
+      }
+      // Grab the outer prefix so we can make sure member name matches the inner type name.
+      llvm::StringRef outer_prefix =
+          cr.Name.drop_back(llvm::StringRef("<unnamed-tag>").size());
+      BoundGenericVisitor visitor(tpi, outer_prefix);
+      if (auto err = visitMemberRecordStream(field_list.Data, visitor)) {
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), std::move(err),
+                       "Failed to walk bound generic field list: {0}");
+        return {};
+      }
+      if (visitor.mangled_name.empty())
+        return {};
+      decorated = visitor.mangled_name;
+    } else {
       return {};
-    decorated = cr.UniqueName;
+    }
     break;
   }
   case LF_ENUM: {

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.cpp
@@ -31,7 +31,7 @@ using namespace llvm::codeview;
 using namespace llvm::pdb;
 
 namespace {
-// Fills `mangled_name` if `cr` is shaped like a bound generic.
+/// Fills `mangled_name` if `cr` is shaped like a bound generic.
 struct BoundGenericVisitor : public TypeVisitorCallbacks {
   TpiStream &tpi;
   llvm::StringRef outer_prefix;
@@ -67,15 +67,15 @@ struct BoundGenericVisitor : public TypeVisitorCallbacks {
 };
 } // namespace
 
-std::optional<llvm::Expected<llvm::StringRef>>
+llvm::Expected<llvm::StringRef>
 PdbAstBuilderSwift::MaybeUnwrapBoundGeneric(const ClassRecord &cr,
                                             TpiStream &tpi) {
   if (!cr.Name.ends_with("::<unnamed-tag>") || cr.FieldList.isNoneType())
-    return std::nullopt;
+    return llvm::StringRef();
 
   CVType field_list_cvt = tpi.getType(cr.FieldList);
   if (field_list_cvt.kind() != LF_FIELDLIST)
-    return std::nullopt;
+    return llvm::StringRef();
 
   FieldListRecord field_list;
   if (llvm::Error err = TypeDeserializer::deserializeAs<FieldListRecord>(
@@ -88,8 +88,6 @@ PdbAstBuilderSwift::MaybeUnwrapBoundGeneric(const ClassRecord &cr,
   if (llvm::Error err = visitMemberRecordStream(field_list.Data, visitor))
     return std::move(err);
 
-  if (visitor.mangled_name.empty())
-    return std::nullopt;
   return visitor.mangled_name;
 }
 
@@ -117,14 +115,14 @@ CompilerType PdbAstBuilderSwift::CreateType(PdbTypeSymId type,
       decorated = cr.UniqueName;
     } else {
       auto unwrapped = MaybeUnwrapBoundGeneric(cr, tpi);
-      if (!unwrapped)
-        return {};
-      if (!*unwrapped) {
-        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), unwrapped->takeError(),
+      if (!unwrapped) {
+        LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), unwrapped.takeError(),
                        "Deserialization failure while checking for Swift bound generic: {0}");
         return {};
       }
-      decorated = **unwrapped;
+      if (unwrapped->empty())
+        return {};
+      decorated = *unwrapped;
     }
     break;
   }

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
@@ -15,8 +15,6 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Error.h"
 
-#include <optional>
-
 namespace llvm::codeview {
 class ClassRecord;
 }
@@ -60,20 +58,20 @@ public:
 
   void Dump(Stream &stream, llvm::StringRef filter) override;
 
-  // To avoid issues with uniquing, bound generics are emitted as follows in DWARF:
-  // - A sized outer structure with no name or identifier
-  // - A sizeless inner structure with the mangled name as the name and no identifier.
-  // The latter is an unnamed member of the former.
-  // CodeView deviates in two major ways:
-  // - Unnamed types are emitted as module name + `::<unnamed-tag>` instead of having an empty name.
-  // - Unnamed forward declared members are dropped entirely. To get around this, we name
-  //   the member with the mangled name of the inner type, since this is illegal in a
-  //   user-written type. See https://github.com/swiftlang/swift/issues/87093
-  // This function returns:
-  // - `std::nullopt` if `cr` is not shaped like a bound generic.
-  // - an error if deserialization fails while checking.
-  // - the mangled name of the inner type if `cr` is shaped like a bound generic.
-  static std::optional<llvm::Expected<llvm::StringRef>>
+  /// To avoid issues with uniquing, bound generics are emitted as follows in DWARF:
+  /// - A sized outer structure with no name or identifier
+  /// - A sizeless inner structure with the mangled name as the name and no identifier.
+  /// The latter is an unnamed member of the former.
+  /// CodeView deviates in two major ways:
+  /// - Unnamed types are emitted as module name + `::<unnamed-tag>` instead of having an empty name.
+  /// - Unnamed forward declared members are dropped entirely. To get around this, we name
+  ///   the member with the mangled name of the inner type, since this is illegal in a
+  ///   user-written type. See https://github.com/swiftlang/swift/issues/87093
+  /// This function returns:
+  /// - an error if deserialization fails while checking.
+  /// - an empty string if `cr` is not shaped like a bound generic.
+  /// - the mangled name of the inner type if `cr` is shaped like a bound generic.
+  static llvm::Expected<llvm::StringRef>
   MaybeUnwrapBoundGeneric(const llvm::codeview::ClassRecord &cr,
                           llvm::pdb::TpiStream &tpi);
 

--- a/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/PdbAstBuilderSwift.h
@@ -12,6 +12,14 @@
 #include "PdbAstBuilder.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+
+#include <optional>
+
+namespace llvm::codeview {
+class ClassRecord;
+}
 
 namespace llvm::pdb {
 class TpiStream;
@@ -51,6 +59,23 @@ public:
   void ParseDeclsForContext(CompilerDeclContext context) override {}
 
   void Dump(Stream &stream, llvm::StringRef filter) override;
+
+  // To avoid issues with uniquing, bound generics are emitted as follows in DWARF:
+  // - A sized outer structure with no name or identifier
+  // - A sizeless inner structure with the mangled name as the name and no identifier.
+  // The latter is an unnamed member of the former.
+  // CodeView deviates in two major ways:
+  // - Unnamed types are emitted as module name + `::<unnamed-tag>` instead of having an empty name.
+  // - Unnamed forward declared members are dropped entirely. To get around this, we name
+  //   the member with the mangled name of the inner type, since this is illegal in a
+  //   user-written type. See https://github.com/swiftlang/swift/issues/87093
+  // This function returns:
+  // - `std::nullopt` if `cr` is not shaped like a bound generic.
+  // - an error if deserialization fails while checking.
+  // - the mangled name of the inner type if `cr` is shaped like a bound generic.
+  static std::optional<llvm::Expected<llvm::StringRef>>
+  MaybeUnwrapBoundGeneric(const llvm::codeview::ClassRecord &cr,
+                          llvm::pdb::TpiStream &tpi);
 
 private:
   CompilerType CreateType(PdbTypeSymId type, llvm::pdb::TpiStream &tpi);

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -59,6 +59,7 @@
 #include <string_view>
 
 #if LLDB_ENABLE_SWIFT
+#include "PdbAstBuilderSwift.h"
 #include "swift/Demangling/Demangle.h"
 #endif
 
@@ -307,10 +308,17 @@ static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
   llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
   if (cr.hasUniqueName())
     return swift::Demangle::isSwiftSymbol(cr.UniqueName);
-  // https://github.com/swiftlang/swift/issues/87093
-  // FIXME: This is more of a heuristic than a definitive check, but we would need to do a
-  // second field-list walk to be sure.
-  return cr.Name.ends_with("::<unnamed-tag>");
+  auto unwrapped = PdbAstBuilderSwift::MaybeUnwrapBoundGeneric(cr, index.tpi());
+  // Doesn't match the shape.
+  if (!unwrapped)
+    return false;
+  // Deserialization failed.
+  if (!*unwrapped) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), unwrapped->takeError(),
+                   "Deserialization failure while checking for Swift bound generic: {0}");
+    return false;
+  }
+  return true;
 #else
   return false;
 #endif

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -305,7 +305,12 @@ static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
     return false;
   ClassRecord cr;
   llvm::cantFail(TypeDeserializer::deserializeAs<ClassRecord>(cvt, cr));
-  return cr.hasUniqueName() && swift::Demangle::isSwiftSymbol(cr.UniqueName);
+  if (cr.hasUniqueName())
+    return swift::Demangle::isSwiftSymbol(cr.UniqueName);
+  // https://github.com/swiftlang/swift/issues/87093
+  // FIXME: This is more of a heuristic than a definitive check, but we would need to do a
+  // second field-list walk to be sure.
+  return cr.Name.ends_with("::<unnamed-tag>");
 #else
   return false;
 #endif

--- a/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
+++ b/lldb/source/Plugins/SymbolFile/NativePDB/SymbolFileNativePDB.cpp
@@ -309,16 +309,14 @@ static bool IsSwiftType(PdbTypeSymId type_id, PdbIndex& index) {
   if (cr.hasUniqueName())
     return swift::Demangle::isSwiftSymbol(cr.UniqueName);
   auto unwrapped = PdbAstBuilderSwift::MaybeUnwrapBoundGeneric(cr, index.tpi());
-  // Doesn't match the shape.
-  if (!unwrapped)
-    return false;
   // Deserialization failed.
-  if (!*unwrapped) {
-    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), unwrapped->takeError(),
+  if (!unwrapped) {
+    LLDB_LOG_ERROR(GetLog(LLDBLog::Symbols), unwrapped.takeError(),
                    "Deserialization failure while checking for Swift bound generic: {0}");
     return false;
   }
-  return true;
+  // Doesn't match the shape.
+  return !unwrapped->empty();
 #else
   return false;
 #endif

--- a/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
@@ -18,6 +18,15 @@ enum Direction {
     case south
 }
 
+struct Box<T> {
+    var value: T
+}
+
+enum Pair<A, B> {
+    case first(A)
+    case second(B)
+}
+
 func main() {
     var myInt32: Int32 = 42
     var myBool: Bool = true
@@ -27,20 +36,27 @@ func main() {
     var myString: String = "hello"
     var myPoint: Point = Point(x: 10, y: 20)
     var myDirection: Direction = .north
+    var myOptional: Int32? = 7
+    var myArray: [Int32] = [1, 2, 3]
+    var myOptionalArray: [Int32]? = [4, 5]
+    var myResult: Result<Int, Error> = .success(42)
+    var myBox: Box<Int32> = Box(value: 99)
+    var myPair: Pair<Int, String> = .first(7)
     let constInt: Int = 100
     let constInt8: Int8 = -42
     let constUInt16: UInt16 = 1000
     let constBool: Bool = false
     let constString: String = "world"
     print(myInt32, myBool, myUInt64, myFloat, myDouble,
-          myString, myPoint, myDirection,
+          myString, myPoint, myDirection, myOptional, myArray,
+          myOptionalArray, myResult, myBox, myPair,
           constInt, constInt8, constUInt16, constBool, constString)
 }
 
 main()
 
 #--- commands.input
-b main.swift:25
+b main.swift:40
 run
 frame variable
 
@@ -54,6 +70,12 @@ frame variable
 # CHECK: (String) myString = "hello"
 # CHECK: (main.Point) myPoint = (x = 10, y = 20)
 # CHECK: (main.Direction) myDirection = north
+# CHECK: (Int32?) myOptional = 7
+# CHECK: ([Int32]) myArray = 3 values
+# CHECK: ([Int32]?) myOptionalArray = 2 values
+# CHECK: (Result<Int, Error>) myResult = success
+# CHECK: (main.Box<Int32>) myBox = (value = 99)
+# CHECK: (main.Pair<Int, String>) myPair = first
 # Local constants
 # CHECK: (Int) constInt = 100
 # CHECK: (Int8) constInt8 = -42

--- a/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
+++ b/lldb/test/Shell/SymbolFile/NativePDB/swift-frame-var.test
@@ -37,6 +37,7 @@ func main() {
     var myPoint: Point = Point(x: 10, y: 20)
     var myDirection: Direction = .north
     var myOptional: Int32? = 7
+    var myNestedOptional: Int32?? = 8
     var myArray: [Int32] = [1, 2, 3]
     var myOptionalArray: [Int32]? = [4, 5]
     var myResult: Result<Int, Error> = .success(42)
@@ -48,7 +49,7 @@ func main() {
     let constBool: Bool = false
     let constString: String = "world"
     print(myInt32, myBool, myUInt64, myFloat, myDouble,
-          myString, myPoint, myDirection, myOptional, myArray,
+          myString, myPoint, myDirection, myOptional, myNestedOptional, myArray,
           myOptionalArray, myResult, myBox, myPair,
           constInt, constInt8, constUInt16, constBool, constString)
 }
@@ -56,7 +57,7 @@ func main() {
 main()
 
 #--- commands.input
-b main.swift:40
+b main.swift:41
 run
 frame variable
 
@@ -71,6 +72,7 @@ frame variable
 # CHECK: (main.Point) myPoint = (x = 10, y = 20)
 # CHECK: (main.Direction) myDirection = north
 # CHECK: (Int32?) myOptional = 7
+# CHECK: (Int32??) myNestedOptional = 8
 # CHECK: ([Int32]) myArray = 3 values
 # CHECK: ([Int32]?) myOptionalArray = 2 values
 # CHECK: (Result<Int, Error>) myResult = success


### PR DESCRIPTION
Bound generic types are represented by nested structs arranged in a certain way (see https://github.com/swiftlang/swift/issues/87093 for details).

Similar to DWARF, this change adds special handling to recognize this pattern and recover the mangled name of the actual type.