### PR TITLE
[lldb] Add tests for Unmanaged<T> of Clang-imported reference types

### DIFF
--- a/lldb/test/API/lang/swift/unmanaged_clang_bridged/Foo/Foo.h
+++ b/lldb/test/API/lang/swift/unmanaged_clang_bridged/Foo/Foo.h
@@ -1,0 +1,2 @@
+typedef struct __attribute__((objc_bridge(id))) {
+} *MyBridgedRef;

--- a/lldb/test/API/lang/swift/unmanaged_clang_bridged/Foo/module.modulemap
+++ b/lldb/test/API/lang/swift/unmanaged_clang_bridged/Foo/module.modulemap
@@ -1,0 +1,3 @@
+module Foo {
+  header "Foo.h"
+}

--- a/lldb/test/API/lang/swift/unmanaged_clang_bridged/Makefile
+++ b/lldb/test/API/lang/swift/unmanaged_clang_bridged/Makefile
@@ -1,0 +1,4 @@
+SWIFT_OBJC_INTEROP := 1
+SWIFT_SOURCES := main.swift
+SWIFTFLAGS_EXTRAS = -Xcc -I$(SRCDIR)/Foo
+include Makefile.rules

--- a/lldb/test/API/lang/swift/unmanaged_clang_bridged/TestSwiftUnmanagedClangBridged.py
+++ b/lldb/test/API/lang/swift/unmanaged_clang_bridged/TestSwiftUnmanagedClangBridged.py
@@ -1,0 +1,43 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftUnmanagedClangBridged(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+
+        frame = thread.frames[0]
+
+        someU = frame.FindVariable("someU")
+        lldbutil.check_variable(
+            self, someU, typename="Swift.Unmanaged<Foo.MyBridgedRef>"
+        )
+        self.assertEqual(
+            someU.GetChildMemberWithName("_value").GetValueAsUnsigned(), 0xdeadbeef
+        )
+
+        optU = frame.FindVariable("optU")
+        lldbutil.check_variable(
+            self,
+            optU,
+            typename="Swift.Optional<Swift.Unmanaged<Foo.MyBridgedRef>>",
+            value="some",
+        )
+        self.assertEqual(
+            optU.GetChildMemberWithName("_value").GetValueAsUnsigned(), 0xdeadbeef
+        )
+
+        nilU = frame.FindVariable("nilU")
+        lldbutil.check_variable(
+            self,
+            nilU,
+            typename="Swift.Optional<Swift.Unmanaged<Foo.MyBridgedRef>>",
+            summary="nil",
+        )

--- a/lldb/test/API/lang/swift/unmanaged_clang_bridged/main.swift
+++ b/lldb/test/API/lang/swift/unmanaged_clang_bridged/main.swift
@@ -1,0 +1,14 @@
+import Foo
+
+@inline(never)
+func makeNil() -> Unmanaged<MyBridged>? { return nil }
+
+func f() {
+  let nilU: Unmanaged<MyBridged>? = makeNil()
+  let p = UnsafeMutableRawPointer(bitPattern: 0xdeadbeef)!
+  let someU: Unmanaged<MyBridged> = Unmanaged.fromOpaque(p)
+  let optU: Unmanaged<MyBridged>? = Unmanaged.fromOpaque(p)
+  print("break here", nilU as Any)
+}
+
+f()

--- a/lldb/test/API/lang/swift/unmanaged_foundationtype/Makefile
+++ b/lldb/test/API/lang/swift/unmanaged_foundationtype/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/unmanaged_foundationtype/TestSwiftUnmanagedFoundationType.py
+++ b/lldb/test/API/lang/swift/unmanaged_foundationtype/TestSwiftUnmanagedFoundationType.py
@@ -1,0 +1,45 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestSwiftUnmanagedFoundationType(TestBase):
+    @swiftTest
+    @skipUnlessFoundation
+    def test(self):
+        """Inspect Unmanaged of a Clang-imported reference type without the AST context."""
+        self.build()
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+
+        frame = thread.frames[0]
+
+        unmanaged = frame.FindVariable("unmanaged")
+        lldbutil.check_variable(
+            self, unmanaged, typename="Swift.Unmanaged<CoreFoundation.CFErrorRef>"
+        )
+        self.assertNotEqual(
+            unmanaged.GetChildMemberWithName("_value").GetValueAsUnsigned(), 0
+        )
+
+        optUnmanaged = frame.FindVariable("optUnmanaged")
+        lldbutil.check_variable(
+            self,
+            optUnmanaged,
+            typename="Swift.Optional<Swift.Unmanaged<CoreFoundation.CFErrorRef>>",
+            value="some",
+        )
+        self.assertNotEqual(
+            optUnmanaged.GetChildMemberWithName("_value").GetValueAsUnsigned(), 0
+        )
+
+        nilUnmanaged = frame.FindVariable("nilUnmanaged")
+        lldbutil.check_variable(
+            self,
+            nilUnmanaged,
+            typename="Swift.Optional<Swift.Unmanaged<CoreFoundation.CFErrorRef>>",
+            summary="nil",
+        )

--- a/lldb/test/API/lang/swift/unmanaged_foundationtype/main.swift
+++ b/lldb/test/API/lang/swift/unmanaged_foundationtype/main.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@inline(never)
+func makeNil() -> Unmanaged<CFError>? { return nil }
+
+func f() {
+  let unmanaged: Unmanaged<CFError> = Unmanaged.passUnretained(
+    CFErrorCreate(nil, kCFErrorDomainPOSIX, 0, nil))
+  let optUnmanaged: Unmanaged<CFError>? = Unmanaged.passUnretained(
+    CFErrorCreate(nil, kCFErrorDomainPOSIX, 0, nil))
+  let nilUnmanaged: Unmanaged<CFError>? = makeNil()
+  print("break here \(unmanaged)")
+}
+
+f()


### PR DESCRIPTION
Exercise the fix for https://github.com/swiftlang/swift/pull/88770 in both configurations: a Clang-bridged opaque pointer type (MyBridgedRef), and a Foundation CF type (CFError).

Assisted-by: claude