### PR TITLE
[dsymutil] Handle DW_OP_GNU_push_tls_address in markEverythingAsKept

### DIFF
--- a/llvm/include/llvm/BinaryFormat/Dwarf.h
+++ b/llvm/include/llvm/BinaryFormat/Dwarf.h
@@ -1083,6 +1083,10 @@ LLVM_ABI std::optional<unsigned> OperationOperands(LocationAtom O);
 /// depending on the argument) or unknown.
 LLVM_ABI std::optional<unsigned> OperationArity(LocationAtom O);
 
+inline bool isTlsAddressOp(uint8_t O) {
+  return O == DW_OP_form_tls_address || O == DW_OP_GNU_push_tls_address;
+}
+
 LLVM_ABI std::optional<unsigned> LanguageLowerBound(SourceLanguage L);
 
 /// The size of a reference determined by the DWARF 32/64-bit format.

--- a/llvm/include/llvm/DWARFLinker/AddressesMap.h
+++ b/llvm/include/llvm/DWARFLinker/AddressesMap.h
@@ -142,7 +142,8 @@ public:
       case dwarf::DW_OP_const2s:
       case dwarf::DW_OP_const4s:
       case dwarf::DW_OP_const8s:
-        if (NextIt == Expression.end() || !isTlsAddressCode(NextIt->getCode()))
+        if (NextIt == Expression.end() ||
+            !dwarf::isTlsAddressOp(NextIt->getCode()))
           break;
         [[fallthrough]];
       case dwarf::DW_OP_addr: {
@@ -177,12 +178,6 @@ public:
     }
 
     return std::make_pair(HasLocationAddress, std::nullopt);
-  }
-
-protected:
-  inline bool isTlsAddressCode(uint8_t DW_OP_Code) {
-    return DW_OP_Code == dwarf::DW_OP_form_tls_address ||
-           DW_OP_Code == dwarf::DW_OP_GNU_push_tls_address;
   }
 };
 

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinker.cpp
@@ -470,11 +470,6 @@ void DWARFLinker::cleanupAuxiliarryData(LinkContext &Context) {
   DIEAlloc.Reset();
 }
 
-static bool isTlsAddressCode(uint8_t DW_OP_Code) {
-  return DW_OP_Code == dwarf::DW_OP_form_tls_address ||
-         DW_OP_Code == dwarf::DW_OP_GNU_push_tls_address;
-}
-
 std::pair<bool, std::optional<int64_t>>
 DWARFLinker::getVariableRelocAdjustment(AddressesMap &RelocMgr,
                                         const DWARFDie &DIE) {
@@ -529,7 +524,8 @@ DWARFLinker::getVariableRelocAdjustment(AddressesMap &RelocMgr,
     case dwarf::DW_OP_const2s:
     case dwarf::DW_OP_const4s:
     case dwarf::DW_OP_const8s:
-      if (NextIt == Expression.end() || !isTlsAddressCode(NextIt->getCode()))
+      if (NextIt == Expression.end() ||
+          !dwarf::isTlsAddressOp(NextIt->getCode()))
         break;
       [[fallthrough]];
     case dwarf::DW_OP_addr: {

--- a/llvm/lib/DWARFLinker/Classic/DWARFLinkerCompileUnit.cpp
+++ b/llvm/lib/DWARFLinker/Classic/DWARFLinkerCompileUnit.cpp
@@ -107,7 +107,7 @@ void CompileUnit::markEverythingAsKept() {
         case dwarf::DW_OP_const4s:
         case dwarf::DW_OP_const8s:
           if (NextIt == Expression.end() ||
-              NextIt->getCode() != dwarf::DW_OP_form_tls_address)
+              !dwarf::isTlsAddressOp(NextIt->getCode()))
             break;
           [[fallthrough]];
         case dwarf::DW_OP_constx:

--- a/llvm/test/tools/dsymutil/X86/tls-variable.test
+++ b/llvm/test/tools/dsymutil/X86/tls-variable.test
@@ -11,6 +11,10 @@
 # RUN: echo '...' >> %t2.map
 # RUN: dsymutil -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
 # RUN: dsymutil --linker parallel -y %t2.map --keep-function-for-static -f -o - | llvm-dwarfdump -a - | FileCheck %s
+#
+## In update mode, markEverythingAsKept must also handle DW_OP_GNU_push_tls_address.
+# RUN: dsymutil -y %t2.map --keep-function-for-static -f -o %t.dSYM
+# RUN: dsymutil -u %t.dSYM -f -o - | llvm-dwarfdump -a - | FileCheck %s --check-prefix=UPDATE
 
 # CHECK: file format Mach-O 64-bit x86-64
 # CHECK: .debug_info contents:
@@ -24,6 +28,20 @@
 # CHECK: DW_AT_location        (DW_OP_const8u 0x{{.*}}, DW_OP_GNU_push_tls_address)
 # CHECK: DW_AT_name{{.*}}"var2"
 # CHECK: DW_AT_location        (DW_OP_const8u 0x{{.*}}, DW_OP_form_tls_address)
+#
+## Check that both TLS variables appear in the accelerator table.
+# CHECK: .apple_names
+# CHECK-DAG: "var1"
+# CHECK-DAG: "var2"
+
+# UPDATE: DW_TAG_variable
+# UPDATE: DW_AT_name{{.*}}"var1"
+# UPDATE: DW_AT_location        (DW_OP_const8u 0x{{.*}}, DW_OP_GNU_push_tls_address)
+# UPDATE: DW_AT_name{{.*}}"var2"
+# UPDATE: DW_AT_location        (DW_OP_const8u 0x{{.*}}, DW_OP_form_tls_address)
+# UPDATE: .apple_names
+# UPDATE-DAG: "var1"
+# UPDATE-DAG: "var2"
 
 --- !mach-o
 FileHeader:


### PR DESCRIPTION
markEverythingAsKept() only checked for DW_OP_form_tls_address when deciding whether a TLS variable should be added to accelerator tables, missing the DW_OP_GNU_push_tls_address extension. This caused TLS variables using the GNU form to be absent from .apple_names when linking in update mode (-u) or when processing Clang modules.

The same bug was previously fixed in getVariableRelocAdjustment() (f9f92f13f62a) but was missed here.

rdar://120678908
(cherry picked from commit 6fb343619009376c19953a82aa52cf293418c9eb)