### PR TITLE
[lldb] Add repeat command for `frame variable` (#194195)

### DIFF
--- a/lldb/source/Commands/CommandObjectFrame.cpp
+++ b/lldb/source/Commands/CommandObjectFrame.cpp
@@ -32,6 +32,8 @@
 #include "lldb/Utility/ValueType.h"
 #include "lldb/ValueObject/ValueObject.h"
 #include "lldb/lldb-enumerations.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 
 #include <memory>
 #include <optional>
@@ -434,6 +436,77 @@ may even involve JITing and running code in the target program.)");
   ~CommandObjectFrameVariable() override = default;
 
   Options *GetOptions() override { return &m_option_group; }
+
+  // `frame variable` repeats by incrementing the printing depth. When the depth
+  // is too shallow, hitting enter a few times will quickly expand the data.
+  std::optional<std::string> GetRepeatCommand(Args &current_command_args,
+                                              uint32_t index) override {
+    llvm::StringRef depth_opt = "--depth";
+
+    Args repeat_args;
+    auto increment_option =
+        [&](llvm::StringRef option) -> std::optional<std::string> {
+      uint32_t num;
+      bool failed = option.getAsInteger(10, num);
+      if (failed)
+        return std::nullopt;
+      return llvm::utostr(num + 1);
+    };
+
+    bool has_depth_option = false;
+    bool increment_next_arg = false;
+    for (const auto &entry : current_command_args) {
+      llvm::StringRef arg = entry.ref();
+
+      if (arg == "-" || arg == "--") {
+        repeat_args.AppendArgument(arg);
+        continue;
+      }
+
+      if (increment_next_arg) {
+        increment_next_arg = false;
+        if (auto maybe_opt = increment_option(arg)) {
+          repeat_args.AppendArgument(*maybe_opt);
+          continue;
+        }
+      }
+
+      if (depth_opt.starts_with(arg) || arg == "-D") {
+        repeat_args.AppendArgument(arg);
+        increment_next_arg = true;
+        has_depth_option = true;
+        continue;
+      }
+      if (arg.consume_front("-D")) {
+        if (auto maybe_opt = increment_option(arg)) {
+          repeat_args.AppendArgument(llvm::formatv("-D{0}", *maybe_opt).str());
+          has_depth_option = true;
+          continue;
+        }
+      }
+
+      repeat_args.AppendArgument(arg);
+    }
+
+    if (!has_depth_option) {
+      // Access the default max-depth from the target. This is because
+      // GetRepeatCommand is called before ParseOptions, which is when
+      // m_varobj_options.max_depth becomes assigned.
+      if (auto target_sp = GetDebugger().GetSelectedTarget()) {
+        auto [default_depth, _] =
+            target_sp->GetMaximumDepthOfChildrenToDisplay();
+        // Insert the depth after `frame variable`, before positional args.
+        assert(repeat_args[0].ref() == "frame" && "expects resolved command");
+        repeat_args.InsertArgumentAtIndex(2, "--depth");
+        repeat_args.InsertArgumentAtIndex(3, llvm::utostr(default_depth + 1));
+      }
+    }
+
+    std::string repeat_command;
+    if (!repeat_args.GetQuotedCommandString(repeat_command))
+      return std::nullopt;
+    return repeat_command;
+  }
 
 protected:
   llvm::StringRef GetScopeString(VariableSP var_sp) {

--- a/lldb/source/DataFormatters/ValueObjectPrinter.cpp
+++ b/lldb/source/DataFormatters/ValueObjectPrinter.cpp
@@ -847,7 +847,7 @@ llvm::Error ValueObjectPrinter::PrintChildrenIfNeeded(bool value_printed,
       PrintChildren(value_printed, summary_printed, curr_ptr_depth);
   } else if (HasReachedMaximumDepth() && IsAggregate() &&
              ShouldPrintValueObject()) {
-    m_stream->PutCString("{...}\n");
+    m_stream->PutCString(" {...}\n");
     // The maximum child depth has been reached. If `m_max_depth` is the default
     // (i.e. the user has _not_ customized it), then lldb presents a warning to
     // the user. The warning tells the user that the limit has been reached, but

--- a/lldb/test/API/commands/frame/var/repeat/Makefile
+++ b/lldb/test/API/commands/frame/var/repeat/Makefile
@@ -1,0 +1,3 @@
+CXX_SOURCES := main.cpp
+
+include Makefile.rules

--- a/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
+++ b/lldb/test/API/commands/frame/var/repeat/TestFrameVarRepeat.py
@@ -1,0 +1,53 @@
+import lldb
+from lldbsuite.test.lldbtest import TestBase
+from lldbsuite.test import lldbutil
+
+
+class TestCase(TestBase):
+    def test_explicit_depth(self):
+        """Test that repeating 'frame variable' increments --depth."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+        self.do_test("--depth ")
+        self.do_test("--de ")
+        self.do_test("-D ")
+        self.do_test("-D")
+
+    def do_test(self, depth_option):
+        # Start with --depth 2, shows a, b, and c, but but not d.
+        self.expect(
+            f"frame variable {depth_option}2 a",
+            inHistory=True,
+            patterns=[r"\(A\) a = {", "b = {", "c = {", r"(?!.*d = {)"],
+        )
+
+        # First repeat: shows d, but not e.
+        self.expect("", patterns=["d = {", "(?!.*e = {)"])
+
+        # Second repeat: shows e, but not f.
+        self.expect("", patterns=["e = {", "(?!.*f = {)"])
+
+        # Third repeat: shows f, but not leaf.
+        self.expect("", patterns=["f = {", "(?!.*leaf = 42)"])
+
+        # Fourth repeat: shows leaf, the deepest child.
+        self.expect("", substrs=["leaf = 42"])
+
+    def test_default_depth(self):
+        """Test that repeating 'frame variable' adds a --depth option."""
+        self.build()
+        lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.cpp")
+        )
+
+        # Default depth shows f but not leaf.
+        self.expect(
+            "frame variable a",
+            inHistory=True,
+            patterns=[r"f = \{...\}", r"(?!.*leaf = 42)"],
+        )
+
+        # Repeat to show leaf.
+        self.expect("", substrs=["leaf = 42"])

--- a/lldb/test/API/commands/frame/var/repeat/main.cpp
+++ b/lldb/test/API/commands/frame/var/repeat/main.cpp
@@ -1,0 +1,28 @@
+struct F {
+  int leaf = 42;
+};
+
+struct E {
+  F f;
+};
+struct D {
+  E e;
+};
+
+struct C {
+  D d;
+};
+
+struct B {
+  C c;
+};
+
+struct A {
+  B b;
+};
+
+int main() {
+  A a;
+  (void)a;
+  return 0; // break here
+}

--- a/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
+++ b/lldb/test/API/functionalities/data-formatter/data-formatter-advanced/TestDataFormatterAdv.py
@@ -365,7 +365,7 @@ class AdvDataFormatterTestCase(TestBase):
         self.expect(
             "frame variable quite_nested",
             matching=True,
-            substrs=["five ={...}", warning],
+            substrs=["five = {...}", warning],
         )
         self.expect(
             "frame variable quite_nested",

--- a/lldb/test/API/lang/cpp/frame-var-depth-and-elem-count/TestFrameVarDepthAndElemCount.py
+++ b/lldb/test/API/lang/cpp/frame-var-depth-and-elem-count/TestFrameVarDepthAndElemCount.py
@@ -19,10 +19,10 @@ class TestFrameVarDepthAndElemCount(TestBase):
         self.expect(
             "frame var --depth 2 --element-count 5 -- c",
             substrs=[
-                "[0] = {\n    b ={...}\n  }",
-                "[1] = {\n    b ={...}\n  }",
-                "[2] = {\n    b ={...}\n  }",
-                "[3] = {\n    b ={...}\n  }",
-                "[4] = {\n    b ={...}\n  }",
+                "[0] = {\n    b = {...}\n  }",
+                "[1] = {\n    b = {...}\n  }",
+                "[2] = {\n    b = {...}\n  }",
+                "[3] = {\n    b = {...}\n  }",
+                "[4] = {\n    b = {...}\n  }",
             ],
         )


### PR DESCRIPTION
Introduce repeat command functionality for `frame variable`. The repeat behavior
increments the printing depth.

For example, when the default depth value (`target.max-children-depth`) is not enough,
hitting enter one or more times will expand the displayed data as deeply as needed.

See #149282 and then #178717.

(cherry picked from commit 91cf9f6341ec2379398210d398847f0e7543cf1e)

rdar://175793936