### PR TITLE
[lldb/test] Fix shared library symlinks for remote testing (#189177)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2213,6 +2213,7 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
                 # Make sure we found the local shared library in the above code
                 self.assertTrue(os.path.exists(local_shlib_path))
 
+            local_shlib_path = os.path.realpath(local_shlib_path)
             # Add the shared library to our target
             shlib_module = target.AddModule(local_shlib_path, None, None, None)
             if lldb.remote_platform:

--- a/lldb/packages/Python/lldbsuite/test/lldbtest.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbtest.py
@@ -2213,7 +2213,8 @@ class TestBase(Base, metaclass=LLDBTestCaseFactory):
                 # Make sure we found the local shared library in the above code
                 self.assertTrue(os.path.exists(local_shlib_path))
 
-            local_shlib_path = os.path.realpath(local_shlib_path)
+            if lldb.remote_platform:
+                local_shlib_path = os.path.realpath(local_shlib_path)
             # Add the shared library to our target
             shlib_module = target.AddModule(local_shlib_path, None, None, None)
             if lldb.remote_platform:

--- a/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
+++ b/lldb/packages/Python/lldbsuite/test/make/Makefile.rules
@@ -56,7 +56,13 @@ else
 	RM = rm $(1) > /dev/null 2>&1 || true
 	RM_F = rm -f $(1)
 	RM_RF = rm -rf $(1)
-	LN_SF = ln -sf $(1) $(2)
+	# Use patsubst to strip the destination's directory from the source
+	# path, turning absolute symlinks into relative ones when both paths
+	# share the same parent directory (e.g. $(BUILDDIR)/Foo.framework/Foo
+	# becomes Foo.framework/Foo). If the paths don't share a directory,
+	# patsubst returns the source unchanged. This ensures symlinks remain
+	# valid when transferred to a remote device.
+	LN_SF = ln -sf $(patsubst $(dir $(2))%,%,$(1)) $(2)
 	ECHO = echo $(1);
 	ECHO_TO_FILE = printf '%s\n' $(1) > "$(2)"
 	ECHO_APPEND_FILE = printf '%s\n' $(1) >> "$(2)"


### PR DESCRIPTION
When running tests on a remote device, framework convenience symlinks created by test Makefiles (e.g. `$(BUILDDIR)/Framework` pointing to `$(BUILDDIR)/Framework.framework/Framework`) cause launch failures.

`Platform::Install` recreates these as symlinks on the remote device pointing to host build paths that don't exist, resulting in "No such file or directory" from dyld.

This patch changes `LN_SF` in Makefile.rules to strip the common directory prefix from the symlink source using `patsubst` so it produces relative symlinks instead of absolute ones.

It also resolve symlinks with `os.path.realpath()` in `registerSharedLibrariesWithTarget` before registering modules so that `Platform::Install` sees a regular file and transfers the actual binary content.

rdar://173566256


(cherry picked from commit a1a40cb725f48d113a5697a9c222d05baec39485)