### PR TITLE
[Cherry-pick into next] [LLDB] Filter out -Werror options when setting up -cc1 Clang Invocations

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -2110,11 +2110,14 @@ void SwiftASTContext::AddExtraClangCC1Args(
       else
         ++it;
     }
-    invocation.getFrontendOpts().ModuleFiles.erase(
-        llvm::remove_if(invocation.getFrontendOpts().ModuleFiles,
-                        [&](const auto &mod) { return !CheckFileExists(mod); }),
-        invocation.getFrontendOpts().ModuleFiles.end());
+    llvm::erase_if(invocation.getFrontendOpts().ModuleFiles,
+                   [&](const auto &mod) { return !CheckFileExists(mod); });
   }
+
+  // Remove -Werror flags.
+  llvm::erase_if(
+      invocation.getDiagnosticOpts().Warnings,
+      [](StringRef Warning) { return Warning.starts_with("error"); });
 
   invocation.generateCC1CommandLine(
       [&](const llvm::Twine &arg) { dest.push_back(arg.str()); });

--- a/lldb/test/API/lang/swift/clangimporter/caching/Makefile
+++ b/lldb/test/API/lang/swift/clangimporter/caching/Makefile
@@ -1,6 +1,6 @@
 SWIFT_SOURCES := main.swift
 SWIFT_ENABLE_EXPLICIT_MODULES := YES
-SWIFTFLAGS_EXTRAS = -I$(SRCDIR) -I/TEST_DIR -F/FRAMEWORK_DIR -cache-compile-job -cas-path $(BUILDDIR)/cas
+SWIFTFLAGS_EXTRAS = -I$(SRCDIR) -I/TEST_DIR -F/FRAMEWORK_DIR -cache-compile-job -cas-path $(BUILDDIR)/cas -Xcc -Werror
 
 all: a.out cas-config
 

--- a/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
+++ b/lldb/test/API/lang/swift/clangimporter/caching/TestSwiftClangImporterCaching.py
@@ -34,5 +34,6 @@ class TestSwiftClangImporterCaching(TestBase):
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DADDED=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift")::LogConfiguration() --     -DEXTRA=1
 #       CHECK:  SwiftASTContextForExpressions(module: "a", cu: "main.swift") Module import remark: loaded module 'ClangA'
+#       CHECK-NOT: -Werror
 #       CHECK-NOT: -cc1
 #       CHECK-NOT: Clang error


### PR DESCRIPTION
```
commit a02746290b49d64b58ec260356fe5ebdbd29c721
Author: Adrian Prantl <aprantl@apple.com>
Date:   Fri Apr 24 12:30:34 2026 -0700

    [LLDB] Filter out -Werror options when setting up -cc1 Clang Invocations
    
    The non-caching code path was already doing this, but the code path
    for cc1 flags was missing this functionality. Even though LLDB is
    replaying the compile-time compiler invocation, we have seen reports
    where additional warnings get diagnosed at debug time, effectively
    rendering the debug session unusable.
    
    rdar://174422552
```
