### PR TITLE
[CAS] Retry blocking syscalls on EINTR

### DIFF
--- a/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
+++ b/llvm/lib/CAS/MappedFileRegionBumpPtr.cpp
@@ -55,6 +55,7 @@
 #include "OnDiskCommon.h"
 #include "llvm/CAS/OnDiskCASLogger.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Errno.h"
 
 #if LLVM_ON_UNIX
 #include <sys/stat.h>
@@ -339,7 +340,7 @@ Expected<int64_t> MappedFileRegionBumpPtr::allocateOffset(uint64_t AllocSize) {
 ErrorOr<FileSizeInfo> FileSizeInfo::get(sys::fs::file_t File) {
 #if LLVM_ON_UNIX && defined(MAPPED_FILE_BSIZE)
   struct stat Status;
-  int StatRet = ::fstat(File, &Status);
+  int StatRet = sys::RetryAfterSignal(-1, ::fstat, File, &Status);
   if (StatRet)
     return errnoAsErrorCode();
   uint64_t AllocatedSize = uint64_t(Status.st_blksize) * MAPPED_FILE_BSIZE;

--- a/llvm/lib/CAS/OnDiskCommon.cpp
+++ b/llvm/lib/CAS/OnDiskCommon.cpp
@@ -9,6 +9,7 @@
 #include "OnDiskCommon.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/Errno.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
@@ -67,7 +68,7 @@ void cas::ondisk::setMaxMappingSize(uint64_t Size) {
 
 std::error_code cas::ondisk::lockFileThreadSafe(int FD, bool Exclusive) {
 #if HAVE_FLOCK
-  if (flock(FD, Exclusive ? LOCK_EX : LOCK_SH) == 0)
+  if (sys::RetryAfterSignal(-1, flock, FD, Exclusive ? LOCK_EX : LOCK_SH) == 0)
     return std::error_code();
   return std::error_code(errno, std::generic_category());
 #elif defined(_WIN32)
@@ -80,7 +81,7 @@ std::error_code cas::ondisk::lockFileThreadSafe(int FD, bool Exclusive) {
 
 std::error_code cas::ondisk::unlockFileThreadSafe(int FD) {
 #if HAVE_FLOCK
-  if (flock(FD, LOCK_UN) == 0)
+  if (sys::RetryAfterSignal(-1, flock, FD, LOCK_UN) == 0)
     return std::error_code();
   return std::error_code(errno, std::generic_category());
 #elif defined(_WIN32)
@@ -98,7 +99,8 @@ cas::ondisk::tryLockFileThreadSafe(int FD, std::chrono::milliseconds Timeout,
   auto Start = std::chrono::steady_clock::now();
   auto End = Start + Timeout;
   do {
-    if (flock(FD, (Exclusive ? LOCK_EX : LOCK_SH) | LOCK_NB) == 0)
+    if (sys::RetryAfterSignal(-1, flock, FD,
+                              (Exclusive ? LOCK_EX : LOCK_SH) | LOCK_NB) == 0)
       return std::error_code();
     int Error = errno;
     if (Error == EWOULDBLOCK) {
@@ -137,7 +139,11 @@ Expected<size_t> cas::ondisk::preallocateFileTail(int FD, size_t CurrentSize, si
   };
 #if defined(HAVE_POSIX_FALLOCATE)
   // Note: posix_fallocate returns its error directly, not via errno.
-  if (int Err = posix_fallocate(FD, CurrentSize, NewSize - CurrentSize))
+  int Err;
+  do {
+    Err = posix_fallocate(FD, CurrentSize, NewSize - CurrentSize);
+  } while (Err == EINTR);
+  if (Err)
     return CreateError(std::error_code(Err, std::generic_category()));
   return NewSize;
 #elif defined(__APPLE__)
@@ -147,7 +153,7 @@ Expected<size_t> cas::ondisk::preallocateFileTail(int FD, size_t CurrentSize, si
   FAlloc.fst_offset = 0;
   FAlloc.fst_length = NewSize - CurrentSize;
   FAlloc.fst_bytesalloc = 0;
-  if (fcntl(FD, F_PREALLOCATE, &FAlloc))
+  if (sys::RetryAfterSignal(-1, ::fcntl, FD, F_PREALLOCATE, &FAlloc) == -1)
     return CreateError(errnoAsErrorCode());
   assert(CurrentSize + FAlloc.fst_bytesalloc >= NewSize);
   return CurrentSize + FAlloc.fst_bytesalloc;

--- a/llvm/lib/Support/Unix/Path.inc
+++ b/llvm/lib/Support/Unix/Path.inc
@@ -594,7 +594,7 @@ std::error_code rename(const Twine &from, const Twine &to) {
 std::error_code resize_file(int FD, uint64_t Size) {
   // Use ftruncate as a fallback. It may or may not allocate space. At least on
   // OS X with HFS+ it does.
-  if (::ftruncate(FD, Size) == -1)
+  if (sys::RetryAfterSignal(-1, ::ftruncate, FD, Size) == -1)
     return errnoAsErrorCode();
 
   return std::error_code();
@@ -882,7 +882,7 @@ void mapped_file_region::unmapImpl() {
 }
 
 std::error_code mapped_file_region::sync() const {
-  if (int Res = ::msync(Mapping, Size, MS_SYNC))
+  if (int Res = sys::RetryAfterSignal(-1, ::msync, Mapping, Size, MS_SYNC))
     return std::error_code(Res, std::generic_category());
   return std::error_code();
 }
@@ -1295,7 +1295,7 @@ std::error_code lockFile(int FD, bool Exclusive) {
   Lock.l_whence = SEEK_SET;
   Lock.l_start = 0;
   Lock.l_len = 0;
-  if (::fcntl(FD, F_SETLKW, &Lock) != -1)
+  if (sys::RetryAfterSignal(-1, ::fcntl, FD, F_SETLKW, &Lock) != -1)
     return std::error_code();
   return errnoAsErrorCode();
 }
@@ -1306,7 +1306,7 @@ std::error_code unlockFile(int FD) {
   Lock.l_whence = SEEK_SET;
   Lock.l_start = 0;
   Lock.l_len = 0;
-  if (::fcntl(FD, F_SETLK, &Lock) != -1)
+  if (sys::RetryAfterSignal(-1, ::fcntl, FD, F_SETLK, &Lock) != -1)
     return std::error_code();
   return errnoAsErrorCode();
 }


### PR DESCRIPTION
Wrap blocking syscalls used by LLVMCAS inside RetryAfterSignal so they are retried on EINTR instead of surfacing as error or silently dropping actions due to failed to acquire locks.