### PR TITLE
[clang][deps] Fix bad merge of #192347

### DIFF
--- a/clang/tools/clang-scan-deps/ClangScanDeps.cpp
+++ b/clang/tools/clang-scan-deps/ClangScanDeps.cpp
@@ -1330,7 +1330,6 @@ int clang_scan_deps_main(int argc, char **argv, const llvm::ToolContext &) {
   Opts.AsyncScanModules = AsyncScanModules;
   Opts.FlushModuleCache = !NoFlushModuleCache;
   Opts.CacheNegativeStats = CacheNegativeStats;
-  DependencyScanningService Service(std::move(Opts));
 
   llvm::Timer T;
   T.startTimer();


### PR DESCRIPTION
The upstream PR moved the service construction into the inner scoped down below. Because the old way of constructing the service wasn't removed during conflict resolution, the actual service ended up using moved-from options.