### PR TITLE
[CXX] Update downstream test to use dead_on_return.

### DIFF
--- a/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-virtual-dtor-call-wrapper-globals.cpp
+++ b/clang/test/CodeGenCXX/ptrauth-apple-kext-indirect-virtual-dtor-call-wrapper-globals.cpp
@@ -45,6 +45,6 @@ void f(SubTempl<int>* t) {
 }
 
 // CHECK: getelementptr inbounds nuw (i8, ptr @_ZTV5TemplIiE, i64 16)
-// CHECK: declare void @_ZN5TemplIiED0Ev(ptr noundef nonnull align 8 dead_on_return(8) dereferenceable(8))
+// CHECK: declare void @_ZN5TemplIiED0Ev(ptr noundef nonnull align 8 dereferenceable(8)) unnamed_addr #4
 // CHECK: define internal void @_ZN5TemplIiE1fEv(ptr noundef nonnull align 8 dereferenceable(8) %this)
 // CHECK: define internal void @_ZN5TemplIiE1gEv(ptr noundef nonnull align 8 dereferenceable(8) %this)


### PR DESCRIPTION
dead_on_return removed after added.

rdar://169994107