### PR TITLE
[lldb][debugserver] Don't duplicate loaded binaries in jStopInfo (#195343)

### DIFF
--- a/lldb/tools/debugserver/source/RNBRemote.cpp
+++ b/lldb/tools/debugserver/source/RNBRemote.cpp
@@ -5640,28 +5640,28 @@ RNBRemote::GetJSONThreadsInfo(bool threads_with_valid_stop_info_only) {
           }
           thread_dict_sp->AddItem("memory", memory_array_sp);
         }
-      }
 
-      std::vector<uint64_t> added_binaries;
-      JSONGenerator::ObjectSP detailed_binary_infos;
+        std::vector<uint64_t> added_binaries;
+        JSONGenerator::ObjectSP detailed_binary_infos;
 
-      // If we've stopped with a breakpoint exception on this
-      // thread, and we're stopped at the dyld notification
-      // function address, collect information about libraries
-      // that have been loaded, expedite that information in
-      // the stop packet.
-      if (tid_stop_info.details.exception.type == EXC_BREAKPOINT &&
-          DNBGetBinariesLoadedInfo(pid, tid, added_binaries,
-                                   detailed_binary_infos)) {
-        JSONGenerator::ArraySP load_addresses;
-        load_addresses = std::make_shared<JSONGenerator::Array>();
-        for (nub_addr_t addr : added_binaries)
-          load_addresses->AddIntegerItem(addr);
-        thread_dict_sp->AddItem("added-binaries", load_addresses);
+        // If we've stopped with a breakpoint exception on this
+        // thread, and we're stopped at the dyld notification
+        // function address, collect information about libraries
+        // that have been loaded, expedite that information in
+        // the stop packet.
+        if (tid_stop_info.details.exception.type == EXC_BREAKPOINT &&
+            DNBGetBinariesLoadedInfo(pid, tid, added_binaries,
+                                     detailed_binary_infos)) {
+          JSONGenerator::ArraySP load_addresses;
+          load_addresses = std::make_shared<JSONGenerator::Array>();
+          for (nub_addr_t addr : added_binaries)
+            load_addresses->AddIntegerItem(addr);
+          thread_dict_sp->AddItem("added-binaries", load_addresses);
 
-        if (detailed_binary_infos)
-          thread_dict_sp->AddItem("detailed-binaries-info",
-                                  detailed_binary_infos);
+          if (detailed_binary_infos)
+            thread_dict_sp->AddItem("detailed-binaries-info",
+                                    detailed_binary_infos);
+        }
       }
 
       threads_array_sp->AddItem(thread_dict_sp);


### PR DESCRIPTION


RNBRemote::GetJSONThreadsInfo() has a bool mode switch: Only exception-related information information about threads which had an exception, or full information about all threads. The exception-related information is what ends up in the `jstopinfo` key in the stop packet, asciihex encoded. The full information is what is sent for the `jThreadsInfo` packet, with full information for all threads at a public stop.

When I added the `added-binaries` and `detailed-binaries-info` keys to the thread description, I incorrectly put this in the exception related block of this method. Move that in to the "full information" section of the method, so we don't duplicate the information that is included in the stop packet, asciihex encoded at that.

rdar://176001611
(cherry picked from commit 491e8cedd4ebcc33f8d8e14f2a0b857cfd191228)