### PR TITLE
[clang][BoundsSafety][UBSan] Fix false-positive UBSan pointer overflow

### DIFF
--- a/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/clang/lib/CodeGen/CGExprAgg.cpp
@@ -1978,6 +1978,10 @@ void AggExprEmitter::EmitCheckedBoundPointerArithmetic(
   LValue BaseLV = CGF.EmitAggExprToLValue(Base);
   EmitBoundPointerArithmetic(DestLV, BaseLV, Idx, IsSigned, IsSub);
 
+  if (IsSub) {
+    Idx = Builder.CreateNeg(Idx, "idx.neg");
+  }
+
   if (CGF.SanOpts.has(SanitizerKind::ArrayBounds))
     CGF.EmitBoundsCheck(E, Base, Idx, IdxType,
                         /*Accessed*/ false);

--- a/clang/test/BoundsSafety/CodeGen/ubsan/ptr-overflow-subtraction.c
+++ b/clang/test/BoundsSafety/CodeGen/ubsan/ptr-overflow-subtraction.c
@@ -1,0 +1,18 @@
+// RUN: %clang_cc1 -O0 -fbounds-safety -fsanitize=pointer-overflow -fsanitize-trap=pointer-overflow -emit-llvm %s -o - | FileCheck %s
+
+#include <ptrcheck.h>
+
+// Regression test for pointer subtraction generating a false-positive
+// UBSan pointer overflow check when -fbounds-safety is enabled.
+// The check must use the negated index so that (base - offset) ule base
+// is checked, not (base + offset) ule base which is unconditionally false.
+void ptr_sub(unsigned char * __bidi_indexable ptr, unsigned int offset) {
+    unsigned char * __bidi_indexable ptr2 = ptr - offset;
+    (void)ptr2;
+}
+
+// CHECK: %[[OFFSET:[a-z0-9]+]] = load i32
+// CHECK: %[[NEG:[a-z0-9.]+]] = sub i32 0, %[[OFFSET]]
+// CHECK: getelementptr{{.*}} %[[NEG]]
+// CHECK: %[[EXT:[a-z0-9.]+]] = sext i32 %[[NEG]] to i64
+// CHECK: call { i64, i1 } @llvm.smul.with.overflow.i64(i64 1, i64 %[[EXT]])


### PR DESCRIPTION
check for pointer subtraction

When -fbounds-safety and -fsanitize=pointer-overflow are both enabled, pointer subtraction unconditionally triggers a UBSan pointer overflow false positive. EmitCheckedBoundPointerArithmetic was passing the raw positive index to EmitCheckedInBoundsGEP without negating it first, causing the check to verify (base + offset) ule base instead of (base - offset) ule base, which is always false for any positive offset.

All other callers of EmitCheckedInBoundsGEP pre-negate the index for subtraction. Fix this by negating the index with CreateNeg before passing it to EmitCheckedInBoundsGEP when IsSub is true.

rdar://173944149