### PR TITLE
[lldb] Handle simulator printout in TestSimulatorPlatform (cherry-pick)

### DIFF
--- a/lldb/packages/Python/lldbsuite/test/lldbutil.py
+++ b/lldb/packages/Python/lldbsuite/test/lldbutil.py
@@ -1883,7 +1883,6 @@ def launch_exe_in_apple_simulator(
     device_uuid,
     exe_path,
     exe_args=[],
-    stderr_lines_to_read=0,
     stderr_patterns=[],
     log=None,
 ):
@@ -1907,19 +1906,22 @@ def launch_exe_in_apple_simulator(
     total_patterns = len(stderr_patterns)
     matches_found = 0
     matched_strings = [None] * total_patterns
-    for _ in range(0, stderr_lines_to_read):
-        stderr = sim_launcher.stderr.readline().decode("utf-8")
-        if not stderr:
-            continue
-        for i, pattern in enumerate(stderr_patterns):
-            if matched_strings[i] is not None:
+    if len(stderr_patterns) != 0:
+        while True:
+            stderr = sim_launcher.stderr.readline().decode("utf-8")
+            if not stderr:
                 continue
-            match = re.match(pattern, stderr)
-            if match:
-                matched_strings[i] = str(match.group(1))
-                matches_found += 1
-        if matches_found == total_patterns:
-            break
+            if log:
+                log(f"searching stderr line: {stderr}")
+            for i, pattern in enumerate(stderr_patterns):
+                if matched_strings[i] is not None:
+                    continue
+                match = re.match(pattern, stderr)
+                if match:
+                    matched_strings[i] = str(match.group(1))
+                    matches_found += 1
+            if matches_found == total_patterns:
+                break
 
     return exe_path, matched_strings
 

--- a/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
+++ b/lldb/test/API/macosx/simulator/TestSimulatorPlatform.py
@@ -96,7 +96,6 @@ class TestSimulatorPlatformLaunching(TestBase):
                 device_udid,
                 self.getBuildArtifact("a.out"),
                 exe_args=[],
-                stderr_lines_to_read=1,  # in hello.cpp, the pid is printed first
                 stderr_patterns=[r"PID: (.*)"],
                 log=self.trace,
             )

--- a/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
+++ b/lldb/test/API/tools/lldb-server/TestAppleSimulatorOSType.py
@@ -10,8 +10,6 @@ import re
 
 
 class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
-    # Number of stderr lines to read from the simctl output.
-    READ_LINES = 10
 
     def check_simulator_ostype(self, sdk, platform_name, arch=platform.machine()):
         # Get simulator
@@ -56,7 +54,6 @@ class TestAppleSimulatorOSType(gdbremote_testcase.GdbRemoteTestCaseBase):
             deviceUDID,
             self.getBuildArtifact(exe_name),
             ["print-pid", "sleep:10"],
-            self.READ_LINES,
             [r"PID: (.*)"],
             self.trace,
         )


### PR DESCRIPTION
This fixes TestSimulatorPlatform.py failures on some host configurations.

cherry picked from commit 918e446ef28ac97df20d6ef2bd50c78e2fe903ac

cherry picked from commit 93845b8ef4790a853068706200d417ef3184a098