### PR TITLE
[lldb] Recurse into nested types when stripping marker protocols

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -1443,7 +1443,7 @@ SwiftLanguageRuntime::GetGenericSignature(llvm::StringRef function_name,
   bool error = false;
   // For each pack_expansion...
   swift::Demangle::NodePointer type_node = nullptr;
-  TypeSystemSwiftTypeRef::PreOrderTraversal(
+  llvm::cantFail(TypeSystemSwiftTypeRef::PreOrderTraversal(
       node, [&](swift::Demangle::NodePointer node) {
         if (node->getKind() == swift::Demangle::Node::Kind::PackExpansion) {
           if (node->getNumChildren() != 2) {
@@ -1481,7 +1481,7 @@ SwiftLanguageRuntime::GetGenericSignature(llvm::StringRef function_name,
         }
         type_node = node;
         return true;
-      });
+      }));
 
   if (error)
     return {};

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.cpp
@@ -262,7 +262,7 @@ std::string TypeSystemSwiftTypeRef::AdjustTypeForOriginallyDefinedInModule(
   llvm::DenseMap<NodePointer, NodePointer> type_to_renamed_type_nodes;
 
   // Visit the demangle tree and populate type_to_renamed_type_nodes.
-  PreOrderTraversal(type_node, [&](NodePointer node) {
+  llvm::cantFail(PreOrderTraversal(type_node, [&](NodePointer node) {
     // We're visiting the entire tree, but we only need to examine "Type" nodes.
     if (node->getKind() != Node::Kind::Type)
       return true;
@@ -321,7 +321,7 @@ std::string TypeSystemSwiftTypeRef::AdjustTypeForOriginallyDefinedInModule(
 
     type_to_renamed_type_nodes[node_with_module_and_name] = new_node;
     return true;
-  });
+  }));
 
   // If there are no renamed modules, there's nothing to do.
   if (type_to_renamed_type_nodes.empty())
@@ -1301,7 +1301,7 @@ TypeSystemSwiftTypeRef::MapOutOfContext(lldb::opaque_compiler_type_t type) {
   unsigned depth = 0;
   using ParamVector = llvm::SmallVector<std::pair<unsigned, unsigned>, 4>;
   llvm::SmallDenseMap<NodePointer, ParamVector, 8> subs;
-  PreOrderTraversal(type_node, [&](NodePointer node) {
+  llvm::cantFail(PreOrderTraversal(type_node, [&](NodePointer node) {
     switch (node->getKind()) {
     case Node::Kind::BoundGenericClass:
     case Node::Kind::BoundGenericEnum:
@@ -1338,7 +1338,7 @@ TypeSystemSwiftTypeRef::MapOutOfContext(lldb::opaque_compiler_type_t type) {
     default:
       return true;
     }
-  });
+  }));
   if (error)
     return {};
 
@@ -1523,16 +1523,21 @@ TypeSystemSwiftTypeRef::TryTransform(
   return fn(node);
 }
 
-void TypeSystemSwiftTypeRef::PreOrderTraversal(
+llvm::Error TypeSystemSwiftTypeRef::PreOrderTraversal(
     swift::Demangle::NodePointer node,
-    std::function<bool(swift::Demangle::NodePointer)> visitor) {
+    std::function<llvm::Expected<bool>(swift::Demangle::NodePointer)> visitor) {
   if (!node)
-    return;
-  if (!visitor(node))
-    return;
+    return llvm::Error::success();
+  auto descend = visitor(node);
+  if (!descend)
+    return descend.takeError();
+  if (!*descend)
+    return llvm::Error::success();
 
-  for (swift::Demangle::NodePointer child : *node) 
-    PreOrderTraversal(child, visitor);
+  for (swift::Demangle::NodePointer child : *node)
+    if (auto err = PreOrderTraversal(child, visitor))
+      return err;
+  return llvm::Error::success();
 }
 
 /// Desugar a sugared type.
@@ -2780,31 +2785,39 @@ TypeSystemSwiftTypeRef::RemoveMarkerProtocols(
     swift::Demangle::Demangler &dem, swift::Demangle::NodePointer node,
     swift::Mangle::ManglingFlavor flavor) {
   using namespace swift::Demangle;
-  NodePointer type_list_node = swift_demangle::NodeAtPath(
-      node, {Node::Kind::Global, Node::Kind::TypeMangling, Node::Kind::Type,
-             Node::Kind::ProtocolList, Node::Kind::TypeList});
-  if (!type_list_node)
+  if (!node)
     return node;
 
-  // Collect indices of marker protocols, then remove in reverse order so
-  // that earlier indices remain valid.
+  // Strip marker protocols from every ProtocolList > TypeList in the tree.
   swift_demangle::NodeBuilder b(dem);
-  llvm::SmallVector<size_t> to_remove;
-  for (size_t i = 0; i < type_list_node->getNumChildren(); ++i) {
-    // Mangle a single-protocol type for this child so we can look it up in the
-    // type cache.
-    auto *protocol_list =
-        b.Node(Node::Kind::ProtocolList,
-               b.Node(Node::Kind::TypeList, type_list_node->getChild(i)));
-    auto mangling = mangleNode(b.GlobalType(protocol_list), flavor);
-    if (!mangling.isSuccess())
-      return llvm::createStringError("failed to mangle protocol in type: " +
-                                     nodeToString(node));
-    if (IsMarkerProtocol(ConstString(mangling.result())))
-      to_remove.push_back(i);
-  }
-  for (size_t i : llvm::reverse(to_remove))
-    type_list_node->removeChildAt(i);
+  if (auto err = PreOrderTraversal(
+          node, [&](NodePointer current) -> llvm::Expected<bool> {
+            if (current->getKind() != Node::Kind::ProtocolList ||
+                current->getNumChildren() != 1 ||
+                current->getFirstChild()->getKind() != Node::Kind::TypeList)
+              return true;
+
+            NodePointer type_list_node = current->getFirstChild();
+            llvm::SmallVector<size_t> to_remove;
+            for (size_t i = 0; i < type_list_node->getNumChildren(); ++i) {
+              // Mangle a single-protocol type for this child so we can look it
+              // up in the type cache.
+              auto *protocol_list = b.Node(
+                  Node::Kind::ProtocolList,
+                  b.Node(Node::Kind::TypeList, type_list_node->getChild(i)));
+              auto mangling = mangleNode(b.GlobalType(protocol_list), flavor);
+              if (!mangling.isSuccess())
+                return llvm::createStringError(
+                    "failed to mangle protocol in type: " +
+                    nodeToString(current));
+              if (IsMarkerProtocol(ConstString(mangling.result())))
+                to_remove.push_back(i);
+            }
+            for (size_t i : llvm::reverse(to_remove))
+              type_list_node->removeChildAt(i);
+            return true;
+          }))
+    return std::move(err);
   return node;
 }
 

--- a/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
+++ b/lldb/source/Plugins/TypeSystem/Swift/TypeSystemSwiftTypeRef.h
@@ -422,12 +422,14 @@ public:
                    swift::Demangle::NodePointer)>
                    visitor);
 
-  /// A left-to-right preorder traversal. Don't visit children if
-  /// visitor returns false.
-  /// The NodePointer passed to \p fn is guaranteed to be non-null.
-  static void
-  PreOrderTraversal(swift::Demangle::NodePointer node,
-                    std::function<bool(swift::Demangle::NodePointer)>);
+  /// A left-to-right preorder traversal. Don't visit children if the visitor
+  /// returns false. If the visitor returns an error, the traversal stops and
+  /// the error is returned to the caller.
+  /// The NodePointer passed to \p visitor is guaranteed to be non-null.
+  static llvm::Error PreOrderTraversal(
+      swift::Demangle::NodePointer node,
+      std::function<llvm::Expected<bool>(swift::Demangle::NodePointer)>
+          visitor);
 
   /// Canonicalize Array, Dictionary and Optional to their sugared form.
   static swift::Demangle::NodePointer

--- a/lldb/test/API/lang/swift/nested_marker_protocol_existential/Makefile
+++ b/lldb/test/API/lang/swift/nested_marker_protocol_existential/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/nested_marker_protocol_existential/TestNestedMarkerProtocolExistential.py
+++ b/lldb/test/API/lang/swift/nested_marker_protocol_existential/TestNestedMarkerProtocolExistential.py
@@ -1,0 +1,49 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestNestedMarkerProtocolExistential(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+
+        # any Foo wrapping an Int: dynamic resolution lifts the payload to Int.
+        lldbutil.check_variable(
+            self, frame.FindVariable("bareMarker"), use_dynamic=True, value="1"
+        )
+
+        # any Foo & Bar wrapping Conformer(bar: 2).
+        bareComposition = frame.FindVariable("bareComposition")
+        lldbutil.check_variable(
+            self, bareComposition.GetChildMemberWithName("bar"), value="2"
+        )
+
+        # [any Foo] = [5, 6, 7]: each element must lift to its Int payload.
+        arrayOfMarker = frame.FindVariable("arrayOfMarker")
+        for i, expected in enumerate(["5", "6", "7"]):
+            lldbutil.check_variable(
+                self,
+                arrayOfMarker.GetChildAtIndex(i),
+                use_dynamic=True,
+                value=expected,
+            )
+
+        # Box<any Foo & Bar>(payload: Conformer(bar: 8), tag: 9).
+        genericBox = frame.FindVariable("genericBox")
+        lldbutil.check_variable(
+            self,
+            genericBox.GetChildMemberWithName("payload").GetChildMemberWithName(
+                "bar"
+            ),
+            value="8",
+        )
+        lldbutil.check_variable(
+            self, genericBox.GetChildMemberWithName("tag"), value="9"
+        )

--- a/lldb/test/API/lang/swift/nested_marker_protocol_existential/main.swift
+++ b/lldb/test/API/lang/swift/nested_marker_protocol_existential/main.swift
@@ -1,0 +1,28 @@
+@_marker protocol Foo {}
+
+extension Int: Foo {}
+
+protocol Bar {
+    var bar: Int { get }
+}
+
+struct Conformer: Foo, Bar {
+    let bar: Int
+}
+
+public struct Box<T> {
+    public var payload: T
+    public var tag: Int
+}
+
+func f() {
+    let bareMarker: any Foo = 1
+    let bareComposition: any Foo & Bar = Conformer(bar: 2)
+    let arrayOfMarker: [any Foo] = [5, 6, 7]
+    let genericBox = Box<any Foo & Bar>(payload: Conformer(bar: 8), tag: 9)
+
+    print("break here")
+    print(bareMarker, bareComposition, arrayOfMarker, genericBox)
+}
+
+f()

--- a/lldb/test/API/lang/swift/stdlib_marker_protocols/Makefile
+++ b/lldb/test/API/lang/swift/stdlib_marker_protocols/Makefile
@@ -1,0 +1,2 @@
+SWIFT_SOURCES := main.swift
+include Makefile.rules

--- a/lldb/test/API/lang/swift/stdlib_marker_protocols/TestStdlibMarkerProtocols.py
+++ b/lldb/test/API/lang/swift/stdlib_marker_protocols/TestStdlibMarkerProtocols.py
@@ -1,0 +1,37 @@
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestStdlibMarkerProtocols(TestBase):
+    @swiftTest
+    def test(self):
+        self.build()
+        self.runCmd("settings set symbols.swift-enable-ast-context false")
+        target, process, thread, bkpt = lldbutil.run_to_source_breakpoint(
+            self, "break here", lldb.SBFileSpec("main.swift")
+        )
+        frame = thread.frames[0]
+
+        lldbutil.check_variable(
+            self, frame.FindVariable("sendable"), use_dynamic=True, value="1"
+        )
+        lldbutil.check_variable(
+            self,
+            frame.FindVariable("bitwiseCopyable"),
+            use_dynamic=True,
+            value="2",
+        )
+        lldbutil.check_variable(
+            self,
+            frame.FindVariable("sendableAndBitwise"),
+            use_dynamic=True,
+            value="3",
+        )
+        lldbutil.check_variable(
+            self,
+            frame.FindVariable("realAndSendable"),
+            use_dynamic=True,
+            value="4",
+        )

--- a/lldb/test/API/lang/swift/stdlib_marker_protocols/main.swift
+++ b/lldb/test/API/lang/swift/stdlib_marker_protocols/main.swift
@@ -1,0 +1,10 @@
+func f() {
+  let sendable: any Sendable = 1
+  let bitwiseCopyable: any BitwiseCopyable = 2
+  let sendableAndBitwise: any Sendable & BitwiseCopyable = 3
+  let realAndSendable: any Hashable & Sendable = 4
+
+  print("break here")
+}
+
+f()


### PR DESCRIPTION
We were only matching on top protocol types, like "any Sendable" or "any Sendable & Foo", but  if the protocol type is not the top type, like Sendable?, we would fail to strip the marker protocol.

Assisted-by: claude

rdar://175984696