### PR TITLE
[stable/21.x][lldb] SwiftASTContext has a few unnecessary copies

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.cpp
@@ -1919,9 +1919,9 @@ void SwiftASTContext::ConfigureModuleValidation(
 }
 
 void SwiftASTContext::AddExtraClangArgs(
-    const std::vector<std::string> &ExtraArgs,
-    const std::vector<std::pair<std::string, bool>> module_search_paths,
-    const std::vector<std::pair<std::string, bool>> framework_search_paths,
+    llvm::ArrayRef<std::string> ExtraArgs,
+    llvm::ArrayRef<std::pair<std::string, bool>> module_search_paths,
+    llvm::ArrayRef<std::pair<std::string, bool>> framework_search_paths,
     StringRef overrideOpts) {
   swift::ClangImporterOptions &importer_options = GetClangImporterOptions();
   auto defer = llvm::make_scope_exit([&]() {
@@ -1999,9 +1999,9 @@ bool SwiftASTContext::IsModuleAvailableInCAS(llvm::StringRef key) const {
 };
 
 void SwiftASTContext::AddExtraClangCC1Args(
-    const std::vector<std::string> &source,
-    const std::vector<std::pair<std::string, bool>> module_search_paths,
-    const std::vector<std::pair<std::string, bool>> framework_search_paths,
+    llvm::ArrayRef<std::string> source,
+    llvm::ArrayRef<std::pair<std::string, bool>> module_search_paths,
+    llvm::ArrayRef<std::pair<std::string, bool>> framework_search_paths,
     std::vector<std::string> &dest) {
   clang::CompilerInvocation invocation;
   std::vector<std::string> default_paths = {

--- a/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/SwiftASTContext.h
@@ -297,15 +297,15 @@ public:
   /// Add a list of Clang arguments to the ClangImporter options and
   /// apply the working directory to any relative paths.
   void AddExtraClangArgs(
-      const std::vector<std::string> &ExtraArgs,
-      const std::vector<std::pair<std::string, bool>> module_search_paths,
-      const std::vector<std::pair<std::string, bool>> framework_search_paths,
+      llvm::ArrayRef<std::string> ExtraArgs,
+      llvm::ArrayRef<std::pair<std::string, bool>> module_search_paths,
+      llvm::ArrayRef<std::pair<std::string, bool>> framework_search_paths,
       llvm::StringRef overrideOpts = "");
 
   void AddExtraClangCC1Args(
-      const std::vector<std::string> &source,
-      const std::vector<std::pair<std::string, bool>> module_search_paths,
-      const std::vector<std::pair<std::string, bool>> framework_search_paths,
+      llvm::ArrayRef<std::string> source,
+      llvm::ArrayRef<std::pair<std::string, bool>> module_search_paths,
+      llvm::ArrayRef<std::pair<std::string, bool>> framework_search_paths,
       std::vector<std::string> &dest);
   static void AddExtraClangArgs(const std::vector<std::string>& source,
                                 std::vector<std::string>& dest);


### PR DESCRIPTION
SwiftASTContext::AddExtraClang(CC1)Args is passing a few vectors by value when they should be by reference. Switch all of the inputs to ArrayRef.

rdar://175729986