### PR TITLE
[LLDB] Store clang type info as BuiltinTypeInfo, not sliced TypeInfo

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntime.h
@@ -23,9 +23,10 @@
 #include "lldb/lldb-private.h"
 #include "swift/Demangling/ManglingFlavor.h"
 
-#include <optional>
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
+#include <optional>
 
 #include <mutex>
 #include <tuple>
@@ -43,6 +44,7 @@ template <unsigned PointerSize> struct RuntimeTarget;
 namespace reflection {
 template <typename T> class ReflectionContext;
 class TypeInfo;
+class BuiltinTypeInfo;
 struct FieldInfo;
 class TypeRef;
 class RecordTypeInfo;
@@ -912,11 +914,12 @@ private:
   /// Cache for the debug-info-originating type infos.
   /// \{
   llvm::DenseMap<lldb::opaque_compiler_type_t,
-                 std::optional<swift::reflection::TypeInfo>>
-      m_clang_type_info;
+                 swift::reflection::BuiltinTypeInfo>
+      m_clang_builtin_type_info;
   llvm::DenseMap<lldb::opaque_compiler_type_t,
-                 std::optional<swift::reflection::RecordTypeInfo>>
+                 swift::reflection::RecordTypeInfo>
       m_clang_record_type_info;
+  llvm::DenseSet<lldb::opaque_compiler_type_t> m_clang_type_info_negative_cache;
   llvm::DenseMap<const char *, CompilerType> m_anonymous_clang_types;
   unsigned m_num_anonymous_clang_types = 0;
   std::recursive_mutex m_clang_type_info_mutex;

--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeDynamicTypeResolution.cpp
@@ -439,21 +439,18 @@ CompilerType SwiftLanguageRuntime::LookupAnonymousClangType(const char *key) {
 std::optional<const swift::reflection::TypeInfo *>
 SwiftLanguageRuntime::lookupClangTypeInfo(CompilerType clang_type) {
   std::lock_guard<std::recursive_mutex> locker(m_clang_type_info_mutex);
+  lldb::opaque_compiler_type_t opaque_type = clang_type.GetOpaqueQualType();
+  if (m_clang_type_info_negative_cache.contains(opaque_type))
+    return nullptr;
   {
-    auto it = m_clang_type_info.find(clang_type.GetOpaqueQualType());
-    if (it != m_clang_type_info.end()) {
-      if (it->second)
-        return &*it->second;
-      return nullptr;
-    }
+    auto it = m_clang_builtin_type_info.find(opaque_type);
+    if (it != m_clang_builtin_type_info.end())
+      return &it->second;
   }
   {
-    auto it = m_clang_record_type_info.find(clang_type.GetOpaqueQualType());
-    if (it != m_clang_record_type_info.end()) {
-      if (it->second)
-        return &*it->second;
-      return nullptr;
-    }
+    auto it = m_clang_record_type_info.find(opaque_type);
+    if (it != m_clang_record_type_info.end())
+      return &it->second;
   }
   return {};
 }
@@ -464,7 +461,7 @@ const swift::reflection::TypeInfo *SwiftLanguageRuntime::emplaceClangTypeInfo(
     llvm::ArrayRef<swift::reflection::FieldInfo> fields) {
   const std::lock_guard<std::recursive_mutex> locker(m_clang_type_info_mutex);
   if (!byte_size || !bit_align) {
-    m_clang_type_info.insert({clang_type.GetOpaqueQualType(), std::nullopt});
+    m_clang_type_info_negative_cache.insert(clang_type.GetOpaqueQualType());
     return nullptr;
   }
   assert(*bit_align % 8 == 0 && "Bit alignment no a multiple of 8!");
@@ -476,14 +473,13 @@ const swift::reflection::TypeInfo *SwiftLanguageRuntime::emplaceClangTypeInfo(
     extra_inhabitants = swift::swift_getHeapObjectExtraInhabitantCount();
 
   if (fields.empty()) {
-    auto it_b = m_clang_type_info.insert(
+    auto it_b = m_clang_builtin_type_info.insert(
         {clang_type.GetOpaqueQualType(),
-         swift::reflection::TypeInfo(swift::reflection::TypeInfoKind::Builtin,
-                 *byte_size, byte_align, byte_stride,
-                 extra_inhabitants,
-                 swift::reflection::BitwiseBorrowability::TakableAndBorrowable,
-                 /*AFD=*/ false)});
-    return &*it_b.first->second;
+         swift::reflection::BuiltinTypeInfo(
+             *byte_size, byte_align, byte_stride, extra_inhabitants,
+             swift::reflection::BitwiseBorrowability::TakableAndBorrowable,
+             /*AFD=*/false)});
+    return &it_b.first->second;
   }
   auto it_b = m_clang_record_type_info.insert(
       {clang_type.GetOpaqueQualType(),
@@ -492,7 +488,7 @@ const swift::reflection::TypeInfo *SwiftLanguageRuntime::emplaceClangTypeInfo(
            swift::reflection::BitwiseBorrowability::None,
            /*AFD=*/true,
            swift::reflection::RecordKind::Struct, fields)});
-  return &*it_b.first->second;
+  return &it_b.first->second;
 }
 
 std::optional<uint64_t>

--- a/lldb/test/API/lang/swift/optional_cstruct/Foo/Foo.h
+++ b/lldb/test/API/lang/swift/optional_cstruct/Foo/Foo.h
@@ -1,0 +1,3 @@
+typedef struct {
+  unsigned int val[4];
+} Foo;

--- a/lldb/test/API/lang/swift/optional_cstruct/Foo/module.modulemap
+++ b/lldb/test/API/lang/swift/optional_cstruct/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+  header "Foo.h"
+}

--- a/lldb/test/API/lang/swift/optional_cstruct/Makefile
+++ b/lldb/test/API/lang/swift/optional_cstruct/Makefile
@@ -1,0 +1,4 @@
+SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR)/Foo
+include Makefile.rules

--- a/lldb/test/API/lang/swift/optional_cstruct/TestSwiftOptionalCStruct.py
+++ b/lldb/test/API/lang/swift/optional_cstruct/TestSwiftOptionalCStruct.py
@@ -1,0 +1,23 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftOptionalCStruct(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+
+        frame = thread.frames[0]
+        variable = frame.FindVariable("variable")
+        lldbutil.check_variable(
+            self, variable, value="some", typename="Swift.Optional<Foo.Foo>"
+        )
+
+        val = variable.GetChildMemberWithName("val")
+        self.assertTrue(val.IsValid(), "val child is valid")

--- a/lldb/test/API/lang/swift/optional_cstruct/main.swift
+++ b/lldb/test/API/lang/swift/optional_cstruct/main.swift
@@ -1,0 +1,9 @@
+import Foo
+
+func f() {
+  let variable: Foo? = Foo()
+  print("break here") // break here
+  _ = variable
+}
+
+f()


### PR DESCRIPTION
SwiftLanguageRuntime::emplaceClangTypeInfo was constructing a plain swift::reflection::TypeInfo with TypeInfoKind::Builtin and storing it by value in m_clang_type_info. Because the map value type was the base class TypeInfo, virtual methods on the cached entry dispatched to the base-class defaults instead of BuiltinTypeInfo's overrides.

Assisted-by: Claude

rdar://175382941