### PR TITLE
[lldb] Fix --source-regexp-function for Swift static functions

### DIFF
--- a/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
+++ b/lldb/source/Plugins/LanguageRuntime/Swift/SwiftLanguageRuntimeNames.cpp
@@ -1069,6 +1069,11 @@ static bool ParseGlobal(const swift::Demangle::NodePointer &node,
   for (swift::Demangle::Node::iterator pos = node->begin(); pos != end; ++pos) {
     swift::Demangle::NodePointer child = *pos;
     if (child) {
+      // Peel off static node.
+      if (child->getKind() == swift::Demangle::Node::Kind::Static &&
+          child->hasChildren())
+        child = child->getFirstChild();
+
       kind = child->getKind();
       switch (child->getKind()) {
       case swift::Demangle::Node::Kind::Allocator:

--- a/lldb/test/API/lang/swift/break_source_regex_static_function/Makefile
+++ b/lldb/test/API/lang/swift/break_source_regex_static_function/Makefile
@@ -1,0 +1,3 @@
+SWIFT_SOURCES := main.swift
+
+include Makefile.rules

--- a/lldb/test/API/lang/swift/break_source_regex_static_function/TestBreakSourceRegexStaticFunction.py
+++ b/lldb/test/API/lang/swift/break_source_regex_static_function/TestBreakSourceRegexStaticFunction.py
@@ -1,0 +1,30 @@
+"""
+Tests source regex breakpoints scoped to Swift static functions (-X option).
+"""
+
+import lldb
+from lldbsuite.test.lldbtest import *
+from lldbsuite.test.decorators import *
+import lldbsuite.test.lldbutil as lldbutil
+
+
+class TestCase(TestBase):
+    @swiftTest
+    def test_source_regex_with_static_function_filter(self):
+        self.build()
+        target, _, _, _ = lldbutil.run_to_name_breakpoint(self, "main")
+        self.expect("breakpoint set -p 'break here' -X first")
+        bp = target.breakpoint[-1]
+        self.assertTrue(bp.IsEnabled())
+        self.assertEqual(bp.GetNumResolvedLocations(), 1)
+        self.assertIn("Scope.first", str(bp.location[0]))
+
+    @swiftTest
+    def test_source_regex_with_static_function_filter_and_file(self):
+        self.build()
+        target, _, _, _ = lldbutil.run_to_name_breakpoint(self, "main")
+        self.expect("breakpoint set -f main.swift -p 'break here' -X second")
+        bp = target.breakpoint[-1]
+        self.assertTrue(bp.IsEnabled())
+        self.assertEqual(bp.GetNumResolvedLocations(), 1)
+        self.assertIn("Scope.second", str(bp.location[0]))

--- a/lldb/test/API/lang/swift/break_source_regex_static_function/main.swift
+++ b/lldb/test/API/lang/swift/break_source_regex_static_function/main.swift
@@ -1,0 +1,16 @@
+enum Scope {
+    static func first() {
+        _ = "break here"
+    }
+
+    static func second() {
+        _ = "break here"
+    }
+}
+
+@main enum Entry {
+    static func main() {
+        Scope.first()
+        Scope.second()
+    }
+}


### PR DESCRIPTION
Fixes the ability to set a source breakpoint with a function filter – where the function is a static Swift function.