### PR TITLE
[NFC][BoundsSafety] Fix `AST/value-dependence.cpp`

### DIFF
--- a/clang/test/BoundsSafety/AST/value-dependence.cpp
+++ b/clang/test/BoundsSafety/AST/value-dependence.cpp
@@ -501,7 +501,7 @@ void lambda(T h) {
 template void lambda<int>(int h);
 #endif
 
-// ATTR-ONLY: `-FunctionTemplateDecl {{.*}} lambda
+// ATTR-ONLY: |-FunctionTemplateDecl {{.*}} lambda
 // ATTR-ONLY:   |-TemplateTypeParmDecl {{.*}} T
 // ATTR-ONLY:   |-FunctionDecl {{.*}} lambda 'void (T)'
 // ATTR-ONLY:   | `-CompoundStmt


### PR DESCRIPTION
The FunctionTemplateDecl node isn't the last node anymore so the FileCheck line stopped matching. The last top level node is now `ExplicitInstantiationDecl`.

This was likely caused by:

```
commit fb024337497f4c158ea16bfb90e50138d9a2a0c6
Author: ykiko <ykikoykikoykiko@gmail.com>
Date:   Thu Apr 23 03:21:27 2026 +0800

     [Clang][AST] Introduce `ExplicitInstantiationDecl` to preserve source info and fix diagnostic locations  (#191658)
```

rdar://175912866